### PR TITLE
Update copyright strings in readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,3 @@ Thanks to [Chromatic](https://www.chromatic.com/) for providing the visual testi
 ## License
 
 [Apache 2.0](LICENSE.txt)
-
-Copyright &copy; Medplum 2025
-
-FHIR&reg; is a registered trademark of HL7.
-
-SNOMED&reg; is a registered trademark of the International Health Terminology Standards Development Organisation.
-
-LOINC&reg; is a registered trademark of Regenstrief Institute, Inc.
-
-DICOM&reg; is the registered trademark of the National Electrical Manufacturers Association (NEMA).

--- a/packages/ccda/README.md
+++ b/packages/ccda/README.md
@@ -8,20 +8,15 @@ The `@medplum/ccda` package enables seamless conversion between C-CDA and FHIR, 
 
 **Key Features:**
 
-* **C-CDA to FHIR:** Convert a C-CDA document to a FHIR Composition bundle using the `convertCcdaToFhir` function.
-* **FHIR to C-CDA:** Convert a FHIR Composition bundle to a C-CDA document using the `convertFhirToCcda` function.
-* **XML Parsing:** Load a C-CDA document from an XML string using the `convertXmlToCcda` function.
-* **XML Serialization:** Serialize a C-CDA document to an XML string using the `convertCcdaToXml` function.
+- **C-CDA to FHIR:** Convert a C-CDA document to a FHIR Composition bundle using the `convertCcdaToFhir` function.
+- **FHIR to C-CDA:** Convert a FHIR Composition bundle to a C-CDA document using the `convertFhirToCcda` function.
+- **XML Parsing:** Load a C-CDA document from an XML string using the `convertXmlToCcda` function.
+- **XML Serialization:** Serialize a C-CDA document to an XML string using the `convertCcdaToXml` function.
 
 ## Usage
 
 ```typescript
-import {
-  convertCcdaToFhir,
-  convertFhirToCcda,
-  convertXmlToCcda,
-  convertCcdaToXml,
-} from '@medplum/ccda';
+import { convertCcdaToFhir, convertFhirToCcda, convertXmlToCcda, convertCcdaToXml } from '@medplum/ccda';
 
 // Convert C-CDA to FHIR
 const bundle = convertCcdaToFhir(ccda);
@@ -40,12 +35,12 @@ const xml = convertCcdaToXml(ccda);
 
 This library is designed to elegantly integrate the following standards and specifications:
 
-* **FHIR R4:** The underlying data model for representing healthcare resources.
-* **US Core:**  A set of FHIR profiles and extensions for US healthcare interoperability.
-* **USCDI:** The United States Core Data for Interoperability, defining a standardized set of health data classes and elements.
-* **International Patient Summary (IPS):** A FHIR-based standard for exchanging patient summaries.
-* **HL7 C-CDA:** A widely used standard for clinical document exchange.
-* **C-CDA R2.1 for USCDI v3:** A specific implementation of C-CDA aligned with the USCDI v3 standard.
+- **FHIR R4:** The underlying data model for representing healthcare resources.
+- **US Core:** A set of FHIR profiles and extensions for US healthcare interoperability.
+- **USCDI:** The United States Core Data for Interoperability, defining a standardized set of health data classes and elements.
+- **International Patient Summary (IPS):** A FHIR-based standard for exchanging patient summaries.
+- **HL7 C-CDA:** A widely used standard for clinical document exchange.
+- **C-CDA R2.1 for USCDI v3:** A specific implementation of C-CDA aligned with the USCDI v3 standard.
 
 By aligning with these standards, this library ensures that C-CDA documents can be effectively converted to and from FHIR, enabling interoperability with modern healthcare systems and applications.
 
@@ -53,25 +48,24 @@ By aligning with these standards, this library ensures that C-CDA documents can 
 
 In addition to the core conversion functions, Medplum provides FHIR server operations for seamless C-CDA import and export:
 
-* **`Patient/{id}/$ccda-import`:** Imports a C-CDA document and updates the corresponding patient record.
-* **`Patient/{id}/$ccda-export`:** Exports a patient's data as a C-CDA document.
+- **`Patient/{id}/$ccda-import`:** Imports a C-CDA document and updates the corresponding patient record.
+- **`Patient/{id}/$ccda-export`:** Exports a patient's data as a C-CDA document.
 
 These operations are documented in the Medplum FHIR server documentation.
 
 ## Additional Notes
 
-* This library is actively maintained and updated to support the latest versions of FHIR, US Core, and C-CDA standards.
-* Contributions and feedback are welcome! Please submit issues or pull requests on GitHub.
+- This library is actively maintained and updated to support the latest versions of FHIR, US Core, and C-CDA standards.
+- Contributions and feedback are welcome! Please submit issues or pull requests on GitHub.
 
 **Links:**
 
-* [Medplum FHIR Server Documentation](https://www.medplum.com/docs/api/fhir)
-* [FHIR R4 Specification](https://hl7.org/fhir/R4/)
-* [US Core Implementation Guide](https://www.hl7.org/fhir/us/core/)
-* [USCDI Website](https://www.healthit.gov/isp/united-states-core-data-interoperability-uscdi)
-* [International Patient Summary Implementation Guide](https://build.fhir.org/ig/HL7/fhir-ips/)
-* [HL7 C-CDA Standard](https://hl7.org/cda/us/ccda/3.0.0/)
-
+- [Medplum FHIR Server Documentation](https://www.medplum.com/docs/api/fhir)
+- [FHIR R4 Specification](https://hl7.org/fhir/R4/)
+- [US Core Implementation Guide](https://www.hl7.org/fhir/us/core/)
+- [USCDI Website](https://www.healthit.gov/isp/united-states-core-data-interoperability-uscdi)
+- [International Patient Summary Implementation Guide](https://build.fhir.org/ig/HL7/fhir-ips/)
+- [HL7 C-CDA Standard](https://hl7.org/cda/us/ccda/3.0.0/)
 
 ## About Medplum
 
@@ -79,4 +73,4 @@ Medplum is a healthcare platform that helps you quickly develop high-quality com
 
 ## License
 
-Apache 2.0. Copyright &copy; Medplum 2025
+[Apache 2.0](../../LICENSE.txt)

--- a/packages/cli-wrapper/README.md
+++ b/packages/cli-wrapper/README.md
@@ -18,4 +18,4 @@ Medplum is a healthcare platform that helps you quickly develop high-quality com
 
 ## License
 
-Apache 2.0. Copyright &copy; Medplum 2025
+[Apache 2.0](../../LICENSE.txt)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,4 +26,4 @@ Medplum is a healthcare platform that helps you quickly develop high-quality com
 
 ## License
 
-Apache 2.0. Copyright &copy; Medplum 2025
+[Apache 2.0](../../LICENSE.txt)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -239,4 +239,4 @@ Medplum is a healthcare platform that helps you quickly develop high-quality com
 
 ## License
 
-Apache 2.0. Copyright &copy; Medplum 2025
+[Apache 2.0](../../LICENSE.txt)

--- a/packages/create-medplum/README.md
+++ b/packages/create-medplum/README.md
@@ -22,4 +22,4 @@ Medplum is a healthcare platform that helps you quickly develop high-quality com
 
 ## License
 
-Apache 2.0. Copyright &copy; Medplum 2025
+[Apache 2.0](../../LICENSE.txt)

--- a/packages/definitions/README.md
+++ b/packages/definitions/README.md
@@ -16,4 +16,4 @@ Medplum is a healthcare platform that helps you quickly develop high-quality com
 
 ## License
 
-Apache 2.0. Copyright &copy; Medplum 2025
+[Apache 2.0](../../LICENSE.txt)

--- a/packages/fhir-router/README.md
+++ b/packages/fhir-router/README.md
@@ -8,4 +8,4 @@ Medplum is a healthcare platform that helps you quickly develop high-quality com
 
 ## License
 
-Apache 2.0. Copyright &copy; Medplum 2025
+[Apache 2.0](../../LICENSE.txt)

--- a/packages/fhirtypes/README.md
+++ b/packages/fhirtypes/README.md
@@ -64,4 +64,4 @@ Medplum is a healthcare platform that helps you quickly develop high-quality com
 
 ## License
 
-Apache 2.0. Copyright &copy; Medplum 2025
+[Apache 2.0](../../LICENSE.txt)

--- a/packages/hl7/README.md
+++ b/packages/hl7/README.md
@@ -10,4 +10,4 @@ See: https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings
 
 ## License
 
-Apache 2.0. Copyright &copy; Medplum 2025
+[Apache 2.0](../../LICENSE.txt)

--- a/packages/mock/README.md
+++ b/packages/mock/README.md
@@ -48,4 +48,4 @@ Medplum is a healthcare platform that helps you quickly develop high-quality com
 
 ## License
 
-Apache 2.0. Copyright &copy; Medplum 2025
+[Apache 2.0](../../LICENSE.txt)

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -113,4 +113,4 @@ Medplum is a healthcare platform that helps you quickly develop high-quality com
 
 ## License
 
-Apache 2.0. Copyright &copy; Medplum 2025
+[Apache 2.0](../../LICENSE.txt)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -86,4 +86,4 @@ Medplum is a healthcare platform that helps you quickly develop high-quality com
 
 ## License
 
-Apache 2.0. Copyright &copy; Medplum 2025
+[Apache 2.0](../../LICENSE.txt)


### PR DESCRIPTION
Simplifies the License section across README files to reference only the LICENSE.txt file.

**Changes:**
- Remove redundant copyright notice (already present in LICENSE.txt)
- Remove third-party trademark acknowledgments

**Rationale:**

The Apache 2.0 LICENSE.txt file is the authoritative source for copyright and licensing information. Duplicating copyright notices in READMEs creates maintenance burden (e.g., annual year updates) without providing additional legal protection—copyright is automatic under the Berne Convention and doesn't require notice.

Third-party trademark acknowledgments (FHIR, SNOMED, LOINC, DICOM) are not required for referential use of these terms. This is consistent with how other healthcare technology projects handle their READMEs.
