### PR TITLE
docs: fix sidebar labels for docs with MDX heading IDs

### DIFF
--- a/packages/docs/docs/careplans/referrals/creation-and-capture.md
+++ b/packages/docs/docs/careplans/referrals/creation-and-capture.md
@@ -1,3 +1,8 @@
+---
+title: Referral Creation & Capture
+sidebar_label: Referral Creation & Capture
+---
+
 # Referral Creation & Capture {/* #referral-creation */}
 
 ## Capturing Referral Requests

--- a/packages/docs/docs/fhir-datastore/patient-deduplication/matching.mdx
+++ b/packages/docs/docs/fhir-datastore/patient-deduplication/matching.mdx
@@ -1,3 +1,8 @@
+---
+title: Matching
+sidebar_label: Matching
+---
+
 import ExampleCode from '!!raw-loader!@site/..//examples/src/fhir-datastore/patient-deduplication/matching.ts';
 import MedplumCodeBlock from '@site/src/components/MedplumCodeBlock';
 import Tabs from '@theme/Tabs';

--- a/packages/docs/docs/fhir-datastore/patient-deduplication/merging.mdx
+++ b/packages/docs/docs/fhir-datastore/patient-deduplication/merging.mdx
@@ -1,3 +1,8 @@
+---
+title: Merging
+sidebar_label: Merging
+---
+
 import ExampleCode from '!!raw-loader!@site/../../examples/medplum-demo-bots/src/deduplication/merge-matching-patients.ts';
 import MedplumCodeBlock from '@site/src/components/MedplumCodeBlock';
 


### PR DESCRIPTION
## Summary
Adds `title` and `sidebar_label` frontmatter for three docs whose H1 uses explicit MDX heading IDs (`{/* #id */}`). Docusaurus was including that fragment in the sidebar and browser tab title ([example](https://www.medplum.com/docs/careplans/referrals/creation-and-capture)).

## Changes
- `creation-and-capture.md` — Referral Creation & Capture
- `patient-deduplication/merging.mdx` — Merging
- `patient-deduplication/matching.mdx` — Matching

Anchors on the H1 are unchanged.

Made with [Cursor](https://cursor.com)