### PR TITLE
Scheduling: Remove "Generic" (aka "Wildcard") availability

### DIFF
--- a/examples/foomedical/README.md
+++ b/examples/foomedical/README.md
@@ -80,6 +80,48 @@ Contact the medplum team ([support@medplum.com](mailto:support@medplum.com) or [
 
 When you log into Foo Medical a set of sample FHIR records is created on your behalf. The ability to run automations is part of the Medplum platform using a framework called [Bots](https://www.medplum.com/docs/bots). For reference, Bot that created the records in Foo Medical can be found [here](https://github.com/medplum/medplum-demo-bots/blob/main/src/sample-account-setup.ts).
 
+### Scheduling
+
+The "Get Care" page is configured to search for availability with service-type "office-visit". Configure your practitioner's schedule with a Medplum scheduling extension such as this one:
+```
+{
+  "resourceType": "Schedule",
+  "active": true,
+  "extension": [
+    {
+      "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
+      "extension": [
+        {
+          "url": "serviceType",
+          "valueCodeableConcept": {
+            "coding": [{"code": "office-visit"}]
+          }
+        },
+        {
+          "url": "duration",
+          "valueDuration": {
+            "value": 1,
+            "unit": "h"
+          }
+        },
+        {
+          "url": "availability",
+          "valueTiming": {
+            "repeat": {
+              "dayOfWeek": ["mon", "tue", "wed", "thu"],
+              "timeOfDay": ["09:00:00"],
+              "duration": 8,
+              "durationUnit": "h"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+
+```
+
 ### Compliance
 
 Medplum backend is HIPAA compliant and SOC 2 certified. Getting an account set up requires registering on [medplum.com](https://www.medplum.com/). Feel free to ask us questions in real time on our [Discord Server](https://discord.gg/medplum).

--- a/examples/foomedical/src/pages/GetCarePage.tsx
+++ b/examples/foomedical/src/pages/GetCarePage.tsx
@@ -25,7 +25,11 @@ export function GetCare(): JSX.Element {
       return [];
     }
 
-    const params = new URLSearchParams({ start: period.start, end: period.end });
+    const params = new URLSearchParams({
+      start: period.start,
+      end: period.end,
+      'service-type': 'office-visit',
+    });
     const findUrl = medplum.fhirUrl('Schedule', schedule.id, '$find');
     const bundle = await medplum.get<Bundle<Slot>>(`${findUrl}?${params}`);
     return bundle.entry?.map((entry) => entry.resource).filter(isDefined) ?? [];

--- a/examples/medplum-provider/src/pages/schedule/FindPane.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/FindPane.test.tsx
@@ -128,17 +128,6 @@ describe('FindPane', () => {
       expect(screen.getByText('Annual Checkup')).toBeInTheDocument();
       expect(screen.getByText('Follow-up Visit')).toBeInTheDocument();
     });
-
-    test('renders "Other" for undefined service types', async () => {
-      const schedule = createScheduleWithServiceTypes([serviceType1, undefined]);
-
-      await act(async () => {
-        setup({ schedule });
-      });
-
-      expect(screen.getByText('Annual Checkup')).toBeInTheDocument();
-      expect(screen.getByText('Other')).toBeInTheDocument();
-    });
   });
 
   describe('Service Type Selection', () => {
@@ -323,18 +312,6 @@ describe('FindPane', () => {
       const callUrl = (medplum.get as ReturnType<typeof vi.fn>).mock.calls[0][0];
       expect(callUrl).toContain('start=');
       expect(callUrl).toContain('end=');
-    });
-
-    test('fetches without service-type param when wildcard (undefined) is selected', async () => {
-      const schedule = createScheduleWithServiceTypes([undefined]);
-
-      await act(async () => {
-        setup({ schedule });
-      });
-
-      // With single undefined service type, it auto-selects
-      const callUrl = (medplum.get as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] || '';
-      expect(callUrl).not.toContain('service-type=');
     });
   });
 

--- a/examples/medplum-provider/src/pages/schedule/FindPane.tsx
+++ b/examples/medplum-provider/src/pages/schedule/FindPane.tsx
@@ -43,20 +43,17 @@ export function FindPane(props: FindPaneProps): JSX.Element {
 
   const medplum = useMedplum();
 
-  // null: no selection made
-  // undefined: "wildcard" availability selected
-  // Coding: a specific service type was selected
-  const [serviceType, setServiceType] = useState<CodeableConcept | undefined | null>(
+  const [serviceType, setServiceType] = useState<CodeableConcept | undefined>(
     // If there is exactly one option, select it immediately instead of forcing user
     // to select it
-    serviceTypes.length === 1 ? serviceTypes[0].codeableConcept : null
+    serviceTypes.length === 1 ? serviceTypes[0].codeableConcept : undefined
   );
 
   // Ensure that we are searching for slots in the future by at least 30 minutes.
   const earliestSchedulable = useSchedulingStartsAt({ minimumNoticeMinutes: 30 });
 
   useEffect(() => {
-    if (!schedule || serviceType === null) {
+    if (!schedule || !serviceType) {
       return () => {};
     }
 
@@ -106,13 +103,13 @@ export function FindPane(props: FindPaneProps): JSX.Element {
   }, [medplum, schedule, serviceType, range, earliestSchedulable]);
 
   const handleDismiss = useCallback(() => {
-    setServiceType(null);
+    setServiceType(undefined);
     setSlots(EMPTY);
   }, []);
 
   const handleBookSuccess = useCallback(
     (results: { appointments: Appointment[]; slots: Slot[] }) => {
-      setServiceType(null);
+      setServiceType(undefined);
       setSlots([]);
       setChosenSlot(undefined);
       onSuccess(results);
@@ -136,9 +133,7 @@ export function FindPane(props: FindPaneProps): JSX.Element {
     );
   }
 
-  // tricky: `undefined` means the "wildcard" service type, so we explicitly
-  // test against `null` here.
-  if (serviceType !== null) {
+  if (serviceType) {
     return (
       <Stack gap="sm" justify="flex-start">
         <Title order={4}>
@@ -178,7 +173,7 @@ export function FindPane(props: FindPaneProps): JSX.Element {
           justify="space-between"
           onClick={() => setServiceType(st.codeableConcept)}
         >
-          {st.codeableConcept ? <CodeableConceptDisplay value={st.codeableConcept} /> : 'Other'}
+          <CodeableConceptDisplay value={st.codeableConcept} />
         </Button>
       ))}
     </Stack>

--- a/examples/medplum-provider/src/utils/scheduling.ts
+++ b/examples/medplum-provider/src/utils/scheduling.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { getExtensionValue, getIdentifier, setIdentifier } from '@medplum/core';
+import { getExtensionValue, getIdentifier, isDefined, setIdentifier } from '@medplum/core';
 import type { CodeableConcept, Identifier, Resource, Schedule } from '@medplum/fhirtypes';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -17,8 +17,8 @@ export const SchedulingTransientIdentifier = {
   },
 };
 
-export function serviceTypesFromSchedulingParameters(schedule: Schedule): (CodeableConcept | undefined)[] {
+export function serviceTypesFromSchedulingParameters(schedule: Schedule): CodeableConcept[] {
   const extensions = schedule?.extension?.filter((ext) => ext.url === SchedulingParametersURI) ?? [];
   const serviceTypes = extensions.map((ext) => getExtensionValue(ext, 'serviceType') as CodeableConcept | undefined);
-  return serviceTypes;
+  return serviceTypes.filter(isDefined);
 }

--- a/packages/docs/docs/scheduling/defining-availability.md
+++ b/packages/docs/docs/scheduling/defining-availability.md
@@ -89,7 +89,7 @@ All scheduling constraints are managed through a single consolidated extension: 
 
 | Url                 | Type                                                        | Applies To                           | Required                                        | Behavior when defined                                                                                                                                                                | Behavior when not defined                                                              |
 | ------------------- | ----------------------------------------------------------- | ------------------------------------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| `serviceType`       | [CodeableConcept](/docs/api/fhir/datatypes/codeableconcept) | Schedule only                        | Optional                                        | Applies configuration only to the specified service type, overriding defaults for that service                                                                                       | Values apply as the default for all services                                           |
+| `serviceType`       | [CodeableConcept](/docs/api/fhir/datatypes/codeableconcept) | Schedule only                        | Required                                        | Applies configuration only to the specified service type, overriding defaults for that service                                                                                       | N/A - must be specified                                                                |
 | `availability`      | [Timing](/docs/api/fhir/datatypes/timing)                   | Schedule only                        | Optional                                        | Bookings must fully fit within the recurring windows                                                                                                                                 | Time is implicitly available by default (unless blocked by Slots or other constraints) |
 | `timezone`          | Code                                                        | Schedule only                        | Optional                                        | Specifies the timezone (IANA timezone identifier, e.g., `America/New_York`) for interpreting the `availability` timing. Falls back to the Schedule's actor timezone if not specified | Uses the timezone defined on the Schedule's actor reference                            |
 | `duration`          | [Duration](/docs/api/fhir/datatypes/duration)               | Both Schedule and ActivityDefinition | Required                                        | Determines how long the time increments for a Slot are                                                                                                                               | N/A - must be specified                                                                |
@@ -106,7 +106,7 @@ All scheduling constraints are managed through a single consolidated extension: 
 {
   "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
   "extension": [
-    // Optional: specify service type (omit for default configuration)
+    // Required on Schedule: you must specify what type of appointment these parameters aply to
     {
       "url": "serviceType",
       "valueCodeableConcept": {
@@ -216,7 +216,7 @@ This approach avoids the need to pre-generate thousands of Slot resources for ev
 
 The [`Schedule`](/docs/api/fhir/resources/schedule) resource is the foundation for defining actor-level availability for a provider, location, or device.
 
-Here is an example of a [Schedule](/docs/api/fhir/resources/schedule) resource that defines general availability for a [Practitioner](/docs/api/fhir/resources/practitioner).
+Here is an example of a [Schedule](/docs/api/fhir/resources/schedule) resource that defines availability for a [Practitioner](/docs/api/fhir/resources/practitioner).
 
 ```tsx
 {
@@ -226,6 +226,12 @@ Here is an example of a [Schedule](/docs/api/fhir/resources/schedule) resource t
   "extension": [{
     "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
     "extension": [
+      {
+        "url": "serviceType",
+        "valueCodeableConcept": {
+          "coding": [{"code": "office-visit"}]
+        }
+      },
       {
         "url": "duration",
         "valueDuration": {
@@ -308,7 +314,7 @@ To get the [Schedule](/docs/api/fhir/resources/schedule) to use the [ActivityDef
 
 A [Practitioner](/docs/api/fhir/resources/practitioner)'s [Schedule](/docs/api/fhir/resources/schedule) can also override the default [ActivityDefinition](/docs/api/fhir/resources/activitydefinition)'s availability for a specific service type by defining a `serviceType` extension.
 
-Here is an example Schedule that defines generic availability for all services and then overrides the availability for a specific service type.
+Here is an example Schedule that overrides the availability for a specific service type.
 
 ```tsx
 {
@@ -321,30 +327,6 @@ Here is an example Schedule that defines generic availability for all services a
   ],
   "actor": [{"reference": "Practitioner/dr-chen"}],
   "extension": [
-    // Practitioner level availability
-    {
-      "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
-      "extension": [
-        {
-          "url": "duration",
-          "valueDuration": {
-            "value": 1,
-            "unit": "h"
-          }
-        },
-        {
-          "url": "availability",
-          "valueTiming": {
-            "repeat": {
-              "dayOfWeek": ["mon", "tue", "wed", "thu", "fri"],
-              "timeOfDay": ["09:00:00"],
-              "duration": 8,
-              "durationUnit": "h"
-            }
-          }
-        }
-      ]
-    },
     // Service type level availability for this Practitioner - overrides any availability parameters specified elsewhere
     {
       "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
@@ -385,7 +367,6 @@ Here is an example Schedule that defines generic availability for all services a
 
 1. Schedule where `https://medplum.com/fhir/StructureDefinition/SchedulingParameters.serviceType` extension matches `service-type` param on `$find` request.
 2. ActivityDefinition where `ActivityDefinition.code` matches `service-type` param on `$find` request. ActivityDefinition parameters are used.
-3. Use generic availability defined on the Schedule.
 
 ### Blocking Time by Service Type
 
@@ -601,29 +582,9 @@ This Schedule shows Dr. Johnson's availability (Mon-Fri 9am-5pm) that inherits a
     "start": "2025-01-01T00:00:00Z",
     "end": "2025-12-31T23:59:59Z"
   },
-  "extension": [{
-    "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
-    "extension": [
-      {
-        "url": "duration",
-        "valueDuration": {
-          "value": 1,
-          "unit": "h"
-        }
-      },
-      {
-        "url": "availability",
-        "valueTiming": {
-          "repeat": {
-            "dayOfWeek": ["mon", "tue", "wed", "thu", "fri"],
-            "timeOfDay": ["09:00:00"],
-            "duration": 8,
-            "durationUnit": "h"
-          }
-        }
-      }
-    ]
-  }]
+  "extension": [
+    // No values here, everything is inherited from shared definitions
+  ]
 }
 ```
 
@@ -631,7 +592,6 @@ This Schedule shows Dr. Johnson's availability (Mon-Fri 9am-5pm) that inherits a
 
 **Result**: Dr. Johnson's schedule inherits all the default parameters from the ActivityDefinition for an office visit:
 
-- $find called with `service-type!=office-visit`: Dr. Johnson is available Mon-Fri 9am-5pm for non-office visits **[from Schedule]**
 - $find called with `service-type=office-visit`: For office visits, available to start every 15 minutes (:00, :15, :30, :45) with 5-minute buffers **[from ActivityDefinition]**
 
 ```mermaid
@@ -757,30 +717,6 @@ This Schedule shows how to configure default availability for all services (Mon-
     "end": "2025-12-31T23:59:59Z"
   },
   "extension": [
-    // Default availability for all services
-    {
-      "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
-      "extension": [
-        {
-          "url": "duration",
-          "valueDuration": {
-            "value": 1,
-            "unit": "h"
-          }
-        },
-        {
-          "url": "availability",
-          "valueTiming": {
-            "repeat": {
-              "dayOfWeek": ["mon", "tue", "wed", "thu", "fri"],
-              "timeOfDay": ["09:00:00"],
-              "duration": 8,
-              "durationUnit": "h"
-            }
-          }
-        }
-      ]
-    },
     // New patient visits only on Tuesday and Thursday mornings
     {
       "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
@@ -951,6 +887,12 @@ This Schedule shows Dr. Martinez's availability for bariatric surgeries, limited
     "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
     "extension": [
       {
+        "url": "serviceType",
+        "valueCodeableConcept": {
+          "coding": [{"system": "http://snomed.info/sct", "code": "287809009"}]
+        }
+      },
+      {
         "url": "duration",
         "valueDuration": {
           "value": 1,
@@ -1037,6 +979,12 @@ This Schedule shows Dr. Kim's availability for surgical procedures, covering wee
   "extension": [{
     "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
     "extension": [
+      {
+        "url": "serviceType",
+        "valueCodeableConcept": {
+          "coding": [{"system": "http://snomed.info/sct", "code": "287809009"}]
+        }
+      },
       {
         "url": "duration",
         "valueDuration": {

--- a/packages/server/src/fhir/operations/book.test.ts
+++ b/packages/server/src/fhir/operations/book.test.ts
@@ -2,7 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
 import { createReference, isDefined, parseSearchRequest } from '@medplum/core';
-import type { Appointment, Bundle, Patient, Practitioner, Resource, Schedule, Slot } from '@medplum/fhirtypes';
+import type {
+  Appointment,
+  Bundle,
+  CodeableConcept,
+  Patient,
+  Practitioner,
+  Resource,
+  Schedule,
+  Slot,
+} from '@medplum/fhirtypes';
 import express from 'express';
 import supertest from 'supertest';
 import { initApp, shutdownApp } from '../../app';
@@ -42,6 +51,10 @@ describe('Appointment/$book', () => {
     await shutdownApp();
   });
 
+  const officeVisit: CodeableConcept = {
+    coding: [{ system: 'https://example.com/fhir', code: 'office-visit' }],
+  };
+
   async function makeSchedule(actor: Practitioner): Promise<WithId<Schedule>> {
     return systemRepo.createResource<Schedule>({
       resourceType: 'Schedule',
@@ -51,6 +64,10 @@ describe('Appointment/$book', () => {
         {
           url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
           extension: [
+            {
+              url: 'serviceType',
+              valueCodeableConcept: officeVisit,
+            },
             {
               url: 'availability',
               valueTiming: {
@@ -107,6 +124,7 @@ describe('Appointment/$book', () => {
             resource: {
               resourceType: 'Slot',
               schedule: createReference(schedule),
+              serviceType: [officeVisit],
               start: '2026-01-15T14:00:00Z',
               end: '2026-01-15T15:00:00Z',
               status: 'free',
@@ -128,6 +146,7 @@ describe('Appointment/$book', () => {
             name: 'slot',
             resource: {
               resourceType: 'Slot',
+              serviceType: [officeVisit],
               schedule: { reference: 'Schedule/fake-12345' },
               start: '2026-01-15T14:00:00Z',
               end: '2026-01-15T15:00:00Z',
@@ -160,6 +179,7 @@ describe('Appointment/$book', () => {
               start,
               end,
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -198,6 +218,7 @@ describe('Appointment/$book', () => {
               start,
               end,
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
           {
@@ -208,6 +229,7 @@ describe('Appointment/$book', () => {
               start,
               end,
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -246,6 +268,7 @@ describe('Appointment/$book', () => {
               start: '2026-01-15T14:00:00Z',
               end: '2026-01-15T15:00:00Z',
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
           {
@@ -256,6 +279,7 @@ describe('Appointment/$book', () => {
               start: '2026-01-15T08:00:00Z',
               end: '2026-01-15T09:00:00Z',
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -290,6 +314,7 @@ describe('Appointment/$book', () => {
               start: '2026-01-15T14:00:00Z',
               end: '2026-01-15T15:00:00Z',
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
           {
@@ -300,6 +325,7 @@ describe('Appointment/$book', () => {
               start: '2026-01-15T14:00:00Z',
               end: '2026-01-15T14:30:00Z',
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -345,6 +371,7 @@ describe('Appointment/$book', () => {
               start,
               end,
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -362,6 +389,38 @@ describe('Appointment/$book', () => {
     // Check no additional slot was created
     const slots = await systemRepo.searchResources<Slot>(parseSearchRequest(`Slot?schedule=Schedule/${schedule.id}`));
     expect(slots).toHaveLength(1);
+  });
+
+  test('fails when trying to use a service type that does not match scheduling parameters', async () => {
+    const schedule = await makeSchedule(practitioner1);
+    const response = await request
+      .post('/fhir/R4/Appointment/$book')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'slot',
+            resource: {
+              resourceType: 'Slot',
+              schedule: createReference(schedule),
+              serviceType: [
+                {
+                  coding: [{ code: 'other' }],
+                },
+              ],
+              start: '2026-01-15T14:00:00Z',
+              end: '2026-01-15T15:00:00Z',
+              status: 'free',
+            } satisfies Slot,
+          },
+        ],
+      });
+    expect(response.body).toMatchObject({
+      resourceType: 'OperationOutcome',
+      issue: [{ severity: 'error', code: 'invalid', details: { text: 'No matching scheduling parameters found' } }],
+    });
+    expect(response.status).toEqual(400);
   });
 
   test('succeeds when there is an explicit "free" slot at the same time', async () => {
@@ -393,6 +452,7 @@ describe('Appointment/$book', () => {
               start,
               end,
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -422,6 +482,7 @@ describe('Appointment/$book', () => {
               start,
               end,
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -466,6 +527,7 @@ describe('Appointment/$book', () => {
               start,
               end,
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
           {
@@ -476,6 +538,7 @@ describe('Appointment/$book', () => {
               start,
               end,
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -517,6 +580,7 @@ describe('Appointment/$book', () => {
               start,
               end,
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -568,6 +632,7 @@ describe('Appointment/$book', () => {
               start,
               end,
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -593,6 +658,7 @@ describe('Appointment/$book', () => {
               start: '2026-01-15T14:00:00Z',
               end: '2026-01-15T14:30:00Z',
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -643,6 +709,10 @@ describe('Appointment/$book', () => {
                 url: 'alignmentOffset',
                 valueDuration: { value: alignmentOffset, unit: 'min' },
               },
+              {
+                url: 'serviceType',
+                valueCodeableConcept: officeVisit,
+              },
             ],
           },
         ],
@@ -662,6 +732,7 @@ describe('Appointment/$book', () => {
                 start,
                 end,
                 status: 'free',
+                serviceType: [officeVisit],
               } satisfies Slot,
             },
           ],
@@ -698,6 +769,10 @@ describe('Appointment/$book', () => {
               url: 'bufferBefore',
               valueDuration: { value: 20, unit: 'min' },
             },
+            {
+              url: 'serviceType',
+              valueCodeableConcept: officeVisit,
+            },
           ],
         },
       ],
@@ -718,6 +793,7 @@ describe('Appointment/$book', () => {
               start: '2026-01-15T09:00:00-05:00',
               end: '2026-01-15T10:00:00-05:00',
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -739,6 +815,7 @@ describe('Appointment/$book', () => {
               start: '2026-01-15T10:00:00-05:00',
               end: '2026-01-15T11:00:00-05:00',
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -776,6 +853,7 @@ describe('Appointment/$book', () => {
               start: '2026-01-15T11:00:00-05:00',
               end: '2026-01-15T12:00:00-05:00',
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -815,6 +893,10 @@ describe('Appointment/$book', () => {
               url: 'alignmentInterval',
               valueDuration: { value: 15, unit: 'min' },
             },
+            {
+              url: 'serviceType',
+              valueCodeableConcept: officeVisit,
+            },
           ],
         },
       ],
@@ -835,6 +917,7 @@ describe('Appointment/$book', () => {
               start: '2026-01-15T16:30:00-05:00',
               end: '2026-01-15T17:00:00-05:00',
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -856,6 +939,7 @@ describe('Appointment/$book', () => {
               start: '2026-01-15T16:00:00-05:00',
               end: '2026-01-15T16:30:00-05:00',
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -893,6 +977,7 @@ describe('Appointment/$book', () => {
               start: '2026-01-15T15:15:00-05:00',
               end: '2026-01-15T15:45:00-05:00',
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
         ],
@@ -919,6 +1004,7 @@ describe('Appointment/$book', () => {
               start,
               end,
               status: 'free',
+              serviceType: [officeVisit],
             } satisfies Slot,
           },
           {
@@ -1006,6 +1092,10 @@ describe('scheduling flow integration test', () => {
     await shutdownApp();
   });
 
+  const officeVisit: CodeableConcept = {
+    coding: [{ system: 'https://example.com/fhir', code: 'office-visit' }],
+  };
+
   test('a slot from $find can be used as input to $book', async () => {
     const practitioner = await systemRepo.createResource<Practitioner>({
       resourceType: 'Practitioner',
@@ -1057,6 +1147,10 @@ describe('scheduling flow integration test', () => {
               url: 'bufferAfter',
               valueDuration: { value: 15, unit: 'min' },
             },
+            {
+              url: 'serviceType',
+              valueCodeableConcept: officeVisit,
+            },
           ],
         },
       ],
@@ -1068,6 +1162,7 @@ describe('scheduling flow integration test', () => {
       .query({
         start: new Date('2026-01-28T07:00:00.000-07:00'),
         end: new Date('2026-01-28T12:00:00.000-07:00'),
+        'service-type': 'https://example.com/fhir|office-visit',
       });
 
     expect(findResponse.body).not.toHaveProperty('issue');

--- a/packages/server/src/fhir/operations/book.ts
+++ b/packages/server/src/fhir/operations/book.ts
@@ -75,11 +75,7 @@ function makeMatcher(slot: Slot): Matcher {
 
 function findMatchingSchedulingParameters(extensions: SchedulingParameters[], slot: Slot): SchedulingParameters[] {
   const matcher = makeMatcher(slot);
-  let parameters = extensions.filter((ext) => matcher(ext));
-  if (parameters.length === 0) {
-    // If no service type match found, fall back to wildcard availability
-    parameters = extensions.filter((ext) => ext.serviceType.length === 0);
-  }
+  const parameters = extensions.filter((ext) => matcher(ext));
 
   const startDate = new Date(slot.start);
   const endDate = new Date(slot.end);
@@ -87,8 +83,7 @@ function findMatchingSchedulingParameters(extensions: SchedulingParameters[], sl
   const durationMs = endDate.getTime() - startDate.getTime();
   const durationMinutes = durationMs / 1000 / 60;
 
-  parameters = parameters.filter((ext) => ext.duration === durationMinutes);
-  return parameters;
+  return parameters.filter((ext) => ext.duration === durationMinutes);
 }
 
 function chooseActiveParameters(

--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -13,9 +13,6 @@ import { createTestProject } from '../../test.setup';
 const app = express();
 const request = supertest(app);
 
-// indicator that availability should be created without specific service-type matching
-const wildcard = '__WILDCARD__';
-
 type AvailabilityOptions = {
   bufferBefore?: number;
   bufferAfter?: number;
@@ -102,14 +99,12 @@ describe('Schedule/:id/$find', () => {
         });
       }
 
-      if (serviceType !== wildcard) {
-        extension.extension.push({
-          url: 'serviceType',
-          valueCodeableConcept: {
-            coding: [{ code: serviceType, system: 'http://example.com' }],
-          },
-        });
-      }
+      extension.extension.push({
+        url: 'serviceType',
+        valueCodeableConcept: {
+          coding: [{ code: serviceType, system: 'http://example.com' }],
+        },
+      });
 
       Object.entries(durations).forEach(([key, value]) =>
         extension.extension.push({ url: key, valueDuration: { value, unit: 'min' } })
@@ -144,7 +139,7 @@ describe('Schedule/:id/$find', () => {
 
   test('searching an interval not overlapping availability returns an empty bundle', async () => {
     const schedule = await makeSchedule({
-      [wildcard]: { availability: fourDayWorkWeek, duration: 20 },
+      'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
     });
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
@@ -152,6 +147,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T00:00:00.000-05:00'),
         end: new Date('2025-12-01T09:00:00.000-05:00'),
+        'service-type': 'http://example.com|generic-visit',
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -164,7 +160,7 @@ describe('Schedule/:id/$find', () => {
 
   test('finds slots that overlap with the availability in the range', async () => {
     const schedule = await makeSchedule({
-      [wildcard]: { availability: fourDayWorkWeek, duration: 20 },
+      'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
     });
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
@@ -172,6 +168,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T00:00:00.000-05:00'),
         end: new Date('2025-12-01T14:00:00.000-05:00'),
+        'service-type': 'http://example.com|generic-visit',
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -212,7 +209,7 @@ describe('Schedule/:id/$find', () => {
 
   test('discovers and removes busy slots from the search results', async () => {
     const schedule = await makeSchedule({
-      [wildcard]: { availability: fourDayWorkWeek, duration: 20 },
+      'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
     });
     await makeSlot({
       start: new Date('2025-12-01T11:10:00.000-05:00'),
@@ -228,6 +225,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2025-12-01T14:00:00.000-05:00').toISOString(),
+        'service-type': 'http://example.com|generic-visit',
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -260,7 +258,7 @@ describe('Schedule/:id/$find', () => {
 
   test('discovers and adds "free" slots into the search results', async () => {
     const schedule = await makeSchedule({
-      [wildcard]: { availability: fourDayWorkWeek, duration: 20 },
+      'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
     });
     await makeSlot({
       start: new Date('2025-12-01T09:00:00.000-05:00'),
@@ -276,6 +274,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2025-12-01T14:00:00.000-05:00').toISOString(),
+        'service-type': 'http://example.com|generic-visit',
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -325,7 +324,7 @@ describe('Schedule/:id/$find', () => {
 
   test('resolving availability with bufferBefore and bufferAfter', async () => {
     const schedule = await makeSchedule({
-      [wildcard]: {
+      'generic-visit': {
         availability: fourDayWorkWeek,
         bufferBefore: 15,
         bufferAfter: 5,
@@ -364,6 +363,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2025-12-01T14:00:00.000-05:00').toISOString(),
+        'service-type': 'http://example.com|generic-visit',
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -388,7 +388,7 @@ describe('Schedule/:id/$find', () => {
 
   test('search input in another timezone finds appropriate overlap', async () => {
     const schedule = await makeSchedule({
-      [wildcard]: { availability: fourDayWorkWeek, duration: 20 },
+      'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
     });
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
@@ -397,6 +397,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T11:00:00.000-05:00').toISOString(),
         end: new Date('2025-12-01T14:00:00.000-05:00').toISOString(),
+        'service-type': 'http://example.com|generic-visit',
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -428,7 +429,7 @@ describe('Schedule/:id/$find', () => {
 
   test('uses default search page size of 20 results', async () => {
     const schedule = await makeSchedule({
-      [wildcard]: { availability: fourDayWorkWeek, duration: 60 },
+      'generic-visit': { availability: fourDayWorkWeek, duration: 60 },
     });
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
@@ -437,6 +438,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2026-01-01T00:00:00.000-05:00').toISOString(),
+        'service-type': 'http://example.com|generic-visit',
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -445,7 +447,7 @@ describe('Schedule/:id/$find', () => {
 
   test('can override search page size with `_count`', async () => {
     const schedule = await makeSchedule({
-      [wildcard]: {
+      'generic-visit': {
         // Alignment slot options to every-two-minutes means that there are
         // lots of results so we can test the maximum page size of 1000
         alignmentInterval: 2,
@@ -461,6 +463,7 @@ describe('Schedule/:id/$find', () => {
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2026-01-01T00:00:00.000-05:00').toISOString(),
         _count: 10,
+        'service-type': 'http://example.com|generic-visit',
       });
     expect(smallResponse.body).not.toHaveProperty('issue');
     expect(smallResponse.status).toBe(200);
@@ -474,6 +477,7 @@ describe('Schedule/:id/$find', () => {
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2026-01-01T00:00:00.000-05:00').toISOString(),
         _count: 1000,
+        'service-type': 'http://example.com|generic-visit',
       });
     expect(largeResponse.body).not.toHaveProperty('issue');
     expect(largeResponse.status).toBe(200);
@@ -482,7 +486,7 @@ describe('Schedule/:id/$find', () => {
 
   test('errors if _count is too low', async () => {
     const schedule = await makeSchedule({
-      [wildcard]: { availability: fourDayWorkWeek, duration: 60 },
+      'generic-visit': { availability: fourDayWorkWeek, duration: 60 },
     });
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
@@ -492,6 +496,7 @@ describe('Schedule/:id/$find', () => {
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2026-01-01T00:00:00.000-05:00').toISOString(),
         _count: 0,
+        'service-type': 'http://example.com|generic-visit',
       });
     expect(response.status).toBe(400);
     expect(response.body.issue).toEqual([
@@ -507,7 +512,7 @@ describe('Schedule/:id/$find', () => {
 
   test('errors if _count is too high', async () => {
     const schedule = await makeSchedule({
-      [wildcard]: { availability: fourDayWorkWeek, duration: 60 },
+      'generic-visit': { availability: fourDayWorkWeek, duration: 60 },
     });
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
@@ -517,6 +522,7 @@ describe('Schedule/:id/$find', () => {
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2026-01-01T00:00:00.000-05:00').toISOString(),
         _count: 1001,
+        'service-type': 'http://example.com|generic-visit',
       });
     expect(response.status).toBe(400);
     expect(response.body.issue).toEqual([
@@ -534,7 +540,7 @@ describe('Schedule/:id/$find', () => {
     // `location` has timezone set to America/Phoenix, which is always at offset -07:00
     const schedule = await makeSchedule(
       {
-        [wildcard]: { availability: fourDayWorkWeek, duration: 20 },
+        'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
       },
       { actor: [createReference(location)] }
     );
@@ -545,6 +551,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T00:00:00.000-07:00').toISOString(),
         end: new Date('2025-12-01T12:00:00.000-07:00').toISOString(),
+        'service-type': 'http://example.com|generic-visit',
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -579,7 +586,7 @@ describe('Schedule/:id/$find', () => {
     // scheduling params have timezone set to Pacific/Honolulu, which is always at offset -10:00
     const schedule = await makeSchedule(
       {
-        [wildcard]: { availability: fourDayWorkWeek, duration: 20, timezone: 'Pacific/Honolulu' },
+        'generic-visit': { availability: fourDayWorkWeek, duration: 20, timezone: 'Pacific/Honolulu' },
       },
       { actor: [createReference(location)] }
     );
@@ -590,6 +597,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T00:00:00.000-10:00').toISOString(),
         end: new Date('2025-12-01T12:00:00.000-10:00').toISOString(),
+        'service-type': 'http://example.com|generic-visit',
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -619,9 +627,9 @@ describe('Schedule/:id/$find', () => {
     });
   });
 
-  test('with a service-type parameter', async () => {
+  test('without a service-type parameter', async () => {
     const schedule = await makeSchedule({
-      [wildcard]: { availability: fourDayWorkWeek, duration: 20 },
+      'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
       'new-patient': { availability: twoDaySchedule, duration: 30 },
     });
     const response = await request
@@ -631,43 +639,27 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-04T10:00:00.000-05:00'),
         end: new Date('2025-12-04T14:00:00.000-05:00'),
-        'service-type': 'http://example.com|new-patient,http://example.com|other',
       });
-    expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toBe(200);
-    expect(response.body).toMatchObject<Bundle>({
-      resourceType: 'Bundle',
-      type: 'searchset',
-      entry: [
+    expect(response.body).toHaveProperty('issue');
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      resourceType: 'OperationOutcome',
+      issue: [
         {
-          resource: {
-            resourceType: 'Slot',
-            start: new Date('2025-12-04T12:00:00.000-05:00').toISOString(),
-            end: new Date('2025-12-04T12:30:00.000-05:00').toISOString(),
-            status: 'free',
-            schedule: createReference(schedule),
-            serviceType: [{ coding: [{ code: 'new-patient', system: 'http://example.com' }] }],
-          },
-        },
-        {
-          resource: {
-            resourceType: 'Slot',
-            start: new Date('2025-12-04T13:00:00.000-05:00').toISOString(),
-            end: new Date('2025-12-04T13:30:00.000-05:00').toISOString(),
-            status: 'free',
-            schedule: createReference(schedule),
-            serviceType: [{ coding: [{ code: 'new-patient', system: 'http://example.com' }] }],
+          code: 'invalid',
+          severity: 'error',
+          details: {
+            text: "Expected at least 1 value(s) for required input parameter 'service-type'",
           },
         },
       ],
     });
   });
 
-  test('when no matching serviceType is found, uses any wildcard availability', async () => {
+  test('when no matching serviceType is found', async () => {
     const schedule = await makeSchedule({
       'new-patient': { availability: fridayOnly, duration: 45, bufferBefore: 15 },
       'office-visit': { availability: twoDaySchedule, duration: 30, alignmentOffset: 15, alignmentInterval: 30 },
-      [wildcard]: { availability: fourDayWorkWeek, duration: 20, alignmentOffset: 30 },
     });
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
@@ -678,39 +670,16 @@ describe('Schedule/:id/$find', () => {
         end: new Date('2025-12-04T14:00:00.000-05:00'),
         'service-type': 'http://example.com|new-patient-visit',
       });
-    expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toBe(200);
-    expect(response.body).toMatchObject<Bundle>({
-      resourceType: 'Bundle',
-      type: 'searchset',
-      entry: [
-        // wildcard slots are 20 minutes long, start on the half-hour, and have no `serviceType` attribute
+    expect(response.body).toHaveProperty('issue');
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      resourceType: 'OperationOutcome',
+      issue: [
         {
-          resource: {
-            resourceType: 'Slot',
-            start: new Date('2025-12-04T10:30:00.000-05:00').toISOString(),
-            end: new Date('2025-12-04T10:50:00.000-05:00').toISOString(),
-            status: 'free',
-            schedule: createReference(schedule),
-          },
-        },
-        {
-          resource: {
-            resourceType: 'Slot',
-            start: new Date('2025-12-04T11:30:00.000-05:00').toISOString(),
-            end: new Date('2025-12-04T11:50:00.000-05:00').toISOString(),
-            status: 'free',
-            schedule: createReference(schedule),
-          },
-        },
-        // No entry at 12:30; there is a lunch gap in the scheduled availability
-        {
-          resource: {
-            resourceType: 'Slot',
-            start: new Date('2025-12-04T13:30:00.000-05:00').toISOString(),
-            end: new Date('2025-12-04T13:50:00.000-05:00').toISOString(),
-            status: 'free',
-            schedule: createReference(schedule),
+          code: 'invalid',
+          severity: 'error',
+          details: {
+            text: 'No scheduling parameters found for the requested service type(s)',
           },
         },
       ],
@@ -721,7 +690,7 @@ describe('Schedule/:id/$find', () => {
     const schedule = await makeSchedule({
       'new-patient': { availability: fridayOnly, duration: 45, bufferBefore: 15 },
       'office-visit': { availability: twoDaySchedule, duration: 30, alignmentOffset: 15, alignmentInterval: 30 },
-      [wildcard]: { availability: fourDayWorkWeek, duration: 20 },
+      'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
     });
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
@@ -801,8 +770,6 @@ describe('Schedule/:id/$find', () => {
             serviceType: [{ coding: [{ code: 'office-visit', system: 'http://example.com' }] }],
           },
         },
-
-        // no wildcard slots returned because we had exact matches
       ],
     });
   });

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -33,7 +33,7 @@ const findOperation = {
   parameter: [
     { use: 'in', name: 'start', type: 'dateTime', min: 1, max: '1' },
     { use: 'in', name: 'end', type: 'dateTime', min: 1, max: '1' },
-    { use: 'in', name: 'service-type', type: 'string', min: 0, max: '*' },
+    { use: 'in', name: 'service-type', type: 'string', min: 1, max: '*' },
     { use: 'in', name: '_count', type: 'integer', min: 0, max: '1' },
     { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
   ],
@@ -50,29 +50,20 @@ type FindParameters = {
 // [SchedulingParameters, serviceType] pairs.
 //
 // - Each schedulingParameters description is returned at most once
-// - If no specific matches are found, falls back to "wildcard" matches
-//   (scheduling parameters having no associated codes match any input codes)
 function filterByServiceTypes(
   schedulingParameters: SchedulingParameters[],
   serviceTypes: string[]
-): [SchedulingParameters, CodeableConcept | undefined][] {
-  if (serviceTypes.length) {
-    const results: [SchedulingParameters, CodeableConcept][] = [];
-    for (const params of schedulingParameters) {
-      const serviceType = params.serviceType.find((codeableConcept) =>
-        codeableConcept.coding?.some((coding) => serviceTypes.includes(`${coding.system}|${coding.code}`))
-      );
-      if (serviceType) {
-        results.push([params, serviceType]);
-      }
-    }
-    if (results.length) {
-      return results;
+): [SchedulingParameters, CodeableConcept][] {
+  const results: [SchedulingParameters, CodeableConcept][] = [];
+  for (const params of schedulingParameters) {
+    const serviceType = params.serviceType.find((codeableConcept) =>
+      codeableConcept.coding?.some((coding) => serviceTypes.includes(`${coding.system}|${coding.code}`))
+    );
+    if (serviceType) {
+      results.push([params, serviceType]);
     }
   }
-
-  // We didn't find any parameters matching serviceType entries, use any wildcard results instead
-  return schedulingParameters.filter((params) => params.serviceType.length === 0).map((params) => [params, undefined]);
+  return results;
 }
 
 /**
@@ -162,9 +153,14 @@ export async function scheduleFindHandler(req: FhirRequest): Promise<FhirRespons
   }
 
   const allSchedulingParameters = parseSchedulingParametersExtensions(schedule);
+  const matchingSchedulingParameters = filterByServiceTypes(allSchedulingParameters, serviceTypes);
+
+  if (matchingSchedulingParameters.length === 0) {
+    throw new OperationOutcomeError(badRequest('No scheduling parameters found for the requested service type(s)'));
+  }
 
   const resultSlots: Slot[] = flatMapMax(
-    filterByServiceTypes(allSchedulingParameters, serviceTypes),
+    matchingSchedulingParameters,
     ([schedulingParameters, serviceType], _idx, maxCount) => {
       // If the scheduling parameters explicitly declare a timezone, use it instead of the actor's TZ
       const activeTimeZone = schedulingParameters.timezone ?? actorTimeZone;

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -144,7 +144,10 @@ export function parseSchedulingParametersExtensions(resource: Schedule | Activit
       'timezone'
     );
 
-    // serviceType has cardinality 0..*
+    // `serviceType` has cardinality 0..* - When used on `Schedule` resources
+    // we expect it to be present, when on `ActivityDefinition` it will not be
+    // (we intend to merge in `ActivityDefinition.code` as the service type later,
+    // see https://github.com/medplum/medplum/issues/8271).
     const serviceType = extension.extension
       .filter((ext) => ext.url === 'serviceType')
       .map((ext) => ext.valueCodeableConcept);


### PR DESCRIPTION
Using the absence of a "service-type" parameter to imply a catch-all availability classification has some challenges;

- it adds complexity to an already rich problem domain
- it can cause surprising scheduling behavior when a request falls back to this "generic" availability

When a user is setting up scheduling, if they want a "default" service type, they should define and instantiate a CodeableConcept to represent that, and explicitly use that service-type in their $find request parameters.

This has some nice bonus effects:
- The provider example app no longer has to distinguish between `null` (meaning "no selection has been made") and `undefined` (meaning "the wildcard availability has been selected").
- Some type annotations get a bit tidier
- Some failure modes become more explicit (such as a typo in a service-type parameter will not be masked by the presence of "generic" availability)

There are some tradeoffs:
- Extra configuration can be required: the "serviceType" subextension is now required when setting up scheduling on Schedule resources.
- Clients who want a "default" or "catch-all" service type will have to explicitly define one and include it in all requests.
- This is a breaking change, but as scheduling is still in "alpha" we consider this acceptable.