### PR TITLE
Assorted minor Sonar fixes

### DIFF
--- a/packages/core/src/base64.ts
+++ b/packages/core/src/base64.ts
@@ -14,7 +14,7 @@ import { getBuffer, isBrowserEnvironment } from './environment';
 export function decodeBase64(data: string): string {
   if (isBrowserEnvironment()) {
     const binaryString = window.atob(data);
-    const bytes = Uint8Array.from(binaryString, (c) => c.charCodeAt(0));
+    const bytes = Uint8Array.from(binaryString, (c) => c.codePointAt(0) as number);
     return new window.TextDecoder().decode(bytes);
   }
   const BufferConstructor = getBuffer();
@@ -34,8 +34,8 @@ export function decodeBase64(data: string): string {
 export function encodeBase64(data: string): string {
   if (isBrowserEnvironment()) {
     const utf8Bytes = new window.TextEncoder().encode(data);
-    // utf8Bytes is a Uint8Array, but String.fromCharCode expects a sequence of numbers.
-    const binaryString = String.fromCharCode.apply(null, utf8Bytes as unknown as number[]);
+    // utf8Bytes is a Uint8Array, but String.fromCodePoint expects a sequence of numbers.
+    const binaryString = String.fromCodePoint.apply(null, utf8Bytes as unknown as number[]);
     return window.btoa(binaryString);
   }
   const BufferConstructor = getBuffer();

--- a/packages/core/src/cds.ts
+++ b/packages/core/src/cds.ts
@@ -244,9 +244,9 @@ const userProfileTokens = new Set([
  *
  * Note that the spec says:
  *
- *   > Individual hooks specify which of their `context` fields can be used as prefetch tokens.
- *   > Only root-level fields with a primitive value within the `context` object are eligible to be used as prefetch tokens.
- *   > For example, `{{context.medication.id}}` is not a valid prefetch token because it attempts to access the `id` field of the `medication` field.
+ *   Individual hooks specify which of their `context` fields can be used as prefetch tokens.
+ *   Only root-level fields with a primitive value within the `context` object are eligible to be used as prefetch tokens.
+ *   For example, `{{context.medication.id}}` is not a valid prefetch token because it attempts to access the `id` field of the `medication` field.
  *
  * Unfortunately, many CDS Hooks services do not follow this rule. Therefore, this implementation allows access to nested fields.
  *

--- a/packages/core/src/fhirlexer/parse.ts
+++ b/packages/core/src/fhirlexer/parse.ts
@@ -131,7 +131,7 @@ export class Parser {
     const token = this.consume();
     const prefix = this.prefixParselets[token.id];
     if (!prefix) {
-      throw Error(
+      throw new Error(
         `Parse error at "${token.value}" (line ${token.line}, column ${token.column}). No matching prefix parselet.`
       );
     }
@@ -161,17 +161,17 @@ export class Parser {
 
   consume(expectedId?: string, expectedValue?: string): Token {
     if (!this.tokens.length) {
-      throw Error('Cant consume unknown more tokens.');
+      throw new Error('Cant consume unknown more tokens.');
     }
     if (expectedId && this.peek()?.id !== expectedId) {
       const actual = this.peek() as Token;
-      throw Error(
+      throw new Error(
         `Expected ${expectedId} but got "${actual.id}" (${actual.value}) at line ${actual.line} column ${actual.column}.`
       );
     }
     if (expectedValue && this.peek()?.value !== expectedValue) {
       const actual = this.peek() as Token;
-      throw Error(
+      throw new Error(
         `Expected "${expectedValue}" but got "${actual.value}" at line ${actual.line} column ${actual.column}.`
       );
     }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -934,7 +934,7 @@ export function arrayBufferToBase64(arrayBuffer: ArrayBufferLike | ArrayBufferVi
   const bytes = new Uint8Array(buffer);
   const result: string[] = new Array(bytes.length);
   for (let i = 0; i < bytes.length; i++) {
-    result[i] = String.fromCharCode(bytes[i]);
+    result[i] = String.fromCodePoint(bytes[i]);
   }
   return window.btoa(result.join(''));
 }

--- a/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
+++ b/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
@@ -92,7 +92,7 @@ export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Elem
     <>
       {slices.map((slice, sliceIndex) => {
         if (!props.path) {
-          throw Error(`Displaying a resource property with slices of type ${props.propertyType} requires path`);
+          throw new Error(`Displaying a resource property with slices of type ${props.propertyType} requires path`);
         }
         let sliceDisplay = (
           <SliceDisplay

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -158,7 +158,7 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
     case PropertyType.Dosage:
     case PropertyType.UsageContext:
       if (!props.path) {
-        throw Error(`Displaying property of type ${props.propertyType} requires path`);
+        throw new Error(`Displaying property of type ${props.propertyType} requires path`);
       }
       return (
         <BackboneElementDisplay
@@ -170,7 +170,7 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
       );
     case PropertyType.Extension:
       if (!props.path) {
-        throw Error(`Displaying property of type ${props.propertyType} requires path`);
+        throw new Error(`Displaying property of type ${props.propertyType} requires path`);
       }
       return (
         <ExtensionDisplay
@@ -183,10 +183,10 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
       );
     default:
       if (!property) {
-        throw Error(`Displaying property of type ${props.propertyType} requires element schema`);
+        throw new Error(`Displaying property of type ${props.propertyType} requires element schema`);
       }
       if (!props.path) {
-        throw Error(`Displaying property of type ${props.propertyType} requires path`);
+        throw new Error(`Displaying property of type ${props.propertyType} requires path`);
       }
       return (
         <BackboneElementDisplay

--- a/packages/react/src/SignatureInput/SignatureInput.test.tsx
+++ b/packages/react/src/SignatureInput/SignatureInput.test.tsx
@@ -179,7 +179,7 @@ describe('SignatureInput', () => {
 
     // Create a mock that simulates binary PNG data
     const binaryData = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82]);
-    const base64Data = btoa(String.fromCharCode(...binaryData));
+    const base64Data = btoa(String.fromCodePoint(...binaryData));
     const dataURL = `data:image/png;base64,${base64Data}`;
 
     const signaturePadMock = jest.fn().mockImplementation(() => ({
@@ -213,9 +213,9 @@ describe('SignatureInput', () => {
     expect(decodedData.length).toBeGreaterThan(0);
 
     // Verify it contains binary data (PNG signature)
-    expect(decodedData.charCodeAt(0)).toBe(137); // PNG signature byte
-    expect(decodedData.charCodeAt(1)).toBe(80); // 'P'
-    expect(decodedData.charCodeAt(2)).toBe(78); // 'N'
-    expect(decodedData.charCodeAt(3)).toBe(71); // 'G'
+    expect(decodedData.codePointAt(0)).toBe(137); // PNG signature byte
+    expect(decodedData.codePointAt(1)).toBe(80); // 'P'
+    expect(decodedData.codePointAt(2)).toBe(78); // 'N'
+    expect(decodedData.codePointAt(3)).toBe(71); // 'G'
   });
 });


### PR DESCRIPTION
1. Replaced all cases of `throw Error` with `throw new Error`
2. Replaced all cases of `.charCodeAt` with `.codePointAt`
3. Replaced all cases of `.fromCharCode` with `.fromCodePoint`
4. Fixed JSdoc warnings in `cds.ts`