### PR TITLE
Fixed Group $everything merge conflict errors

### DIFF
--- a/packages/server/src/fhir/operations/groupeverything.test.ts
+++ b/packages/server/src/fhir/operations/groupeverything.test.ts
@@ -123,7 +123,7 @@ describe('Group Everything Operation', () => {
     const result = everythingRes.body as Bundle;
     expect(result.resourceType).toBe('Bundle');
     expect(result.type).toBe('searchset');
-    expect(result.total).toBeGreaterThanOrEqual(6);
+    expect(result.entry?.length).toBeGreaterThanOrEqual(6);
 
     // Verify all expected resources are included
     const resourceRefs = result.entry?.map((e) => getReferenceString(e.resource as Resource)) || [];
@@ -354,6 +354,6 @@ describe('Group Everything Operation', () => {
     expect(result.link?.some((link) => link.relation === 'previous')).toBeTruthy();
 
     // Verify entry count respects _count
-    expect(result.entry?.length).toBeLessThanOrEqual(3);
+    expect(result.entry?.length).toStrictEqual(4);
   });
 });

--- a/packages/server/src/fhir/operations/groupeverything.ts
+++ b/packages/server/src/fhir/operations/groupeverything.ts
@@ -172,6 +172,7 @@ async function searchGroupCompartments(
     count: search?.count ?? defaultMaxResults,
     offset: search?.offset,
     sortRules: [{ code: '_id' }], // Must make sort deterministic to ensure pagination works correctly
+    total: 'accurate',
   });
 
   // Add the group itself to the results

--- a/packages/server/src/fhir/operations/groupeverything.ts
+++ b/packages/server/src/fhir/operations/groupeverything.ts
@@ -129,7 +129,7 @@ async function searchGroupCompartments(
   search?: Partial<SearchRequest>
 ): Promise<Bundle<WithId<Resource>>> {
   const resourceList = getPatientCompartments().resource as CompartmentDefinitionResource[];
-  const types = search?.types ?? resourceList.map((r) => r.code as ResourceType).filter((t) => t !== 'Binary');
+  const types = search?.types ?? resourceList.map((r) => r.code).filter((t) => t !== 'Binary');
 
   // Include Group in the types
   if (!types.includes('Group')) {

--- a/packages/server/src/oauth/authorize.test.ts
+++ b/packages/server/src/oauth/authorize.test.ts
@@ -5,7 +5,7 @@ import { Operator } from '@medplum/core';
 import type { ClientApplication, Login, Project, SmartAppLaunch } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
-import setCookieParser from 'set-cookie-parser';
+import { parse as parseCookie } from 'set-cookie-parser';
 import request from 'supertest';
 import { URL, URLSearchParams } from 'url';
 import { inviteUser } from '../admin/invite';
@@ -297,7 +297,7 @@ describe('OAuth Authorize', () => {
     expect(res2.status).toBe(200);
     expect(res2.body.id_token).toBeDefined();
 
-    const cookies = setCookieParser.parse(res1.headers['set-cookie']);
+    const cookies = parseCookie(res1.headers['set-cookie']);
     expect(cookies.length).toBe(1);
 
     const cookie = cookies[0];
@@ -344,7 +344,7 @@ describe('OAuth Authorize', () => {
     expect(res2.status).toBe(200);
     expect(res2.body.id_token).toBeDefined();
 
-    const cookies = setCookieParser.parse(res1.headers['set-cookie']);
+    const cookies = parseCookie(res1.headers['set-cookie']);
     expect(cookies.length).toBe(1);
 
     const cookie = cookies[0];
@@ -392,7 +392,7 @@ describe('OAuth Authorize', () => {
     expect(res2.status).toBe(200);
     expect(res2.body.id_token).toBeDefined();
 
-    const cookies = setCookieParser.parse(res1.headers['set-cookie']);
+    const cookies = parseCookie(res1.headers['set-cookie']);
     expect(cookies.length).toBe(1);
 
     const cookie = cookies[0];
@@ -453,7 +453,7 @@ describe('OAuth Authorize', () => {
     expect(res2.status).toBe(200);
     expect(res2.body.id_token).toBeDefined();
 
-    const cookies = setCookieParser.parse(res1.headers['set-cookie']);
+    const cookies = parseCookie(res1.headers['set-cookie']);
     expect(cookies.length).toBe(1);
 
     const cookie = cookies[0];

--- a/postgres/init_test.sql
+++ b/postgres/init_test.sql
@@ -6,6 +6,9 @@ GRANT ALL PRIVILEGES ON DATABASE medplum_test TO medplum;
 
 \c medplum_test
 
+GRANT ALL ON SCHEMA public TO medplum;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO medplum;
+
 CREATE USER medplum_test_readonly WITH PASSWORD 'medplum_test_readonly';
 GRANT CONNECT ON DATABASE medplum_test TO medplum_test_readonly;
 GRANT USAGE ON SCHEMA public TO medplum_test_readonly;


### PR DESCRIPTION
We recently merged https://github.com/medplum/medplum/pull/7799 which was long in the tooth and had some behavioral merge conflicts.

Unfortunately, we cannot use the GitHub "merge queue" for PR's from forks due to the GitHub permission model.  That would have caught these, but it didn't run.

Key changes:
1. Group `$everything` mimics Patient `$everything`, which had some changes
2. Multi-type search pagination had some changes
3. Some new ESLint rules

I'm doing some quick fixes here to unblock open PR's.  We may want to take a deeper dive on the exact behaviors here.

cc @jdjkelly 