### PR TITLE
Provider: Perform encounter creation in a transaction

### DIFF
--- a/examples/medplum-provider/src/utils/encounter.test.ts
+++ b/examples/medplum-provider/src/utils/encounter.test.ts
@@ -27,14 +27,16 @@ describe('encounter utils', () => {
 
   describe('createEncounter', () => {
     test('creates encounter and related resources', async () => {
-      // Capture createResource calls and respond with deterministic IDs
+      const executeBatchSpy = vi.spyOn(medplum, 'executeBatch').mockResolvedValue({
+        resourceType: 'Bundle',
+        type: 'transaction-response',
+        entry: [
+          { resource: { resourceType: 'Appointment', id: 'appt-1', status: 'booked' } },
+          { resource: { resourceType: 'Encounter', id: 'enc-1', status: 'planned' } },
+          { resource: { resourceType: 'ClinicalImpression', id: 'ci-1', status: 'in-progress' } },
+        ],
+      } as any);
       const createResourceSpy = vi.spyOn(medplum, 'createResource').mockImplementation(async (resource: any) => {
-        if (resource.resourceType === 'Appointment') {
-          return { ...resource, id: 'appt-1' };
-        }
-        if (resource.resourceType === 'Encounter') {
-          return { ...resource, id: 'enc-1' };
-        }
         if (resource.resourceType === 'ChargeItem') {
           return { ...resource, id: `charge-${Math.random()}` };
         }
@@ -95,7 +97,17 @@ describe('encounter utils', () => {
 
       expect(encounter.status).toBe('planned');
       expect(encounter.id).toBe('enc-1');
-      expect(createResourceSpy).toHaveBeenCalledWith(expect.objectContaining({ resourceType: 'Appointment' }));
+      expect(executeBatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resourceType: 'Bundle',
+          type: 'transaction',
+          entry: expect.arrayContaining([
+            expect.objectContaining({ resource: expect.objectContaining({ resourceType: 'Appointment' }) }),
+            expect.objectContaining({ resource: expect.objectContaining({ resourceType: 'Encounter' }) }),
+            expect.objectContaining({ resource: expect.objectContaining({ resourceType: 'ClinicalImpression' }) }),
+          ]),
+        })
+      );
       expect(postSpy).toHaveBeenCalled();
       expect(searchSpy).toHaveBeenCalledWith('Task', expect.objectContaining({ encounter: 'Encounter/enc-1' }));
       expect(readReferenceSpy).toHaveBeenCalledWith({ reference: 'ServiceRequest/sr-1' });

--- a/examples/medplum-provider/src/utils/encounter.ts
+++ b/examples/medplum-provider/src/utils/encounter.ts
@@ -4,6 +4,8 @@ import type { MedplumClient, WithId } from '@medplum/core';
 import { createReference, getExtension, getReferenceString, HTTP_HL7_ORG } from '@medplum/core';
 import type {
   Appointment,
+  Bundle,
+  BundleEntry,
   ChargeItem,
   ClinicalImpression,
   Coding,
@@ -11,9 +13,28 @@ import type {
   Patient,
   PlanDefinition,
   Practitioner,
+  Resource,
   ServiceRequest,
   Task,
 } from '@medplum/fhirtypes';
+import { v4 as uuidv4 } from 'uuid';
+
+type BundleEntryify<T extends Resource[]> = { [K in keyof T]: BundleEntry<T[K]> };
+type TransactionResponseBundle<T extends Resource[]> = Omit<Bundle, 'entry'> & {
+  entry: BundleEntryify<T>;
+  type: 'transaction-response';
+};
+
+function transact<T extends Resource[]>(
+  medplum: MedplumClient,
+  entry: BundleEntryify<T>
+): Promise<TransactionResponseBundle<T>> {
+  return medplum.executeBatch({
+    resourceType: 'Bundle',
+    type: 'transaction',
+    entry,
+  }) as Promise<TransactionResponseBundle<T>>;
+}
 
 export async function createEncounter(
   medplum: MedplumClient,
@@ -23,48 +44,73 @@ export async function createEncounter(
   patient: Patient,
   planDefinition: PlanDefinition
 ): Promise<Encounter> {
-  const appointment = await medplum.createResource({
-    resourceType: 'Appointment',
-    status: 'booked',
-    start: start.toISOString(),
-    end: end.toISOString(),
-    participant: [
-      {
-        actor: createReference(patient),
-        status: 'accepted',
-      },
-      {
-        actor: createReference(medplum.getProfile() as Practitioner),
-        status: 'accepted',
-      },
-    ],
-  });
-
-  const encounter: Encounter = await medplum.createResource({
-    resourceType: 'Encounter',
-    status: 'planned',
-    statusHistory: [],
-    classHistory: [],
-    class: classification,
-    subject: createReference(patient),
-    appointment: [createReference(appointment)],
-    participant: [
-      {
-        individual: createReference(medplum.getProfile() as Practitioner),
-      },
-    ],
-  });
-
-  const clinicalImpressionData: ClinicalImpression = {
-    resourceType: 'ClinicalImpression',
-    status: 'in-progress',
-    description: 'Initial clinical impression',
-    subject: createReference(patient),
-    encounter: createReference(encounter),
-    date: new Date().toISOString(),
+  const appointmentEntry: BundleEntry<Appointment> = {
+    fullUrl: `urn:uuid:${uuidv4()}`,
+    request: {
+      method: 'POST',
+      url: 'Appointment',
+    },
+    resource: {
+      resourceType: 'Appointment',
+      status: 'booked',
+      start: start.toISOString(),
+      end: end.toISOString(),
+      participant: [
+        {
+          actor: createReference(patient),
+          status: 'accepted',
+        },
+        {
+          actor: createReference(medplum.getProfile() as Practitioner),
+          status: 'accepted',
+        },
+      ],
+    },
   };
 
-  await medplum.createResource(clinicalImpressionData);
+  const encounterEntry: BundleEntry<Encounter> = {
+    fullUrl: `urn:uuid:${uuidv4()}`,
+    request: {
+      method: 'POST',
+      url: 'Encounter',
+    },
+    resource: {
+      resourceType: 'Encounter',
+      status: 'planned',
+      statusHistory: [],
+      classHistory: [],
+      class: classification,
+      subject: createReference(patient),
+      appointment: [{ reference: appointmentEntry.fullUrl }],
+      participant: [
+        {
+          individual: createReference(medplum.getProfile() as Practitioner),
+        },
+      ],
+    },
+  };
+
+  const clinicalImpressionEntry: BundleEntry<ClinicalImpression> = {
+    request: {
+      method: 'POST',
+      url: 'ClinicalImpression',
+    },
+    resource: {
+      resourceType: 'ClinicalImpression',
+      status: 'in-progress',
+      description: 'Initial clinical impression',
+      subject: createReference(patient),
+      encounter: { reference: encounterEntry.fullUrl },
+      date: new Date().toISOString(),
+    },
+  };
+
+  const result = await transact(medplum, [appointmentEntry, encounterEntry, clinicalImpressionEntry]);
+
+  const encounter = result.entry[1].resource;
+  if (!encounter) {
+    throw new Error('Transaction succeeded but did not return an encounter resource in position 1');
+  }
 
   await medplum.post(medplum.fhirUrl('PlanDefinition', planDefinition.id as string, '$apply'), {
     resourceType: 'Parameters',


### PR DESCRIPTION
I'd like to add behavior here where we create a `Slot` resource at the same time as the `Appointment` is created, to prevent future scheduling operations from colliding with these appointments. ($find and $book, for example, use Slot resources for computing availability and don't inspect Appointment resources.)

Moving these initial resource creations into a transaction gives me a good place to hook in to in the future.