### PR TITLE
Fix scheduling ops during UTC/local date discrepancy

### DIFF
--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -13,12 +13,9 @@ type DayOfWeek = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
 const dayNames: DayOfWeek[] = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
 
 function eachDayOfInterval(interval: Interval, timeZone: string): Temporal.ZonedDateTime[] {
-  let t = Temporal.ZonedDateTime.from({
-    year: interval.start.getFullYear(),
-    month: interval.start.getMonth() + 1,
-    day: interval.start.getDate(),
-    timeZone,
-  });
+  let t = Temporal.Instant.fromEpochMilliseconds(interval.start.valueOf())
+    .toZonedDateTimeISO(timeZone)
+    .withPlainTime({ hour: 0, minute: 0, second: 0, millisecond: 0 });
 
   const results: Temporal.ZonedDateTime[] = [];
   while (t.epochMilliseconds < interval.end.valueOf()) {


### PR DESCRIPTION
For operations like `$find` and `$book`, there is an interesting edge case: when the server is run in a different time zone (such as a server in UTC and clients in the US), there is a window where the current date in the server local time is different from the client date.

The original implementation of `eachDayOfInterval` naively used the date component from the interval start without the time components, and so wasn't shifting appropriately to the correct time when the timezone information was added.

I've adjusted the implementation to begin by creating an exact `Temporal.Instant` from the interval start date, and then using `.toZonedDateTime(timezone)` to shift that into the desired timezone. Finally, to keep the previous behavior of emitting start-of-day temporal instances, we explicitly set the time components to zero with `withPlainTime(...)`.

Implementation Note: Testing this is a bit of a chore. The test case as written passes on my machine when run naively with `npm test`, because Node defaults to running with the same time zone as the local system. You can see the test fail by explicitly setting the process to be in a different timezone: `TZ=utc npm test`. Ideally we should be able to test different server/client timezone options, but adjusting the Node timezone after startup seems to be more fraught than expected (see packages like https://www.npmjs.com/package/timezone-mock for some potential solutions).

For now I'm adding a test case that would reveal the problem in CI, where tests are run with the system time set to UTC. In the long term, we probably want a set of integration tests that spin up servers with a variety of configurations, which would allow us to test multiple servers with different timezones and compare their results. I'm deferring building that into the future for now.

Fixes: https://github.com/medplum/medplum/issues/8417