### PR TITLE
fix(hl7): wait before destroying HL7 conn socket

### DIFF
--- a/packages/hl7/src/connection.test.ts
+++ b/packages/hl7/src/connection.test.ts
@@ -4,7 +4,7 @@ import { Hl7Message } from '@medplum/core';
 import iconv from 'iconv-lite';
 import { Hl7Connection } from './connection';
 import { CR, FS, VT } from './constants';
-import { Hl7EnhancedAckSentEvent, Hl7MessageEvent } from './events';
+import { Hl7EnhancedAckSentEvent, Hl7MessageEvent, Hl7WarningEvent } from './events';
 import { MockSocket } from './test-utils';
 
 describe('HL7 Connection', () => {
@@ -185,6 +185,37 @@ PID|1||12345^^^MRN^MR||DOE^JOHN^A||19800101|M|||123 MAIN ST^^CITY^ST^12345^USA`)
 
       await connection.close();
     });
+  });
+
+  test('Data received after close emits warning', async () => {
+    const mockSocket = new MockSocket();
+    const messageListener = jest.fn();
+    const warningListener = jest.fn();
+
+    const connection = new Hl7Connection(mockSocket as any);
+    connection.addEventListener('message', messageListener);
+    connection.addEventListener('warning', warningListener);
+
+    // Initiate close but don't await yet — this sets the closing flag
+    const closePromise = connection.close();
+
+    // Emit data after close was initiated
+    const msg = `MSH|^~\\&|SENDING_APP|SENDING_FAC|REC_APP|REC_FAC|20240218153044||ADT^A01|MSG00001|P|2.3\rPID|1||12345^^^MRN^MR||DOE^JOHN^A||19800101|M`;
+    const messageBuffer = iconv.encode(msg, 'utf-8');
+    const outputBuffer = Buffer.alloc(messageBuffer.length + 3);
+    outputBuffer.writeInt8(VT, 0);
+    messageBuffer.copy(outputBuffer, 1);
+    outputBuffer.writeInt8(FS, messageBuffer.length + 1);
+    outputBuffer.writeInt8(CR, messageBuffer.length + 2);
+    mockSocket.emit('data', outputBuffer);
+
+    // Warning should have been emitted, message should not
+    expect(warningListener).toHaveBeenCalledTimes(1);
+    const event = warningListener.mock.calls[0][0] as Hl7WarningEvent;
+    expect(event).toBeInstanceOf(Hl7WarningEvent);
+    expect(messageListener).not.toHaveBeenCalled();
+
+    await closePromise;
   });
 
   describe('parseMessages', () => {

--- a/packages/hl7/src/connection.ts
+++ b/packages/hl7/src/connection.ts
@@ -30,6 +30,7 @@ export interface SendAndWaitOptions {
 
 export interface Hl7ConnectionOptions {
   messagesPerMin?: number;
+  gracefulCloseTimeoutMs?: number;
 }
 
 /**
@@ -41,6 +42,7 @@ export interface Hl7ConnectionOptions {
 export type EnhancedMode = 'standard' | 'aaMode' | undefined;
 
 export const DEFAULT_ENCODING = 'utf-8';
+export const GRACEFUL_CLOSE_TIMEOUT_MS = 5000;
 const ONE_MINUTE = 60 * 1000;
 
 export class Hl7Connection extends Hl7Base {
@@ -48,11 +50,13 @@ export class Hl7Connection extends Hl7Base {
   encoding: string;
   enhancedMode: EnhancedMode = undefined;
   private messagesPerMin: number | undefined = undefined;
+  private gracefulCloseTimeoutMs: number;
   private chunks: Buffer[] = [];
   private readonly pendingMessages: Map<string, Hl7MessageQueueItem> = new Map<string, Hl7MessageQueueItem>();
   private readonly responseQueue: Hl7MessageEvent[] = [];
   private lastMessageDispatchedTime = 0;
   private responseQueueProcessing = false;
+  private closing = false;
 
   constructor(
     socket: net.Socket,
@@ -66,8 +70,28 @@ export class Hl7Connection extends Hl7Base {
     this.encoding = encoding;
     this.enhancedMode = enhancedMode;
     this.messagesPerMin = options.messagesPerMin;
+    this.gracefulCloseTimeoutMs = options.gracefulCloseTimeoutMs ?? GRACEFUL_CLOSE_TIMEOUT_MS;
 
     socket.on('data', (data: Buffer) => {
+      if (this.closing) {
+        this.dispatchEvent(
+          new Hl7WarningEvent(
+            new OperationOutcomeError({
+              resourceType: 'OperationOutcome',
+              issue: [
+                {
+                  severity: 'warning',
+                  code: 'transient',
+                  details: {
+                    text: 'Data received after close was initiated',
+                  },
+                },
+              ],
+            })
+          )
+        );
+        return;
+      }
       try {
         this.appendData(data);
         const messages = this.parseMessages();
@@ -306,15 +330,21 @@ export class Hl7Connection extends Hl7Base {
     if (this.isClosed()) {
       return;
     }
+    this.closing = true;
     this.socket.end();
-    this.socket.destroy();
     // drainPendingMessages is also called by the socket 'close' handler, but we call it here first so
     // that rejections are delivered before the close event is dispatched when close() is called explicitly.
     // The socket 'close' handler's call will be a no-op since the map will already be empty.
     this.drainPendingMessages();
-    await new Promise((resolve) => {
-      // Register a temporary listener to help resolve the promise once close has been emitted
-      this.socket.once('close', resolve);
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        this.socket.destroy();
+      }, this.gracefulCloseTimeoutMs);
+
+      this.socket.once('close', () => {
+        clearTimeout(timer);
+        resolve();
+      });
     });
   }
 


### PR DESCRIPTION
In an attempt to deflake a lot of the HL7 related tests, I noticed we destroy the underlying `Socket` immediately after calling `.end()` on it in our `Hl7Connection#close`, which means we don't allow for proper graceful TCP closing in most circumstances via the `FIN` packet.

This is possibly causing a lot of our issues in tests and probably also showing up as timeouts on the other side of the TCP connection which is not ideal.