### PR TITLE
Improve $find service type matching

### DIFF
--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -22,6 +22,8 @@ import {
   calculateAge,
   calculateAgeString,
   capitalize,
+  codeableConceptMatchesToken,
+  codingMatchesToken,
   concatUrls,
   createReference,
   deepClone,
@@ -876,6 +878,51 @@ describe('Core Utils', () => {
     expect(findCodeBySystem(categories, 'x')).toStrictEqual('1');
     expect(findCodeBySystem(categories, 'y')).toStrictEqual('2');
     expect(findCodeBySystem(categories, 'z')).toStrictEqual(undefined);
+  });
+
+  test('codingMatchesToken', () => {
+    expect(codingMatchesToken({ code: 'hello' }, 'hello')).toStrictEqual(true);
+    expect(codingMatchesToken({ system: 'https://example.com/fhir', code: 'hello' }, 'hello')).toStrictEqual(true);
+
+    expect(codingMatchesToken({ code: 'hello' }, 'world')).toStrictEqual(false);
+    expect(codingMatchesToken({ system: 'https://example.com/fhir', code: 'hello' }, 'world')).toStrictEqual(false);
+
+    expect(codingMatchesToken({ code: 'hello' }, '|hello')).toStrictEqual(true);
+    expect(codingMatchesToken({ system: 'https://example.com/fhir', code: 'hello' }, '|hello')).toStrictEqual(false);
+
+    expect(codingMatchesToken({ code: 'hello' }, 'https://example.com/fhir|')).toStrictEqual(false);
+    expect(
+      codingMatchesToken({ system: 'https://example.com/fhir', code: 'hello' }, 'https://example.com/fhir|')
+    ).toStrictEqual(true);
+
+    expect(codingMatchesToken({ code: 'hello' }, 'https://example.com/fhir|hello')).toStrictEqual(false);
+    expect(
+      codingMatchesToken({ system: 'https://example.com/fhir', code: 'hello' }, 'https://example.com/fhir|hello')
+    ).toStrictEqual(true);
+  });
+
+  test('codeableConceptMatchesToken', () => {
+    // true when there is one coding that matches
+    expect(codeableConceptMatchesToken({ coding: [{ code: 'hello' }] }, 'hello')).toEqual(true);
+
+    // returns true when there are multiple codings and at least one matches
+    expect(codeableConceptMatchesToken({ coding: [{ code: 'different' }, { code: 'hello' }] }, 'hello')).toEqual(true);
+
+    // returns false when no coding matches
+    expect(
+      codeableConceptMatchesToken(
+        {
+          coding: [
+            { code: 'different' },
+            { code: 'hello' }, // not a match: no `system` component
+          ],
+        },
+        'https://example.com/fhir|hello'
+      )
+    ).toEqual(false);
+
+    // returns false when the concept has no codings
+    expect(codeableConceptMatchesToken({}, 'hello')).toEqual(false);
   });
 
   test('Capitalize', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -912,6 +912,48 @@ export function findCodeBySystem(categories: CodeableConcept[] | undefined, syst
 }
 
 /**
+ * Checks if a Coding matches a token search string
+ * https://build.fhir.org/search.html#token
+ *
+ * @param coding - The Coding to test
+ * @param token - The token string to test
+ * @returns True if the Coding matches the token
+ */
+export function codingMatchesToken(coding: Coding, token: string): boolean {
+  const [system, code] = splitN(token, '|', 2);
+
+  if (code === undefined) {
+    // There was no '|' delimiter in the token, so we treat the whole token as a code and
+    // match irrespective of the `system` property
+    return coding.code === token;
+  }
+
+  if (system === '') {
+    // The token was of the form '|[code]', which only matches Coding values with no `system`
+    return coding.system === undefined && coding.code === code;
+  }
+
+  if (code === '') {
+    // The token was of the form '[system]|', which matches any Coding belonging to that system
+    return coding.system === system;
+  }
+
+  return coding.system === system && coding.code === code;
+}
+
+/**
+ * Checks if a CodeableConcept matches a token search string
+ * https://build.fhir.org/search.html#token
+ *
+ * @param codeableConcept - The CodeableConcept to test
+ * @param token - The token string to test
+ * @returns True if the CodeableConcept matches the token
+ */
+export function codeableConceptMatchesToken(codeableConcept: CodeableConcept, token: string): boolean {
+  return (codeableConcept.coding ?? EMPTY).some((coding) => codingMatchesToken(coding, token));
+}
+
+/**
  * Returns true if the input value is an object with a string text property.
  * This is a heuristic check based on the presence of the "text" property.
  * @param value - The candidate value.

--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -686,6 +686,38 @@ describe('Schedule/:id/$find', () => {
     });
   });
 
+  test('when serviceType has no `system` component', async () => {
+    const schedule = await systemRepo.createResource<Schedule>({
+      resourceType: 'Schedule',
+      meta: { project: project.id },
+      actor: [createReference(practitioner)],
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [
+            { url: 'availability', valueTiming: { repeat: twoDaySchedule } },
+            { url: 'duration', valueDuration: { value: 30, unit: 'min' } },
+            { url: 'serviceType', valueCodeableConcept: { coding: [{ code: 'office-visit' }] } },
+          ],
+        },
+      ],
+    });
+
+    const response = await request
+      .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .query({
+        start: new Date('2025-12-05T10:00:00.000-05:00').toISOString(),
+        end: new Date('2025-12-05T14:00:00.000-05:00').toISOString(),
+        'service-type': 'office-visit',
+      });
+    expect(response.body).not.toHaveProperty('issue');
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('entry');
+    expect(response.body.entry).toHaveLength(2);
+  });
+
   test('returns appropriate slots for each serviceType passed', async () => {
     const schedule = await makeSchedule({
       'new-patient': { availability: fridayOnly, duration: 45, bufferBefore: 15 },

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -3,6 +3,7 @@
 import {
   allOk,
   badRequest,
+  codeableConceptMatchesToken,
   createReference,
   DEFAULT_MAX_SEARCH_COUNT,
   DEFAULT_SEARCH_COUNT,
@@ -57,7 +58,7 @@ function filterByServiceTypes(
   const results: [SchedulingParameters, CodeableConcept][] = [];
   for (const params of schedulingParameters) {
     const serviceType = params.serviceType.find((codeableConcept) =>
-      codeableConcept.coding?.some((coding) => serviceTypes.includes(`${coding.system}|${coding.code}`))
+      serviceTypes.some((token) => codeableConceptMatchesToken(codeableConcept, token))
     );
     if (serviceType) {
       results.push([params, serviceType]);


### PR DESCRIPTION
The initial implementation here worked for exact matching of both "system" and "code" elements of the search, but we want to support some more cases. The most common one is coding values with no system component; for example, in our defining-availability documentation we use samples like this:
```
  "url": "serviceType",
  "valueCodeableConcept": {
    "coding": [
      { "code": "office-visit" }
    ]
  }
```

We expect that a query like `$find?service-type=office-visit` would match this, but our earlier attempt wouldn't work for this.

We had been concatenating the system and code components, and so we were comparing the input string "office-visit" with a computed value from that coding of "|office-visit" (with the leading delimiter).

I've added utilities that implement the token matching properties described in the FHIR search documentation (https://build.fhir.org/search.html#token), and updated $find to use them.