### PR TITLE
fix(server/cors): expose `RateLimit` header for cors

### DIFF
--- a/packages/server/src/cors.test.ts
+++ b/packages/server/src/cors.test.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { Request } from 'express';
+import express, { type Request } from 'express';
+import request from 'supertest';
+import { initApp, shutdownApp } from './app';
 import { getConfig, loadTestConfig } from './config/loader';
 import { corsOptions } from './cors';
 
@@ -39,6 +41,19 @@ describe('CORS', () => {
     expect(callback).toHaveBeenCalledWith(
       null,
       expect.objectContaining({ credentials: true, origin: 'http://localhost:3000' })
+    );
+  });
+
+  test('Exposes RateLimit header on FHIR requests', () => {
+    const req = {
+      header: () => 'http://localhost:3000',
+      path: '/fhir/R4/Patient',
+    } as unknown as Request;
+    const callback = jest.fn();
+    corsOptions(req, callback);
+    expect(callback).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({ exposedHeaders: expect.arrayContaining(['RateLimit']) })
     );
   });
 
@@ -90,5 +105,17 @@ describe('CORS', () => {
     const callback = jest.fn();
     corsOptions(req, callback);
     expect(callback).toHaveBeenCalledWith(null, { origin: false });
+  });
+
+  test('FHIR response includes RateLimit in Access-Control-Expose-Headers', async () => {
+    const app = express();
+    const config = await loadTestConfig();
+    await initApp(app, config);
+    const res = await request(app).get('/fhir/R4/Patient').set('Origin', 'http://localhost:3000');
+    expect(res.headers['access-control-expose-headers']).toBeDefined();
+    expect(res.headers['access-control-expose-headers'].split(',').map((h: string) => h.trim())).toEqual(
+      expect.arrayContaining(['RateLimit'])
+    );
+    expect(await shutdownApp()).toBeUndefined();
   });
 });

--- a/packages/server/src/cors.test.ts
+++ b/packages/server/src/cors.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { Request } from 'express';
 import express from 'express';
-import type {Request} from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from './app';
 import { getConfig, loadTestConfig } from './config/loader';

--- a/packages/server/src/cors.test.ts
+++ b/packages/server/src/cors.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import express, { type Request } from 'express';
+import express from 'express';
+import type {Request} from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from './app';
 import { getConfig, loadTestConfig } from './config/loader';

--- a/packages/server/src/cors.ts
+++ b/packages/server/src/cors.ts
@@ -4,7 +4,7 @@ import type cors from 'cors';
 import type { Request } from 'express';
 import { getConfig } from './config/loader';
 
-const exposedHeaders = ['Content-Location', 'ETag', 'Last-Modified', 'Location'];
+const exposedHeaders = ['Content-Location', 'ETag', 'Last-Modified', 'Location', 'RateLimit'];
 
 /**
  * CORS configuration.


### PR DESCRIPTION
Currently fetch in the browser from non-Medplum origins will not allow `MedplumClient` to access the `RateLimit` header, because we were not including `RateLimit` in the CORS `Access-Control-Expose-Headers` header. This PR fixes that.