### PR TITLE
Add test case for Patient using $book operation

### DIFF
--- a/packages/docs/docs/access/access-policies.md
+++ b/packages/docs/docs/access/access-policies.md
@@ -518,6 +518,10 @@ Binary resources cannot use compartment-based access controls. They require expl
       "criteria": "Subscription?type=websocket&author=%profile"
     },
     {
+      "resourceType": "HealthcareService",
+      "readonly": true
+    },
+    {
       "resourceType": "Organization",
       "readonly": true
     },

--- a/packages/server/src/admin/project.test.ts
+++ b/packages/server/src/admin/project.test.ts
@@ -157,7 +157,9 @@ describe('Project Admin routes', () => {
       })
     );
 
-    const bobRegistration = await addTestUser(aliceRegistration.project, { resourceType: 'AccessPolicy' });
+    const bobRegistration = await addTestUser(aliceRegistration.project, {
+      accessPolicy: { resourceType: 'AccessPolicy' },
+    });
 
     // Try to access Alice's project using Alices's access token
     // Should succeed
@@ -580,7 +582,9 @@ describe('Project Admin routes', () => {
   test('Set password access denied', async () => {
     // Create test user in project
     const testProjectUser = await addTestUser(testProjectAdmin.project, {
-      resourceType: 'AccessPolicy',
+      accessPolicy: {
+        resourceType: 'AccessPolicy',
+      },
     });
 
     // Try to set password using user's access token

--- a/packages/server/src/fhir/onbehalfof.test.ts
+++ b/packages/server/src/fhir/onbehalfof.test.ts
@@ -42,16 +42,20 @@ describe('On Behalf Of', () => {
 
       const org1 = 'Organization/' + randomUUID();
       const testAccount1 = await addTestUser(project, {
-        resourceType: 'AccessPolicy',
-        compartment: { reference: org1 },
-        resource: [{ resourceType: 'Patient', criteria: 'Patient?_compartment=' + org1 }],
+        accessPolicy: {
+          resourceType: 'AccessPolicy',
+          compartment: { reference: org1 },
+          resource: [{ resourceType: 'Patient', criteria: 'Patient?_compartment=' + org1 }],
+        },
       });
 
       const org2 = 'Organization/' + randomUUID();
       const testAccount2 = await addTestUser(project, {
-        resourceType: 'AccessPolicy',
-        compartment: { reference: org2 },
-        resource: [{ resourceType: 'Patient', criteria: 'Patient?_compartment=' + org2 }],
+        accessPolicy: {
+          resourceType: 'AccessPolicy',
+          compartment: { reference: org2 },
+          resource: [{ resourceType: 'Patient', criteria: 'Patient?_compartment=' + org2 }],
+        },
       });
 
       // Create a patient on behalf of test account 1
@@ -154,16 +158,20 @@ describe('On Behalf Of', () => {
 
       const org1 = 'Organization/' + randomUUID();
       const testAccount1 = await addTestUser(project, {
-        resourceType: 'AccessPolicy',
-        compartment: { reference: org1 },
-        resource: [{ resourceType: 'Patient', criteria: 'Patient?_compartment=' + org1 }],
+        accessPolicy: {
+          resourceType: 'AccessPolicy',
+          compartment: { reference: org1 },
+          resource: [{ resourceType: 'Patient', criteria: 'Patient?_compartment=' + org1 }],
+        },
       });
 
       const org2 = 'Organization/' + randomUUID();
       const testAccount2 = await addTestUser(project, {
-        resourceType: 'AccessPolicy',
-        compartment: { reference: org2 },
-        resource: [{ resourceType: 'Patient', criteria: 'Patient?_compartment=' + org2 }],
+        accessPolicy: {
+          resourceType: 'AccessPolicy',
+          compartment: { reference: org2 },
+          resource: [{ resourceType: 'Patient', criteria: 'Patient?_compartment=' + org2 }],
+        },
       });
 
       // Create a patient on behalf of test account 1
@@ -343,9 +351,11 @@ describe('On Behalf Of', () => {
       // They will be the "onBehalfOf" users for all HTTP requests
       const account = 'Organization/' + randomUUID();
       const testAccount = await addTestUser(project, {
-        resourceType: 'AccessPolicy',
-        compartment: { reference: account },
-        resource: [{ resourceType: 'Patient', criteria: 'Patient?_compartment=' + account }],
+        accessPolicy: {
+          resourceType: 'AccessPolicy',
+          compartment: { reference: account },
+          resource: [{ resourceType: 'Patient', criteria: 'Patient?_compartment=' + account }],
+        },
       });
 
       // Create a patient on behalf of test account 1

--- a/packages/server/src/fhir/operations/book.test.ts
+++ b/packages/server/src/fhir/operations/book.test.ts
@@ -21,8 +21,8 @@ import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
 import { getGlobalSystemRepo } from '../../fhir/repo';
 import type { TestProjectResult } from '../../test.setup';
-import { toCodeableReferenceLike } from '../../util/servicetype';
 import { addTestUser, createTestProject } from '../../test.setup';
+import { toCodeableReferenceLike } from '../../util/servicetype';
 
 import type {
   SchedulingParametersExtension,
@@ -1475,6 +1475,11 @@ describe('Appointment/$book', () => {
 
 describe('scheduling flow integration test', () => {
   let project: TestProjectResult<{ withAccessToken: true }>;
+  let service: WithId<HealthcareService>;
+
+  const officeVisitConcept: CodeableConcept = {
+    coding: [{ system: 'https://example.com/fhir', code: 'office-visit' }],
+  };
 
   beforeAll(async () => {
     const config = await loadTestConfig();
@@ -1482,24 +1487,19 @@ describe('scheduling flow integration test', () => {
     config.transactionAttempts = 5;
     await initApp(app, config);
     project = await createTestProject({ withAccessToken: true });
+    service = await systemRepo.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      name: 'Office Visit',
+      type: [officeVisitConcept],
+      meta: { project: project.project.id },
+    });
   });
 
   afterAll(async () => {
     await shutdownApp();
   });
 
-  const officeVisit: CodeableConcept = {
-    coding: [{ system: 'https://example.com/fhir', code: 'office-visit' }],
-  };
-
   test('a slot from $find can be used as input to $book', async () => {
-    const service = await systemRepo.createResource<HealthcareService>({
-      resourceType: 'HealthcareService',
-      name: 'Office Visit',
-      type: [officeVisit],
-      meta: { project: project.project.id },
-    });
-
     const practitioner = await systemRepo.createResource<Practitioner>({
       resourceType: 'Practitioner',
       meta: { project: project.project.id },
@@ -1598,13 +1598,14 @@ describe('scheduling flow integration test', () => {
       resourceType: 'Schedule',
       meta: { project: project.project.id },
       actor: [createReference(practitioner)],
+      serviceType: toCodeableReferenceLike(service),
       extension: [
         {
           url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
           extension: [
             {
-              url: 'serviceType',
-              valueCodeableConcept: officeVisit,
+              url: 'service',
+              valueReference: createReference(service),
             },
             {
               url: 'availability',
@@ -1684,7 +1685,7 @@ describe('scheduling flow integration test', () => {
               start,
               end,
               status: 'free',
-              serviceType: [officeVisit],
+              serviceType: [officeVisitConcept],
             } satisfies Slot,
           },
           {

--- a/packages/server/src/fhir/operations/book.test.ts
+++ b/packages/server/src/fhir/operations/book.test.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { createReference, isDefined, parseSearchRequest } from '@medplum/core';
+import { createReference, getReferenceString, isDefined, parseSearchRequest } from '@medplum/core';
 import type {
+  AccessPolicy,
   Appointment,
   Bundle,
   CodeableConcept,
@@ -20,8 +21,9 @@ import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
 import { getGlobalSystemRepo } from '../../fhir/repo';
 import type { TestProjectResult } from '../../test.setup';
-import { createTestProject } from '../../test.setup';
 import { toCodeableReferenceLike } from '../../util/servicetype';
+import { addTestUser, createTestProject } from '../../test.setup';
+
 import type {
   SchedulingParametersExtension,
   SchedulingParametersExtensionExtension,
@@ -1578,5 +1580,183 @@ describe('scheduling flow integration test', () => {
 
     expect(bookResponse.body).not.toHaveProperty('issue');
     expect(bookResponse.status).toBe(201);
+  });
+
+  test('booking a slot as a patient with a minimal access policy', async () => {
+    const practitioner = await systemRepo.createResource<Practitioner>({
+      resourceType: 'Practitioner',
+      meta: { project: project.project.id },
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/StructureDefinition/timezone',
+          valueCode: 'America/Phoenix',
+        },
+      ],
+    });
+
+    const schedule = await systemRepo.createResource<Schedule>({
+      resourceType: 'Schedule',
+      meta: { project: project.project.id },
+      actor: [createReference(practitioner)],
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [
+            {
+              url: 'serviceType',
+              valueCodeableConcept: officeVisit,
+            },
+            {
+              url: 'availability',
+              extension: [
+                {
+                  url: 'availableTime',
+                  extension: [
+                    { url: 'daysOfWeek', valueCode: 'tue' },
+                    { url: 'daysOfWeek', valueCode: 'wed' },
+                    { url: 'daysOfWeek', valueCode: 'thu' },
+                    { url: 'availableStartTime', valueTime: '09:00:00' },
+                    { url: 'availableEndTime', valueTime: '17:00:00' },
+                  ],
+                },
+              ],
+            },
+            {
+              url: 'duration',
+              valueDuration: { value: 60, unit: 'min' },
+            },
+          ],
+        },
+      ],
+    });
+
+    const minimalPolicy: AccessPolicy = {
+      resourceType: 'AccessPolicy',
+      resource: [
+        {
+          resourceType: 'Practitioner',
+          interaction: ['read'],
+        },
+        {
+          resourceType: 'HealthcareService',
+          interaction: ['search'],
+        },
+        {
+          resourceType: 'Schedule',
+          interaction: ['read'],
+        },
+        {
+          resourceType: 'Patient',
+          criteria: 'Patient?_compartment=%patient',
+          interaction: ['read'],
+        },
+        {
+          resourceType: 'Slot',
+          interaction: ['create', 'search'],
+        },
+        {
+          resourceType: 'Appointment',
+          interaction: ['create'],
+          criteria: 'Appointment?_compartment=%patient',
+        },
+      ],
+    };
+
+    const { accessToken, profile } = await addTestUser(project.project, {
+      accessPolicy: minimalPolicy,
+      resourceType: 'Patient',
+    });
+
+    const start = '2026-01-28T16:00:00Z'; // 09:00 America/Phoenix (UTC-7)
+    const end = '2026-01-28T17:00:00Z'; // 10:00 America/Phoenix
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$book')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'slot',
+            resource: {
+              resourceType: 'Slot',
+              schedule: createReference(schedule),
+              start,
+              end,
+              status: 'free',
+              serviceType: [officeVisit],
+            } satisfies Slot,
+          },
+          {
+            name: 'patient-reference',
+            valueReference: createReference(profile),
+          },
+        ],
+      });
+
+    expect(response.body).not.toHaveProperty('issue');
+    expect(response.status).toEqual(201);
+
+    const entries = ((response.body as Bundle).entry ?? []).map((entry) => entry.resource).filter(isDefined);
+
+    const appointments = entries.filter(isAppointment);
+    expect(appointments).toHaveLength(1);
+    expect(appointments[0]).toHaveProperty('status', 'booked');
+    expect(appointments[0]).toHaveProperty('start', start);
+    expect(appointments[0]).toHaveProperty('end', end);
+    expect(appointments[0].participant).toContainEqual({
+      actor: createReference(profile),
+      status: 'accepted',
+    });
+
+    const slots = entries.filter(isSlot);
+    expect(slots).toHaveLength(1);
+    expect(slots[0]).toHaveProperty('status', 'busy');
+
+    // Test that another patient with the same access policy can read the Slot
+    // created, and that it has no PHI in it.
+    const otherPatient = await addTestUser(project.project, {
+      accessPolicy: minimalPolicy,
+      resourceType: 'Patient',
+    });
+
+    const otherPatientResponse = await request
+      .get('/fhir/R4/Slot')
+      .query({ schedule: getReferenceString(schedule) })
+      .set('Authorization', `Bearer ${otherPatient.accessToken}`)
+      .send();
+
+    expect(otherPatientResponse.body).not.toHaveProperty('issue');
+    expect(otherPatientResponse.status).toEqual(200);
+    expect(otherPatientResponse.body).toHaveProperty('entry');
+    expect(otherPatientResponse.body.entry).toHaveLength(1);
+    expect(otherPatientResponse.body.entry[0].resource).toEqual({
+      resourceType: 'Slot',
+      schedule: {
+        reference: `Schedule/${schedule.id}`,
+      },
+      start: '2026-01-28T16:00:00Z',
+      end: '2026-01-28T17:00:00Z',
+      status: 'busy',
+      serviceType: [
+        {
+          coding: [
+            {
+              system: 'https://example.com/fhir',
+              code: 'office-visit',
+            },
+          ],
+        },
+      ],
+      id: slots[0].id,
+      meta: {
+        versionId: slots[0].meta?.versionId,
+        lastUpdated: slots[0].meta?.lastUpdated,
+      },
+    });
+
+    // explicit check against a possible problem: creating the Slot does not
+    // set `meta.author` to the creating Patient, which could leak PHI.
+    expect(otherPatientResponse.body.entry[0].resource.meta).not.toHaveProperty('author');
   });
 });

--- a/packages/server/src/fhir/operations/graphql.test.ts
+++ b/packages/server/src/fhir/operations/graphql.test.ts
@@ -107,20 +107,22 @@ describe('GraphQL', () => {
 
       // Invite Bob with the access policy
       const bobRegistration = await addTestUser(aliceRegistration.project, {
-        resourceType: 'AccessPolicy',
-        resource: [
-          {
-            resourceType: 'Encounter',
-          },
-          {
-            resourceType: 'Patient',
-            hiddenFields: ['telecom'],
-          },
-          {
-            resourceType: 'ServiceRequest',
-            criteria: 'ServiceRequest?status=completed',
-          },
-        ],
+        accessPolicy: {
+          resourceType: 'AccessPolicy',
+          resource: [
+            {
+              resourceType: 'Encounter',
+            },
+            {
+              resourceType: 'Patient',
+              hiddenFields: ['telecom'],
+            },
+            {
+              resourceType: 'ServiceRequest',
+              criteria: 'ServiceRequest?status=completed',
+            },
+          ],
+        },
       });
       bobAccessToken = bobRegistration.accessToken;
     });
@@ -1043,25 +1045,29 @@ describe('GraphQL', () => {
       hasId(obs);
 
       const { accessToken: restrictedAccessToken } = await addTestUser(project, {
-        resourceType: 'AccessPolicy',
-        resource: [
-          {
-            resourceType: 'Patient',
-          },
-        ],
+        accessPolicy: {
+          resourceType: 'AccessPolicy',
+          resource: [
+            {
+              resourceType: 'Patient',
+            },
+          ],
+        },
       });
 
       const { accessToken: hiddenBodySiteAccessToken } = await addTestUser(project, {
-        resourceType: 'AccessPolicy',
-        resource: [
-          {
-            resourceType: 'Patient',
-          },
-          {
-            resourceType: 'Observation',
-            hiddenFields: ['bodySite'],
-          },
-        ],
+        accessPolicy: {
+          resourceType: 'AccessPolicy',
+          resource: [
+            {
+              resourceType: 'Patient',
+            },
+            {
+              resourceType: 'Observation',
+              hiddenFields: ['bodySite'],
+            },
+          ],
+        },
       });
 
       // No AccessPolicy

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -2263,12 +2263,14 @@ describe('OAuth2 Token', () => {
 
   test('Pre-authorized code IP address restriction', async () => {
     const testAccount = await addTestUser(project, {
-      resourceType: 'AccessPolicy',
-      resource: [{ resourceType: '*' }],
-      ipAccessRule: [
-        { name: 'Block test', value: '6.6.6.6', action: 'block' },
-        { name: 'Allow by default', value: '*', action: 'allow' },
-      ],
+      accessPolicy: {
+        resourceType: 'AccessPolicy',
+        resource: [{ resourceType: '*' }],
+        ipAccessRule: [
+          { name: 'Block test', value: '6.6.6.6', action: 'block' },
+          { name: 'Allow by default', value: '*', action: 'allow' },
+        ],
+      },
     });
 
     const res = await request(app)

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -177,8 +177,14 @@ export async function initTestAuth(options?: TestProjectOptions): Promise<string
 
 export async function addTestUser(
   project: WithId<Project>,
-  accessPolicy?: AccessPolicy
+  options?: {
+    accessPolicy?: AccessPolicy;
+    resourceType?: 'Practitioner' | 'Patient';
+  }
 ): Promise<ServerInviteResponse & { accessToken: string }> {
+  let accessPolicy = options?.accessPolicy;
+  const resourceType = options?.resourceType ?? 'Practitioner';
+
   if (accessPolicy) {
     const systemRepo = await getProjectSystemRepo(project);
     accessPolicy = await systemRepo.createResource<AccessPolicy>({
@@ -193,7 +199,7 @@ export async function addTestUser(
     project,
     email,
     password,
-    resourceType: 'Practitioner',
+    resourceType,
     firstName: 'Bob',
     lastName: 'Jones',
     sendEmail: false,
@@ -210,6 +216,7 @@ export async function addTestUser(
     password,
     scope: 'openid',
     nonce: 'nonce',
+    projectId: project.id,
   });
 
   const accessToken = await generateAccessToken({


### PR DESCRIPTION
This is likely to move into $hold when we implement it (see https://github.com/medplum/medplum/issues/7688); for now we have started using $book to demonstrate the flow in FooMedical (see https://github.com/medplum/medplum/pull/8599) and so we would like to add some test coverage supporting that use case.

Implementation notes:
- Adjusted `addTestUser` to accept an options object as its second argument. Previously this took an optional access policy, but switching to an options object lets us add features like `resourceType` in a clear way.

- `addTestUser` tries to log in as the newly created user, which requires a project ID for a user with a `Patient` profile. This means that `Practitioner` users are also now specifying that parameter, but my belief is that this was implicitly looked up from the user's projectMembership in that scenario and this represents no functional change.