### PR TITLE
Backport RDS retain features for 2.1.26

### DIFF
--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -18,7 +18,9 @@ import {
 } from 'aws-cdk-lib';
 import { Repository } from 'aws-cdk-lib/aws-ecr';
 import { ClusterInstance } from 'aws-cdk-lib/aws-rds';
+import { Secret, SecretTargetAttachment } from 'aws-cdk-lib/aws-secretsmanager';
 import { Construct } from 'constructs';
+import assert from 'node:assert';
 import { awsManagedRules } from './waf';
 
 /**
@@ -90,7 +92,7 @@ export class BackEnd extends Construct {
 
     // RDS
     this.rdsSecretsArn = config.rdsSecretsArn;
-    if (!this.rdsSecretsArn) {
+    if (!this.rdsSecretsArn || config.rdsForceRetain) {
       // See: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_rds-readme.html#migrating-from-instanceprops
       const instanceProps: rds.ProvisionedClusterInstanceProps = {
         instanceType: config.rdsInstanceType ? new ec2.InstanceType(config.rdsInstanceType) : undefined,
@@ -136,9 +138,25 @@ export class BackEnd extends Construct {
         },
         cloudwatchLogsExports: ['postgresql'],
         instanceUpdateBehaviour: rds.InstanceUpdateBehaviour.ROLLING,
+        removalPolicy: RemovalPolicy.RETAIN,
       });
 
-      this.rdsSecretsArn = (this.rdsCluster.secret as secretsmanager.ISecret).secretArn;
+      const secretAttachment = this.rdsCluster.secret;
+      assert(secretAttachment !== undefined, 'rdsCluster.secret is undefined');
+
+      secretAttachment.applyRemovalPolicy(RemovalPolicy.RETAIN);
+
+      // rdsCluster.secret is actually a SecretAttachment; not the secret itself
+      assert(secretAttachment instanceof SecretTargetAttachment, 'rdsCluster.secret is not a SecretTargetAttachment');
+
+      // there is no direct way to get from SecretTargetAttachment to Secret, so break glass by going through node.scope
+      const secret = secretAttachment.node.scope;
+      assert(secret instanceof Secret, 'rdsCluster.secretAttachment.node.scope is not a Secret');
+      secret.applyRemovalPolicy(RemovalPolicy.RETAIN);
+
+      if (!this.rdsSecretsArn) {
+        this.rdsSecretsArn = secretAttachment.secretArn;
+      }
     }
 
     // Redis
@@ -411,9 +429,19 @@ export class BackEnd extends Construct {
       webAclArn: this.waf.attrArn,
     });
 
-    // Grant RDS access to the fargate group
     if (this.rdsCluster) {
+      // Grant RDS access to the fargate group
       this.rdsCluster.connections.allowDefaultPortFrom(this.fargateSecurityGroup);
+
+      // Retain RDS cluster security groups and their rules
+      this.rdsCluster.connections.securityGroups.forEach((sg) => {
+        sg.applyRemovalPolicy(RemovalPolicy.RETAIN);
+        sg.node.children.forEach((child) => {
+          if (child instanceof ec2.CfnSecurityGroupIngress || child instanceof ec2.CfnSecurityGroupEgress) {
+            child.applyRemovalPolicy(RemovalPolicy.RETAIN);
+          }
+        });
+      });
     }
 
     // Grant Redis access to the fargate group

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -43,6 +43,7 @@ export interface MedplumSourceInfraConfig {
   rdsInstanceType: ValueOrExternalSecret<string>;
   rdsInstanceVersion: ValueOrExternalSecret<string>;
   rdsSecretsArn?: ValueOrExternalSecret<string>;
+  rdsForceRetain?: ValueOrExternalSecret<boolean>;
   cacheNodeType?: ValueOrExternalSecret<string>;
   desiredServerCount: ValueOrExternalSecret<number>;
   serverImage: ValueOrExternalSecret<string>;
@@ -102,6 +103,7 @@ export interface MedplumInfraConfig {
   rdsInstanceType: string;
   rdsInstanceVersion?: string;
   rdsSecretsArn?: string;
+  rdsForceRetain?: boolean;
   cacheNodeType?: string;
   desiredServerCount: number;
   serverImage: string;


### PR DESCRIPTION
Backport for enterprise customer

Building:

```bash
nvm use 18
rm -rf examples/medplum-nextjs-demo
rm -rf examples/medplum-react-native-example
rm -rf packages/docs
rm -rf packages/expo-polyfills
./scripts/reinstall.sh
npm run build:all -- --force '--filter=!@medplum/generator'
```