### PR TITLE
Fixes #8745 - always populate ProjectMembership.invitedBy

### DIFF
--- a/packages/definitions/src/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/src/fhir/r4/profiles-medplum.json
@@ -1633,7 +1633,9 @@
             "max" : "1",
             "type" : [{
               "code" : "Reference",
-              "targetProfile" : ["https://medplum.com/fhir/StructureDefinition/User"]
+              "targetProfile" : ["https://medplum.com/fhir/StructureDefinition/Bot",
+                "https://medplum.com/fhir/StructureDefinition/ClientApplication",
+                "https://medplum.com/fhir/StructureDefinition/User"]
             }],
             "base": {
               "path" : "ProjectMembership.invitedBy",

--- a/packages/fhirtypes/dist/ProjectMembership.d.ts
+++ b/packages/fhirtypes/dist/ProjectMembership.d.ts
@@ -121,7 +121,7 @@ export interface ProjectMembership {
   /**
    * The project administrator who invited the user to the project.
    */
-  invitedBy?: Reference<User>;
+  invitedBy?: Reference<Bot | ClientApplication | User>;
 
   /**
    * User that is granted access to the project.

--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -55,7 +55,11 @@ describe('Admin Invite', () => {
 
   test('New user to project', async () => {
     // First, Alice creates a project
-    const { project, accessToken } = await withTestContext(() =>
+    const {
+      project,
+      accessToken,
+      user: aliceUser,
+    } = await withTestContext(() =>
       registerNew({
         firstName: 'Alice',
         lastName: 'Smith',
@@ -78,6 +82,7 @@ describe('Admin Invite', () => {
       });
 
     expect(res2.status).toBe(200);
+    expect(res2.body.invitedBy).toMatchObject(createReference(aliceUser));
     expect(mockSESv2Client.send.callCount).toBe(1);
     expect(mockSESv2Client).toHaveReceivedCommandTimes(SendEmailCommand, 1);
 
@@ -750,6 +755,7 @@ describe('Admin Invite', () => {
     expect(res4.status).toBe(200);
     expect(res4.body.resourceType).toBe('ProjectMembership');
     expect(res4.body.id).toStrictEqual(res2.body.id);
+    expect(res4.body.invitedBy).toBeDefined();
 
     // Invite Bob again with different profiile - should fail
     const res5 = await request(app)

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -22,7 +22,7 @@ import { authenticator } from 'otplib';
 import { resetPassword } from '../auth/resetpassword';
 import { bcryptHashPassword, createProjectMembership } from '../auth/utils';
 import { getConfig } from '../config/loader';
-import { getAuthenticatedContext } from '../context';
+import { getAuthenticatedContext, tryGetRequestContext } from '../context';
 import { sendEmail } from '../email/email';
 import type { SystemRepository } from '../fhir/repo';
 import { getProjectSystemRepo } from '../fhir/repo';
@@ -334,6 +334,7 @@ async function upsertProjectMembership(
     accessPolicy: request.accessPolicy,
     access: request.access,
     admin: request.admin,
+    invitedBy: tryGetRequestContext()?.authState?.membership?.user,
     ...request.membership,
   };
 


### PR DESCRIPTION
The `ProjectMembership.invitedBy` was originally added for SCIM, and was not properly handled in the normal invite flow.  This PR updates the invite flow to always populate `invitedBy` with the current user.