### PR TITLE
feat(server): support externalAuthProviders via environment variable

### DIFF
--- a/packages/server/src/config/loader.test.ts
+++ b/packages/server/src/config/loader.test.ts
@@ -107,6 +107,19 @@ describe('Config', () => {
     expect(config.botCustomFunctionsEnabled).toBe(true);
   });
 
+  test('Env config externalAuthProviders as JSON array', async () => {
+    setEnv('MEDPLUM_BASE_URL', 'http://localhost:3000');
+    setEnv(
+      'MEDPLUM_EXTERNAL_AUTH_PROVIDERS',
+      JSON.stringify([{ issuer: 'https://idp.example.com', userInfoUrl: 'https://idp.example.com/userinfo' }])
+    );
+
+    const config = await loadConfig('env');
+    expect(config.externalAuthProviders).toHaveLength(1);
+    expect(config.externalAuthProviders?.[0].issuer).toStrictEqual('https://idp.example.com');
+    expect(config.externalAuthProviders?.[0].userInfoUrl).toStrictEqual('https://idp.example.com/userinfo');
+  });
+
   test('Env config integer values', async () => {
     setEnv('MEDPLUM_BASE_URL', 'http://localhost:3000');
     setEnv('MEDPLUM_PORT', '9000');

--- a/packages/server/src/config/utils.ts
+++ b/packages/server/src/config/utils.ts
@@ -184,6 +184,7 @@ const objectKeys = new Set([
   'ssl',
   'defaultProjectSystemSetting',
   'defaultOAuthClients',
+  'externalAuthProviders',
   'smtp',
   'arrayColumnPadding',
   'subscriptionAutoDisable',


### PR DESCRIPTION
## Summary

- Adds `externalAuthProviders` to the `objectKeys` set in the env config loader, enabling it to be set via the `MEDPLUM_EXTERNAL_AUTH_PROVIDERS` environment variable
- Previously the field was silently stored as a raw string instead of a parsed JSON array, making env-based configuration non-functional
- Adds a test covering the env var loading path

Usage would look like 

`MEDPLUM_EXTERNAL_AUTH_PROVIDERS='[{"issuer":"<ISSUER>","userInfoUrl":"<USER_INFO_URL>"}]'`