### PR TITLE
fix: close OAuth callback server after extra browser requests post-login (#6144)

### DIFF
--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -64,6 +64,7 @@ async function startLogin(medplum: MedplumClient, profile: Profile): Promise<voi
 }
 
 async function startWebServer(medplum: MedplumClient): Promise<void> {
+  let authComplete = false;
   const server = createServer(async (req, res) => {
     const url = new URL(req.url as string, 'http://localhost:9615');
     const code = url.searchParams.get('code');
@@ -84,12 +85,17 @@ async function startWebServer(medplum: MedplumClient): Promise<void> {
         res.writeHead(400, { 'Content-Type': ContentType.TEXT });
         res.end(`Error: ${normalizeErrorString(err)}`);
       } finally {
+        authComplete = true;
         server.close();
         process.exit(0);
       }
     } else {
       res.writeHead(404, { 'Content-Type': ContentType.TEXT });
       res.end('Not found');
+      if (authComplete) {
+        server.close();
+        process.exit(0);
+      }
     }
   }).listen(9615);
 }


### PR DESCRIPTION
Fixes #6144

## Problem
When `medplum login` completes the OAuth code exchange, the `finally` block correctly calls `server.close()` and `process.exit(0)`. However, browsers typically fire additional HTTP requests after the redirect (e.g. `/favicon.ico`), which hit the `else` branch ("Not found") and were silently ignored — keeping the Node.js process alive indefinitely.

This is why users see the process hang even though login was successful.

## Fix
Added an `authComplete` flag (initialized to `false`) that is set to `true` inside the `finally` block after successful auth. The `else` branch now checks this flag and calls `server.close()` + `process.exit(0)` if auth has already completed, allowing the process to cleanly terminate.

## Changes
- `packages/cli/src/auth.ts` — 3 lines added