### PR TITLE
Fixed react test warnings

### DIFF
--- a/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.test.tsx
+++ b/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.test.tsx
@@ -70,9 +70,7 @@ describe('PlanDefinitionBuilder', () => {
 
     expect(screen.getByTestId('action1')).not.toHaveClass('hovering');
 
-    await act(async () => {
-      fireEvent.mouseOver(await screen.findByDisplayValue('Example Action'));
-    });
+    fireEvent.mouseOver(await screen.findByDisplayValue('Example Action'));
 
     expect(screen.getByTestId('action1')).toHaveClass('hovering');
 
@@ -146,9 +144,7 @@ describe('PlanDefinitionBuilder', () => {
 
     expect(await screen.findByDisplayValue('Example Action')).toBeInTheDocument();
 
-    await act(async () => {
-      fireEvent.click(await screen.findByDisplayValue('Example Action'));
-    });
+    fireEvent.click(await screen.findByDisplayValue('Example Action'));
 
     await act(async () => {
       fireEvent.change(screen.getByDisplayValue('Example Action'), {


### PR DESCRIPTION
The warning was confusing.  I believe what's happening is that `findByDisplayValue` call to `act` internally.

```
  ● Console

    console.error
      You called act(async () => ...) without await. This could lead to unexpected testing behaviour, interleaving multiple act calls and mixing their scopes. You should - await act(async () => ...);

      148 |
      149 |     await act(async () => {
    > 150 |       fireEvent.click(await screen.findByDisplayValue('Example Action'));
          |                       ^
      151 |     });
      152 |
      153 |     await act(async () => {

      at ../../node_modules/react/cjs/react.development.js:835:21
      at runJobs (../../node_modules/@sinonjs/fake-timers/src/fake-timers-src.js:573:22)
      at doTick (../../node_modules/@sinonjs/fake-timers/src/fake-timers-src.js:1394:13)
      at Object.tick (../../node_modules/@sinonjs/fake-timers/src/fake-timers-src.js:1502:20)
      at FakeTimers.advanceTimersByTime (../../node_modules/@jest/fake-timers/build/index.js:576:19)
      at ../../node_modules/@testing-library/react/dist/pure.js:97:16
      at Object.asyncWrapper (../../node_modules/@testing-library/react/dist/pure.js:92:13)
      at src/PlanDefinitionBuilder/PlanDefinitionBuilder.test.tsx:150:23
```

cc @techdavidy 