### PR TITLE
Log into dhi.io in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hub Hardened Images
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        with:
+          registry: dhi.io
+          username: ${{ secrets.STAGING_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.STAGING_DOCKERHUB_TOKEN }}
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
       - name: Deploy


### PR DESCRIPTION
Follow-up to https://github.com/medplum/medplum/pull/8109

When using [Docker Hardened Images](https://www.docker.com/products/hardened-images/), we need to also login to `dhi.io`.

In #8109, we added this to `staging.yml` but neglected to add it to `deploy.yml`.

