### PR TITLE
Add MedplumClient support for ReadableStream and Readable

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -4369,6 +4369,55 @@ describe('Client', () => {
     const getPromise2 = client.get(client.fhirUrl('Patient', '123'));
     await expect(getPromise2).resolves.toEqual(patient);
   });
+
+  test('Browser ReadableStream uses duplex half', async () => {
+    const fetch = mockFetch(200, { success: true });
+    const client = new MedplumClient({ fetch });
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('Hello world'));
+        controller.close();
+      },
+    });
+    const response = await client.post('/test', stream, 'application/octet-stream');
+    expect(response).toBeDefined();
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.medplum.com/test',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/octet-stream',
+        }),
+        body: expect.any(ReadableStream),
+        duplex: 'half',
+      })
+    );
+  });
+
+  test('Node.js Readable uses duplex half', async () => {
+    const fetch = mockFetch(200, { success: true });
+    const client = new MedplumClient({ fetch });
+    // const stream = Readable.from(['Hello world']);
+    const stream = {
+      pipe: vi.fn(),
+      on: vi.fn(),
+    };
+    const response = await client.post('/test', stream, 'application/octet-stream');
+    expect(response).toBeDefined();
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.medplum.com/test',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/octet-stream',
+        }),
+        body: stream,
+        duplex: 'half',
+      })
+    );
+  });
 });
 
 describe('Passed in async-backed `ClientStorage`', () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -450,6 +450,11 @@ export interface MedplumRequestOptions extends RequestInit {
    * Only applies when the client is configured with auto-batching enabled.
    */
   disableAutoBatch?: boolean;
+
+  /**
+   * See: https://developer.mozilla.org/en-US/docs/Web/API/Request/duplex
+   */
+  duplex?: 'half';
 }
 
 export interface PushToAgentOptions extends MedplumRequestOptions {
@@ -3934,6 +3939,13 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       (typeof Uint8Array !== 'undefined' && (data instanceof Uint8Array || data?.constructor.name === 'Uint8Array'))
     ) {
       options.body = data;
+    } else if (
+      typeof data === 'object' &&
+      data !== null &&
+      (typeof data.getReader === 'function' || (typeof data.pipe === 'function' && typeof data.on === 'function'))
+    ) {
+      options.body = data;
+      options.duplex = 'half'; // Required for ReadableStream in Node 18+
     } else if (data) {
       options.body = JSON.stringify(data);
     }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3945,7 +3945,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       (typeof data.getReader === 'function' || (typeof data.pipe === 'function' && typeof data.on === 'function'))
     ) {
       options.body = data;
-      options.duplex = 'half'; // Required for ReadableStream in Node 18+
+      options.duplex = 'half'; // Required for ReadableStream in Node 18+ and in most browsers
     } else if (data) {
       options.body = JSON.stringify(data);
     }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "esnext",
-    "types": ["vitest/globals", "vite/client"],
+    "types": ["node", "vitest/globals", "vite/client"],
     "lib": ["esnext", "dom"],
     "rootDir": "src",
     "outDir": "dist/types",


### PR DESCRIPTION
Extracted from https://github.com/medplum/medplum/pull/8988

`MedplumClient` currently supports a few input types for HTTP request content body:

1. `string`
2. `Blob`
3. `File`
4. `Uint8Array`
5. Or a JavaScript object, which is automatically converted to a JSON string

This PR adds two more types:

1. `ReadableStream` - browser stream (detected as `.getReader`)
2. `Readable` - Node.js stream (detected via `.pipe` and `.on`)

If a stream is detected, `MedplumClient` will automatically add `duplex: 'half'` (see https://developer.mozilla.org/en-US/docs/Web/API/Request/duplex)