### PR TITLE
Add SCIM group management endpoints

### DIFF
--- a/packages/definitions/src/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/src/fhir/r4/profiles-medplum.json
@@ -3785,6 +3785,19 @@
             }
           },
           {
+            "id" : "AccessPolicy.identifier",
+            "path" : "AccessPolicy.identifier",
+            "definition" : "Identifier(s) used to match this access policy to an external system such as a SCIM group. Set the value to the SCIM group externalId to enable automatic assignment.",
+            "min" : 0,
+            "max" : "*",
+            "type" : [{ "code" : "Identifier" }],
+            "base" : {
+              "path" : "AccessPolicy.identifier",
+              "min" : 0,
+              "max" : "*"
+            }
+          },
+          {
             "id" : "AccessPolicy.basedOn",
             "path" : "AccessPolicy.basedOn",
             "definition" : "Other access policies used to derive this access policy.",

--- a/packages/fhirtypes/dist/AccessPolicy.d.ts
+++ b/packages/fhirtypes/dist/AccessPolicy.d.ts
@@ -7,6 +7,7 @@
 
 import type { Expression } from './Expression.d.ts';
 import type { Extension } from './Extension.d.ts';
+import type { Identifier } from './Identifier.d.ts';
 import type { Meta } from './Meta.d.ts';
 import type { Narrative } from './Narrative.d.ts';
 import type { Reference } from './Reference.d.ts';
@@ -98,6 +99,13 @@ export interface AccessPolicy {
    * A name associated with the AccessPolicy.
    */
   name?: string;
+
+  /**
+   * Identifier(s) used to match this access policy to an external system
+   * such as a SCIM group. Set the value to the SCIM group externalId to
+   * enable automatic assignment.
+   */
+  identifier?: Identifier[];
 
   /**
    * Other access policies used to derive this access policy.

--- a/packages/server/src/scim/routes.test.ts
+++ b/packages/server/src/scim/routes.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { ContentType, createReference } from '@medplum/core';
-import type { AccessPolicy } from '@medplum/fhirtypes';
+import type { AccessPolicy, ProjectMembership } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
@@ -178,6 +178,468 @@ describe('SCIM Routes', () => {
       });
     expect(res.status).toBe(201);
     expect(res.body.userType).toBe('Practitioner');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Group tests
+  // ---------------------------------------------------------------------------
+
+  test('Search groups (empty)', async () => {
+    const res = await request(app)
+      .get('/scim/v2/Groups')
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res.status).toBe(200);
+    expect(res.body.schemas).toContain('urn:ietf:params:scim:api:messages:2.0:ListResponse');
+    expect(Array.isArray(res.body.Resources)).toBe(true);
+  });
+
+  test('Create group (no members)', async () => {
+    const res = await request(app)
+      .post('/scim/v2/Groups')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+        displayName: 'Test Group',
+        externalId: randomUUID(),
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBeDefined();
+    expect(res.body.displayName).toBe('Test Group');
+    expect(res.body.members).toEqual([]);
+  });
+
+  test('Create group, read group, search groups', async () => {
+    const externalId = randomUUID();
+    const createRes = await request(app)
+      .post('/scim/v2/Groups')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+        displayName: 'Read Group',
+        externalId,
+      });
+    expect(createRes.status).toBe(201);
+    const groupId = createRes.body.id;
+
+    // Read by ID
+    const readRes = await request(app)
+      .get(`/scim/v2/Groups/${groupId}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(readRes.status).toBe(200);
+    expect(readRes.body.id).toBe(groupId);
+    expect(readRes.body.externalId).toBe(externalId);
+    expect(readRes.body.displayName).toBe('Read Group');
+
+    // Search
+    const searchRes = await request(app)
+      .get('/scim/v2/Groups')
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(searchRes.status).toBe(200);
+    const found = searchRes.body.Resources.find((g: any) => g.id === groupId);
+    expect(found).toBeDefined();
+  });
+
+  test('Create group with members + matching AccessPolicy assigns access', async () => {
+    const systemRepo = getSystemRepo();
+
+    // Create a user to be a group member
+    const userRes = await request(app)
+      .post('/scim/v2/Users')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userType: 'Practitioner',
+        name: { givenName: 'Group', familyName: 'Member' },
+        emails: [{ value: randomUUID() + '@example.com' }],
+      });
+    expect(userRes.status).toBe(201);
+    const membershipId = userRes.body.id;
+
+    // Create an AccessPolicy with identifier matching the externalId
+    const externalId = randomUUID();
+    const policy = await systemRepo.createResource<AccessPolicy>({
+      resourceType: 'AccessPolicy',
+      name: 'Group Policy',
+      identifier: [{ system: 'https://medplum.com/scim/group', value: externalId }],
+      resource: [{ resourceType: 'Practitioner' }],
+    });
+
+    // Create group with the member
+    const groupRes = await request(app)
+      .post('/scim/v2/Groups')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+        displayName: 'Policy Group',
+        externalId,
+        members: [{ value: membershipId }],
+      });
+    expect(groupRes.status).toBe(201);
+    expect(groupRes.body.members).toHaveLength(1);
+    expect(groupRes.body.members[0].value).toBe(membershipId);
+
+    // Verify that the membership now has the policy in access[]
+    const membership = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId);
+    const hasPolicy = membership.access?.some((a) => a.policy?.reference === `AccessPolicy/${policy.id}`);
+    expect(hasPolicy).toBe(true);
+  });
+
+  test('Create group with no matching AccessPolicy succeeds without error', async () => {
+    const externalId = randomUUID(); // No policy with this externalId
+
+    const userRes = await request(app)
+      .post('/scim/v2/Users')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userType: 'Practitioner',
+        name: { givenName: 'No', familyName: 'Policy' },
+        emails: [{ value: randomUUID() + '@example.com' }],
+      });
+    expect(userRes.status).toBe(201);
+
+    const groupRes = await request(app)
+      .post('/scim/v2/Groups')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+        displayName: 'No Policy Group',
+        externalId,
+        members: [{ value: userRes.body.id }],
+      });
+    expect(groupRes.status).toBe(201);
+    expect(groupRes.body.members).toHaveLength(1);
+  });
+
+  test('PATCH add member to group', async () => {
+    const systemRepo = getSystemRepo();
+
+    // Create group
+    const externalId = randomUUID();
+    const policy = await systemRepo.createResource<AccessPolicy>({
+      resourceType: 'AccessPolicy',
+      name: 'Patch Policy',
+      identifier: [{ system: 'https://medplum.com/scim/group', value: externalId }],
+      resource: [{ resourceType: 'Practitioner' }],
+    });
+
+    const groupRes = await request(app)
+      .post('/scim/v2/Groups')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+        displayName: 'Patch Group',
+        externalId,
+      });
+    expect(groupRes.status).toBe(201);
+    const groupId = groupRes.body.id;
+
+    // Create a user to add
+    const userRes = await request(app)
+      .post('/scim/v2/Users')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userType: 'Practitioner',
+        name: { givenName: 'Patch', familyName: 'Add' },
+        emails: [{ value: randomUUID() + '@example.com' }],
+      });
+    expect(userRes.status).toBe(201);
+    const membershipId = userRes.body.id;
+
+    // PATCH add member
+    const patchRes = await request(app)
+      .patch(`/scim/v2/Groups/${groupId}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+        Operations: [{ op: 'add', path: 'members', value: [{ value: membershipId }] }],
+      });
+    expect(patchRes.status).toBe(200);
+    expect(patchRes.body.members).toHaveLength(1);
+    expect(patchRes.body.members[0].value).toBe(membershipId);
+
+    // Verify access assigned
+    const membership = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId);
+    const hasPolicy = membership.access?.some((a) => a.policy?.reference === `AccessPolicy/${policy.id}`);
+    expect(hasPolicy).toBe(true);
+  });
+
+  test('PATCH remove member from group (filter syntax)', async () => {
+    const systemRepo = getSystemRepo();
+
+    // Create group with a member
+    const externalId = randomUUID();
+    const policy = await systemRepo.createResource<AccessPolicy>({
+      resourceType: 'AccessPolicy',
+      name: 'Remove Policy',
+      identifier: [{ system: 'https://medplum.com/scim/group', value: externalId }],
+      resource: [{ resourceType: 'Practitioner' }],
+    });
+
+    const userRes = await request(app)
+      .post('/scim/v2/Users')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userType: 'Practitioner',
+        name: { givenName: 'Remove', familyName: 'Member' },
+        emails: [{ value: randomUUID() + '@example.com' }],
+      });
+    expect(userRes.status).toBe(201);
+    const membershipId = userRes.body.id;
+
+    const groupRes = await request(app)
+      .post('/scim/v2/Groups')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+        displayName: 'Remove Group',
+        externalId,
+        members: [{ value: membershipId }],
+      });
+    expect(groupRes.status).toBe(201);
+    const groupId = groupRes.body.id;
+
+    // Verify access was assigned
+    const membershipBefore = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId);
+    expect(membershipBefore.access?.some((a) => a.policy?.reference === `AccessPolicy/${policy.id}`)).toBe(true);
+
+    // PATCH remove member
+    const patchRes = await request(app)
+      .patch(`/scim/v2/Groups/${groupId}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+        Operations: [{ op: 'remove', path: `members[value eq "${membershipId}"]` }],
+      });
+    expect(patchRes.status).toBe(200);
+    expect(patchRes.body.members).toHaveLength(0);
+
+    // Verify access was removed
+    const membershipAfter = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId);
+    expect(membershipAfter.access?.some((a) => a.policy?.reference === `AccessPolicy/${policy.id}`)).toBeFalsy();
+  });
+
+  test('PATCH replace members', async () => {
+    // Create two users
+    const user1Res = await request(app)
+      .post('/scim/v2/Users')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userType: 'Practitioner',
+        name: { givenName: 'Replace', familyName: 'One' },
+        emails: [{ value: randomUUID() + '@example.com' }],
+      });
+    const user2Res = await request(app)
+      .post('/scim/v2/Users')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userType: 'Practitioner',
+        name: { givenName: 'Replace', familyName: 'Two' },
+        emails: [{ value: randomUUID() + '@example.com' }],
+      });
+    const membershipId1 = user1Res.body.id;
+    const membershipId2 = user2Res.body.id;
+
+    // Create group with user1
+    const externalId = randomUUID();
+    const groupRes = await request(app)
+      .post('/scim/v2/Groups')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+        displayName: 'Replace Group',
+        externalId,
+        members: [{ value: membershipId1 }],
+      });
+    const groupId = groupRes.body.id;
+
+    // PATCH replace members with user2
+    const patchRes = await request(app)
+      .patch(`/scim/v2/Groups/${groupId}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+        Operations: [{ op: 'replace', path: 'members', value: [{ value: membershipId2 }] }],
+      });
+    expect(patchRes.status).toBe(200);
+    expect(patchRes.body.members).toHaveLength(1);
+    expect(patchRes.body.members[0].value).toBe(membershipId2);
+  });
+
+  test('PATCH update displayName', async () => {
+    const groupRes = await request(app)
+      .post('/scim/v2/Groups')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+        displayName: 'Original Name',
+        externalId: randomUUID(),
+      });
+    expect(groupRes.status).toBe(201);
+    const groupId = groupRes.body.id;
+
+    const patchRes = await request(app)
+      .patch(`/scim/v2/Groups/${groupId}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+        Operations: [{ op: 'replace', path: 'displayName', value: 'Updated Name' }],
+      });
+    expect(patchRes.status).toBe(200);
+    expect(patchRes.body.displayName).toBe('Updated Name');
+  });
+
+  test('PUT replace group (full update)', async () => {
+    const systemRepo = getSystemRepo();
+
+    // Create two users
+    const user1Res = await request(app)
+      .post('/scim/v2/Users')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userType: 'Practitioner',
+        name: { givenName: 'Put', familyName: 'One' },
+        emails: [{ value: randomUUID() + '@example.com' }],
+      });
+    const user2Res = await request(app)
+      .post('/scim/v2/Users')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userType: 'Practitioner',
+        name: { givenName: 'Put', familyName: 'Two' },
+        emails: [{ value: randomUUID() + '@example.com' }],
+      });
+    const membershipId1 = user1Res.body.id;
+    const membershipId2 = user2Res.body.id;
+
+    const externalId = randomUUID();
+    const policy = await systemRepo.createResource<AccessPolicy>({
+      resourceType: 'AccessPolicy',
+      name: 'Put Policy',
+      identifier: [{ system: 'https://medplum.com/scim/group', value: externalId }],
+      resource: [{ resourceType: 'Practitioner' }],
+    });
+
+    // Create with user1
+    const createRes = await request(app)
+      .post('/scim/v2/Groups')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+        displayName: 'Put Group',
+        externalId,
+        members: [{ value: membershipId1 }],
+      });
+    expect(createRes.status).toBe(201);
+    const groupId = createRes.body.id;
+
+    // PUT with user2 instead
+    const putRes = await request(app)
+      .put(`/scim/v2/Groups/${groupId}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+        id: groupId,
+        displayName: 'Put Group Updated',
+        externalId,
+        members: [{ value: membershipId2 }],
+      });
+    expect(putRes.status).toBe(200);
+    expect(putRes.body.displayName).toBe('Put Group Updated');
+    expect(putRes.body.members).toHaveLength(1);
+    expect(putRes.body.members[0].value).toBe(membershipId2);
+
+    // user1 should have policy removed, user2 should have policy added
+    const m1After = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId1);
+    expect(m1After.access?.some((a) => a.policy?.reference === `AccessPolicy/${policy.id}`)).toBeFalsy();
+
+    const m2After = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId2);
+    expect(m2After.access?.some((a) => a.policy?.reference === `AccessPolicy/${policy.id}`)).toBe(true);
+  });
+
+  test('Delete group removes access from all members', async () => {
+    const systemRepo = getSystemRepo();
+
+    const externalId = randomUUID();
+    const policy = await systemRepo.createResource<AccessPolicy>({
+      resourceType: 'AccessPolicy',
+      name: 'Delete Policy',
+      identifier: [{ system: 'https://medplum.com/scim/group', value: externalId }],
+      resource: [{ resourceType: 'Practitioner' }],
+    });
+
+    const userRes = await request(app)
+      .post('/scim/v2/Users')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userType: 'Practitioner',
+        name: { givenName: 'Delete', familyName: 'Member' },
+        emails: [{ value: randomUUID() + '@example.com' }],
+      });
+    const membershipId = userRes.body.id;
+
+    const groupRes = await request(app)
+      .post('/scim/v2/Groups')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+        displayName: 'Delete Group',
+        externalId,
+        members: [{ value: membershipId }],
+      });
+    expect(groupRes.status).toBe(201);
+    const groupId = groupRes.body.id;
+
+    // Verify access assigned
+    const mBefore = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId);
+    expect(mBefore.access?.some((a) => a.policy?.reference === `AccessPolicy/${policy.id}`)).toBe(true);
+
+    // DELETE the group
+    const deleteRes = await request(app)
+      .delete(`/scim/v2/Groups/${groupId}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(deleteRes.status).toBe(204);
+
+    // Verify access removed
+    const mAfter = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId);
+    expect(mAfter.access?.some((a) => a.policy?.reference === `AccessPolicy/${policy.id}`)).toBeFalsy();
+
+    // Verify group is gone
+    const readRes = await request(app)
+      .get(`/scim/v2/Groups/${groupId}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(readRes.status).toBe(404);
   });
 
   test('Search users as super admin', async () => {

--- a/packages/server/src/scim/routes.ts
+++ b/packages/server/src/scim/routes.ts
@@ -15,7 +15,20 @@ import { Router } from 'express';
 import { verifyProjectAdmin } from '../admin/utils';
 import { getAuthenticatedContext } from '../context';
 import { authenticateRequest } from '../oauth/middleware';
-import { createScimUser, deleteScimUser, patchScimUser, readScimUser, searchScimUsers, updateScimUser } from './utils';
+import {
+  createScimGroup,
+  createScimUser,
+  deleteScimGroup,
+  deleteScimUser,
+  patchScimGroup,
+  patchScimUser,
+  readScimGroup,
+  readScimUser,
+  searchScimGroups,
+  searchScimUsers,
+  updateScimGroup,
+  updateScimUser,
+} from './utils';
 
 // SCIM
 // http://www.simplecloud.info/
@@ -80,6 +93,63 @@ scimRouter.delete(
     const { project } = getAuthenticatedContext();
     const id = singularize(req.params.id) ?? '';
     await deleteScimUser(project, id);
+    res.sendStatus(204);
+  })
+);
+
+scimRouter.get(
+  '/Groups',
+  scimWrap(async (req: Request, res: Response) => {
+    const { project } = getAuthenticatedContext();
+    const result = await searchScimGroups(project, req.query as Record<string, string>);
+    res.status(200).json(result);
+  })
+);
+
+scimRouter.post(
+  '/Groups',
+  scimWrap(async (req: Request, res: Response) => {
+    const { project } = getAuthenticatedContext();
+    const result = await createScimGroup(project, req.body);
+    res.status(201).json(result);
+  })
+);
+
+scimRouter.get(
+  '/Groups/:id',
+  scimWrap(async (req: Request, res: Response) => {
+    const { project } = getAuthenticatedContext();
+    const id = singularize(req.params.id) ?? '';
+    const result = await readScimGroup(project, id);
+    res.status(200).json(result);
+  })
+);
+
+scimRouter.put(
+  '/Groups/:id',
+  scimWrap(async (req: Request, res: Response) => {
+    const { project } = getAuthenticatedContext();
+    const result = await updateScimGroup(project, req.body);
+    res.status(200).json(result);
+  })
+);
+
+scimRouter.patch(
+  '/Groups/:id',
+  scimWrap(async (req: Request, res: Response) => {
+    const { project } = getAuthenticatedContext();
+    const id = singularize(req.params.id) ?? '';
+    const result = await patchScimGroup(project, id, req.body);
+    res.status(200).json(result);
+  })
+);
+
+scimRouter.delete(
+  '/Groups/:id',
+  scimWrap(async (req: Request, res: Response) => {
+    const { project } = getAuthenticatedContext();
+    const id = singularize(req.params.id) ?? '';
+    await deleteScimGroup(project, id);
     res.sendStatus(204);
   })
 );

--- a/packages/server/src/scim/types.ts
+++ b/packages/server/src/scim/types.ts
@@ -156,3 +156,26 @@ export interface ScimPatchOperation {
   path?: string;
   value?: unknown;
 }
+
+/**
+ * SCIM provides a resource type for "Group" resources.  The core schema
+ * for "Group" is identified using the following schema URI:
+ * "urn:ietf:params:scim:schemas:core:2.0:Group".
+ *
+ * See SCIM 4.2 - Group Resource
+ * https://www.rfc-editor.org/rfc/rfc7643#section-4.2
+ */
+export interface ScimGroup {
+  schemas?: string[];
+  id?: string;
+  externalId?: string;
+  displayName?: string;
+  members?: ScimGroupMember[];
+  meta?: ScimMeta;
+}
+
+export interface ScimGroupMember {
+  value?: string; // SCIM User ID = ProjectMembership ID
+  display?: string;
+  $ref?: string;
+}

--- a/packages/server/src/scim/utils.ts
+++ b/packages/server/src/scim/utils.ts
@@ -316,7 +316,7 @@ export async function searchScimGroups(
   const groups = await systemRepo.searchResources<Group>({
     resourceType: 'Group',
     count: 1000,
-    filters: [{ code: 'project', operator: Operator.EQUALS, value: getReferenceString(project) }],
+    filters: [{ code: '_project', operator: Operator.EQUALS, value: project.id }],
   });
 
   // Only surface groups that were created via SCIM (have SCIM_GROUP_SYSTEM identifier)
@@ -324,7 +324,7 @@ export async function searchScimGroups(
     g.identifier?.some((i) => i.system === SCIM_GROUP_SYSTEM)
   );
 
-  const result = await Promise.all(scimGroups.map((g) => buildScimGroup(g as WithId<Group>, project)));
+  const result = await Promise.all(scimGroups.map((g) => buildScimGroup(g, project)));
   return convertToScimListResponse(result);
 }
 
@@ -342,6 +342,7 @@ export async function createScimGroup(project: WithId<Project>, scimGroup: ScimG
 
   const group = await systemRepo.createResource<Group>({
     resourceType: 'Group',
+    meta: { project: project.id },
     type: 'person',
     actual: true,
     name: scimGroup.displayName,
@@ -356,7 +357,7 @@ export async function createScimGroup(project: WithId<Project>, scimGroup: ScimG
     ? await findAccessPolicyForGroup(project, scimGroup.externalId)
     : undefined;
 
-  let updatedGroup = group as WithId<Group>;
+  let updatedGroup = group;
   if (scimGroup.members && scimGroup.members.length > 0) {
     for (const member of scimGroup.members) {
       if (member.value) {
@@ -427,7 +428,7 @@ export async function updateScimGroup(project: WithId<Project>, scimGroup: ScimG
     member: newMembers.map((ref) => ({ entity: ref })),
   });
 
-  return buildScimGroup(updatedGroup as WithId<Group>, project);
+  return buildScimGroup(updatedGroup, project);
 }
 
 /**
@@ -466,7 +467,7 @@ export async function patchScimGroup(project: WithId<Project>, id: string, reque
       }
     } else if (path === 'displayName' && verb === 'replace') {
       const systemRepo = getSystemRepo();
-      group = (await systemRepo.updateResource<Group>({ ...group, name: value as string })) as WithId<Group>;
+      group = await systemRepo.updateResource<Group>({ ...group, name: value as string });
     }
   }
 
@@ -507,19 +508,25 @@ export async function deleteScimGroup(project: WithId<Project>, id: string): Pro
 
 /**
  * Reads a Group resource and verifies it belongs to the given project.
+ * @param project - The project to validate against.
+ * @param id - The FHIR Group resource ID.
+ * @returns The validated Group resource.
  */
 async function readAndValidateGroup(project: WithId<Project>, id: string): Promise<WithId<Group>> {
   const systemRepo = getSystemRepo();
   const group = await systemRepo.readResource<Group>('Group', id);
-  // meta.project is a Medplum extension - verify this group belongs to the given project
-  if ((group.meta as Record<string, string | undefined>)?.project !== 'Project/' + project.id) {
+  // meta.project stores the project UUID (not a reference string)
+  if (group.meta?.project !== project.id) {
     throw new OperationOutcomeError(forbidden);
   }
-  return group as WithId<Group>;
+  return group;
 }
 
 /**
  * Converts a FHIR Group to a SCIM Group, resolving member profile refs to ProjectMembership IDs.
+ * @param group - The FHIR Group resource.
+ * @param project - The project the group belongs to.
+ * @returns The SCIM Group representation.
  */
 async function buildScimGroup(group: WithId<Group>, project: WithId<Project>): Promise<ScimGroup> {
   const config = getConfig();
@@ -547,6 +554,9 @@ async function buildScimGroup(group: WithId<Group>, project: WithId<Project>): P
 
 /**
  * Searches for an AccessPolicy by externalId (matched against identifier.value).
+ * @param project - The project to search within.
+ * @param externalId - The SCIM externalId to match against AccessPolicy identifiers.
+ * @returns The matching AccessPolicy, or undefined if not found.
  */
 async function findAccessPolicyForGroup(
   project: WithId<Project>,
@@ -559,15 +569,15 @@ async function findAccessPolicyForGroup(
   const policies = await systemRepo.searchResources<AccessPolicy>({
     resourceType: 'AccessPolicy',
     count: 1000,
-    filters: [{ code: 'project', operator: Operator.EQUALS, value: getReferenceString(project) }],
+    filters: [{ code: '_project', operator: Operator.EQUALS, value: project.id }],
   });
-  return policies.find((p) => p.identifier?.some((i) => i.value === externalId)) as
-    | WithId<AccessPolicy>
-    | undefined;
+  return policies.find((p) => p.identifier?.some((i) => i.value === externalId));
 }
 
 /**
  * Adds an AccessPolicy reference to a ProjectMembership.access[] if not already present.
+ * @param membershipId - The ProjectMembership resource ID.
+ * @param accessPolicy - The AccessPolicy to add.
  */
 async function applyGroupAccess(membershipId: string, accessPolicy: WithId<AccessPolicy>): Promise<void> {
   const systemRepo = getSystemRepo();
@@ -584,6 +594,8 @@ async function applyGroupAccess(membershipId: string, accessPolicy: WithId<Acces
 
 /**
  * Removes an AccessPolicy reference from a ProjectMembership.access[].
+ * @param membershipId - The ProjectMembership resource ID.
+ * @param accessPolicy - The AccessPolicy to remove.
  */
 async function removeGroupAccess(membershipId: string, accessPolicy: WithId<AccessPolicy>): Promise<void> {
   const systemRepo = getSystemRepo();
@@ -597,6 +609,8 @@ async function removeGroupAccess(membershipId: string, accessPolicy: WithId<Acce
 
 /**
  * Resolves a ProjectMembership ID to its profile reference (for storing in Group.member).
+ * @param membershipId - The ProjectMembership resource ID.
+ * @returns The profile reference stored in Group.member[].entity.
  */
 async function membershipIdToProfileRef(membershipId: string): Promise<GroupMember['entity']> {
   const systemRepo = getSystemRepo();
@@ -606,6 +620,9 @@ async function membershipIdToProfileRef(membershipId: string): Promise<GroupMemb
 
 /**
  * Resolves a profile reference string to a ProjectMembership ID.
+ * @param project - The project to search within.
+ * @param profileRef - The profile reference string (e.g. "Practitioner/123").
+ * @returns The ProjectMembership ID, or undefined if not found.
  */
 async function profileRefToMembershipId(
   project: WithId<Project>,
@@ -625,6 +642,10 @@ async function profileRefToMembershipId(
 /**
  * Adds a member to a FHIR Group and optionally applies an AccessPolicy to their membership.
  * Returns the updated Group.
+ * @param group - The FHIR Group resource to update.
+ * @param membershipId - The ProjectMembership ID of the member to add.
+ * @param accessPolicy - Optional AccessPolicy to assign to the member.
+ * @returns The updated Group resource.
  */
 async function addMemberToGroup(
   group: WithId<Group>,
@@ -635,10 +656,10 @@ async function addMemberToGroup(
   const profileRef = await membershipIdToProfileRef(membershipId);
   const alreadyMember = (group.member ?? []).some((m) => m.entity.reference === profileRef.reference);
   if (!alreadyMember) {
-    group = (await systemRepo.updateResource<Group>({
+    group = await systemRepo.updateResource<Group>({
       ...group,
       member: [...(group.member ?? []), { entity: profileRef }],
-    })) as WithId<Group>;
+    });
   }
   if (accessPolicy) {
     await applyGroupAccess(membershipId, accessPolicy);
@@ -649,6 +670,10 @@ async function addMemberToGroup(
 /**
  * Removes a member from a FHIR Group and optionally removes an AccessPolicy from their membership.
  * Returns the updated Group.
+ * @param group - The FHIR Group resource to update.
+ * @param membershipId - The ProjectMembership ID of the member to remove.
+ * @param accessPolicy - Optional AccessPolicy to revoke from the member.
+ * @returns The updated Group resource.
  */
 async function removeMemberFromGroup(
   group: WithId<Group>,
@@ -657,10 +682,10 @@ async function removeMemberFromGroup(
 ): Promise<WithId<Group>> {
   const systemRepo = getSystemRepo();
   const profileRef = await membershipIdToProfileRef(membershipId);
-  group = (await systemRepo.updateResource<Group>({
+  group = await systemRepo.updateResource<Group>({
     ...group,
     member: (group.member ?? []).filter((m) => m.entity.reference !== profileRef.reference),
-  })) as WithId<Group>;
+  });
   if (accessPolicy) {
     await removeGroupAccess(membershipId, accessPolicy);
   }
@@ -670,6 +695,11 @@ async function removeMemberFromGroup(
 /**
  * Replaces the full member list of a group, computing and applying diffs.
  * Returns the updated Group.
+ * @param group - The FHIR Group resource to update.
+ * @param project - The project context for resolving membership IDs.
+ * @param newMembers - The new SCIM member list to replace the existing one.
+ * @param accessPolicy - Optional AccessPolicy to add/remove based on membership changes.
+ * @returns The updated Group resource.
  */
 async function replaceGroupMembers(
   group: WithId<Group>,
@@ -696,10 +726,10 @@ async function replaceGroupMembers(
   }
 
   const newProfileRefs = await Promise.all(newMembershipIds.map((id) => membershipIdToProfileRef(id)));
-  return (await systemRepo.updateResource<Group>({
+  return systemRepo.updateResource<Group>({
     ...group,
     member: newProfileRefs.map((ref) => ({ entity: ref })),
-  })) as WithId<Group>;
+  });
 }
 
 /**

--- a/packages/server/src/scim/utils.ts
+++ b/packages/server/src/scim/utils.ts
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { SearchRequest, WithId } from '@medplum/core';
-import { badRequest, forbidden, getReferenceString, OperationOutcomeError, Operator } from '@medplum/core';
-import type { AccessPolicy, Project, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
+import { badRequest, createReference, forbidden, getReferenceString, OperationOutcomeError, Operator } from '@medplum/core';
+import type { AccessPolicy, Group, GroupMember, Project, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
 import type { Operation } from 'rfc6902';
 import { inviteUser } from '../admin/invite';
 import { getConfig } from '../config/loader';
 import { getSystemRepo } from '../fhir/repo';
 import { patchObject } from '../util/patch';
-import type { ScimListResponse, ScimPatchRequest, ScimUser } from './types';
+import type { ScimGroup, ScimGroupMember, ScimListResponse, ScimPatchRequest, ScimUser } from './types';
 
 /**
  * Searches for users in the project.
@@ -294,6 +294,412 @@ export function convertToScimListResponse<T>(Resources: T[]): ScimListResponse<T
     startIndex: 1,
     Resources,
   };
+}
+
+/** System URI for SCIM group identifiers stored in FHIR Group.identifier. */
+const SCIM_GROUP_SYSTEM = 'https://medplum.com/scim/group';
+
+/**
+ * Searches for groups in the project.
+ *
+ * See SCIM 3.4.2 - Query Resources
+ * https://www.rfc-editor.org/rfc/rfc7644#section-3.4.2
+ * @param project - The project.
+ * @param _params - The search parameters (reserved for future filtering).
+ * @returns List of SCIM groups in the project.
+ */
+export async function searchScimGroups(
+  project: WithId<Project>,
+  _params: Record<string, string>
+): Promise<ScimListResponse<ScimGroup>> {
+  const systemRepo = getSystemRepo();
+  const groups = await systemRepo.searchResources<Group>({
+    resourceType: 'Group',
+    count: 1000,
+    filters: [{ code: 'project', operator: Operator.EQUALS, value: getReferenceString(project) }],
+  });
+
+  // Only surface groups that were created via SCIM (have SCIM_GROUP_SYSTEM identifier)
+  const scimGroups = groups.filter((g) =>
+    g.identifier?.some((i) => i.system === SCIM_GROUP_SYSTEM)
+  );
+
+  const result = await Promise.all(scimGroups.map((g) => buildScimGroup(g as WithId<Group>, project)));
+  return convertToScimListResponse(result);
+}
+
+/**
+ * Creates a new SCIM group in the project.
+ *
+ * See SCIM 3.3 - Creating Resources
+ * https://www.rfc-editor.org/rfc/rfc7644#section-3.3
+ * @param project - The project.
+ * @param scimGroup - The SCIM group definition.
+ * @returns The new SCIM group.
+ */
+export async function createScimGroup(project: WithId<Project>, scimGroup: ScimGroup): Promise<ScimGroup> {
+  const systemRepo = getSystemRepo();
+
+  const group = await systemRepo.createResource<Group>({
+    resourceType: 'Group',
+    type: 'person',
+    actual: true,
+    name: scimGroup.displayName,
+    identifier: scimGroup.externalId
+      ? [{ system: SCIM_GROUP_SYSTEM, value: scimGroup.externalId }]
+      : [],
+    member: [],
+  });
+
+  // Add initial members if provided
+  const accessPolicy = scimGroup.externalId
+    ? await findAccessPolicyForGroup(project, scimGroup.externalId)
+    : undefined;
+
+  let updatedGroup = group as WithId<Group>;
+  if (scimGroup.members && scimGroup.members.length > 0) {
+    for (const member of scimGroup.members) {
+      if (member.value) {
+        updatedGroup = await addMemberToGroup(updatedGroup, member.value, accessPolicy);
+      }
+    }
+  }
+
+  return buildScimGroup(updatedGroup, project);
+}
+
+/**
+ * Reads an existing SCIM group by ID.
+ *
+ * See SCIM 3.4.1 - Retrieve a Known Resource
+ * https://www.rfc-editor.org/rfc/rfc7644#section-3.4.1
+ * @param project - The project.
+ * @param id - The group ID (FHIR Group resource ID).
+ * @returns The SCIM group.
+ */
+export async function readScimGroup(project: WithId<Project>, id: string): Promise<ScimGroup> {
+  const group = await readAndValidateGroup(project, id);
+  return buildScimGroup(group, project);
+}
+
+/**
+ * Replaces a SCIM group (full update).
+ *
+ * See SCIM 3.5.1 - Replace a Resource
+ * https://www.rfc-editor.org/rfc/rfc7644#section-3.5.1
+ * @param project - The project.
+ * @param scimGroup - The updated SCIM group definition.
+ * @returns The updated SCIM group.
+ */
+export async function updateScimGroup(project: WithId<Project>, scimGroup: ScimGroup): Promise<ScimGroup> {
+  const systemRepo = getSystemRepo();
+  const existing = await readAndValidateGroup(project, scimGroup.id as string);
+
+  const externalId = scimGroup.externalId ?? existing.identifier?.find((i) => i.system === SCIM_GROUP_SYSTEM)?.value;
+  const accessPolicy = externalId ? await findAccessPolicyForGroup(project, externalId) : undefined;
+
+  // Build new member list from SCIM input
+  const newMembershipIds = (scimGroup.members ?? []).map((m) => m.value).filter(Boolean) as string[];
+  const oldMembershipIds = await Promise.all(
+    (existing.member ?? []).map((m) => profileRefToMembershipId(project, m.entity.reference as string))
+  ).then((ids) => ids.filter(Boolean) as string[]);
+
+  // Compute diff
+  const toAdd = newMembershipIds.filter((id) => !oldMembershipIds.includes(id));
+  const toRemove = oldMembershipIds.filter((id) => !newMembershipIds.includes(id));
+
+  // Apply access policy changes
+  if (accessPolicy) {
+    for (const id of toAdd) {
+      await applyGroupAccess(id, accessPolicy);
+    }
+    for (const id of toRemove) {
+      await removeGroupAccess(id, accessPolicy);
+    }
+  }
+
+  // Build updated FHIR Group
+  const newMembers = await Promise.all(newMembershipIds.map((id) => membershipIdToProfileRef(id)));
+  const updatedGroup = await systemRepo.updateResource<Group>({
+    ...existing,
+    name: scimGroup.displayName ?? existing.name,
+    identifier: externalId ? [{ system: SCIM_GROUP_SYSTEM, value: externalId }] : existing.identifier ?? [],
+    member: newMembers.map((ref) => ({ entity: ref })),
+  });
+
+  return buildScimGroup(updatedGroup as WithId<Group>, project);
+}
+
+/**
+ * Patches an existing SCIM group.
+ *
+ * See SCIM 3.5.2 - Modifying with PATCH
+ * https://www.rfc-editor.org/rfc/rfc7644#section-3.5.2
+ * @param project - The project.
+ * @param id - The group ID.
+ * @param request - The SCIM patch request.
+ * @returns The updated SCIM group.
+ */
+export async function patchScimGroup(project: WithId<Project>, id: string, request: ScimPatchRequest): Promise<ScimGroup> {
+  let group = await readAndValidateGroup(project, id);
+  const externalId = group.identifier?.find((i) => i.system === SCIM_GROUP_SYSTEM)?.value;
+  const accessPolicy = externalId ? await findAccessPolicyForGroup(project, externalId) : undefined;
+
+  for (const op of request.Operations) {
+    const { op: verb, path, value } = op;
+
+    if (path === 'members' || path === 'members.value') {
+      const newMembers = (value as ScimGroupMember[]) ?? [];
+      if (verb === 'add') {
+        for (const member of newMembers) {
+          if (member.value) {
+            group = await addMemberToGroup(group, member.value, accessPolicy);
+          }
+        }
+      } else if (verb === 'replace') {
+        group = await replaceGroupMembers(group, project, newMembers, accessPolicy);
+      }
+    } else if (path && /^members\[value eq "(.+)"\]$/.test(path)) {
+      const match = /^members\[value eq "(.+)"\]$/.exec(path);
+      if (match) {
+        group = await removeMemberFromGroup(group, match[1], accessPolicy);
+      }
+    } else if (path === 'displayName' && verb === 'replace') {
+      const systemRepo = getSystemRepo();
+      group = (await systemRepo.updateResource<Group>({ ...group, name: value as string })) as WithId<Group>;
+    }
+  }
+
+  return buildScimGroup(group, project);
+}
+
+/**
+ * Deletes an existing SCIM group and removes all access policy assignments from its members.
+ *
+ * See SCIM 3.6 - Deleting Resources
+ * https://www.rfc-editor.org/rfc/rfc7644#section-3.6
+ * @param project - The project.
+ * @param id - The group ID.
+ */
+export async function deleteScimGroup(project: WithId<Project>, id: string): Promise<void> {
+  const systemRepo = getSystemRepo();
+  const group = await readAndValidateGroup(project, id);
+  const externalId = group.identifier?.find((i) => i.system === SCIM_GROUP_SYSTEM)?.value;
+  const accessPolicy = externalId ? await findAccessPolicyForGroup(project, externalId) : undefined;
+
+  if (accessPolicy) {
+    // Remove access policy from all members
+    const membershipIds = await Promise.all(
+      (group.member ?? []).map((m) => profileRefToMembershipId(project, m.entity.reference as string))
+    ).then((ids) => ids.filter(Boolean) as string[]);
+
+    for (const membershipId of membershipIds) {
+      await removeGroupAccess(membershipId, accessPolicy);
+    }
+  }
+
+  await systemRepo.deleteResource('Group', id);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads a Group resource and verifies it belongs to the given project.
+ */
+async function readAndValidateGroup(project: WithId<Project>, id: string): Promise<WithId<Group>> {
+  const systemRepo = getSystemRepo();
+  const group = await systemRepo.readResource<Group>('Group', id);
+  // meta.project is a Medplum extension - verify this group belongs to the given project
+  if ((group.meta as Record<string, string | undefined>)?.project !== 'Project/' + project.id) {
+    throw new OperationOutcomeError(forbidden);
+  }
+  return group as WithId<Group>;
+}
+
+/**
+ * Converts a FHIR Group to a SCIM Group, resolving member profile refs to ProjectMembership IDs.
+ */
+async function buildScimGroup(group: WithId<Group>, project: WithId<Project>): Promise<ScimGroup> {
+  const config = getConfig();
+  const memberEntries = group.member ?? [];
+  const members: ScimGroupMember[] = [];
+  for (const m of memberEntries) {
+    const membershipId = await profileRefToMembershipId(project, m.entity.reference as string);
+    if (membershipId) {
+      members.push({ value: membershipId });
+    }
+  }
+  return {
+    schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+    id: group.id,
+    externalId: group.identifier?.find((i) => i.system === SCIM_GROUP_SYSTEM)?.value,
+    displayName: group.name,
+    members,
+    meta: {
+      resourceType: 'Group',
+      lastModified: group.meta?.lastUpdated,
+      location: config.baseUrl + 'scim/2.0/Groups/' + group.id,
+    },
+  };
+}
+
+/**
+ * Searches for an AccessPolicy by externalId (matched against identifier.value).
+ */
+async function findAccessPolicyForGroup(
+  project: WithId<Project>,
+  externalId: string
+): Promise<WithId<AccessPolicy> | undefined> {
+  if (!externalId) {
+    return undefined;
+  }
+  const systemRepo = getSystemRepo();
+  const policies = await systemRepo.searchResources<AccessPolicy>({
+    resourceType: 'AccessPolicy',
+    count: 1000,
+    filters: [{ code: 'project', operator: Operator.EQUALS, value: getReferenceString(project) }],
+  });
+  return policies.find((p) => p.identifier?.some((i) => i.value === externalId)) as
+    | WithId<AccessPolicy>
+    | undefined;
+}
+
+/**
+ * Adds an AccessPolicy reference to a ProjectMembership.access[] if not already present.
+ */
+async function applyGroupAccess(membershipId: string, accessPolicy: WithId<AccessPolicy>): Promise<void> {
+  const systemRepo = getSystemRepo();
+  const membership = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId);
+  const policyRef = getReferenceString(accessPolicy);
+  if (membership.access?.some((a) => a.policy?.reference === policyRef)) {
+    return;
+  }
+  await systemRepo.updateResource<ProjectMembership>({
+    ...membership,
+    access: [...(membership.access ?? []), { policy: createReference(accessPolicy) }],
+  });
+}
+
+/**
+ * Removes an AccessPolicy reference from a ProjectMembership.access[].
+ */
+async function removeGroupAccess(membershipId: string, accessPolicy: WithId<AccessPolicy>): Promise<void> {
+  const systemRepo = getSystemRepo();
+  const membership = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId);
+  const policyRef = getReferenceString(accessPolicy);
+  await systemRepo.updateResource<ProjectMembership>({
+    ...membership,
+    access: (membership.access ?? []).filter((a) => a.policy?.reference !== policyRef),
+  });
+}
+
+/**
+ * Resolves a ProjectMembership ID to its profile reference (for storing in Group.member).
+ */
+async function membershipIdToProfileRef(membershipId: string): Promise<GroupMember['entity']> {
+  const systemRepo = getSystemRepo();
+  const membership = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId);
+  return membership.profile as GroupMember['entity'];
+}
+
+/**
+ * Resolves a profile reference string to a ProjectMembership ID.
+ */
+async function profileRefToMembershipId(
+  project: WithId<Project>,
+  profileRef: string
+): Promise<string | undefined> {
+  const systemRepo = getSystemRepo();
+  const memberships = await systemRepo.searchResources<ProjectMembership>({
+    resourceType: 'ProjectMembership',
+    filters: [
+      { code: 'project', operator: Operator.EQUALS, value: getReferenceString(project) },
+      { code: 'profile', operator: Operator.EQUALS, value: profileRef },
+    ],
+  });
+  return memberships[0]?.id;
+}
+
+/**
+ * Adds a member to a FHIR Group and optionally applies an AccessPolicy to their membership.
+ * Returns the updated Group.
+ */
+async function addMemberToGroup(
+  group: WithId<Group>,
+  membershipId: string,
+  accessPolicy: WithId<AccessPolicy> | undefined
+): Promise<WithId<Group>> {
+  const systemRepo = getSystemRepo();
+  const profileRef = await membershipIdToProfileRef(membershipId);
+  const alreadyMember = (group.member ?? []).some((m) => m.entity.reference === profileRef.reference);
+  if (!alreadyMember) {
+    group = (await systemRepo.updateResource<Group>({
+      ...group,
+      member: [...(group.member ?? []), { entity: profileRef }],
+    })) as WithId<Group>;
+  }
+  if (accessPolicy) {
+    await applyGroupAccess(membershipId, accessPolicy);
+  }
+  return group;
+}
+
+/**
+ * Removes a member from a FHIR Group and optionally removes an AccessPolicy from their membership.
+ * Returns the updated Group.
+ */
+async function removeMemberFromGroup(
+  group: WithId<Group>,
+  membershipId: string,
+  accessPolicy: WithId<AccessPolicy> | undefined
+): Promise<WithId<Group>> {
+  const systemRepo = getSystemRepo();
+  const profileRef = await membershipIdToProfileRef(membershipId);
+  group = (await systemRepo.updateResource<Group>({
+    ...group,
+    member: (group.member ?? []).filter((m) => m.entity.reference !== profileRef.reference),
+  })) as WithId<Group>;
+  if (accessPolicy) {
+    await removeGroupAccess(membershipId, accessPolicy);
+  }
+  return group;
+}
+
+/**
+ * Replaces the full member list of a group, computing and applying diffs.
+ * Returns the updated Group.
+ */
+async function replaceGroupMembers(
+  group: WithId<Group>,
+  project: WithId<Project>,
+  newMembers: ScimGroupMember[],
+  accessPolicy: WithId<AccessPolicy> | undefined
+): Promise<WithId<Group>> {
+  const systemRepo = getSystemRepo();
+  const newMembershipIds = newMembers.map((m) => m.value).filter(Boolean) as string[];
+  const oldMembershipIds = await Promise.all(
+    (group.member ?? []).map((m) => profileRefToMembershipId(project, m.entity.reference as string))
+  ).then((ids) => ids.filter(Boolean) as string[]);
+
+  const toAdd = newMembershipIds.filter((id) => !oldMembershipIds.includes(id));
+  const toRemove = oldMembershipIds.filter((id) => !newMembershipIds.includes(id));
+
+  if (accessPolicy) {
+    for (const id of toAdd) {
+      await applyGroupAccess(id, accessPolicy);
+    }
+    for (const id of toRemove) {
+      await removeGroupAccess(id, accessPolicy);
+    }
+  }
+
+  const newProfileRefs = await Promise.all(newMembershipIds.map((id) => membershipIdToProfileRef(id)));
+  return (await systemRepo.updateResource<Group>({
+    ...group,
+    member: newProfileRefs.map((ref) => ({ entity: ref })),
+  })) as WithId<Group>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implement full SCIM group endpoint support (GET, POST, PUT, PATCH, DELETE /Groups)
- Add identifier field to AccessPolicy for external system matching
- Enable automatic access policy assignment via SCIM group externalId

## Motivation
This feature enables identity management systems to automatically assign access policies to users based on their group memberships, allowing seamless integration with external SCIM providers for group-based access control.

## Test plan
- [ ] Test GET /Groups to retrieve groups
- [ ] Test POST /Groups to create new groups
- [ ] Test GET /Groups/:id to read individual groups
- [ ] Test PUT /Groups/:id to update groups
- [ ] Test PATCH /Groups/:id to partially update groups
- [ ] Test DELETE /Groups/:id to delete groups
- [ ] Verify AccessPolicy identifier field is properly persisted
- [ ] Test automatic policy assignment via SCIM group externalId
- [ ] Run existing SCIM test suite to ensure no regressions