### PR TITLE
Display `time` properties in resources

### DIFF
--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.test.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.test.tsx
@@ -455,6 +455,28 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText(value.endpoint as string)).toBeInTheDocument();
   });
 
+  test('Renders date', async () => {
+    await setup(
+      <ResourcePropertyDisplay
+        property={{ ...baseProperty, type: [{ code: 'date' }] }}
+        propertyType={PropertyType.date}
+        value={'2026-01-15'}
+      />
+    );
+    expect(screen.getByText('2026-01-15')).toBeInTheDocument();
+  });
+
+  test('Renders time', async () => {
+    await setup(
+      <ResourcePropertyDisplay
+        property={{ ...baseProperty, type: [{ code: 'time' }] }}
+        propertyType={PropertyType.time}
+        value={'14:45:00'}
+      />
+    );
+    expect(screen.getByText('2:45 PM')).toBeInTheDocument();
+  });
+
   test('Handles unknown property', async () => {
     await expect(
       setup(<ResourcePropertyDisplay propertyType={PropertyType.BackboneElement} value={{}} />)

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ActionIcon, CopyButton, Flex, Tooltip } from '@mantine/core';
 import type { InternalSchemaElement } from '@medplum/core';
-import { PropertyType, formatDateTime, formatPeriod, formatTiming, isEmpty } from '@medplum/core';
+import { PropertyType, formatDateTime, formatPeriod, formatTiming, formatWallTime, isEmpty } from '@medplum/core';
 import type { ElementDefinitionType } from '@medplum/fhirtypes';
 import { IconCheck, IconCopy, IconEye, IconEyeOff } from '@tabler/icons-react';
 import type { JSX } from 'react';
@@ -120,6 +120,8 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
     case PropertyType.dateTime:
     case PropertyType.instant:
       return <>{formatDateTime(value)}</>;
+    case PropertyType.time:
+      return <>{formatWallTime(value)}</>;
     case PropertyType.markdown:
       return <pre>{value}</pre>;
     case PropertyType.Address:


### PR DESCRIPTION
In the Scheduling line of work, we expect folks to use `Timing.repeat.timeOfDay` properties, which are of type `time`. These represent unqualified times of day like "10 AM". Use our "formatWallTime" helper to display them.