### PR TITLE
Allow passing Reference parameters via GET querystring

### DIFF
--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -1065,4 +1065,40 @@ describe('Schedule/:id/$find', () => {
     expect(response.body).toHaveProperty('entry');
     expect(response.body.entry).toHaveLength(2);
   });
+
+  test('POST with a Parameters body returns the same results as GET', async () => {
+    const schedule = await makeSchedule([{ service: genericVisit, duration: 30, availability: twoDaySchedule }]);
+
+    const getResponse = await request
+      .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .query({
+        start: new Date('2026-03-16T00:00:00-04:00').toISOString(),
+        end: new Date('2026-03-17T00:00:00-04:00').toISOString(),
+        'service-type-reference': `HealthcareService/${genericVisit.id}`,
+        schedule: `Schedule/${schedule.id}`,
+      });
+
+    const postResponse = await request
+      .post(`/fhir/R4/Schedule/${schedule.id}/$find`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'start', valueDateTime: new Date('2026-03-16T00:00:00-04:00').toISOString() },
+          { name: 'end', valueDateTime: new Date('2026-03-17T00:00:00-04:00').toISOString() },
+          { name: 'service-type-reference', valueReference: { reference: `HealthcareService/${genericVisit.id}` } },
+          { name: 'schedule', valueReference: { reference: `Schedule/${schedule.id}` } },
+        ],
+      });
+
+    expect(postResponse.body).not.toHaveProperty('issue');
+    expect(postResponse.status).toBe(200);
+
+    const getStarts = (getResponse.body as Bundle<Slot>).entry?.map((e) => e.resource?.start);
+    const postStarts = (postResponse.body as Bundle<Slot>).entry?.map((e) => e.resource?.start);
+    expect(postStarts).toEqual(getStarts);
+  });
 });

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -11,7 +11,7 @@ import {
   Operator,
 } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Bundle, HealthcareService, OperationDefinition, Schedule, Slot } from '@medplum/fhirtypes';
+import type { Bundle, HealthcareService, OperationDefinition, Reference, Schedule, Slot } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { isCodeableReferenceLikeTo, toCodeableReferenceLike } from '../../util/servicetype';
 import { findSlotTimes } from './utils/find';
@@ -32,7 +32,14 @@ const findOperation = {
   parameter: [
     { use: 'in', name: 'start', type: 'dateTime', min: 1, max: '1' },
     { use: 'in', name: 'end', type: 'dateTime', min: 1, max: '1' },
-    { use: 'in', name: 'service-type-reference', type: 'string', min: 1, max: '1', searchType: 'reference' },
+    {
+      use: 'in',
+      name: 'service-type-reference',
+      type: 'Reference',
+      min: 1,
+      max: '1',
+      targetProfile: ['HealthcareService'],
+    },
     { use: 'in', name: '_count', type: 'integer', min: 0, max: '1' },
     { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
   ],
@@ -41,7 +48,7 @@ const findOperation = {
 type FindParameters = {
   start: string;
   end: string;
-  'service-type-reference': string;
+  'service-type-reference': Reference<HealthcareService> & { reference: string };
   _count?: number;
 };
 
@@ -109,7 +116,7 @@ export async function scheduleFindHandler(req: FhirRequest): Promise<FhirRespons
         },
       ],
     }),
-    ctx.repo.readReference<HealthcareService>({ reference: params['service-type-reference'] }).catch((err) => {
+    ctx.repo.readReference(params['service-type-reference']).catch((err) => {
       if (err instanceof OperationOutcomeError && isNotFound(err.outcome)) {
         throw new OperationOutcomeError(badRequest('HealthcareService not found'));
       }

--- a/packages/server/src/fhir/operations/utils/parameters.test.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.test.ts
@@ -330,11 +330,29 @@ describe('Operation Input/Output Parameters', () => {
       expect(parseInputParameters(opDef, req)).toEqual({ requiredIn: true, multiIn: ['foo', 'bar'] });
     });
 
+    test('Parses Reference query string parameter as { reference } object', () => {
+      const req: Request = {
+        method: 'GET',
+        query: parse('requiredIn=true&complexIn=Patient/foo'),
+      } as unknown as Request;
+      expect(parseInputParameters(opDef, req)).toMatchObject({
+        requiredIn: true,
+        complexIn: { reference: 'Patient/foo' },
+      });
+    });
+
+    test('Parses multiple Reference query string parameters into an array', () => {
+      const req: Request = {
+        method: 'GET',
+        query: parse('requiredIn=true&complexIn=Patient/foo&complexIn=Patient/bar'),
+      } as unknown as Request;
+      expect(parseInputParameters(opDef, req)).toMatchObject({
+        requiredIn: true,
+        complexIn: [{ reference: 'Patient/foo' }, { reference: 'Patient/bar' }],
+      });
+    });
+
     test.each<[string, string]>([
-      [
-        'requiredIn=true&complexIn={"reference":"Patient/foo"}',
-        'Complex parameter complexIn (Reference) cannot be passed via query string',
-      ],
       ['requiredIn=false&numeric=wrong', `Invalid value 'wrong' provided for integer parameter 'numeric'`],
       ['requiredIn=false&fractional=wrong', `Invalid value 'wrong' provided for decimal parameter 'fractional'`],
       ['requiredIn=1', `Invalid value '1' provided for boolean parameter 'requiredIn'`],

--- a/packages/server/src/fhir/operations/utils/parameters.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.ts
@@ -75,6 +75,12 @@ function parseQueryString(
     if (!value) {
       continue;
     }
+    if (param.type === 'Reference') {
+      // Reference params are passed as plain strings in query strings (e.g. Schedule/123)
+      parsed[param.name] = Array.isArray(value) ? value.map((v) => ({ reference: v })) : { reference: value };
+      continue;
+    }
+
     if (param.part || param.type?.match(/^[A-Z]/)) {
       // Query parameters cannot contain complex types
       throw new OperationOutcomeError(

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -375,6 +375,7 @@ function initInternalFhirRouter(): FhirRouter {
 
   // Schedule $find operation
   router.add('GET', '/Schedule/:id/$find', scheduleFindHandler);
+  router.add('POST', '/Schedule/:id/$find', scheduleFindHandler);
 
   // Appointment $book operation
   router.add('POST', '/Appointment/$book', appointmentBookHandler);


### PR DESCRIPTION
For operations like $find it is nice to be able to support both GET requests (encoding the parameters as query-string entries) and as POST requests (encoding the parameters in the body as a `Parameters` object).

To support our use case of a `Reference` parameter, we need to teach our decoder that such a querystring parameter should be wrapped in a `{reference: %s }` value.

This makes our documentation for this endpoint (which shows POST style access) accurate, without breaking our GET support.