### PR TITLE
Fixes #8472 - better date validation

### DIFF
--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -1142,7 +1142,7 @@ describe('project-scoped Repository', () => {
     ['1985-11-30T05:05:55-14:00', true],
     ['1985-11-30T05:05:55.000000000-14:00', true],
     ['1985-11-30T05:05:55-15:00', false],
-    ['2026-02-29', false],   
+    ['2026-02-29', false],
     ['2024-02-29', true],
   ])('Handle_lastUpdated value %s, isValid? %s', async (value, isValid) =>
     withTestContext(async () => {

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -1405,10 +1405,10 @@ function validateDateValue(value: string): void {
   if (Number.isNaN(dateValue.getTime())) {
     throw new OperationOutcomeError(badRequest(`Invalid date value: ${value}`));
   }
-  /** 
-  *  new Date(value) silently rolls over invalid dates to the next valid date (e.g. 2026-02-29 -> 2026-03-01).
-  *  Throws a badRequest OperationOutcomeError if the parsed components do not match the original input.
-  */
+  /**
+   *  new Date(value) silently rolls over invalid dates to the next valid date (e.g. 2026-02-29 -> 2026-03-01).
+   *  Throws a badRequest OperationOutcomeError if the parsed components do not match the original input.
+   */
   const match = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
   if (match) {
     const [, year, month, day] = match.map(Number);


### PR DESCRIPTION
Fix issue #8472 

In search.ts line 1399, throw a badRequest OperationOutcomeError if new Date(value) silently rolls over invalid dates to the next valid date