### PR TITLE
Fixes #7968 - DescriptionList spacing

### DIFF
--- a/packages/react/src/DescriptionList/DescriptionList.module.css
+++ b/packages/react/src/DescriptionList/DescriptionList.module.css
@@ -5,7 +5,7 @@
 
   & > dt,
   & > dd {
-    padding: var(--mantine-spacing-sm);
+    padding: var(--mantine-spacing-xs);
     border-top: 0.1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
     margin: 0;
   }
@@ -13,12 +13,6 @@
   & > dt:first-of-type,
   & > dd:first-of-type {
     border-top: 0;
-    padding-top: 0;
-  }
-
-  & > dt:last-of-type,
-  & > dd:last-of-type {
-    padding-bottom: 0;
   }
 }
 
@@ -27,8 +21,8 @@
 
   & > dt,
   & > dd {
-    padding: 0 0 var(--mantine-spacing-xs);
-    border-top: 0;
+    border: 0;
+    padding: 0;
   }
 
   & > dt {
@@ -41,6 +35,6 @@
 
   & > dt:last-of-type,
   & > dd:last-of-type {
-    padding-bottom: 0;
+    padding-bottom: var(--mantine-spacing-xs);
   }
 }


### PR DESCRIPTION
Before:

<img width="1143" height="241" alt="Image" src="https://github.com/user-attachments/assets/5d4b2baf-00c6-446e-840d-72174fb0dd03" />

Note how value "test1" looks associated with name "test2".

After:

<img width="1136" height="229" alt="image" src="https://github.com/user-attachments/assets/12a41c5f-3cc4-452e-b788-4fbaba84be5f" />
