### PR TITLE
feat(docs): Add Metriport to integration partners list

### DIFF
--- a/packages/docs/docs/integration/index.md
+++ b/packages/docs/docs/integration/index.md
@@ -57,6 +57,12 @@ Medplum supports the following first party integrations.
       <td colspan="4"><strong>Clinical Systems (EHR, HIE, Labs)</strong></td>
     </tr>
     <tr>
+      <td><a href="https://www.metriport.com/">Metriport</a></td>
+      <td>HIE</td>
+      <td>Nationwide patient record aggregation via CareQuality, CommonWell, and eHealth Exchange</td>
+      <td><a href="https://docs.metriport.com/medical-api/getting-started/quickstart">Metriport Medical API</a></td>
+    </tr>
+    <tr>
       <td><a href="https://www.epic.com/">Epic Systems</a></td>
       <td>EHR</td>
       <td>Read/Write via FHIR API</td>


### PR DESCRIPTION
Add Metriport to the first-party integrations table under Clinical Systems (HIE).

[Metriport](https://www.metriport.com/) is an open-source healthcare data API that provides nationwide patient record aggregation via CareQuality, CommonWell, and eHealth Exchange HIE networks.

Metriport uses several Medplum open-source packages (`@medplum/core`, `@medplum/fhirtypes`, `@medplum/fhir-router`, `@medplum/hl7`) to power its FHIR operations, terminology server, and HL7v2 processing.

<img width="2558" height="1234" alt="Screenshot 2026-02-12 at 10 11 30 AM" src="https://github.com/user-attachments/assets/f75af9bd-2265-4152-84a4-3e70c206c3c1" />
