### PR TITLE
Fixed medplum_test_readonly permissions on pg17

### DIFF
--- a/postgres/init_test.sql
+++ b/postgres/init_test.sql
@@ -9,5 +9,4 @@ GRANT ALL PRIVILEGES ON DATABASE medplum_test TO medplum;
 CREATE USER medplum_test_readonly WITH PASSWORD 'medplum_test_readonly';
 GRANT CONNECT ON DATABASE medplum_test TO medplum_test_readonly;
 GRANT USAGE ON SCHEMA public TO medplum_test_readonly;
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO medplum_test_readonly;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO medplum_test_readonly;
+GRANT pg_read_all_data TO medplum_test_readonly;


### PR DESCRIPTION
My `medplum_test_readonly` user started hitting `permission denied` errors after running on Postgres 17.  Apparently PostgreSQL revoked implicit `PUBLIC` schema privileges and tightened access to sequences and other object types, so the previous grants were no longer sufficient.

I don't fully understand why this doesn't repro with the Postgres 18 CI/CD tests?

### Solution

Replace the manual `GRANT SELECT ON ALL TABLES` / `ALTER DEFAULT PRIVILEGES` grants with the built-in `pg_read_all_data` role (available since PG14). This role covers read access to all tables, views, sequences, and foreign tables across all schemas — including future objects — without needing per-type grants or `ALTER DEFAULT PRIVILEGES` statements.

### Changes

- Remove `GRANT SELECT ON ALL TABLES IN SCHEMA public`
- Remove `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES`
- Add `GRANT pg_read_all_data TO medplum_test_readonly`

### Notes

- No application behavior changes; this only affects the readonly test user
- `pg_read_all_data` requires PostgreSQL 14+, which aligns with our minimum supported version