### PR TITLE
Exclude content column from reindex upsert to avoid TOAST churn

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1288,7 +1288,9 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     }
 
     await this.batchWriteLookupTables(conn, resources, false);
-    await this.batchWriteResources(conn, resources);
+    // Exclude 'content' from the upsert merge: reindexing updates search columns only,
+    // never the stored resource content. This avoids unnecessary TOAST table churn.
+    await this.batchWriteResources(conn, resources, ['content']);
   }
 
   /**
@@ -1782,7 +1784,11 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     await new InsertQuery(resource.resourceType, [this.buildResourceRow(resource)]).mergeOnConflict().execute(client);
   }
 
-  private async batchWriteResources(client: PoolClient, resources: Resource[]): Promise<void> {
+  private async batchWriteResources(
+    client: PoolClient,
+    resources: Resource[],
+    mergeExcludeColumns?: string[]
+  ): Promise<void> {
     if (!resources.length) {
       return;
     }
@@ -1791,7 +1797,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       resources[0].resourceType,
       resources.map((r) => this.buildResourceRow(r))
     )
-      .mergeOnConflict()
+      .mergeOnConflict(undefined, undefined, mergeExcludeColumns)
       .execute(client);
   }
 

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -1049,6 +1049,7 @@ export class InsertQuery extends BaseQuery {
   private returnColumns?: string[];
   private conflictColumns?: string[];
   private conflictCondition?: Condition;
+  private mergeExcludeColumns?: string[];
   private ignoreConflict?: boolean;
 
   constructor(tableName: string, values: Record<string, any>[] | SelectQuery) {
@@ -1060,10 +1061,13 @@ export class InsertQuery extends BaseQuery {
     }
   }
 
-  mergeOnConflict(columns?: string[], where?: Condition): this {
+  mergeOnConflict(columns?: string[], where?: Condition, excludeColumns?: string[]): this {
     this.conflictColumns = columns ?? ['id'];
     if (where) {
       this.conflictCondition = where;
+    }
+    if (excludeColumns) {
+      this.mergeExcludeColumns = excludeColumns;
     }
     return this;
   }
@@ -1163,7 +1167,7 @@ export class InsertQuery extends BaseQuery {
     const columns = Object.keys(this.values[0]);
     let first = true;
     for (const columnName of columns) {
-      if (this.conflictColumns.includes(columnName)) {
+      if (this.conflictColumns.includes(columnName) || this.mergeExcludeColumns?.includes(columnName)) {
         continue;
       }
       if (!first) {


### PR DESCRIPTION
## Summary

- Exclude the `content` column from the `DO UPDATE SET` clause when reindexing resources, avoiding unnecessary PostgreSQL TOAST table churn
- Add `mergeExcludeColumns` support to `InsertQuery.mergeOnConflict()` as general-purpose SQL plumbing
- We are evaluating fully removing `content` from the resource table and reading content via a join on `versionId` to the history table. Making that schema change would by default result in not updating `content` during reindexes since `<Resource>_History` tables are not written/updated. We would have to explicitly expand the definition/role of reindexing to include rewriting history.

## Background

When `ReindexJob` reindexes resources, it recomputes search parameter columns and writes them back via an `INSERT INTO ... ON CONFLICT (id) DO UPDATE SET ...` query. This query included all columns, including `content` (the JSON-serialized FHIR resource), which is not modified during a reindex (with the exception of any differences in the roundtrip of `JSON.parse` and `stringify` from `@medplum/core`).

PostgreSQL's TOAST mechanism stores large column values (typically >2KB) in a separate TOAST table. When an `UPDATE` includes a TOASTed column in the `SET` clause, PostgreSQL writes a new copy of the TOAST data even if the value is byte-for-byte identical, and marks the old copy as a dead tuple for later vacuuming. For large tables with large resources, this creates significant unnecessary I/O and TOAST table bloat during reindex operations.

## Changes

**`packages/server/src/fhir/sql.ts`**
- Added `mergeExcludeColumns` field to `InsertQuery`
- Extended `mergeOnConflict()` to accept an optional `excludeColumns` parameter
- `appendMerge()` skips excluded columns when building the `DO UPDATE SET` clause

**`packages/server/src/fhir/repo.ts`**
- `batchWriteResources()` accepts an optional `mergeExcludeColumns` parameter
- `reindexResources()` always excludes `content` from the merge. This is not opt-in, since reindexing by definition updates search indexes only, never stored resource content.

## Test plan

- [x] Existing reindex worker tests pass (30 tests)
- [x] Existing repo tests pass (166 tests)
- [ ] Verify on a staging environment that reindexed resources retain correct `content` values
- [ ] Confirm reduced TOAST table growth during a bulk reindex compared to before this change

## Alternative

Since the rows written during rewritten are guaranteed to be updating an existing row, using a plain old `UPDATE ...` query instead `INSERT INTO ... ON CONFLICT ...` would simplify some of the logic here with the trade off being an additional write path.
