### PR TITLE
Fixes #7787 - added ES256 to id_token_signing_alg_values_supported

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { MedplumClient, WithId } from '@medplum/core';
-import { ContentType, encodeBase64 } from '@medplum/core';
+import { ContentType, encodeBase64, OAuthSigningAlgorithm } from '@medplum/core';
 import type { Bot, Extension, OperationOutcome } from '@medplum/fhirtypes';
 import { Command } from 'commander';
 import { SignJWT } from 'jose';
@@ -277,7 +277,7 @@ export function profileExists(storage: FileSystemStorage, profile: string): bool
 export async function jwtBearerLogin(medplum: MedplumClient, profile: Profile): Promise<void> {
   const header = {
     typ: 'JWT',
-    alg: 'HS256',
+    alg: OAuthSigningAlgorithm.HS256,
   };
 
   const currentTimestamp = Math.floor(Date.now() / 1000);
@@ -302,7 +302,7 @@ export async function jwtBearerLogin(medplum: MedplumClient, profile: Profile): 
 export async function jwtAssertionLogin(medplum: MedplumClient, profile: Profile): Promise<void> {
   const privateKey = createPrivateKey(readFileSync(resolve(profile.privateKeyPath as string)));
   const jwt = await new SignJWT({})
-    .setProtectedHeader({ alg: 'RS384', typ: 'JWT' })
+    .setProtectedHeader({ typ: 'JWT', alg: OAuthSigningAlgorithm.RS384 })
     .setIssuer(profile.clientId as string)
     .setSubject(profile.clientId as string)
     .setAudience(`${profile.baseUrl}${profile.audience}`)

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -768,6 +768,21 @@ export const OAuthClientAssertionType = {
 } as const;
 export type OAuthClientAssertionType = (typeof OAuthClientAssertionType)[keyof typeof OAuthClientAssertionType];
 
+/**
+ * OAuth Signing Algorithms
+ * See {@link https://datatracker.ietf.org/doc/html/rfc7519 | RFC 7519} for full details.
+ */
+export const OAuthSigningAlgorithm = {
+  ES256: 'ES256',
+  ES384: 'ES384',
+  ES512: 'ES512',
+  HS256: 'HS256',
+  RS256: 'RS256',
+  RS384: 'RS384',
+  RS512: 'RS512',
+} as const;
+export type OAuthSigningAlgorithm = (typeof OAuthSigningAlgorithm)[keyof typeof OAuthSigningAlgorithm];
+
 interface SessionDetails {
   project: Project;
   membership: ProjectMembership;

--- a/packages/server/src/auth/google.ts
+++ b/packages/server/src/auth/google.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { badRequest, isString, isUUID, Operator } from '@medplum/core';
+import { badRequest, isString, isUUID, OAuthSigningAlgorithm, Operator } from '@medplum/core';
 import type { Project, ResourceType, User } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import { body } from 'express-validator';
@@ -78,7 +78,7 @@ export async function googleHandler(req: Request, res: Response): Promise<void> 
 
   const verifyOptions: JWTVerifyOptions = {
     issuer: 'https://accounts.google.com',
-    algorithms: ['RS256'],
+    algorithms: [OAuthSigningAlgorithm.RS256],
     audience: googleClientId,
   };
 

--- a/packages/server/src/fhir/smart.ts
+++ b/packages/server/src/fhir/smart.ts
@@ -6,7 +6,14 @@
  * https://build.fhir.org/ig/HL7/smart-app-launch/scopes-and-launch-context.html
  */
 
-import { ContentType, deepClone, OAuthGrantType, OAuthTokenAuthMethod, splitN } from '@medplum/core';
+import {
+  ContentType,
+  deepClone,
+  OAuthGrantType,
+  OAuthSigningAlgorithm,
+  OAuthTokenAuthMethod,
+  splitN,
+} from '@medplum/core';
 import type { AccessPolicy, AccessPolicyResource } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import qs from 'node:querystring';
@@ -50,7 +57,11 @@ export function smartConfigurationHandler(_req: Request, res: Response): void {
         OAuthTokenAuthMethod.ClientSecretPost,
         OAuthTokenAuthMethod.PrivateKeyJwt,
       ],
-      token_endpoint_auth_signing_alg_values_supported: ['RS256', 'RS384', 'ES384'],
+      token_endpoint_auth_signing_alg_values_supported: [
+        OAuthSigningAlgorithm.RS256,
+        OAuthSigningAlgorithm.RS384,
+        OAuthSigningAlgorithm.ES384,
+      ],
       scopes_supported: [
         'patient/*.rs',
         'user/*.cruds',

--- a/packages/server/src/oauth/keys.ts
+++ b/packages/server/src/oauth/keys.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Operator } from '@medplum/core';
+import { OAuthSigningAlgorithm, Operator } from '@medplum/core';
 import type { JsonWebKey } from '@medplum/fhirtypes';
 import type { JWK, JWSHeaderParameters, JWTPayload, JWTVerifyOptions, KeyLike } from 'jose';
 import { exportJWK, generateKeyPair, importJWK, jwtVerify, SignJWT } from 'jose';
@@ -80,10 +80,8 @@ export interface MedplumRefreshTokenClaims extends MedplumBaseClaims {
  * Note: AWS Cognito uses RS256. Auth0 supports RS256, HS256, and PS256 options.
  */
 
-const ALG_ES256 = 'ES256';
-const ALG_RS256 = 'RS256';
-const PREFERRED_ALG = ALG_ES256;
-const LEGACY_DEFAULT_ALG = ALG_RS256;
+const PREFERRED_ALG = OAuthSigningAlgorithm.ES256;
+const LEGACY_DEFAULT_ALG = OAuthSigningAlgorithm.RS256;
 const DEFAULT_ACCESS_LIFETIME = '1h';
 const DEFAULT_REFRESH_LIFETIME = '2w';
 
@@ -144,7 +142,7 @@ export async function initKeys(config: MedplumServerConfig): Promise<void> {
       kty: jwk.kty,
       use: 'sig',
     };
-    if (jwk.alg === ALG_ES256) {
+    if (jwk.alg === OAuthSigningAlgorithm.ES256) {
       publicKey.x = jwk.x;
       publicKey.y = jwk.y;
       publicKey.crv = jwk.crv as string;
@@ -273,7 +271,7 @@ export async function verifyJwt(token: string): Promise<{ payload: JWTPayload; p
 
   const verifyOptions: JWTVerifyOptions = {
     issuer,
-    algorithms: [ALG_ES256, ALG_RS256],
+    algorithms: [OAuthSigningAlgorithm.ES256, OAuthSigningAlgorithm.RS256],
   };
 
   return jwtVerify(token, getKeyForHeader, verifyOptions);

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -5,6 +5,7 @@ import {
   ContentType,
   OAuthClientAssertionType,
   OAuthGrantType,
+  OAuthSigningAlgorithm,
   OAuthTokenType,
   Operator,
   createReference,
@@ -524,7 +525,14 @@ async function parseClientAssertion(
 
   const verifyOptions: JWTVerifyOptions = {
     issuer: clientId,
-    algorithms: ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512'],
+    algorithms: [
+      OAuthSigningAlgorithm.RS256,
+      OAuthSigningAlgorithm.RS384,
+      OAuthSigningAlgorithm.RS512,
+      OAuthSigningAlgorithm.ES256,
+      OAuthSigningAlgorithm.ES384,
+      OAuthSigningAlgorithm.ES512,
+    ],
     audience: tokenUrl,
   };
 

--- a/packages/server/src/wellknown.ts
+++ b/packages/server/src/wellknown.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { OAuthGrantType, OAuthTokenAuthMethod } from '@medplum/core';
+import { OAuthGrantType, OAuthSigningAlgorithm, OAuthTokenAuthMethod } from '@medplum/core';
 import type { Request, Response } from 'express';
 import { Router } from 'express';
 import { getConfig } from './config/loader';
@@ -23,7 +23,11 @@ function handleOAuthConfig(_req: Request, res: Response): void {
     jwks_uri: config.jwksUrl,
     introspection_endpoint: config.introspectUrl,
     registration_endpoint: config.registerUrl,
-    id_token_signing_alg_values_supported: ['RS256'],
+    id_token_signing_alg_values_supported: [
+      OAuthSigningAlgorithm.ES256,
+      OAuthSigningAlgorithm.HS256,
+      OAuthSigningAlgorithm.RS256,
+    ],
     grant_types_supported: [
       OAuthGrantType.ClientCredentials,
       OAuthGrantType.AuthorizationCode,


### PR DESCRIPTION
Added a `const` enum to clean up all of the floating constants.

The only functional change is the fix for #7787 which adds ES256 to `id_token_signing_alg_values_supported`