### PR TITLE
docs: Update comment to clarify AccessPolicy.compartment behavior

### DIFF
--- a/packages/docs/docs/access/access-policies.md
+++ b/packages/docs/docs/access/access-policies.md
@@ -399,7 +399,7 @@ This access policy grants read-only access to all Patients that are within that 
 {
   "resourceType": "AccessPolicy",
   "name": "Patient Example",
-  // Any resource created or updated will be tagged with `meta.account` set to `Organization/abc-123`
+  // Any resource created will be tagged with `meta.account` set to `Organization/abc-123`
   "compartment": {
     "reference": "Organization/abc-123",
     "display": "Example Customer Organization"


### PR DESCRIPTION
Tangentially related to #8161. It seems this behavior is [explicitly excluded](https://github.com/medplum/medplum/blob/06bf457aee2f2c1174fb8aa3dd635c06470f6bc0/packages/server/src/fhir/repo.ts#L2027-L2030) in `getAccounts`.
``` typescript
    if (!existing && this.context.accessPolicy?.compartment?.reference) {
      // If the creator's access policy specifies a compartment, then use it as the account.
      // The writer's access policy is only applied at resource creation: simply editing a
      // resource does NOT pull it into the user's account.
      accounts.add(this.context.accessPolicy.compartment.reference);
    }
```
~~(I'll fix DCO shortly)~~