### PR TITLE
fix: handle JSON Patch 'add' with '/-' when target array doesn't exist

### DIFF
--- a/packages/server/src/util/patch.ts
+++ b/packages/server/src/util/patch.ts
@@ -12,6 +12,30 @@ import { applyPatch } from 'rfc6902';
  * @param patch - The patch to apply.
  */
 export function patchObject(obj: any, patch: Operation[]): void {
+  // Pre-process: ensure parent arrays exist for 'add' operations with '/-' path suffix.
+  // Per RFC 6902, 'add' with '/-' should append to an array. When the array
+  // doesn't exist yet, we create it so the append operation can succeed.
+  for (const op of patch) {
+    if (op.op === 'add' && op.path.endsWith('/-')) {
+      const parentPath = op.path.slice(0, -2);
+      const segments = parentPath.split('/').filter(Boolean);
+      let current: any = obj;
+      for (let i = 0; i < segments.length; i++) {
+        const segment = decodeURIComponent(segments[i].replace(/~1/g, '/').replace(/~0/g, '~'));
+        if (i === segments.length - 1) {
+          if (current[segment] === undefined || current[segment] === null) {
+            current[segment] = [];
+          }
+        } else {
+          if (current[segment] === undefined || current[segment] === null) {
+            break;
+          }
+          current = current[segment];
+        }
+      }
+    }
+  }
+
   try {
     const patchErrors = applyPatch(obj, patch).filter(Boolean);
     if (patchErrors.length) {


### PR DESCRIPTION
## Summary

Fixes #6711

**Root cause:** The `rfc6902` library's `applyPatch` throws when an `add` operation with path ending in `/-` targets a non-existent array. Per RFC 6902, `/-` means "append to the end of the array."

## Changes

- `packages/server/src/util/patch.ts`: Pre-processes patch operations to create missing parent arrays for `add` operations with `/-` paths before passing to `applyPatch`.

## Risk Assessment

**Low** - Only affects the specific case of `add` + `/-` when the array is missing. All other patch operations are unaffected.