### PR TITLE
fix: add db persistence to the docker compose files

### DIFF
--- a/docker-compose.full-stack.yml
+++ b/docker-compose.full-stack.yml
@@ -5,6 +5,8 @@ services:
     environment:
       - POSTGRES_USER=medplum
       - POSTGRES_PASSWORD=medplum
+    volumes:
+      - medplum-postgres-data:/var/lib/postgresql/data
     command:
       # We use command line args instead of a postgres.conf to avoid additional setup out of the box
       - 'postgres'
@@ -107,3 +109,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+volumes:
+  medplum-postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - ./postgres/postgres.conf:/usr/local/etc/postgres/postgres.conf
       - ./postgres/:/docker-entrypoint-initdb.d/
+      - medplum-postgres-data:/var/lib/postgresql/data
     command: postgres -c config_file=/usr/local/etc/postgres/postgres.conf
     ports:
       - '5432:5432'
@@ -22,3 +23,6 @@ services:
     command: redis-server --requirepass medplum
     ports:
       - '6379:6379'
+
+volumes:
+  medplum-postgres-data:


### PR DESCRIPTION
Summary:
This adds docker volumes for PostgreSQL to the docker compose files. This enables local development of applications that use Medplum without having to reinitialize all the resources whenever the container is removed.