### PR TITLE
Support specifying timezone in SchedulingParams

### DIFF
--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.test.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.test.ts
@@ -60,6 +60,7 @@ describe('parseSchedulingParametersExtensions', () => {
         alignmentOffset: 0,
         duration: 120,
         serviceType: [],
+        timezone: undefined,
       },
     ]);
   });
@@ -80,6 +81,7 @@ describe('parseSchedulingParametersExtensions', () => {
             { url: 'serviceType', valueCoding: { code: 'new-patient', system: 'http://example.com' } },
             { url: 'serviceType', valueCoding: { code: 'office-visit', system: 'http://example.com' } },
             { url: 'duration', valueDuration: { unit: 'h', value: 2 } },
+            { url: 'timezone', valueCode: 'America/Phoenix' },
             {
               url: 'availability',
               valueTiming: {
@@ -130,6 +132,7 @@ describe('parseSchedulingParametersExtensions', () => {
           { code: 'new-patient', system: 'http://example.com' },
           { code: 'office-visit', system: 'http://example.com' },
         ],
+        timezone: 'America/Phoenix',
       },
     ]);
   });

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -33,6 +33,7 @@ type SchedulingParametersExtensionExtension =
   | { url: 'alignmentOffset'; valueDuration: HardDuration }
   | { url: 'duration'; valueDuration: HardDuration }
   | { url: 'serviceType'; valueCoding: HardCoding }
+  | { url: 'timezone'; valueCode: string }
   | {
       url: 'availability';
       valueTiming: {
@@ -66,6 +67,7 @@ export type SchedulingParameters = {
   alignmentOffset: number; // minutes
   duration: number; // minutes
   serviceType: HardCoding[]; // codes that may be booked into this availability
+  timezone?: string;
 };
 
 function durationToMinutes(duration: Duration): number {
@@ -144,6 +146,10 @@ export function parseSchedulingParametersExtensions(resource: Schedule | Activit
       extension.extension.filter((ext) => ext.url === 'alignmentInterval'),
       'alignmentInterval'
     );
+    const timezone = atMostOne(
+      extension.extension.filter((ext) => ext.url === 'timezone'),
+      'timezone'
+    );
 
     // serviceType has cardinality 0..*
     const serviceType = extension.extension.filter((ext) => ext.url === 'serviceType').map((ext) => ext.valueCoding);
@@ -171,6 +177,7 @@ export function parseSchedulingParametersExtensions(resource: Schedule | Activit
       alignmentOffset: alignmentOffset ? durationToMinutes(alignmentOffset.valueDuration) : 0,
       duration: durationToMinutes(duration.valueDuration),
       serviceType,
+      timezone: timezone?.valueCode,
     };
   });
 }


### PR DESCRIPTION
In https://github.com/medplum/medplum/pull/8158 the spec was amended to include a `timezone` component in the extension that, when present, takes precedence over an actor's timezone.

It appears that I didn't merge this change into the original implementation branch (https://github.com/medplum/medplum/pull/7967). Oops. Let's get this fixed up to match the spec.