### PR TITLE
fix(fhirtypes): explicitly export types for `NodeNext`

### DIFF
--- a/packages/fhirtypes/package.json
+++ b/packages/fhirtypes/package.json
@@ -30,6 +30,11 @@
   "author": "Medplum <hello@medplum.com>",
   "sideEffects": false,
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts"
+    }
+  },
   "main": "",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
Fixes #8348 