### PR TITLE
Support publishing non-latest versions

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -6,6 +6,10 @@ on:
       version:
         description: 'New version (leave blank for automatic)'
         type: string
+      is_latest:
+        description: 'Tag this release as the latest (default: true)'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -32,3 +36,4 @@ jobs:
         run: ./scripts/prepare-release.sh ${{ inputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.MEDPLUM_BOT_GITHUB_ACCESS_TOKEN }}
+          IS_LATEST: ${{ inputs.is_latest }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
+      GITHUB_TOKEN: ${{ github.token }}
       NODE_VERSION: '22'
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
@@ -30,6 +31,26 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Check if latest version
+        id: check-latest
+        run: |
+          CURRENT_TAG="${GITHUB_REF#refs/tags/}"
+          echo "Current Tag: ${CURRENT_TAG}"
+
+          LATEST_TAG=$(gh release list --order desc --limit 1 --json tagName -q '.[].tagName')
+          echo "Latest Tag: ${LATEST_TAG}"
+
+          HIGHEST_TAG=$(printf '%s\n%s' "${CURRENT_TAG}" "${LATEST_TAG}" | sort -V | tail -n1)
+          echo "Highest Tag: ${HIGHEST_TAG}"
+
+          if [ "${CURRENT_TAG}" = "${HIGHEST_TAG}" ]; then
+            echo "Current tag is the latest."
+            echo "result=true" >> $GITHUB_OUTPUT
+          else
+            echo "Current tag is not the latest."
+            echo "result=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
@@ -75,6 +96,7 @@ jobs:
         run: ./scripts/publish.sh
 
       - name: Sync example repos
+        if: steps.check-latest.outputs.result == 'true'
         run: ./scripts/update-example-changes.sh "${{ secrets.SYNC_REPO_TOKEN }}"
 
       - name: Login to Docker Hub
@@ -87,12 +109,22 @@ jobs:
         uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
 
       - name: Build and push server Docker image
-        run: ./scripts/build-docker-server.sh --release
+        run: |
+          if [ "${{ steps.check-latest.outputs.result }}" = "true" ]; then
+            ./scripts/build-docker-server.sh --release --latest
+          else
+            ./scripts/build-docker-server.sh --release
+          fi
         env:
           SERVER_DOCKERHUB_REPOSITORY: ${{ secrets.DOCKERHUB_REPOSITORY }}
 
       - name: Build and push app Docker image
-        run: ./scripts/build-docker-app.sh --release
+        run: |
+          if [ "${{ steps.check-latest.outputs.result }}" = "true" ]; then
+            ./scripts/build-docker-app.sh --release --latest
+          else
+            ./scripts/build-docker-app.sh --release
+          fi
         env:
           APP_DOCKERHUB_REPOSITORY: ${{ secrets.APP_DOCKERHUB_REPOSITORY }}
 
@@ -103,6 +135,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Deploy bot layer
+        if: steps.check-latest.outputs.result == 'true' # only deploy latest versions
         run: ./scripts/deploy-bot-layer.sh
 
   build_agent_win64:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -67,7 +67,7 @@ jobs:
         uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
 
       - name: Build App Docker Image
-        run: ./scripts/build-docker-app.sh
+        run: ./scripts/build-docker-app.sh --latest
         env:
           APP_DOCKERHUB_REPOSITORY: ${{ secrets.STAGING_APP_DOCKERHUB_REPOSITORY }}
 
@@ -82,7 +82,7 @@ jobs:
           AWS_REGION: ${{ secrets.STAGING_AWS_REGION }}
 
       - name: Build Server Docker Image
-        run: ./scripts/build-docker-server.sh
+        run: ./scripts/build-docker-server.sh --latest
         env:
           SERVER_DOCKERHUB_REPOSITORY: ${{ secrets.STAGING_DOCKERHUB_REPOSITORY }}
 

--- a/scripts/build-docker-app.sh
+++ b/scripts/build-docker-app.sh
@@ -35,18 +35,26 @@ PLATFORMS="--platform linux/amd64,linux/arm64"
 # If this is a release, get version information
 # Release is specified with a "--release" argument
 IS_RELEASE=false
+IS_LATEST=false
 for arg in "$@"; do
   if [[ "$arg" == "--release" ]]; then
     IS_RELEASE=true
     FULL_VERSION=$(node -p "require('./package.json').version")
     MAJOR_DOT_MINOR=$(node -p "require('./package.json').version.split('.').slice(0, 2).join('.')")
-    break
+    continue
+  fi
+  if [[ "$arg" == "--latest" ]]; then
+    IS_LATEST=true
+    continue
   fi
 done
 
 # This is so we can build the staging server Dockerfile without having to build app
 # Build and push app Docker images
-APP_TAGS="--tag $APP_DOCKERHUB_REPOSITORY:latest --tag $APP_DOCKERHUB_REPOSITORY:$GITHUB_SHA"
+APP_TAGS="--tag $APP_DOCKERHUB_REPOSITORY:$GITHUB_SHA"
+if [[ "$IS_LATEST" == "true" ]]; then
+  APP_TAGS="$APP_TAGS --tag $APP_DOCKERHUB_REPOSITORY:latest"
+fi
 if [[ "$IS_RELEASE" == "true" ]]; then
   APP_TAGS="$APP_TAGS --tag $APP_DOCKERHUB_REPOSITORY:$FULL_VERSION --tag $APP_DOCKERHUB_REPOSITORY:$MAJOR_DOT_MINOR"
 fi

--- a/scripts/build-docker-server.sh
+++ b/scripts/build-docker-server.sh
@@ -48,17 +48,25 @@ PLATFORMS="--platform linux/amd64,linux/arm64"
 # If this is a release, get version information
 # Release is specified with a "--release" argument
 IS_RELEASE=false
+IS_LATEST=false
 for arg in "$@"; do
   if [[ "$arg" == "--release" ]]; then
     IS_RELEASE=true
     FULL_VERSION=$(node -p "require('./package.json').version")
     MAJOR_DOT_MINOR=$(node -p "require('./package.json').version.split('.').slice(0, 2).join('.')")
-    break
+    continue
+  fi
+  if [[ "$arg" == "--latest" ]]; then
+    IS_LATEST=true
+    continue
   fi
 done
 
 # Build and push server Docker images
-SERVER_TAGS="--tag $SERVER_DOCKERHUB_REPOSITORY:latest --tag $SERVER_DOCKERHUB_REPOSITORY:$GITHUB_SHA"
+SERVER_TAGS="--tag $SERVER_DOCKERHUB_REPOSITORY:$GITHUB_SHA"
+if [[ "$IS_LATEST" == "true" ]]; then
+  SERVER_TAGS="$SERVER_TAGS --tag $SERVER_DOCKERHUB_REPOSITORY:latest"
+fi
 if [[ "$IS_RELEASE" == "true" ]]; then
   SERVER_TAGS="$SERVER_TAGS --tag $SERVER_DOCKERHUB_REPOSITORY:$FULL_VERSION --tag $SERVER_DOCKERHUB_REPOSITORY:$MAJOR_DOT_MINOR"
 fi

--- a/scripts/cicd-deploy.sh
+++ b/scripts/cicd-deploy.sh
@@ -138,7 +138,7 @@ if [[ "$DEPLOY_APP" = true ]]; then
     npm run build -- --force --filter=@medplum/app
   )
 
-  source ./scripts/build-docker-app.sh
+  source ./scripts/build-docker-app.sh --latest
   source ./scripts/deploy-app.sh
 fi
 
@@ -151,6 +151,6 @@ fi
 if [[ "$DEPLOY_SERVER" = true ]]; then
   echo "Deploy server"
   npm run build -- --force --filter=@medplum/server
-  source ./scripts/build-docker-server.sh
+  source ./scripts/build-docker-server.sh --latest
   source ./scripts/deploy-server.sh
 fi

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -12,6 +12,21 @@ CURR_VERSION=$(node -p "require('./package.json').version")
 # Convert version string to array using '.' as delimiter
 IFS='.' read -ra CURR_VERSION_PARTS <<< "$CURR_VERSION"
 
+if [[ -z "${GITHUB_REF_NAME}" ]]; then
+  echo "GITHUB_REF_NAME is missing"
+  exit 1
+fi
+
+if [[ -z "${IS_LATEST}" ]]; then
+  echo "IS_LATEST is missing"
+  exit 1
+fi
+
+if [[ "${IS_LATEST}" != "true" && "${IS_LATEST}" != "false" ]]; then
+  echo "IS_LATEST must be 'true' or 'false'"
+  exit 1
+fi
+
 # Check if a new requiredBefore entry has been added to the data migration manifest
 DIFF_OUTPUT=$(git diff v$CURR_VERSION -- packages/server/src/migrations/data/data-version-manifest.json) || true
 ADDED_REQUIRED_BEFORE=$(echo "$DIFF_OUTPUT" | grep -e '^\+.*"requiredBefore"' || true)
@@ -74,7 +89,7 @@ git commit -s -m "Release Version $NEW_VERSION" -m "$RELEASE_NOTES"
 git push origin "$BRANCH_NAME"
 
 # Create pull request
-gh pr create --title "Release Version $NEW_VERSION" --body "$RELEASE_NOTES"
+gh pr create --title "Release Version $NEW_VERSION" --body "$RELEASE_NOTES" --base "$GITHUB_REF_NAME"
 
 # Create draft release
-gh release create "v$NEW_VERSION" --notes "$RELEASE_NOTES" --title "Version $NEW_VERSION" --draft
+gh release create "v$NEW_VERSION" --notes "$RELEASE_NOTES" --title "Version $NEW_VERSION" --draft --latest=$IS_LATEST


### PR DESCRIPTION
Deployed to staging to validate that the `--latest` flag on `build-docker-app.sh` and `build-docker-server.sh` behaved as expected.
* [Action run](https://github.com/medplum/medplum/actions/runs/20082346966)

Prepared a release to validate changes in `prepare-release.yml`.
* [Action run](https://github.com/medplum/medplum/actions/runs/20082609536)
* [Draft release](https://github.com/medplum/medplum/releases/tag/untagged-fd8e209e368eb3663e48) (deleted)
* [Draft release PR](https://github.com/medplum/medplum/pull/8016) (manually closed)

Validated changes in publish by creating [a stripped down POC publish workflow](https://github.com/medplum/medplum/commit/9da14c56e2fac343ca84f4bea84e255085ca0be4) and then pushing a tag to trigger it. The rest of the changes of the actual publish workflow don't have a good way to test in a sandboxed way.
* [Action run](https://github.com/medplum/medplum/actions/runs/20081117070/job/57608187689) for tag `mattv4.1.12-2`