### PR TITLE
Adds single-type reference search match to memory repo

### DIFF
--- a/packages/core/src/search/match.test.ts
+++ b/packages/core/src/search/match.test.ts
@@ -156,6 +156,15 @@ describe('Search matching', () => {
 
     search.filters[0].value = 'Patient/456';
     expect(matchesSearchRequest(resource, search as SearchRequest)).toBe(true);
+
+    // ID-only special case does not work with `subject` because it has multiple target types
+    search.filters[0].operator = Operator.EQUALS;
+    search.filters[0].value = '123';
+    expect(matchesSearchRequest(resource, search as SearchRequest)).toBe(false);
+
+    // ID-only special case does work with `patient` because it has only one target type
+    search.filters[0].code = 'patient';
+    expect(matchesSearchRequest(resource, search as SearchRequest)).toBe(true);
   });
 
   test('Empty reference filter', () => {

--- a/packages/core/src/search/match.ts
+++ b/packages/core/src/search/match.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { Period, Resource } from '@medplum/fhirtypes';
+import type { Period, Resource, SearchParameter } from '@medplum/fhirtypes';
 import { LRUCache } from '../cache';
 import type { FhirPathAtom } from '../fhirpath/atoms';
 import { evalFhirPathTyped } from '../fhirpath/parse';
@@ -61,7 +61,7 @@ function matchesSearchFilter(resource: Resource, searchRequest: SearchRequest, f
   }
   switch (searchParam.type) {
     case 'reference':
-      return matchesReferenceFilter(typedValues, filter);
+      return matchesReferenceFilter(searchParam, typedValues, filter);
     case 'string':
     case 'uri':
       return matchesStringFilter(typedValues, filter);
@@ -84,7 +84,7 @@ function matchesMissingOrPresent(typedValues: TypedValue[], filter: Filter): boo
   return desired === exists;
 }
 
-function matchesReferenceFilter(typedValues: TypedValue[], filter: Filter): boolean {
+function matchesReferenceFilter(searchParam: SearchParameter, typedValues: TypedValue[], filter: Filter): boolean {
   const negated = isNegated(filter.operator);
 
   if (filter.value === '' && typedValues.length === 0) {
@@ -97,12 +97,13 @@ function matchesReferenceFilter(typedValues: TypedValue[], filter: Filter): bool
   const references = convertToSearchableReferences(typedValues);
 
   for (const filterValue of splitSearchOnComma(filter.value)) {
-    let match = references.includes(filterValue);
-    if (!match && filter.code === '_compartment') {
-      // Backwards compability for compartment search parameter
-      // In previous versions, the resource type was not required in compartment values
-      // So, "123" would match "Patient/123"
-      // We need to maintain this behavior for backwards compatibility
+    let match = false;
+    if (filterValue.includes('/')) {
+      match = references.includes(filterValue);
+    } else if (searchParam.target?.length === 1 || filter.code === '_compartment') {
+      // If the filter value does not include a resource type, then it can match any reference that ends with '/' + filterValue
+      // This is only allowed if the search parameter has a single target type,
+      // or if the search parameter is _compartment (which is a special case for backwards compatibility reasons)
       match = references.some((reference) => reference?.endsWith('/' + filterValue));
     }
     if (match) {


### PR DESCRIPTION
Support `reference=id` style searches when the `SearchParameter` only has one target type.

We already support this in the Postgres reference search.  Adding it to the in-memory search for compatibility.

See: https://hl7.org/fhir/R4/search.html#reference