### PR TITLE
Use cleanResource on EditPage -> Patch

### DIFF
--- a/packages/app/src/resource/EditPage.tsx
+++ b/packages/app/src/resource/EditPage.tsx
@@ -51,7 +51,7 @@ export function EditPage(): JSX.Element | null {
   const handlePatch = useCallback(
     (newResource: Resource): void => {
       setOutcome(undefined);
-      const patchOperations = createPatch(original, newResource);
+      const patchOperations = createPatch(original, cleanResource(newResource));
       medplum
         .patchResource(resourceType, id, patchOperations)
         .then(() => {


### PR DESCRIPTION
This PR addresses an issue where edits made via the "Patch" button in the Medplum UI were sometimes attributed to the "System" rather than the active user.

Context: https://medplum.slack.com/archives/C051SKJKZ50/p1767376670108949

### The Problem

When a Super Admin edits a resource, they have the permission to set or preserve the `meta.author` field. In the current implementation, the "Patch" functionality was not utilizing the `cleanResource()` helper utility. Consequently, if a resource with `meta.author = 'system'` was patched, the server would preserve that system attribution instead of stamping it with the current user's identity.

### The Fix

* Updated the "Patch" logic to ensure `meta.author` is cleared/handled similarly to the "Edit" and "JSON" workflows.
* This ensures that the server automatically assigns the active user as the author, providing a proper audit trail for "entitlements" and other critical resource changes.
