### PR TITLE
Update timeout-minutes usage for claude action v1

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,6 +26,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -36,4 +37,3 @@ jobs:
         uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          timeout_minutes: '60'


### PR DESCRIPTION
Missed this step: https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md#timeout-configuration