### PR TITLE
Fixes #8454 - CDK option for rdsForceRetain

### DIFF
--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -102,7 +102,7 @@ export class BackEnd extends Construct {
 
     // RDS
     this.rdsSecretsArn = config.rdsSecretsArn;
-    if (!this.rdsSecretsArn) {
+    if (!this.rdsSecretsArn || config.rdsForceRetain) {
       const { engine, majorVersion } = getPostgresEngine(
         config.rdsInstanceVersion,
         rds.AuroraPostgresEngineVersion.VER_16_9
@@ -233,7 +233,9 @@ export class BackEnd extends Construct {
       assert(secret instanceof Secret, 'rdsCluster.secretAttachment.node.scope is not a Secret');
       secret.applyRemovalPolicy(RemovalPolicy.RETAIN);
 
-      this.rdsSecretsArn = secretAttachment.secretArn;
+      if (!this.rdsSecretsArn) {
+        this.rdsSecretsArn = secretAttachment.secretArn;
+      }
 
       if (config.rdsProxyEnabled) {
         this.rdsProxy = new rds.DatabaseProxy(this, 'DatabaseProxy', {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -52,6 +52,7 @@ export interface MedplumSourceInfraConfig {
   rdsReaderInstanceType?: ValueOrExternalSecret<string>;
   rdsProxyEnabled?: ValueOrExternalSecret<boolean>;
   rdsClusterParameters?: StringMap;
+  rdsForceRetain?: ValueOrExternalSecret<boolean>;
   rdsAutoMinorVersionUpgrade?: ValueOrExternalSecret<boolean>;
   cacheNodeType?: ValueOrExternalSecret<string>;
   cacheSecurityGroupId?: ValueOrExternalSecret<string>;
@@ -156,6 +157,7 @@ export interface MedplumInfraConfig {
   rdsSecretsArn?: string;
   rdsReaderInstanceType?: string;
   rdsProxyEnabled?: boolean;
+  rdsForceRetain?: boolean;
   cacheNodeType?: string;
   cacheSecurityGroupId?: string;
   desiredServerCount: number;


### PR DESCRIPTION
Customers requested the ability to switch to a different database instance (via the `rdsSecretsArn` CDK setting), but still retain the original CDK-managed RDS instance and all surrounding resources (parameter groups, networking resources, etc).

Note that we already use `removalPolicy: RemovalPolicy.RETAIN` for many/most of those resources, however, the CDK diff message can be quite intimidating for infra teams, so this was explicitly requested

To use this, you would:
1. Set `rdsSecretsArn` to the ARN of the AWS Secret with the connection details (as described in docs under "Bring Your Own Database")
2. Set `rdsForceRetain` to `true`