### PR TITLE
ci(sonar): re-enable `Sonar` on all PRs and merge groups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: SonarCloud Scan
-        if: ${{ matrix.node-version == 22 && matrix.pg-version == 14 && matrix.redis-version == 7 && (vars.SONAR_ENABLED == 'true' || github.ref == 'refs/heads/main') }}
+        if: ${{ matrix.node-version == 22 && matrix.pg-version == 14 && matrix.redis-version == 7 }}
         continue-on-error: true
         uses: SonarSource/sonarqube-scan-action@9598b8a83feef37de07f549027fab50ecffe6a6e # master
         env:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,12 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "never"
   },
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    // This "yaml.format.enable" is for the RedHat YAML plugin which has great IDE hints
+    // But also turns on conflicting formatting by default
+    // Which prettier cannot even correct after it's been applied
+    "yaml.format.enable": false
+  },
   "cSpell.words": ["auditevent", "bullmq", "FHIR", "Fhircast", "Medplum"]
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -41,5 +41,4 @@ sonar.links.scm=https://github.com/medplum/medplum
 sonar.links.ci=https://github.com/medplum/medplum/actions
 sonar.links.issue=https://github.com/medplum/medplum/issues
 sonar.scanner.javaOpts=-Xmx12G -Xms1024m
-sonar.verbose=true
 sonar.architecture.enable=false

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -34,7 +34,7 @@ sonar.exclusions=**/node_modules/**,\
   packages/server/src/migrations/migrate-main.ts,\
   packages/server/src/migrations/data/**/*.ts,\
   packages/server/src/migrations/schema/**/*.ts
-sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
+sonar.tests=**/*.test.ts,**/*.test.tsx
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.links.homepage=https://www.medplum.com/
 sonar.links.scm=https://github.com/medplum/medplum

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -34,7 +34,7 @@ sonar.exclusions=**/node_modules/**,\
   packages/server/src/migrations/migrate-main.ts,\
   packages/server/src/migrations/data/**/*.ts,\
   packages/server/src/migrations/schema/**/*.ts
-sonar.tests=**/*.test.ts,**/*.test.tsx
+sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.links.homepage=https://www.medplum.com/
 sonar.links.scm=https://github.com/medplum/medplum


### PR DESCRIPTION
This PR re-enables Sonar on all PRs and merge groups, previously removed as it was crashing. Now it appears to be working so we can finally add it back 🥳 🎉 

Before, the scan of `main` hadn't succeeded for ~2 months. Now it's back in working order! 
<img width="1008" height="244" alt="Screenshot 2026-04-30 at 9 21 24 AM" src="https://github.com/user-attachments/assets/37f1f0d9-1535-461b-ab6a-948b11e6c452" />
