### PR TITLE
Scheduling: Use Reference<HealthcareService> in place of CodeableConcept[]

### DIFF
--- a/examples/foomedical/src/pages/GetCarePage.tsx
+++ b/examples/foomedical/src/pages/GetCarePage.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Alert, Loader } from '@mantine/core';
-import type { Appointment, Bundle, Patient, Slot } from '@medplum/fhirtypes';
-import { createReference, isDefined, normalizeErrorString } from '@medplum/core';
+import type { Appointment, Bundle, HealthcareService, Patient, Reference, Slot } from '@medplum/fhirtypes';
+import { createReference, getExtensionValue, isDefined, normalizeErrorString } from '@medplum/core';
 import { Document, Scheduler, useMedplum } from '@medplum/react';
 import type { SlotSearchFunction } from '@medplum/react';
 import { useSearchOne } from '@medplum/react-hooks';
@@ -10,13 +10,21 @@ import { IconInfoCircle } from '@tabler/icons-react';
 import { useState } from 'react';
 import type { JSX } from 'react';
 
+const SERVICE_TYPE_REFERENCE_URI = 'https://medplum.com/fhir/service-type-reference';
+
 export function GetCare(): JSX.Element {
   const medplum = useMedplum();
   const patient = medplum.getProfile() as Patient;
   const [schedule, loading] = useSearchOne('Schedule');
 
+  const healthcareServiceRef = schedule?.serviceType
+    ?.map(
+      (concept) => getExtensionValue(concept, SERVICE_TYPE_REFERENCE_URI) as Reference<HealthcareService> | undefined
+    )
+    .find(isDefined);
+
   const fetchSlots: SlotSearchFunction = async (period) => {
-    if (!schedule) {
+    if (!schedule || !healthcareServiceRef?.reference) {
       return [];
     }
 
@@ -28,7 +36,7 @@ export function GetCare(): JSX.Element {
     const params = new URLSearchParams({
       start: period.start,
       end: period.end,
-      'service-type': 'office-visit',
+      'service-type-reference': healthcareServiceRef.reference,
     });
     const findUrl = medplum.fhirUrl('Schedule', schedule.id, '$find');
     const bundle = await medplum.get<Bundle<Slot>>(`${findUrl}?${params}`);
@@ -69,6 +77,16 @@ export function GetCare(): JSX.Element {
       <Document width={800}>
         <Alert variant="outline" color="red" title="Schedule unavailable" icon={<IconInfoCircle />}>
           Loading the schedule failed.
+        </Alert>
+      </Document>
+    );
+  }
+
+  if (!healthcareServiceRef) {
+    return (
+      <Document width={800}>
+        <Alert variant="outline" color="red" title="Schedule unavailable" icon={<IconInfoCircle />}>
+          No appointment type is configured for this schedule.
         </Alert>
       </Document>
     );

--- a/examples/medplum-provider/src/App.tsx
+++ b/examples/medplum-provider/src/App.tsx
@@ -52,6 +52,7 @@ import { ResourceEditPage } from './pages/resource/ResourceEditPage';
 import { ResourceHistoryPage } from './pages/resource/ResourceHistoryPage';
 import { ResourcePage } from './pages/resource/ResourcePage';
 import { SchedulePage } from './pages/schedule/SchedulePage';
+import { ScheduleSettingsPage } from './pages/schedule/ScheduleSettingsPage';
 import { SearchPage } from './pages/SearchPage';
 import { SignInPage } from './pages/SignInPage';
 import { SpacesPage } from './pages/spaces/SpacesPage';
@@ -226,6 +227,7 @@ export function App(): JSX.Element | null {
               <Route path="/onboarding" element={<IntakeFormPage />} />
               <Route path="/Calendar/Schedule" element={<SchedulePage />} />
               <Route path="/Calendar/Schedule/:id" element={<SchedulePage />} />
+              <Route path="/Calendar/Schedule/:id/settings" element={<ScheduleSettingsPage />} />
               <Route path="/signin" element={<SignInPage />} />
               {hasDoseSpot && <Route path="/dosespot" element={<DoseSpotNotificationsPage />} />}
               {hasScriptSure && <Route path="/scriptsure" element={<ScriptSurePage />} />}

--- a/examples/medplum-provider/src/components/AlphaBanner.tsx
+++ b/examples/medplum-provider/src/components/AlphaBanner.tsx
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { BoxProps } from '@mantine/core';
+import { Box, Group, Pill } from '@mantine/core';
+import type { JSX } from 'react';
+
+interface AlphaBannerProps extends BoxProps {
+  children: React.ReactNode;
+}
+
+export function AlphaBanner(props: AlphaBannerProps): JSX.Element {
+  const { children, ...boxProps } = props;
+  return (
+    <Box bg="violet.0" p="sm" {...boxProps}>
+      <Group gap="md">
+        <Pill bg="violet.4" c="white">
+          Alpha
+        </Pill>
+        <span>{children}</span>
+      </Group>
+    </Box>
+  );
+}

--- a/examples/medplum-provider/src/components/DocsLink.tsx
+++ b/examples/medplum-provider/src/components/DocsLink.tsx
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { AnchorProps } from '@mantine/core';
+import { Anchor } from '@mantine/core';
+import type { JSX } from 'react';
+
+interface DocsLinkProps extends Omit<AnchorProps, 'href'> {
+  path: string;
+  children: React.ReactNode;
+}
+
+// A Hyperlink to the Medplum docs
+//
+// TODO: Consider if we can generate a list of paths of pages under /docs at
+// build time, so that a link to a nonexistent page could emit a type error.
+export function DocsLink(props: DocsLinkProps): JSX.Element {
+  return (
+    <Anchor href={`https://www.medplum.com/docs/${props.path}`} target="_blank">
+      {props.children}
+    </Anchor>
+  );
+}

--- a/examples/medplum-provider/src/pages/schedule/FindPane.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/FindPane.test.tsx
@@ -11,42 +11,23 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { toCodeableReferenceLike } from '../../utils/servicetype';
 import { FindPane } from './FindPane';
 
 const SchedulingParametersURI = 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters';
+const ServiceTypeReferenceURI = 'https://medlpum.com/fhir/service-type-reference';
 
 describe('FindPane', () => {
   let medplum: MockClient;
+  let healthcareService: WithId<HealthcareService>;
+  let healthcareService2: WithId<HealthcareService>;
 
-  const serviceType1: CodeableConcept = {
-    coding: [
-      {
-        system: 'http://example.com/service-types',
-        code: 'checkup',
-      },
-    ],
-    text: 'Annual Checkup',
-  };
-
-  const serviceType2: CodeableConcept = {
-    coding: [
-      {
-        code: 'followup',
-      },
-    ],
-    text: 'Follow-up Visit',
-  };
-
-  const createScheduleWithServiceTypes = (serviceTypes: CodeableConcept[]): WithId<Schedule> => ({
+  const createScheduleWithServices = (services: WithId<HealthcareService>[]): WithId<Schedule> => ({
     resourceType: 'Schedule',
     id: 'schedule-1',
     actor: [{ reference: 'Practitioner/practitioner-1' }],
     active: true,
-    serviceType: serviceTypes,
-    extension: serviceTypes.map((st) => ({
-      url: SchedulingParametersURI,
-      extension: st ? [{ url: 'serviceType', valueCodeableConcept: st }] : [],
-    })),
+    serviceType: services.flatMap(toCodeableReferenceLike),
   });
 
   const defaultRange = {
@@ -92,19 +73,19 @@ describe('FindPane', () => {
       return originalGet(url, options);
     });
 
-    await medplum.createResource<HealthcareService>({
+    healthcareService = await medplum.createResource<HealthcareService>({
       resourceType: 'HealthcareService',
       name: 'Annual Checkup',
-      type: [serviceType1],
+      type: [{ coding: [{ system: ServiceTypeReferenceURI, code: 'checkup' }], text: 'Annual Checkup' }],
       extension: [
         { url: SchedulingParametersURI, extension: [{ url: 'duration', valueDuration: { value: 20, unit: 'min' } }] },
       ],
     });
 
-    await medplum.createResource<HealthcareService>({
+    healthcareService2 = await medplum.createResource<HealthcareService>({
       resourceType: 'HealthcareService',
       name: 'Follow-up Visit',
-      type: [serviceType2],
+      type: [{ coding: [{ code: 'followup' }], text: 'Follow-up Visit' }],
       extension: [
         { url: SchedulingParametersURI, extension: [{ url: 'duration', valueDuration: { value: 20, unit: 'min' } }] },
       ],
@@ -131,7 +112,7 @@ describe('FindPane', () => {
 
   const setup = (options: SetupOptions = {}): ReturnType<typeof render> => {
     const {
-      schedule = createScheduleWithServiceTypes([serviceType1, serviceType2]),
+      schedule = createScheduleWithServices([healthcareService, healthcareService2]),
       range = defaultRange,
       onSuccess = vi.fn(),
     } = options;
@@ -199,9 +180,11 @@ describe('FindPane', () => {
         expect.any(Object)
       );
 
-      // check that it was called with the service-type parameter
+      // check that it was called with the service-type-reference parameter
       expect(medplum.get).toHaveBeenCalledWith(
-        expect.stringContaining(`service-type=${encodeURIComponent('http://example.com/service-types|checkup')}`),
+        expect.stringContaining(
+          `service-type-reference=${encodeURIComponent(`HealthcareService/${healthcareService.id}`)}`
+        ),
         expect.any(Object)
       );
     });
@@ -267,7 +250,7 @@ describe('FindPane', () => {
 
   describe('Auto-Selection with Single Service', () => {
     test('auto-selects when there is exactly one schedulable service', async () => {
-      const schedule = createScheduleWithServiceTypes([serviceType1]);
+      const schedule = createScheduleWithServices([healthcareService]);
 
       await act(async () => {
         setup({ schedule });
@@ -282,7 +265,7 @@ describe('FindPane', () => {
     });
 
     test('does not show dismiss button when auto-selected with single option', async () => {
-      const schedule = createScheduleWithServiceTypes([serviceType1]);
+      const schedule = createScheduleWithServices([healthcareService]);
 
       await act(async () => {
         setup({ schedule });
@@ -370,44 +353,6 @@ describe('FindPane', () => {
       expect(callUrl).toContain('start=');
       expect(callUrl).toContain('end=');
     });
-
-    test('uses `system|code` style for service-type parameter', async () => {
-      const user = userEvent.setup();
-      const range = {
-        start: new Date('2024-02-01T00:00:00Z'),
-        end: new Date('2024-02-07T23:59:59Z'),
-      };
-
-      await act(async () => {
-        setup({ range });
-      });
-
-      await user.click(screen.getByText('Annual Checkup'));
-
-      const callUrl = (medplum.get as ReturnType<typeof vi.fn>).mock.calls
-        .map((call) => call[0])
-        .find((url) => url.toString().includes('$find'));
-      expect(callUrl).toContain(`service-type=${encodeURIComponent('http://example.com/service-types|checkup')}`);
-    });
-
-    test('service-type parameters with no system component use "|code" style', async () => {
-      const user = userEvent.setup();
-      const range = {
-        start: new Date('2024-02-01T00:00:00Z'),
-        end: new Date('2024-02-07T23:59:59Z'),
-      };
-
-      await act(async () => {
-        setup({ range });
-      });
-
-      await user.click(screen.getByText('Follow-up Visit'));
-
-      const callUrl = (medplum.get as ReturnType<typeof vi.fn>).mock.calls
-        .map((call) => call[0])
-        .find((url) => url.toString().includes('$find'));
-      expect(callUrl).toContain(`service-type=${encodeURIComponent('|followup')}`);
-    });
   });
 
   describe('HealthcareService Integration', () => {
@@ -417,9 +362,8 @@ describe('FindPane', () => {
     };
 
     test('shows service types from HealthcareService resources', async () => {
-      await medplum.createResource<HealthcareService>({
+      const hs = await medplum.createResource<HealthcareService>({
         resourceType: 'HealthcareService',
-        id: 'hs-1',
         type: [healthcareServiceType],
         extension: [{ url: SchedulingParametersURI }],
       });
@@ -429,7 +373,7 @@ describe('FindPane', () => {
         id: 'schedule-123',
         actor: [{ reference: 'Practitioner/practitioner-123' }],
         active: true,
-        serviceType: [healthcareServiceType],
+        serviceType: toCodeableReferenceLike(hs),
       } satisfies Schedule;
 
       await act(async () => setup({ schedule }));
@@ -472,6 +416,75 @@ describe('FindPane', () => {
         expect.any(String),
         expect.objectContaining({ signal: expect.any(AbortSignal) })
       );
+    });
+  });
+
+  describe('Reference deduplication', () => {
+    test('shows a service only once when its multiple type codings produce duplicate references', async () => {
+      // A service with 2 types produces 2 CodeableConcept entries via toCodeableReferenceLike,
+      // both carrying a reference to the same HealthcareService.
+      const multiTypeService = await medplum.createResource<HealthcareService>({
+        resourceType: 'HealthcareService',
+        name: 'Multi-Type Service',
+        type: [
+          { coding: [{ code: 'type-a' }], text: 'Type A' },
+          { coding: [{ code: 'type-b' }], text: 'Type B' },
+        ],
+        extension: [
+          { url: SchedulingParametersURI, extension: [{ url: 'duration', valueDuration: { value: 30, unit: 'min' } }] },
+        ],
+      });
+
+      // toCodeableReferenceLike produces one concept per type entry, each referencing the same service
+      const schedule = createScheduleWithServices([multiTypeService]);
+      expect(schedule.serviceType).toHaveLength(2); // confirm two entries in serviceType
+
+      const readRefSpy = vi.spyOn(medplum, 'readReference');
+
+      await act(async () => setup({ schedule }));
+
+      // Service button appears exactly once
+      await waitFor(() => expect(screen.getByText('Multi-Type Service')).toBeInTheDocument());
+      expect(screen.getAllByText('Multi-Type Service')).toHaveLength(1);
+
+      // readReference was called once for HealthcareService (deduplicated)
+      const hsCalls = readRefSpy.mock.calls.filter(([ref]) =>
+        (ref as { reference?: string }).reference?.startsWith('HealthcareService/')
+      );
+      expect(hsCalls).toHaveLength(1);
+    });
+
+    test('skips serviceType concepts that have no reference field without crashing', async () => {
+      // Build a schedule with one valid concept and one malformed concept (extension with no reference).
+      const validServiceTypes = toCodeableReferenceLike(healthcareService);
+      const malformedConcept = {
+        extension: [
+          {
+            url: ServiceTypeReferenceURI,
+            valueReference: {}, // intentionally missing `reference`
+          },
+        ],
+      };
+
+      const schedule: WithId<Schedule> = {
+        resourceType: 'Schedule',
+        id: 'schedule-dedup',
+        actor: [{ reference: 'Practitioner/practitioner-1' }],
+        active: true,
+        serviceType: [...validServiceTypes, malformedConcept],
+      };
+
+      const readRefSpy = vi.spyOn(medplum, 'readReference');
+
+      await act(async () => setup({ schedule }));
+
+      // The valid service still appears; no crash from the malformed concept
+      await waitFor(() => expect(screen.getByText('Annual Checkup')).toBeInTheDocument());
+
+      // readReference was NOT called for the malformed concept (which has no reference string)
+      const calls = readRefSpy.mock.calls;
+      const calledRefs = calls.map(([ref]) => (ref as { reference?: string }).reference);
+      expect(calledRefs.every((r) => r && r.length > 0)).toBe(true);
     });
   });
 });

--- a/examples/medplum-provider/src/pages/schedule/FindPane.tsx
+++ b/examples/medplum-provider/src/pages/schedule/FindPane.tsx
@@ -4,7 +4,7 @@ import { Button, Group, Stack, Title } from '@mantine/core';
 import type { WithId } from '@medplum/core';
 import { EMPTY, formatDateTime, isDefined } from '@medplum/core';
 import type { Appointment, Bundle, HealthcareService, Schedule, Slot } from '@medplum/fhirtypes';
-import { CodeableConceptDisplay, useMedplum, useSearchResources } from '@medplum/react';
+import { CodeableConceptDisplay, useMedplum } from '@medplum/react';
 import { IconChevronRight, IconX } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -13,6 +13,7 @@ import { useSchedulingStartsAt } from '../../hooks/useSchedulingStartsAt';
 import type { Range } from '../../types/scheduling';
 import { showErrorNotification } from '../../utils/notifications';
 import { hasSchedulingParameters, SchedulingTransientIdentifier } from '../../utils/scheduling';
+import { extractReferencesFromCodeableReferenceLike } from '../../utils/servicetype';
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -46,24 +47,30 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
   const medplum = useMedplum();
   const [slots, setSlots] = useState<readonly Slot[] | undefined>(undefined);
   const [chosenSlot, setChosenSlot] = useState<Slot | undefined>(undefined);
-  const [selectedHealthcareService, setSelectedHealthcareService] = useState<HealthcareService | undefined>();
+  const [selectedHealthcareService, setSelectedHealthcareService] = useState<WithId<HealthcareService> | undefined>();
   const { schedule, range, onSuccess } = props;
 
-  const serviceTypeSearch = useMemo(() => {
-    const tokenSet = new Set<string>();
-    for (const concept of schedule.serviceType ?? EMPTY) {
-      for (const coding of concept.coding ?? EMPTY) {
-        tokenSet.add(`${coding.system ?? ''}|${coding.code ?? ''}`);
-      }
-    }
-    return [...tokenSet].join(',');
-  }, [schedule]);
+  const [healthcareServices, setHealthcareServices] = useState<WithId<HealthcareService>[] | undefined>();
 
-  const [healthcareServices] = useSearchResources<'HealthcareService'>(
-    'HealthcareService',
-    `service-type=${serviceTypeSearch}`,
-    { enabled: serviceTypeSearch !== '' }
-  );
+  useEffect(() => {
+    const seen = new Set<string>();
+    const allRefs = extractReferencesFromCodeableReferenceLike(schedule.serviceType);
+    const refs = allRefs.filter((ref) => {
+      if (!ref.reference) {
+        return false;
+      }
+      if (seen.has(ref.reference)) {
+        return false;
+      }
+      seen.add(ref.reference);
+      return true;
+    });
+
+    Promise.all(refs.map((ref) => medplum.readReference(ref))).then(
+      (services) => setHealthcareServices(services),
+      (err) => showErrorNotification(err)
+    );
+  }, [medplum, schedule]);
 
   const scheduleableServices = useMemo(
     () => healthcareServices?.filter((service) => hasSchedulingParameters(service)),
@@ -86,10 +93,6 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
       return () => {};
     }
 
-    const serviceTypeParam = (selectedHealthcareService.type ?? EMPTY)
-      .flatMap((concept) => (concept.coding ?? EMPTY).map((coding) => `${coding.system ?? ''}|${coding.code ?? ''}`))
-      .join(',');
-
     // Compute search range
     const searchStart = range.start < earliestSchedulable ? earliestSchedulable : range.start;
     const searchEnd = searchStart < range.end ? range.end : new Date(searchStart.getTime() + ONE_WEEK_MS);
@@ -102,7 +105,7 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
     const params = new URLSearchParams({
       start,
       end,
-      'service-type': serviceTypeParam,
+      'service-type-reference': `HealthcareService/${selectedHealthcareService.id}`,
     });
 
     medplum

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
+import type { WithId } from '@medplum/core';
 import { createReference, ReadablePromise } from '@medplum/core';
 import type { Appointment, Bundle, CodeableConcept, HealthcareService, Schedule, Slot } from '@medplum/fhirtypes';
 import { DrAliceSmith, DrAliceSmithSchedule, HomerSimpson, MockClient } from '@medplum/mock';
@@ -10,6 +11,7 @@ import { act, getByText, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { toCodeableReferenceLike } from '../../utils/servicetype';
 import { SchedulePage } from './SchedulePage';
 
 const SchedulingParametersURI = 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters';
@@ -58,6 +60,7 @@ describe('SchedulePage', () => {
             <Routes>
               <Route path="/Calendar/Schedule/:id" element={<SchedulePage />} />
               <Route path="/Calendar/Schedule" element={<SchedulePage />} />
+              <Route path="/Calendar/Schedule/:id/settings" element={<div>Settings Page</div>} />
             </Routes>
           </MantineProvider>
         </MedplumProvider>
@@ -305,10 +308,47 @@ describe('SchedulePage', () => {
       });
     });
   });
+
+  describe('Settings gear icon', () => {
+    test('gear icon is hidden when the schedule lacks SchedulingParameters', async () => {
+      await act(async () => setup());
+      await waitFor(() => expect(screen.getByText('Today')).toBeInTheDocument());
+      expect(screen.queryByRole('button', { name: 'Schedule settings' })).not.toBeInTheDocument();
+    });
+
+    test('gear icon is visible when the schedule has SchedulingParameters', async () => {
+      const scheduleWithParams = {
+        ...mockSchedule,
+        extension: [{ url: SchedulingParametersURI }],
+      };
+      await medplum.updateResource(scheduleWithParams);
+      medplum.searchOne = vi.fn().mockResolvedValue(scheduleWithParams);
+
+      await act(async () => setup());
+      await waitFor(() => expect(screen.getByText('Today')).toBeInTheDocument());
+
+      expect(screen.getByRole('button', { name: 'Schedule settings' })).toBeInTheDocument();
+    });
+
+    test('clicking the gear icon navigates to the schedule settings page', async () => {
+      const user = userEvent.setup();
+      const scheduleWithParams = {
+        ...mockSchedule,
+        extension: [{ url: SchedulingParametersURI }],
+      };
+      await medplum.updateResource(scheduleWithParams);
+      medplum.searchOne = vi.fn().mockResolvedValue(scheduleWithParams);
+
+      await act(async () => setup());
+      await user.click(screen.getByRole('button', { name: 'Schedule settings' }));
+      await waitFor(() => expect(screen.getByText('Settings Page')).toBeInTheDocument());
+    });
+  });
 });
 
 describe('$find/$book component integration tests', () => {
   let medplum: MockClient;
+  let healthcareService: WithId<HealthcareService>;
 
   const serviceType1: CodeableConcept = {
     coding: [
@@ -331,7 +371,7 @@ describe('$find/$book component integration tests', () => {
       value: 800,
     });
 
-    await medplum.createResource<HealthcareService>({
+    healthcareService = await medplum.createResource<HealthcareService>({
       resourceType: 'HealthcareService',
       name: 'Annual Checkup',
       type: [serviceType1],
@@ -369,7 +409,7 @@ describe('$find/$book component integration tests', () => {
     // Add scheduling parameter extension to Alice's schedule
     await medplum.updateResource({
       ...DrAliceSmithSchedule,
-      serviceType: [serviceType1],
+      serviceType: toCodeableReferenceLike(healthcareService),
       extension: [
         {
           url: SchedulingParametersURI,

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Drawer, Text } from '@mantine/core';
+import { ActionIcon, Box, Drawer, Group, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import type { WithId } from '@medplum/core';
 import { createReference, EMPTY, getReferenceString } from '@medplum/core';
 import type { Appointment, Practitioner, Reference, Schedule, Slot } from '@medplum/fhirtypes';
 import { ReferenceInput, useMedplum, useMedplumProfile } from '@medplum/react';
+import { IconSettings } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import type { SlotInfo } from 'react-big-calendar';
@@ -15,6 +16,7 @@ import { AppointmentDetails } from '../../components/schedule/AppointmentDetails
 import { CreateVisit } from '../../components/schedule/CreateVisit';
 import type { Range } from '../../types/scheduling';
 import { showErrorNotification } from '../../utils/notifications';
+import { hasSchedulingParameters } from '../../utils/scheduling';
 import { mergeOverlappingSlots } from '../../utils/slots';
 import { FindPane } from './FindPane';
 import classes from './SchedulePage.module.css';
@@ -218,16 +220,27 @@ export function SchedulePage(): JSX.Element | null {
   return (
     <Box pos="relative" bg="white" p="md" style={{ height }}>
       <div className={classes.wrapper}>
-        <Box mb="sm" maw={320}>
-          <ReferenceInput
-            key={schedule?.id}
-            name="schedule-actor"
-            targetTypes={['Practitioner']}
-            placeholder="Switch schedule..."
-            defaultValue={schedule?.actor?.[0] as Reference<Practitioner>}
-            onChange={handleActorChange}
-          />
-        </Box>
+        <Group justify="space-between">
+          <Box mb="sm" w={320}>
+            <ReferenceInput
+              key={schedule?.id}
+              name="schedule-actor"
+              targetTypes={['Practitioner']}
+              placeholder="Switch schedule..."
+              defaultValue={schedule?.actor?.[0] as Reference<Practitioner>}
+              onChange={handleActorChange}
+            />
+          </Box>
+          {schedule && hasSchedulingParameters(schedule) && (
+            <ActionIcon
+              variant="subtle"
+              aria-label="Schedule settings"
+              onClick={() => navigate(`/Calendar/Schedule/${schedule.id}/settings`)}
+            >
+              <IconSettings />
+            </ActionIcon>
+          )}
+        </Group>
         <div className={classes.container}>
           <div className={classes.calendar}>
             <Calendar

--- a/examples/medplum-provider/src/pages/schedule/ScheduleSettingsPage.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/ScheduleSettingsPage.test.tsx
@@ -79,19 +79,12 @@ describe('ScheduleSettings', () => {
       expect(screen.getByRole('switch', { name: 'Annual Checkup' })).toBeInTheDocument();
     });
 
-    test('lists unschedulable services in a separate section', async () => {
+    test('unschedulable services have disabled checkboxes', async () => {
       await act(async () => renderSettings(defaultSchedule));
-      expect(screen.getByText('Unschedulable Healthcare Services')).toBeInTheDocument();
       if (!unschedulableService.name) {
         throw new Error('Precondition failed; unschedulableService.name');
       }
-      expect(screen.getByText(unschedulableService.name)).toBeInTheDocument();
-    });
-
-    test('omits unschedulable section when all services are schedulable', async () => {
-      medplum.searchResources = vi.fn().mockResolvedValue([schedulableService]);
-      await act(async () => renderSettings(defaultSchedule));
-      expect(screen.queryByText('Unschedulable Healthcare Services')).not.toBeInTheDocument();
+      expect(screen.getByRole('switch', { name: unschedulableService.name })).toHaveAttribute('disabled');
     });
 
     test('switch is checked when the service is already linked to the schedule', async () => {
@@ -282,7 +275,7 @@ describe('ScheduleSettingsPage', () => {
 
   test('renders the "Schedule Settings" heading', async () => {
     await act(async () => setup());
-    expect(screen.getByRole('heading', { name: 'Schedule Settings' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Schedule Settings - Dr. Alice Smith' })).toBeInTheDocument();
   });
 
   test('renders the ScheduleSettings form once the schedule has loaded', async () => {

--- a/examples/medplum-provider/src/pages/schedule/ScheduleSettingsPage.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/ScheduleSettingsPage.test.tsx
@@ -18,15 +18,9 @@ const ServiceTypeReferenceURI = 'https://medplum.com/fhir/service-type-reference
 
 describe('ScheduleSettings', () => {
   let medplum: MockClient;
+  let defaultSchedule: WithId<Schedule>;
   let schedulableService: WithId<HealthcareService>;
   let unschedulableService: WithId<HealthcareService>;
-
-  const defaultSchedule: Schedule = {
-    resourceType: 'Schedule',
-    id: 'schedule-1',
-    actor: [{ reference: 'Practitioner/practitioner-1' }],
-    active: true,
-  };
 
   beforeEach(async () => {
     // Prevent notifications from leaking across test cases
@@ -36,6 +30,12 @@ describe('ScheduleSettings', () => {
   beforeEach(async () => {
     medplum = new MockClient();
     vi.clearAllMocks();
+
+    defaultSchedule = await medplum.createResource<Schedule>({
+      resourceType: 'Schedule',
+      actor: [{ reference: 'Practitioner/practitioner-1' }],
+      active: true,
+    });
 
     schedulableService = await medplum.createResource<HealthcareService>({
       resourceType: 'HealthcareService',
@@ -165,6 +165,15 @@ describe('ScheduleSettings', () => {
                 ],
               },
             ],
+          }),
+          // MedplumClient.put() mutates the options object in-place (adding body,
+          // method, cache, etc.), so the spy sees the fully-expanded RequestInit
+          // rather than the original { headers } literal. Use objectContaining to
+          // assert only on the header we care about.
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              'If-Match': `W/"${defaultSchedule.meta?.versionId}"`,
+            }),
           })
         );
       });

--- a/examples/medplum-provider/src/pages/schedule/ScheduleSettingsPage.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/ScheduleSettingsPage.test.tsx
@@ -1,0 +1,316 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { MantineProvider } from '@mantine/core';
+import { Notifications, notifications } from '@mantine/notifications';
+import type { WithId } from '@medplum/core';
+import type { HealthcareService, Schedule } from '@medplum/fhirtypes';
+import { DrAliceSmith, DrAliceSmithSchedule, MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { isCodeableReferenceLikeTo, toCodeableReferenceLike } from '../../utils/servicetype';
+import { ScheduleSettings, ScheduleSettingsPage } from './ScheduleSettingsPage';
+
+const SchedulingParametersURI = 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters';
+const ServiceTypeReferenceURI = 'https://medplum.com/fhir/service-type-reference';
+
+describe('ScheduleSettings', () => {
+  let medplum: MockClient;
+  let schedulableService: WithId<HealthcareService>;
+  let unschedulableService: WithId<HealthcareService>;
+
+  const defaultSchedule: Schedule = {
+    resourceType: 'Schedule',
+    id: 'schedule-1',
+    actor: [{ reference: 'Practitioner/practitioner-1' }],
+    active: true,
+  };
+
+  beforeEach(async () => {
+    // Prevent notifications from leaking across test cases
+    notifications.clean();
+  });
+
+  beforeEach(async () => {
+    medplum = new MockClient();
+    vi.clearAllMocks();
+
+    schedulableService = await medplum.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      name: 'Annual Checkup',
+      type: [{ coding: [{ code: 'checkup' }], text: 'Annual Checkup' }],
+      extension: [{ url: SchedulingParametersURI }],
+    });
+
+    unschedulableService = await medplum.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      name: 'Unschedulable Service',
+      type: [{ coding: [{ code: 'unschedulable' }], text: 'Unschedulable' }],
+      // no SchedulingParameters extension
+    });
+  });
+
+  function renderSettings(schedule: Schedule): ReturnType<typeof render> {
+    return render(
+      <MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <MantineProvider>
+            <Notifications />
+            <ScheduleSettings schedule={schedule} />
+          </MantineProvider>
+        </MedplumProvider>
+      </MemoryRouter>
+    );
+  }
+
+  describe('Empty / no-services state', () => {
+    test('shows "No HealthcareServices found" alert when services list is empty', async () => {
+      medplum.searchResources = vi.fn().mockResolvedValue([]);
+      await act(async () => renderSettings(defaultSchedule));
+      expect(screen.getByText('No HealthcareServices found.')).toBeInTheDocument();
+    });
+  });
+
+  describe('Service list rendering', () => {
+    test('shows schedulable services as labeled switches', async () => {
+      await act(async () => renderSettings(defaultSchedule));
+      expect(screen.getByRole('switch', { name: 'Annual Checkup' })).toBeInTheDocument();
+    });
+
+    test('lists unschedulable services in a separate section', async () => {
+      await act(async () => renderSettings(defaultSchedule));
+      expect(screen.getByText('Unschedulable Healthcare Services')).toBeInTheDocument();
+      if (!unschedulableService.name) {
+        throw new Error('Precondition failed; unschedulableService.name');
+      }
+      expect(screen.getByText(unschedulableService.name)).toBeInTheDocument();
+    });
+
+    test('omits unschedulable section when all services are schedulable', async () => {
+      medplum.searchResources = vi.fn().mockResolvedValue([schedulableService]);
+      await act(async () => renderSettings(defaultSchedule));
+      expect(screen.queryByText('Unschedulable Healthcare Services')).not.toBeInTheDocument();
+    });
+
+    test('switch is checked when the service is already linked to the schedule', async () => {
+      const schedule: Schedule = {
+        ...defaultSchedule,
+        serviceType: toCodeableReferenceLike(schedulableService),
+      };
+      await act(async () => renderSettings(schedule));
+      expect(screen.getByRole('switch', { name: 'Annual Checkup' })).toBeChecked();
+    });
+
+    test('switch is unchecked when the service is not linked to the schedule', async () => {
+      await act(async () => renderSettings(defaultSchedule));
+      expect(screen.getByRole('switch', { name: 'Annual Checkup' })).not.toBeChecked();
+    });
+  });
+
+  describe('Cancel / Back button label', () => {
+    test('shows "Back" when no changes have been made', async () => {
+      await act(async () => renderSettings(defaultSchedule));
+      expect(screen.getByText('Back')).toBeInTheDocument();
+      expect(screen.queryByText('Cancel')).not.toBeInTheDocument();
+    });
+
+    test('shows "Cancel" after a switch is toggled', async () => {
+      const user = userEvent.setup();
+      await act(async () => renderSettings(defaultSchedule));
+
+      await user.click(screen.getByRole('switch', { name: 'Annual Checkup' }));
+
+      expect(screen.getByText('Cancel')).toBeInTheDocument();
+      expect(screen.queryByText('Back')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Save Changes button state', () => {
+    test('Save Changes button is disabled initially', async () => {
+      await act(async () => renderSettings(defaultSchedule));
+      expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled();
+    });
+
+    test('Save Changes button is enabled after toggling a switch', async () => {
+      const user = userEvent.setup();
+      await act(async () => renderSettings(defaultSchedule));
+
+      await user.click(screen.getByRole('switch', { name: 'Annual Checkup' }));
+
+      expect(screen.getByRole('button', { name: 'Save Changes' })).not.toBeDisabled();
+    });
+  });
+
+  describe('Toggle behavior', () => {
+    test('saving after toggling a switch on calls updateResource with the new serviceType entry', async () => {
+      const user = userEvent.setup();
+      const updateSpy = vi.spyOn(medplum, 'updateResource');
+      await act(async () => renderSettings(defaultSchedule));
+
+      await user.click(screen.getByRole('switch', { name: 'Annual Checkup' }));
+      await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      await waitFor(() => {
+        expect(updateSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            resourceType: 'Schedule',
+            id: defaultSchedule.id,
+            serviceType: [
+              {
+                coding: [{ code: 'checkup' }],
+                text: 'Annual Checkup',
+                extension: [
+                  {
+                    url: ServiceTypeReferenceURI,
+                    valueReference: {
+                      reference: `HealthcareService/${schedulableService.id}`,
+                      display: schedulableService.name,
+                    },
+                  },
+                ],
+              },
+            ],
+          })
+        );
+      });
+    });
+
+    test('toggling a switch on then back off leaves no reference artifacts in serviceType', async () => {
+      // Set an unlinked entry into schedule.serviceType that should remain unchanged
+      const schedule = await medplum.updateResource({
+        ...defaultSchedule,
+        serviceType: [{ coding: [{ code: 'demo' }] }],
+      });
+
+      const user = userEvent.setup();
+      const updateSpy = vi.spyOn(medplum, 'updateResource');
+      // Start with the service not linked
+      await act(async () => renderSettings(schedule));
+
+      // Toggle on then back off
+      await user.click(screen.getByRole('switch', { name: 'Annual Checkup' }));
+      await user.click(screen.getByRole('switch', { name: 'Annual Checkup' }));
+      await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      await waitFor(() => {
+        const [savedSchedule] = updateSpy.mock.calls[0] as [Schedule];
+        expect(savedSchedule.serviceType).toEqual([{ coding: [{ code: 'demo' }] }]);
+      });
+    });
+
+    test('toggling a switch off removes that service from serviceType', async () => {
+      const user = userEvent.setup();
+      const schedule: Schedule = {
+        ...defaultSchedule,
+        serviceType: toCodeableReferenceLike(schedulableService),
+      };
+      const updateSpy = vi.spyOn(medplum, 'updateResource');
+      await act(async () => renderSettings(schedule));
+
+      // Switch starts checked; toggle it off
+      await user.click(screen.getByRole('switch', { name: 'Annual Checkup' }));
+      await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      await waitFor(() => {
+        const [savedSchedule] = updateSpy.mock.calls[0] as [Schedule];
+        expect(isCodeableReferenceLikeTo(savedSchedule.serviceType, schedulableService)).toBeFalsy();
+      });
+    });
+  });
+
+  describe('Save flow', () => {
+    test('successful save shows success notification and resets dirty state', async () => {
+      const user = userEvent.setup();
+      await act(async () => renderSettings(defaultSchedule));
+
+      await user.click(screen.getByRole('switch', { name: 'Annual Checkup' }));
+      await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Schedule updated')).toBeInTheDocument();
+      });
+
+      // Dirty state cleared: Save is disabled again and label returns to "Back"
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled();
+        expect(screen.getByText('Back')).toBeInTheDocument();
+      });
+    });
+
+    test('failed save shows an error notification and preserves dirty state', async () => {
+      const user = userEvent.setup();
+      vi.spyOn(medplum, 'updateResource').mockRejectedValue(new Error('Save failed'));
+      await act(async () => renderSettings(defaultSchedule));
+
+      await user.click(screen.getByRole('switch', { name: 'Annual Checkup' }));
+      await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Save failed/i)).toBeInTheDocument();
+      });
+
+      // Dirty state not cleared; Save button remains enabled
+      expect(screen.getByRole('button', { name: 'Save Changes' })).not.toBeDisabled();
+    });
+  });
+});
+
+describe('ScheduleSettingsPage', () => {
+  let medplum: MockClient;
+
+  beforeEach(() => {
+    medplum = new MockClient({ profile: DrAliceSmith });
+    vi.clearAllMocks();
+  });
+
+  function setup(path = `/Calendar/Schedule/${DrAliceSmithSchedule.id}/settings`): ReturnType<typeof render> {
+    return render(
+      <MemoryRouter initialEntries={[path]}>
+        <MedplumProvider medplum={medplum}>
+          <MantineProvider>
+            <Notifications />
+            <Routes>
+              <Route path="/Calendar/Schedule/:id/settings" element={<ScheduleSettingsPage />} />
+            </Routes>
+          </MantineProvider>
+        </MedplumProvider>
+      </MemoryRouter>
+    );
+  }
+
+  test('renders the "Schedule Settings" heading', async () => {
+    await act(async () => setup());
+    expect(screen.getByRole('heading', { name: 'Schedule Settings' })).toBeInTheDocument();
+  });
+
+  test('renders the ScheduleSettings form once the schedule has loaded', async () => {
+    await act(async () => setup());
+
+    // With no HealthcareServices, the form shows the empty-state alert
+    await waitFor(() => {
+      expect(screen.getByText('No HealthcareServices found.')).toBeInTheDocument();
+    });
+  });
+
+  test('shows a loader while the schedule is resolving', () => {
+    // Prevent readReference from resolving so the schedule stays undefined
+    medplum.readReference = vi.fn().mockReturnValue(new Promise(() => {}));
+    render(
+      <MemoryRouter initialEntries={[`/Calendar/Schedule/unknown-id/settings`]}>
+        <MedplumProvider medplum={medplum}>
+          <MantineProvider>
+            <Notifications />
+            <Routes>
+              <Route path="/Calendar/Schedule/:id/settings" element={<ScheduleSettingsPage />} />
+            </Routes>
+          </MantineProvider>
+        </MedplumProvider>
+      </MemoryRouter>
+    );
+
+    // Schedule not yet resolved — form buttons should not be present
+    expect(screen.queryByRole('button', { name: 'Save Changes' })).not.toBeInTheDocument();
+  });
+});

--- a/examples/medplum-provider/src/pages/schedule/ScheduleSettingsPage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/ScheduleSettingsPage.tsx
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Alert, Button, Group, Loader, Stack, Switch, Title } from '@mantine/core';
+import { Alert, Button, Group, Loader, Stack, Switch, Text, Title, Tooltip } from '@mantine/core';
 import type { WithId } from '@medplum/core';
-import { EMPTY, formatReferenceString, getExtensionValue, getReferenceString } from '@medplum/core';
+import { deepClone, EMPTY, formatReferenceString, getExtensionValue, getReferenceString } from '@medplum/core';
 import type { HealthcareService, Reference, Schedule } from '@medplum/fhirtypes';
 import { Document, MedplumLink, useMedplum } from '@medplum/react';
 import { useResource, useSearchResources } from '@medplum/react-hooks';
-import { IconInfoCircle } from '@tabler/icons-react';
+import { IconAlertCircle } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { Fragment, useState } from 'react';
 import { useParams } from 'react-router';
@@ -16,15 +16,23 @@ import { showErrorNotification, showSuccessNotification } from '../../utils/noti
 import { hasSchedulingParameters } from '../../utils/scheduling';
 import { isCodeableReferenceLikeTo, ServiceTypeReferenceURI, toCodeableReferenceLike } from '../../utils/servicetype';
 
+// Eventually we should paginate the HealthcareService search so this is not a
+// hard limit. We expect that 1000 rows should be plenty for most providers, so
+// temporarily shipping with a single large page fetch.
+const MAX_PAGE_SIZE = 1000;
+
 export function ScheduleSettings(props: { schedule: Schedule }): JSX.Element | null {
   const medplum = useMedplum();
-  const [services, servicesLoading] = useSearchResources('HealthcareService');
+  const [services, servicesLoading] = useSearchResources('HealthcareService', {
+    _sort: 'name',
+    _count: MAX_PAGE_SIZE.toString(),
+  });
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
 
   // Store a copy of the Schedule that we can mutate while the viewer manipulates
   // the UI
-  const [schedule, setSchedule] = useState({ ...props.schedule });
+  const [schedule, setSchedule] = useState(deepClone(props.schedule));
 
   if (servicesLoading) {
     return <Loader />;
@@ -39,9 +47,6 @@ export function ScheduleSettings(props: { schedule: Schedule }): JSX.Element | n
       </Group>
     );
   }
-
-  const schedulableServices = services.filter((service) => hasSchedulingParameters(service));
-  const unschedulableServices = services.filter((service) => !hasSchedulingParameters(service));
 
   function toggleServiceType(service: WithId<HealthcareService>, enabled: boolean): void {
     setDirty(true);
@@ -77,45 +82,42 @@ export function ScheduleSettings(props: { schedule: Schedule }): JSX.Element | n
   }
 
   return (
-    <Stack gap="xl">
-      <Stack gap="sm">
-        <Title order={3}>Schedule Actor</Title>
-        <div>
-          {schedule.actor.map((actor, i) => (
-            <Fragment key={actor.reference}>
-              {i > 0 && ', '}
-              <MedplumLink to={actor}>{formatReferenceString(actor)}</MedplumLink>
-            </Fragment>
-          ))}
-        </div>
+    <Stack gap="lg">
+      <Stack gap="0">
+        <Title order={3}>Appointment Types</Title>
+        <Text fs="italic" c="dimmed">
+          Choose what appointment types can be scheduled on this calendar. Learn more about{' '}
+          <DocsLink path="scheduling">configuring Scheduling</DocsLink>.
+        </Text>
       </Stack>
-      <Stack gap="sm">
-        <Title order={3}>Schedulable Healthcare Services</Title>
-        {schedulableServices.map((service) => (
-          <Switch
-            key={service.id}
-            label={service.name}
-            checked={isCodeableReferenceLikeTo(schedule.serviceType, service)}
-            onChange={(e) => toggleServiceType(service, e.target.checked)}
-          />
-        ))}
-      </Stack>
-      {unschedulableServices.length > 0 && (
-        <Stack gap="sm">
-          <Title order={4}>Unschedulable Healthcare Services</Title>
-          <Group>
-            <Alert color="yellow.5" variant="outline" icon={<IconInfoCircle />}>
-              These services do not have a{' '}
-              <DocsLink path="scheduling/defining-availability">SchedulingParameters</DocsLink> extension.
-            </Alert>
-          </Group>
-          <ul>
-            {unschedulableServices.map((service) => (
-              <li key={service.id}>{service.name}</li>
-            ))}
-          </ul>
-        </Stack>
+      {services.length >= MAX_PAGE_SIZE && (
+        <Alert color="yellow" variant="outline" icon={<IconAlertCircle />}>
+          HealthcareService page size reached; some rows may not have been fetched.
+        </Alert>
       )}
+      <Stack gap="sm">
+        {services.map((service) => {
+          const schedulable = hasSchedulingParameters(service);
+          return (
+            <Group key={service.id}>
+              <Tooltip
+                label={'This HealthcareService does not have a SchedulingParameters extension'}
+                disabled={schedulable}
+                position="right"
+                refProp="rootRef"
+                withArrow
+              >
+                <Switch
+                  label={service.name}
+                  checked={isCodeableReferenceLikeTo(schedule.serviceType, service)}
+                  onChange={(e) => toggleServiceType(service, e.target.checked)}
+                  disabled={!schedulable}
+                />
+              </Tooltip>
+            </Group>
+          );
+        })}
+      </Stack>
       <Group justify="flex-end">
         <Button variant="outline" disabled={saving} component={MedplumLink} to={`/Calendar/Schedule/${schedule.id}`}>
           {dirty ? 'Cancel' : 'Back'}
@@ -134,7 +136,15 @@ export function ScheduleSettingsPage(): JSX.Element {
 
   return (
     <Document>
-      <Title order={1}>Schedule Settings</Title>
+      <Title order={1} mb="sm">
+        Schedule Settings
+        {schedule?.actor.map((actor, i) => (
+          <Fragment key={actor.reference}>
+            {i === 0 ? ' - ' : ', '}
+            {formatReferenceString(actor)}
+          </Fragment>
+        ))}
+      </Title>
       <AlphaBanner bdrs="md" mb="lg">
         Medplum Scheduling is in an Alpha period and is subject to change.
       </AlphaBanner>

--- a/examples/medplum-provider/src/pages/schedule/ScheduleSettingsPage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/ScheduleSettingsPage.tsx
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Alert, Button, Group, Loader, Stack, Switch, Title } from '@mantine/core';
+import type { WithId } from '@medplum/core';
+import { EMPTY, formatReferenceString, getExtensionValue, getReferenceString } from '@medplum/core';
+import type { HealthcareService, Reference, Schedule } from '@medplum/fhirtypes';
+import { Document, MedplumLink, useMedplum } from '@medplum/react';
+import { useResource, useSearchResources } from '@medplum/react-hooks';
+import { IconInfoCircle } from '@tabler/icons-react';
+import type { JSX } from 'react';
+import { Fragment, useState } from 'react';
+import { useParams } from 'react-router';
+import { AlphaBanner } from '../../components/AlphaBanner';
+import { DocsLink } from '../../components/DocsLink';
+import { showErrorNotification, showSuccessNotification } from '../../utils/notifications';
+import { hasSchedulingParameters } from '../../utils/scheduling';
+import { isCodeableReferenceLikeTo, ServiceTypeReferenceURI, toCodeableReferenceLike } from '../../utils/servicetype';
+
+export function ScheduleSettings(props: { schedule: Schedule }): JSX.Element | null {
+  const medplum = useMedplum();
+  const [services, servicesLoading] = useSearchResources('HealthcareService');
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Store a copy of the Schedule that we can mutate while the viewer manipulates
+  // the UI
+  const [schedule, setSchedule] = useState({ ...props.schedule });
+
+  if (servicesLoading) {
+    return <Loader />;
+  }
+
+  if (!services?.length) {
+    return (
+      <Group>
+        <Alert color="red" variant="outline">
+          No HealthcareServices found.
+        </Alert>
+      </Group>
+    );
+  }
+
+  const schedulableServices = services.filter((service) => hasSchedulingParameters(service));
+  const unschedulableServices = services.filter((service) => !hasSchedulingParameters(service));
+
+  function toggleServiceType(service: WithId<HealthcareService>, enabled: boolean): void {
+    setDirty(true);
+    if (enabled) {
+      const serviceType = toCodeableReferenceLike(service);
+      setSchedule((prevValue) => ({
+        ...prevValue,
+        serviceType: [...(prevValue.serviceType ?? EMPTY), ...serviceType],
+      }));
+    } else {
+      setSchedule((prevValue) => {
+        const refString = getReferenceString(service);
+        const serviceType = prevValue.serviceType?.filter((cc) => {
+          const ref = getExtensionValue(cc, ServiceTypeReferenceURI) as Reference<HealthcareService> | undefined;
+          return ref?.reference !== refString;
+        });
+        return { ...prevValue, serviceType };
+      });
+    }
+  }
+
+  async function submit(): Promise<void> {
+    setSaving(true);
+    try {
+      await medplum.updateResource(schedule);
+      showSuccessNotification({ message: 'Schedule updated' });
+      setDirty(false);
+    } catch (err) {
+      showErrorNotification(err);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Stack gap="xl">
+      <Stack gap="sm">
+        <Title order={3}>Schedule Actor</Title>
+        <div>
+          {schedule.actor.map((actor, i) => (
+            <Fragment key={actor.reference}>
+              {i > 0 && ', '}
+              <MedplumLink to={actor}>{formatReferenceString(actor)}</MedplumLink>
+            </Fragment>
+          ))}
+        </div>
+      </Stack>
+      <Stack gap="sm">
+        <Title order={3}>Schedulable Healthcare Services</Title>
+        {schedulableServices.map((service) => (
+          <Switch
+            key={service.id}
+            label={service.name}
+            checked={isCodeableReferenceLikeTo(schedule.serviceType, service)}
+            onChange={(e) => toggleServiceType(service, e.target.checked)}
+          />
+        ))}
+      </Stack>
+      {unschedulableServices.length > 0 && (
+        <Stack gap="sm">
+          <Title order={4}>Unschedulable Healthcare Services</Title>
+          <Group>
+            <Alert color="yellow.5" variant="outline" icon={<IconInfoCircle />}>
+              These services do not have a{' '}
+              <DocsLink path="scheduling/defining-availability">SchedulingParameters</DocsLink> extension.
+            </Alert>
+          </Group>
+          <ul>
+            {unschedulableServices.map((service) => (
+              <li key={service.id}>{service.name}</li>
+            ))}
+          </ul>
+        </Stack>
+      )}
+      <Group justify="flex-end">
+        <Button variant="outline" disabled={saving} component={MedplumLink} to={`/Calendar/Schedule/${schedule.id}`}>
+          {dirty ? 'Cancel' : 'Back'}
+        </Button>
+        <Button disabled={!dirty} onClick={submit} loading={saving}>
+          Save Changes
+        </Button>
+      </Group>
+    </Stack>
+  );
+}
+
+export function ScheduleSettingsPage(): JSX.Element {
+  const { id } = useParams<{ id: string }>();
+  const schedule = useResource<Schedule>({ reference: `Schedule/${id}` });
+
+  return (
+    <Document>
+      <Title order={1}>Schedule Settings</Title>
+      <AlphaBanner bdrs="md" mb="lg">
+        Medplum Scheduling is in an Alpha period and is subject to change.
+      </AlphaBanner>
+      {schedule ? <ScheduleSettings schedule={schedule} key={schedule.id} /> : <Loader />}
+    </Document>
+  );
+}

--- a/examples/medplum-provider/src/pages/schedule/ScheduleSettingsPage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/ScheduleSettingsPage.tsx
@@ -71,7 +71,12 @@ export function ScheduleSettings(props: { schedule: Schedule }): JSX.Element | n
   async function submit(): Promise<void> {
     setSaving(true);
     try {
-      await medplum.updateResource(schedule);
+      const updated = await medplum.updateResource(schedule, {
+        headers: {
+          'If-Match': schedule.meta?.versionId ? `W/"${schedule.meta.versionId}"` : '',
+        },
+      });
+      setSchedule(deepClone(updated));
       showSuccessNotification({ message: 'Schedule updated' });
       setDirty(false);
     } catch (err) {

--- a/examples/medplum-provider/src/utils/notifications.ts
+++ b/examples/medplum-provider/src/utils/notifications.ts
@@ -13,3 +13,20 @@ export const showErrorNotification = (err: unknown): void => {
     message: normalizeErrorString(err),
   });
 };
+
+export const showSuccessNotification = ({
+  title,
+  message,
+  icon,
+}: {
+  title?: string;
+  message?: string;
+  icon?: React.ReactNode;
+}): void => {
+  notifications.show({
+    color: 'green',
+    icon: icon ?? '✓',
+    title,
+    message,
+  });
+};

--- a/examples/medplum-provider/src/utils/servicetype.ts
+++ b/examples/medplum-provider/src/utils/servicetype.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Mirrors packages/server/src/util/servicetype.ts. That utility lives in the
+// server package which can't be imported here, but since it only depends on
+// @medplum/core and @medplum/fhirtypes we maintain a copy for client-side use.
+
+import type { WithId } from '@medplum/core';
+import { createReference, getExtensionValue, getReferenceString, isDefined } from '@medplum/core';
+import type { CodeableConcept, HealthcareService, Reference } from '@medplum/fhirtypes';
+
+export const ServiceTypeReferenceURI = 'https://medplum.com/fhir/service-type-reference';
+
+export function extractReferencesFromCodeableReferenceLike(
+  serviceType: CodeableConcept[] | undefined
+): Reference<HealthcareService>[] {
+  if (!serviceType?.length) {
+    return [];
+  }
+  return serviceType
+    .map((concept) => getExtensionValue(concept, ServiceTypeReferenceURI) as Reference<HealthcareService> | undefined)
+    .filter(isDefined);
+}
+
+export function toCodeableReferenceLike(service: WithId<HealthcareService>): CodeableConcept[] {
+  const extension = [{ url: ServiceTypeReferenceURI, valueReference: createReference(service) }];
+  if (!service.type?.length) {
+    return [{ extension }];
+  }
+  return service.type.map((concept) => ({ ...concept, extension: [...(concept.extension ?? []), ...extension] }));
+}
+
+export function isCodeableReferenceLikeTo(
+  serviceType: CodeableConcept[] | undefined,
+  service: WithId<HealthcareService> | (Reference<HealthcareService> & { reference: string })
+): boolean {
+  if (!serviceType?.length) {
+    return false;
+  }
+  const refString = getReferenceString(service);
+  return serviceType.some((concept) => {
+    const ref = getExtensionValue(concept, ServiceTypeReferenceURI) as Reference<HealthcareService> | undefined;
+    return ref?.reference === refString;
+  });
+}

--- a/packages/docs/docs/scheduling/appointment-book.md
+++ b/packages/docs/docs/scheduling/appointment-book.md
@@ -50,6 +50,15 @@ const result = await medplum.post(
           start: '2026-03-10T09:00:00.000Z',
           end: '2026-03-10T10:00:00.000Z',
           schedule: { reference: 'Schedule/my-schedule-id' },
+          serviceType: [
+            {
+              coding: [{ code: 'inital-visit' }],
+              extension: [
+                url: 'https://medplum.com/fhir/service-type-reference',
+                valueReference: { reference: "HealthcareService/my-healthcareservice-id"}
+              ]
+            }
+          ]
         } satisfies Slot,
       },
       {
@@ -82,7 +91,13 @@ const result = await medplum.post(
           start: '2026-03-11T08:00:00.000Z',
           end: '2026-03-11T10:00:00.000Z',
           schedule: { reference: 'Schedule/surgeon-schedule-id' },
-          serviceType: [{ coding: [{ code: 'bariatric-surgery' }] }],
+          serviceType: [{
+            coding: [{ code: 'bariatric-surgery' }],
+            extension: [
+              url: 'https://medplum.com/fhir/service-type-reference',
+              valueReference: { reference: "HealthcareService/my-healthcareservice-id"}
+            ]
+          }],
         } satisfies Slot,
       },
       {
@@ -93,6 +108,13 @@ const result = await medplum.post(
           start: '2026-03-11T08:00:00.000Z',
           end: '2026-03-11T10:00:00.000Z',
           schedule: { reference: 'Schedule/or-room-schedule-id' },
+          serviceType: [{
+            coding: [{ code: 'bariatric-surgery' }],
+            extension: [
+              url: 'https://medplum.com/fhir/service-type-reference',
+              valueReference: { reference: "HealthcareService/my-healthcareservice-id"}
+            ]
+          }],
         } satisfies Slot,
       },
     ],
@@ -118,6 +140,13 @@ curl -X POST 'https://api.medplum.com/fhir/R4/Appointment/$book' \
           "start": "2026-03-10T09:00:00.000Z",
           "end": "2026-03-10T10:00:00.000Z",
           "schedule": { "reference": "Schedule/my-schedule-id" }
+          "serviceType": [{
+            "coding": [{ "code": "bariatric-surgery" }],
+            "extension": [
+              "url": 'https://medplum.com/fhir/service-type-reference',
+              "valueReference": { "reference": "HealthcareService/my-healthcareservice-id"}
+            ]
+          }],
         }
       },
       {
@@ -133,14 +162,14 @@ curl -X POST 'https://api.medplum.com/fhir/R4/Appointment/$book' \
 
 ## Parameters
 
-| Name               | Type        | Description                                                                                                               | Required |
-| ------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `slot`             | `Resource`  | A `Slot` resource describing the desired booking time. Must include `start`, `end`, and `schedule`. Repeatable for multi-resource bookings. | Yes (1+) |
-| `patient-reference`| `Reference` | Reference to a [`Patient`](/docs/api/fhir/resources/patient) to include as a participant on the Appointment               | No       |
+| Name               | Type        | Description                                                                                                                                                | Required |
+| ------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `slot`             | `Resource`  | A `Slot` resource describing the desired booking time. Must include `start`, `end`, `schedule`, and `serviceType`. Repeatable for multi-resource bookings. | Yes (1+) |
+| `patient-reference`| `Reference` | Reference to a [`Patient`](/docs/api/fhir/resources/patient) to include as a participant on the Appointment                                                | No       |
 
 ### Multi-resource Bookings
 
-Pass multiple `slot` parameters (one per Schedule) to book all resources atomically. All slots must share the same `start` and `end` times.
+Pass multiple `slot` parameters (one per Schedule) to book all resources atomically. All slots must share the same `start` time, `end` time, and `serviceType`.
 
 ```json
 {
@@ -154,7 +183,13 @@ Pass multiple `slot` parameters (one per Schedule) to book all resources atomica
         "start": "2026-03-11T08:00:00.000Z",
         "end": "2026-03-11T10:00:00.000Z",
         "schedule": { "reference": "Schedule/surgeon-schedule-id" },
-        "serviceType": [{ "coding": [{ "code": "bariatric-surgery" }] }]
+        "serviceType": [{
+          "coding": [{ "code": "bariatric-surgery" }]
+          "extension": [
+            "url": 'https://medplum.com/fhir/service-type-reference',
+            "valueReference": { "reference": "HealthcareService/my-healthcareservice-id"}
+          ]
+        }]
       }
     },
     {
@@ -165,6 +200,13 @@ Pass multiple `slot` parameters (one per Schedule) to book all resources atomica
         "start": "2026-03-11T08:00:00.000Z",
         "end": "2026-03-11T10:00:00.000Z",
         "schedule": { "reference": "Schedule/or-room-schedule-id" }
+        "serviceType": [{
+          "coding": [{ "code": "bariatric-surgery" }]
+          "extension": [
+            "url": 'https://medplum.com/fhir/service-type-reference',
+            "valueReference": { "reference": "HealthcareService/my-healthcareservice-id"}
+          ]
+        }]
       }
     }
   ]
@@ -173,11 +215,14 @@ Pass multiple `slot` parameters (one per Schedule) to book all resources atomica
 
 ### Constraints
 
-- All `slot` parameters must share the same `start` and `end` times
+- All `slot` parameters must have matching `start`, `end` , and `serviceType` attributes
 - Each referenced Schedule must have exactly **one actor**
 - Each actor must have a timezone defined via the `http://hl7.org/fhir/StructureDefinition/timezone` extension
 - The requested time must match a valid slot duration from the Schedule's `SchedulingParameters`
 - No existing busy Slots may overlap the requested time window (including buffer windows)
+- The `serviceType` attribute must reference the HealthcareService you are trying to schedule
+
+The easiest way to meet these requirements is to use a result from a [`$find` operation](/docs/scheduling/schedule-find).
 
 ## Output
 

--- a/packages/docs/docs/scheduling/defining-availability.md
+++ b/packages/docs/docs/scheduling/defining-availability.md
@@ -48,7 +48,7 @@ All scheduling constraints are managed through a single consolidated extension: 
 
 | Url                 | Type                                                        | Applies To                          | Required                                        | Behavior when defined                                                                                                                                                                | Behavior when not defined                                                              |
 | ------------------- | ----------------------------------------------------------- | ----------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| `serviceType`       | [CodeableConcept](/docs/api/fhir/datatypes/codeableconcept) | Schedule only                       | Required                                        | Applies configuration only to the specified service type, overriding defaults for that service                                                                                       | N/A - must be specified                                                                |
+| `service`           | Reference(HealthcareService)                                | Schedule only                       | Required                                        | Applies configuration only to the specified service type, overriding defaults for that service                                                                                       | N/A - must be specified                                                                |
 | `availability`      | [Nested extension](#availability-extension)                 | Schedule only                       | Optional                                        | Bookings must fully fit within the recurring windows (day-of-week + start time + end time).                                                                                          | Time is implicitly available by default (unless blocked by Slots or other constraints) |
 | `timezone`          | Code                                                        | Schedule only                       | Optional                                        | Specifies the timezone (IANA timezone identifier, e.g., `America/New_York`) for interpreting availability times. Falls back to the Schedule's actor timezone if not specified        | Uses the timezone defined on the Schedule's actor reference                            |
 | `duration`          | [Duration](/docs/api/fhir/datatypes/duration)               | Both Schedule and HealthcareService | Required                                        | Determines how long the time increments for a Slot are                                                                                                                               | N/A - must be specified                                                                |
@@ -67,9 +67,10 @@ All scheduling constraints are managed through a single consolidated extension: 
   "extension": [
     // Required on Schedule: you must specify what type of appointment these parameters apply to
     {
-      "url": "serviceType",
-      "valueCodeableConcept": {
-        "coding": [{"code": "bariatric-surgery"}]
+      "url": "service",
+      "valueReference": {
+        "reference": "HealthcareService/5d02acfd-fbe8-4537-84e4-31f5116be105",
+        "display": "Bariatric Surgery"
       }
     },
 
@@ -193,6 +194,15 @@ Here is an example of a [Schedule](/docs/api/fhir/resources/schedule) resource t
       "text": "Office Visit",
       "coding": [
         { "code": "office-visit" }
+      ],
+      "extension": [
+        {
+          "url": "https://medplum.com/fhir/service-type-reference",
+          "valueReference": {
+            "reference": "HealthcareService/23c3f1cc-4f55-4990-9775-511b02487e7e",
+            "display": "Office Visit"
+          }
+        }
       ]
     }
   ],
@@ -200,9 +210,10 @@ Here is an example of a [Schedule](/docs/api/fhir/resources/schedule) resource t
     "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
     "extension": [
       {
-        "url": "serviceType",
-        "valueCodeableConcept": {
-          "coding": [{"code": "office-visit"}]
+        "url": "service",
+        "valueReference": {
+            "reference": "HealthcareService/23c3f1cc-4f55-4990-9775-511b02487e7e",
+            "display": "Office Visit"
         }
       },
       {
@@ -258,6 +269,15 @@ The `availability` sub-extension mirrors the FHIR R5+ [`Availability`](https://h
       "text": "Office Visit",
       "coding": [
         { "code": "office-visit" }
+      ],
+      "extension":[
+        {
+          "url": "https://medplum.com/fhir/service-type-reference",
+          "valueReference": {
+            "reference": "HealthcareService/23c3f1cc-4f55-4990-9775-511b02487e7e",
+            "display": "Office Visit"
+          }
+        }
       ]
     }
   ],
@@ -265,9 +285,10 @@ The `availability` sub-extension mirrors the FHIR R5+ [`Availability`](https://h
     "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
     "extension": [
       {
-        "url": "serviceType",
-        "valueCodeableConcept": {
-          "coding": [{"code": "office-visit"}]
+        "url": "service",
+        "valueReference": {
+            "reference": "HealthcareService/23c3f1cc-4f55-4990-9775-511b02487e7e",
+            "display": "Office Visit"
         }
       },
       {
@@ -302,17 +323,17 @@ The `availability` sub-extension mirrors the FHIR R5+ [`Availability`](https://h
 
 An [HealthcareService](/docs/api/fhir/resources/healthcareservice) gives a mechanism to define the default scheduling parameters for a specific service type (appointment type), which can then be used by multiple [Practitioner](/docs/api/fhir/resources/practitioner)'s [Schedules](/docs/api/fhir/resources/schedule). This allows you to define standard appointment durations, buffer times, alignment intervals, and booking limits once and apply them across multiple providers.
 
-To get the [Schedule](/docs/api/fhir/resources/schedule) to use the [HealthcareService](/docs/api/fhir/resources/healthcareservice)'s scheduling parameters, the `Schedule.serviceType` must match the `HealthcareService.type`.
+To get the [Schedule](/docs/api/fhir/resources/schedule) to use the [HealthcareService](/docs/api/fhir/resources/healthcareservice)'s scheduling parameters, the `Schedule.serviceType` must include a reference to the HealthcareService in its extensions.
 
 ```tsx
 {
   "resourceType": "HealthcareService",
-  "id": "office-visit",
+  "id": "23c3f1cc-4f55-4990-9775-511b02487e7e",
   "type": [{
     "text": "Office Visit",
     "coding": [{
       "system": "http://example.org/appointment-types",
-      "code": "office-visit"  // ← This is the key
+      "code": "office-visit"
     }]
   }],
   "availableTime": [
@@ -341,6 +362,23 @@ To get the [Schedule](/docs/api/fhir/resources/schedule) to use the [HealthcareS
   "resourceType": "Schedule",
   "id": "dr-smith-schedule",
   "actor": [{"reference": "Practitioner/dr-smith"}],
+  "serviceType": [
+    {
+      "text": "Office Visit",
+      "coding": [
+        { "code": "office-visit" }
+      ],
+      "extension":[
+        {
+          "url": "https://medplum.com/fhir/service-type-reference",
+          "valueReference": {
+            "reference": "HealthcareService/23c3f1cc-4f55-4990-9775-511b02487e7e",
+            "display": "Office Visit"
+          }
+        }
+      ]
+    }
+  ]
   //...
 }
 ```
@@ -357,8 +395,30 @@ Here is an example Schedule that overrides the availability for a specific servi
   "id": "dr-chen-schedule",
   "active": true,
   "serviceType": [
-    {"coding": [{"code": "new-patient-visit"}]},
-    {"coding": [{"code": "follow-up"}]}
+    {
+      "coding": [{"code": "new-patient-visit"}]
+      "extension":[
+        {
+          "url": "https://medplum.com/fhir/service-type-reference",
+          "valueReference": {
+            "reference": "HealthcareService/f44bbf25-bf57-4263-8f10-be060cc91672",
+            "display": "New Patient visit"
+          }
+        }
+      ]
+    },
+    {
+      "coding": [{"code": "follow-up"}]
+      "extension":[
+        {
+          "url": "https://medplum.com/fhir/service-type-reference",
+          "valueReference": {
+            "reference": "HealthcareService/5f93269f-b5de-4d76-9672-e35ecb37f201",
+            "display": "Follow-up visit"
+          }
+        }
+      ]
+    }
   ],
   "actor": [{"reference": "Practitioner/dr-chen"}],
   "extension": [
@@ -367,9 +427,10 @@ Here is an example Schedule that overrides the availability for a specific servi
       "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
       "extension": [
         {
-          "url": "serviceType",
-          "valueCodeableConcept": {
-            "coding": [{"code": "new-patient-visit"}]
+          "url": "service",
+          "valueReference": {
+            "reference": "HealthcareService/f44bbf25-bf57-4263-8f10-be060cc91672",
+            "display": "New Patient visit"
           }
         },
         {
@@ -399,12 +460,12 @@ Here is an example Schedule that overrides the availability for a specific servi
 }
 ```
 
-**All-or-nothing rule**: When a `SchedulingParameters` extension includes a `serviceType`, it **completely replaces** the default configuration for that service type. No attribute-level merging occurs.
+**All-or-nothing rule**: When a `SchedulingParameters` extension includes a `service`, it **completely replaces** the default configuration for that service. No attribute-level merging occurs.
 
 **Priority order** (highest to lowest):
 
-1. Schedule where `https://medplum.com/fhir/StructureDefinition/SchedulingParameters.serviceType` extension matches `service-type` param on `$find` request.
-2. HealthcareService where `HealthcareService.code` matches `service-type` param on `$find` request. HealthcareService parameters are used.
+1. Schedule where `https://medplum.com/fhir/StructureDefinition/SchedulingParameters.service` extension matches `service-type-reference` parameter on `$find` request.
+2. HealthcareService matching `service-type-reference` param on `$find` request. HealthcareService parameters are used.
 
 ### Blocking Time by Service Type
 
@@ -444,7 +505,7 @@ The `timezone` parameter allows you to specify different timezones for different
 }
 ```
 
-:::tip Adding a Timezone to an Actor
+:::tip[Adding a Timezone to an Actor]
 
 There is no native timezone field on [`Practitioner`](/docs/api/fhir/resources/practitioner), [`Location`](/docs/api/fhir/resources/location), or [`Device`](/docs/api/fhir/resources/device), so you must add it via the FHIR timezone extension:
 
@@ -955,7 +1016,13 @@ This Schedule shows Dr. Martinez's availability for bariatric surgeries, limited
   "id": "surgeon-martinez-schedule",
   "active": true,
   "serviceType": [
-    {"coding": [{"system": "http://snomed.info/sct", "code": "287809009"}]}
+    {
+      "coding": [{"system": "http://snomed.info/sct", "code": "287809009"}]
+      "extension": [{
+        "url": "https://medplum.com/fhir/service-type-reference",
+        "valueReference": { "reference": "HealthcareService/bariatric-surgery" }
+      }]
+    }
   ],
   "actor": [{
     "reference": "PractitionerRole/surgeon-martinez",
@@ -965,10 +1032,8 @@ This Schedule shows Dr. Martinez's availability for bariatric surgeries, limited
     "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
     "extension": [
       {
-        "url": "serviceType",
-        "valueCodeableConcept": {
-          "coding": [{"system": "http://snomed.info/sct", "code": "287809009"}]
-        }
+        "url": "service",
+        "valueReference": { "reference": "HealthcareService/bariatric-surgery" }
       },
       {
         "url": "duration",
@@ -1013,11 +1078,22 @@ This Schedule shows Operating Room 3's availability for surgical procedures, ava
     "display": "Operating Room 3"
   }],
   "serviceType": [
-    {"coding": [{"system": "http://snomed.info/sct", "code": "287809009"}]}
+    {
+      "coding": [{"system": "http://snomed.info/sct", "code": "287809009"}]
+      "extension": [{
+        "url": "https://medplum.com/fhir/service-type-reference",
+        "valueReference": { "reference": "HealthcareService/bariatric-surgery" }
+      }]
+    }
   ],
   "extension": [{
     "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
     "extension": [
+      {
+        "url": "service",
+        "valueReference": { "reference": "HealthcareService/bariatric-surgery" }
+        }
+      },
       {
         "url": "duration",
         "valueDuration": {
@@ -1060,7 +1136,13 @@ This Schedule shows Dr. Kim's availability for surgical procedures, covering wee
   "id": "anesthesiologist-kim-schedule",
   "active": true,
   "serviceType": [
-    {"coding": [{"system": "http://snomed.info/sct", "code": "287809009"}]}
+    {
+      "coding": [{"system": "http://snomed.info/sct", "code": "287809009"}]
+      "extension": [{
+        "url": "https://medplum.com/fhir/service-type-reference",
+        "valueReference": { "reference": "HealthcareService/bariatric-surgery" }
+      }]
+    }
   ],
   "actor": [{
     "reference": "PractitionerRole/anesthesiologist-kim",
@@ -1070,10 +1152,8 @@ This Schedule shows Dr. Kim's availability for surgical procedures, covering wee
     "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
     "extension": [
       {
-        "url": "serviceType",
-        "valueCodeableConcept": {
-          "coding": [{"system": "http://snomed.info/sct", "code": "287809009"}]
-        }
+        "url": "service",
+        "valueReference": { "reference": "HealthcareService/bariatric-surgery" }
       },
       {
         "url": "duration",
@@ -1184,7 +1264,7 @@ graph TD
 
 #### 1. Use All-or-Nothing Overrides
 
-If adding a `serviceType` configuration on Schedule, **specify ALL attributes** to avoid confusion about inheritance.
+If adding a `service` configuration on Schedule, **specify ALL attributes** to avoid confusion about inheritance.
 
 #### 2. Minimize Pre-Generated Slots
 

--- a/packages/docs/docs/scheduling/index.md
+++ b/packages/docs/docs/scheduling/index.md
@@ -1,3 +1,6 @@
+import ExampleCode from '!!raw-loader!@site/../examples/src/scheduling/index.ts';
+import MedplumCodeBlock from '@site/src/components/MedplumCodeBlock';
+
 # Scheduling
 
 :::info
@@ -6,11 +9,28 @@ Medplum Scheduling is currently in alpha.
 
 Welcome to the Medplum Scheduling documentation. We currently support a range of scheduling operations that are available via the FHIR API. The following sections walk through the FHIR resources that are used to model scheduling and how the operations interact with them.
 
-**We like to separate scheduling into three main steps:**
+**We like to separate scheduling into four main steps:**
 
 ---
 
-## Step 1: [Defining Availability](/docs/scheduling/defining-availability)
+## Step 1: Defining Service Types
+
+Decide what types of appointments you would like to offer. Create a [HealthcareService](/docs/api/fhir/resources/healthcareservice) resource for each type. Set a SchedulingParameters extension on each to define attributes like the length of the visit.
+
+Mark which [Schedule](/docs/api/fhir/resources/schedule) resources should be able to schedule appointments of that type by setting a reference to the HealthcareService in the Schedule.serviceType attribute.
+
+<details>
+  <summary>Referencing a HealthcareService</summary>
+
+  In future FHIR revisions, Schedule.serviceType will have type `CodeableReference(HealthcareService)`. In Medplum's R4 implementation, this is achieved by including an extension on a `CodeableConcept` in that attribute.
+
+  <MedplumCodeBlock language="ts" selectBlocks="scheduleServiceTypeLink">
+    {ExampleCode}
+  </MedplumCodeBlock>
+</details>
+
+
+## Step 2: [Defining Availability](/docs/scheduling/defining-availability)
 
 The resources used to model availability for a provider, location, or device and the different service-specific scheduling parameters that can be defined.
 

--- a/packages/docs/docs/scheduling/schedule-find.md
+++ b/packages/docs/docs/scheduling/schedule-find.md
@@ -11,7 +11,7 @@ The `$find` operation is currently in alpha. It supports only Schedules with a s
 
 :::
 
-The `$find` operation returns a bundle of available (free) [`Slot`](/docs/api/fhir/resources/slot) resources for a given [`Schedule`](/docs/api/fhir/resources/schedule) within a specified time range. Slots are computed dynamically from the Schedule's [`SchedulingParameters`](/docs/scheduling/defining-availability) extension — no Slots need to be pre-generated.
+The `$find` operation takes a [`Schedule`](/docs/api/fhir/resources/schedule) and a [`HealthcareService`](/docs/api/fhir/resources/healthcareservice) and returns a bundle of available (free) [`Slot`](/docs/api/fhir/resources/slot) resources within a specified time range. Slots are computed dynamically from the Schedule's [`SchedulingParameters`](/docs/scheduling/defining-availability) extension — no Slots need to be pre-generated.
 
 ## Use Cases
 
@@ -44,8 +44,7 @@ const result = await medplum.post(
     parameter: [
       { name: 'start', valueDateTime: '2026-03-10T09:00:00-05:00' },
       { name: 'end', valueDateTime: '2026-03-10T17:00:00-05:00' },
-      // Optional: filter by service type (format: "system|code")
-      { name: 'service-type', valueString: 'http://example.org/appointment-types|office-visit' },
+      { name: 'service-type-reference', valueReference: { reference: "HealthcareService/my-healthcareservice-id"},
       // Optional: limit number of results
       { name: '_count', valueInteger: 10 },
     ],
@@ -68,6 +67,7 @@ curl -X POST 'https://api.medplum.com/fhir/R4/Schedule/my-schedule-id/$find' \
     "parameter": [
       { "name": "start", "valueDateTime": "2026-03-10T09:00:00-05:00" },
       { "name": "end",   "valueDateTime": "2026-03-10T17:00:00-05:00" }
+      { name: "service-type-reference", "valueReference": { "reference": "HealthcareService/my-healthcareservice-id"},
     ]
   }'
 ```
@@ -77,19 +77,19 @@ curl -X POST 'https://api.medplum.com/fhir/R4/Schedule/my-schedule-id/$find' \
 
 ## Parameters
 
-| Name           | Type       | Description                                                                                  | Required |
-| -------------- | ---------- | ---------------------------------------------------------------------------------------------| -------- |
-| `start`        | `dateTime` | Start of the search window (inclusive)                                                       | Yes      |
-| `end`          | `dateTime` | End of the search window (inclusive)                                                         | Yes      |
-| `service-type` | `string`   | Filter slots by service type. Format: `system\|code`. Multiple codes can be comma-separated. | Yes      |
-| `_count`       | `integer`  | Maximum number of Slot resources to return. Defaults to 20. Maximum is 1000.                 | No       |
+| Name                     | Type                             | Description                                                                                  | Required |
+| ------------------------ | -------------------------------- | ---------------------------------------------------------------------------------------------| -------- |
+| `start`                  | `dateTime`                       | Start of the search window (inclusive)                                                       | Yes      |
+| `end`                    | `dateTime`                       | End of the search window (inclusive)                                                         | Yes      |
+| `service-type-reference` | `reference(HealthcareService)`   | The HealthcareService describing the type of appointment to be scheduled.                    | Yes      |
+| `_count`                 | `integer`                        | Maximum number of Slot resources to return. Defaults to 20. Maximum is 1000.                 | No       |
 
 ### Constraints
 
 - `start` must be before `end`
 - The search window cannot exceed **31 days**
 - The Schedule must have exactly **one actor** reference
-- The Schedule's `serviceType` field must match the requested service-type
+- The Schedule's `serviceType` field must match the requested HealthcareService.type
 - The actor (Practitioner, Location, or Device) must have a timezone defined via the `http://hl7.org/fhir/StructureDefinition/timezone` extension
 
 ## Output
@@ -118,7 +118,15 @@ Returns a [`Parameters`](/docs/api/fhir/resources/parameters) resource wrapping 
               "serviceType": [
                 {
                   "coding": [
-                    { "code": "office-visit" }
+                    {
+                      "code": "office-visit"
+                    }
+                  ],
+                  "extension": [
+                    {
+                      "url": "https://medplum.com/fhir/service-type-reference",
+                      "valueReference": { "reference": "HealthcareService/my-healthcareservice-id"}
+                    }
                   ]
                 }
               ]
@@ -135,6 +143,12 @@ Returns a [`Parameters`](/docs/api/fhir/resources/parameters) resource wrapping 
                 {
                   "coding": [
                     { "code": "office-visit" }
+                  ]
+                  "extension": [
+                    {
+                      "url": "https://medplum.com/fhir/service-type-reference",
+                      "valueReference": { "reference": "HealthcareService/my-healthcareservice-id"}
+                    }
                   ]
                 }
               ]
@@ -198,7 +212,7 @@ See [Defining Availability](/docs/scheduling/defining-availability) for full det
 }
 ```
 
-### Schedule Does not have the requested service-type in `Schedule.serviceType`
+### `Schedule.serviceType` does not match `HealthcareService.type`
 
 ```json
 {

--- a/packages/examples/src/scheduling/index.ts
+++ b/packages/examples/src/scheduling/index.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { Schedule } from '@medplum/fhirtypes';
+
+const schedule: Schedule =
+  // start-block scheduleServiceTypeLink
+  {
+    resourceType: 'Schedule',
+    actor: [
+      {
+        reference: 'Practitioner/dr-alice-smith',
+      },
+    ],
+    serviceType: [
+      {
+        coding: [{ code: 'office-visit' }],
+        extension: [
+          {
+            url: 'https://medplum.com/fhir/service-type-reference',
+            valueReference: {
+              reference: 'HealthcareService/5d02acfd-fbe8-4537-84e4-31f5116be105',
+              display: 'Office Visit',
+            },
+          },
+        ],
+      },
+    ],
+  };
+// end-block scheduleServiceTypeLink
+
+console.log(schedule);

--- a/packages/server/src/fhir/operations/book.test.ts
+++ b/packages/server/src/fhir/operations/book.test.ts
@@ -21,6 +21,7 @@ import { loadTestConfig } from '../../config/loader';
 import { getGlobalSystemRepo } from '../../fhir/repo';
 import type { TestProjectResult } from '../../test.setup';
 import { createTestProject } from '../../test.setup';
+import { toCodeableReferenceLike } from '../../util/servicetype';
 import type {
   SchedulingParametersExtension,
   SchedulingParametersExtensionExtension,
@@ -59,6 +60,12 @@ describe('Appointment/$book', () => {
   let practitioner1: Practitioner;
   let practitioner2: Practitioner;
   let patient: Patient;
+  let officeVisitService: WithId<HealthcareService>;
+  let followupService: WithId<HealthcareService>;
+
+  const officeVisit: CodeableConcept = {
+    coding: [{ system: 'https://example.com/fhir', code: 'office-visit' }],
+  };
 
   beforeAll(async () => {
     const config = await loadTestConfig();
@@ -67,18 +74,27 @@ describe('Appointment/$book', () => {
     practitioner1 = await makePractitioner({ timezone: 'America/New_York' });
     practitioner2 = await makePractitioner({ timezone: 'America/New_York' });
     patient = await makePatient();
+
+    officeVisitService = await systemRepo.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      name: 'Office Visit',
+      type: [officeVisit],
+      meta: { project: project.project.id },
+    });
+
+    followupService = await systemRepo.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      name: 'Follow Up Visit',
+      meta: { project: project.project.id },
+    });
   });
 
   afterAll(async () => {
     await shutdownApp();
   });
 
-  const officeVisit: CodeableConcept = {
-    coding: [{ system: 'https://example.com/fhir', code: 'office-visit' }],
-  };
-
   function makeSchedulingExtension(opts?: {
-    serviceType?: CodeableConcept;
+    service?: WithId<HealthcareService>;
     duration?: number;
   }): SchedulingParametersExtension {
     const duration = opts?.duration ?? 60;
@@ -93,10 +109,10 @@ describe('Appointment/$book', () => {
       ],
     };
 
-    if (opts?.serviceType) {
+    if (opts?.service) {
       extension.extension.push({
-        url: 'serviceType',
-        valueCodeableConcept: opts.serviceType,
+        url: 'service',
+        valueReference: createReference(opts.service),
       });
     }
 
@@ -108,7 +124,8 @@ describe('Appointment/$book', () => {
       resourceType: 'Schedule',
       meta: { project: project.project.id },
       actor: [createReference(opts.actor)],
-      extension: opts.extension ?? [makeSchedulingExtension({ serviceType: officeVisit })],
+      serviceType: toCodeableReferenceLike(officeVisitService),
+      extension: opts.extension ?? [makeSchedulingExtension({ service: officeVisitService })],
     });
   }
 
@@ -147,7 +164,7 @@ describe('Appointment/$book', () => {
             resource: {
               resourceType: 'Slot',
               schedule: createReference(schedule),
-              serviceType: [officeVisit],
+              serviceType: toCodeableReferenceLike(officeVisitService),
               start: '2026-01-15T14:00:00Z',
               end: '2026-01-15T15:00:00Z',
               status: 'free',
@@ -370,6 +387,52 @@ describe('Appointment/$book', () => {
     expect(response.status).toEqual(400);
   });
 
+  test('when slots have different service types', async () => {
+    const schedule1 = await makeSchedule({ actor: practitioner1 });
+    const schedule2 = await makeSchedule({ actor: practitioner2 });
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$book')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'slot',
+            resource: {
+              resourceType: 'Slot',
+              schedule: createReference(schedule1),
+              start: '2026-01-15T14:00:00Z',
+              end: '2026-01-15T15:00:00Z',
+              status: 'free',
+              serviceType: toCodeableReferenceLike(officeVisitService),
+            } satisfies Slot,
+          },
+          {
+            name: 'slot',
+            resource: {
+              resourceType: 'Slot',
+              schedule: createReference(schedule2),
+              start: '2026-01-15T14:00:00Z',
+              end: '2026-01-15T15:00:00Z',
+              status: 'free',
+              serviceType: toCodeableReferenceLike(followupService),
+            } satisfies Slot,
+          },
+        ],
+      });
+    expect(response.body).toHaveProperty('issue', [
+      {
+        severity: 'error',
+        code: 'invalid',
+        details: {
+          text: 'Mismatched service types',
+        },
+      },
+    ]);
+    expect(response.status).toEqual(400);
+  });
+
   test('fails with Conflict when there is an overlapping busy slot booked', async () => {
     const practitioner = await makePractitioner({ timezone: 'America/New_York' });
     const schedule = await makeSchedule({ actor: practitioner });
@@ -446,7 +509,7 @@ describe('Appointment/$book', () => {
       });
     expect(response.body).toMatchObject({
       resourceType: 'OperationOutcome',
-      issue: [{ severity: 'error', code: 'invalid', details: { text: 'No matching scheduling parameters found' } }],
+      issue: [{ severity: 'error', code: 'invalid', details: { text: 'No matching HealthcareService found' } }],
     });
     expect(response.status).toEqual(400);
   });
@@ -710,6 +773,7 @@ describe('Appointment/$book', () => {
         resourceType: 'Schedule',
         meta: { project: project.project.id },
         actor: [createReference(practitioner1)],
+        serviceType: toCodeableReferenceLike(officeVisitService),
         extension: [
           {
             url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
@@ -728,8 +792,8 @@ describe('Appointment/$book', () => {
                 valueDuration: { value: alignmentOffset, unit: 'min' },
               },
               {
-                url: 'serviceType',
-                valueCodeableConcept: officeVisit,
+                url: 'service',
+                valueReference: createReference(officeVisitService),
               },
             ],
           },
@@ -764,6 +828,7 @@ describe('Appointment/$book', () => {
       resourceType: 'Schedule',
       meta: { project: project.project.id },
       actor: [createReference(practitioner1)],
+      serviceType: toCodeableReferenceLike(officeVisitService),
       extension: [
         {
           url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
@@ -778,8 +843,8 @@ describe('Appointment/$book', () => {
               valueDuration: { value: 20, unit: 'min' },
             },
             {
-              url: 'serviceType',
-              valueCodeableConcept: officeVisit,
+              url: 'service',
+              valueReference: createReference(officeVisitService),
             },
           ],
         },
@@ -874,6 +939,7 @@ describe('Appointment/$book', () => {
       resourceType: 'Schedule',
       meta: { project: project.project.id },
       actor: [createReference(practitioner1)],
+      serviceType: toCodeableReferenceLike(officeVisitService),
       extension: [
         {
           url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
@@ -892,8 +958,8 @@ describe('Appointment/$book', () => {
               valueDuration: { value: 15, unit: 'min' },
             },
             {
-              url: 'serviceType',
-              valueCodeableConcept: officeVisit,
+              url: 'service',
+              valueReference: createReference(officeVisitService),
             },
           ],
         },
@@ -1129,6 +1195,43 @@ describe('Appointment/$book', () => {
       expect(response.status).toEqual(201);
     });
 
+    test('fails when multiple HealthcareServices match the slot service type tokens', async () => {
+      // Two HealthcareServices sharing the same coding — the token-based fallback is
+      // ambiguous and must fail rather than silently picking one.
+      const sharedCode = { coding: [{ system: 'http://example.com', code: 'shared-svc' }] };
+      await makeHealthcareService(sharedCode, 45);
+      await makeHealthcareService(sharedCode, 60);
+      const schedule = await makeScheduleNoParams(practitioner1);
+
+      const response = await request
+        .post('/fhir/R4/Appointment/$book')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'slot',
+              resource: {
+                resourceType: 'Slot',
+                schedule: createReference(schedule),
+                serviceType: [sharedCode],
+                start: '2026-01-15T14:00:00Z',
+                end: '2026-01-15T15:00:00Z',
+                status: 'free',
+              } satisfies Slot,
+            },
+          ],
+        });
+
+      expect(response.status).toEqual(400);
+      expect(response.body).toMatchObject({
+        resourceType: 'OperationOutcome',
+        issue: [
+          { severity: 'error', code: 'invalid', details: { text: 'Multiple matching HealthcareServices found' } },
+        ],
+      });
+    });
+
     test('fails when booking outside HealthcareService availability', async () => {
       const serviceType = { coding: [{ system: 'http://example.com', code: 'consult' }] };
       await makeHealthcareService(serviceType, 60);
@@ -1165,7 +1268,7 @@ describe('Appointment/$book', () => {
       // overridden).
       const serviceType = { coding: [{ system: 'http://example.com', code: 'dentistry' }] };
 
-      await systemRepo.createResource<HealthcareService>({
+      const service = await systemRepo.createResource<HealthcareService>({
         resourceType: 'HealthcareService',
         meta: { project: project.project.id },
         type: [serviceType],
@@ -1189,13 +1292,14 @@ describe('Appointment/$book', () => {
         resourceType: 'Schedule',
         meta: { project: project.project.id },
         actor: [createReference(practitioner1)],
+        serviceType: toCodeableReferenceLike(service),
         extension: [
           {
             url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
             extension: [
               threeDayAvailability,
               { url: 'duration', valueDuration: { value: 60, unit: 'min' } },
-              { url: 'serviceType', valueCodeableConcept: serviceType },
+              { url: 'service', valueReference: createReference(service) },
             ],
           },
         ],
@@ -1302,17 +1406,25 @@ describe('Appointment/$book', () => {
       text: 'Simple initial visit',
       coding: [{ code: 'simple-initial-visit' }],
     };
+
+    const service = await systemRepo.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      type: [initialVisit],
+      meta: { project: project.project.id },
+    });
+
     const schedule = await systemRepo.createResource<Schedule>({
       resourceType: 'Schedule',
       meta: { project: project.project.id },
       actor: [createReference(practitioner1)],
+      serviceType: toCodeableReferenceLike(service),
       extension: [
         {
           url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
           extension: [
             {
-              url: 'serviceType',
-              valueCodeableConcept: initialVisit,
+              url: 'service',
+              valueReference: createReference(service),
             },
             threeDayAvailability,
             {
@@ -1365,6 +1477,13 @@ describe('scheduling flow integration test', () => {
   };
 
   test('a slot from $find can be used as input to $book', async () => {
+    const service = await systemRepo.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      name: 'Office Visit',
+      type: [officeVisit],
+      meta: { project: project.project.id },
+    });
+
     const practitioner = await systemRepo.createResource<Practitioner>({
       resourceType: 'Practitioner',
       meta: { project: project.project.id },
@@ -1380,7 +1499,7 @@ describe('scheduling flow integration test', () => {
       resourceType: 'Schedule',
       meta: { project: project.project.id },
       actor: [createReference(practitioner)],
-      serviceType: [officeVisit],
+      serviceType: toCodeableReferenceLike(service),
       extension: [
         {
           url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
@@ -1407,8 +1526,8 @@ describe('scheduling flow integration test', () => {
               valueDuration: { value: 15, unit: 'min' },
             },
             {
-              url: 'serviceType',
-              valueCodeableConcept: officeVisit,
+              url: 'service',
+              valueReference: createReference(service),
             },
           ],
         },
@@ -1421,7 +1540,7 @@ describe('scheduling flow integration test', () => {
       .query({
         start: new Date('2026-01-28T07:00:00.000-07:00'),
         end: new Date('2026-01-28T12:00:00.000-07:00'),
-        'service-type': 'https://example.com/fhir|office-visit',
+        'service-type-reference': `HealthcareService/${service.id}`,
       });
 
     expect(findResponse.body).not.toHaveProperty('issue');

--- a/packages/server/src/fhir/operations/book.ts
+++ b/packages/server/src/fhir/operations/book.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
 import {
   badRequest,
   conflict,
@@ -24,9 +25,9 @@ import type {
 import { getAuthenticatedContext } from '../../context';
 import { addMinutes, areIntervalsOverlapping } from '../../util/date';
 import { invariant } from '../../util/invariant';
+import { extractReferencesFromCodeableReferenceLike } from '../../util/servicetype';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 import { applyExistingSlots, getTimeZone, resolveAvailability } from './utils/scheduling';
-import type { SchedulingParameters } from './utils/scheduling-parameters';
 import { chooseSchedulingParameters } from './utils/scheduling-parameters';
 
 const bookOperation = {
@@ -77,33 +78,6 @@ function serviceTypeTokens(slots: Slot[]): string[] {
     }
   }
   return [...tokenSet.values()];
-}
-
-function chooseActiveParameters(
-  proposedSlot: Slot,
-  parameters: SchedulingParameters[],
-  actorTimeZone: string,
-  existingSlots: Slot[]
-): SchedulingParameters | undefined {
-  const startDate = new Date(proposedSlot.start);
-  const endDate = new Date(proposedSlot.end);
-  return parameters.find((params) => {
-    const timeZone = params.timezone ?? actorTimeZone;
-    const range = {
-      start: addMinutes(startDate, -1 * params.bufferBefore),
-      end: addMinutes(endDate, params.bufferAfter),
-    };
-    const availability = resolveAvailability(params, range, timeZone);
-    const result = applyExistingSlots({
-      availability,
-      slots: existingSlots,
-      range,
-      serviceType: proposedSlot.serviceType ?? EMPTY,
-    });
-    return result.some(
-      (interval) => interval.start.getTime() <= range.start.getTime() && interval.end.getTime() >= range.end.getTime()
-    );
-  });
 }
 
 /**
@@ -157,17 +131,43 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
   const actors = await ctx.repo.readReferences(schedules.flatMap((schedule) => schedule.actor));
   assertAllOk(actors, 'Schedule.actor load failed', 'Parameters.parameter[%i].schedule.actor');
 
-  // Collect all unique service type codes across all proposed slots, then fetch
-  // matching HealthcareService resources in a single query.
-  const allServiceTypes = serviceTypeTokens(proposedSlots);
+  let healthcareService: WithId<HealthcareService>;
+  // We expect that at most one unique serviceType reference will be found
+  const serviceRefs = proposedSlots.flatMap((slot) => extractReferencesFromCodeableReferenceLike(slot.serviceType));
+  const serviceRefString = assertAllMatch(
+    serviceRefs.map((ref) => ref.reference),
+    'Mismatched service types'
+  );
 
-  const healthcareServices: HealthcareService[] =
-    allServiceTypes.length > 0
-      ? await ctx.repo.searchResources<HealthcareService>({
-          resourceType: 'HealthcareService',
-          filters: [{ code: 'service-type', operator: Operator.EQUALS, value: allServiceTypes.join(',') }],
-        })
-      : [];
+  if (serviceRefString) {
+    healthcareService = await ctx.repo.readReference({ reference: serviceRefString });
+    if (!healthcareService) {
+      throw new OperationOutcomeError(badRequest('HealthcareService not found'));
+    }
+  } else {
+    // Collect all unique service type codes across all proposed slots, then fetch
+    // matching HealthcareService resources in a single query.
+    //
+    // Q: Do we support this style or require the CodeableReference style above?
+    const allServiceTypes = serviceTypeTokens(proposedSlots);
+
+    const healthcareServices: WithId<HealthcareService>[] =
+      allServiceTypes.length > 0
+        ? await ctx.repo.searchResources<HealthcareService>({
+            resourceType: 'HealthcareService',
+            filters: [{ code: 'service-type', operator: Operator.EQUALS, value: allServiceTypes.join(',') }],
+          })
+        : [];
+
+    if (healthcareServices.length === 0) {
+      throw new OperationOutcomeError(badRequest('No matching HealthcareService found'));
+    }
+
+    if (healthcareServices.length > 1) {
+      throw new OperationOutcomeError(badRequest('Multiple matching HealthcareServices found'));
+    }
+    healthcareService = healthcareServices[0];
+  }
 
   const bufferSlots: Slot[] = [];
 
@@ -187,24 +187,21 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
               badRequest('No timezone specified', `Parameters.parameter[${index}].schedule.actor`)
             );
           }
-
-          const slotServiceTypes = serviceTypeTokens([proposedSlot]);
-
           const durationMinutes = (Date.parse(proposedSlot.end) - Date.parse(proposedSlot.start)) / 60000;
+          const parameters = chooseSchedulingParameters(schedule, healthcareService);
 
-          const parameters = chooseSchedulingParameters(schedule, healthcareServices, slotServiceTypes)
-            .map(([params]) => params)
-            .filter((params) => params.duration === durationMinutes);
-
-          if (parameters.length === 0) {
+          if (parameters?.duration !== durationMinutes) {
             throw new OperationOutcomeError(badRequest('No matching scheduling parameters found'));
           }
 
-          const bufferBeforeMax = Math.max(...parameters.map((p) => p.bufferBefore));
-          const bufferAfterMax = Math.max(...parameters.map((p) => p.bufferAfter));
+          const timeZone = parameters.timezone ?? actorTimeZone;
 
-          const searchStart = addMinutes(startDate, -1 * bufferBeforeMax).toISOString();
-          const searchEnd = addMinutes(endDate, bufferAfterMax).toISOString();
+          const range = {
+            start: addMinutes(startDate, -1 * parameters.bufferBefore),
+            end: addMinutes(endDate, parameters.bufferAfter),
+          };
+          const searchStart = range.start.toISOString();
+          const searchEnd = range.end.toISOString();
 
           const existingSlots = await ctx.repo.searchResources<Slot>({
             resourceType: 'Slot',
@@ -249,28 +246,37 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
             throw new OperationOutcomeError(conflict('Requested time slot is no longer available'));
           }
 
-          const activeParameters = chooseActiveParameters(proposedSlot, parameters, actorTimeZone, existingSlots);
+          const availability = applyExistingSlots({
+            availability: resolveAvailability(parameters, range, timeZone),
+            slots: existingSlots,
+            range,
+            serviceType: healthcareService.type,
+          });
 
-          if (!activeParameters) {
+          const hasAvailability = availability.some(
+            (interval) => interval.start <= range.start && interval.end >= range.end
+          );
+
+          if (!hasAvailability) {
             throw new OperationOutcomeError(badRequest('No availability found at this time'));
           }
 
-          if (activeParameters.bufferBefore) {
+          if (parameters.bufferBefore) {
             bufferSlots.push({
               resourceType: 'Slot',
               status: 'busy-unavailable',
-              start: addMinutes(startDate, -1 * activeParameters.bufferBefore).toISOString(),
+              start: searchStart,
               end: startDate.toISOString(),
               schedule: proposedSlot.schedule,
             });
           }
 
-          if (activeParameters.bufferAfter) {
+          if (parameters.bufferAfter) {
             bufferSlots.push({
               resourceType: 'Slot',
               status: 'busy-unavailable',
               start: endDate.toISOString(),
-              end: addMinutes(endDate, activeParameters.bufferAfter).toISOString(),
+              end: searchEnd,
               schedule: proposedSlot.schedule,
             });
           }

--- a/packages/server/src/fhir/operations/book.ts
+++ b/packages/server/src/fhir/operations/book.ts
@@ -140,9 +140,13 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
   );
 
   if (serviceRefString) {
-    healthcareService = await ctx.repo.readReference({ reference: serviceRefString });
-    if (!healthcareService) {
-      throw new OperationOutcomeError(badRequest('HealthcareService not found'));
+    try {
+      healthcareService = await ctx.repo.readReference({ reference: serviceRefString });
+    } catch (err) {
+      if (err instanceof OperationOutcomeError && isNotFound(err.outcome)) {
+        throw new OperationOutcomeError(badRequest('HealthcareService not found'));
+      }
+      throw err;
     }
   } else {
     // Collect all unique service type codes across all proposed slots, then fetch

--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -19,12 +19,14 @@ import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
 import type { SystemRepository } from '../../fhir/repo';
 import { createTestProject } from '../../test.setup';
+import { ServiceTypeReferenceURI, toCodeableReferenceLike } from '../../util/servicetype';
 import type { SchedulingParametersExtensionExtension } from './utils/scheduling-parameters';
 
 const app = express();
 const request = supertest(app);
 
 type AvailabilityOptions = {
+  service: WithId<HealthcareService>;
   bufferBefore?: number;
   bufferAfter?: number;
   alignmentInterval?: number;
@@ -94,9 +96,13 @@ const fridayOnly = {
 describe('Schedule/:id/$find', () => {
   let location: Location;
   let practitioner: Practitioner;
+  let officeVisit: WithId<HealthcareService>;
+  let genericVisit: WithId<HealthcareService>;
   let project: WithId<Project>;
   let accessToken: string;
   let systemRepo: SystemRepository;
+
+  const servicesMap: Record<string, HealthcareService> = {};
 
   beforeAll(async () => {
     const config = await loadTestConfig();
@@ -116,15 +122,52 @@ describe('Schedule/:id/$find', () => {
       meta: { project: project.id },
       extension: [{ url: 'http://hl7.org/fhir/StructureDefinition/timezone', valueCode: 'America/Phoenix' }],
     });
+    genericVisit = await systemRepo.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      meta: { project: project.id },
+      type: [{ coding: [{ system: 'http://example.com', code: 'generic-visit' }] }],
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [
+            {
+              url: 'duration',
+              valueDuration: { value: 20, unit: 'min' },
+            },
+          ],
+        },
+      ],
+      name: 'Visit',
+    });
+    officeVisit = await systemRepo.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      meta: { project: project.id },
+      type: [{ coding: [{ code: 'office-visit' }] }],
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [
+            {
+              url: 'duration',
+              valueDuration: { value: 20, unit: 'min' },
+            },
+          ],
+        },
+      ],
+      name: 'Office Visit',
+    });
+
+    servicesMap[genericVisit.id] = genericVisit;
+    servicesMap[officeVisit.id] = officeVisit;
   });
 
   afterAll(async () => {
     await shutdownApp();
   });
 
-  function makeSchedulingExtension(availability: Record<string, AvailabilityOptions>): Extension[] {
-    return Object.entries(availability).map(([serviceType, options]) => {
-      const { availability, timezone, ...durations } = options;
+  function makeSchedulingExtension(availability: AvailabilityOptions[]): Extension[] {
+    return availability.map((options) => {
+      const { availability, timezone, service, ...durations } = options;
 
       const extension = {
         url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
@@ -143,10 +186,8 @@ describe('Schedule/:id/$find', () => {
       }
 
       extension.extension.push({
-        url: 'serviceType',
-        valueCodeableConcept: {
-          coding: [{ code: serviceType, system: 'http://example.com' }],
-        },
+        url: 'service',
+        valueReference: createReference(service),
       });
 
       Object.entries(durations).forEach(([key, value]) =>
@@ -158,12 +199,10 @@ describe('Schedule/:id/$find', () => {
   }
 
   async function makeSchedule(
-    availability: Record<string, AvailabilityOptions>,
+    availability: AvailabilityOptions[],
     opts?: { actor?: Schedule['actor'] }
   ): Promise<Schedule> {
-    const serviceType: CodeableConcept[] = Object.keys(availability).map((code) => ({
-      coding: [{ system: 'http://example.com', code }],
-    }));
+    const serviceType = availability.flatMap((entry) => toCodeableReferenceLike(entry.service));
     return systemRepo.createResource<Schedule>({
       resourceType: 'Schedule',
       meta: { project: project.id },
@@ -192,16 +231,14 @@ describe('Schedule/:id/$find', () => {
   }
 
   test('searching an interval not overlapping availability returns an empty bundle', async () => {
-    const schedule = await makeSchedule({
-      'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
-    });
+    const schedule = await makeSchedule([{ service: genericVisit, availability: fourDayWorkWeek, duration: 20 }]);
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
       .set('Authorization', `Bearer ${accessToken}`)
       .query({
         start: new Date('2025-12-01T00:00:00.000-05:00'),
         end: new Date('2025-12-01T09:00:00.000-05:00'),
-        'service-type': 'http://example.com|generic-visit',
+        'service-type-reference': `HealthcareService/${genericVisit.id}`,
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -213,16 +250,14 @@ describe('Schedule/:id/$find', () => {
   });
 
   test('finds slots that overlap with the availability in the range', async () => {
-    const schedule = await makeSchedule({
-      'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
-    });
+    const schedule = await makeSchedule([{ service: genericVisit, availability: fourDayWorkWeek, duration: 20 }]);
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
       .set('Authorization', `Bearer ${accessToken}`)
       .query({
         start: new Date('2025-12-01T00:00:00.000-05:00'),
         end: new Date('2025-12-01T14:00:00.000-05:00'),
-        'service-type': 'http://example.com|generic-visit',
+        'service-type-reference': `HealthcareService/${genericVisit.id}`,
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -262,9 +297,7 @@ describe('Schedule/:id/$find', () => {
   });
 
   test('discovers and removes busy slots from the search results', async () => {
-    const schedule = await makeSchedule({
-      'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
-    });
+    const schedule = await makeSchedule([{ service: genericVisit, availability: fourDayWorkWeek, duration: 20 }]);
     await makeSlot({
       start: new Date('2025-12-01T11:10:00.000-05:00'),
       end: new Date('2025-12-01T11:40:00.000-05:00'),
@@ -279,7 +312,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2025-12-01T14:00:00.000-05:00').toISOString(),
-        'service-type': 'http://example.com|generic-visit',
+        'service-type-reference': `HealthcareService/${genericVisit.id}`,
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -311,9 +344,7 @@ describe('Schedule/:id/$find', () => {
   });
 
   test('discovers and adds "free" slots into the search results', async () => {
-    const schedule = await makeSchedule({
-      'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
-    });
+    const schedule = await makeSchedule([{ service: genericVisit, availability: fourDayWorkWeek, duration: 20 }]);
 
     // Free slots with no service type can be used for any service type
     await makeSlot({
@@ -330,7 +361,7 @@ describe('Schedule/:id/$find', () => {
       end: new Date('2025-12-01T14:00:00.000-05:00'),
       status: 'free',
       schedule,
-      serviceType: [{ coding: [{ system: 'http://example.com', code: 'generic-visit' }] }],
+      serviceType: genericVisit.type,
     });
 
     const response = await request
@@ -340,7 +371,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2025-12-01T14:00:00.000-05:00').toISOString(),
-        'service-type': 'http://example.com|generic-visit',
+        'service-type-reference': `HealthcareService/${genericVisit.id}`,
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -439,14 +470,15 @@ describe('Schedule/:id/$find', () => {
   });
 
   test('resolving availability with bufferBefore and bufferAfter', async () => {
-    const schedule = await makeSchedule({
-      'generic-visit': {
+    const schedule = await makeSchedule([
+      {
+        service: genericVisit,
         availability: fourDayWorkWeek,
         bufferBefore: 15,
         bufferAfter: 5,
         duration: 20,
       },
-    });
+    ]);
 
     // Mark busy directly after the 12:00 slot, blocking it
     await makeSlot({
@@ -479,7 +511,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2025-12-01T14:00:00.000-05:00').toISOString(),
-        'service-type': 'http://example.com|generic-visit',
+        'service-type-reference': `HealthcareService/${genericVisit.id}`,
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -503,9 +535,7 @@ describe('Schedule/:id/$find', () => {
   });
 
   test('search input in another timezone finds appropriate overlap', async () => {
-    const schedule = await makeSchedule({
-      'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
-    });
+    const schedule = await makeSchedule([{ service: genericVisit, availability: fourDayWorkWeek, duration: 20 }]);
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
       .set('Authorization', `Bearer ${accessToken}`)
@@ -513,7 +543,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T11:00:00.000-05:00').toISOString(),
         end: new Date('2025-12-01T14:00:00.000-05:00').toISOString(),
-        'service-type': 'http://example.com|generic-visit',
+        'service-type-reference': `HealthcareService/${genericVisit.id}`,
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -544,9 +574,7 @@ describe('Schedule/:id/$find', () => {
   });
 
   test('uses default search page size of 20 results', async () => {
-    const schedule = await makeSchedule({
-      'generic-visit': { availability: fourDayWorkWeek, duration: 60 },
-    });
+    const schedule = await makeSchedule([{ service: genericVisit, availability: fourDayWorkWeek, duration: 60 }]);
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
       .set('Authorization', `Bearer ${accessToken}`)
@@ -554,7 +582,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2026-01-01T00:00:00.000-05:00').toISOString(),
-        'service-type': 'http://example.com|generic-visit',
+        'service-type-reference': `HealthcareService/${genericVisit.id}`,
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -562,15 +590,16 @@ describe('Schedule/:id/$find', () => {
   });
 
   test('can override search page size with `_count`', async () => {
-    const schedule = await makeSchedule({
-      'generic-visit': {
+    const schedule = await makeSchedule([
+      {
+        service: genericVisit,
         // Alignment slot options to every-two-minutes means that there are
         // lots of results so we can test the maximum page size of 1000
         alignmentInterval: 2,
         availability: fourDayWorkWeek,
         duration: 60,
       },
-    });
+    ]);
     const smallResponse = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
       .set('Authorization', `Bearer ${accessToken}`)
@@ -579,7 +608,7 @@ describe('Schedule/:id/$find', () => {
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2026-01-01T00:00:00.000-05:00').toISOString(),
         _count: 10,
-        'service-type': 'http://example.com|generic-visit',
+        'service-type-reference': `HealthcareService/${genericVisit.id}`,
       });
     expect(smallResponse.body).not.toHaveProperty('issue');
     expect(smallResponse.status).toBe(200);
@@ -593,7 +622,7 @@ describe('Schedule/:id/$find', () => {
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2026-01-01T00:00:00.000-05:00').toISOString(),
         _count: 1000,
-        'service-type': 'http://example.com|generic-visit',
+        'service-type-reference': `HealthcareService/${genericVisit.id}`,
       });
     expect(largeResponse.body).not.toHaveProperty('issue');
     expect(largeResponse.status).toBe(200);
@@ -601,9 +630,7 @@ describe('Schedule/:id/$find', () => {
   });
 
   test('errors if _count is too low', async () => {
-    const schedule = await makeSchedule({
-      'generic-visit': { availability: fourDayWorkWeek, duration: 60 },
-    });
+    const schedule = await makeSchedule([{ service: genericVisit, availability: fourDayWorkWeek, duration: 60 }]);
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
       .set('Authorization', `Bearer ${accessToken}`)
@@ -612,7 +639,7 @@ describe('Schedule/:id/$find', () => {
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2026-01-01T00:00:00.000-05:00').toISOString(),
         _count: 0,
-        'service-type': 'http://example.com|generic-visit',
+        'service-type-reference': `HealthcareService/${genericVisit.id}`,
       });
     expect(response.status).toBe(400);
     expect(response.body.issue).toEqual([
@@ -627,9 +654,7 @@ describe('Schedule/:id/$find', () => {
   });
 
   test('errors if _count is too high', async () => {
-    const schedule = await makeSchedule({
-      'generic-visit': { availability: fourDayWorkWeek, duration: 60 },
-    });
+    const schedule = await makeSchedule([{ service: genericVisit, availability: fourDayWorkWeek, duration: 60 }]);
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
       .set('Authorization', `Bearer ${accessToken}`)
@@ -638,7 +663,7 @@ describe('Schedule/:id/$find', () => {
         start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
         end: new Date('2026-01-01T00:00:00.000-05:00').toISOString(),
         _count: 1001,
-        'service-type': 'http://example.com|generic-visit',
+        'service-type-reference': `HealthcareService/${genericVisit.id}`,
       });
     expect(response.status).toBe(400);
     expect(response.body.issue).toEqual([
@@ -654,12 +679,9 @@ describe('Schedule/:id/$find', () => {
 
   test("gets timezone data from the schedule's actor", async () => {
     // `location` has timezone set to America/Phoenix, which is always at offset -07:00
-    const schedule = await makeSchedule(
-      {
-        'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
-      },
-      { actor: [createReference(location)] }
-    );
+    const schedule = await makeSchedule([{ service: genericVisit, availability: fourDayWorkWeek, duration: 20 }], {
+      actor: [createReference(location)],
+    });
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
       .set('Authorization', `Bearer ${accessToken}`)
@@ -667,7 +689,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T00:00:00.000-07:00').toISOString(),
         end: new Date('2025-12-01T12:00:00.000-07:00').toISOString(),
-        'service-type': 'http://example.com|generic-visit',
+        'service-type-reference': `HealthcareService/${genericVisit.id}`,
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -701,9 +723,7 @@ describe('Schedule/:id/$find', () => {
     // `location` has timezone set to America/Phoenix, which is always at offset -07:00
     // scheduling params have timezone set to Pacific/Honolulu, which is always at offset -10:00
     const schedule = await makeSchedule(
-      {
-        'generic-visit': { availability: fourDayWorkWeek, duration: 20, timezone: 'Pacific/Honolulu' },
-      },
+      [{ service: genericVisit, availability: fourDayWorkWeek, duration: 20, timezone: 'Pacific/Honolulu' }],
       { actor: [createReference(location)] }
     );
     const response = await request
@@ -713,7 +733,7 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-01T00:00:00.000-10:00').toISOString(),
         end: new Date('2025-12-01T12:00:00.000-10:00').toISOString(),
-        'service-type': 'http://example.com|generic-visit',
+        'service-type-reference': `HealthcareService/${genericVisit.id}`,
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
@@ -744,10 +764,7 @@ describe('Schedule/:id/$find', () => {
   });
 
   test('without a service-type parameter', async () => {
-    const schedule = await makeSchedule({
-      'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
-      'new-patient': { availability: twoDaySchedule, duration: 30 },
-    });
+    const schedule = await makeSchedule([]);
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
       .set('Authorization', `Bearer ${accessToken}`)
@@ -765,7 +782,7 @@ describe('Schedule/:id/$find', () => {
           code: 'invalid',
           severity: 'error',
           details: {
-            text: "Expected at least 1 value(s) for required input parameter 'service-type'",
+            text: "Expected at least 1 value(s) for required input parameter 'service-type-reference'",
           },
         },
       ],
@@ -774,16 +791,16 @@ describe('Schedule/:id/$find', () => {
 
   describe('Loading schedulingParameters from HealthcareServices', () => {
     test('works when scheduling parameters only exist on a HealthcareService', async () => {
-      const code = 'blood-donation';
-      await systemRepo.createResource<HealthcareService>({
+      const bloodDonation: CodeableConcept = {
+        coding: [{ system: 'http://example.com', code: 'blood-donation' }],
+      };
+
+      const service = await systemRepo.createResource<HealthcareService>({
         resourceType: 'HealthcareService',
+        name: 'Blood Donation',
         meta: { project: project.id },
         active: true,
-        type: [
-          {
-            coding: [{ system: 'http://example.com', code }],
-          },
-        ],
+        type: [bloodDonation],
         availableTime: [
           {
             daysOfWeek: ['thu', 'fri'],
@@ -803,7 +820,7 @@ describe('Schedule/:id/$find', () => {
         resourceType: 'Schedule',
         meta: { project: project.id },
         actor: [createReference(practitioner)],
-        serviceType: [{ coding: [{ system: 'http://example.com', code }] }],
+        serviceType: toCodeableReferenceLike(service),
       });
 
       const response = await request
@@ -813,10 +830,11 @@ describe('Schedule/:id/$find', () => {
         .query({
           start: new Date('2025-12-04T10:00:00.000-05:00'),
           end: new Date('2025-12-04T14:00:00.000-05:00'),
-          'service-type': `http://example.com|${code},http://example.com|other`,
+          'service-type-reference': `HealthcareService/${service.id}`,
         });
       expect(response.body).not.toHaveProperty('issue');
       expect(response.status).toBe(200);
+
       expect(response.body).toMatchObject<Bundle>({
         resourceType: 'Bundle',
         type: 'searchset',
@@ -828,7 +846,7 @@ describe('Schedule/:id/$find', () => {
               end: new Date('2025-12-04T12:30:00.000-05:00').toISOString(),
               status: 'free',
               schedule: createReference(schedule),
-              serviceType: [{ coding: [{ code, system: 'http://example.com' }] }],
+              serviceType: [bloodDonation],
             },
           },
           {
@@ -838,7 +856,7 @@ describe('Schedule/:id/$find', () => {
               end: new Date('2025-12-04T13:30:00.000-05:00').toISOString(),
               status: 'free',
               schedule: createReference(schedule),
-              serviceType: [{ coding: [{ code, system: 'http://example.com' }] }],
+              serviceType: [bloodDonation],
             },
           },
         ],
@@ -846,15 +864,11 @@ describe('Schedule/:id/$find', () => {
     });
 
     test('schedule-specific parameters override those on the HealthcareService', async () => {
-      const code = 'yoga';
-      await systemRepo.createResource<HealthcareService>({
+      const concept = { coding: [{ system: 'http://example.com', code: 'yoga' }] };
+      const service = await systemRepo.createResource<HealthcareService>({
         resourceType: 'HealthcareService',
         meta: { project: project.id },
-        type: [
-          {
-            coding: [{ system: 'http://example.com', code }],
-          },
-        ],
+        type: [concept],
         availableTime: [
           {
             daysOfWeek: ['mon', 'tue', 'wed', 'thu'],
@@ -875,8 +889,21 @@ describe('Schedule/:id/$find', () => {
         ],
       });
 
-      const schedule = await makeSchedule({
-        [code]: { availability: twoDaySchedule, duration: 30 },
+      const schedule = await systemRepo.createResource<Schedule>({
+        resourceType: 'Schedule',
+        meta: { project: project.id },
+        actor: [createReference(practitioner)],
+        serviceType: toCodeableReferenceLike(service),
+        extension: [
+          {
+            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+            extension: [
+              twoDaySchedule,
+              { url: 'duration', valueDuration: { value: 30, unit: 'min' } },
+              { url: 'service', valueReference: createReference(service) },
+            ],
+          },
+        ],
       });
 
       const response = await request
@@ -886,7 +913,7 @@ describe('Schedule/:id/$find', () => {
         .query({
           start: new Date('2025-12-04T10:00:00.000-05:00'),
           end: new Date('2025-12-04T14:00:00.000-05:00'),
-          'service-type': `http://example.com|${code},http://example.com|other`,
+          'service-type-reference': `HealthcareService/${service.id}`,
         });
       expect(response.body).not.toHaveProperty('issue');
       expect(response.status).toBe(200);
@@ -901,7 +928,7 @@ describe('Schedule/:id/$find', () => {
               end: new Date('2025-12-04T12:30:00.000-05:00').toISOString(),
               status: 'free',
               schedule: createReference(schedule),
-              serviceType: [{ coding: [{ code, system: 'http://example.com' }] }],
+              serviceType: [concept],
             },
           },
           {
@@ -911,7 +938,7 @@ describe('Schedule/:id/$find', () => {
               end: new Date('2025-12-04T13:30:00.000-05:00').toISOString(),
               status: 'free',
               schedule: createReference(schedule),
-              serviceType: [{ coding: [{ code, system: 'http://example.com' }] }],
+              serviceType: [concept],
             },
           },
         ],
@@ -919,11 +946,11 @@ describe('Schedule/:id/$find', () => {
     });
   });
 
-  test('when no matching serviceType is found', async () => {
-    const schedule = await makeSchedule({
-      'new-patient': { availability: fridayOnly, duration: 45, bufferBefore: 15 },
-      'office-visit': { availability: twoDaySchedule, duration: 30, alignmentOffset: 15, alignmentInterval: 30 },
-    });
+  test('when the healthcare service is not found', async () => {
+    const schedule = await makeSchedule([
+      { service: genericVisit, availability: fridayOnly, duration: 45, bufferBefore: 15 },
+      { service: officeVisit, availability: twoDaySchedule, duration: 30, alignmentOffset: 15, alignmentInterval: 30 },
+    ]);
     const response = await request
       .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
       .set('Authorization', `Bearer ${accessToken}`)
@@ -931,7 +958,36 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-04T10:00:00.000-05:00'),
         end: new Date('2025-12-04T14:00:00.000-05:00'),
-        'service-type': 'http://example.com|new-patient-visit',
+        'service-type-reference': 'HealthcareService/12345',
+      });
+    expect(response.body).toHaveProperty('issue');
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      resourceType: 'OperationOutcome',
+      issue: [
+        {
+          code: 'invalid',
+          severity: 'error',
+          details: {
+            text: 'HealthcareService not found',
+          },
+        },
+      ],
+    });
+  });
+
+  test(`when the HealthcareService.type  does not match Schedule.serviceType`, async () => {
+    const schedule = await makeSchedule([
+      { service: genericVisit, availability: fridayOnly, duration: 45, bufferBefore: 15 },
+    ]);
+    const response = await request
+      .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .query({
+        start: new Date('2025-12-04T10:00:00.000-05:00'),
+        end: new Date('2025-12-04T14:00:00.000-05:00'),
+        'service-type-reference': `HealthcareService/${officeVisit.id}`,
       });
     expect(response.body).toHaveProperty('issue');
     expect(response.status).toBe(400);
@@ -949,19 +1005,47 @@ describe('Schedule/:id/$find', () => {
     });
   });
 
-  test('when serviceType has no `system` component', async () => {
+  test('when serviceType has no codes', async () => {
+    // create a HealthcareService with no `type` attribute
+    const emptyService = await systemRepo.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      meta: { project: project.id },
+      name: 'Empty Service',
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [
+            {
+              url: 'duration',
+              valueDuration: { value: 20, unit: 'min' },
+            },
+          ],
+        },
+      ],
+    });
+
+    // Link a schedule to it
     const schedule = await systemRepo.createResource<Schedule>({
       resourceType: 'Schedule',
       meta: { project: project.id },
       actor: [createReference(practitioner)],
-      serviceType: [{ coding: [{ code: 'office-visit' }] }],
+      serviceType: [
+        {
+          extension: [
+            {
+              url: ServiceTypeReferenceURI,
+              valueReference: createReference(emptyService),
+            },
+          ],
+        },
+      ],
       extension: [
         {
           url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
           extension: [
             twoDaySchedule,
             { url: 'duration', valueDuration: { value: 30, unit: 'min' } },
-            { url: 'serviceType', valueCodeableConcept: { coding: [{ code: 'office-visit' }] } },
+            { url: 'service', valueReference: createReference(emptyService) },
           ],
         },
       ],
@@ -974,99 +1058,11 @@ describe('Schedule/:id/$find', () => {
       .query({
         start: new Date('2025-12-05T10:00:00.000-05:00').toISOString(),
         end: new Date('2025-12-05T14:00:00.000-05:00').toISOString(),
-        'service-type': 'office-visit',
+        'service-type-reference': `HealthcareService/${emptyService.id}`,
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('entry');
     expect(response.body.entry).toHaveLength(2);
-  });
-
-  test('returns appropriate slots for each serviceType passed', async () => {
-    const schedule = await makeSchedule({
-      'new-patient': { availability: fridayOnly, duration: 45, bufferBefore: 15 },
-      'office-visit': { availability: twoDaySchedule, duration: 30, alignmentOffset: 15, alignmentInterval: 30 },
-      'generic-visit': { availability: fourDayWorkWeek, duration: 20 },
-    });
-    const response = await request
-      .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
-      .set('Authorization', `Bearer ${accessToken}`)
-      .set('Content-Type', ContentType.FHIR_JSON)
-      .query({
-        start: new Date('2025-12-05T10:00:00.000-05:00').toISOString(),
-        end: new Date('2025-12-05T14:00:00.000-05:00').toISOString(),
-        'service-type': 'http://example.com|new-patient,http://example.com|office-visit',
-      });
-    expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toBe(200);
-    expect(response.body).toMatchObject<Bundle>({
-      resourceType: 'Bundle',
-      type: 'searchset',
-      entry: [
-        // new-patient slots are 45 minutes long and start on the hour
-        {
-          resource: {
-            resourceType: 'Slot',
-            start: new Date('2025-12-05T11:00:00.000-05:00').toISOString(),
-            end: new Date('2025-12-05T11:45:00.000-05:00').toISOString(),
-            status: 'free',
-            schedule: createReference(schedule),
-            serviceType: [{ coding: [{ code: 'new-patient', system: 'http://example.com' }] }],
-          },
-        },
-        {
-          resource: {
-            resourceType: 'Slot',
-            start: new Date('2025-12-05T12:00:00.000-05:00').toISOString(),
-            end: new Date('2025-12-05T12:45:00.000-05:00').toISOString(),
-            status: 'free',
-            schedule: createReference(schedule),
-            serviceType: [{ coding: [{ code: 'new-patient', system: 'http://example.com' }] }],
-          },
-        },
-        {
-          resource: {
-            resourceType: 'Slot',
-            start: new Date('2025-12-05T13:00:00.000-05:00').toISOString(),
-            end: new Date('2025-12-05T13:45:00.000-05:00').toISOString(),
-            status: 'free',
-            schedule: createReference(schedule),
-            serviceType: [{ coding: [{ code: 'new-patient', system: 'http://example.com' }] }],
-          },
-        },
-
-        // office-visit slots are 30 minutes long and start at X:15 or X:45
-        {
-          resource: {
-            resourceType: 'Slot',
-            start: new Date('2025-12-05T12:15:00.000-05:00').toISOString(),
-            end: new Date('2025-12-05T12:45:00.000-05:00').toISOString(),
-            status: 'free',
-            schedule: createReference(schedule),
-            serviceType: [{ coding: [{ code: 'office-visit', system: 'http://example.com' }] }],
-          },
-        },
-        {
-          resource: {
-            resourceType: 'Slot',
-            start: new Date('2025-12-05T12:45:00.000-05:00').toISOString(),
-            end: new Date('2025-12-05T13:15:00.000-05:00').toISOString(),
-            status: 'free',
-            schedule: createReference(schedule),
-            serviceType: [{ coding: [{ code: 'office-visit', system: 'http://example.com' }] }],
-          },
-        },
-        {
-          resource: {
-            resourceType: 'Slot',
-            start: new Date('2025-12-05T13:15:00.000-05:00').toISOString(),
-            end: new Date('2025-12-05T13:45:00.000-05:00').toISOString(),
-            status: 'free',
-            schedule: createReference(schedule),
-            serviceType: [{ coding: [{ code: 'office-visit', system: 'http://example.com' }] }],
-          },
-        },
-      ],
-    });
   });
 });

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -6,22 +6,17 @@ import {
   createReference,
   DEFAULT_MAX_SEARCH_COUNT,
   DEFAULT_SEARCH_COUNT,
+  isNotFound,
   OperationOutcomeError,
   Operator,
 } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Bundle, HealthcareService, OperationDefinition, Schedule, Slot } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
-import { flatMapMax } from '../../util/array';
+import { isCodeableReferenceLikeTo, toCodeableReferenceLike } from '../../util/servicetype';
 import { findSlotTimes } from './utils/find';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
-import {
-  applyExistingSlots,
-  getTimeZone,
-  resolveAvailability,
-  serviceTypeMatchesTokens,
-  TimezoneExtensionURI,
-} from './utils/scheduling';
+import { applyExistingSlots, getTimeZone, resolveAvailability, TimezoneExtensionURI } from './utils/scheduling';
 import { chooseSchedulingParameters } from './utils/scheduling-parameters';
 
 const findOperation = {
@@ -37,7 +32,7 @@ const findOperation = {
   parameter: [
     { use: 'in', name: 'start', type: 'dateTime', min: 1, max: '1' },
     { use: 'in', name: 'end', type: 'dateTime', min: 1, max: '1' },
-    { use: 'in', name: 'service-type', type: 'string', min: 1, max: '1' },
+    { use: 'in', name: 'service-type-reference', type: 'string', min: 1, max: '1', searchType: 'reference' },
     { use: 'in', name: '_count', type: 'integer', min: 0, max: '1' },
     { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
   ],
@@ -46,7 +41,7 @@ const findOperation = {
 type FindParameters = {
   start: string;
   end: string;
-  'service-type': string;
+  'service-type-reference': string;
   _count?: number;
 };
 
@@ -63,9 +58,6 @@ export async function scheduleFindHandler(req: FhirRequest): Promise<FhirRespons
   const ctx = getAuthenticatedContext();
   const params = parseInputParameters<FindParameters>(findOperation, req);
   const { start, end, _count } = params;
-
-  // service types are in `${system}|${code}` format, in a comma separated list
-  const serviceTypeTokens = params['service-type'].split(',');
 
   const pageSize = _count ?? DEFAULT_SEARCH_COUNT;
   if (pageSize < 1) {
@@ -87,18 +79,7 @@ export async function scheduleFindHandler(req: FhirRequest): Promise<FhirRespons
     throw new OperationOutcomeError(badRequest('Search range cannot exceed 31 days'));
   }
 
-  const healthcareServiceSearch: Promise<HealthcareService[]> = ctx.repo.searchResources<HealthcareService>({
-    resourceType: 'HealthcareService',
-    filters: [
-      {
-        code: 'service-type',
-        operator: Operator.EQUALS,
-        value: params['service-type'],
-      },
-    ],
-  });
-
-  const [schedule, slots, healthcareServices] = await Promise.all([
+  const [schedule, existingSlots, healthcareService] = await Promise.all([
     ctx.repo.readResource<Schedule>('Schedule', req.params.id),
     ctx.repo.searchResources<Slot>({
       resourceType: 'Slot',
@@ -128,16 +109,21 @@ export async function scheduleFindHandler(req: FhirRequest): Promise<FhirRespons
         },
       ],
     }),
-    healthcareServiceSearch,
+    ctx.repo.readReference<HealthcareService>({ reference: params['service-type-reference'] }).catch((err) => {
+      if (err instanceof OperationOutcomeError && isNotFound(err.outcome)) {
+        throw new OperationOutcomeError(badRequest('HealthcareService not found'));
+      }
+      throw err;
+    }),
   ]);
 
-  if (!schedule.serviceType || !serviceTypeMatchesTokens(schedule.serviceType, serviceTypeTokens)) {
+  if (!isCodeableReferenceLikeTo(schedule.serviceType, healthcareService)) {
     throw new OperationOutcomeError(badRequest('Schedule is not scheduleable for requested service type'));
   }
 
   // If we filled a full search page of slots, then there may be slots we
   // didn't fetch that would impact availability. Fail loudly here.
-  if (slots.length === DEFAULT_MAX_SEARCH_COUNT) {
+  if (existingSlots.length === DEFAULT_MAX_SEARCH_COUNT) {
     throw new OperationOutcomeError(badRequest('Too many slots found in range; try searching with smaller bounds'));
   }
 
@@ -152,39 +138,39 @@ export async function scheduleFindHandler(req: FhirRequest): Promise<FhirRespons
     );
   }
 
-  const schedulingParameters = chooseSchedulingParameters(schedule, healthcareServices, serviceTypeTokens);
-  if (schedulingParameters.length === 0) {
-    throw new OperationOutcomeError(badRequest('No scheduling parameters found for the requested service type(s)'));
+  const schedulingParameters = chooseSchedulingParameters(schedule, healthcareService);
+  if (!schedulingParameters) {
+    throw new OperationOutcomeError(badRequest('SchedulingParameters not present on Schedule or HealthcareService'));
   }
 
-  const resultSlots: Slot[] = flatMapMax(
-    schedulingParameters,
-    ([schedulingParameters, serviceType], _idx, maxCount) => {
-      // If the scheduling parameters explicitly declare a timezone, use it instead of the actor's TZ
-      const activeTimeZone = schedulingParameters.timezone ?? actorTimeZone;
-      let availability = resolveAvailability(schedulingParameters, range, activeTimeZone);
-      availability = applyExistingSlots({
-        availability,
-        slots,
-        range,
-        serviceType: [serviceType],
-      });
-      return findSlotTimes(schedulingParameters, availability, { maxCount }).map(({ start, end }) => ({
+  const activeTimeZone = schedulingParameters.timezone ?? actorTimeZone;
+
+  let availability = resolveAvailability(schedulingParameters, range, activeTimeZone);
+  availability = applyExistingSlots({
+    availability,
+    slots: existingSlots,
+    range,
+    serviceType: healthcareService.type,
+  });
+
+  const serviceType = toCodeableReferenceLike(healthcareService);
+
+  const resultSlots = findSlotTimes(schedulingParameters, availability, { maxCount: pageSize }).map(
+    ({ start, end }) =>
+      ({
         resourceType: 'Slot',
         start: start.toISOString(),
         end: end.toISOString(),
         schedule: createReference(schedule),
         status: 'free',
-        serviceType: [serviceType],
-      }));
-    },
-    pageSize
+        serviceType,
+      }) satisfies Slot
   );
 
   const bundle: Bundle<Slot> = {
     resourceType: 'Bundle',
     type: 'searchset',
-    entry: resultSlots.slice(0, pageSize).map((slot) => ({ resource: slot })),
+    entry: resultSlots.map((slot) => ({ resource: slot })),
   };
 
   return [allOk, buildOutputParameters(findOperation, bundle)];

--- a/packages/server/src/fhir/operations/utils/find.test.ts
+++ b/packages/server/src/fhir/operations/utils/find.test.ts
@@ -161,7 +161,7 @@ describe('findSlotTimes', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
-      serviceType: [],
+      service: { reference: 'HealthcareService/abcde' },
     };
     const availability = [{ start: new Date('2025-12-01T12:00:00Z'), end: new Date('2025-12-01T15:00:00Z') }];
     expect(findSlotTimes(schedulingParameters, availability)).toEqual([
@@ -179,7 +179,7 @@ describe('findSlotTimes', () => {
       bufferAfter: 0,
       alignmentInterval: 30,
       alignmentOffset: 15,
-      serviceType: [],
+      service: { reference: 'HealthcareService/abcde' },
     };
     const availability = [{ start: new Date('2025-12-01T12:00:00Z'), end: new Date('2025-12-01T15:00:00Z') }];
     expect(findSlotTimes(schedulingParameters, availability)).toEqual([
@@ -199,7 +199,7 @@ describe('findSlotTimes', () => {
       bufferAfter: 30,
       alignmentInterval: 30,
       alignmentOffset: 15,
-      serviceType: [],
+      service: { reference: 'HealthcareService/abcde' },
     };
     const availability = [{ start: new Date('2025-12-01T12:00:00Z'), end: new Date('2025-12-01T15:00:00Z') }];
     expect(findSlotTimes(schedulingParameters, availability)).toEqual([
@@ -219,7 +219,7 @@ describe('findSlotTimes', () => {
       bufferAfter: 0,
       alignmentInterval: 30,
       alignmentOffset: 15,
-      serviceType: [],
+      service: { reference: 'HealthcareService/abcde' },
     };
     const availability = [{ start: new Date('2025-12-01T12:00:00Z'), end: new Date('2025-12-01T15:00:00Z') }];
     expect(findSlotTimes(schedulingParameters, availability, { maxCount: 3 })).toEqual([

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.test.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.test.ts
@@ -753,7 +753,7 @@ describe('chooseSchedulingParameters', () => {
     expect(chooseSchedulingParameters(schedule, service1)).toEqual(undefined);
   });
 
-  test('falls back to HealthcareService when Schedule has no matching parameters', () => {
+  test('falls back to HealthcareService when Schedule has no SchedulingParameters extension', () => {
     const service: WithId<HealthcareService> = {
       resourceType: 'HealthcareService',
       type: [consultType],
@@ -775,6 +775,51 @@ describe('chooseSchedulingParameters', () => {
 
     const result = chooseSchedulingParameters(schedule, service);
     expect(result?.duration).toBe(30);
+  });
+
+  test('falls back to HealthcareService when Schedule has no matching parameters', () => {
+    // Schedule has two extensions — each points at a different service.
+    // We query with a third service that has its own parameters. Neither Schedule
+    // extension matches, so chooseSchedulingParameters should fall through to
+    // the HealthcareService's own parameters.
+    const service1: WithId<HealthcareService> = { resourceType: 'HealthcareService', id: 'hcs-1' };
+    const service2: WithId<HealthcareService> = { resourceType: 'HealthcareService', id: 'hcs-2' };
+    const targetService: WithId<HealthcareService> = {
+      resourceType: 'HealthcareService',
+      id: 'hcs-target',
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [{ url: 'duration', valueDuration: { unit: 'min', value: 45 } }],
+        },
+      ],
+    };
+
+    const schedule: Schedule = {
+      resourceType: 'Schedule',
+      actor: [{ reference: 'Practitioner/test' }],
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [
+            { url: 'duration', valueDuration: { unit: 'min', value: 30 } },
+            { url: 'service', valueReference: createReference(service1) },
+            mondayAvailability,
+          ],
+        },
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [
+            { url: 'duration', valueDuration: { unit: 'min', value: 60 } },
+            { url: 'service', valueReference: createReference(service2) },
+            mondayAvailability,
+          ],
+        },
+      ],
+    };
+
+    const result = chooseSchedulingParameters(schedule, targetService);
+    expect(result?.duration).toBe(45);
   });
 
   test('Schedule-specific parameters take priority over HealthcareService', () => {

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.test.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.test.ts
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { WithId } from '@medplum/core';
 import { createReference, generateId } from '@medplum/core';
 import type { HealthcareService, Practitioner, Project, Schedule } from '@medplum/fhirtypes';
+import { toCodeableReferenceLike } from '../../../util/servicetype';
 import { chooseSchedulingParameters, parseSchedulingParametersExtensions } from './scheduling-parameters';
 
 describe('parseSchedulingParametersExtensions', () => {
@@ -18,17 +20,25 @@ describe('parseSchedulingParametersExtensions', () => {
   };
 
   test('minimally specified extension sets default values', () => {
+    const service: WithId<HealthcareService> = {
+      resourceType: 'HealthcareService',
+      id: 'hs-12345',
+    };
+
     const schedule: Schedule = {
       resourceType: 'Schedule',
       meta: { project: project.id },
       actor: [createReference(practitioner)],
+      serviceType: toCodeableReferenceLike(service),
       extension: [
         {
           url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
           extension: [
-            // duration is required to have exactly one entry
+            // `duration` is required to have exactly one entry
             { url: 'duration', valueDuration: { unit: 'h', value: 2 } },
-            // availability is required to have at least one entry
+            // `service` is required to have exactly one entry
+            { url: 'service', valueReference: createReference(service) },
+            // `availability` is required to have at least one entry
             {
               url: 'availability',
               extension: [
@@ -61,17 +71,23 @@ describe('parseSchedulingParametersExtensions', () => {
         alignmentInterval: 60,
         alignmentOffset: 0,
         duration: 120,
-        serviceType: [],
+        service: { reference: 'HealthcareService/hs-12345' },
         timezone: undefined,
       },
     ]);
   });
 
   test('with all the options', () => {
+    const service: WithId<HealthcareService> = {
+      resourceType: 'HealthcareService',
+      id: 'hs-12345',
+    };
+
     const schedule: Schedule = {
       resourceType: 'Schedule',
       meta: { project: project.id },
       actor: [createReference(practitioner)],
+      serviceType: toCodeableReferenceLike(service),
       extension: [
         {
           url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
@@ -80,14 +96,7 @@ describe('parseSchedulingParametersExtensions', () => {
             { url: 'alignmentOffset', valueDuration: { unit: 'min', value: 5 } },
             { url: 'bufferAfter', valueDuration: { unit: 'min', value: 15 } },
             { url: 'bufferBefore', valueDuration: { unit: 'min', value: 10 } },
-            {
-              url: 'serviceType',
-              valueCodeableConcept: { coding: [{ code: 'new-patient', system: 'http://example.com' }] },
-            },
-            {
-              url: 'serviceType',
-              valueCodeableConcept: { coding: [{ code: 'office-visit', system: 'http://example.com' }] },
-            },
+            { url: 'service', valueReference: createReference(service) },
             { url: 'duration', valueDuration: { unit: 'h', value: 2 } },
             { url: 'timezone', valueCode: 'America/Phoenix' },
             {
@@ -141,26 +150,30 @@ describe('parseSchedulingParametersExtensions', () => {
         alignmentInterval: 30,
         alignmentOffset: 5,
         duration: 120,
-        serviceType: [
-          { coding: [{ code: 'new-patient', system: 'http://example.com' }] },
-          { coding: [{ code: 'office-visit', system: 'http://example.com' }] },
-        ],
+        service: { reference: `HealthcareService/${service.id}` },
         timezone: 'America/Phoenix',
       },
     ]);
   });
 
   describe('with availability extension', () => {
+    const service: WithId<HealthcareService> = {
+      resourceType: 'HealthcareService',
+      id: 'hs-12345',
+    };
+
     test('basic start/end time pair parses to correct availability', () => {
       const schedule: Schedule = {
         resourceType: 'Schedule',
         meta: { project: project.id },
         actor: [createReference(practitioner)],
+        serviceType: toCodeableReferenceLike(service),
         extension: [
           {
             url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
             extension: [
               { url: 'duration', valueDuration: { unit: 'h', value: 1 } },
+              { url: 'service', valueReference: createReference(service) },
               {
                 url: 'availability',
                 extension: [
@@ -184,20 +197,29 @@ describe('parseSchedulingParametersExtensions', () => {
         {
           availability: [{ dayOfWeek: ['mon', 'wed'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' }],
           duration: 60,
+          service: { reference: `HealthcareService/${service.id}` },
         },
       ]);
     });
 
     test('allDay: true produces full-day availability', () => {
+      const hs: WithId<HealthcareService> = {
+        resourceType: 'HealthcareService',
+        id: 'hs-12345',
+        type: [{ coding: [{ code: 'consult', system: 'http://example.com' }] }],
+      };
+
       const schedule: Schedule = {
         resourceType: 'Schedule',
         meta: { project: project.id },
         actor: [createReference(practitioner)],
+        serviceType: toCodeableReferenceLike(hs),
         extension: [
           {
             url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
             extension: [
               { url: 'duration', valueDuration: { unit: 'min', value: 30 } },
+              { url: 'service', valueReference: createReference(hs) },
               {
                 url: 'availability',
                 extension: [
@@ -233,15 +255,23 @@ describe('parseSchedulingParametersExtensions', () => {
     });
 
     test('notAvailableTime is accepted without error and does not affect parsed availability', () => {
+      const hs: WithId<HealthcareService> = {
+        resourceType: 'HealthcareService',
+        id: 'hs-12345',
+        type: [{ coding: [{ code: 'consult', system: 'http://example.com' }] }],
+      };
+
       const schedule: Schedule = {
         resourceType: 'Schedule',
         meta: { project: project.id },
         actor: [createReference(practitioner)],
+        serviceType: toCodeableReferenceLike(hs),
         extension: [
           {
             url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
             extension: [
               { url: 'duration', valueDuration: { unit: 'min', value: 30 } },
+              { url: 'service', valueReference: createReference(hs) },
               {
                 url: 'availability',
                 extension: [
@@ -274,15 +304,23 @@ describe('parseSchedulingParametersExtensions', () => {
     });
 
     test('availableTime missing both allDay and start/end is filtered out', () => {
+      const hs: WithId<HealthcareService> = {
+        resourceType: 'HealthcareService',
+        id: 'hs-12345',
+        type: [{ coding: [{ code: 'consult', system: 'http://example.com' }] }],
+      };
+
       const schedule: Schedule = {
         resourceType: 'Schedule',
         meta: { project: project.id },
         actor: [createReference(practitioner)],
+        serviceType: toCodeableReferenceLike(hs),
         extension: [
           {
             url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
             extension: [
               { url: 'duration', valueDuration: { unit: 'min', value: 30 } },
+              { url: 'service', valueReference: createReference(hs) },
               {
                 url: 'availability',
                 extension: [
@@ -425,16 +463,24 @@ describe('parseSchedulingParametersExtensions', () => {
   );
 
   test('with an ambiguous duration unit', () => {
+    const hs: WithId<HealthcareService> = {
+      resourceType: 'HealthcareService',
+      id: 'hs-12345',
+      type: [{ coding: [{ code: 'consult', system: 'http://example.com' }] }],
+    };
+
     const unit = 'm'; // 'm' is "month" which is ambiguous (anywhere from 28 - 31 days)
     const schedule: Schedule = {
       resourceType: 'Schedule',
       meta: { project: project.id },
       actor: [createReference(practitioner)],
+      serviceType: toCodeableReferenceLike(hs),
       extension: [
         {
           url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
           extension: [
             { url: 'duration', valueDuration: { unit, value: 1 } },
+            { url: 'service', valueReference: createReference(hs) },
             {
               url: 'availability',
               extension: [
@@ -463,6 +509,7 @@ describe('parseSchedulingParametersExtensions', () => {
     test('derives serviceType from HealthcareService.type and availability from availableTime', () => {
       const hs: HealthcareService = {
         resourceType: 'HealthcareService',
+        id: 'hs-12345',
         type: [{ coding: [{ code: 'consult', system: 'http://example.com' }] }],
         availableTime: [{ daysOfWeek: ['mon', 'tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' }],
         extension: [
@@ -475,7 +522,7 @@ describe('parseSchedulingParametersExtensions', () => {
 
       expect(parseSchedulingParametersExtensions(hs)).toMatchObject([
         {
-          serviceType: [{ coding: [{ code: 'consult', system: 'http://example.com' }] }],
+          service: { reference: `HealthcareService/${hs.id}` },
           availability: [{ dayOfWeek: ['mon', 'tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' }],
           duration: 30,
           bufferBefore: 0,
@@ -550,6 +597,7 @@ describe('parseSchedulingParametersExtensions', () => {
       // No availableTime on resource, no availability in extension — should not throw
       const hs: HealthcareService = {
         resourceType: 'HealthcareService',
+        id: 'hs-123',
         extension: [
           { url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters', extension: [durationExt] },
         ],
@@ -559,7 +607,7 @@ describe('parseSchedulingParametersExtensions', () => {
       expect(parseSchedulingParametersExtensions(hs)).toMatchObject([
         {
           availability: [],
-          serviceType: [],
+          service: { reference: 'HealthcareService/hs-123' },
           duration: 30,
         },
       ]);
@@ -618,19 +666,19 @@ describe('parseSchedulingParametersExtensions', () => {
       );
     });
 
-    test('"serviceType" is not allowed in HealthcareService extension', () => {
+    test('"service" is not allowed in HealthcareService extension', () => {
       const hs: HealthcareService = {
         resourceType: 'HealthcareService',
         extension: [
           {
             url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-            extension: [durationExt, { url: 'serviceType', valueCodeableConcept: {} }],
+            extension: [durationExt, { url: 'service', valueReference: { reference: 'HealthcareService/123' } }],
           },
         ],
       };
 
       expect(() => parseSchedulingParametersExtensions(hs)).toThrow(
-        "Scheduling parameter attribute 'serviceType' is not allowed on HealthcareService"
+        "Scheduling parameter attribute 'service' is not allowed on HealthcareService"
       );
     });
   });
@@ -638,7 +686,7 @@ describe('parseSchedulingParametersExtensions', () => {
 
 describe('chooseSchedulingParameters', () => {
   const consultType = { coding: [{ system: 'http://example.com', code: 'consult' }] };
-  const consultToken = 'http://example.com|consult';
+  const yogaType = { coding: [{ code: 'yoga' }] };
 
   // Reusable availability extension for Schedule resources (required on Schedule, not on HealthcareService)
   const mondayAvailability = {
@@ -655,98 +703,153 @@ describe('chooseSchedulingParameters', () => {
     ],
   };
 
-  function makeSchedule(extensions?: Schedule['extension']): Schedule {
-    return {
-      resourceType: 'Schedule',
-      actor: [{ reference: 'Practitioner/test' }],
-      extension: extensions,
-    };
-  }
-
-  function makeHealthcareService(duration: number): HealthcareService {
-    return {
+  test('returns undefined when neither Schedule nor HealthcareService have the SchedulingParameters extension', () => {
+    const service: WithId<HealthcareService> = {
       resourceType: 'HealthcareService',
       type: [consultType],
+      id: 'hcs-100',
+      availableTime: [{ daysOfWeek: ['mon', 'tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' }],
+    };
+
+    const schedule: Schedule = {
+      resourceType: 'Schedule',
+      serviceType: toCodeableReferenceLike(service),
+      actor: [{ reference: 'Practitioner/test' }],
+    };
+
+    expect(chooseSchedulingParameters(schedule, service)).toEqual(undefined);
+  });
+
+  test('returns undefined when the Schedule has no SchedulingParameters matching HealthcareService.type', () => {
+    const service1: WithId<HealthcareService> = {
+      resourceType: 'HealthcareService',
+      type: [consultType],
+      id: 'hcs-100',
+    };
+
+    const service2: WithId<HealthcareService> = {
+      resourceType: 'HealthcareService',
+      type: [yogaType],
+      id: 'hcs-123',
+    };
+
+    // Linked to service1 in serviceType, but only has scheduling parameters set for service2.
+    const schedule: Schedule = {
+      resourceType: 'Schedule',
+      serviceType: toCodeableReferenceLike(service1),
+      actor: [{ reference: 'Practitioner/test' }],
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [
+            { url: 'duration', valueDuration: { unit: 'min', value: 30 } },
+            { url: 'service', valueReference: createReference(service2) },
+            mondayAvailability,
+          ],
+        },
+      ],
+    };
+
+    expect(chooseSchedulingParameters(schedule, service1)).toEqual(undefined);
+  });
+
+  test('falls back to HealthcareService when Schedule has no matching parameters', () => {
+    const service: WithId<HealthcareService> = {
+      resourceType: 'HealthcareService',
+      type: [consultType],
+      id: 'hcs-100',
       availableTime: [{ daysOfWeek: ['mon', 'tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' }],
       extension: [
         {
           url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-          extension: [{ url: 'duration', valueDuration: { unit: 'min', value: duration } }],
+          extension: [{ url: 'duration', valueDuration: { unit: 'min', value: 30 } }],
         },
       ],
     };
-  }
 
-  test('returns [] when neither Schedule nor HealthcareService match the token', () => {
-    expect(chooseSchedulingParameters(makeSchedule(), [], ['http://example.com|no-match'])).toEqual([]);
-  });
+    const schedule: Schedule = {
+      resourceType: 'Schedule',
+      serviceType: toCodeableReferenceLike(service),
+      actor: [{ reference: 'Practitioner/test' }],
+    };
 
-  test('returns [] when no service type tokens are given', () => {
-    expect(chooseSchedulingParameters(makeSchedule(), [makeHealthcareService(30)], [])).toEqual([]);
-  });
-
-  test('falls back to HealthcareService when Schedule has no matching parameters', () => {
-    const result = chooseSchedulingParameters(makeSchedule(), [makeHealthcareService(30)], [consultToken]);
-
-    expect(result).toHaveLength(1);
-    expect(result[0][0].duration).toBe(30);
-    expect(result[0][1]).toMatchObject(consultType);
+    const result = chooseSchedulingParameters(schedule, service);
+    expect(result?.duration).toBe(30);
   });
 
   test('Schedule-specific parameters take priority over HealthcareService', () => {
-    const schedule = makeSchedule([
-      {
-        url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-        extension: [
-          { url: 'duration', valueDuration: { unit: 'min', value: 60 } },
-          mondayAvailability,
-          { url: 'serviceType', valueCodeableConcept: consultType },
-        ],
-      },
-    ]);
+    const service: WithId<HealthcareService> = {
+      resourceType: 'HealthcareService',
+      type: [consultType],
+      id: 'hcs-100',
+      availableTime: [{ daysOfWeek: ['mon', 'tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' }],
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [{ url: 'duration', valueDuration: { unit: 'min', value: 30 } }],
+        },
+      ],
+    };
+
+    const schedule: Schedule = {
+      resourceType: 'Schedule',
+      serviceType: toCodeableReferenceLike(service),
+      actor: [{ reference: 'Practitioner/test' }],
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [
+            { url: 'duration', valueDuration: { unit: 'min', value: 60 } },
+            mondayAvailability,
+            { url: 'service', valueReference: createReference(service) },
+          ],
+        },
+      ],
+    };
+
     // HealthcareService says 30 min — Schedule's 60 min should win
-    const result = chooseSchedulingParameters(schedule, [makeHealthcareService(30)], [consultToken]);
-
-    expect(result).toHaveLength(1);
-    expect(result[0][0].duration).toBe(60);
-  });
-
-  test('multiple HealthcareServices each contribute when they match the token', () => {
-    const result = chooseSchedulingParameters(
-      makeSchedule(),
-      [makeHealthcareService(30), makeHealthcareService(60)],
-      [consultToken]
-    );
-
-    expect(result).toHaveLength(2);
-    expect(result.map((r) => r[0].duration)).toEqual(expect.arrayContaining([30, 60]));
+    const result = chooseSchedulingParameters(schedule, service);
+    expect(result?.duration).toBe(60);
   });
 
   test('only the matching Schedule entry is returned when multiple extensions exist', () => {
-    const yogaType = { coding: [{ system: 'http://example.com', code: 'yoga' }] };
-    const schedule = makeSchedule([
-      {
-        url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-        extension: [
-          { url: 'duration', valueDuration: { unit: 'min', value: 60 } },
-          mondayAvailability,
-          { url: 'serviceType', valueCodeableConcept: consultType },
-        ],
-      },
-      {
-        url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-        extension: [
-          { url: 'duration', valueDuration: { unit: 'min', value: 45 } },
-          mondayAvailability,
-          { url: 'serviceType', valueCodeableConcept: yogaType },
-        ],
-      },
-    ]);
+    const service1: WithId<HealthcareService> = {
+      resourceType: 'HealthcareService',
+      type: [consultType],
+      id: 'hcs-100',
+    };
 
-    const result = chooseSchedulingParameters(schedule, [], [consultToken]);
+    const service2: WithId<HealthcareService> = {
+      resourceType: 'HealthcareService',
+      type: [yogaType],
+      id: 'hcs-123',
+    };
 
-    expect(result).toHaveLength(1);
-    expect(result[0][0].duration).toBe(60);
-    expect(result[0][1]).toMatchObject(consultType);
+    const schedule: Schedule = {
+      resourceType: 'Schedule',
+      serviceType: [...toCodeableReferenceLike(service1), ...toCodeableReferenceLike(service2)],
+      actor: [{ reference: 'Practitioner/test' }],
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [
+            { url: 'duration', valueDuration: { unit: 'min', value: 60 } },
+            { url: 'service', valueReference: createReference(service1) },
+            mondayAvailability,
+          ],
+        },
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [
+            { url: 'duration', valueDuration: { unit: 'min', value: 45 } },
+            { url: 'service', valueReference: createReference(service2) },
+            mondayAvailability,
+          ],
+        },
+      ],
+    };
+
+    const result = chooseSchedulingParameters(schedule, service1);
+    expect(result?.duration).toBe(60);
   });
 });

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -163,7 +163,7 @@ export function chooseSchedulingParameters(
 ): SchedulingParameters | undefined {
   const scheduleSchedulingParameters = parseSchedulingParametersExtensions(schedule);
 
-  // Top priority: entries on an schedule pointing at this service
+  // Top priority: entries on the schedule pointing at this service
   const specificMatch = scheduleSchedulingParameters.find((schedulingParameters) =>
     isReferenceTo(schedulingParameters.service, healthcareService)
   );

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { codeableConceptMatchesToken, EMPTY, isDefined } from '@medplum/core';
+import type { WithId } from '@medplum/core';
+import { EMPTY, createReference, isDefined } from '@medplum/core';
 import type {
-  CodeableConcept,
   Duration,
   HealthcareService,
   HealthcareServiceAvailableTime,
   Period,
+  Reference,
+  Resource,
   Schedule,
 } from '@medplum/fhirtypes';
 
@@ -55,7 +57,7 @@ export type SchedulingParametersExtensionExtension =
   | { url: 'alignmentInterval'; valueDuration: HardDuration }
   | { url: 'alignmentOffset'; valueDuration: HardDuration }
   | { url: 'duration'; valueDuration: HardDuration }
-  | { url: 'serviceType'; valueCodeableConcept: CodeableConcept }
+  | { url: 'service'; valueReference: Reference<HealthcareService> & { reference: string } }
   | { url: 'timezone'; valueCode: string }
   | {
       url: 'availability';
@@ -82,9 +84,17 @@ export type SchedulingParameters = {
   alignmentInterval: number; // minutes
   alignmentOffset: number; // minutes
   duration: number; // minutes
-  serviceType: CodeableConcept[]; // codes that may be booked into this availability
+  service: Reference<HealthcareService> & { reference: string };
   timezone?: string;
 };
+
+function isReferenceTo<T extends Resource>(reference: Reference<T>, resource: WithId<T>): boolean {
+  if (!reference.reference) {
+    return false;
+  }
+  const [refType, id] = reference.reference.split('/');
+  return refType === resource.resourceType && id === resource.id;
+}
 
 function durationToMinutes(duration: Duration): number {
   const { value, unit } = duration;
@@ -136,61 +146,39 @@ function exactlyZero(arr: unknown[], attribute: string, resourceType: string): v
 }
 
 /**
- * Given a Schedule, HealthcareServices, and an array of input service type
- * tokens, return [SchedulingParameters, serviceType] pairs that satisfy the
- * requested service types.
+ * Given a Schedule and a HealthcareService, return the SchedulingParameters to
+ * use.
  *
  * Priority order (highest to lowest):
- *  1. Entries from the Schedule matching a requested service-type
- *  2. Entries from HealthcareService matching a requested service-type
+ *  1. Entries from the Schedule matching the requested service-type
+ *  2. Entries from HealthcareService
  *
- * Each SchedulingParameters description is returned at most once. If matches are found at a given
- * priority level, lower-priority levels are not returned.
- *
- * @param schedule - The schedule resource to consider
- * @param healthcareServices - HealthcareServices to consider
- * @param serviceTypeTokens - Service type tokens to restrict scheduling parameters to
- * @returns pairs of [SchedulingParameters, CodeableConcept]
+ * @param schedule - Schedule resource
+ * @param healthcareService - HealthcareService resource
+ * @returns SchedulingParameters
  */
 export function chooseSchedulingParameters(
   schedule: Schedule,
-  healthcareServices: HealthcareService[],
-  serviceTypeTokens: string[]
-): (readonly [SchedulingParameters, CodeableConcept])[] {
+  healthcareService: WithId<HealthcareService>
+): SchedulingParameters | undefined {
   const scheduleSchedulingParameters = parseSchedulingParametersExtensions(schedule);
 
-  // Top priority: entries on an individual schedule matching a service type
-  const specificMatches = scheduleSchedulingParameters
-    .map((schedulingParameters) => {
-      const serviceType = schedulingParameters.serviceType.find((st) =>
-        serviceTypeTokens.some((token) => codeableConceptMatchesToken(st, token))
-      );
-      return serviceType ? ([schedulingParameters, serviceType] as const) : undefined;
-    })
-    .filter(isDefined);
-
-  if (specificMatches.length) {
-    return specificMatches;
-  }
-
-  // Next: entries on HealthcareService resources matching a service type
-  const healthcareServiceSchedulingParameters = healthcareServices.flatMap((healthcareService) =>
-    parseSchedulingParametersExtensions(healthcareService)
+  // Top priority: entries on an schedule pointing at this service
+  const specificMatch = scheduleSchedulingParameters.find((schedulingParameters) =>
+    isReferenceTo(schedulingParameters.service, healthcareService)
   );
-  const sharedMatches = healthcareServiceSchedulingParameters
-    .map((schedulingParameters) => {
-      const serviceType = schedulingParameters.serviceType.find((st) =>
-        serviceTypeTokens.some((token) => codeableConceptMatchesToken(st, token))
-      );
-      return serviceType ? ([schedulingParameters, serviceType] as const) : undefined;
-    })
-    .filter(isDefined);
 
-  if (sharedMatches.length) {
-    return sharedMatches;
+  if (specificMatch) {
+    return specificMatch;
   }
 
-  return [];
+  // Return the first scheduling extension on HealthcareService
+  const healthcareServiceSchedulingParameters = parseSchedulingParametersExtensions(healthcareService);
+  if (healthcareServiceSchedulingParameters.length) {
+    return healthcareServiceSchedulingParameters[0];
+  }
+
+  return undefined;
 }
 
 // Convert a single availability extension into SchedulingParametersAvailability entries.
@@ -265,7 +253,7 @@ export function parseSchedulingParametersExtensions(resource: Schedule | Healthc
   // each extension on the resource
   const resourceParameters: Partial<SchedulingParameters> = {};
   if (resource.resourceType === 'HealthcareService') {
-    resourceParameters.serviceType = resource.type ?? [];
+    resourceParameters.service = createReference(resource);
     resourceParameters.availability = (resource.availableTime ?? EMPTY).map(extractAvailability).filter(isDefined);
   }
 
@@ -313,13 +301,13 @@ export function parseSchedulingParametersExtensions(resource: Schedule | Healthc
       resource.resourceType
     );
 
-    // `serviceType` is expected in Schedule, not allowed in HealthcareService
-    // (where we read from HealthcareService.type instead)
-    const rawServiceType = extension.extension.filter((ext) => ext.url === 'serviceType');
+    // `service` is expected in Schedule, not allowed in HealthcareService
+    const rawService = extension.extension.filter((ext) => ext.url === 'service');
     if (resource.resourceType === 'HealthcareService') {
-      exactlyZero(rawServiceType, 'serviceType', resource.resourceType);
+      exactlyZero(rawService, 'service', resource.resourceType);
     }
-    const serviceType = resourceParameters.serviceType ?? rawServiceType.map((ext) => ext.valueCodeableConcept);
+    const service =
+      resourceParameters.service ?? exactlyOne(rawService, 'service', resource.resourceType).valueReference;
 
     // default alignmentInterval is "on the hour" (0)
     let alignmentInterval = rawAlignmentInterval ? durationToMinutes(rawAlignmentInterval.valueDuration) : 0;
@@ -328,7 +316,7 @@ export function parseSchedulingParametersExtensions(resource: Schedule | Healthc
     alignmentInterval = alignmentInterval === 0 ? 60 : alignmentInterval;
 
     return {
-      serviceType, // HealthcareService.type or `serviceType` extension parameter
+      service, // Reference to a HealthcareService these parameters are used for
       availability, // HealthcareService.availableTime or `availability` extension parameter
 
       // These attributes always come from the extension

--- a/packages/server/src/fhir/operations/utils/scheduling.test.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.test.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
 import { createReference, generateId } from '@medplum/core';
-import type { Practitioner, Project, Schedule, Slot } from '@medplum/fhirtypes';
+import type { HealthcareService, Practitioner, Project, Schedule, Slot } from '@medplum/fhirtypes';
 import type { Interval } from '../../../util/date';
 import { applyExistingSlots, normalizeIntervals, removeAvailability, resolveAvailability } from './scheduling';
 import type { SchedulingParameters } from './scheduling-parameters';
@@ -24,6 +25,12 @@ const schedule: Schedule = {
   actor: [createReference(practitioner)],
 };
 
+const service: WithId<HealthcareService> = {
+  resourceType: 'HealthcareService',
+  id: generateId(),
+  meta: { project: project.id },
+};
+
 describe('resolveAvailability', () => {
   test('having multiple days and times', async () => {
     const schedulingParameters: SchedulingParameters = {
@@ -44,7 +51,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
-      serviceType: [],
+      service: createReference(service),
     };
 
     const range = {
@@ -77,7 +84,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
-      serviceType: [],
+      service: createReference(service),
     };
 
     const range = {
@@ -105,7 +112,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
-      serviceType: [],
+      service: createReference(service),
     };
 
     const range = {
@@ -135,7 +142,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
-      serviceType: [],
+      service: createReference(service),
     };
 
     const range = {
@@ -163,7 +170,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
-      serviceType: [],
+      service: createReference(service),
     };
 
     const range = {
@@ -192,7 +199,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
-      serviceType: [],
+      service: createReference(service),
     };
 
     const range = {
@@ -220,7 +227,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
-      serviceType: [],
+      service: createReference(service),
     };
 
     // NY has a DST "spring forward" on March 8 2026
@@ -258,7 +265,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
-      serviceType: [],
+      service: createReference(service),
     };
 
     // NY has a DST "spring forward" on March 8 2026
@@ -300,7 +307,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
-      serviceType: [],
+      service: createReference(service),
     };
 
     // NY has a DST "fall back" on Nov 2 2025: 1:30am: happens twice
@@ -330,7 +337,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
-      serviceType: [],
+      service: createReference(service),
     };
 
     // NY has a DST "spring forward" on March 8 2026; 2:30am never happens

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { codeableConceptMatchesToken, EMPTY, getExtensionValue, isDefined } from '@medplum/core';
+import { EMPTY, getExtensionValue, isDefined } from '@medplum/core';
 import type { CodeableConcept, Resource, Slot } from '@medplum/fhirtypes';
 import { Temporal } from 'temporal-polyfill';
 import type { Interval } from '../../../util/date';
@@ -269,8 +269,4 @@ export function applyExistingSlots(params: {
   );
   const allAvailability = normalizeIntervals(params.availability.concat(freeSlotIntervals));
   return removeAvailability(allAvailability, busySlotIntervals);
-}
-
-export function serviceTypeMatchesTokens(serviceType: CodeableConcept[], tokens: string[]): boolean {
-  return tokens.some((token) => serviceType.some((concept) => codeableConceptMatchesToken(concept, token)));
 }

--- a/packages/server/src/util/servicetype.test.ts
+++ b/packages/server/src/util/servicetype.test.ts
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import type { CodeableConcept, HealthcareService, Reference } from '@medplum/fhirtypes';
+import {
+  extractReferencesFromCodeableReferenceLike,
+  isCodeableReferenceLikeTo,
+  ServiceTypeReferenceURI,
+  toCodeableReferenceLike,
+} from './servicetype';
+
+describe('toCodeableReferenceLike', () => {
+  test('returns a single concept with only the reference extension when service has no type', () => {
+    const service: WithId<HealthcareService> = { resourceType: 'HealthcareService', id: 'svc-1' };
+    const result = toCodeableReferenceLike(service);
+    expect(result).toHaveLength(1);
+    expect(result[0].extension).toHaveLength(1);
+    expect(result[0].extension?.[0]).toMatchObject({
+      url: ServiceTypeReferenceURI,
+      valueReference: { reference: 'HealthcareService/svc-1' },
+    });
+  });
+
+  test('adds the reference extension to each type entry', () => {
+    const service: WithId<HealthcareService> = {
+      resourceType: 'HealthcareService',
+      id: 'svc-2',
+      type: [{ coding: [{ code: 'checkup' }] }, { coding: [{ code: 'followup' }] }],
+    };
+    const result = toCodeableReferenceLike(service);
+    expect(result).toHaveLength(2);
+    for (const concept of result) {
+      expect(concept.extension).toContainEqual(
+        expect.objectContaining({
+          url: ServiceTypeReferenceURI,
+          valueReference: { reference: 'HealthcareService/svc-2' },
+        })
+      );
+    }
+  });
+
+  test('preserves existing extensions on type entries', () => {
+    const service: WithId<HealthcareService> = {
+      resourceType: 'HealthcareService',
+      id: 'svc-3',
+      type: [
+        {
+          coding: [{ code: 'checkup' }],
+          extension: [{ url: 'http://existing.com', valueString: 'keep-me' }],
+        },
+      ],
+    };
+    const result = toCodeableReferenceLike(service);
+    expect(result[0].extension).toContainEqual({ url: 'http://existing.com', valueString: 'keep-me' });
+    expect(result[0].extension).toContainEqual(expect.objectContaining({ url: ServiceTypeReferenceURI }));
+  });
+});
+
+describe('isCodeableReferenceLikeTo', () => {
+  const service: WithId<HealthcareService> = { resourceType: 'HealthcareService', id: 'svc-1' };
+
+  test('returns false for undefined serviceType', () => {
+    expect(isCodeableReferenceLikeTo(undefined, service)).toBe(false);
+  });
+
+  test('returns false for empty serviceType array', () => {
+    expect(isCodeableReferenceLikeTo([], service)).toBe(false);
+  });
+
+  test('returns true when a concept references the service', () => {
+    const serviceType = toCodeableReferenceLike(service);
+    expect(isCodeableReferenceLikeTo(serviceType, service)).toBe(true);
+  });
+
+  test('returns false when no concept references the service', () => {
+    const otherService: WithId<HealthcareService> = { resourceType: 'HealthcareService', id: 'svc-other' };
+    const serviceType = toCodeableReferenceLike(otherService);
+    expect(isCodeableReferenceLikeTo(serviceType, service)).toBe(false);
+  });
+
+  test('returns false when concepts have no reference extension at all', () => {
+    const plainConcepts: CodeableConcept[] = [{ coding: [{ code: 'checkup' }] }];
+    expect(isCodeableReferenceLikeTo(plainConcepts, service)).toBe(false);
+  });
+
+  test('accepts a Reference object in place of a resource', () => {
+    const serviceType = toCodeableReferenceLike(service);
+    const ref: Reference<HealthcareService> & { reference: string } = { reference: 'HealthcareService/svc-1' };
+    expect(isCodeableReferenceLikeTo(serviceType, ref)).toBe(true);
+  });
+});
+
+describe('extractReferencesFromCodeableReferenceLike', () => {
+  test('returns empty array for undefined input', () => {
+    expect(extractReferencesFromCodeableReferenceLike(undefined)).toEqual([]);
+  });
+
+  test('returns empty array for concepts with no reference extension', () => {
+    const concepts: CodeableConcept[] = [{ coding: [{ code: 'checkup' }] }];
+    expect(extractReferencesFromCodeableReferenceLike(concepts)).toEqual([]);
+  });
+
+  test('only returns references for concepts that have the extension', () => {
+    const service1: WithId<HealthcareService> = { resourceType: 'HealthcareService', id: 'svc-1' };
+    const service2: WithId<HealthcareService> = { resourceType: 'HealthcareService', id: 'svc-2' };
+    const concepts: CodeableConcept[] = [
+      ...toCodeableReferenceLike(service1),
+      { coding: [{ code: 'plain-no-ref' }] },
+      ...toCodeableReferenceLike(service2),
+    ];
+    const refs = extractReferencesFromCodeableReferenceLike(concepts);
+    expect(refs).toHaveLength(2);
+    expect(refs.map((r) => r.reference)).toContain('HealthcareService/svc-1');
+    expect(refs.map((r) => r.reference)).toContain('HealthcareService/svc-2');
+  });
+
+  test('returns one reference per type entry when a service has multiple type entries', () => {
+    const service: WithId<HealthcareService> = {
+      resourceType: 'HealthcareService',
+      id: 'svc-1',
+      type: [{ coding: [{ code: 'a' }] }, { coding: [{ code: 'b' }] }],
+    };
+    const refs = extractReferencesFromCodeableReferenceLike(toCodeableReferenceLike(service));
+    expect(refs).toHaveLength(2);
+    expect(refs.every((r) => r.reference === 'HealthcareService/svc-1')).toBe(true);
+  });
+});

--- a/packages/server/src/util/servicetype.ts
+++ b/packages/server/src/util/servicetype.ts
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import { createReference, EMPTY, getExtensionValue, getReferenceString, isDefined } from '@medplum/core';
+import type { CodeableConcept, HealthcareService, Reference } from '@medplum/fhirtypes';
+
+/**
+ * In R5/R6, `serviceType` attributes are changing from `CodeableConcept[]` to
+ * `CodeableReference<HealthcareService>`.
+ *
+ * We're choosing to represent this in R4 by adding an extension to CodeableConcept that holds
+ * a Reference<HealthcareService>.
+ *
+ * Example: A Schedule with a serviceType referring to a HealthcareService:
+ * ```
+ * {
+ *   resourceType: 'Schedule',
+ *   actor: [{ reference: "Practitioner/abc" }],
+ *   serviceType: [
+ *     {
+ *       extension: [
+ *         {
+ *           url: "https://medplum.com/fhir/service-type-reference",
+ *           valueReference: { reference: "HealthcareService/123" }
+ *         }
+ *       ]
+ *     }
+ *  ]
+ *
+ * This constant holds the extension URI used to hold the reference.
+ */
+export const ServiceTypeReferenceURI = 'https://medplum.com/fhir/service-type-reference';
+
+/**
+ * Convert a HealthcareService into a CodeableReference (as best as we can
+ * represent it in R4)
+ *
+ * @param service - A HealthcareService resource
+ * @returns - An array of CodeableConcepts with embedded references to the service
+ */
+export function toCodeableReferenceLike(service: WithId<HealthcareService>): CodeableConcept[] {
+  const extension = [{ url: ServiceTypeReferenceURI, valueReference: createReference(service) }];
+
+  if (!service.type?.length) {
+    return [{ extension }];
+  }
+
+  return service.type.map((concept) => ({
+    ...concept,
+    extension: [...(concept.extension ?? EMPTY), ...extension],
+  }));
+}
+
+/**
+ * Check if a service type is a CodeableReferenceLike pointing to a given
+ * HealthcareService
+ *
+ * @param serviceType - An array of CodeableConcepts that can each hold an embedded reference
+ * @param service - A HealthcareService resource
+ * @returns boolean - true if any concept in the serviceType explicitly refers to the given service
+ */
+export function isCodeableReferenceLikeTo(
+  serviceType: CodeableConcept[] | undefined,
+  service: WithId<HealthcareService> | (Reference<HealthcareService> & { reference: string })
+): boolean {
+  if (!serviceType?.length) {
+    return false;
+  }
+  const refString = getReferenceString(service);
+  return serviceType.some((concept) => {
+    const ref = getExtensionValue(concept, ServiceTypeReferenceURI) as Reference<HealthcareService> | undefined;
+    return ref?.reference === refString;
+  });
+}
+
+/**
+ * Extract References from an array of CodeableReferenceLike objects
+ * @param serviceType - An array of CodableConcepts that can each hold an embedded reference
+ * @returns An array of HealthcareService references
+ */
+export function extractReferencesFromCodeableReferenceLike(
+  serviceType: CodeableConcept[] | undefined
+): Reference<HealthcareService>[] {
+  if (!serviceType?.length) {
+    return [];
+  }
+
+  return serviceType
+    .map((concept) => getExtensionValue(concept, ServiceTypeReferenceURI) as Reference<HealthcareService> | undefined)
+    .filter(isDefined);
+}


### PR DESCRIPTION
There were some challenges relating to Scheduling when everything was being implemented in terms of linking ServiceType attributes that were CodeableConcept arrays:

- Comparing two CodeableConcept entries is not a strongly defined operation; we had implemented such that two concepts are considered "matching" if they have even a single overlapping Coding. This could result in surprising matches (if a single code was present in multiple places) or mismatches (if a Coding didn't match exactly, such as if one had a `system` attribute and one didn't).

- Following a Reference<HealthcareService> lets us read from the primary key index instead of doing a search on the `service-type` search parameter in more places.

- If passing a reference to a HealthcareService that the caller can't read (either due to permissions or because it doesn't exist), we can emit a more useful error message.

- Previously, changing `HealthcareService.type` to a new code would break relationships from any Schedules pointing at it. By encoding the links as References, they are now stable (although it can be confusing if they store denormalized data, as in `Schedule.serviceType[].coding`, that gets out of sync).

Implementation Notes:
=====================

- When linking a Schedule to a HealthcareService, in Schedule.serviceType we expect the CodeableConcept entries to carry an extra extension holding an explicit reference to a HealthcareService. This is similar in concept to an R5 CodeableReference (which this field will be changing to in the future).

  In the meantime, this style lets us perform cleaner checks if a Schedule is intended to be linked to a specific HealthcareService by reading these references.

- The SchedulingParameters extension on Schedule now has a subextension `url: "service", valueReference: Reference<HealthcareService>`. This makes the intention of overriding a specific HealthcareService clear.

  Aside: Down the line we think there will be configurations where a Schedule wants to override availability on many/all HealthcareService rows. At the time that we implement that we will likely make the contraint on this field weaker. For now, we consider it as a requirement and fail without this explicit linkage.

- Changed the parameter type on $find - `service-type` used to take a comma-separated list of code tokens. It now takes `service-type-reference`, which must be exactly one `Reference<HealthcareService>`. This makes it abundantly clear what the intention is: "schedule an appointment of this type", where the caller has made the type selection already by inspecting the list of available HealthcareServices.

- Added a Schedule Settings Page to Provider app to ease configuration.

  When the viewing the Provider app SchedulePage for a ScheduleResource with a Medplum SchedulingParameters extension, we add a gear icon in the top right that links to this page. It allows easily setting Schedule.serviceType entries by toggling switches for HealthcareService resources.


UI Demo:
=======

https://github.com/user-attachments/assets/1ba269b1-2d3d-46ea-8f6f-d257655051a3

