### PR TITLE
fix: rewrite attachment urls in transaction bundles

### DIFF
--- a/packages/core/src/bundle.test.ts
+++ b/packages/core/src/bundle.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type {
+  Binary,
   Bundle,
   BundleEntry,
   DiagnosticReport,
@@ -235,6 +236,48 @@ describe('Bundle tests', () => {
           },
         ],
       });
+    });
+
+    test('Rewrite Attachment.url references to Binary resources in the same bundle', () => {
+      const inputBundle: Bundle = {
+        resourceType: 'Bundle',
+        type: 'searchset',
+        entry: [
+          {
+            fullUrl: 'https://example.com/Binary/file-123',
+            resource: {
+              resourceType: 'Binary',
+              id: 'file-123',
+              contentType: 'text/plain',
+              data: 'aGVsbG8=',
+            } satisfies Binary,
+          },
+          {
+            fullUrl: 'https://example.com/DocumentReference/doc-123',
+            resource: {
+              resourceType: 'DocumentReference',
+              id: 'doc-123',
+              status: 'current',
+              content: [
+                {
+                  attachment: {
+                    contentType: 'text/plain',
+                    url: 'Binary/file-123',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      };
+
+      const result = convertToTransactionBundle(inputBundle);
+      const binaryEntry = result.entry?.find((entry) => entry.resource?.resourceType === 'Binary');
+      const documentReference = result.entry?.find((entry) => entry.resource?.resourceType === 'DocumentReference')
+        ?.resource as any;
+
+      expect(binaryEntry?.fullUrl).toMatch(/^urn:uuid:/);
+      expect(documentReference?.content?.[0]?.attachment?.url).toBe(binaryEntry?.fullUrl);
     });
 
     test('Remove empty resource.meta', () => {

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -68,8 +68,12 @@ export function convertToTransactionBundle(bundle: Bundle): Bundle {
 function referenceReplacer(key: string, value: string, idToUuid: Record<string, string>): string {
   if ((key === 'reference' || key === 'url') && typeof value === 'string') {
     let id;
+    if (key === 'url' && !value.startsWith('Binary/')) {
+      return value;
+    }
     if (value.includes('/')) {
-      id = value.split('/')[1];
+      const parts = value.split('/');
+      id = parts[parts.length - 1];
     } else if (value.startsWith('urn:uuid:')) {
       id = value.slice(9);
     } else if (value.startsWith('#')) {


### PR DESCRIPTION
## Summary
- rewrite `Attachment.url` values when they point to `Binary/{id}` resources present in the same bundle
- add regression coverage for `convertToTransactionBundle` so Binary attachment URLs are rewritten to the generated `urn:uuid:` value

## Validation
- `npm test --workspace packages/core -- bundle.test.ts`
- `npx prettier --check packages/core/src/bundle.ts packages/core/src/bundle.test.ts`

Closes #8664
