### PR TITLE
Add .claude to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,5 +97,8 @@ playwright/.cache/
 # Cursor
 .cursor/
 
+# Claude
+.claude/
+
 # 0x profiling data
 *.0x


### PR DESCRIPTION
  - Add .claude to .gitignore to prevent Claude Code's local project files from being accidentally committed to the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)