### PR TITLE
docs(auth): add direct-external-auth to sidebar and overview

### DIFF
--- a/packages/docs/docs/auth/direct-external-auth.md
+++ b/packages/docs/docs/auth/direct-external-auth.md
@@ -7,7 +7,8 @@ tags: [auth]
 
 Medplum supports authenticating users directly with an external Identity Provider (IDP) access token, without requiring a token exchange or authorization code flow. This is useful when your application already holds a valid JWT from an external IDP and wants to access the Medplum API directly.
 
-:::caution Self-Hosted Deployments Only
+:::caution
+Self-Hosted Deployments Only
 
 This feature requires super admin privileges to configure `externalAuthProviders` in the [server config](/docs/self-hosting/server-config), which is only available on self-hosted Medplum deployments. If you are using Medplum's cloud-hosted service and need this capability, please contact [Medplum support](/contact).
 

--- a/packages/docs/docs/auth/direct-external-auth.md
+++ b/packages/docs/docs/auth/direct-external-auth.md
@@ -108,7 +108,8 @@ To find a user's `sub` value, decode the JWT from your IDP or check the IDP's us
 4. Searches for a `ProjectMembership` where `externalId` matches the `sub` value
 5. Returns auth credentials scoped to that membership
 
-:::caution Uniqueness
+:::caution 
+Uniqueness
 
 The `externalId` must be unique across all project memberships. If multiple memberships share the same `externalId`, authentication will fail with a `401` response to prevent ambiguity.
 

--- a/packages/docs/docs/auth/index.md
+++ b/packages/docs/docs/auth/index.md
@@ -9,7 +9,8 @@ This page helps you choose the correct authentication method for your applicatio
 
 For **user-facing applications (web or mobile apps)**, use [_browser-based authentication_](#browser-based-authentication).
 
-:::caution Patient Login
+:::caution 
+Patient Login
 The Medplum App (https://app.medplum.com) is an administrative tool for clinical users and developers. Patients **cannot** log in to this application directly. To provide patient access, you must build a custom patient portal using the Medplum SDK.
 :::
 
@@ -24,6 +25,7 @@ This category is for user-facing applications that connect directly to Medplum. 
 | [Medplum as IDP](/docs/auth/medplum-as-idp)                    | (default) **Get going fast**, and don't have external compliance requirements.                 |
 | [External IDP](/docs/auth/external-identity-providers.mdx)     | Connect to an external IDP, like [Google Auth](/docs/auth/google-auth), Auth0, or AWS Cognito. |
 | [Domain-level IDP](/docs/auth/domain-level-identity-providers) | Use your enterprise, domain-level **corporate identity solution.**                             |
+| [Direct External Auth](/docs/auth/direct-external-auth)        | Authenticate directly with an external IDP token, without a token exchange flow (self-hosted only). |
 
 ## Server-side Authentication
 

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -254,6 +254,7 @@ const sidebars: SidebarsConfig = {
         { type: 'doc', id: 'auth/external-identity-providers' },
         { type: 'doc', id: 'auth/google-auth' },
         { type: 'doc', id: 'auth/domain-level-identity-providers' },
+        { type: 'doc', id: 'auth/direct-external-auth' },
         { type: 'html', value: '<strong class="menu__link">Server-side Auth</strong>' },
         { type: 'doc', id: 'auth/client-credentials' },
         { type: 'doc', id: 'auth/on-behalf-of' },


### PR DESCRIPTION
## Summary

- Adds `direct-external-auth` to the left sidebar under the **Identity Providers** section
- Adds a row for Direct External Auth in the auth overview table in `index.md`
- Fixes admonition rendering in `direct-external-auth.md` and `index.md` by moving the title text to the line after the opening `:::` (required with `future.v4` enabled)
