### PR TITLE
Replace deprecated method in MCP server

### DIFF
--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -27,15 +27,15 @@ const dummyDocument = {
   uri: 'https://example.com/dummy-doc',
 } as const;
 
-server.tool('search', { query: z.string() }, async ({ query }) => {
+server.registerTool('search', { inputSchema: { query: z.string() } }, async ({ query }) => {
   getLogger().debug(`Performing search for: "${query}"`);
   return { content: [dummyDocument] };
 });
 
-server.tool(
+server.registerTool(
   'fetch',
   {
-    id: z.string().describe('The ID of the resource to fetch, obtained from a search result.'),
+    inputSchema: { id: z.string().describe('The ID of the resource to fetch, obtained from a search result.') },
   },
   async ({ id }) => {
     getLogger().debug(`Performing fetch for ID: "${id}"`);
@@ -47,12 +47,14 @@ server.tool(
 // The current implmentation uses the very suboptimal approach of re-fetching the URL on behalf of the client.
 // Over time, we should definitely replace this with the "FhirRouter" approach, which would stay within the Medplum server and not re-fetch the URL.
 // However, there are a few FHIR endpoints that are not yet available in FhirRouter, so we need to use fetch for now.
-server.tool(
+server.registerTool(
   'fhir-request',
   {
-    method: z.string(),
-    path: z.string(),
-    body: z.any(),
+    inputSchema: {
+      method: z.string(),
+      path: z.string(),
+      body: z.any(),
+    },
   },
   async ({ method, path, body }) => {
     const ctx = getAuthenticatedContext();


### PR DESCRIPTION
The `tool()` method has been deprecated in favor of `registerTool()`. The main change is that the new version accepts an options hash that avoids some ambiguity in parsing the arguments. We now explicitly describe the intention of the argument, which is to validate input to the tool.

Spotted while investigating uses of Zod in the codebase.

The new API is introduced in https://github.com/modelcontextprotocol/typescript-sdk/pull/454, while the old one was marked deprecated in https://github.com/modelcontextprotocol/typescript-sdk/pull/1018.