### PR TITLE
Add token ':text' modifier to SearchControl

### DIFF
--- a/packages/react/src/SearchControl/SearchUtils.tsx
+++ b/packages/react/src/SearchControl/SearchUtils.tsx
@@ -12,7 +12,7 @@ import type { SearchControlField } from './SearchControlField';
 const searchParamToOperators: Record<string, Operator[]> = {
   string: [Operator.EQUALS, Operator.NOT, Operator.CONTAINS, Operator.EXACT],
   fulltext: [Operator.EQUALS, Operator.NOT, Operator.CONTAINS, Operator.EXACT],
-  token: [Operator.EQUALS, Operator.NOT],
+  token: [Operator.EQUALS, Operator.NOT, Operator.TEXT],
   reference: [Operator.EQUALS, Operator.NOT],
   numeric: [
     Operator.EQUALS,

--- a/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
+++ b/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
@@ -560,6 +560,73 @@ describe('SearchPopupMenu', () => {
     }
   });
 
+  test('Token submenu prompt', async () => {
+    const searchParam = globalSchema.types['MedicationRequest'].searchParams?.['code'] as SearchParameter;
+    const onPrompt = jest.fn();
+
+    await setup({
+      search: {
+        resourceType: 'MedicationRequest',
+      },
+      searchParams: [searchParam],
+      onPrompt,
+    });
+
+    const options = [
+      { text: 'Equals...', operator: Operator.EQUALS },
+      { text: 'Does not equal...', operator: Operator.NOT },
+      { text: 'Text contains...', operator: Operator.TEXT },
+    ];
+
+    for (const option of options) {
+      onPrompt.mockClear();
+
+      const optionButton = await screen.findByText(option.text);
+      await act(async () => {
+        fireEvent.click(optionButton);
+      });
+
+      expect(onPrompt).toHaveBeenCalledWith(searchParam, {
+        code: 'code',
+        operator: option.operator,
+        value: '',
+      } as Filter);
+    }
+  });
+
+  test('URI submenu prompt', async () => {
+    const searchParam = globalSchema.types['Device'].searchParams?.['url'] as SearchParameter;
+    const onPrompt = jest.fn();
+
+    await setup({
+      search: {
+        resourceType: 'Device',
+      },
+      searchParams: [searchParam],
+      onPrompt,
+    });
+
+    const options = [
+      { text: 'Equals...', operator: Operator.EQUALS },
+      { text: 'Does not equal...', operator: Operator.NOT },
+    ];
+
+    for (const option of options) {
+      onPrompt.mockClear();
+
+      const optionButton = await screen.findByText(option.text);
+      await act(async () => {
+        fireEvent.click(optionButton);
+      });
+
+      expect(onPrompt).toHaveBeenCalledWith(searchParam, {
+        code: 'url',
+        operator: option.operator,
+        value: '',
+      } as Filter);
+    }
+  });
+
   test('Renders meta.versionId', async () => {
     const search: SearchRequest = {
       resourceType: 'Patient',

--- a/packages/react/src/SearchPopupMenu/SearchPopupMenu.tsx
+++ b/packages/react/src/SearchPopupMenu/SearchPopupMenu.tsx
@@ -109,8 +109,9 @@ function SearchParameterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
     case 'string':
       return <TextFilterSubMenu {...props} />;
     case 'token':
-    case 'uri':
       return <TokenFilterSubMenu {...props} />;
+    case 'uri':
+      return <UriFilterSubMenu {...props} />;
     default:
       return <>Unknown search param type: {props.searchParam.type}</>;
   }
@@ -307,6 +308,25 @@ function TextFilterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
 }
 
 function TokenFilterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
+  const { searchParam } = props;
+  return (
+    <Menu.Dropdown>
+      <Menu.Item leftSection={<IconEqual size={14} />} onClick={() => props.onPrompt(searchParam, Operator.EQUALS)}>
+        Equals...
+      </Menu.Item>
+      <Menu.Item leftSection={<IconEqualNot size={14} />} onClick={() => props.onPrompt(searchParam, Operator.NOT)}>
+        Does not equal...
+      </Menu.Item>
+      <Menu.Divider />
+      <Menu.Item leftSection={<IconEqual size={14} />} onClick={() => props.onPrompt(searchParam, Operator.TEXT)}>
+        Text contains...
+      </Menu.Item>
+      <CommonMenuItems {...props} />
+    </Menu.Dropdown>
+  );
+}
+
+function UriFilterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
   const { searchParam } = props;
   return (
     <Menu.Dropdown>


### PR DESCRIPTION
Added "Text contains..." to the popup menu:

<img width="723" height="473" alt="image" src="https://github.com/user-attachments/assets/0e9366dd-1399-4f06-bcf4-4d8b6023ba64" />


Added "text" to the filter editor dialog:

<img width="1263" height="363" alt="image" src="https://github.com/user-attachments/assets/fa609814-360e-4c9b-aa85-b287f69511fa" />
