### PR TITLE
feat: Add common console methods to MockConsole

### DIFF
--- a/packages/server/src/util/console.test.ts
+++ b/packages/server/src/util/console.test.ts
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { MockConsole } from './console';
+
+describe('MockConsole', () => {
+  let mockConsole: MockConsole;
+
+  beforeEach(() => {
+    mockConsole = new MockConsole();
+  });
+
+  test('log', () => {
+    mockConsole.log('hello', 'world');
+    expect(mockConsole.messages).toEqual(['hello world']);
+  });
+
+  test('error', () => {
+    mockConsole.error('something went wrong');
+    expect(mockConsole.messages).toEqual(['something went wrong']);
+  });
+
+  test('warn', () => {
+    mockConsole.warn('be careful');
+    expect(mockConsole.messages).toEqual(['be careful']);
+  });
+
+  test('info', () => {
+    mockConsole.info('for your information');
+    expect(mockConsole.messages).toEqual(['for your information']);
+  });
+
+  test('debug', () => {
+    mockConsole.debug('debug details');
+    expect(mockConsole.messages).toEqual(['debug details']);
+  });
+
+  test('trace', () => {
+    mockConsole.trace('trace info');
+    expect(mockConsole.messages).toEqual(['trace info']);
+  });
+
+  test('dir', () => {
+    mockConsole.dir({ key: 'value' });
+    expect(mockConsole.messages).toHaveLength(1);
+    expect(JSON.parse(mockConsole.messages[0])).toEqual({ key: 'value' });
+  });
+
+  test('dir with string', () => {
+    mockConsole.dir('plain string');
+    expect(mockConsole.messages).toEqual(['plain string']);
+  });
+
+  test('dir with undefined', () => {
+    mockConsole.dir(undefined);
+    expect(mockConsole.messages).toHaveLength(0);
+  });
+
+  test('assert with truthy condition', () => {
+    mockConsole.assert(true, 'should not appear');
+    expect(mockConsole.messages).toHaveLength(0);
+  });
+
+  test('assert with falsy condition', () => {
+    mockConsole.assert(false, 'expected true');
+    expect(mockConsole.messages).toEqual(['Assertion failed: expected true']);
+  });
+
+  test('time and timeEnd do not throw', () => {
+    expect(() => {
+      mockConsole.time('timer');
+      mockConsole.timeEnd('timer');
+    }).not.toThrow();
+  });
+
+  test('timeLog does not throw', () => {
+    expect(() => {
+      mockConsole.timeLog('timer', 'data');
+    }).not.toThrow();
+  });
+
+  test('group', () => {
+    mockConsole.group('group label');
+    expect(mockConsole.messages).toEqual(['group label']);
+  });
+
+  test('groupEnd does not throw', () => {
+    expect(() => mockConsole.groupEnd()).not.toThrow();
+  });
+
+  test('table with object', () => {
+    mockConsole.table([1, 2, 3]);
+    expect(mockConsole.messages).toHaveLength(1);
+    expect(JSON.parse(mockConsole.messages[0])).toEqual([1, 2, 3]);
+  });
+
+  test('table with undefined', () => {
+    mockConsole.table(undefined);
+    expect(mockConsole.messages).toHaveLength(0);
+  });
+
+  test('clear does not remove messages', () => {
+    mockConsole.log('preserved');
+    mockConsole.clear();
+    expect(mockConsole.messages).toEqual(['preserved']);
+  });
+
+  test('count and countReset do not throw', () => {
+    expect(() => {
+      mockConsole.count('label');
+      mockConsole.countReset('label');
+    }).not.toThrow();
+  });
+
+  test('toString', () => {
+    mockConsole.log('line 1');
+    mockConsole.error('line 2');
+    mockConsole.warn('line 3');
+    expect(mockConsole.toString()).toBe('line 1\nline 2\nline 3');
+  });
+
+  test('multiple params joined with space', () => {
+    mockConsole.error('Error:', 404, 'Not Found');
+    expect(mockConsole.messages).toEqual(['Error: 404 Not Found']);
+  });
+});

--- a/packages/server/src/util/console.ts
+++ b/packages/server/src/util/console.ts
@@ -75,12 +75,10 @@ export class MockConsole {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  count(label?: string): undefined {
-  }
+  count(label?: string): undefined {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  countReset(label?: string): undefined {
-  }
+  countReset(label?: string): undefined {}
 
   toString(): string {
     return this.messages.join('\n');

--- a/packages/server/src/util/console.ts
+++ b/packages/server/src/util/console.ts
@@ -3,8 +3,83 @@
 export class MockConsole {
   readonly messages: string[] = [];
 
-  log(...params: any[]): void {
+  log(...params: any[]): undefined {
     this.messages.push(params.join(' '));
+  }
+
+  error(...params: any[]): undefined {
+    this.messages.push(params.join(' '));
+  }
+
+  warn(...params: any[]): undefined {
+    this.messages.push(params.join(' '));
+  }
+
+  info(...params: any[]): undefined {
+    this.messages.push(params.join(' '));
+  }
+
+  debug(...params: any[]): undefined {
+    this.messages.push(params.join(' '));
+  }
+
+  trace(...params: any[]): undefined {
+    this.messages.push(params.join(' '));
+  }
+
+  dir(item?: any): undefined {
+    if (item !== undefined) {
+      this.messages.push(typeof item === 'string' ? item : JSON.stringify(item, undefined, 2));
+    }
+  }
+
+  assert(condition?: boolean, ...params: any[]): undefined {
+    if (!condition) {
+      this.messages.push('Assertion failed: ' + params.join(' '));
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  time(label?: string): undefined {
+    // No-op: timer start not tracked in mock
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  timeEnd(label?: string): undefined {
+    // No-op: timer end not tracked in mock
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  timeLog(label?: string, ...params: any[]): undefined {
+    // No-op: timer log not tracked in mock
+  }
+
+  group(...params: any[]): undefined {
+    if (params.length > 0) {
+      this.messages.push(params.join(' '));
+    }
+  }
+
+  groupEnd(): undefined {
+    // No-op
+  }
+
+  table(tabularData?: any): undefined {
+    if (tabularData !== undefined) {
+      this.messages.push(typeof tabularData === 'string' ? tabularData : JSON.stringify(tabularData, undefined, 2));
+    }
+  }
+
+  clear(): undefined {
+    // No-op: does not clear messages array to preserve test assertions
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  count(label?: string): undefined {
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  countReset(label?: string): undefined {
   }
 
   toString(): string {


### PR DESCRIPTION
## Summary

Adds commonly used `console` methods to `MockConsole` so that vmcontext bots using third-party packages that call methods beyond `console.log()` don't encounter runtime errors.

## Changes

### New methods added to `MockConsole`:

| Method | Behavior |
|--------|----------|
| `error(...params)` | Appends joined params to messages |
| `warn(...params)` | Appends joined params to messages |
| `info(...params)` | Appends joined params to messages |
| `debug(...params)` | Appends joined params to messages |
| `trace(...params)` | Appends joined params to messages |
| `dir(item)` | Appends JSON-stringified item to messages |
| `assert(condition, ...params)` | Appends failure message when condition is falsy |
| `time(label)` | No-op (timer not tracked) |
| `timeEnd(label)` | No-op (timer not tracked) |
| `timeLog(label, ...params)` | No-op (timer not tracked) |
| `group(...params)` | Appends group label to messages |
| `groupEnd()` | No-op |
| `table(data)` | Appends JSON-stringified data to messages |
| `clear()` | No-op (preserves messages for test assertions) |
| `count(label)` | No-op |
| `countReset(label)` | No-op |

### Tests

Added comprehensive test suite in `console.test.ts` covering all new and existing methods.

## Motivation

As described in #4928, third-party packages imported by bots may call `console.error`, `console.warn`, or other standard console methods. Without these methods on `MockConsole`, the bot execution fails with a runtime error.

Closes #4928