### PR TITLE
Fixed react test warnings

### DIFF
--- a/packages/react/src/AppShell/Spotlight.tsx
+++ b/packages/react/src/AppShell/Spotlight.tsx
@@ -110,11 +110,9 @@ export function Spotlight({ patientsOnly }: SpotlightProps): JSX.Element {
           autoCorrect: 'off',
           spellCheck: false,
           name: patientsOnly ? 'provider-spotlight-search' : 'spotlight-search',
-          inputProps: {
-            // Tell common password managers to ignore this field
-            'data-1p-ignore': 'true',
-            'data-lpignore': 'true',
-          },
+          // Tell common password managers to ignore this field
+          'data-1p-ignore': 'true',
+          'data-lpignore': 'true',
           leftSectionProps: {
             style: { marginLeft: 'calc(var(--mantine-spacing-md) - 12px)' },
           },

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -10,7 +10,7 @@ import {
   useQuestionnaireForm,
 } from '@medplum/react-hooks';
 import type { JSX } from 'react';
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Form } from '../Form/Form';
 import { SubmitButton } from '../Form/SubmitButton';
 import { SignatureInput } from '../SignatureInput/SignatureInput';
@@ -34,13 +34,13 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
   const medplum = useMedplum();
   const [signatureRequiredSubmitted, setSignatureRequiredSubmitted] = useState(false);
   const propsRef = useRef(props);
+  const pendingChangeRef = useRef<QuestionnaireResponse | undefined>(undefined);
   useLayoutEffect(() => {
     propsRef.current = props;
   });
 
   const onFormChange = useCallback((response: QuestionnaireResponse) => {
-    setSignatureRequiredSubmitted(false);
-    propsRef.current.onChange?.(response);
+    pendingChangeRef.current = response;
   }, []);
 
   const formState = useQuestionnaireForm({
@@ -55,6 +55,17 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
   const formStateRef = useRef(formState);
   useLayoutEffect(() => {
     formStateRef.current = formState;
+  });
+
+  useEffect(() => {
+    const pendingChange = pendingChangeRef.current;
+    if (!pendingChange) {
+      return;
+    }
+
+    pendingChangeRef.current = undefined;
+    setSignatureRequiredSubmitted(false);
+    propsRef.current.onChange?.(pendingChange);
   });
 
   const isSignatureRequired = useMemo(() => {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -57,6 +57,23 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
     formStateRef.current = formState;
   });
 
+  // Intentionally run after every commit.
+  //
+  // `useQuestionnaireForm` currently invokes its `onChange` callback while the form
+  // is rendering/initializing. Calling `setState` directly from that callback caused
+  // React to warn that `QuestionnaireForm` was updating a parent during render.
+  //
+  // To avoid that render-phase update, `onFormChange` stages the latest response in
+  // `pendingChangeRef`, and this effect flushes it after commit. The effect clears
+  // the ref before calling `setSignatureRequiredSubmitted(false)`, so the state
+  // update does not create an infinite loop: the rerender triggered by `setState`
+  // immediately exits because there is no longer a pending change to flush.
+  //
+  // A more complete fix would be to move `useQuestionnaireForm`'s `onChange`
+  // emission out of render entirely. Until then, this effect must run on every
+  // commit so it can detect newly staged ref-based changes that do not participate
+  // in React's dependency tracking.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     const pendingChange = pendingChangeRef.current;
     if (!pendingChange) {

--- a/packages/react/src/chat/ThreadInbox/ParticipantFilter.test.tsx
+++ b/packages/react/src/chat/ThreadInbox/ParticipantFilter.test.tsx
@@ -6,7 +6,7 @@ import { DrAliceSmith, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { UserEvent } from '@testing-library/user-event';
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor } from '../../test-utils/render';
+import { act, render, screen, waitFor } from '../../test-utils/render';
 import { ParticipantFilter } from './ParticipantFilter';
 
 const mockPractitioner: Practitioner = {
@@ -26,6 +26,14 @@ const mockOnFilterChange = jest.fn();
 describe('ParticipantFilter', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
   });
 
   const setup = async (
@@ -39,7 +47,7 @@ describe('ParticipantFilter', () => {
     await medplum.updateResource(mockPractitioner as WithId<Practitioner>);
     await medplum.updateResource(mockPatient as WithId<Patient>);
 
-    const user = userEvent.setup();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     render(
       <ParticipantFilter selectedParticipants={selectedParticipants} onFilterChange={mockOnFilterChange} />,
       ({ children }) => <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
@@ -96,7 +104,11 @@ describe('ParticipantFilter', () => {
     const button = screen.getByRole('button');
     await user.click(button);
 
-    const checkboxes = await screen.findAllByRole('checkbox');
+    await waitFor(() => {
+      expect(screen.getByText('Message Participants')).toBeInTheDocument();
+    });
+
+    const checkboxes = document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
     expect(checkboxes[0]).not.toBeChecked();
   });
 
@@ -106,7 +118,11 @@ describe('ParticipantFilter', () => {
     const button = screen.getByRole('button');
     await user.click(button);
 
-    const checkboxes = await screen.findAllByRole('checkbox');
+    await waitFor(() => {
+      expect(screen.getByText('Message Participants')).toBeInTheDocument();
+    });
+
+    const checkboxes = document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
     expect(checkboxes[0]).toBeChecked();
   });
 
@@ -355,7 +371,11 @@ describe('ParticipantFilter', () => {
     const button = screen.getByRole('button');
     await user.click(button);
 
-    const checkboxes = await screen.findAllByRole('checkbox');
+    await waitFor(() => {
+      expect(screen.getByText('Message Participants')).toBeInTheDocument();
+    });
+
+    const checkboxes = document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
     expect(checkboxes[0]).toBeChecked();
     expect(checkboxes[1]).toBeChecked();
   });
@@ -451,7 +471,7 @@ describe('ParticipantFilter', () => {
     await user.click(button);
 
     await waitFor(() => {
-      const checkboxes = screen.getAllByRole('checkbox');
+      const checkboxes = document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
       expect(checkboxes).toHaveLength(1);
     });
   });
@@ -518,8 +538,8 @@ describe('ParticipantFilter', () => {
     const searchInput = screen.getByPlaceholderText('Search for a Patient or Practitioner...');
     await user.type(searchInput, '   ');
 
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 400);
+    await act(async () => {
+      jest.advanceTimersByTime(400);
     });
 
     expect(searchSpy).not.toHaveBeenCalled();

--- a/packages/react/src/chat/ThreadInbox/ParticipantFilter.tsx
+++ b/packages/react/src/chat/ThreadInbox/ParticipantFilter.tsx
@@ -92,6 +92,7 @@ export function ParticipantFilter(props: ParticipantFilterProps): JSX.Element {
 
   useEffect(() => {
     debouncedSearch(searchQuery);
+    return debouncedSearch.cancel;
   }, [searchQuery, debouncedSearch]);
 
   const isSelected = (participant: Reference<Patient | Practitioner>): boolean => {

--- a/packages/react/src/chat/ThreadInbox/ThreadInbox.test.tsx
+++ b/packages/react/src/chat/ThreadInbox/ThreadInbox.test.tsx
@@ -6,7 +6,7 @@ import { HomerSimpson, MockClient } from '@medplum/mock';
 import * as reactHooks from '@medplum/react-hooks';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { MemoryRouter } from 'react-router';
-import { render, screen, userEvent, waitFor } from '../../test-utils/render';
+import { act, render, screen, userEvent, waitFor } from '../../test-utils/render';
 import { ThreadInbox } from './ThreadInbox';
 
 jest.mock('@medplum/react-hooks', () => ({
@@ -25,6 +25,7 @@ const mockCommunication: Communication | undefined = {
 const mockOnNew = jest.fn();
 const mockGetThreadUri = jest.fn((topic: Communication) => `/Message/${topic.id}`);
 const mockOnChange = jest.fn();
+const mockNavigate = jest.fn();
 
 describe('ThreadInbox', () => {
   let medplum: MockClient;
@@ -33,6 +34,7 @@ describe('ThreadInbox', () => {
     medplum = new MockClient();
     jest.clearAllMocks();
     jest.mocked(reactHooks.useSubscription).mockClear();
+    mockNavigate.mockClear();
 
     medplum.search = jest.fn().mockResolvedValue({
       resourceType: 'Bundle',
@@ -45,28 +47,39 @@ describe('ThreadInbox', () => {
     });
   });
 
-  const setup = (props?: { threadId?: string; showPatientSummary?: boolean; subject?: typeof HomerSimpson }): void => {
-    render(
-      <>
-        <Notifications />
-        <ThreadInbox
-          query="_sort=-_lastUpdated"
-          threadId={props?.threadId}
-          showPatientSummary={props?.showPatientSummary ?? false}
-          subject={props?.subject}
-          onNew={mockOnNew}
-          getThreadUri={mockGetThreadUri}
-          onChange={mockOnChange}
-          inProgressUri="/Communication?status=in-progress"
-          completedUri="/Communication?status=completed"
-        />
-      </>,
-      ({ children }) => (
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
-      )
-    );
+  const setup = async (props?: {
+    threadId?: string;
+    showPatientSummary?: boolean;
+    subject?: typeof HomerSimpson;
+  }): Promise<void> => {
+    await act(async () => {
+      render(
+        <>
+          <Notifications />
+          <ThreadInbox
+            query="_sort=-_lastUpdated"
+            threadId={props?.threadId}
+            showPatientSummary={props?.showPatientSummary ?? false}
+            subject={props?.subject}
+            onNew={mockOnNew}
+            getThreadUri={mockGetThreadUri}
+            onChange={mockOnChange}
+            inProgressUri="/Communication?status=in-progress"
+            completedUri="/Communication?status=completed"
+          />
+        </>,
+        ({ children }) => (
+          <MemoryRouter>
+            <MedplumProvider medplum={medplum} navigate={mockNavigate}>
+              {children}
+            </MedplumProvider>
+          </MemoryRouter>
+        )
+      );
+
+      await Promise.resolve();
+      await Promise.resolve();
+    });
   };
 
   test('renders filter buttons and new message button', async () => {
@@ -85,7 +98,7 @@ describe('ThreadInbox', () => {
 
   test('shows loading skeletons when loading', async () => {
     medplum.search = jest.fn().mockImplementation(() => new Promise(() => {}));
-    setup();
+    await setup();
 
     await waitFor(() => {
       const skeletons = document.querySelectorAll('.mantine-Skeleton-root');
@@ -156,7 +169,7 @@ describe('ThreadInbox', () => {
       })
     );
 
-    setup();
+    await setup();
 
     await waitFor(
       () => {
@@ -168,14 +181,14 @@ describe('ThreadInbox', () => {
   });
 
   test('shows no messages state when no thread is selected', async () => {
-    setup();
+    await setup();
     await waitFor(() => {
       expect(screen.getByText('Select a message from the list to view details')).toBeInTheDocument();
     });
   });
 
   test('shows empty messages state when no messages are found', async () => {
-    setup();
+    await setup();
     await waitFor(
       () => {
         expect(screen.getByText('No messages found')).toBeInTheDocument();
@@ -194,7 +207,7 @@ describe('ThreadInbox', () => {
     });
     medplum.graphql = jest.fn().mockResolvedValue({ data: { CommunicationList: [] } });
 
-    setup({ threadId: 'comm-123' });
+    await setup({ threadId: 'comm-123' });
 
     await waitFor(
       () => {
@@ -220,7 +233,7 @@ describe('ThreadInbox', () => {
     });
     medplum.graphql = jest.fn().mockResolvedValue({ data: { CommunicationList: [] } });
 
-    setup({ showPatientSummary: true, threadId: 'comm-123' });
+    await setup({ showPatientSummary: true, threadId: 'comm-123' });
 
     await waitFor(
       () => {
@@ -243,7 +256,7 @@ describe('ThreadInbox', () => {
     });
     medplum.graphql = jest.fn().mockResolvedValue({ data: { CommunicationList: [] } });
 
-    setup({ showPatientSummary: false, threadId: 'comm-123' });
+    await setup({ showPatientSummary: false, threadId: 'comm-123' });
 
     await waitFor(
       () => {
@@ -255,7 +268,7 @@ describe('ThreadInbox', () => {
 
   test('opens new topic dialog when plus button is clicked', async () => {
     const user = userEvent.setup();
-    setup();
+    await setup();
 
     const iconButtons = screen.getAllByRole('button', { name: '' });
     const plusButton = iconButtons[iconButtons.length - 1];
@@ -268,7 +281,7 @@ describe('ThreadInbox', () => {
 
   test('closes new topic dialog when close is clicked', async () => {
     const user = userEvent.setup();
-    setup();
+    await setup();
 
     const iconButtons = screen.getAllByRole('button', { name: '' });
     const plusButton = iconButtons[iconButtons.length - 1];
@@ -299,7 +312,7 @@ describe('ThreadInbox', () => {
     });
     medplum.graphql = jest.fn().mockResolvedValue({ data: { CommunicationList: [] } });
 
-    setup({ threadId: 'comm-123' });
+    await setup({ threadId: 'comm-123' });
 
     await waitFor(
       () => {
@@ -312,7 +325,7 @@ describe('ThreadInbox', () => {
 
   test('changes status filter to completed when Completed button is clicked', async () => {
     const user = userEvent.setup();
-    setup();
+    await setup();
 
     const completedButton = screen.getByText('Completed');
     await user.click(completedButton);
@@ -333,7 +346,7 @@ describe('ThreadInbox', () => {
     });
     medplum.graphql = jest.fn().mockResolvedValue({ data: { CommunicationList: [] } });
 
-    setup({ threadId: 'comm-123' });
+    await setup({ threadId: 'comm-123' });
 
     await waitFor(
       () => {
@@ -364,7 +377,7 @@ describe('ThreadInbox', () => {
 
     const updateResourceSpy = jest.spyOn(medplum, 'updateResource');
 
-    setup({ threadId: 'comm-123' });
+    await setup({ threadId: 'comm-123' });
 
     await waitFor(
       () => {
@@ -401,7 +414,7 @@ describe('ThreadInbox', () => {
     });
     medplum.graphql = jest.fn().mockResolvedValue({ data: { CommunicationList: [] } });
 
-    setup({ threadId: 'comm-123' });
+    await setup({ threadId: 'comm-123' });
 
     await waitFor(
       () => {
@@ -424,7 +437,7 @@ describe('ThreadInbox', () => {
     });
     medplum.graphql = jest.fn().mockResolvedValue({ data: { CommunicationList: [] } });
 
-    setup({ threadId: 'comm-123' });
+    await setup({ threadId: 'comm-123' });
 
     await waitFor(
       () => {
@@ -448,7 +461,7 @@ describe('ThreadInbox', () => {
     medplum.graphql = jest.fn().mockResolvedValue({ data: { CommunicationList: [] } });
     medplum.updateResource = jest.fn().mockRejectedValue(new Error('Status update failed'));
 
-    setup({ threadId: 'comm-123' });
+    await setup({ threadId: 'comm-123' });
 
     await waitFor(
       () => {
@@ -485,7 +498,7 @@ describe('ThreadInbox', () => {
     });
     medplum.graphql = jest.fn().mockResolvedValue({ data: { CommunicationList: [] } });
 
-    setup();
+    await setup();
 
     await waitFor(
       () => {

--- a/packages/react/src/chat/ThreadInbox/ThreadInbox.test.tsx
+++ b/packages/react/src/chat/ThreadInbox/ThreadInbox.test.tsx
@@ -78,7 +78,6 @@ describe('ThreadInbox', () => {
       );
 
       await Promise.resolve();
-      await Promise.resolve();
     });
   };
 


### PR DESCRIPTION
This PR removes the noisy React test warnings in `@medplum/react`

The main functional fix is in `packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx`. `QuestionnaireForm` was invoking parent `onChange` handlers during render/initialization, which caused "Cannot update a component while rendering a different component" warnings in `NewTopicDialog`. The form now stages pending response changes and emits them from an effect after render.

The `Spotlight` warning was fixed in `packages/react/src/AppShell/Spotlight.tsx` by removing the unsupported `inputProps` nesting and passing the password-manager ignore attributes directly through Mantine’s supported `searchProps` input props.

The remaining warning cleanup was test-focused:

- `packages/react/src/chat/ThreadInbox/ThreadInbox.test.tsx` now awaits initial async render work and injects a mock navigate function into `MedplumProvider`, which eliminates the `act(...)` warnings and the `jsdom` navigation to another Document errors.
- `packages/react/src/chat/ThreadInbox/ParticipantFilter.tsx` now cancels pending debounced searches on cleanup.
- `packages/react/src/chat/ThreadInbox/ParticipantFilter.test.tsx` now uses fake timers with `userEvent` timer advancement and flushes pending timers in `act(...)`, which removes the debounce/transition warning noise.
