### PR TITLE
Fix OAuth token caching issue in Next.js 14 App Router

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -4271,6 +4271,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       headers,
       body: formBody.toString(),
       credentials: 'include',
+      cache: 'no-store', // Prevent caching in Next.js 14 App Router and other environments
     };
 
     let response: Response;


### PR DESCRIPTION
## Summary

Fixes an OAuth token caching issue in Next.js 14 App Router that causes authentication failures when using `startClientLogin()` for server-side authentication.

- Adds `cache: 'no-store'` to OAuth token requests to prevent caching
- Resolves "Token expired" errors on subsequent API calls after initial authentication

## Background

In Next.js 14 App Router, `fetch()` is cached by default. This causes OAuth token requests to return stale tokens after they expire, resulting in authentication failures where the first API call succeeds but subsequent calls fail with "Unauthorized; Token expired" errors.

The issue was traced to the `verifyTokens()` call, which would fail on the second request due to receiving a cached expired token instead of fetching a fresh one.

## Solution

Added `cache: 'no-store'` to the fetch options in the `fetchTokens()` method to explicitly disable caching. This ensures fresh tokens are always fetched from the OAuth endpoint.

Note: Next.js 15 uses `no-store` by default, so this change ensures compatibility with both Next.js 14 and 15.

## Test plan

- [ ] Verify OAuth token requests are not cached in Next.js 14 App Router
- [ ] Test that `startClientLogin()` works correctly across multiple API calls
- [ ] Confirm no regression in other authentication flows
- [ ] Validate behavior in both Next.js 14 and Next.js 15 environments