### PR TITLE
Transaction dead connection management

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -1789,6 +1789,58 @@ describe('FHIR Repo', () => {
     expect(postCommit).toHaveBeenCalledTimes(0);
   });
 
+  test('withTransaction releases connection when rollback fails on a dead backend', async () => {
+    const { repo } = await createTestProject({ withRepo: true });
+
+    const warnSpy = jest.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(getLogger(), 'error').mockImplementation(() => {});
+    let querySpy: jest.SpyInstance | undefined;
+    let releaseSpy: jest.SpyInstance | undefined;
+
+    await expect(
+      repo.withTransaction(async (client) => {
+        querySpy = jest.spyOn(client, 'query').mockImplementation(() => {
+          // Simulates a session killed by idle_in_transaction_session_timeout: every query
+          // issued on the client — including the ROLLBACK the error handler sends — rejects.
+          const terminationErr = Object.assign(new Error('terminating connection due to idle-in-transaction timeout'), {
+            code: '57P01',
+          });
+          throw terminationErr;
+        });
+        releaseSpy = jest.spyOn(client, 'release');
+        await client.query('SELECT 1');
+      })
+    ).rejects.toThrow('terminating connection due to idle-in-transaction timeout');
+
+    if (!querySpy) {
+      throw new Error('querySpy is undefined');
+    }
+    if (!releaseSpy) {
+      throw new Error('releaseSpy is undefined');
+    }
+
+    // Bookkeeping must be fully reset so the repo is safe for future use
+    expect((repo as any).transactionDepth).toBe(0);
+    expect((repo as any).conn).toBeUndefined();
+
+    // Dead client must be released with a truthy err so pg-pool discards it
+    expect(releaseSpy).toHaveBeenCalledTimes(1);
+    expect(releaseSpy?.mock.calls[0][0]).toBeDefined();
+
+    // The rollback failure should be logged, not thrown
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Error rolling back transaction',
+      expect.objectContaining({
+        err: expect.stringContaining('terminating connection'),
+      })
+    );
+
+    querySpy.mockRestore();
+    releaseSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
   test.each(['commit', 'rollback'])('Post-commit handling on %s', async (mode) => {
     const repo = systemRepo;
     const loggerErrorSpy = jest.spyOn(getLogger(), 'error').mockImplementation(() => {});

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -2623,26 +2623,17 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     const conn = await this.getConnection(DatabaseMode.WRITER);
     if (this.transactionDepth === 1) {
       await this.processPreCommit();
-      try {
-        await conn.query('COMMIT');
-      } catch (err) {
-        // COMMIT failed (e.g. connection was terminated by idle_in_transaction_session_timeout).
-        // Postgres has already rolled back, so skip ROLLBACK attempts.
-        this.abortTransaction(err as Error);
-        throw err;
-      }
+      await conn.query('COMMIT');
       this.transactionDepth--;
       this.releaseConnection();
       this.clearCallbackStack();
       await this.processPostCommit();
     } else {
-      try {
-        await conn.query('RELEASE SAVEPOINT sp' + this.transactionDepth);
-      } catch (err) {
-        // Savepoint release failed; outer transaction is toast. Abort the whole chain.
-        this.abortTransaction(err as Error);
-        throw err;
-      }
+      // If RELEASE SAVEPOINT fails (e.g. transaction in aborted state), let the error propagate.
+      // withTransaction's catch will invoke rollbackTransaction, which can run ROLLBACK TO SAVEPOINT
+      // even against an aborted transaction to recover — aborting here would discard work the outer
+      // scope can still commit. rollbackTransaction's own catch handles the truly-dead-connection case.
+      await conn.query('RELEASE SAVEPOINT sp' + this.transactionDepth);
       this.transactionDepth--;
       this.popCallbackFrame();
     }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -2516,8 +2516,21 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
    * @param err - Optional error to remove the connection from the pool.
    */
   private releaseConnection(err?: boolean | Error): void {
-    if (this.conn && this.disposable) {
-      this.conn.release(err);
+    if (!this.conn) {
+      return;
+    }
+    if (this.disposable) {
+      try {
+        this.conn.release(err);
+      } catch (releaseErr) {
+        // pg-pool throws if release() is called twice (e.g. socket already errored out).
+        // We've done our part; just log and move on.
+        getLogger().warn('Error releasing database client', { err: normalizeErrorString(releaseErr) });
+      }
+      this.conn = undefined;
+    } else if (err) {
+      // Shared connection is known to be dead. Drop our reference so we don't reuse it.
+      // The owner of the connection is responsible for the actual release.
       this.conn = undefined;
     }
   }
@@ -2610,31 +2623,74 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     const conn = await this.getConnection(DatabaseMode.WRITER);
     if (this.transactionDepth === 1) {
       await this.processPreCommit();
-      await conn.query('COMMIT');
+      try {
+        await conn.query('COMMIT');
+      } catch (err) {
+        // COMMIT failed (e.g. connection was terminated by idle_in_transaction_session_timeout).
+        // Postgres has already rolled back, so skip ROLLBACK attempts.
+        this.abortTransaction(err as Error);
+        throw err;
+      }
       this.transactionDepth--;
       this.releaseConnection();
       this.clearCallbackStack();
       await this.processPostCommit();
     } else {
-      await conn.query('RELEASE SAVEPOINT sp' + this.transactionDepth);
+      try {
+        await conn.query('RELEASE SAVEPOINT sp' + this.transactionDepth);
+      } catch (err) {
+        // Savepoint release failed; outer transaction is toast. Abort the whole chain.
+        this.abortTransaction(err as Error);
+        throw err;
+      }
       this.transactionDepth--;
       this.popCallbackFrame();
     }
   }
 
   private async rollbackTransaction(error: Error): Promise<void> {
-    this.assertInTransaction();
-    const conn = await this.getConnection(DatabaseMode.WRITER);
-    if (this.transactionDepth === 1) {
-      await conn.query('ROLLBACK');
-      this.transactionDepth--;
-      this.truncateCommitCallbacks();
-      this.releaseConnection(error);
-    } else {
-      await conn.query('ROLLBACK TO SAVEPOINT sp' + this.transactionDepth);
-      this.transactionDepth--;
-      this.truncateCommitCallbacks();
+    // Tolerate being called after state has already been reset (e.g. when a prior
+    // cleanup path in commit/rollback fully aborted the transaction on a dead connection).
+    if (this.transactionDepth <= 0) {
+      return;
     }
+    const conn = await this.getConnection(DatabaseMode.WRITER);
+    const isOuter = this.transactionDepth === 1;
+    try {
+      if (isOuter) {
+        await conn.query('ROLLBACK');
+      } else {
+        await conn.query('ROLLBACK TO SAVEPOINT sp' + this.transactionDepth);
+      }
+    } catch (rollbackErr) {
+      // ROLLBACK itself failed — connection is almost certainly dead (e.g. killed by
+      // idle_in_transaction_session_timeout). Pass the original triggering error to
+      // abortTransaction so the client is released with the right root cause.
+      getLogger().warn('Error rolling back transaction', {
+        err: normalizeErrorString(rollbackErr),
+        originalErr: normalizeErrorString(error),
+      });
+      this.abortTransaction(error);
+      return;
+    }
+    this.transactionDepth--;
+    this.truncateCommitCallbacks();
+    if (isOuter) {
+      this.releaseConnection(error);
+    }
+  }
+
+  /**
+   * Fully abort the transaction hierarchy: reset depth, drop pending pre/post-commit
+   * callbacks, and release the connection with an error so pg-pool discards it.
+   * Invoked from commit/rollback error paths when further recovery on the current
+   * connection is not possible.
+   * @param err - The error that triggered the abort; forwarded to `release()`.
+   */
+  private abortTransaction(err: Error): void {
+    this.transactionDepth = 0;
+    this.clearCallbackStack();
+    this.releaseConnection(err);
   }
 
   private endTransaction(): void {

--- a/packages/server/src/otel/otel.ts
+++ b/packages/server/src/otel/otel.ts
@@ -117,6 +117,10 @@ export function initOtelHeartbeat(): void {
     const writerPool = getDatabasePool(DatabaseMode.WRITER);
     const readerPool = getDatabasePool(DatabaseMode.READER);
 
+    setGauge('medplum.db.totalConnections', writerPool.totalCount, {
+      ...BASE_METRIC_OPTIONS,
+      attributes: { ...BASE_METRIC_OPTIONS.attributes, dbInstanceType: 'writer' },
+    });
     setGauge('medplum.db.idleConnections', writerPool.idleCount, {
       ...BASE_METRIC_OPTIONS,
       attributes: { ...BASE_METRIC_OPTIONS.attributes, dbInstanceType: 'writer' },
@@ -127,6 +131,10 @@ export function initOtelHeartbeat(): void {
     });
 
     if (writerPool !== readerPool) {
+      setGauge('medplum.db.totalConnections', readerPool.totalCount, {
+        ...BASE_METRIC_OPTIONS,
+        attributes: { ...BASE_METRIC_OPTIONS.attributes, dbInstanceType: 'reader' },
+      });
       setGauge('medplum.db.idleConnections', readerPool.idleCount, {
         ...BASE_METRIC_OPTIONS,
         attributes: { ...BASE_METRIC_OPTIONS.attributes, dbInstanceType: 'reader' },


### PR DESCRIPTION
Fix connection leak when transaction rollback fails on dead backend

  When a transaction's client is killed mid-flight (e.g., by
  idle_in_transaction_session_timeout), rollbackTransaction's ROLLBACK
  query also rejects. The subsequent depth-- / releaseConnection() lines
  never run, leaving the client checked out forever. Over time the pool
  saturates; on shutdown, pool.end() hangs waiting for the leaked client.

  - Wrap ROLLBACK / ROLLBACK TO SAVEPOINT in try/catch. On failure,
    abortTransaction() resets depth, clears the callback stack, and
    releases the client with the original error so pg-pool discards it.
  - releaseConnection() guards against double-release and clears
    this.conn even on non-disposable repos when an error is passed, so a
    dead client is never reused.
  - rollbackTransaction() no-ops at depth 0, preventing "Not in
    transaction" from masking the root cause when cleanup already ran.
  - commitTransaction() intentionally unchanged: RELEASE SAVEPOINT
    failures (aborted-transaction state) are still recoverable by the
    outer scope's rollback, which can run ROLLBACK TO SAVEPOINT against
    an aborted transaction.
  - Add medplum.db.totalConnections gauge to the otel heartbeat so slow
    leaks are observable before shutdown (idleCount / waitingCount alone
    don't show stuck-checked-out clients).
  - Regression test asserts state fully cleans up when ROLLBACK rejects.

Fixes #8984 
