### PR TITLE
ci(sonar): temporarily disable sonar on most builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: SonarCloud Scan
-        if: ${{ github.event_name != 'merge_group' && matrix.node-version == 22 && matrix.pg-version == 14 && matrix.redis-version == 7 && (vars.SONAR_ENABLED == 'true' || github.ref == 'refs/heads/main') }}
+        if: ${{ matrix.node-version == 22 && matrix.pg-version == 14 && matrix.redis-version == 7 && (vars.SONAR_ENABLED == 'true' || github.ref == 'refs/heads/main') }}
         continue-on-error: true
         uses: SonarSource/sonarqube-scan-action@9598b8a83feef37de07f549027fab50ecffe6a6e # master
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: SonarCloud Scan
-        if: ${{ github.event_name != 'merge_group' && matrix.node-version == 22 && matrix.pg-version == 14 && matrix.redis-version == 7 }}
+        if: ${{ github.event_name != 'merge_group' && matrix.node-version == 22 && matrix.pg-version == 14 && matrix.redis-version == 7 && (vars.SONAR_ENABLED == 'true' || github.ref == 'refs/heads/main') }}
         continue-on-error: true
         uses: SonarSource/sonarqube-scan-action@9598b8a83feef37de07f549027fab50ecffe6a6e # master
         env:


### PR DESCRIPTION
Since Sonar has been stalling many of our CI runs, taking 20 minutes only to run out of memory before completing, we should temporarily disable the SonarQube Scan action until we get it working again 