### PR TITLE
URL decode errors return 400 instead of 500

### DIFF
--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -236,6 +236,16 @@ describe('App', () => {
       // Request should be logged
       expect(logObj).toMatchObject({ method: 'GET', path: '/fhir/R4/Patient', status: 400 });
     });
+
+    test('Route parsing error', async () => {
+      const accessToken = await initTestAuth();
+      const res1 = await request(app)
+        .get('/fhir/R4/Organization/%account')
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .send();
+      expect(res1.status).toBe(400);
+    });
   });
 
   test('Internal Server Error', async () => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -156,6 +156,11 @@ function errorHandler(err: any, req: Request, res: Response, next: NextFunction)
     sendOutcome(res, unsupportedMediaType);
     return;
   }
+  if (err instanceof URIError && 'status' in err && err.status === 400) {
+    // the router package sets err.status to 400 when decodeURIComponent throws a URIError
+    sendOutcome(res, badRequest(err.message));
+    return;
+  }
   getLogger().error('Unhandled error', err);
   res.status(500).json({ msg: 'Internal Server Error' });
 }


### PR DESCRIPTION
Example 500 error:

```
@timestamp
1775755143881
error
URIError: Failed to decode param '%account'
level
ERROR
message
Failed to decode param '%account'
msg
Unhandled error
name
URIError
stack.0
URIError: Failed to decode param '%account'
stack.1
at decodeURIComponent (<anonymous>)
stack.10
at Layer.handleRequest (/usr/src/medplum/node_modules/router/lib/layer.js:152:17)
stack.2
at decodeParam (/usr/src/medplum/node_modules/router/lib/layer.js:225:12)
stack.3
at Array.map (<anonymous>)
stack.4
at /usr/src/medplum/node_modules/path-to-regexp/dist/index.js:231:50
stack.5
at Array.match (/usr/src/medplum/node_modules/path-to-regexp/dist/index.js:244:32)
stack.6
at Layer.match (/usr/src/medplum/node_modules/router/lib/layer.js:192:31)
stack.7
at matchLayer (/usr/src/medplum/node_modules/router/index.js:519:18)
stack.8
at next (/usr/src/medplum/node_modules/router/index.js:237:15)
stack.9
at authenticateRequest (file:///usr/src/medplum/packages/server/dist/index.js:33730:5)
status
400
timestamp
2026-04-09T17:19:03.881Z
```