### PR TITLE
Document login rate limit category

### DIFF
--- a/packages/docs/docs/rate-limits/index.md
+++ b/packages/docs/docs/rate-limits/index.md
@@ -9,10 +9,11 @@ send many requests in quick succession may receive HTTP error responses with sta
 
 ## Total Requests Rate Limit
 
-| Category                      | Free tier                        | Paid tier                         |
-| ----------------------------- | -------------------------------- | --------------------------------- |
-| Auth (`/auth/*`, `/oauth2/*`) | 160 requests per IP per minute   | 160 requests per IP per minute    |
-| Others (including `/auth/me`) | 6,000 requests per IP per minute | 60,000 requests per IP per minute |
+| Category                                                              | Free tier                        | Paid tier                         |
+| --------------------------------------------------------------------- | -------------------------------- | --------------------------------- |
+| Login (`/auth/login`, `/auth/newuser`, `/auth/newproject`)            | 5 requests per IP per minute     | 5 requests per IP per minute      |
+| Auth (other `/auth/*` and `/oauth2/*` endpoints)                      | 160 requests per IP per minute   | 160 requests per IP per minute    |
+| Default (all other endpoints, including `/auth/me`)                   | 6,000 requests per IP per minute | 60,000 requests per IP per minute |
 
 All rate limits are calculated per IP address over a one minute window.
 


### PR DESCRIPTION
## Summary

- The rate limiter has three categories (login, auth, default) but the docs only described two
- Adds the login category row (5 req/IP/min) covering `/auth/login`, `/auth/newuser`, and `/auth/newproject`
- Clarifies that the auth category covers _other_ `/auth/*` and `/oauth2/*` endpoints, and that `/auth/me` falls under default

## Test plan

- [x] Verify table renders correctly in the docs site