### PR TITLE
Fix scheduling Month view

### DIFF
--- a/examples/medplum-provider/src/components/Calendar.tsx
+++ b/examples/medplum-provider/src/components/Calendar.tsx
@@ -204,7 +204,7 @@ export function Calendar(props: {
   }, []);
 
   return (
-    <div data-testid="calendar">
+    <div data-testid="calendar" style={{ height: '100%' }}>
       <ReactBigCalendar
         components={COMPONENTS}
         view={view}


### PR DESCRIPTION
In commit b0aa196c66 I wrapped ReactBigCalendar in this div to target it via `data-testid`. What I didn't anticipate is that it would restrict the height of the BigCalendar Month view which tries to fit into its parent element's height. Whoops.

Adding an explicit `height: 100%` to this wrapper makes the calendar work as expected again.

Resolves: https://github.com/medplum/medplum/issues/9021