### PR TITLE
Sort resource array columns without an accompanying sort column

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -21,6 +21,7 @@ import {
 import type {
   Binary,
   BundleEntry,
+  DocumentReference,
   ElementDefinition,
   Login,
   Observation,
@@ -55,7 +56,9 @@ import { bundleContains, createTestProject, withTestContext } from '../test.setu
 import { AuditEventOutcome, createAuditEvent, ReadInteraction, RestfulOperationType } from '../util/auditevent';
 import * as workersModule from '../workers';
 import { getRepoForLogin } from './accesspolicy';
+import type { ColumnValue } from './repo';
 import {
+  compareColumnValues,
   getGlobalSystemRepo,
   getProjectSystemRepo,
   getShardSystemRepo,
@@ -1420,6 +1423,85 @@ describe('FHIR Repo', () => {
     );
   });
 
+  describe('Array column value sorting', () => {
+    test('stores multi-valued reference column in sorted order (DocumentReference.author)', () =>
+      withTestContext(async () => {
+        const authorRefs = [
+          'Practitioner/zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz',
+          'Patient/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+          'Practitioner/11111111-1111-1111-1111-111111111111',
+        ];
+        const expected = [...authorRefs].sort(compareColumnValues);
+
+        const doc = await systemRepo.createResource<DocumentReference>({
+          resourceType: 'DocumentReference',
+          status: 'current',
+          content: [{ attachment: { url: 'https://example.com/doc.pdf' } }],
+          author: [{ reference: authorRefs[0] }, { reference: authorRefs[1] }, { reference: authorRefs[2] }],
+        });
+
+        const db = getDatabasePool(DatabaseMode.READER);
+        const results = await db.query('SELECT "author" FROM "DocumentReference" WHERE "id" = $1', [doc.id]);
+        expect(results.rows).toStrictEqual([{ author: expected }]);
+      }));
+
+    test('same reference values in different resource order yield identical stored array', () =>
+      withTestContext(async () => {
+        const a = 'Patient/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const b = 'Practitioner/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        const expected = [a, b].sort(compareColumnValues);
+
+        const doc1 = await systemRepo.createResource<DocumentReference>({
+          resourceType: 'DocumentReference',
+          status: 'current',
+          content: [{ attachment: { url: 'https://example.com/a.pdf' } }],
+          author: [{ reference: b }, { reference: a }],
+        });
+        const doc2 = await systemRepo.createResource<DocumentReference>({
+          resourceType: 'DocumentReference',
+          status: 'current',
+          content: [{ attachment: { url: 'https://example.com/b.pdf' } }],
+          author: [{ reference: a }, { reference: b }],
+        });
+
+        const db = getDatabasePool(DatabaseMode.READER);
+        const r1 = await db.query('SELECT "author" FROM "DocumentReference" WHERE "id" = $1', [doc1.id]);
+        const r2 = await db.query('SELECT "author" FROM "DocumentReference" WHERE "id" = $1', [doc2.id]);
+        expect(r1.rows).toStrictEqual([{ author: expected }]);
+        expect(r2.rows).toStrictEqual([{ author: expected }]);
+      }));
+
+    test('stores multi-valued quantity column in sorted order (Observation.component)', () =>
+      withTestContext(async () => {
+        const values = [100.5, 3.14, 42];
+        const expected = [...values].sort(compareColumnValues);
+
+        const obs = await systemRepo.createResource<Observation>({
+          resourceType: 'Observation',
+          status: 'final',
+          code: { text: 'component quantity sort test' },
+          component: [
+            {
+              code: { text: 'first' },
+              valueQuantity: { value: values[0], unit: '1', system: 'http://unitsofmeasure.org', code: '1' },
+            },
+            {
+              code: { text: 'second' },
+              valueQuantity: { value: values[1], unit: '1', system: 'http://unitsofmeasure.org', code: '1' },
+            },
+            {
+              code: { text: 'third' },
+              valueQuantity: { value: values[2], unit: '1', system: 'http://unitsofmeasure.org', code: '1' },
+            },
+          ],
+        });
+
+        const db = getDatabasePool(DatabaseMode.READER);
+        const results = await db.query('SELECT "componentValueQuantity" FROM "Observation" WHERE "id" = $1', [obs.id]);
+        expect(results.rows).toStrictEqual([{ componentValueQuantity: expected }]);
+      }));
+  });
+
   test('Conditional reference resolution', async () =>
     withTestContext(async () => {
       const practitionerIdentifier = randomUUID();
@@ -2047,6 +2129,136 @@ describe('FHIR Repo', () => {
         client.release();
       }
     }));
+});
+
+describe('compareColumnValues', () => {
+  describe('returns 0 when a === b', () => {
+    test.each<[ColumnValue, ColumnValue]>([
+      [null, null],
+      [undefined, undefined],
+      ['Patient/1', 'Patient/1'],
+      ['https://example.org/fhir/Patient/abc', 'https://example.org/fhir/Patient/abc'],
+      ['', ''],
+      [' ', ' '],
+      [0, 0],
+      [-0, 0],
+      [3.14, 3.14],
+      [-100, -100],
+      [Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
+      [Number.MIN_SAFE_INTEGER, Number.MIN_SAFE_INTEGER],
+      [true, true],
+      [false, false],
+    ])('compareColumnValues(%p, %p) === 0', (a, b) => {
+      expect(compareColumnValues(a, b)).toBe(0);
+    });
+  });
+
+  describe('returns 1 when a is null or undefined and b is defined', () => {
+    test.each<[ColumnValue, ColumnValue]>([
+      [null, 'x'],
+      [undefined, 'x'],
+      [null, ''],
+      [undefined, ''],
+      [null, ' '],
+      [undefined, 'Patient/1'],
+      [null, 0],
+      [undefined, 0],
+      [null, -1],
+      [undefined, 3.14],
+      [undefined, Number.NaN],
+      [null, Number.POSITIVE_INFINITY],
+      [undefined, Number.MIN_SAFE_INTEGER],
+      [null, false],
+      [undefined, true],
+    ])('compareColumnValues(%p, %p) === 1', (a, b) => {
+      expect(compareColumnValues(a, b)).toBe(1);
+    });
+  });
+
+  describe('null and undefined are equal', () => {
+    test.each<[ColumnValue, ColumnValue, 0]>([
+      [null, undefined, 0],
+      [undefined, null, 0],
+    ])('compareColumnValues(%p, %p) === %s', (a, b, expected) => {
+      expect(compareColumnValues(a, b)).toBe(expected);
+    });
+  });
+
+  describe('returns -1 when b is null or undefined and a is defined', () => {
+    test.each<[ColumnValue, ColumnValue]>([
+      ['x', null],
+      ['x', undefined],
+      ['', null],
+      ['Patient/1', undefined],
+      [0, null],
+      [0, undefined],
+      [-1, undefined],
+      [3.14, null],
+      [Number.NaN, null],
+      [Number.POSITIVE_INFINITY, undefined],
+      [false, null],
+      [true, undefined],
+    ])('compareColumnValues(%p, %p) === -1', (a, b) => {
+      expect(compareColumnValues(a, b)).toBe(-1);
+    });
+  });
+
+  describe('returns a - b when both operands are numbers', () => {
+    test.each<[number, number, number]>([
+      [1, 2, -1],
+      [2, 1, 1],
+      [0, -1, 1],
+      [-1, -2, 1],
+      [-1, 1, -2],
+      [100, 50, 50],
+      [Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER - 1, 1],
+      [Number.MIN_SAFE_INTEGER, Number.MIN_SAFE_INTEGER + 1, -1],
+      [0, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY],
+      [Number.POSITIVE_INFINITY, 0, Number.POSITIVE_INFINITY],
+      [Number.NEGATIVE_INFINITY, 0, Number.NEGATIVE_INFINITY],
+      [0, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY],
+    ])('compareColumnValues(%p, %p) === %p', (a, b, expected) => {
+      expect(compareColumnValues(a, b)).toBe(expected);
+    });
+
+    test('NaN arithmetic and negative minus positive infinity', () => {
+      expect(compareColumnValues(Number.NaN, 1)).toBeNaN();
+      expect(compareColumnValues(1, Number.NaN)).toBeNaN();
+      expect(compareColumnValues(Number.NaN, Number.NaN)).toBeNaN();
+      expect(compareColumnValues(Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY)).toBe(Number.NEGATIVE_INFINITY);
+    });
+  });
+
+  describe('returns Number(a) - Number(b) when both operands are booleans', () => {
+    test.each<[boolean, boolean, number]>([
+      [false, true, -1],
+      [true, false, 1],
+    ])('compareColumnValues(%p, %p) === %p', (a, b, expected) => {
+      expect(compareColumnValues(a, b)).toBe(expected);
+    });
+  });
+
+  describe('uses String(a).localeCompare(String(b)) when types are not both number or both boolean', () => {
+    test.each<[ColumnValue, ColumnValue]>([
+      ['apple', 'banana'],
+      ['banana', 'apple'],
+      ['', 'z'],
+      ['a', 'Z'],
+      ['prefix', 'prefixLonger'],
+      ['Observation/10', 'Observation/2'],
+      [1, '2'],
+      [0, '0'],
+      [-5, '5'],
+      [true, 'false'],
+      [false, '0'],
+      [1, true],
+      [0, false],
+      [false, 0],
+      [true, 1],
+    ])('compareColumnValues(%p, %p) matches localeCompare', (a, b) => {
+      expect(compareColumnValues(a, b)).toBe(String(a).localeCompare(String(b)));
+    });
+  });
 });
 
 function shuffleString(s: string): string {

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -340,7 +340,8 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
    * 11. 09/25/25 - Added ConceptMapping lookup table (https://github.com/medplum/medplum/pull/7469)
    * 12. 12/01/25 - Added search param `Bot-cds-hook` (https://github.com/medplum/medplum/pull/7933)
    * 13. 01/05/25 - Added search params: ActivityDefinition-code, Communication-priority, Communication-priority-order, ProjectMembership-active (https://github.com/medplum/medplum/pull/8160)
-   * 14. 04/08/26 - Added search params: ProjectMembership-admin, Practitioner-qualification-code (https://github.com/medplum/medplum/pull/8919) and sort inline array columns
+   * 14. 04/14/26 - Added search params: ProjectMembership-admin, Practitioner-qualification-code (https://github.com/medplum/medplum/pull/8919)
+   *                and sort inline array columns (https://github.com/medplum/medplum/pull/8961)
    */
   static readonly VERSION: number = 14;
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -282,6 +282,27 @@ export interface ProcessAllResourcesOptions {
   delayBetweenPagesMs?: number;
 }
 
+export type ColumnValue = boolean | number | string | undefined | null;
+
+export function compareColumnValues(a: ColumnValue, b: ColumnValue): number {
+  if ((a ?? null) === (b ?? null)) {
+    return 0;
+  }
+  if (a === null || a === undefined) {
+    return 1;
+  }
+  if (b === null || b === undefined) {
+    return -1;
+  }
+  if (typeof a === 'number' && typeof b === 'number') {
+    return a - b;
+  }
+  if (typeof a === 'boolean' && typeof b === 'boolean') {
+    return Number(a) - Number(b);
+  }
+  return String(a).localeCompare(String(b));
+}
+
 /**
  * The Repository class manages reading and writing to the FHIR repository.
  * It is a thin layer on top of the database.
@@ -1918,6 +1939,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     impl satisfies ColumnSearchParameterImplementation;
     const columnValues = this.buildColumnValues(searchParam, impl, typedValues);
     if (impl.array) {
+      columnValues.sort(compareColumnValues);
       columns[impl.columnName] = columnValues.length > 0 ? columnValues : undefined;
     } else {
       columns[impl.columnName] = columnValues[0];
@@ -1937,7 +1959,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     searchParam: SearchParameter,
     details: SearchParameterDetails,
     typedValues: TypedValue[]
-  ): (boolean | number | string | undefined | null)[] {
+  ): ColumnValue[] {
     if (details.type === SearchParameterType.BOOLEAN) {
       const value = typedValues[0]?.value;
       if (value === undefined || value === null) {

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -340,8 +340,9 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
    * 11. 09/25/25 - Added ConceptMapping lookup table (https://github.com/medplum/medplum/pull/7469)
    * 12. 12/01/25 - Added search param `Bot-cds-hook` (https://github.com/medplum/medplum/pull/7933)
    * 13. 01/05/25 - Added search params: ActivityDefinition-code, Communication-priority, Communication-priority-order, ProjectMembership-active (https://github.com/medplum/medplum/pull/8160)
+   * 14. 04/08/26 - Added search params: ProjectMembership-admin, Practitioner-qualification-code (https://github.com/medplum/medplum/pull/8919) and sort inline array columns
    */
-  static readonly VERSION: number = 13;
+  static readonly VERSION: number = 14;
 
   constructor(context: RepositoryContext, conn?: PoolClient) {
     super();


### PR DESCRIPTION
Since there is not an accompanying sort column, make a best effort based on postgres behavior when sorting by search parameters backed by an array column.