### PR TITLE
fix(otel): use `ExponentialHistogram` view

### DIFF
--- a/packages/server/src/otel/instrumentation.ts
+++ b/packages/server/src/otel/instrumentation.ts
@@ -16,7 +16,7 @@ import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
 import { RuntimeNodeInstrumentation } from '@opentelemetry/instrumentation-runtime-node';
 import { defaultResource, resourceFromAttributes } from '@opentelemetry/resources';
 import type { MetricReader } from '@opentelemetry/sdk-metrics';
-import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { AggregationType, InstrumentType, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import type { SpanExporter } from '@opentelemetry/sdk-trace-base';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
@@ -102,6 +102,12 @@ export function initOpenTelemetry(): void {
     instrumentations,
     metricReaders: metricReader ? [metricReader] : undefined,
     traceExporter,
+    views: [
+      {
+        instrumentType: InstrumentType.HISTOGRAM,
+        aggregation: { type: AggregationType.EXPONENTIAL_HISTOGRAM },
+      },
+    ],
   });
   sdk.start();
 }


### PR DESCRIPTION
Previously our histograms have been using the default explicit buckets for histograms, which are arbitrarily set (0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000), leading to truncated graphs which don't make as much sense whenever data points suddenly spike but stay within the arbitrarily set lower value buckets. This PR fixes that by using the automatically calculated buckets via an exponential histogram view, which is now the default for most other OTel SDKs in other languages. 

The exponential histogram uses up to 160 buckets by default, selected to support a high-resolution distribution covering 1ms to 100s with less than 5% relative error — making it strictly better than simply tweaking the explicit bucket boundaries.