### PR TITLE
fix(fhircast): prevent `DiagnosticReport-update` while in other resource type contexts

### DIFF
--- a/packages/server/src/fhircast/routes.test.ts
+++ b/packages/server/src/fhircast/routes.test.ts
@@ -866,4 +866,35 @@ describe('FHIRcast routes', () => {
       (publishRes.body.event.event as FhircastEventPayload<'DiagnosticReport-update'>)['context.priorVersionId']
     ).toStrictEqual(versionId);
   });
+
+  test('`DiagnosticReport-update` returns 400 when current context is not a DiagnosticReport', async () => {
+    const topic = randomUUID();
+    const versionId = generateId();
+
+    // Setup a Patient context (no content bundle)
+    await setTopicCurrentContext(project.id, topic, {
+      'context.type': 'Patient',
+      'context.versionId': versionId,
+      context: [{ key: 'patient', resource: { id: 'xyz-789', resourceType: 'Patient' } }],
+    });
+
+    const context = [
+      { key: 'report', reference: { reference: 'DiagnosticReport/123' } },
+      { key: 'patient', reference: { reference: 'Patient/xyz-789' } },
+      { key: 'updates', resource: { id: 'bundle-123', resourceType: 'Bundle', type: 'transaction' } },
+    ] satisfies FhircastEventContext<'DiagnosticReport-update'>[];
+
+    const payload = createFhircastMessagePayload(topic, 'DiagnosticReport-update', context, versionId);
+
+    const res = await request(server)
+      .post(STU3_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send(payload);
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      resourceType: 'OperationOutcome',
+      issue: [{ severity: 'error', details: { text: 'No DiagnosticReport currently open for this topic' } }],
+    });
+  });
 });

--- a/packages/server/src/fhircast/routes.ts
+++ b/packages/server/src/fhircast/routes.ts
@@ -340,8 +340,8 @@ async function handleUpdateContextChangeRequest(req: Request, res: Response): Pr
   const { event } = req.body as FhircastMessagePayload;
   const projectId = ctx.project.id;
 
-  const currentContext = await getCurrentContext<'DiagnosticReport'>(projectId, event['hub.topic']);
-  if (!currentContext) {
+  const currentContext = await getCurrentContext(projectId, event['hub.topic']);
+  if (currentContext?.['context.type'] !== 'DiagnosticReport') {
     sendOutcome(res, badRequest('No DiagnosticReport currently open for this topic'));
     return;
   }
@@ -378,8 +378,8 @@ async function handleUpdateContextChangeRequest(req: Request, res: Response): Pr
 }
 
 function processUpdateBundle(updatesBundle: Bundle, currentContext: CurrentContext<'DiagnosticReport'>): void {
+  const contentBundle = currentContext.context.find((ctx) => ctx.key === 'content')?.resource as Bundle;
   for (const entry of updatesBundle?.entry ?? EMPTY) {
-    const contentBundle = currentContext.context.find((ctx) => ctx.key === 'content')?.resource as Bundle;
     // Only PUT and DELETE are supported
     // See: https://build.fhir.org/ig/HL7/fhircast-docs/StructureDefinition-fhircast-content-update-bundle.html
     switch (entry.request?.method) {


### PR DESCRIPTION
Fixes #8788 