### PR TITLE
Removed package-lock.json from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,14 @@ ENV NODE_ENV=production
 WORKDIR /usr/src/medplum
 
 # Add the application files
+# The archive is decompressed and extracted into the specified destination.
+# We do this to preserve the folder structure in a single layer.
+# See: https://docs.docker.com/reference/dockerfile/#adding-local-tar-archives
 ADD ./medplum-server.tar.gz ./
 
 # Install dependencies, create non-root user, and set permissions in one layer
 RUN npm ci && \
+  rm package-lock.json && \
   groupadd -r medplum && \
   useradd -r -g medplum medplum && \
   chown -R medplum:medplum /usr/src/medplum


### PR DESCRIPTION
This change updates the `Dockerfile` to explicitly remove the `package-lock.json` file immediately after running `npm ci`. This is done to significantly reduce the attack surface and eliminate false positive alerts generated by security scanners in CI/CD environments.

### 📝 Problem

When building the server Docker image, we include the monorepo's root `package-lock.json` file via the source tarball. Since we utilize NPM Workspaces, this lockfile contains the dependency graph for **all** packages in the monorepo (including development, example, and frontend packages), even though our server only installs a small, relevant subset of dependencies.

This leads to:

1.  **False Positives:** Security scanners flag vulnerabilities in dependencies (e.g., Next.js components, testing frameworks) that are listed in the `package-lock.json` but are **not installed** in the server's `node_modules` directory and are not executed at runtime.
2.  **Increased Compliance Overhead:** These false positives create unnecessary noise and manual review burden for our security and compliance teams.

### ✅ Solution

We have modified the dependency installation `RUN` layer in the `Dockerfile` to include a clean-up command.

By removing `package-lock.json` after successful dependency installation (`npm ci`), we ensure:

  * **Determinism is Preserved:** `npm ci` still uses the lockfile to create a reproducible `node_modules`.
  * **Security Surface is Reduced:** The final runtime image no longer contains the build-time metadata that triggers the false positive security alerts.

### 🔬 Rationale and Impact

  * **Security Best Practice:** This aligns with general containerization best practices, similar to multi-stage builds which intentionally discard build-time artifacts (like lockfiles) from the final production image.
  * **Runtime unaffected:** The Node.js application only relies on the contents of the `node_modules` directory and compiled assets, not the dependency source files.
  * **Why not `package.json`?** We are surgically removing only the `package-lock.json` as it contains the full dependency tree that causes scanner issues. The core `package.json` file is sometimes useful for runtime introspection or debugging, and removing only the lockfile achieves the primary security goal with minimal disruption.