### PR TITLE
Fixes #7170 - Handle NULL values in token :not search

### DIFF
--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -1441,6 +1441,27 @@ describe('project-scoped Repository', () => {
       expect(bundleContains(bundle1, serviceRequest2)).toBeDefined();
     }));
 
+  test('Token not equals matches missing value', () =>
+    withTestContext(async () => {
+      const family = randomUUID();
+
+      const patient1 = await repo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ family }],
+        gender: 'male',
+      });
+
+      const patient2 = await repo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ family }],
+      });
+
+      const bundle1 = await repo.search(parseSearchRequest('Patient', { name: family, 'gender:not': 'male' }));
+      expect(bundle1.entry?.length).toStrictEqual(1);
+      expect(bundleContains(bundle1, patient1)).toBeUndefined();
+      expect(bundleContains(bundle1, patient2)).toBeDefined();
+    }));
+
   test('Token array not equals', () =>
     withTestContext(async () => {
       const category1 = randomUUID();

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -1040,7 +1040,7 @@ function buildNormalSearchFilterExpression(
       if (impl.type === SearchParameterType.BOOLEAN) {
         return buildBooleanSearchFilter(table, impl, filter);
       } else {
-        return buildTokenSearchFilter(table, impl, filter.operator, splitSearchOnComma(filter.value));
+        return buildTokenSearchFilter(table, impl, filter, splitSearchOnComma(filter.value));
       }
     case 'reference':
       return buildReferenceSearchFilter(table, impl, filter, splitSearchOnComma(filter.value));
@@ -1263,33 +1263,24 @@ function buildIdSearchFilter(table: string, impl: ColumnSearchParameterImplement
     }
   }
 
-  const condition = buildEqualityCondition(impl, values, new Column(table, impl.columnName));
-  if (filter.operator === Operator.NOT_EQUALS || filter.operator === Operator.NOT) {
-    return new Negation(condition);
-  }
-  return condition;
+  return buildCondition(impl, filter, values, new Column(table, impl.columnName));
 }
 
 /**
  * Adds a token search filter as "WHERE" clause to the query builder.
  * @param table - The resource table.
  * @param impl - The search parameter implementation info.
- * @param operator - The search operator.
+ * @param filter - The search filter.
  * @param values - The string values to search against.
  * @returns The select query condition.
  */
 function buildTokenSearchFilter(
   table: string,
   impl: ColumnSearchParameterImplementation,
-  operator: Operator,
+  filter: Filter,
   values: string[]
 ): Expression {
-  const column = new Column(table, impl.columnName);
-  const condition = buildEqualityCondition(impl, values, column);
-  if (operator === Operator.NOT_EQUALS || operator === Operator.NOT) {
-    return new Negation(condition);
-  }
-  return condition;
+  return buildCondition(impl, filter, values, new Column(table, impl.columnName));
 }
 
 const allowedBooleanValues = ['true', 'false'];
@@ -1561,18 +1552,22 @@ function fhirOperatorToSqlOperator(fhirOperator: Operator): keyof typeof SQL {
   }
 }
 
-function buildEqualityCondition(
+function buildCondition(
   impl: ColumnSearchParameterImplementation,
+  filter: Filter,
   values: string[],
   column?: Column | string
-): Condition {
+): Condition | Negation {
   column = column ?? impl.columnName;
+  const negated = filter.operator === Operator.NOT_EQUALS || filter.operator === Operator.NOT;
   if (impl.array) {
-    return new Condition(column, 'ARRAY_OVERLAPS_AND_IS_NOT_NULL', values, impl.type + '[]');
+    const condition = new Condition(column, 'ARRAY_OVERLAPS_AND_IS_NOT_NULL', values, impl.type + '[]');
+    return negated ? new Negation(condition) : condition;
   } else if (values.length > 1) {
-    return new Condition(column, 'IN', values, impl.type);
+    const condition = new Condition(column, 'IN', values, impl.type);
+    return negated ? new Negation(condition) : condition;
   } else {
-    return new Condition(column, '=', values[0], impl.type);
+    return new Condition(column, negated ? 'IS_DISTINCT_FROM' : '=', values[0], impl.type);
   }
 }
 

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -64,6 +64,7 @@ export const Operator = {
   '>': simpleBinaryOperator('>'),
   '>=': simpleBinaryOperator('>='),
   IN: simpleBinaryOperator('IN'),
+  IS_DISTINCT_FROM: simpleBinaryOperator('IS DISTINCT FROM'),
   /*
     Why do both of these exist? Mainly for consideration when negating the condition:
     Negating ARRAY_OVERLAPS_AND_IS_NOT_NULL includes records where the column is NULL.


### PR DESCRIPTION
### Problem

The FHIR `:not` search modifier was incorrectly excluding rows with NULL values. Per the FHIR specification, the `:not` modifier should match all resources that don't have the specified value, **including those where the field is missing/null**.

**Example**: `Patient?gender:not=male` should return:
- ✅ Patients with gender='female'  
- ✅ Patients with gender='other'
- ✅ Patients with gender=NULL *(but we were excluding these)*

### Root Cause
Our SQL generation was using `NOT(column = value)` which, due to SQL's three-valued logic, evaluates to NULL (not TRUE) when the column is NULL:
```sql
-- This excludes NULL values (incorrect for FHIR)
WHERE NOT("gender" = 'male')
```

### Solution
Special-case the `:not` modifier to use PostgreSQL's `IS DISTINCT FROM` operator:
```sql
-- This includes NULL values (correct for FHIR)
WHERE "gender" IS DISTINCT FROM 'male'
```

### Performance Impact

 `IS DISTINCT FROM` can use standard B-tree indexes efficiently, unlike the alternative `(column <> value OR column IS NULL)` pattern which requires OR logic that often prevents optimal index usage.

