### PR TITLE
`$resend` with `versionId`

### DIFF
--- a/packages/docs/docs/api/fhir/operations/resend.md
+++ b/packages/docs/docs/api/fhir/operations/resend.md
@@ -20,7 +20,7 @@ When a subscription notification fails or you need to reprocess a resource throu
 - **Debugging Subscriptions**: Test subscription logic during development by manually triggering notifications
 - **Data Synchronization**: Force re-sync of specific resources to external systems after fixing integration issues
 - **Selective Replay**: Re-trigger a specific subscription for a resource instead of all subscriptions
-- **Historical Replay**: Replay a notification against a specific historical `versionId` so subscription handlers that diff `previous` against `current` see the same state as the original event, even if the resource has since been updated
+- **Historical Replay**: Replay a notification against a specific historical `versionId` so subscription handlers that diff `%previous` against `%current` see the same state as the original event, even if the resource has since been updated
 - **Integration Testing**: Verify that subscriptions fire correctly without creating new test data
 
 :::note[Admin Required]
@@ -36,7 +36,7 @@ The operation takes an optional `option` parameter, which is an object containin
 | `verbose`      | Indicates if verbose logging should be enabled.                                                                                                                                                                                                                                                                                      | `boolean`                                | `false`       |
 | `interaction`  | [`Subscriptions`](/docs/api/fhir/resources/subscription) can be configured to trigger only when a resource is created or deleted as opposed to any update. This option allows you to specify which interaction type will be sent.                                                                                                    | `update` &#124; `create` &#124; `delete` | `update`      |
 | `subscription` | A specific [`Subscription`](/docs/api/fhir/resources/subscription) to trigger, formatted as `Subscription/<id>`. If left undefined, all [`Subscriptions`](/docs/api/fhir/resources/subscription) will be triggered.                                                                                                                  | `string`                                 | `undefined`   |
-| `versionId`    | Resend subscriptions for a specific historical version of the resource instead of the current version. When set, the `previous` passed to subscription evaluation is the version immediately prior to this one in history (if any). Useful for replaying a failed notification when the resource has since been updated.     | `string`                                 | `undefined`   |
+| `versionId`    | Resend subscriptions for a specific historical version of the resource instead of the current version. When set, the `%previous` passed to subscription evaluation is the version immediately prior to this one in history (if any). Useful for replaying a failed notification when the resource has since been updated.     | `string`                                 | `undefined`   |
 
 ## Invoke the `$resend` operation
 

--- a/packages/docs/docs/api/fhir/operations/resend.md
+++ b/packages/docs/docs/api/fhir/operations/resend.md
@@ -20,6 +20,7 @@ When a subscription notification fails or you need to reprocess a resource throu
 - **Debugging Subscriptions**: Test subscription logic during development by manually triggering notifications
 - **Data Synchronization**: Force re-sync of specific resources to external systems after fixing integration issues
 - **Selective Replay**: Re-trigger a specific subscription for a resource instead of all subscriptions
+- **Historical Replay**: Replay a notification against a specific historical `versionId` so subscription handlers that diff `previousVersion` against `resource` see the same state as the original event, even if the resource has since been updated
 - **Integration Testing**: Verify that subscriptions fire correctly without creating new test data
 
 :::note[Admin Required]
@@ -28,13 +29,14 @@ The User, Bot, or ClientApplication invoking this operation must have [project a
 
 ## Parameters
 
-The operation takes an optional `option` parameter, which is an object containing three fields:
+The operation takes an optional `option` parameter, which is an object containing the following fields:
 
-| Option         | Description                                                                                                                                                                                                                       | Data Type                                | Default Value |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ------------- |
-| `verbose`      | Indicates if verbose logging should be enabled.                                                                                                                                                                                   | `boolean`                                | `false`       |
-| `interaction`  | [`Subscriptions`](/docs/api/fhir/resources/subscription) can be configured to trigger only when a resource is created or deleted as opposed to any update. This option allows you to specify which interaction type will be sent. | `update` &#124; `create` &#124; `delete` | `update`      |
-| `subscription` | A specific [`Subscription`](/docs/api/fhir/resources/subscription) to trigger, formatted as `Subscription/<id>`. If left undefined, all [`Subscriptions`](/docs/api/fhir/resources/subscription) will be triggered.               | `string`                                 | `undefined`   |
+| Option         | Description                                                                                                                                                                                                                                                                                                                          | Data Type                                | Default Value |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- | ------------- |
+| `verbose`      | Indicates if verbose logging should be enabled.                                                                                                                                                                                                                                                                                      | `boolean`                                | `false`       |
+| `interaction`  | [`Subscriptions`](/docs/api/fhir/resources/subscription) can be configured to trigger only when a resource is created or deleted as opposed to any update. This option allows you to specify which interaction type will be sent.                                                                                                    | `update` &#124; `create` &#124; `delete` | `update`      |
+| `subscription` | A specific [`Subscription`](/docs/api/fhir/resources/subscription) to trigger, formatted as `Subscription/<id>`. If left undefined, all [`Subscriptions`](/docs/api/fhir/resources/subscription) will be triggered.                                                                                                                  | `string`                                 | `undefined`   |
+| `versionId`    | Resend subscriptions for a specific historical version of the resource instead of the current version. When set, the `previousVersion` passed to subscription evaluation is the version immediately prior to this one in history (if any). Useful for replaying a failed notification when the resource has since been updated.     | `string`                                 | `undefined`   |
 
 ## Invoke the `$resend` operation
 
@@ -71,6 +73,23 @@ curl 'https://api.medplum.com/fhir/R4/<resourceType>/<resourceId>/$resend' \
 
   </TabItem>
 </Tabs>
+
+### Replay a specific historical version
+
+To replay a subscription using a specific past version of the resource (rather than the current version), pass `versionId`. The server will load that exact version, set `previousVersion` to the version immediately preceding it in history, and evaluate subscriptions against that pair.
+
+```ts
+await medplum.post(medplum.fhirUrl('Patient', patientId, '$resend'), {
+  versionId: 'a1b2c3d4-...', // a versionId from the resource's history
+  subscription: 'Subscription/123',
+});
+```
+
+If the supplied `versionId` does not exist in history, the operation returns `404 Not Found`.
+
+When `versionId` is supplied without an explicit `interaction`, the server derives one from the version's position in history: the first version of a resource resolves to `create`, any later version resolves to `update`. Pass `interaction` explicitly to override this — e.g. `interaction: 'update'` against a first version (which has no prior) returns `412 Precondition Failed`.
+
+When neither `versionId` nor `interaction` is supplied, `interaction` defaults to `update` and the resource must have a prior version in history; otherwise the operation returns `412 Precondition Failed`. Pass `interaction: 'create'` to resend the very first version of a resource.
 
 ### Output
 

--- a/packages/docs/docs/api/fhir/operations/resend.md
+++ b/packages/docs/docs/api/fhir/operations/resend.md
@@ -76,7 +76,9 @@ curl 'https://api.medplum.com/fhir/R4/<resourceType>/<resourceId>/$resend' \
 
 ### Replay a specific historical version
 
-To replay a subscription using a specific past version of the resource (rather than the current version), pass `versionId`. The server will load that exact version, set `previous` to the version immediately preceding it in history, and evaluate subscriptions against that pair.
+To replay a subscription using a specific past version of the resource (rather than the current version), pass `versionId`. The server will load that exact version, set `%previous` to the version immediately preceding it in history, and evaluate subscriptions against that pair.
+
+Here, `%previous` refers to the prior-version resource exposed to [expression-based subscription criteria](/docs/subscriptions/subscription-extensions#expression-based-criteria), which diff `%previous` against `%current` to decide whether to fire.
 
 ```ts
 await medplum.post(medplum.fhirUrl('Patient', patientId, '$resend'), {

--- a/packages/docs/docs/api/fhir/operations/resend.md
+++ b/packages/docs/docs/api/fhir/operations/resend.md
@@ -89,7 +89,7 @@ If the supplied `versionId` does not exist in history, the operation returns `40
 
 When `versionId` is supplied without an explicit `interaction`, the server derives one from the version's position in history: the first version of a resource resolves to `create`, any later version resolves to `update`. Pass `interaction` explicitly to override this — e.g. `interaction: 'update'` against a first version (which has no prior) returns `412 Precondition Failed`.
 
-When neither `versionId` nor `interaction` is supplied, `interaction` defaults to `update` and the resource must have a prior version in history; otherwise the operation returns `412 Precondition Failed`. Pass `interaction: 'create'` to resend the very first version of a resource.
+When neither `versionId` nor `interaction` is supplied, `interaction` defaults to `update` and the resource must have a prior version in history; otherwise the operation returns `412 Precondition Failed`.
 
 ### Output
 

--- a/packages/docs/docs/api/fhir/operations/resend.md
+++ b/packages/docs/docs/api/fhir/operations/resend.md
@@ -20,7 +20,7 @@ When a subscription notification fails or you need to reprocess a resource throu
 - **Debugging Subscriptions**: Test subscription logic during development by manually triggering notifications
 - **Data Synchronization**: Force re-sync of specific resources to external systems after fixing integration issues
 - **Selective Replay**: Re-trigger a specific subscription for a resource instead of all subscriptions
-- **Historical Replay**: Replay a notification against a specific historical `versionId` so subscription handlers that diff `previousVersion` against `resource` see the same state as the original event, even if the resource has since been updated
+- **Historical Replay**: Replay a notification against a specific historical `versionId` so subscription handlers that diff `previous` against `current` see the same state as the original event, even if the resource has since been updated
 - **Integration Testing**: Verify that subscriptions fire correctly without creating new test data
 
 :::note[Admin Required]
@@ -36,7 +36,7 @@ The operation takes an optional `option` parameter, which is an object containin
 | `verbose`      | Indicates if verbose logging should be enabled.                                                                                                                                                                                                                                                                                      | `boolean`                                | `false`       |
 | `interaction`  | [`Subscriptions`](/docs/api/fhir/resources/subscription) can be configured to trigger only when a resource is created or deleted as opposed to any update. This option allows you to specify which interaction type will be sent.                                                                                                    | `update` &#124; `create` &#124; `delete` | `update`      |
 | `subscription` | A specific [`Subscription`](/docs/api/fhir/resources/subscription) to trigger, formatted as `Subscription/<id>`. If left undefined, all [`Subscriptions`](/docs/api/fhir/resources/subscription) will be triggered.                                                                                                                  | `string`                                 | `undefined`   |
-| `versionId`    | Resend subscriptions for a specific historical version of the resource instead of the current version. When set, the `previousVersion` passed to subscription evaluation is the version immediately prior to this one in history (if any). Useful for replaying a failed notification when the resource has since been updated.     | `string`                                 | `undefined`   |
+| `versionId`    | Resend subscriptions for a specific historical version of the resource instead of the current version. When set, the `previous` passed to subscription evaluation is the version immediately prior to this one in history (if any). Useful for replaying a failed notification when the resource has since been updated.     | `string`                                 | `undefined`   |
 
 ## Invoke the `$resend` operation
 
@@ -76,7 +76,7 @@ curl 'https://api.medplum.com/fhir/R4/<resourceType>/<resourceId>/$resend' \
 
 ### Replay a specific historical version
 
-To replay a subscription using a specific past version of the resource (rather than the current version), pass `versionId`. The server will load that exact version, set `previousVersion` to the version immediately preceding it in history, and evaluate subscriptions against that pair.
+To replay a subscription using a specific past version of the resource (rather than the current version), pass `versionId`. The server will load that exact version, set `previous` to the version immediately preceding it in history, and evaluate subscriptions against that pair.
 
 ```ts
 await medplum.post(medplum.fhirUrl('Patient', patientId, '$resend'), {

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -553,10 +553,10 @@ describe('FHIR Repo', () => {
 
     test('skips siblings sharing the same lastUpdated and warns', () =>
       withTestContext(async () => {
-        const warnSpy = jest.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+        const warnSpy = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
         // Fake only the clock (not timer fns) so consecutive updates can be
         // forced to share the exact same server-assigned `lastUpdated`.
-        jest.useFakeTimers({
+        vi.useFakeTimers({
           doNotFake: [
             'setTimeout',
             'setInterval',
@@ -573,10 +573,10 @@ describe('FHIR Repo', () => {
         try {
           const base = Date.now();
           // v1 in the past
-          jest.setSystemTime(base - 2000);
+          vi.setSystemTime(base - 2000);
           const v1 = await systemRepo.createResource<Patient>({ resourceType: 'Patient' });
           // v2 and v3 share the same instant -> tie among priors
-          jest.setSystemTime(base - 1000);
+          vi.setSystemTime(base - 1000);
           const v2 = await systemRepo.updateResource<Patient>({
             resourceType: 'Patient',
             id: v1.id,
@@ -588,7 +588,7 @@ describe('FHIR Repo', () => {
             active: false,
           });
           // v4 is the newest, with a unique timestamp
-          jest.setSystemTime(base);
+          vi.setSystemTime(base);
           const v4 = await systemRepo.updateResource<Patient>({
             resourceType: 'Patient',
             id: v1.id,
@@ -606,15 +606,15 @@ describe('FHIR Repo', () => {
             })
           );
         } finally {
-          jest.useRealTimers();
+          vi.useRealTimers();
           warnSpy.mockRestore();
         }
       }));
 
     test('warns when incoming resource ties with chosen prior', () =>
       withTestContext(async () => {
-        const warnSpy = jest.spyOn(getLogger(), 'warn').mockImplementation(() => {});
-        jest.useFakeTimers({
+        const warnSpy = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+        vi.useFakeTimers({
           doNotFake: [
             'setTimeout',
             'setInterval',
@@ -630,11 +630,11 @@ describe('FHIR Repo', () => {
         });
         try {
           const base = Date.now();
-          jest.setSystemTime(base - 1000);
+          vi.setSystemTime(base - 1000);
           const v1 = await systemRepo.createResource<Patient>({ resourceType: 'Patient' });
           // v2 and v3 share the same instant; v3 is the incoming resource, so it
           // ties with its chosen prior (v2).
-          jest.setSystemTime(base);
+          vi.setSystemTime(base);
           const v2 = await systemRepo.updateResource<Patient>({
             resourceType: 'Patient',
             id: v1.id,
@@ -656,7 +656,7 @@ describe('FHIR Repo', () => {
             })
           );
         } finally {
-          jest.useRealTimers();
+          vi.useRealTimers();
           warnSpy.mockRestore();
         }
       }));

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -554,30 +554,45 @@ describe('FHIR Repo', () => {
     test('skips siblings sharing the same lastUpdated and warns', () =>
       withTestContext(async () => {
         const warnSpy = jest.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+        // Fake only the clock (not timer fns) so consecutive updates can be
+        // forced to share the exact same server-assigned `lastUpdated`.
+        jest.useFakeTimers({
+          doNotFake: [
+            'setTimeout',
+            'setInterval',
+            'setImmediate',
+            'clearTimeout',
+            'clearInterval',
+            'clearImmediate',
+            'nextTick',
+            'queueMicrotask',
+            'hrtime',
+            'performance',
+          ],
+        });
         try {
           const base = Date.now();
-          const sharedTs = new Date(base - 1000).toISOString();
-          const v1 = await systemRepo.createResource<Patient>({
-            resourceType: 'Patient',
-            meta: { lastUpdated: new Date(base - 2000).toISOString() },
-          });
+          // v1 in the past
+          jest.setSystemTime(base - 2000);
+          const v1 = await systemRepo.createResource<Patient>({ resourceType: 'Patient' });
+          // v2 and v3 share the same instant -> tie among priors
+          jest.setSystemTime(base - 1000);
           const v2 = await systemRepo.updateResource<Patient>({
             resourceType: 'Patient',
             id: v1.id,
             active: true,
-            meta: { lastUpdated: sharedTs },
           });
           const v3 = await systemRepo.updateResource<Patient>({
             resourceType: 'Patient',
             id: v1.id,
             active: false,
-            meta: { lastUpdated: sharedTs },
           });
+          // v4 is the newest, with a unique timestamp
+          jest.setSystemTime(base);
           const v4 = await systemRepo.updateResource<Patient>({
             resourceType: 'Patient',
             id: v1.id,
             active: true,
-            meta: { lastUpdated: new Date(base).toISOString() },
           });
 
           const prev = await systemRepo.readPreviousVersion<Patient>(v4);
@@ -591,6 +606,7 @@ describe('FHIR Repo', () => {
             })
           );
         } finally {
+          jest.useRealTimers();
           warnSpy.mockRestore();
         }
       }));
@@ -598,24 +614,36 @@ describe('FHIR Repo', () => {
     test('warns when incoming resource ties with chosen prior', () =>
       withTestContext(async () => {
         const warnSpy = jest.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+        jest.useFakeTimers({
+          doNotFake: [
+            'setTimeout',
+            'setInterval',
+            'setImmediate',
+            'clearTimeout',
+            'clearInterval',
+            'clearImmediate',
+            'nextTick',
+            'queueMicrotask',
+            'hrtime',
+            'performance',
+          ],
+        });
         try {
           const base = Date.now();
-          const sharedTs = new Date(base).toISOString();
-          const v1 = await systemRepo.createResource<Patient>({
-            resourceType: 'Patient',
-            meta: { lastUpdated: new Date(base - 1000).toISOString() },
-          });
+          jest.setSystemTime(base - 1000);
+          const v1 = await systemRepo.createResource<Patient>({ resourceType: 'Patient' });
+          // v2 and v3 share the same instant; v3 is the incoming resource, so it
+          // ties with its chosen prior (v2).
+          jest.setSystemTime(base);
           const v2 = await systemRepo.updateResource<Patient>({
             resourceType: 'Patient',
             id: v1.id,
             active: true,
-            meta: { lastUpdated: sharedTs },
           });
           const v3 = await systemRepo.updateResource<Patient>({
             resourceType: 'Patient',
             id: v1.id,
             active: false,
-            meta: { lastUpdated: sharedTs },
           });
 
           const prev = await systemRepo.readPreviousVersion<Patient>(v3);
@@ -628,6 +656,7 @@ describe('FHIR Repo', () => {
             })
           );
         } finally {
+          jest.useRealTimers();
           warnSpy.mockRestore();
         }
       }));

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -516,6 +516,144 @@ describe('FHIR Repo', () => {
     });
   });
 
+  describe('readPreviousVersion', () => {
+    test('returns undefined for the first version', () =>
+      withTestContext(async () => {
+        const v1 = await systemRepo.createResource<Patient>({ resourceType: 'Patient' });
+        const prev = await systemRepo.readPreviousVersion<Patient>(v1);
+        expect(prev).toBeUndefined();
+      }));
+
+    test('returns the immediately preceding version', () =>
+      withTestContext(async () => {
+        const base = Date.now();
+        const v1 = await systemRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          meta: { lastUpdated: new Date(base - 2000).toISOString() },
+        });
+        const v2 = await systemRepo.updateResource<Patient>({
+          resourceType: 'Patient',
+          id: v1.id,
+          active: true,
+          meta: { lastUpdated: new Date(base - 1000).toISOString() },
+        });
+        const v3 = await systemRepo.updateResource<Patient>({
+          resourceType: 'Patient',
+          id: v1.id,
+          active: false,
+          meta: { lastUpdated: new Date(base).toISOString() },
+        });
+
+        const prevOfV3 = await systemRepo.readPreviousVersion<Patient>(v3);
+        expect(prevOfV3?.meta?.versionId).toBe(v2.meta?.versionId);
+
+        const prevOfV2 = await systemRepo.readPreviousVersion<Patient>(v2);
+        expect(prevOfV2?.meta?.versionId).toBe(v1.meta?.versionId);
+      }));
+
+    test('skips siblings sharing the same lastUpdated and warns', () =>
+      withTestContext(async () => {
+        const warnSpy = jest.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+        try {
+          const base = Date.now();
+          const sharedTs = new Date(base - 1000).toISOString();
+          const v1 = await systemRepo.createResource<Patient>({
+            resourceType: 'Patient',
+            meta: { lastUpdated: new Date(base - 2000).toISOString() },
+          });
+          const v2 = await systemRepo.updateResource<Patient>({
+            resourceType: 'Patient',
+            id: v1.id,
+            active: true,
+            meta: { lastUpdated: sharedTs },
+          });
+          const v3 = await systemRepo.updateResource<Patient>({
+            resourceType: 'Patient',
+            id: v1.id,
+            active: false,
+            meta: { lastUpdated: sharedTs },
+          });
+          const v4 = await systemRepo.updateResource<Patient>({
+            resourceType: 'Patient',
+            id: v1.id,
+            active: true,
+            meta: { lastUpdated: new Date(base).toISOString() },
+          });
+
+          const prev = await systemRepo.readPreviousVersion<Patient>(v4);
+          expect([v2.meta?.versionId, v3.meta?.versionId]).toContain(prev?.meta?.versionId);
+          expect(warnSpy).toHaveBeenCalledWith(
+            'readPreviousVersion: ambiguous prior version (lastUpdated tie)',
+            expect.objectContaining({
+              tiedAmongPriors: true,
+              tiedWithIncoming: false,
+              tiedVersionIds: expect.arrayContaining([v2.meta?.versionId, v3.meta?.versionId]),
+            })
+          );
+        } finally {
+          warnSpy.mockRestore();
+        }
+      }));
+
+    test('warns when incoming resource ties with chosen prior', () =>
+      withTestContext(async () => {
+        const warnSpy = jest.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+        try {
+          const base = Date.now();
+          const sharedTs = new Date(base).toISOString();
+          const v1 = await systemRepo.createResource<Patient>({
+            resourceType: 'Patient',
+            meta: { lastUpdated: new Date(base - 1000).toISOString() },
+          });
+          const v2 = await systemRepo.updateResource<Patient>({
+            resourceType: 'Patient',
+            id: v1.id,
+            active: true,
+            meta: { lastUpdated: sharedTs },
+          });
+          const v3 = await systemRepo.updateResource<Patient>({
+            resourceType: 'Patient',
+            id: v1.id,
+            active: false,
+            meta: { lastUpdated: sharedTs },
+          });
+
+          const prev = await systemRepo.readPreviousVersion<Patient>(v3);
+          expect(prev?.meta?.versionId).toBe(v2.meta?.versionId);
+          expect(warnSpy).toHaveBeenCalledWith(
+            'readPreviousVersion: ambiguous prior version (lastUpdated tie)',
+            expect.objectContaining({
+              tiedWithIncoming: true,
+              tiedVersionIds: expect.arrayContaining([v2.meta?.versionId, v3.meta?.versionId]),
+            })
+          );
+        } finally {
+          warnSpy.mockRestore();
+        }
+      }));
+
+    test('throws preconditionFailed when lastUpdated missing', () =>
+      withTestContext(async () => {
+        const v1 = await systemRepo.createResource<Patient>({ resourceType: 'Patient' });
+        const stripped = { ...v1, meta: { ...v1.meta, lastUpdated: undefined } } as WithId<Patient>;
+        await expect(systemRepo.readPreviousVersion<Patient>(stripped)).rejects.toThrow(
+          new OperationOutcomeError(preconditionFailed)
+        );
+      }));
+
+    test('throws notFound when id is not a UUID', () =>
+      withTestContext(async () => {
+        const fake = {
+          resourceType: 'Patient',
+          id: 'not-a-uuid',
+          meta: { lastUpdated: new Date().toISOString(), versionId: randomUUID() },
+        } as WithId<Patient>;
+        await expect(systemRepo.readPreviousVersion<Patient>(fake)).rejects.toThrow(
+          new OperationOutcomeError(notFound)
+        );
+      }));
+  });
+
   test('Update patient', () =>
     withTestContext(async () => {
       const patient1 = await systemRepo.createResource<Patient>({

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -7,6 +7,7 @@ import {
   allOk,
   append,
   badRequest,
+  createReference,
   deepClone,
   deepEquals,
   DEFAULT_MAX_SEARCH_COUNT,

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -905,7 +905,17 @@ export class Repository extends FhirRepository implements Disposable {
    * given resource is the first version.
    *
    * Unlike scanning a paged `readHistory()` result, this query is bounded to
-   * one row regardless of how many historical versions the resource has.
+   * a small constant number of rows regardless of history length.
+   *
+   * Caveat: history rows are ordered solely by `meta.lastUpdated`, which is
+   * generated from `new Date().toISOString()` (millisecond precision) and may
+   * also be set directly by ClientApplications with elevated permissions. As
+   * a result, multiple history rows can share the same `lastUpdated` value.
+   * When that happens, the row immediately preceding the given resource is
+   * not deterministically defined and this method may return any one of the
+   * tied rows. The query uses `<=` and filters out the supplied resource's
+   * own `versionId` so siblings at the exact same timestamp are still
+   * considered as candidates for the prior version.
    * @param resource - A version of the resource (current or historical) to look back from.
    * @returns The prior version, or `undefined` if none exists.
    */
@@ -917,15 +927,46 @@ export class Repository extends FhirRepository implements Disposable {
     if (!isUUID(resource.id)) {
       throw new OperationOutcomeError(notFound);
     }
+    // Fetch up to 2 candidates so we can detect ties at the same `lastUpdated`.
+    // We use `<=` (rather than `<`) and filter out the supplied versionId
+    // ourselves so siblings sharing the resource's exact timestamp are still
+    // considered as candidates for the prior version.
     const rows = await new SelectQuery(resource.resourceType + '_History')
+      .column('versionId')
       .column('content')
+      .column('lastUpdated')
       .where('id', '=', resource.id)
-      .where('lastUpdated', '<', lastUpdated)
+      .where('lastUpdated', '<=', lastUpdated)
+      .where('versionId', '!=', resource.meta?.versionId)
       .orderBy('lastUpdated', true)
-      .limit(1)
+      .limit(2)
       .execute(this.getDatabaseClient(DatabaseMode.READER));
     if (rows.length === 0 || !rows[0].content) {
       return undefined;
+    }
+    // Compare timestamps via numeric ms epoch. `new Date(x).getTime()` accepts
+    // both Date instances (which the pg driver currently returns for
+    // TIMESTAMPTZ columns) and ISO date strings (defensive against future
+    // driver/config changes), and yields a primitive number that is safe to
+    // compare with `===`. An invalid value would produce `NaN`, which would
+    // simply not match — we'd skip the warn but still return the first row,
+    // so this can't break the correctness of the prior-version lookup.
+    if (
+      rows.length > 1 &&
+      new Date(rows[0].lastUpdated).getTime() === new Date(rows[1].lastUpdated).getTime()
+    ) {
+      // Two or more candidate prior versions share the same `lastUpdated`
+      // timestamp, so the chosen prior is nondeterministic. This is rare
+      // (high-throughput writes within the same millisecond, or callers
+      // setting protected meta directly) but worth surfacing.
+      // TODO: emit a metric for this collision rate so we can decide whether
+      // a monotonic ordering column on `_History` is justified.
+      getLogger().warn('readPreviousVersion: ambiguous prior version (lastUpdated tie)', {
+        resource: { reference: getReferenceString(resource) },
+        versionId: resource.meta?.versionId,
+        lastUpdated,
+        candidateVersionIds: rows.map((r) => r.versionId),
+      });
     }
     return this.removeHiddenFields(JSON.parse(rows[0].content as string)) as T;
   }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -946,42 +946,60 @@ export class Repository extends FhirRepository implements Disposable {
     if (rows.length === 0 || !rows[0].content) {
       return undefined;
     }
-    // Compare timestamps via numeric ms epoch. `new Date(x).getTime()` accepts
-    // both Date instances (which the pg driver currently returns for
-    // TIMESTAMPTZ columns) and ISO date strings (defensive against future
-    // driver/config changes), and yields a primitive number that is safe to
-    // compare with `===`. An invalid value would produce `NaN`, which would
-    // simply not match — we'd skip the warn but still return the first row,
-    // so this can't break the correctness of the prior-version lookup.
-    // Ambiguity arises in two cases:
-    //   1. The incoming resource and the chosen prior share `lastUpdated`,
-    //      so current-vs-prior ordering itself is nondeterministic.
-    //   2. Two or more candidate priors share `lastUpdated`, so which one is
-    //      "immediately prior" is nondeterministic.
+    this.warnIfAmbiguousPreviousVersion(resource, lastUpdated, rows);
+    return this.removeHiddenFields(JSON.parse(rows[0].content as string)) as T;
+  }
+
+  /**
+   * Logs a warning when the prior version returned by {@link readPreviousVersion}
+   * is not deterministically defined due to a `lastUpdated` tie.
+   *
+   * Ambiguity arises in two cases:
+   *   1. The incoming resource and the chosen prior share `lastUpdated`, so
+   *      current-vs-prior ordering itself is nondeterministic.
+   *   2. Two or more candidate priors share `lastUpdated`, so which one is
+   *      "immediately prior" is nondeterministic.
+   *
+   * Timestamps are compared via numeric ms epoch. `new Date(x).getTime()`
+   * accepts both Date instances (which the pg driver currently returns for
+   * TIMESTAMPTZ columns) and ISO date strings (defensive against future
+   * driver/config changes), and yields a primitive number safe to compare
+   * with `===`. An invalid value would produce `NaN`, which simply won't
+   * match — we'd skip the warn but the caller still returns the first row, so
+   * this can't break the correctness of the prior-version lookup.
+   * @param resource - The resource the lookup was performed from.
+   * @param lastUpdated - The `meta.lastUpdated` of the supplied resource.
+   * @param rows - Up to two candidate prior rows, ordered by `lastUpdated` desc.
+   */
+  private warnIfAmbiguousPreviousVersion<T extends Resource>(
+    resource: WithId<T>,
+    lastUpdated: string,
+    rows: { versionId: string; lastUpdated: string }[]
+  ): void {
     const incomingMs = new Date(lastUpdated).getTime();
     const firstMs = new Date(rows[0].lastUpdated).getTime();
     const secondMs = rows.length > 1 ? new Date(rows[1].lastUpdated).getTime() : undefined;
     const tiedWithIncoming = incomingMs === firstMs;
     const tiedAmongPriors = secondMs !== undefined && firstMs === secondMs;
-    if (tiedWithIncoming || tiedAmongPriors) {
-      // Rare (high-throughput writes within the same millisecond, or callers
-      // setting protected meta directly) but worth surfacing.
-      // Include all versionIds sharing the tied timestamp so the log reflects
-      // the actual ambiguity set, regardless of which case triggered it.
-      const tiedVersionIds = [
-        ...(tiedWithIncoming && resource.meta?.versionId ? [resource.meta.versionId] : []),
-        ...rows.filter((r) => new Date(r.lastUpdated).getTime() === firstMs).map((r) => r.versionId),
-      ];
-      getLogger().warn('readPreviousVersion: ambiguous prior version (lastUpdated tie)', {
-        resource: { reference: getReferenceString(resource) },
-        versionId: resource.meta?.versionId,
-        lastUpdated,
-        tiedWithIncoming,
-        tiedAmongPriors,
-        tiedVersionIds,
-      });
+    if (!tiedWithIncoming && !tiedAmongPriors) {
+      return;
     }
-    return this.removeHiddenFields(JSON.parse(rows[0].content as string)) as T;
+    // Rare (high-throughput writes within the same millisecond, or callers
+    // setting protected meta directly) but worth surfacing.
+    // Include all versionIds sharing the tied timestamp so the log reflects
+    // the actual ambiguity set, regardless of which case triggered it.
+    const tiedVersionIds = [
+      ...(tiedWithIncoming && resource.meta?.versionId ? [resource.meta.versionId] : []),
+      ...rows.filter((r) => new Date(r.lastUpdated).getTime() === firstMs).map((r) => r.versionId),
+    ];
+    getLogger().warn('readPreviousVersion: ambiguous prior version (lastUpdated tie)', {
+      resource: createReference(resource),
+      versionId: resource.meta?.versionId,
+      lastUpdated,
+      tiedWithIncoming,
+      tiedAmongPriors,
+      tiedVersionIds,
+    });
   }
 
   async updateResource<T extends Resource>(resource: T, options?: UpdateResourceOptions): Promise<WithId<T>> {

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -251,7 +251,7 @@ export interface ResendSubscriptionsOptions extends InteractionOptions {
   subscription?: string;
   /**
    * Resend subscriptions for a specific historical version of the resource
-   * instead of the current version. When set, `previous` passed to
+   * instead of the current version. When set, `%previous` passed to
    * subscription evaluation is the version immediately prior to this one
    * in history (if any).
    */

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -249,6 +249,13 @@ export interface ReadResourceOptions extends InteractionOptions {
 export interface ResendSubscriptionsOptions extends InteractionOptions {
   interaction?: BackgroundJobInteraction;
   subscription?: string;
+  /**
+   * Resend subscriptions for a specific historical version of the resource
+   * instead of the current version. When set, `previousVersion` passed to
+   * subscription evaluation is the version immediately prior to this one
+   * in history (if any).
+   */
+  versionId?: string;
 }
 
 export interface ProcessAllResourcesOptions {
@@ -892,6 +899,37 @@ export class Repository extends FhirRepository implements Disposable {
     }
   }
 
+  /**
+   * Reads the version of a resource immediately preceding the given resource
+   * in history (ordered by `meta.lastUpdated`). Returns `undefined` if the
+   * given resource is the first version.
+   *
+   * Unlike scanning a paged `readHistory()` result, this query is bounded to
+   * one row regardless of how many historical versions the resource has.
+   * @param resource - A version of the resource (current or historical) to look back from.
+   * @returns The prior version, or `undefined` if none exists.
+   */
+  async readPreviousVersion<T extends Resource>(resource: WithId<T>): Promise<T | undefined> {
+    const lastUpdated = resource.meta?.lastUpdated;
+    if (!lastUpdated) {
+      throw new OperationOutcomeError(preconditionFailed);
+    }
+    if (!isUUID(resource.id)) {
+      throw new OperationOutcomeError(notFound);
+    }
+    const rows = await new SelectQuery(resource.resourceType + '_History')
+      .column('content')
+      .where('id', '=', resource.id)
+      .where('lastUpdated', '<', lastUpdated)
+      .orderBy('lastUpdated', true)
+      .limit(1)
+      .execute(this.getDatabaseClient(DatabaseMode.READER));
+    if (rows.length === 0 || !rows[0].content) {
+      return undefined;
+    }
+    return this.removeHiddenFields(JSON.parse(rows[0].content as string)) as T;
+  }
+
   async updateResource<T extends Resource>(resource: T, options?: UpdateResourceOptions): Promise<WithId<T>> {
     await this.recordFhirQuota(FhirQuotaCost.WRITE);
 
@@ -1292,16 +1330,29 @@ export class Repository extends FhirRepository implements Disposable {
       throw new OperationOutcomeError(forbidden);
     }
 
-    const resource = await this.readResourceImpl<T>(resourceType, id);
-    const interaction = options?.interaction ?? 'update';
+    const resource = options?.versionId
+      ? await this.readVersion<T>(resourceType, id, options.versionId)
+      : await this.readResourceImpl<T>(resourceType, id);
+    let interaction = options?.interaction;
     let previousVersion: T | undefined;
 
-    if (interaction === 'update') {
-      const history = await this.readHistory(resourceType, id, { limit: 2 });
-      if (history.entry?.[0]?.resource?.meta?.versionId !== resource.meta?.versionId) {
-        throw new OperationOutcomeError(preconditionFailed);
+    if (options?.versionId && !interaction) {
+      // When a caller pins to a specific historical version but doesn't
+      // specify the interaction, derive it from the version's position in
+      // history: a version with no prior is the create event for the
+      // resource; otherwise it's an update.
+      previousVersion = await this.readPreviousVersion<T>(resource);
+      interaction = previousVersion ? 'update' : 'create';
+    } else {
+      interaction = interaction ?? 'update';
+      if (interaction === 'update') {
+        previousVersion = await this.readPreviousVersion<T>(resource);
+        if (!previousVersion) {
+          // interaction='update' implies a state transition, so a prior version
+          // is required. Use interaction='create' to resend the first version.
+          throw new OperationOutcomeError(preconditionFailed);
+        }
       }
-      previousVersion = history.entry?.[1]?.resource;
     }
 
     return addSubscriptionJobs(

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -911,11 +911,13 @@ export class Repository extends FhirRepository implements Disposable {
    * generated from `new Date().toISOString()` (millisecond precision) and may
    * also be set directly by ClientApplications with elevated permissions. As
    * a result, multiple history rows can share the same `lastUpdated` value.
-   * When that happens, the row immediately preceding the given resource is
-   * not deterministically defined and this method may return any one of the
-   * tied rows. The query uses `<=` and filters out the supplied resource's
-   * own `versionId` so siblings at the exact same timestamp are still
-   * considered as candidates for the prior version.
+   * When that happens, the prior version is not deterministically defined —
+   * either because multiple candidates tie with each other, or because the
+   * supplied resource ties with the chosen prior (so even current-vs-prior
+   * ordering is ambiguous). In those cases this method may return any one of
+   * the tied rows. The query uses `<=` and filters out the supplied
+   * resource's own `versionId` so siblings at the exact same timestamp are
+   * still considered as candidates for the prior version.
    * @param resource - A version of the resource (current or historical) to look back from.
    * @returns The prior version, or `undefined` if none exists.
    */
@@ -951,16 +953,32 @@ export class Repository extends FhirRepository implements Disposable {
     // compare with `===`. An invalid value would produce `NaN`, which would
     // simply not match — we'd skip the warn but still return the first row,
     // so this can't break the correctness of the prior-version lookup.
-    if (rows.length > 1 && new Date(rows[0].lastUpdated).getTime() === new Date(rows[1].lastUpdated).getTime()) {
-      // Two or more candidate prior versions share the same `lastUpdated`
-      // timestamp, so the chosen prior is nondeterministic. This is rare
-      // (high-throughput writes within the same millisecond, or callers
+    // Ambiguity arises in two cases:
+    //   1. The incoming resource and the chosen prior share `lastUpdated`,
+    //      so current-vs-prior ordering itself is nondeterministic.
+    //   2. Two or more candidate priors share `lastUpdated`, so which one is
+    //      "immediately prior" is nondeterministic.
+    const incomingMs = new Date(lastUpdated).getTime();
+    const firstMs = new Date(rows[0].lastUpdated).getTime();
+    const secondMs = rows.length > 1 ? new Date(rows[1].lastUpdated).getTime() : undefined;
+    const tiedWithIncoming = incomingMs === firstMs;
+    const tiedAmongPriors = secondMs !== undefined && firstMs === secondMs;
+    if (tiedWithIncoming || tiedAmongPriors) {
+      // Rare (high-throughput writes within the same millisecond, or callers
       // setting protected meta directly) but worth surfacing.
+      // Include all versionIds sharing the tied timestamp so the log reflects
+      // the actual ambiguity set, regardless of which case triggered it.
+      const tiedVersionIds = [
+        ...(tiedWithIncoming && resource.meta?.versionId ? [resource.meta.versionId] : []),
+        ...rows.filter((r) => new Date(r.lastUpdated).getTime() === firstMs).map((r) => r.versionId),
+      ];
       getLogger().warn('readPreviousVersion: ambiguous prior version (lastUpdated tie)', {
         resource: { reference: getReferenceString(resource) },
         versionId: resource.meta?.versionId,
         lastUpdated,
-        candidateVersionIds: rows.map((r) => r.versionId),
+        tiedWithIncoming,
+        tiedAmongPriors,
+        tiedVersionIds,
       });
     }
     return this.removeHiddenFields(JSON.parse(rows[0].content as string)) as T;

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -251,7 +251,7 @@ export interface ResendSubscriptionsOptions extends InteractionOptions {
   subscription?: string;
   /**
    * Resend subscriptions for a specific historical version of the resource
-   * instead of the current version. When set, `previousVersion` passed to
+   * instead of the current version. When set, `previous` passed to
    * subscription evaluation is the version immediately prior to this one
    * in history (if any).
    */

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -951,10 +951,7 @@ export class Repository extends FhirRepository implements Disposable {
     // compare with `===`. An invalid value would produce `NaN`, which would
     // simply not match — we'd skip the warn but still return the first row,
     // so this can't break the correctness of the prior-version lookup.
-    if (
-      rows.length > 1 &&
-      new Date(rows[0].lastUpdated).getTime() === new Date(rows[1].lastUpdated).getTime()
-    ) {
+    if (rows.length > 1 && new Date(rows[0].lastUpdated).getTime() === new Date(rows[1].lastUpdated).getTime()) {
       // Two or more candidate prior versions share the same `lastUpdated`
       // timestamp, so the chosen prior is nondeterministic. This is rare
       // (high-throughput writes within the same millisecond, or callers

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -956,8 +956,6 @@ export class Repository extends FhirRepository implements Disposable {
       // timestamp, so the chosen prior is nondeterministic. This is rare
       // (high-throughput writes within the same millisecond, or callers
       // setting protected meta directly) but worth surfacing.
-      // TODO: emit a metric for this collision rate so we can decide whether
-      // a monotonic ordering column on `_History` is justified.
       getLogger().warn('readPreviousVersion: ambiguous prior version (lastUpdated tie)', {
         resource: { reference: getReferenceString(resource) },
         versionId: resource.meta?.versionId,

--- a/packages/server/src/fhir/repository/method-guards.test.ts
+++ b/packages/server/src/fhir/repository/method-guards.test.ts
@@ -94,6 +94,7 @@ const knownPrivateMembers = new Set<PropertyKey>([
   'createTransactionScopedRepo',
   'assertUsable',
   'authorizeBinarySecurityContext',
+  'warnIfAmbiguousPreviousVersion',
 ]);
 
 interface MethodInvocation {
@@ -102,7 +103,11 @@ interface MethodInvocation {
   invoke: (repo: Repository) => unknown;
 }
 
-const guardedPatient: WithId<Patient> = { resourceType: 'Patient', id: NIL };
+const guardedPatient: WithId<Patient> = {
+  resourceType: 'Patient',
+  id: NIL,
+  meta: { lastUpdated: new Date().toISOString() },
+};
 
 /**
  * Representative invocations for each guarded public method/getter/setter. Each invocation
@@ -306,6 +311,11 @@ const guardedInvocations: MethodInvocation[] = [
         },
         []
       ),
+  },
+  {
+    name: 'readPreviousVersion',
+    kind: 'method',
+    invoke: (repo) => repo.readPreviousVersion(guardedPatient),
   },
 ];
 

--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -736,25 +736,161 @@ describe('FHIR Routes', () => {
       })
     );
 
+    // Bump to a second version so interaction='update' has a prior version to diff against
+    const profileRef = getReferenceString(profile);
+    const get = await request(app)
+      .get(`/fhir/R4/${profileRef}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(get.status).toBe(200);
+    const updateRes = await request(app)
+      .put(`/fhir/R4/${profileRef}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({ ...get.body, telecom: [{ system: 'phone', value: '555-0100' }] });
+    expect(updateRes.status).toBe(200);
+
     const res = await request(app)
-      .post(`/fhir/R4/${getReferenceString(profile)}/$resend`)
+      .post(`/fhir/R4/${profileRef}/$resend`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({});
     expect(res).toHaveStatus(200);
 
     // Resend with verbose=true
     const res2 = await request(app)
-      .post(`/fhir/R4/${getReferenceString(profile)}/$resend`)
+      .post(`/fhir/R4/${profileRef}/$resend`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ verbose: true });
     expect(res2).toHaveStatus(200);
 
     // Resend with subscription option
     const res3 = await request(app)
-      .post(`/fhir/R4/${getReferenceString(profile)}/$resend`)
+      .post(`/fhir/R4/${profileRef}/$resend`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ subscription: 'Subscription/123' });
     expect(res3).toHaveStatus(200);
+    expect(res3.status).toBe(200);
+
+    // interaction='create' does not require a prior version
+    const resCreate = await request(app)
+      .post(`/fhir/R4/${profileRef}/$resend`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({ interaction: 'create' });
+    expect(resCreate.status).toBe(200);
+  });
+
+  test('Resend with no prior version returns 412', async () => {
+    const { profile, accessToken } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Edith',
+        lastName: 'Smith',
+        projectName: `Edith Project ${randomUUID()}`,
+        email: `edith${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+
+    // First version of the resource — interaction='update' (default) has no prior to diff
+    const res = await request(app)
+      .post(`/fhir/R4/${getReferenceString(profile)}/$resend`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({});
+    expect(res.status).toBe(412);
+
+    // interaction='create' avoids the prior-version requirement
+    const resCreate = await request(app)
+      .post(`/fhir/R4/${getReferenceString(profile)}/$resend`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({ interaction: 'create' });
+    expect(resCreate.status).toBe(200);
+  });
+
+  test('Resend with versionId targets historical version', async () => {
+    const { profile, accessToken } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Carol',
+        lastName: 'Smith',
+        projectName: `Carol Project ${randomUUID()}`,
+        email: `carol${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+
+    // Create a patient
+    const create = await request(app)
+      .post(`/fhir/R4/Patient`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({ resourceType: 'Patient', active: true, name: [{ family: 'Original' }] });
+    expect(create.status).toBe(201);
+    const created = create.body as WithId<Patient>;
+    const v1 = created.meta?.versionId as string;
+
+    // Update the patient -> creates v2
+    const update = await request(app)
+      .put(`/fhir/R4/Patient/${created.id}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({ ...created, name: [{ family: 'Updated' }] });
+    expect(update.status).toBe(200);
+    const v2 = (update.body as WithId<Patient>).meta?.versionId as string;
+    expect(v2).not.toEqual(v1);
+
+    // Resend pinned to v1 with no explicit interaction succeeds: server
+    // auto-derives interaction='create' because v1 has no prior version
+    const pinnedV1Auto = await request(app)
+      .post(`/fhir/R4/Patient/${created.id}/$resend`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({ versionId: v1 });
+    expect(pinnedV1Auto.status).toBe(200);
+
+    // Resend pinned to v1 with explicit interaction='update' fails: v1 has no prior version
+    const pinnedV1Update = await request(app)
+      .post(`/fhir/R4/Patient/${created.id}/$resend`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({ versionId: v1, interaction: 'update' });
+    expect(pinnedV1Update.status).toBe(412);
+
+    // Resend pinned to v1 with explicit interaction='create' succeeds
+    const pinnedV1Create = await request(app)
+      .post(`/fhir/R4/Patient/${created.id}/$resend`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({ versionId: v1, interaction: 'create' });
+    expect(pinnedV1Create.status).toBe(200);
+
+    // Resend pinned to v2 (current) succeeds — has v1 as prior
+    const pinnedCurrent = await request(app)
+      .post(`/fhir/R4/Patient/${created.id}/$resend`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({ versionId: v2 });
+    expect(pinnedCurrent.status).toBe(200);
+
+    // Default (no versionId) succeeds since v2 is current and has v1 as prior
+    const defaultResend = await request(app)
+      .post(`/fhir/R4/Patient/${created.id}/$resend`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({});
+    expect(defaultResend.status).toBe(200);
+
+    // profile is unused beyond auth context here; reference it to satisfy lint
+    expect(profile).toBeDefined();
+  });
+
+  test('Resend with unknown versionId returns 404', async () => {
+    const { profile, accessToken } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Dave',
+        lastName: 'Smith',
+        projectName: `Dave Project ${randomUUID()}`,
+        email: `dave${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+
+    const res = await request(app)
+      .post(`/fhir/R4/${getReferenceString(profile)}/$resend`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({ versionId: randomUUID() });
+    expect(res.status).toBe(404);
   });
 
   test('ProjectMembership with null access policy', async () =>

--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -870,7 +870,7 @@ describe('FHIR Routes', () => {
       .post(`/fhir/R4/${getReferenceString(profile)}/$resend`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ versionId: randomUUID() });
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('ProjectMembership with null access policy', async () =>

--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -778,32 +778,6 @@ describe('FHIR Routes', () => {
     expect(resCreate.status).toBe(200);
   });
 
-  test('Resend with no prior version returns 412', async () => {
-    const { profile, accessToken } = await withTestContext(() =>
-      registerNew({
-        firstName: 'Edith',
-        lastName: 'Smith',
-        projectName: `Edith Project ${randomUUID()}`,
-        email: `edith${randomUUID()}@example.com`,
-        password: 'password!@#',
-      })
-    );
-
-    // First version of the resource — interaction='update' (default) has no prior to diff
-    const res = await request(app)
-      .post(`/fhir/R4/${getReferenceString(profile)}/$resend`)
-      .set('Authorization', 'Bearer ' + accessToken)
-      .send({});
-    expect(res.status).toBe(412);
-
-    // interaction='create' avoids the prior-version requirement
-    const resCreate = await request(app)
-      .post(`/fhir/R4/${getReferenceString(profile)}/$resend`)
-      .set('Authorization', 'Bearer ' + accessToken)
-      .send({ interaction: 'create' });
-    expect(resCreate.status).toBe(200);
-  });
-
   test('Resend with versionId targets historical version', async () => {
     const { profile, accessToken } = await withTestContext(() =>
       registerNew({
@@ -871,8 +845,14 @@ describe('FHIR Routes', () => {
       .send({});
     expect(defaultResend.status).toBe(200);
 
-    // profile is unused beyond auth context here; reference it to satisfy lint
-    expect(profile).toBeDefined();
+    // Default (no versionId) on a resource with no prior version returns 412.
+    // `profile` is the freshly registered Practitioner from registerNew, which
+    // is still on its first version.
+    const noPrior = await request(app)
+      .post(`/fhir/R4/${getReferenceString(profile)}/$resend`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({});
+    expect(noPrior.status).toBe(412);
   });
 
   test('Resend with unknown versionId returns 404', async () => {


### PR DESCRIPTION
# Add `versionId` support to `$resend`

## Why

Subscription handlers sometimes diff `previousVersion` against the current resource to decide whether to fire (lightweight idempotency). When a delivery fails and the resource is later updated, today's `$resend` always replays against the **current** version — handlers then evaluate against drifted state and can incorrectly no-op or fire.

Replay needs the `(version, previousVersion)` pair from the original failure point.

## What

- New optional `versionId` parameter on `POST /[Type]/[id]/$resend`. When set, the server loads that historical version and derives `previousVersion` from history.
- New `Repository.readPreviousVersion(resource)` helper — single-row SQL lookup, replaces ad-hoc paginated history scans.
- When `versionId` is supplied without `interaction`, the server auto-derives it: first version → `create`, otherwise → `update`.