### PR TITLE
Fixed dark mode on visit details page

### DIFF
--- a/examples/medplum-provider/src/components/encounter/EncounterHeader.tsx
+++ b/examples/medplum-provider/src/components/encounter/EncounterHeader.tsx
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Button, Flex, Group, Menu, Paper, SegmentedControl, Stack, Text, Modal, ActionIcon } from '@mantine/core';
+import { ActionIcon, Box, Button, Flex, Group, Menu, Modal, Paper, SegmentedControl, Stack, Text } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import { formatDate, formatHumanName } from '@medplum/core';
 import type { Encounter, HumanName, Practitioner, Reference } from '@medplum/fhirtypes';
 import { IconChevronDown, IconLock, IconLockOpen } from '@tabler/icons-react';
-import { useState } from 'react';
 import type { JSX } from 'react';
-import { useDisclosure } from '@mantine/hooks';
-import { SignLockDialog } from './SignLockDialog';
+import { useState } from 'react';
 import { ChartNoteStatus } from '../../types/encounter';
+import { SignLockDialog } from './SignLockDialog';
 
 interface EncounterHeaderProps {
   encounter: Encounter;
@@ -176,22 +176,7 @@ export const EncounterHeader = (props: EncounterHeaderProps): JSX.Element => {
             ]}
             fullWidth
             radius="md"
-            color="gray"
             size="md"
-            styles={(theme) => ({
-              root: {
-                backgroundColor: theme.colors.gray[1],
-                borderRadius: theme.radius.md,
-              },
-              indicator: {
-                backgroundColor: theme.white,
-              },
-              label: {
-                fontWeight: 500,
-                color: theme.colors.dark[9],
-                padding: `${theme.spacing.xs} ${theme.spacing.md}`,
-              },
-            })}
           />
         </Box>
       </Paper>


### PR DESCRIPTION
Before:

<img width="1892" height="435" alt="image" src="https://github.com/user-attachments/assets/0bcccce8-225a-49ca-ab7e-a7e295782203" />


After:

<img width="1886" height="395" alt="image" src="https://github.com/user-attachments/assets/1f6aaad7-bfa4-42b9-8fe0-3c1e501661c2" />


For reference, here is light mode:

Before:

<img width="1899" height="418" alt="image" src="https://github.com/user-attachments/assets/37291e89-907c-4a7d-bad4-2d9943d7459b" />


After:

<img width="1894" height="404" alt="image" src="https://github.com/user-attachments/assets/00b85235-9c5c-4995-85c5-fe42aff1f268" />

We should default to "Stock Mantine" whenever possible; it’s more robust, easier to maintain, and ensures dark mode and customer theming work out of the box. I want us to prioritize a consistent, "invisible" user experience over custom visual tweaks that add maintenance overhead.