### PR TITLE
Disable MedplumClient caching with on-behalf-of

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -4091,6 +4091,52 @@ describe('Client', () => {
     // Now the second request should have been executed
     expect(fetch).toHaveBeenCalledTimes(2);
   });
+
+  test('Do not use cache with on-behalf-of header object', async () => {
+    const fetch = mockFetch(200, {});
+    const client = new MedplumClient({ fetch });
+    const request1 = await client.get('Practitioner/123', { headers: { 'x-medplum-on-behalf-of': 'Patient/123' } });
+    const request2 = client.get('Practitioner/123', { headers: { 'x-medplum-on-behalf-of': 'Patient/456' } });
+    expect(request2).not.toBe(request1);
+
+    const response1 = await request1;
+    expect(response1).toBeDefined();
+    const response2 = await request2;
+    expect(response2).toBeDefined();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('Do not use cache with on-behalf-of header array', async () => {
+    const fetch = mockFetch(200, {});
+    const client = new MedplumClient({ fetch });
+    const request1 = await client.get('Practitioner/123', { headers: [['x-medplum-on-behalf-of', 'Patient/123']] });
+    const request2 = client.get('Practitioner/123', { headers: [['x-medplum-on-behalf-of', 'Patient/456']] });
+    expect(request2).not.toBe(request1);
+
+    const response1 = await request1;
+    expect(response1).toBeDefined();
+    const response2 = await request2;
+    expect(response2).toBeDefined();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('Do not use cache with on-behalf-of header instance', async () => {
+    const fetch = mockFetch(200, {});
+    const client = new MedplumClient({ fetch });
+    const request1 = await client.get('Practitioner/123', {
+      headers: new Headers({ 'x-medplum-on-behalf-of': 'Patient/123' }),
+    });
+    const request2 = client.get('Practitioner/123', {
+      headers: new Headers({ 'x-medplum-on-behalf-of': 'Patient/456' }),
+    });
+    expect(request2).not.toBe(request1);
+
+    const response1 = await request1;
+    expect(response1).toBeDefined();
+    const response2 = await request2;
+    expect(response2).toBeDefined();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('Passed in async-backed `ClientStorage`', () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3382,13 +3382,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   private isCacheEnabled(
     options: MedplumRequestOptions | undefined
   ): this is this & { requestCache: LRUCache<RequestCacheEntry> } {
-    return !!(
-      this.requestCache &&
-      options?.cache !== 'no-cache' &&
-      options?.cache !== 'reload' &&
-      !this.defaultHeaders?.['on-behalf-of'] &&
-      !this.getRequestHeader(options, 'on-behalf-of')
-    );
+    return !!this.requestCache && !this.getRequestHeader(options, 'x-medplum-on-behalf-of');
   }
 
   /**
@@ -3398,7 +3392,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * @returns The cached entry if found.
    */
   private getCacheEntry(key: string, options: MedplumRequestOptions | undefined): RequestCacheEntry | undefined {
-    if (!this.isCacheEnabled(options)) {
+    if (!this.isCacheEnabled(options) || options?.cache === 'no-cache' || options?.cache === 'reload') {
       return undefined;
     }
     const entry = this.requestCache.get(key);


### PR DESCRIPTION
This PR disables client-side response caching whenever the `on-behalf-of` header is present.

The MedplumClient caching layer was originally designed around a **single effective principal** per client instance. When `on-behalf-of` is used, that assumption no longer holds, and naive response caching can produce incorrect or surprising behavior if enabled.

While server-side authorization is always enforced correctly, this change makes the SDK more defensive by preventing cached responses from being reused across different effective principals.

**Rationale**

* `on-behalf-of` introduces multiple effective security contexts on a single client
* Client-side caching is not principal-aware
* Even though caching may be disabled by default in some environments, it is easy for applications to enable it without realizing the interaction
* Disabling caching in this case enforces a safer invariant and removes a sharp edge for developers

**Behavior change**

* If an `on-behalf-of` header is present, MedplumClient caching is automatically disabled
* This applies regardless of configured cache time
* No server-side behavior or authorization logic is affected

**Notes**

This is a defensive SDK hardening change intended to improve developer ergonomics and reduce the risk of incorrect client behavior. No server-side security issue or data isolation problem is involved.
