### PR TITLE
fix(ci): stop double caching node modules

### DIFF
--- a/.github/workflows/autofix-ci.yml
+++ b/.github/workflows/autofix-ci.yml
@@ -22,6 +22,21 @@ jobs:
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version: '24'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
+
+      - name: Cache node modules
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
 
       - run: npm ci
       - run: npm run prettier

--- a/.github/workflows/autofix-ci.yml
+++ b/.github/workflows/autofix-ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: '24'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
 
       - name: Cache node modules

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
 
       # See: https://github.com/actions/cache/blob/cdf6c1fa76f9f475f3d7449005a359c84ca0f306/examples.md#node---npm
       - name: Get npm cache directory
@@ -229,6 +232,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
 
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -311,6 +317,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
 
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -393,6 +402,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
 
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -49,7 +49,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
 
       # See: https://github.com/actions/cache/blob/cdf6c1fa76f9f475f3d7449005a359c84ca0f306/examples.md#node---npm
@@ -233,7 +233,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
 
       - name: Cache node modules
@@ -318,7 +318,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
 
       - name: Cache node modules
@@ -403,7 +403,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
 
       - name: Cache node modules

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
 
       - name: Cache node modules

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -35,6 +35,21 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
+
+      - name: Cache node modules
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/build-helm-charts.yml
+++ b/.github/workflows/build-helm-charts.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
 
       - name: Setup Helm

--- a/.github/workflows/build-helm-charts.yml
+++ b/.github/workflows/build-helm-charts.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
 
       - name: Setup Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         env:
@@ -91,6 +94,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         env:
@@ -199,6 +205,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         env:
@@ -301,6 +310,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         env:
@@ -401,6 +413,9 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -95,7 +95,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -206,7 +206,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -311,7 +311,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -414,7 +414,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
 
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
 
       - name: Cache node modules

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/madge.yml
+++ b/.github/workflows/madge.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/madge.yml
+++ b/.github/workflows/madge.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         env:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
+
       # npm 11.6.2 is currently bundled with Node v24 and has an irksome bug affecting
       # `peer` attributes in the lockfile (https://github.com/npm/cli/issues/8690).
       # Upgrade to a patched version; this should be removed after Node has a tagged

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
 
       # npm 11.6.2 is currently bundled with Node v24 and has an irksome bug affecting

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
 
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -176,6 +179,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
 
       # See: https://github.com/actions/cache/blob/cdf6c1fa76f9f475f3d7449005a359c84ca0f306/examples.md#node---npm
       - name: Get npm cache directory
@@ -384,6 +390,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
 
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -474,6 +483,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
 
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
 
       - name: Cache node modules
@@ -180,7 +180,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
 
       # See: https://github.com/actions/cache/blob/cdf6c1fa76f9f475f3d7449005a359c84ca0f306/examples.md#node---npm
@@ -391,7 +391,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
 
       - name: Cache node modules
@@ -484,7 +484,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
 
       - name: Cache node modules

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
       - name: Cache node modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         env:

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
-          # See: https://github.com/actions/setup-node/issues/1120
+          # See: https://github.com/actions/setup-node/issues/328
           package-manager-cache: false
       # npm 11.6.2 is currently bundled with Node v24 and has an irksome bug affecting
       # `peer` attributes in the lockfile (https://github.com/npm/cli/issues/8690).

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # After v6, the default for `package-manager-cache` is true. We however, have historically used caching with a fallback which is not supported by the setup-node action
+          # See: https://github.com/actions/setup-node/issues/1120
+          package-manager-cache: false
       # npm 11.6.2 is currently bundled with Node v24 and has an irksome bug affecting
       # `peer` attributes in the lockfile (https://github.com/npm/cli/issues/8690).
       # Upgrade to a patched version; this should be removed after Node has a tagged


### PR DESCRIPTION
After v6 of the `setup-node` action, node modules for NPM are cached by default. That means we download the same cache twice from two different caches. 

See: https://github.com/actions/setup-node#:~:text=Caching%20is%20now,the%20cache%20input.

This PR stops that behavior.

I considered letting the `setup-node` do the caching and removing our explicit use of `actions/cache`, however, `setup-node` is very strict about restoring caches with only strict matching of `package-lock.json`, which diverges from our current caching behavior of falling back to prefix matches. There is an open issue for this behavior on the `setup-node` repo, but it looks like the maintainers are strictly against this and recommend disabling automatic caching and explicitly using the `actions/cache` action like we are already doing.

See: https://github.com/actions/setup-node/issues/328
