### PR TITLE
fix: add missing Appointment date search parameter (#5614)

### DIFF
--- a/packages/definitions/src/fhir/r4/search-parameters-medplum.json
+++ b/packages/definitions/src/fhir/r4/search-parameters-medplum.json
@@ -781,6 +781,24 @@
       }
     },
     {
+      "fullUrl": "https://medplum.com/fhir/SearchParameter/Appointment-date",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "Appointment-date",
+        "url": "https://medplum.com/fhir/SearchParameter/Appointment-date",
+        "version": "4.0.1",
+        "name": "date",
+        "status": "draft",
+        "publisher": "Medplum",
+        "description": "Appointment date/time",
+        "code": "date",
+        "base": ["Appointment"],
+        "type": "date",
+        "expression": "Appointment.start",
+        "target": ["Appointment"]
+      }
+    },
+    {
       "fullUrl": "https://medplum.com/fhir/SearchParameter/Slot-end",
       "resource": {
         "resourceType": "SearchParameter",


### PR DESCRIPTION
Fixes #5614

The `date` search parameter for `Appointment` was missing from `search-parameters-medplum.json`.

This caused `Appointment?date=ge2024-11-25` to return no results, while the equivalent `_filter=date ge 2024-11-25` worked correctly — because `_filter` uses a different code path that does not rely on the SearchParameter definitions.

**Fix:** Added `Appointment-date` SearchParameter with `expression: "Appointment.start"` per the [FHIR R4 spec](https://hl7.org/fhir/R4/appointment.html#search).

**File changed:** `packages/definitions/src/fhir/r4/search-parameters-medplum.json` (+18 lines)