### PR TITLE
Provider: Make `<AlphaBanner>` dark-mode friendly

### DIFF
--- a/examples/medplum-provider/src/components/AlphaBanner.module.css
+++ b/examples/medplum-provider/src/components/AlphaBanner.module.css
@@ -1,0 +1,10 @@
+.alphaBanner {
+  background-color: light-dark(var(--mantine-color-violet-1), var(--mantine-color-violet-9));
+  color: light-dark(var(--mantine-color-dark-8), var(--mantine-color-gray-3));
+}
+
+.alphaPill {
+  background-color: light-dark(var(--mantine-color-violet-4), var(--mantine-color-violet-2));
+  color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-8));
+  font-weight: 600;
+}

--- a/examples/medplum-provider/src/components/AlphaBanner.tsx
+++ b/examples/medplum-provider/src/components/AlphaBanner.tsx
@@ -2,20 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { BoxProps } from '@mantine/core';
 import { Box, Group, Pill } from '@mantine/core';
+import cx from 'clsx';
 import type { JSX } from 'react';
+import classes from './AlphaBanner.module.css';
 
 interface AlphaBannerProps extends BoxProps {
   children: React.ReactNode;
 }
 
 export function AlphaBanner(props: AlphaBannerProps): JSX.Element {
-  const { children, ...boxProps } = props;
+  const { children, className, ...boxProps } = props;
   return (
-    <Box bg="violet.0" p="sm" {...boxProps}>
+    <Box p="sm" {...boxProps} className={cx(classes.alphaBanner, className)}>
       <Group gap="md">
-        <Pill bg="violet.4" c="white">
-          Alpha
-        </Pill>
+        <Pill className={classes.alphaPill}>Alpha</Pill>
         <span>{children}</span>
       </Group>
     </Box>


### PR DESCRIPTION
Tweaking the colors a bit here makes this much nicer when someone is using the dark theme.

## Before
<img width="1453" height="925" alt="Screenshot 2026-04-30 at 11 44 03 AM" src="https://github.com/user-attachments/assets/135c884d-1ca6-4253-8ff8-7af26338e98a" />

## After
<img width="1453" height="925" alt="Screenshot 2026-04-30 at 11 43 39 AM" src="https://github.com/user-attachments/assets/2e48ae38-3899-4d4e-ab93-3923c48e6917" />