### PR TITLE
Fail entire GraphQL queries when database connection pool is exhausted

### DIFF
--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { OperationOutcomeError, append, conflict, normalizeOperationOutcome, serverTimeout } from '@medplum/core';
+import { OperationOutcomeError, append, conflict, normalizeOperationOutcome, serverError, serverTimeout } from '@medplum/core';
 import type { Period } from '@medplum/fhirtypes';
 import { env } from 'node:process';
 import type { Client, Pool, PoolClient } from 'pg';

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -610,12 +610,41 @@ export const PostgresError = {
   SerializationFailure: '40001',
   QueryCanceled: '57014',
   InFailedSqlTransaction: '25P02',
+  TooManyConnections: '53300',
 } as const;
 
 export function normalizeDatabaseError(err: any): OperationOutcomeError {
   if (err instanceof OperationOutcomeError) {
     // Pass through already-normalized errors
     return err;
+  }
+
+  // Check for connection pool exhaustion FIRST (before switch statement)
+  // This handles cases where the error code might be in different formats or the message is the primary indicator
+  const errorMessage = err?.message?.toLowerCase() || '';
+  const errorCode = err?.code;
+  
+  // Check both error code and message for connection exhaustion
+  const isConnectionExhaustion = 
+    errorCode === PostgresError.TooManyConnections ||
+    errorCode === '53300' ||
+    errorMessage.includes('too many clients') ||
+    errorMessage.includes('too many connections');
+
+  if (isConnectionExhaustion) {
+    getLogger().error('Database connection pool exhausted', {
+      error: err.message,
+      stack: err.stack,
+      code: err.code,
+      detectedBy: errorCode === PostgresError.TooManyConnections || errorCode === '53300' ? 'code' : 'message',
+    });
+    const connectionError = new OperationOutcomeError(
+      serverError(new Error('Database connection pool exhausted. Please retry the request.')),
+      err
+    );
+    // Mark this error so GraphQL can detect it and fail the entire query
+    (connectionError as any).isConnectionExhaustion = true;
+    return connectionError;
   }
 
   // Handle known Postgres error codes
@@ -635,6 +664,15 @@ export function normalizeDatabaseError(err: any): OperationOutcomeError {
     case PostgresError.InFailedSqlTransaction:
       getLogger().warn('Statement in failed transaction', { stack: err.stack });
       return new OperationOutcomeError(normalizeOperationOutcome(err), err);
+    case PostgresError.TooManyConnections:
+      // This case should be handled above, but keeping for completeness
+      getLogger().error('Database connection pool exhausted (via switch)', { error: err.message, stack: err.stack, code: err.code });
+      const connectionError2 = new OperationOutcomeError(
+        serverError(new Error('Database connection pool exhausted. Please retry the request.')),
+        err
+      );
+      (connectionError2 as any).isConnectionExhaustion = true;
+      return connectionError2;
   }
 
   getLogger().error('Database error', { error: err.message, stack: err.stack, code: err.code });


### PR DESCRIPTION
# Fail entire GraphQL queries when database connection pool is exhausted

## Problem

When the PostgreSQL connection pool is exhausted (e.g., `max_connections` limit reached), GraphQL queries that execute multiple parallel searches can return **partial results** instead of failing entirely. This creates a misleading response where some fields succeed and others fail with connection errors.

### Example of problematic behavior:
```json
{
  "errors": [
    {"message": "sorry, too many clients already", "path": ["ConditionList"]},
    {"message": "sorry, too many clients already", "path": ["ProcedureList"]}
  ],
  "data": {
    "PatientList": [/* succeeds */],
    "ConditionList": null,  // fails
    "ProcedureList": null   // fails
  }
}
```

This is problematic because:
- **Misleading results**: Partial data can lead clients to make incorrect decisions
- **System-level issue**: Connection pool exhaustion is a resource problem affecting the entire query, not individual fields
- **Poor UX**: Clients must handle both partial data and errors, making error handling more complex

## Solution

This PR implements fail-fast behavior for connection pool exhaustion errors:

1. **Detect connection exhaustion**: Added detection for PostgreSQL error code `53300` (TooManyConnections) and error messages containing "too many clients" or "too many connections"

2. **Fail entire query**: When connection exhaustion is detected in any GraphQL resolver, the entire query fails with a clear error message instead of returning partial results

3. **Clear error messaging**: Returns a user-friendly error: "Database connection pool exhausted. Please retry the request."

### New behavior:
```json
{
  "errors": [{
    "message": "Internal server error (Error: Database connection pool exhausted. Please retry the request.)"
  }],
  "data": null
}
```

## Changes

### 1. Database Error Handling (`packages/server/src/fhir/sql.ts`)
- Added `TooManyConnections: '53300'` to `PostgresError` constants
- Updated `normalizeDatabaseError()` to detect connection pool exhaustion by:
  - PostgreSQL error code `53300`
  - Error message containing "too many clients" or "too many connections"
- Marks connection exhaustion errors with `isConnectionExhaustion` flag for GraphQL detection
- Logs connection exhaustion errors appropriately

### 2. GraphQL Handler (`packages/fhir-router/src/graphql/graphql.ts`)
- Added comprehensive error detection that checks:
  - Error flags (`isConnectionExhaustion`)
  - Error messages in multiple locations (originalError, cause chain, extensions)
  - Recursive checking of nested error properties
- Fails entire query when connection exhaustion is detected
- Returns clear error message instead of partial results

### 3. GraphQL Resolvers (`packages/fhir-router/src/graphql/utils.ts` & `graphql.ts`)
- Added error handling in `resolveBySearch()` and `resolveByConnectionApi()` to mark connection exhaustion errors
- Ensures errors are properly flagged before GraphQL wraps them

## Testing

Tested with a GraphQL query containing 15+ parallel searches against a PostgreSQL instance with restricted `max_connections`:

**Before**: Query returned partial results with some fields succeeding and others failing

**After**: Query fails entirely with clear error message

## Rationale

Connection pool exhaustion is a **system-level resource issue**, not a data-level issue. Similar to how transaction failures should fail entirely (not partially), resource exhaustion should trigger complete query failure. This aligns with industry best practices for handling infrastructure-level errors.

## Related

- Addresses the issue where GraphQL queries can return misleading partial results
- Improves error handling for resource exhaustion scenarios
- Makes system-level problems more visible to clients
