### PR TITLE
perf(subscription): prefer nonblocking `unlink` over `del` for bulk deletes

### DIFF
--- a/packages/server/src/pubsub.ts
+++ b/packages/server/src/pubsub.ts
@@ -25,7 +25,7 @@ export function getActiveSubscriptions(projectId: string, resourceType: string):
   return getPubSubRedis().hgetall(getActiveSubsKey(projectId, resourceType));
 }
 
-export function removeActiveSubscriptions(projectId: string, resourceType: string, ...refs: string[]): Promise<number> {
+export function removeActiveSubscriptions(projectId: string, resourceType: string, refs: string[]): Promise<number> {
   return getPubSubRedis().hdel(getActiveSubsKey(projectId, resourceType), ...refs);
 }
 

--- a/packages/server/src/subscriptions/websockets.ts
+++ b/packages/server/src/subscriptions/websockets.ts
@@ -534,13 +534,19 @@ export async function markInMemorySubscriptionsInactive(
     const refs = ids.map((id) => `Subscription/${id}`);
     refStrs.push(...refs);
     try {
-      await removeActiveSubscriptions(projectId, resourceType, ...refs);
+      await removeActiveSubscriptions(projectId, resourceType, refs);
     } catch {
       globalLogger.debug('Attempted to mark subscriptions as inactive when Redis is closed');
       return;
     }
   }
   if (cacheRedis) {
-    await cacheRedis.del(refStrs);
+    // In the case where we could be deleting a lot of keys at once, we prefer
+    // `unlink` due to it essentially being the same command ad `del`, just the nonblocking version
+    // Keys are unlinked from keyspace but the actual memory is not reclaimed immediately, and is done separately
+    // in a background thread
+    // See: https://redis.io/docs/latest/commands/unlink/
+    // See: https://support.redislabs.com/hc/en-us/articles/32321430231186-Massive-Key-Deletion-in-Redis-Without-Impacting-Performance
+    await cacheRedis.unlink(refStrs);
   }
 }

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -463,7 +463,7 @@ async function getSubscriptions(resource: Resource, project: WithId<Project>): P
             inactiveSubs.push(redisOnlySubRefStrs[i]);
           }
         }
-        await removeActiveSubscriptions(projectId, resource.resourceType, ...inactiveSubs);
+        await removeActiveSubscriptions(projectId, resource.resourceType, inactiveSubs);
       }
       const subArrStr = '[' + activeSubStrs.join(',') + ']';
       const inMemorySubs = JSON.parse(subArrStr) as { resource: WithId<Subscription>; projectId: string }[];


### PR DESCRIPTION
`UNLINK` is typically preferred over `DEL` for bulk deletes since it does not block the main thread for cleanup and instead defers cleanup to a background thread.

See: https://support.redislabs.com/hc/en-us/articles/32321430231186-Massive-Key-Deletion-in-Redis-Without-Impacting-Performance