### PR TITLE
Provider: Fix "Details" link tab

### DIFF
--- a/examples/medplum-provider/src/App.tsx
+++ b/examples/medplum-provider/src/App.tsx
@@ -237,6 +237,7 @@ export function App(): JSX.Element | null {
               <Route path="/:resourceType/new" element={<ResourceCreatePage />} />
               <Route path="/:resourceType/:id" element={<ResourcePage />}>
                 <Route path="" element={<ResourceDetailPage />} />
+                <Route path="details" element={<ResourceDetailPage />} />
                 <Route path="edit" element={<ResourceEditPage />} />
                 <Route path="history" element={<ResourceHistoryPage />} />
               </Route>


### PR DESCRIPTION
When clicking around the tabs in the Provider app, trying to return to the first one ("Details") lands you on an empty screen at the `/:resourceType/:id/details` URL.

Adding a route for `/details` is slightly duplicative, but avoids pushing more logic into the tab rendering to know which ones should send the viewer to the index route.

## Example: Before

https://github.com/user-attachments/assets/836c958f-a243-4f61-ba62-51dc64b6c6c0

