### PR TITLE
Disable CodeQL on merge queue

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,8 +21,6 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
-  merge_group:
-    types: [checks_requested]
   schedule:
     - cron: '30 14 * * 4'
 


### PR DESCRIPTION
CodeQL is frequently failing on the merge queue.   Our current hypothesis is that the Github merge queue is deleting the temp branch before CodeQL completes, which then causes errors when CodeQL tries to access it.

For example: https://github.com/medplum/medplum/actions/runs/24743932011/job/72390529194

We will continue to use CodeQL on PR's and on `main`.