### PR TITLE
Restore all SDK documentation pages

### DIFF
--- a/packages/docs/markdown-to-mdx.mjs
+++ b/packages/docs/markdown-to-mdx.mjs
@@ -7,52 +7,6 @@
 import { copyFileSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
-const allowList = [
-  'index.md',
-
-  // Top pages from Google Analytics
-  'core.md',
-  'core.medplumclient.md',
-  'core.medplumrequestoptions.md',
-  'core.medplumclient.executebatch.md',
-  'core.medplumclient.search.md',
-  'core.medplumclient.searchresources.md',
-  'core.hl7message.md',
-  'core.medplumclient.readpatienteverything.md',
-  'core.botevent.md',
-  'core.clientstorage.md',
-
-  // Sidebar links
-  'core.createpdffunction.md',
-  'core.mailaddress.md',
-  'core.mailattachment.md',
-  'core.mailoptions.md',
-
-  // Other linked pages
-  'core.medplumclient.createresourceifnoneexist.md',
-  'core.medplumclient.readhistory.md',
-  'core.medplumclient.sendemail.md',
-  'core.medplumclient.startclientlogin.md',
-  'core.medplumclient.signinwithexternalauth.md',
-  'core.medplumclient.processcode.md',
-  'core.medplumclient.startgooglelogin.md',
-  'core.medplumclient.startlogin.md',
-  'core.medplumclient.signinwithredirect.md',
-  'core.medplumclient.exchangeexternalaccesstoken.md',
-  'core.getquestionnaireanswers.md',
-  'core.medplumclient.createresource.md',
-  'core.botevent.secrets.md',
-  'core.medplumclient.createpdf.md',
-  'core.findobservationinterval.md',
-  'core.findobservationreferencerange.md',
-  'core.matchesrange.md',
-  'core.validateresource.md',
-  'core.medplumclient.setbasicauth.md',
-  'core.getreferencestring.md',
-  'core.medplumclient.searchresourcepages.md',
-  'core.medplumclient.getprofile.md',
-];
-
 function copyDir(sourceDir, targetDir) {
   const files = readdirSync(sourceDir, { withFileTypes: true });
   mkdirSync(targetDir, { recursive: true });
@@ -69,9 +23,6 @@ function copyDir(sourceDir, targetDir) {
 }
 
 function copyFile(sourceFile, targetFile) {
-  if (!allowList.includes(basename(sourceFile))) {
-    return;
-  }
   if (sourceFile.endsWith('.md')) {
     writeFileSync(targetFile.replace('.md', '.mdx'), escapeMdx(sourceFile, readFileSync(sourceFile, 'utf8')));
   } else {
@@ -92,16 +43,6 @@ function escapeMdx(fileName, text) {
   } else {
     text = text.replaceAll('[Home](./index)', '[Home](./)');
   }
-
-  // Remove links to any relative .md files not in the allow list
-  // Example: [TypedEventTarget](./core.typedeventtarget)
-  text = text.replaceAll(/\[([^\]]+)\]\(\.\/([^)]+)\)/g, (match, p1, p2) => {
-    if (allowList.includes(p2 + '.md')) {
-      return `[${p1}](./${p2})`;
-    } else {
-      return p1;
-    }
-  });
 
   // Escape { and } characters outside of code blocks
   const specialChars = ['{', '}'];


### PR DESCRIPTION
Reverts changes from https://github.com/medplum/medplum/pull/8131

Context:
* Algolia was not indexing certain pages because they were "too big"
* In particular, many of our documentation index pages, such as the entry point to `@medplum/core` or `MedplumClient`
* So, in #8131, we trimmed down those pages
* However, that didn't fixed the Algolia issue, and also caused customer confusion over missing pages

This PR reverts the change, and brings back all of the autogenerated SDK documentation pages.

We're still working on the best solution for the "too big" pages which are not indexed by Algolia.