### PR TITLE
Enforce login membership before scope

### DIFF
--- a/packages/server/src/auth/scope.test.ts
+++ b/packages/server/src/auth/scope.test.ts
@@ -116,6 +116,32 @@ describe('Scope', () => {
     expect(res2.body.issue[0].details.text).toBe('Login granted');
   });
 
+  test('Missing membership', async () => {
+    const res1 = await request(app).post('/auth/login').type('json').send({
+      scope: 'openid profile',
+      email,
+      password,
+    });
+    expect(res1.status).toBe(200);
+    expect(res1.body.login).toBeDefined();
+
+    const login = await systemRepo.readResource<Login>('Login', res1.body.login);
+    await withTestContext(() =>
+      systemRepo.updateResource({
+        ...login,
+        membership: undefined,
+      })
+    );
+
+    const res2 = await request(app).post('/auth/scope').type('json').send({
+      login: res1.body.login,
+      scope: 'openid profile',
+    });
+    expect(res2.status).toBe(400);
+    expect(res2.body.issue).toBeDefined();
+    expect(res2.body.issue[0].details.text).toBe('Login profile not set');
+  });
+
   test('Success', async () => {
     const res1 = await request(app).post('/auth/login').type('json').send({
       scope: 'openid profile',

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -564,6 +564,9 @@ export async function setLoginScope(systemRepo: SystemRepository, login: Login, 
   if (login.granted) {
     throw new OperationOutcomeError(badRequest('Login granted'));
   }
+  if (!login.membership) {
+    throw new OperationOutcomeError(badRequest('Login profile not set'));
+  }
 
   const existingScopes = parseSmartScopes(login.scope);
   const submittedScopes = parseSmartScopes(scope);


### PR DESCRIPTION
Before, it was theoretically possible for a user to choose OAuth scopes before project membership.  In theory, that's not totally wrong, but it's not as intended.

After, must choose membership before scope.

Context: https://docs.google.com/presentation/d/1l92v3kMWQmMVhVRE8m1UavSpoK0Cz0MxPndTWqQDq30/edit?slide=id.g1b462728f6f_0_0#slide=id.g1b462728f6f_0_0