### PR TITLE
Rewrite Attachment.url in convertToTransactionBundle (#8664)

### DIFF
--- a/packages/core/src/bundle.test.ts
+++ b/packages/core/src/bundle.test.ts
@@ -234,6 +234,110 @@ describe('Bundle tests', () => {
       });
     });
 
+    test('Rewrites Attachment.url referencing a Binary in the bundle', () => {
+      const inputBundle: Bundle = {
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [
+          {
+            fullUrl: 'https://example.com/DocumentReference/doc1',
+            resource: {
+              resourceType: 'DocumentReference',
+              id: 'doc1',
+              status: 'current',
+              content: [
+                {
+                  attachment: {
+                    contentType: 'application/pdf',
+                    url: 'Binary/bin1',
+                  },
+                },
+              ],
+            },
+          },
+          {
+            fullUrl: 'https://example.com/Binary/bin1',
+            resource: {
+              resourceType: 'Binary',
+              id: 'bin1',
+              contentType: 'application/pdf',
+            },
+          },
+        ],
+      };
+
+      const result = convertToTransactionBundle(inputBundle);
+      const docRef = result.entry?.find((e) => e.resource?.resourceType === 'DocumentReference');
+      const attachmentUrl = (docRef?.resource as any)?.content?.[0]?.attachment?.url;
+      expect(attachmentUrl).toMatch(/^urn:uuid:[a-f0-9-]+$/);
+    });
+
+    test('Does not rewrite Attachment.url for external URLs', () => {
+      const inputBundle: Bundle = {
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [
+          {
+            fullUrl: 'https://example.com/DocumentReference/doc1',
+            resource: {
+              resourceType: 'DocumentReference',
+              id: 'doc1',
+              status: 'current',
+              content: [
+                {
+                  attachment: {
+                    contentType: 'image/png',
+                    url: 'https://example.com/images/photo.png',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      };
+
+      const result = convertToTransactionBundle(inputBundle);
+      const docRef = result.entry?.find((e) => e.resource?.resourceType === 'DocumentReference');
+      const attachmentUrl = (docRef?.resource as any)?.content?.[0]?.attachment?.url;
+      expect(attachmentUrl).toBe('https://example.com/images/photo.png');
+    });
+
+    test('Orders Binary before DocumentReference when Attachment.url references it', () => {
+      const inputBundle: Bundle = {
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [
+          {
+            fullUrl: 'https://example.com/DocumentReference/doc1',
+            resource: {
+              resourceType: 'DocumentReference',
+              id: 'doc1',
+              status: 'current',
+              content: [
+                {
+                  attachment: {
+                    contentType: 'application/pdf',
+                    url: 'Binary/bin1',
+                  },
+                },
+              ],
+            },
+          },
+          {
+            fullUrl: 'https://example.com/Binary/bin1',
+            resource: {
+              resourceType: 'Binary',
+              id: 'bin1',
+              contentType: 'application/pdf',
+            },
+          },
+        ],
+      };
+
+      const result = convertToTransactionBundle(inputBundle);
+      expect(result.entry?.map((e) => e.resource?.resourceType)).toStrictEqual(['Binary', 'DocumentReference']);
+    });
+
     test('Remove empty resource.meta', () => {
       const patient: Patient = {
         resourceType: 'Patient',

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -66,7 +66,7 @@ export function convertToTransactionBundle(bundle: Bundle): Bundle {
 }
 
 function referenceReplacer(key: string, value: string, idToUuid: Record<string, string>): string {
-  if (key === 'reference' && typeof value === 'string') {
+  if ((key === 'reference' || key === 'url') && typeof value === 'string') {
     let id;
     if (value.includes('/')) {
       id = value.split('/')[1];
@@ -212,6 +212,8 @@ function findReferences(resource: any, callback: (reference: string) => void): v
       } else {
         findReferences(value, callback);
       }
+    } else if (key === 'url' && typeof resource[key] === 'string' && resource[key].startsWith('urn:uuid:')) {
+      callback(resource[key]);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Extend `convertToTransactionBundle` to rewrite `Attachment.url` when it references a Binary resource in the bundle (e.g. `Binary/abc123`)
- Update `referenceReplacer` to handle `key === 'url'` in addition to `key === 'reference'`
- Update `findReferences` to detect `urn:uuid:` URLs for correct topological bundle ordering
- External URLs (e.g. `https://...`) are left untouched since they won't match any ID in the bundle

## Test plan
- [x] Added test: Attachment.url pointing to Binary in bundle is rewritten to `urn:uuid:`
- [x] Added test: External URLs are not rewritten
- [x] Added test: Binary is ordered before DocumentReference when referenced via Attachment.url
- [x] All 19 tests pass

Closes #8664