### PR TITLE
Update diagnoses binding URL in OrderLabsPage component

### DIFF
--- a/examples/medplum-provider/src/pages/labs/OrderLabsPage.tsx
+++ b/examples/medplum-provider/src/pages/labs/OrderLabsPage.tsx
@@ -201,7 +201,7 @@ export function OrderLabsPage(props: OrderLabsPageProps): JSX.Element {
             <div>
               <ValueSetAutocomplete
                 label="Diagnoses"
-                binding="http://hl7.org/fhir/sid/icd-10-cm"
+                binding="http://hl7.org/fhir/sid/icd-10-cm/vs"
                 name="diagnoses"
                 maxValues={10}
                 onChange={(items) => {


### PR DESCRIPTION
binding URL updated from `http://hl7.org/fhir/sid/icd-10-cm` to `http://hl7.org/fhir/sid/icd-10-cm/vs`, to resolve ValueSet $expand "not found" error