### PR TITLE
Docs: Update Node.js Version Requirement To 22+

### DIFF
--- a/packages/docs/docs/contributing/run-the-stack.md
+++ b/packages/docs/docs/contributing/run-the-stack.md
@@ -15,7 +15,7 @@ Follow these instructions to get the complete Medplum stack running directly on 
 ## Prerequisites
 
 1. **[Git](https://git-scm.com/)**
-2. **[Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)** (version 20+ required)
+2. **[Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)** (version 22+ required)
 3. **[Docker](https://docs.docker.com/engine/install/)**
 4. [Clone the Medplum repo](./local-dev-setup#clone-the-repo)
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 22+
 - npm 10+
 - Postgres 13+
 - Redis 6+


### PR DESCRIPTION
  Body:
  The docs state Node.js 20+ is required, but `package.json` specifies `^22.18.0 || >=24.2.0`.

  Updated:
  - `packages/docs/docs/contributing/run-the-stack.md`
  - `packages/server/README.md`