### PR TITLE
docs: clarify external idp auth and cli testing

### DIFF
--- a/examples/medplum-client-external-idp-demo/src/SignInPage.tsx
+++ b/examples/medplum-client-external-idp-demo/src/SignInPage.tsx
@@ -10,14 +10,14 @@ import { MEDPLUM_BASE_URL } from './contants';
  * Your Medplum project ID.
  * You can find this value on the "Project Admin" page in the Medplum web app.
  */
-const MEDPLUM_PROJECT_ID = '';
+const MEDPLUM_PROJECT_ID = '5aee64f7-7993-4a3c-a791-773fbb8d0d2a';
 
 /**
  * Your Medplum client ID.
  * You can find this value on the "Project Admin" page in the Medplum web app.
  * Note that the client must have the correct external auth provider configured.
  */
-const MEDPLUM_CLIENT_ID = '=';
+const MEDPLUM_CLIENT_ID = '07f12dc5-e304-40b2-a625-258df4fd63a8';
 
 /**
  * Your web application redirect URL.
@@ -30,13 +30,13 @@ const WEB_APP_REDIRECT_URI = 'http://localhost:8000/signin';
  * For example, this would be an Auth0, AWS Cognito, or Okta URL.
  * This value is specific to your external auth provider.
  */
-const EXTERNAL_AUTHORIZE_URL = '';
+const EXTERNAL_AUTHORIZE_URL = 'https://dev-43cuzvn02g1spky2.us.auth0.com/authorize';
 
 /**
  * External OAuth2 client ID.
  * This value is specific to your external auth provider.
  */
-const EXTERNAL_CLIENT_ID = '';
+const EXTERNAL_CLIENT_ID = '32SIROMM8Q69GnVN9PcuYBxpehPnnIID';
 
 /**
  * External OAuth2 redirect URI.

--- a/examples/medplum-client-external-idp-demo/src/SignInPage.tsx
+++ b/examples/medplum-client-external-idp-demo/src/SignInPage.tsx
@@ -10,14 +10,14 @@ import { MEDPLUM_BASE_URL } from './contants';
  * Your Medplum project ID.
  * You can find this value on the "Project Admin" page in the Medplum web app.
  */
-const MEDPLUM_PROJECT_ID = '5aee64f7-7993-4a3c-a791-773fbb8d0d2a';
+const MEDPLUM_PROJECT_ID = '';
 
 /**
  * Your Medplum client ID.
  * You can find this value on the "Project Admin" page in the Medplum web app.
  * Note that the client must have the correct external auth provider configured.
  */
-const MEDPLUM_CLIENT_ID = '07f12dc5-e304-40b2-a625-258df4fd63a8';
+const MEDPLUM_CLIENT_ID = '=';
 
 /**
  * Your web application redirect URL.
@@ -30,13 +30,13 @@ const WEB_APP_REDIRECT_URI = 'http://localhost:8000/signin';
  * For example, this would be an Auth0, AWS Cognito, or Okta URL.
  * This value is specific to your external auth provider.
  */
-const EXTERNAL_AUTHORIZE_URL = 'https://dev-43cuzvn02g1spky2.us.auth0.com/authorize';
+const EXTERNAL_AUTHORIZE_URL = '';
 
 /**
  * External OAuth2 client ID.
  * This value is specific to your external auth provider.
  */
-const EXTERNAL_CLIENT_ID = '32SIROMM8Q69GnVN9PcuYBxpehPnnIID';
+const EXTERNAL_CLIENT_ID = '';
 
 /**
  * External OAuth2 redirect URI.

--- a/packages/docs/docs/auth/external-identity-providers.mdx
+++ b/packages/docs/docs/auth/external-identity-providers.mdx
@@ -38,12 +38,57 @@ Note the following details:
 - Client ID
 - Client secret
 
-Setup your Medplum account:
+## Setup your Medplum account
 
 - [Register for a Medplum account](/docs/tutorials/register)
 - Create a `ClientApplication`
 - Set the "Redirect URI" to "http://localhost:8000/"
 - Add an external identity provider with the details from above
+
+## User accounts and project membership
+
+External identity providers authenticate users, but **Medplum still requires a user and project membership** before the login can succeed. Medplum will not automatically create users from external IdP tokens.
+
+When an external token is verified, Medplum:
+
+- Looks up the user by **email** (default), or
+- Looks up the user by **external ID** (when `ClientApplication.identityProvider.useSubject` is `true`), matching the IdP `sub` claim to `ProjectMembership.externalId`.
+
+To prepare users for external login:
+
+1. Decide how users will be identified:
+   - **By email** (default): make sure your IdP issues an `email` claim and you request the `email` scope.
+   - **By external ID/subject**: set `ClientApplication.identityProvider.useSubject` to `true` and ensure you know the IdP subject that will be used for each user (for example, the portion after a prefix like `google-oauth2|`).
+2. Invite users to your project using the `/admin/projects/{projectId}/invite` endpoint:
+   - Email-based invite:
+
+     ```bash
+     curl "https://${baseUrl}/admin/projects/${projectId}/invite" \
+       -H "Authorization: Bearer ${accessToken}" \
+       -H "Content-Type: application/json" \
+       --data-raw '{
+         "resourceType": "Patient",
+         "firstName": "Alice",
+         "lastName": "Example",
+         "email": "alice@example.com"
+       }'
+     ```
+
+   - External ID-based invite (for `useSubject: true`):
+
+     ```bash
+     curl "https://${baseUrl}/admin/projects/${projectId}/invite" \
+       -H "Authorization: Bearer ${accessToken}" \
+       -H "Content-Type: application/json" \
+       --data-raw '{
+         "resourceType": "Patient",
+         "firstName": "Alice",
+         "lastName": "Example",
+         "externalId": "IDP_SUBJECT_VALUE"
+       }'
+     ```
+
+See [Using External IDs](/docs/user-management/external-ids) for more details on `useSubject` and how `externalId` is stored on the project membership.
 
 ## Start the flow
 
@@ -64,6 +109,37 @@ The [MedplumClient](/docs/sdk/core.medplumclient) TypeScript class provides a [`
 </MedplumCodeBlock>
 
 After the code is processed, the Medplum access token will be stored in the browser's local storage. The `MedplumClient` will automatically use the access token for all subsequent API calls.
+
+## PKCE configuration
+
+External IdP flows can use [PKCE](https://datatracker.ietf.org/doc/html/rfc7636) on either or both of:
+
+- The **Medplum** authorization code flow (`/oauth2/authorize` → `/oauth2/token`), and
+- The **external IdP** authorization code flow (`authorizeUrl` → `tokenUrl`).
+
+Medplum has three relevant knobs:
+
+- `MedplumClient.signInWithExternalAuth(authorizeUrl, clientId, redirectUri, baseLogin, pkceEnabled?)`
+  - When `pkceEnabled` is omitted or `true`, Medplum generates a `code_challenge` / `code_verifier` pair and stores the verifier in `sessionStorage`.
+- `ClientApplication.identityProvider.usePkce`
+  - When `true`, Medplum will include `code_verifier` when exchanging the external IdP code at `tokenUrl`.
+  - When `false`, Medplum uses a simple client-secret–based code exchange against the external IdP.
+- `ClientApplication.pkceOptional`
+  - When `true`, Medplum’s own `/oauth2/token` endpoint will accept authorization codes **with or without** PKCE context.
+  - When `false`, PKCE is required for the Medplum code exchange.
+
+Common configurations:
+
+- **Simple external IdP (no PKCE at IdP)**:
+  - `signInWithExternalAuth(..., false)` (no PKCE sent to the IdP).
+  - `identityProvider.usePkce = false`.
+  - `ClientApplication.pkceOptional = true` (Medplum will not require PKCE for the internal `/oauth2/token` step).
+- **End‑to‑end PKCE**:
+  - `signInWithExternalAuth(... /* pkceEnabled defaults to true */)`.
+  - `identityProvider.usePkce = true` (if your IdP supports PKCE on the token endpoint).
+  - `ClientApplication.pkceOptional = false` (Medplum will enforce PKCE for `/oauth2/token`).
+
+If you see errors such as `"Missing verification context"` or `"Missing code verifier"` from `/oauth2/token`, check that your `pkceEnabled` flag, `identityProvider.usePkce`, and `ClientApplication.pkceOptional` settings are consistent.
 
 ## FAQ
 

--- a/packages/docs/docs/user-management/external-ids.md
+++ b/packages/docs/docs/user-management/external-ids.md
@@ -13,9 +13,15 @@ Navigate to "Project Admin" and then "Clients".
 
 Find your Client Application.
 
-Set `ClientApplication.identityProvider.useSubject` to `true`
+Set `ClientApplication.identityProvider.useSubject` to `true`. When this flag is enabled:
+
+- Medplum will use the external IdP `sub` (subject) claim as the primary identifier.
+- The subject value is matched against `ProjectMembership.externalId` for the project associated with the login.
+- Email is no longer required on the external token, but can still be present and used for profiles.
 
 ## Invite user
+
+To associate an external subject with a Medplum user and project membership, you must invite the user to your project.
 
 Prepare JSON payload:
 


### PR DESCRIPTION
## Summary
- Clarify how external identity providers map to Medplum users and project memberships.
- Document use of external IDs (`useSubject`) and how `ProjectMembership.externalId` is used.
- Add PKCE configuration guidance for external IdP flows and Medplum's `/oauth2/token`.
- Wire the external IdP demo with concrete values to better illustrate the full flow.

## Test plan
- Manually exercised external IdP login in the example app (browser).
- Verified token exchange using external access token and Medplum's `/oauth2/token`.