### PR TITLE
Provider: Fix Scheduling FindPane for systemless service types

### DIFF
--- a/examples/medplum-provider/src/pages/schedule/FindPane.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/FindPane.test.tsx
@@ -30,7 +30,6 @@ describe('FindPane', () => {
   const serviceType2: CodeableConcept = {
     coding: [
       {
-        system: 'http://example.com/service-types',
         code: 'followup',
       },
     ],
@@ -312,6 +311,40 @@ describe('FindPane', () => {
       const callUrl = (medplum.get as ReturnType<typeof vi.fn>).mock.calls[0][0];
       expect(callUrl).toContain('start=');
       expect(callUrl).toContain('end=');
+    });
+
+    test('uses `system|code` style for service-type parameter', async () => {
+      const user = userEvent.setup();
+      const range = {
+        start: new Date('2024-02-01T00:00:00Z'),
+        end: new Date('2024-02-07T23:59:59Z'),
+      };
+
+      await act(async () => {
+        setup({ range });
+      });
+
+      await user.click(screen.getByText('Annual Checkup'));
+
+      const callUrl = (medplum.get as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(callUrl).toContain(`service-type=${encodeURIComponent('http://example.com/service-types|checkup')}`);
+    });
+
+    test('service-type parameters with no system component use "|code" style', async () => {
+      const user = userEvent.setup();
+      const range = {
+        start: new Date('2024-02-01T00:00:00Z'),
+        end: new Date('2024-02-07T23:59:59Z'),
+      };
+
+      await act(async () => {
+        setup({ range });
+      });
+
+      await user.click(screen.getByText('Follow-up Visit'));
+
+      const callUrl = (medplum.get as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(callUrl).toContain(`service-type=${encodeURIComponent('|followup')}`);
     });
   });
 

--- a/examples/medplum-provider/src/pages/schedule/FindPane.tsx
+++ b/examples/medplum-provider/src/pages/schedule/FindPane.tsx
@@ -69,7 +69,7 @@ export function FindPane(props: FindPaneProps): JSX.Element {
     const params = new URLSearchParams({ start, end });
     if (serviceType) {
       serviceType.coding?.forEach((coding) => {
-        params.append('service-type', `${coding.system}|${coding.code}`);
+        params.append('service-type', `${coding.system ?? ''}|${coding.code ?? ''}`);
       });
     }
     medplum


### PR DESCRIPTION
In https://github.com/medplum/medplum/pull/8683 we changed how service type matching works; previously the server was also directly interpolating `${coding.system}|${coding.code}`, which meant that in both client and server we would be generating strings like "undefined|office-visit".

After that change though, the server was interpreting this input as meaning "find exactly a coding matching system: 'undefined'", which is more correct and also didn't match anything.

By coercing `undefined` values to the empty string, the new input parameter is like "service-type=|office-visit", which will match only codings missing a `system` attribute and with a `code` matching "office-visit".

This fixes the scheduling FindPane for scheduling parameters with no "system" component in their service types.