### PR TITLE
fix(ci): fix flaky `Spotlight` test

### DIFF
--- a/packages/react/src/AppShell/Spotlight.test.tsx
+++ b/packages/react/src/AppShell/Spotlight.test.tsx
@@ -56,11 +56,16 @@ describe('Spotlight', () => {
     jest.clearAllMocks();
     mockNavigate.mockReset();
     medplum = new MockClient();
-    spotlight.close();
+
+    act(() => {
+      spotlight.close();
+    });
   });
 
   afterEach(() => {
-    spotlight.close();
+    act(() => {
+      spotlight.close();
+    });
   });
 
   describe('Initial render', () => {


### PR DESCRIPTION
Fixes #8358

I was getting this test flaking consistently while trying to configure Turbo's concurrency feature. Looks like it was mostly an issue of timeouts being too short if CI slows down.

I also noticed that we basically have been mocking the entirety of `@medplum/spotlight` in our test, so I unmocked it and tweaked the tests to actually test the real depedency.