### PR TITLE
docs: add `--snapshot` option to sushi command

### DIFF
--- a/packages/docs/docs/fhir-datastore/profiles.md
+++ b/packages/docs/docs/fhir-datastore/profiles.md
@@ -123,7 +123,7 @@ For a complete working example, see the [Medplum FSH Profiles repository](https:
 
 3. **Build Profiles**:
    ```bash
-   sushi .
+   sushi . --snapshot
    ```
 
 This generates FHIR JSON `StructureDefinition` resources in the `fsh-generated` directory.


### PR DESCRIPTION
Updates the `sushi` command in the Profiles docs to add the [--snapshot](https://fshschool.org/docs/sushi/running/#--snapshot) option, which otherwise defaults to `false`. The `snapshot` is required on the generated `StructureDefinition` for profile validation in Medplum. https://discord.com/channels/905144809105260605/1444521145721163796/1444521145721163796