### PR TITLE
CDS prefetch allow nested object paths

### DIFF
--- a/packages/core/src/cds.ts
+++ b/packages/core/src/cds.ts
@@ -13,7 +13,7 @@ import type {
 import type { MedplumClient } from './client';
 import { generateId } from './crypto';
 import type { WithId } from './utils';
-import { isString, splitN } from './utils';
+import { isObject, isString, splitN } from './utils';
 
 /**
  * CDS Service definition.
@@ -233,7 +233,29 @@ const userProfileTokens = new Set([
   'userRelatedPersonId',
 ]);
 
-function replaceQueryVariables(user: CdsUserResource, context: Record<string, unknown>, query: string): string {
+/**
+ * Replaces prefetch query variables with values from the context or user profile.
+ *
+ * A prefetch token is a placeholder in a prefetch template that is *replaced by information from the hook's context*
+ * to construct the FHIR URL used to request the prefetch data.
+ *
+ * Prefetch tokens MUST be delimited by `{{` and `}}`, and MUST contain only the qualified path to a hook context field
+ * or one of the following user identifiers: `userPractitionerId`, `userPractitionerRoleId`, `userPatientId`, or `userRelatedPersonId`.
+ *
+ * Note that the spec says:
+ *
+ *   > Individual hooks specify which of their `context` fields can be used as prefetch tokens.
+ *   > Only root-level fields with a primitive value within the `context` object are eligible to be used as prefetch tokens.
+ *   > For example, `{{context.medication.id}}` is not a valid prefetch token because it attempts to access the `id` field of the `medication` field.
+ *
+ * Unfortunately, many CDS Hooks services do not follow this rule. Therefore, this implementation allows access to nested fields.
+ *
+ * @param user - The user resource.
+ * @param context - The CDS request context.
+ * @param query - The prefetch query template.
+ * @returns The prefetch query with variables replaced.
+ */
+export function replaceQueryVariables(user: CdsUserResource, context: Record<string, unknown>, query: string): string {
   return query.replaceAll(/\{\{([^}]+)\}\}/g, (substring, varName) => {
     varName = varName.trim();
 
@@ -242,14 +264,38 @@ function replaceQueryVariables(user: CdsUserResource, context: Record<string, un
     }
 
     if (varName.startsWith('context.')) {
-      const contextVarName = varName.substring('context.'.length);
-      const value = context[contextVarName];
+      const contextPath = varName.substring('context.'.length);
+      const value = getNestedValue(context, contextPath);
       if (isString(value)) {
         return value;
+      }
+      if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
       }
     }
 
     // No match; return the original substring
     return substring;
   });
+}
+
+/**
+ * Safely gets a nested property value from an object using a dot-notated path.
+ * @param obj - The object to traverse
+ * @param path - Dot-notated path like "draftOrders.ServiceRequest.id"
+ * @returns The value at the path, or undefined if not found
+ */
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split('.');
+  let current: unknown = obj;
+
+  for (const part of parts) {
+    if (current && isObject(current) && part in current) {
+      current = current[part];
+    } else {
+      return undefined;
+    }
+  }
+
+  return current;
 }


### PR DESCRIPTION
The [spec](https://cds-hooks.hl7.org/#prefetch-tokens) explicitly does not allow this:

> Only root-level fields with a primitive value within the context object are eligible to be used as prefetch tokens. For example, `{{context.medication.id}}` is not a valid prefetch token because it attempts to access the id field of the medication field.

But naturally it happens [in the wild](https://crd.davinci.hl7.org/r4/cds-services):

```json
"prefetch": {
  "serviceRequestBundle": "ServiceRequest?_id={{context.draftOrders.ServiceRequest.id}}&_include=ServiceRequest:patient&_include=ServiceRequest:performer&_include=ServiceRequest:requester&_include:iterate=PractitionerRole:organization&_include:iterate=PractitionerRole:practitioner",
  "medicationRequestBundle": "MedicationRequest?_id={{context.medications.MedicationRequest.id}}&_include=MedicationRequest:patient&_include=MedicationRequest:intended-dispenser&_include=MedicationRequest:requester:PractitionerRole&_include=MedicationRequest:medication&_include:iterate=PractitionerRole:organization&_include:iterate=PractitionerRole:practitioner",
  "coverageBundle": "Coverage?patient={{context.patientId}}",
  "deviceRequestBundle": "DeviceRequest?_id={{context.draftOrders.DeviceRequest.id}}&_include=DeviceRequest:patient&_include=DeviceRequest:performer&_include=DeviceRequest:requester&_include=DeviceRequest:device&_include:iterate=PractitionerRole:organization&_include:iterate=PractitionerRole:practitioner"
},
```