### PR TITLE
fix(ci): get latest direct from GH API

### DIFF
--- a/.github/workflows/publish-meta.yml
+++ b/.github/workflows/publish-meta.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           # Download releases data
           curl -s "https://api.github.com/repos/medplum/medplum/releases?per_page=100" > releases.json
+          curl -s "https://api.github.com/repos/medplum/medplum/releases/latest" > latest-tmp.json
 
           # Track whether we should continue syncing
           DONE=false
@@ -102,7 +103,7 @@ jobs:
           }' releases.json > all.json
 
           # Create latest release file
-          jq '.[0] | . as $release | {
+          jq '. as $release | {
             tag_name,
             version: (.tag_name | ltrimstr("v")),
             published_at,
@@ -114,7 +115,7 @@ jobs:
                 browser_download_url: "https://download.medplum.com/releases/\($release.tag_name)/\(.name)"
               }
             ]
-          }' releases.json > latest.json
+          }' latest-tmp.json > latest.json
 
           # Extract version tag for versioned filename
           VERSION_TAG=$(jq -r '.[0].tag_name' releases.json)


### PR DESCRIPTION
This makes it so that we can publish new releases which will not be the latest version. Currently they would be added to the `latest.json` since we were previously naively grabbing the 0th element from the total list of releases. Now we specifically grab `latest` from the `releases/latest` endpoint.