### PR TITLE
Add scheduling feature flag

### DIFF
--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
@@ -310,35 +310,31 @@ describe('SchedulePage', () => {
   });
 
   describe('Settings gear icon', () => {
-    test('gear icon is hidden when the schedule lacks SchedulingParameters', async () => {
+    test('when the scheduling feature is disabled the gear icon is hidden', async () => {
       await act(async () => setup());
       await waitFor(() => expect(screen.getByText('Today')).toBeInTheDocument());
       expect(screen.queryByRole('button', { name: 'Schedule settings' })).not.toBeInTheDocument();
     });
 
-    test('gear icon is visible when the schedule has SchedulingParameters', async () => {
-      const scheduleWithParams = {
-        ...mockSchedule,
-        extension: [{ url: SchedulingParametersURI }],
-      };
-      await medplum.updateResource(scheduleWithParams);
-      medplum.searchOne = vi.fn().mockResolvedValue(scheduleWithParams);
-
+    test('when the scheduling feature is enabled the gear icon is visible', async () => {
+      medplum.getProject = vi.fn().mockReturnValue({
+        resourceType: 'Project',
+        id: 'project-123',
+        features: ['scheduling'],
+      });
       await act(async () => setup());
       await waitFor(() => expect(screen.getByText('Today')).toBeInTheDocument());
-
       expect(screen.getByRole('button', { name: 'Schedule settings' })).toBeInTheDocument();
     });
 
     test('clicking the gear icon navigates to the schedule settings page', async () => {
       const user = userEvent.setup();
-      const scheduleWithParams = {
-        ...mockSchedule,
-        extension: [{ url: SchedulingParametersURI }],
-      };
-      await medplum.updateResource(scheduleWithParams);
-      medplum.searchOne = vi.fn().mockResolvedValue(scheduleWithParams);
 
+      medplum.getProject = vi.fn().mockReturnValue({
+        resourceType: 'Project',
+        id: 'project-123',
+        features: ['scheduling'],
+      });
       await act(async () => setup());
       await user.click(screen.getByRole('button', { name: 'Schedule settings' }));
       await waitFor(() => expect(screen.getByText('Settings Page')).toBeInTheDocument());

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
@@ -16,7 +16,6 @@ import { AppointmentDetails } from '../../components/schedule/AppointmentDetails
 import { CreateVisit } from '../../components/schedule/CreateVisit';
 import type { Range } from '../../types/scheduling';
 import { showErrorNotification } from '../../utils/notifications';
-import { hasSchedulingParameters } from '../../utils/scheduling';
 import { mergeOverlappingSlots } from '../../utils/slots';
 import { FindPane } from './FindPane';
 import classes from './SchedulePage.module.css';
@@ -31,6 +30,7 @@ export function SchedulePage(): JSX.Element | null {
   const { id } = useParams<{ id: string }>();
   const medplum = useMedplum();
   const profile = useMedplumProfile() as Practitioner;
+  const project = medplum.getProject();
 
   // Redirect to the current user's schedule if no id in the URL
   useEffect(() => {
@@ -226,6 +226,8 @@ export function SchedulePage(): JSX.Element | null {
     [medplum, navigate]
   );
 
+  const schedulingEnabled = project?.features?.includes('scheduling');
+
   return (
     <Box pos="relative" bg="white" p="md" style={{ height }}>
       <div className={classes.wrapper}>
@@ -240,7 +242,7 @@ export function SchedulePage(): JSX.Element | null {
               onChange={handleActorChange}
             />
           </Box>
-          {schedule && hasSchedulingParameters(schedule) && (
+          {schedule && schedulingEnabled && (
             <ActionIcon
               variant="subtle"
               aria-label="Schedule settings"

--- a/packages/definitions/src/fhir/r4/fhir.schema.json
+++ b/packages/definitions/src/fhir/r4/fhir.schema.json
@@ -61413,6 +61413,7 @@
               "email",
               "google-auth-required",
               "graphql-introspection",
+              "scheduling",
               "websocket-subscriptions",
               "transaction-bundles",
               "validate-terminology"

--- a/packages/definitions/src/fhir/r4/valuesets-medplum.json
+++ b/packages/definitions/src/fhir/r4/valuesets-medplum.json
@@ -165,6 +165,11 @@
             "definition": "GraphQL Introspection"
           },
           {
+            "code": "scheduling",
+            "display": "Scheduling",
+            "definition": "Enable Medplum Scheduling features"
+          },
+          {
             "code": "websocket-subscriptions",
             "display": "WebSocket Subscriptions",
             "definition": "WebSocket Subscriptions"

--- a/packages/fhirtypes/dist/Project.d.ts
+++ b/packages/fhirtypes/dist/Project.d.ts
@@ -139,7 +139,8 @@ export interface Project {
    * A list of optional features that are enabled for the project.
    */
   features?: ('ai' | 'aws-comprehend' | 'aws-textract' | 'bots' | 'cron' | 'email' | 'google-auth-required' |
-      'graphql-introspection' | 'websocket-subscriptions' | 'transaction-bundles' | 'validate-terminology')[];
+      'graphql-introspection' | 'scheduling' | 'websocket-subscriptions' | 'transaction-bundles' |
+      'validate-terminology')[];
 
   /**
    * The default access policy for patients using open registration.


### PR DESCRIPTION
Up until now I've been trying to have folks opt-in to Scheduling UI features by using the presence of the SchedulingParameters extension, but as we start looking at multi-resource issues that's going to become troublesome.

For now, I'm using this flag to decide if the "Scheduling Settings" gear should be shown on the calendar page, (without needing to do queries for HealthcareService resources to see if they are schedulable).