### PR TITLE
Fixed CodeQL regex warnings

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3530,8 +3530,8 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       return [];
     }
     const header = this.currentRateLimits;
-    return header.split(/\s*;\s*/g).map((str) => {
-      const parts = str.split(/\s*,\s*/g);
+    return header.split(';').map((str) => {
+      const parts = str.split(',').map((s) => s.trim());
       if (parts.length !== 3) {
         throw new Error('Could not parse RateLimit header: ' + header);
       }


### PR DESCRIPTION
CodeQL was complaining about these regexes.  I don't think it's actually a big deal, but making the changes to keep the tools happy.