### PR TITLE
Unify sendBotResponse

### DIFF
--- a/packages/server/src/bots/utils.ts
+++ b/packages/server/src/bots/utils.ts
@@ -6,8 +6,11 @@ import {
   badRequest,
   ContentType,
   createReference,
+  getStatus,
   Hl7Message,
+  isOk,
   isOperationOutcome,
+  isResource,
   normalizeErrorString,
   OperationOutcomeError,
   resolveId,
@@ -24,12 +27,14 @@ import type {
   ProjectSetting,
   Reference,
 } from '@medplum/fhirtypes';
-import type { Request } from 'express';
+import type { Request, Response } from 'express';
 import { randomUUID } from 'node:crypto';
 import { extname } from 'node:path';
 import type { AuthenticatedRequestContext } from '../context';
+import { sendOutcome } from '../fhir/outcomes';
 import type { SystemRepository } from '../fhir/repo';
 import { getGlobalSystemRepo } from '../fhir/repo';
+import { sendFhirResponse } from '../fhir/response';
 import { getLogger } from '../logger';
 import { generateAccessToken } from '../oauth/keys';
 import { getBinaryStorage } from '../storage/loader';
@@ -74,9 +79,15 @@ export function getBotDefaultHeaders(req: Request | FhirRequest, bot: WithId<Bot
   }
   return defaultHeaders;
 }
-export function getResponseBodyFromResult(
-  result: BotExecutionResult
-): string | { [key: string]: any } | any[] | boolean {
+
+/**
+ * Returns the response body to send to the client based on the bot execution result.
+ * If the bot execution result does not include a return value, then an OperationOutcome is returned with the log result.
+ * If the bot execution result includes a return value, then that is returned directly.
+ * @param result - The bot execution result.
+ * @returns The response body to send to the client.
+ */
+function getResponseBodyFromResult(result: BotExecutionResult): string | { [key: string]: any } | any[] | boolean {
   let responseBody = result.returnValue;
   if (responseBody === undefined) {
     // If the bot did not return a value, then return an OperationOutcome
@@ -274,7 +285,7 @@ async function addBotSecrets(
 
 const MIRRORED_CONTENT_TYPES: string[] = [ContentType.TEXT, ContentType.HL7_V2];
 
-export function getResponseContentType(req: Request): string {
+function getResponseContentType(req: Request): string {
   const requestContentType = req.get('Content-Type');
   if (requestContentType && MIRRORED_CONTENT_TYPES.includes(requestContentType)) {
     return requestContentType;
@@ -308,4 +319,44 @@ export function getJsFileExtension(bot: Bot, code: string): string {
 
   // 3. Default to CJS
   return '.cjs';
+}
+
+/**
+ * Sends the bot execution result to the client.
+ * If the bot execution result is an OperationOutcome, then it is sent as an OperationOutcome response.
+ * Otherwise, the return value is sent as the response body. If the return value is undefined, then the log result is sent as an OperationOutcome.
+ *
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
+ * @param result - The bot execution result.
+ * @returns A promise that resolves when the response is sent.
+ */
+export async function sendBotResponse(
+  req: Request,
+  res: Response,
+  result: OperationOutcome | BotExecutionResult
+): Promise<void> {
+  if (isOperationOutcome(result)) {
+    sendOutcome(res, result);
+    return;
+  }
+
+  const responseBody = getResponseBodyFromResult(result);
+
+  // If the bot returned an error OperationOutcome, send it with proper HTTP status
+  if (isOperationOutcome(responseBody) && !isOk(responseBody)) {
+    sendOutcome(res, responseBody);
+    return;
+  }
+
+  const outcome = result.success ? allOk : badRequest(result.logResult);
+
+  if (isResource(responseBody)) {
+    await sendFhirResponse(req, res, outcome, responseBody, { forceRawBinaryResponse: true });
+    return;
+  }
+
+  // Send the response
+  // The body parameter can be a Buffer object, a String, an object, Boolean, or an Array.
+  res.status(getStatus(outcome)).type(getResponseContentType(req)).send(responseBody);
 }

--- a/packages/server/src/cds/routes.ts
+++ b/packages/server/src/cds/routes.ts
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { allOk, badRequest, ContentType, getStatus, Operator } from '@medplum/core';
+import { ContentType, Operator } from '@medplum/core';
 import type { Bot } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import { Router } from 'express';
 import { executeBot } from '../bots/execute';
-import { getBotDefaultHeaders, getResponseBodyFromResult } from '../bots/utils';
+import { getBotDefaultHeaders, sendBotResponse } from '../bots/utils';
 import { getAuthenticatedContext } from '../context';
 import { authenticateRequest } from '../oauth/middleware';
 
@@ -75,7 +75,5 @@ cdsRouter.post('/:id', async (req: Request, res: Response) => {
     defaultHeaders: getBotDefaultHeaders(req, bot),
   });
 
-  const responseBody = getResponseBodyFromResult(result);
-  const outcome = result.success ? allOk : badRequest(result.logResult);
-  res.status(getStatus(outcome)).type(ContentType.JSON).send(responseBody);
+  await sendBotResponse(req, res, result);
 });

--- a/packages/server/src/cloud/aws/execute.test.ts
+++ b/packages/server/src/cloud/aws/execute.test.ts
@@ -99,7 +99,7 @@ describe('Execute', () => {
         name: [{ given: ['John'], family: ['Doe'] }],
       });
     expect(res.status).toBe(200);
-    expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
+    expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
   });
 
   test('Submit FHIR without content type', async () => {
@@ -111,7 +111,7 @@ describe('Execute', () => {
         name: [{ given: ['John'], family: ['Doe'] }],
       });
     expect(res.status).toBe(200);
-    expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
+    expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
   });
 
   test('Submit HL7', async () => {

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -239,7 +239,6 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken1)
       .send({
-        resourceType: 'Patient',
         name: [{ given: ['John'], family: ['Doe'] }],
         identifier: [],
       });
@@ -253,7 +252,6 @@ describe('Execute', () => {
       .post(`/fhir/R4/Bot/${bots.systemEchoBot.id}/$execute`)
       .set('Authorization', 'Bearer ' + accessToken1)
       .send({
-        resourceType: 'Patient',
         name: [{ given: ['John'], family: ['Doe'] }],
         identifier: [],
       });

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -2,12 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { BotResponseStream, WithId } from '@medplum/core';
 import {
-  allOk,
   badRequest,
-  getStatus,
   isOk,
   isOperationOutcome,
-  isResource,
   notFound,
   OperationOutcomeError,
   Operator,
@@ -21,12 +18,9 @@ import {
   getBotDefaultHeaders,
   getBotProjectMembership,
   getOutParametersFromResult,
-  getResponseBodyFromResult,
-  getResponseContentType,
+  sendBotResponse,
 } from '../../bots/utils';
 import { getAuthenticatedContext } from '../../context';
-import { sendOutcome } from '../outcomes';
-import { sendFhirResponse } from '../response';
 import { sendAsyncResponse } from './utils/asyncjobexecutor';
 
 export const DEFAULT_VM_CONTEXT_TIMEOUT = 10000;
@@ -59,29 +53,7 @@ export const executeHandler = async (req: Request, res: Response): Promise<void>
       return;
     }
 
-    if (isOperationOutcome(result)) {
-      sendOutcome(res, result);
-      return;
-    }
-
-    const responseBody = getResponseBodyFromResult(result);
-
-    // If the bot returned an error OperationOutcome, send it with proper HTTP status
-    if (isOperationOutcome(responseBody) && !isOk(responseBody)) {
-      sendOutcome(res, responseBody);
-      return;
-    }
-
-    const outcome = result.success ? allOk : badRequest(result.logResult);
-
-    if (isResource(responseBody, 'Binary')) {
-      await sendFhirResponse(req, res, outcome, responseBody);
-      return;
-    }
-
-    // Send the response
-    // The body parameter can be a Buffer object, a String, an object, Boolean, or an Array.
-    res.status(getStatus(outcome)).type(getResponseContentType(req)).send(responseBody);
+    await sendBotResponse(req, res, result);
   }
 };
 

--- a/packages/server/src/fhir/response.ts
+++ b/packages/server/src/fhir/response.ts
@@ -5,7 +5,7 @@ import type { FhirResponseOptions } from '@medplum/fhir-router';
 import type { Binary, OperationOutcome, Resource } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import { getConfig } from '../config/loader';
-import { getAuthenticatedContext } from '../context';
+import { AuthenticatedRequestContext, tryGetRequestContext } from '../context';
 import { getBinaryStorage } from '../storage/loader';
 import { RewriteMode, rewriteAttachments } from './rewrite';
 
@@ -61,8 +61,12 @@ export async function sendFhirResponse(
     return;
   }
 
-  const ctx = getAuthenticatedContext();
-  const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, ctx.repo, body);
+  let result = body;
+
+  const ctx = tryGetRequestContext();
+  if (ctx instanceof AuthenticatedRequestContext) {
+    result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, ctx.repo, body);
+  }
 
   res.set('Content-Type', options?.contentType ?? ContentType.FHIR_JSON);
   res.json(result);

--- a/packages/server/src/webhook/routes.ts
+++ b/packages/server/src/webhook/routes.ts
@@ -1,14 +1,13 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { allOk, badRequest, getStatus, isOperationOutcome, singularize } from '@medplum/core';
-import type { Binary, Bot, ProjectMembership, Reference } from '@medplum/fhirtypes';
+import { isOperationOutcome, singularize } from '@medplum/core';
+import type { Bot, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import { Router } from 'express';
 import { executeBot } from '../bots/execute';
-import { getResponseBodyFromResult, getResponseContentType } from '../bots/utils';
+import { sendBotResponse } from '../bots/utils';
 import { sendOutcome } from '../fhir/outcomes';
 import { getGlobalSystemRepo, getProjectSystemRepo } from '../fhir/repo';
-import { sendBinaryResponse } from '../fhir/response';
 
 /**
  * Handles HTTP requests for anonymous webhooks.
@@ -59,14 +58,7 @@ export const webhookHandler = async (req: Request, res: Response): Promise<void>
     return;
   }
 
-  const responseBody = getResponseBodyFromResult(result);
-  const outcome = result.success ? allOk : badRequest(result.logResult);
-
-  if (result.returnValue?.resourceType === 'Binary') {
-    await sendBinaryResponse(res, result.returnValue as Binary);
-  } else {
-    res.status(getStatus(outcome)).contentType(getResponseContentType(req)).send(responseBody);
-  }
+  await sendBotResponse(req, res, result);
 };
 
 export const webhookRouter = Router();


### PR DESCRIPTION
`executeBot` returns `OperationOutcome | BotExecutionResult`

In 3 separate places, we call `executeBot` and return the result as an HTTP response:

1. `$execute`
2. [Unauthenticated webhooks](https://www.medplum.com/docs/bots/consuming-webhooks#unauthenticated-webhooks)
3. CDS Services

We have accumulated a number of special cases when it comes to converting that to an HTTP response.  Those special cases were not consistently applied across all 3 call sites.  So this PR introduces a single utility `sendBotResponse`.