### PR TITLE
fix(provider): Coverage eligibility handle errors and include timestamps

### DIFF
--- a/examples/medplum-provider/src/components/encounter/EncounterCoverageEligibilityModal.tsx
+++ b/examples/medplum-provider/src/components/encounter/EncounterCoverageEligibilityModal.tsx
@@ -237,7 +237,10 @@ function CoverageCard(props: CoverageCardProps): JSX.Element {
         <DetailField label="Type" value={getCoverageType(coverage)} />
         <DetailField label="Patient ID" value={coverage.subscriberId ?? coverage.identifier?.[0]?.value ?? '—'} />
         <DetailField label="Group Number" value={getGroupNumber(coverage)} />
-        <DetailField label="Effective Date" value={coverage.period?.start ? formatDateTime(coverage.period.start) : '—'} />
+        <DetailField
+          label="Effective Date"
+          value={coverage.period?.start ? formatDateTime(coverage.period.start) : '—'}
+        />
         <DetailField label="End Date" value={coverage.period?.end ? formatDateTime(coverage.period.end) : '—'} />
       </SimpleGrid>
 

--- a/examples/medplum-provider/src/components/encounter/EncounterCoverageEligibilityModal.tsx
+++ b/examples/medplum-provider/src/components/encounter/EncounterCoverageEligibilityModal.tsx
@@ -19,7 +19,7 @@ import {
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
-import { createReference, formatDate, getReferenceString } from '@medplum/core';
+import { createReference, formatDateTime, getReferenceString } from '@medplum/core';
 import type {
   Bot,
   Coverage,
@@ -237,8 +237,8 @@ function CoverageCard(props: CoverageCardProps): JSX.Element {
         <DetailField label="Type" value={getCoverageType(coverage)} />
         <DetailField label="Patient ID" value={coverage.subscriberId ?? coverage.identifier?.[0]?.value ?? '—'} />
         <DetailField label="Group Number" value={getGroupNumber(coverage)} />
-        <DetailField label="Effective Date" value={coverage.period?.start ? formatDate(coverage.period.start) : '—'} />
-        <DetailField label="End Date" value={coverage.period?.end ? formatDate(coverage.period.end) : '—'} />
+        <DetailField label="Effective Date" value={coverage.period?.start ? formatDateTime(coverage.period.start) : '—'} />
+        <DetailField label="End Date" value={coverage.period?.end ? formatDateTime(coverage.period.end) : '—'} />
       </SimpleGrid>
 
       <Divider />
@@ -250,7 +250,7 @@ function CoverageCard(props: CoverageCardProps): JSX.Element {
             {benefitsLoading && <Loader size="xs" />}
             {latestRequest && (
               <Text size="xs" c="dimmed">
-                Last checked: {formatDate(latestRequest.created ?? latestRequest.meta?.lastUpdated ?? '')}
+                Last checked: {formatDateTime(latestRequest.created ?? latestRequest.meta?.lastUpdated ?? '')}
               </Text>
             )}
             {benefitsOpened ? <IconChevronUp size={18} /> : <IconChevronDown size={18} />}
@@ -266,7 +266,13 @@ function CoverageCard(props: CoverageCardProps): JSX.Element {
                   : 'No eligibility check found. Contact support to enable eligibility checks.'}
               </Text>
             )}
+            {!benefitsLoading && eligibilityResponse?.outcome === 'error' && (
+              <Text size="sm" c="red">
+                {eligibilityResponse.disposition ?? 'Eligibility check returned an error.'}
+              </Text>
+            )}
             {!benefitsLoading &&
+              eligibilityResponse?.outcome !== 'error' &&
               eligibilityResponse?.insurance?.map((ins, i) => {
                 const items = ins.item;
                 if (!items || items.length === 0) {

--- a/examples/medplum-provider/src/components/encounter/EncounterHeader.tsx
+++ b/examples/medplum-provider/src/components/encounter/EncounterHeader.tsx
@@ -136,7 +136,7 @@ export const EncounterHeader = (props: EncounterHeaderProps): JSX.Element => {
               leftSection={<IconShieldCheck size={16} />}
               onClick={handleCheckEligibility}
             >
-              Check Insurance Eligibility
+              Insurance Eligibility
             </Button>
             {status === 'cancelled' || status === 'finished' ? (
               <>

--- a/examples/medplum-provider/src/components/insurance/EligibilityDetails.tsx
+++ b/examples/medplum-provider/src/components/insurance/EligibilityDetails.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Divider, ScrollArea, Skeleton, Stack, Table, Text, Title } from '@mantine/core';
-import { formatDate, formatPeriod } from '@medplum/core';
+import { formatDateTime, formatPeriod } from '@medplum/core';
 import type {
   CoverageEligibilityRequest,
   CoverageEligibilityResponse,
@@ -31,7 +31,7 @@ export function EligibilityDetails({ request, response, loadingResponse }: Eligi
 
 function getServicedDateText(request: CoverageEligibilityRequest): string {
   if (request.servicedDate) {
-    return formatDate(request.servicedDate);
+    return formatDateTime(request.servicedDate);
   }
   if (request.servicedPeriod) {
     return formatPeriod(request.servicedPeriod);
@@ -45,7 +45,7 @@ function RequestSection({ request }: { request: CoverageEligibilityRequest }): J
       <Title order={5}>Eligibility Request</Title>
       <Table>
         <Table.Tbody>
-          <DetailRow label="Created" value={formatDate(request.created)} />
+          <DetailRow label="Created" value={formatDateTime(request.created)} />
           <DetailRow label="Purpose" value={request.purpose?.map(formatPurpose).join(', ') ?? '—'} />
           <DetailRow label="Serviced Date" value={getServicedDateText(request)} />
           <DetailRow label="Insurer" value={request.insurer?.display ?? request.insurer?.reference ?? '—'} />
@@ -94,7 +94,7 @@ function ResponseSection({
           <DetailRow label="Outcome" value={formatOutcome(response.outcome)} />
           {response.disposition && <DetailRow label="Disposition" value={response.disposition} />}
           <DetailRow label="Insurer" value={response.insurer?.display ?? response.insurer?.reference ?? '—'} />
-          <DetailRow label="Created" value={formatDate(response.created)} />
+          <DetailRow label="Created" value={formatDateTime(response.created)} />
         </Table.Tbody>
       </Table>
       {response.insurance?.map((insurance, index) => (

--- a/examples/medplum-provider/src/components/insurance/EligibilityListItem.tsx
+++ b/examples/medplum-provider/src/components/insurance/EligibilityListItem.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Group, Stack, Text } from '@mantine/core';
-import { formatDate } from '@medplum/core';
+import { formatDateTime } from '@medplum/core';
 import type { CoverageEligibilityRequest } from '@medplum/fhirtypes';
 import { MedplumLink } from '@medplum/react';
 import cx from 'clsx';
@@ -30,7 +30,7 @@ export function EligibilityListItem({ request, isSelected, href }: EligibilityLi
             {purposes}
           </Text>
           <Text size="sm" c="dimmed">
-            {formatDate(request.created)}
+            {formatDateTime(request.created)}
           </Text>
         </Stack>
       </Group>


### PR DESCRIPTION
- Display errors in encounter eligibility check 
- Display date and times of requests/responses created.

<img width="1160" height="801" alt="Screenshot 2026-04-08 at 11 47 29 AM" src="https://github.com/user-attachments/assets/06f52f5b-695b-4549-bbc5-5f736af65c1e" />
