### PR TITLE
tweak(cdk): make `minHealthyPercent` 100

### DIFF
--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -513,7 +513,7 @@ export class BackEnd extends Construct {
       desiredCount: config.desiredServerCount,
       securityGroups: [this.fargateSecurityGroup],
       healthCheckGracePeriod: Duration.minutes(5),
-      minHealthyPercent: 100, // 50% is the default; make it explicit
+      minHealthyPercent: 100, // 50% is the default
     });
 
     // Add autoscaling
@@ -885,7 +885,7 @@ export class BackEnd extends Construct {
       desiredCount: service.desiredCount,
       securityGroups: [this.fargateSecurityGroup],
       healthCheckGracePeriod: Duration.minutes(5),
-      minHealthyPercent: 100,
+      minHealthyPercent: 100, // 50% is the default
     });
 
     // Add dependencies - same as primary service


### PR DESCRIPTION
Currently our min healthy percentage during migration is only 50%, meaning if new nodes start failing within the grace period we might end up down to 50% of our target during a migration, rather than the 200% we expect to be there. For our new worker deployment where there are already fewer nodes, this is especially undesirable.