### PR TITLE
fix(deploy): make all deployments share concurrency group

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Deploy
 
 concurrency:
-  group: ci-deploy-${{ github.sha }}
+  group: ci-deploy-main
   cancel-in-progress: false
 
 on:


### PR DESCRIPTION
Fixes #8473 


This PR makes it so that deployments will be queued if they defeat the merge queue and multiple deploy jobs are attempted concurrently