### PR TITLE
Update jest coverage exclusions

### DIFF
--- a/packages/mock/jest.config.json
+++ b/packages/mock/jest.config.json
@@ -10,6 +10,6 @@
   "testMatch": ["**/src/**/*.test.ts"],
   "coverageDirectory": "coverage",
   "coverageReporters": ["json", "text"],
-  "collectCoverageFrom": ["**/src/**/*.ts"],
+  "collectCoverageFrom": ["**/src/**/*.ts", "!**/src/test-resources/*.ts"],
   "setupFiles": ["./src/test.setup.ts"]
 }

--- a/packages/server/jest.config.json
+++ b/packages/server/jest.config.json
@@ -15,6 +15,7 @@
   "collectCoverageFrom": [
     "**/src/**/*",
     "!**/src/__mocks__/**/*.ts",
+    "!**/src/migrations/migrate-main.ts",
     "!**/src/migrations/schema/**/*.ts",
     "!**/src/migrations/data/**/*.ts"
   ]


### PR DESCRIPTION
Test coverage exclusions are in 2 separate places:

* Jest `collectCoverageFrom` - this is for local coverage tools and for [Coveralls](https://coveralls.io/github/medplum/medplum)
* `sonar-project.properties` - this is for [Sonar](https://sonarcloud.io/project/overview?id=medplum_medplum)

Developers tend to pay more attention to the Sonar exclusions, because that will block PRs from merging.  But we should try to keep them in sync.

Yes, this is for marketing.  Look at us, we do marketing.