### PR TITLE
refactor(agent): always collect HL7 conn stats

### DIFF
--- a/packages/agent/src/app.test.ts
+++ b/packages/agent/src/app.test.ts
@@ -3904,7 +3904,6 @@ describe('App', () => {
       expect(app.hl7Clients.size).toBe(1);
       const pool = app.hl7Clients.get(`mllp://localhost:${port}`);
       expect(pool).toBeDefined();
-      expect(pool?.isTrackingStats()).toBe(true);
       const client = pool?.getClients()[0];
       expect(client?.stats).toBeDefined();
       expect(client?.stats?.getSampleCount()).toBe(1);
@@ -4024,12 +4023,8 @@ describe('App', () => {
         await sleep(100);
       }
 
-      // Should have 2 pools with stats tracking enabled
+      // Should have 2 pools
       expect(app.hl7Clients.size).toBe(2);
-      const pool1 = app.hl7Clients.get(`mllp://localhost:${port1}`);
-      const pool2 = app.hl7Clients.get(`mllp://localhost:${port2}`);
-      expect(pool1?.isTrackingStats()).toBe(true);
-      expect(pool2?.isTrackingStats()).toBe(true);
 
       // Update agent to disable keepAlive
       await medplum.updateResource<Agent>({
@@ -4067,7 +4062,7 @@ describe('App', () => {
       console.log = originalConsoleLog;
     });
 
-    test('When logStatsFreqSecs goes from on to off, cleanup all stats', async () => {
+    test('When logStatsFreqSecs goes from on to off, pool keeps tracking stats (default-on)', async () => {
       const originalConsoleLog = console.log;
       console.log = jest.fn();
 
@@ -4144,10 +4139,8 @@ describe('App', () => {
         await sleep(100);
       }
 
-      // Pool should have stats tracking enabled
+      // Pool should exist
       expect(app.hl7Clients.size).toBe(1);
-      const pool = app.hl7Clients.get(`mllp://localhost:${port}`);
-      expect(pool?.isTrackingStats()).toBe(true);
 
       // Update agent to disable logStatsFreqSecs
       await medplum.updateResource<Agent>({
@@ -4169,10 +4162,8 @@ describe('App', () => {
         await sleep(100);
       }
 
-      // Pool should still exist but stats tracking should be disabled
+      // Pool should still exist (stats are collected by default)
       expect(app.hl7Clients.size).toBe(1);
-      const poolAfterReload = app.hl7Clients.get(`mllp://localhost:${port}`);
-      expect(poolAfterReload?.isTrackingStats()).toBe(false);
 
       await app.stop();
       await hl7Server.stop({ forceDrainTimeoutMs: 100 });
@@ -4183,7 +4174,7 @@ describe('App', () => {
       console.log = originalConsoleLog;
     });
 
-    test('When logStatsFreqSecs goes from off to on, start tracking stats', async () => {
+    test('Pool tracks stats by default when keepAlive is on, regardless of logStatsFreqSecs', async () => {
       const originalConsoleLog = console.log;
       console.log = jest.fn();
 
@@ -4257,10 +4248,9 @@ describe('App', () => {
         await sleep(100);
       }
 
-      // Pool should exist but not have stats tracking enabled
+      // Pool should exist and have stats tracking enabled by default
       expect(app.hl7Clients.size).toBe(1);
       let pool = app.hl7Clients.get(`mllp://localhost:${port}`);
-      expect(pool?.isTrackingStats()).toBe(false);
 
       // Update agent to enable logStatsFreqSecs
       await medplum.updateResource<Agent>({
@@ -4288,7 +4278,6 @@ describe('App', () => {
       // Pool should now have stats tracking enabled
       expect(app.hl7Clients.size).toBe(1);
       pool = app.hl7Clients.get(`mllp://localhost:${port}`);
-      expect(pool?.isTrackingStats()).toBe(true);
 
       // Send another message to verify stats tracking works
       state.transmitResponses = [];
@@ -4313,9 +4302,9 @@ describe('App', () => {
         await sleep(100);
       }
 
-      // Stats should have recorded the new message
+      // Stats should have recorded both messages (tracking is on from the start)
       const client = pool?.getClients()[0];
-      expect(client?.stats?.getSampleCount()).toBe(1);
+      expect(client?.stats?.getSampleCount()).toBe(2);
 
       await app.stop();
       await hl7Server.stop({ forceDrainTimeoutMs: 100 });

--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -42,7 +42,6 @@ import WebSocket from 'ws';
 import { AgentByteStreamChannel } from './bytestream';
 import type { Channel } from './channel';
 import { ChannelType, getChannelType, getChannelTypeShortName } from './channel';
-import type { ChannelStats } from './channel-stats-tracker';
 import {
   DEFAULT_MAX_CLIENTS_PER_REMOTE,
   DEFAULT_PING_TIMEOUT,
@@ -371,11 +370,6 @@ export class App {
           this.log.error(normalizeErrorString(result.reason));
         }
       }
-      // We need to stop tracking stats for each client so that the heartbeat listener is removed
-      // Before clearing the clients
-      for (const pool of this.hl7Clients.values()) {
-        pool.stopTrackingStats();
-      }
       this.hl7Clients.clear();
     }
 
@@ -406,16 +400,7 @@ export class App {
 
     if (this.logStatsFreqSecs > 0) {
       this.log.info(`Stats logging enabled. Logging stats every ${this.logStatsFreqSecs} seconds...`);
-      if (this.keepAlive) {
-        for (const pool of this.hl7Clients.values()) {
-          pool.startTrackingStats();
-        }
-      }
       this.logStatsTimer ??= setInterval(() => this.logStats(), this.logStatsFreqSecs * 1000);
-    } else {
-      for (const pool of this.hl7Clients.values()) {
-        pool.stopTrackingStats();
-      }
     }
 
     await this.hydrateListeners();
@@ -432,14 +417,14 @@ export class App {
 
     const hl7Channels = Array.from(this.channels.values()).filter((channel) => channel instanceof AgentHl7Channel);
     const channelStats = Object.fromEntries(
-      hl7Channels.map((channel) => [channel.getDefinition().name, channel.stats?.getStats() as ChannelStats])
+      hl7Channels.map((channel) => [channel.getDefinition().name, channel.stats.getStats()])
     );
 
     const pools = Array.from(this.hl7Clients.values());
     const clientStats = Object.fromEntries(
       pools.map((pool) => [
         `mllp://${pool.host}:${pool.port}?encoding=${pool.encoding ?? DEFAULT_ENCODING}`,
-        pool.getPoolStats() as ChannelStats,
+        pool.getPoolStats(),
       ])
     );
 
@@ -1081,7 +1066,6 @@ export class App {
     if (this.hl7Clients.has(message.remote)) {
       pool = this.hl7Clients.get(message.remote) as Hl7ClientPool;
     } else {
-      const keepAlive = this.keepAlive;
       pool = new Hl7ClientPool({
         host: address.hostname,
         port: Number.parseInt(address.port, 10),
@@ -1092,14 +1076,10 @@ export class App {
         heartbeatEmitter: this.heartbeatEmitter,
       });
       this.hl7Clients.set(message.remote, pool);
-      if (keepAlive && this.logStatsFreqSecs > 0) {
-        pool.startTrackingStats();
-      }
       this.log.info(`Client pool created for remote '${message.remote}'`, {
         keepAlive: this.keepAlive,
         maxClients: this.maxClientsPerRemote,
         encoding,
-        trackingStats: this.logStatsFreqSecs > 0,
       });
     }
 

--- a/packages/agent/src/enhanced-hl7-client.test.ts
+++ b/packages/agent/src/enhanced-hl7-client.test.ts
@@ -15,8 +15,8 @@ describe('EnhancedHl7Client', () => {
     mockLogger = createMockLogger();
   });
 
-  describe('send with tracking off', () => {
-    test('Send does not record stats when tracking is off', async () => {
+  describe('send', () => {
+    test('Send records message sent', async () => {
       const port = await getFreePort();
       const server = new Hl7Server((connection) => {
         connection.addEventListener('message', ({ message }) => {
@@ -29,70 +29,6 @@ describe('EnhancedHl7Client', () => {
         host: 'localhost',
         port,
         log: mockLogger,
-      });
-
-      const message = Hl7Message.parse(
-        'MSH|^~\\&|ADT1|MCM|LABADT|MCM|198808181126|SECURITY|ADT^A01|MSG00001|P|2.2\r' +
-          'PID|||PATID1234^5^M11||JONES^WILLIAM^A^III||19610615|M-'
-      );
-
-      await client.send(message);
-
-      expect(client.stats).toBeUndefined();
-
-      await client.close();
-      await server.stop();
-    });
-  });
-
-  describe('sendAndWait with tracking off', () => {
-    test('SendAndWait does not record stats when tracking is off', async () => {
-      const port = await getFreePort();
-      const server = new Hl7Server((connection) => {
-        connection.addEventListener('message', ({ message }) => {
-          connection.send(message.buildAck());
-        });
-      });
-      await server.start(port);
-
-      const { client } = createTestEnhancedHl7Client({
-        host: 'localhost',
-        port,
-        log: mockLogger,
-      });
-
-      const message = Hl7Message.parse(
-        'MSH|^~\\&|ADT1|MCM|LABADT|MCM|198808181126|SECURITY|ADT^A01|MSG00001|P|2.2\r' +
-          'PID|||PATID1234^5^M11||JONES^WILLIAM^A^III||19610615|M-'
-      );
-
-      const response = await client.sendAndWait(message);
-
-      expect(response).toBeDefined();
-      expect(client.stats).toBeUndefined();
-
-      await client.close();
-      await server.stop();
-    });
-  });
-
-  describe('send with tracking on', () => {
-    test('Send records message sent when tracking is on', async () => {
-      const port = await getFreePort();
-      const server = new Hl7Server((connection) => {
-        connection.addEventListener('message', ({ message }) => {
-          connection.send(message.buildAck());
-        });
-      });
-      await server.start(port);
-
-      const { client } = createTestEnhancedHl7Client({
-        host: 'localhost',
-        port,
-        log: mockLogger,
-      });
-
-      client.startTrackingStats({
         heartbeatEmitter: mockHeartbeatEmitter,
       });
 
@@ -106,8 +42,8 @@ describe('EnhancedHl7Client', () => {
       await client.send(message);
 
       // Message should be recorded as pending
-      expect(client.stats?.getPendingCount()).toBe(1);
-      expect(client.stats?.getSampleCount()).toBe(0);
+      expect(client.stats.getPendingCount()).toBe(1);
+      expect(client.stats.getSampleCount()).toBe(0);
 
       await client.close();
       await server.stop();
@@ -126,9 +62,6 @@ describe('EnhancedHl7Client', () => {
         host: 'localhost',
         port,
         log: mockLogger,
-      });
-
-      client.startTrackingStats({
         heartbeatEmitter: mockHeartbeatEmitter,
       });
 
@@ -140,16 +73,16 @@ describe('EnhancedHl7Client', () => {
       await client.send(message);
 
       // No stats should be recorded
-      expect(client.stats?.getPendingCount()).toBe(0);
-      expect(client.stats?.getSampleCount()).toBe(0);
+      expect(client.stats.getPendingCount()).toBe(0);
+      expect(client.stats.getSampleCount()).toBe(0);
 
       await client.close();
       await server.stop();
     });
   });
 
-  describe('sendAndWait with tracking on', () => {
-    test('SendAndWait records RTT when tracking is on', async () => {
+  describe('sendAndWait', () => {
+    test('SendAndWait records RTT', async () => {
       const port = await getFreePort();
       const server = new Hl7Server((connection) => {
         connection.addEventListener('message', ({ message }) => {
@@ -162,9 +95,6 @@ describe('EnhancedHl7Client', () => {
         host: 'localhost',
         port,
         log: mockLogger,
-      });
-
-      client.startTrackingStats({
         heartbeatEmitter: mockHeartbeatEmitter,
       });
 
@@ -180,10 +110,10 @@ describe('EnhancedHl7Client', () => {
       expect(response).toBeDefined();
 
       // RTT should be recorded
-      expect(client.stats?.getPendingCount()).toBe(0);
-      expect(client.stats?.getSampleCount()).toBe(1);
+      expect(client.stats.getPendingCount()).toBe(0);
+      expect(client.stats.getSampleCount()).toBe(1);
 
-      const stats = client.stats?.getRttStats();
+      const stats = client.stats.getRttStats();
       expect(stats?.count).toBe(1);
       expect(stats?.min).toBeGreaterThanOrEqual(0);
       expect(stats?.max).toBeGreaterThanOrEqual(0);
@@ -205,9 +135,6 @@ describe('EnhancedHl7Client', () => {
         host: 'localhost',
         port,
         log: mockLogger,
-      });
-
-      client.startTrackingStats({
         heartbeatEmitter: mockHeartbeatEmitter,
       });
 
@@ -222,11 +149,11 @@ describe('EnhancedHl7Client', () => {
       }
 
       // All RTTs should be recorded
-      expect(client.stats?.getPendingCount()).toBe(0);
-      expect(client.stats?.getSampleCount()).toBe(3);
-      expect(client.stats?.getRttSamples().length).toBe(3);
+      expect(client.stats.getPendingCount()).toBe(0);
+      expect(client.stats.getSampleCount()).toBe(3);
+      expect(client.stats.getRttSamples().length).toBe(3);
 
-      const stats = client.stats?.getRttStats();
+      const stats = client.stats.getRttStats();
       expect(stats?.count).toBe(3);
 
       await client.close();
@@ -246,9 +173,6 @@ describe('EnhancedHl7Client', () => {
         host: 'localhost',
         port,
         log: mockLogger,
-      });
-
-      client.startTrackingStats({
         heartbeatEmitter: mockHeartbeatEmitter,
       });
 
@@ -261,83 +185,31 @@ describe('EnhancedHl7Client', () => {
       await expect(client.sendAndWait(message)).rejects.toThrow('Required field missing: MSH.10');
 
       // No stats should be recorded
-      expect(client.stats?.getPendingCount()).toBe(0);
-      expect(client.stats?.getSampleCount()).toBe(0);
+      expect(client.stats.getPendingCount()).toBe(0);
+      expect(client.stats.getSampleCount()).toBe(0);
 
       await client.close();
       await server.stop();
     });
   });
 
-  describe('startTrackingStats', () => {
-    test('Does not start tracking if already tracking', async () => {
+  describe('close', () => {
+    test('Cleans up stats tracker on close', async () => {
       const port = await getFreePort();
       const { client } = createTestEnhancedHl7Client({
         host: 'localhost',
         port,
         log: mockLogger,
-      });
-
-      client.startTrackingStats({
-        heartbeatEmitter: mockHeartbeatEmitter,
-      });
-
-      const firstStatsTracker = client.stats;
-      expect(firstStatsTracker).toBeDefined();
-      expect(mockHeartbeatEmitter.listenerCount('heartbeat')).toBe(1);
-
-      // Try to start tracking again
-      client.startTrackingStats({
-        heartbeatEmitter: mockHeartbeatEmitter,
-      });
-
-      // Should still be the same stats tracker
-      expect(client.stats).toBe(firstStatsTracker);
-      // Should not have added another listener
-      expect(mockHeartbeatEmitter.listenerCount('heartbeat')).toBe(1);
-
-      await client.close();
-    });
-  });
-
-  describe('stopTrackingStats', () => {
-    test('Calls cleanup on stats tracker when stopping', async () => {
-      const port = await getFreePort();
-      const { client } = createTestEnhancedHl7Client({
-        host: 'localhost',
-        port,
-        log: mockLogger,
-      });
-
-      client.startTrackingStats({
         heartbeatEmitter: mockHeartbeatEmitter,
       });
 
       expect(client.stats).toBeDefined();
       expect(mockHeartbeatEmitter.listenerCount('heartbeat')).toBe(1);
 
-      client.stopTrackingStats();
+      await client.close();
 
       // Cleanup should have removed the heartbeat listener
       expect(mockHeartbeatEmitter.listenerCount('heartbeat')).toBe(0);
-
-      await client.close();
-    });
-
-    test('Does not error when stopping tracking when not tracking', async () => {
-      const port = await getFreePort();
-      const { client } = createTestEnhancedHl7Client({
-        host: 'localhost',
-        port,
-        log: mockLogger,
-      });
-
-      expect(client.stats).toBeUndefined();
-
-      // Should not throw
-      expect(() => client.stopTrackingStats()).not.toThrow();
-
-      await client.close();
     });
   });
 
@@ -364,6 +236,7 @@ describe('EnhancedHl7Client', () => {
         host: 'localhost',
         port,
         log: mockLogger,
+        heartbeatEmitter: mockHeartbeatEmitter,
       });
 
       const message = Hl7Message.parse(
@@ -404,6 +277,7 @@ describe('EnhancedHl7Client', () => {
         host: 'localhost',
         port,
         log: mockLogger,
+        heartbeatEmitter: mockHeartbeatEmitter,
       });
 
       const message = Hl7Message.parse(
@@ -441,9 +315,6 @@ describe('EnhancedHl7Client', () => {
         host: 'localhost',
         port,
         log: mockLogger,
-      });
-
-      client.startTrackingStats({
         heartbeatEmitter: mockHeartbeatEmitter,
       });
 
@@ -455,8 +326,8 @@ describe('EnhancedHl7Client', () => {
       await client.sendAndWait(message, { returnAck: ReturnAckCategory.APPLICATION });
 
       // Stats should have been recorded
-      expect(client.stats?.getSampleCount()).toBe(1);
-      expect(client.stats?.getPendingCount()).toBe(0);
+      expect(client.stats.getSampleCount()).toBe(1);
+      expect(client.stats.getPendingCount()).toBe(0);
 
       await client.close();
       await server.stop();

--- a/packages/agent/src/enhanced-hl7-client.ts
+++ b/packages/agent/src/enhanced-hl7-client.ts
@@ -14,24 +14,22 @@ import { ChannelStatsTracker } from './channel-stats-tracker';
 import { Hl7MessageTracker, TrackedHl7Connection } from './hl7-message-tracker';
 import type { HeartbeatEmitter } from './types';
 
-export interface ClientStatsTrackingOptions {
-  heartbeatEmitter: HeartbeatEmitter;
-}
-
 export interface ExtendedHl7ClientOptions extends Hl7ClientOptions {
   messageTracker?: Hl7MessageTracker;
   log?: ILogger;
+  heartbeatEmitter: HeartbeatEmitter;
 }
 
 export class EnhancedHl7Client extends Hl7Client {
   readonly messageTracker: Hl7MessageTracker;
-  stats?: ChannelStatsTracker;
+  readonly stats: ChannelStatsTracker;
   log?: ILogger;
 
   constructor(options: ExtendedHl7ClientOptions) {
     super(options);
     this.messageTracker = options.messageTracker ?? new Hl7MessageTracker();
     this.log = options.log;
+    this.stats = new ChannelStatsTracker({ log: this.log, heartbeatEmitter: options.heartbeatEmitter });
   }
 
   protected override createConnection(
@@ -45,7 +43,7 @@ export class EnhancedHl7Client extends Hl7Client {
 
   send(msg: Hl7Message): Promise<void> {
     const msgControlId = msg.getSegment('MSH')?.getField(10)?.toString();
-    if (this.stats && msgControlId) {
+    if (msgControlId) {
       this.stats.recordMessageSent(msgControlId);
     }
     return super.send(msg);
@@ -53,25 +51,18 @@ export class EnhancedHl7Client extends Hl7Client {
 
   async sendAndWait(msg: Hl7Message, options?: SendAndWaitOptions): Promise<Hl7Message> {
     const msgControlId = msg.getSegment('MSH')?.getField(10)?.toString();
-    if (this.stats && msgControlId) {
+    if (msgControlId) {
       this.stats.recordMessageSent(msgControlId);
     }
     const response = await super.sendAndWait(msg, options);
-    if (this.stats && msgControlId) {
+    if (msgControlId) {
       this.stats.recordAckReceived(msgControlId);
     }
     return response;
   }
 
-  startTrackingStats(options: ClientStatsTrackingOptions): void {
-    if (this.stats) {
-      return;
-    }
-    this.stats = new ChannelStatsTracker({ log: this.log, ...options });
-  }
-
-  stopTrackingStats(): void {
-    this.stats?.cleanup();
-    this.stats = undefined;
+  override async close(): Promise<void> {
+    this.stats.cleanup();
+    return super.close();
   }
 }

--- a/packages/agent/src/hl7-client-pool.test.ts
+++ b/packages/agent/src/hl7-client-pool.test.ts
@@ -59,15 +59,7 @@ function createFakeClient({
           getPendingMessageCount: jest.fn().mockReturnValue(pendingMessages ?? 0),
         }
       : undefined,
-    startTrackingStats: jest.fn(() => {
-      if (stats) {
-        client.stats = stats as any;
-      }
-    }),
-    stopTrackingStats: jest.fn(() => {
-      client.stats = undefined;
-    }),
-    stats: stats as any,
+    stats: (stats ?? { getRttSamples: () => [], getPendingCount: () => 0 }) as any,
   } as unknown as EnhancedHl7Client;
 
   return client;
@@ -852,15 +844,12 @@ describe('Hl7ClientPool', () => {
 
       const clientA = createFakeClient({ stats: clientAStats });
       const clientB = createFakeClient({ stats: clientBStats });
-      const clientWithoutStats = createFakeClient();
 
-      pool.getClients().push(clientA, clientB, clientWithoutStats);
-
-      pool.startTrackingStats();
+      pool.getClients().push(clientA, clientB);
 
       const poolStats = pool.getPoolStats();
       expect(poolStats).toBeDefined();
-      expect(poolStats?.rtt).toStrictEqual({
+      expect(poolStats.rtt).toStrictEqual({
         count: 3,
         min: 100,
         max: 200,

--- a/packages/agent/src/hl7-client-pool.ts
+++ b/packages/agent/src/hl7-client-pool.ts
@@ -40,7 +40,6 @@ export class Hl7ClientPool {
   private nextClientIdx: number = 0;
   private readonly heartbeatEmitter: HeartbeatEmitter;
   readonly messageTracker: Hl7MessageTracker;
-  private trackingStats = false;
   private gcListener: (() => void) | undefined;
 
   constructor(options: Hl7ClientPoolOptions) {
@@ -247,15 +246,12 @@ export class Hl7ClientPool {
       keepAlive: this.keepAlive,
       log: this.log,
       messageTracker: this.messageTracker,
+      heartbeatEmitter: this.heartbeatEmitter,
     });
 
     // If GC is running, we should add the current timestamp as last used for this client
     if (this.gcListener) {
       this.lastUsedTimestamps.set(client, Date.now());
-    }
-
-    if (this.trackingStats) {
-      client.startTrackingStats({ heartbeatEmitter: this.heartbeatEmitter });
     }
 
     this.clients.push(client);
@@ -294,32 +290,11 @@ export class Hl7ClientPool {
     return this.maxClients;
   }
 
-  startTrackingStats(): void {
-    this.trackingStats = true;
-    for (const client of this.clients) {
-      client.startTrackingStats({ heartbeatEmitter: this.heartbeatEmitter });
-    }
-  }
-
-  stopTrackingStats(): void {
-    this.trackingStats = false;
-    for (const client of this.clients) {
-      client.stopTrackingStats();
-    }
-  }
-
-  isTrackingStats(): boolean {
-    return this.trackingStats;
-  }
-
-  getPoolStats(): ChannelStats | undefined {
-    if (!this.trackingStats) {
-      return undefined;
-    }
-    const allRttSamples = this.clients.flatMap((client) => client.stats?.getRttSamples() ?? []);
+  getPoolStats(): ChannelStats {
+    const allRttSamples = this.clients.flatMap((client) => client.stats.getRttSamples());
     let totalPendingCount = 0;
     for (const client of this.clients) {
-      totalPendingCount += client.stats?.getPendingCount() ?? 0;
+      totalPendingCount += client.stats.getPendingCount();
     }
     return { rtt: calculateRttStats(allRttSamples, totalPendingCount) };
   }

--- a/packages/agent/src/hl7-message-tracker.test.ts
+++ b/packages/agent/src/hl7-message-tracker.test.ts
@@ -112,6 +112,7 @@ describe('Hl7MessageTracker', () => {
         port,
         log: mockLogger,
         messageTracker: tracker,
+        heartbeatEmitter: new TypedEventTarget(),
       });
 
       const message = Hl7Message.parse(
@@ -143,6 +144,7 @@ describe('Hl7MessageTracker', () => {
         port,
         log: mockLogger,
         messageTracker: tracker,
+        heartbeatEmitter: new TypedEventTarget(),
       });
 
       // Establish the connection first to avoid timing issues
@@ -212,6 +214,7 @@ describe('Hl7MessageTracker', () => {
         port,
         log: mockLogger,
         messageTracker: tracker,
+        heartbeatEmitter: new TypedEventTarget(),
       });
 
       // Manually register the message in the tracker with a promise we control
@@ -239,6 +242,7 @@ describe('Hl7MessageTracker', () => {
         port,
         log: mockLogger,
         messageTracker: tracker,
+        heartbeatEmitter: new TypedEventTarget(),
       });
 
       // Send the same message on client2 — the server ACKs it
@@ -359,6 +363,7 @@ describe('Hl7MessageTracker', () => {
         port,
         log: mockLogger,
         messageTracker: tracker,
+        heartbeatEmitter: new TypedEventTarget(),
       });
 
       // Establish connection first
@@ -412,9 +417,8 @@ describe('Hl7MessageTracker', () => {
         port,
         log: mockLogger,
         messageTracker: tracker,
+        heartbeatEmitter: mockHeartbeatEmitter,
       });
-
-      client.startTrackingStats({ heartbeatEmitter: mockHeartbeatEmitter });
 
       const message = Hl7Message.parse(
         'MSH|^~\\&|ADT1|MCM|LABADT|MCM|198808181126|SECURITY|ADT^A01|MSG00001|P|2.2\r' +
@@ -424,8 +428,8 @@ describe('Hl7MessageTracker', () => {
       const response = await client.sendAndWait(message);
       expect(response).toBeDefined();
 
-      expect(client.stats?.getSampleCount()).toBe(1);
-      expect(client.stats?.getPendingCount()).toBe(0);
+      expect(client.stats.getSampleCount()).toBe(1);
+      expect(client.stats.getPendingCount()).toBe(0);
       expect(tracker.getPendingMessageCount()).toBe(0);
 
       await client.close();

--- a/packages/agent/src/hl7.test.ts
+++ b/packages/agent/src/hl7.test.ts
@@ -2409,7 +2409,7 @@ describe('HL7', () => {
       await app.stop();
     });
 
-    test('When logStatsFreqSecs is not set, channel should not track stats', async () => {
+    test('Channel should track stats by default, even when logStatsFreqSecs is not set', async () => {
       mockServer.on('connection', (socket) => {
         socket.on('message', (data) => {
           const command = JSON.parse((data as Buffer).toString('utf8'));
@@ -2475,13 +2475,13 @@ describe('HL7', () => {
       const channel = app.channels.get('test');
       expect(channel).toBeDefined();
 
-      // Channel should NOT have stats tracker
-      expect((channel as AgentHl7Channel).stats).toBeUndefined();
+      // Channel should have stats tracker by default
+      expect((channel as AgentHl7Channel).stats).toBeDefined();
 
       await app.stop();
     });
 
-    test('When logStatsFreqSecs is set via reload, channel should start tracking', async () => {
+    test('When logStatsFreqSecs is set via reload, channel still has stats tracker', async () => {
       const state = {
         mySocket: undefined as Client | undefined,
         reloadConfigResponse: null as AgentReloadConfigRequest | null,
@@ -2534,8 +2534,8 @@ describe('HL7', () => {
       let channel = app.channels.get('test');
       expect(channel).toBeDefined();
 
-      // Channel should NOT have stats tracker initially
-      expect((channel as AgentHl7Channel).stats).toBeUndefined();
+      // Channel should have stats tracker by default
+      expect((channel as AgentHl7Channel).stats).toBeDefined();
 
       // Update agent to enable logStatsFreqSecs
       await medplum.updateResource<Agent>({
@@ -2568,7 +2568,7 @@ describe('HL7', () => {
       await app.stop();
     });
 
-    test('When logStatsFreqSecs is removed via reload, channel should stop tracking', async () => {
+    test('When logStatsFreqSecs is removed via reload, channel should keep tracking stats', async () => {
       const state = {
         mySocket: undefined as Client | undefined,
         reloadConfigResponse: null as AgentReloadConfigRequest | null,
@@ -2650,8 +2650,8 @@ describe('HL7', () => {
       channel = app.channels.get('test');
       expect(channel).toBeDefined();
 
-      // Channel should NO LONGER have stats tracker
-      expect((channel as AgentHl7Channel).stats).toBeUndefined();
+      // Channel should still have stats tracker (stats are collected by default)
+      expect((channel as AgentHl7Channel).stats).toBeDefined();
 
       await app.stop();
     });

--- a/packages/agent/src/hl7.ts
+++ b/packages/agent/src/hl7.ts
@@ -41,7 +41,7 @@ export class AgentHl7Channel extends BaseChannel {
   readonly log: ILogger;
   readonly channelLog: ILogger;
   private prefix: string;
-  stats?: ChannelStatsTracker;
+  stats: ChannelStatsTracker;
   private appLevelAckMode: AppLevelAckMode = 'AL'; // Default app level ack mode is AL (Always)
   private assignSeqNo: boolean = false;
   private lastSeqNo = -1;
@@ -56,6 +56,7 @@ export class AgentHl7Channel extends BaseChannel {
     this.prefix = `[HL7:${definition.name}] `;
     this.log = app.log.clone({ options: { prefix: this.prefix } });
     this.channelLog = app.channelLog.clone({ options: { prefix: this.prefix } });
+    this.stats = new ChannelStatsTracker({ heartbeatEmitter: app.heartbeatEmitter, log: this.log });
   }
 
   async start(): Promise<void> {
@@ -66,7 +67,7 @@ export class AgentHl7Channel extends BaseChannel {
 
     const address = new URL(this.getEndpoint().address);
     this.log.info(`Channel starting on ${address}...`);
-    this.configureStatsTracker();
+    this.stats = new ChannelStatsTracker({ heartbeatEmitter: this.app.heartbeatEmitter, log: this.log });
     this.configureHl7ServerAndConnections();
     await this.server.start(Number.parseInt(address.port, 10));
     this.log.info('Channel started successfully');
@@ -79,7 +80,7 @@ export class AgentHl7Channel extends BaseChannel {
     this.log.info('Channel stopping...');
     await Promise.allSettled(Array.from(this.connections.values()).map((connection) => connection.close()));
     await this.server.stop();
-    this.stats?.cleanup();
+    this.stats.cleanup();
     this.started = false;
     this.log.info('Channel stopped successfully');
   }
@@ -120,7 +121,7 @@ export class AgentHl7Channel extends BaseChannel {
       connection.hl7Connection.send(Hl7Message.parse(msg.body));
 
       if (msgControlId) {
-        this.stats?.recordAckReceived(msgControlId);
+        this.stats.recordAckReceived(msgControlId);
       }
     } else {
       this.log.warn(`Attempted to send message to disconnected remote: ${msg.remote}`);
@@ -134,8 +135,6 @@ export class AgentHl7Channel extends BaseChannel {
     this.prefix = `[HL7:${definition.name}] `;
 
     this.log.info('Reloading config... Evaluating if channel needs to change address...');
-
-    this.configureStatsTracker();
 
     if (this.needToRebindToPort(previousEndpoint, endpoint)) {
       await this.stop();
@@ -159,18 +158,6 @@ export class AgentHl7Channel extends BaseChannel {
       return false;
     }
     return true;
-  }
-
-  private configureStatsTracker(): void {
-    const logStatsFreqSecs =
-      this.app.getAgentConfig()?.setting?.find((setting) => setting.name === 'logStatsFreqSecs')?.valueInteger ?? -1;
-
-    if (logStatsFreqSecs > 0 && !this.stats) {
-      this.stats = new ChannelStatsTracker({ heartbeatEmitter: this.app.heartbeatEmitter, log: this.log });
-    } else if (logStatsFreqSecs <= 0 && this.stats) {
-      this.stats.cleanup();
-      this.stats = undefined;
-    }
   }
 
   private configureHl7ServerAndConnections(): void {
@@ -264,7 +251,7 @@ export class AgentHl7ChannelConnection {
 
       // Log stats
       if (msgControlId) {
-        this.channel.stats?.recordMessageSent(msgControlId);
+        this.channel.stats.recordMessageSent(msgControlId);
       }
     } catch (err) {
       this.channel.log.error(`HL7 error occurred - check channel logs`);

--- a/packages/agent/src/test-utils.ts
+++ b/packages/agent/src/test-utils.ts
@@ -86,11 +86,15 @@ export function generateTestLogs(
 }
 
 export function createTestEnhancedHl7Client(
-  options: Omit<ExtendedHl7ClientOptions, 'messageTracker'> & { messageTracker?: Hl7MessageTracker }
-): { client: EnhancedHl7Client; messageTracker: Hl7MessageTracker } {
+  options: Omit<ExtendedHl7ClientOptions, 'messageTracker' | 'heartbeatEmitter'> & {
+    messageTracker?: Hl7MessageTracker;
+    heartbeatEmitter?: HeartbeatEmitter;
+  }
+): { client: EnhancedHl7Client; messageTracker: Hl7MessageTracker; heartbeatEmitter: HeartbeatEmitter } {
   const messageTracker = options.messageTracker ?? new Hl7MessageTracker();
-  const client = new EnhancedHl7Client({ ...options, messageTracker });
-  return { client, messageTracker };
+  const heartbeatEmitter = options.heartbeatEmitter ?? new TypedEventTarget();
+  const client = new EnhancedHl7Client({ ...options, messageTracker, heartbeatEmitter });
+  return { client, messageTracker, heartbeatEmitter };
 }
 
 export function createTestHl7ClientPool(


### PR DESCRIPTION
Factored out from #9078

Now that we have an operation which can be called at any time, it's probably worth it to assume stats should always be collected. Not only does it better support the `Agent/$stats` operation, but it also simplifies the code around handling stats signficantly.