### PR TITLE
tweak(subscription): adjust gc threshold from `50` -> `5`

### DIFF
--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -466,7 +466,13 @@ async function getSubscriptions(resource: Resource, project: WithId<Project>): P
     const redisOnlySubStrs = await cacheRedis.mget(redisOnlySubRefStrs);
     if (project.features?.includes('websocket-subscriptions')) {
       const activeSubStrs = redisOnlySubStrs.filter(Boolean);
-      if (redisOnlySubStrs.length - activeSubStrs.length >= 50) {
+      // This used to be set to 50 because we evaluated every Subscription for the entire project at this point
+      // However, we now store the Subscription criteria and use that to filter before doing the mget above,
+      // Which means by this point only Subscriptions with not only the same resource type but also have matching criteria
+      // Would be in the list by now
+      // That means for subscriptions with niche criteria we may not get enough subs to trigger any GC unless the threshold is pretty low
+      // Trying 5 for now (50 -> 5)
+      if (redisOnlySubStrs.length - activeSubStrs.length >= 5) {
         getLogger().warn('Excessive subscription cache miss', {
           numKeys: redisOnlySubRefStrs.length,
           hitRate: activeSubStrs.length / redisOnlySubStrs.length,


### PR DESCRIPTION
Previously we evaluated every Subscription for the current project at the point of GC, but we've gotten a lot more surgical about which Subscriptions we evaluate by storing the criteria with the reference string in our set in Redis. Now by the time we get to GC, subscriptions have been filtered to a subset for this resource type and also only the one's whose criteria actually matches the resource. 

This means our threshold of 50 does not hit nearly as often, especially for users who are using criteria that contain search parameters for a certain resource (eg. `Communication?sender=x&recipient=y`).

This PR would adjust the threshold to 5 which would probably hit as often as our 50 did before, or maybe even less often since it takes 48 hours for a subscription cache entry to expire completely.