### PR TITLE
Fix requester not being forwarded to vmcontext bot handler

### DIFF
--- a/packages/server/src/bots/vmcontext.ts
+++ b/packages/server/src/bots/vmcontext.ts
@@ -87,7 +87,7 @@ export async function runInVmContext(request: BotExecutionContext): Promise<BotE
   // End user code
 
   (async () => {
-    const { bot, baseUrl, accessToken, contentType, secrets, traceId, headers, defaultHeaders } = event;
+    const { bot, baseUrl, accessToken, requester, contentType, secrets, traceId, headers, defaultHeaders } = event;
     const medplum = new MedplumClient({
       baseUrl,
       defaultHeaders,
@@ -104,7 +104,7 @@ export async function runInVmContext(request: BotExecutionContext): Promise<BotE
       if (contentType === ContentType.HL7_V2 && input) {
         input = Hl7Message.parse(input);
       }
-      let result = await exports.handler(medplum, { bot, input, contentType, secrets, traceId, headers });
+      let result = await exports.handler(medplum, { bot, requester, input, contentType, secrets, traceId, headers });
       if (contentType === ContentType.HL7_V2 && result) {
         result = result.toString();
       }


### PR DESCRIPTION
This is the PR for Issue #7921. Details from the issue:

> Inside the handler of any bot, `requester` will be `undefined` because `vmcontext.ts` isn't forwarding `request.requester` (which *is* defined).
> 
> The fix is simple. In the `wrappedCode`, `event.requester` just needs to be included in the `BotEvent` passed to `exports.handler()`.

No other `BotEvent` fields appear to have been left out this way.