### PR TITLE
Fixes #8371 - basic auth and inactive project membership

### DIFF
--- a/packages/server/src/oauth/middleware.test.ts
+++ b/packages/server/src/oauth/middleware.test.ts
@@ -200,6 +200,14 @@ describe('Auth middleware', () => {
     expect(res.status).toBe(401);
   });
 
+  test('Basic auth with inactive project membership', async () => {
+    const client = await createTestClient({ membership: { active: false } });
+    const res = await request(app)
+      .get('/fhir/R4/Patient')
+      .set('Authorization', 'Basic ' + Buffer.from(client.id + ':' + client.secret).toString('base64'));
+    expect(res.status).toBe(401);
+  });
+
   test('Basic auth with super admin client', async () => {
     const { client } = await createTestProject({ superAdmin: true, withClient: true });
     const res = await request(app)

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -972,7 +972,7 @@ export async function getLoginForBasicAuth(req: IncomingMessage, token: string):
   }
 
   const membership = await getClientApplicationMembership(client);
-  if (!membership) {
+  if (!membership || membership.active === false) {
     return undefined;
   }
 


### PR DESCRIPTION
Follow-up to https://github.com/medplum/medplum/pull/8164

The original implementation checked `ProjectMembership.active` for "Bearer" tokens, but not for "Basic" auth.