### PR TITLE
Fix client parsing of RateLimit header

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -3763,8 +3763,8 @@ describe('Client', () => {
     expect(result).toBeDefined();
     expect(client.rateLimitStatus()).toStrictEqual(
       expect.arrayContaining([
-        { name: 'requests', remainingUnits: 15, secondsUntilReset: 59 },
-        { name: 'fhirInteractions', remainingUnits: 255, secondsUntilReset: 59 },
+        { name: 'requests', remainingUnits: 15, secondsUntilReset: 59, resetsAfter: expect.any(Number) },
+        { name: 'fhirInteractions', remainingUnits: 255, secondsUntilReset: 59, resetsAfter: expect.any(Number) },
       ])
     );
   });
@@ -3789,8 +3789,8 @@ describe('Client', () => {
     expect(result).toBeDefined();
     expect(client.rateLimitStatus()).toStrictEqual(
       expect.arrayContaining([
-        { name: 'requests', remainingUnits: 59539, secondsUntilReset: 4 },
-        { name: 'fhirInteractions', remainingUnits: 0, secondsUntilReset: 3 },
+        { name: 'requests', remainingUnits: 59539, secondsUntilReset: 4, resetsAfter: expect.any(Number) },
+        { name: 'fhirInteractions', remainingUnits: 0, secondsUntilReset: 3, resetsAfter: expect.any(Number) },
       ])
     );
   });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -543,9 +543,14 @@ export interface InviteRequest {
 }
 
 export type RateLimitInfo = {
+  /** Name of the rate limiter. */
   name: string;
+  /** Remaining rate limit quota units. */
   remainingUnits: number;
+  /** Number of seconds until the rate limit resets to its full quota. */
   secondsUntilReset: number;
+  /** Timestamp (seconds from 1970-01-01T00:00:00Z) after which the rate limiter resets to its full quota. */
+  resetsAfter: number;
 };
 
 /**
@@ -3566,7 +3571,12 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
         throw new Error('Could not parse RateLimit header: ' + header);
       }
 
-      return { name, remainingUnits, secondsUntilReset };
+      return {
+        name,
+        remainingUnits,
+        secondsUntilReset,
+        resetsAfter: Math.ceil((Date.now() + 1000 * secondsUntilReset) / 1000),
+      };
     });
   }
 


### PR DESCRIPTION
Fixes `MedplumClient` to use the [correct format](https://www.ietf.org/archive/id/draft-ietf-httpapi-ratelimit-headers-10.html#name-ratelimit-field) when parsing `RateLimit` headers from the server