### PR TITLE
Include Project in presigned URLs

### DIFF
--- a/packages/server/src/storage/presign.ts
+++ b/packages/server/src/storage/presign.ts
@@ -24,6 +24,10 @@ export async function generatePresignedUrl(binary: Binary, opts?: PresignedUrlOp
   dateLessThan.setHours(dateLessThan.getHours() + 1);
   result.searchParams.set('Expires', Math.floor(dateLessThan.getTime() / 1000).toString());
 
+  if (binary.meta?.project) {
+    result.searchParams.set('Project', binary.meta.project);
+  }
+
   const url = (opts?.upload ? 'PUT ' : 'GET ') + result.toString();
   if (config.signingKey) {
     const privateKey = { key: config.signingKey, passphrase: config.signingKeyPassphrase };

--- a/packages/server/src/storage/routes.test.ts
+++ b/packages/server/src/storage/routes.test.ts
@@ -11,7 +11,7 @@ import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
 import { getGlobalSystemRepo } from '../fhir/repo';
-import { withTestContext } from '../test.setup';
+import { createTestProject, withTestContext } from '../test.setup';
 import { getBinaryStorage } from './loader';
 
 const app = express();
@@ -161,5 +161,79 @@ describe('Storage Routes', () => {
     dateLessThan.setHours(dateLessThan.getHours() + 1);
     const res = await request(app).put(`/storage/${binary.id}?Signature=xyz&Expires=${dateLessThan.getTime()}`);
     expect(res.status).toBe(401);
+  });
+
+  describe('Project query param', () => {
+    let projectId: string;
+    let projectBinary: Binary;
+
+    beforeAll(async () => {
+      const { project } = await createTestProject();
+      projectId = project.id;
+      projectBinary = await withTestContext(async () => {
+        return systemRepo.createResource<Binary>({
+          resourceType: 'Binary',
+          contentType: ContentType.TEXT,
+          meta: { project: projectId },
+        });
+      });
+
+      const req = new Readable();
+      req.push('project hello');
+      req.push(null);
+      (req as any).headers = {};
+      await getBinaryStorage().writeBinary(projectBinary, 'hello.txt', ContentType.TEXT, req as Request);
+    });
+
+    test('Presigned URL includes Project before Signature', async () => {
+      const url = await getBinaryStorage().getPresignedUrl(projectBinary);
+      const parsed = new URL(url);
+      expect(parsed.searchParams.get('Project')).toBe(projectId);
+      const projectIdx = parsed.search.indexOf('Project=');
+      const signatureIdx = parsed.search.indexOf('Signature=');
+      expect(projectIdx).toBeGreaterThanOrEqual(0);
+      expect(signatureIdx).toBeGreaterThanOrEqual(0);
+      expect(projectIdx).toBeLessThan(signatureIdx);
+    });
+
+    test('Presigned URL omits Project when binary has no project', async () => {
+      const url = await getBinaryStorage().getPresignedUrl(binary);
+      const parsed = new URL(url);
+      expect(parsed.searchParams.get('Project')).toBeNull();
+    });
+
+    test('GET success with Project param', async () => {
+      const req = request(app).get('/');
+      config.storageBaseUrl = req.url + 'storage/';
+      req.url = await getBinaryStorage().getPresignedUrl(projectBinary);
+      const res = await req;
+      expect(res.status).toBe(200);
+    });
+
+    test('GET tampered Project fails signature', async () => {
+      const req = request(app).get('/');
+      config.storageBaseUrl = req.url + 'storage/';
+      const url = await getBinaryStorage().getPresignedUrl(projectBinary);
+      req.url = url.replace(`Project=${projectId}`, `Project=${randomUUID()}`);
+      const res = await req;
+      expect(res.status).toBe(401);
+    });
+
+    test('PUT success with Project param', async () => {
+      const req = request(app).put('/').set('Content-Type', 'text/plain');
+      config.storageBaseUrl = req.url + 'storage/';
+      req.url = await getBinaryStorage().getPresignedUrl(projectBinary, { upload: true });
+      const res = await req.send('project upload content');
+      expect(res.status).toBe(200);
+    });
+
+    test('PUT tampered Project fails signature', async () => {
+      const req = request(app).put('/').set('Content-Type', 'text/plain');
+      config.storageBaseUrl = req.url + 'storage/';
+      const url = await getBinaryStorage().getPresignedUrl(projectBinary, { upload: true });
+      req.url = url.replace(`Project=${projectId}`, `Project=${randomUUID()}`);
+      const res = await req.send('tampered');
+      expect(res.status).toBe(401);
+    });
   });
 });

--- a/packages/server/src/storage/routes.ts
+++ b/packages/server/src/storage/routes.ts
@@ -9,8 +9,7 @@ import { createPrivateKey, createPublicKey, createVerify } from 'node:crypto';
 import { pipeline } from 'node:stream';
 import { promisify } from 'node:util';
 import { getConfig } from '../config/loader';
-import { getShardSystemRepo } from '../fhir/repo';
-import { TODO_SHARD_ID } from '../fhir/sharding';
+import { getGlobalSystemRepo, getProjectSystemRepo } from '../fhir/repo';
 import { getBinaryStorage } from './loader';
 
 export const storageRouter = Router();
@@ -20,41 +19,10 @@ const pump = promisify(pipeline);
 let cachedPublicKey: KeyObject | undefined = undefined;
 
 storageRouter.get('/:id{/:versionId}', async (req: Request, res: Response) => {
-  const originalUrl = new URL(req.originalUrl, `${req.protocol}://${req.get('host')}`);
-  const signature = originalUrl.searchParams.get('Signature');
-  if (!signature) {
-    res.sendStatus(401);
+  const binary = await verifyAndLoadBinary(req, res, 'GET');
+  if (!binary) {
     return;
   }
-
-  const expires = req.query['Expires'];
-  if (!expires || Math.floor(Date.now() / 1000) > Number.parseInt(expires as string, 10)) {
-    res.status(410).send('URL has expired');
-    return;
-  }
-
-  originalUrl.searchParams.delete('Signature');
-  const urlToVerify = originalUrl.toString();
-
-  const verifier = createVerify('sha256');
-  verifier.update('GET ');
-  verifier.update(urlToVerify);
-  const publicKey = getPublicKey();
-  const isVerified = verifier.verify(publicKey, signature, 'base64');
-  if (!isVerified) {
-    // Try legacy format without HTTP method
-    const verifier = createVerify('sha256');
-    verifier.update(urlToVerify);
-    const legacyVerified = verifier.verify(publicKey, signature, 'base64');
-    if (!legacyVerified) {
-      res.status(401).send('Invalid signature');
-      return;
-    }
-  }
-
-  const id = singularize(req.params.id) ?? '';
-  const systemRepo = getShardSystemRepo(TODO_SHARD_ID); // unauthenticated; how to know which shard to query for the Binary?
-  const binary = await systemRepo.readResource<Binary>('Binary', id);
 
   try {
     const stream = await getBinaryStorage().readBinary(binary);
@@ -66,35 +34,10 @@ storageRouter.get('/:id{/:versionId}', async (req: Request, res: Response) => {
 });
 
 storageRouter.put('/:id{/:versionId}', async (req: Request, res: Response) => {
-  const originalUrl = new URL(req.originalUrl, `${req.protocol}://${req.get('host')}`);
-  const signature = originalUrl.searchParams.get('Signature');
-  if (!signature) {
-    res.sendStatus(401);
+  const binary = await verifyAndLoadBinary(req, res, 'PUT');
+  if (!binary) {
     return;
   }
-
-  const expires = req.query['Expires'];
-  if (!expires || Math.floor(Date.now() / 1000) > Number.parseInt(expires as string, 10)) {
-    res.status(410).send('URL has expired');
-    return;
-  }
-
-  originalUrl.searchParams.delete('Signature');
-  const urlToVerify = originalUrl.toString();
-
-  const verifier = createVerify('sha256');
-  verifier.update('PUT ');
-  verifier.update(urlToVerify);
-  const publicKey = getPublicKey();
-  const isVerified = verifier.verify(publicKey, signature, 'base64');
-  if (!isVerified) {
-    res.status(401).send('Invalid signature');
-    return;
-  }
-
-  const id = singularize(req.params.id) ?? '';
-  const systemRepo = getShardSystemRepo(TODO_SHARD_ID); // unauthenticated; how to know which shard to query for the Binary?
-  const binary = await systemRepo.readResource<Binary>('Binary', id);
 
   const contentType = req.headers['content-type'];
   if (contentType && contentType !== binary.contentType) {
@@ -109,6 +52,43 @@ storageRouter.put('/:id{/:versionId}', async (req: Request, res: Response) => {
     res.sendStatus(400);
   }
 });
+
+async function verifyAndLoadBinary(req: Request, res: Response, method: 'GET' | 'PUT'): Promise<Binary | undefined> {
+  const originalUrl = new URL(req.originalUrl, `${req.protocol}://${req.get('host')}`);
+  const signature = originalUrl.searchParams.get('Signature');
+  if (!signature) {
+    res.sendStatus(401);
+    return undefined;
+  }
+
+  const expires = req.query['Expires'];
+  if (!expires || Math.floor(Date.now() / 1000) > Number.parseInt(expires as string, 10)) {
+    res.status(410).send('URL has expired');
+    return undefined;
+  }
+
+  originalUrl.searchParams.delete('Signature');
+  const urlToVerify = originalUrl.toString();
+  const publicKey = getPublicKey();
+
+  let isVerified = createVerify('sha256')
+    .update(method + ' ')
+    .update(urlToVerify)
+    .verify(publicKey, signature, 'base64');
+  if (!isVerified && method === 'GET') {
+    // Try legacy format without HTTP method
+    isVerified = createVerify('sha256').update(urlToVerify).verify(publicKey, signature, 'base64');
+  }
+  if (!isVerified) {
+    res.status(401).send('Invalid signature');
+    return undefined;
+  }
+
+  const id = singularize(req.params.id) ?? '';
+  const projectId = originalUrl.searchParams.get('Project');
+  const systemRepo = projectId ? await getProjectSystemRepo(projectId) : getGlobalSystemRepo();
+  return systemRepo.readResource<Binary>('Binary', id);
+}
 
 function getPublicKey(): KeyObject {
   cachedPublicKey ??= buildPublicKey();


### PR DESCRIPTION
This facilitates the sharding endeavor by making the Project ID of the Binary at hand known in the unauthenticated storage routes.