### PR TITLE
Extract distinct functionality from `repo.ts`

### DIFF
--- a/packages/server/src/fhir/operations/clearallwssubs.ts
+++ b/packages/server/src/fhir/operations/clearallwssubs.ts
@@ -6,7 +6,7 @@ import type { OperationDefinition, Subscription } from '@medplum/fhirtypes';
 import { requireSuperAdmin } from '../../admin/super';
 import { getActiveSubsKey } from '../../pubsub';
 import { getCacheRedis, getPubSubRedis } from '../../redis';
-import type { CacheEntry } from '../repo';
+import type { CacheEntry } from '../repository/resource-cache';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
 const operation: OperationDefinition = {

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -35,8 +35,6 @@ import type {
 import { randomBytes, randomUUID } from 'crypto';
 import type { PoolClient } from 'pg';
 import { initAppServices, shutdownApp } from '../app';
-import type { RegisterRequest } from '../auth/register';
-import { registerNew } from '../auth/register';
 import { getConfig, loadTestConfig } from '../config/loader';
 import { r4ProjectId, systemResourceProjectId } from '../constants';
 import { DatabaseMode } from '../database';
@@ -692,23 +690,7 @@ describe('FHIR Repo', () => {
 
   test('Compartment permissions', () =>
     withTestContext(async () => {
-      const registration1: RegisterRequest = {
-        firstName: randomUUID(),
-        lastName: randomUUID(),
-        projectName: randomUUID(),
-        email: randomUUID() + '@example.com',
-        password: randomUUID(),
-      };
-
-      const result1 = await registerNew(registration1);
-      expect(result1.profile).toBeDefined();
-
-      const repo1 = await getRepoForLogin({
-        project: result1.project,
-        membership: result1.membership,
-        login: result1.login,
-        userConfig: {} as UserConfiguration,
-      });
+      const { repo: repo1 } = await createTestProject({ withRepo: true });
       const patient1 = await repo1.createResource<Patient>({
         resourceType: 'Patient',
       });
@@ -720,23 +702,7 @@ describe('FHIR Repo', () => {
       expect(patient2).toBeDefined();
       expect(patient2.id).toStrictEqual(patient1.id);
 
-      const registration2: RegisterRequest = {
-        firstName: randomUUID(),
-        lastName: randomUUID(),
-        projectName: randomUUID(),
-        email: randomUUID() + '@example.com',
-        password: randomUUID(),
-      };
-
-      const result2 = await registerNew(registration2);
-      expect(result2.profile).toBeDefined();
-
-      const repo2 = await getRepoForLogin({
-        project: result2.project,
-        membership: result2.membership,
-        login: result2.login,
-        userConfig: {} as UserConfiguration,
-      });
+      const { repo: repo2 } = await createTestProject({ withRepo: true });
       try {
         await repo2.readResource('Patient', patient1.id);
         fail('Should have thrown');
@@ -1881,30 +1847,13 @@ describe('FHIR Repo', () => {
         withRepo: true,
       });
 
-      const regRequest: RegisterRequest = {
-        firstName: randomUUID(),
-        lastName: randomUUID(),
-        projectName: randomUUID(),
-        email: randomUUID() + '@example.com',
-        password: randomUUID(),
-      };
-
-      const regResult = await registerNew(regRequest);
-      let project = regResult.project;
-
-      // add linkedProject to `Project.link`
-      project = await globalSystemRepo.updateResource({
-        ...project,
-        link: [{ project: createReference(linkedProject) }],
+      const { project, repo } = await createTestProject({
+        project: { link: [{ project: createReference(linkedProject) }] },
+        membership: { admin: true },
+        withRepo: true,
       });
 
-      const repo = await getRepoForLogin({
-        project,
-        membership: regResult.membership,
-        login: regResult.login,
-        userConfig: {} as UserConfiguration,
-      });
-
+      // Creating via linkedRepo warms the Redis cache for this resource.
       const linkedOrg = await linkedRepo.createResource<Organization>({
         resourceType: 'Organization',
         name: 'Linked Organization',
@@ -1941,52 +1890,12 @@ describe('FHIR Repo', () => {
       expect(orgs.length).toStrictEqual(2);
       expect(orgs.map((p) => p.id)).toContain(org.id);
       expect(orgs.map((p) => p.id)).toContain(linkedOrg.id);
-    }));
 
-  test('Project.exportedResourceType enforced on cached reads', () =>
-    withTestContext(async () => {
       // Regression: a non-exported resource in a linked project should not be
       // readable even when it is present in the Redis cache. Previously,
       // canPerformInteraction only checked project-compartment membership and
       // ignored the linked project's `exportedResourceType`, so the cache path
       // bypassed the filter enforced by addProjectFilters in SQL.
-      const { project: linkedProject, repo: linkedRepo } = await createTestProject({
-        project: { exportedResourceType: ['Organization'] },
-        withRepo: true,
-      });
-
-      const regRequest: RegisterRequest = {
-        firstName: randomUUID(),
-        lastName: randomUUID(),
-        projectName: randomUUID(),
-        email: randomUUID() + '@example.com',
-        password: randomUUID(),
-      };
-
-      const regResult = await registerNew(regRequest);
-      let project = regResult.project;
-      project = await globalSystemRepo.updateResource({
-        ...project,
-        link: [{ project: createReference(linkedProject) }],
-      });
-
-      const repo = await getRepoForLogin({
-        project,
-        membership: regResult.membership,
-        login: regResult.login,
-        userConfig: {} as UserConfiguration,
-      });
-
-      // Creating via linkedRepo warms the Redis cache for this resource.
-      const linkedOrg = await linkedRepo.createResource<Organization>({
-        resourceType: 'Organization',
-        name: 'Linked Organization',
-      });
-      const linkedPatient = await linkedRepo.createResource<Patient>({
-        resourceType: 'Patient',
-        name: [{ given: ['Linked'], family: 'Patient' }],
-        managingOrganization: createReference(linkedOrg),
-      });
 
       // Exported type: should still be readable from the linked project.
       const readOrg = await repo.readResource<Organization>('Organization', linkedOrg.id);

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -16,7 +16,6 @@ import {
   Operator,
   parseSearchRequest,
   preconditionFailed,
-  toTypedValue,
 } from '@medplum/core';
 import type {
   Binary,
@@ -58,14 +57,7 @@ import { AuditEventOutcome, createAuditEvent, ReadInteraction, RestfulOperationT
 import * as workersModule from '../workers';
 import { getRepoForLogin } from './accesspolicy';
 import type { ColumnValue } from './repo';
-import {
-  compareColumnValues,
-  getGlobalSystemRepo,
-  getProjectSystemRepo,
-  getShardSystemRepo,
-  Repository,
-  setTypedPropertyValue,
-} from './repo';
+import { compareColumnValues, getGlobalSystemRepo, getProjectSystemRepo, getShardSystemRepo, Repository } from './repo';
 import { RepositoryConnection } from './repository/repository-connection';
 import { PostgresError, SelectQuery } from './sql';
 
@@ -1821,24 +1813,6 @@ describe('FHIR Repo', () => {
       expect(results).toHaveLength(0);
     }));
 
-  test('setTypedValue', () => {
-    const patient: Patient = {
-      resourceType: 'Patient',
-      photo: [
-        {
-          contentType: 'image/png',
-          url: 'https://example.com/photo.png',
-        },
-        {
-          contentType: 'image/png',
-          data: 'base64data',
-        },
-      ],
-    };
-
-    setTypedPropertyValue(toTypedValue(patient), 'photo[1].contentType', { type: 'string', value: 'image/jpeg' });
-    expect(patient.photo?.[1].contentType).toStrictEqual('image/jpeg');
-  });
   async function getProjectIdColumn(id: string): Promise<string | null> {
     const projectIdQuery = new SelectQuery('User').column('projectId').where('id', '=', id);
     const client = systemRepo.getDatabaseClient(DatabaseMode.WRITER);

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -18,9 +18,7 @@ import {
 import type {
   Binary,
   BundleEntry,
-  ElementDefinition,
   Login,
-  Observation,
   OperationOutcome,
   Organization,
   Patient,
@@ -31,15 +29,10 @@ import type {
   ResearchDefinition,
   ResourceType,
   ServiceRequest,
-  StructureDefinition,
   User,
   UserConfiguration,
-  ValueSet,
 } from '@medplum/fhirtypes';
 import { randomBytes, randomUUID } from 'crypto';
-import { readFileSync } from 'fs';
-import assert from 'node:assert';
-import { resolve } from 'path';
 import type { PoolClient } from 'pg';
 import { initAppServices, shutdownApp } from '../app';
 import type { RegisterRequest } from '../auth/register';
@@ -65,10 +58,6 @@ describe('FHIR Repo', () => {
 
   let testProjectRepo: Repository;
   let systemRepo: Repository;
-
-  const usCorePatientProfile = JSON.parse(
-    readFileSync(resolve(__dirname, '__test__/us-core-patient.json'), 'utf8')
-  ) as StructureDefinition;
 
   beforeAll(async () => {
     const config = await loadTestConfig();
@@ -1200,183 +1189,6 @@ describe('FHIR Repo', () => {
     await expect(systemRepo.updateResource({ resourceType: 'Patient', id: '123' })).rejects.toThrow('Invalid id');
   });
 
-  test('Profile validation', async () =>
-    withTestContext(async () => {
-      const { repo } = await createTestProject({ withRepo: true });
-
-      const profile = { ...usCorePatientProfile, url: 'urn:uuid:' + randomUUID() };
-      const patient: Patient = {
-        resourceType: 'Patient',
-        meta: {
-          profile: [profile.url],
-        },
-        identifier: [
-          {
-            system: 'http://example.com/patient-id',
-            value: 'foo',
-          },
-        ],
-        name: [
-          {
-            given: ['Alex'],
-            family: 'Baker',
-          },
-        ],
-        // Missing gender property is required by profile
-      };
-
-      await expect(repo.createResource(patient)).resolves.toBeTruthy();
-      await repo.createResource(profile);
-      await expect(repo.createResource(patient)).rejects.toThrow(
-        new Error('Missing required property (Patient.gender)')
-      );
-    }));
-
-  test('Profile update', async () =>
-    withTestContext(async () => {
-      const { repo } = await createTestProject({ withRepo: true });
-
-      const profile = await repo.createResource({
-        ...usCorePatientProfile,
-        url: 'urn:uuid:' + randomUUID(),
-      });
-
-      const patient: Patient = {
-        resourceType: 'Patient',
-        meta: { profile: [profile.url] },
-        identifier: [{ system: 'http://example.com/patient-id', value: 'foo' }],
-        name: [{ given: ['Alex'], family: 'Baker' }],
-        gender: 'male',
-      };
-
-      // Create the patient
-      // This should succeed
-      await expect(repo.createResource(patient)).resolves.toBeTruthy();
-
-      // Now update the profile to make "address" a required field
-      await repo.updateResource<StructureDefinition>({
-        ...profile,
-        snapshot: {
-          ...profile.snapshot,
-          element: profile.snapshot?.element?.map((e) => {
-            if (e.path === 'Patient.address') {
-              return {
-                ...e,
-                min: 1,
-              };
-            }
-            return e;
-          }) as ElementDefinition[],
-        },
-      });
-
-      // Now try to create another patient without an address
-      // This should fail
-      await expect(repo.createResource(patient)).rejects.toThrow(
-        new Error('Missing required property (Patient.address)')
-      );
-    }));
-
-  describe('Update resource with terminology validation', () => {
-    const patient: Patient = {
-      resourceType: 'Patient',
-      identifier: [{ use: 'usual', system: 'urn:oid:1.2.36.146.595.217.0.1', value: '12345' }],
-      active: true,
-      name: [
-        { use: 'official', family: 'Chalmers', given: ['Peter', 'James'] },
-        { use: 'usual', given: ['Jim'] },
-        { use: 'maiden', family: 'Windsor', given: ['Peter', 'James'] },
-      ],
-      telecom: [
-        { use: 'home', system: 'url', value: 'http://example.com' },
-        { system: 'phone', value: '(03) 5555 6473', use: 'work', rank: 1 },
-        { system: 'phone', value: '(03) 3410 5613', use: 'mobile', rank: 2 },
-        { system: 'phone', value: '(03) 5555 8834', use: 'old' },
-      ],
-      gender: 'male',
-      birthDate: '1974-12-25',
-      address: [{ use: 'home', type: 'both', text: '534 Erewhon St PeasantVille, Rainbow, Vic  3999' }],
-      contact: [
-        {
-          name: { use: 'usual', family: 'du Marché', given: ['Bénédicte'] },
-          telecom: [{ system: 'phone', value: '+33 (237) 998327', use: 'home' }],
-          address: { use: 'home', type: 'both', line: ['534 Erewhon St'], city: 'PleasantVille', postalCode: '3999' },
-          gender: 'female',
-        },
-      ],
-      communication: [{ language: { coding: [{ system: 'urn:ietf:bcp:47', code: 'en' }] } }],
-    };
-
-    let repo: Repository;
-    let profile: StructureDefinition;
-    beforeAll(async () => {
-      const result = await createTestProject({ withRepo: true, project: { features: ['validate-terminology'] } });
-      repo = result.repo;
-
-      // Create modified US Core Patient profile to have 'required' binding for communication.language
-      const modifiedPatientProfile = JSON.parse(
-        readFileSync(resolve(__dirname, '__test__/us-core-patient.json'), 'utf8')
-      ) as StructureDefinition;
-
-      const commLang = modifiedPatientProfile.snapshot?.element.find((e) => e.id === 'Patient.communication.language');
-      assert(commLang?.binding?.valueSet === 'http://hl7.org/fhir/us/core/ValueSet/simple-language');
-      assert(commLang.binding.strength === 'extensible');
-      commLang.binding.strength = 'required';
-
-      profile = await repo.createResource({
-        ...modifiedPatientProfile,
-        url: 'urn:uuid:' + randomUUID(),
-      });
-
-      // Create a ValueSet for the US Core Patient profile that includes only 'en' as a valid language
-      await repo.createResource<ValueSet>({
-        resourceType: 'ValueSet',
-        url: 'http://hl7.org/fhir/us/core/ValueSet/simple-language',
-        expansion: {
-          timestamp: new Date().toISOString(),
-          contains: [
-            {
-              system: 'urn:ietf:bcp:47',
-              code: 'en',
-            },
-          ],
-        },
-        status: 'active',
-      });
-    });
-    test('Valid patient without any profiles', async () =>
-      withTestContext(async () => {
-        await expect(repo.createResource(patient)).resolves.toBeDefined();
-      }));
-
-    test('Invalid gender', async () =>
-      withTestContext(async () => {
-        await expect(
-          repo.createResource({ ...patient, gender: 'enby' as unknown as Patient['gender'] })
-        ).rejects.toThrow(
-          `Value "enby" did not satisfy terminology binding http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1 (Patient.gender)`
-        );
-      }));
-
-    test('Valid patient with US Core Patient profile', async () =>
-      withTestContext(async () => {
-        await expect(repo.createResource({ ...patient, meta: { profile: [profile.url] } })).resolves.toBeDefined();
-      }));
-
-    test('Invalid patient with US Core Patient profile (communication.language not in ValueSet)', async () =>
-      withTestContext(async () => {
-        await expect(
-          repo.createResource({
-            ...patient,
-            meta: { profile: [profile.url] },
-            communication: [{ language: { coding: [{ system: 'urn:ietf:bcp:47', code: 'fr' }] } }],
-          })
-        ).rejects.toThrow(
-          `Value {"coding":[{"system":"urn:ietf:bcp:47","code":"fr"}]} did not satisfy terminology binding http://hl7.org/fhir/us/core/ValueSet/simple-language (Patient.communication[0].language)`
-        );
-      }));
-  });
-
   test('Conditional update', () =>
     withTestContext(async () => {
       const mrn = randomUUID();
@@ -1548,40 +1360,6 @@ describe('FHIR Repo', () => {
         ],
       } as unknown as ServiceRequest;
       await expect(systemRepo.createResource(serviceRequest)).rejects.toThrow(/^Expected single .*?performerType\)$/);
-    }));
-
-  test('Project default profiles', async () =>
-    withTestContext(async () => {
-      const { repo } = await createTestProject({
-        withClient: true,
-        withRepo: true,
-        project: {
-          defaultProfile: [
-            { resourceType: 'Observation', profile: ['http://hl7.org/fhir/StructureDefinition/vitalsigns'] },
-          ],
-        },
-      });
-
-      const observation: Observation = {
-        resourceType: 'Observation',
-        status: 'final',
-        category: [
-          { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'vital-signs' }] },
-        ],
-        code: { text: 'Strep test' },
-        effectiveDateTime: '2024-02-13T14:34:56Z',
-        valueBoolean: true,
-      };
-
-      await expect(systemRepo.createResource(observation)).resolves.toBeDefined();
-      await expect(repo.createResource(observation)).rejects.toThrow('Missing required property (Observation.subject)');
-
-      observation.subject = { identifier: { value: randomUUID() } };
-      await expect(repo.createResource(observation)).resolves.toMatchObject<Partial<Observation>>({
-        meta: expect.objectContaining({
-          profile: ['http://hl7.org/fhir/StructureDefinition/vitalsigns'],
-        }),
-      });
     }));
 
   test('Prevents setting Project compartments', async () =>

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -1852,66 +1852,6 @@ describe('FHIR Repo', () => {
       expect(await getProjectIdColumn(user3.id)).toStrictEqual(systemResourceProjectId);
     }));
 
-  test('Handles caching of profile from linked project', async () =>
-    withTestContext(async () => {
-      const { membership, project } = await registerNew({
-        firstName: randomUUID(),
-        lastName: randomUUID(),
-        projectName: randomUUID(),
-        email: randomUUID() + '@example.com',
-        password: randomUUID(),
-      });
-
-      const { membership: membership2, project: project2 } = await registerNew({
-        firstName: randomUUID(),
-        lastName: randomUUID(),
-        projectName: randomUUID(),
-        email: randomUUID() + '@example.com',
-        password: randomUUID(),
-      });
-      const updatedProject = await globalSystemRepo.updateResource({
-        ...project,
-        link: [{ project: createReference(project2) }],
-      });
-
-      const repo2 = await getRepoForLogin({
-        login: {} as Login,
-        membership: membership2,
-        project: project2,
-        userConfig: {} as UserConfiguration,
-      });
-      const profile = await repo2.createResource({ ...usCorePatientProfile, url: 'urn:uuid:' + randomUUID() });
-
-      const patientJson: Patient = {
-        resourceType: 'Patient',
-        meta: {
-          profile: [profile.url],
-        },
-      };
-
-      // Resource upload should fail with profile linked
-      let repo = await getRepoForLogin({
-        login: {} as Login,
-        membership,
-        project: updatedProject,
-        userConfig: {} as UserConfiguration,
-      });
-      await expect(repo.createResource(patientJson)).rejects.toThrow(/Missing required property/);
-
-      // Unlink Project and verify that profile is not cached; resource upload should succeed without access to profile
-      const unlinkedProject = await systemRepo.updateResource({
-        ...updatedProject,
-        link: undefined,
-      });
-      repo = await getRepoForLogin({
-        login: {} as Login,
-        membership,
-        project: unlinkedProject,
-        userConfig: {} as UserConfiguration,
-      });
-      await expect(repo.createResource(patientJson)).resolves.toBeDefined();
-    }));
-
   test('Retry after create should not execute post-commit hooks from rollback', () =>
     withTestContext(async () => {
       const { repo } = await createTestProject({ withRepo: true });

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -4,10 +4,8 @@ import type { WithId } from '@medplum/core';
 import {
   allOk,
   badRequest,
-  ContentType,
   created,
   createReference,
-  encodeBase64,
   getReferenceString,
   isOk,
   normalizeErrorString,
@@ -20,7 +18,6 @@ import {
 import type {
   Binary,
   BundleEntry,
-  DocumentReference,
   ElementDefinition,
   Login,
   Observation,
@@ -48,18 +45,17 @@ import { initAppServices, shutdownApp } from '../app';
 import type { RegisterRequest } from '../auth/register';
 import { registerNew } from '../auth/register';
 import { getConfig, loadTestConfig } from '../config/loader';
-import type { ArrayColumnPaddingConfig, MedplumServerConfig } from '../config/types';
 import { r4ProjectId, systemResourceProjectId } from '../constants';
-import { DatabaseMode, getDatabasePool } from '../database';
+import { DatabaseMode } from '../database';
 import { getLogger } from '../logger';
 import { bundleContains, createTestProject, withTestContext } from '../test.setup';
 import { AuditEventOutcome, createAuditEvent, ReadInteraction, RestfulOperationType } from '../util/auditevent';
 import * as workersModule from '../workers';
 import { getRepoForLogin } from './accesspolicy';
-import type { ColumnValue } from './repo';
-import { compareColumnValues, getGlobalSystemRepo, getProjectSystemRepo, getShardSystemRepo, Repository } from './repo';
+import { getGlobalSystemRepo, getProjectSystemRepo, getShardSystemRepo, Repository } from './repo';
 import { RepositoryConnection } from './repository/repository-connection';
 import { PostgresError, SelectQuery } from './sql';
+import * as tokenColumnModule from './token-column';
 
 jest.mock('hibp');
 
@@ -849,7 +845,8 @@ describe('FHIR Repo', () => {
       identifier: [{ system: 'https://example.com/', value: 'some-value' }],
     });
 
-    const buildColumnSpy = jest.spyOn(Repository.prototype as any, 'buildColumn').mockImplementation(() => {
+    // rely on Patient having a search parameter with token-column strategy
+    const buildTokenColumnsSpy = jest.spyOn(tokenColumnModule, 'buildTokenColumns').mockImplementation(() => {
       throw new Error('test error');
     });
     const logger = getLogger();
@@ -865,7 +862,7 @@ describe('FHIR Repo', () => {
       err: expect.any(Error),
     });
 
-    buildColumnSpy.mockRestore();
+    buildTokenColumnsSpy.mockRestore();
     errorSpy.mockRestore();
   });
 
@@ -1454,215 +1451,6 @@ describe('FHIR Repo', () => {
       await systemRepo.deleteResource(patient.resourceType, patient.id);
       await expect(systemRepo.deleteResource(patient.resourceType, patient.id)).resolves.toBeUndefined();
     }));
-
-  describe('Array column padding', () => {
-    let prevConfig: string | undefined;
-    beforeEach(() => {
-      const config = getConfig();
-      prevConfig = config.arrayColumnPadding && JSON.stringify(config.arrayColumnPadding);
-    });
-
-    afterEach(() => {
-      if (prevConfig) {
-        const config = getConfig();
-        config.arrayColumnPadding = JSON.parse(prevConfig);
-      }
-    });
-
-    const ENSURE_PADDING: ArrayColumnPaddingConfig = {
-      m: 1,
-      lambda: 300,
-      statisticsTarget: 1,
-    };
-
-    test.each([
-      ['no config', undefined, false], // off by default
-      [
-        'no resourceType array',
-        {
-          identifier: {
-            config: ENSURE_PADDING,
-          },
-        },
-        true,
-      ],
-      [
-        'resourceType in the resourceType array',
-        {
-          identifier: {
-            resourceType: ['Patient', 'Observation'],
-            config: ENSURE_PADDING,
-          },
-        },
-        true,
-      ],
-      [
-        'resourceType NOT in the resourceType array',
-        {
-          identifier: {
-            resourceType: ['Patient'],
-            config: ENSURE_PADDING,
-          },
-        },
-        false,
-      ],
-      [
-        'array with entry with no resourceType array in second element',
-        {
-          identifier: [
-            {
-              resourceType: ['Task'],
-              config: ENSURE_PADDING,
-            },
-            {
-              config: ENSURE_PADDING,
-            },
-          ],
-        },
-        true,
-      ],
-      [
-        'array with resourceType in second entry resourceType array',
-        {
-          identifier: [
-            {
-              resourceType: ['Patient'],
-              config: ENSURE_PADDING,
-            },
-            {
-              resourceType: ['Task', 'Observation'],
-              config: ENSURE_PADDING,
-            },
-          ],
-        },
-        true,
-      ],
-      [
-        'array with resourceType NOT in any resourceType array',
-        {
-          identifier: [
-            {
-              resourceType: ['Patient'],
-              config: ENSURE_PADDING,
-            },
-            {
-              resourceType: ['Task'],
-              config: ENSURE_PADDING,
-            },
-          ],
-        },
-        false,
-      ],
-    ])('with %s', async (_desc, arrayColumnPadding: MedplumServerConfig['arrayColumnPadding'] | undefined, shouldPad) =>
-      withTestContext(async () => {
-        const config = getConfig();
-        if (arrayColumnPadding) {
-          config.arrayColumnPadding = arrayColumnPadding;
-        }
-        const res = await systemRepo.createResource<Observation>({
-          resourceType: 'Observation',
-          status: 'unknown',
-          code: { coding: [{ system: 'http://loinc.org', code: '72166-2', display: 'Test Observation' }] },
-        });
-
-        const db = getDatabasePool(DatabaseMode.READER);
-        const results = await db.query('SELECT "__identifier" FROM "Observation" WHERE "id" = $1', [res.id]);
-        if (shouldPad) {
-          expect(results.rows).toStrictEqual([{ __identifier: ['00000000-0000-0000-0000-000000000000'] }]);
-        } else {
-          expect(results.rows).toStrictEqual([{ __identifier: [] }]);
-        }
-
-        // deleted rows also get padded
-        await systemRepo.deleteResource(res.resourceType, res.id);
-
-        if (shouldPad) {
-          expect(results.rows).toStrictEqual([{ __identifier: ['00000000-0000-0000-0000-000000000000'] }]);
-        } else {
-          expect(results.rows).toStrictEqual([{ __identifier: [] }]);
-        }
-      })
-    );
-  });
-
-  describe('Array column value sorting', () => {
-    test('stores multi-valued reference column in sorted order (DocumentReference.author)', () =>
-      withTestContext(async () => {
-        const authorRefs = [
-          'Practitioner/zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz',
-          'Patient/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-          'Practitioner/11111111-1111-1111-1111-111111111111',
-        ];
-        const expected = [...authorRefs].sort(compareColumnValues);
-
-        const doc = await systemRepo.createResource<DocumentReference>({
-          resourceType: 'DocumentReference',
-          status: 'current',
-          content: [{ attachment: { url: 'https://example.com/doc.pdf' } }],
-          author: [{ reference: authorRefs[0] }, { reference: authorRefs[1] }, { reference: authorRefs[2] }],
-        });
-
-        const db = getDatabasePool(DatabaseMode.READER);
-        const results = await db.query('SELECT "author" FROM "DocumentReference" WHERE "id" = $1', [doc.id]);
-        expect(results.rows).toStrictEqual([{ author: expected }]);
-      }));
-
-    test('same reference values in different resource order yield identical stored array', () =>
-      withTestContext(async () => {
-        const a = 'Patient/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
-        const b = 'Practitioner/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
-        const expected = [a, b].sort(compareColumnValues);
-
-        const doc1 = await systemRepo.createResource<DocumentReference>({
-          resourceType: 'DocumentReference',
-          status: 'current',
-          content: [{ attachment: { url: 'https://example.com/a.pdf' } }],
-          author: [{ reference: b }, { reference: a }],
-        });
-        const doc2 = await systemRepo.createResource<DocumentReference>({
-          resourceType: 'DocumentReference',
-          status: 'current',
-          content: [{ attachment: { url: 'https://example.com/b.pdf' } }],
-          author: [{ reference: a }, { reference: b }],
-        });
-
-        const db = getDatabasePool(DatabaseMode.READER);
-        const r1 = await db.query('SELECT "author" FROM "DocumentReference" WHERE "id" = $1', [doc1.id]);
-        const r2 = await db.query('SELECT "author" FROM "DocumentReference" WHERE "id" = $1', [doc2.id]);
-        expect(r1.rows).toStrictEqual([{ author: expected }]);
-        expect(r2.rows).toStrictEqual([{ author: expected }]);
-      }));
-
-    test('stores multi-valued quantity column in sorted order (Observation.component)', () =>
-      withTestContext(async () => {
-        const values = [100.5, 3.14, 42];
-        const expected = [...values].sort(compareColumnValues);
-
-        const obs = await systemRepo.createResource<Observation>({
-          resourceType: 'Observation',
-          status: 'final',
-          code: { text: 'component quantity sort test' },
-          component: [
-            {
-              code: { text: 'first' },
-              valueQuantity: { value: values[0], unit: '1', system: 'http://unitsofmeasure.org', code: '1' },
-            },
-            {
-              code: { text: 'second' },
-              valueQuantity: { value: values[1], unit: '1', system: 'http://unitsofmeasure.org', code: '1' },
-            },
-            {
-              code: { text: 'third' },
-              valueQuantity: { value: values[2], unit: '1', system: 'http://unitsofmeasure.org', code: '1' },
-            },
-          ],
-        });
-
-        const db = getDatabasePool(DatabaseMode.READER);
-        const results = await db.query('SELECT "componentValueQuantity" FROM "Observation" WHERE "id" = $1', [obs.id]);
-        expect(results.rows).toStrictEqual([{ componentValueQuantity: expected }]);
-      }));
-  });
 
   test('Conditional reference resolution', async () =>
     withTestContext(async () => {
@@ -2450,37 +2238,6 @@ describe('FHIR Repo', () => {
       expect(readPatient.id).toStrictEqual(patient.id);
     }));
 
-  test('Binary writes no search parameter columns', () =>
-    withTestContext(async () => {
-      const { project, repo } = await createTestProject({ withClient: true, withRepo: true });
-      const buildResourceRowSpy = jest.spyOn(Repository.prototype as any, 'buildResourceRow');
-      const binary = await repo.createResource<Binary>({
-        resourceType: 'Binary',
-        contentType: ContentType.TEXT,
-        data: encodeBase64('this is some test data'),
-        meta: {
-          tag: [{ system: 'https://example.com', code: 'tag' }],
-          security: [{ system: 'https://example.com', code: 'security' }],
-        },
-      });
-      expect(binary).toBeDefined();
-      expect(binary.id).toBeDefined();
-
-      expect(buildResourceRowSpy).toHaveBeenCalledTimes(1);
-      const binaryRow = buildResourceRowSpy.mock.results[0].value as Record<string, any>;
-
-      expect(binaryRow).toStrictEqual({
-        id: binary.id,
-        lastUpdated: expect.any(String),
-        deleted: false,
-        projectId: project.id,
-        content: expect.any(String),
-        __version: Repository.VERSION,
-      });
-
-      buildResourceRowSpy.mockRestore();
-    }));
-
   test('constructor and clone add the synthetic R4 project only once to shared context', () => {
     const project: WithId<Project> = {
       resourceType: 'Project',
@@ -2518,136 +2275,6 @@ describe('FHIR Repo', () => {
       });
       expect(checked).toBe(true);
     }));
-});
-
-describe('compareColumnValues', () => {
-  describe('returns 0 when a === b', () => {
-    test.each<[ColumnValue, ColumnValue]>([
-      [null, null],
-      [undefined, undefined],
-      ['Patient/1', 'Patient/1'],
-      ['https://example.org/fhir/Patient/abc', 'https://example.org/fhir/Patient/abc'],
-      ['', ''],
-      [' ', ' '],
-      [0, 0],
-      [-0, 0],
-      [3.14, 3.14],
-      [-100, -100],
-      [Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
-      [Number.MIN_SAFE_INTEGER, Number.MIN_SAFE_INTEGER],
-      [true, true],
-      [false, false],
-    ])('compareColumnValues(%p, %p) === 0', (a, b) => {
-      expect(compareColumnValues(a, b)).toBe(0);
-    });
-  });
-
-  describe('returns 1 when a is null or undefined and b is defined', () => {
-    test.each<[ColumnValue, ColumnValue]>([
-      [null, 'x'],
-      [undefined, 'x'],
-      [null, ''],
-      [undefined, ''],
-      [null, ' '],
-      [undefined, 'Patient/1'],
-      [null, 0],
-      [undefined, 0],
-      [null, -1],
-      [undefined, 3.14],
-      [undefined, Number.NaN],
-      [null, Number.POSITIVE_INFINITY],
-      [undefined, Number.MIN_SAFE_INTEGER],
-      [null, false],
-      [undefined, true],
-    ])('compareColumnValues(%p, %p) === 1', (a, b) => {
-      expect(compareColumnValues(a, b)).toBe(1);
-    });
-  });
-
-  describe('null and undefined are equal', () => {
-    test.each<[ColumnValue, ColumnValue, 0]>([
-      [null, undefined, 0],
-      [undefined, null, 0],
-    ])('compareColumnValues(%p, %p) === %s', (a, b, expected) => {
-      expect(compareColumnValues(a, b)).toBe(expected);
-    });
-  });
-
-  describe('returns -1 when b is null or undefined and a is defined', () => {
-    test.each<[ColumnValue, ColumnValue]>([
-      ['x', null],
-      ['x', undefined],
-      ['', null],
-      ['Patient/1', undefined],
-      [0, null],
-      [0, undefined],
-      [-1, undefined],
-      [3.14, null],
-      [Number.NaN, null],
-      [Number.POSITIVE_INFINITY, undefined],
-      [false, null],
-      [true, undefined],
-    ])('compareColumnValues(%p, %p) === -1', (a, b) => {
-      expect(compareColumnValues(a, b)).toBe(-1);
-    });
-  });
-
-  describe('returns a - b when both operands are numbers', () => {
-    test.each<[number, number, number]>([
-      [1, 2, -1],
-      [2, 1, 1],
-      [0, -1, 1],
-      [-1, -2, 1],
-      [-1, 1, -2],
-      [100, 50, 50],
-      [Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER - 1, 1],
-      [Number.MIN_SAFE_INTEGER, Number.MIN_SAFE_INTEGER + 1, -1],
-      [0, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY],
-      [Number.POSITIVE_INFINITY, 0, Number.POSITIVE_INFINITY],
-      [Number.NEGATIVE_INFINITY, 0, Number.NEGATIVE_INFINITY],
-      [0, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY],
-    ])('compareColumnValues(%p, %p) === %p', (a, b, expected) => {
-      expect(compareColumnValues(a, b)).toBe(expected);
-    });
-
-    test('NaN arithmetic and negative minus positive infinity', () => {
-      expect(compareColumnValues(Number.NaN, 1)).toBeNaN();
-      expect(compareColumnValues(1, Number.NaN)).toBeNaN();
-      expect(compareColumnValues(Number.NaN, Number.NaN)).toBeNaN();
-      expect(compareColumnValues(Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY)).toBe(Number.NEGATIVE_INFINITY);
-    });
-  });
-
-  describe('returns Number(a) - Number(b) when both operands are booleans', () => {
-    test.each<[boolean, boolean, number]>([
-      [false, true, -1],
-      [true, false, 1],
-    ])('compareColumnValues(%p, %p) === %p', (a, b, expected) => {
-      expect(compareColumnValues(a, b)).toBe(expected);
-    });
-  });
-
-  describe('uses String(a).localeCompare(String(b)) when types are not both number or both boolean', () => {
-    test.each<[ColumnValue, ColumnValue]>([
-      ['apple', 'banana'],
-      ['banana', 'apple'],
-      ['', 'z'],
-      ['a', 'Z'],
-      ['prefix', 'prefixLonger'],
-      ['Observation/10', 'Observation/2'],
-      [1, '2'],
-      [0, '0'],
-      [-5, '5'],
-      [true, 'false'],
-      [false, '0'],
-      [1, true],
-      [0, false],
-      [false, 0],
-      [true, 1],
-    ])('compareColumnValues(%p, %p) matches localeCompare', (a, b) => {
-      expect(compareColumnValues(a, b)).toBe(String(a).localeCompare(String(b)));
-    });
-  });
 });
 
 function shuffleString(s: string): string {

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1,13 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type {
-  BackgroundJobInteraction,
-  Filter,
-  SearchRequest,
-  TypedValueWithPath,
-  ValidatorOptions,
-  WithId,
-} from '@medplum/core';
+import type { BackgroundJobInteraction, Filter, SearchRequest, WithId } from '@medplum/core';
 import {
   AccessPolicyInteraction,
   accessPolicySupportsInteraction,
@@ -22,7 +15,6 @@ import {
   extractAccountReferences,
   forbidden,
   formatSearchQuery,
-  getReferenceString,
   getStatus,
   gone,
   isGone,
@@ -36,7 +28,6 @@ import {
   normalizeOperationOutcome,
   notFound,
   OperationOutcomeError,
-  Operator,
   parseReference,
   parseSearchRequest,
   preconditionFailed,
@@ -47,7 +38,6 @@ import {
   satisfiedAccessPolicy,
   sleep,
   stringify,
-  validateResource,
   validateResourceType,
 } from '@medplum/core';
 import type {
@@ -63,17 +53,12 @@ import type {
   Binary,
   Bundle,
   BundleEntry,
-  CodeableConcept,
-  Coding,
   Meta,
   OperationOutcome,
-  OperationOutcomeIssue,
   Project,
   Reference,
   Resource,
   ResourceType,
-  StructureDefinition,
-  ValueSet,
 } from '@medplum/fhirtypes';
 import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
@@ -114,18 +99,16 @@ import { addBackgroundJobs } from '../workers';
 import { addSubscriptionJobs } from '../workers/subscription';
 import { checkWebSocketSubscriptionLimit } from '../ws/subscriptions';
 import type { FhirRateLimiter } from './fhirquota';
-import { validateResourceWithJsonSchema } from './jsonschema';
 import { clamp } from './operations/utils/parameters';
-import { findTerminologyResource } from './operations/utils/terminology';
-import { validateCodingInValueSet } from './operations/valuesetvalidatecode';
 import { getPatients } from './patient';
 import { preCommitValidation } from './precommit';
 import { replaceConditionalReferences, validateResourceReferences } from './references';
 import { removeField } from './repository/field-utils';
-import { cacheProfile, getCachedProfile, removeCachedProfile } from './repository/profile-cache';
+import { removeCachedProfile } from './repository/profile-cache';
 import type { StatementTimeoutOptions } from './repository/repository-connection';
 import { RepositoryConnection } from './repository/repository-connection';
 import { buildDeletedResourceRow, buildResourceRow } from './repository/row-builder';
+import { validateRepositoryResource } from './repository/validation';
 import type { ResourceCap } from './resource-cap';
 import { getFullUrl } from './response';
 import { rewriteAttachments, RewriteMode } from './rewrite';
@@ -846,7 +829,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     resultMeta.compartment = this.getCompartments(result);
 
     // Validate resource after all modifications and touchups above are done
-    await this.validateResource(result);
+    await validateRepositoryResource(this, result);
     // If this is a Subscription resource we are creating, we want to make sure the user is not over their per-user limit
     if (create && result.resourceType === 'Subscription' && result.channel?.type === 'websocket') {
       const projectId = result.meta?.project;
@@ -972,191 +955,6 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     if (resource.resourceType === 'StructureDefinition') {
       await removeCachedProfile(resource);
     }
-  }
-
-  /**
-   * Validates a resource against the current project configuration.
-   * If strict mode is enabled (default), validates against base StructureDefinition and all profiles.
-   * If strict mode is disabled, validates against the legacy JSONSchema validator.
-   * Throws on validation errors.
-   * Returns silently on success.
-   * @param resource - The candidate resource to validate.
-   */
-  async validateResource(resource: Resource): Promise<void> {
-    if (this.context.strictMode) {
-      await this.validateResourceStrictly(resource);
-    } else {
-      // Perform loose validation first to detect any severe issues
-      validateResourceWithJsonSchema(resource);
-
-      // Attempt strict validation and log warnings on failure
-      try {
-        await this.validateResourceStrictly(resource);
-      } catch (err: any) {
-        getLogger().warn('Strict validation would fail', {
-          resource: getReferenceString(resource),
-          err,
-        });
-      }
-    }
-  }
-
-  async validateResourceStrictly(resource: Resource): Promise<void> {
-    const logger = getLogger();
-    const start = process.hrtime.bigint();
-
-    // Prepare validator options
-    let options: ValidatorOptions | undefined;
-    if (this.context.validateTerminology) {
-      const tokens = Object.create(null);
-      options = { ...options, collect: { tokens } };
-    }
-
-    // Validate resource against base FHIR spec
-    const issues = validateResource(resource, { ...options, base64BinaryMaxBytes: getConfig().base64BinaryMaxBytes });
-
-    for (const issue of issues) {
-      logger.warn(`Validator warning: ${issue.details?.text}`, { project: this.context.projects?.[0]?.id, issue });
-    }
-
-    // Validate profiles after verifying compliance with base spec
-    const profileUrls = resource.meta?.profile;
-    if (profileUrls) {
-      await this.validateProfiles(resource, profileUrls, options);
-    }
-
-    // (Optionally) check any required terminology bindings found
-    if (this.context.validateTerminology && options?.collect?.tokens) {
-      await this.validateTerminology(options.collect.tokens, issues);
-      if (issues.some((iss) => iss.severity === 'error')) {
-        throw new OperationOutcomeError({ resourceType: 'OperationOutcome', issue: issues });
-      }
-    }
-
-    // Track latency for successful validation
-    const durationMs = Number(process.hrtime.bigint() - start) / 1e6; // Convert nanoseconds to milliseconds
-    recordHistogramValue('medplum.server.validationDurationMs', durationMs, { options: { unit: 'ms' } });
-    if (durationMs > 10) {
-      logger.debug('High validator latency', {
-        resourceType: resource.resourceType,
-        id: resource.id,
-        durationMs,
-      });
-    }
-  }
-
-  private async validateProfiles(resource: Resource, profileUrls: string[], options?: ValidatorOptions): Promise<void> {
-    const logger = getLogger();
-    for (const url of profileUrls) {
-      const loadStart = process.hrtime.bigint();
-      const profile = await this.loadProfile(url);
-      const loadTime = Number(process.hrtime.bigint() - loadStart);
-      if (!profile) {
-        logger.warn('Unknown profile referenced', {
-          resource: `${resource.resourceType}/${resource.id}`,
-          url,
-        });
-        continue;
-      }
-
-      const validateStart = process.hrtime.bigint();
-      validateResource(resource, { ...options, profile });
-      const validateTime = Number(process.hrtime.bigint() - validateStart);
-      logger.debug('Profile loaded', {
-        url,
-        loadTime,
-        validateTime,
-      });
-    }
-  }
-
-  private async validateTerminology(
-    tokens: Record<string, TypedValueWithPath[]>,
-    issues: OperationOutcomeIssue[]
-  ): Promise<void> {
-    for (const [url, values] of Object.entries(tokens)) {
-      const valueSet = await findTerminologyResource<ValueSet>(this, 'ValueSet', url);
-
-      const resultCache: Record<string, boolean | undefined> = Object.create(null);
-      for (const value of values) {
-        let codings: Coding[] | undefined;
-        switch (value.type) {
-          case 'CodeableConcept':
-            codings = (value.value as CodeableConcept).coding;
-            break;
-          case 'Coding':
-            codings = [value.value as Coding];
-            break;
-          default: {
-            const cachedResult = resultCache[`${value.type}|${value.value}`];
-            if (cachedResult === false) {
-              issues.push({
-                severity: 'error',
-                code: 'value',
-                details: { text: `Value ${JSON.stringify(value.value)} did not satisfy terminology binding ${url}` },
-                expression: [value.path],
-              });
-            }
-            if (cachedResult !== undefined) {
-              continue;
-            }
-            codings = [{ code: value.value as string }];
-            break;
-          }
-        }
-        if (!codings?.length) {
-          continue;
-        }
-
-        const matchedCoding = await validateCodingInValueSet(this, valueSet, codings);
-        resultCache[`${value.type}|${value.value}`] = Boolean(matchedCoding);
-        if (!matchedCoding) {
-          issues.push({
-            severity: 'error',
-            code: 'value',
-            details: { text: `Value ${JSON.stringify(value.value)} did not satisfy terminology binding ${url}` },
-            expression: [value.path],
-          });
-        }
-      }
-    }
-  }
-
-  private async loadProfile(url: string): Promise<StructureDefinition | undefined> {
-    if (this.context.projects?.length) {
-      // Try loading from cache, using all available Project IDs
-      const cachedProfile = await getCachedProfile(this.context.projects, url);
-      if (cachedProfile) {
-        return cachedProfile;
-      }
-    }
-
-    // Fall back to loading from the DB; descending version sort approximates version resolution for some cases
-    const profile = await this.searchOne<StructureDefinition>({
-      resourceType: 'StructureDefinition',
-      filters: [
-        {
-          code: 'url',
-          operator: Operator.EQUALS,
-          value: url,
-        },
-      ],
-      sortRules: [
-        {
-          code: 'version',
-          descending: true,
-        },
-        {
-          code: 'date',
-          descending: true,
-        },
-      ],
-    });
-
-    if (this.context.projects?.length && profile) {
-      await cacheProfile(profile);
-    }
-    return profile;
   }
 
   /**

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -3,9 +3,7 @@
 import type {
   BackgroundJobInteraction,
   Filter,
-  SearchParameterDetails,
   SearchRequest,
-  TypedValue,
   TypedValueWithPath,
   ValidatorOptions,
   WithId,
@@ -16,20 +14,12 @@ import {
   allOk,
   append,
   badRequest,
-  convertToSearchableDates,
-  convertToSearchableNumbers,
-  convertToSearchableQuantities,
-  convertToSearchableReferences,
-  convertToSearchableStrings,
-  convertToSearchableTokens,
-  convertToSearchableUris,
   deepClone,
   deepEquals,
   DEFAULT_MAX_SEARCH_COUNT,
   EMPTY,
   evalFhirPathTyped,
   extractAccountReferences,
-  flatMapFilter,
   forbidden,
   formatSearchQuery,
   getReferenceString,
@@ -55,11 +45,8 @@ import {
   readInteractions,
   resolveId,
   satisfiedAccessPolicy,
-  SearchParameterType,
   sleep,
   stringify,
-  toPeriod,
-  toTypedValue,
   validateResource,
   validateResourceType,
 } from '@medplum/core';
@@ -85,7 +72,6 @@ import type {
   Reference,
   Resource,
   ResourceType,
-  SearchParameter,
   StructureDefinition,
   ValueSet,
 } from '@medplum/fhirtypes';
@@ -95,8 +81,7 @@ import { Readable } from 'node:stream';
 import type { Pool, PoolClient } from 'pg';
 import type { Operation } from 'rfc6902';
 import { getConfig } from '../config/loader';
-import type { ArrayColumnPaddingConfig } from '../config/types';
-import { syntheticR4Project, systemResourceProjectId } from '../constants';
+import { syntheticR4Project } from '../constants';
 import { AuthenticatedRequestContext, tryGetRequestContext } from '../context';
 import { DatabaseMode } from '../database';
 import { getLogger } from '../logger';
@@ -130,9 +115,6 @@ import { addSubscriptionJobs } from '../workers/subscription';
 import { checkWebSocketSubscriptionLimit } from '../ws/subscriptions';
 import type { FhirRateLimiter } from './fhirquota';
 import { validateResourceWithJsonSchema } from './jsonschema';
-import type { HumanNameResource } from './lookups/humanname';
-import { getHumanNameSortValue } from './lookups/humanname';
-import { getStandardAndDerivedSearchParameters } from './lookups/util';
 import { clamp } from './operations/utils/parameters';
 import { findTerminologyResource } from './operations/utils/terminology';
 import { validateCodingInValueSet } from './operations/valuesetvalidatecode';
@@ -143,25 +125,16 @@ import { removeField } from './repository/field-utils';
 import { cacheProfile, getCachedProfile, removeCachedProfile } from './repository/profile-cache';
 import type { StatementTimeoutOptions } from './repository/repository-connection';
 import { RepositoryConnection } from './repository/repository-connection';
+import { buildDeletedResourceRow, buildResourceRow } from './repository/row-builder';
 import type { ResourceCap } from './resource-cap';
 import { getFullUrl } from './response';
 import { rewriteAttachments, RewriteMode } from './rewrite';
 import type { SearchOptions } from './search';
 import { buildSearchExpression, searchByReferenceImpl, searchImpl } from './search';
-import type { ColumnSearchParameterImplementation } from './searchparameter';
-import { getSearchParameterImplementation, lookupTables } from './searchparameter';
+import { lookupTables } from './searchparameter';
 import { GLOBAL_SHARD_ID } from './sharding';
 import type { Expression } from './sql';
-import {
-  Condition,
-  DeleteQuery,
-  Disjunction,
-  InsertQuery,
-  periodToRangeString,
-  SelectQuery,
-  truncateTextColumn,
-} from './sql';
-import { buildTokenColumns } from './token-column';
+import { Condition, DeleteQuery, Disjunction, InsertQuery, SelectQuery } from './sql';
 
 export type { StatementTimeoutOptions } from './repository/repository-connection';
 
@@ -279,27 +252,6 @@ export interface ResendSubscriptionsOptions extends InteractionOptions {
 
 export interface ProcessAllResourcesOptions {
   delayBetweenPagesMs?: number;
-}
-
-export type ColumnValue = boolean | number | string | undefined | null;
-
-export function compareColumnValues(a: ColumnValue, b: ColumnValue): number {
-  if ((a ?? null) === (b ?? null)) {
-    return 0;
-  }
-  if (a === null || a === undefined) {
-    return 1;
-  }
-  if (b === null || b === undefined) {
-    return -1;
-  }
-  if (typeof a === 'number' && typeof b === 'number') {
-    return a - b;
-  }
-  if (typeof a === 'boolean' && typeof b === 'boolean') {
-    return Number(a) - Number(b);
-  }
-  return String(a).localeCompare(String(b));
 }
 
 function addSyntheticR4ProjectIfMissing(context: RepositoryContext): void {
@@ -1411,20 +1363,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
 
       if (!this.isCacheOnly(resource)) {
         await this.ensureInTransaction(async (conn) => {
-          const lastUpdated = new Date();
-          const content = '';
-          const columns: Record<string, any> = {
-            id,
-            lastUpdated,
-            deleted: true,
-            projectId: resource.meta?.project ?? systemResourceProjectId,
-            content,
-            __version: -1,
-          };
-
-          for (const searchParam of getStandardAndDerivedSearchParameters(resourceType)) {
-            this.buildColumn({ resourceType } as Resource, columns, searchParam);
-          }
+          const columns = buildDeletedResourceRow(resourceType, id, resource.meta?.project);
 
           await new InsertQuery(resourceType, [columns]).mergeOnConflict().execute(conn);
 
@@ -1432,8 +1371,8 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
             {
               id,
               versionId: this.generateId(),
-              lastUpdated,
-              content,
+              lastUpdated: columns.lastUpdated,
+              content: columns.content,
             },
           ]).execute(conn);
 
@@ -1803,46 +1742,6 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     }
   }
 
-  private buildResourceRow(resource: Resource): Record<string, any> {
-    const resourceType = resource.resourceType;
-    const meta = resource.meta as Meta;
-    const content = stringify(resource);
-
-    const row: Record<string, any> = {
-      id: resource.id,
-      lastUpdated: meta.lastUpdated,
-      deleted: false,
-      projectId: meta.project ?? systemResourceProjectId,
-      content,
-      __version: Repository.VERSION,
-    };
-
-    const searchParams = getStandardAndDerivedSearchParameters(resourceType);
-    if (searchParams.length > 0) {
-      const startTime = process.hrtime.bigint();
-      try {
-        for (const searchParam of searchParams) {
-          this.buildColumn(resource, row, searchParam);
-        }
-      } catch (err) {
-        getLogger().error('Error building row for resource', {
-          resource: `${resourceType}/${resource.id}`,
-          err,
-        });
-        throw err;
-      }
-      recordHistogramValue(
-        'medplum.server.indexingDurationMs',
-        Number(process.hrtime.bigint() - startTime) / 1e6, // High resolution time, converted from ns to ms
-        {
-          options: { unit: 'ms' },
-        }
-      );
-    }
-
-    return row;
-  }
-
   /**
    * Writes the resource to the resource table.
    * This builds all search parameter columns.
@@ -1851,7 +1750,9 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
    * @param resource - The resource.
    */
   private async writeResource(client: PoolClient, resource: Resource): Promise<void> {
-    await new InsertQuery(resource.resourceType, [this.buildResourceRow(resource)]).mergeOnConflict().execute(client);
+    await new InsertQuery(resource.resourceType, [buildResourceRow(resource, Repository.VERSION)])
+      .mergeOnConflict()
+      .execute(client);
   }
 
   private async batchWriteResources(client: PoolClient, resources: Resource[]): Promise<void> {
@@ -1861,7 +1762,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
 
     await new InsertQuery(
       resources[0].resourceType,
-      resources.map((r) => this.buildResourceRow(r))
+      resources.map((r) => buildResourceRow(r, Repository.VERSION))
     )
       .mergeOnConflict()
       .execute(client);
@@ -1935,149 +1836,6 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     }
 
     return results;
-  }
-
-  /**
-   * Builds the columns to write for a given resource and search parameter.
-   * If nothing to write, then no columns will be added.
-   * Some search parameters can result in multiple columns (for example, Reference objects).
-   * @param resource - The resource to write.
-   * @param columns - The output columns to write.
-   * @param searchParam - The search parameter definition.
-   */
-  private buildColumn(resource: Resource, columns: Record<string, any>, searchParam: SearchParameter): void {
-    if (
-      searchParam.code === '_id' ||
-      searchParam.code === '_lastUpdated' ||
-      searchParam.code === '_compartment:identifier' ||
-      searchParam.code === '_deleted' ||
-      searchParam.code === '_project' ||
-      searchParam.type === 'composite'
-    ) {
-      return;
-    }
-
-    if (searchParam.code === '_compartment') {
-      columns['compartments'] = resource.meta?.compartment?.map((ref) => resolveId(ref)) ?? [];
-      return;
-    }
-
-    const impl = getSearchParameterImplementation(resource.resourceType, searchParam);
-    if (impl.searchStrategy === 'lookup-table') {
-      if (impl.sortColumnName) {
-        columns[impl.sortColumnName] = truncateTextColumn(
-          getHumanNameSortValue((resource as HumanNameResource).name, searchParam)
-        );
-      }
-      return;
-    }
-
-    const typedValues = evalFhirPathTyped(impl.parsedExpression, [toTypedValue(resource)]);
-
-    // Handle special case for "MeasureReport-period"
-    // This is a trial for using "tstzrange" columns for date/time ranges.
-    // Eventually, this special case will go away, and this will become the default behavior for all "date" search parameters.
-    if (searchParam.id === 'MeasureReport-period') {
-      columns['period_range'] = this.buildPeriodColumn(typedValues[0]?.value);
-    }
-
-    if (impl.searchStrategy === 'token-column') {
-      buildTokenColumns(searchParam, impl, columns, resource, {
-        paddingConfig: getArrayPaddingConfig(searchParam, resource.resourceType),
-      });
-      return;
-    }
-
-    impl satisfies ColumnSearchParameterImplementation;
-    const columnValues = this.buildColumnValues(searchParam, impl, typedValues);
-    if (impl.array) {
-      columnValues.sort(compareColumnValues);
-      columns[impl.columnName] = columnValues.length > 0 ? columnValues : undefined;
-    } else {
-      columns[impl.columnName] = columnValues[0];
-    }
-  }
-
-  /**
-   * Builds a single value for a given search parameter.
-   * If the search parameter is an array, then this method will be called for each element.
-   * If the search parameter is not an array, then this method will be called for the value.
-   * @param searchParam - The search parameter definition.
-   * @param details - The extra search parameter details.
-   * @param typedValues - The FHIR resource value.
-   * @returns The column value.
-   */
-  private buildColumnValues(
-    searchParam: SearchParameter,
-    details: SearchParameterDetails,
-    typedValues: TypedValue[]
-  ): ColumnValue[] {
-    if (details.type === SearchParameterType.BOOLEAN) {
-      const value = typedValues[0]?.value;
-      if (value === undefined || value === null) {
-        return [null];
-      }
-      return [value === true || value === 'true'];
-    }
-
-    if (details.type === SearchParameterType.DATE) {
-      // "Date" column is a special case that only applies when the following conditions are true:
-      // 1. The search parameter is a date type.
-      // 2. The underlying FHIR ElementDefinition referred to by the search parameter has a type of "date".
-      return flatMapFilter(convertToSearchableDates(typedValues), (p) => (p.start ?? p.end)?.substring(0, 10));
-    }
-
-    if (details.type === SearchParameterType.DATETIME) {
-      // Future work: write the whole period to the DB after migrating all "date" search parameters to use a tstzrange.
-      return flatMapFilter(convertToSearchableDates(typedValues), (p) => p.start ?? p.end);
-    }
-
-    if (searchParam.type === 'number') {
-      // Future work: write the whole range to the DB after migrating all "number" search parameters to use a range.
-      return flatMapFilter(convertToSearchableNumbers(typedValues), ([low, high]) => low ?? high);
-    }
-
-    if (searchParam.type === 'quantity') {
-      // Future work: write the whole range to the DB after migrating all "quantity" search parameters to use a range.
-      return flatMapFilter(convertToSearchableQuantities(typedValues), (q) => q.value);
-    }
-
-    if (searchParam.type === 'reference') {
-      return flatMapFilter(convertToSearchableReferences(typedValues), truncateTextColumn);
-    }
-
-    if (searchParam.type === 'token') {
-      return flatMapFilter(convertToSearchableTokens(typedValues), (t) => truncateTextColumn(t.value));
-    }
-
-    if (searchParam.type === 'string') {
-      return flatMapFilter(convertToSearchableStrings(typedValues), truncateTextColumn);
-    }
-
-    if (searchParam.type === 'uri') {
-      return flatMapFilter(convertToSearchableUris(typedValues), truncateTextColumn);
-    }
-
-    if (searchParam.type === 'special' || searchParam.type === 'composite') {
-      // Special and composite search parameters are not supported in the database.
-      return [];
-    }
-
-    throw new Error('Unrecognized search parameter type: ' + searchParam.type);
-  }
-
-  /**
-   * Builds the column value for a "date" search parameter.
-   * This is currently in trial mode. The intention is for this to replace all "date" and "date/time" search parameters.
-   * @param value - The FHIRPath result value.
-   * @returns The period column string value.
-   */
-  private buildPeriodColumn(value: any): string | undefined {
-    const period = toPeriod(value);
-    if (period) {
-      return periodToRangeString(period);
-    }
-    return undefined;
   }
 
   /**
@@ -2814,26 +2572,4 @@ export async function getProjectSystemRepo(
   // a SystemRepository for that shard.
   // But for now, all projects are on the global shard.
   return getGlobalSystemRepo();
-}
-
-function getArrayPaddingConfig(
-  searchParam: SearchParameter,
-  resourceType: string
-): ArrayColumnPaddingConfig | undefined {
-  const paddingConfigEntry = getConfig().arrayColumnPadding?.[searchParam.code];
-  if (paddingConfigEntry) {
-    if (Array.isArray(paddingConfigEntry)) {
-      for (const entry of paddingConfigEntry) {
-        if (entry.resourceType === undefined || entry.resourceType.includes(resourceType)) {
-          return entry.config;
-        }
-      }
-      return undefined;
-    }
-
-    if (paddingConfigEntry.resourceType === undefined || paddingConfigEntry.resourceType.includes(resourceType)) {
-      return paddingConfigEntry.config;
-    }
-  }
-  return undefined;
 }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -38,7 +38,6 @@ import {
   gone,
   isGone,
   isNotFound,
-  isObject,
   isOk,
   isResource,
   isResourceType,
@@ -53,7 +52,6 @@ import {
   parseSearchRequest,
   preconditionFailed,
   projectAdminResourceTypes,
-  PropertyType,
   protectedResourceTypes,
   readInteractions,
   resolveId,
@@ -142,6 +140,7 @@ import { validateCodingInValueSet } from './operations/valuesetvalidatecode';
 import { getPatients } from './patient';
 import { preCommitValidation } from './precommit';
 import { replaceConditionalReferences, validateResourceReferences } from './references';
+import { removeField } from './repository/field-utils';
 import type { StatementTimeoutOptions } from './repository/repository-connection';
 import { RepositoryConnection } from './repository/repository-connection';
 import type { ResourceCap } from './resource-cap';
@@ -2387,7 +2386,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
   removeHiddenFields<T extends Resource>(input: T): T {
     const policy = satisfiedAccessPolicy(input, AccessPolicyInteraction.READ, this.context.accessPolicy);
     for (const field of policy?.hiddenFields ?? EMPTY) {
-      this.removeField(input, field);
+      removeField(input, field);
     }
     if (!this.context.extendedMode && input.meta) {
       const meta = input.meta;
@@ -2424,7 +2423,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       fieldsToRestore.push(...policy.hiddenFields);
     }
     for (const field of fieldsToRestore) {
-      this.removeField(input, field);
+      removeField(input, field);
       // only top-level fields can be restored.
       // choice-of-type fields technically aren't allowed in readonlyFields/hiddenFields,
       // but that isn't currently enforced at write time, so exclude them here
@@ -2436,43 +2435,6 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       }
     }
     return input;
-  }
-
-  /**
-   * Removes a field from the input resource; supports nested fields.
-   * @param input - The input resource.
-   * @param path - The path to the field to remove
-   */
-  private removeField<T extends Resource>(input: T, path: string): void {
-    let last: any[] = [input];
-    const pathParts = path.split('.');
-    for (let i = 0; i < pathParts.length; i++) {
-      const pathPart = pathParts[i];
-
-      if (i === pathParts.length - 1) {
-        // final key part
-        for (const item of last) {
-          for (const key of resolveFieldName(item, pathPart)) {
-            delete item[key];
-          }
-        }
-      } else {
-        // intermediate key part
-        const next: any[] = [];
-        for (const lastItem of last) {
-          for (const key of resolveFieldName(lastItem, pathPart)) {
-            if (lastItem[key] !== undefined) {
-              if (Array.isArray(lastItem[key])) {
-                next.push(...lastItem[key]);
-              } else if (isObject(lastItem[key])) {
-                next.push(lastItem[key]);
-              }
-            }
-          }
-        }
-        last = next;
-      }
-    }
   }
 
   isSuperAdmin(): boolean {
@@ -2895,35 +2857,6 @@ export async function getProjectSystemRepo(
   // a SystemRepository for that shard.
   // But for now, all projects are on the global shard.
   return getGlobalSystemRepo();
-}
-
-function lowercaseFirstLetter(str: string): string {
-  return str.charAt(0).toLowerCase() + str.slice(1);
-}
-
-function resolveFieldName(input: any, fieldName: string): string[] {
-  if (!fieldName.endsWith('[x]')) {
-    return [fieldName];
-  }
-
-  const baseKey = fieldName.slice(0, -3);
-  return Object.keys(input).filter((k) => {
-    if (k.startsWith(baseKey)) {
-      const maybePropertyType = k.substring(baseKey.length);
-      if (maybePropertyType in PropertyType || lowercaseFirstLetter(maybePropertyType) in PropertyType) {
-        return true;
-      }
-    }
-    return false;
-  });
-}
-
-export function setTypedPropertyValue(target: TypedValue, path: string, replacement: TypedValue): void {
-  let patchPath = '/' + path.replaceAll(/\[|\]\.|\./g, '/');
-  if (patchPath.endsWith(']')) {
-    patchPath = patchPath.slice(0, -1);
-  }
-  patchObject(target.value, [{ op: 'replace', path: patchPath, value: replacement.value }]);
 }
 
 function getArrayPaddingConfig(

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -23,7 +23,6 @@ import {
   convertToSearchableStrings,
   convertToSearchableTokens,
   convertToSearchableUris,
-  createReference,
   deepClone,
   deepEquals,
   DEFAULT_MAX_SEARCH_COUNT,
@@ -141,6 +140,7 @@ import { getPatients } from './patient';
 import { preCommitValidation } from './precommit';
 import { replaceConditionalReferences, validateResourceReferences } from './references';
 import { removeField } from './repository/field-utils';
+import { cacheProfile, getCachedProfile, removeCachedProfile } from './repository/profile-cache';
 import type { StatementTimeoutOptions } from './repository/repository-connection';
 import { RepositoryConnection } from './repository/repository-connection';
 import type { ResourceCap } from './resource-cap';
@@ -1173,11 +1173,9 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
   private async loadProfile(url: string): Promise<StructureDefinition | undefined> {
     if (this.context.projects?.length) {
       // Try loading from cache, using all available Project IDs
-      const cacheKeys = this.context.projects.map((p) => getProfileCacheKey(p.id, url));
-      const results = await getCacheRedis().mget(...cacheKeys);
-      const cachedProfile = results.find(Boolean) as string | undefined;
+      const cachedProfile = await getCachedProfile(this.context.projects, url);
       if (cachedProfile) {
-        return (JSON.parse(cachedProfile) as CacheEntry<StructureDefinition>).resource;
+        return cachedProfile;
       }
     }
 
@@ -1204,8 +1202,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     });
 
     if (this.context.projects?.length && profile) {
-      // Store loaded profile in cache
-      await cacheProfile(this.getSystemRepo(), profile);
+      await cacheProfile(profile);
     }
     return profile;
   }
@@ -2708,7 +2705,6 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
 }
 
 const REDIS_CACHE_EX_SECONDS = 24 * 60 * 60; // 24 hours in seconds
-const PROFILE_CACHE_EX_SECONDS = 5 * 60; // 5 minutes in seconds
 
 /**
  * Returns the redis cache key for the given resource type and resource ID.
@@ -2718,45 +2714,6 @@ const PROFILE_CACHE_EX_SECONDS = 5 * 60; // 5 minutes in seconds
  */
 function getCacheKey(resourceType: string, id: string): string {
   return `${resourceType}/${id}`;
-}
-
-/**
- * Writes a FHIR profile cache entry to Redis.
- * @param systemRepo - The system repository.
- * @param profile - The profile structure definition.
- */
-async function cacheProfile(systemRepo: SystemRepository, profile: StructureDefinition): Promise<void> {
-  if (!profile.url || !profile.meta?.project) {
-    return;
-  }
-  profile = await systemRepo.readReference(createReference(profile));
-  await getCacheRedis().set(
-    getProfileCacheKey(profile.meta?.project as string, profile.url),
-    JSON.stringify({ resource: profile, projectId: profile.meta?.project }),
-    'EX',
-    PROFILE_CACHE_EX_SECONDS
-  );
-}
-
-/**
- * Writes a FHIR profile cache entry to Redis.
- * @param profile - The profile structure definition.
- */
-async function removeCachedProfile(profile: StructureDefinition): Promise<void> {
-  if (!profile.url || !profile.meta?.project) {
-    return;
-  }
-  await getCacheRedis().del(getProfileCacheKey(profile.meta.project, profile.url));
-}
-
-/**
- * Returns the redis cache key for the given profile resource.
- * @param projectId - The ID of the Project to which the profile belongs.
- * @param url - The canonical URL of the profile.
- * @returns The Redis cache key.
- */
-function getProfileCacheKey(projectId: string, url: string): string {
-  return `Project/${projectId}/StructureDefinition/${url}`;
 }
 
 export class SystemRepository extends Repository {}

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -77,7 +77,6 @@ import {
   removeActiveSubscriptions,
   removeUserActiveWebSocketSubscriptions,
 } from '../pubsub';
-import { getCacheRedis } from '../redis';
 import { getBinaryStorage } from '../storage/loader';
 import type { AuditEventSubtype } from '../util/auditevent';
 import {
@@ -105,6 +104,14 @@ import { preCommitValidation } from './precommit';
 import { replaceConditionalReferences, validateResourceReferences } from './references';
 import { removeField } from './repository/field-utils';
 import { removeCachedProfile } from './repository/profile-cache';
+import type { CacheEntry } from './repository/resource-cache';
+import {
+  deleteResourceCacheEntries,
+  deleteResourceCacheEntry,
+  getResourceCacheEntries,
+  getResourceCacheEntry,
+  setResourceCacheEntry,
+} from './repository/resource-cache';
 import type { StatementTimeoutOptions } from './repository/repository-connection';
 import { RepositoryConnection } from './repository/repository-connection';
 import { buildDeletedResourceRow, buildResourceRow } from './repository/row-builder';
@@ -213,11 +220,6 @@ export interface RepositoryContext {
    * Optional flag to skip scheduling background jobs for writes.
    */
   skipBackgroundJobs?: boolean;
-}
-
-export interface CacheEntry<T extends Resource = Resource> {
-  resource: T;
-  projectId: string;
 }
 
 export interface InteractionOptions {
@@ -2131,8 +2133,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     if (this.connection.isInTransaction()) {
       return undefined;
     }
-    const cachedValue = await getCacheRedis().get(getCacheKey(resourceType, id));
-    return cachedValue ? (JSON.parse(cachedValue) as CacheEntry<WithId<T>>) : undefined;
+    return getResourceCacheEntry<T>(resourceType, id);
   }
 
   /**
@@ -2146,37 +2147,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       return new Array(references.length);
     }
 
-    const referenceKeys: string[] = [];
-
-    // Build referenceKeys only for valid input references and track
-    // their indices in the original array so that the result array
-    // is constructed in the correct order.
-    const referenceKeyIndices: number[] = new Array(references.length);
-    for (let i = 0; i < references.length; i++) {
-      const r = references[i];
-      if (r.reference) {
-        referenceKeys.push(r.reference);
-        referenceKeyIndices[i] = referenceKeys.length - 1;
-      }
-    }
-
-    if (referenceKeys.length === 0) {
-      // Return early to avoid calling mget() with no args, which is an error
-      return new Array(references.length);
-    }
-
-    const cachedValues = await getCacheRedis().mget(referenceKeys);
-
-    const result = new Array<CacheEntry | undefined>(references.length);
-    for (let i = 0; i < references.length; i++) {
-      if (referenceKeyIndices[i] === undefined) {
-        result[i] = undefined;
-      } else {
-        const cachedValue = cachedValues[referenceKeyIndices[i]];
-        result[i] = cachedValue ? (JSON.parse(cachedValue) as CacheEntry) : undefined;
-      }
-    }
-    return result;
+    return getResourceCacheEntries(references);
   }
 
   /**
@@ -2193,13 +2164,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       return;
     }
 
-    const projectId = resource.meta?.project;
-    await getCacheRedis().set(
-      getCacheKey(resource.resourceType, resource.id),
-      stringify({ resource, projectId }),
-      'EX',
-      REDIS_CACHE_EX_SECONDS
-    );
+    await setResourceCacheEntry(resource);
   }
 
   /**
@@ -2214,7 +2179,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       return;
     }
 
-    await getCacheRedis().del(getCacheKey(resourceType, id));
+    await deleteResourceCacheEntry(resourceType, id);
   }
 
   /**
@@ -2229,11 +2194,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       return;
     }
 
-    const cacheKeys = ids.map((id) => {
-      return getCacheKey(resourceType, id);
-    });
-
-    await getCacheRedis().del(cacheKeys);
+    await deleteResourceCacheEntries(resourceType, ids);
   }
 
   async ensureInTransaction<TResult>(callback: (client: PoolClient) => Promise<TResult>): Promise<TResult> {
@@ -2258,18 +2219,6 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       throw new Error('Already closed');
     }
   }
-}
-
-const REDIS_CACHE_EX_SECONDS = 24 * 60 * 60; // 24 hours in seconds
-
-/**
- * Returns the redis cache key for the given resource type and resource ID.
- * @param resourceType - The resource type.
- * @param id - The resource ID.
- * @returns The Redis cache key.
- */
-function getCacheKey(resourceType: string, id: string): string {
-  return `${resourceType}/${id}`;
 }
 
 export class SystemRepository extends Repository {}

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -104,6 +104,8 @@ import { preCommitValidation } from './precommit';
 import { replaceConditionalReferences, validateResourceReferences } from './references';
 import { removeField } from './repository/field-utils';
 import { removeCachedProfile } from './repository/profile-cache';
+import type { StatementTimeoutOptions } from './repository/repository-connection';
+import { RepositoryConnection } from './repository/repository-connection';
 import type { CacheEntry } from './repository/resource-cache';
 import {
   deleteResourceCacheEntries,
@@ -112,8 +114,6 @@ import {
   getResourceCacheEntry,
   setResourceCacheEntry,
 } from './repository/resource-cache';
-import type { StatementTimeoutOptions } from './repository/repository-connection';
-import { RepositoryConnection } from './repository/repository-connection';
 import { buildDeletedResourceRow, buildResourceRow } from './repository/row-builder';
 import { validateRepositoryResource } from './repository/validation';
 import type { ResourceCap } from './resource-cap';

--- a/packages/server/src/fhir/repository/field-utils.ts
+++ b/packages/server/src/fhir/repository/field-utils.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { isObject, PropertyType } from '@medplum/core';
+import type { Resource } from '@medplum/fhirtypes';
+
+function lowercaseFirstLetter(str: string): string {
+  return str.charAt(0).toLowerCase() + str.slice(1);
+}
+
+function resolveFieldName(input: any, fieldName: string): string[] {
+  if (!fieldName.endsWith('[x]')) {
+    return [fieldName];
+  }
+
+  const baseKey = fieldName.slice(0, -3);
+  return Object.keys(input).filter((k) => {
+    if (k.startsWith(baseKey)) {
+      const maybePropertyType = k.substring(baseKey.length);
+      if (maybePropertyType in PropertyType || lowercaseFirstLetter(maybePropertyType) in PropertyType) {
+        return true;
+      }
+    }
+    return false;
+  });
+}
+
+/**
+ * Removes a field from the input resource; supports nested fields.
+ * @param input - The input resource.
+ * @param path - The path to the field to remove
+ */
+export function removeField<T extends Resource>(input: T, path: string): void {
+  let last: any[] = [input];
+  const pathParts = path.split('.');
+  for (let i = 0; i < pathParts.length; i++) {
+    const pathPart = pathParts[i];
+
+    if (i === pathParts.length - 1) {
+      // final key part
+      for (const item of last) {
+        for (const key of resolveFieldName(item, pathPart)) {
+          delete item[key];
+        }
+      }
+    } else {
+      // intermediate key part
+      const next: any[] = [];
+      for (const lastItem of last) {
+        for (const key of resolveFieldName(lastItem, pathPart)) {
+          if (lastItem[key] !== undefined) {
+            if (Array.isArray(lastItem[key])) {
+              next.push(...lastItem[key]);
+            } else if (isObject(lastItem[key])) {
+              next.push(lastItem[key]);
+            }
+          }
+        }
+      }
+      last = next;
+    }
+  }
+}

--- a/packages/server/src/fhir/repository/profile-cache.test.ts
+++ b/packages/server/src/fhir/repository/profile-cache.test.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { createReference } from '@medplum/core';
+import type { Login, Patient, StructureDefinition, UserConfiguration } from '@medplum/fhirtypes';
+import { randomUUID } from 'crypto';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { initAppServices, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config/loader';
+import { createTestProject, withTestContext } from '../../test.setup';
+import { getRepoForLogin } from '../accesspolicy';
+
+jest.mock('hibp');
+
+describe('Repository profile cache', () => {
+  const usCorePatientProfile = JSON.parse(
+    readFileSync(resolve(__dirname, '../__test__/us-core-patient.json'), 'utf8')
+  ) as StructureDefinition;
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initAppServices(config);
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test('Handles caching of profile from linked project', async () =>
+    withTestContext(async () => {
+      const { project: project2, repo: repo2 } = await createTestProject({ withRepo: true });
+      const { project, repo, membership } = await createTestProject({
+        withRepo: true,
+        withClient: true,
+        membership: { admin: true },
+        project: { link: [{ project: createReference(project2) }] },
+      });
+
+      const profile = await repo2.createResource<StructureDefinition>({
+        ...usCorePatientProfile,
+        url: 'urn:uuid:' + randomUUID(),
+      });
+
+      const patientJson: Patient = {
+        resourceType: 'Patient',
+        meta: {
+          profile: [profile.url],
+        },
+      };
+
+      // Resource upload should fail with profile linked
+      await expect(repo.createResource(patientJson)).rejects.toThrow(/Missing required property/);
+
+      // Unlink Project and verify that profile is not cached; resource upload should succeed without access to profile
+      const unlinkedProject = await repo.updateResource({
+        ...project,
+        link: undefined,
+      });
+
+      const newRepo = await getRepoForLogin({
+        login: {} as Login,
+        membership,
+        project: unlinkedProject,
+        userConfig: {} as UserConfiguration,
+      });
+      await expect(repo.createResource(patientJson)).rejects.toThrow(/Missing required property/);
+      await expect(newRepo.createResource(patientJson)).resolves.toBeDefined();
+    }));
+});

--- a/packages/server/src/fhir/repository/profile-cache.ts
+++ b/packages/server/src/fhir/repository/profile-cache.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import type { Project, StructureDefinition } from '@medplum/fhirtypes';
+import { getCacheRedis } from '../../redis';
+
+const PROFILE_CACHE_EX_SECONDS = 5 * 60; // 5 minutes in seconds
+
+interface ProfileCacheEntry {
+  resource: StructureDefinition;
+  projectId: string;
+}
+
+/**
+ * Gets a cached profile from Redis if it exists for the given URL and projects prioritizing based on project order.
+ * @param projects - The projects to search for the profile.
+ * @param url - The canonical URL of the profile.
+ * @returns The cached profile if it exists; otherwise, undefined.
+ */
+export async function getCachedProfile(
+  projects: WithId<Project>[],
+  url: string
+): Promise<StructureDefinition | undefined> {
+  const cacheKeys = projects.map((p) => getProfileCacheKey(p.id, url));
+  const results = await getCacheRedis().mget(...cacheKeys);
+  const cachedProfile = results.find(Boolean) as string | undefined;
+  if (cachedProfile) {
+    return (JSON.parse(cachedProfile) as ProfileCacheEntry).resource;
+  }
+  return undefined;
+}
+
+/**
+ * Writes a FHIR profile cache entry to Redis.
+ * @param profile - The profile structure definition.
+ */
+export async function cacheProfile(profile: WithId<StructureDefinition>): Promise<void> {
+  if (!profile.url || !profile.meta?.project) {
+    return;
+  }
+  const cacheEntry: ProfileCacheEntry = {
+    resource: profile,
+    projectId: profile.meta.project,
+  };
+  await getCacheRedis().set(
+    getProfileCacheKey(profile.meta.project, profile.url),
+    JSON.stringify(cacheEntry),
+    'EX',
+    PROFILE_CACHE_EX_SECONDS
+  );
+}
+
+/**
+ * Deletes a FHIR profile cache entry from Redis if it exists
+ * @param profile - The profile structure definition.
+ */
+export async function removeCachedProfile(profile: StructureDefinition): Promise<void> {
+  if (!profile.url || !profile.meta?.project) {
+    return;
+  }
+  await getCacheRedis().del(getProfileCacheKey(profile.meta.project, profile.url));
+}
+
+/**
+ * Returns the redis cache key for the given profile resource.
+ * @param projectId - The ID of the Project to which the profile belongs.
+ * @param url - The canonical URL of the profile.
+ * @returns The Redis cache key.
+ */
+function getProfileCacheKey(projectId: string, url: string): string {
+  return `Project/${projectId}/StructureDefinition/${url}`;
+}

--- a/packages/server/src/fhir/repository/resource-cache.test.ts
+++ b/packages/server/src/fhir/repository/resource-cache.test.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import type { Patient, Reference } from '@medplum/fhirtypes';
+import { randomUUID } from 'node:crypto';
+import { initAppServices, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config/loader';
+import {
+  deleteResourceCacheEntries,
+  deleteResourceCacheEntry,
+  getResourceCacheEntries,
+  getResourceCacheEntry,
+  getResourceCacheKey,
+  setResourceCacheEntry,
+} from './resource-cache';
+
+jest.mock('hibp');
+
+describe('Repository resource cache', () => {
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initAppServices(config);
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test('Returns resource cache key', () => {
+    expect(getResourceCacheKey('Patient', '123')).toStrictEqual('Patient/123');
+  });
+
+  test('Sets, reads, and deletes resource cache entry', async () => {
+    const patient = buildPatient();
+
+    try {
+      await setResourceCacheEntry(patient);
+
+      const cacheEntry = await getResourceCacheEntry<Patient>('Patient', patient.id);
+      expect(cacheEntry).toStrictEqual({
+        resource: patient,
+        projectId: patient.meta?.project,
+      });
+    } finally {
+      await deleteResourceCacheEntry('Patient', patient.id);
+    }
+
+    await expect(getResourceCacheEntry<Patient>('Patient', patient.id)).resolves.toBeUndefined();
+  });
+
+  test('Bulk reads preserve reference order', async () => {
+    const patient1 = buildPatient();
+    const patient2 = buildPatient();
+    const missingId = randomUUID();
+
+    try {
+      await setResourceCacheEntry(patient1);
+      await setResourceCacheEntry(patient2);
+
+      const references: Reference[] = [
+        { reference: `Patient/${patient1.id}` },
+        {},
+        { reference: `Patient/${missingId}` },
+        { reference: `Patient/${patient2.id}` },
+      ];
+
+      const cacheEntries = await getResourceCacheEntries(references);
+      expect(cacheEntries).toStrictEqual([
+        { resource: patient1, projectId: patient1.meta?.project },
+        undefined,
+        undefined,
+        { resource: patient2, projectId: patient2.meta?.project },
+      ]);
+    } finally {
+      await deleteResourceCacheEntries('Patient', [patient1.id, patient2.id, missingId]);
+    }
+  });
+
+  test('Deletes resource cache entries', async () => {
+    const patient1 = buildPatient();
+    const patient2 = buildPatient();
+
+    await setResourceCacheEntry(patient1);
+    await setResourceCacheEntry(patient2);
+
+    await deleteResourceCacheEntries('Patient', [patient1.id, patient2.id]);
+
+    await expect(getResourceCacheEntry<Patient>('Patient', patient1.id)).resolves.toBeUndefined();
+    await expect(getResourceCacheEntry<Patient>('Patient', patient2.id)).resolves.toBeUndefined();
+  });
+});
+
+function buildPatient(): WithId<Patient> {
+  return {
+    resourceType: 'Patient',
+    id: randomUUID(),
+    meta: {
+      project: randomUUID(),
+    },
+  };
+}

--- a/packages/server/src/fhir/repository/resource-cache.ts
+++ b/packages/server/src/fhir/repository/resource-cache.ts
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import { stringify } from '@medplum/core';
+import type { Reference, Resource } from '@medplum/fhirtypes';
+import { getCacheRedis } from '../../redis';
+
+const RESOURCE_CACHE_EX_SECONDS = 24 * 60 * 60; // 24 hours in seconds
+
+export interface CacheEntry<T extends Resource = Resource> {
+  resource: T;
+  projectId: string;
+}
+
+/**
+ * Tries to read a cache entry from Redis by resource type and ID.
+ * @param resourceType - The resource type.
+ * @param id - The resource ID.
+ * @returns The cache entry if found; otherwise, undefined.
+ */
+export async function getResourceCacheEntry<T extends Resource>(
+  resourceType: string,
+  id: string
+): Promise<CacheEntry<WithId<T>> | undefined> {
+  const cachedValue = await getCacheRedis().get(getResourceCacheKey(resourceType, id));
+  return cachedValue ? (JSON.parse(cachedValue) as CacheEntry<WithId<T>>) : undefined;
+}
+
+/**
+ * Performs a bulk read of cache entries from Redis.
+ * @param references - Array of FHIR references.
+ * @returns Array of cache entries or undefined.
+ */
+export async function getResourceCacheEntries(references: Reference[]): Promise<(CacheEntry | undefined)[]> {
+  const referenceKeys: string[] = [];
+
+  // Build referenceKeys only for valid input references and track
+  // their indices in the original array so that the result array
+  // is constructed in the correct order.
+  const referenceKeyIndices: (number | undefined)[] = new Array(references.length);
+  for (let i = 0; i < references.length; i++) {
+    const r = references[i];
+    if (r.reference) {
+      referenceKeys.push(r.reference);
+      referenceKeyIndices[i] = referenceKeys.length - 1;
+    }
+  }
+
+  if (referenceKeys.length === 0) {
+    // Return early to avoid calling mget() with no args, which is an error
+    return new Array(references.length);
+  }
+
+  const cachedValues = await getCacheRedis().mget(referenceKeys);
+
+  const result = new Array<CacheEntry | undefined>(references.length);
+  for (let i = 0; i < references.length; i++) {
+    const referenceKeyIndex = referenceKeyIndices[i];
+    if (referenceKeyIndex === undefined) {
+      result[i] = undefined;
+    } else {
+      const cachedValue = cachedValues[referenceKeyIndex];
+      result[i] = cachedValue ? (JSON.parse(cachedValue) as CacheEntry) : undefined;
+    }
+  }
+  return result;
+}
+
+/**
+ * Writes a cache entry to Redis.
+ * @param resource - The resource to cache.
+ */
+export async function setResourceCacheEntry(resource: WithId<Resource>): Promise<void> {
+  const projectId = resource.meta?.project;
+  await getCacheRedis().set(
+    getResourceCacheKey(resource.resourceType, resource.id),
+    stringify({ resource, projectId }),
+    'EX',
+    RESOURCE_CACHE_EX_SECONDS
+  );
+}
+
+/**
+ * Deletes a cache entry from Redis.
+ * @param resourceType - The resource type.
+ * @param id - The resource ID.
+ */
+export async function deleteResourceCacheEntry(resourceType: string, id: string): Promise<void> {
+  await getCacheRedis().del(getResourceCacheKey(resourceType, id));
+}
+
+/**
+ * Deletes cache entries from Redis.
+ * @param resourceType - The resource type.
+ * @param ids - The resource IDs.
+ */
+export async function deleteResourceCacheEntries(resourceType: string, ids: string[]): Promise<void> {
+  const cacheKeys = ids.map((id) => {
+    return getResourceCacheKey(resourceType, id);
+  });
+
+  await getCacheRedis().del(cacheKeys);
+}
+
+/**
+ * Returns the redis cache key for the given resource type and resource ID.
+ * @param resourceType - The resource type.
+ * @param id - The resource ID.
+ * @returns The Redis cache key.
+ */
+export function getResourceCacheKey(resourceType: string, id: string): string {
+  return `${resourceType}/${id}`;
+}

--- a/packages/server/src/fhir/repository/row-builder.test.ts
+++ b/packages/server/src/fhir/repository/row-builder.test.ts
@@ -1,0 +1,396 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import { encodeBase64 } from '@medplum/core';
+import type { Binary, DocumentReference, Observation, Project } from '@medplum/fhirtypes';
+import { randomUUID } from 'node:crypto';
+import { initAppServices, shutdownApp } from '../../app';
+import { getConfig, loadTestConfig } from '../../config/loader';
+import type { ArrayColumnPaddingConfig, MedplumServerConfig } from '../../config/types';
+import { DatabaseMode, getDatabasePool } from '../../database';
+import { createTestProject, withTestContext } from '../../test.setup';
+import { getProjectSystemRepo, Repository } from '../repo';
+import type { ColumnValue } from './row-builder';
+import { buildResourceRow, compareColumnValues } from './row-builder';
+
+describe('Repository Row Builder', () => {
+  let testProject: WithId<Project>;
+  let systemRepo: Repository;
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initAppServices(config);
+    const { project } = await createTestProject();
+
+    testProject = project;
+    systemRepo = await getProjectSystemRepo(testProject);
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test('Binary writes no search parameter columns', () => {
+    const binary: Binary = {
+      resourceType: 'Binary',
+      id: randomUUID(),
+      contentType: 'text/plain',
+      data: encodeBase64('this is some test data'),
+      meta: {
+        lastUpdated: new Date().toISOString(),
+        project: randomUUID(),
+        tag: [{ system: 'https://example.com', code: 'tag' }],
+        security: [{ system: 'https://example.com', code: 'security' }],
+      },
+    };
+
+    expect(buildResourceRow(binary, Repository.VERSION)).toStrictEqual({
+      id: binary.id,
+      lastUpdated: binary.meta?.lastUpdated,
+      deleted: false,
+      projectId: binary.meta?.project,
+      content: expect.any(String),
+      __version: Repository.VERSION,
+    });
+  });
+
+  describe('Array column padding', () => {
+    let prevConfig: string | undefined;
+    beforeEach(() => {
+      const config = getConfig();
+      prevConfig = config.arrayColumnPadding && JSON.stringify(config.arrayColumnPadding);
+    });
+
+    afterEach(() => {
+      if (prevConfig) {
+        const config = getConfig();
+        config.arrayColumnPadding = JSON.parse(prevConfig);
+      }
+    });
+
+    const ENSURE_PADDING: ArrayColumnPaddingConfig = {
+      m: 1,
+      lambda: 300,
+      statisticsTarget: 1,
+    };
+
+    test.each([
+      ['no config', undefined, false], // off by default
+      [
+        'no resourceType array',
+        {
+          identifier: {
+            config: ENSURE_PADDING,
+          },
+        },
+        true,
+      ],
+      [
+        'resourceType in the resourceType array',
+        {
+          identifier: {
+            resourceType: ['Patient', 'Observation'],
+            config: ENSURE_PADDING,
+          },
+        },
+        true,
+      ],
+      [
+        'resourceType NOT in the resourceType array',
+        {
+          identifier: {
+            resourceType: ['Patient'],
+            config: ENSURE_PADDING,
+          },
+        },
+        false,
+      ],
+      [
+        'array with entry with no resourceType array in second element',
+        {
+          identifier: [
+            {
+              resourceType: ['Task'],
+              config: ENSURE_PADDING,
+            },
+            {
+              config: ENSURE_PADDING,
+            },
+          ],
+        },
+        true,
+      ],
+      [
+        'array with resourceType in second entry resourceType array',
+        {
+          identifier: [
+            {
+              resourceType: ['Patient'],
+              config: ENSURE_PADDING,
+            },
+            {
+              resourceType: ['Task', 'Observation'],
+              config: ENSURE_PADDING,
+            },
+          ],
+        },
+        true,
+      ],
+      [
+        'array with resourceType NOT in any resourceType array',
+        {
+          identifier: [
+            {
+              resourceType: ['Patient'],
+              config: ENSURE_PADDING,
+            },
+            {
+              resourceType: ['Task'],
+              config: ENSURE_PADDING,
+            },
+          ],
+        },
+        false,
+      ],
+    ])('with %s', async (_desc, arrayColumnPadding: MedplumServerConfig['arrayColumnPadding'] | undefined, shouldPad) =>
+      withTestContext(async () => {
+        const config = getConfig();
+        if (arrayColumnPadding) {
+          config.arrayColumnPadding = arrayColumnPadding;
+        }
+        const res = await systemRepo.createResource<Observation>({
+          resourceType: 'Observation',
+          status: 'unknown',
+          code: { coding: [{ system: 'http://loinc.org', code: '72166-2', display: 'Test Observation' }] },
+        });
+
+        const db = getDatabasePool(DatabaseMode.READER);
+        const results = await db.query('SELECT "__identifier" FROM "Observation" WHERE "id" = $1', [res.id]);
+        if (shouldPad) {
+          expect(results.rows).toStrictEqual([{ __identifier: ['00000000-0000-0000-0000-000000000000'] }]);
+        } else {
+          expect(results.rows).toStrictEqual([{ __identifier: [] }]);
+        }
+
+        // deleted rows also get padded
+        await systemRepo.deleteResource(res.resourceType, res.id);
+        const deletedResults = await db.query('SELECT "__identifier" FROM "Observation" WHERE "id" = $1', [res.id]);
+
+        if (shouldPad) {
+          expect(deletedResults.rows).toStrictEqual([{ __identifier: ['00000000-0000-0000-0000-000000000000'] }]);
+        } else {
+          expect(deletedResults.rows).toStrictEqual([{ __identifier: [] }]);
+        }
+      })
+    );
+  });
+
+  describe('Array column value sorting', () => {
+    test('stores multi-valued reference column in sorted order (DocumentReference.author)', () =>
+      withTestContext(async () => {
+        const authorRefs = [
+          'Practitioner/zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz',
+          'Patient/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+          'Practitioner/11111111-1111-1111-1111-111111111111',
+        ];
+        const expected = [...authorRefs].sort(compareColumnValues);
+
+        const doc = await systemRepo.createResource<DocumentReference>({
+          resourceType: 'DocumentReference',
+          status: 'current',
+          content: [{ attachment: { url: 'https://example.com/doc.pdf' } }],
+          author: [{ reference: authorRefs[0] }, { reference: authorRefs[1] }, { reference: authorRefs[2] }],
+        });
+
+        const db = getDatabasePool(DatabaseMode.READER);
+        const results = await db.query('SELECT "author" FROM "DocumentReference" WHERE "id" = $1', [doc.id]);
+        expect(results.rows).toStrictEqual([{ author: expected }]);
+      }));
+
+    test('same reference values in different resource order yield identical stored array', () =>
+      withTestContext(async () => {
+        const a = 'Patient/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const b = 'Practitioner/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        const expected = [a, b].sort(compareColumnValues);
+
+        const doc1 = await systemRepo.createResource<DocumentReference>({
+          resourceType: 'DocumentReference',
+          status: 'current',
+          content: [{ attachment: { url: 'https://example.com/a.pdf' } }],
+          author: [{ reference: b }, { reference: a }],
+        });
+        const doc2 = await systemRepo.createResource<DocumentReference>({
+          resourceType: 'DocumentReference',
+          status: 'current',
+          content: [{ attachment: { url: 'https://example.com/b.pdf' } }],
+          author: [{ reference: a }, { reference: b }],
+        });
+
+        const db = getDatabasePool(DatabaseMode.READER);
+        const r1 = await db.query('SELECT "author" FROM "DocumentReference" WHERE "id" = $1', [doc1.id]);
+        const r2 = await db.query('SELECT "author" FROM "DocumentReference" WHERE "id" = $1', [doc2.id]);
+        expect(r1.rows).toStrictEqual([{ author: expected }]);
+        expect(r2.rows).toStrictEqual([{ author: expected }]);
+      }));
+
+    test('stores multi-valued quantity column in sorted order (Observation.component)', () =>
+      withTestContext(async () => {
+        const values = [100.5, 3.14, 42];
+        const expected = [...values].sort(compareColumnValues);
+
+        const obs = await systemRepo.createResource<Observation>({
+          resourceType: 'Observation',
+          status: 'final',
+          code: { text: 'component quantity sort test' },
+          component: [
+            {
+              code: { text: 'first' },
+              valueQuantity: { value: values[0], unit: '1', system: 'http://unitsofmeasure.org', code: '1' },
+            },
+            {
+              code: { text: 'second' },
+              valueQuantity: { value: values[1], unit: '1', system: 'http://unitsofmeasure.org', code: '1' },
+            },
+            {
+              code: { text: 'third' },
+              valueQuantity: { value: values[2], unit: '1', system: 'http://unitsofmeasure.org', code: '1' },
+            },
+          ],
+        });
+
+        const db = getDatabasePool(DatabaseMode.READER);
+        const results = await db.query('SELECT "componentValueQuantity" FROM "Observation" WHERE "id" = $1', [obs.id]);
+        expect(results.rows).toStrictEqual([{ componentValueQuantity: expected }]);
+      }));
+  });
+});
+
+describe('compareColumnValues', () => {
+  describe('returns 0 when a === b', () => {
+    test.each<[ColumnValue, ColumnValue]>([
+      [null, null],
+      [undefined, undefined],
+      ['Patient/1', 'Patient/1'],
+      ['https://example.org/fhir/Patient/abc', 'https://example.org/fhir/Patient/abc'],
+      ['', ''],
+      [' ', ' '],
+      [0, 0],
+      [-0, 0],
+      [3.14, 3.14],
+      [-100, -100],
+      [Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
+      [Number.MIN_SAFE_INTEGER, Number.MIN_SAFE_INTEGER],
+      [true, true],
+      [false, false],
+    ])('compareColumnValues(%p, %p) === 0', (a, b) => {
+      expect(compareColumnValues(a, b)).toBe(0);
+    });
+  });
+
+  describe('returns 1 when a is null or undefined and b is defined', () => {
+    test.each<[ColumnValue, ColumnValue]>([
+      [null, 'x'],
+      [undefined, 'x'],
+      [null, ''],
+      [undefined, ''],
+      [null, ' '],
+      [undefined, 'Patient/1'],
+      [null, 0],
+      [undefined, 0],
+      [null, -1],
+      [undefined, 3.14],
+      [undefined, Number.NaN],
+      [null, Number.POSITIVE_INFINITY],
+      [undefined, Number.MIN_SAFE_INTEGER],
+      [null, false],
+      [undefined, true],
+    ])('compareColumnValues(%p, %p) === 1', (a, b) => {
+      expect(compareColumnValues(a, b)).toBe(1);
+    });
+  });
+
+  describe('null and undefined are equal', () => {
+    test.each<[ColumnValue, ColumnValue, 0]>([
+      [null, undefined, 0],
+      [undefined, null, 0],
+    ])('compareColumnValues(%p, %p) === %s', (a, b, expected) => {
+      expect(compareColumnValues(a, b)).toBe(expected);
+    });
+  });
+
+  describe('returns -1 when b is null or undefined and a is defined', () => {
+    test.each<[ColumnValue, ColumnValue]>([
+      ['x', null],
+      ['x', undefined],
+      ['', null],
+      ['Patient/1', undefined],
+      [0, null],
+      [0, undefined],
+      [-1, undefined],
+      [3.14, null],
+      [Number.NaN, null],
+      [Number.POSITIVE_INFINITY, undefined],
+      [false, null],
+      [true, undefined],
+    ])('compareColumnValues(%p, %p) === -1', (a, b) => {
+      expect(compareColumnValues(a, b)).toBe(-1);
+    });
+  });
+
+  describe('returns a - b when both operands are numbers', () => {
+    test.each<[number, number, number]>([
+      [1, 2, -1],
+      [2, 1, 1],
+      [0, -1, 1],
+      [-1, -2, 1],
+      [-1, 1, -2],
+      [100, 50, 50],
+      [Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER - 1, 1],
+      [Number.MIN_SAFE_INTEGER, Number.MIN_SAFE_INTEGER + 1, -1],
+      [0, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY],
+      [Number.POSITIVE_INFINITY, 0, Number.POSITIVE_INFINITY],
+      [Number.NEGATIVE_INFINITY, 0, Number.NEGATIVE_INFINITY],
+      [0, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY],
+    ])('compareColumnValues(%p, %p) === %p', (a, b, expected) => {
+      expect(compareColumnValues(a, b)).toBe(expected);
+    });
+
+    test('NaN arithmetic and negative minus positive infinity', () => {
+      expect(compareColumnValues(Number.NaN, 1)).toBeNaN();
+      expect(compareColumnValues(1, Number.NaN)).toBeNaN();
+      expect(compareColumnValues(Number.NaN, Number.NaN)).toBeNaN();
+      expect(compareColumnValues(Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY)).toBe(Number.NEGATIVE_INFINITY);
+    });
+  });
+
+  describe('returns Number(a) - Number(b) when both operands are booleans', () => {
+    test.each<[boolean, boolean, number]>([
+      [false, true, -1],
+      [true, false, 1],
+    ])('compareColumnValues(%p, %p) === %p', (a, b, expected) => {
+      expect(compareColumnValues(a, b)).toBe(expected);
+    });
+  });
+
+  describe('uses String(a).localeCompare(String(b)) when types are not both number or both boolean', () => {
+    test.each<[ColumnValue, ColumnValue]>([
+      ['apple', 'banana'],
+      ['banana', 'apple'],
+      ['', 'z'],
+      ['a', 'Z'],
+      ['prefix', 'prefixLonger'],
+      ['Observation/10', 'Observation/2'],
+      [1, '2'],
+      [0, '0'],
+      [-5, '5'],
+      [true, 'false'],
+      [false, '0'],
+      [1, true],
+      [0, false],
+      [false, 0],
+      [true, 1],
+    ])('compareColumnValues(%p, %p) matches localeCompare', (a, b) => {
+      expect(compareColumnValues(a, b)).toBe(String(a).localeCompare(String(b)));
+    });
+  });
+});

--- a/packages/server/src/fhir/repository/row-builder.ts
+++ b/packages/server/src/fhir/repository/row-builder.ts
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { SearchParameterDetails, TypedValue } from '@medplum/core';
+import {
+  convertToSearchableDates,
+  convertToSearchableNumbers,
+  convertToSearchableQuantities,
+  convertToSearchableReferences,
+  convertToSearchableStrings,
+  convertToSearchableTokens,
+  convertToSearchableUris,
+  evalFhirPathTyped,
+  flatMapFilter,
+  resolveId,
+  SearchParameterType,
+  stringify,
+  toPeriod,
+  toTypedValue,
+} from '@medplum/core';
+import type { Meta, Resource, ResourceType, SearchParameter } from '@medplum/fhirtypes';
+import { getConfig } from '../../config/loader';
+import type { ArrayColumnPaddingConfig } from '../../config/types';
+import { systemResourceProjectId } from '../../constants';
+import { getLogger } from '../../logger';
+import { recordHistogramValue } from '../../otel/otel';
+import type { HumanNameResource } from '../lookups/humanname';
+import { getHumanNameSortValue } from '../lookups/humanname';
+import { getStandardAndDerivedSearchParameters } from '../lookups/util';
+import type { ColumnSearchParameterImplementation } from '../searchparameter';
+import { getSearchParameterImplementation } from '../searchparameter';
+import { periodToRangeString, truncateTextColumn } from '../sql';
+import { buildTokenColumns } from '../token-column';
+
+export type ColumnValue = boolean | number | string | undefined | null;
+
+export function buildDeletedResourceRow(
+  resourceType: ResourceType,
+  id: string,
+  projectId: string | undefined
+): { id: string; lastUpdated: Date; deleted: boolean; projectId: string; content: string; __version: number } & Record<
+  string,
+  any
+> {
+  const lastUpdated = new Date();
+  const content = '';
+  const columns = {
+    id,
+    lastUpdated,
+    deleted: true,
+    projectId: projectId ?? systemResourceProjectId,
+    content,
+    __version: -1,
+  };
+
+  for (const searchParam of getStandardAndDerivedSearchParameters(resourceType)) {
+    buildColumn({ resourceType } as Resource, columns, searchParam);
+  }
+
+  return columns;
+}
+export function buildResourceRow(resource: Resource, version: number): Record<string, any> {
+  const resourceType = resource.resourceType;
+  const meta = resource.meta as Meta;
+  const content = stringify(resource);
+
+  const row: Record<string, any> = {
+    id: resource.id,
+    lastUpdated: meta.lastUpdated,
+    deleted: false,
+    projectId: meta.project ?? systemResourceProjectId,
+    content,
+    __version: version,
+  };
+
+  const searchParams = getStandardAndDerivedSearchParameters(resourceType);
+  if (searchParams.length > 0) {
+    const startTime = process.hrtime.bigint();
+    try {
+      for (const searchParam of searchParams) {
+        buildColumn(resource, row, searchParam);
+      }
+    } catch (err) {
+      getLogger().error('Error building row for resource', {
+        resource: `${resourceType}/${resource.id}`,
+        err,
+      });
+      throw err;
+    }
+    recordHistogramValue(
+      'medplum.server.indexingDurationMs',
+      Number(process.hrtime.bigint() - startTime) / 1e6, // High resolution time, converted from ns to ms
+      {
+        options: { unit: 'ms' },
+      }
+    );
+  }
+
+  return row;
+}
+
+/**
+ * Builds the columns to write for a given resource and search parameter.
+ * If nothing to write, then no columns will be added.
+ * Some search parameters can result in multiple columns (for example, Reference objects).
+ * @param resource - The resource to write.
+ * @param columns - The output columns to write.
+ * @param searchParam - The search parameter definition.
+ */
+function buildColumn(resource: Resource, columns: Record<string, any>, searchParam: SearchParameter): void {
+  if (
+    searchParam.code === '_id' ||
+    searchParam.code === '_lastUpdated' ||
+    searchParam.code === '_compartment:identifier' ||
+    searchParam.code === '_deleted' ||
+    searchParam.code === '_project' ||
+    searchParam.type === 'composite'
+  ) {
+    return;
+  }
+
+  if (searchParam.code === '_compartment') {
+    columns['compartments'] = resource.meta?.compartment?.map((ref) => resolveId(ref)) ?? [];
+    return;
+  }
+
+  const impl = getSearchParameterImplementation(resource.resourceType, searchParam);
+  if (impl.searchStrategy === 'lookup-table') {
+    if (impl.sortColumnName) {
+      columns[impl.sortColumnName] = truncateTextColumn(
+        getHumanNameSortValue((resource as HumanNameResource).name, searchParam)
+      );
+    }
+    return;
+  }
+
+  const typedValues = evalFhirPathTyped(impl.parsedExpression, [toTypedValue(resource)]);
+
+  // Handle special case for "MeasureReport-period"
+  // This is a trial for using "tstzrange" columns for date/time ranges.
+  // Eventually, this special case will go away, and this will become the default behavior for all "date" search parameters.
+  if (searchParam.id === 'MeasureReport-period') {
+    columns['period_range'] = buildPeriodColumn(typedValues[0]?.value);
+  }
+
+  if (impl.searchStrategy === 'token-column') {
+    buildTokenColumns(searchParam, impl, columns, resource, {
+      paddingConfig: getArrayPaddingConfig(searchParam, resource.resourceType),
+    });
+    return;
+  }
+
+  impl satisfies ColumnSearchParameterImplementation;
+  const columnValues = buildColumnValues(searchParam, impl, typedValues);
+  if (impl.array) {
+    columnValues.sort(compareColumnValues);
+    columns[impl.columnName] = columnValues.length > 0 ? columnValues : undefined;
+  } else {
+    columns[impl.columnName] = columnValues[0];
+  }
+}
+
+/**
+ * Builds a single value for a given search parameter.
+ * If the search parameter is an array, then this method will be called for each element.
+ * If the search parameter is not an array, then this method will be called for the value.
+ * @param searchParam - The search parameter definition.
+ * @param details - The extra search parameter details.
+ * @param typedValues - The FHIR resource value.
+ * @returns The column value.
+ */
+function buildColumnValues(
+  searchParam: SearchParameter,
+  details: SearchParameterDetails,
+  typedValues: TypedValue[]
+): ColumnValue[] {
+  if (details.type === SearchParameterType.BOOLEAN) {
+    const value = typedValues[0]?.value;
+    if (value === undefined || value === null) {
+      return [null];
+    }
+    return [value === true || value === 'true'];
+  }
+
+  if (details.type === SearchParameterType.DATE) {
+    // "Date" column is a special case that only applies when the following conditions are true:
+    // 1. The search parameter is a date type.
+    // 2. The underlying FHIR ElementDefinition referred to by the search parameter has a type of "date".
+    return flatMapFilter(convertToSearchableDates(typedValues), (p) => (p.start ?? p.end)?.substring(0, 10));
+  }
+
+  if (details.type === SearchParameterType.DATETIME) {
+    // Future work: write the whole period to the DB after migrating all "date" search parameters to use a tstzrange.
+    return flatMapFilter(convertToSearchableDates(typedValues), (p) => p.start ?? p.end);
+  }
+
+  if (searchParam.type === 'number') {
+    // Future work: write the whole range to the DB after migrating all "number" search parameters to use a range.
+    return flatMapFilter(convertToSearchableNumbers(typedValues), ([low, high]) => low ?? high);
+  }
+
+  if (searchParam.type === 'quantity') {
+    // Future work: write the whole range to the DB after migrating all "quantity" search parameters to use a range.
+    return flatMapFilter(convertToSearchableQuantities(typedValues), (q) => q.value);
+  }
+
+  if (searchParam.type === 'reference') {
+    return flatMapFilter(convertToSearchableReferences(typedValues), truncateTextColumn);
+  }
+
+  if (searchParam.type === 'token') {
+    return flatMapFilter(convertToSearchableTokens(typedValues), (t) => truncateTextColumn(t.value));
+  }
+
+  if (searchParam.type === 'string') {
+    return flatMapFilter(convertToSearchableStrings(typedValues), truncateTextColumn);
+  }
+
+  if (searchParam.type === 'uri') {
+    return flatMapFilter(convertToSearchableUris(typedValues), truncateTextColumn);
+  }
+
+  if (searchParam.type === 'special' || searchParam.type === 'composite') {
+    // Special and composite search parameters are not supported in the database.
+    return [];
+  }
+
+  throw new Error('Unrecognized search parameter type: ' + searchParam.type);
+}
+
+/**
+ * Builds the column value for a "date" search parameter.
+ * This is currently in trial mode. The intention is for this to replace all "date" and "date/time" search parameters.
+ * @param value - The FHIRPath result value.
+ * @returns The period column string value.
+ */
+function buildPeriodColumn(value: any): string | undefined {
+  const period = toPeriod(value);
+  if (period) {
+    return periodToRangeString(period);
+  }
+  return undefined;
+}
+
+export function compareColumnValues(a: ColumnValue, b: ColumnValue): number {
+  if ((a ?? null) === (b ?? null)) {
+    return 0;
+  }
+  if (a === null || a === undefined) {
+    return 1;
+  }
+  if (b === null || b === undefined) {
+    return -1;
+  }
+  if (typeof a === 'number' && typeof b === 'number') {
+    return a - b;
+  }
+  if (typeof a === 'boolean' && typeof b === 'boolean') {
+    return Number(a) - Number(b);
+  }
+  return String(a).localeCompare(String(b));
+}
+
+function getArrayPaddingConfig(
+  searchParam: SearchParameter,
+  resourceType: string
+): ArrayColumnPaddingConfig | undefined {
+  const paddingConfigEntry = getConfig().arrayColumnPadding?.[searchParam.code];
+  if (paddingConfigEntry) {
+    if (Array.isArray(paddingConfigEntry)) {
+      for (const entry of paddingConfigEntry) {
+        if (entry.resourceType === undefined || entry.resourceType.includes(resourceType)) {
+          return entry.config;
+        }
+      }
+      return undefined;
+    }
+
+    if (paddingConfigEntry.resourceType === undefined || paddingConfigEntry.resourceType.includes(resourceType)) {
+      return paddingConfigEntry.config;
+    }
+  }
+  return undefined;
+}

--- a/packages/server/src/fhir/repository/validation.test.ts
+++ b/packages/server/src/fhir/repository/validation.test.ts
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ElementDefinition, Observation, Patient, StructureDefinition, ValueSet } from '@medplum/fhirtypes';
+import { randomUUID } from 'crypto';
+import { readFileSync } from 'fs';
+import assert from 'node:assert';
+import { resolve } from 'path';
+import { initAppServices, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config/loader';
+import { createTestProject, withTestContext } from '../../test.setup';
+import type { Repository } from '../repo';
+import { getGlobalSystemRepo } from '../repo';
+
+jest.mock('hibp');
+
+describe('Repository validation', () => {
+  const systemRepo = getGlobalSystemRepo();
+  const rawUsCorePatientProfile = readFileSync(resolve(__dirname, '../__test__/us-core-patient.json'), 'utf8');
+  const usCorePatientProfile = JSON.parse(rawUsCorePatientProfile) as StructureDefinition;
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initAppServices(config);
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test('Profile validation', async () =>
+    withTestContext(async () => {
+      const { repo } = await createTestProject({ withRepo: true });
+
+      const profile = { ...usCorePatientProfile, url: 'urn:uuid:' + randomUUID() };
+      const patient: Patient = {
+        resourceType: 'Patient',
+        meta: {
+          profile: [profile.url],
+        },
+        identifier: [
+          {
+            system: 'http://example.com/patient-id',
+            value: 'foo',
+          },
+        ],
+        name: [
+          {
+            given: ['Alex'],
+            family: 'Baker',
+          },
+        ],
+        // Missing gender property is required by profile
+      };
+
+      await expect(repo.createResource(patient)).resolves.toBeTruthy();
+      await repo.createResource(profile);
+      await expect(repo.createResource(patient)).rejects.toThrow(
+        new Error('Missing required property (Patient.gender)')
+      );
+    }));
+
+  test('Profile update', async () =>
+    withTestContext(async () => {
+      const { repo } = await createTestProject({ withRepo: true });
+
+      const profile = await repo.createResource({
+        ...usCorePatientProfile,
+        url: 'urn:uuid:' + randomUUID(),
+      });
+
+      const patient: Patient = {
+        resourceType: 'Patient',
+        meta: { profile: [profile.url] },
+        identifier: [{ system: 'http://example.com/patient-id', value: 'foo' }],
+        name: [{ given: ['Alex'], family: 'Baker' }],
+        gender: 'male',
+      };
+
+      // Create the patient
+      // This should succeed
+      await expect(repo.createResource(patient)).resolves.toBeTruthy();
+
+      // Now update the profile to make "address" a required field
+      await repo.updateResource<StructureDefinition>({
+        ...profile,
+        snapshot: {
+          ...profile.snapshot,
+          element: profile.snapshot?.element?.map((e) => {
+            if (e.path === 'Patient.address') {
+              return {
+                ...e,
+                min: 1,
+              };
+            }
+            return e;
+          }) as ElementDefinition[],
+        },
+      });
+
+      // Now try to create another patient without an address
+      // This should fail
+      await expect(repo.createResource(patient)).rejects.toThrow(
+        new Error('Missing required property (Patient.address)')
+      );
+    }));
+
+  describe('Update resource with terminology validation', () => {
+    const patient: Patient = {
+      resourceType: 'Patient',
+      identifier: [{ use: 'usual', system: 'urn:oid:1.2.36.146.595.217.0.1', value: '12345' }],
+      active: true,
+      name: [
+        { use: 'official', family: 'Chalmers', given: ['Peter', 'James'] },
+        { use: 'usual', given: ['Jim'] },
+        { use: 'maiden', family: 'Windsor', given: ['Peter', 'James'] },
+      ],
+      telecom: [
+        { use: 'home', system: 'url', value: 'http://example.com' },
+        { system: 'phone', value: '(03) 5555 6473', use: 'work', rank: 1 },
+        { system: 'phone', value: '(03) 3410 5613', use: 'mobile', rank: 2 },
+        { system: 'phone', value: '(03) 5555 8834', use: 'old' },
+      ],
+      gender: 'male',
+      birthDate: '1974-12-25',
+      address: [{ use: 'home', type: 'both', text: '534 Erewhon St PeasantVille, Rainbow, Vic  3999' }],
+      contact: [
+        {
+          name: { use: 'usual', family: 'du Marché', given: ['Bénédicte'] },
+          telecom: [{ system: 'phone', value: '+33 (237) 998327', use: 'home' }],
+          address: { use: 'home', type: 'both', line: ['534 Erewhon St'], city: 'PleasantVille', postalCode: '3999' },
+          gender: 'female',
+        },
+      ],
+      communication: [{ language: { coding: [{ system: 'urn:ietf:bcp:47', code: 'en' }] } }],
+    };
+
+    let repo: Repository;
+    let profile: StructureDefinition;
+    beforeAll(async () => {
+      const result = await createTestProject({ withRepo: true, project: { features: ['validate-terminology'] } });
+      repo = result.repo;
+
+      // Create modified US Core Patient profile to have 'required' binding for communication.language
+      const modifiedPatientProfile = JSON.parse(rawUsCorePatientProfile) as StructureDefinition;
+
+      const commLang = modifiedPatientProfile.snapshot?.element.find((e) => e.id === 'Patient.communication.language');
+      assert(commLang?.binding?.valueSet === 'http://hl7.org/fhir/us/core/ValueSet/simple-language');
+      assert(commLang.binding.strength === 'extensible');
+      commLang.binding.strength = 'required';
+
+      profile = await repo.createResource({
+        ...modifiedPatientProfile,
+        url: 'urn:uuid:' + randomUUID(),
+      });
+
+      // Create a ValueSet for the US Core Patient profile that includes only 'en' as a valid language
+      await repo.createResource<ValueSet>({
+        resourceType: 'ValueSet',
+        url: 'http://hl7.org/fhir/us/core/ValueSet/simple-language',
+        expansion: {
+          timestamp: new Date().toISOString(),
+          contains: [
+            {
+              system: 'urn:ietf:bcp:47',
+              code: 'en',
+            },
+          ],
+        },
+        status: 'active',
+      });
+    });
+    test('Valid patient without any profiles', async () =>
+      withTestContext(async () => {
+        await expect(repo.createResource(patient)).resolves.toBeDefined();
+      }));
+
+    test('Invalid gender', async () =>
+      withTestContext(async () => {
+        await expect(
+          repo.createResource({ ...patient, gender: 'enby' as unknown as Patient['gender'] })
+        ).rejects.toThrow(
+          `Value "enby" did not satisfy terminology binding http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1 (Patient.gender)`
+        );
+      }));
+
+    test('Valid patient with US Core Patient profile', async () =>
+      withTestContext(async () => {
+        await expect(repo.createResource({ ...patient, meta: { profile: [profile.url] } })).resolves.toBeDefined();
+      }));
+
+    test('Invalid patient with US Core Patient profile (communication.language not in ValueSet)', async () =>
+      withTestContext(async () => {
+        await expect(
+          repo.createResource({
+            ...patient,
+            meta: { profile: [profile.url] },
+            communication: [{ language: { coding: [{ system: 'urn:ietf:bcp:47', code: 'fr' }] } }],
+          })
+        ).rejects.toThrow(
+          `Value {"coding":[{"system":"urn:ietf:bcp:47","code":"fr"}]} did not satisfy terminology binding http://hl7.org/fhir/us/core/ValueSet/simple-language (Patient.communication[0].language)`
+        );
+      }));
+  });
+
+  test('Project default profiles', async () =>
+    withTestContext(async () => {
+      const { repo } = await createTestProject({
+        withRepo: true,
+        project: {
+          defaultProfile: [
+            { resourceType: 'Observation', profile: ['http://hl7.org/fhir/StructureDefinition/vitalsigns'] },
+          ],
+        },
+      });
+
+      const observation: Observation = {
+        resourceType: 'Observation',
+        status: 'final',
+        category: [
+          { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'vital-signs' }] },
+        ],
+        code: { text: 'Strep test' },
+        effectiveDateTime: '2024-02-13T14:34:56Z',
+        valueBoolean: true,
+      };
+
+      await expect(systemRepo.createResource(observation)).resolves.toBeDefined();
+      await expect(repo.createResource(observation)).rejects.toThrow('Missing required property (Observation.subject)');
+
+      observation.subject = { identifier: { value: randomUUID() } };
+      await expect(repo.createResource(observation)).resolves.toMatchObject<Partial<Observation>>({
+        meta: expect.objectContaining({
+          profile: ['http://hl7.org/fhir/StructureDefinition/vitalsigns'],
+        }),
+      });
+    }));
+});

--- a/packages/server/src/fhir/repository/validation.ts
+++ b/packages/server/src/fhir/repository/validation.ts
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { TypedValueWithPath, ValidatorOptions } from '@medplum/core';
+import { getReferenceString, OperationOutcomeError, Operator, validateResource } from '@medplum/core';
+import type {
+  CodeableConcept,
+  Coding,
+  OperationOutcomeIssue,
+  Resource,
+  StructureDefinition,
+  ValueSet,
+} from '@medplum/fhirtypes';
+import { getConfig } from '../../config/loader';
+import { getLogger } from '../../logger';
+import { recordHistogramValue } from '../../otel/otel';
+import { validateResourceWithJsonSchema } from '../jsonschema';
+import { findTerminologyResource } from '../operations/utils/terminology';
+import { validateCodingInValueSet } from '../operations/valuesetvalidatecode';
+import type { Repository } from '../repo';
+import { cacheProfile, getCachedProfile } from './profile-cache';
+
+/**
+ * Validates a resource against the current project configuration.
+ * If strict mode is enabled (default), validates against base StructureDefinition and all profiles.
+ * If strict mode is disabled, validates against the legacy JSONSchema validator.
+ * Throws on validation errors.
+ * Returns silently on success.
+ * @param repo - The repository to use for validation.
+ * @param resource - The candidate resource to validate.
+ */
+export async function validateRepositoryResource(repo: Repository, resource: Resource): Promise<void> {
+  if (repo.getConfig().strictMode) {
+    await validateRepositoryResourceStrictly(repo, resource);
+  } else {
+    // Perform loose validation first to detect any severe issues
+    validateResourceWithJsonSchema(resource);
+
+    // Attempt strict validation and log warnings on failure
+    try {
+      await validateRepositoryResourceStrictly(repo, resource);
+    } catch (err: any) {
+      getLogger().warn('Strict validation would fail', {
+        resource: getReferenceString(resource),
+        err,
+      });
+    }
+  }
+}
+
+export async function validateRepositoryResourceStrictly(repo: Repository, resource: Resource): Promise<void> {
+  const logger = getLogger();
+  const start = process.hrtime.bigint();
+  const context = repo.getConfig();
+
+  // Prepare validator options
+  let options: ValidatorOptions | undefined;
+  if (context.validateTerminology) {
+    const tokens = Object.create(null);
+    options = { ...options, collect: { tokens } };
+  }
+
+  // Validate resource against base FHIR spec
+  const issues = validateResource(resource, { ...options, base64BinaryMaxBytes: getConfig().base64BinaryMaxBytes });
+
+  for (const issue of issues) {
+    logger.warn(`Validator warning: ${issue.details?.text}`, { project: context.projects?.[0]?.id, issue });
+  }
+
+  // Validate profiles after verifying compliance with base spec
+  const profileUrls = resource.meta?.profile;
+  if (profileUrls) {
+    await validateProfiles(repo, resource, profileUrls, options);
+  }
+
+  // (Optionally) check any required terminology bindings found
+  if (context.validateTerminology && options?.collect?.tokens) {
+    await validateTerminology(repo, options.collect.tokens, issues);
+    if (issues.some((iss) => iss.severity === 'error')) {
+      throw new OperationOutcomeError({ resourceType: 'OperationOutcome', issue: issues });
+    }
+  }
+
+  // Track latency for successful validation
+  const durationMs = Number(process.hrtime.bigint() - start) / 1e6; // Convert nanoseconds to milliseconds
+  recordHistogramValue('medplum.server.validationDurationMs', durationMs, { options: { unit: 'ms' } });
+  if (durationMs > 10) {
+    logger.debug('High validator latency', {
+      resourceType: resource.resourceType,
+      id: resource.id,
+      durationMs,
+    });
+  }
+}
+
+async function validateProfiles(
+  repo: Repository,
+  resource: Resource,
+  profileUrls: string[],
+  options?: ValidatorOptions
+): Promise<void> {
+  const logger = getLogger();
+  for (const url of profileUrls) {
+    const loadStart = process.hrtime.bigint();
+    const profile = await loadProfile(repo, url);
+    const loadTime = Number(process.hrtime.bigint() - loadStart);
+    if (!profile) {
+      logger.warn('Unknown profile referenced', {
+        resource: `${resource.resourceType}/${resource.id}`,
+        url,
+      });
+      continue;
+    }
+
+    const validateStart = process.hrtime.bigint();
+    validateResource(resource, { ...options, profile });
+    const validateTime = Number(process.hrtime.bigint() - validateStart);
+    logger.debug('Profile loaded', {
+      url,
+      loadTime,
+      validateTime,
+    });
+  }
+}
+
+async function validateTerminology(
+  repo: Repository,
+  tokens: Record<string, TypedValueWithPath[]>,
+  issues: OperationOutcomeIssue[]
+): Promise<void> {
+  for (const [url, values] of Object.entries(tokens)) {
+    const valueSet = await findTerminologyResource<ValueSet>(repo, 'ValueSet', url);
+
+    const resultCache: Record<string, boolean | undefined> = Object.create(null);
+    for (const value of values) {
+      let codings: Coding[] | undefined;
+      switch (value.type) {
+        case 'CodeableConcept':
+          codings = (value.value as CodeableConcept).coding;
+          break;
+        case 'Coding':
+          codings = [value.value as Coding];
+          break;
+        default: {
+          const cachedResult = resultCache[`${value.type}|${value.value}`];
+          if (cachedResult === false) {
+            issues.push({
+              severity: 'error',
+              code: 'value',
+              details: { text: `Value ${JSON.stringify(value.value)} did not satisfy terminology binding ${url}` },
+              expression: [value.path],
+            });
+          }
+          if (cachedResult !== undefined) {
+            continue;
+          }
+          codings = [{ code: value.value as string }];
+          break;
+        }
+      }
+      if (!codings?.length) {
+        continue;
+      }
+
+      const matchedCoding = await validateCodingInValueSet(repo, valueSet, codings);
+      resultCache[`${value.type}|${value.value}`] = Boolean(matchedCoding);
+      if (!matchedCoding) {
+        issues.push({
+          severity: 'error',
+          code: 'value',
+          details: { text: `Value ${JSON.stringify(value.value)} did not satisfy terminology binding ${url}` },
+          expression: [value.path],
+        });
+      }
+    }
+  }
+}
+
+async function loadProfile(repo: Repository, url: string): Promise<StructureDefinition | undefined> {
+  const context = repo.getConfig();
+  // Profile fetching/caching should be pushed to a lower level of Repository; as it is, if `repo` has an
+  // AccessPolicy on StructureDefinition hiding fields (that would be a strange choice, but possible), then caching
+  // it here would impact other repositories in the project with different AccessPolicies.
+  if (context.projects?.length) {
+    // Try loading from cache, using all available Project IDs
+    const cachedProfile = await getCachedProfile(context.projects, url);
+    if (cachedProfile) {
+      return cachedProfile;
+    }
+  }
+
+  // Fall back to loading from the DB; descending version sort approximates version resolution for some cases
+  const profile = await repo.searchOne<StructureDefinition>({
+    resourceType: 'StructureDefinition',
+    filters: [
+      {
+        code: 'url',
+        operator: Operator.EQUALS,
+        value: url,
+      },
+    ],
+    sortRules: [
+      {
+        code: 'version',
+        descending: true,
+      },
+      {
+        code: 'date',
+        descending: true,
+      },
+    ],
+  });
+
+  if (context.projects?.length && profile) {
+    await cacheProfile(profile);
+  }
+  return profile;
+}

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -74,6 +74,7 @@ import { updateUserEmailOperation } from './operations/update-user-email';
 import { valueSetValidateOperation } from './operations/valuesetvalidatecode';
 import { sendOutcome } from './outcomes';
 import type { ResendSubscriptionsOptions } from './repo';
+import { validateRepositoryResourceStrictly } from './repository/validation';
 import { sendFhirResponse } from './response';
 import { smartConfigurationHandler, smartStylingHandler } from './smart';
 
@@ -386,7 +387,7 @@ function initInternalFhirRouter(): FhirRouter {
   // Validate create resource
   router.add('POST', '/:resourceType/$validate', async (req: FhirRequest) => {
     const ctx = getAuthenticatedContext();
-    await ctx.repo.validateResourceStrictly(req.body);
+    await validateRepositoryResourceStrictly(ctx.repo, req.body);
     return [allOk];
   });
 

--- a/packages/server/src/pubsub.ts
+++ b/packages/server/src/pubsub.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { isResourceType } from '@medplum/core';
 import type { ResourceType, Subscription } from '@medplum/fhirtypes';
-import type { CacheEntry } from './fhir/repo';
+import type { CacheEntry } from './fhir/repository/resource-cache';
 import { globalLogger } from './logger';
 import { getCacheRedis, getPubSubRedis } from './redis';
 

--- a/packages/server/src/ws/subscriptions.ts
+++ b/packages/server/src/ws/subscriptions.ts
@@ -13,7 +13,7 @@ import type { RawData, WebSocket } from 'ws';
 import { getConfig } from '../config/loader';
 import { WEBSOCKET_SUB_PUBLISH_CHANNEL } from '../constants';
 import type { AdditionalWsBindingClaims } from '../fhir/operations/getwsbindingtoken';
-import type { CacheEntry } from '../fhir/repo';
+import type { CacheEntry } from '../fhir/repository/resource-cache';
 import { getFullUrl } from '../fhir/response';
 import { rewriteAttachments, RewriteMode } from '../fhir/rewrite';
 import { DEFAULT_HEARTBEAT_MS, heartbeat } from '../heartbeat';


### PR DESCRIPTION
`repo.ts` and its test suite are monolithic files. This extracts several aspects of them into separate source files to make them easier to work with for humans and robots.

This is strictly code re-organization; no intended change in functionality.

I'm deferring resolving the merge conflicts until range search (#9051) lands.