### PR TITLE
fix(server): return 400 for date/time field overflow from Postgres (#8472)

### DIFF
--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -4,6 +4,7 @@ import {
   OperationOutcomeError,
   SearchParameterType,
   append,
+  badRequest,
   conflict,
   normalizeOperationOutcome,
   serverTimeout,
@@ -619,6 +620,7 @@ export const PostgresError = {
   SerializationFailure: '40001',
   QueryCanceled: '57014',
   InFailedSqlTransaction: '25P02',
+  DatetimeFieldOverflow: '22008',
 } as const;
 
 export function normalizeDatabaseError(err: any): OperationOutcomeError {
@@ -644,6 +646,9 @@ export function normalizeDatabaseError(err: any): OperationOutcomeError {
     case PostgresError.InFailedSqlTransaction:
       getLogger().warn('Statement in failed transaction', { stack: err.stack });
       return new OperationOutcomeError(normalizeOperationOutcome(err), err);
+    case PostgresError.DatetimeFieldOverflow:
+      // Date/time value out of range (e.g. Feb 29 on a non-leap year) -> 400 Bad Request
+      return new OperationOutcomeError(badRequest(err.message), err);
   }
 
   getLogger().error('Database error', { error: err.message, stack: err.stack, code: err.code });


### PR DESCRIPTION
## Summary

Fixes #8472

When a FHIR search uses a date value that does not exist (e.g., `2026-02-29` on a non-leap year), Postgres raises error code `22008` (`datetime_field_overflow`). Previously this propagated as an unhandled database error resulting in a 500 response with a stack trace in the logs. The caller had no useful error message.

## Changes

**`packages/server/src/fhir/sql.ts`**

- Added `DatetimeFieldOverflow: '22008'` to the `PostgresError` constants (alongside the existing codes for `UniqueViolation`, `SerializationFailure`, etc.)
- Added a `case` in `normalizeDatabaseError` that maps this error to a `400 Bad Request` `OperationOutcome` via `badRequest(err.message)`
- Imported `badRequest` from `@medplum/core`

## Before / After

**Before:**
```
HTTP 500 Internal Server Error
error: date/time field value out of range: "2026-02-29"
```

**After:**
```json
HTTP 400 Bad Request
{
  "resourceType": "OperationOutcome",
  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "date/time field value out of range: \"2026-02-29\"" } }]
}
```