### PR TITLE
Provider: Adding a "visit" adds a busy slot

### DIFF
--- a/examples/medplum-provider/src/components/schedule/CreateVisit.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateVisit.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
-import type { Patient } from '@medplum/fhirtypes';
+import type { Patient, Schedule } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, render, screen, waitFor } from '@testing-library/react';
@@ -44,13 +44,13 @@ describe('CreateVisit', () => {
     });
   });
 
-  const setup = (appointmentSlot?: SlotInfo): ReturnType<typeof render> => {
+  const setup = (appointmentSlot?: SlotInfo, schedule?: Schedule): ReturnType<typeof render> => {
     return render(
       <MemoryRouter>
         <MedplumProvider medplum={medplum}>
           <MantineProvider>
             <Notifications />
-            <CreateVisit appointmentSlot={appointmentSlot} />
+            <CreateVisit appointmentSlot={appointmentSlot} schedule={schedule} />
           </MantineProvider>
         </MedplumProvider>
       </MemoryRouter>
@@ -80,6 +80,22 @@ describe('CreateVisit', () => {
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /Create Visit/i })).toBeInTheDocument();
+      });
+    });
+
+    test('renders correctly when schedule prop is provided', async () => {
+      const schedule: Schedule = {
+        resourceType: 'Schedule',
+        id: 'sched-1',
+        actor: [{ reference: 'Practitioner/practitioner-1' }],
+      };
+      await act(async () => {
+        setup(mockSlotInfo, schedule);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Create Visit/i })).toBeInTheDocument();
+        expect(screen.getByLabelText(/Patient/i)).toBeInTheDocument();
       });
     });
   });

--- a/examples/medplum-provider/src/components/schedule/CreateVisit.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateVisit.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Button, Card, Flex, Stack, Text, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
-import type { Coding, Patient, PlanDefinition, PlanDefinitionAction } from '@medplum/fhirtypes';
+import type { Coding, Patient, PlanDefinition, PlanDefinitionAction, Schedule } from '@medplum/fhirtypes';
 import { CodingInput, DateTimeInput, Form, ResourceInput, useMedplum } from '@medplum/react';
 import { IconAlertSquareRounded, IconCircleCheck, IconCirclePlus } from '@tabler/icons-react';
 import type { JSX } from 'react';
@@ -15,10 +15,11 @@ import classes from './CreateVisit.module.css';
 
 interface CreateVisitProps {
   appointmentSlot: Range | undefined;
+  schedule?: Schedule;
 }
 
 export function CreateVisit(props: CreateVisitProps): JSX.Element {
-  const { appointmentSlot } = props;
+  const { appointmentSlot, schedule } = props;
   const [patient, setPatient] = useState<Patient | undefined>();
   const [planDefinitionData, setPlanDefinitionData] = useState<PlanDefinition | undefined>();
   const [encounterClass, setEncounterClass] = useState<Coding | undefined>();
@@ -64,7 +65,15 @@ export function CreateVisit(props: CreateVisitProps): JSX.Element {
     }
     setIsLoading(true);
     try {
-      const encounter = await createEncounter(medplum, start, end, encounterClass, patient, planDefinitionData);
+      const encounter = await createEncounter(
+        medplum,
+        start,
+        end,
+        encounterClass,
+        patient,
+        planDefinitionData,
+        schedule
+      );
       showNotification({ icon: <IconCircleCheck />, title: 'Success', message: 'Visit created' });
       navigate(`/Patient/${patient.id}/Encounter/${encounter.id}`)?.catch(console.error);
     } catch (err) {

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
@@ -214,7 +214,7 @@ export function SchedulePage(): JSX.Element | null {
         position="right"
         h="100%"
       >
-        <CreateVisit appointmentSlot={appointmentSlot} />
+        <CreateVisit appointmentSlot={appointmentSlot} schedule={schedule} />
       </Drawer>
       <Drawer
         opened={appointmentDetailsOpened}


### PR DESCRIPTION
Eventually we want to consolidate the $find/$book path with this "visit" scheduling pathway, but for now we can make them play together more nicely.

When creating a visit, we now also create a Slot resource for the schedule on screen with `status: 'busy'`. This will make that time unavailable for $find/$book operations, which don't consider Appointment resources when checking availability.