### PR TITLE
Parse mixed alphanumeric tokens with leading digit as string

### DIFF
--- a/packages/core/src/fhirlexer/tokenize.ts
+++ b/packages/core/src/fhirlexer/tokenize.ts
@@ -278,7 +278,7 @@ export class Tokenizer {
         id = 'Quantity';
         this.consumeToken();
       }
-    } else if (terminal && /\w/.exec(terminal)) {
+    } else if (terminal && /[a-zA-Z_$]/.exec(terminal)) {
       // This cannot be a number, fall back to parsing as string
       this.pos.index = start - 1;
       return this.consumeString(' ');

--- a/packages/core/src/filter/parse.test.ts
+++ b/packages/core/src/filter/parse.test.ts
@@ -233,10 +233,10 @@ describe('_filter Parameter parser', () => {
   });
 
   test('parse raw token with leading digits', () => {
-    const result = parseFilterParameter('identifier eq 123abc');
+    const result = parseFilterParameter('identifier eq 123_abc');
     expect(result).toBeInstanceOf(FhirFilterComparison);
 
     const comp = result as FhirFilterComparison;
-    expect(comp.value).toEqual('123abc');
+    expect(comp.value).toEqual('123_abc');
   });
 });


### PR DESCRIPTION
This prevents parsing unquoted filter parameter values (e.g. UUIDs) as numbers, and renders them correctly as strings