### PR TITLE
Alternative approach in `parseParameter`

### DIFF
--- a/packages/core/src/filter/parse.test.ts
+++ b/packages/core/src/filter/parse.test.ts
@@ -1,18 +1,38 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert';
 import { Operator } from '../search/search';
 import { parseFilterParameter } from './parse';
 import { FhirFilterComparison, FhirFilterConnective, FhirFilterNegation } from './types';
 
 describe('_filter Parameter parser', () => {
-  test('Simple comparison', () => {
-    const result = parseFilterParameter('name co "pet"');
-    expect(result).toBeInstanceOf(FhirFilterComparison);
-
-    const comp = result as FhirFilterComparison;
-    expect(comp.path).toBe('name');
-    expect(comp.operator).toBe(Operator.CONTAINS);
-    expect(comp.value).toBe('pet');
+  test.each<[string, string, FhirFilterComparison]>([
+    ['simple comparison', 'name co "pet"', { path: 'name', operator: Operator.CONTAINS, value: 'pet' }],
+    [
+      'system and code',
+      'code eq http://loinc.org|1234-5',
+      { path: 'code', operator: Operator.EXACT, value: 'http://loinc.org|1234-5' },
+    ],
+    [
+      'identifier search',
+      'performer identifier https://example.com/1234',
+      { path: 'performer', operator: Operator.IDENTIFIER, value: 'https://example.com/1234' },
+    ],
+    ['Starts with', 'name sw ali', { path: 'name', operator: Operator.STARTS_WITH, value: 'ali' }],
+    [
+      'Raw token with leading digits',
+      'identifier eq 123_abc',
+      { path: 'identifier', operator: Operator.EXACT, value: '123_abc' },
+    ],
+    [
+      'Reverse chained search',
+      "_has:Observation:patient:_id ne ''",
+      { path: '_has:Observation:patient:_id', operator: Operator.NOT_EQUALS, value: '' },
+    ],
+  ])('%s', (_, filter, expected) => {
+    const result = parseFilterParameter(filter);
+    assert(result instanceof FhirFilterComparison);
+    expect(result).toMatchObject(expected);
   });
 
   test('Negation', () => {
@@ -200,49 +220,7 @@ describe('_filter Parameter parser', () => {
     expect(fourth.value).toBe('456');
   });
 
-  test('Observation with system and code', () => {
-    const result = parseFilterParameter('code eq http://loinc.org|1234-5');
-    expect(result).toBeInstanceOf(FhirFilterComparison);
-
-    const comp = result as FhirFilterComparison;
-    expect(comp.path).toBe('code');
-    expect(comp.operator).toBe(Operator.EXACT);
-    expect(comp.value).toBe('http://loinc.org|1234-5');
-  });
-
-  test('Identifier search', () => {
-    const result = parseFilterParameter('performer identifier https://example.com/1234');
-    expect(result).toBeInstanceOf(FhirFilterComparison);
-
-    const comp = result as FhirFilterComparison;
-    expect(comp.path).toBe('performer');
-    expect(comp.operator).toBe(Operator.IDENTIFIER);
-    expect(comp.value).toBe('https://example.com/1234');
-  });
-
-  test('Starts with', () => {
-    const result = parseFilterParameter('name sw ali');
-    expect(result).toBeInstanceOf(FhirFilterComparison);
-
-    const comp = result as FhirFilterComparison;
-    expect(comp.operator).toEqual(Operator.STARTS_WITH);
-  });
-
   test('Unsupported search operator', () => {
     expect(() => parseFilterParameter('name ew ali')).toThrow('Invalid operator: ew');
-  });
-
-  test('Reverse chained search', () => {
-    const result = parseFilterParameter(`_has:Observation:patient:_id ne ''`);
-    expect(result).toBeInstanceOf(FhirFilterComparison);
-    expect((result as FhirFilterComparison).operator).toBe(Operator.NOT_EQUALS);
-  });
-
-  test('parse raw token with leading digits', () => {
-    const result = parseFilterParameter('identifier eq 123_abc');
-    expect(result).toBeInstanceOf(FhirFilterComparison);
-
-    const comp = result as FhirFilterComparison;
-    expect(comp.value).toEqual('123_abc');
   });
 });

--- a/packages/core/src/search/search.test.ts
+++ b/packages/core/src/search/search.test.ts
@@ -52,7 +52,7 @@ describe('Search Utils', () => {
     ['', new Error('Invalid search URL')],
     ['Observation?date=12/17', new Error('Invalid format for date search parameter: 12/17')],
     ['Observation?date=012522', new Error('Invalid format for date search parameter: 012522')],
-  ])('parseSearchRequest(%p) => %p', (url, expected) => {
+  ])('parseSearchRequest($0) => $1', (url, expected) => {
     if (expected instanceof Error) {
       expect(() => parseSearchRequest(url)).toThrow(expected);
     } else {
@@ -234,7 +234,7 @@ describe('Search Utils', () => {
       'Patient?_lastUpdated:foobar=2025-10-15',
       { resourceType: 'Patient', filters: [{ code: '_lastUpdated', operator: 'foobar', value: '2025-10-15' }] },
     ],
-  ])('Invalid modifiers still parsed in %p', (url, expected) => {
+  ])('Invalid modifiers still parsed in $0', (url, expected) => {
     if (expected instanceof Error) {
       expect(() => parseSearchRequest(url)).toThrow(expected);
     } else {
@@ -242,42 +242,57 @@ describe('Search Utils', () => {
     }
   });
 
-  test('Parse chained search parameters', () => {
-    const searchReq = parseSearchRequest(
-      'Patient?organization.name=Kaiser%20Permanente&_has:Observation:subject:performer:Practitioner.name=Alice'
-    );
-
-    expect(searchReq).toMatchObject<SearchRequest>({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'organization.name',
-          operator: Operator.EQUALS,
-          value: 'Kaiser Permanente',
-        },
-        {
-          code: '_has:Observation:subject:performer:Practitioner.name',
-          operator: Operator.EQUALS,
-          value: 'Alice',
-        },
-      ],
-    });
-  });
-
-  test('Parsed chained search', () => {
-    const searchReq = parseSearchRequest(
-      `Patient?_has:Observation:subject:encounter:Encounter._has:DiagnosticReport:encounter:result.specimen.parent.collected=2023`
-    );
-    expect(searchReq).toMatchObject<SearchRequest>({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: '_has:Observation:subject:encounter:Encounter._has:DiagnosticReport:encounter:result.specimen.parent.collected',
-          operator: Operator.EQUALS,
-          value: '2023',
-        },
-      ],
-    });
+  test.each([
+    [
+      'single-link chained search parameter',
+      'Patient?organization.name=Kaiser%20Permanente&_has:Observation:subject:performer:Practitioner.name=Alice',
+      {
+        resourceType: 'Patient',
+        filters: [
+          {
+            code: 'organization.name',
+            operator: Operator.EQUALS,
+            value: 'Kaiser Permanente',
+          },
+          {
+            code: '_has:Observation:subject:performer:Practitioner.name',
+            operator: Operator.EQUALS,
+            value: 'Alice',
+          },
+        ],
+      },
+    ],
+    [
+      'multi-link chained search parameter',
+      'Patient?_has:Observation:subject:encounter:Encounter._has:DiagnosticReport:encounter:result.specimen.parent.collected=2023',
+      {
+        resourceType: 'Patient',
+        filters: [
+          {
+            code: '_has:Observation:subject:encounter:Encounter._has:DiagnosticReport:encounter:result.specimen.parent.collected',
+            operator: Operator.EQUALS,
+            value: '2023',
+          },
+        ],
+      },
+    ],
+    [
+      'prefixes are not processed for chained search parameters',
+      'Patient?_has:EpisodeOfCare:patient:date=ge2026-04-01',
+      {
+        resourceType: 'Patient',
+        filters: [
+          {
+            code: '_has:EpisodeOfCare:patient:date',
+            operator: Operator.EQUALS,
+            value: 'ge2026-04-01',
+          },
+        ],
+      },
+    ],
+  ])('chained search parseSearchRequest %s', (_, url, expected) => {
+    const searchReq = parseSearchRequest(url);
+    expect(searchReq).toMatchObject(expected);
   });
 
   test('Format Patient search', () => {

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -304,7 +304,7 @@ function parseKeyValue(searchRequest: SearchRequest, key: string, value: string)
     default: {
       const param = globalSchema.types[searchRequest.resourceType]?.searchParams?.[code];
       if (param) {
-        searchRequest.filters = append(searchRequest.filters, parseParameter(param, modifier, value));
+        searchRequest.filters = append(searchRequest.filters, parseParameter(param, Operator.EQUALS, modifier, value));
       } else {
         searchRequest.filters = append(searchRequest.filters, parseUnknownParameter(code, modifier, value));
       }
@@ -330,11 +330,16 @@ function parseSortRule(searchRequest: SearchRequest, value: string): void {
 }
 
 const presenceOperators: Operator[] = [Operator.MISSING, Operator.PRESENT];
-export function parseParameter(searchParam: SearchParameter, modifier: string, value: string): Filter {
-  if (presenceOperators.includes(modifier as Operator)) {
+export function parseParameter(
+  searchParam: SearchParameter,
+  operator: Operator,
+  modifier: string,
+  value: string
+): Filter {
+  if (presenceOperators.includes((modifier as Operator) || operator)) {
     return {
       code: searchParam.code,
-      operator: modifier as Operator,
+      operator: (modifier as Operator) || operator,
       value,
     };
   }
@@ -363,15 +368,7 @@ export function parseParameter(searchParam: SearchParameter, modifier: string, v
           badRequest(`Invalid format for ${searchParam.type} search parameter: ${value}`)
         );
       }
-      let operator = parseModifier(modifier);
-      if (!operator) {
-        if (modifier === Operator.NOT_EQUALS) {
-          operator = Operator.NOT_EQUALS;
-        } else {
-          operator = Operator.EQUALS;
-        }
-      }
-      return { code: searchParam.code, operator: operator, value };
+      return { code: searchParam.code, operator: parseModifier(modifier) ?? operator, value };
     }
     default:
       throw new Error('Unrecognized search parameter type: ' + searchParam.type);

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -5,6 +5,7 @@ import {
   createReference,
   getReferenceString,
   getSearchParameter,
+  isDefined,
   LOINC,
   normalizeErrorString,
   Operator,
@@ -50,6 +51,7 @@ import type {
   Task,
 } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
+import assert from 'node:assert';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
@@ -57,10 +59,12 @@ import { DatabaseMode } from '../database';
 import { bundleContains, createTestProject, withTestContext } from '../test.setup';
 import type { SystemRepository } from './repo';
 import { getGlobalSystemRepo, Repository } from './repo';
-import { clampEstimateCount, getCount } from './search';
+import type { ChainedSearchLink } from './search';
+import { clampEstimateCount, Direction, getCount, parseChainedParameter } from './search';
 import type { TokenColumnSearchParameterImplementation } from './searchparameter';
 import { getSearchParameterImplementation } from './searchparameter';
 import { SelectQuery } from './sql';
+import { loadStructureDefinitions } from './structure';
 
 jest.mock('hibp');
 
@@ -3681,6 +3685,12 @@ describe('project-scoped Repository', () => {
         identifier: [{ system: 'http://example.com/mrn', value: mrn }],
       });
 
+      // Patient not expected to match any searches
+      await repo.createResource<Patient>({
+        resourceType: 'Patient',
+        identifier: [{ system: 'http://example.com/mrn', value: 'no-match' }],
+      });
+
       const practitioner = await repo.createResource<Practitioner>({
         resourceType: 'Practitioner',
         name: [{ given: ['Yves'] }],
@@ -3718,23 +3728,31 @@ describe('project-scoped Repository', () => {
       });
 
       expect(result.entry).toHaveLength(2);
-      expect(result.entry?.map((e) => e.resource?.id)).toStrictEqual(
-        expect.arrayContaining([observation1.id, observation2.id])
+      expect(getEntryIds(result)).toStrictEqual(expect.arrayContaining([observation1.id, observation2.id]));
+
+      // Patients with observations performed by themselves with an ID equal to observation1.id
+      const result2 = await repo.search(
+        parseSearchRequest(`Patient?_filter=_has:Observation:performer:_id eq '${observation1.id}'`)
       );
+      expect(getEntryIds(result2)).toStrictEqual([patient.id]);
 
-      const result2 = await repo.search({
-        resourceType: 'Patient',
-        filters: [
-          {
-            code: '_filter',
-            operator: Operator.EQUALS,
-            value: `_has:Observation:performer:_id ne '${observation2.id}'`,
-          },
-        ],
-      });
+      // Patients with observations performed by themselves with an ID equal to observation2.id
+      const result3 = await repo.search(
+        parseSearchRequest(`Patient?_filter=_has:Observation:performer:_id eq '${observation2.id}'`)
+      );
+      expect(getEntryIds(result3)).toStrictEqual([patient.id]);
 
-      expect(result2.entry).toHaveLength(1);
-      expect(result2.entry?.[0].resource?.id).toStrictEqual(patient.id);
+      // Patients with observations performed by themselves with an ID NOT equal to observation1.id
+      const result4 = await repo.search(
+        parseSearchRequest(`Patient?_filter=_has:Observation:performer:_id ne '${observation1.id}'`)
+      );
+      expect(getEntryIds(result4)).toStrictEqual([]);
+
+      // Patients with observations performed by themselves with an ID NOT equal to observation2.id
+      const result5 = await repo.search(
+        parseSearchRequest(`Patient?_filter=_has:Observation:performer:_id ne '${observation2.id}'`)
+      );
+      expect(getEntryIds(result5)).toStrictEqual([patient.id]);
     }));
 
   test('reverse chain with prefix modifier', async () =>
@@ -3755,19 +3773,8 @@ describe('project-scoped Repository', () => {
         valueQuantity: { value: 101, code: '[degF]', system: UCUM },
       });
 
-      const result = await repo.search({
-        resourceType: 'Patient',
-        filters: [
-          {
-            code: '_has:Observation:subject:value-quantity',
-            operator: Operator.EQUALS,
-            value: 'gt100',
-          },
-        ],
-      });
-
-      expect(result.entry).toHaveLength(1);
-      expect(result.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
+      const result = await repo.search(parseSearchRequest('Patient?_has:Observation:subject:value-quantity=gt100'));
+      expect(getEntryIds(result)).toStrictEqual([patient.id]);
     }));
 
   test('Lookup table exact match with comma disjunction', () =>
@@ -5575,4 +5582,36 @@ describe('systemRepo', () => {
       })
     );
   });
+});
+
+function getEntryIds(result: Bundle<WithId<Resource>>): string[] {
+  return result.entry?.map((e) => e.resource?.id).filter(isDefined) ?? [];
+}
+
+describe('parseChainedParameter', () => {
+  beforeAll(async () => {
+    await loadTestConfig();
+    loadStructureDefinitions();
+  });
+  test('reverse chained search with prefix operators', () =>
+    withTestContext(async () => {
+      const searchRequest = parseSearchRequest('Patient?_has:EpisodeOfCare:patient:date=ge2026-04-01');
+      expect(searchRequest.filters?.length).toStrictEqual(1);
+      const filter = searchRequest.filters?.[0];
+      assert(filter);
+
+      const chain = parseChainedParameter(searchRequest.resourceType, filter);
+      expect(chain.chain.length).toStrictEqual(1);
+      expect(chain.chain[0]).toMatchObject<Partial<ChainedSearchLink>>({
+        originType: 'Patient',
+        targetType: 'EpisodeOfCare',
+        code: 'patient',
+        direction: Direction.REVERSE,
+      });
+      expect(chain.filter).toMatchObject<Partial<Filter>>({
+        code: 'date',
+        operator: Operator.GREATER_THAN_OR_EQUALS,
+        value: '2026-04-01',
+      });
+    }));
 });

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -3740,7 +3740,7 @@ describe('project-scoped Repository', () => {
       const result3 = await repo.search(
         parseSearchRequest(`Patient?_filter=_has:Observation:performer:_id eq '${observation2.id}'`)
       );
-      expect(getEntryIds(result3)).toStrictEqual([patient.id]);
+      expect(getEntryIds(result3)).toStrictEqual([]);
 
       // Patients with observations performed by themselves with an ID NOT equal to observation1.id
       const result4 = await repo.search(

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -5590,28 +5590,26 @@ function getEntryIds(result: Bundle<WithId<Resource>>): string[] {
 
 describe('parseChainedParameter', () => {
   beforeAll(async () => {
-    await loadTestConfig();
     loadStructureDefinitions();
   });
-  test('reverse chained search with prefix operators', () =>
-    withTestContext(async () => {
-      const searchRequest = parseSearchRequest('Patient?_has:EpisodeOfCare:patient:date=ge2026-04-01');
-      expect(searchRequest.filters?.length).toStrictEqual(1);
-      const filter = searchRequest.filters?.[0];
-      assert(filter);
+  test('reverse chained search with prefix operators', () => {
+    const searchRequest = parseSearchRequest('Patient?_has:EpisodeOfCare:patient:date=ge2026-04-01');
+    expect(searchRequest.filters?.length).toStrictEqual(1);
+    const filter = searchRequest.filters?.[0];
+    assert(filter);
 
-      const chain = parseChainedParameter(searchRequest.resourceType, filter);
-      expect(chain.chain.length).toStrictEqual(1);
-      expect(chain.chain[0]).toMatchObject<Partial<ChainedSearchLink>>({
-        originType: 'Patient',
-        targetType: 'EpisodeOfCare',
-        code: 'patient',
-        direction: Direction.REVERSE,
-      });
-      expect(chain.filter).toMatchObject<Partial<Filter>>({
-        code: 'date',
-        operator: Operator.GREATER_THAN_OR_EQUALS,
-        value: '2026-04-01',
-      });
-    }));
+    const chain = parseChainedParameter(searchRequest.resourceType, filter);
+    expect(chain.chain.length).toStrictEqual(1);
+    expect(chain.chain[0]).toMatchObject<Partial<ChainedSearchLink>>({
+      originType: 'Patient',
+      targetType: 'EpisodeOfCare',
+      code: 'patient',
+      direction: Direction.REVERSE,
+    });
+    expect(chain.filter).toMatchObject<Partial<Filter>>({
+      code: 'date',
+      operator: Operator.GREATER_THAN_OR_EQUALS,
+      value: '2026-04-01',
+    });
+  });
 });

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -97,12 +97,12 @@ interface Cursor {
 }
 
 /** Linking direction for chained search. */
-const Direction = {
+export const Direction = {
   FORWARD: 1,
   REVERSE: -1,
 } as const;
 
-interface ChainedSearchLink {
+export interface ChainedSearchLink {
   originType: string;
   targetType: string;
   code: string;
@@ -971,7 +971,7 @@ export function buildSearchExpression(
   const expressions: Expression[] = [];
   for (const filter of searchRequest.filters ?? EMPTY) {
     const expr = buildSearchFilterExpression(repo, selectQuery, resourceType, resourceType, filter);
-      expressions.push(expr);
+    expressions.push(expr);
   }
   if (expressions.length === 0) {
     return undefined;
@@ -1792,7 +1792,7 @@ function lookupTableJoinCondition(currentTable: string, link: ChainedSearchLink,
   ]);
 }
 
-function parseChainedParameter(resourceType: string, searchFilter: Filter): ChainedSearchParameter {
+export function parseChainedParameter(resourceType: string, searchFilter: Filter): ChainedSearchParameter {
   let currentResourceType = resourceType;
   const parts = splitChainedSearch(searchFilter.code);
 

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -970,17 +970,8 @@ export function buildSearchExpression(
 ): Expression | undefined {
   const expressions: Expression[] = [];
   for (const filter of searchRequest.filters ?? EMPTY) {
-    let expr: Expression | undefined;
-    if (isChainedSearchFilter(filter)) {
-      const chain = parseChainedParameter(searchRequest.resourceType, filter);
-      expr = buildChainedSearch(repo, selectQuery, searchRequest.resourceType, chain);
-    } else {
-      expr = buildSearchFilterExpression(repo, selectQuery, resourceType, resourceType, filter);
-    }
-
-    if (expr) {
+    const expr = buildSearchFilterExpression(repo, selectQuery, resourceType, resourceType, filter);
       expressions.push(expr);
-    }
   }
   if (expressions.length === 0) {
     return undefined;
@@ -1015,7 +1006,7 @@ function buildSearchFilterExpression(
     throw new OperationOutcomeError(badRequest('Search filter value cannot contain null bytes'));
   }
 
-  if (filter.code.startsWith('_has:') || filter.code.includes('.')) {
+  if (isChainedSearchFilter(filter)) {
     const chain = parseChainedParameter(resourceType, filter);
     return buildChainedSearch(repo, selectQuery, resourceType, chain);
   }

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -1813,7 +1813,7 @@ function parseChainedParameter(resourceType: string, searchFilter: Filter): Chai
         if (!searchParam) {
           throw new Error(`Invalid search parameter at end of chain: ${currentResourceType}?${code}`);
         }
-        filter = parseParameter(searchParam, modifier ?? searchFilter.operator, searchFilter.value);
+        filter = parseParameter(searchParam, searchFilter.operator, modifier, searchFilter.value);
       }
     } else {
       const link = parseChainLink(part, currentResourceType);


### PR DESCRIPTION
The crux of the changes is that `parseParameter` now takes both `operator` and `modifier` as inputs so that `operator` can be used as a fallback/default return value.

Let's consider the search

```
Patient?_filter=_has:Observation:performer:_id ne 'some-id'
```

Part of the chain of execution is `buildFilterParameterComparison` --> `buildSearchFilterExpression` --> `parseChainedParameter` --> `parseParameter`

Now, `parseParameter` is called with operator `ne` and modifier as the empty string.



