### PR TITLE
fix(provider): filter DocumentReference tab by current patient

### DIFF
--- a/examples/medplum-provider/src/pages/patient/PatientPage.utils.ts
+++ b/examples/medplum-provider/src/pages/patient/PatientPage.utils.ts
@@ -76,7 +76,7 @@ export const PatientPageTabs: PatientPageTabInfo[] = [
   },
   {
     id: 'documentreference',
-    url: 'DocumentReference',
+    url: 'DocumentReference?subject=%patient.id',
     label: 'Documents',
   },
   {


### PR DESCRIPTION
## Summary

- The Documents tab in the provider patient page used `url: 'DocumentReference'` with no subject filter, causing **all** `DocumentReference` resources in the project to appear for every patient.
- Adds `?subject=%patient.id` to the tab URL, following the same pattern already used by the Encounters, Medications, Devices, and Care Plans tabs.

## Root Cause

`PatientPage.utils.ts` `PatientPageTabs` array, `documentreference` entry:

```ts
// Before
url: 'DocumentReference',

// After
url: 'DocumentReference?subject=%patient.id',
```

`PatientSearchPage` uses `formatPatientPageTabUrl` to substitute `%patient.id` with the actual patient ID before navigating, so the resulting FHIR search becomes `DocumentReference?subject=<patientId>&_count=20&_fields=_id,_lastUpdated`.

## Test plan

- [ ] Navigate to a patient's Documents tab — verify only that patient's documents appear
- [ ] Confirm the URL contains `subject=<patientId>` after navigation
- [ ] Verify the existing `PatientPage.utils.test.ts` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)