### PR TITLE
Allow specifying timezone only on SchedulingParameters for $find

### DIFF
--- a/packages/core/src/outcomes.test.ts
+++ b/packages/core/src/outcomes.test.ts
@@ -89,6 +89,10 @@ describe('Outcomes', () => {
   test('Bad Request', () => {
     expect(isOk(badRequest('bad'))).toBe(false);
     expect(badRequest('bad', 'bad').issue?.[0]?.expression?.[0]).toBe('bad');
+    expect(badRequest('bad', ['Patient.extension[0]', 'Patient.extension[1]']).issue?.[0]?.expression).toEqual([
+      'Patient.extension[0]',
+      'Patient.extension[1]',
+    ]);
   });
 
   test.each([

--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -219,7 +219,10 @@ export function accepted(location: string): OperationOutcome {
   };
 }
 
-export function badRequest(details: string, expression?: string): OperationOutcome {
+export function badRequest(details: string, expression?: string | string[]): OperationOutcome {
+  if (typeof expression === 'string') {
+    expression = [expression];
+  }
   return {
     resourceType: 'OperationOutcome',
     issue: [
@@ -229,7 +232,7 @@ export function badRequest(details: string, expression?: string): OperationOutco
         details: {
           text: details,
         },
-        ...(expression ? { expression: [expression] } : undefined),
+        ...(expression ? { expression } : undefined),
       },
     ],
   };

--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -9,6 +9,7 @@ import { loadTestConfig } from '../../config/loader';
 import { getSystemRepo } from '../../fhir/repo';
 import type { TestProjectResult } from '../../test.setup';
 import { createTestProject } from '../../test.setup';
+import { TimezoneExtensionURI } from './utils/scheduling';
 
 const systemRepo = getSystemRepo();
 const app = express();
@@ -60,12 +61,12 @@ describe('Schedule/:id/$find', () => {
     practitioner = await systemRepo.createResource<Practitioner>({
       resourceType: 'Practitioner',
       meta: { project: project.project.id },
-      extension: [{ url: 'http://hl7.org/fhir/StructureDefinition/timezone', valueCode: 'America/New_York' }],
+      extension: [{ url: TimezoneExtensionURI, valueCode: 'America/New_York' }],
     });
     location = await systemRepo.createResource<Location>({
       resourceType: 'Location',
       meta: { project: project.project.id },
-      extension: [{ url: 'http://hl7.org/fhir/StructureDefinition/timezone', valueCode: 'America/Phoenix' }],
+      extension: [{ url: TimezoneExtensionURI, valueCode: 'America/Phoenix' }],
     });
   });
 
@@ -612,6 +613,36 @@ describe('Schedule/:id/$find', () => {
         },
       ],
     });
+  });
+
+  test('When no timezone is available', async () => {
+    // no timezone extension no practitioner
+    const practitioner = await systemRepo.createResource<Practitioner>({
+      resourceType: 'Practitioner',
+      meta: { project: project.project.id },
+    });
+    // no timezone in scheduling parameters sub extensions
+    const schedule = await makeSchedule(
+      {
+        [wildcard]: { availability: fourDayWorkWeek, duration: 20 },
+      },
+      { actor: [createReference(practitioner)] }
+    );
+
+    const response = await request
+      .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .query({
+        start: new Date('2025-12-04T10:00:00.000-05:00'),
+        end: new Date('2025-12-04T14:00:00.000-05:00'),
+        'service-type': 'http://example.com|new-patient,http://example.com|other',
+      });
+    expect(response.status).toBe(400);
+    expect(response.body.issue[0]).toHaveProperty('expression', [
+      `Schedule.actor[0].extension(${TimezoneExtensionURI})`,
+      'Schedule.extension[0]',
+    ]);
   });
 
   test('with a service-type parameter', async () => {

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -155,12 +155,6 @@ export async function scheduleFindHandler(req: FhirRequest): Promise<FhirRespons
   }
   const actor = await ctx.repo.readReference(schedule.actor[0]);
   const actorTimeZone = getTimeZone(actor);
-  if (!actorTimeZone) {
-    throw new OperationOutcomeError(
-      badRequest('No timezone specified', `Schedule.actor[0].extension(${TimezoneExtensionURI})`)
-    );
-  }
-
   const allSchedulingParameters = parseSchedulingParametersExtensions(schedule);
 
   const resultSlots: Slot[] = flatMapMax(
@@ -168,6 +162,15 @@ export async function scheduleFindHandler(req: FhirRequest): Promise<FhirRespons
     ([schedulingParameters, serviceType], _idx, maxCount) => {
       // If the scheduling parameters explicitly declare a timezone, use it instead of the actor's TZ
       const activeTimeZone = schedulingParameters.timezone ?? actorTimeZone;
+      if (!activeTimeZone) {
+        throw new OperationOutcomeError(
+          badRequest('No timezone specified', [
+            `Schedule.actor[0].extension(${TimezoneExtensionURI})`,
+            schedulingParameters.path,
+          ])
+        );
+      }
+
       let availability = resolveAvailability(schedulingParameters, range, activeTimeZone);
       availability = applyExistingSlots({
         availability,

--- a/packages/server/src/fhir/operations/utils/find.test.ts
+++ b/packages/server/src/fhir/operations/utils/find.test.ts
@@ -162,6 +162,7 @@ describe('findSlotTimes', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       serviceType: [],
+      path: 'Schedule.extension[0]',
     };
     const availability = [{ start: new Date('2025-12-01T12:00:00Z'), end: new Date('2025-12-01T15:00:00Z') }];
     expect(findSlotTimes(schedulingParameters, availability)).toEqual([
@@ -180,6 +181,7 @@ describe('findSlotTimes', () => {
       alignmentInterval: 30,
       alignmentOffset: 15,
       serviceType: [],
+      path: 'Schedule.extension[0]',
     };
     const availability = [{ start: new Date('2025-12-01T12:00:00Z'), end: new Date('2025-12-01T15:00:00Z') }];
     expect(findSlotTimes(schedulingParameters, availability)).toEqual([
@@ -200,6 +202,7 @@ describe('findSlotTimes', () => {
       alignmentInterval: 30,
       alignmentOffset: 15,
       serviceType: [],
+      path: 'Schedule.extension[0]',
     };
     const availability = [{ start: new Date('2025-12-01T12:00:00Z'), end: new Date('2025-12-01T15:00:00Z') }];
     expect(findSlotTimes(schedulingParameters, availability)).toEqual([
@@ -220,6 +223,7 @@ describe('findSlotTimes', () => {
       alignmentInterval: 30,
       alignmentOffset: 15,
       serviceType: [],
+      path: 'Schedule.extension[0]',
     };
     const availability = [{ start: new Date('2025-12-01T12:00:00Z'), end: new Date('2025-12-01T15:00:00Z') }];
     expect(findSlotTimes(schedulingParameters, availability, { maxCount: 3 })).toEqual([

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -61,6 +61,7 @@ export type SchedulingParameters = {
   duration: number; // minutes
   serviceType: CodeableConcept[]; // codes that may be booked into this availability
   timezone?: string;
+  path: string;
 };
 
 function durationToMinutes(duration: Duration): number {
@@ -111,10 +112,11 @@ function exactlyOne<T>(arr: T[], attribute: string): T {
  * @returns SchedulingParameters[] - An array of objects describing scheduling configuration
  */
 export function parseSchedulingParametersExtensions(resource: Schedule | ActivityDefinition): SchedulingParameters[] {
-  const extensions = (resource.extension ?? []).filter(
-    (ext) => ext.url === SchedulingParametersURI
-  ) as SchedulingParametersExtension[];
-  return extensions.map((extension) => {
+  const extensions = (resource.extension ?? [])
+    .map((ext, index) => [ext, index] as const)
+    .filter(([ext, _index]) => ext.url === SchedulingParametersURI) as [SchedulingParametersExtension, number][];
+
+  return extensions.map(([extension, index]) => {
     const duration = exactlyOne(
       extension.extension.filter((ext) => ext.url === 'duration'),
       'duration'
@@ -173,6 +175,7 @@ export function parseSchedulingParametersExtensions(resource: Schedule | Activit
       duration: durationToMinutes(duration.valueDuration),
       serviceType,
       timezone: timezone?.valueCode,
+      path: `${resource.resourceType}.extension[${index}]`,
     };
   });
 }

--- a/packages/server/src/fhir/operations/utils/scheduling.test.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.test.ts
@@ -40,6 +40,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       serviceType: [],
+      path: 'Schedule.extension[0]',
     };
 
     const range = {
@@ -73,6 +74,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       serviceType: [],
+      path: 'Schedule.extension[0]',
     };
 
     const range = {
@@ -101,6 +103,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       serviceType: [],
+      path: 'Schedule.extension[0]',
     };
 
     const range = {
@@ -129,6 +132,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       serviceType: [],
+      path: 'Schedule.extension[0]',
     };
 
     const range = {
@@ -157,6 +161,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       serviceType: [],
+      path: 'Schedule.extension[0]',
     };
 
     // NY has a DST "spring forward" on March 8 2026
@@ -195,6 +200,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       serviceType: [],
+      path: 'Schedule.extension[0]',
     };
 
     // NY has a DST "spring forward" on March 8 2026
@@ -235,6 +241,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       serviceType: [],
+      path: 'Schedule.extension[0]',
     };
 
     // NY has a DST "fall back" on Nov 2 2025: 1:30am: happens twice
@@ -264,6 +271,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       serviceType: [],
+      path: 'Schedule.extension[0]',
     };
 
     // NY has a DST "spring forward" on March 8 2026; 2:30am never happens


### PR DESCRIPTION
In the original implementation, we had expected that timezone would
always be expressed as an attribute of an actor, and so had made that a
requirement to use the scheduling features.

Some use cases exist where folks want to specify the timezone in the
scheduling parameters extension - this likely will be more useful in the
future when this extension can be specified on a shared
ActivityDefinition that could be used for all practitioners in a state,
for example.

Spec update introducing this: commit https://github.com/medplum/medplum/commit/ba37a1b638d4ecb9368f9a987bb0e90724606e2e (https://github.com/medplum/medplum/pull/8158)
Original parameter implementation: commit https://github.com/medplum/medplum/commit/dad7aa0ed2a71b73f1cd6135c0d5961ef554efca (https://github.com/medplum/medplum/pull/8247)