### PR TITLE
fix(ccda): add null check for reaction manifestation before setting extension

### DIFF
--- a/packages/ccda/src/ccda-to-fhir.ts
+++ b/packages/ccda/src/ccda-to-fhir.ts
@@ -752,7 +752,7 @@ class CcdaToFhirConverter {
     this.processSeverity(reactionObs, reaction);
 
     // Add reaction reference
-    if (reaction.manifestation && reaction.manifestation.length > 0 && reactionObs.text?.reference?.['@_value']) {
+    if (reaction.manifestation?.[0] && reactionObs.text?.reference?.['@_value']) {
       reaction.manifestation[0].extension = this.mapTextReference(reactionObs.text);
     }
 


### PR DESCRIPTION
## Problem

`processReaction` in `ccda-to-fhir.ts` crashes with:

```
TypeError: Cannot set properties of undefined (setting 'extension')
```

when converting CCDA documents that contain allergy reactions with unmappable observation codes.

## Root Cause

`mapCode()` can return `undefined` when a CCDA code element has no system, code value, display, translations, or original text. The manifestation array is initialized as:

```typescript
manifestation: [this.mapCode(reactionObs.value as CcdaCode)] as CodeableConcept[]
```

When `mapCode()` returns `undefined`, this creates `[undefined]`. The existing guard:

```typescript
if (reaction.manifestation && reaction.manifestation.length > 0 && reactionObs.text?.reference?.['@_value']) {
```

passes because the array has length 1, but `manifestation[0]` is `undefined`.

## Fix

Add `reaction.manifestation[0] &&` to the guard before accessing the element:

```typescript
if (reaction.manifestation && reaction.manifestation.length > 0 && reaction.manifestation[0] && reactionObs.text?.reference?.['@_value']) {
```

## Context

We encountered this in production processing real-world EHI (Electronic Health Information) exports. Multiple patient CCDAs had allergy sections with reaction observations whose codes couldn't be mapped, causing the entire CCDA-to-FHIR conversion to fail.