### PR TITLE
Hooks: `useSearch` result types should be `WithId<T>`

### DIFF
--- a/packages/react-hooks/src/useSearch/useSearch.ts
+++ b/packages/react-hooks/src/useSearch/useSearch.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { QueryTypes, ResourceArray } from '@medplum/core';
+import type { QueryTypes, ResourceArray, WithId } from '@medplum/core';
 import { allOk, normalizeOperationOutcome } from '@medplum/core';
 import type { Bundle, ExtractResource, OperationOutcome, ResourceType } from '@medplum/fhirtypes';
 import { useEffect, useMemo, useState } from 'react';
@@ -26,8 +26,8 @@ export function useSearch<K extends ResourceType>(
   resourceType: K,
   query?: QueryTypes,
   options?: SearchOptions
-): [Bundle<ExtractResource<K>> | undefined, boolean, OperationOutcome | undefined] {
-  return useSearchImpl<K, Bundle<ExtractResource<K>>>('search', resourceType, query, options);
+): [Bundle<WithId<ExtractResource<K>>> | undefined, boolean, OperationOutcome | undefined] {
+  return useSearchImpl<K, Bundle<WithId<ExtractResource<K>>>>('search', resourceType, query, options);
 }
 
 /**
@@ -44,8 +44,8 @@ export function useSearchOne<K extends ResourceType>(
   resourceType: K,
   query?: QueryTypes,
   options?: SearchOptions
-): [ExtractResource<K> | undefined, boolean, OperationOutcome | undefined] {
-  return useSearchImpl<K, ExtractResource<K>>('searchOne', resourceType, query, options);
+): [WithId<ExtractResource<K>> | undefined, boolean, OperationOutcome | undefined] {
+  return useSearchImpl<K, WithId<ExtractResource<K>>>('searchOne', resourceType, query, options);
 }
 
 /**
@@ -62,8 +62,8 @@ export function useSearchResources<K extends ResourceType>(
   resourceType: K,
   query?: QueryTypes,
   options?: SearchOptions
-): [ResourceArray<ExtractResource<K>> | undefined, boolean, OperationOutcome | undefined] {
-  return useSearchImpl<K, ResourceArray<ExtractResource<K>>>('searchResources', resourceType, query, options);
+): [ResourceArray<WithId<ExtractResource<K>>> | undefined, boolean, OperationOutcome | undefined] {
+  return useSearchImpl<K, ResourceArray<WithId<ExtractResource<K>>>>('searchResources', resourceType, query, options);
 }
 
 function useSearchImpl<K extends ResourceType, SearchReturnType>(


### PR DESCRIPTION
Resources coming from the search API will have the `id` attribute set.

This is already a guarantee the client methods powering these hooks makes. Example: https://github.com/medplum/medplum/blob/v5.1.1/packages/core/src/client.ts#L1726

This lets us avoid introducing extra `if (resource.id)` checks or `as WithId<Resource>` type assertions down the line.