### PR TITLE
docs(opentelemetry): fix environment variable references for OTLP configuration

### DIFF
--- a/packages/docs/docs/self-hosting/opentelemetry.md
+++ b/packages/docs/docs/self-hosting/opentelemetry.md
@@ -55,7 +55,7 @@ OpenTelemetry cannot be configured through the normal `medplum.config.json` file
 Instead, you must add the following environment variables:
 
 ```bash
-export OTLP_TRACES_ENDPOINT="http://localhost:4318/v1/traces"
+export OTLP_TRACE_ENDPOINT="http://localhost:4318/v1/traces"
 export OTLP_METRICS_ENDPOINT="http://localhost:4318/v1/metrics"
 ```
 
@@ -81,7 +81,7 @@ Next, add the following to your Medplum CDK JSON config file:
   "stackName": "MedplumStagingStack",
   // ...
   "environment": {
-    "OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces",
+    "OTLP_TRACE_ENDPOINT": "http://localhost:4318/v1/traces",
     "OTLP_METRICS_ENDPOINT": "http://localhost:4318/v1/metrics"
   },
   // ...


### PR DESCRIPTION
## Summary

- Corrects `OTLP_TRACES_ENDPOINT` to `OTLP_TRACE_ENDPOINT` in the OpenTelemetry self-hosting docs

The server reads `process.env.OTLP_TRACE_ENDPOINT` (singular) in [`instrumentation.ts:39`](https://github.com/medplum/medplum/blob/main/packages/server/src/otel/instrumentation.ts#L39), but the docs documented it as `OTLP_TRACES_ENDPOINT` (plural). This would cause tracing to silently not work for users following the docs.

`OTLP_METRICS_ENDPOINT` was already correct and is unchanged.