### PR TITLE
feat(server): Add SSE-C encryption support for S3 binary storage

### DIFF
--- a/packages/docs/docs/self-hosting/server-config.md
+++ b/packages/docs/docs/self-hosting/server-config.md
@@ -354,6 +354,22 @@ The AWS Region identifier.
 **Created by:** `cdk`
 **Default:** `us-east-1`
 
+### sseCustomerKey
+
+Optional base64-encoded 256-bit key for S3 Server-Side Encryption with Customer-Provided Keys (SSE-C). When set, all S3 operations (upload, download, copy, presigned URLs) will use SSE-C encryption with the `AES256` algorithm.
+
+To generate a suitable key:
+
+```bash
+openssl rand -base64 32
+```
+
+:::caution
+You must store this key securely. If the key is lost, all data encrypted with it becomes permanently inaccessible. AWS does not store or manage SSE-C keys.
+:::
+
+**Default:** None
+
 ### accurateCountThreshold
 
 Optional threshold for accurate count queries. The server will always perform an estimate count first (to protect database performance), and an accurate count if the estimate is below this threshold.

--- a/packages/server/src/cloud/aws/storage.test.ts
+++ b/packages/server/src/cloud/aws/storage.test.ts
@@ -16,8 +16,9 @@ import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 import type { Request } from 'express';
 import type internal from 'stream';
+import { createHash } from 'node:crypto';
 import { Readable } from 'stream';
-import { loadTestConfig } from '../../config/loader';
+import { getConfig, loadTestConfig } from '../../config/loader';
 import { getBinaryStorage, initBinaryStorage } from '../../storage/loader';
 
 describe('Storage', () => {
@@ -222,6 +223,81 @@ describe('Storage', () => {
       CopySource: 'foo/binary/123/456',
       Bucket: 'foo',
       Key: 'binary/789/012',
+    });
+  });
+
+  describe('SSE-C encryption', () => {
+    const testKey = 'MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE='; // base64 of 32-byte key
+    const expectedMD5 = createHash('md5').update(Buffer.from(testKey, 'base64')).digest('base64');
+
+    beforeEach(() => {
+      getConfig().sseCustomerKey = testKey;
+    });
+
+    afterEach(() => {
+      getConfig().sseCustomerKey = undefined;
+    });
+
+    test('Write file includes SSE-C params', async () => {
+      initBinaryStorage('s3:foo');
+      const storage = getBinaryStorage();
+
+      const binary = { resourceType: 'Binary', id: '123', meta: { versionId: '456' } } as Binary;
+      const req = new Readable();
+      req.push('foo');
+      req.push(null);
+      (req as any).headers = {};
+
+      await storage.writeBinary(binary, 'test.txt', ContentType.TEXT, req as Request);
+
+      expect(mockS3Client).toReceiveCommandWith(PutObjectCommand, {
+        Bucket: 'foo',
+        Key: 'binary/123/456',
+        SSECustomerAlgorithm: 'AES256',
+        SSECustomerKey: testKey,
+        SSECustomerKeyMD5: expectedMD5,
+      });
+    });
+
+    test('Read file includes SSE-C params', async () => {
+      initBinaryStorage('s3:foo');
+      const storage = getBinaryStorage();
+
+      const binary = { resourceType: 'Binary', id: '123', meta: { versionId: '456' } } as Binary;
+      const sdkStream = sdkStreamMixin(Readable.from('foo'));
+      mockS3Client.on(GetObjectCommand).resolves({ Body: sdkStream });
+
+      await storage.readBinary(binary);
+
+      expect(mockS3Client).toReceiveCommandWith(GetObjectCommand, {
+        Bucket: 'foo',
+        Key: 'binary/123/456',
+        SSECustomerAlgorithm: 'AES256',
+        SSECustomerKey: testKey,
+        SSECustomerKeyMD5: expectedMD5,
+      });
+    });
+
+    test('Copy file includes SSE-C params for source and destination', async () => {
+      initBinaryStorage('s3:foo');
+      const storage = getBinaryStorage();
+
+      const sourceBinary = { resourceType: 'Binary', id: '123', meta: { versionId: '456' } } as Binary;
+      const destBinary = { resourceType: 'Binary', id: '789', meta: { versionId: '012' } } as Binary;
+
+      await storage.copyBinary(sourceBinary, destBinary);
+
+      expect(mockS3Client).toReceiveCommandWith(CopyObjectCommand, {
+        CopySource: 'foo/binary/123/456',
+        Bucket: 'foo',
+        Key: 'binary/789/012',
+        SSECustomerAlgorithm: 'AES256',
+        SSECustomerKey: testKey,
+        SSECustomerKeyMD5: expectedMD5,
+        CopySourceSSECustomerAlgorithm: 'AES256',
+        CopySourceSSECustomerKey: testKey,
+        CopySourceSSECustomerKeyMD5: expectedMD5,
+      });
     });
   });
 });

--- a/packages/server/src/cloud/aws/storage.ts
+++ b/packages/server/src/cloud/aws/storage.ts
@@ -6,11 +6,18 @@ import { Upload } from '@aws-sdk/lib-storage';
 import { getSignedUrl as s3GetSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { concatUrls } from '@medplum/core';
 import type { Binary } from '@medplum/fhirtypes';
+import { createHash } from 'node:crypto';
 import type { Readable } from 'node:stream';
 import { getConfig } from '../../config/loader';
 import type { PresignedUrlOptions } from '../../storage/base';
 import { BaseBinaryStorage } from '../../storage/base';
 import type { BinarySource } from '../../storage/types';
+
+interface SseCParams {
+  SSECustomerAlgorithm: string;
+  SSECustomerKey: string;
+  SSECustomerKeyMD5: string;
+}
 
 /**
  * The S3Storage class stores binary data in an AWS S3 bucket.
@@ -19,11 +26,21 @@ import type { BinarySource } from '../../storage/types';
 export class S3Storage extends BaseBinaryStorage {
   private readonly client: S3Client;
   readonly bucket: string;
+  private readonly sseC: SseCParams | undefined;
 
   constructor(bucket: string) {
     super();
-    this.client = new S3Client({ region: getConfig().awsRegion });
+    const config = getConfig();
+    this.client = new S3Client({ region: config.awsRegion });
     this.bucket = bucket;
+
+    if (config.sseCustomerKey) {
+      this.sseC = {
+        SSECustomerAlgorithm: 'AES256',
+        SSECustomerKey: config.sseCustomerKey,
+        SSECustomerKeyMD5: createHash('md5').update(Buffer.from(config.sseCustomerKey, 'base64')).digest('base64'),
+      };
+    }
   }
 
   /**
@@ -60,6 +77,7 @@ export class S3Storage extends BaseBinaryStorage {
         CacheControl: 'max-age=3600, s-maxage=86400',
         ContentType: contentType ?? 'application/octet-stream',
         Body: stream,
+        ...this.sseC,
       },
       client: this.client,
       queueSize: 3,
@@ -73,6 +91,7 @@ export class S3Storage extends BaseBinaryStorage {
       new GetObjectCommand({
         Bucket: this.bucket,
         Key: key,
+        ...this.sseC,
       })
     );
     return output.Body as Readable;
@@ -84,6 +103,12 @@ export class S3Storage extends BaseBinaryStorage {
         CopySource: `${this.bucket}/${sourceKey}`,
         Bucket: this.bucket,
         Key: destinationKey,
+        ...this.sseC,
+        ...(this.sseC && {
+          CopySourceSSECustomerAlgorithm: this.sseC.SSECustomerAlgorithm,
+          CopySourceSSECustomerKey: this.sseC.SSECustomerKey,
+          CopySourceSSECustomerKeyMD5: this.sseC.SSECustomerKeyMD5,
+        }),
       })
     );
   }
@@ -104,8 +129,8 @@ export class S3Storage extends BaseBinaryStorage {
     if (!config.signingKey || !config.signingKeyId || opts?.upload) {
       const Key = this.getKey(binary);
       const cmd = opts?.upload
-        ? new PutObjectCommand({ Bucket: this.bucket, Key })
-        : new GetObjectCommand({ Bucket: this.bucket, Key });
+        ? new PutObjectCommand({ Bucket: this.bucket, Key, ...this.sseC })
+        : new GetObjectCommand({ Bucket: this.bucket, Key, ...this.sseC });
       return s3GetSignedUrl(this.client, cmd, { expiresIn: 3600 });
     }
 

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -64,6 +64,8 @@ export interface MedplumServerConfig {
   maxBatchSize: string;
   allowedOrigins?: string;
   awsRegion: string;
+  /** Optional base64-encoded 256-bit key for S3 SSE-C (Server-Side Encryption with Customer-Provided Keys) */
+  sseCustomerKey?: string;
   botLambdaRoleArn: string;
   botLambdaLayerName: string;
   botCustomFunctionsEnabled?: boolean;


### PR DESCRIPTION
## Summary
- Add optional `sseCustomerKey` server config for S3 Server-Side Encryption with Customer-Provided Keys (SSE-C)
- When configured, all S3 operations (upload, download, copy, presigned URLs) include SSE-C headers with AES256 encryption
- Document the new config option in the self-hosting server config docs

## Test plan
- [x] Unit tests for SSE-C params passed to `PutObjectCommand` (write)
- [x] Unit tests for SSE-C params passed to `GetObjectCommand` (read)
- [x] Unit tests for SSE-C params passed to `CopyObjectCommand` with both source and destination params (copy)
- [x] Existing tests pass without SSE-C configured (no regression)

