### PR TITLE
Handle out-of-order query results in `useSearch`

### DIFF
--- a/packages/react-hooks/src/useSearch/useSearch.ts
+++ b/packages/react-hooks/src/useSearch/useSearch.ts
@@ -92,17 +92,26 @@ function useSearchImpl<K extends ResourceType, SearchReturnType>(
   const [debouncedSearchValue] = useDebouncedValue(searchValue, debounceMs, { leading: true });
 
   useEffect(() => {
+    let active = true;
     medplum[searchFn](debouncedSearchValue.resourceType, debouncedSearchValue.query)
       .then((res) => {
-        setLoading(false);
-        setResult(res as SearchReturnType);
-        setOutcome(allOk);
+        if (active) {
+          setLoading(false);
+          setResult(res as SearchReturnType);
+          setOutcome(allOk);
+        }
       })
       .catch((err) => {
-        setLoading(false);
-        setResult(undefined);
-        setOutcome(normalizeOperationOutcome(err));
+        if (active) {
+          setLoading(false);
+          setResult(undefined);
+          setOutcome(normalizeOperationOutcome(err));
+        }
       });
+
+    return () => {
+      active = false;
+    };
   }, [medplum, searchFn, debouncedSearchValue]);
 
   return [result, loading, outcome];


### PR DESCRIPTION
There are a variety of situations where query results may come in out-of-order; there may be network congestion, one search may have higher complexity, a later request may be served from cache, ...

In such a case, we should not overwrite the results of a request with the slow results from an earlier request.

This method (closing over a variable to track if the effect has been cancelled) is recommended in the official React docs:
https://react.dev/reference/react/useEffect#fetching-data-with-effects

To make this fix more clearly correct, I started by removing a piece of state (`lastSearch`) that made thinking about the effect more difficult.