### PR TITLE
Provider: Reveal more slots in SchedulePage

### DIFF
--- a/examples/medplum-provider/src/components/Calendar.test.tsx
+++ b/examples/medplum-provider/src/components/Calendar.test.tsx
@@ -341,6 +341,95 @@ describe('Calendar', () => {
       await userEvent.click(screen.getByText('Available'));
       expect(onSelectSlot).toHaveBeenCalledWith(slot);
     });
+
+    test('filters out entered-in-error slots', async () => {
+      const slot = createSlot({ status: 'entered-in-error' });
+      setup({ slots: [slot] });
+
+      expect(screen.queryByText('Available')).not.toBeInTheDocument();
+      expect(screen.queryByText('Blocked')).not.toBeInTheDocument();
+    });
+
+    test('shows busy slot not referenced by any appointment', async () => {
+      const busySlot = createSlot({ id: 'busy-slot-1', status: 'busy' });
+      setup({ slots: [busySlot] });
+
+      expect(screen.getByText('Blocked')).toBeInTheDocument();
+    });
+
+    test('hides slot referenced by appointment when start/end times match exactly', async () => {
+      const slotStart = new Date(baseDate.getTime()).toISOString();
+      const slotEnd = new Date(baseDate.getTime() + 30 * 60 * 1000).toISOString();
+
+      const slot = createSlot({ id: 'linked-slot', status: 'busy', start: slotStart, end: slotEnd });
+      const appointment = createAppointment({
+        start: slotStart,
+        end: slotEnd,
+        slot: [{ reference: 'Slot/linked-slot' }],
+      });
+
+      setup({ slots: [slot], appointments: [appointment] });
+
+      expect(screen.getByText(/John Doe/)).toBeInTheDocument();
+      expect(screen.queryByText('Blocked')).not.toBeInTheDocument();
+    });
+
+    test('shows slot referenced by appointment when start/end times differ', async () => {
+      // Example: "bufferAfter" slot may be referenced from appointment, but
+      // covers time after the appointment ends. This should be visible as a
+      // block on the calendar.
+      const appointmentStart = new Date(baseDate.getTime()).toISOString();
+      const appointmentEnd = new Date(baseDate.getTime() + 45 * 60 * 1000).toISOString();
+      const bufferAfterEnd = new Date(baseDate.getTime() + 60 * 60 * 1000).toISOString();
+
+      const busySlot = createSlot({
+        id: 'linked-slot',
+        status: 'busy',
+        start: appointmentStart,
+        end: appointmentEnd,
+      });
+
+      const bufferSlot = createSlot({
+        id: 'buffer-after-slot',
+        status: 'busy',
+        start: appointmentEnd,
+        end: bufferAfterEnd,
+      });
+
+      const appointment = createAppointment({
+        start: appointmentStart,
+        end: appointmentEnd,
+        slot: [{ reference: 'Slot/linked-slot' }, { reference: 'Slot/buffer-after-slot' }],
+      });
+
+      setup({ slots: [busySlot, bufferSlot], appointments: [appointment] });
+
+      expect(screen.getByText(/John Doe/)).toBeInTheDocument();
+      expect(screen.getByText('Blocked')).toBeInTheDocument();
+    });
+
+    test('hides only the slot matching an appointment, shows unrelated slots', async () => {
+      const slotStart = new Date(baseDate.getTime()).toISOString();
+      const slotEnd = new Date(baseDate.getTime() + 30 * 60 * 1000).toISOString();
+
+      const linkedSlot = createSlot({ id: 'linked-slot', status: 'busy', start: slotStart, end: slotEnd });
+      const freeSlot = createSlot({
+        id: 'free-slot',
+        status: 'free',
+        start: new Date(baseDate.getTime() + 60 * 60 * 1000).toISOString(),
+        end: new Date(baseDate.getTime() + 90 * 60 * 1000).toISOString(),
+      });
+      const appointment = createAppointment({
+        start: slotStart,
+        end: slotEnd,
+        slot: [{ reference: 'Slot/linked-slot' }],
+      });
+
+      setup({ slots: [linkedSlot, freeSlot], appointments: [appointment] });
+
+      expect(screen.queryByText('Blocked')).not.toBeInTheDocument();
+      expect(screen.getByText('Available')).toBeInTheDocument();
+    });
   });
 
   describe('onRangeChange', () => {

--- a/examples/medplum-provider/src/components/Calendar.tsx
+++ b/examples/medplum-provider/src/components/Calendar.tsx
@@ -12,7 +12,6 @@ import type { Event, SlotInfo, ToolbarProps, View } from 'react-big-calendar';
 import { Calendar as ReactBigCalendar, dayjsLocalizer } from 'react-big-calendar';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import type { Range } from '../types/scheduling';
-import { SchedulingTransientIdentifier } from '../utils/scheduling';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -183,18 +182,9 @@ export function Calendar(props: {
     [onSelectAppointment, onSelectSlot]
   );
 
-  const events = useMemo(
-    () => [
-      ...appointmentsToEvents(props.appointments),
-      ...slotsToEvents(props.slots.filter((slot) => SchedulingTransientIdentifier.get(slot))),
-    ],
-    [props.appointments, props.slots]
-  );
+  const events = useMemo(() => appointmentsToEvents(props.appointments), [props.appointments]);
 
-  const backgroundEvents = useMemo(
-    () => slotsToEvents(props.slots.filter((slot) => !SchedulingTransientIdentifier.get(slot))),
-    [props.slots]
-  );
+  const backgroundEvents = useMemo(() => slotsToEvents(props.slots), [props.slots]);
 
   const onNavigate = useCallback((newDate: Date, newView: View) => {
     setDate(newDate);

--- a/examples/medplum-provider/src/components/Calendar.tsx
+++ b/examples/medplum-provider/src/components/Calendar.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Button, Group, SegmentedControl, Title } from '@mantine/core';
-import { getReferenceString } from '@medplum/core';
+import { EMPTY, getReferenceString } from '@medplum/core';
 import type { Appointment, Slot } from '@medplum/fhirtypes';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import dayjs from 'dayjs';
@@ -187,7 +187,7 @@ export function Calendar(props: {
 
   const backgroundEvents = useMemo(() => {
     const appointmentIndex = props.appointments.reduce<Record<string, Appointment>>((acc, appointment) => {
-      (appointment.slot ?? []).forEach((slotRef) => {
+      (appointment.slot ?? EMPTY).forEach((slotRef) => {
         const key = getReferenceString(slotRef);
         if (key) {
           acc[key] = appointment;

--- a/examples/medplum-provider/src/components/Calendar.tsx
+++ b/examples/medplum-provider/src/components/Calendar.tsx
@@ -192,7 +192,6 @@ export function Calendar(props: {
         if (key) {
           acc[key] = appointment;
         }
-        return acc;
       });
       return acc;
     }, {});

--- a/examples/medplum-provider/src/components/Calendar.tsx
+++ b/examples/medplum-provider/src/components/Calendar.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Button, Group, SegmentedControl, Title } from '@mantine/core';
+import { getReferenceString } from '@medplum/core';
 import type { Appointment, Slot } from '@medplum/fhirtypes';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import dayjs from 'dayjs';
@@ -184,7 +185,34 @@ export function Calendar(props: {
 
   const events = useMemo(() => appointmentsToEvents(props.appointments), [props.appointments]);
 
-  const backgroundEvents = useMemo(() => slotsToEvents(props.slots), [props.slots]);
+  const backgroundEvents = useMemo(() => {
+    const appointmentIndex = props.appointments.reduce<Record<string, Appointment>>((acc, appointment) => {
+      (appointment.slot ?? []).forEach((slotRef) => {
+        const key = getReferenceString(slotRef);
+        if (key) {
+          acc[key] = appointment;
+        }
+        return acc;
+      });
+      return acc;
+    }, {});
+
+    const filteredSlots = props.slots.filter((slot) => {
+      // never show "entered-in-error" slots on the calendar
+      if (slot.status === 'entered-in-error') {
+        return false;
+      }
+      const key = getReferenceString(slot);
+      if (key && appointmentIndex[key]) {
+        const appointment = appointmentIndex[key];
+        if (slot.start === appointment.start && slot.end === appointment.end) {
+          return false;
+        }
+      }
+      return true;
+    });
+    return slotsToEvents(filteredSlots);
+  }, [props.slots, props.appointments]);
 
   const onNavigate = useCallback((newDate: Date, newView: View) => {
     setDate(newDate);

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
@@ -454,6 +454,7 @@ describe('$find/$book component integration tests', () => {
             status: 'booked',
             start: slotStart,
             end: slotEnd,
+            slot: [{ reference: 'Slot/slot-123' }, { reference: 'Slot/slot-124' }],
             participant: [
               { actor: { reference: 'Practitioner/practitioner-1' }, status: 'tentative' },
               { actor: createReference(HomerSimpson), status: 'accepted' },

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
@@ -89,7 +89,7 @@ export function SchedulePage(): JSX.Element | null {
         ['schedule', getReferenceString(schedule)],
         ['start', `ge${range.start.toISOString()}`],
         ['start', `le${range.end.toISOString()}`],
-        ['status', 'free,busy-unavailable'],
+        ['status:not', 'entered-in-error'],
       ])
       .then((rawSlots) => active && setSlots(mergeOverlappingSlots(rawSlots)))
       .catch((error: unknown) => active && showErrorNotification(error));
@@ -160,15 +160,7 @@ export function SchedulePage(): JSX.Element | null {
       setAppointments((state) => results.appointments.concat(state ?? EMPTY));
       setAppointmentDetails(results.appointments[0]);
       appointmentDetailsHandlers.open();
-      setSlots((state) =>
-        results.slots
-          .filter(
-            // We don't show "busy" slots, assuming that they are duplicative of
-            // more descriptive Appointment resources.
-            (slot) => slot.status !== 'busy'
-          )
-          .concat(state ?? EMPTY)
-      );
+      setSlots((state) => results.slots.concat(state ?? EMPTY));
     },
     [appointmentDetailsHandlers]
   );


### PR DESCRIPTION
Previously, we were not showing "busy" slots, presumably with the assumption that they mapped one-to-one to Appointments that would be displayed. This sometimes causes confusion when that relationship doesn't hold, such as when someone has deleted an Appointment without also deleting the related Slot resources.

We now explicitly hide Slots that are referenced by an Appointment that we are displaying _and_ exactly match the start/end times.

We also explicitly hide slots with status "entered-in-error", as those should not affect availability.