### PR TITLE
feat(agent): add Agent/$stats operation for remote stats retrieval

### DIFF
--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -349,10 +349,7 @@ export class App {
                 (channel) => channel instanceof AgentHl7Channel
               );
               const channelStats = Object.fromEntries(
-                hl7Channels.map((channel) => [
-                  channel.getDefinition().name,
-                  channel.stats?.getStats() as ChannelStats,
-                ])
+                hl7Channels.map((channel) => [channel.getDefinition().name, channel.stats?.getStats() as ChannelStats])
               );
 
               const pools = Array.from(this.hl7Clients.values());

--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -5,6 +5,7 @@ import type {
   AgentLogsRequest,
   AgentMessage,
   AgentReloadConfigResponse,
+  AgentStatsResponse,
   AgentTransmitRequest,
   AgentTransmitResponse,
   AgentUpgradeRequest,
@@ -335,6 +336,55 @@ export class App {
             break;
           case 'agent:logs:request':
             await this.handleLogRequest(command);
+            break;
+          case 'agent:stats:request':
+            try {
+              const stats = getCurrentStats();
+              let totalHl7Clients = 0;
+              for (const pool of this.hl7Clients.values()) {
+                totalHl7Clients += pool.size();
+              }
+
+              const hl7Channels = Array.from(this.channels.values()).filter(
+                (channel) => channel instanceof AgentHl7Channel
+              );
+              const channelStats = Object.fromEntries(
+                hl7Channels.map((channel) => [
+                  channel.getDefinition().name,
+                  channel.stats?.getStats() as ChannelStats,
+                ])
+              );
+
+              const pools = Array.from(this.hl7Clients.values());
+              const clientStats = Object.fromEntries(
+                pools.map((pool) => [
+                  `mllp://${pool.host}:${pool.port}?encoding=${pool.encoding ?? DEFAULT_ENCODING}`,
+                  pool.getPoolStats() as ChannelStats,
+                ])
+              );
+
+              await this.sendToWebSocket({
+                type: 'agent:stats:response',
+                statusCode: 200,
+                callback: command.callback,
+                stats: {
+                  ...stats,
+                  webSocketQueueDepth: this.webSocketQueue.length,
+                  hl7QueueDepth: this.hl7Queue.length,
+                  hl7ClientCount: totalHl7Clients,
+                  live: this.live,
+                  outstandingHeartbeats: this.outstandingHeartbeats,
+                  channelStats,
+                  clientStats,
+                },
+              } satisfies AgentStatsResponse);
+            } catch (err: unknown) {
+              await this.sendToWebSocket({
+                type: 'agent:error',
+                body: normalizeErrorString(err),
+                callback: command.callback,
+              });
+            }
             break;
           case 'agent:error':
             this.log.error(command.body);

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -91,13 +91,24 @@ export interface AgentLogsResponse extends BaseAgentMessage {
   logs: LogMessage[];
 }
 
+export interface AgentStatsRequest extends BaseAgentRequestMessage {
+  type: 'agent:stats:request';
+}
+
+export interface AgentStatsResponse extends BaseAgentMessage {
+  type: 'agent:stats:response';
+  statusCode: number;
+  stats: Record<string, unknown>;
+}
+
 export type AgentRequestMessage =
   | AgentConnectRequest
   | AgentHeartbeatRequest
   | AgentTransmitRequest
   | AgentReloadConfigRequest
   | AgentUpgradeRequest
-  | AgentLogsRequest;
+  | AgentLogsRequest
+  | AgentStatsRequest;
 
 export type AgentResponseMessage =
   | AgentConnectResponse
@@ -106,6 +117,7 @@ export type AgentResponseMessage =
   | AgentReloadConfigResponse
   | AgentUpgradeResponse
   | AgentLogsResponse
+  | AgentStatsResponse
   | AgentError;
 
 export type AgentMessage = AgentRequestMessage | AgentResponseMessage;

--- a/packages/server/src/fhir/operations/agentstats.ts
+++ b/packages/server/src/fhir/operations/agentstats.ts
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { AgentStatsResponse, WithId } from '@medplum/core';
+import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
+import type { Agent, OperationDefinition } from '@medplum/fhirtypes';
+import { handleBulkAgentOperation, sendAndHandleAgentRequest } from './utils/agentutils';
+
+export const operation: OperationDefinition = {
+  resourceType: 'OperationDefinition',
+  name: 'agent-stats',
+  status: 'active',
+  kind: 'operation',
+  code: 'stats',
+  experimental: true,
+  resource: ['Agent'],
+  system: false,
+  type: true,
+  instance: true,
+  parameter: [{ use: 'out', name: 'return', type: 'Parameters', min: 1, max: '1' }],
+};
+
+/**
+ * Handles HTTP requests for the Agent $stats operation.
+ *
+ * Endpoints:
+ *   [fhir base]/Agent/$stats
+ *   [fhir base]/Agent/[id]/$stats
+ *
+ * @param req - The FHIR request.
+ * @returns The FHIR response.
+ */
+export async function agentStatsHandler(req: FhirRequest): Promise<FhirResponse> {
+  return handleBulkAgentOperation(req, async (agent) => getStats(agent));
+}
+
+async function getStats(agent: WithId<Agent>): Promise<FhirResponse> {
+  return sendAndHandleAgentRequest<AgentStatsResponse>(
+    agent,
+    { type: 'agent:stats:request' },
+    'agent:stats:response',
+    {
+      successHandler: (response) => {
+        return {
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'stats',
+              valueString: JSON.stringify(response.stats),
+            },
+          ],
+        };
+      },
+    }
+  );
+}

--- a/packages/server/src/fhir/operations/agentstats.ts
+++ b/packages/server/src/fhir/operations/agentstats.ts
@@ -34,22 +34,17 @@ export async function agentStatsHandler(req: FhirRequest): Promise<FhirResponse>
 }
 
 async function getStats(agent: WithId<Agent>): Promise<FhirResponse> {
-  return sendAndHandleAgentRequest<AgentStatsResponse>(
-    agent,
-    { type: 'agent:stats:request' },
-    'agent:stats:response',
-    {
-      successHandler: (response) => {
-        return {
-          resourceType: 'Parameters',
-          parameter: [
-            {
-              name: 'stats',
-              valueString: JSON.stringify(response.stats),
-            },
-          ],
-        };
-      },
-    }
-  );
+  return sendAndHandleAgentRequest<AgentStatsResponse>(agent, { type: 'agent:stats:request' }, 'agent:stats:response', {
+    successHandler: (response) => {
+      return {
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'stats',
+            valueString: JSON.stringify(response.stats),
+          },
+        ],
+      };
+    },
+  });
 }

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -18,6 +18,7 @@ import { agentBulkStatusHandler } from './operations/agentbulkstatus';
 import { agentFetchLogsHandler } from './operations/agentfetchlogs';
 import { agentPushHandler } from './operations/agentpush';
 import { agentReloadConfigHandler } from './operations/agentreloadconfig';
+import { agentStatsHandler } from './operations/agentstats';
 import { agentStatusHandler } from './operations/agentstatus';
 import { agentUpgradeHandler } from './operations/agentupgrade';
 import { aiOperationHandler } from './operations/ai';
@@ -291,6 +292,10 @@ function initInternalFhirRouter(): FhirRouter {
   // Agent $fetch-logs operation
   router.add('GET', '/Agent/$fetch-logs', agentFetchLogsHandler);
   router.add('GET', '/Agent/:id/$fetch-logs', agentFetchLogsHandler);
+
+  // Agent $stats operation
+  router.add('GET', '/Agent/$stats', agentStatsHandler);
+  router.add('GET', '/Agent/:id/$stats', agentStatsHandler);
 
   // AsyncJob $cancel operation
   router.add('POST', '/AsyncJob/:id/$cancel', asyncJobCancelHandler);


### PR DESCRIPTION
## Summary
Closes #7221

Add a new `$stats` FHIR operation for the Agent resource that allows fetching runtime statistics remotely via WebSocket.

### Changes
- **`packages/core/src/agent.ts`** — Added `AgentStatsRequest` and `AgentStatsResponse` message interfaces
- **`packages/server/src/fhir/operations/agentstats.ts`** — New operation handler (follows `$fetch-logs` pattern)
- **`packages/server/src/fhir/routes.ts`** — Registered `GET /Agent/$stats` and `GET /Agent/:id/$stats` routes
- **`packages/agent/src/app.ts`** — Handle `agent:stats:request`, collect and return stats (queue depths, HL7 client counts, channel/client stats, heartbeat status)

### Endpoints
- `GET [fhir base]/Agent/$stats` — all agents
- `GET [fhir base]/Agent/[id]/$stats` — specific agent

### Stats returned
- WebSocket/HL7 queue depths
- HL7 client count
- Live status & outstanding heartbeats
- Per-channel and per-client statistics
