### PR TITLE
fix(provider): rename page schedule to calendar

### DIFF
--- a/examples/medplum-provider/src/App.tsx
+++ b/examples/medplum-provider/src/App.tsx
@@ -90,7 +90,7 @@ export function App(): JSX.Element | null {
                     label: 'Patients',
                     href: '/Patient?_count=20&_fields=name,email,gender&_sort=-_lastUpdated',
                   },
-                  { icon: <IconCalendarEvent />, label: 'Schedule', href: '/schedule' },
+                  { icon: <IconCalendarEvent />, label: 'Schedule', href: '/calendar' },
                   {
                     icon: <IconMail />,
                     label: 'Messages',
@@ -203,7 +203,7 @@ export function App(): JSX.Element | null {
               <Route path="Task" element={<TasksPage />} />
               <Route path="Task/:taskId" element={<TasksPage />} />
               <Route path="/onboarding" element={<IntakeFormPage />} />
-              <Route path="/schedule" element={<SchedulePage />} />
+              <Route path="/calendar" element={<SchedulePage />} />
               <Route path="/signin" element={<SignInPage />} />
               {hasDoseSpot && <Route path="/dosespot" element={<DoseSpotNotificationsPage />} />}
               <Route path="/integrations" element={<IntegrationsPage />} />


### PR DESCRIPTION
For context, we would use resource names for pages when presenting corresponding resources in the same page.