### PR TITLE
fix(ci): login to docker for svc containers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,6 +181,9 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       redis:
         image: redis:${{ matrix.redis-version }}
         options: >-
@@ -190,6 +193,9 @@ jobs:
           --health-retries 5
         ports:
           - 6379:6379
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -283,6 +289,9 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       redis:
         image: redis:${{ matrix.redis-version }}
         options: >-
@@ -292,6 +301,9 @@ jobs:
           --health-retries 5
         ports:
           - 6379:6379
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
Fixes the following rate limits getting triggered by our service containers attempting to pull images:
<img width="1544" height="519" alt="image" src="https://github.com/user-attachments/assets/0473e122-7d62-4f21-a5b1-894efe847a8e" />
