### PR TITLE
Fixed FHIR JSONschema

### DIFF
--- a/packages/definitions/src/fhir/r4/fhir.schema.json
+++ b/packages/definitions/src/fhir/r4/fhir.schema.json
@@ -190,7 +190,13 @@
       "ViewDefinitionSelectColumn": "#/definitions/ViewDefinitionSelectColumn",
       "ViewDefinitionSelect": "#/definitions/ViewDefinitionSelect",
       "ViewDefinitionWhere": "#/definitions/ViewDefinitionWhere",
-      "ClientApplicationSignInForm": "#/definitions/ClientApplicationSignInForm"
+      "ClientApplicationSignInForm": "#/definitions/ClientApplicationSignInForm",
+      "ClientApplicationLaunchIdentifierSystems": "#/definitions/ClientApplicationLaunchIdentifierSystems",
+      "BotCdsServicePrefetch": "#/definitions/BotCdsServicePrefetch",
+      "BotCdsService": "#/definitions/BotCdsService",
+      "Package": "#/definitions/Package",
+      "PackageRelease": "#/definitions/PackageRelease",
+      "PackageInstallation": "#/definitions/PackageInstallation"
     }
   },
   "oneOf": [
@@ -751,6 +757,24 @@
     },
     {
       "$ref": "#/definitions/ClientApplicationSignInForm"
+    },
+    {
+      "$ref": "#/definitions/ClientApplicationLaunchIdentifierSystems"
+    },
+    {
+      "$ref": "#/definitions/BotCdsServicePrefetch"
+    },
+    {
+      "$ref": "#/definitions/BotCdsService"
+    },
+    {
+      "$ref": "#/definitions/Package"
+    },
+    {
+      "$ref": "#/definitions/PackageRelease"
+    },
+    {
+      "$ref": "#/definitions/PackageInstallation"
     }
   ],
   "definitions": {
@@ -1313,6 +1337,24 @@
         },
         {
           "$ref": "#/definitions/ClientApplicationSignInForm"
+        },
+        {
+          "$ref": "#/definitions/ClientApplicationLaunchIdentifierSystems"
+        },
+        {
+          "$ref": "#/definitions/BotCdsServicePrefetch"
+        },
+        {
+          "$ref": "#/definitions/BotCdsService"
+        },
+        {
+          "$ref": "#/definitions/Package"
+        },
+        {
+          "$ref": "#/definitions/PackageRelease"
+        },
+        {
+          "$ref": "#/definitions/PackageInstallation"
         }
       ]
     },
@@ -1766,7 +1808,12 @@
         },
         "status": {
           "description": "The status of the narrative - whether it\u0027s entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.",
-          "enum": ["generated", "extensions", "additional", "empty"]
+          "enum": [
+            "generated",
+            "extensions",
+            "additional",
+            "empty"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -1778,7 +1825,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["div"]
+      "required": [
+        "div"
+      ]
     },
     "Annotation": {
       "description": "A  text note which also  contains information about who made the statement and when.",
@@ -1923,7 +1972,13 @@
         },
         "use": {
           "description": "The purpose of this identifier.",
-          "enum": ["usual", "official", "temp", "secondary", "old"]
+          "enum": [
+            "usual",
+            "official",
+            "temp",
+            "secondary",
+            "old"
+          ]
         },
         "_use": {
           "description": "Extensions for use",
@@ -2073,7 +2128,12 @@
         },
         "comparator": {
           "description": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"\u003c\" , then the real value is \u003c stated value.",
-          "enum": ["\u003c", "\u003c\u003d", "\u003e\u003d", "\u003e"]
+          "enum": [
+            "\u003c",
+            "\u003c\u003d",
+            "\u003e\u003d",
+            "\u003e"
+          ]
         },
         "_comparator": {
           "description": "Extensions for comparator",
@@ -2130,7 +2190,12 @@
         },
         "comparator": {
           "description": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"\u003c\" , then the real value is \u003c stated value.",
-          "enum": ["\u003c", "\u003c\u003d", "\u003e\u003d", "\u003e"]
+          "enum": [
+            "\u003c",
+            "\u003c\u003d",
+            "\u003e\u003d",
+            "\u003e"
+          ]
         },
         "_comparator": {
           "description": "Extensions for comparator",
@@ -2187,7 +2252,12 @@
         },
         "comparator": {
           "description": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"\u003c\" , then the real value is \u003c stated value.",
-          "enum": ["\u003c", "\u003c\u003d", "\u003e\u003d", "\u003e"]
+          "enum": [
+            "\u003c",
+            "\u003c\u003d",
+            "\u003e\u003d",
+            "\u003e"
+          ]
         },
         "_comparator": {
           "description": "Extensions for comparator",
@@ -2244,7 +2314,12 @@
         },
         "comparator": {
           "description": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"\u003c\" , then the real value is \u003c stated value.",
-          "enum": ["\u003c", "\u003c\u003d", "\u003e\u003d", "\u003e"]
+          "enum": [
+            "\u003c",
+            "\u003c\u003d",
+            "\u003e\u003d",
+            "\u003e"
+          ]
         },
         "_comparator": {
           "description": "Extensions for comparator",
@@ -2334,7 +2409,12 @@
         },
         "comparator": {
           "description": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"\u003c\" , then the real value is \u003c stated value.",
-          "enum": ["\u003c", "\u003c\u003d", "\u003e\u003d", "\u003e"]
+          "enum": [
+            "\u003c",
+            "\u003c\u003d",
+            "\u003e\u003d",
+            "\u003e"
+          ]
         },
         "_comparator": {
           "description": "Extensions for comparator",
@@ -2567,7 +2647,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["origin"]
+      "required": [
+        "origin"
+      ]
     },
     "Signature": {
       "description": "A signature along with supporting context. The signature may be a digital signature that is cryptographic in nature, or some other signature acceptable to the domain. This other signature may be as simple as a graphical image representing a hand-written signature, or a signature ceremony Different signature approaches have different utilities.",
@@ -2632,7 +2714,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type", "who"]
+      "required": [
+        "type",
+        "who"
+      ]
     },
     "HumanName": {
       "description": "A human\u0027s name with the ability to identify parts and usage.",
@@ -2650,7 +2735,15 @@
         },
         "use": {
           "description": "Identifies the purpose for this name.",
-          "enum": ["usual", "official", "temp", "nickname", "anonymous", "old", "maiden"]
+          "enum": [
+            "usual",
+            "official",
+            "temp",
+            "nickname",
+            "anonymous",
+            "old",
+            "maiden"
+          ]
         },
         "_use": {
           "description": "Extensions for use",
@@ -2737,7 +2830,13 @@
         },
         "use": {
           "description": "The purpose of this address.",
-          "enum": ["home", "work", "temp", "old", "billing"]
+          "enum": [
+            "home",
+            "work",
+            "temp",
+            "old",
+            "billing"
+          ]
         },
         "_use": {
           "description": "Extensions for use",
@@ -2745,7 +2844,11 @@
         },
         "type": {
           "description": "Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care-of addresses). Most addresses are both.",
-          "enum": ["postal", "physical", "both"]
+          "enum": [
+            "postal",
+            "physical",
+            "both"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -2836,7 +2939,15 @@
         },
         "system": {
           "description": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
-          "enum": ["phone", "fax", "email", "pager", "url", "sms", "other"]
+          "enum": [
+            "phone",
+            "fax",
+            "email",
+            "pager",
+            "url",
+            "sms",
+            "other"
+          ]
         },
         "_system": {
           "description": "Extensions for system",
@@ -2852,7 +2963,13 @@
         },
         "use": {
           "description": "Identifies the purpose for the contact point.",
-          "enum": ["home", "work", "temp", "old", "mobile"]
+          "enum": [
+            "home",
+            "work",
+            "temp",
+            "old",
+            "mobile"
+          ]
         },
         "_use": {
           "description": "Extensions for use",
@@ -2986,7 +3103,15 @@
         },
         "durationUnit": {
           "description": "The units of time for the duration, in UCUM units.",
-          "enum": ["s", "min", "h", "d", "wk", "mo", "a"]
+          "enum": [
+            "s",
+            "min",
+            "h",
+            "d",
+            "wk",
+            "mo",
+            "a"
+          ]
         },
         "_durationUnit": {
           "description": "Extensions for durationUnit",
@@ -3026,7 +3151,15 @@
         },
         "periodUnit": {
           "description": "The units of time for the period in UCUM units.",
-          "enum": ["s", "min", "h", "d", "wk", "mo", "a"]
+          "enum": [
+            "s",
+            "min",
+            "h",
+            "d",
+            "wk",
+            "mo",
+            "a"
+          ]
         },
         "_periodUnit": {
           "description": "Extensions for periodUnit",
@@ -3241,7 +3374,12 @@
         },
         "type": {
           "description": "The type of contributor.",
-          "enum": ["author", "editor", "reviewer", "endorser"]
+          "enum": [
+            "author",
+            "editor",
+            "reviewer",
+            "endorser"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -3487,7 +3625,10 @@
         },
         "direction": {
           "description": "The direction of the sort, ascending or descending.",
-          "enum": ["ascending", "descending"]
+          "enum": [
+            "ascending",
+            "descending"
+          ]
         },
         "_direction": {
           "description": "Extensions for direction",
@@ -3754,7 +3895,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code"]
+      "required": [
+        "code"
+      ]
     },
     "Dosage": {
       "description": "Indicates how the medication is/was taken or should be taken by the patient.",
@@ -3993,7 +4136,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["period", "type"]
+      "required": [
+        "period",
+        "type"
+      ]
     },
     "ProdCharacteristic": {
       "description": "The marketing status describes the date when a medicinal product is actually put on the market or the date as of which it is no longer available.",
@@ -4137,7 +4283,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["country", "dateRange", "status"]
+      "required": [
+        "country",
+        "dateRange",
+        "status"
+      ]
     },
     "SubstanceAmount": {
       "description": "Chemical substances are a single substance type whose primary defining element is the molecular structure. Chemical substances shall be defined on the basis of their complete covalent molecular structure; the presence of a salt (counter-ion) and/or solvates (water, alcohols) is also captured. Purity, grade, physical form or particle size are not taken into account in the definition of a chemical substance or in the assignment of a Substance ID.",
@@ -4260,7 +4410,11 @@
         },
         "language": {
           "description": "The media type of the language for the expression.",
-          "enum": ["text/cql", "text/fhirpath", "application/x-fhir-query"]
+          "enum": [
+            "text/cql",
+            "text/fhirpath",
+            "application/x-fhir-query"
+          ]
         },
         "_language": {
           "description": "Extensions for language",
@@ -4317,7 +4471,13 @@
         "representation": {
           "description": "Codes that define how this element is represented in instances, when the deviation varies from the normal case.",
           "items": {
-            "enum": ["xmlAttr", "xmlText", "typeAttr", "cdaText", "xhtml"]
+            "enum": [
+              "xmlAttr",
+              "xmlText",
+              "typeAttr",
+              "cdaText",
+              "xhtml"
+            ]
           },
           "type": "array"
         },
@@ -5625,7 +5785,11 @@
         },
         "rules": {
           "description": "Whether additional slices are allowed or not. When the slices are ordered, profile authors can also say that additional slices are only allowed at the end.",
-          "enum": ["closed", "open", "openAtEnd"]
+          "enum": [
+            "closed",
+            "open",
+            "openAtEnd"
+          ]
         },
         "_rules": {
           "description": "Extensions for rules",
@@ -5657,7 +5821,13 @@
         },
         "type": {
           "description": "How the element value is interpreted when discrimination is evaluated.",
-          "enum": ["value", "exists", "pattern", "type", "profile"]
+          "enum": [
+            "value",
+            "exists",
+            "pattern",
+            "type",
+            "profile"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -5768,7 +5938,11 @@
         "aggregation": {
           "description": "If the type is a reference to another resource, how the resource is or can be aggregated - is it a contained resource, or a reference, and if the context is a bundle, is it included in the bundle.",
           "items": {
-            "enum": ["contained", "referenced", "bundled"]
+            "enum": [
+              "contained",
+              "referenced",
+              "bundled"
+            ]
           },
           "type": "array"
         },
@@ -5781,7 +5955,11 @@
         },
         "versioning": {
           "description": "Whether this reference needs to be version specific or version independent, or whether either can be used.",
-          "enum": ["either", "independent", "specific"]
+          "enum": [
+            "either",
+            "independent",
+            "specific"
+          ]
         },
         "_versioning": {
           "description": "Extensions for versioning",
@@ -6156,7 +6334,10 @@
         },
         "severity": {
           "description": "Identifies the impact constraint violation has on the conformance of the instance.",
-          "enum": ["error", "warning"]
+          "enum": [
+            "error",
+            "warning"
+          ]
         },
         "_severity": {
           "description": "Extensions for severity",
@@ -6216,7 +6397,12 @@
         },
         "strength": {
           "description": "Indicates the degree of conformance expectations associated with this binding - that is, the degree to which the provided value set must be adhered to in the instances.",
-          "enum": ["required", "extensible", "preferred", "example"]
+          "enum": [
+            "required",
+            "extensible",
+            "preferred",
+            "example"
+          ]
         },
         "_strength": {
           "description": "Extensions for strength",
@@ -6358,7 +6544,13 @@
         },
         "status": {
           "description": "Indicates whether the account is presently used/usable or not.",
-          "enum": ["active", "inactive", "entered-in-error", "on-hold", "unknown"]
+          "enum": [
+            "active",
+            "inactive",
+            "entered-in-error",
+            "on-hold",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -6419,7 +6611,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Account_Coverage": {
       "description": "A financial tool for tracking value accrued for a particular purpose.  In the healthcare field, used to track charges for a patient, cost centers, etc.",
@@ -6456,7 +6650,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["coverage"]
+      "required": [
+        "coverage"
+      ]
     },
     "Account_Guarantor": {
       "description": "A financial tool for tracking value accrued for a particular purpose.  In the healthcare field, used to track charges for a patient, cost centers, etc.",
@@ -6497,7 +6693,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["party"]
+      "required": [
+        "party"
+      ]
     },
     "ActivityDefinition": {
       "description": "This resource allows for the definition of some activity to be performed, independent of a particular patient, practitioner, or other performance context.",
@@ -6604,7 +6802,12 @@
         },
         "status": {
           "description": "The status of this activity definition. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -6904,7 +7107,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "ActivityDefinition_Participant": {
       "description": "This resource allows for the definition of some activity to be performed, independent of a particular patient, practitioner, or other performance context.",
@@ -6977,7 +7182,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["expression"]
+      "required": [
+        "expression"
+      ]
     },
     "AdverseEvent": {
       "description": "Actual or  potential/avoided event causing unintended physical injury resulting from or contributed to by medical care, a research study or other healthcare setting factors that requires additional monitoring, treatment, or hospitalization, or that results in death.",
@@ -7041,7 +7248,10 @@
         },
         "actuality": {
           "description": "Whether the event actually happened, or just had the potential to. Note that this is independent of whether anyone was affected or harmed or how severely.",
-          "enum": ["actual", "potential"]
+          "enum": [
+            "actual",
+            "potential"
+          ]
         },
         "_actuality": {
           "description": "Extensions for actuality",
@@ -7154,7 +7364,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["subject", "resourceType"]
+      "required": [
+        "subject",
+        "resourceType"
+      ]
     },
     "AdverseEvent_SuspectEntity": {
       "description": "Actual or  potential/avoided event causing unintended physical injury resulting from or contributed to by medical care, a research study or other healthcare setting factors that requires additional monitoring, treatment, or hospitalization, or that results in death.",
@@ -7190,7 +7403,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["instance"]
+      "required": [
+        "instance"
+      ]
     },
     "AdverseEvent_Causality": {
       "description": "Actual or  potential/avoided event causing unintended physical injury resulting from or contributed to by medical care, a research study or other healthcare setting factors that requires additional monitoring, treatment, or hospitalization, or that results in death.",
@@ -7309,7 +7524,10 @@
         },
         "type": {
           "description": "Identification of the underlying physiological mechanism for the reaction risk.",
-          "enum": ["allergy", "intolerance"]
+          "enum": [
+            "allergy",
+            "intolerance"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -7318,7 +7536,12 @@
         "category": {
           "description": "Category of the identified substance.",
           "items": {
-            "enum": ["food", "medication", "environment", "biologic"]
+            "enum": [
+              "food",
+              "medication",
+              "environment",
+              "biologic"
+            ]
           },
           "type": "array"
         },
@@ -7331,7 +7554,11 @@
         },
         "criticality": {
           "description": "Estimate of the potential clinical harm, or seriousness, of the reaction to the identified substance.",
-          "enum": ["low", "high", "unable-to-assess"]
+          "enum": [
+            "low",
+            "high",
+            "unable-to-assess"
+          ]
         },
         "_criticality": {
           "description": "Extensions for criticality",
@@ -7419,7 +7646,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["patient", "resourceType"]
+      "required": [
+        "patient",
+        "resourceType"
+      ]
     },
     "AllergyIntolerance_Reaction": {
       "description": "Risk of harmful or undesirable, physiological response which is unique to an individual and associated with exposure to a substance.",
@@ -7471,7 +7701,11 @@
         },
         "severity": {
           "description": "Clinical assessment of the severity of the reaction event as a whole, potentially considering multiple different manifestations.",
-          "enum": ["mild", "moderate", "severe"]
+          "enum": [
+            "mild",
+            "moderate",
+            "severe"
+          ]
         },
         "_severity": {
           "description": "Extensions for severity",
@@ -7490,7 +7724,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["manifestation"]
+      "required": [
+        "manifestation"
+      ]
     },
     "Appointment": {
       "description": "A booking of a healthcare event among patient(s), practitioner(s), related person(s) and/or device(s) for a specific date/time. This may result in one or more Encounter(s).",
@@ -7718,7 +7954,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["participant", "resourceType"]
+      "required": [
+        "participant",
+        "resourceType"
+      ]
     },
     "Appointment_Participant": {
       "description": "A booking of a healthcare event among patient(s), practitioner(s), related person(s) and/or device(s) for a specific date/time. This may result in one or more Encounter(s).",
@@ -7754,7 +7993,11 @@
         },
         "required": {
           "description": "Whether this participant is required to be present at the meeting. This covers a use-case where two doctors need to meet to discuss the results for a specific patient, and the patient is not required to be present.",
-          "enum": ["required", "optional", "information-only"]
+          "enum": [
+            "required",
+            "optional",
+            "information-only"
+          ]
         },
         "_required": {
           "description": "Extensions for required",
@@ -7762,7 +8005,12 @@
         },
         "status": {
           "description": "Participation status of the actor.",
-          "enum": ["accepted", "declined", "tentative", "needs-action"]
+          "enum": [
+            "accepted",
+            "declined",
+            "tentative",
+            "needs-action"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -7887,7 +8135,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["appointment", "resourceType"]
+      "required": [
+        "appointment",
+        "resourceType"
+      ]
     },
     "AuditEvent": {
       "description": "A record of an event made for purposes of maintaining a security log. Typical uses include detection of intrusion attempts and monitoring for inappropriate usage.",
@@ -7958,7 +8209,13 @@
         },
         "action": {
           "description": "Indicator for type of action performed during the event that generated the audit.",
-          "enum": ["C", "R", "U", "D", "E"]
+          "enum": [
+            "C",
+            "R",
+            "U",
+            "D",
+            "E"
+          ]
         },
         "_action": {
           "description": "Extensions for action",
@@ -7978,7 +8235,12 @@
         },
         "outcome": {
           "description": "Indicates whether the event succeeded or failed.",
-          "enum": ["0", "4", "8", "12"]
+          "enum": [
+            "0",
+            "4",
+            "8",
+            "12"
+          ]
         },
         "_outcome": {
           "description": "Extensions for outcome",
@@ -8019,7 +8281,12 @@
         }
       },
       "additionalProperties": false,
-      "required": ["agent", "source", "type", "resourceType"]
+      "required": [
+        "agent",
+        "source",
+        "type",
+        "resourceType"
+      ]
     },
     "AuditEvent_Agent": {
       "description": "A record of an event made for purposes of maintaining a security log. Typical uses include detection of intrusion attempts and monitoring for inappropriate usage.",
@@ -8148,7 +8415,13 @@
         },
         "type": {
           "description": "An identifier for the type of network access point that originated the audit event.",
-          "enum": ["1", "2", "3", "4", "5"]
+          "enum": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -8199,7 +8472,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["observer"]
+      "required": [
+        "observer"
+      ]
     },
     "AuditEvent_Entity": {
       "description": "A record of an event made for purposes of maintaining a security log. Typical uses include detection of intrusion attempts and monitoring for inappropriate usage.",
@@ -8414,7 +8689,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code", "resourceType"]
+      "required": [
+        "code",
+        "resourceType"
+      ]
     },
     "Binary": {
       "description": "A resource that represents the data of a single raw artifact as digital content accessible in its native format.  A Binary resource can contain any content, whether text, image, pdf, zip archive, etc.",
@@ -8469,7 +8747,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "BiologicallyDerivedProduct": {
       "description": "A material substance originating from a biological entity intended to be transplanted or infused\ninto another (possibly the same) biological entity.",
@@ -8536,7 +8816,13 @@
         },
         "productCategory": {
           "description": "Broad category of this product.",
-          "enum": ["organ", "tissue", "fluid", "cells", "biologicalAgent"]
+          "enum": [
+            "organ",
+            "tissue",
+            "fluid",
+            "cells",
+            "biologicalAgent"
+          ]
         },
         "_productCategory": {
           "description": "Extensions for productCategory",
@@ -8548,7 +8834,10 @@
         },
         "status": {
           "description": "Whether the product is currently available.",
-          "enum": ["available", "unavailable"]
+          "enum": [
+            "available",
+            "unavailable"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -8600,7 +8889,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "BiologicallyDerivedProduct_Collection": {
       "description": "A material substance originating from a biological entity intended to be transplanted or infused\ninto another (possibly the same) biological entity.",
@@ -8784,7 +9075,11 @@
         },
         "scale": {
           "description": "Temperature scale used.",
-          "enum": ["farenheit", "celsius", "kelvin"]
+          "enum": [
+            "farenheit",
+            "celsius",
+            "kelvin"
+          ]
         },
         "_scale": {
           "description": "Extensions for scale",
@@ -8904,7 +9199,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["patient", "resourceType"]
+      "required": [
+        "patient",
+        "resourceType"
+      ]
     },
     "Bundle": {
       "description": "A container for a collection of resources.",
@@ -8995,7 +9293,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Bundle_Link": {
       "description": "A container for a collection of resources.",
@@ -9115,7 +9415,11 @@
         },
         "mode": {
           "description": "Why this entry is in the result set - whether it\u0027s included as a match or because of an _include requirement, or to convey information or warning information about the search process.",
-          "enum": ["match", "include", "outcome"]
+          "enum": [
+            "match",
+            "include",
+            "outcome"
+          ]
         },
         "_mode": {
           "description": "Extensions for mode",
@@ -9155,7 +9459,14 @@
         },
         "method": {
           "description": "In a transaction or batch, this is the HTTP action to be executed for this entry. In a history bundle, this indicates the HTTP action that occurred.",
-          "enum": ["GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"]
+          "enum": [
+            "GET",
+            "HEAD",
+            "POST",
+            "PUT",
+            "DELETE",
+            "PATCH"
+          ]
         },
         "_method": {
           "description": "Extensions for method",
@@ -9354,7 +9665,12 @@
         },
         "status": {
           "description": "The status of this capability statement. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -9431,7 +9747,11 @@
         },
         "kind": {
           "description": "The way that this statement is intended to be used, to describe an actual running instance of software, a particular product (kind, not instance of software) or a class of implementation (e.g. a desired purchase).",
-          "enum": ["instance", "capability", "requirements"]
+          "enum": [
+            "instance",
+            "capability",
+            "requirements"
+          ]
         },
         "_kind": {
           "description": "Extensions for kind",
@@ -9548,7 +9868,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "CapabilityStatement_Software": {
       "description": "A Capability Statement documents a set of capabilities (behaviors) of a FHIR Server for a particular version of FHIR that may be used as a statement of actual server functionality or a statement of required or desired server implementation.",
@@ -9665,7 +9987,10 @@
         },
         "mode": {
           "description": "Identifies whether this portion of the statement is describing the ability to initiate or receive restful operations.",
-          "enum": ["client", "server"]
+          "enum": [
+            "client",
+            "server"
+          ]
         },
         "_mode": {
           "description": "Extensions for mode",
@@ -9825,7 +10150,11 @@
         },
         "versioning": {
           "description": "This field is set to no-version to specify that the system does not support (server) or use (client) versioning for this resource type. If this has some other value, the server must at least correctly track and populate the versionId meta-property on resources. If the value is \u0027versioned-update\u0027, then the server supports all the versioning features, including using e-tags for version integrity in the API.",
-          "enum": ["no-version", "versioned", "versioned-update"]
+          "enum": [
+            "no-version",
+            "versioned",
+            "versioned-update"
+          ]
         },
         "_versioning": {
           "description": "Extensions for versioning",
@@ -9857,7 +10186,12 @@
         },
         "conditionalRead": {
           "description": "A code that indicates how the server supports conditional read.",
-          "enum": ["not-supported", "modified-since", "not-match", "full-support"]
+          "enum": [
+            "not-supported",
+            "modified-since",
+            "not-match",
+            "full-support"
+          ]
         },
         "_conditionalRead": {
           "description": "Extensions for conditionalRead",
@@ -9873,7 +10207,11 @@
         },
         "conditionalDelete": {
           "description": "A code that indicates how the server supports conditional delete.",
-          "enum": ["not-supported", "single", "multiple"]
+          "enum": [
+            "not-supported",
+            "single",
+            "multiple"
+          ]
         },
         "_conditionalDelete": {
           "description": "Extensions for conditionalDelete",
@@ -9882,7 +10220,13 @@
         "referencePolicy": {
           "description": "A set of flags that defines how references are supported.",
           "items": {
-            "enum": ["literal", "logical", "resolves", "enforced", "local"]
+            "enum": [
+              "literal",
+              "logical",
+              "resolves",
+              "enforced",
+              "local"
+            ]
           },
           "type": "array"
         },
@@ -10023,7 +10367,17 @@
         },
         "type": {
           "description": "The type of value a search parameter refers to, and how the content is interpreted.",
-          "enum": ["number", "date", "string", "token", "reference", "composite", "quantity", "uri", "special"]
+          "enum": [
+            "number",
+            "date",
+            "string",
+            "token",
+            "reference",
+            "composite",
+            "quantity",
+            "uri",
+            "special"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -10083,7 +10437,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["definition"]
+      "required": [
+        "definition"
+      ]
     },
     "CapabilityStatement_Interaction1": {
       "description": "A Capability Statement documents a set of capabilities (behaviors) of a FHIR Server for a particular version of FHIR that may be used as a statement of actual server functionality or a statement of required or desired server implementation.",
@@ -10108,7 +10464,12 @@
         },
         "code": {
           "description": "A coded identifier of the operation, supported by the system.",
-          "enum": ["transaction", "batch", "search-system", "history-system"]
+          "enum": [
+            "transaction",
+            "batch",
+            "search-system",
+            "history-system"
+          ]
         },
         "_code": {
           "description": "Extensions for code",
@@ -10214,7 +10575,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["protocol"]
+      "required": [
+        "protocol"
+      ]
     },
     "CapabilityStatement_SupportedMessage": {
       "description": "A Capability Statement documents a set of capabilities (behaviors) of a FHIR Server for a particular version of FHIR that may be used as a statement of actual server functionality or a statement of required or desired server implementation.",
@@ -10239,7 +10602,10 @@
         },
         "mode": {
           "description": "The mode of this event declaration - whether application is sender or receiver.",
-          "enum": ["sender", "receiver"]
+          "enum": [
+            "sender",
+            "receiver"
+          ]
         },
         "_mode": {
           "description": "Extensions for mode",
@@ -10251,7 +10617,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["definition"]
+      "required": [
+        "definition"
+      ]
     },
     "CapabilityStatement_Document": {
       "description": "A Capability Statement documents a set of capabilities (behaviors) of a FHIR Server for a particular version of FHIR that may be used as a statement of actual server functionality or a statement of required or desired server implementation.",
@@ -10276,7 +10644,10 @@
         },
         "mode": {
           "description": "Mode of this document declaration - whether an application is a producer or consumer.",
-          "enum": ["producer", "consumer"]
+          "enum": [
+            "producer",
+            "consumer"
+          ]
         },
         "_mode": {
           "description": "Extensions for mode",
@@ -10296,7 +10667,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["profile"]
+      "required": [
+        "profile"
+      ]
     },
     "CarePlan": {
       "description": "Describes the intention of how one or more practitioners intend to deliver care for a particular patient, group or community for a period of time, possibly limited to care for a specific condition or set of conditions.",
@@ -10517,7 +10890,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["subject", "resourceType"]
+      "required": [
+        "subject",
+        "resourceType"
+      ]
     },
     "CarePlan_Activity": {
       "description": "Describes the intention of how one or more practitioners intend to deliver care for a particular patient, group or community for a period of time, possibly limited to care for a specific condition or set of conditions.",
@@ -10797,7 +11173,13 @@
         },
         "status": {
           "description": "Indicates the current state of the care team.",
-          "enum": ["proposed", "active", "suspended", "inactive", "entered-in-error"]
+          "enum": [
+            "proposed",
+            "active",
+            "suspended",
+            "inactive",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -10874,7 +11256,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "CareTeam_Participant": {
       "description": "The Care Team includes all the people and organizations who plan to participate in the coordination and delivery of care for a patient.",
@@ -11014,7 +11398,12 @@
         },
         "status": {
           "description": "Used to support catalog exchange even for unsupported products, e.g. getting list of medications even if not prescribable.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -11063,7 +11452,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType", "referencedItem"]
+      "required": [
+        "resourceType",
+        "referencedItem"
+      ]
     },
     "CatalogEntry_RelatedEntry": {
       "description": "Catalog entries are wrappers that contextualize items included in a catalog.",
@@ -11088,7 +11480,10 @@
         },
         "relationtype": {
           "description": "The type of relation to the related item: child, parent, packageContent, containerPackage, usedIn, uses, requires, etc.",
-          "enum": ["triggers", "is-replaced-by"]
+          "enum": [
+            "triggers",
+            "is-replaced-by"
+          ]
         },
         "_relationtype": {
           "description": "Extensions for relationtype",
@@ -11100,7 +11495,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["item"]
+      "required": [
+        "item"
+      ]
     },
     "ChargeItem": {
       "description": "The resource ChargeItem describes the provision of healthcare provider products for a certain patient, therefore referring not only to the product, but containing in addition details of the provision, like date, time, amounts and participating organizations and persons. Main Usage of the ChargeItem is to enable the billing process and internal cost allocation.",
@@ -11188,7 +11585,15 @@
         },
         "status": {
           "description": "The current state of the ChargeItem.",
-          "enum": ["planned", "billable", "not-billable", "aborted", "billed", "entered-in-error", "unknown"]
+          "enum": [
+            "planned",
+            "billable",
+            "not-billable",
+            "aborted",
+            "billed",
+            "entered-in-error",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -11337,7 +11742,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code", "subject", "resourceType"]
+      "required": [
+        "code",
+        "subject",
+        "resourceType"
+      ]
     },
     "ChargeItem_Performer": {
       "description": "The resource ChargeItem describes the provision of healthcare provider products for a certain patient, therefore referring not only to the product, but containing in addition details of the provision, like date, time, amounts and participating organizations and persons. Main Usage of the ChargeItem is to enable the billing process and internal cost allocation.",
@@ -11370,7 +11779,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["actor"]
+      "required": [
+        "actor"
+      ]
     },
     "ChargeItemDefinition": {
       "description": "The ChargeItemDefinition resource provides the properties that apply to the (billing) codes necessary to calculate costs and prices. The properties may differ largely depending on type and realm, therefore this resource gives only a rough structure and requires profiling for each type of billing code system.",
@@ -11489,7 +11900,12 @@
         },
         "status": {
           "description": "The current state of the ChargeItemDefinition.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -11603,7 +12019,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "ChargeItemDefinition_Applicability": {
       "description": "The ChargeItemDefinition resource provides the properties that apply to the (billing) codes necessary to calculate costs and prices. The properties may differ largely depending on type and realm, therefore this resource gives only a rough structure and requires profiling for each type of billing code system.",
@@ -11820,7 +12238,11 @@
         },
         "use": {
           "description": "A code to indicate whether the nature of the request is: to request adjudication of products and services previously rendered; or requesting authorization and adjudication for provision in the future; or requesting the non-binding adjudication of the listed products and services which could be provided in the future.",
-          "enum": ["claim", "preauthorization", "predetermination"]
+          "enum": [
+            "claim",
+            "preauthorization",
+            "predetermination"
+          ]
         },
         "_use": {
           "description": "Extensions for use",
@@ -11941,7 +12363,14 @@
         }
       },
       "additionalProperties": false,
-      "required": ["insurance", "provider", "patient", "type", "priority", "resourceType"]
+      "required": [
+        "insurance",
+        "provider",
+        "patient",
+        "type",
+        "priority",
+        "resourceType"
+      ]
     },
     "Claim_Related": {
       "description": "A provider issued list of professional services and products which have been provided, or are to be provided, to a patient which is sent to an insurer for reimbursement.",
@@ -12010,7 +12439,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "Claim_CareTeam": {
       "description": "A provider issued list of professional services and products which have been provided, or are to be provided, to a patient which is sent to an insurer for reimbursement.",
@@ -12063,7 +12494,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["provider"]
+      "required": [
+        "provider"
+      ]
     },
     "Claim_SupportingInfo": {
       "description": "A provider issued list of professional services and products which have been provided, or are to be provided, to a patient which is sent to an insurer for reimbursement.",
@@ -12151,7 +12584,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["category"]
+      "required": [
+        "category"
+      ]
     },
     "Claim_Diagnosis": {
       "description": "A provider issued list of professional services and products which have been provided, or are to be provided, to a patient which is sent to an insurer for reimbursement.",
@@ -12343,7 +12778,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["coverage"]
+      "required": [
+        "coverage"
+      ]
     },
     "Claim_Accident": {
       "description": "A provider issued list of professional services and products which have been provided, or are to be provided, to a patient which is sent to an insurer for reimbursement.",
@@ -12579,7 +13016,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["productOrService"]
+      "required": [
+        "productOrService"
+      ]
     },
     "Claim_Detail": {
       "description": "A provider issued list of professional services and products which have been provided, or are to be provided, to a patient which is sent to an insurer for reimbursement.",
@@ -12672,7 +13111,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["productOrService"]
+      "required": [
+        "productOrService"
+      ]
     },
     "Claim_SubDetail": {
       "description": "A provider issued list of professional services and products which have been provided, or are to be provided, to a patient which is sent to an insurer for reimbursement.",
@@ -12758,7 +13199,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["productOrService"]
+      "required": [
+        "productOrService"
+      ]
     },
     "ClaimResponse": {
       "description": "This resource provides the adjudication details from the processing of a Claim resource.",
@@ -12977,7 +13420,12 @@
         }
       },
       "additionalProperties": false,
-      "required": ["patient", "insurer", "type", "resourceType"]
+      "required": [
+        "patient",
+        "insurer",
+        "type",
+        "resourceType"
+      ]
     },
     "ClaimResponse_Item": {
       "description": "This resource provides the adjudication details from the processing of a Claim resource.",
@@ -13038,7 +13486,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["adjudication"]
+      "required": [
+        "adjudication"
+      ]
     },
     "ClaimResponse_Adjudication": {
       "description": "This resource provides the adjudication details from the processing of a Claim resource.",
@@ -13083,7 +13533,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["category"]
+      "required": [
+        "category"
+      ]
     },
     "ClaimResponse_Detail": {
       "description": "This resource provides the adjudication details from the processing of a Claim resource.",
@@ -13144,7 +13596,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["adjudication"]
+      "required": [
+        "adjudication"
+      ]
     },
     "ClaimResponse_SubDetail": {
       "description": "This resource provides the adjudication details from the processing of a Claim resource.",
@@ -13373,7 +13827,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["adjudication", "productOrService"]
+      "required": [
+        "adjudication",
+        "productOrService"
+      ]
     },
     "ClaimResponse_Detail1": {
       "description": "This resource provides the adjudication details from the processing of a Claim resource.",
@@ -13457,7 +13914,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["adjudication", "productOrService"]
+      "required": [
+        "adjudication",
+        "productOrService"
+      ]
     },
     "ClaimResponse_SubDetail1": {
       "description": "This resource provides the adjudication details from the processing of a Claim resource.",
@@ -13534,7 +13994,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["adjudication", "productOrService"]
+      "required": [
+        "adjudication",
+        "productOrService"
+      ]
     },
     "ClaimResponse_Total": {
       "description": "This resource provides the adjudication details from the processing of a Claim resource.",
@@ -13567,7 +14030,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["amount", "category"]
+      "required": [
+        "amount",
+        "category"
+      ]
     },
     "ClaimResponse_Payment": {
       "description": "This resource provides the adjudication details from the processing of a Claim resource.",
@@ -13620,7 +14086,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["amount", "type"]
+      "required": [
+        "amount",
+        "type"
+      ]
     },
     "ClaimResponse_ProcessNote": {
       "description": "This resource provides the adjudication details from the processing of a Claim resource.",
@@ -13653,7 +14122,11 @@
         },
         "type": {
           "description": "The business purpose of the note text.",
-          "enum": ["display", "print", "printoper"]
+          "enum": [
+            "display",
+            "print",
+            "printoper"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -13729,7 +14202,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["coverage"]
+      "required": [
+        "coverage"
+      ]
     },
     "ClaimResponse_Error": {
       "description": "This resource provides the adjudication details from the processing of a Claim resource.",
@@ -13782,7 +14257,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code"]
+      "required": [
+        "code"
+      ]
     },
     "ClinicalImpression": {
       "description": "A record of a clinical assessment performed to determine what problem(s) may affect the patient and before planning the treatments or management strategies that are best to manage a patient\u0027s condition. Assessments are often 1:1 with a clinical consultation / encounter,  but this varies greatly depending on the clinical workflow. This resource is called \"ClinicalImpression\" rather than \"ClinicalAssessment\" to avoid confusion with the recording of assessment tools such as Apgar score.",
@@ -13981,7 +14458,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["subject", "resourceType"]
+      "required": [
+        "subject",
+        "resourceType"
+      ]
     },
     "ClinicalImpression_Investigation": {
       "description": "A record of a clinical assessment performed to determine what problem(s) may affect the patient and before planning the treatments or management strategies that are best to manage a patient\u0027s condition. Assessments are often 1:1 with a clinical consultation / encounter,  but this varies greatly depending on the clinical workflow. This resource is called \"ClinicalImpression\" rather than \"ClinicalAssessment\" to avoid confusion with the recording of assessment tools such as Apgar score.",
@@ -14017,7 +14497,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code"]
+      "required": [
+        "code"
+      ]
     },
     "ClinicalImpression_Finding": {
       "description": "A record of a clinical assessment performed to determine what problem(s) may affect the patient and before planning the treatments or management strategies that are best to manage a patient\u0027s condition. Assessments are often 1:1 with a clinical consultation / encounter,  but this varies greatly depending on the clinical workflow. This resource is called \"ClinicalImpression\" rather than \"ClinicalAssessment\" to avoid confusion with the recording of assessment tools such as Apgar score.",
@@ -14156,7 +14638,12 @@
         },
         "status": {
           "description": "The date (and optionally time) when the code system resource was created or revised.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -14245,7 +14732,12 @@
         },
         "hierarchyMeaning": {
           "description": "The meaning of the hierarchy of concepts as represented in this resource.",
-          "enum": ["grouped-by", "is-a", "part-of", "classified-with"]
+          "enum": [
+            "grouped-by",
+            "is-a",
+            "part-of",
+            "classified-with"
+          ]
         },
         "_hierarchyMeaning": {
           "description": "Extensions for hierarchyMeaning",
@@ -14269,7 +14761,13 @@
         },
         "content": {
           "description": "The extent of the content of the code system (the concepts and codes it defines) are represented in this resource instance.",
-          "enum": ["not-present", "example", "fragment", "complete", "supplement"]
+          "enum": [
+            "not-present",
+            "example",
+            "fragment",
+            "complete",
+            "supplement"
+          ]
         },
         "_content": {
           "description": "Extensions for content",
@@ -14310,7 +14808,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "CodeSystem_Filter": {
       "description": "The CodeSystem resource is used to declare the existence of and describe a code system or code system supplement and its key properties, and optionally define a part or all of its content.",
@@ -14421,7 +14921,15 @@
         },
         "type": {
           "description": "The type of the property value. Properties of type \"code\" contain a code defined by the code system (e.g. a reference to another defined concept).",
-          "enum": ["code", "Coding", "string", "integer", "boolean", "dateTime", "decimal"]
+          "enum": [
+            "code",
+            "Coding",
+            "string",
+            "integer",
+            "boolean",
+            "dateTime",
+            "decimal"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -14848,7 +15356,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Communication_Payload": {
       "description": "An occurrence of information being transmitted; e.g. an alert that was sent to a responsible provider, a public health agency that was notified about a reportable condition.",
@@ -15095,7 +15605,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "CommunicationRequest_Payload": {
       "description": "A request to convey information; e.g. the CDS system proposes that an alert be sent to a responsible provider, the CDS system proposes that the public health agency be notified about a reportable condition.",
@@ -15220,7 +15732,12 @@
         },
         "status": {
           "description": "The status of this compartment definition. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -15282,7 +15799,13 @@
         },
         "code": {
           "description": "Which compartment this definition describes.",
-          "enum": ["Patient", "Encounter", "RelatedPerson", "Practitioner", "Device"]
+          "enum": [
+            "Patient",
+            "Encounter",
+            "RelatedPerson",
+            "Practitioner",
+            "Device"
+          ]
         },
         "_code": {
           "description": "Extensions for code",
@@ -15305,7 +15828,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "CompartmentDefinition_Resource": {
       "description": "A compartment definition that defines how resources are accessed on a server.",
@@ -15423,7 +15948,12 @@
         },
         "status": {
           "description": "The workflow/clinical status of this composition. The status is a marker for the clinical standing of the document.",
-          "enum": ["preliminary", "final", "amended", "entered-in-error"]
+          "enum": [
+            "preliminary",
+            "final",
+            "amended",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -15513,7 +16043,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["author", "type", "resourceType"]
+      "required": [
+        "author",
+        "type",
+        "resourceType"
+      ]
     },
     "Composition_Attester": {
       "description": "A set of healthcare-related information that is assembled together into a single logical package that provides a single coherent statement of meaning, establishes its own context and that has clinical attestation with regard to who is making the statement. A Composition defines the structure and narrative content necessary for a document. However, a Composition alone does not constitute a document. Rather, the Composition must be the first entry in a Bundle where Bundle.type\u003ddocument, and any other resources referenced from Composition must be included as subsequent entries in the Bundle (for example Patient, Practitioner, Encounter, etc.).",
@@ -15538,7 +16072,12 @@
         },
         "mode": {
           "description": "The type of attestation the authenticator offers.",
-          "enum": ["personal", "professional", "legal", "official"]
+          "enum": [
+            "personal",
+            "professional",
+            "legal",
+            "official"
+          ]
         },
         "_mode": {
           "description": "Extensions for mode",
@@ -15816,7 +16355,12 @@
         },
         "status": {
           "description": "The status of this concept map. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -15936,7 +16480,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "ConceptMap_Group": {
       "description": "A statement of relationships from one set of concepts to one or more other concepts - either concepts in code systems, or data element/data element concepts, or classes in class models.",
@@ -16004,7 +16550,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["element"]
+      "required": [
+        "element"
+      ]
     },
     "ConceptMap_Element": {
       "description": "A statement of relationships from one set of concepts to one or more other concepts - either concepts in code systems, or data element/data element concepts, or classes in class models.",
@@ -16209,7 +16757,11 @@
         },
         "mode": {
           "description": "Defines which action to take if there is no match for the source concept in the target system designated for the group. One of 3 actions are possible: use the unmapped code (this is useful when doing a mapping between versions, and only a few codes have changed), use a fixed code (a default code), or alternatively, a reference to a different concept map can be provided (by canonical URL).",
-          "enum": ["provided", "fixed", "other-map"]
+          "enum": [
+            "provided",
+            "fixed",
+            "other-map"
+          ]
         },
         "_mode": {
           "description": "Extensions for mode",
@@ -16438,7 +16990,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["subject", "resourceType"]
+      "required": [
+        "subject",
+        "resourceType"
+      ]
     },
     "Condition_Stage": {
       "description": "A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern.",
@@ -16582,7 +17137,14 @@
         },
         "status": {
           "description": "Indicates the current state of this consent.",
-          "enum": ["draft", "proposed", "active", "rejected", "inactive", "entered-in-error"]
+          "enum": [
+            "draft",
+            "proposed",
+            "active",
+            "rejected",
+            "inactive",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -16657,7 +17219,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["scope", "category", "resourceType"]
+      "required": [
+        "scope",
+        "category",
+        "resourceType"
+      ]
     },
     "Consent_Policy": {
       "description": "A record of a healthcare consumer’s  choices, which permits or denies identified recipient(s) or recipient role(s) to perform one or more actions within a given policy context, for specific purposes and periods of time.",
@@ -16766,7 +17332,10 @@
         },
         "type": {
           "description": "Action  to take - permit or deny - when the rule conditions are met.  Not permitted in root rule, required in all nested rules.",
-          "enum": ["deny", "permit"]
+          "enum": [
+            "deny",
+            "permit"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -16870,7 +17439,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["reference", "role"]
+      "required": [
+        "reference",
+        "role"
+      ]
     },
     "Consent_Data": {
       "description": "A record of a healthcare consumer’s  choices, which permits or denies identified recipient(s) or recipient role(s) to perform one or more actions within a given policy context, for specific purposes and periods of time.",
@@ -16895,7 +17467,12 @@
         },
         "meaning": {
           "description": "How the resource reference is interpreted when testing consent restrictions.",
-          "enum": ["instance", "related", "dependents", "authoredby"]
+          "enum": [
+            "instance",
+            "related",
+            "dependents",
+            "authoredby"
+          ]
         },
         "_meaning": {
           "description": "Extensions for meaning",
@@ -16907,7 +17484,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["reference"]
+      "required": [
+        "reference"
+      ]
     },
     "Contract": {
       "description": "Legally enforceable, formally recorded unilateral or bilateral directive i.e., a policy or agreement.",
@@ -17188,7 +17767,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Contract_ContentDefinition": {
       "description": "Legally enforceable, formally recorded unilateral or bilateral directive i.e., a policy or agreement.",
@@ -17249,7 +17830,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "Contract_Term": {
       "description": "Legally enforceable, formally recorded unilateral or bilateral directive i.e., a policy or agreement.",
@@ -17346,7 +17929,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["offer"]
+      "required": [
+        "offer"
+      ]
     },
     "Contract_SecurityLabel": {
       "description": "Legally enforceable, formally recorded unilateral or bilateral directive i.e., a policy or agreement.",
@@ -17403,7 +17988,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["classification"]
+      "required": [
+        "classification"
+      ]
     },
     "Contract_Offer": {
       "description": "Legally enforceable, formally recorded unilateral or bilateral directive i.e., a policy or agreement.",
@@ -17539,7 +18126,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["reference", "role"]
+      "required": [
+        "reference",
+        "role"
+      ]
     },
     "Contract_Answer": {
       "description": "Legally enforceable, formally recorded unilateral or bilateral directive i.e., a policy or agreement.",
@@ -18171,7 +18761,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type", "intent", "status"]
+      "required": [
+        "type",
+        "intent",
+        "status"
+      ]
     },
     "Contract_Subject": {
       "description": "Legally enforceable, formally recorded unilateral or bilateral directive i.e., a policy or agreement.",
@@ -18207,7 +18801,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["reference"]
+      "required": [
+        "reference"
+      ]
     },
     "Contract_Signer": {
       "description": "Legally enforceable, formally recorded unilateral or bilateral directive i.e., a policy or agreement.",
@@ -18247,7 +18843,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["signature", "type", "party"]
+      "required": [
+        "signature",
+        "type",
+        "party"
+      ]
     },
     "Contract_Friendly": {
       "description": "Legally enforceable, formally recorded unilateral or bilateral directive i.e., a policy or agreement.",
@@ -18510,7 +19110,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["payor", "beneficiary", "resourceType"]
+      "required": [
+        "payor",
+        "beneficiary",
+        "resourceType"
+      ]
     },
     "Coverage_Class": {
       "description": "Financial instrument which may be used to reimburse or pay for health care products and services. Includes both insurance and self-payment.",
@@ -18555,7 +19159,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "Coverage_CostToBeneficiary": {
       "description": "Financial instrument which may be used to reimburse or pay for health care products and services. Includes both insurance and self-payment.",
@@ -18631,7 +19237,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "CoverageEligibilityRequest": {
       "description": "The CoverageEligibilityRequest provides patient and insurance coverage information to an insurer for them to respond, in the form of an CoverageEligibilityResponse, with information regarding whether the stated coverage is valid and in-force and optionally to provide the insurance details of the policy.",
@@ -18711,7 +19319,12 @@
         "purpose": {
           "description": "Code to specify whether requesting: prior authorization requirements for some service categories or billing codes; benefits for coverages specified or discovered; discovery and return of coverages for the patient; and/or validation that the specified coverage is in-force at the date/period specified or \u0027now\u0027 if not specified.",
           "items": {
-            "enum": ["auth-requirements", "benefits", "discovery", "validation"]
+            "enum": [
+              "auth-requirements",
+              "benefits",
+              "discovery",
+              "validation"
+            ]
           },
           "type": "array"
         },
@@ -18786,7 +19399,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["patient", "insurer", "resourceType"]
+      "required": [
+        "patient",
+        "insurer",
+        "resourceType"
+      ]
     },
     "CoverageEligibilityRequest_SupportingInfo": {
       "description": "The CoverageEligibilityRequest provides patient and insurance coverage information to an insurer for them to respond, in the form of an CoverageEligibilityResponse, with information regarding whether the stated coverage is valid and in-force and optionally to provide the insurance details of the policy.",
@@ -18831,7 +19448,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["information"]
+      "required": [
+        "information"
+      ]
     },
     "CoverageEligibilityRequest_Insurance": {
       "description": "The CoverageEligibilityRequest provides patient and insurance coverage information to an insurer for them to respond, in the form of an CoverageEligibilityResponse, with information regarding whether the stated coverage is valid and in-force and optionally to provide the insurance details of the policy.",
@@ -18876,7 +19495,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["coverage"]
+      "required": [
+        "coverage"
+      ]
     },
     "CoverageEligibilityRequest_Item": {
       "description": "The CoverageEligibilityRequest provides patient and insurance coverage information to an insurer for them to respond, in the form of an CoverageEligibilityResponse, with information regarding whether the stated coverage is valid and in-force and optionally to provide the insurance details of the policy.",
@@ -19067,7 +19688,12 @@
         "purpose": {
           "description": "Code to specify whether requesting: prior authorization requirements for some service categories or billing codes; benefits for coverages specified or discovered; discovery and return of coverages for the patient; and/or validation that the specified coverage is in-force at the date/period specified or \u0027now\u0027 if not specified.",
           "items": {
-            "enum": ["auth-requirements", "benefits", "discovery", "validation"]
+            "enum": [
+              "auth-requirements",
+              "benefits",
+              "discovery",
+              "validation"
+            ]
           },
           "type": "array"
         },
@@ -19113,7 +19739,12 @@
         },
         "outcome": {
           "description": "The outcome of the request processing.",
-          "enum": ["queued", "complete", "error", "partial"]
+          "enum": [
+            "queued",
+            "complete",
+            "error",
+            "partial"
+          ]
         },
         "_outcome": {
           "description": "Extensions for outcome",
@@ -19159,7 +19790,12 @@
         }
       },
       "additionalProperties": false,
-      "required": ["request", "patient", "insurer", "resourceType"]
+      "required": [
+        "request",
+        "patient",
+        "insurer",
+        "resourceType"
+      ]
     },
     "CoverageEligibilityResponse_Insurance": {
       "description": "This resource provides eligibility and plan details from the processing of an CoverageEligibilityRequest resource.",
@@ -19207,7 +19843,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["coverage"]
+      "required": [
+        "coverage"
+      ]
     },
     "CoverageEligibilityResponse_Item": {
       "description": "This resource provides eligibility and plan details from the processing of an CoverageEligibilityRequest resource.",
@@ -19389,7 +20027,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "CoverageEligibilityResponse_Error": {
       "description": "This resource provides eligibility and plan details from the processing of an CoverageEligibilityRequest resource.",
@@ -19418,7 +20058,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code"]
+      "required": [
+        "code"
+      ]
     },
     "DetectedIssue": {
       "description": "Indicates an actual or potential clinical issue with or between one or more active or proposed clinical actions for a patient; e.g. Drug-drug interaction, Ineffective treatment frequency, Procedure-condition conflict, etc.",
@@ -19497,7 +20139,11 @@
         },
         "severity": {
           "description": "Indicates the degree of importance associated with the identified issue based on the potential impact on the patient.",
-          "enum": ["high", "moderate", "low"]
+          "enum": [
+            "high",
+            "moderate",
+            "low"
+          ]
         },
         "_severity": {
           "description": "Extensions for severity",
@@ -19563,7 +20209,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "DetectedIssue_Evidence": {
       "description": "Indicates an actual or potential clinical issue with or between one or more active or proposed clinical actions for a patient; e.g. Drug-drug interaction, Ineffective treatment frequency, Procedure-condition conflict, etc.",
@@ -19642,7 +20290,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["action"]
+      "required": [
+        "action"
+      ]
     },
     "Device": {
       "description": "A type of a manufactured item that is used in the provision of healthcare without being substantially changed through that activity. The device may be a medical or non-medical device.",
@@ -19720,7 +20370,12 @@
         },
         "status": {
           "description": "Status of the Device availability.",
-          "enum": ["active", "inactive", "entered-in-error", "unknown"]
+          "enum": [
+            "active",
+            "inactive",
+            "entered-in-error",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -19876,7 +20531,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Device_UdiCarrier": {
       "description": "A type of a manufactured item that is used in the provision of healthcare without being substantially changed through that activity. The device may be a medical or non-medical device.",
@@ -19941,7 +20598,14 @@
         },
         "entryType": {
           "description": "A coded entry to indicate how the data was entered.",
-          "enum": ["barcode", "rfid", "manual", "card", "self-reported", "unknown"]
+          "enum": [
+            "barcode",
+            "rfid",
+            "manual",
+            "card",
+            "self-reported",
+            "unknown"
+          ]
         },
         "_entryType": {
           "description": "Extensions for entryType",
@@ -20032,7 +20696,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["systemType"]
+      "required": [
+        "systemType"
+      ]
     },
     "Device_Version": {
       "description": "A type of a manufactured item that is used in the provision of healthcare without being substantially changed through that activity. The device may be a medical or non-medical device.",
@@ -20115,7 +20781,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "DeviceDefinition": {
       "description": "The characteristics, operational status and capabilities of a medical-related component of a medical device.",
@@ -20337,7 +21005,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "DeviceDefinition_UdiDeviceIdentifier": {
       "description": "The characteristics, operational status and capabilities of a medical-related component of a medical device.",
@@ -20508,7 +21178,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "DeviceDefinition_Property": {
       "description": "The characteristics, operational status and capabilities of a medical-related component of a medical device.",
@@ -20551,7 +21223,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "DeviceDefinition_Material": {
       "description": "The characteristics, operational status and capabilities of a medical-related component of a medical device.",
@@ -20596,7 +21270,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["substance"]
+      "required": [
+        "substance"
+      ]
     },
     "DeviceDefinition_Classification": {
       "description": "What kind of device or device system this is.",
@@ -20711,7 +21387,12 @@
         },
         "operationalStatus": {
           "description": "Indicates current operational state of the device. For example: On, Off, Standby, etc.",
-          "enum": ["on", "off", "standby", "entered-in-error"]
+          "enum": [
+            "on",
+            "off",
+            "standby",
+            "entered-in-error"
+          ]
         },
         "_operationalStatus": {
           "description": "Extensions for operationalStatus",
@@ -20719,7 +21400,16 @@
         },
         "color": {
           "description": "Describes the color representation for the metric. This is often used to aid clinicians to track and identify parameter types by color. In practice, consider a Patient Monitor that has ECG/HR and Pleth for example; the parameters are displayed in different characteristic colors, such as HR-blue, BP-green, and PR and SpO2- magenta.",
-          "enum": ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]
+          "enum": [
+            "black",
+            "red",
+            "green",
+            "yellow",
+            "blue",
+            "magenta",
+            "cyan",
+            "white"
+          ]
         },
         "_color": {
           "description": "Extensions for color",
@@ -20727,7 +21417,12 @@
         },
         "category": {
           "description": "Indicates the category of the observation generation process. A DeviceMetric can be for example a setting, measurement, or calculation.",
-          "enum": ["measurement", "setting", "calculation", "unspecified"]
+          "enum": [
+            "measurement",
+            "setting",
+            "calculation",
+            "unspecified"
+          ]
         },
         "_category": {
           "description": "Extensions for category",
@@ -20746,7 +21441,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type", "resourceType"]
+      "required": [
+        "type",
+        "resourceType"
+      ]
     },
     "DeviceMetric_Calibration": {
       "description": "Describes a measurement, calculation or setting capability of a medical device.",
@@ -20771,7 +21469,12 @@
         },
         "type": {
           "description": "Describes the type of the calibration method.",
-          "enum": ["unspecified", "offset", "gain", "two-point"]
+          "enum": [
+            "unspecified",
+            "offset",
+            "gain",
+            "two-point"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -20779,7 +21482,12 @@
         },
         "state": {
           "description": "Describes the state of the calibration.",
-          "enum": ["not-calibrated", "calibration-required", "calibrated", "unspecified"]
+          "enum": [
+            "not-calibrated",
+            "calibration-required",
+            "calibrated",
+            "unspecified"
+          ]
         },
         "_state": {
           "description": "Extensions for state",
@@ -21026,7 +21734,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["subject", "resourceType"]
+      "required": [
+        "subject",
+        "resourceType"
+      ]
     },
     "DeviceRequest_Parameter": {
       "description": "Represents a request for a patient to employ a medical device. The device may be an implantable device, or an external assistive device, such as a walker.",
@@ -21149,7 +21860,14 @@
         },
         "status": {
           "description": "A code representing the patient or other source\u0027s judgment about the state of the device used that this statement is about.  Generally this will be active or completed.",
-          "enum": ["active", "completed", "entered-in-error", "intended", "stopped", "on-hold"]
+          "enum": [
+            "active",
+            "completed",
+            "entered-in-error",
+            "intended",
+            "stopped",
+            "on-hold"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -21226,7 +21944,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["subject", "device", "resourceType"]
+      "required": [
+        "subject",
+        "device",
+        "resourceType"
+      ]
     },
     "DiagnosticReport": {
       "description": "The findings and interpretation of diagnostic  tests performed on patients, groups of patients, devices, and locations, and/or specimens derived from these. The report includes clinical context such as requesting and provider information, and some mix of atomic results, images, textual and coded interpretations, and formatted representation of diagnostic reports.",
@@ -21423,7 +22145,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code", "resourceType"]
+      "required": [
+        "code",
+        "resourceType"
+      ]
     },
     "DiagnosticReport_Media": {
       "description": "The findings and interpretation of diagnostic  tests performed on patients, groups of patients, devices, and locations, and/or specimens derived from these. The report includes clinical context such as requesting and provider information, and some mix of atomic results, images, textual and coded interpretations, and formatted representation of diagnostic reports.",
@@ -21460,7 +22185,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["link"]
+      "required": [
+        "link"
+      ]
     },
     "DocumentManifest": {
       "description": "A collection of documents compiled for a purpose together with metadata that applies to the collection.",
@@ -21531,7 +22258,11 @@
         },
         "status": {
           "description": "The status of this document manifest.",
-          "enum": ["current", "superseded", "entered-in-error"]
+          "enum": [
+            "current",
+            "superseded",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -21599,7 +22330,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["content", "resourceType"]
+      "required": [
+        "content",
+        "resourceType"
+      ]
     },
     "DocumentManifest_Related": {
       "description": "A collection of documents compiled for a purpose together with metadata that applies to the collection.",
@@ -21702,7 +22436,11 @@
         },
         "status": {
           "description": "The status of this document reference.",
-          "enum": ["current", "superseded", "entered-in-error"]
+          "enum": [
+            "current",
+            "superseded",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -21789,7 +22527,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["content", "resourceType"]
+      "required": [
+        "content",
+        "resourceType"
+      ]
     },
     "DocumentReference_RelatesTo": {
       "description": "A reference to a document of any kind for any purpose. Provides metadata about the document so that the document can be discovered and managed. The scope of a document is any seralized object with a mime-type, so includes formal patient centric documents (CDA), cliical notes, scanned paper, and non-patient specific documents like policy text.",
@@ -21814,7 +22555,12 @@
         },
         "code": {
           "description": "The type of relationship that this document has with anther document.",
-          "enum": ["replaces", "transforms", "signs", "appends"]
+          "enum": [
+            "replaces",
+            "transforms",
+            "signs",
+            "appends"
+          ]
         },
         "_code": {
           "description": "Extensions for code",
@@ -21826,7 +22572,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["target"]
+      "required": [
+        "target"
+      ]
     },
     "DocumentReference_Content": {
       "description": "A reference to a document of any kind for any purpose. Provides metadata about the document so that the document can be discovered and managed. The scope of a document is any seralized object with a mime-type, so includes formal patient centric documents (CDA), cliical notes, scanned paper, and non-patient specific documents like policy text.",
@@ -21859,7 +22607,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["attachment"]
+      "required": [
+        "attachment"
+      ]
     },
     "DocumentReference_Context": {
       "description": "A reference to a document of any kind for any purpose. Provides metadata about the document so that the document can be discovered and managed. The scope of a document is any seralized object with a mime-type, so includes formal patient centric documents (CDA), cliical notes, scanned paper, and non-patient specific documents like policy text.",
@@ -22019,7 +22769,12 @@
         },
         "status": {
           "description": "The status of this effect evidence synthesis. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -22198,7 +22953,13 @@
         }
       },
       "additionalProperties": false,
-      "required": ["exposureAlternative", "exposure", "outcome", "resourceType", "population"]
+      "required": [
+        "exposureAlternative",
+        "exposure",
+        "outcome",
+        "resourceType",
+        "population"
+      ]
     },
     "EffectEvidenceSynthesis_SampleSize": {
       "description": "The EffectEvidenceSynthesis resource describes the difference in an outcome between exposures states in a population where the effect estimate is derived from a combination of research studies.",
@@ -22279,7 +23040,10 @@
         },
         "exposureState": {
           "description": "Whether these results are for the exposure state or alternative exposure state.",
-          "enum": ["exposure", "exposure-alternative"]
+          "enum": [
+            "exposure",
+            "exposure-alternative"
+          ]
         },
         "_exposureState": {
           "description": "Extensions for exposureState",
@@ -22295,7 +23059,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["riskEvidenceSynthesis"]
+      "required": [
+        "riskEvidenceSynthesis"
+      ]
     },
     "EffectEvidenceSynthesis_EffectEstimate": {
       "description": "The EffectEvidenceSynthesis resource describes the difference in an outcome between exposures states in a population where the effect estimate is derived from a combination of research studies.",
@@ -22698,7 +23464,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["class", "resourceType"]
+      "required": [
+        "class",
+        "resourceType"
+      ]
     },
     "Encounter_StatusHistory": {
       "description": "An interaction between a patient and healthcare provider(s) for the purpose of providing healthcare service(s) or assessing the health status of a patient.",
@@ -22745,7 +23514,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["period"]
+      "required": [
+        "period"
+      ]
     },
     "Encounter_ClassHistory": {
       "description": "An interaction between a patient and healthcare provider(s) for the purpose of providing healthcare service(s) or assessing the health status of a patient.",
@@ -22778,7 +23549,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["period", "class"]
+      "required": [
+        "period",
+        "class"
+      ]
     },
     "Encounter_Participant": {
       "description": "An interaction between a patient and healthcare provider(s) for the purpose of providing healthcare service(s) or assessing the health status of a patient.",
@@ -22858,7 +23632,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["condition"]
+      "required": [
+        "condition"
+      ]
     },
     "Encounter_Hospitalization": {
       "description": "An interaction between a patient and healthcare provider(s) for the purpose of providing healthcare service(s) or assessing the health status of a patient.",
@@ -22956,7 +23732,12 @@
         },
         "status": {
           "description": "The status of the participants\u0027 presence at the specified location during the period specified. If the participant is no longer at the location, then the period will have an end date/time.",
-          "enum": ["planned", "active", "reserved", "completed"]
+          "enum": [
+            "planned",
+            "active",
+            "reserved",
+            "completed"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -22972,7 +23753,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["location"]
+      "required": [
+        "location"
+      ]
     },
     "Endpoint": {
       "description": "The technical details of an endpoint that can be used for electronic services, such as for web services providing XDS.b or a REST endpoint for another FHIR server. This may include any security context information.",
@@ -23039,7 +23822,14 @@
         },
         "status": {
           "description": "active | suspended | error | off | test.",
-          "enum": ["active", "suspended", "error", "off", "entered-in-error", "test"]
+          "enum": [
+            "active",
+            "suspended",
+            "error",
+            "off",
+            "entered-in-error",
+            "test"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -23117,7 +23907,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["payloadType", "connectionType", "resourceType"]
+      "required": [
+        "payloadType",
+        "connectionType",
+        "resourceType"
+      ]
     },
     "EnrollmentRequest": {
       "description": "This resource provides the insurance enrollment details to the insurer regarding a specified coverage.",
@@ -23216,7 +24010,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "EnrollmentResponse": {
       "description": "This resource provides enrollment and plan details from the processing of an EnrollmentRequest resource.",
@@ -23295,7 +24091,12 @@
         },
         "outcome": {
           "description": "Processing status: error, complete.",
-          "enum": ["queued", "complete", "error", "partial"]
+          "enum": [
+            "queued",
+            "complete",
+            "error",
+            "partial"
+          ]
         },
         "_outcome": {
           "description": "Extensions for outcome",
@@ -23327,7 +24128,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "EpisodeOfCare": {
       "description": "An association between a patient and an organization / healthcare provider(s) during which time encounters may occur. The managing organization assumes a level of responsibility for the patient during this time.",
@@ -23394,7 +24197,15 @@
         },
         "status": {
           "description": "planned | waitlist | active | onhold | finished | cancelled.",
-          "enum": ["planned", "waitlist", "active", "onhold", "finished", "cancelled", "entered-in-error"]
+          "enum": [
+            "planned",
+            "waitlist",
+            "active",
+            "onhold",
+            "finished",
+            "cancelled",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -23460,7 +24271,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["patient", "resourceType"]
+      "required": [
+        "patient",
+        "resourceType"
+      ]
     },
     "EpisodeOfCare_StatusHistory": {
       "description": "An association between a patient and an organization / healthcare provider(s) during which time encounters may occur. The managing organization assumes a level of responsibility for the patient during this time.",
@@ -23485,7 +24299,15 @@
         },
         "status": {
           "description": "planned | waitlist | active | onhold | finished | cancelled.",
-          "enum": ["planned", "waitlist", "active", "onhold", "finished", "cancelled", "entered-in-error"]
+          "enum": [
+            "planned",
+            "waitlist",
+            "active",
+            "onhold",
+            "finished",
+            "cancelled",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -23497,7 +24319,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["period"]
+      "required": [
+        "period"
+      ]
     },
     "EpisodeOfCare_Diagnosis": {
       "description": "An association between a patient and an organization / healthcare provider(s) during which time encounters may occur. The managing organization assumes a level of responsibility for the patient during this time.",
@@ -23538,7 +24362,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["condition"]
+      "required": [
+        "condition"
+      ]
     },
     "EventDefinition": {
       "description": "The EventDefinition resource provides a reusable description of when a particular event can occur.",
@@ -23645,7 +24471,12 @@
         },
         "status": {
           "description": "The status of this event definition. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -23807,7 +24638,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["trigger", "resourceType"]
+      "required": [
+        "trigger",
+        "resourceType"
+      ]
     },
     "Evidence": {
       "description": "The Evidence resource describes the conditional state (population and any exposures being compared within the population) and outcome (if specified) that the knowledge (evidence, assertion, recommendation) is about.",
@@ -23922,7 +24756,12 @@
         },
         "status": {
           "description": "The status of this evidence. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -24070,7 +24909,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["exposureBackground", "resourceType"]
+      "required": [
+        "exposureBackground",
+        "resourceType"
+      ]
     },
     "EvidenceVariable": {
       "description": "The EvidenceVariable resource describes a \"PICO\" element that knowledge (evidence, assertion, recommendation) is about.",
@@ -24185,7 +25027,12 @@
         },
         "status": {
           "description": "The status of this evidence variable. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -24315,7 +25162,11 @@
         },
         "type": {
           "description": "The type of evidence element, a population, an exposure, or an outcome.",
-          "enum": ["dichotomous", "continuous", "descriptive"]
+          "enum": [
+            "dichotomous",
+            "continuous",
+            "descriptive"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -24330,7 +25181,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["characteristic", "resourceType"]
+      "required": [
+        "characteristic",
+        "resourceType"
+      ]
     },
     "EvidenceVariable_Characteristic": {
       "description": "The EvidenceVariable resource describes a \"PICO\" element that knowledge (evidence, assertion, recommendation) is about.",
@@ -24432,7 +25286,14 @@
         },
         "groupMeasure": {
           "description": "Indicates how elements are aggregated within the study effective period.",
-          "enum": ["mean", "median", "mean-of-mean", "mean-of-median", "median-of-mean", "median-of-median"]
+          "enum": [
+            "mean",
+            "median",
+            "mean-of-mean",
+            "mean-of-median",
+            "median-of-mean",
+            "median-of-median"
+          ]
         },
         "_groupMeasure": {
           "description": "Extensions for groupMeasure",
@@ -24530,7 +25391,12 @@
         },
         "status": {
           "description": "The status of this example scenario. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -24627,7 +25493,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "ExampleScenario_Actor": {
       "description": "Example of workflow instance.",
@@ -24660,7 +25528,10 @@
         },
         "type": {
           "description": "The type of actor - person or system.",
-          "enum": ["person", "entity"]
+          "enum": [
+            "person",
+            "entity"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -25156,7 +26027,12 @@
         },
         "status": {
           "description": "The status of the resource instance.",
-          "enum": ["active", "cancelled", "draft", "entered-in-error"]
+          "enum": [
+            "active",
+            "cancelled",
+            "draft",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -25397,7 +26273,14 @@
         }
       },
       "additionalProperties": false,
-      "required": ["insurance", "provider", "patient", "insurer", "type", "resourceType"]
+      "required": [
+        "insurance",
+        "provider",
+        "patient",
+        "insurer",
+        "type",
+        "resourceType"
+      ]
     },
     "ExplanationOfBenefit_Related": {
       "description": "This resource provides: the claim details; adjudication details from the processing of a Claim; and optionally account balance information, for informing the subscriber of the benefits provided.",
@@ -25518,7 +26401,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["provider"]
+      "required": [
+        "provider"
+      ]
     },
     "ExplanationOfBenefit_SupportingInfo": {
       "description": "This resource provides: the claim details; adjudication details from the processing of a Claim; and optionally account balance information, for informing the subscriber of the benefits provided.",
@@ -25606,7 +26491,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["category"]
+      "required": [
+        "category"
+      ]
     },
     "ExplanationOfBenefit_Diagnosis": {
       "description": "This resource provides: the claim details; adjudication details from the processing of a Claim; and optionally account balance information, for informing the subscriber of the benefits provided.",
@@ -25774,7 +26661,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["coverage"]
+      "required": [
+        "coverage"
+      ]
     },
     "ExplanationOfBenefit_Accident": {
       "description": "This resource provides: the claim details; adjudication details from the processing of a Claim; and optionally account balance information, for informing the subscriber of the benefits provided.",
@@ -26031,7 +26920,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["productOrService"]
+      "required": [
+        "productOrService"
+      ]
     },
     "ExplanationOfBenefit_Adjudication": {
       "description": "This resource provides: the claim details; adjudication details from the processing of a Claim; and optionally account balance information, for informing the subscriber of the benefits provided.",
@@ -26076,7 +26967,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["category"]
+      "required": [
+        "category"
+      ]
     },
     "ExplanationOfBenefit_Detail": {
       "description": "This resource provides: the claim details; adjudication details from the processing of a Claim; and optionally account balance information, for informing the subscriber of the benefits provided.",
@@ -26190,7 +27083,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["productOrService"]
+      "required": [
+        "productOrService"
+      ]
     },
     "ExplanationOfBenefit_SubDetail": {
       "description": "This resource provides: the claim details; adjudication details from the processing of a Claim; and optionally account balance information, for informing the subscriber of the benefits provided.",
@@ -26297,7 +27192,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["productOrService"]
+      "required": [
+        "productOrService"
+      ]
     },
     "ExplanationOfBenefit_AddItem": {
       "description": "This resource provides: the claim details; adjudication details from the processing of a Claim; and optionally account balance information, for informing the subscriber of the benefits provided.",
@@ -26473,7 +27370,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["productOrService"]
+      "required": [
+        "productOrService"
+      ]
     },
     "ExplanationOfBenefit_Detail1": {
       "description": "This resource provides: the claim details; adjudication details from the processing of a Claim; and optionally account balance information, for informing the subscriber of the benefits provided.",
@@ -26557,7 +27456,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["productOrService"]
+      "required": [
+        "productOrService"
+      ]
     },
     "ExplanationOfBenefit_SubDetail1": {
       "description": "This resource provides: the claim details; adjudication details from the processing of a Claim; and optionally account balance information, for informing the subscriber of the benefits provided.",
@@ -26634,7 +27535,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["productOrService"]
+      "required": [
+        "productOrService"
+      ]
     },
     "ExplanationOfBenefit_Total": {
       "description": "This resource provides: the claim details; adjudication details from the processing of a Claim; and optionally account balance information, for informing the subscriber of the benefits provided.",
@@ -26667,7 +27570,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["amount", "category"]
+      "required": [
+        "amount",
+        "category"
+      ]
     },
     "ExplanationOfBenefit_Payment": {
       "description": "This resource provides: the claim details; adjudication details from the processing of a Claim; and optionally account balance information, for informing the subscriber of the benefits provided.",
@@ -26752,7 +27658,11 @@
         },
         "type": {
           "description": "The business purpose of the note text.",
-          "enum": ["display", "print", "printoper"]
+          "enum": [
+            "display",
+            "print",
+            "printoper"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -26843,7 +27753,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["category"]
+      "required": [
+        "category"
+      ]
     },
     "ExplanationOfBenefit_Financial": {
       "description": "This resource provides: the claim details; adjudication details from the processing of a Claim; and optionally account balance information, for informing the subscriber of the benefits provided.",
@@ -26907,7 +27819,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "FamilyMemberHistory": {
       "description": "Significant health conditions for a person related to the patient relevant in the context of care for the patient.",
@@ -26995,7 +27909,12 @@
         },
         "status": {
           "description": "A code specifying the status of the record of the family history of a specific family member.",
-          "enum": ["partial", "completed", "entered-in-error", "health-unknown"]
+          "enum": [
+            "partial",
+            "completed",
+            "entered-in-error",
+            "health-unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -27145,7 +28064,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["patient", "relationship", "resourceType"]
+      "required": [
+        "patient",
+        "relationship",
+        "resourceType"
+      ]
     },
     "FamilyMemberHistory_Condition": {
       "description": "Significant health conditions for a person related to the patient relevant in the context of care for the patient.",
@@ -27214,7 +28137,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code"]
+      "required": [
+        "code"
+      ]
     },
     "Flag": {
       "description": "Prospective warnings of potential issues when providing care to the patient.",
@@ -27281,7 +28206,11 @@
         },
         "status": {
           "description": "Supports basic workflow.",
-          "enum": ["active", "inactive", "entered-in-error"]
+          "enum": [
+            "active",
+            "inactive",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -27316,7 +28245,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code", "subject", "resourceType"]
+      "required": [
+        "code",
+        "subject",
+        "resourceType"
+      ]
     },
     "Goal": {
       "description": "Describes the intended objective(s) for a patient, group or organization care, for example, weight loss, restoring an activity of daily living, obtaining herd immunity via immunization, meeting a process improvement objective, etc.",
@@ -27492,7 +28425,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["subject", "description", "resourceType"]
+      "required": [
+        "subject",
+        "description",
+        "resourceType"
+      ]
     },
     "Goal_Target": {
       "description": "Describes the intended objective(s) for a patient, group or organization care, for example, weight loss, restoring an activity of daily living, obtaining herd immunity via immunization, meeting a process improvement objective, etc.",
@@ -27660,7 +28597,12 @@
         },
         "status": {
           "description": "The status of this graph definition. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -27748,7 +28690,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "GraphDefinition_Link": {
       "description": "A formal computable definition of a graph of resources - that is, a coherent set of resources that form a graph by following references. The Graph Definition resource defines a set and makes rules about the set.",
@@ -27902,7 +28846,10 @@
         },
         "use": {
           "description": "Defines how the compartment rule is used - whether it it is used to test whether resources are subject to the rule, or whether it is a rule that must be followed.",
-          "enum": ["condition", "requirement"]
+          "enum": [
+            "condition",
+            "requirement"
+          ]
         },
         "_use": {
           "description": "Extensions for use",
@@ -27918,7 +28865,12 @@
         },
         "rule": {
           "description": "identical | matching | different | no-rule | custom.",
-          "enum": ["identical", "matching", "different", "custom"]
+          "enum": [
+            "identical",
+            "matching",
+            "different",
+            "custom"
+          ]
         },
         "_rule": {
           "description": "Extensions for rule",
@@ -28016,7 +28968,14 @@
         },
         "type": {
           "description": "Identifies the broad classification of the kind of resources the group includes.",
-          "enum": ["person", "animal", "practitioner", "device", "medication", "substance"]
+          "enum": [
+            "person",
+            "animal",
+            "practitioner",
+            "device",
+            "medication",
+            "substance"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -28070,7 +29029,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Group_Characteristic": {
       "description": "Represents a defined collection of entities that may be discussed or acted upon collectively but which are not expected to act collectively, and are not formally or legally recognized; i.e. a collection of entities that isn\u0027t an Organization.",
@@ -28136,7 +29097,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code"]
+      "required": [
+        "code"
+      ]
     },
     "Group_Member": {
       "description": "Represents a defined collection of entities that may be discussed or acted upon collectively but which are not expected to act collectively, and are not formally or legally recognized; i.e. a collection of entities that isn\u0027t an Organization.",
@@ -28177,7 +29140,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["entity"]
+      "required": [
+        "entity"
+      ]
     },
     "GuidanceResponse": {
       "description": "A guidance response is the formal response to a guidance request, including any output parameters returned by the evaluation, as well as the description of any proposed actions to be taken.",
@@ -28270,7 +29235,14 @@
         },
         "status": {
           "description": "The status of the response. If the evaluation is completed successfully, the status will indicate success. However, in order to complete the evaluation, the engine may require more information. In this case, the status will be data-required, and the response will contain a description of the additional required information. If the evaluation completed successfully, but the engine determines that a potentially more accurate response could be provided if more data was available, the status will be data-requested, and the response will contain a description of the additional requested information.",
-          "enum": ["success", "data-requested", "data-required", "in-progress", "failure", "entered-in-error"]
+          "enum": [
+            "success",
+            "data-requested",
+            "data-required",
+            "in-progress",
+            "failure",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -28341,7 +29313,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "HealthcareService": {
       "description": "The details of a healthcare service available at a location.",
@@ -28569,7 +29543,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "HealthcareService_Eligibility": {
       "description": "The details of a healthcare service available at a location.",
@@ -28631,7 +29607,15 @@
         "daysOfWeek": {
           "description": "Indicates which days of the week are available between the start and end Times.",
           "items": {
-            "enum": ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+            "enum": [
+              "mon",
+              "tue",
+              "wed",
+              "thu",
+              "fri",
+              "sat",
+              "sun"
+            ]
           },
           "type": "array"
         },
@@ -28770,7 +29754,13 @@
         },
         "status": {
           "description": "The current state of the ImagingStudy.",
-          "enum": ["registered", "available", "cancelled", "entered-in-error", "unknown"]
+          "enum": [
+            "registered",
+            "available",
+            "cancelled",
+            "entered-in-error",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -28893,7 +29883,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["subject", "resourceType"]
+      "required": [
+        "subject",
+        "resourceType"
+      ]
     },
     "ImagingStudy_Series": {
       "description": "Representation of the content produced in a DICOM imaging study. A study comprises a set of series, each of which includes a set of Service-Object Pair Instances (SOP Instances - images or other data) acquired or produced in a common context.  A series is of only one modality (e.g. X-ray, CT, MR, ultrasound), but a study may have multiple series of different modalities.",
@@ -28998,7 +29991,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["modality"]
+      "required": [
+        "modality"
+      ]
     },
     "ImagingStudy_Performer": {
       "description": "Representation of the content produced in a DICOM imaging study. A study comprises a set of series, each of which includes a set of Service-Object Pair Instances (SOP Instances - images or other data) acquired or produced in a common context.  A series is of only one modality (e.g. X-ray, CT, MR, ultrasound), but a study may have multiple series of different modalities.",
@@ -29031,7 +30026,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["actor"]
+      "required": [
+        "actor"
+      ]
     },
     "ImagingStudy_Instance": {
       "description": "Representation of the content produced in a DICOM imaging study. A study comprises a set of series, each of which includes a set of Service-Object Pair Instances (SOP Instances - images or other data) acquired or produced in a common context.  A series is of only one modality (e.g. X-ray, CT, MR, ultrasound), but a study may have multiple series of different modalities.",
@@ -29084,7 +30081,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["sopClass"]
+      "required": [
+        "sopClass"
+      ]
     },
     "Immunization": {
       "description": "Describes the event of a patient being administered a vaccine or a record of an immunization as reported by a patient, a clinician or another party.",
@@ -29324,7 +30323,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["patient", "vaccineCode", "resourceType"]
+      "required": [
+        "patient",
+        "vaccineCode",
+        "resourceType"
+      ]
     },
     "Immunization_Performer": {
       "description": "Describes the event of a patient being administered a vaccine or a record of an immunization as reported by a patient, a clinician or another party.",
@@ -29357,7 +30360,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["actor"]
+      "required": [
+        "actor"
+      ]
     },
     "Immunization_Education": {
       "description": "Describes the event of a patient being administered a vaccine or a record of an immunization as reported by a patient, a clinician or another party.",
@@ -29698,7 +30703,13 @@
         }
       },
       "additionalProperties": false,
-      "required": ["doseStatus", "patient", "targetDisease", "immunizationEvent", "resourceType"]
+      "required": [
+        "doseStatus",
+        "patient",
+        "targetDisease",
+        "immunizationEvent",
+        "resourceType"
+      ]
     },
     "ImmunizationRecommendation": {
       "description": "A patient\u0027s point-in-time set of recommendations (i.e. forecasting) according to a published schedule with optional supporting justification.",
@@ -29788,7 +30799,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["patient", "recommendation", "resourceType"]
+      "required": [
+        "patient",
+        "recommendation",
+        "resourceType"
+      ]
     },
     "ImmunizationRecommendation_Recommendation": {
       "description": "A patient\u0027s point-in-time set of recommendations (i.e. forecasting) according to a published schedule with optional supporting justification.",
@@ -29915,7 +30930,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["forecastStatus"]
+      "required": [
+        "forecastStatus"
+      ]
     },
     "ImmunizationRecommendation_DateCriterion": {
       "description": "A patient\u0027s point-in-time set of recommendations (i.e. forecasting) according to a published schedule with optional supporting justification.",
@@ -29952,7 +30969,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code"]
+      "required": [
+        "code"
+      ]
     },
     "ImplementationGuide": {
       "description": "A set of rules of how a particular interoperability or standards problem is solved - typically through the use of FHIR resources. This resource is used to gather all the parts of an implementation guide into a logical whole and to publish a computable definition of all the parts.",
@@ -30044,7 +31063,12 @@
         },
         "status": {
           "description": "The status of this implementation guide. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -30535,7 +31559,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "ImplementationGuide_DependsOn": {
       "description": "A set of rules of how a particular interoperability or standards problem is solved - typically through the use of FHIR resources. This resource is used to gather all the parts of an implementation guide into a logical whole and to publish a computable definition of all the parts.",
@@ -30580,7 +31606,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["uri"]
+      "required": [
+        "uri"
+      ]
     },
     "ImplementationGuide_Global": {
       "description": "A set of rules of how a particular interoperability or standards problem is solved - typically through the use of FHIR resources. This resource is used to gather all the parts of an implementation guide into a logical whole and to publish a computable definition of all the parts.",
@@ -30617,7 +31645,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["profile"]
+      "required": [
+        "profile"
+      ]
     },
     "ImplementationGuide_Definition": {
       "description": "A set of rules of how a particular interoperability or standards problem is solved - typically through the use of FHIR resources. This resource is used to gather all the parts of an implementation guide into a logical whole and to publish a computable definition of all the parts.",
@@ -30674,7 +31704,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resource"]
+      "required": [
+        "resource"
+      ]
     },
     "ImplementationGuide_Grouping": {
       "description": "A set of rules of how a particular interoperability or standards problem is solved - typically through the use of FHIR resources. This resource is used to gather all the parts of an implementation guide into a logical whole and to publish a computable definition of all the parts.",
@@ -30822,7 +31854,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["reference"]
+      "required": [
+        "reference"
+      ]
     },
     "ImplementationGuide_Page": {
       "description": "A set of rules of how a particular interoperability or standards problem is solved - typically through the use of FHIR resources. This resource is used to gather all the parts of an implementation guide into a logical whole and to publish a computable definition of all the parts.",
@@ -30868,7 +31902,12 @@
         },
         "generation": {
           "description": "A code that indicates how the page is generated.",
-          "enum": ["html", "markdown", "xml", "generated"]
+          "enum": [
+            "html",
+            "markdown",
+            "xml",
+            "generated"
+          ]
         },
         "_generation": {
           "description": "Extensions for generation",
@@ -31056,7 +32095,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resource"]
+      "required": [
+        "resource"
+      ]
     },
     "ImplementationGuide_Resource1": {
       "description": "A set of rules of how a particular interoperability or standards problem is solved - typically through the use of FHIR resources. This resource is used to gather all the parts of an implementation guide into a logical whole and to publish a computable definition of all the parts.",
@@ -31111,7 +32152,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["reference"]
+      "required": [
+        "reference"
+      ]
     },
     "ImplementationGuide_Page1": {
       "description": "A set of rules of how a particular interoperability or standards problem is solved - typically through the use of FHIR resources. This resource is used to gather all the parts of an implementation guide into a logical whole and to publish a computable definition of all the parts.",
@@ -31232,7 +32275,12 @@
         },
         "status": {
           "description": "The current state of the health insurance product.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -31323,7 +32371,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "InsurancePlan_Contact": {
       "description": "Details of a Health Insurance product/plan provided by an organization.",
@@ -31409,7 +32459,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type", "benefit"]
+      "required": [
+        "type",
+        "benefit"
+      ]
     },
     "InsurancePlan_Benefit": {
       "description": "Details of a Health Insurance product/plan provided by an organization.",
@@ -31453,7 +32506,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "InsurancePlan_Limit": {
       "description": "Details of a Health Insurance product/plan provided by an organization.",
@@ -31632,7 +32687,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["category"]
+      "required": [
+        "category"
+      ]
     },
     "InsurancePlan_Benefit1": {
       "description": "Details of a Health Insurance product/plan provided by an organization.",
@@ -31668,7 +32725,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "InsurancePlan_Cost": {
       "description": "Details of a Health Insurance product/plan provided by an organization.",
@@ -31712,7 +32771,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "Invoice": {
       "description": "Invoice containing collected ChargeItems from an Account with calculated individual and total price for Billing purpose.",
@@ -31779,7 +32840,13 @@
         },
         "status": {
           "description": "The current state of the Invoice.",
-          "enum": ["draft", "issued", "balanced", "cancelled", "entered-in-error"]
+          "enum": [
+            "draft",
+            "issued",
+            "balanced",
+            "cancelled",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -31867,7 +32934,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Invoice_Participant": {
       "description": "Invoice containing collected ChargeItems from an Account with calculated individual and total price for Billing purpose.",
@@ -31900,7 +32969,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["actor"]
+      "required": [
+        "actor"
+      ]
     },
     "Invoice_LineItem": {
       "description": "Invoice containing collected ChargeItems from an Account with calculated individual and total price for Billing purpose.",
@@ -31972,7 +33043,14 @@
         },
         "type": {
           "description": "This code identifies the type of the component.",
-          "enum": ["base", "surcharge", "deduction", "discount", "tax", "informational"]
+          "enum": [
+            "base",
+            "surcharge",
+            "deduction",
+            "discount",
+            "tax",
+            "informational"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -32102,7 +33180,12 @@
         },
         "status": {
           "description": "The status of this library. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -32282,7 +33365,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type", "resourceType"]
+      "required": [
+        "type",
+        "resourceType"
+      ]
     },
     "Linkage": {
       "description": "Identifies two or more records (resource instances) that refer to the same real-world \"occurrence\".",
@@ -32361,7 +33447,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["item", "resourceType"]
+      "required": [
+        "item",
+        "resourceType"
+      ]
     },
     "Linkage_Item": {
       "description": "Identifies two or more records (resource instances) that refer to the same real-world \"occurrence\".",
@@ -32386,7 +33475,11 @@
         },
         "type": {
           "description": "Distinguishes which item is \"source of truth\" (if any) and which items are no longer considered to be current representations.",
-          "enum": ["source", "alternate", "historical"]
+          "enum": [
+            "source",
+            "alternate",
+            "historical"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -32398,7 +33491,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resource"]
+      "required": [
+        "resource"
+      ]
     },
     "List": {
       "description": "A list is a curated collection of resources.",
@@ -32465,7 +33560,11 @@
         },
         "status": {
           "description": "Indicates the current state of this list.",
-          "enum": ["current", "retired", "entered-in-error"]
+          "enum": [
+            "current",
+            "retired",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -32473,7 +33572,11 @@
         },
         "mode": {
           "description": "How this list was prepared - whether it is a working list that is suitable for being maintained on an ongoing basis, or if it represents a snapshot of a list of items from another source, or whether it is a prepared list where items may be marked as added, modified or deleted.",
-          "enum": ["working", "snapshot", "changes"]
+          "enum": [
+            "working",
+            "snapshot",
+            "changes"
+          ]
         },
         "_mode": {
           "description": "Extensions for mode",
@@ -32535,7 +33638,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "List_Entry": {
       "description": "A list is a curated collection of resources.",
@@ -32584,7 +33689,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["item"]
+      "required": [
+        "item"
+      ]
     },
     "Location": {
       "description": "Details and position information for a physical place where services are provided and resources and participants may be stored, found, contained, or accommodated.",
@@ -32651,7 +33758,11 @@
         },
         "status": {
           "description": "The status property covers the general availability of the resource, not the current value which may be covered by the operationStatus, or by a schedule/slots if they are configured for the location.",
-          "enum": ["active", "suspended", "inactive"]
+          "enum": [
+            "active",
+            "suspended",
+            "inactive"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -32693,7 +33804,10 @@
         },
         "mode": {
           "description": "Indicates whether a resource instance represents a specific location or a class of locations.",
-          "enum": ["instance", "kind"]
+          "enum": [
+            "instance",
+            "kind"
+          ]
         },
         "_mode": {
           "description": "Extensions for mode",
@@ -32757,7 +33871,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Location_Position": {
       "description": "Details and position information for a physical place where services are provided and resources and participants may be stored, found, contained, or accommodated.",
@@ -32974,7 +34090,12 @@
         },
         "status": {
           "description": "The status of this measure. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -33231,7 +34352,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Measure_Group": {
       "description": "The Measure resource provides the definition of a quality measure.",
@@ -33322,7 +34445,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["criteria"]
+      "required": [
+        "criteria"
+      ]
     },
     "Measure_Stratifier": {
       "description": "The Measure resource provides the definition of a quality measure.",
@@ -33410,7 +34535,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["criteria"]
+      "required": [
+        "criteria"
+      ]
     },
     "Measure_SupplementalData": {
       "description": "The Measure resource provides the definition of a quality measure.",
@@ -33458,7 +34585,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["criteria"]
+      "required": [
+        "criteria"
+      ]
     },
     "MeasureReport": {
       "description": "The MeasureReport resource contains the results of the calculation of a measure; and optionally a reference to the resources involved in that calculation.",
@@ -33525,7 +34654,11 @@
         },
         "status": {
           "description": "The MeasureReport status. No data will be available until the MeasureReport status is complete.",
-          "enum": ["complete", "pending", "error"]
+          "enum": [
+            "complete",
+            "pending",
+            "error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -33533,7 +34666,12 @@
         },
         "type": {
           "description": "The type of measure report. This may be an individual report, which provides the score for the measure for an individual member of the population; a subject-listing, which returns the list of members that meet the various criteria in the measure; a summary report, which returns a population count for each of the criteria in the measure; or a data-collection, which enables the MeasureReport to be used to exchange the data-of-interest for a quality measure.",
-          "enum": ["individual", "subject-list", "summary", "data-collection"]
+          "enum": [
+            "individual",
+            "subject-list",
+            "summary",
+            "data-collection"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -33583,7 +34721,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["period", "measure", "resourceType"]
+      "required": [
+        "period",
+        "measure",
+        "resourceType"
+      ]
     },
     "MeasureReport_Group": {
       "description": "The MeasureReport resource contains the results of the calculation of a measure; and optionally a reference to the resources involved in that calculation.",
@@ -33786,7 +34928,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code", "value"]
+      "required": [
+        "code",
+        "value"
+      ]
     },
     "MeasureReport_Population1": {
       "description": "The MeasureReport resource contains the results of the calculation of a measure; and optionally a reference to the resources involved in that calculation.",
@@ -34026,7 +35171,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["content", "resourceType"]
+      "required": [
+        "content",
+        "resourceType"
+      ]
     },
     "Medication": {
       "description": "This resource is primarily used for the identification and definition of a medication for the purposes of prescribing, dispensing, and administering a medication as well as for making statements about medication use.",
@@ -34128,7 +35276,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Medication_Ingredient": {
       "description": "This resource is primarily used for the identification and definition of a medication for the purposes of prescribing, dispensing, and administering a medication as well as for making statements about medication use.",
@@ -34405,7 +35555,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["subject", "resourceType"]
+      "required": [
+        "subject",
+        "resourceType"
+      ]
     },
     "MedicationAdministration_Performer": {
       "description": "Describes the event of a patient consuming or otherwise being administered a medication.  This may be as simple as swallowing a tablet or it may be a long running infusion.  Related resources tie this event to the authorizing prescription, and the specific encounter between patient and health care practitioner.",
@@ -34438,7 +35591,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["actor"]
+      "required": [
+        "actor"
+      ]
     },
     "MedicationAdministration_Dosage": {
       "description": "Describes the event of a patient consuming or otherwise being administered a medication.  This may be as simple as swallowing a tablet or it may be a long running infusion.  Related resources tie this event to the authorizing prescription, and the specific encounter between patient and health care practitioner.",
@@ -34700,7 +35855,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "MedicationDispense_Performer": {
       "description": "Indicates that a medication product is to be or has been dispensed for a named person/patient.  This includes a description of the medication product (supply) provided and the instructions for administering the medication.  The medication dispense is the result of a pharmacy system responding to a medication order.",
@@ -34733,7 +35890,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["actor"]
+      "required": [
+        "actor"
+      ]
     },
     "MedicationDispense_Substitution": {
       "description": "Indicates that a medication product is to be or has been dispensed for a named person/patient.  This includes a description of the medication product (supply) provided and the instructions for administering the medication.  The medication dispense is the result of a pharmacy system responding to a medication order.",
@@ -34991,7 +36150,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "MedicationKnowledge_RelatedMedicationKnowledge": {
       "description": "Information about a medication that is used to support knowledge.",
@@ -35027,7 +36188,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["reference", "type"]
+      "required": [
+        "reference",
+        "type"
+      ]
     },
     "MedicationKnowledge_Monograph": {
       "description": "Information about a medication that is used to support knowledge.",
@@ -35144,7 +36308,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["cost", "type"]
+      "required": [
+        "cost",
+        "type"
+      ]
     },
     "MedicationKnowledge_MonitoringProgram": {
       "description": "Information about a medication that is used to support knowledge.",
@@ -35262,7 +36429,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["dosage", "type"]
+      "required": [
+        "dosage",
+        "type"
+      ]
     },
     "MedicationKnowledge_PatientCharacteristics": {
       "description": "Information about a medication that is used to support knowledge.",
@@ -35344,7 +36514,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "MedicationKnowledge_Packaging": {
       "description": "Information about a medication that is used to support knowledge.",
@@ -35477,7 +36649,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["regulatoryAuthority"]
+      "required": [
+        "regulatoryAuthority"
+      ]
     },
     "MedicationKnowledge_Substitution": {
       "description": "Information about a medication that is used to support knowledge.",
@@ -35514,7 +36688,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "MedicationKnowledge_Schedule": {
       "description": "Information about a medication that is used to support knowledge.",
@@ -35543,7 +36719,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["schedule"]
+      "required": [
+        "schedule"
+      ]
     },
     "MedicationKnowledge_MaxDispense": {
       "description": "Information about a medication that is used to support knowledge.",
@@ -35576,7 +36754,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["quantity"]
+      "required": [
+        "quantity"
+      ]
     },
     "MedicationKnowledge_Kinetics": {
       "description": "Information about a medication that is used to support knowledge.",
@@ -35892,7 +37072,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["subject", "resourceType"]
+      "required": [
+        "subject",
+        "resourceType"
+      ]
     },
     "MedicationRequest_DispenseRequest": {
       "description": "An order or request for both supply of the medication and the instructions for administration of the medication to a patient. The resource is called \"MedicationRequest\" rather than \"MedicationPrescription\" or \"MedicationOrder\" to generalize the use across inpatient and outpatient settings, including care plans, etc., and to harmonize with workflow patterns.",
@@ -36197,7 +37380,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["subject", "resourceType"]
+      "required": [
+        "subject",
+        "resourceType"
+      ]
     },
     "MedicinalProduct": {
       "description": "Detailed definition of a medicinal product, typically for uses other than direct patient care (e.g. regulatory use).",
@@ -36386,7 +37572,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name", "resourceType"]
+      "required": [
+        "name",
+        "resourceType"
+      ]
     },
     "MedicinalProduct_Name": {
       "description": "Detailed definition of a medicinal product, typically for uses other than direct patient care (e.g. regulatory use).",
@@ -36469,7 +37658,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "MedicinalProduct_CountryLanguage": {
       "description": "Detailed definition of a medicinal product, typically for uses other than direct patient care (e.g. regulatory use).",
@@ -36506,7 +37697,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["country", "language"]
+      "required": [
+        "country",
+        "language"
+      ]
     },
     "MedicinalProduct_ManufacturingBusinessOperation": {
       "description": "Detailed definition of a medicinal product, typically for uses other than direct patient care (e.g. regulatory use).",
@@ -36776,7 +37970,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "MedicinalProductAuthorization_JurisdictionalAuthorization": {
       "description": "The regulatory authorization of a medicinal product.",
@@ -36879,7 +38075,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "MedicinalProductContraindication": {
       "description": "The clinical particulars - indications, contraindications etc. of a medicinal product, including for regulatory purposes.",
@@ -36982,7 +38180,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "MedicinalProductContraindication_OtherTherapy": {
       "description": "The clinical particulars - indications, contraindications etc. of a medicinal product, including for regulatory purposes.",
@@ -37019,7 +38219,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["therapyRelationshipType"]
+      "required": [
+        "therapyRelationshipType"
+      ]
     },
     "MedicinalProductIndication": {
       "description": "Indication for the Medicinal Product.",
@@ -37130,7 +38332,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "MedicinalProductIndication_OtherTherapy": {
       "description": "Indication for the Medicinal Product.",
@@ -37167,7 +38371,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["therapyRelationshipType"]
+      "required": [
+        "therapyRelationshipType"
+      ]
     },
     "MedicinalProductIngredient": {
       "description": "An ingredient of a manufactured item or pharmaceutical product.",
@@ -37261,7 +38467,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["role", "resourceType"]
+      "required": [
+        "role",
+        "resourceType"
+      ]
     },
     "MedicinalProductIngredient_SpecifiedSubstance": {
       "description": "An ingredient of a manufactured item or pharmaceutical product.",
@@ -37305,7 +38514,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code", "group"]
+      "required": [
+        "code",
+        "group"
+      ]
     },
     "MedicinalProductIngredient_Strength": {
       "description": "An ingredient of a manufactured item or pharmaceutical product.",
@@ -37368,7 +38580,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["presentation"]
+      "required": [
+        "presentation"
+      ]
     },
     "MedicinalProductIngredient_ReferenceStrength": {
       "description": "An ingredient of a manufactured item or pharmaceutical product.",
@@ -37420,7 +38634,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["strength"]
+      "required": [
+        "strength"
+      ]
     },
     "MedicinalProductIngredient_Substance": {
       "description": "An ingredient of a manufactured item or pharmaceutical product.",
@@ -37456,7 +38672,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code"]
+      "required": [
+        "code"
+      ]
     },
     "MedicinalProductInteraction": {
       "description": "The interactions of the medicinal product with other medicinal products, or other forms of interactions.",
@@ -37554,7 +38772,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "MedicinalProductInteraction_Interactant": {
       "description": "The interactions of the medicinal product with other medicinal products, or other forms of interactions.",
@@ -37683,7 +38903,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["quantity", "manufacturedDoseForm", "resourceType"]
+      "required": [
+        "quantity",
+        "manufacturedDoseForm",
+        "resourceType"
+      ]
     },
     "MedicinalProductPackaged": {
       "description": "A medicinal product in a container or package.",
@@ -37801,7 +39025,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["packageItem", "resourceType"]
+      "required": [
+        "packageItem",
+        "resourceType"
+      ]
     },
     "MedicinalProductPackaged_BatchIdentifier": {
       "description": "A medicinal product in a container or package.",
@@ -37834,7 +39061,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["outerPackaging"]
+      "required": [
+        "outerPackaging"
+      ]
     },
     "MedicinalProductPackaged_PackageItem": {
       "description": "A medicinal product in a container or package.",
@@ -37934,7 +39163,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["quantity", "type"]
+      "required": [
+        "quantity",
+        "type"
+      ]
     },
     "MedicinalProductPharmaceutical": {
       "description": "A pharmaceutical product described in terms of its composition and dose form.",
@@ -38037,7 +39269,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["administrableDoseForm", "routeOfAdministration", "resourceType"]
+      "required": [
+        "administrableDoseForm",
+        "routeOfAdministration",
+        "resourceType"
+      ]
     },
     "MedicinalProductPharmaceutical_Characteristics": {
       "description": "A pharmaceutical product described in terms of its composition and dose form.",
@@ -38070,7 +39306,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code"]
+      "required": [
+        "code"
+      ]
     },
     "MedicinalProductPharmaceutical_RouteOfAdministration": {
       "description": "A pharmaceutical product described in terms of its composition and dose form.",
@@ -38126,7 +39364,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code"]
+      "required": [
+        "code"
+      ]
     },
     "MedicinalProductPharmaceutical_TargetSpecies": {
       "description": "A pharmaceutical product described in terms of its composition and dose form.",
@@ -38162,7 +39402,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code"]
+      "required": [
+        "code"
+      ]
     },
     "MedicinalProductPharmaceutical_WithdrawalPeriod": {
       "description": "A pharmaceutical product described in terms of its composition and dose form.",
@@ -38203,7 +39445,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["tissue", "value"]
+      "required": [
+        "tissue",
+        "value"
+      ]
     },
     "MedicinalProductUndesirableEffect": {
       "description": "Describe the undesirable effects of the medicinal product.",
@@ -38289,7 +39534,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "MessageDefinition": {
       "description": "Defines the characteristics of a message that can be shared between systems, including the type of event that initiates the message, the content to be transmitted and what response(s), if any, are permitted.",
@@ -38395,7 +39642,12 @@
         },
         "status": {
           "description": "The status of this message definition. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -38496,7 +39748,11 @@
         },
         "category": {
           "description": "The impact of the content of the message.",
-          "enum": ["consequence", "currency", "notification"]
+          "enum": [
+            "consequence",
+            "currency",
+            "notification"
+          ]
         },
         "_category": {
           "description": "Extensions for category",
@@ -38511,7 +39767,12 @@
         },
         "responseRequired": {
           "description": "Declare at a message definition level whether a response is required or only upon error or success, or never.",
-          "enum": ["always", "on-error", "never", "on-success"]
+          "enum": [
+            "always",
+            "on-error",
+            "never",
+            "on-success"
+          ]
         },
         "_responseRequired": {
           "description": "Extensions for responseRequired",
@@ -38533,7 +39794,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "MessageDefinition_Focus": {
       "description": "Defines the characteristics of a message that can be shared between systems, including the type of event that initiates the message, the content to be transmitted and what response(s), if any, are permitted.",
@@ -38622,7 +39885,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["message"]
+      "required": [
+        "message"
+      ]
     },
     "MessageHeader": {
       "description": "The header for a message exchange that is either requesting or responding to an action.  The reference(s) that are the subject of the action as well as other information related to the action are typically transmitted in a bundle in which the MessageHeader resource instance is the first resource in the bundle.",
@@ -38741,7 +40006,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["source", "resourceType"]
+      "required": [
+        "source",
+        "resourceType"
+      ]
     },
     "MessageHeader_Destination": {
       "description": "The header for a message exchange that is either requesting or responding to an action.  The reference(s) that are the subject of the action as well as other information related to the action are typically transmitted in a bundle in which the MessageHeader resource instance is the first resource in the bundle.",
@@ -38882,7 +40150,11 @@
         },
         "code": {
           "description": "Code that identifies the type of response to the message - whether it was successful or not, and whether it should be resent or not.",
-          "enum": ["ok", "transient-error", "fatal-error"]
+          "enum": [
+            "ok",
+            "transient-error",
+            "fatal-error"
+          ]
         },
         "_code": {
           "description": "Extensions for code",
@@ -38960,7 +40232,11 @@
         },
         "type": {
           "description": "Amino Acid Sequence/ DNA Sequence / RNA Sequence.",
-          "enum": ["aa", "dna", "rna"]
+          "enum": [
+            "aa",
+            "dna",
+            "rna"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -39051,7 +40327,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "MolecularSequence_ReferenceSeq": {
       "description": "Raw data describing a biological sequence.",
@@ -39088,7 +40366,10 @@
         },
         "orientation": {
           "description": "A relative reference to a DNA strand based on gene orientation. The strand that contains the open reading frame of the gene is the \"sense\" strand, and the opposite complementary strand is the \"antisense\" strand.",
-          "enum": ["sense", "antisense"]
+          "enum": [
+            "sense",
+            "antisense"
+          ]
         },
         "_orientation": {
           "description": "Extensions for orientation",
@@ -39112,7 +40393,10 @@
         },
         "strand": {
           "description": "An absolute reference to a strand. The Watson strand is the strand whose 5\u0027-end is on the short arm of the chromosome, and the Crick strand as the one whose 5\u0027-end is on the long arm.",
-          "enum": ["watson", "crick"]
+          "enum": [
+            "watson",
+            "crick"
+          ]
         },
         "_strand": {
           "description": "Extensions for strand",
@@ -39228,7 +40512,11 @@
         },
         "type": {
           "description": "INDEL / SNP / Undefined variant.",
-          "enum": ["indel", "snp", "unknown"]
+          "enum": [
+            "indel",
+            "snp",
+            "unknown"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -39478,7 +40766,13 @@
         },
         "type": {
           "description": "Click and see / RESTful API / Need login to see / RESTful API with authentication / Other ways to see resource.",
-          "enum": ["directlink", "openapi", "login", "oauth", "other"]
+          "enum": [
+            "directlink",
+            "openapi",
+            "login",
+            "oauth",
+            "other"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -39725,7 +41019,12 @@
         },
         "status": {
           "description": "The status of this naming system. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -39733,7 +41032,11 @@
         },
         "kind": {
           "description": "Indicates the purpose for the naming system - what kinds of things does it make unique?",
-          "enum": ["codesystem", "identifier", "root"]
+          "enum": [
+            "codesystem",
+            "identifier",
+            "root"
+          ]
         },
         "_kind": {
           "description": "Extensions for kind",
@@ -39813,7 +41116,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["uniqueId", "resourceType"]
+      "required": [
+        "uniqueId",
+        "resourceType"
+      ]
     },
     "NamingSystem_UniqueId": {
       "description": "A curated namespace that issues unique symbols within that namespace for the identification of concepts, people, devices, etc.  Represents a \"System\" used within the Identifier and Coding data types.",
@@ -39838,7 +41144,12 @@
         },
         "type": {
           "description": "Identifies the unique identifier scheme used for this particular identifier.",
-          "enum": ["oid", "uuid", "uri", "other"]
+          "enum": [
+            "oid",
+            "uuid",
+            "uri",
+            "other"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -40054,7 +41365,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["patient", "resourceType"]
+      "required": [
+        "patient",
+        "resourceType"
+      ]
     },
     "NutritionOrder_OralDiet": {
       "description": "A request to supply a diet, formula feeding (enteral) or oral nutritional supplement to a patient/resident.",
@@ -40651,7 +41965,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code", "resourceType"]
+      "required": [
+        "code",
+        "resourceType"
+      ]
     },
     "Observation_ReferenceRange": {
       "description": "Measurements and simple assertions made about a patient, device or other subject.",
@@ -40822,7 +42139,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code"]
+      "required": [
+        "code"
+      ]
     },
     "ObservationDefinition": {
       "description": "Set of definitional characteristics for a kind of observation or measurement produced or consumed by an orderable health care service.",
@@ -40977,7 +42296,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code", "resourceType"]
+      "required": [
+        "code",
+        "resourceType"
+      ]
     },
     "ObservationDefinition_QuantitativeDetails": {
       "description": "Set of definitional characteristics for a kind of observation or measurement produced or consumed by an orderable health care service.",
@@ -41050,7 +42372,11 @@
         },
         "category": {
           "description": "The category of interval of values for continuous or ordinal observations conforming to this ObservationDefinition.",
-          "enum": ["reference", "critical", "absolute"]
+          "enum": [
+            "reference",
+            "critical",
+            "absolute"
+          ]
         },
         "_category": {
           "description": "Extensions for category",
@@ -41073,7 +42399,12 @@
         },
         "gender": {
           "description": "Sex of the population the range applies to.",
-          "enum": ["male", "female", "other", "unknown"]
+          "enum": [
+            "male",
+            "female",
+            "other",
+            "unknown"
+          ]
         },
         "_gender": {
           "description": "Extensions for gender",
@@ -41188,7 +42519,12 @@
         },
         "status": {
           "description": "The status of this operation definition. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -41196,7 +42532,10 @@
         },
         "kind": {
           "description": "Whether this is an operation or a named query.",
-          "enum": ["operation", "query"]
+          "enum": [
+            "operation",
+            "query"
+          ]
         },
         "_kind": {
           "description": "Extensions for kind",
@@ -41353,7 +42692,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "OperationDefinition_Parameter": {
       "description": "A formal computable definition of an operation (on the RESTful interface) or a named query (using the search interaction).",
@@ -41386,7 +42727,10 @@
         },
         "use": {
           "description": "Whether this is an input or an output parameter.",
-          "enum": ["in", "out"]
+          "enum": [
+            "in",
+            "out"
+          ]
         },
         "_use": {
           "description": "Extensions for use",
@@ -41433,7 +42777,17 @@
         },
         "searchType": {
           "description": "How the parameter is understood as a search parameter. This is only used if the parameter type is \u0027string\u0027.",
-          "enum": ["number", "date", "string", "token", "reference", "composite", "quantity", "uri", "special"]
+          "enum": [
+            "number",
+            "date",
+            "string",
+            "token",
+            "reference",
+            "composite",
+            "quantity",
+            "uri",
+            "special"
+          ]
         },
         "_searchType": {
           "description": "Extensions for searchType",
@@ -41483,7 +42837,12 @@
         },
         "strength": {
           "description": "Indicates the degree of conformance expectations associated with this binding - that is, the degree to which the provided value set must be adhered to in the instances.",
-          "enum": ["required", "extensible", "preferred", "example"]
+          "enum": [
+            "required",
+            "extensible",
+            "preferred",
+            "example"
+          ]
         },
         "_strength": {
           "description": "Extensions for strength",
@@ -41495,7 +42854,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["valueSet"]
+      "required": [
+        "valueSet"
+      ]
     },
     "OperationDefinition_ReferencedFrom": {
       "description": "A formal computable definition of an operation (on the RESTful interface) or a named query (using the search interaction).",
@@ -41656,7 +43017,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["issue", "resourceType"]
+      "required": [
+        "issue",
+        "resourceType"
+      ]
     },
     "OperationOutcome_Issue": {
       "description": "A collection of error, warning, or information messages that result from a system action.",
@@ -41681,7 +43045,12 @@
         },
         "severity": {
           "description": "Indicates whether the issue indicates a variation from successful processing.",
-          "enum": ["fatal", "error", "warning", "information"]
+          "enum": [
+            "fatal",
+            "error",
+            "warning",
+            "information"
+          ]
         },
         "_severity": {
           "description": "Extensions for severity",
@@ -41904,7 +43273,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Organization_Contact": {
       "description": "A formally or informally recognized grouping of people or organizations formed for the purpose of achieving some form of collective action.  Includes companies, institutions, corporations, departments, community groups, healthcare practice groups, payer/insurer, etc.",
@@ -42083,7 +43454,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Parameters": {
       "description": "This resource is a non-persisted resource used to pass information into and back from an [operation](operations.html). It has no other use, and there is no RESTful endpoint associated with it.",
@@ -42125,7 +43498,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Parameters_Parameter": {
       "description": "This resource is a non-persisted resource used to pass information into and back from an [operation](operations.html). It has no other use, and there is no RESTful endpoint associated with it.",
@@ -42552,7 +43927,12 @@
         },
         "gender": {
           "description": "Administrative Gender - the gender that the patient is considered to have for administration and record keeping purposes.",
-          "enum": ["male", "female", "other", "unknown"]
+          "enum": [
+            "male",
+            "female",
+            "other",
+            "unknown"
+          ]
         },
         "_gender": {
           "description": "Extensions for gender",
@@ -42654,7 +44034,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Patient_Contact": {
       "description": "Demographics and other administrative information about an individual or animal receiving care or other health-related services.",
@@ -42701,7 +44083,12 @@
         },
         "gender": {
           "description": "Administrative Gender - the gender that the contact person is considered to have for administration and record keeping purposes.",
-          "enum": ["male", "female", "other", "unknown"]
+          "enum": [
+            "male",
+            "female",
+            "other",
+            "unknown"
+          ]
         },
         "_gender": {
           "description": "Extensions for gender",
@@ -42753,7 +44140,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["language"]
+      "required": [
+        "language"
+      ]
     },
     "Patient_Link": {
       "description": "Demographics and other administrative information about an individual or animal receiving care or other health-related services.",
@@ -42782,7 +44171,12 @@
         },
         "type": {
           "description": "The type of link between this patient resource and another patient resource.",
-          "enum": ["replaced-by", "replaces", "refer", "seealso"]
+          "enum": [
+            "replaced-by",
+            "replaces",
+            "refer",
+            "seealso"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -42790,7 +44184,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["other"]
+      "required": [
+        "other"
+      ]
     },
     "PaymentNotice": {
       "description": "This resource provides the status of the payment for goods and services rendered, and the request and response resource references.",
@@ -42913,7 +44309,12 @@
         }
       },
       "additionalProperties": false,
-      "required": ["amount", "recipient", "payment", "resourceType"]
+      "required": [
+        "amount",
+        "recipient",
+        "payment",
+        "resourceType"
+      ]
     },
     "PaymentReconciliation": {
       "description": "This resource provides the details including amount of a payment and allocates the payment items being paid.",
@@ -43012,7 +44413,12 @@
         },
         "outcome": {
           "description": "The outcome of a request for a reconciliation.",
-          "enum": ["queued", "complete", "error", "partial"]
+          "enum": [
+            "queued",
+            "complete",
+            "error",
+            "partial"
+          ]
         },
         "_outcome": {
           "description": "Extensions for outcome",
@@ -43062,7 +44468,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["paymentAmount", "resourceType"]
+      "required": [
+        "paymentAmount",
+        "resourceType"
+      ]
     },
     "PaymentReconciliation_Detail": {
       "description": "This resource provides the details including amount of a payment and allocates the payment items being paid.",
@@ -43131,7 +44540,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "PaymentReconciliation_ProcessNote": {
       "description": "This resource provides the details including amount of a payment and allocates the payment items being paid.",
@@ -43156,7 +44567,11 @@
         },
         "type": {
           "description": "The business purpose of the note text.",
-          "enum": ["display", "print", "printoper"]
+          "enum": [
+            "display",
+            "print",
+            "printoper"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -43252,7 +44667,12 @@
         },
         "gender": {
           "description": "Administrative Gender.",
-          "enum": ["male", "female", "other", "unknown"]
+          "enum": [
+            "male",
+            "female",
+            "other",
+            "unknown"
+          ]
         },
         "_gender": {
           "description": "Extensions for gender",
@@ -43298,7 +44718,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Person_Link": {
       "description": "Demographics and administrative information about a person independent of a specific health-related context.",
@@ -43327,7 +44749,12 @@
         },
         "assurance": {
           "description": "Level of assurance that this link is associated with the target resource.",
-          "enum": ["level1", "level2", "level3", "level4"]
+          "enum": [
+            "level1",
+            "level2",
+            "level3",
+            "level4"
+          ]
         },
         "_assurance": {
           "description": "Extensions for assurance",
@@ -43335,7 +44762,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["target"]
+      "required": [
+        "target"
+      ]
     },
     "PlanDefinition": {
       "description": "This resource allows for the definition of various types of plans as a sharable, consumable, and executable artifact. The resource is general enough to support the description of a broad range of clinical artifacts such as clinical decision support rules, order sets and protocols.",
@@ -43446,7 +44875,12 @@
         },
         "status": {
           "description": "The status of this plan definition. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -43622,7 +45056,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "PlanDefinition_Goal": {
       "description": "This resource allows for the definition of various types of plans as a sharable, consumable, and executable artifact. The resource is general enough to support the description of a broad range of clinical artifacts such as clinical decision support rules, order sets and protocols.",
@@ -43684,7 +45120,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["description"]
+      "required": [
+        "description"
+      ]
     },
     "PlanDefinition_Target": {
       "description": "This resource allows for the definition of various types of plans as a sharable, consumable, and executable artifact. The resource is general enough to support the description of a broad range of clinical artifacts such as clinical decision support rules, order sets and protocols.",
@@ -43911,7 +45349,11 @@
         },
         "groupingBehavior": {
           "description": "Defines the grouping behavior for the action and its children.",
-          "enum": ["visual-group", "logical-group", "sentence-group"]
+          "enum": [
+            "visual-group",
+            "logical-group",
+            "sentence-group"
+          ]
         },
         "_groupingBehavior": {
           "description": "Extensions for groupingBehavior",
@@ -43919,7 +45361,14 @@
         },
         "selectionBehavior": {
           "description": "Defines the selection behavior for the action and its children.",
-          "enum": ["any", "all", "all-or-none", "exactly-one", "at-most-one", "one-or-more"]
+          "enum": [
+            "any",
+            "all",
+            "all-or-none",
+            "exactly-one",
+            "at-most-one",
+            "one-or-more"
+          ]
         },
         "_selectionBehavior": {
           "description": "Extensions for selectionBehavior",
@@ -43927,7 +45376,11 @@
         },
         "requiredBehavior": {
           "description": "Defines the required behavior for the action.",
-          "enum": ["must", "could", "must-unless-documented"]
+          "enum": [
+            "must",
+            "could",
+            "must-unless-documented"
+          ]
         },
         "_requiredBehavior": {
           "description": "Extensions for requiredBehavior",
@@ -43935,7 +45388,10 @@
         },
         "precheckBehavior": {
           "description": "Defines whether the action should usually be preselected.",
-          "enum": ["yes", "no"]
+          "enum": [
+            "yes",
+            "no"
+          ]
         },
         "_precheckBehavior": {
           "description": "Extensions for precheckBehavior",
@@ -43943,7 +45399,10 @@
         },
         "cardinalityBehavior": {
           "description": "Defines whether the action can be selected multiple times.",
-          "enum": ["single", "multiple"]
+          "enum": [
+            "single",
+            "multiple"
+          ]
         },
         "_cardinalityBehavior": {
           "description": "Extensions for cardinalityBehavior",
@@ -44011,7 +45470,11 @@
         },
         "kind": {
           "description": "The kind of condition.",
-          "enum": ["applicability", "start", "stop"]
+          "enum": [
+            "applicability",
+            "start",
+            "stop"
+          ]
         },
         "_kind": {
           "description": "Extensions for kind",
@@ -44105,7 +45568,12 @@
         },
         "type": {
           "description": "The type of participant in the action.",
-          "enum": ["patient", "practitioner", "related-person", "device"]
+          "enum": [
+            "patient",
+            "practitioner",
+            "related-person",
+            "device"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -44248,7 +45716,12 @@
         },
         "gender": {
           "description": "Administrative Gender - the gender that the person is considered to have for administration and record keeping purposes.",
-          "enum": ["male", "female", "other", "unknown"]
+          "enum": [
+            "male",
+            "female",
+            "other",
+            "unknown"
+          ]
         },
         "_gender": {
           "description": "Extensions for gender",
@@ -44285,7 +45758,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Practitioner_Qualification": {
       "description": "A person who is directly or indirectly involved in the provisioning of healthcare.",
@@ -44329,7 +45804,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code"]
+      "required": [
+        "code"
+      ]
     },
     "PractitionerRole": {
       "description": "A specific set of Roles/Locations/specialties/services that a practitioner may perform at an organization for a period of time.",
@@ -44480,7 +45957,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "PractitionerRole_AvailableTime": {
       "description": "A specific set of Roles/Locations/specialties/services that a practitioner may perform at an organization for a period of time.",
@@ -44838,7 +46317,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["subject", "resourceType"]
+      "required": [
+        "subject",
+        "resourceType"
+      ]
     },
     "Procedure_Performer": {
       "description": "An action that is or was performed on or for a patient. This can be a physical intervention like an operation, or less invasive like long term services, counseling, or hypnotherapy.",
@@ -44875,7 +46357,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["actor"]
+      "required": [
+        "actor"
+      ]
     },
     "Procedure_FocalDevice": {
       "description": "An action that is or was performed on or for a patient. This can be a physical intervention like an operation, or less invasive like long term services, counseling, or hypnotherapy.",
@@ -44908,7 +46392,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["manipulated"]
+      "required": [
+        "manipulated"
+      ]
     },
     "Provenance": {
       "description": "Provenance of a resource is a record that describes entities and processes involved in producing and delivering or otherwise influencing that resource. Provenance provides a critical foundation for assessing authenticity, enabling trust, and allowing reproducibility. Provenance assertions are a form of contextual metadata and can themselves become important records with their own provenance. Provenance statement indicates clinical significance in terms of confidence in authenticity, reliability, and trustworthiness, integrity, and stage in lifecycle (e.g. Document Completion - has the artifact been legally authenticated), all of which may impact security, privacy, and trust policies.",
@@ -45046,7 +46532,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["agent", "resourceType", "target"]
+      "required": [
+        "agent",
+        "resourceType",
+        "target"
+      ]
     },
     "Provenance_Agent": {
       "description": "Provenance of a resource is a record that describes entities and processes involved in producing and delivering or otherwise influencing that resource. Provenance provides a critical foundation for assessing authenticity, enabling trust, and allowing reproducibility. Provenance assertions are a form of contextual metadata and can themselves become important records with their own provenance. Provenance statement indicates clinical significance in terms of confidence in authenticity, reliability, and trustworthiness, integrity, and stage in lifecycle (e.g. Document Completion - has the artifact been legally authenticated), all of which may impact security, privacy, and trust policies.",
@@ -45090,7 +46580,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["who"]
+      "required": [
+        "who"
+      ]
     },
     "Provenance_Entity": {
       "description": "Provenance of a resource is a record that describes entities and processes involved in producing and delivering or otherwise influencing that resource. Provenance provides a critical foundation for assessing authenticity, enabling trust, and allowing reproducibility. Provenance assertions are a form of contextual metadata and can themselves become important records with their own provenance. Provenance statement indicates clinical significance in terms of confidence in authenticity, reliability, and trustworthiness, integrity, and stage in lifecycle (e.g. Document Completion - has the artifact been legally authenticated), all of which may impact security, privacy, and trust policies.",
@@ -45115,7 +46607,13 @@
         },
         "role": {
           "description": "How the entity was used during the activity.",
-          "enum": ["derivation", "revision", "quotation", "source", "removal"]
+          "enum": [
+            "derivation",
+            "revision",
+            "quotation",
+            "source",
+            "removal"
+          ]
         },
         "_role": {
           "description": "Extensions for role",
@@ -45134,7 +46632,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["what"]
+      "required": [
+        "what"
+      ]
     },
     "Questionnaire": {
       "description": "A structured set of questions intended to guide the collection of answers from end-users. Questionnaires provide detailed control over order, presentation, phraseology and grouping to allow coherent, consistent data collection.",
@@ -45240,7 +46740,12 @@
         },
         "status": {
           "description": "The status of this questionnaire. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -45365,7 +46870,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Questionnaire_Item": {
       "description": "A structured set of questions intended to guide the collection of answers from end-users. Questionnaires provide detailed control over order, presentation, phraseology and grouping to allow coherent, consistent data collection.",
@@ -45461,7 +46968,10 @@
         },
         "enableBehavior": {
           "description": "Controls how multiple enableWhen values are interpreted -  whether all or any must be true.",
-          "enum": ["all", "any"]
+          "enum": [
+            "all",
+            "any"
+          ]
         },
         "_enableBehavior": {
           "description": "Extensions for enableBehavior",
@@ -45558,7 +47068,15 @@
         },
         "operator": {
           "description": "Specifies the criteria by which the question is enabled.",
-          "enum": ["exists", "\u003d", "!\u003d", "\u003e", "\u003c", "\u003e\u003d", "\u003c\u003d"]
+          "enum": [
+            "exists",
+            "\u003d",
+            "!\u003d",
+            "\u003e",
+            "\u003c",
+            "\u003e\u003d",
+            "\u003c\u003d"
+          ]
         },
         "_operator": {
           "description": "Extensions for operator",
@@ -45910,7 +47428,13 @@
         },
         "status": {
           "description": "The position of the questionnaire response within its overall lifecycle.",
-          "enum": ["in-progress", "completed", "amended", "entered-in-error", "stopped"]
+          "enum": [
+            "in-progress",
+            "completed",
+            "amended",
+            "entered-in-error",
+            "stopped"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -45949,7 +47473,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "QuestionnaireResponse_Item": {
       "description": "A structured set of questions and their answers. The questions are ordered and grouped into coherent subsets, corresponding to the structure of the grouping of the questionnaire being responded to.",
@@ -46230,7 +47756,12 @@
         },
         "gender": {
           "description": "Administrative Gender - the gender that the person is considered to have for administration and record keeping purposes.",
-          "enum": ["male", "female", "other", "unknown"]
+          "enum": [
+            "male",
+            "female",
+            "other",
+            "unknown"
+          ]
         },
         "_gender": {
           "description": "Extensions for gender",
@@ -46271,7 +47802,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["patient", "resourceType"]
+      "required": [
+        "patient",
+        "resourceType"
+      ]
     },
     "RelatedPerson_Communication": {
       "description": "Information about a person that is involved in the care for a patient, but who is not the target of healthcare, nor has a formal responsibility in the care process.",
@@ -46308,7 +47842,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["language"]
+      "required": [
+        "language"
+      ]
     },
     "RequestGroup": {
       "description": "A group of related requests that can be used to capture intended activities that have inter-dependencies such as \"give this medication after that one\".",
@@ -46497,7 +48033,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "RequestGroup_Action": {
       "description": "A group of related requests that can be used to capture intended activities that have inter-dependencies such as \"give this medication after that one\".",
@@ -46879,7 +48417,12 @@
         },
         "status": {
           "description": "The status of this research definition. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -47071,7 +48614,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType", "population"]
+      "required": [
+        "resourceType",
+        "population"
+      ]
     },
     "ResearchElementDefinition": {
       "description": "The ResearchElementDefinition resource describes a \"PICO\" element that knowledge (evidence, assertion, recommendation) is about.",
@@ -47186,7 +48732,12 @@
         },
         "status": {
           "description": "The status of this research element definition. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -47362,7 +48913,11 @@
         },
         "type": {
           "description": "The type of research element, a population, an exposure, or an outcome.",
-          "enum": ["population", "exposure", "outcome"]
+          "enum": [
+            "population",
+            "exposure",
+            "outcome"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -47370,7 +48925,11 @@
         },
         "variableType": {
           "description": "The type of the outcome (e.g. Dichotomous, Continuous, or Descriptive).",
-          "enum": ["dichotomous", "continuous", "descriptive"]
+          "enum": [
+            "dichotomous",
+            "continuous",
+            "descriptive"
+          ]
         },
         "_variableType": {
           "description": "Extensions for variableType",
@@ -47385,7 +48944,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["characteristic", "resourceType"]
+      "required": [
+        "characteristic",
+        "resourceType"
+      ]
     },
     "ResearchElementDefinition_Characteristic": {
       "description": "The ResearchElementDefinition resource describes a \"PICO\" element that knowledge (evidence, assertion, recommendation) is about.",
@@ -47483,7 +49045,14 @@
         },
         "studyEffectiveGroupMeasure": {
           "description": "Indicates how elements are aggregated within the study effective period.",
-          "enum": ["mean", "median", "mean-of-mean", "mean-of-median", "median-of-mean", "median-of-median"]
+          "enum": [
+            "mean",
+            "median",
+            "mean-of-mean",
+            "mean-of-median",
+            "median-of-mean",
+            "median-of-median"
+          ]
         },
         "_studyEffectiveGroupMeasure": {
           "description": "Extensions for studyEffectiveGroupMeasure",
@@ -47524,7 +49093,14 @@
         },
         "participantEffectiveGroupMeasure": {
           "description": "Indicates how elements are aggregated within the study effective period.",
-          "enum": ["mean", "median", "mean-of-mean", "mean-of-median", "median-of-mean", "median-of-median"]
+          "enum": [
+            "mean",
+            "median",
+            "mean-of-mean",
+            "mean-of-median",
+            "median-of-mean",
+            "median-of-median"
+          ]
         },
         "_participantEffectiveGroupMeasure": {
           "description": "Extensions for participantEffectiveGroupMeasure",
@@ -47756,7 +49332,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "ResearchStudy_Arm": {
       "description": "A process where a researcher or organization plans and then executes a series of steps intended to increase the field of healthcare-related knowledge.  This includes studies of safety, efficacy, comparative effectiveness and other information about medications, devices, therapies and other interventional and investigative techniques.  A ResearchStudy involves the gathering of information about human or animal subjects.",
@@ -47957,7 +49535,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["study", "individual", "resourceType"]
+      "required": [
+        "study",
+        "individual",
+        "resourceType"
+      ]
     },
     "RiskAssessment": {
       "description": "An assessment of the likely outcome(s) for a patient or other subject as well as the likelihood of each outcome.",
@@ -48120,7 +49702,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["subject", "resourceType"]
+      "required": [
+        "subject",
+        "resourceType"
+      ]
     },
     "RiskAssessment_Prediction": {
       "description": "An assessment of the likely outcome(s) for a patient or other subject as well as the likelihood of each outcome.",
@@ -48288,7 +49873,12 @@
         },
         "status": {
           "description": "The status of this risk evidence synthesis. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -48453,7 +50043,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["outcome", "resourceType", "population"]
+      "required": [
+        "outcome",
+        "resourceType",
+        "population"
+      ]
     },
     "RiskEvidenceSynthesis_SampleSize": {
       "description": "The RiskEvidenceSynthesis resource describes the likelihood of an outcome in a population plus exposure state where the risk estimate is derived from a combination of research studies.",
@@ -48826,7 +50420,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["actor", "resourceType"]
+      "required": [
+        "actor",
+        "resourceType"
+      ]
     },
     "SearchParameter": {
       "description": "A search parameter that defines a named search item that can be used to search/filter on a resource.",
@@ -48914,7 +50511,12 @@
         },
         "status": {
           "description": "The status of this search parameter. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -49005,7 +50607,17 @@
         },
         "type": {
           "description": "The type of value that a search parameter may contain, and how the content is interpreted.",
-          "enum": ["number", "date", "string", "token", "reference", "composite", "quantity", "uri", "special"]
+          "enum": [
+            "number",
+            "date",
+            "string",
+            "token",
+            "reference",
+            "composite",
+            "quantity",
+            "uri",
+            "special"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -49029,7 +50641,13 @@
         },
         "xpathUsage": {
           "description": "How the search parameter relates to the set of elements returned by evaluating the xpath query.",
-          "enum": ["normal", "phonetic", "nearby", "distance", "other"]
+          "enum": [
+            "normal",
+            "phonetic",
+            "nearby",
+            "distance",
+            "other"
+          ]
         },
         "_xpathUsage": {
           "description": "Extensions for xpathUsage",
@@ -49068,7 +50686,17 @@
         "comparator": {
           "description": "Comparators supported for the search parameter.",
           "items": {
-            "enum": ["eq", "ne", "gt", "lt", "ge", "le", "sa", "eb", "ap"]
+            "enum": [
+              "eq",
+              "ne",
+              "gt",
+              "lt",
+              "ge",
+              "le",
+              "sa",
+              "eb",
+              "ap"
+            ]
           },
           "type": "array"
         },
@@ -49129,7 +50757,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "SearchParameter_Component": {
       "description": "A search parameter that defines a named search item that can be used to search/filter on a resource.",
@@ -49166,7 +50796,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["definition"]
+      "required": [
+        "definition"
+      ]
     },
     "ServiceRequest": {
       "description": "A record of a request for service such as diagnostic investigations, treatments, or operations to be performed.",
@@ -49473,7 +51105,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["subject", "resourceType"]
+      "required": [
+        "subject",
+        "resourceType"
+      ]
     },
     "Slot": {
       "description": "A slot of time on a schedule that may be available for booking appointments.",
@@ -49569,7 +51204,13 @@
         },
         "status": {
           "description": "busy | free | busy-unavailable | busy-tentative | entered-in-error.",
-          "enum": ["busy", "free", "busy-unavailable", "busy-tentative", "entered-in-error"]
+          "enum": [
+            "busy",
+            "free",
+            "busy-unavailable",
+            "busy-tentative",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -49609,7 +51250,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["schedule", "resourceType"]
+      "required": [
+        "schedule",
+        "resourceType"
+      ]
     },
     "Specimen": {
       "description": "A sample to be used for analysis.",
@@ -49680,7 +51324,12 @@
         },
         "status": {
           "description": "The availability of the specimen.",
-          "enum": ["available", "unavailable", "unsatisfactory", "entered-in-error"]
+          "enum": [
+            "available",
+            "unavailable",
+            "unsatisfactory",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -49750,7 +51399,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Specimen_Collection": {
       "description": "A sample to be used for analysis.",
@@ -50027,7 +51678,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "SpecimenDefinition_TypeTested": {
       "description": "A kind of specimen with associated set of requirements.",
@@ -50064,7 +51717,10 @@
         },
         "preference": {
           "description": "The preference for this type of conditioned specimen.",
-          "enum": ["preferred", "alternate"]
+          "enum": [
+            "preferred",
+            "alternate"
+          ]
         },
         "_preference": {
           "description": "Extensions for preference",
@@ -50352,7 +52008,12 @@
         },
         "status": {
           "description": "The status of this structure definition. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -50474,7 +52135,12 @@
         },
         "kind": {
           "description": "Defines the kind of structure that this definition is describing.",
-          "enum": ["primitive-type", "complex-type", "resource", "logical"]
+          "enum": [
+            "primitive-type",
+            "complex-type",
+            "resource",
+            "logical"
+          ]
         },
         "_kind": {
           "description": "Extensions for kind",
@@ -50523,7 +52189,10 @@
         },
         "derivation": {
           "description": "How the type relates to the baseDefinition.",
-          "enum": ["specialization", "constraint"]
+          "enum": [
+            "specialization",
+            "constraint"
+          ]
         },
         "_derivation": {
           "description": "Extensions for derivation",
@@ -50539,7 +52208,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "StructureDefinition_Mapping": {
       "description": "A definition of a FHIR structure. This resource is used to describe the underlying resources, data types defined in FHIR, and also for describing extensions and constraints on resources and data types.",
@@ -50620,7 +52291,11 @@
         },
         "type": {
           "description": "Defines how to interpret the expression that defines what the context of the extension is.",
-          "enum": ["fhirpath", "element", "extension"]
+          "enum": [
+            "fhirpath",
+            "element",
+            "extension"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -50667,7 +52342,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["element"]
+      "required": [
+        "element"
+      ]
     },
     "StructureDefinition_Differential": {
       "description": "A definition of a FHIR structure. This resource is used to describe the underlying resources, data types defined in FHIR, and also for describing extensions and constraints on resources and data types.",
@@ -50699,7 +52376,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["element"]
+      "required": [
+        "element"
+      ]
     },
     "StructureMap": {
       "description": "A Map of relationships between 2 structures that can be used to transform data.",
@@ -50798,7 +52477,12 @@
         },
         "status": {
           "description": "The status of this structure map. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -50896,7 +52580,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType", "group"]
+      "required": [
+        "resourceType",
+        "group"
+      ]
     },
     "StructureMap_Structure": {
       "description": "A Map of relationships between 2 structures that can be used to transform data.",
@@ -50925,7 +52612,12 @@
         },
         "mode": {
           "description": "How the referenced structure is used in this mapping.",
-          "enum": ["source", "queried", "target", "produced"]
+          "enum": [
+            "source",
+            "queried",
+            "target",
+            "produced"
+          ]
         },
         "_mode": {
           "description": "Extensions for mode",
@@ -50949,7 +52641,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["url"]
+      "required": [
+        "url"
+      ]
     },
     "StructureMap_Group": {
       "description": "A Map of relationships between 2 structures that can be used to transform data.",
@@ -50990,7 +52684,11 @@
         },
         "typeMode": {
           "description": "If this is the default rule set to apply for the source type or this combination of types.",
-          "enum": ["none", "types", "type-and-types"]
+          "enum": [
+            "none",
+            "types",
+            "type-and-types"
+          ]
         },
         "_typeMode": {
           "description": "Extensions for typeMode",
@@ -51020,7 +52718,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["input", "rule"]
+      "required": [
+        "input",
+        "rule"
+      ]
     },
     "StructureMap_Input": {
       "description": "A Map of relationships between 2 structures that can be used to transform data.",
@@ -51061,7 +52762,10 @@
         },
         "mode": {
           "description": "Mode for this instance of data.",
-          "enum": ["source", "target"]
+          "enum": [
+            "source",
+            "target"
+          ]
         },
         "_mode": {
           "description": "Extensions for mode",
@@ -51145,7 +52849,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["source"]
+      "required": [
+        "source"
+      ]
     },
     "StructureMap_Source": {
       "description": "A Map of relationships between 2 structures that can be used to transform data.",
@@ -51505,7 +53211,13 @@
         },
         "listMode": {
           "description": "How to handle the list mode for this element.",
-          "enum": ["first", "not_first", "last", "not_last", "only_one"]
+          "enum": [
+            "first",
+            "not_first",
+            "last",
+            "not_last",
+            "only_one"
+          ]
         },
         "_listMode": {
           "description": "Extensions for listMode",
@@ -51577,7 +53289,10 @@
         },
         "contextType": {
           "description": "How to interpret the context.",
-          "enum": ["type", "variable"]
+          "enum": [
+            "type",
+            "variable"
+          ]
         },
         "_contextType": {
           "description": "Extensions for contextType",
@@ -51602,7 +53317,12 @@
         "listMode": {
           "description": "If field is a list, how to manage the list.",
           "items": {
-            "enum": ["first", "share", "last", "collate"]
+            "enum": [
+              "first",
+              "share",
+              "last",
+              "collate"
+            ]
           },
           "type": "array"
         },
@@ -51830,7 +53550,12 @@
         },
         "status": {
           "description": "The status of the subscription, which marks the server state for managing the subscription.",
-          "enum": ["requested", "active", "error", "off"]
+          "enum": [
+            "requested",
+            "active",
+            "error",
+            "off"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -51881,7 +53606,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["channel", "resourceType"]
+      "required": [
+        "channel",
+        "resourceType"
+      ]
     },
     "Subscription_Channel": {
       "description": "The subscription resource is used to define a push-based subscription from a server to another system. Once a subscription is registered with the server, the server checks every resource that is created or updated, and if the resource matches the given criteria, it sends a message on the defined \"channel\" so that another system can take an appropriate action.",
@@ -51906,7 +53634,13 @@
         },
         "type": {
           "description": "The type of channel to send notifications on.",
-          "enum": ["rest-hook", "websocket", "email", "sms", "message"]
+          "enum": [
+            "rest-hook",
+            "websocket",
+            "email",
+            "sms",
+            "message"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -52010,7 +53744,11 @@
         },
         "status": {
           "description": "A code to indicate if the substance is actively used.",
-          "enum": ["active", "inactive", "entered-in-error"]
+          "enum": [
+            "active",
+            "inactive",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -52051,7 +53789,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["code", "resourceType"]
+      "required": [
+        "code",
+        "resourceType"
+      ]
     },
     "Substance_Instance": {
       "description": "A homogeneous material with a definite composition.",
@@ -52218,7 +53959,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "SubstanceNucleicAcid_Subunit": {
       "description": "Nucleic acids are defined by three distinct elements: the base, sugar and linkage. Individual substance/moiety IDs will be created for each of these elements. The nucleotide sequence will be always entered in the 5’-3’ direction.",
@@ -52491,7 +54234,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "SubstancePolymer_MonomerSet": {
       "description": "Todo.",
@@ -52840,7 +54585,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "SubstanceProtein_Subunit": {
       "description": "A SubstanceProtein is defined as a single unit of a linear amino acid sequence, or a combination of subunits that are either covalently linked or have a defined invariant stoichiometric relationship. This includes all synthetic, recombinant and purified SubstanceProteins of defined sequence, whether the use is therapeutic or prophylactic. This set of elements will be used to describe albumins, coagulation factors, cytokines, growth factors, peptide/SubstanceProtein hormones, enzymes, toxins, toxoids, recombinant vaccines, and immunomodulators.",
@@ -53012,7 +54759,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "SubstanceReferenceInformation_Gene": {
       "description": "Todo.",
@@ -53356,7 +55105,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "SubstanceSourceMaterial_FractionDescription": {
       "description": "Source material shall capture information on the taxonomic and anatomical origins as well as the fraction of a material that can result in or can be modified to form a substance. This set of data elements shall be used to define polymer substances isolated from biological matrices. Taxonomic and anatomical origins shall be described using a controlled vocabulary as required. This information is captured for naturally derived polymers ( . starch) and structurally diverse substances. For Organisms belonging to the Kingdom Plantae the Substance level defines the fresh material of a single species or infraspecies, the Herbal Drug and the Herbal preparation. For Herbal preparations, the fraction information will be captured at the Substance information level and additional information for herbal extracts will be captured at the Specified Substance Group 1 information level. See for further explanation the Substance Class: Structurally Diverse and the herbal annex.",
@@ -53788,7 +55539,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "SubstanceSpecification_Moiety": {
       "description": "The detailed description of a substance, typically at a level beyond what is used for prescribing.",
@@ -54464,7 +56217,12 @@
         },
         "status": {
           "description": "A code specifying the state of the dispense event.",
-          "enum": ["in-progress", "completed", "abandoned", "entered-in-error"]
+          "enum": [
+            "in-progress",
+            "completed",
+            "abandoned",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -54516,7 +56274,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "SupplyDelivery_SuppliedItem": {
       "description": "Record of delivery of what is supplied.",
@@ -54619,7 +56379,15 @@
         },
         "status": {
           "description": "Status of the supply request.",
-          "enum": ["draft", "active", "suspended", "cancelled", "completed", "entered-in-error", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "suspended",
+            "cancelled",
+            "completed",
+            "entered-in-error",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -54716,7 +56484,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["quantity", "resourceType"]
+      "required": [
+        "quantity",
+        "resourceType"
+      ]
     },
     "SupplyRequest_Parameter": {
       "description": "A record of a request for a medication, substance or device used in the healthcare setting.",
@@ -55027,7 +56798,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Task_Restriction": {
       "description": "A task to be performed.",
@@ -55394,7 +57167,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "Task_Output": {
       "description": "A task to be performed.",
@@ -55718,7 +57493,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "TerminologyCapabilities": {
       "description": "A TerminologyCapabilities resource documents a set of capabilities (behaviors) of a FHIR Terminology Server that may be used as a statement of actual server functionality or a statement of required or desired server implementation.",
@@ -55810,7 +57587,12 @@
         },
         "status": {
           "description": "The status of this terminology capabilities. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -55922,7 +57704,10 @@
         },
         "codeSearch": {
           "description": "The degree to which the server supports the code search parameter on ValueSet, if it is supported.",
-          "enum": ["explicit", "all"]
+          "enum": [
+            "explicit",
+            "all"
+          ]
         },
         "_codeSearch": {
           "description": "Extensions for codeSearch",
@@ -55942,7 +57727,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "TerminologyCapabilities_Software": {
       "description": "A TerminologyCapabilities resource documents a set of capabilities (behaviors) of a FHIR Terminology Server that may be used as a statement of actual server functionality or a statement of required or desired server implementation.",
@@ -56465,7 +58252,13 @@
         },
         "status": {
           "description": "The current state of this test report.",
-          "enum": ["completed", "in-progress", "waiting", "stopped", "entered-in-error"]
+          "enum": [
+            "completed",
+            "in-progress",
+            "waiting",
+            "stopped",
+            "entered-in-error"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -56477,7 +58270,11 @@
         },
         "result": {
           "description": "The overall result from the execution of the TestScript.",
-          "enum": ["pass", "fail", "pending"]
+          "enum": [
+            "pass",
+            "fail",
+            "pending"
+          ]
         },
         "_result": {
           "description": "Extensions for result",
@@ -56531,7 +58328,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["testScript", "resourceType"]
+      "required": [
+        "testScript",
+        "resourceType"
+      ]
     },
     "TestReport_Participant": {
       "description": "A summary of information based on the results of executing a TestScript.",
@@ -56556,7 +58356,11 @@
         },
         "type": {
           "description": "The type of participant.",
-          "enum": ["test-engine", "client", "server"]
+          "enum": [
+            "test-engine",
+            "client",
+            "server"
+          ]
         },
         "_type": {
           "description": "Extensions for type",
@@ -56611,7 +58415,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["action"]
+      "required": [
+        "action"
+      ]
     },
     "TestReport_Action": {
       "description": "A summary of information based on the results of executing a TestScript.",
@@ -56668,7 +58474,13 @@
         },
         "result": {
           "description": "The result of this operation.",
-          "enum": ["pass", "skip", "fail", "warning", "error"]
+          "enum": [
+            "pass",
+            "skip",
+            "fail",
+            "warning",
+            "error"
+          ]
         },
         "_result": {
           "description": "Extensions for result",
@@ -56716,7 +58528,13 @@
         },
         "result": {
           "description": "The result of this assertion.",
-          "enum": ["pass", "skip", "fail", "warning", "error"]
+          "enum": [
+            "pass",
+            "skip",
+            "fail",
+            "warning",
+            "error"
+          ]
         },
         "_result": {
           "description": "Extensions for result",
@@ -56787,7 +58605,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["action"]
+      "required": [
+        "action"
+      ]
     },
     "TestReport_Action1": {
       "description": "A summary of information based on the results of executing a TestScript.",
@@ -56851,7 +58671,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["action"]
+      "required": [
+        "action"
+      ]
     },
     "TestReport_Action2": {
       "description": "A summary of information based on the results of executing a TestScript.",
@@ -56880,7 +58702,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["operation"]
+      "required": [
+        "operation"
+      ]
     },
     "TestScript": {
       "description": "A structured set of tests against a FHIR server or client implementation to determine compliance against the FHIR specification.",
@@ -56976,7 +58800,12 @@
         },
         "status": {
           "description": "The status of this test script. Enables tracking the life-cycle of the content.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -57107,7 +58936,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "TestScript_Origin": {
       "description": "A structured set of tests against a FHIR server or client implementation to determine compliance against the FHIR specification.",
@@ -57144,7 +58975,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["profile"]
+      "required": [
+        "profile"
+      ]
     },
     "TestScript_Destination": {
       "description": "A structured set of tests against a FHIR server or client implementation to determine compliance against the FHIR specification.",
@@ -57181,7 +59014,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["profile"]
+      "required": [
+        "profile"
+      ]
     },
     "TestScript_Metadata": {
       "description": "A structured set of tests against a FHIR server or client implementation to determine compliance against the FHIR specification.",
@@ -57220,7 +59055,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["capability"]
+      "required": [
+        "capability"
+      ]
     },
     "TestScript_Link": {
       "description": "A structured set of tests against a FHIR server or client implementation to determine compliance against the FHIR specification.",
@@ -57349,7 +59186,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["capabilities"]
+      "required": [
+        "capabilities"
+      ]
     },
     "TestScript_Fixture": {
       "description": "A structured set of tests against a FHIR server or client implementation to determine compliance against the FHIR specification.",
@@ -57513,7 +59352,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["action"]
+      "required": [
+        "action"
+      ]
     },
     "TestScript_Action": {
       "description": "A structured set of tests against a FHIR server or client implementation to determine compliance against the FHIR specification.",
@@ -57630,7 +59471,15 @@
         },
         "method": {
           "description": "The HTTP method the test engine MUST use for this operation regardless of any other operation details.",
-          "enum": ["delete", "get", "options", "patch", "post", "put", "head"]
+          "enum": [
+            "delete",
+            "get",
+            "options",
+            "patch",
+            "post",
+            "put",
+            "head"
+          ]
         },
         "_method": {
           "description": "Extensions for method",
@@ -57781,7 +59630,10 @@
         },
         "direction": {
           "description": "The direction to use for the assertion.",
-          "enum": ["response", "request"]
+          "enum": [
+            "response",
+            "request"
+          ]
         },
         "_direction": {
           "description": "Extensions for direction",
@@ -57881,7 +59733,15 @@
         },
         "requestMethod": {
           "description": "The request method or HTTP operation code to compare against that used by the client system under test.",
-          "enum": ["delete", "get", "options", "patch", "post", "put", "head"]
+          "enum": [
+            "delete",
+            "get",
+            "options",
+            "patch",
+            "post",
+            "put",
+            "head"
+          ]
         },
         "_requestMethod": {
           "description": "Extensions for requestMethod",
@@ -58013,7 +59873,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["action"]
+      "required": [
+        "action"
+      ]
     },
     "TestScript_Action1": {
       "description": "A structured set of tests against a FHIR server or client implementation to determine compliance against the FHIR specification.",
@@ -58077,7 +59939,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["action"]
+      "required": [
+        "action"
+      ]
     },
     "TestScript_Action2": {
       "description": "A structured set of tests against a FHIR server or client implementation to determine compliance against the FHIR specification.",
@@ -58106,7 +59970,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["operation"]
+      "required": [
+        "operation"
+      ]
     },
     "ValueSet": {
       "description": "A ValueSet resource instance specifies a set of codes drawn from one or more code systems, intended for use in a particular context. Value sets link between [[[CodeSystem]]] definitions and their use in [coded elements](terminologies.html).",
@@ -58205,7 +60071,12 @@
         },
         "status": {
           "description": "The status of this value set. Enables tracking the life-cycle of the content. The status of the value set applies to the value set definition (ValueSet.compose) and the associated ValueSet metadata. Expansions do not have a state.",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "_status": {
           "description": "Extensions for status",
@@ -58298,7 +60169,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "ValueSet_Compose": {
       "description": "A ValueSet resource instance specifies a set of codes drawn from one or more code systems, intended for use in a particular context. Value sets link between [[[CodeSystem]]] definitions and their use in [coded elements](terminologies.html).",
@@ -58353,7 +60226,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["include"]
+      "required": [
+        "include"
+      ]
     },
     "ValueSet_Include": {
       "description": "A ValueSet resource instance specifies a set of codes drawn from one or more code systems, intended for use in a particular context. Value sets link between [[[CodeSystem]]] definitions and their use in [coded elements](terminologies.html).",
@@ -58538,7 +60413,17 @@
         },
         "op": {
           "description": "The kind of operation to perform as a part of the filter criteria.",
-          "enum": ["\u003d", "is-a", "descendent-of", "is-not-a", "regex", "in", "not-in", "generalizes", "exists"]
+          "enum": [
+            "\u003d",
+            "is-a",
+            "descendent-of",
+            "is-not-a",
+            "regex",
+            "in",
+            "not-in",
+            "generalizes",
+            "exists"
+          ]
         },
         "_op": {
           "description": "Extensions for op",
@@ -58958,7 +60843,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "VerificationResult_PrimarySource": {
       "description": "Describes validation requirements, source(s), status and dates for one or more elements.",
@@ -59132,7 +61019,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["organization"]
+      "required": [
+        "organization"
+      ]
     },
     "VisionPrescription": {
       "description": "An authorization for the provision of glasses and/or contact lenses to a patient.",
@@ -59242,7 +61131,12 @@
         }
       },
       "additionalProperties": false,
-      "required": ["prescriber", "patient", "lensSpecification", "resourceType"]
+      "required": [
+        "prescriber",
+        "patient",
+        "lensSpecification",
+        "resourceType"
+      ]
     },
     "VisionPrescription_LensSpecification": {
       "description": "An authorization for the provision of glasses and/or contact lenses to a patient.",
@@ -59271,7 +61165,10 @@
         },
         "eye": {
           "description": "The eye for which the lens specification applies.",
-          "enum": ["right", "left"]
+          "enum": [
+            "right",
+            "left"
+          ]
         },
         "_eye": {
           "description": "Extensions for eye",
@@ -59369,7 +61266,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["product"]
+      "required": [
+        "product"
+      ]
     },
     "VisionPrescription_Prism": {
       "description": "An authorization for the provision of glasses and/or contact lenses to a patient.",
@@ -59402,7 +61301,12 @@
         },
         "base": {
           "description": "The relative base, or reference lens edge, for the prism.",
-          "enum": ["up", "down", "in", "out"]
+          "enum": [
+            "up",
+            "down",
+            "in",
+            "out"
+          ]
         },
         "_base": {
           "description": "Extensions for base",
@@ -59720,7 +61624,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "Project_Secret": {
       "description": "Secure environment variable that can be used to store secrets for bots.",
@@ -59747,7 +61653,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     },
     "Project_Site": {
       "description": "Web application or web site that is associated with the project.",
@@ -59781,7 +61689,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name", "domain"]
+      "required": [
+        "name",
+        "domain"
+      ]
     },
     "ProjectMembership": {
       "description": "Medplum project membership. A project membership grants a user access to a project.",
@@ -59887,7 +61798,12 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType", "project", "user", "profile"]
+      "required": [
+        "resourceType",
+        "project",
+        "user",
+        "profile"
+      ]
     },
     "ClientApplication": {
       "description": "Medplum client application for automated access.",
@@ -59939,7 +61855,11 @@
         },
         "status": {
           "description": "The client application status. The status is active by default. The status can be set to error to indicate that the client application is not working properly. The status can be set to off to indicate that the client application is no longer in use.",
-          "enum": ["active", "off", "error"]
+          "enum": [
+            "active",
+            "off",
+            "error"
+          ]
         },
         "name": {
           "description": "A name associated with the ClientApplication.",
@@ -59965,10 +61885,6 @@
           "description": "Optional JWKS URI for public key verification of JWTs issued by the authorization server (client_secret_jwt).",
           "$ref": "#/definitions/uri"
         },
-        "redirectUri": {
-          "description": "@deprecated This field is deprecated. Use redirectUris instead.",
-          "$ref": "#/definitions/uri"
-        },
         "redirectUris": {
           "description": "Optional redirect URI array used when redirecting a client back to the client application.",
           "items": {
@@ -59979,6 +61895,13 @@
         "launchUri": {
           "description": "Optional launch URI for SMART EHR launch sequence.",
           "$ref": "#/definitions/uri"
+        },
+        "launchIdentifierSystems": {
+          "description": "Optional array of identifier systems to use in SMART launch context. When specified, the resource\u0027s identifier with the matching system will be included in the SmartAppLaunch resource\u0027s reference and returned to the SMART app in the token response.",
+          "items": {
+            "$ref": "#/definitions/ClientApplicationLaunchIdentifierSystems"
+          },
+          "type": "array"
         },
         "pkceOptional": {
           "description": "Flag to make PKCE optional for this client application. PKCE is required by default for compliance with Smart App Launch. It can be disabled for compatibility with legacy client applications.",
@@ -60013,10 +61936,16 @@
         "certificateTrustStore": {
           "description": "Optional PEM-formatted certificates that are allowed to authenticate to this service via mutual TLS. Supports both Certificate Authorities (CAs) and self-signed certificates. Multiple certificates can be included.",
           "$ref": "#/definitions/string"
+        },
+        "redirectUri": {
+          "description": "@deprecated This field is deprecated. Use redirectUris instead.",
+          "$ref": "#/definitions/uri"
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "User": {
       "description": "Representation of a human user of the system.",
@@ -60119,7 +62048,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType", "firstName", "lastName"]
+      "required": [
+        "resourceType",
+        "firstName",
+        "lastName"
+      ]
     },
     "Login": {
       "description": "Login event and session details.",
@@ -60195,7 +62128,14 @@
         },
         "authMethod": {
           "description": "The authentication method used to obtain the code (password or google).",
-          "enum": ["client", "exchange", "execute", "external", "google", "password"]
+          "enum": [
+            "client",
+            "exchange",
+            "execute",
+            "external",
+            "google",
+            "password"
+          ]
         },
         "authTime": {
           "description": "Time when the End-User authentication occurred.",
@@ -60215,7 +62155,10 @@
         },
         "codeChallengeMethod": {
           "description": "OPTIONAL, defaults to \"plain\" if not present in the request.  Code verifier transformation method is \"S256\" or \"plain\".",
-          "enum": ["plain", "S256"]
+          "enum": [
+            "plain",
+            "S256"
+          ]
         },
         "refreshSecret": {
           "description": "Optional secure random string that can be used in an OAuth refresh token.",
@@ -60263,7 +62206,12 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType", "user", "authMethod", "authTime"]
+      "required": [
+        "resourceType",
+        "user",
+        "authMethod",
+        "authTime"
+      ]
     },
     "JsonWebKey": {
       "description": "A JSON object that represents a cryptographic key. The members of the object represent properties of the key, including its value.",
@@ -60397,7 +62345,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType", "alg", "kty"]
+      "required": [
+        "resourceType",
+        "alg",
+        "kty"
+      ]
     },
     "Bot": {
       "description": "Bot account for automated actions.",
@@ -60464,7 +62416,11 @@
         },
         "runtimeVersion": {
           "description": "The identifier of the bot runtime environment (i.e., vmcontext, awslambda, etc).",
-          "enum": ["awslambda", "vmcontext", "fission"]
+          "enum": [
+            "awslambda",
+            "vmcontext",
+            "fission"
+          ]
         },
         "timeout": {
           "description": "The maximum allowed execution time of the bot in seconds.",
@@ -60501,14 +62457,26 @@
           "description": "Optional flag to indicate that the bot can be used as an unauthenticated public webhook. Note that this is a security risk and should only be used for public bots that do not require authentication.",
           "$ref": "#/definitions/boolean"
         },
+        "streamingEnabled": {
+          "description": "Optional flag to indicate that the bot should be deployed in a streaming-enabled context, allowing it to execute with streaming responses.",
+          "$ref": "#/definitions/boolean"
+        },
         "auditEventTrigger": {
           "description": "Criteria for creating an AuditEvent as a result of the bot invocation. Possible values are \u0027always\u0027, \u0027never\u0027, \u0027on-error\u0027, or \u0027on-output\u0027. Default value is \u0027always\u0027.",
-          "enum": ["always", "never", "on-error", "on-output"]
+          "enum": [
+            "always",
+            "never",
+            "on-error",
+            "on-output"
+          ]
         },
         "auditEventDestination": {
           "description": "The destination system in which the AuditEvent is to be sent. Possible values are \u0027log\u0027 or \u0027resource\u0027. Default value is \u0027resource\u0027.",
           "items": {
-            "enum": ["log", "resource"]
+            "enum": [
+              "log",
+              "resource"
+            ]
           },
           "type": "array"
         },
@@ -60520,13 +62488,19 @@
           "description": "Bot logic in executable form as a result of compiling and bundling source code.",
           "$ref": "#/definitions/Attachment"
         },
+        "cdsService": {
+          "description": "CDS service definition if the bot is used as a CDS Hooks service. See https://cds-hooks.hl7.org/ for more details.",
+          "$ref": "#/definitions/BotCdsService"
+        },
         "code": {
           "description": "@deprecated Bot logic script. Use Bot.sourceCode or Bot.executableCode instead.",
           "$ref": "#/definitions/string"
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "AccessPolicy": {
       "description": "Access Policy for user or user group that defines how entities can or cannot access resources.",
@@ -60607,7 +62581,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "AccessPolicy_Resource": {
       "description": "Access details for a resource type.",
@@ -60651,7 +62627,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "UserConfiguration": {
       "description": "User specific configuration for the Medplum application.",
@@ -60728,7 +62706,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "UserConfiguration_Menu": {
       "description": "Optional menu of shortcuts to URLs.",
@@ -60746,7 +62726,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["title"]
+      "required": [
+        "title"
+      ]
     },
     "UserConfiguration_Menu_Link": {
       "description": "Shortcut links to URLs.",
@@ -60761,7 +62743,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name", "target"]
+      "required": [
+        "name",
+        "target"
+      ]
     },
     "UserConfiguration_Search": {
       "description": "Shortcut links to URLs.",
@@ -60776,7 +62761,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name", "criteria"]
+      "required": [
+        "name",
+        "criteria"
+      ]
     },
     "UserConfiguration_Option": {
       "description": "User options that control the display of the application.",
@@ -60807,7 +62795,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["id"]
+      "required": [
+        "id"
+      ]
     },
     "IdentityProvider": {
       "description": "External Identity Provider (IdP) configuration details.",
@@ -60822,7 +62812,10 @@
         },
         "tokenAuthMethod": {
           "description": "Client Authentication method used by Clients to authenticate to the Authorization Server when using the Token Endpoint. If no method is registered, the default method is client_secret_basic.",
-          "enum": ["client_secret_basic", "client_secret_post"]
+          "enum": [
+            "client_secret_basic",
+            "client_secret_post"
+          ]
         },
         "userInfoUrl": {
           "description": "Remote URL for the external Identity Provider userinfo endpoint.",
@@ -60846,7 +62839,13 @@
         }
       },
       "additionalProperties": false,
-      "required": ["authorizeUrl", "tokenUrl", "userInfoUrl", "clientId", "clientSecret"]
+      "required": [
+        "authorizeUrl",
+        "tokenUrl",
+        "userInfoUrl",
+        "clientId",
+        "clientSecret"
+      ]
     },
     "ProjectMembership_Access": {
       "description": "Extended access configuration using parameterized access policies.",
@@ -60864,7 +62863,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["policy"]
+      "required": [
+        "policy"
+      ]
     },
     "ProjectMembership_Access_Parameter": {
       "description": "User options that control the display of the application.",
@@ -60883,7 +62884,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     },
     "BulkDataExport": {
       "description": "User specific configuration for the Medplum application.",
@@ -60935,7 +62938,13 @@
         },
         "status": {
           "description": "The status of the request.",
-          "enum": ["accepted", "active", "completed", "error", "cancelled"]
+          "enum": [
+            "accepted",
+            "active",
+            "completed",
+            "error",
+            "cancelled"
+          ]
         },
         "requestTime": {
           "description": "Indicates the server\u0027s time when the query is requested.",
@@ -60976,7 +62985,12 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType", "status", "requestTime", "request"]
+      "required": [
+        "resourceType",
+        "status",
+        "requestTime",
+        "request"
+      ]
     },
     "BulkDataExport_Output": {
       "description": "An array of file items with one entry for each generated file. If no resources are returned from the kick-off request, the server SHOULD return an empty array.",
@@ -60991,7 +63005,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type", "url"]
+      "required": [
+        "type",
+        "url"
+      ]
     },
     "BulkDataExport_Deleted": {
       "description": "An array of deleted file items following the same structure as the output array.",
@@ -61006,7 +63023,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type", "url"]
+      "required": [
+        "type",
+        "url"
+      ]
     },
     "BulkDataExport_Error": {
       "description": "Array of message file items following the same structure as the output array.",
@@ -61021,7 +63041,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type", "url"]
+      "required": [
+        "type",
+        "url"
+      ]
     },
     "SmartAppLaunch": {
       "description": "This resource contains context details for a SMART App Launch.",
@@ -61078,10 +63101,19 @@
         "encounter": {
           "description": "Optional encounter indicating that the app was launched in the encounter context.",
           "$ref": "#/definitions/Reference"
+        },
+        "fhirContext": {
+          "description": "Optional FHIR context indicating the resources that were included when the app was launched.",
+          "items": {
+            "$ref": "#/definitions/Reference"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "DomainConfiguration": {
       "description": "Domain specific configuration for the Medplum application.",
@@ -61138,10 +63170,20 @@
         "identityProvider": {
           "description": "Optional external Identity Provider (IdP) for the domain name.",
           "$ref": "#/definitions/IdentityProvider"
+        },
+        "allowedPostLoginRedirectUrls": {
+          "description": "List of allowed post-login redirect URLs for this domain configuration.",
+          "items": {
+            "$ref": "#/definitions/uri"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType", "domain"]
+      "required": [
+        "resourceType",
+        "domain"
+      ]
     },
     "AccessPolicy_IpAccessRule": {
       "description": "Use IP Access Rules to allowlist, block, and challenge traffic based on the visitor IP address.",
@@ -61156,11 +63198,17 @@
         },
         "action": {
           "description": "Access rule can perform one of the following actions: \"allow\" | \"block\".",
-          "enum": ["allow", "block"]
+          "enum": [
+            "allow",
+            "block"
+          ]
         }
       },
       "additionalProperties": false,
-      "required": ["value", "action"]
+      "required": [
+        "value",
+        "action"
+      ]
     },
     "AsyncJob": {
       "description": "Contains details of long running asynchronous/background jobs.",
@@ -61212,7 +63260,13 @@
         },
         "status": {
           "description": "The status of the request.",
-          "enum": ["accepted", "active", "completed", "error", "cancelled"]
+          "enum": [
+            "accepted",
+            "active",
+            "completed",
+            "error",
+            "cancelled"
+          ]
         },
         "requestTime": {
           "description": "Indicates the server\u0027s time when the query is requested.",
@@ -61232,7 +63286,9 @@
         },
         "type": {
           "description": "The type of the AsyncJob.",
-          "enum": ["data-migration"]
+          "enum": [
+            "data-migration"
+          ]
         },
         "dataVersion": {
           "description": "The data version of the migration this job represents.",
@@ -61244,7 +63300,12 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType", "status", "requestTime", "request"]
+      "required": [
+        "resourceType",
+        "status",
+        "requestTime",
+        "request"
+      ]
     },
     "Agent": {
       "description": "Configuration details for an instance of the Medplum agent application.",
@@ -61307,7 +63368,11 @@
         },
         "status": {
           "description": "The status of the agent.",
-          "enum": ["active", "off", "error"]
+          "enum": [
+            "active",
+            "off",
+            "error"
+          ]
         },
         "device": {
           "description": "Optional device resource representing the device running the agent.",
@@ -61329,7 +63394,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType", "name", "status"]
+      "required": [
+        "resourceType",
+        "name",
+        "status"
+      ]
     },
     "Agent_Channel": {
       "description": "Details where to send notifications when resources are received that meet the criteria.",
@@ -61348,7 +63417,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["endpoint"]
+      "required": [
+        "endpoint"
+      ]
     },
     "Agent_Setting": {
       "description": "The settings for the agent.",
@@ -61375,7 +63446,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     },
     "AccessPolicy_Resource_WriteCriteria": {
       "description": "Invariants that must be satisfied for the resource to be written.",
@@ -61441,7 +63514,11 @@
         },
         "type": {
           "description": "The type of user security request.",
-          "enum": ["invite", "verify-email", "reset"]
+          "enum": [
+            "invite",
+            "verify-email",
+            "reset"
+          ]
         },
         "user": {
           "description": "The user performing the security request.",
@@ -61461,7 +63538,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType", "user", "secret"]
+      "required": [
+        "resourceType",
+        "user",
+        "secret"
+      ]
     },
     "ViewDefinition": {
       "description": "View definitions represent a tabular projection of a FHIR resource, where the columns and inclusion \ncriteria are defined by FHIRPath expressions. ",
@@ -61488,7 +63569,12 @@
         },
         "status": {
           "description": "draft | active | retired | unknown",
-          "enum": ["draft", "active", "retired", "unknown"]
+          "enum": [
+            "draft",
+            "active",
+            "retired",
+            "unknown"
+          ]
         },
         "experimental": {
           "description": "For testing purposes, not real usage",
@@ -61726,7 +63812,11 @@
         }
       },
       "additionalProperties": false,
-      "required": ["status", "resource", "select"]
+      "required": [
+        "status",
+        "resource",
+        "select"
+      ]
     },
     "ProjectSetting": {
       "description": "Option or parameter that can be adjusted within the Medplum Project to customize its behavior.",
@@ -61753,7 +63843,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     },
     "ProjectSite": {
       "description": "Web application or web site that is associated with the project.",
@@ -61787,7 +63879,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name", "domain"]
+      "required": [
+        "name",
+        "domain"
+      ]
     },
     "ProjectLink": {
       "description": "Linked Projects whose contents are made available to this one",
@@ -61798,7 +63893,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["project"]
+      "required": [
+        "project"
+      ]
     },
     "ProjectDefaultProfile": {
       "description": "Default profiles to apply to resources in this project that do not individually specify profiles",
@@ -61965,7 +64062,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType", "profile"]
+      "required": [
+        "resourceType",
+        "profile"
+      ]
     },
     "ProjectMembershipAccessParameter": {
       "description": "User options that control the display of the application.",
@@ -61984,7 +64084,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     },
     "ProjectMembershipAccess": {
       "description": "Extended access configuration using parameterized access policies.",
@@ -62002,7 +64104,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["policy"]
+      "required": [
+        "policy"
+      ]
     },
     "AccessPolicyResource": {
       "description": "Access details for a resource type.",
@@ -62026,7 +64130,15 @@
         "interaction": {
           "description": "Permitted FHIR interactions with this resource type",
           "items": {
-            "enum": ["read", "vread", "update", "delete", "history", "create", "search"]
+            "enum": [
+              "read",
+              "vread",
+              "update",
+              "delete",
+              "history",
+              "create",
+              "search"
+            ]
           },
           "type": "array"
         },
@@ -62053,7 +64165,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": [
+        "resourceType"
+      ]
     },
     "AccessPolicyIpAccessRule": {
       "description": "Use IP Access Rules to allowlist, block, and challenge traffic based on the visitor IP address.",
@@ -62068,11 +64182,17 @@
         },
         "action": {
           "description": "Access rule can perform one of the following actions: \"allow\" | \"block\".",
-          "enum": ["allow", "block"]
+          "enum": [
+            "allow",
+            "block"
+          ]
         }
       },
       "additionalProperties": false,
-      "required": ["value", "action"]
+      "required": [
+        "value",
+        "action"
+      ]
     },
     "UserConfigurationMenuLink": {
       "description": "Shortcut links to URLs.",
@@ -62087,7 +64207,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name", "target"]
+      "required": [
+        "name",
+        "target"
+      ]
     },
     "UserConfigurationMenu": {
       "description": "Optional menu of shortcuts to URLs.",
@@ -62105,7 +64228,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["title"]
+      "required": [
+        "title"
+      ]
     },
     "UserConfigurationSearch": {
       "description": "Shortcut links to URLs.",
@@ -62120,7 +64245,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name", "criteria"]
+      "required": [
+        "name",
+        "criteria"
+      ]
     },
     "UserConfigurationOption": {
       "description": "User options that control the display of the application.",
@@ -62151,7 +64279,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["id"]
+      "required": [
+        "id"
+      ]
     },
     "BulkDataExportOutput": {
       "description": "An array of file items with one entry for each generated file. If no resources are returned from the kick-off request, the server SHOULD return an empty array.",
@@ -62166,7 +64296,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type", "url"]
+      "required": [
+        "type",
+        "url"
+      ]
     },
     "BulkDataExportDeleted": {
       "description": "An array of deleted file items following the same structure as the output array.",
@@ -62181,7 +64314,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type", "url"]
+      "required": [
+        "type",
+        "url"
+      ]
     },
     "BulkDataExportError": {
       "description": "Array of message file items following the same structure as the output array.",
@@ -62196,7 +64332,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["type", "url"]
+      "required": [
+        "type",
+        "url"
+      ]
     },
     "AgentSetting": {
       "description": "The settings for the agent.",
@@ -62223,7 +64362,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     },
     "AgentChannel": {
       "description": "Details where to send notifications when resources are received that meet the criteria.",
@@ -62246,7 +64387,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name", "endpoint"]
+      "required": [
+        "name",
+        "endpoint"
+      ]
     },
     "ViewDefinitionConstant": {
       "description": "A constant is a value that is injected into a FHIRPath expression through the use of a FHIRPath\nexternal constant with the same name.",
@@ -62351,7 +64495,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     },
     "ViewDefinitionSelectColumnTag": {
       "description": "Tags can be used to attach additional metadata to columns, such as implementation-specific \ndirectives or database-specific type hints.",
@@ -62384,7 +64530,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name", "value"]
+      "required": [
+        "name",
+        "value"
+      ]
     },
     "ViewDefinitionSelectColumn": {
       "description": "A column to be produced in the resulting table. The column is relative to the select structure\nthat contains it.",
@@ -62436,7 +64585,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["path", "name"]
+      "required": [
+        "path",
+        "name"
+      ]
     },
     "ViewDefinitionSelect": {
       "description": "The select structure defines the columns to be used in the resulting view. These are expressed\nin the `column` structure below, or in nested `select`s for nested resources.",
@@ -62522,7 +64674,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["path"]
+      "required": [
+        "path"
+      ]
     },
     "ClientApplicationSignInForm": {
       "description": "Custom values for the Log In form.",
@@ -62537,6 +64691,338 @@
         }
       },
       "additionalProperties": false
+    },
+    "ClientApplicationLaunchIdentifierSystems": {
+      "description": "Optional array of identifier systems to use in SMART launch context. When specified, the resource\u0027s identifier with the matching system will be included in the SmartAppLaunch resource\u0027s reference and returned to the SMART app in the token response.",
+      "properties": {
+        "resourceType": {
+          "description": "The resource type for which to use the identifier system (e.g., \u0027Patient\u0027, \u0027Encounter\u0027).",
+          "$ref": "#/definitions/code"
+        },
+        "system": {
+          "description": "The identifier system URI to use for the specified resource type.",
+          "$ref": "#/definitions/uri"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "resourceType",
+        "system"
+      ]
+    },
+    "BotCdsServicePrefetch": {
+      "description": "An object containing key/value pairs of FHIR queries that this service is requesting the CDS Client to perform and provide on each service call.",
+      "properties": {
+        "key": {
+          "description": "The type of data being requested. See https://cds-hooks.hl7.org/#prefetch-template",
+          "$ref": "#/definitions/code"
+        },
+        "query": {
+          "description": "The FHIR query used to retrieve the requested data. See https://cds-hooks.hl7.org/#prefetch-template",
+          "$ref": "#/definitions/string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "key",
+        "query"
+      ]
+    },
+    "BotCdsService": {
+      "description": "CDS service definition if the bot is used as a CDS Hooks service. See https://cds-hooks.hl7.org/ for more details.",
+      "properties": {
+        "hook": {
+          "description": "The hook this service should be invoked on. See https://cds-hooks.hl7.org/#hooks for possible values.",
+          "$ref": "#/definitions/code"
+        },
+        "title": {
+          "description": "The human-friendly name of this CDS service.",
+          "$ref": "#/definitions/string"
+        },
+        "description": {
+          "description": "The description of this CDS service.",
+          "$ref": "#/definitions/string"
+        },
+        "usageRequirements": {
+          "description": "Optional human-friendly description of any preconditions for the use of this CDS Service.",
+          "$ref": "#/definitions/string"
+        },
+        "prefetch": {
+          "description": "An object containing key/value pairs of FHIR queries that this service is requesting the CDS Client to perform and provide on each service call.",
+          "items": {
+            "$ref": "#/definitions/BotCdsServicePrefetch"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "hook",
+        "title",
+        "description"
+      ]
+    },
+    "Package": {
+      "description": "Definition of a marketplace package, which represents a set of automated actions that can be taken by a system, such as a subscription or a workflow.",
+      "properties": {
+        "resourceType": {
+          "description": "This is a Package resource",
+          "const": "Package"
+        },
+        "id": {
+          "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+          "$ref": "#/definitions/string"
+        },
+        "meta": {
+          "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+          "$ref": "#/definitions/Meta"
+        },
+        "implicitRules": {
+          "description": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+          "$ref": "#/definitions/uri"
+        },
+        "language": {
+          "description": "The base language in which the resource is written.",
+          "$ref": "#/definitions/code"
+        },
+        "text": {
+          "description": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+          "$ref": "#/definitions/Narrative"
+        },
+        "contained": {
+          "description": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+          "items": {
+            "$ref": "#/definitions/Resource"
+          },
+          "type": "array"
+        },
+        "extension": {
+          "description": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          },
+          "type": "array"
+        },
+        "modifierExtension": {
+          "description": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element\u0027s descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          },
+          "type": "array"
+        },
+        "identifier": {
+          "description": "An identifier for this package.",
+          "items": {
+            "$ref": "#/definitions/Identifier"
+          },
+          "type": "array"
+        },
+        "status": {
+          "description": "The status of the package.",
+          "enum": [
+            "pending",
+            "active",
+            "end-of-life"
+          ]
+        },
+        "name": {
+          "description": "A name associated with the Package.",
+          "$ref": "#/definitions/string"
+        },
+        "description": {
+          "description": "A summary, characterization or explanation of the Package.",
+          "$ref": "#/definitions/markdown"
+        },
+        "category": {
+          "description": "A code that classifies the service for searching, sorting and display purposes (e.g. \"Surgical Procedure\").",
+          "items": {
+            "$ref": "#/definitions/CodeableConcept"
+          },
+          "type": "array"
+        },
+        "author": {
+          "description": "Reference to the resource that represents the author of the package.",
+          "$ref": "#/definitions/Reference"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "resourceType",
+        "status",
+        "name",
+        "author"
+      ]
+    },
+    "PackageRelease": {
+      "description": "Definition of a marketplace package release, which represents a specific release of a package that can be installed and used by a system.",
+      "properties": {
+        "resourceType": {
+          "description": "This is a PackageRelease resource",
+          "const": "PackageRelease"
+        },
+        "id": {
+          "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+          "$ref": "#/definitions/string"
+        },
+        "meta": {
+          "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+          "$ref": "#/definitions/Meta"
+        },
+        "implicitRules": {
+          "description": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+          "$ref": "#/definitions/uri"
+        },
+        "language": {
+          "description": "The base language in which the resource is written.",
+          "$ref": "#/definitions/code"
+        },
+        "text": {
+          "description": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+          "$ref": "#/definitions/Narrative"
+        },
+        "contained": {
+          "description": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+          "items": {
+            "$ref": "#/definitions/Resource"
+          },
+          "type": "array"
+        },
+        "extension": {
+          "description": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          },
+          "type": "array"
+        },
+        "modifierExtension": {
+          "description": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element\u0027s descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          },
+          "type": "array"
+        },
+        "identifier": {
+          "description": "An identifier for this package release.",
+          "items": {
+            "$ref": "#/definitions/Identifier"
+          },
+          "type": "array"
+        },
+        "package": {
+          "description": "The Package of this release.",
+          "$ref": "#/definitions/Reference"
+        },
+        "version": {
+          "description": "The version of the PackageRelease.",
+          "$ref": "#/definitions/string"
+        },
+        "description": {
+          "description": "A summary, characterization or explanation of the PackageRelease.",
+          "$ref": "#/definitions/markdown"
+        },
+        "content": {
+          "description": "The actual content of the package release.",
+          "$ref": "#/definitions/Attachment"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "resourceType",
+        "package",
+        "version",
+        "content"
+      ]
+    },
+    "PackageInstallation": {
+      "description": "Definition of a marketplace package installation, which represents the installation of a specific package release in a system.",
+      "properties": {
+        "resourceType": {
+          "description": "This is a PackageInstallation resource",
+          "const": "PackageInstallation"
+        },
+        "id": {
+          "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+          "$ref": "#/definitions/string"
+        },
+        "meta": {
+          "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+          "$ref": "#/definitions/Meta"
+        },
+        "implicitRules": {
+          "description": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+          "$ref": "#/definitions/uri"
+        },
+        "language": {
+          "description": "The base language in which the resource is written.",
+          "$ref": "#/definitions/code"
+        },
+        "text": {
+          "description": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+          "$ref": "#/definitions/Narrative"
+        },
+        "contained": {
+          "description": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+          "items": {
+            "$ref": "#/definitions/Resource"
+          },
+          "type": "array"
+        },
+        "extension": {
+          "description": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          },
+          "type": "array"
+        },
+        "modifierExtension": {
+          "description": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element\u0027s descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          },
+          "type": "array"
+        },
+        "identifier": {
+          "description": "An identifier for this package installation.",
+          "items": {
+            "$ref": "#/definitions/Identifier"
+          },
+          "type": "array"
+        },
+        "package": {
+          "description": "The Package of this installation.",
+          "$ref": "#/definitions/Reference"
+        },
+        "packageRelease": {
+          "description": "The PackageRelease of this installation.",
+          "$ref": "#/definitions/Reference"
+        },
+        "version": {
+          "description": "The version of the PackageInstallation.",
+          "$ref": "#/definitions/string"
+        },
+        "status": {
+          "description": "The status of the package installation.",
+          "enum": [
+            "requested",
+            "installing",
+            "installed",
+            "error"
+          ]
+        },
+        "installedBy": {
+          "description": "Reference to the resource that represents the installer of the package.",
+          "$ref": "#/definitions/Reference"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "resourceType",
+        "package",
+        "packageRelease",
+        "version",
+        "status",
+        "installedBy"
+      ]
     }
   }
 }

--- a/packages/generator/src/jsonschema.ts
+++ b/packages/generator/src/jsonschema.ts
@@ -66,7 +66,7 @@ export function main(): void {
   }
 
   writeFileSync(
-    resolve(import.meta.dirname, '../../definitions/dist/fhir/r4/fhir.schema.json'),
+    resolve(import.meta.dirname, '../../definitions/src/fhir/r4/fhir.schema.json'),
     JSON.stringify(fhirSchema, undefined, 2)
       .replaceAll("'", '\\u0027')
       .replaceAll('<', '\\u003c')


### PR DESCRIPTION
Back in November in https://github.com/medplum/medplum/pull/7710 we changed how the `generator` package interacted with the `definitions` package.

Before, `generator` would write directly to `definitions/dist`.

After, `generator` writes to `definitions/src` and requires a build step in `definitions`.

It looks like `generator/src/jsonschema.ts` was not updated, and therefore `fhir/r4/fhir.schema.json` has not been updated since then.  At this point, this really only applies to projects that disabled "Strict Mode" and want to use custom Medplum types.  I found this by running some tests in an old project with "Strict Mode" disabled.

The big diff is mostly whitespace.  It looks like the `JSON.stringify(fhirSchema, undefined, 2)` behavior changed since our last run.