### PR TITLE
Tightens access controls for linked projects

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -223,6 +223,12 @@ function getOrInitTypeSchema(resourceType: string): TypeInfo {
         type: 'token',
         expression: resourceType + '.meta.tag',
       } as SearchParameter,
+      _project: {
+        base: [resourceType],
+        code: '_project',
+        type: 'token', // Intentionally use `token`, similar to `_id`
+        expression: resourceType + '.meta.project',
+      } as SearchParameter,
     };
   }
 

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -3086,7 +3086,6 @@ describe('AccessPolicy', () => {
       expect(usersB[0].id).toStrictEqual(userB.id);
 
       const membershipsB = await repoB.searchResources<ProjectMembership>({ resourceType: 'ProjectMembership' });
-      console.log(JSON.stringify(membershipsB, null, 2));
       expect(membershipsB).toHaveLength(1);
     }));
 });

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -40,7 +40,7 @@ import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config/loader';
 import { addTestUser, createTestProject, withTestContext } from '../test.setup';
 import { buildAccessPolicy, getRepoForLogin } from './accesspolicy';
-import { getProjectSystemRepo, Repository } from './repo';
+import { getGlobalSystemRepo, getProjectSystemRepo, Repository } from './repo';
 
 describe('AccessPolicy', () => {
   let testProject: WithId<Project>;
@@ -3030,5 +3030,63 @@ describe('AccessPolicy', () => {
 
       const results = await repo2.searchResources<Device>({ resourceType: 'Device' });
       expect(results).toHaveLength(1);
+    }));
+
+  test('Protected resource types in linked projects', async () =>
+    withTestContext(async () => {
+      const systemRepo = getGlobalSystemRepo();
+
+      const { project: projectA, repo: repoA } = await createTestProject({
+        membership: { admin: true },
+        withRepo: true,
+      });
+      const userA = await systemRepo.createResource<User>({
+        resourceType: 'User',
+        meta: { project: projectA.id },
+        project: createReference(projectA),
+        email: randomUUID() + '@example.com',
+        firstName: 'User',
+        lastName: 'A',
+      });
+
+      const projectsA = await repoA.searchResources<Project>({ resourceType: 'Project' });
+      expect(projectsA).toHaveLength(2);
+      expect(projectsA.find((p) => p.name === 'FHIR R4')).toBeDefined();
+      expect(projectsA.find((p) => p.id === projectA.id)).toBeDefined();
+
+      const usersA = await repoA.searchResources<User>({ resourceType: 'User' });
+      expect(usersA).toHaveLength(1);
+      expect(usersA[0].id).toStrictEqual(userA.id);
+
+      const membershipsA = await repoA.searchResources<ProjectMembership>({ resourceType: 'ProjectMembership' });
+      expect(membershipsA).toHaveLength(1);
+
+      const { project: projectB, repo: repoB } = await createTestProject({
+        project: { link: [{ project: createReference(projectA) }] },
+        membership: { admin: true },
+        withRepo: true,
+      });
+      const userB = await systemRepo.createResource<User>({
+        resourceType: 'User',
+        meta: { project: projectB.id },
+        project: createReference(projectB),
+        email: randomUUID() + '@example.com',
+        firstName: 'User',
+        lastName: 'B',
+      });
+
+      const projectsB = await repoB.searchResources<Project>({ resourceType: 'Project' });
+      expect(projectsB).toHaveLength(3);
+      expect(projectsB.find((p) => p.name === 'FHIR R4')).toBeDefined();
+      expect(projectsB.find((p) => p.id === projectA.id)).toBeDefined();
+      expect(projectsB.find((p) => p.id === projectB.id)).toBeDefined();
+
+      const usersB = await repoB.searchResources<User>({ resourceType: 'User' });
+      expect(usersB).toHaveLength(1);
+      expect(usersB[0].id).toStrictEqual(userB.id);
+
+      const membershipsB = await repoB.searchResources<ProjectMembership>({ resourceType: 'ProjectMembership' });
+      console.log(JSON.stringify(membershipsB, null, 2));
+      expect(membershipsB).toHaveLength(1);
     }));
 });

--- a/packages/server/src/fhir/accesspolicy.ts
+++ b/packages/server/src/fhir/accesspolicy.ts
@@ -281,33 +281,22 @@ function applyProjectAdminAccessPolicy(
     // then grant limited access to the project admin resource types
     accessPolicy.resource = accessPolicy.resource?.filter((r) => !projectAdminResourceTypes.includes(r.resourceType));
 
-    // Project admins can read all projects that they have access to
-    accessPolicy.resource.push({
-      resourceType: 'Project',
-      readonlyFields: ['features', 'link', 'systemSetting'],
-      hiddenFields: ['superAdmin', 'systemSecret', 'strictMode'],
-      interaction: ['read', 'vread', 'history', 'search'],
-    });
-
-    // But they can only edit their own project
-    accessPolicy.resource.push({
-      resourceType: 'Project',
-      criteria: `Project?_id=${resolveId(membership.project)}`,
-      readonlyFields: ['features', 'link', 'systemSetting'],
-      hiddenFields: ['superAdmin', 'systemSecret', 'strictMode'],
-      interaction: ['read', 'vread', 'update', 'history', 'create', 'search'], // Everything except delete
-    });
-
-    if (project.link) {
-      accessPolicy.resource.push({
-        resourceType: 'Project',
-        criteria: `Project?_id=${project.link.map((link) => resolveId(link.project)).join(',')}`,
-        readonly: true,
-        hiddenFields: ['superAdmin', 'setting', 'systemSetting', 'secret', 'systemSecret', 'strictMode'],
-      });
-    }
-
+    // Project admins can edit their own project
     accessPolicy.resource.push(
+      {
+        // Project admins have full access to their own project, except for a few sensitive fields
+        resourceType: 'Project',
+        criteria: `Project?_id=${resolveId(membership.project)}`,
+        readonlyFields: ['features', 'link', 'systemSetting'],
+        hiddenFields: ['superAdmin', 'systemSecret', 'strictMode'],
+        interaction: ['read', 'vread', 'update', 'history', 'create', 'search'], // Everything except delete
+      },
+      {
+        // Project admins have read-only access to linked projects, and cannot see sensitive fields
+        resourceType: 'Project',
+        hiddenFields: ['superAdmin', 'setting', 'systemSetting', 'secret', 'systemSecret', 'strictMode'],
+        interaction: ['read', 'vread', 'history', 'search'], // Read-only access to linked projects
+      },
       {
         resourceType: 'ProjectMembership',
         criteria: `ProjectMembership?_project=${resolveId(membership.project)}`,

--- a/packages/server/src/fhir/accesspolicy.ts
+++ b/packages/server/src/fhir/accesspolicy.ts
@@ -300,14 +300,17 @@ function applyProjectAdminAccessPolicy(
     accessPolicy.resource.push(
       {
         resourceType: 'ProjectMembership',
+        criteria: `ProjectMembership?_project=${resolveId(membership.project)}`,
         readonlyFields: ['project', 'user'],
       },
       {
         resourceType: 'UserSecurityRequest',
+        criteria: `ProjectMembership?_project=${resolveId(membership.project)}`,
         readonly: true,
       },
       {
         resourceType: 'User',
+        criteria: `ProjectMembership?_project=${resolveId(membership.project)}`,
         hiddenFields: ['passwordHash', 'mfaSecret'],
         readonlyFields: ['email', 'emailVerified', 'mfaEnrolled', 'project'],
       },

--- a/packages/server/src/fhir/accesspolicy.ts
+++ b/packages/server/src/fhir/accesspolicy.ts
@@ -280,6 +280,16 @@ function applyProjectAdminAccessPolicy(
     // If the user is a project admin,
     // then grant limited access to the project admin resource types
     accessPolicy.resource = accessPolicy.resource?.filter((r) => !projectAdminResourceTypes.includes(r.resourceType));
+
+    // Project admins can read all projects that they have access to
+    accessPolicy.resource.push({
+      resourceType: 'Project',
+      readonlyFields: ['features', 'link', 'systemSetting'],
+      hiddenFields: ['superAdmin', 'systemSecret', 'strictMode'],
+      interaction: ['read', 'vread', 'history', 'search'],
+    });
+
+    // But they can only edit their own project
     accessPolicy.resource.push({
       resourceType: 'Project',
       criteria: `Project?_id=${resolveId(membership.project)}`,
@@ -305,12 +315,12 @@ function applyProjectAdminAccessPolicy(
       },
       {
         resourceType: 'UserSecurityRequest',
-        criteria: `ProjectMembership?_project=${resolveId(membership.project)}`,
+        criteria: `UserSecurityRequest?_project=${resolveId(membership.project)}`,
         readonly: true,
       },
       {
         resourceType: 'User',
-        criteria: `ProjectMembership?_project=${resolveId(membership.project)}`,
+        criteria: `User?_project=${resolveId(membership.project)}`,
         hiddenFields: ['passwordHash', 'mfaSecret'],
         readonlyFields: ['email', 'emailVerified', 'mfaEnrolled', 'project'],
       },

--- a/packages/server/src/fhir/fhirquota.test.ts
+++ b/packages/server/src/fhir/fhirquota.test.ts
@@ -144,6 +144,7 @@ describe('FHIR Rate Limits', () => {
     await initApp(app, config);
 
     const { accessToken, repo, membership } = await createTestProject({
+      membership: { admin: true },
       withAccessToken: true,
       withRepo: true,
       withClient: true,

--- a/packages/server/src/fhir/operations/ai.test.ts
+++ b/packages/server/src/fhir/operations/ai.test.ts
@@ -317,7 +317,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(403);
   });
 
   test('Missing API key in project settings', async () => {

--- a/packages/server/src/fhir/operations/getwsbindingtoken.test.ts
+++ b/packages/server/src/fhir/operations/getwsbindingtoken.test.ts
@@ -269,8 +269,8 @@ describe('Get WebSocket binding token', () => {
     // subscription with empty criteria directly — testing the defensive `!subscription.criteria` branch.
     const { accessToken: projectAccessToken, repo } = await createTestProject({
       withAccessToken: true,
-      withRepo: { strictMode: false },
-      project: { features: ['websocket-subscriptions'] },
+      withRepo: true,
+      project: { features: ['websocket-subscriptions'], strictMode: false },
     });
 
     const createdSub = await repo.createResource({

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -1151,7 +1151,7 @@ describe('FHIR Repo', () => {
     let repo: Repository;
     let profile: StructureDefinition;
     beforeAll(async () => {
-      const result = await createTestProject({ withRepo: { validateTerminology: true } });
+      const result = await createTestProject({ withRepo: true, project: { features: ['validate-terminology'] } });
       repo = result.repo;
 
       // Create modified US Core Patient profile to have 'required' binding for communication.language
@@ -1810,7 +1810,7 @@ describe('FHIR Repo', () => {
   test('Patch post-commit stores full resource in cache', async () =>
     withTestContext(async () => {
       const { project, repo, login, membership } = await createTestProject({
-        withRepo: { extendedMode: false },
+        withRepo: true,
         withAccessToken: true,
         withClient: true,
       });

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -1677,7 +1677,7 @@ describe('FHIR Repo', () => {
 
   test('Super admin can edit User.meta.project', async () =>
     withTestContext(async () => {
-      const { project, repo } = await createTestProject({ withRepo: true });
+      const { project, repo } = await createTestProject({ withRepo: true, membership: { admin: true } });
 
       // Create a user in the project
       const user1 = await repo.createResource<User>({
@@ -1813,6 +1813,7 @@ describe('FHIR Repo', () => {
         withRepo: true,
         withAccessToken: true,
         withClient: true,
+        extendedMode: false,
       });
       const extendedRepo = await getRepoForLogin(
         { login, project, membership, userConfig: {} as UserConfiguration },

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1666,10 +1666,17 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
    */
   private getPermittedProjectIds(resourceType: string): string[] | undefined {
     if (!this.context.projects?.length) {
+      // The repository is system-level, so all projects are permitted.
       return undefined;
     }
 
     const projectIds = [this.context.projects[0].id]; // Always include the first project
+
+    if (resourceType !== 'Project' && projectAdminResourceTypes.includes(resourceType as ResourceType)) {
+      // If the resource type is a project admin resource, only include the current project (the first project)
+      return projectIds;
+    }
+
     for (let i = 1; i < this.context.projects.length; i++) {
       const project = this.context.projects[i];
       if (

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -52,6 +52,7 @@ import {
   parseReference,
   parseSearchRequest,
   preconditionFailed,
+  projectAdminResourceTypes,
   PropertyType,
   protectedResourceTypes,
   readInteractions,
@@ -1718,9 +1719,11 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
 
     const expressions: Expression[] = [];
 
+    const isProjectAdminResource = projectAdminResourceTypes.includes(resourceType as ResourceType);
+
     for (const policy of accessPolicy.resource) {
       if (
-        (policy.resourceType === resourceType || policy.resourceType === '*') &&
+        (policy.resourceType === resourceType || (policy.resourceType === '*' && !isProjectAdminResource)) &&
         (!policy.interaction || policy.interaction.includes(interaction))
       ) {
         const policyCompartmentId = resolveId(policy.compartment);
@@ -1916,6 +1919,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       searchParam.code === '_lastUpdated' ||
       searchParam.code === '_compartment:identifier' ||
       searchParam.code === '_deleted' ||
+      searchParam.code === '_project' ||
       searchParam.type === 'composite'
     ) {
       return;

--- a/packages/server/src/migrations/migrate.ts
+++ b/packages/server/src/migrations/migrate.ts
@@ -316,7 +316,7 @@ export function buildCreateTables(result: SchemaDefinition, resourceType: Resour
   );
 }
 
-const IgnoredSearchParameters = new Set(['_id', '_lastUpdated', '_profile', '_compartment', '_source']);
+const IgnoredSearchParameters = new Set(['_id', '_lastUpdated', '_profile', '_compartment', '_source', '_project']);
 
 function buildSearchColumns(tableDefinition: TableDefinition, resourceType: string): void {
   for (const searchParam of getStandardAndDerivedSearchParameters(resourceType)) {

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -28,13 +28,13 @@ import type { ServerInviteResponse } from './admin/invite';
 import { inviteUser } from './admin/invite';
 import type { MedplumRedisConfig } from './config/types';
 import { RequestContext } from './context';
-import type { RepositoryContext } from './fhir/repo';
-import { getProjectSystemRepo, getShardSystemRepo, Repository } from './fhir/repo';
+import { getRepoForLogin } from './fhir/accesspolicy';
+import type { Repository } from './fhir/repo';
+import { getProjectSystemRepo, getShardSystemRepo } from './fhir/repo';
 import { PLACEHOLDER_SHARD_ID } from './fhir/sharding';
 import { generateAccessToken } from './oauth/keys';
 import { tryLogin } from './oauth/utils';
 import { requestContextStore } from './request-context-store';
-
 // supertest v7 can cause websocket tests to hang without this
 setDefaultResultOrder('ipv4first');
 
@@ -46,7 +46,7 @@ export interface TestProjectOptions {
   superAdmin?: boolean;
   withClient?: boolean;
   withAccessToken?: boolean;
-  withRepo?: boolean | Partial<RepositoryContext>;
+  withRepo?: boolean;
 }
 
 type Exact<T, U extends T> = T & Record<Exclude<keyof U, keyof T>, never>;
@@ -59,7 +59,7 @@ export type TestProjectResult<T extends TestProjectOptions> = {
   membership: T['withClient'] extends true ? WithId<ProjectMembership> : undefined;
   login: T['withAccessToken'] extends true ? WithId<Login> : undefined;
   accessToken: T['withAccessToken'] extends true ? string : undefined;
-  repo: T['withRepo'] extends true | Partial<RepositoryContext> ? Repository : undefined;
+  repo: T['withRepo'] extends true ? Repository : undefined;
 };
 
 export async function createTestProject<T extends StrictTestProjectOptions<T> = TestProjectOptions>(
@@ -86,7 +86,7 @@ export async function createTestProject<T extends StrictTestProjectOptions<T> = 
 
   let client: WithId<ClientApplication> | undefined;
   let accessPolicy: AccessPolicy | undefined;
-  let membership: ProjectMembership | undefined;
+  let membership: WithId<ProjectMembership> | undefined;
   let login: WithId<Login> | undefined;
   let accessToken: string | undefined;
   let repo: Repository | undefined;
@@ -126,7 +126,7 @@ export async function createTestProject<T extends StrictTestProjectOptions<T> = 
       ...options?.membership,
     });
 
-    if (options?.withAccessToken) {
+    if (options?.withAccessToken || options?.withRepo) {
       const scope = 'openid';
 
       login = await systemRepo.createResource<Login>({
@@ -147,25 +147,11 @@ export async function createTestProject<T extends StrictTestProjectOptions<T> = 
         profile: client.resourceType + '/' + client.id,
         scope,
       });
-    }
 
-    if (options?.withRepo) {
-      const repoContext: RepositoryContext = {
-        projects: [project],
-        currentProject: project,
-        author: createReference(client),
-        superAdmin: options?.superAdmin,
-        projectAdmin: options?.membership?.admin,
-        accessPolicy,
-        strictMode: project.strictMode,
-        extendedMode: true,
-        checkReferencesOnWrite: project.checkReferencesOnWrite,
-      };
-
-      if (typeof options.withRepo === 'object') {
-        Object.assign(repoContext, options.withRepo);
+      if (options?.withRepo) {
+        const userConfig = { resourceType: 'UserConfiguration' } as const;
+        repo = await getRepoForLogin({ login, project, membership, userConfig }, true);
       }
-      repo = new Repository(repoContext);
     }
   }
 

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -47,6 +47,7 @@ export interface TestProjectOptions {
   withClient?: boolean;
   withAccessToken?: boolean;
   withRepo?: boolean;
+  extendedMode?: boolean;
 }
 
 type Exact<T, U extends T> = T & Record<Exclude<keyof U, keyof T>, never>;
@@ -150,7 +151,7 @@ export async function createTestProject<T extends StrictTestProjectOptions<T> = 
 
       if (options?.withRepo) {
         const userConfig = { resourceType: 'UserConfiguration' } as const;
-        repo = await getRepoForLogin({ login, project, membership, userConfig }, true);
+        repo = await getRepoForLogin({ login, project, membership, userConfig }, options?.extendedMode ?? true);
       }
     }
   }

--- a/packages/server/src/workers/download.test.ts
+++ b/packages/server/src/workers/download.test.ts
@@ -326,7 +326,7 @@ describe('Download Worker', () => {
 
   test('Stop retries if auto download disabled', () =>
     withTestContext(async () => {
-      const { project, repo } = await createTestProject({ withRepo: true });
+      const { project, repo } = await createTestProject({ withRepo: true, membership: { admin: true } });
 
       const media = await repo.createResource<Media>({
         resourceType: 'Media',
@@ -450,9 +450,9 @@ describe('Download Worker', () => {
       expect(afterSecondDownload.meta?.author?.reference).toBe('system');
     }));
 
-  test('Stop retries if auto download disabled', () =>
+  test('Stop retries if ignored url prefixes changes', () =>
     withTestContext(async () => {
-      const { project, repo } = await createTestProject({ withRepo: true });
+      const { project, repo } = await createTestProject({ withRepo: true, membership: { admin: true } });
 
       const media = await repo.createResource<Media>({
         resourceType: 'Media',
@@ -465,7 +465,7 @@ describe('Download Worker', () => {
       expect(media).toBeDefined();
 
       // At this point the job should be in the queue
-      // But let's disable auto download in the project
+      // But let's change the ignored URL prefixes in the project
       await repo.updateResource({
         ...project,
         setting: [{ name: 'autoDownloadIgnoredUrlPrefixes', valueString: 'https://example.com' }],

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -1694,7 +1694,7 @@ describe('Subscription Worker', () => {
       // This should trigger an error when the subscription is executed
       const accessPolicy = await repo.createResource<AccessPolicy>({
         resourceType: 'AccessPolicy',
-        resource: [{ resourceType: 'Patient', readonly: false }],
+        resource: [{ resourceType: 'Patient', readonly: false }, { resourceType: 'Subscription' }],
       });
 
       const { repo: apTestRepo } = await createTestProject({
@@ -1764,7 +1764,7 @@ describe('Subscription Worker', () => {
       // This should trigger an error when the subscription is executed
       const accessPolicy = await repo.createResource<AccessPolicy>({
         resourceType: 'AccessPolicy',
-        resource: [{ resourceType: 'Patient', criteria: `Patient?_id=${generateId()}` }],
+        resource: [{ resourceType: 'Patient' }, { resourceType: 'Subscription' }],
       });
 
       const { repo: apTestRepo } = await createTestProject({
@@ -2214,7 +2214,7 @@ describe('Subscription Worker', () => {
         // This should trigger an error when the subscription is executed
         const accessPolicy = await repo.createResource<AccessPolicy>({
           resourceType: 'AccessPolicy',
-          resource: [{ resourceType: 'Patient', criteria: `Patient?_id=${generateId()}` }],
+          resource: [{ resourceType: 'Patient' }, { resourceType: 'Subscription' }],
         });
 
         // Create an access policy in different project
@@ -2274,7 +2274,10 @@ describe('Subscription Worker', () => {
         // An access policy that restricts Patient to a specific ID that will never match our patient.
         const accessPolicy = await repo.createResource<AccessPolicy>({
           resourceType: 'AccessPolicy',
-          resource: [{ resourceType: 'Patient', criteria: `Patient?_id=${generateId()}` }],
+          resource: [
+            { resourceType: 'Patient', criteria: `Patient?_id=${generateId()}` },
+            { resourceType: 'Subscription' },
+          ],
         });
 
         // Create a project whose membership carries the denying access policy.
@@ -2316,8 +2319,9 @@ describe('Subscription Worker', () => {
         // any spurious WebSocket publish is caught immediately.
         const assertPromise = assertNoWsNotifications();
 
-        const patient = await testRepo.createResource<Patient>({
+        const patient = await superAdminRepo.createResource<Patient>({
           resourceType: 'Patient',
+          meta: { project: testProject.id },
           name: [{ given: ['Alice'], family: 'Smith' }],
         });
 
@@ -2338,7 +2342,7 @@ describe('Subscription Worker', () => {
 
         const accessPolicy = await superAdminRepo.createResource<AccessPolicy>({
           resourceType: 'AccessPolicy',
-          resource: [{ resourceType: 'Patient', readonly: true }, { resourceType: 'Subscription' }],
+          resource: [{ resourceType: 'Patient' }, { resourceType: 'Subscription' }],
         });
 
         const {
@@ -2402,7 +2406,7 @@ describe('Subscription Worker', () => {
 
         const accessPolicy = await superAdminRepo.createResource<AccessPolicy>({
           resourceType: 'AccessPolicy',
-          resource: [{ resourceType: 'Patient', readonly: true }, { resourceType: 'Subscription' }],
+          resource: [{ resourceType: 'Patient' }, { resourceType: 'Subscription' }],
         });
 
         const {


### PR DESCRIPTION
Linked Projects were originally used in a limited way (primarily for sharing reference data like `CodeSystem` and `ValueSet`). As usage has expanded, we’re refining how administrative resources are scoped and exposed across project boundaries.

Project admin resources are now scoped strictly to their originating project and are no longer visible via linked projects. This applies to:

* `ProjectMembership`
* `User`
* `UserSecurityRequest`

Notes:
* Linked Projects still provide read-only access to non-admin resources as before
* This aligns behavior with the intended project isolation model
* Projects can optionally configure exported resource types to explicitly control what is shared. We expect to make this required in the future as Linked Projects see broader use

--------

Notes to reviewers:

* The diff is big because I changed the behavior of `createTestProject()`, which is used all over the place
* Before, it made some assumptions and called `new Repository()` directly
* After, it uses `getRepoForLogin()` which makes it more representative of real world usage