### PR TITLE
fix(sonar): don't run sonar on merge group checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: SonarCloud Scan
-        if: ${{ matrix.node-version == 22 && matrix.pg-version == 14 && matrix.redis-version == 7 }}
+        if: ${{ github.event_name != 'merge_group' && matrix.node-version == 22 && matrix.pg-version == 14 && matrix.redis-version == 7 }}
         continue-on-error: true
         uses: SonarSource/sonarqube-scan-action@01850e2590cc09ed26831056406ae1525aa41ad5 # master
         env:


### PR DESCRIPTION
This is a temporary change to stop running Sonar on merge group checks since there is a bug that causes it to silently hang for ~8 minutes and then fail on a merge group check. We should fix this and re-enable this later, but for now we are getting no value out of it since it fails to publish any results after crashing in the action after 8 minutes.

Sonar will however continue to run on PRs, so we should still get the info there