### PR TITLE
Added 'Why Open Source' page

### DIFF
--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -138,6 +138,10 @@ const config: Config = {
               to: '/docs',
             },
             {
+              label: 'Why Open Source',
+              to: '/open-source',
+            },
+            {
               label: 'Search',
               to: '/search',
             },

--- a/packages/docs/src/pages/open-source.md
+++ b/packages/docs/src/pages/open-source.md
@@ -1,0 +1,212 @@
+---
+id: open-source
+slug: /open-source
+---
+
+# Why Medplum Is Open Source
+
+Medplum exists because healthcare infrastructure needs to be more open, more interoperable, and more developer-friendly.
+
+For decades, healthcare software has often been built around proprietary data models, closed integration layers, and vendor-controlled ecosystems. These approaches make interoperability difficult and slow down innovation.
+
+Medplum takes a different approach.
+
+The platform is built around **open standards**, especially **FHIR**, and most of the Medplum platform is released as **open source software under the Apache 2.0 license**.
+
+We believe healthcare infrastructure works best when it is:
+
+- **Open**
+- **Standards-based**
+- **Developer-friendly**
+- **Transparent**
+
+This page explains how that philosophy shapes the way we build Medplum and how we balance open source with a sustainable business model.
+
+## What We Provide for Free
+
+A large portion of the Medplum platform is available to the community at no cost.
+
+### Open Source Platform
+
+Most of Medplum is open source under the **Apache 2.0 license**, including:
+
+- The Medplum FHIR server
+- Core APIs
+- Developer SDKs
+- The Medplum React component library
+- Command-line tooling
+- Documentation and examples
+
+Anyone can download the code, run it, modify it, and deploy it in their own infrastructure.
+
+You are free to build products and businesses on top of Medplum.
+
+This permissive licensing model is intentional. We want developers and organizations to be able to adopt Medplum without worrying about licensing complexity or vendor lock-in.
+
+### Self-Hosting
+
+Organizations can run Medplum on their own infrastructure.
+
+Many teams deploy Medplum using:
+
+- Kubernetes
+- Cloud infrastructure such as AWS, Azure, or GCP
+- On-premise environments
+
+Self-hosting gives organizations full control over their infrastructure, data, and deployment model.
+
+### Community Resources
+
+We also provide community support resources, including:
+
+- Public documentation
+- GitHub issues and discussions
+- Community chat channels
+- Examples and developer guides
+
+We do our best to answer questions and help developers succeed with Medplum.
+
+However, community support is **best-effort**. Our team must balance community questions with engineering work, customer commitments, and ongoing development of the platform.
+
+### Pre-Sales Collaboration
+
+Healthcare systems are complex, and many organizations evaluating Medplum need help understanding how it fits into their architecture.
+
+During evaluations, we often work closely with teams through:
+
+- Architecture discussions
+- Technical workshops
+- Developer onboarding sessions
+- Early prototype guidance
+
+We believe this collaboration helps organizations make better long-term infrastructure decisions.
+
+## What Is Not Free
+
+While most of the Medplum platform is open source, some services require a commercial relationship.
+
+These services support organizations running production healthcare systems that require reliability, compliance, and operational support.
+
+### Hosted Infrastructure
+
+Many organizations prefer a managed deployment rather than running the platform themselves.
+
+The Medplum hosted platform includes:
+
+- Managed infrastructure
+- Automated upgrades
+- Security monitoring
+- Backups and disaster recovery
+- Reliability and uptime management
+- Compliance support (SOC2, HITRUST, and other frameworks)
+
+Operating healthcare infrastructure at scale requires significant operational expertise, and hosted deployments help organizations avoid that burden.
+
+### Enterprise Support
+
+Healthcare organizations often require dedicated support resources, including:
+
+- Guaranteed response times
+- Direct access to engineering support
+- Security reviews and documentation
+- Compliance assistance
+- Deployment guidance
+
+These services require sustained time and attention from our engineering team and are provided through paid support agreements.
+
+### Integrations and Custom Work
+
+Some organizations request help with:
+
+- EHR integrations
+- Data migration
+- Workflow design
+- Regulatory compliance
+- Custom development
+
+These services are typically delivered through consulting or enterprise partnerships.
+
+## Why We Charge for These Services
+
+Open source software can be free to use without requiring the people who build it to work for free.
+
+Medplum is developed by a full-time team of engineers and healthcare experts who work continuously to improve the platform.
+
+Revenue from hosted deployments, enterprise support, and consulting allows us to:
+
+- Continue maintaining the open source platform
+- Invest in new features
+- Improve documentation and developer experience
+- Support the broader healthcare developer ecosystem
+
+This model—open source software combined with paid infrastructure and support—is widely used by successful open source companies.
+
+It allows the platform to remain open while ensuring the team building it can continue investing in its future.
+
+## Why Medplum Uses Apache 2.0
+
+Medplum is released under the **Apache 2.0 license**, one of the most permissive open source licenses available.
+
+We chose Apache 2.0 deliberately.
+
+It allows anyone to:
+
+- Use Medplum commercially
+- Modify the software
+- Deploy it privately
+- Build businesses on top of it
+- Fork the project if necessary
+
+In other words, organizations are never locked into a single vendor.
+
+Healthcare systems often operate for decades. The infrastructure supporting them should be designed with that same time horizon in mind.
+
+By releasing Medplum under Apache 2.0, we ensure that:
+
+- Organizations can always run Medplum independently
+- Developers can extend the platform to meet their needs
+- The community can continue development even if the company changes
+- The software remains available for the long term
+
+This licensing choice reflects our belief that **critical healthcare infrastructure should remain open and durable**.
+
+## Why Open Standards Matter
+
+Medplum is built around open healthcare standards such as **FHIR**.
+
+Open standards are essential for interoperability. They make it possible for healthcare systems to exchange data without relying on proprietary integration layers.
+
+With standards like FHIR:
+
+- Data models are transparent
+- APIs are consistent across systems
+- Integrations become easier to build
+- Developers can focus on solving real problems instead of reverse-engineering interfaces
+
+Open source infrastructure and open standards reinforce each other.
+
+FHIR provides a common language for healthcare data.
+Open source platforms provide transparent infrastructure for implementing those standards.
+
+Together, they create a healthier and more collaborative healthcare technology ecosystem.
+
+## A Note to the Community
+
+We are grateful for the growing Medplum community.
+
+Many developers, startups, healthcare organizations, and researchers are building new systems on top of the platform. That collaboration is one of the most rewarding parts of building Medplum.
+
+At the same time, our team must balance community support with the realities of operating a sustainable company and maintaining production healthcare infrastructure.
+
+We strive to maintain a respectful and constructive community environment and prioritize collaboration with users who engage in good faith.
+
+## In Summary
+
+Medplum’s approach is simple:
+
+- The platform is **open source**
+- Self-hosting is **fully supported**
+- Community use is **encouraged**
+- Hosted infrastructure, enterprise support, and consulting are **paid services**
+
+This model allows us to continue building open healthcare infrastructure while supporting the team that makes it possible.

--- a/packages/docs/src/pages/pricing.tsx
+++ b/packages/docs/src/pages/pricing.tsx
@@ -510,7 +510,8 @@ export default function PricingPage(): JSX.Element {
             <h3>Notes</h3>
             <ol>
               <li id="note1">
-                <strong>Free</strong>: recommended for prototyping or learning.
+                <strong>Free</strong>: recommended for prototyping or learning. See{' '}
+                <Link href="/open-source">Why Open Source</Link>.
               </li>
               <li id="note2">
                 <strong>Production</strong>: recommended for production applications, e.g. treatment of patients or
@@ -526,7 +527,8 @@ export default function PricingPage(): JSX.Element {
               </li>
               <li id="note5">
                 <strong>Community</strong>: refers to self-hosting the{' '}
-                <Link href="https://github.com/medplum/medplum">Medplum application</Link>.
+                <Link href="https://github.com/medplum/medplum">Medplum application</Link>. See{' '}
+                <Link href="/open-source">Why Open Source</Link>.
               </li>
               <li id="note6">
                 <strong>Enterprise Self-Hosted</strong>: recommended for those who must host the application on their


### PR DESCRIPTION
This PR adds a new documentation page describing Medplum’s open source philosophy and how we balance open source software with a sustainable business model.

Medplum provides most of the platform as open source under the Apache 2.0 license, and we want to be clear and transparent about what that means in practice. The new page explains:

* Why Medplum is open source
* What parts of the platform are available for free
* What services require a commercial relationship (hosting, enterprise support, consulting)
* Why we chose the Apache 2.0 license
* How open standards like FHIR fit into our long-term vision for healthcare infrastructure

The goal of this page is to set clear expectations and help developers, startups, and healthcare organizations understand how they can use Medplum.

Feedback from the community is very welcome.
