### PR TITLE
ChooseProfileForm: Add ability to filter memberships by label

### DIFF
--- a/packages/react/src/auth/ChooseProfileForm.tsx
+++ b/packages/react/src/auth/ChooseProfileForm.tsx
@@ -29,7 +29,11 @@ export function ChooseProfileForm(props: ChooseProfileFormProps): JSX.Element {
   }
 
   function filterMembership(membership: ProjectMembership): boolean {
-    return filterDisplay(membership.profile?.display) || filterDisplay(membership.project?.display);
+    return (
+      filterDisplay(membership.profile?.display) ||
+      filterDisplay(membership.project?.display) ||
+      filterDisplay(getMembershipLabel(membership))
+    );
   }
 
   function handleValueSelect(membershipId: string): void {


### PR DESCRIPTION
Hey Medplum,

We have a problem with the ChooseProfileForm where we have more than 10 ProjectMemberships within a Project, so even after searching, the bottom of the list overflows the component. We've used the new "labels" feature to tag the memberships, and this MR allows the search component to filter by them. Happy to add a test but wasn't sure if it was too trivial for one - let me know. 

Jeff