### PR TITLE
fix: exit with non-zero code when bot deploy fails

### DIFF
--- a/packages/cli/src/bots.ts
+++ b/packages/cli/src/bots.ts
@@ -33,7 +33,12 @@ botDeployCommand
   .action(async (botName, options) => {
     const medplum = await createMedplumClient(options);
 
-    await botWrapper(medplum, botName, true);
+    try {
+      await botWrapper(medplum, botName, true);
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
   });
 
 botCreateCommand
@@ -96,7 +101,12 @@ deployBotDeprecate
   .action(async (botName, options) => {
     const medplum = await createMedplumClient(options);
 
-    await botWrapper(medplum, botName, true);
+    try {
+      await botWrapper(medplum, botName, true);
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
   });
 
 createBotDeprecate


### PR DESCRIPTION
Fixes #3692

## Problem

When `medplum bot deploy` encounters an error (e.g. bot ID not found, returning a 404), it logs the error but still exits with code 0, causing CI/CD pipelines to treat failed deployments as successful.

## Fix

Wrap the `botWrapper` call in both the new `botDeployCommand` and the deprecated `deployBotDeprecate` action handlers with a `try/catch` block that logs the error message and calls `process.exit(1)`, ensuring a non-zero exit code on failure.