### PR TITLE
Fix transaction consistency in readResourceFromDatabase

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -505,7 +505,12 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     }
 
     const resource = JSON.parse(rows[0].content as string) as WithId<T>;
-    await this.setCacheEntry(resource);
+
+    if (!this.transactionDepth) {
+      // Only set cache entry if not in a transaction
+      await this.setCacheEntry(resource);
+    }
+
     return resource;
   }
 


### PR DESCRIPTION
Context:
* https://medplum.slack.com/archives/C066H5ND51T/p1772388069476159
* https://docs.google.com/spreadsheets/d/1n9U3KJj9FOf_NNXJXfh4RostKg7htqckaWL7uuFXlPw/edit?gid=0#gid=0

The `readResourceFromDatabase` method is a private internal method for reading a FHIR resource directly from the database.  It uses a "cache on read" model.  It is an old method that pre-dates our support for FHIR transaction bundles.

When using FHIR transaction bundles, Medplum server intentionally does not read from cache, and therefore will use `readResourceFromDatabase` for most "read by ID" operations.  However, those reads should definitely not "cache on read", due to all of the complex behavior that can happen within a transaction.