### PR TITLE
Fix agent channel reload when endpoint protocol changes

### DIFF
--- a/packages/agent/src/app.test.ts
+++ b/packages/agent/src/app.test.ts
@@ -38,6 +38,7 @@ import type { Hl7ClientPool } from './hl7-client-pool';
 import * as pidModule from './pid';
 import { createEndpointWithRandomPort, getFreePort } from './test-utils';
 import { mockFetchForUpgrader } from './upgrader-test-utils';
+import { AgentByteStreamChannel } from './bytestream';
 
 jest.mock('./constants', () => ({
   ...jest.requireActual('./constants'),
@@ -732,6 +733,105 @@ describe('App', () => {
     clearTimeout(timeout);
     expect(stagingChannel.server.server).not.toBeDefined();
 
+    // Verify protocol changes replace the channel instance instead of no-op reloading it.
+
+    const hl7TestChannelBefore = app.channels.get('hl7-test') as AgentHl7Channel;
+    expect(hl7TestChannelBefore).toBeDefined();
+
+    const protocolSwapAddress = new URL(hl7TestEndpoint2.address);
+    protocolSwapAddress.protocol = 'tcp:';
+    protocolSwapAddress.searchParams.set('startChar', 'a');
+    protocolSwapAddress.searchParams.set('endChar', 'b');
+
+    const hl7TestEndpoint3 = await medplum.updateResource<Endpoint>({
+      ...hl7TestEndpoint2,
+      address: protocolSwapAddress.toString(),
+      connectionType: { code: ContentType.OCTET_STREAM },
+      payloadType: [{ coding: [{ code: ContentType.OCTET_STREAM }] }],
+    });
+
+    await medplum.updateResource({
+      ...agent,
+      channel: [
+        {
+          name: 'hl7-test',
+          endpoint: createReference(hl7TestEndpoint3),
+          targetReference: createReference(bot),
+        },
+        {
+          name: 'hl7-prod',
+          endpoint: createReference(hl7ProdEndpoint),
+          targetReference: createReference(bot),
+        },
+        {
+          name: 'dicom-test',
+          endpoint: createReference(dicomTestEndpoint2),
+          targetReference: createReference(bot),
+        },
+        {
+          name: 'dicom-prod',
+          endpoint: createReference(dicomProdEndpoint),
+          targetReference: createReference(bot),
+        },
+        {
+          name: 'hl7-dev',
+          endpoint: createReference(hl7StagingEndpoint),
+          targetReference: createReference(bot),
+        },
+        {
+          name: 'bytestream-prod',
+          endpoint: createReference(bytestreamProdEndpoint),
+          targetReference: createReference(bot),
+        },
+      ],
+    });
+
+    state.gotAgentReloadResponse = false;
+    state.gotAgentError = false;
+    state.agentError = undefined;
+
+    state.mySocket.send(
+      JSON.stringify({
+        type: 'agent:reloadconfig:request',
+        callback: getReferenceString(agent) + '-' + randomUUID(),
+      } satisfies AgentReloadConfigRequest)
+    );
+
+    shouldThrow = false;
+    timeout = setTimeout(() => {
+      shouldThrow = true;
+    }, 3000);
+
+    while (!state.gotAgentReloadResponse && !state.gotAgentError) {
+    if (shouldThrow) {
+      throw new Error('Timeout');
+    }
+      await sleep(100);
+    }
+    clearTimeout(timeout);
+
+    expect(state.gotAgentReloadResponse).toStrictEqual(true);
+    expect(state.gotAgentError).toStrictEqual(false);
+
+    const hl7TestChannelAfter = app.channels.get('hl7-test');
+    expect(hl7TestChannelAfter).toBeInstanceOf(AgentByteStreamChannel);
+    expect(hl7TestChannelAfter).not.toBe(hl7TestChannelBefore);
+
+    shouldThrow = false;
+    timeout = setTimeout(() => {
+      shouldThrow = true;
+    }, 2000);
+
+    while (hl7TestChannelBefore.server.server) {
+      if (shouldThrow) {
+        throw new Error('Timeout');
+      }
+      await sleep(100);
+    }
+    clearTimeout(timeout);
+
+    expect(hl7TestChannelBefore.server.server).not.toBeDefined();
+
     // Now we should test accidentally adding endpoints with conflicting ports
 
     // Endpoints with conflicting ports
@@ -757,7 +857,7 @@ describe('App', () => {
         // No changes
         {
           name: 'hl7-test',
-          endpoint: createReference(hl7TestEndpoint2),
+          endpoint: createReference(hl7TestEndpoint3),
           targetReference: createReference(bot),
         },
         // No changes

--- a/packages/agent/src/app.test.ts
+++ b/packages/agent/src/app.test.ts
@@ -33,12 +33,12 @@ import os from 'node:os';
 import { resolve } from 'node:path';
 import { EventEmitter, Readable, Writable } from 'node:stream';
 import { App } from './app';
+import { AgentByteStreamChannel } from './bytestream';
 import type { AgentHl7Channel, AgentHl7ChannelConnection } from './hl7';
 import type { Hl7ClientPool } from './hl7-client-pool';
 import * as pidModule from './pid';
 import { createEndpointWithRandomPort, getFreePort } from './test-utils';
 import { mockFetchForUpgrader } from './upgrader-test-utils';
-import { AgentByteStreamChannel } from './bytestream';
 
 jest.mock('./constants', () => ({
   ...jest.requireActual('./constants'),
@@ -803,9 +803,9 @@ describe('App', () => {
     }, 3000);
 
     while (!state.gotAgentReloadResponse && !state.gotAgentError) {
-    if (shouldThrow) {
-      throw new Error('Timeout');
-    }
+      if (shouldThrow) {
+        throw new Error('Timeout');
+      }
       await sleep(100);
     }
     clearTimeout(timeout);

--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -611,7 +611,7 @@ export class App {
       this.channels.delete(definition.name);
 
       let replacementChannel: Channel;
-      
+
       try {
         replacementChannel = this.createChannel(nextType, definition, endpoint);
       } catch (err) {
@@ -624,7 +624,7 @@ export class App {
       return;
     }
 
-    let channel: Channel
+    let channel: Channel;
 
     try {
       const channelType = getChannelType(endpoint);

--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -609,19 +609,6 @@ export class App {
 
       await existingChannel.stop();
       this.channels.delete(definition.name);
-
-      let replacementChannel: Channel;
-
-      try {
-        replacementChannel = this.createChannel(nextType, definition, endpoint);
-      } catch (err) {
-        this.log.error(normalizeErrorString(err));
-        return;
-      }
-
-      await replacementChannel.start();
-      this.channels.set(definition.name, replacementChannel);
-      return;
     }
 
     let channel: Channel;

--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -596,28 +596,39 @@ export class App {
   }
 
   private async startOrReloadChannel(definition: AgentChannel, endpoint: Endpoint): Promise<void> {
-    let channel: Channel | undefined = this.channels.get(definition.name);
+    const existingChannel = this.channels.get(definition.name);
 
-    if (channel) {
-      await channel.reloadConfig(definition, endpoint);
+    if (existingChannel) {
+      const previousType = getChannelType(existingChannel.getEndpoint());
+      const nextType = getChannelType(endpoint);
+
+      if (previousType === nextType) {
+        await existingChannel.reloadConfig(definition, endpoint);
+        return;
+      }
+
+      await existingChannel.stop();
+      this.channels.delete(definition.name);
+
+      let replacementChannel: Channel;
+      
+      try {
+        replacementChannel = this.createChannel(nextType, definition, endpoint);
+      } catch (err) {
+        this.log.error(normalizeErrorString(err));
+        return;
+      }
+
+      await replacementChannel.start();
+      this.channels.set(definition.name, replacementChannel);
       return;
     }
 
+    let channel: Channel
+
     try {
       const channelType = getChannelType(endpoint);
-      switch (channelType) {
-        case ChannelType.DICOM:
-          channel = new AgentDicomChannel(this, definition, endpoint);
-          break;
-        case ChannelType.HL7_V2:
-          channel = new AgentHl7Channel(this, definition, endpoint);
-          break;
-        case ChannelType.BYTE_STREAM:
-          channel = new AgentByteStreamChannel(this, definition, endpoint);
-          break;
-        default:
-          throw new Error(`Unsupported endpoint type: ${endpoint.address}`);
-      }
+      channel = this.createChannel(channelType, definition, endpoint);
     } catch (err) {
       this.log.error(normalizeErrorString(err));
       return;
@@ -625,6 +636,19 @@ export class App {
 
     await channel.start();
     this.channels.set(definition.name, channel);
+  }
+
+  private createChannel(channelType: ChannelType, definition: AgentChannel, endpoint: Endpoint): Channel {
+    switch (channelType) {
+      case ChannelType.DICOM:
+        return new AgentDicomChannel(this, definition, endpoint);
+      case ChannelType.HL7_V2:
+        return new AgentHl7Channel(this, definition, endpoint);
+      case ChannelType.BYTE_STREAM:
+        return new AgentByteStreamChannel(this, definition, endpoint);
+      default:
+        throw new Error(`Unsupported endpoint type: ${endpoint.address}`);
+    }
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
## What this fixes

This fixes a bug where changing a channel endpoint from one protocol to another on the same channel name was getting treated like a no-op reload.

So if a channel changed from something like `mllp://...` to `tcp://...`, we were reusing the existing channel instance instead of shutting down the old one and starting the right channel type.

## What changed

- if the existing channel type and the new endpoint type are the same, we still use the normal `reloadConfig()` path
- If the type changed, we now stop the old channel, remove it, create the right channel type, and start that instead
- pulled channel creation into a small helper so we don’t repeat the same switch in two places
- added coverage to the existing reload-config test to make sure a protocol change actually replaces the channel instance

## Testing

- ran the agent reload-config test
- verified same-type reloads still work
- verified protocol changes swap the channel instance instead of being ignored
- verified that the old channel gets closed after the replacement

Closes #6729 