### PR TITLE
fix(ccda): Populate Observation referenceRange from CCDA data

### DIFF
--- a/packages/ccda/src/ccda-to-fhir.ts
+++ b/packages/ccda/src/ccda-to-fhir.ts
@@ -115,6 +115,7 @@ import type {
   CcdaPatientRole,
   CcdaPerformer,
   CcdaProcedure,
+  CcdaQuantity,
   CcdaReferenceRange,
   CcdaSection,
   CcdaSubstanceAdministration,
@@ -1317,6 +1318,28 @@ class CcdaToFhirConverter {
     const result: ObservationReferenceRange = {};
 
     result.extension = this.mapTextReference(observationRange.text);
+
+    const value = observationRange.value as CcdaQuantity | undefined;
+    if (value?.low) {
+      result.low = {
+        value: value.low['@_value'] ? Number.parseFloat(value.low['@_value']) : undefined,
+        unit: value.low['@_unit'],
+        system: UCUM,
+        code: value.low['@_unit'],
+      };
+    }
+    if (value?.high) {
+      result.high = {
+        value: value.high['@_value'] ? Number.parseFloat(value.high['@_value']) : undefined,
+        unit: value.high['@_unit'],
+        system: UCUM,
+        code: value.high['@_unit'],
+      };
+    }
+
+    if (!result.extension && !result.low && !result.high) {
+      return undefined;
+    }
 
     return result;
   }

--- a/packages/ccda/src/fhir-to-ccda/entries/observation.test.ts
+++ b/packages/ccda/src/fhir-to-ccda/entries/observation.test.ts
@@ -1129,8 +1129,41 @@ describe('observation entry functions', () => {
       const result = mapReferenceRange(referenceRange);
 
       expect(result).toBeDefined();
-      // createTextFromExtensions returns undefined if no narrative reference extension
-      expect(result?.observationRange?.text).toBeUndefined();
+      expect(result?.observationRange?.value).toEqual({
+        '@_xsi:type': 'IVL_PQ',
+        low: { '@_value': '60', '@_unit': 'bpm' },
+        high: { '@_value': '100', '@_unit': 'bpm' },
+      });
+    });
+
+    test('should map reference range with only low', () => {
+      const referenceRange = {
+        low: { value: 60, unit: 'bpm' },
+      };
+
+      const result = mapReferenceRange(referenceRange);
+
+      expect(result).toBeDefined();
+      expect(result?.observationRange?.value).toEqual({
+        '@_xsi:type': 'IVL_PQ',
+        low: { '@_value': '60', '@_unit': 'bpm' },
+        high: undefined,
+      });
+    });
+
+    test('should map reference range with only high', () => {
+      const referenceRange = {
+        high: { value: 100, unit: 'bpm' },
+      };
+
+      const result = mapReferenceRange(referenceRange);
+
+      expect(result).toBeDefined();
+      expect(result?.observationRange?.value).toEqual({
+        '@_xsi:type': 'IVL_PQ',
+        low: undefined,
+        high: { '@_value': '100', '@_unit': 'bpm' },
+      });
     });
   });
 });

--- a/packages/ccda/src/fhir-to-ccda/entries/observation.ts
+++ b/packages/ccda/src/fhir-to-ccda/entries/observation.ts
@@ -310,6 +310,22 @@ export function mapReferenceRange(
     };
   }
 
+  if (referenceRange.low || referenceRange.high) {
+    return {
+      observationRange: {
+        value: {
+          '@_xsi:type': 'IVL_PQ',
+          low: referenceRange.low
+            ? { '@_value': referenceRange.low.value?.toString(), '@_unit': referenceRange.low.unit }
+            : undefined,
+          high: referenceRange.high
+            ? { '@_value': referenceRange.high.value?.toString(), '@_unit': referenceRange.high.unit }
+            : undefined,
+        },
+      },
+    };
+  }
+
   return {
     observationRange: {
       text: createTextFromExtensions(referenceRange.extension),

--- a/packages/ccda/src/types.ts
+++ b/packages/ccda/src/types.ts
@@ -290,9 +290,11 @@ export interface CcdaSubstanceAdministration {
 }
 
 export interface CcdaQuantity {
-  '@_xsi:type'?: 'PQ' | 'CO';
+  '@_xsi:type'?: 'PQ' | 'CO' | 'IVL_PQ';
   '@_value'?: string;
   '@_unit'?: string;
+  low?: CcdaQuantity;
+  high?: CcdaQuantity;
 }
 
 export interface CcdaInteger {


### PR DESCRIPTION
## Why
- `mapReferenceRange` only reads observationRange.text (for narrative reference extensions) and ignores observationRange.value. When the value is an IVL_PQ with low/high bounds, the output is `referenceRange: [{}]` which is invalid FHIR that can't be uploaded to Medplum.

## What
- Extend `CcdaQuantity` to support IVL_PQ by adding low/high children and the 'IVL_PQ' discriminant
- Update `mapReferenceRange` (CCDA→FHIR) to extract low and high from observationRange.value 
    - Return `undefined` when a reference range has no extension, low, or high to prevent empty objects
- Update reverse `mapReferenceRange` (FHIR→CCDA) to write IVL_PQ low/high for roundtrip fidelity