### PR TITLE
fix(agent): return explicit error when upgrade artifact is missing

### DIFF
--- a/packages/agent/src/app.test.ts
+++ b/packages/agent/src/app.test.ts
@@ -3129,6 +3129,102 @@ describe('App', () => {
       createPidFileSpy.mockRestore();
       console.log = originalConsoleLog;
     });
+
+    test('Upgrade -- Missing artifact for platform', async () => {
+      const platformSpy = jest.spyOn(os, 'platform').mockImplementation(jest.fn(() => 'win32'));
+
+      // Manifest only has a Linux asset, no Windows asset
+      const manifest = {
+        tag_name: 'v4.2.5',
+        assets: [
+          {
+            name: 'medplum-agent-4.2.5-linux',
+            browser_download_url: 'https://example.com/linux',
+          },
+        ],
+      };
+
+      const fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(
+        jest.fn(async () => {
+          return new Response(JSON.stringify(manifest), {
+            headers: { 'content-type': 'application/json' },
+            status: 200,
+          });
+        })
+      );
+
+      const state = {
+        mySocket: undefined as Client | undefined,
+        agentError: undefined as AgentError | undefined,
+      };
+
+      function mockConnectionHandler(socket: Client): void {
+        state.mySocket = socket;
+        socket.on('message', (data) => {
+          const command = JSON.parse((data as Buffer).toString('utf8')) as AgentMessage;
+          switch (command.type) {
+            case 'agent:connect:request':
+              socket.send(Buffer.from(JSON.stringify({ type: 'agent:connect:response' })));
+              break;
+            case 'agent:heartbeat:request':
+              socket.send(Buffer.from(JSON.stringify({ type: 'agent:heartbeat:response' })));
+              break;
+            case 'agent:error':
+              state.agentError = command;
+              break;
+            default:
+              break;
+          }
+        });
+      }
+
+      const mockServer = new Server('wss://example.com/ws/agent');
+      mockServer.on('connection', mockConnectionHandler);
+
+      const agent = await medplum.createResource<Agent>({
+        resourceType: 'Agent',
+        name: 'Test Agent',
+        status: 'active',
+      });
+
+      const app = new App(medplum, agent.id, LogLevel.INFO);
+      await app.start();
+
+      while (!state.mySocket) {
+        await sleep(100);
+      }
+
+      state.mySocket.send(
+        JSON.stringify({
+          type: 'agent:upgrade:request',
+          version: '4.2.5',
+          callback: getReferenceString(agent) + '-' + randomUUID(),
+        } satisfies AgentUpgradeRequest)
+      );
+
+      let shouldThrow = false;
+      const timeout = setTimeout(() => {
+        shouldThrow = true;
+      }, 2500);
+
+      while (!state.agentError) {
+        if (shouldThrow) {
+          throw new Error('Timeout');
+        }
+        await sleep(100);
+      }
+      clearTimeout(timeout);
+
+      expect(state.agentError.body).toContain("No download URL found for release 'v4.2.5' for win32");
+
+      await app.stop();
+      await new Promise<void>((resolve) => {
+        mockServer.stop(resolve);
+      });
+
+      platformSpy.mockRestore();
+      fetchSpy.mockRestore();
+    });
   });
 
   test('Upgrading -- Upgrade in progress, should error', async () => {

--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -23,6 +23,7 @@ import {
   TypedEventTarget,
   checkIfValidMedplumVersion,
   fetchLatestVersionString,
+  fetchVersionManifest,
   isValidHostname,
   normalizeErrorString,
   sleep,
@@ -57,7 +58,7 @@ import { isWinstonWrapperLogger } from './logger';
 import { createPidFile, forceKillApp, isAppRunning, removePidFile, waitForPidFile } from './pid';
 import { getCurrentStats, updateStat } from './stats';
 import type { HeartbeatEmitter } from './types';
-import { UPGRADER_LOG_PATH, UPGRADE_MANIFEST_PATH } from './upgrader-utils';
+import { UPGRADER_LOG_PATH, UPGRADE_MANIFEST_PATH, parseDownloadUrl } from './upgrader-utils';
 
 async function execAsync(
   command: string,
@@ -895,6 +896,22 @@ export class App {
       }
       // Clean up upgrade.json
       unlinkSync(UPGRADE_MANIFEST_PATH);
+    }
+
+    // Pre-check: verify artifact exists for this OS before spawning upgrader
+    try {
+      const release = await fetchVersionManifest('agent-upgrader', targetVersion);
+      parseDownloadUrl(release, platform());
+    } catch (err) {
+      const versionTag = message.version ? `v${message.version}` : 'latest';
+      const errMsg = `Error during upgrading to version '${versionTag}': ${normalizeErrorString(err)}`;
+      this.log.error(errMsg);
+      await this.sendToWebSocket({
+        type: 'agent:error',
+        callback: message.callback,
+        body: errMsg,
+      } satisfies AgentError);
+      return;
     }
 
     try {

--- a/packages/agent/src/upgrader-utils.test.ts
+++ b/packages/agent/src/upgrader-utils.test.ts
@@ -41,6 +41,41 @@ describe.each(ALL_PLATFORMS_LIST)('Upgrader Utils -- All Platforms -- %s', (_pla
     expect(() => parseDownloadUrl(manifest, 'darwin')).toThrow('Unsupported platform: darwin');
   });
 
+  test('parseDownloadUrl -- missing artifact for platform', () => {
+    const manifestOnlyWindows = {
+      tag_name: 'v4.2.5',
+      assets: [
+        {
+          name: 'medplum-agent-installer-4.2.5-windows.exe',
+          browser_download_url: 'https://example.com/win32',
+        },
+      ],
+    } satisfies ReleaseManifest;
+    const manifestOnlyLinux = {
+      tag_name: 'v4.2.5',
+      assets: [
+        {
+          name: 'medplum-agent-4.2.5-linux',
+          browser_download_url: 'https://example.com/linux',
+        },
+      ],
+    } satisfies ReleaseManifest;
+    const emptyManifest = {
+      tag_name: 'v4.2.5',
+      assets: [],
+    } satisfies ReleaseManifest;
+
+    expect(() => parseDownloadUrl(manifestOnlyWindows, 'linux')).toThrow(
+      "No download URL found for release 'v4.2.5' for linux"
+    );
+    expect(() => parseDownloadUrl(manifestOnlyLinux, 'win32')).toThrow(
+      "No download URL found for release 'v4.2.5' for win32"
+    );
+    expect(() => parseDownloadUrl(emptyManifest, 'win32')).toThrow(
+      "No download URL found for release 'v4.2.5' for win32"
+    );
+  });
+
   test('getReleaseBinPath', () => {
     switch (_platform) {
       case 'win32':


### PR DESCRIPTION
## Summary
- Pre-validates that a release artifact exists for the current OS **before** spawning the upgrader child process
- Returns a clear error message (e.g., `No download URL found for release 'v4.2.5' for win32`) instead of the generic 15s timeout: `Timed out while waiting for message from child`
- Adds tests for missing artifact scenarios in both `upgrader-utils.test.ts` and `app.test.ts`

Closes #7940

## Test plan
- [x] `parseDownloadUrl` correctly throws when release has no matching asset for platform (win32-only, linux-only, empty assets)
- [x] `App` upgrade flow returns `agent:error` with explicit message when artifact is missing, without spawning the child process
- [x] All existing upgrade tests continue to pass