### PR TITLE
FHIRCast PACs secure websocket

### DIFF
--- a/packages/server/src/fhircast/routes.ts
+++ b/packages/server/src/fhircast/routes.ts
@@ -37,6 +37,7 @@ import {
   cleanupContextForResource,
   extractAnchorResourceType,
   getCurrentContext,
+  getEndpointEventsKey,
   getTopicContextStorageKey,
   getTopicCurrentContextKey,
   setTopicCurrentContext,
@@ -201,6 +202,8 @@ async function handleSubscriptionRequest(req: Request, res: Response): Promise<v
     subscriptionEndpoint = result as string;
     const endpointTopicKey = `medplum:fhircast:endpoint:${subscriptionEndpoint}:topic`;
     await getCacheRedis().setnx(endpointTopicKey, `${ctx.project.id}:${topic}`);
+    // Always overwrite the events since a re-subscribe may request different events
+    await getCacheRedis().set(getEndpointEventsKey(subscriptionEndpoint), req.body['hub.events'] ?? '');
   } catch (err) {
     sendOutcome(res, serverError(new Error('Failed to get endpoint for topic')));
     getLogger().error(`[FHIRcast]: Received error while retrieving endpoint for topic`, {

--- a/packages/server/src/fhircast/utils.ts
+++ b/packages/server/src/fhircast/utils.ts
@@ -20,6 +20,10 @@ export function getTopicContextStorageKey(projectId: string, topic: string): str
   return `medplum:fhircast:project:${projectId}:topic:${topic}:contexts`;
 }
 
+export function getEndpointEventsKey(endpointId: string): string {
+  return `medplum:fhircast:endpoint:${endpointId}:events`;
+}
+
 export function extractAnchorResourceType(eventName: string): FhircastAnchorResourceType {
   const loweredResourceType = eventName.split('-')[0].toLowerCase();
   const extractedResourceType = RESOURCE_TYPE_LOWER_TO_VALID_RESOURCE_TYPE[loweredResourceType];

--- a/packages/server/src/fhircast/websocket.test.ts
+++ b/packages/server/src/fhircast/websocket.test.ts
@@ -71,8 +71,16 @@ describe('FHIRcast WebSocket', () => {
         await request(server)
           .ws(pathname)
           .expectJson((obj) => {
-            // Connection verification message
+            // Connection verification message — must only contain WebSocket-relevant fields
+            expect(obj['hub.mode']).toBe('subscribe');
             expect(obj['hub.topic']).toBe(topic);
+            expect(obj['hub.events']).toBe('Patient-open');
+            expect(obj['hub.lease_seconds']).toBe(3600);
+            // Webhook-specific fields must not be present
+            expect(obj['hub.callback']).toBeUndefined();
+            expect(obj['hub.channel']).toBeUndefined();
+            expect(obj['hub.secret']).toBeUndefined();
+            expect(obj['hub.subscriber']).toBeUndefined();
           })
           .exec(async () => {
             const res2 = await request(server)
@@ -213,7 +221,9 @@ describe('FHIRcast WebSocket', () => {
           .ws(pathname)
           .expectJson((obj) => {
             // Connection verification message
+            expect(obj['hub.mode']).toBe('subscribe');
             expect(obj['hub.topic']).toBe(topic);
+            expect(obj['hub.events']).toBe('DiagnosticReport-open,DiagnosticReport-close,DiagnosticReport-update');
           })
           .exec(async () => {
             // Initial DiagnosticReport-open of Report 1
@@ -776,6 +786,61 @@ describe('FHIRcast WebSocket', () => {
           })
           .expectClosed();
       }));
+
+    test('Malformed JSON from subscriber does not crash connection', () =>
+      withTestContext(async () => {
+        const topic = randomUUID();
+        const patient = randomUUID();
+
+        const res1 = await request(server)
+          .post('/fhircast/STU3')
+          .set('Content-Type', ContentType.FORM_URL_ENCODED)
+          .set('Authorization', 'Bearer ' + accessToken)
+          .send(
+            serializeFhircastSubscriptionRequest({
+              mode: 'subscribe',
+              channelType: 'websocket',
+              topic,
+              events: ['Patient-open'],
+            })
+          );
+
+        const endpoint = res1.body['hub.channel.endpoint'];
+        const pathname = new URL(endpoint).pathname;
+
+        // Verify that sending malformed JSON does not crash the connection.
+        // After sending invalid data the server should still deliver a valid event.
+        await request(server)
+          .ws(pathname)
+          .expectJson((obj) => {
+            expect(obj['hub.mode']).toBe('subscribe');
+            expect(obj['hub.topic']).toBe(topic);
+          })
+          .send('this is not valid JSON')
+          .exec(async () => {
+            // Publish a real event — the server must still be alive to fan it out
+            const res2 = await request(server)
+              .post(`/fhircast/STU3/${topic}`)
+              .set('Content-Type', ContentType.JSON)
+              .set('Authorization', 'Bearer ' + accessToken)
+              .send({
+                timestamp: new Date().toISOString(),
+                id: randomUUID(),
+                event: {
+                  'hub.topic': topic,
+                  'hub.event': 'Patient-open',
+                  context: [{ key: 'patient', resource: { resourceType: 'Patient', id: patient } }],
+                },
+              });
+            expect(res2.status).toBe(202);
+          })
+          .expectJson((obj) => {
+            // If we receive this event the connection survived the malformed message
+            expect(obj.event['hub.event']).toBe('Patient-open');
+          })
+          .close()
+          .expectClosed();
+      }));
   });
 
   describe('Heartbeat', () => {
@@ -825,7 +890,9 @@ describe('FHIRcast WebSocket', () => {
           .ws(pathname)
           .expectJson((obj) => {
             // Connection verification message
+            expect(obj['hub.mode']).toBe('subscribe');
             expect(obj['hub.topic']).toBe(topic);
+            expect(obj['hub.events']).toBe('Patient-open');
           })
           .expectJson((obj) => {
             expect(obj).toMatchObject({
@@ -868,7 +935,9 @@ describe('FHIRcast WebSocket', () => {
           .ws(pathname)
           .expectJson((obj) => {
             // Connection verification message
+            expect(obj['hub.mode']).toBe('subscribe');
             expect(obj['hub.topic']).toBe(topic);
+            expect(obj['hub.events']).toBe('Patient-open');
           })
           .expectJson((obj) => {
             // Event message
@@ -881,7 +950,9 @@ describe('FHIRcast WebSocket', () => {
               .ws(pathname)
               .expectJson((obj) => {
                 // Connection verification message
+                expect(obj['hub.mode']).toBe('subscribe');
                 expect(obj['hub.topic']).toBe(topic);
+                expect(obj['hub.events']).toBe('Patient-open');
               })
               .expectJson((obj) => {
                 // Event message

--- a/packages/server/src/fhircast/websocket.ts
+++ b/packages/server/src/fhircast/websocket.ts
@@ -10,6 +10,7 @@ import { globalLogger } from '../logger';
 import { setGauge } from '../otel/otel';
 import { publish } from '../pubsub';
 import { getCacheRedis, getPubSubRedisSubscriber } from '../redis';
+import { getEndpointEventsKey } from './utils';
 
 const hostname = os.hostname();
 const METRIC_OPTIONS = { attributes: { hostname } };
@@ -71,7 +72,11 @@ export async function handleFhircastConnection(socket: WebSocket, request: Incom
   const topicEndpoint = (request.url as string).split('/').filter(Boolean)[2];
   const endpointTopicKey = `medplum:fhircast:endpoint:${topicEndpoint}:topic`;
 
-  const projectAndTopic = await getCacheRedis().get(endpointTopicKey);
+  const [projectAndTopic, events] = await Promise.all([
+    getCacheRedis().get(endpointTopicKey),
+    getCacheRedis().get(getEndpointEventsKey(topicEndpoint)),
+  ]);
+
   if (!projectAndTopic) {
     globalLogger.error(`[FHIRcast]: No topic associated with the endpoint '${topicEndpoint}'`);
     // Close the socket since this endpoint is not valid
@@ -113,8 +118,12 @@ export async function handleFhircastConnection(socket: WebSocket, request: Incom
     'message',
     AsyncLocalStorage.bind(async (data: RawData) => {
       fhircastMessagesReceived++;
-      const message = JSON.parse((data as Buffer).toString('utf8'));
-      globalLogger.debug('message', message);
+      try {
+        const message = JSON.parse((data as Buffer).toString('utf8'));
+        globalLogger.debug('message', message);
+      } catch (err) {
+        globalLogger.error('[FHIRcast]: Failed to parse message from subscriber', { error: err });
+      }
     })
   );
 
@@ -134,18 +143,14 @@ export async function handleFhircastConnection(socket: WebSocket, request: Incom
     redisSubscriber.disconnect();
   });
 
-  // Send initial connection verification
-  // TODO: Fill in these properties
+  // Send initial connection verification per the FHIRcast spec
+  // See: https://build.fhir.org/ig/HL7/fhircast-docs/2-4-Subscribing.html#subscription-confirmation
   socket.send(
     JSON.stringify({
-      'hub.callback': '',
-      'hub.channel': '',
-      'hub.events': '',
-      'hub.lease_seconds': 3600,
       'hub.mode': 'subscribe',
-      'hub.secret': '',
-      'hub.subscriber': '',
       'hub.topic': topic,
+      'hub.events': events ?? '',
+      'hub.lease_seconds': 3600,
     }),
     { binary: false }
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix FHIRCast WebSocket connection confirmation, persist `hub.events`, and add `JSON.parse` error handling.

The previous implementation sent an incomplete/wrong WebSocket confirmation message, didn't persist `hub.events` for subscribers, and lacked error handling for malformed JSON messages, leading to spec violations and connection instability.

---
<p><a href="https://cursor.com/agents/bc-77646373-ed98-42d7-b483-e70379d7b02f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77646373-ed98-42d7-b483-e70379d7b02f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->