### PR TITLE
docs: add multiple locations guide to Health Gorilla integration

### DIFF
--- a/packages/docs/docs/integration/health-gorilla/hg-changelog.md
+++ b/packages/docs/docs/integration/health-gorilla/hg-changelog.md
@@ -10,8 +10,6 @@ This page tracks updates, improvements, and changes to the HealthGorilla integra
 
 ## [April 2026]
 
-- Multiple Locations Support: Added the `sync-locations` bot to sync practice locations to Health Gorilla and updated the `sync-practitioner` bot to enroll practitioners at specific locations.
-- Physician-Level Lab Accounts: The `sync-practitioner` bot now syncs physician-level lab account numbers (AN identifiers) to Health Gorilla.
 - Security Enhancement: Removed email sync to Health Gorilla in the `sync-practitioner` bot to prevent self-service password reset attacks.
 - Shared Project Deployment: Health Gorilla bots and OperationDefinitions can now be deployed from a shared Medplum project, streamlining customer installations.
 - Subscription Management: The integration now automatically recreates Health Gorilla subscriptions when the webhook URL becomes stale.

--- a/packages/docs/docs/integration/health-gorilla/hg-changelog.md
+++ b/packages/docs/docs/integration/health-gorilla/hg-changelog.md
@@ -8,6 +8,26 @@ sidebar_position: 99
 
 This page tracks updates, improvements, and changes to the HealthGorilla integration in Medplum.
 
+## [April 2026]
+
+- Multiple Locations Support: Added the `sync-locations` bot to sync practice locations to Health Gorilla and updated the `sync-practitioner` bot to enroll practitioners at specific locations.
+- Physician-Level Lab Accounts: The `sync-practitioner` bot now syncs physician-level lab account numbers (AN identifiers) to Health Gorilla.
+- Security Enhancement: Removed email sync to Health Gorilla in the `sync-practitioner` bot to prevent self-service password reset attacks.
+- Shared Project Deployment: Health Gorilla bots and OperationDefinitions can now be deployed from a shared Medplum project, streamlining customer installations.
+- Subscription Management: The integration now automatically recreates Health Gorilla subscriptions when the webhook URL becomes stale.
+
+## [March 2026]
+
+- OAuth Token Caching: Improved the Health Gorilla OAuth integration by caching the access token across bot invocations, reducing frequent token requests.
+- Order Sync Reliability: Refactored the `send-to-health-gorilla` bot to always read the latest `ServiceRequest` to prevent syncing outdated orders.
+- Async Batch Upload: Switched to asynchronous batch uploads for Health Gorilla organization resources during sync to mitigate rate-limiting issues.
+- Identifier Merging: Enhanced organization syncing to preserve existing payor identifiers when syncing the Health Gorilla ID back to the Medplum organization.
+- Address Syncing: The `send-to-health-gorilla` bot now includes default address fields if none exist, ensuring full address structure is sent.
+
+## [February 2026]
+
+- Resource Sync Logic: Enhanced the `receive-from-health-gorilla` bot to use safe update operations for modifying the status and supporting info of lab orders, ensuring data integrity.
+
 ## [October 2025]
 
 - Atomic ServiceRequest Updates: Switched to batched PATCH operations to sync HealthGorilla order identifiers, preventing race conditions.
@@ -53,3 +73,4 @@ This page tracks updates, improvements, and changes to the HealthGorilla integra
 1. Created Detected Issues for unsolicited reports with unknown patients.
 2. Improved resource sync and subscription logic.
 3. Practitioner sync supports multiple names and new order of operations.
+

--- a/packages/docs/docs/integration/health-gorilla/multiple-locations.md
+++ b/packages/docs/docs/integration/health-gorilla/multiple-locations.md
@@ -1,0 +1,149 @@
+---
+sidebar_position: 4
+---
+
+# Multiple Locations
+
+This guide describes how to work with multiple locations in Health Gorilla. This is especially relevant for Management Services Organizations (MSOs) or practices with multiple clinic locations where different practitioners are assigned to different locations.
+
+## Medplum Data Model
+
+To support multiple locations, you will use `Organization` resources in Medplum to represent both the subtenant and the individual practice locations.
+
+### Subtenant Organization
+
+The subtenant organization represents the top-level entity and links directly to your Health Gorilla subtenant. It should already exist in your setup.
+
+```js
+{
+  "resourceType": "Organization",
+  "identifier": [
+    {
+      "system": "https://www.healthgorilla.com",
+      "value": "t-{hg-subtenant-id}" // Health Gorilla subtenant ID
+    }
+  ]
+}
+```
+
+### Practice Location Organization
+
+Each individual practice location is represented by an `Organization` resource that references the subtenant organization via the `partOf` field. This resource uses the `MedplumHealthGorillaPracticeLocation` profile.
+
+```js {6}
+{
+  "resourceType": "Organization",
+  "name": "Foo Health2",
+  "partOf": {
+    "reference": "Organization/{subtenant-id}" // Reference to the subtenant organization
+  },
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "https://www.healthgorilla.com/fhir/organization-type",
+          "code": "PRL" // Practice Location code
+        }
+      ]
+    }
+  ],
+  "address": [
+    {
+      "line": ["123 Main St"],
+      "city": "SF",
+      "state": "CA",
+      "postalCode": "94110",
+      "country": "USA" // Country is required by Health Gorilla
+    }
+  ],
+  "identifier": [
+    {
+      "system": "https://www.healthgorilla.com",
+      "value": "tl-..." // This is written back after the location is synced
+    }
+  ]
+}
+```
+
+### Practitioner Data Model
+
+The `Practitioner` resource in Medplum needs specific identifiers to correctly sync with Health Gorilla and associate the practitioner with the correct lab account numbers.
+
+A Medplum `Practitioner` holds:
+
+- An array of `identifier` with system `http://hl7.org/fhir/v2/0203` and type code `AN`. These are physician-level lab account numbers, one per lab. They are distinguished by `assigner.reference` which points to a Medplum `Organization` reference.
+- An `identifier` with the NPI system (required).
+- An `identifier` with the Health Gorilla system (written back after enrollment).
+- An optional Health Gorilla login extension.
+
+**Important:** The assigner `Organization` in Medplum must have its own identifier with the Health Gorilla system so the bot can resolve it to an `Organization/f-...` reference that Health Gorilla understands.
+
+## Bot Call Patterns
+
+Bots are invoked via `POST /fhir/R4/Bot/$execute?identifier={system}|{value}`.
+
+### Syncing Locations
+
+To sync a practice location to Health Gorilla, you call the `sync-locations` bot. This creates the location in Health Gorilla and writes the `tl-...` ID back to the Medplum `Organization`.
+
+```bash
+curl -X POST "https://api.medplum.com/fhir/R4/Bot/$execute?identifier=https://medplum.com/bots|sync-locations" \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "Parameters",
+    "parameter": [
+      {
+        "name": "location",
+        "valueReference": {
+          "reference": "Organization/{medplum-org-id}" // Reference to the practice location organization
+        }
+      }
+    ]
+  }'
+```
+
+### Enrolling Practitioners to a Location
+
+Once the location is synced, you can enroll a practitioner into that specific location by providing the location reference to the `sync-practitioner` bot.
+
+```bash {10-13}
+curl -X POST "https://api.medplum.com/fhir/R4/Bot/$execute?identifier=https://medplum.com/bots|sync-practitioner" \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "Parameters",
+    "parameter": [
+      {
+        "name": "practitioner",
+        "valueReference": {
+          "reference": "Practitioner/{id}" // Reference to the practitioner
+        }
+      },
+      {
+        "name": "location",
+        "valueReference": {
+          "reference": "Organization/{practice-location-id}" // Reference to the practice location organization
+        }
+      }
+    ]
+  }'
+```
+
+:::caution Known Limitation
+Health Gorilla only supports location assignment at `PractitionerRole` creation time. Updates via `PUT` or `PATCH` are silently ignored for the location field. Re-assigning a practitioner to a different location requires re-enrollment.
+:::
+
+### Practitioner Sync Bot Flow
+
+The `sync-practitioner` bot performs the following 7 steps on every call to ensure the practitioner is correctly enrolled and updated:
+
+1. **Resolve AN assigners**: Reads each `AN` identifier's assigner `Organization` from Medplum, extracts its Health Gorilla ID, and rewrites `assigner.reference` to `Organization/f-<hgId>`.
+2. **Require NPI**: Throws an error if the NPI is missing.
+3. **Find or enroll**: Looks up the `PractitionerRole` in Health Gorilla by NPI and tenant. If not found, it calls `enrollClinicalUser` (passing the resolved `AN`s so they are included at creation).
+4. **Load Practitioner**: Loads the Health Gorilla `Practitioner` from the role's practitioner reference.
+5. **Consistency check**: Writes the Health Gorilla ID back to Medplum if absent. Throws an error if Medplum's stored ID mismatches what Health Gorilla returned.
+6. **Sync AN identifiers**: Upserts `AN` identifiers onto the Health Gorilla `PractitionerRole` via the contained Practitioner pattern (`PractitionerRole.contained = [practitioner]`, `PractitionerRole.practitioner = { reference: '#pr' }`).
+7. **Sync email telecom**: Uses the same contained-update pattern to sync the practitioner's email.
+
+To take advantage of this flow, add `AN`-typed identifiers to the Medplum `Practitioner`, with each `assigner.reference` pointing at the Medplum `Organization` for that lab. Ensure that the lab `Organization` itself has a Health Gorilla system identifier. The next time the `sync-practitioner` bot runs, it will propagate these identifiers to Health Gorilla automatically.

--- a/packages/docs/docs/integration/health-gorilla/multiple-locations.md
+++ b/packages/docs/docs/integration/health-gorilla/multiple-locations.md
@@ -30,7 +30,7 @@ The subtenant organization represents the top-level entity and links directly to
 
 Each individual practice location is represented by an `Organization` resource that references the subtenant organization via the `partOf` field. This resource uses the `MedplumHealthGorillaPracticeLocation` profile.
 
-```js {6}
+```js
 {
   "resourceType": "Organization",
   "name": "Foo Health2",
@@ -65,29 +65,16 @@ Each individual practice location is represented by an `Organization` resource t
 }
 ```
 
-### Practitioner Data Model
-
-The `Practitioner` resource in Medplum needs specific identifiers to correctly sync with Health Gorilla and associate the practitioner with the correct lab account numbers.
-
-A Medplum `Practitioner` holds:
-
-- An array of `identifier` with system `http://hl7.org/fhir/v2/0203` and type code `AN`. These are physician-level lab account numbers, one per lab. They are distinguished by `assigner.reference` which points to a Medplum `Organization` reference.
-- An `identifier` with the NPI system (required).
-- An `identifier` with the Health Gorilla system (written back after enrollment).
-- An optional Health Gorilla login extension.
-
-**Important:** The assigner `Organization` in Medplum must have its own identifier with the Health Gorilla system so the bot can resolve it to an `Organization/f-...` reference that Health Gorilla understands.
-
 ## Bot Call Patterns
 
-Bots are invoked via `POST /fhir/R4/Bot/$execute?identifier={system}|{value}`.
+Bots are invoked via `POST /fhir/R4/Bot/$execute?identifier={system}|{value}`. Alternatively, you can use the corresponding OperationDefinition.
 
 ### Syncing Locations
 
 To sync a practice location to Health Gorilla, you call the `sync-locations` bot. This creates the location in Health Gorilla and writes the `tl-...` ID back to the Medplum `Organization`.
 
 ```bash
-curl -X POST "https://api.medplum.com/fhir/R4/Bot/$execute?identifier=https://medplum.com/bots|sync-locations" \
+curl -X POST "https://api.medplum.com/fhir/R4/Bot/$execute?identifier=https://www.medplum.com/integrations/bot-identifier|health-gorilla-labs/sync-locations" \
   -H "Authorization: Bearer {token}" \
   -H "Content-Type: application/fhir+json" \
   -d '{
@@ -107,8 +94,29 @@ curl -X POST "https://api.medplum.com/fhir/R4/Bot/$execute?identifier=https://me
 
 Once the location is synced, you can enroll a practitioner into that specific location by providing the location reference to the `sync-practitioner` bot.
 
+You can execute the `sync-practitioner` OperationDefinition on the `Practitioner` resource:
+
 ```bash {10-13}
-curl -X POST "https://api.medplum.com/fhir/R4/Bot/$execute?identifier=https://medplum.com/bots|sync-practitioner" \
+curl -X POST "https://api.medplum.com/fhir/R4/Practitioner/{id}/\$sync-practitioner" \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "Parameters",
+    "parameter": [
+      {
+        "name": "location",
+        "valueReference": {
+          "reference": "Organization/{practice-location-id}" // Reference to the practice location organization
+        }
+      }
+    ]
+  }'
+```
+
+Alternatively, you can execute the bot directly:
+
+```bash {10-13}
+curl -X POST "https://api.medplum.com/fhir/R4/Bot/$execute?identifier=https://www.medplum.com/integrations/bot-identifier|health-gorilla-labs/sync-practitioner" \
   -H "Authorization: Bearer {token}" \
   -H "Content-Type: application/fhir+json" \
   -d '{
@@ -130,20 +138,6 @@ curl -X POST "https://api.medplum.com/fhir/R4/Bot/$execute?identifier=https://me
   }'
 ```
 
-:::caution Known Limitation
+:::caution[Known Limitation]
 Health Gorilla only supports location assignment at `PractitionerRole` creation time. Updates via `PUT` or `PATCH` are silently ignored for the location field. Re-assigning a practitioner to a different location requires re-enrollment.
 :::
-
-### Practitioner Sync Bot Flow
-
-The `sync-practitioner` bot performs the following 7 steps on every call to ensure the practitioner is correctly enrolled and updated:
-
-1. **Resolve AN assigners**: Reads each `AN` identifier's assigner `Organization` from Medplum, extracts its Health Gorilla ID, and rewrites `assigner.reference` to `Organization/f-<hgId>`.
-2. **Require NPI**: Throws an error if the NPI is missing.
-3. **Find or enroll**: Looks up the `PractitionerRole` in Health Gorilla by NPI and tenant. If not found, it calls `enrollClinicalUser` (passing the resolved `AN`s so they are included at creation).
-4. **Load Practitioner**: Loads the Health Gorilla `Practitioner` from the role's practitioner reference.
-5. **Consistency check**: Writes the Health Gorilla ID back to Medplum if absent. Throws an error if Medplum's stored ID mismatches what Health Gorilla returned.
-6. **Sync AN identifiers**: Upserts `AN` identifiers onto the Health Gorilla `PractitionerRole` via the contained Practitioner pattern (`PractitionerRole.contained = [practitioner]`, `PractitionerRole.practitioner = { reference: '#pr' }`).
-7. **Sync email telecom**: Uses the same contained-update pattern to sync the practitioner's email.
-
-To take advantage of this flow, add `AN`-typed identifiers to the Medplum `Practitioner`, with each `assigner.reference` pointing at the Medplum `Organization` for that lab. Ensure that the lab `Organization` itself has a Health Gorilla system identifier. The next time the `sync-practitioner` bot runs, it will propagate these identifiers to Health Gorilla automatically.

--- a/packages/docs/docs/integration/health-gorilla/sending-orders.md
+++ b/packages/docs/docs/integration/health-gorilla/sending-orders.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Sending Orders
 
-:::info Prerequisites
+:::info[Prerequisites]
 For a vendor-neutral overview of diagnostic ordering concepts and the FHIR data model, see [Labs & Imaging](/docs/labs-imaging) and [Order Labs and Imaging](/docs/labs-imaging/ordering-labs-imaging).
 :::
 
@@ -22,15 +22,13 @@ Laboratory ordering involves unique complexities: coordinating between providers
 
 The following concepts form the foundation of laboratory ordering:
 
-
-| Concept                  | Description                                                                                                      | Importance                                                                                                                                                                                                                                  |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Order                    | Request for one or more lab tests, uniquely identified and tracked.                                              | Organizes tests, specimens and results. Maintains chain of custody and enables status tracking.                                                                                                                                             |
-| Test                     | Specific diagnostic procedure with defined requirements for specimen and data collection.                        | Determines specimen needs, required clinical data, and handling protocols. Impacts turnaround times and costs.                                                                                                                              |
-| Specimen                 | Physical sample (blood, urine, etc.) for analysis.                                                               | Samples are only valid for a certain amount of time after collection. Accurately measuring sample collection time is critical for accurate processing Samples can either be collected by the performing lab, or by the requesting provider. |
-| Ask on Order Entry (AOE) | **Required** questions for some labs to gather additional clinical context for test processing.                  | Affects lab processing, result interpretation, and billing. Missing data can cause rejections or delays.                                                                                                                                    |
-| Order Splitting          | Breaking a single order into multiple independent orders, typically when tests require different specimen types. | Allows labs to process specimens independently and maintain separate workflows for different test types. Prevents delays when specimens are collected at different times.                                                                   |
-
+| Concept                  | Description                                                                                                      | Importance                                                                                                                                                                                                                                             |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Order                    | Request for one or more lab tests, uniquely identified and tracked.                                              | Organizes tests, specimens and results. Maintains chain of custody and enables status tracking.                                                                                                                                                        |
+| Test                     | Specific diagnostic procedure with defined requirements for specimen and data collection.                        | Determines specimen needs, required clinical data, and handling protocols. Impacts turnaround times and costs.                                                                                                                                         |
+| Specimen                 | Physical sample (blood, urine, etc.) for analysis.                                                               | Samples are only valid for a certain amount of time after collection. Accurately measuring sample collection time is critical for accurate processing <br/><br/> Samples can either be collected by the performing lab, or by the requesting provider. |
+| Ask on Order Entry (AOE) | **Required** questions for some labs to gather additional clinical context for test processing.                  | Affects lab processing, result interpretation, and billing. Missing data can cause rejections or delays.                                                                                                                                               |
+| Order Splitting          | Breaking a single order into multiple independent orders, typically when tests require different specimen types. | Allows labs to process specimens independently and maintain separate workflows for different test types. Prevents delays when specimens are collected at different times.                                                                              |
 
 ## Creating an Order Form in React
 
@@ -75,7 +73,7 @@ function OrderPage() {
 }
 ```
 
-1. Initialize with context:
+2. Initialize with context:
 
 ```tsx
 function OrderForm() {
@@ -89,7 +87,7 @@ function OrderForm() {
 }
 ```
 
-1. Access operations:
+3. Access operations:
 
 ```tsx
 const {
@@ -104,7 +102,6 @@ const {
 } = labOrderReturn;
 ```
 
-
 | Command                         | Purpose                                                                                                         |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `searchAvailableTests`          | Uses the `autocomplete` bot to fetch available lab tests from Health Gorilla's API based on search string       |
@@ -118,7 +115,6 @@ const {
 | `setPerformingLab`              | Sets which lab will process the tests                                                                           |
 | `setPerformingLabAccountNumber` | Sets the clients lab account number to be used for selected lab (e.g. Quest account number)                     |
 | `validateOrder`                 | Checks order for required fields and valid data                                                                 |
-
 
 #### Example
 
@@ -265,8 +261,6 @@ graph TD
     class Specimen specimen
 ```
 
-
-
 ### Order Structure
 
 The parent order is represented by a `ServiceRequest` resource with the profile `https://medplum.com/profiles/integrations/health-gorilla/StructureDefinition/MedplumHealthGorillaOrder`. This order contains high-level information like:
@@ -287,45 +281,51 @@ Each individual test within the order is represented by its own `ServiceRequest`
 Several additional FHIR resources provide important order details:
 
 1. **Ask on Entry (AoE) Responses**
-  - Stored as `QuestionnaireResponse` resources
-  - Referenced by each test's `ServiceRequest.supportingInfo`
-  - Contains answers to test-specific questions
+   - Stored as `QuestionnaireResponse` resources
+   - Referenced by each test's `ServiceRequest.supportingInfo`
+   - Contains answers to test-specific questions
+
 2. **Specimens**
-  - The `Specimen` resource tracks specimen details
-  - Particularly important for recording `collectionDate` with in-house collections
-  - Links specimen type and collection method information
+   - The `Specimen` resource tracks specimen details
+   - Particularly important for recording `collectionDate` with in-house collections
+   - Links specimen type and collection method information
+
 3. **Documents**
-  Two types of `DocumentReference` resources are linked through `ServiceRequest.supportingInfo`:
-  - **Requisition Form**: The official order documentation with the lab's requisition number
-  - **Specimen Label**: PDF with specimen labeling information that can be affixed to sample collection tubes (used for in-house specimen collection)
+   Two types of `DocumentReference` resources are linked through `ServiceRequest.supportingInfo`:
+   - **Requisition Form**: The official order documentation with the lab's requisition number
+   - **Specimen Label**: PDF with specimen labeling information that can be affixed to sample collection tubes (used for in-house specimen collection)
 
 ## Order Lifecycle
 
 Orders progress through several states:
 
 1. `draft`
-  - Initial state from the order form
-  - Order has not yet been sent to the Health Gorilla
-  - All updates and changes are allowed in Medplum
+   - Initial state from the order form
+   - Order has not yet been sent to the Health Gorilla
+   - All updates and changes are allowed in Medplum
+
 2. `active`
-  - Order has been transmitted to Health Gorilla and the performing lab
-  - The downstream lab (e.g Quest, Labcorp) consider this order immutable
-  - No modifications allowed in lab's system
-  - Set by the `send-to-health-gorilla` bot
+   - Order has been transmitted to Health Gorilla and the performing lab
+   - The downstream lab (e.g Quest, Labcorp) consider this order immutable
+   - No modifications allowed in lab's system
+   - Set by the `send-to-health-gorilla` bot
+
 3. `completed`
-  - Results have been received
-  - Order processing is finished
-  - Set by the `receive-from-health-gorilla` bot
+   - Results have been received
+   - Order processing is finished
+   - Set by the `receive-from-health-gorilla` bot
+
 4. `on-hold`
-  - An error occurred during processing
-  - Set
-  - Error details can be found
-  - Requires intervention to resolve
-  - Set by the `send-to-health-gorilla` bot
+   - An error occurred during processing
+   - Set
+   - Error details can be found
+   - Requires intervention to resolve
+   - Set by the `send-to-health-gorilla` bot
+
 5. `revoked`
-  - Order has been canceled
-  - Cannot be reactivated
-  - Set by the client application
+   - Order has been canceled
+   - Cannot be reactivated
+   - Set by the client application
 
 ::: caution
 
@@ -346,8 +346,8 @@ Actions:
 3. Transmits order with billing information
 4. Updates order status
 5. Downloads and stores:
-  - Requisition forms
-  - Specimen labels
+   - Requisition forms
+   - Specimen labels
 
 ### split-order Bot
 

--- a/packages/docs/docs/integration/health-gorilla/sending-orders.md
+++ b/packages/docs/docs/integration/health-gorilla/sending-orders.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Sending Orders
 
-:::info[Prerequisites]
+:::info Prerequisites
 For a vendor-neutral overview of diagnostic ordering concepts and the FHIR data model, see [Labs & Imaging](/docs/labs-imaging) and [Order Labs and Imaging](/docs/labs-imaging/ordering-labs-imaging).
 :::
 
@@ -22,13 +22,15 @@ Laboratory ordering involves unique complexities: coordinating between providers
 
 The following concepts form the foundation of laboratory ordering:
 
-| Concept                  | Description                                                                                                      | Importance                                                                                                                                                                                                                                             |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Order                    | Request for one or more lab tests, uniquely identified and tracked.                                              | Organizes tests, specimens and results. Maintains chain of custody and enables status tracking.                                                                                                                                                        |
-| Test                     | Specific diagnostic procedure with defined requirements for specimen and data collection.                        | Determines specimen needs, required clinical data, and handling protocols. Impacts turnaround times and costs.                                                                                                                                         |
-| Specimen                 | Physical sample (blood, urine, etc.) for analysis.                                                               | Samples are only valid for a certain amount of time after collection. Accurately measuring sample collection time is critical for accurate processing <br/><br/> Samples can either be collected by the performing lab, or by the requesting provider. |
-| Ask on Order Entry (AOE) | **Required** questions for some labs to gather additional clinical context for test processing.                  | Affects lab processing, result interpretation, and billing. Missing data can cause rejections or delays.                                                                                                                                               |
-| Order Splitting          | Breaking a single order into multiple independent orders, typically when tests require different specimen types. | Allows labs to process specimens independently and maintain separate workflows for different test types. Prevents delays when specimens are collected at different times.                                                                              |
+
+| Concept                  | Description                                                                                                      | Importance                                                                                                                                                                                                                                  |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Order                    | Request for one or more lab tests, uniquely identified and tracked.                                              | Organizes tests, specimens and results. Maintains chain of custody and enables status tracking.                                                                                                                                             |
+| Test                     | Specific diagnostic procedure with defined requirements for specimen and data collection.                        | Determines specimen needs, required clinical data, and handling protocols. Impacts turnaround times and costs.                                                                                                                              |
+| Specimen                 | Physical sample (blood, urine, etc.) for analysis.                                                               | Samples are only valid for a certain amount of time after collection. Accurately measuring sample collection time is critical for accurate processing Samples can either be collected by the performing lab, or by the requesting provider. |
+| Ask on Order Entry (AOE) | **Required** questions for some labs to gather additional clinical context for test processing.                  | Affects lab processing, result interpretation, and billing. Missing data can cause rejections or delays.                                                                                                                                    |
+| Order Splitting          | Breaking a single order into multiple independent orders, typically when tests require different specimen types. | Allows labs to process specimens independently and maintain separate workflows for different test types. Prevents delays when specimens are collected at different times.                                                                   |
+
 
 ## Creating an Order Form in React
 
@@ -73,7 +75,7 @@ function OrderPage() {
 }
 ```
 
-2. Initialize with context:
+1. Initialize with context:
 
 ```tsx
 function OrderForm() {
@@ -87,7 +89,7 @@ function OrderForm() {
 }
 ```
 
-3. Access operations:
+1. Access operations:
 
 ```tsx
 const {
@@ -102,6 +104,7 @@ const {
 } = labOrderReturn;
 ```
 
+
 | Command                         | Purpose                                                                                                         |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `searchAvailableTests`          | Uses the `autocomplete` bot to fetch available lab tests from Health Gorilla's API based on search string       |
@@ -115,6 +118,7 @@ const {
 | `setPerformingLab`              | Sets which lab will process the tests                                                                           |
 | `setPerformingLabAccountNumber` | Sets the clients lab account number to be used for selected lab (e.g. Quest account number)                     |
 | `validateOrder`                 | Checks order for required fields and valid data                                                                 |
+
 
 #### Example
 
@@ -261,6 +265,8 @@ graph TD
     class Specimen specimen
 ```
 
+
+
 ### Order Structure
 
 The parent order is represented by a `ServiceRequest` resource with the profile `https://medplum.com/profiles/integrations/health-gorilla/StructureDefinition/MedplumHealthGorillaOrder`. This order contains high-level information like:
@@ -281,51 +287,45 @@ Each individual test within the order is represented by its own `ServiceRequest`
 Several additional FHIR resources provide important order details:
 
 1. **Ask on Entry (AoE) Responses**
-   - Stored as `QuestionnaireResponse` resources
-   - Referenced by each test's `ServiceRequest.supportingInfo`
-   - Contains answers to test-specific questions
-
+  - Stored as `QuestionnaireResponse` resources
+  - Referenced by each test's `ServiceRequest.supportingInfo`
+  - Contains answers to test-specific questions
 2. **Specimens**
-   - The `Specimen` resource tracks specimen details
-   - Particularly important for recording `collectionDate` with in-house collections
-   - Links specimen type and collection method information
-
+  - The `Specimen` resource tracks specimen details
+  - Particularly important for recording `collectionDate` with in-house collections
+  - Links specimen type and collection method information
 3. **Documents**
-   Two types of `DocumentReference` resources are linked through `ServiceRequest.supportingInfo`:
-   - **Requisition Form**: The official order documentation with the lab's requisition number
-   - **Specimen Label**: PDF with specimen labeling information that can be affixed to sample collection tubes (used for in-house specimen collection)
+  Two types of `DocumentReference` resources are linked through `ServiceRequest.supportingInfo`:
+  - **Requisition Form**: The official order documentation with the lab's requisition number
+  - **Specimen Label**: PDF with specimen labeling information that can be affixed to sample collection tubes (used for in-house specimen collection)
 
 ## Order Lifecycle
 
 Orders progress through several states:
 
 1. `draft`
-   - Initial state from the order form
-   - Order has not yet been sent to the Health Gorilla
-   - All updates and changes are allowed in Medplum
-
+  - Initial state from the order form
+  - Order has not yet been sent to the Health Gorilla
+  - All updates and changes are allowed in Medplum
 2. `active`
-   - Order has been transmitted to Health Gorilla and the performing lab
-   - The downstream lab (e.g Quest, Labcorp) consider this order immutable
-   - No modifications allowed in lab's system
-   - Set by the `send-to-health-gorilla` bot
-
+  - Order has been transmitted to Health Gorilla and the performing lab
+  - The downstream lab (e.g Quest, Labcorp) consider this order immutable
+  - No modifications allowed in lab's system
+  - Set by the `send-to-health-gorilla` bot
 3. `completed`
-   - Results have been received
-   - Order processing is finished
-   - Set by the `receive-from-health-gorilla` bot
-
+  - Results have been received
+  - Order processing is finished
+  - Set by the `receive-from-health-gorilla` bot
 4. `on-hold`
-   - An error occurred during processing
-   - Set
-   - Error details can be found
-   - Requires intervention to resolve
-   - Set by the `send-to-health-gorilla` bot
-
+  - An error occurred during processing
+  - Set
+  - Error details can be found
+  - Requires intervention to resolve
+  - Set by the `send-to-health-gorilla` bot
 5. `revoked`
-   - Order has been canceled
-   - Cannot be reactivated
-   - Set by the client application
+  - Order has been canceled
+  - Cannot be reactivated
+  - Set by the client application
 
 ::: caution
 
@@ -346,8 +346,8 @@ Actions:
 3. Transmits order with billing information
 4. Updates order status
 5. Downloads and stores:
-   - Requisition forms
-   - Specimen labels
+  - Requisition forms
+  - Specimen labels
 
 ### split-order Bot
 

--- a/packages/docs/docs/integration/health-gorilla/user-management.md
+++ b/packages/docs/docs/integration/health-gorilla/user-management.md
@@ -8,19 +8,44 @@ The `sync-practitioner` bot is responsible for syncing practitioner data between
 
 The basic process is:
 
-1.  **Read NPI**: The integration reads the NPI number from the Practitioner in Medplum.
-2.  **Check and Enroll**: It checks if the practitioner is already enrolled in your Health Gorilla tenant. If not, it searches the Health Gorilla NPI registry and automatically enrolls them as a clinical user.
-3.  **Sync Identifiers**: The Health Gorilla ID and login details are saved back to the Medplum `Practitioner`.
-4.  **Sync Telecom**: The practitioner's email address in Medplum is synced to Health Gorilla.
+1. **Read NPI**: The integration reads the NPI number from the Practitioner in Medplum.
+2. **Check and Enroll**: It checks if the practitioner is already enrolled in your Health Gorilla tenant. If not, it searches the Health Gorilla NPI registry and automatically enrolls them as a clinical user.
+3. **Sync Identifiers**: The Health Gorilla ID and login details are saved back to the Medplum `Practitioner`.
+4. **Sync Telecom**: The practitioner's email address in Medplum is synced to Health Gorilla.
+
+### Bot Call Pattern
+
+To trigger the sync for a practitioner, you can execute the `sync-practitioner` bot with a `Parameters` resource containing a reference to the `Practitioner`:
+
+```bash
+curl -X POST "https://api.medplum.com/fhir/R4/Bot/$execute?identifier=https://medplum.com/bots|sync-practitioner" \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "Parameters",
+    "parameter": [
+      {
+        "name": "practitioner",
+        "valueReference": {
+          "reference": "Practitioner/{id}" // Reference to the practitioner to sync
+        }
+      }
+    ]
+  }'
+```
+
+:::info Multiple Locations
+If you are operating a Management Services Organization (MSO) or a practice with multiple locations, the sync process involves additional steps for mapping lab account numbers to specific practice locations. See the [Multiple Locations](./multiple-locations) guide for more details.
+:::
 
 ### Name Matching and Validation
 
 When enrolling a new practitioner, Health Gorilla requires the name to match the NPI registry. The sync bot performs the following validation:
 
-*   It searches Health Gorilla by NPI to find the existing record.
-*   It compares the name in Medplum against the name found in Health Gorilla.
-*   **Family Name**: Must match exactly (case-insensitive, ignoring leading/trailing whitespace). Suffixes or titles (like "DNP, MSN, APRN") should not be included in the family name unless they are part of the legal name in the NPI registry.
-*   **Given Name**: The first given name in Health Gorilla (`name.given[0]`) must match either the entire given name string in Medplum, or any individual word within Medplum's given names (case-insensitive). This gracefully handles common variations in middle names and spacing.
+- It searches Health Gorilla by NPI to find the existing record.
+- It compares the name in Medplum against the name found in Health Gorilla.
+- **Family Name**: Must match exactly (case-insensitive, ignoring leading/trailing whitespace). Suffixes or titles (like "DNP, MSN, APRN") should not be included in the family name unless they are part of the legal name in the NPI registry.
+- **Given Name**: The first given name in Health Gorilla (`name.given[0]`) must match either the entire given name string in Medplum, or any individual word within Medplum's given names (case-insensitive). This gracefully handles common variations in middle names and spacing.
 
 If a practitioner has multiple names (e.g., a maiden name), you can add multiple names to the Medplum `Practitioner` resource and set the `use` field appropriately. The bot will check against all names provided in Medplum to find a match with Health Gorilla.
 
@@ -30,12 +55,13 @@ If a practitioner has multiple names (e.g., a maiden name), you can add multiple
 
 The sync bot handles this by:
 
-1.  Filtering all telecom entries on the Medplum `Practitioner` where `system` is `email`.
-2.  Sorting them by the `rank` field (lower rank values are more preferred).
-3.  Attempting to sync each email to Health Gorilla in order of precedence until one succeeds.
+1. Filtering all telecom entries on the Medplum `Practitioner` where `system` is `email`.
+2. Sorting them by the `rank` field (lower rank values are more preferred).
+3. Attempting to sync each email to Health Gorilla in order of precedence until one succeeds.
 
 This allows you to provide an email alias as a fallback. For example:
-*   `doctor.smith@example.com` (rank 0)
-*   `doctor.smith+alias@example.com` (rank 1)
+
+- `doctor.smith@example.com` (rank 0)
+- `doctor.smith+alias@example.com` (rank 1)
 
 If the first email is already in use in Health Gorilla, the bot will automatically fall back to the second email.

--- a/packages/docs/docs/integration/health-gorilla/user-management.md
+++ b/packages/docs/docs/integration/health-gorilla/user-management.md
@@ -8,17 +8,29 @@ The `sync-practitioner` bot is responsible for syncing practitioner data between
 
 The basic process is:
 
-1. **Read NPI**: The integration reads the NPI number from the Practitioner in Medplum.
+1. **Read NPI**: The integration reads the NPI number from the Practitioner in Medplum. (NPI is unconditionally required).
 2. **Check and Enroll**: It checks if the practitioner is already enrolled in your Health Gorilla tenant. If not, it searches the Health Gorilla NPI registry and automatically enrolls them as a clinical user.
-3. **Sync Identifiers**: The Health Gorilla ID and login details are saved back to the Medplum `Practitioner`.
-4. **Sync Telecom**: The practitioner's email address in Medplum is synced to Health Gorilla.
+3. **Sync Identifiers**: The Health Gorilla ID and login details are saved back to the Medplum `Practitioner`. Health Gorilla ID consistency is validated on every sync.
+4. **Sync Lab Account Numbers**: Physician-level lab account numbers (AN identifiers) are resolved and merged into the Health Gorilla `PractitionerRole`.
 
 ### Bot Call Pattern
 
-To trigger the sync for a practitioner, you can execute the `sync-practitioner` bot with a `Parameters` resource containing a reference to the `Practitioner`:
+To trigger the sync for a practitioner, you can execute the `sync-practitioner` OperationDefinition on the `Practitioner` resource:
 
 ```bash
-curl -X POST "https://api.medplum.com/fhir/R4/Bot/$execute?identifier=https://medplum.com/bots|sync-practitioner" \
+curl -X POST "https://api.medplum.com/fhir/R4/Practitioner/{id}/\$sync-practitioner" \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "Parameters",
+    "parameter": []
+  }'
+```
+
+Alternatively, you can execute the bot directly:
+
+```bash
+curl -X POST "https://api.medplum.com/fhir/R4/Bot/$execute?identifier=https://www.medplum.com/integrations/bot-identifier|health-gorilla-labs/sync-practitioner" \
   -H "Authorization: Bearer {token}" \
   -H "Content-Type: application/fhir+json" \
   -d '{
@@ -49,19 +61,38 @@ When enrolling a new practitioner, Health Gorilla requires the name to match the
 
 If a practitioner has multiple names (e.g., a maiden name), you can add multiple names to the Medplum `Practitioner` resource and set the `use` field appropriately. The bot will check against all names provided in Medplum to find a match with Health Gorilla.
 
-### Email Sync and Precedence
+### Physician-Level Lab Account Numbers
 
-**Health Gorilla considers emails to be globally unique across all tenants.** Therefore, adding an email address that is already shared by another Health Gorilla Practitioner will fail.
+Health Gorilla supports physician-level lab account numbers (AN identifiers) which can be synced from Medplum to Health Gorilla during practitioner enrollment and re-sync.
 
-The sync bot handles this by:
+Lab account numbers are modeled as `Identifier` resources on the Medplum `Practitioner` with:
+- `type.coding[].system` = `http://hl7.org/fhir/v2/0203` or `http://terminology.hl7.org/CodeSystem/v2-0203`
+- `type.coding[].code` = `AN`
+- `assigner.reference` pointing at the Medplum `Organization` for the lab (which must itself carry a `HEALTH_GORILLA_SYSTEM` identifier)
 
-1. Filtering all telecom entries on the Medplum `Practitioner` where `system` is `email`.
-2. Sorting them by the `rank` field (lower rank values are more preferred).
-3. Attempting to sync each email to Health Gorilla in order of precedence until one succeeds.
+```json
+{
+  "resourceType": "Practitioner",
+  "identifier": [
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "AN"
+          }
+        ]
+      },
+      "value": "12345",
+      "assigner": {
+        "reference": "Organization/lab-org-id"
+      }
+    }
+  ]
+}
+```
 
-This allows you to provide an email alias as a fallback. For example:
-
-- `doctor.smith@example.com` (rank 0)
-- `doctor.smith+alias@example.com` (rank 1)
-
-If the first email is already in use in Health Gorilla, the bot will automatically fall back to the second email.
+On each sync, the bot:
+1. Resolves each AN identifier's assigner Organization to a Health Gorilla `Organization/f-...` reference.
+2. Merges the resolved ANs into the Health Gorilla `Practitioner` via the contained-Practitioner pattern on `PractitionerRole`.
+3. Embeds ANs at initial enrollment so they are present from the moment the clinical user is created.


### PR DESCRIPTION
## Summary
- Adds a new guide for handling multiple locations in the Health Gorilla integration
- Updates the sending orders and user management guides to fix formatting and link to the new guide
- Documents the `sync-practitioner` bot call pattern and multi-location complexities

## Test plan
- Verify the new multiple locations page renders correctly in the docs
- Verify the links from user management point to the correct location

Made with [Cursor](https://cursor.com)