### PR TITLE
Enforce Project.exportedResourceType on cached reads

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -2129,6 +2129,79 @@ describe('FHIR Repo', () => {
       expect(orgs.map((p) => p.id)).toContain(linkedOrg.id);
     }));
 
+  test('Project.exportedResourceType enforced on cached reads', () =>
+    withTestContext(async () => {
+      // Regression: a non-exported resource in a linked project should not be
+      // readable even when it is present in the Redis cache. Previously,
+      // canPerformInteraction only checked project-compartment membership and
+      // ignored the linked project's `exportedResourceType`, so the cache path
+      // bypassed the filter enforced by addProjectFilters in SQL.
+      const { project: linkedProject, repo: linkedRepo } = await createTestProject({
+        project: { exportedResourceType: ['Organization'] },
+        withRepo: true,
+      });
+
+      const regRequest: RegisterRequest = {
+        firstName: randomUUID(),
+        lastName: randomUUID(),
+        projectName: randomUUID(),
+        email: randomUUID() + '@example.com',
+        password: randomUUID(),
+      };
+
+      const regResult = await registerNew(regRequest);
+      let project = regResult.project;
+      project = await globalSystemRepo.updateResource({
+        ...project,
+        link: [{ project: createReference(linkedProject) }],
+      });
+
+      const repo = await getRepoForLogin({
+        project,
+        membership: regResult.membership,
+        login: regResult.login,
+        userConfig: {} as UserConfiguration,
+      });
+
+      // Creating via linkedRepo warms the Redis cache for this resource.
+      const linkedOrg = await linkedRepo.createResource<Organization>({
+        resourceType: 'Organization',
+        name: 'Linked Organization',
+      });
+      const linkedPatient = await linkedRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['Linked'], family: 'Patient' }],
+        managingOrganization: createReference(linkedOrg),
+      });
+
+      // Exported type: should still be readable from the linked project.
+      const readOrg = await repo.readResource<Organization>('Organization', linkedOrg.id);
+      expect(readOrg.id).toStrictEqual(linkedOrg.id);
+
+      // Non-exported type: must not be readable even with a cache hit.
+      await expect(repo.readResource<Patient>('Patient', linkedPatient.id)).rejects.toThrow(
+        new OperationOutcomeError(notFound)
+      );
+    }));
+
+  test('Project.exportedResourceType allows resources in primary project', () =>
+    withTestContext(async () => {
+      // Sanity check: exportedResourceType on the *primary* project is not
+      // used to filter access to the owner's own resources.
+      const { repo } = await createTestProject({
+        project: { exportedResourceType: ['Organization'] },
+        withRepo: true,
+      });
+
+      const patient = await repo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['Primary'], family: 'Patient' }],
+      });
+
+      const readPatient = await repo.readResource<Patient>('Patient', patient.id);
+      expect(readPatient.id).toStrictEqual(patient.id);
+    }));
+
   test('Binary writes no search parameter columns', () =>
     withTestContext(async () => {
       const { project, repo } = await createTestProject({ withClient: true, withRepo: true });

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -2259,7 +2259,19 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       }
       // Non-Superusers can only access resources in their Project, with read-only access to linked Projects
       if (readInteractions.includes(interaction)) {
-        if (!this.context.projects?.some((p) => p.id === resource.meta?.project)) {
+        const resourceProject = this.context.projects?.find((p) => p.id === resource.meta?.project);
+        if (!resourceProject) {
+          return undefined;
+        }
+        // Enforce `exportedResourceType` on linked projects; mirrors addProjectFilters.
+        // The primary (owning) and "current" projects always expose all resource types.
+        if (
+          resource.resourceType !== 'Project' &&
+          resourceProject.id !== this.context.projects?.[0]?.id &&
+          resourceProject.id !== this.context.currentProject?.id &&
+          resourceProject.exportedResourceType?.length &&
+          !resourceProject.exportedResourceType.includes(resource.resourceType as ResourceType)
+        ) {
           return undefined;
         }
       } else if (resource.meta?.project !== this.context.projects?.[0]?.id) {


### PR DESCRIPTION
## Summary

`Repository.canPerformInteraction` only verified project-compartment membership, so a read that hit the Redis cache could return a resource belonging to a linked project even when its `resourceType` was not in that project's `exportedResourceType`. The SQL path in `addProjectFilters` already applies this filter, so the two paths disagreed and the cache effectively bypassed the export policy.

### Repro

With a target project linking to a source project whose `exportedResourceType: [\"Bot\", \"OperationDefinition\"]`, a `ClientApplication` in the source project could be read from the target project if it was cached (e.g. warmed by a superuser read or by any flow using the owning project's repo).

### Fix

Mirror the carve-outs from `addProjectFilters` inside `canPerformInteraction`:
- primary (first) project is always allowed
- current project is always allowed
- `Project` resource type is always allowed
- linked project with empty/missing `exportedResourceType` is allowed
- otherwise, the resource type must be in the linked project's `exportedResourceType`

## Test plan

- [x] New regression test `Project.exportedResourceType enforced on cached reads` warms the cache via the linked project's repo, then asserts the exported type (`Organization`) reads successfully and the non-exported type (`Patient`) returns `notFound`.
- [x] New sanity test `Project.exportedResourceType allows resources in primary project` confirms `exportedResourceType` on the *primary* project does not block the owner's own reads.
- [x] Verified the new cache-path test fails on pre-fix code and passes with the fix.
- [x] `npm run test:seed` in `packages/server`
- [x] `repo.test.ts` full suite passes (169/169)
- [x] `accesspolicy` suite passes (57/57)

## Notes / follow-ups

- Auth flows (`getClientApplication`, `clientInfoHandler`, `tryLogin`, OAuth endpoints) still use `getGlobalSystemRepo()` to resolve `ClientApplication` and do not consult `exportedResourceType`. That appears intentional for sign-in UX but is worth a separate discussion; not addressed here.


Made with [Cursor](https://cursor.com)