### PR TITLE
Edit dark mode color in resource timeline 

### DIFF
--- a/packages/react/src/Timeline/Timeline.tsx
+++ b/packages/react/src/Timeline/Timeline.tsx
@@ -42,7 +42,7 @@ export function TimelineItem(props: TimelineItemProps): JSX.Element {
         <ResourceAvatar value={author} link={true} size="md" />
         <div style={{ flex: 1 }}>
           <Text size="sm">
-            <ResourceName c="dark" fw={500} value={author} link={true} />
+            <ResourceName c="inherit" fw={500} value={author} link={true} />
           </Text>
           <Text size="xs">
             <MedplumLink c="dimmed" to={props.resource}>


### PR DESCRIPTION
Currently, in dark mode, action author names are set to dark, making them difficult to read against the dark background: 
<img width="271" height="76" alt="Screenshot 2026-01-22 at 9 31 12 AM" src="https://github.com/user-attachments/assets/cfdb2f04-133e-4b02-b4f9-b451e92927e8" />


This PR changes the color to inherit the theme, such that both light and dark mode are readable 
<img width="315" height="82" alt="Screenshot 2026-01-22 at 9 30 42 AM" src="https://github.com/user-attachments/assets/478e6d79-57d3-4d46-a39c-e50073d59dec" />
<img width="305" height="78" alt="Screenshot 2026-01-22 at 9 30 32 AM" src="https://github.com/user-attachments/assets/e7d89bf7-c81f-4308-be19-cd3b8f94ff5f" />
