### PR TITLE
DB migration tests

### DIFF
--- a/packages/server/src/migrations/migrate.ts
+++ b/packages/server/src/migrations/migrate.ts
@@ -7,7 +7,6 @@ import {
   getResourceTypes,
   indexSearchParameterBundle,
   indexStructureDefinitionBundle,
-  isPopulated,
   SearchParameterType,
 } from '@medplum/core';
 import { readJson, SEARCH_PARAMETER_BUNDLE_FILES } from '@medplum/definitions';
@@ -55,10 +54,6 @@ export function indexStructureDefinitionsAndSearchParameters(): void {
   for (const filename of SEARCH_PARAMETER_BUNDLE_FILES) {
     const bundle = readJson(filename) as Bundle<SearchParameter>;
     indexSearchParameterBundle(bundle);
-
-    if (!isPopulated(bundle.entry)) {
-      throw new Error('Empty search parameter bundle: ' + filename);
-    }
   }
 }
 


### PR DESCRIPTION
In the beginning, `migrate.ts` lived in `packages/generator`, and was strictly run offline at dev time.

Then, as time went on, two things happened:
1. The migration logic became more complex, and needed more access to `server` code
2. The execution of migrations also depended on many of those same utils

So we moved `migrate.ts` and related helpers into `packages/server`.  

That made sense from a code organization perspective, but it did create a bit of a conundrum, because there were not any tests (because `generator` is exempt from code coverage requirements).

Before this PR, `migrate.ts` had the dubious honor of "most uncovered lines" (212).

After this PR, which just adds a few minor tests which essentially say "make sure this doesn't throw", we can dramatically improve coverage.

As time goes on, this file and the entire `migrations` folder will need more tests, because we intend to use it as the basis for "Custom FHIR Resources" and "Custom FHIR Search Parameters", which are two features planned for 2026.  The tentative plan is for those features to run "online" directly from the `server` process, which will put much more pressure on correctness and testing.