### PR TITLE
Add maxResults prop to ResourceInput and ReferenceInput

### DIFF
--- a/packages/react/src/ReferenceInput/ReferenceInput.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.tsx
@@ -20,6 +20,8 @@ export interface ReferenceInputProps<T extends Resource = Resource> {
   readonly required?: boolean;
   readonly onChange?: (value: Reference<T> | undefined) => void;
   readonly disabled?: boolean;
+  /** Maximum number of search results to return. Defaults to 10. */
+  readonly maxResults?: number;
 }
 
 interface BaseTargetType {
@@ -194,6 +196,7 @@ export function ReferenceInput<T extends Resource = Resource>(props: ReferenceIn
           searchCriteria={searchCriteria}
           onChange={setValueHelper}
           disabled={props.disabled}
+          maxResults={props.maxResults}
         />
       </Group>
     </>

--- a/packages/react/src/ResourceInput/ResourceInput.test.tsx
+++ b/packages/react/src/ResourceInput/ResourceInput.test.tsx
@@ -183,6 +183,33 @@ describe('ResourceInput', () => {
     expect(onChange).toHaveBeenCalledWith(undefined);
   });
 
+  test('Respects maxResults prop in search query', async () => {
+    const searchResourcesSpy = jest.spyOn(medplum, 'searchResources');
+
+    setup({
+      resourceType: 'Patient',
+      name: 'foo',
+      placeholder: 'Test',
+      maxResults: 25,
+    });
+
+    const input = screen.getByPlaceholderText('Test');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Simpson' } });
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const callArgs = searchResourcesSpy.mock.calls[0];
+    const searchParams = callArgs[1] as URLSearchParams;
+    expect(searchParams.get('_count')).toBe('25');
+
+    searchResourcesSpy.mockRestore();
+  });
+
   test('Custom item component', async () => {
     const MyTestItemComponent = forwardRef<HTMLDivElement, AsyncAutocompleteOption<Resource>>(
       ({ label, resource, active: _active, ...others }: AsyncAutocompleteOption<Resource>, ref) => {

--- a/packages/react/src/ResourceInput/ResourceInput.tsx
+++ b/packages/react/src/ResourceInput/ResourceInput.tsx
@@ -90,6 +90,8 @@ export interface ResourceInputProps<T extends Resource = Resource> {
   readonly disabled?: boolean;
   readonly label?: AsyncAutocompleteProps<T>['label'];
   readonly error?: AsyncAutocompleteProps<T>['error'];
+  /** Maximum number of search results to return. Defaults to 10. */
+  readonly maxResults?: number;
 }
 
 function toOption<T extends Resource>(resource: T): AsyncAutocompleteOption<T> {
@@ -102,7 +104,7 @@ function toOption<T extends Resource>(resource: T): AsyncAutocompleteOption<T> {
 
 export function ResourceInput<T extends Resource = Resource>(props: ResourceInputProps<T>): JSX.Element | null {
   const medplum = useMedplum();
-  const { resourceType, searchCriteria } = props;
+  const { resourceType, searchCriteria, maxResults = 10 } = props;
   const [outcome, setOutcome] = useState<OperationOutcome>();
   const defaultValue = useResource(props.defaultValue, setOutcome);
   const ItemComponent = props.itemComponent ?? DefaultItemComponent;
@@ -113,14 +115,14 @@ export function ResourceInput<T extends Resource = Resource>(props: ResourceInpu
       const searchCode = getSearchParamForResourceType(resourceType);
       const searchParams = new URLSearchParams({
         [searchCode]: input ?? '',
-        _count: '10',
+        _count: String(maxResults),
         ...searchCriteria,
       });
 
       const resources = await medplum.searchResources(resourceType, searchParams, { signal });
       return resources as unknown as T[];
     },
-    [medplum, resourceType, searchCriteria]
+    [medplum, maxResults, resourceType, searchCriteria]
   );
 
   const handleChange = useCallback(


### PR DESCRIPTION
## Summary
Added support for configurable maximum search results in ResourceInput and ReferenceInput components, allowing consumers to control the `_count` parameter passed to search queries.

## Key Changes
- Added `maxResults` prop to `ResourceInputProps` interface with a default value of 10
- Updated `ResourceInput` component to use the `maxResults` prop when constructing search parameters
- Added `maxResults` prop to `ReferenceInputProps` interface and passed it through to the underlying `ResourceInput` component
- Added JSDoc comment documenting the new prop and its default behavior
- Updated the dependency array in the `useCallback` hook to include `maxResults`
- Added test case to verify that the `maxResults` prop correctly sets the `_count` query parameter

## Implementation Details
- The `maxResults` prop defaults to 10 to maintain backward compatibility with existing behavior
- The prop is converted to a string when passed to `URLSearchParams` via `String(maxResults)`
- Both `ResourceInput` and `ReferenceInput` now support this configuration, with `ReferenceInput` passing it through to its internal `ResourceInput` usage

https://claude.ai/code/session_017b7JsxAFCdSaFee7aYPEmX