### PR TITLE
docs: clarify patient login and launchUri #5792

### DIFF
--- a/packages/docs/docs/auth/index.md
+++ b/packages/docs/docs/auth/index.md
@@ -7,7 +7,11 @@ tags: [auth]
 
 This page helps you choose the correct authentication method for your application, whether it's a browser, a server, or a device. The primary goal is to guide you to the right documentation page based on your use case.
 
-For **user-facing applications (web or mobile apps)**, user [_browser-based authentication_](#browser-based-authentication). 
+For **user-facing applications (web or mobile apps)**, use [_browser-based authentication_](#browser-based-authentication). 
+
+:::caution Patient Login
+The Medplum App (https://app.medplum.com) is an administrative tool for clinical users and developers. Patients **cannot** log in to this application directly. To provide patient access, you must build a custom patient portal using the Medplum SDK.
+:::
 
 For applications running in a **trusted, back-end environment**, use [_server-side authentication_](#server-side-authentication). 
 

--- a/packages/docs/docs/integration/smart-app-launch.md
+++ b/packages/docs/docs/integration/smart-app-launch.md
@@ -10,6 +10,10 @@ Medplum is an open source implementation of [SMART App Launch 2.0.0](https://www
 - Navigate to the "Edit" tab
 - Add the `JWKS URI`, `Redirect URI` and `Launch URI` to the Client Application and save
 
+:::tip SMART Launch Configuration
+The `launchUri` is the most critical field on the `ClientApplication` resource in the context of a SMART launch. This URI serves as the entry point where Medplum will redirect the user to initiate the authentication handshake.
+:::
+
 In the example below, this application is configured to launch Inferno, the testing tool for SMART App Launch.
 
 ```json
@@ -18,9 +22,9 @@ In the example below, this application is configured to launch Inferno, the test
   "name": "Inferno Client",
   "id": "<id here>",
   "secret": "<secret here>",
-  "redirectUri": "https://inferno.healthit.gov/suites/custom/smart/redirect",
-  "jwksUri": "https://inferno.healthit.gov/suites/custom/g10_certification/.well-known/jwks.json",
-  "launchUri": "https://inferno.healthit.gov/suites/custom/smart/launch"
+  "redirectUri": "[https://inferno.healthit.gov/suites/custom/smart/redirect](https://inferno.healthit.gov/suites/custom/smart/redirect)",
+  "jwksUri": "[https://inferno.healthit.gov/suites/custom/g10_certification/.well-known/jwks.json](https://inferno.healthit.gov/suites/custom/g10_certification/.well-known/jwks.json)",
+  "launchUri": "[https://inferno.healthit.gov/suites/custom/smart/launch](https://inferno.healthit.gov/suites/custom/smart/launch)"
 }
 ```
 


### PR DESCRIPTION
# Description

This PR addresses common user pain points regarding patient access and SMART on FHIR configuration as outlined in issue #5792. 

### Changes
* **Authentication Overview:** Added a `:::caution` block to `packages/docs/docs/auth/index.md` to clarify that patients cannot log directly into the administrative console (`app.medplum.com`).
* **SMART App Launch:** Added a `:::tip` block to `packages/docs/docs/integration/smart-app-launch.md` to emphasize that the `launchUri` is the critical field for initiating a SMART launch sequence.



### Related Issues
Closes #5792

### Checklist
- [x] I have signed my commits with `git commit -s` (DCO).
- [x] I have verified that I added the new blocks without deleting existing code.
- [x] I have checked the formatting of the `:::caution` and `:::tip` blocks.