### PR TITLE
Fixed bug with SMART scopes and MFA

### DIFF
--- a/packages/server/src/auth/newpatient.ts
+++ b/packages/server/src/auth/newpatient.ts
@@ -9,7 +9,7 @@ import { sendOutcome } from '../fhir/outcomes';
 import { getGlobalSystemRepo, getProjectSystemRepo } from '../fhir/repo';
 import { setLoginMembership } from '../oauth/utils';
 import { makeValidationMiddleware } from '../util/validator';
-import { createProfile, createProjectMembership } from './utils';
+import { createProfile, createProjectMembership, sendLoginResult } from './utils';
 
 export const newPatientValidator = makeValidationMiddleware([
   body('login').notEmpty().withMessage('Missing login'),
@@ -45,10 +45,7 @@ export async function newPatientHandler(req: Request, res: Response): Promise<vo
   // Update the login
   const updated = await setLoginMembership(login, membership);
 
-  res.status(200).json({
-    login: updated.id,
-    code: updated.code,
-  });
+  await sendLoginResult(res, updated);
 }
 
 /**

--- a/packages/server/src/auth/newproject.ts
+++ b/packages/server/src/auth/newproject.ts
@@ -9,6 +9,7 @@ import { sendOutcome } from '../fhir/outcomes';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { setLoginMembership } from '../oauth/utils';
 import { makeValidationMiddleware } from '../util/validator';
+import { sendLoginResult } from './utils';
 
 export interface NewProjectRequest {
   readonly loginId: string;
@@ -40,9 +41,5 @@ export async function newProjectHandler(req: Request, res: Response): Promise<vo
   const user = await systemRepo.readReference<User>(login.user as Reference<User>);
   const { membership } = await createProject(projectName, user);
   const updatedLogin = await setLoginMembership(login, membership);
-
-  res.status(200).json({
-    login: updatedLogin.id,
-    code: updatedLogin.code,
-  });
+  await sendLoginResult(res, updatedLogin);
 }

--- a/packages/server/src/auth/profile.ts
+++ b/packages/server/src/auth/profile.ts
@@ -8,7 +8,7 @@ import { body } from 'express-validator';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { setLoginMembership } from '../oauth/utils';
 import { makeValidationMiddleware } from '../util/validator';
-import { sendLoginCookie } from './utils';
+import { sendLoginResult } from './utils';
 
 /*
  * The profile handler is used during login when a user has multiple profiles.
@@ -35,12 +35,6 @@ export async function profileHandler(req: Request, res: Response): Promise<void>
   // Update the login
   const updated = await setLoginMembership(login, membership);
 
-  // Send login cookie
-  sendLoginCookie(res, login);
-
-  // Send code
-  res.status(200).json({
-    login: updated.id,
-    code: updated.code,
-  });
+  // Send login result
+  await sendLoginResult(res, updated);
 }

--- a/packages/server/src/auth/scope.test.ts
+++ b/packages/server/src/auth/scope.test.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { Login, User } from '@medplum/fhirtypes';
-import { authenticator } from 'otplib';
 import { randomUUID } from 'crypto';
 import express from 'express';
+import { authenticator } from 'otplib';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
@@ -264,10 +264,13 @@ describe('Scope', () => {
       expect(loginRes.status).toBe(200);
       expect(loginRes.body.mfaRequired).toBe(true);
 
-      const mfaRes = await request(app).post('/auth/mfa/verify').type('json').send({
-        login: loginRes.body.login,
-        token: authenticator.generate(mfaSecret),
-      });
+      const mfaRes = await request(app)
+        .post('/auth/mfa/verify')
+        .type('json')
+        .send({
+          login: loginRes.body.login,
+          token: authenticator.generate(mfaSecret),
+        });
       expect(mfaRes.status).toBe(200);
       expect(mfaRes.body.code).toBeDefined();
 

--- a/packages/server/src/auth/scope.test.ts
+++ b/packages/server/src/auth/scope.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { Login } from '@medplum/fhirtypes';
+import type { Login, User } from '@medplum/fhirtypes';
+import { authenticator } from 'otplib';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
@@ -205,5 +206,78 @@ describe('Scope', () => {
     expect(res2.status).toBe(400);
     expect(res2.body.issue).toBeDefined();
     expect(res2.body.issue[0].details.text).toBe('Invalid scope');
+  });
+
+  describe('MFA-pending login', () => {
+    const mfaEmail = `mfa${randomUUID()}@example.com`;
+    const mfaPassword = randomUUID();
+    let mfaSecret: string;
+
+    beforeAll(async () => {
+      const registration = await withTestContext(() =>
+        registerNew({
+          firstName: 'MFA',
+          lastName: 'User',
+          projectName: 'MFA Scope Project',
+          email: mfaEmail,
+          password: mfaPassword,
+        })
+      );
+
+      // Enroll MFA directly on the user record so future logins require verification.
+      mfaSecret = authenticator.generateSecret();
+      await withTestContext(() =>
+        systemRepo.updateResource<User>({
+          ...registration.user,
+          mfaEnrolled: true,
+          mfaSecret,
+        })
+      );
+    });
+
+    test('Does not leak auth code when MFA is enrolled but not verified', async () => {
+      const loginRes = await request(app).post('/auth/login').type('json').send({
+        scope: 'openid profile',
+        email: mfaEmail,
+        password: mfaPassword,
+      });
+      expect(loginRes.status).toBe(200);
+      expect(loginRes.body.login).toBeDefined();
+      expect(loginRes.body.mfaRequired).toBe(true);
+      expect(loginRes.body.code).toBeUndefined();
+
+      const scopeRes = await request(app).post('/auth/scope').type('json').send({
+        login: loginRes.body.login,
+        scope: 'openid profile',
+      });
+      expect(scopeRes.status).toBe(200);
+      expect(scopeRes.body.mfaRequired).toBe(true);
+      expect(scopeRes.body.code).toBeUndefined();
+    });
+
+    test('Releases auth code once MFA is verified', async () => {
+      const loginRes = await request(app).post('/auth/login').type('json').send({
+        scope: 'openid profile',
+        email: mfaEmail,
+        password: mfaPassword,
+      });
+      expect(loginRes.status).toBe(200);
+      expect(loginRes.body.mfaRequired).toBe(true);
+
+      const mfaRes = await request(app).post('/auth/mfa/verify').type('json').send({
+        login: loginRes.body.login,
+        token: authenticator.generate(mfaSecret),
+      });
+      expect(mfaRes.status).toBe(200);
+      expect(mfaRes.body.code).toBeDefined();
+
+      const scopeRes = await request(app).post('/auth/scope').type('json').send({
+        login: loginRes.body.login,
+        scope: 'openid profile',
+      });
+      expect(scopeRes.status).toBe(200);
+      expect(scopeRes.body.code).toBeDefined();
+      expect(scopeRes.body.mfaRequired).toBeUndefined();
+    });
   });
 });

--- a/packages/server/src/auth/scope.ts
+++ b/packages/server/src/auth/scope.ts
@@ -6,6 +6,7 @@ import { body } from 'express-validator';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { setLoginScope } from '../oauth/utils';
 import { makeValidationMiddleware } from '../util/validator';
+import { sendLoginResult } from './utils';
 
 /*
  * The scope handler is used during login to allow a user to select the scope of the login.
@@ -20,13 +21,6 @@ export const scopeValidator = makeValidationMiddleware([
 export async function scopeHandler(req: Request, res: Response): Promise<void> {
   const systemRepo = getGlobalSystemRepo();
   const login = await systemRepo.readResource<Login>('Login', req.body.login);
-
-  // Update the login
   const updated = await setLoginScope(systemRepo, login, req.body.scope);
-
-  // Send code
-  res.status(200).json({
-    login: updated.id,
-    code: updated.code,
-  });
+  await sendLoginResult(res, updated);
 }


### PR DESCRIPTION
The SMART scope handler did not properly check MFA status.

All auth flow endpoints must use `sendLoginResult()` rather than returning a response directly.

Context: https://docs.google.com/presentation/d/1l92v3kMWQmMVhVRE8m1UavSpoK0Cz0MxPndTWqQDq30/edit?slide=id.g1b462728f6f_0_0#slide=id.g1b462728f6f_0_0