### PR TITLE
Prevent client caching of Abort signals

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3439,6 +3439,14 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   private setCacheEntry(key: string, value: ReadablePromise<any>, options: MedplumRequestOptions | undefined): void {
     if (this.isCacheEnabled(options)) {
       this.requestCache.set(key, { requestTime: Date.now(), value });
+
+      // If the request is aborted, remove the abort result from the cache so
+      // later attempts will not re-resolve the abort.
+      if (options?.signal) {
+        options.signal.addEventListener('abort', () => {
+          this.requestCache.delete(key);
+        });
+      }
     }
   }
 


### PR DESCRIPTION
When React is in Strict Mode, effects are run twice (https://react.dev/reference/react/StrictMode#fixing-bugs-found-by-re-running-effects-in-development).

When working on the Scheduling $find Pane, I added an effect with an abort controller that would try to clean up any outstanding requests. This was running once and getting removed by the strict mode double-up.

That had the surprising side-effect of leaving a rejected promise in the client cache. That value represents that the specific request was cancelled, not that any future requests should immediately reject as aborted.

Adding this signal handler that removes the promise from the cache is an incremental step. There is a broader problem if multiple requesters are attached to the promise and the original aborts, but I am not handling that at this time.