### PR TITLE
fix(provider): Resolve participant name from resource instead of reference display

### DIFF
--- a/examples/medplum-provider/src/components/messages/ParticipantFilter.test.tsx
+++ b/examples/medplum-provider/src/components/messages/ParticipantFilter.test.tsx
@@ -38,6 +38,10 @@ describe('ParticipantFilter', () => {
       medplum.setProfile(mockPractitioner);
     }
 
+    // Ensure mock resources are available for useResource hook
+    await medplum.updateResource(mockPractitioner as WithId<Practitioner>);
+    await medplum.updateResource(mockPatient as WithId<Patient>);
+
     const user = userEvent.setup();
     await act(async () => {
       render(
@@ -446,14 +450,16 @@ describe('ParticipantFilter', () => {
     expect(screen.queryByText('(you)')).not.toBeInTheDocument();
   });
 
-  test('shows participant reference when display is not available', async () => {
+  test('does not render participant when resource cannot be resolved', async () => {
     const user = await setup(undefined, [{ reference: 'Patient/unknown-patient' }]);
 
     const button = screen.getByRole('button');
     await user.click(button);
 
     await waitFor(() => {
-      expect(screen.getByText('Patient/unknown-patient')).toBeInTheDocument();
+      // Only the current user checkbox should render; unresolved participant returns null
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(1);
     });
   });
 

--- a/examples/medplum-provider/src/components/messages/ParticipantFilter.tsx
+++ b/examples/medplum-provider/src/components/messages/ParticipantFilter.tsx
@@ -3,9 +3,9 @@
 
 import { ActionIcon, Checkbox, CloseButton, Group, Popover, Stack, Text, TextInput } from '@mantine/core';
 import { useDebouncedCallback, useDisclosure } from '@mantine/hooks';
-import { createReference, getReferenceString } from '@medplum/core';
+import { createReference, formatHumanName, getReferenceString } from '@medplum/core';
 import type { Patient, Practitioner, Reference } from '@medplum/fhirtypes';
-import { ResourceAvatar, useMedplum, useMedplumProfile } from '@medplum/react';
+import { ResourceAvatar, useMedplum, useMedplumProfile, useResource } from '@medplum/react';
 import { IconUsers } from '@tabler/icons-react';
 import { useEffect, useMemo, useState } from 'react';
 import type { JSX } from 'react';
@@ -206,8 +206,13 @@ interface ParticipantItemProps {
   onRemove?: () => void;
 }
 
-function ParticipantItem(props: ParticipantItemProps): JSX.Element {
+function ParticipantItem(props: ParticipantItemProps): JSX.Element | null {
   const { participant, isSelected, isCurrentUser, onToggle, onRemove } = props;
+  const patientResource = useResource(participant);
+
+  if (!patientResource) {
+    return null;
+  }
 
   return (
     <Group justify="space-between" wrap="nowrap" className={classes.participantItem}>
@@ -215,7 +220,7 @@ function ParticipantItem(props: ParticipantItemProps): JSX.Element {
         <Checkbox checked={isSelected} onChange={onToggle} />
         <ResourceAvatar value={participant} radius="xl" size={32} />
         <Text size="sm" truncate style={{ flex: 1 }}>
-          {participant.display ?? participant.reference}
+          {formatHumanName(patientResource?.name?.[0] ?? {})}
           {isCurrentUser && (
             <Text component="span" c="dimmed" size="sm">
               {' '}


### PR DESCRIPTION
The ParticipantItem component was updated to resolve the full resource via useResource and display  the participant's name using formatHumanName(patientResource?.name?.[0] ?? {}) instead of relying on participant.display from the Reference object. If the resource cannot be resolved, the component now returns null instead of rendering with a potentially stale or missing display name.
              

<img width="599" height="284" alt="Screenshot 2026-02-10 at 10 57 00 AM" src="https://github.com/user-attachments/assets/8af9abb7-d4a0-48ff-b762-965948f0741f" />
