### PR TITLE
fix(mock): Support _project search parameter in MockClient

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -205,6 +205,12 @@ function getOrInitTypeSchema(resourceType: string): TypeInfo {
         type: 'uri',
         expression: resourceType + '.meta.profile',
       } as SearchParameter,
+      _project: {
+        base: [resourceType],
+        code: '_project',
+        type: 'reference',
+        expression: resourceType + '.meta.project',
+      } as SearchParameter,
       _security: {
         base: [resourceType],
         code: '_security',


### PR DESCRIPTION
## Summary

Adds support for the Medplum-specific _project search parameter to MockClient and MemoryRepository. Previously, searches including _project would silently return zero results because it was an unknown parameter. This change defines _project as a built-in search parameter for all resource types, enabling correct filtering by project in tests using MockClient.

## Changes

- **packages/core/src/types.ts**: Added the _project search parameter to the list of default search parameters for all resource types. This enables MockClient to correctly filter resources by project.

## Related Issue

Closes #8831

