### PR TITLE
Add healthcheck validation for custom base URLs

### DIFF
--- a/packages/cli/src/util/client.test.ts
+++ b/packages/cli/src/util/client.test.ts
@@ -60,11 +60,26 @@ describe('createMedplumClient', () => {
   });
 
   test('with global options set', async () => {
+    const fetch = jest.fn(async (url: string) => {
+      if (url.includes('healthcheck')) {
+        return {
+          status: 200,
+          ok: true,
+          json: jest.fn(async () => ({ ok: true })),
+        };
+      }
+      return {
+        status: 200,
+        ok: true,
+        json: jest.fn(async () => ({})),
+      };
+    });
     const options: MedplumClientOptions = {
       baseUrl: 'http://example.com/',
       fhirUrlPath: '/fhir/test/path/',
       tokenUrl: 'http://example.com/oauth/token',
       accessToken: 'test-access-token',
+      fetch,
     };
     process.env.MEDPLUM_BASE_URL = 'http://example.com';
     process.env.MEDPLUM_FHIR_URL_PATH = '/fhir/test/path/';
@@ -114,5 +129,94 @@ describe('createMedplumClient', () => {
     } catch {
       expect(console.log).toHaveBeenCalledWith('Unauthenticated: run `npx medplum login` to sign in');
     }
+  });
+
+  test('validates base URL healthcheck on non-default URL', async () => {
+    const fetch = jest.fn(async (url: string) => {
+      if (url.includes('healthcheck')) {
+        return {
+          status: 200,
+          ok: true,
+          json: jest.fn(async () => ({ ok: true })),
+        };
+      }
+      return {
+        status: 200,
+        ok: true,
+        json: jest.fn(async () => ({})),
+      };
+    });
+
+    const medplumClient = await createMedplumClient({
+      baseUrl: 'http://custom.example.com/',
+      fetch,
+    });
+
+    expect(medplumClient.getBaseUrl()).toContain('http://custom.example.com/');
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('healthcheck'));
+  });
+
+  test('throws error when healthcheck fails', async () => {
+    const fetch = jest.fn(async (url: string) => {
+      if (url.includes('healthcheck')) {
+        return {
+          status: 500,
+          ok: false,
+          json: jest.fn(async () => ({ ok: false })),
+        };
+      }
+      return {
+        status: 200,
+        ok: true,
+        json: jest.fn(async () => ({})),
+      };
+    });
+
+    await expect(
+      createMedplumClient({
+        baseUrl: 'http://custom.example.com/',
+        fetch,
+      })
+    ).rejects.toThrow('Failed to validate base URL');
+  });
+
+  test('throws error when healthcheck response missing ok field', async () => {
+    const fetch = jest.fn(async (url: string) => {
+      if (url.includes('healthcheck')) {
+        return {
+          status: 200,
+          ok: true,
+          json: jest.fn(async () => ({ status: 'ok' })),
+        };
+      }
+      return {
+        status: 200,
+        ok: true,
+        json: jest.fn(async () => ({})),
+      };
+    });
+
+    await expect(
+      createMedplumClient({
+        baseUrl: 'http://custom.example.com/',
+        fetch,
+      })
+    ).rejects.toThrow('Healthcheck response does not have "ok": true');
+  });
+
+  test('does not validate healthcheck for default URL', async () => {
+    const fetch = jest.fn(async () => {
+      return {
+        status: 200,
+        ok: true,
+        json: jest.fn(async () => ({})),
+      };
+    });
+
+    const medplumClient = await createMedplumClient({ fetch });
+
+    expect(medplumClient.getBaseUrl()).toContain('https://api.medplum.com/');
+    // Verify healthcheck was not called for default URL
+    expect(fetch).not.toHaveBeenCalledWith(expect.stringContaining('healthcheck'));
   });
 });

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -22,6 +22,12 @@ export async function createMedplumClient(
     storage
   );
   const fetchApi = options.fetch ?? fetch;
+
+  // Validate base URL if non-default is specified
+  if (options.baseUrl && options.baseUrl !== 'https://api.medplum.com/') {
+    await validateBaseUrl(options.baseUrl, fetchApi);
+  }
+
   const medplumClient = new MedplumClient({
     fetch: fetchApi,
     baseUrl,
@@ -66,6 +72,27 @@ function getClientValues(options: MedplumClientOptions, storage: FileSystemStora
   const clientSecret = options.clientSecret ?? storageOptions?.clientSecret ?? process.env['MEDPLUM_CLIENT_SECRET'];
 
   return { baseUrl, fhirUrlPath, accessToken, tokenUrl, authorizeUrl, clientId, clientSecret };
+}
+
+async function validateBaseUrl(
+  baseUrl: string,
+  fetchApi: (input: string, init?: RequestInit) => Promise<Response>
+): Promise<void> {
+  try {
+    const url = new URL('healthcheck', baseUrl).toString();
+    const response = await fetchApi(url);
+    if (!response.ok) {
+      throw new Error(`Healthcheck returned status ${response.status}`);
+    }
+    const data = (await response.json()) as { ok?: unknown };
+    if (data.ok === true) {
+      return;
+    }
+    throw new Error('Healthcheck response does not have "ok": true');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to validate base URL "${baseUrl}": ${message}`);
+  }
 }
 
 export function onUnauthenticated(): void {


### PR DESCRIPTION
## Summary
Add healthcheck validation for custom base URLs in the Medplum CLI to ensure that custom endpoints are accessible and functioning correctly.

## Motivation
When users configure a custom base URL for the Medplum client, there's no validation that the URL is actually reachable or properly configured. This can lead to confusing errors later in the workflow. Adding a healthcheck validation on initialization provides early feedback.

## Test plan
- Run existing test suite to ensure no regressions
- Review new test cases for healthcheck validation on non-default URLs
- Test with valid and invalid custom base URLs