### PR TITLE
Clarify maxBatchSize applies to async batches

### DIFF
--- a/packages/docs/docs/self-hosting/server-config.md
+++ b/packages/docs/docs/self-hosting/server-config.md
@@ -306,7 +306,7 @@ Maximum JSON size for API calls. String is parsed with the [bytes](https://www.n
 
 ### maxBatchSize
 
-Maximum batch size for API calls. String is parsed with the [bytes](https://www.npmjs.com/package/bytes) library.
+Maximum batch size for Async Batches. When processing Async Batches, this limit overrides `maxJsonSize`. See [Asynchronous Batch Requests](/docs/fhir-datastore/fhir-batch-requests#asynchronous-batch-requests) for more details. String is parsed with the [bytes](https://www.npmjs.com/package/bytes) library.
 
 **Default:** `50mb`
 


### PR DESCRIPTION
## Summary

Clarified server configuration documentation to explicitly state that `maxBatchSize` is the limit for Async Batches and that it overrides `maxJsonSize` when processing async batches. Added a link to the Asynchronous Batch Requests documentation.

## Motivation

Reagan confirmed that maxBatchSize specifically applies to Async Batches and overrides the general maxJsonSize limit. This clarification prevents confusion about which size limit applies in different contexts.

## Test plan

- [x] Documentation updated with clearer description
- [x] Link to async batch documentation included for reference
- [x] No code changes affecting functionality