### PR TITLE
Add $hold Scheduling operation

### DIFF
--- a/packages/docs/docs/scheduling/appointment-hold.md
+++ b/packages/docs/docs/scheduling/appointment-hold.md
@@ -1,0 +1,356 @@
+import ExampleCode from '!!raw-loader!@site/../examples/src/scheduling/hold.ts';
+import MedplumCodeBlock from '@site/src/components/MedplumCodeBlock';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Appointment $hold
+
+:::info[Alpha]
+
+The `$hold` operation is currently in alpha.
+
+:::
+
+The `$hold` operation places a hold on one or more schedules by atomically creating an [`Appointment`](/docs/api/fhir/resources/appointment) and [`Slot`](/docs/api/fhir/resources/slot) resources. The operation validates that the requested time is genuinely available before committing.
+
+## Booking Lifecycle
+
+`$hold` is the second step in a three-step booking flow:
+
+1. **[`$find`](/docs/scheduling/appointment-find)** — Query available time slots. Returns virtual `Appointment` resources with `contained` Slot resources.
+2. **`$hold`** — Submit one of those virtual Appointments to reserve the time. Creates a real `Appointment` (status: `proposed`) and `Slot` (status: `busy-tentative`).
+3. **[`$book`](/docs/scheduling/appointment-book)** — Confirm the hold, attach a patient, and transition the `Appointment` to `booked`.
+
+## Use Cases
+
+- **Patient self-serve booking**: Reserve a slot from `$find` results while the patient confirms their details, before committing to a booked appointment.
+- **Multi-provider holds**: Atomically hold time across multiple schedules (e.g., surgeon + OR room) before requiring patient confirmation.
+- **Unconfirmed booking flows**: Create a pending appointment that staff can review and confirm via `$book`.
+
+## Invoke the `$hold` operation
+
+```
+[base]/R4/Appointment/$hold
+```
+
+<Tabs>
+<TabItem value="ts" label="TypeScript">
+
+<MedplumCodeBlock language="ts" selectBlocks="holdOne">
+    {ExampleCode}
+</MedplumCodeBlock>
+
+</TabItem>
+<TabItem value="curl" label="cURL">
+
+```bash
+curl -X POST 'https://api.medplum.com/fhir/R4/Appointment/$hold' \
+  -H "Content-Type: application/fhir+json" \
+  -H "Authorization: Bearer MY_ACCESS_TOKEN" \
+  -d '{
+    "resourceType": "Parameters",
+    "parameter": [
+      {
+        "name": "appointment",
+        "resource": {
+          "resourceType": "Appointment",
+          "status": "proposed",
+          "start": "2026-03-10T09:00:00.000Z",
+          "end": "2026-03-10T10:00:00.000Z",
+          "serviceType": [
+            {
+              "coding": [{ "code": "initial-visit" }],
+              "extension": [
+                {
+                  "url": "https://medplum.com/fhir/service-type-reference",
+                  "valueReference": { "reference": "HealthcareService/my-healthcareservice-id" }
+                }
+              ]
+            }
+          ],
+          "participant": [
+            {
+              "actor": { "reference": "Practitioner/dr-smith" },
+              "required": "required",
+              "status": "needs-action"
+            }
+          ],
+          "contained": [
+            {
+              "resourceType": "Slot",
+              "status": "busy",
+              "schedule": { "reference": "Schedule/dr-smith-schedule" },
+              "start": "2026-03-10T09:00:00.000Z",
+              "end": "2026-03-10T10:00:00.000Z"
+            }
+          ]
+        }
+      }
+    ]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+
+## Parameters
+
+| Name          | Type        | Description                                                                                                                                                    | Required |
+| --------------| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------| -------- |
+| `appointment` | `Resource`  | An `Appointment` resource describing the desired appointment time. Must include `start`, `end`, and `serviceType`. Must have `Slot` resources in `contained`.  | Yes      |
+
+
+### Constraints
+
+- Each referenced Schedule must have exactly **one actor**
+- Each actor must have a timezone defined via the `http://hl7.org/fhir/StructureDefinition/timezone` extension
+- The requested time must match a valid slot duration from the Schedule's `SchedulingParameters`
+- No existing busy Slots may overlap the requested time window (including buffer windows)
+- The `serviceType` attribute must reference the HealthcareService you are trying to schedule via the `https://medplum.com/fhir/service-type-reference` extension
+- The input `Appointment` must not already contain `slot` references (these are set by `$hold`)
+
+The easiest way to meet these requirements is to use a result from a [`$find` operation](/docs/scheduling/appointment-find).
+
+#### Schedule.Actor must have a TimeZone
+
+Scheduling checks availability for each Actor with respect to their local time zone. For more details, see [Time Zones](/docs/scheduling/timezones).
+
+```json
+{
+  "resourceType": "Practitioner",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/timezone",
+      "valueCode": "America/New_York"
+    }
+  ]
+}
+```
+
+
+#### `Appointment.serviceType` must reference a `HealthcareService`
+
+Medplum Scheduling starts from a [`HealthcareService`](/docs/api/fhir/resources/healthcareservice) as a representation of a schedulable appointment type. Medplum Scheduling requires embedding a reference to the specific `HealthcareService` in an extension.
+
+<details>
+  <summary>Why this extension?</summary>
+
+  While codes are a very flexible way to build connections to services, they also create a lot of opportunity for ambiguity. Medplum Scheduling has decided to use explicit references to specific HealthcareServices to resolve that tension.
+
+  In FHIR R5+ the type of these `serviceType` fields is `CodeableReference(HealthcareService)`, meaning that it will eventually be valid to store a `Reference<HealthcareService>` in this attribute directly. In the meantime, in our FHIR R4 implementation we mimic this feature by using a custom extension.
+</details>
+
+```json
+{
+  "resourceType": "Appointment",
+  "serviceType": [
+    {
+      "coding": [{ "code": "bariatric-surgery" }],
+      "extension": [
+        {
+          "url": "https://medplum.com/fhir/service-type-reference",
+          "valueReference": { "reference": "HealthcareService/my-healthcareservice-id" }
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+#### `Appointment.contained` holds virtual `Slot` resources
+
+The `$hold` endpoint expects that its input describe exactly what slots should be created, including references to specific `Schedule` resources. The easiest way to construct a valid input is to pass an `Appointment` returned by [`$find`](/docs/scheduling/appointment-find) directly — `$find` already populates `contained` with the correct virtual Slot resources.
+
+These slots will be removed from the `Appointment.contained` array when they are persisted to real `Slot` resources during `$hold`.
+
+### Multi-Schedule Holds
+
+Pass multiple virtual Slot resources in `Appointment.contained` to hold time across multiple Schedules atomically. All slots must share the same `start` and `end` time.
+
+```json
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "appointment",
+      "resource": {
+        "resourceType": "Appointment",
+        "status": "proposed",
+        "start": "2026-03-11T08:00:00.000Z",
+        "end": "2026-03-11T10:00:00.000Z",
+        "serviceType": [
+          {
+            "coding": [{ "code": "bariatric-surgery" }],
+            "extension": [
+              {
+                "url": "https://medplum.com/fhir/service-type-reference",
+                "valueReference": { "reference": "HealthcareService/my-healthcareservice-id" }
+              }
+            ]
+          }
+        ],
+        "participant": [
+          { "actor": { "reference": "Practitioner/dr-smith" }, "required": "required", "status": "needs-action" },
+          { "actor": { "reference": "Location/or-room-1" }, "required": "required", "status": "needs-action" }
+        ],
+        "contained": [
+          {
+            "resourceType": "Slot",
+            "status": "busy",
+            "schedule": { "reference": "Schedule/dr-smith-schedule" },
+            "start": "2026-03-11T08:00:00.000Z",
+            "end": "2026-03-11T10:00:00.000Z"
+          },
+          {
+            "resourceType": "Slot",
+            "status": "busy",
+            "schedule": { "reference": "Schedule/or-room-schedule" },
+            "start": "2026-03-11T08:00:00.000Z",
+            "end": "2026-03-11T10:00:00.000Z"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+## Output
+
+Returns `201 Created` with a response body containing a `Bundle` of all persisted resources:
+
+- One [`Appointment`](/docs/api/fhir/resources/appointment) with `status: "proposed"`
+- One `Slot` per contained slot parameter. Slots with status `"busy"` will be saved with status `"busy-tentative"`.
+
+### Example Response
+
+```json
+{
+  "resourceType": "Bundle",
+  "type": "transaction-response",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Appointment",
+        "status": "proposed",
+        "start": "2026-03-14T16:00:00.000Z",
+        "end": "2026-03-14T16:45:00.000Z",
+        "participant": [
+          {
+            "actor": {
+              "reference": "Practitioner/348708c1-6a8e-4405-b36b-93f590ed7948"
+            },
+            "status": "needs-action"
+          }
+        ],
+        "serviceType": [
+          {
+            "extension": [
+              {
+                "url": "https://medplum.com/fhir/service-type-reference",
+                "valueReference": {
+                  "reference": "HealthcareService/23c3f1cc-4f55-4990-9775-511b02487e7e"
+                }
+              }
+            ]
+          }
+        ],
+        "slot": [
+          {
+            "reference": "Slot/52fbef8f-e9e6-4810-be53-e481649a72d8"
+          }
+        ],
+        "id": "bdd87182-a05d-4ccc-ae7b-2ecd3f6049df",
+        "meta": {
+          "versionId": "0cb595fc-35d2-46be-9104-35332d6177e6",
+          "lastUpdated": "2026-05-05T23:50:57.302Z"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Slot",
+        "start": "2026-03-14T16:00:00.000Z",
+        "end": "2026-03-14T16:45:00.000Z",
+        "schedule": {
+          "reference": "Schedule/cc26e4b9-a92d-420c-873d-82e7d20152e7"
+        },
+        "status": "busy-tentative",
+        "id": "52fbef8f-e9e6-4810-be53-e481649a72d8",
+        "meta": {
+          "versionId": "46689bb4-bc6d-4ac6-a917-cfe739a1ecd6",
+          "lastUpdated": "2026-05-05T23:50:57.294Z"
+        }
+      }
+    }
+  ]
+}
+```
+
+## Hold Logic
+
+`$hold` performs the following steps inside a serializable transaction:
+
+1. Validates that each proposed Slot's start/end matches a valid slot duration defined in the Schedule's `SchedulingParameters`
+2. Loads existing Slots in the time window (including buffer margins) for each Schedule
+3. Checks that no existing busy Slot overlaps the requested time
+4. Verifies the requested time falls within the Schedule's defined availability windows
+5. Creates the `Appointment`, busy-tentative `Slot`(s), and any buffer `Slot`(s) atomically
+6. Returns all created resources in the response Bundle
+
+The transaction uses serializable isolation to prevent double-booking under concurrent requests.
+
+## Error Responses
+
+All error responses return HTTP 400 with an `OperationOutcome` body.
+
+### Time Not Available
+
+Returned when the requested time overlaps an existing busy Slot or falls outside the Schedule's defined availability windows.
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "Requested time slot is not available" } }]
+}
+```
+
+### Mismatched Slot Times
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "Mismatched slot start times" } }]
+}
+```
+
+### No Scheduling Parameters Found
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "No SchedulingParameters found on Schedule or HealthcareService" } }]
+}
+```
+
+### Actor Missing Timezone
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "No timezone specified" } }]
+}
+```
+
+## Related
+
+- [Appointment `$find`](/docs/scheduling/appointment-find) - Find available Slots
+- [Appointment `$book`](/docs/scheduling/appointment-book) - Transition Appointment.status from "proposed" to "booked" with `$book`
+- [Defining Availability](/docs/scheduling/defining-availability) - How to configure `SchedulingParameters` on a Schedule
+- [Scheduling Overview](/docs/scheduling) - High-level scheduling concepts
+- [`Appointment` resource](/docs/api/fhir/resources/appointment)
+- [`Slot` resource](/docs/api/fhir/resources/slot)
+- [FHIR Transaction Bundles](/docs/fhir-datastore/fhir-batch-requests#batches-vs-transactions)
+

--- a/packages/docs/docs/scheduling/appointment-hold.md
+++ b/packages/docs/docs/scheduling/appointment-hold.md
@@ -18,7 +18,7 @@ The `$hold` operation places a hold on one or more schedules by atomically creat
 `$hold` is the second step in a three-step booking flow:
 
 1. **[`$find`](/docs/scheduling/appointment-find)** — Query available time slots. Returns virtual `Appointment` resources with `contained` Slot resources.
-2. **`$hold`** — Submit one of those virtual Appointments to reserve the time. Creates a real `Appointment` (status: `proposed`) and `Slot` (status: `busy-tentative`).
+2. **`$hold`** — Submit one of those virtual Appointments to reserve the time. Creates a real `Appointment` (status: `pending`) and `Slot` (status: `busy-tentative`).
 3. **[`$book`](/docs/scheduling/appointment-book)** — Confirm the hold, attach a patient, and transition the `Appointment` to `booked`.
 
 ## Use Cases
@@ -221,7 +221,7 @@ Pass multiple virtual Slot resources in `Appointment.contained` to hold time acr
 
 Returns `201 Created` with a response body containing a `Bundle` of all persisted resources:
 
-- One [`Appointment`](/docs/api/fhir/resources/appointment) with `status: "proposed"`
+- One [`Appointment`](/docs/api/fhir/resources/appointment) with `status: "pending"`
 - One `Slot` per contained slot parameter. Slots with status `"busy"` will be saved with status `"busy-tentative"`.
 
 ### Example Response
@@ -234,7 +234,7 @@ Returns `201 Created` with a response body containing a `Bundle` of all persiste
     {
       "resource": {
         "resourceType": "Appointment",
-        "status": "proposed",
+        "status": "pending",
         "start": "2026-03-14T16:00:00.000Z",
         "end": "2026-03-14T16:45:00.000Z",
         "participant": [
@@ -347,7 +347,7 @@ Returned when the requested time overlaps an existing busy Slot or falls outside
 ## Related
 
 - [Appointment `$find`](/docs/scheduling/appointment-find) - Find available Slots
-- [Appointment `$book`](/docs/scheduling/appointment-book) - Transition Appointment.status from "proposed" to "booked" with `$book`
+- [Appointment `$book`](/docs/scheduling/appointment-book) - Transition Appointment.status from "pending" to "booked" with `$book`
 - [Defining Availability](/docs/scheduling/defining-availability) - How to configure `SchedulingParameters` on a Schedule
 - [Scheduling Overview](/docs/scheduling) - High-level scheduling concepts
 - [`Appointment` resource](/docs/api/fhir/resources/appointment)

--- a/packages/docs/docs/scheduling/appointment-hold.md
+++ b/packages/docs/docs/scheduling/appointment-hold.md
@@ -96,9 +96,9 @@ curl -X POST 'https://api.medplum.com/fhir/R4/Appointment/$hold' \
 
 ## Parameters
 
-| Name          | Type        | Description                                                                                                                                                    | Required |
-| --------------| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------| -------- |
-| `appointment` | `Resource`  | An `Appointment` resource describing the desired appointment time. Must include `start`, `end`, and `serviceType`. Must have `Slot` resources in `contained`.  | Yes      |
+| Name          | Type           | Description                                                                                                                                                    | Required |
+| --------------| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------| -------- |
+| `appointment` | `Appointment`  | An `Appointment` resource describing the desired appointment time. Must include `start`, `end`, and `serviceType`. Must have `Slot` resources in `contained`.  | Yes      |
 
 
 ### Constraints
@@ -291,7 +291,7 @@ Returns `201 Created` with a response body containing a `Bundle` of all persiste
 
 ## Hold Logic
 
-`$hold` performs the following steps inside a serializable transaction:
+`$hold` performs the following steps atomically inside a database transaction:
 
 1. Validates that each proposed Slot's start/end matches a valid slot duration defined in the Schedule's `SchedulingParameters`
 2. Loads existing Slots in the time window (including buffer margins) for each Schedule

--- a/packages/docs/docs/scheduling/appointment-hold.md
+++ b/packages/docs/docs/scheduling/appointment-hold.md
@@ -19,7 +19,7 @@ The `$hold` operation places a hold on one or more schedules by atomically creat
 
 1. **[`$find`](/docs/scheduling/appointment-find)** — Query available time slots. Returns virtual `Appointment` resources with `contained` Slot resources.
 2. **`$hold`** — Submit one of those virtual Appointments to reserve the time. Creates a real `Appointment` (status: `pending`) and `Slot` (status: `busy-tentative`).
-3. **[`$book`](/docs/scheduling/appointment-book)** — Confirm the hold, attach a patient, and transition the `Appointment` to `booked`.
+3. **[`$book`](/docs/scheduling/appointment-book)** — Confirm the hold, attach a patient, and transition the `Appointment` to `booked`. *Not yet implemented.*
 
 ## Use Cases
 

--- a/packages/examples/src/scheduling/hold.ts
+++ b/packages/examples/src/scheduling/hold.ts
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// start-block holdOne
+import { isResource, MedplumClient } from '@medplum/core';
+import type { Appointment, Bundle, Slot } from '@medplum/fhirtypes';
+
+const medplum = new MedplumClient();
+
+const result = await medplum.post<Bundle<Appointment | Slot>>(medplum.fhirUrl('Appointment', '$hold'), {
+  resourceType: 'Parameters',
+  parameter: [
+    {
+      name: 'appointment',
+      resource: {
+        resourceType: 'Appointment',
+        status: 'proposed',
+        start: '2026-03-10T09:00:00.000Z',
+        end: '2026-03-10T10:00:00.000Z',
+        serviceType: [
+          {
+            coding: [{ code: 'initial-visit' }],
+            extension: [
+              {
+                url: 'https://medplum.com/fhir/service-type-reference',
+                valueReference: { reference: 'HealthcareService/my-healthcareservice-id' },
+              },
+            ],
+          },
+        ],
+        participant: [
+          {
+            actor: { reference: 'Practitioner/dr-smith' },
+            required: 'required',
+            status: 'needs-action',
+          },
+        ],
+        contained: [
+          {
+            resourceType: 'Slot',
+            status: 'busy',
+            schedule: { reference: 'Schedule/dr-smith-schedule' },
+            start: '2026-03-10T09:00:00.000Z',
+            end: '2026-03-10T10:00:00.000Z',
+          } satisfies Slot,
+        ],
+      } satisfies Appointment,
+    },
+  ],
+});
+
+const appointment = result.entry?.map((e) => e.resource).find((r) => isResource<Appointment>(r, 'Appointment'));
+// end-block holdOne
+
+console.log(appointment);

--- a/packages/server/src/fhir/operations/book.ts
+++ b/packages/server/src/fhir/operations/book.ts
@@ -25,12 +25,12 @@ import assert from 'node:assert';
 import { getAuthenticatedContext } from '../../context';
 import { addMinutes, areIntervalsOverlapping } from '../../util/date';
 import { getServiceTypeReferences } from '../../util/servicetype';
-import type { WithPath } from '../../util/withpath';
-import { copyPaths, getPath, withPath, withPaths } from '../../util/withpath';
+import { copyPaths, withPath, withPaths } from '../../util/withpath';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 import {
   applyExistingSlots,
   assertAllLoaded,
+  assertAllMatch,
   getSchedulingParametersGroup,
   resolveAvailability,
   slotsOverlappingInterval,
@@ -57,28 +57,6 @@ type BookParameters = {
   slot: Slot[];
   'patient-reference'?: Reference<Patient>;
 };
-
-// Finds keys that can be used to index into `T` and yield a primitive type
-// that can be compared with strict equality.
-type PrimitiveKey<T> = {
-  [K in keyof T]-?: T[K] extends string | number | boolean | undefined ? K : never;
-}[keyof T];
-
-function assertAllMatch<T extends object>(
-  objects: WithPath<T>[],
-  attribute: PrimitiveKey<T> & string,
-  msg: string
-): void {
-  if (objects.length <= 1) {
-    return;
-  }
-  const mismatched = objects.find((value) => value[attribute] !== objects[0][attribute]);
-  if (mismatched) {
-    throw new OperationOutcomeError(
-      badRequest(msg, [`${getPath(objects[0])}.${attribute}`, `${getPath(mismatched)}.${attribute}`])
-    );
-  }
-}
 
 function serviceTypeTokens(slots: Slot[]): string[] {
   const tokenSet = new Set<string>();

--- a/packages/server/src/fhir/operations/book.ts
+++ b/packages/server/src/fhir/operations/book.ts
@@ -31,11 +31,10 @@ import { buildOutputParameters, parseInputParameters } from './utils/parameters'
 import {
   applyExistingSlots,
   assertAllLoaded,
-  getTimeZone,
+  getSchedulingParametersGroup,
   resolveAvailability,
   slotsOverlappingInterval,
 } from './utils/scheduling';
-import { chooseSchedulingParameters } from './utils/scheduling-parameters';
 
 const bookOperation = {
   resourceType: 'OperationDefinition',
@@ -131,17 +130,6 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
     .then((schedules) => copyPaths(proposedSlots, schedules, { suffix: '.schedule' }));
   assertAllLoaded(schedules, 'Schedule load failed');
 
-  schedules.forEach((schedule) => {
-    if (schedule.actor.length !== 1) {
-      throw new OperationOutcomeError(badRequest('$book only supported on schedules with exactly one actor'));
-    }
-  });
-
-  const actors = await ctx.repo
-    .readReferences(schedules.flatMap((schedule) => schedule.actor))
-    .then((actors) => copyPaths(schedules, actors, { suffix: '.actor[0]' }));
-  assertAllLoaded(actors, 'Schedule.actor load failed');
-
   let healthcareService: WithId<HealthcareService>;
   // We expect that at most one unique serviceType reference will be found
   const serviceRefs = proposedSlots.flatMap((slot) => getServiceTypeReferences(slot));
@@ -182,6 +170,12 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
     healthcareService = healthcareServices[0];
   }
 
+  const parameterGroup = await getSchedulingParametersGroup(
+    ctx.repo,
+    schedules,
+    withPath(healthcareService, 'Parameters.service-type-reference')
+  );
+
   const createdResources = await ctx.repo.withTransaction(
     async () => {
       const bufferSlots: Slot[] = [];
@@ -191,21 +185,13 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
           const scheduleRefString = getReferenceString(proposedSlot.schedule);
           const schedule = schedules.find((s) => `Schedule/${s.id}` === scheduleRefString);
           assert(schedule, 'Slot.schedule not loaded');
-
-          const actor = actors.find((a) => `${a.resourceType}/${a.id}` === schedule.actor[0].reference);
-          assert(actor, 'Slot.schedule.actor not loaded');
-          const actorTimeZone = getTimeZone(actor);
-          if (!actorTimeZone) {
-            throw new OperationOutcomeError(badRequest('No timezone specified', getPath(actor)));
-          }
           const durationMinutes = (Date.parse(proposedSlot.end) - Date.parse(proposedSlot.start)) / 60000;
-          const parameters = chooseSchedulingParameters(schedule, withPath(healthcareService, 'HealthcareService'));
+          const parameters = parameterGroup.get(schedule);
+          assert(parameters);
 
-          if (parameters?.duration !== durationMinutes) {
+          if (parameters.duration !== durationMinutes) {
             throw new OperationOutcomeError(badRequest('No matching scheduling parameters found'));
           }
-
-          const timeZone = parameters.timezone ?? actorTimeZone;
 
           const range = {
             start: addMinutes(startDate, -1 * parameters.bufferBefore),
@@ -232,7 +218,7 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
           }
 
           const availability = applyExistingSlots({
-            availability: resolveAvailability(parameters, range, timeZone),
+            availability: resolveAvailability(parameters, range, parameters.timezone),
             slots: existingSlots,
             range,
             serviceType: healthcareService.type,

--- a/packages/server/src/fhir/operations/book.ts
+++ b/packages/server/src/fhir/operations/book.ts
@@ -5,7 +5,6 @@ import {
   badRequest,
   conflict,
   created,
-  DEFAULT_MAX_SEARCH_COUNT,
   EMPTY,
   getReferenceString,
   isNotFound,
@@ -29,7 +28,13 @@ import { getServiceTypeReferences } from '../../util/servicetype';
 import type { WithPath } from '../../util/withpath';
 import { copyPaths, getPath, withPath, withPaths } from '../../util/withpath';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
-import { applyExistingSlots, assertAllLoaded, getTimeZone, resolveAvailability } from './utils/scheduling';
+import {
+  applyExistingSlots,
+  assertAllLoaded,
+  getTimeZone,
+  resolveAvailability,
+  slotsOverlappingInterval,
+} from './utils/scheduling';
 import { chooseSchedulingParameters } from './utils/scheduling-parameters';
 
 const bookOperation = {
@@ -209,33 +214,7 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
           const searchStart = range.start.toISOString();
           const searchEnd = range.end.toISOString();
 
-          const existingSlots = await ctx.repo.searchResources<Slot>({
-            resourceType: 'Slot',
-            count: DEFAULT_MAX_SEARCH_COUNT,
-            filters: [
-              {
-                code: 'schedule',
-                operator: Operator.EQUALS,
-                value: getReferenceString(schedule),
-              },
-              {
-                code: 'status',
-                operator: Operator.EQUALS,
-                value: 'busy,busy-tentative,busy-unavailable,free',
-              },
-              {
-                code: '_filter',
-                operator: Operator.EQUALS,
-                value: `((start ge "${searchStart}" and start le "${searchEnd}") or (end ge "${searchStart}" and end le "${searchEnd}") or (start lt "${searchStart}" and end gt "${searchEnd}"))`,
-              },
-            ],
-          });
-
-          // If we filled a full search page of slots, then there may be slots we
-          // didn't fetch that would impact availability. Fail loudly here.
-          if (existingSlots.length === DEFAULT_MAX_SEARCH_COUNT) {
-            throw new OperationOutcomeError(badRequest('Too many existing slots found in range. Try another time.'));
-          }
+          const existingSlots = await slotsOverlappingInterval(ctx.repo, [schedule], range);
 
           // If there exists busy slots overlapping with the requested booking time,
           // we can bail out now with an informative error message.

--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -1569,7 +1569,7 @@ describe('Appointment/$find', () => {
       schedule: `Schedule/${schedule.id}`,
     });
     expect(response.status).toBe(400);
-    expect(response.body.issue[0].details.text).toBe('$find only supported on schedules with exactly one actor');
+    expect(response.body.issue[0].details.text).toBe('Scheduling only supported on schedules with exactly one actor');
   });
 
   test('errors when service type is not present on all schedules', async () => {

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -248,7 +248,16 @@ async function handler(params: {
       return resultSlots;
     });
 
-    const actors = schedules.flatMap((schedule) => schedule.actor);
+    const participant = schedules.flatMap((schedule) =>
+      schedule.actor.map(
+        (actor) =>
+          ({
+            actor,
+            required: 'required',
+            status: 'needs-action',
+          }) as const
+      )
+    );
 
     const appointment = {
       resourceType: 'Appointment',
@@ -256,11 +265,7 @@ async function handler(params: {
       end,
       status: 'proposed',
       serviceType,
-      participant: actors.map((actor) => ({
-        actor: actor,
-        required: 'required',
-        status: 'needs-action',
-      })),
+      participant,
       contained: slots,
     } satisfies Appointment;
 

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -35,12 +35,11 @@ import { buildOutputParameters, parseInputParameters } from './utils/parameters'
 import {
   applyExistingSlots,
   assertAllLoaded,
-  getTimeZone,
+  getSchedulingParametersGroup,
   resolveAvailability,
   slotsOverlappingInterval,
-  TimezoneExtensionURI,
 } from './utils/scheduling';
-import { chooseSchedulingParameterGroup, extractCommonParameters } from './utils/scheduling-parameters';
+import { extractCommonParameters } from './utils/scheduling-parameters';
 
 const scheduleFindOperation = {
   resourceType: 'OperationDefinition',
@@ -139,7 +138,8 @@ async function handler(params: {
 
   assertAllLoaded(schedules, 'Loading schedule failed');
 
-  const parameterGroup = chooseSchedulingParameterGroup(
+  const parameterGroup = await getSchedulingParametersGroup(
+    ctx.repo,
     schedules,
     withPath(healthcareService, 'Parameters.service-type-reference')
   );
@@ -150,48 +150,17 @@ async function handler(params: {
         badRequest('Schedule is not schedulable for requested service type', getPath(schedule))
       );
     }
-
-    if (schedule.actor.length !== 1) {
-      throw new OperationOutcomeError(
-        badRequest('$find only supported on schedules with exactly one actor', getPath(schedule))
-      );
-    }
-
-    if (!parameterGroup.get(schedule)) {
-      throw new OperationOutcomeError(
-        badRequest('No SchedulingParameters found on Schedule or HealthcareService', getPath(schedule))
-      );
-    }
   });
 
   const commonParameters = extractCommonParameters([...parameterGroup.values()]);
-
-  // If we filled a full search page of slots, then there may be slots we
-  // didn't fetch that would impact availability. Fail loudly here.
-  if (existingSlots.length === DEFAULT_MAX_SEARCH_COUNT) {
-    throw new OperationOutcomeError(badRequest('Too many slots found in range; try searching with smaller bounds'));
-  }
-
-  const actors = await ctx.repo
-    .readReferences(schedules.map((schedule) => schedule.actor[0]))
-    .then((actors) => copyPaths(schedules, actors, { suffix: '.actor[0]' }));
-  assertAllLoaded(actors, 'Loading schedule.actor failed');
-
   const serviceType = toCodeableReferenceLike(healthcareService);
 
-  const allAvailability = schedules.map((schedule, idx) => {
+  const allAvailability = schedules.map((schedule) => {
     const schedulingParameters = parameterGroup.get(schedule);
     assert(schedulingParameters);
-    const actor = actors[idx];
-    const activeTimeZone = schedulingParameters.timezone ?? getTimeZone(actor);
-    if (!activeTimeZone) {
-      throw new OperationOutcomeError(
-        badRequest('No timezone specified', `${getPath(actor)}.extension(${TimezoneExtensionURI})`)
-      );
-    }
 
     const scheduleSlots = existingSlots.filter((slot) => resolveId(slot.schedule) === schedule.id);
-    let availability = resolveAvailability(schedulingParameters, range, activeTimeZone);
+    let availability = resolveAvailability(schedulingParameters, range, schedulingParameters.timezone);
     availability = applyExistingSlots({
       availability,
       slots: scheduleSlots,
@@ -279,6 +248,8 @@ async function handler(params: {
       return resultSlots;
     });
 
+    const actors = schedules.flatMap((schedule) => schedule.actor);
+
     const appointment = {
       resourceType: 'Appointment',
       start,
@@ -286,7 +257,7 @@ async function handler(params: {
       status: 'proposed',
       serviceType,
       participant: actors.map((actor) => ({
-        actor: createReference(actor),
+        actor: actor,
         required: 'required',
         status: 'needs-action',
       })),

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -11,7 +11,6 @@ import {
   isReference,
   isResource,
   OperationOutcomeError,
-  Operator,
   resolveId,
 } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
@@ -38,6 +37,7 @@ import {
   assertAllLoaded,
   getTimeZone,
   resolveAvailability,
+  slotsOverlappingInterval,
   TimezoneExtensionURI,
 } from './utils/scheduling';
 import { chooseSchedulingParameterGroup, extractCommonParameters } from './utils/scheduling-parameters';
@@ -128,34 +128,7 @@ async function handler(params: {
 
   const [schedules, existingSlots, healthcareService] = await Promise.all([
     ctx.repo.readReferences(params.schedules).then((schedules) => copyPaths(params.schedules, schedules)),
-    ctx.repo.searchResources<Slot>({
-      resourceType: 'Slot',
-
-      count: DEFAULT_MAX_SEARCH_COUNT,
-
-      filters: [
-        {
-          code: 'schedule',
-          operator: Operator.EQUALS,
-          value: params.schedules.map((ref) => ref.reference).join(','),
-        },
-
-        {
-          code: '_filter',
-          operator: Operator.EQUALS,
-          // Slot starts sometime in range, OR
-          // Slot ends sometime in range, OR
-          // Slot time fully contains range
-          value: `((start ge "${params.start}" and start le "${params.end}") or (end ge "${params.start}" and end le "${params.end}") or (start lt "${params.start}" and end gt "${params.end}"))`,
-        },
-
-        {
-          code: 'status',
-          operator: Operator.EQUALS,
-          value: 'busy,busy-tentative,busy-unavailable,free',
-        },
-      ],
-    }),
+    slotsOverlappingInterval(ctx.repo, params.schedules, range),
     ctx.repo.readReference<HealthcareService>(params.healthcareService).catch((err) => {
       if (err instanceof OperationOutcomeError && isNotFound(err.outcome)) {
         throw new OperationOutcomeError(badRequest('HealthcareService not found'));

--- a/packages/server/src/fhir/operations/hold.test.ts
+++ b/packages/server/src/fhir/operations/hold.test.ts
@@ -1,0 +1,1259 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import { createReference, isDefined, isResource, parseSearchRequest } from '@medplum/core';
+import type {
+  Appointment,
+  Bundle,
+  CodeableConcept,
+  Device,
+  Extension,
+  HealthcareService,
+  Patient,
+  Practitioner,
+  Resource,
+  Schedule,
+  Slot,
+} from '@medplum/fhirtypes';
+import express from 'express';
+import supertest from 'supertest';
+import { initApp, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config/loader';
+import { getGlobalSystemRepo } from '../../fhir/repo';
+import type { TestProjectResult } from '../../test.setup';
+import { createTestProject } from '../../test.setup';
+import { toCodeableReferenceLike } from '../../util/servicetype';
+import type {
+  SchedulingParametersExtension,
+  SchedulingParametersExtensionExtension,
+} from './utils/scheduling-parameters';
+
+const systemRepo = getGlobalSystemRepo();
+const app = express();
+const request = supertest(app);
+
+function isAppointment(obj: Resource): obj is Appointment {
+  return isResource<Appointment>(obj, 'Appointment');
+}
+
+function isSlot(obj: Resource): obj is Slot {
+  return isResource<Slot>(obj, 'Slot');
+}
+
+const threeDayAvailability: SchedulingParametersExtensionExtension = {
+  url: 'availability',
+  extension: [
+    {
+      url: 'availableTime',
+      extension: [
+        { url: 'daysOfWeek', valueCode: 'tue' },
+        { url: 'daysOfWeek', valueCode: 'wed' },
+        { url: 'daysOfWeek', valueCode: 'thu' },
+        { url: 'availableStartTime', valueTime: '09:00:00' },
+        { url: 'availableEndTime', valueTime: '17:00:00' },
+      ],
+    },
+  ],
+};
+
+describe('Appointment/$hold', () => {
+  let project: TestProjectResult<{ withAccessToken: true }>;
+  let practitioner1: WithId<Practitioner>;
+  let practitioner2: WithId<Practitioner>;
+  let patient: WithId<Patient>;
+  let officeVisitService: WithId<HealthcareService>;
+
+  const officeVisit: CodeableConcept = {
+    coding: [{ system: 'https://example.com/fhir', code: 'office-visit' }],
+  };
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initApp(app, config);
+    project = await createTestProject({ withAccessToken: true });
+    patient = await makePatient();
+    practitioner1 = await makePractitioner({ timezone: 'America/New_York' });
+    practitioner2 = await makePractitioner({ timezone: 'America/New_York' });
+
+    officeVisitService = await systemRepo.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      name: 'Office Visit',
+      type: [officeVisit],
+      meta: { project: project.project.id },
+    });
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  function makeSchedulingExtension(opts?: {
+    service?: WithId<HealthcareService>;
+    duration?: number;
+    bufferBefore?: number;
+    bufferAfter?: number;
+  }): SchedulingParametersExtension {
+    const duration = opts?.duration ?? 60;
+    const extension: SchedulingParametersExtension = {
+      url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+      extension: [
+        threeDayAvailability,
+        {
+          url: 'duration',
+          valueDuration: { value: duration, unit: 'min' },
+        },
+      ],
+    };
+
+    if (opts?.service) {
+      extension.extension.push({
+        url: 'service',
+        valueReference: createReference(opts.service),
+      });
+    }
+    if (opts?.bufferBefore) {
+      extension.extension.push({
+        url: 'bufferBefore',
+        valueDuration: { value: opts.bufferBefore, unit: 'min' },
+      });
+    }
+    if (opts?.bufferAfter) {
+      extension.extension.push({
+        url: 'bufferAfter',
+        valueDuration: { value: opts.bufferAfter, unit: 'min' },
+      });
+    }
+
+    return extension;
+  }
+
+  async function makeSchedule(opts: {
+    actor: WithId<Practitioner | Device>;
+    extension?: Extension[];
+  }): Promise<WithId<Schedule>> {
+    return systemRepo.createResource<Schedule>({
+      resourceType: 'Schedule',
+      meta: { project: project.project.id },
+      actor: [createReference(opts.actor)],
+      serviceType: toCodeableReferenceLike(officeVisitService),
+      extension: opts.extension ?? [makeSchedulingExtension({ service: officeVisitService })],
+    });
+  }
+
+  async function makePractitioner({ timezone }: { timezone?: string } = {}): Promise<WithId<Practitioner>> {
+    const extension: Extension[] = [];
+    if (timezone) {
+      extension.push({ url: 'http://hl7.org/fhir/StructureDefinition/timezone', valueCode: timezone });
+    }
+    return systemRepo.createResource<Practitioner>({
+      resourceType: 'Practitioner',
+      meta: { project: project.project.id },
+      extension,
+    });
+  }
+
+  async function makePatient(): Promise<WithId<Patient>> {
+    return systemRepo.createResource<Patient>({
+      resourceType: 'Patient',
+      meta: { project: project.project.id },
+    });
+  }
+
+  // Builds the Parameters body for $hold with a single schedule's slots
+  function holdParams(opts: { schedule: WithId<Schedule>; start: string; end: string; extraSlots?: Slot[] }): object {
+    return {
+      resourceType: 'Parameters',
+      parameter: [
+        {
+          name: 'appointment',
+          resource: {
+            resourceType: 'Appointment',
+            status: 'proposed',
+            start: opts.start,
+            end: opts.end,
+            serviceType: toCodeableReferenceLike(officeVisitService),
+            participant: [{ actor: createReference(practitioner1), status: 'tentative' }],
+            contained: [
+              {
+                resourceType: 'Slot',
+                status: 'busy',
+                schedule: createReference(opts.schedule),
+                start: opts.start,
+                end: opts.end,
+                serviceType: toCodeableReferenceLike(officeVisitService),
+              } satisfies Slot,
+              ...(opts.extraSlots ?? []),
+            ],
+          } satisfies Appointment,
+        },
+      ],
+    };
+  }
+
+  test('succeeds with 201 Created', async () => {
+    const schedule = await makeSchedule({ actor: practitioner1 });
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send(holdParams({ schedule, start: '2026-01-15T14:00:00Z', end: '2026-01-15T15:00:00Z' }));
+
+    expect(response.body).not.toHaveProperty('issue');
+    expect(response.status).toEqual(201);
+  });
+
+  test('creates an Appointment and busy-tentative Slot', async () => {
+    const schedule = await makeSchedule({ actor: practitioner1 });
+    const start = '2026-01-15T14:00:00Z';
+    const end = '2026-01-15T15:00:00Z';
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send(holdParams({ schedule, start, end }));
+
+    expect(response.status).toEqual(201);
+
+    const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
+
+    const appointments = entries.filter(isAppointment);
+    expect(appointments).toHaveLength(1);
+    expect(appointments[0]).toHaveProperty('id');
+    expect(appointments[0]).toHaveProperty('start', start);
+    expect(appointments[0]).toHaveProperty('end', end);
+    // Hold strips contained resources from the appointment — they should not be persisted
+    expect(appointments[0]).not.toHaveProperty('contained');
+
+    // The main slot should be busy-tentative, not busy
+    const slots = entries.filter(isSlot);
+    const mainSlots = slots.filter((s) => s.status === 'busy-tentative');
+    expect(mainSlots).toHaveLength(1);
+    expect(mainSlots[0]).toHaveProperty('start', start);
+    expect(mainSlots[0]).toHaveProperty('end', end);
+
+    // The Appointment should hold references to created slots
+    expect(appointments[0]).toHaveProperty('slot', [createReference(mainSlots[0])]);
+  });
+
+  test('with multiple schedules creates one busy-tentative slot per schedule', async () => {
+    const schedule1 = await makeSchedule({ actor: practitioner1 });
+    const schedule2 = await makeSchedule({ actor: practitioner2 });
+    const start = '2026-01-15T14:00:00Z';
+    const end = '2026-01-15T15:00:00Z';
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              status: 'proposed',
+              start,
+              end,
+              serviceType: toCodeableReferenceLike(officeVisitService),
+              participant: [
+                { actor: createReference(practitioner1), status: 'tentative' },
+                { actor: createReference(practitioner2), status: 'tentative' },
+              ],
+              contained: [
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(schedule1),
+                  start,
+                  end,
+                  serviceType: toCodeableReferenceLike(officeVisitService),
+                } satisfies Slot,
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(schedule2),
+                  start,
+                  end,
+                  serviceType: toCodeableReferenceLike(officeVisitService),
+                } satisfies Slot,
+              ],
+            },
+          },
+        ],
+      });
+
+    expect(response.body).not.toHaveProperty('issue');
+    expect(response.status).toEqual(201);
+
+    const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
+    const tentativeSlots = entries.filter(isSlot).filter((s) => s.status === 'busy-tentative');
+    expect(tentativeSlots).toHaveLength(2);
+    tentativeSlots.forEach((slot) => {
+      expect(slot).toHaveProperty('start', start);
+      expect(slot).toHaveProperty('end', end);
+    });
+  });
+
+  test('rejects when appointment has no service reference', async () => {
+    const schedule = await makeSchedule({ actor: practitioner1 });
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              status: 'proposed',
+              start: '2026-01-15T14:00:00Z',
+              end: '2026-01-15T15:00:00Z',
+              // serviceType has no embedded reference — plain CodeableConcept only
+              serviceType: [{ coding: [{ code: 'office-visit' }] }],
+              participant: [{ actor: createReference(practitioner1), status: 'tentative' }],
+              contained: [
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(schedule),
+                  start: '2026-01-15T14:00:00Z',
+                  end: '2026-01-15T15:00:00Z',
+                } satisfies Slot,
+              ],
+            },
+          },
+        ],
+      });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toHaveProperty('issue', [
+      expect.objectContaining({
+        code: 'invalid',
+        severity: 'error',
+        details: { text: 'Appointment has no service reference' },
+        expression: ['Parameters.appointment.serviceType'],
+      }),
+    ]);
+  });
+
+  test('rejects when appointment serviceType is missing entirely', async () => {
+    const schedule = await makeSchedule({ actor: practitioner1 });
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              status: 'proposed',
+              start: '2026-01-15T14:00:00Z',
+              end: '2026-01-15T15:00:00Z',
+              participant: [{ actor: createReference(practitioner1), status: 'tentative' }],
+              contained: [
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(schedule),
+                  start: '2026-01-15T14:00:00Z',
+                  end: '2026-01-15T15:00:00Z',
+                } satisfies Slot,
+              ],
+            },
+          },
+        ],
+      });
+
+    expect(response.body).toHaveProperty('issue', [
+      expect.objectContaining({ severity: 'error', details: { text: 'Appointment has no service reference' } }),
+    ]);
+    expect(response.status).toEqual(400);
+  });
+
+  test('rejects when appointment has no contained Slot resources', async () => {
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              status: 'proposed',
+              start: '2026-01-15T14:00:00Z',
+              end: '2026-01-15T15:00:00Z',
+              serviceType: toCodeableReferenceLike(officeVisitService),
+              participant: [{ actor: createReference(practitioner1), status: 'tentative' }],
+            },
+          },
+        ],
+      });
+
+    expect(response.body).toHaveProperty('issue', [
+      expect.objectContaining({
+        severity: 'error',
+        details: { text: 'Appointment has no contained Slot resources' },
+      }),
+    ]);
+    expect(response.status).toEqual(400);
+  });
+
+  test('rejects when contained has no Slot resources', async () => {
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              status: 'proposed',
+              start: '2026-01-15T14:00:00Z',
+              end: '2026-01-15T15:00:00Z',
+              serviceType: toCodeableReferenceLike(officeVisitService),
+              participant: [{ actor: createReference(practitioner1), status: 'tentative' }],
+              contained: [{ resourceType: 'Patient', id: 'inline-patient' }],
+            },
+          },
+        ],
+      });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toHaveProperty('issue', [
+      expect.objectContaining({
+        severity: 'error',
+        details: { text: 'Appointment has no contained Slot resources' },
+      }),
+    ]);
+  });
+
+  test('rejects when embedded "busy" slots have mismatched start times', async () => {
+    const schedule1 = await makeSchedule({ actor: practitioner1 });
+    const schedule2 = await makeSchedule({ actor: practitioner2 });
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              status: 'proposed',
+              start: '2026-01-15T14:00:00Z',
+              end: '2026-01-15T15:00:00Z',
+              serviceType: toCodeableReferenceLike(officeVisitService),
+              participant: [
+                { actor: createReference(practitioner1), status: 'tentative' },
+                { actor: createReference(practitioner2), status: 'tentative' },
+              ],
+              contained: [
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(schedule1),
+                  start: '2026-01-15T14:00:00Z',
+                  end: '2026-01-15T15:00:00Z',
+                  serviceType: toCodeableReferenceLike(officeVisitService),
+                } satisfies Slot,
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(schedule2),
+                  start: '2026-01-15T15:00:00Z',
+                  end: '2026-01-15T16:00:00Z',
+                  serviceType: toCodeableReferenceLike(officeVisitService),
+                } satisfies Slot,
+              ],
+            },
+          },
+        ],
+      });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toHaveProperty('issue', [
+      expect.objectContaining({
+        severity: 'error',
+        details: { text: 'Mismatched slot start times' },
+      }),
+    ]);
+  });
+
+  test('rejects with mismatched busy slot end times', async () => {
+    const schedule1 = await makeSchedule({ actor: practitioner1 });
+    const schedule2 = await makeSchedule({ actor: practitioner2 });
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              status: 'proposed',
+              start: '2026-01-15T14:00:00Z',
+              end: '2026-01-15T15:00:00Z',
+              serviceType: toCodeableReferenceLike(officeVisitService),
+              participant: [
+                { actor: createReference(practitioner1), status: 'tentative' },
+                { actor: createReference(practitioner2), status: 'tentative' },
+              ],
+              contained: [
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(schedule1),
+                  start: '2026-01-15T14:00:00Z',
+                  end: '2026-01-15T15:00:00Z',
+                  serviceType: toCodeableReferenceLike(officeVisitService),
+                } satisfies Slot,
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(schedule2),
+                  start: '2026-01-15T14:00:00Z',
+                  end: '2026-01-15T14:30:00Z',
+                  serviceType: toCodeableReferenceLike(officeVisitService),
+                } satisfies Slot,
+              ],
+            },
+          },
+        ],
+      });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toHaveProperty('issue', [
+      expect.objectContaining({
+        severity: 'error',
+        details: { text: 'Mismatched slot end times' },
+      }),
+    ]);
+  });
+
+  test('rejects when referenced schedule does not exist', async () => {
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              status: 'proposed',
+              start: '2026-01-15T14:00:00Z',
+              end: '2026-01-15T15:00:00Z',
+              serviceType: toCodeableReferenceLike(officeVisitService),
+              participant: [{ actor: createReference(practitioner1), status: 'tentative' }],
+              contained: [
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: { reference: 'Schedule/nonexistent-12345' },
+                  start: '2026-01-15T14:00:00Z',
+                  end: '2026-01-15T15:00:00Z',
+                } satisfies Slot,
+              ],
+            },
+          },
+        ],
+      });
+
+    expect(response.body).toHaveProperty('issue', [
+      expect.objectContaining({
+        code: 'invalid',
+        severity: 'error',
+        details: {
+          text: 'Schedule load failed',
+        },
+        expression: ['Parameters.appointment.contained[0].schedule'],
+      }),
+    ]);
+    expect(response.status).toEqual(400);
+  });
+
+  test('rejects when slot duration does not match scheduling parameters', async () => {
+    const schedule = await makeSchedule({ actor: practitioner1 }); // 60-min slots
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              status: 'proposed',
+              start: '2026-01-15T14:00:00Z',
+              end: '2026-01-15T14:30:00Z',
+              serviceType: toCodeableReferenceLike(officeVisitService),
+              participant: [{ actor: createReference(practitioner1), status: 'tentative' }],
+              contained: [
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(schedule),
+                  start: '2026-01-15T14:00:00Z',
+                  end: '2026-01-15T14:30:00Z', // 30 min instead of 60
+                  serviceType: toCodeableReferenceLike(officeVisitService),
+                } satisfies Slot,
+              ],
+            },
+          },
+        ],
+      });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toHaveProperty('issue', [
+      expect.objectContaining({
+        severity: 'error',
+        details: { text: 'Slot duration does not match scheduling parameters duration' },
+      }),
+    ]);
+  });
+
+  test('rejects when the slot is outside availability windows', async () => {
+    const schedule = await makeSchedule({ actor: practitioner1 });
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send(
+        holdParams({
+          schedule,
+          // 06:00–07:00 ET is before the 09:00–17:00 window
+          start: '2026-01-15T06:00:00-05:00',
+          end: '2026-01-15T07:00:00-05:00',
+        })
+      );
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toHaveProperty('issue', [
+      expect.objectContaining({
+        severity: 'error',
+        details: { text: 'Requested time slot is not available' },
+      }),
+    ]);
+  });
+
+  test('rejects when a busy slot already exists at the requested time', async () => {
+    const practitioner = await makePractitioner({ timezone: 'America/New_York' });
+    const schedule = await makeSchedule({ actor: practitioner });
+    const start = '2026-01-15T14:00:00Z';
+    const end = '2026-01-15T15:00:00Z';
+
+    await systemRepo.createResource<Slot>({
+      resourceType: 'Slot',
+      start,
+      end,
+      status: 'busy',
+      schedule: createReference(schedule),
+      meta: { project: project.project.id },
+    });
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send(holdParams({ schedule, start, end }));
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toHaveProperty('issue', [
+      expect.objectContaining({
+        severity: 'error',
+        details: { text: 'Requested time slot is not available' },
+      }),
+    ]);
+
+    // Verify no new slots were created
+    const slots = await systemRepo.searchResources<Slot>(parseSearchRequest(`Slot?schedule=Schedule/${schedule.id}`));
+    expect(slots).toHaveLength(1); // only the original busy slot
+  });
+
+  test('rejects when a busy-tentative slot already exists at the requested time (double hold)', async () => {
+    const practitioner = await makePractitioner({ timezone: 'America/New_York' });
+    const schedule = await makeSchedule({ actor: practitioner });
+    const start = '2026-01-15T14:00:00Z';
+    const end = '2026-01-15T15:00:00Z';
+
+    // Simulate a prior hold
+    await systemRepo.createResource<Slot>({
+      resourceType: 'Slot',
+      start,
+      end,
+      status: 'busy-tentative',
+      schedule: createReference(schedule),
+      meta: { project: project.project.id },
+    });
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send(holdParams({ schedule, start, end }));
+
+    expect(response.status).toEqual(400);
+  });
+
+  test('rejects when there are no embedded "busy" slots for a schedule', async () => {
+    const schedule = await makeSchedule({ actor: practitioner1 });
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              status: 'proposed',
+              start: '2026-01-15T14:00:00Z',
+              end: '2026-01-15T15:00:00Z',
+              serviceType: toCodeableReferenceLike(officeVisitService),
+              participant: [{ actor: createReference(practitioner1), status: 'tentative' }],
+              contained: [
+                {
+                  resourceType: 'Slot',
+                  status: 'free', // not 'busy' — should fail
+                  schedule: createReference(schedule),
+                  start: '2026-01-15T14:00:00Z',
+                  end: '2026-01-15T15:00:00Z',
+                  serviceType: toCodeableReferenceLike(officeVisitService),
+                } satisfies Slot,
+              ],
+            },
+          },
+        ],
+      });
+
+    expect(response.body).toHaveProperty('issue', [
+      expect.objectContaining({
+        severity: 'error',
+        details: { text: "Expected exactly one 'busy' slot per schedule" },
+      }),
+    ]);
+    expect(response.status).toEqual(400);
+  });
+
+  test('rejects when there are multiple embedded "busy" slots for the same schedule', async () => {
+    const schedule = await makeSchedule({ actor: practitioner1 });
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              status: 'proposed',
+              start: '2026-01-15T14:00:00Z',
+              end: '2026-01-15T15:00:00Z',
+              serviceType: toCodeableReferenceLike(officeVisitService),
+              participant: [{ actor: createReference(practitioner1), status: 'tentative' }],
+              contained: [
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(schedule),
+                  start: '2026-01-15T14:00:00Z',
+                  end: '2026-01-15T15:00:00Z',
+                  serviceType: toCodeableReferenceLike(officeVisitService),
+                } satisfies Slot,
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(schedule),
+                  start: '2026-01-15T14:00:00Z',
+                  end: '2026-01-15T15:00:00Z',
+                  serviceType: toCodeableReferenceLike(officeVisitService),
+                } satisfies Slot,
+              ],
+            },
+          },
+        ],
+      });
+
+    expect(response.body).toHaveProperty('issue', [
+      expect.objectContaining({
+        severity: 'error',
+        details: { text: "Expected exactly one 'busy' slot per schedule" },
+        expression: ['Parameters.appointment.contained[0]', 'Parameters.appointment.contained[1]'],
+      }),
+    ]);
+    expect(response.status).toEqual(400);
+  });
+
+  test('with a patient participant preserved in the created appointment', async () => {
+    const schedule = await makeSchedule({ actor: practitioner1 });
+    const start = '2026-01-15T14:00:00Z';
+    const end = '2026-01-15T15:00:00Z';
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              status: 'proposed',
+              start,
+              end,
+              serviceType: toCodeableReferenceLike(officeVisitService),
+              participant: [
+                { actor: createReference(practitioner1), status: 'tentative' },
+                { actor: createReference(patient), status: 'accepted' },
+              ],
+              contained: [
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(schedule),
+                  start,
+                  end,
+                  serviceType: toCodeableReferenceLike(officeVisitService),
+                } satisfies Slot,
+              ],
+            },
+          },
+        ],
+      });
+
+    expect(response.body).not.toHaveProperty('issue');
+    expect(response.status).toEqual(201);
+
+    const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
+    const appointments = entries.filter(isAppointment);
+    expect(appointments).toHaveLength(1);
+    expect(appointments[0].participant).toEqual(
+      expect.arrayContaining([expect.objectContaining({ actor: createReference(patient) })])
+    );
+  });
+
+  describe('with bufferBefore', () => {
+    test('succeeds when a correctly-sized bufferBefore slot is included', async () => {
+      const schedule = await makeSchedule({
+        actor: practitioner1,
+        extension: [makeSchedulingExtension({ service: officeVisitService, duration: 60, bufferBefore: 20 })],
+      });
+      const bufferStart = '2026-01-15T09:00:00-05:00';
+      const busyStart = '2026-01-15T09:20:00-05:00';
+      const busyEnd = '2026-01-15T10:20:00-05:00';
+
+      const response = await request
+        .post('/fhir/R4/Appointment/$hold')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send(
+          holdParams({
+            schedule,
+            start: busyStart,
+            end: busyEnd,
+            extraSlots: [
+              {
+                resourceType: 'Slot',
+                status: 'busy-unavailable',
+                schedule: createReference(schedule),
+                start: bufferStart,
+                end: busyStart,
+                serviceType: toCodeableReferenceLike(officeVisitService),
+              },
+            ],
+          })
+        );
+
+      expect(response.status).toEqual(201);
+
+      const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
+      const slots = entries.filter(isSlot);
+      const bufferSlots = slots.filter((s) => s.status === 'busy-unavailable');
+      expect(bufferSlots).toHaveLength(1);
+      expect(bufferSlots[0]).toMatchObject({
+        status: 'busy-unavailable',
+        schedule: createReference(schedule),
+      });
+    });
+
+    test('rejects when bufferBefore is not available', async () => {
+      const schedule = await makeSchedule({
+        actor: practitioner1,
+        extension: [makeSchedulingExtension({ service: officeVisitService, duration: 60, bufferBefore: 20 })],
+      });
+      const bufferStart = '2026-01-15T09:00:00-05:00';
+      const busyStart = '2026-01-15T09:20:00-05:00';
+      const busyEnd = '2026-01-15T10:20:00-05:00';
+
+      // Create an existing slot partially overlapping the requested buffer
+      await systemRepo.createResource<Slot>({
+        resourceType: 'Slot',
+        start: '2026-01-15T08:40:00-05:00',
+        end: '2026-01-15T09:10:00-05:00',
+        status: 'busy',
+        schedule: createReference(schedule),
+        meta: { project: project.project.id },
+      });
+
+      const response = await request
+        .post('/fhir/R4/Appointment/$hold')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send(
+          holdParams({
+            schedule,
+            start: busyStart,
+            end: busyEnd,
+            extraSlots: [
+              {
+                resourceType: 'Slot',
+                status: 'busy-unavailable',
+                schedule: createReference(schedule),
+                start: bufferStart,
+                end: busyStart,
+                serviceType: toCodeableReferenceLike(officeVisitService),
+              },
+            ],
+          })
+        );
+
+      expect(response.body).toHaveProperty('issue', [
+        expect.objectContaining({
+          severity: 'error',
+          details: { text: 'Requested time slot is not available' },
+        }),
+      ]);
+      expect(response.status).toEqual(400);
+    });
+
+    test('rejects when bufferBefore slot is missing', async () => {
+      const schedule = await makeSchedule({
+        actor: practitioner1,
+        extension: [makeSchedulingExtension({ service: officeVisitService, duration: 60, bufferBefore: 20 })],
+      });
+
+      // No busy-unavailable slot ending at busyStart
+      const response = await request
+        .post('/fhir/R4/Appointment/$hold')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send(holdParams({ schedule, start: '2026-01-15T10:00:00-05:00', end: '2026-01-15T11:00:00-05:00' }));
+
+      expect(response.status).toEqual(400);
+      expect(response.body).toHaveProperty('issue', [
+        expect.objectContaining({
+          severity: 'error',
+          details: {
+            text: "Expected exactly one 'busy-unavailable' slot ending at the start of the busy slot (bufferBefore)",
+          },
+        }),
+      ]);
+    });
+
+    test('rejects when bufferBefore slot has wrong duration', async () => {
+      const schedule = await makeSchedule({
+        actor: practitioner1,
+        extension: [makeSchedulingExtension({ service: officeVisitService, duration: 60, bufferBefore: 20 })],
+      });
+      const busyStart = '2026-01-15T10:00:00-05:00';
+      const busyEnd = '2026-01-15T11:00:00-05:00';
+
+      // Buffer is only 10 min, but parameters require 20 min
+      const response = await request
+        .post('/fhir/R4/Appointment/$hold')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send(
+          holdParams({
+            schedule,
+            start: busyStart,
+            end: busyEnd,
+            extraSlots: [
+              {
+                resourceType: 'Slot',
+                status: 'busy-unavailable',
+                schedule: createReference(schedule),
+                start: '2026-01-15T09:50:00-05:00', // only 10 min before busyStart
+                end: busyStart,
+                serviceType: toCodeableReferenceLike(officeVisitService),
+              },
+            ],
+          })
+        );
+
+      expect(response.status).toEqual(400);
+      expect(response.body).toHaveProperty('issue', [
+        expect.objectContaining({
+          severity: 'error',
+          details: {
+            text: expect.stringContaining('does not match scheduling parameters bufferBefore'),
+          },
+        }),
+      ]);
+    });
+  });
+
+  describe('with bufferAfter', () => {
+    test('succeeds when a correctly-sized bufferAfter slot is included', async () => {
+      const schedule = await makeSchedule({
+        actor: practitioner1,
+        extension: [makeSchedulingExtension({ service: officeVisitService, duration: 60, bufferAfter: 20 })],
+      });
+      const busyStart = '2026-01-15T09:00:00-05:00';
+      const busyEnd = '2026-01-15T10:00:00-05:00';
+      const bufferEnd = '2026-01-15T10:20:00-05:00';
+
+      const response = await request
+        .post('/fhir/R4/Appointment/$hold')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send(
+          holdParams({
+            schedule,
+            start: busyStart,
+            end: busyEnd,
+            extraSlots: [
+              {
+                resourceType: 'Slot',
+                status: 'busy-unavailable',
+                schedule: createReference(schedule),
+                start: busyEnd,
+                end: bufferEnd,
+                serviceType: toCodeableReferenceLike(officeVisitService),
+              },
+            ],
+          })
+        );
+
+      expect(response.status).toEqual(201);
+
+      const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
+      const bufferSlots = entries.filter(isSlot).filter((s) => s.status === 'busy-unavailable');
+      expect(bufferSlots).toHaveLength(1);
+    });
+
+    test('rejects when bufferAfter slot is missing', async () => {
+      const schedule = await makeSchedule({
+        actor: practitioner1,
+        extension: [makeSchedulingExtension({ service: officeVisitService, duration: 60, bufferAfter: 20 })],
+      });
+
+      const response = await request
+        .post('/fhir/R4/Appointment/$hold')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send(holdParams({ schedule, start: '2026-01-15T09:00:00-05:00', end: '2026-01-15T10:00:00-05:00' }));
+
+      expect(response.status).toEqual(400);
+      expect(response.body).toHaveProperty('issue', [
+        expect.objectContaining({
+          severity: 'error',
+          details: {
+            text: "Expected exactly one 'busy-unavailable' slot starting at the end of the busy slot (bufferAfter)",
+          },
+        }),
+      ]);
+    });
+
+    test('rejects when bufferAfter slot has wrong duration', async () => {
+      const schedule = await makeSchedule({
+        actor: practitioner1,
+        extension: [makeSchedulingExtension({ service: officeVisitService, duration: 60, bufferAfter: 20 })],
+      });
+
+      const busyStart = '2026-01-15T09:00:00-05:00';
+      const busyEnd = '2026-01-15T10:00:00-05:00';
+
+      // Buffer is only 10 min, but parameters require 20 min
+      const response = await request
+        .post('/fhir/R4/Appointment/$hold')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send(
+          holdParams({
+            schedule,
+            start: busyStart,
+            end: busyEnd,
+            extraSlots: [
+              {
+                resourceType: 'Slot',
+                status: 'busy-unavailable',
+                schedule: createReference(schedule),
+                start: busyEnd,
+                end: '2026-01-15T10:10:00-05:00', // only 10 min, not 20
+                serviceType: toCodeableReferenceLike(officeVisitService),
+              },
+            ],
+          })
+        );
+
+      expect(response.status).toEqual(400);
+      expect(response.body).toHaveProperty('issue', [
+        expect.objectContaining({
+          severity: 'error',
+          details: {
+            text: expect.stringContaining('does not match scheduling parameters bufferAfter'),
+          },
+        }),
+      ]);
+    });
+  });
+
+  test('fails when the schedule has more than one actor', async () => {
+    const extraPractitioner = await makePractitioner({ timezone: 'America/New_York' });
+    const schedule = await systemRepo.createResource<Schedule>({
+      resourceType: 'Schedule',
+      meta: { project: project.project.id },
+      actor: [createReference(practitioner1), createReference(extraPractitioner)],
+      serviceType: toCodeableReferenceLike(officeVisitService),
+      extension: [makeSchedulingExtension({ service: officeVisitService })],
+    });
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send(holdParams({ schedule, start: '2026-01-15T14:00:00Z', end: '2026-01-15T15:00:00Z' }));
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toMatchObject({
+      resourceType: 'OperationOutcome',
+      issue: [{ details: { text: 'Scheduling only supported on schedules with exactly one actor' } }],
+    });
+  });
+
+  test('fails when the schedule actor has no timezone', async () => {
+    const practitionerWithoutTz = await makePractitioner(); // no timezone extension
+    const schedule = await makeSchedule({ actor: practitionerWithoutTz });
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send(holdParams({ schedule, start: '2026-01-15T14:00:00Z', end: '2026-01-15T15:00:00Z' }));
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toMatchObject({
+      resourceType: 'OperationOutcome',
+      issue: [{ details: { text: 'No timezone specified' } }],
+    });
+  });
+});
+
+describe('scheduling flow integration test', () => {
+  let project: TestProjectResult<{ withAccessToken: true }>;
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initApp(app, config);
+    project = await createTestProject({ withAccessToken: true });
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  const officeVisit: CodeableConcept = {
+    coding: [{ system: 'https://example.com/fhir', code: 'office-visit' }],
+  };
+
+  test('a Slot from Appointment/$find can be used as input to Appointment/$hold', async () => {
+    const service = await systemRepo.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      name: 'Office Visit',
+      type: [officeVisit],
+      meta: { project: project.project.id },
+    });
+
+    const device = await systemRepo.createResource<Device>({
+      resourceType: 'Device',
+      meta: { project: project.project.id },
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/StructureDefinition/timezone',
+          valueCode: 'America/Phoenix',
+        },
+      ],
+    });
+
+    const schedule = await systemRepo.createResource<Schedule>({
+      resourceType: 'Schedule',
+      meta: { project: project.project.id },
+      actor: [createReference(device)],
+      serviceType: toCodeableReferenceLike(service),
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [
+            threeDayAvailability,
+            {
+              url: 'duration',
+              valueDuration: { value: 35, unit: 'min' },
+            },
+            {
+              url: 'alignmentInterval',
+              valueDuration: { value: 30, unit: 'min' },
+            },
+            {
+              url: 'alignmentOffset',
+              valueDuration: { value: 5, unit: 'min' },
+            },
+            {
+              url: 'bufferBefore',
+              valueDuration: { value: 10, unit: 'min' },
+            },
+            {
+              url: 'bufferAfter',
+              valueDuration: { value: 15, unit: 'min' },
+            },
+            {
+              url: 'service',
+              valueReference: createReference(service),
+            },
+          ],
+        },
+      ],
+    });
+
+    const findResponse = await request
+      .get(`/fhir/R4/Appointment/$find`)
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .query({
+        start: new Date('2026-01-28T07:00:00.000-07:00'),
+        end: new Date('2026-01-28T12:00:00.000-07:00'),
+        'service-type-reference': `HealthcareService/${service.id}`,
+        schedule: `Schedule/${schedule.id}`,
+      });
+
+    expect(findResponse.body).not.toHaveProperty('issue');
+    expect(findResponse.status).toBe(200);
+    expect(findResponse.body).toHaveProperty('entry');
+    expect(findResponse.body.entry).toHaveLength(4);
+    const proposedAppointment: Appointment = findResponse.body.entry[1].resource;
+
+    const bookResponse = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: proposedAppointment,
+          },
+        ],
+      });
+
+    expect(bookResponse.body).not.toHaveProperty('issue');
+    expect(bookResponse.status).toBe(201);
+  });
+});

--- a/packages/server/src/fhir/operations/hold.test.ts
+++ b/packages/server/src/fhir/operations/hold.test.ts
@@ -405,6 +405,50 @@ describe('Appointment/$hold', () => {
     expect(response.status).toEqual(400);
   });
 
+  test('rejects when appointment already has references in `slot`', async () => {
+    const schedule = await makeSchedule({ actor: practitioner1 });
+    const start = '2026-01-15T14:00:00Z';
+    const end = '2026-01-15T15:00:00Z';
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              slot: [{ reference: 'Slot/abc' }],
+              status: 'proposed',
+              start,
+              end,
+              serviceType: toCodeableReferenceLike(officeVisitService),
+              participant: [{ actor: createReference(practitioner1), status: 'tentative' }],
+              contained: [
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(schedule),
+                  start,
+                  end,
+                  serviceType: toCodeableReferenceLike(officeVisitService),
+                } satisfies Slot,
+              ],
+            } satisfies Appointment,
+          },
+        ],
+      });
+
+    expect(response.body).toHaveProperty('issue', [
+      expect.objectContaining({
+        severity: 'error',
+        details: { text: 'Proposed appointment may not have Slot references' },
+      }),
+    ]);
+    expect(response.status).toEqual(400);
+  });
+
   test('rejects when contained has no Slot resources', async () => {
     const response = await request
       .post('/fhir/R4/Appointment/$hold')

--- a/packages/server/src/fhir/operations/hold.test.ts
+++ b/packages/server/src/fhir/operations/hold.test.ts
@@ -443,7 +443,7 @@ describe('Appointment/$hold', () => {
     expect(response.body).toHaveProperty('issue', [
       expect.objectContaining({
         severity: 'error',
-        details: { text: 'Proposed appointment may not have Slot references' },
+        details: { text: 'Proposed appointment must not have Slot references' },
       }),
     ]);
     expect(response.status).toEqual(400);

--- a/packages/server/src/fhir/operations/hold.test.ts
+++ b/packages/server/src/fhir/operations/hold.test.ts
@@ -201,7 +201,7 @@ describe('Appointment/$hold', () => {
     expect(response.status).toEqual(201);
   });
 
-  test('creates an Appointment and busy-tentative Slot', async () => {
+  test('creates a "pending" Appointment and "busy-tentative" Slot', async () => {
     const schedule = await makeSchedule({ actor: practitioner1 });
     const start = '2026-01-15T14:00:00Z';
     const end = '2026-01-15T15:00:00Z';
@@ -220,6 +220,7 @@ describe('Appointment/$hold', () => {
     expect(appointments[0]).toHaveProperty('id');
     expect(appointments[0]).toHaveProperty('start', start);
     expect(appointments[0]).toHaveProperty('end', end);
+    expect(appointments[0]).toHaveProperty('status', 'pending');
     // Hold strips contained resources from the appointment — they should not be persisted
     expect(appointments[0]).not.toHaveProperty('contained');
 

--- a/packages/server/src/fhir/operations/hold.ts
+++ b/packages/server/src/fhir/operations/hold.ts
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { badRequest, created, createReference, OperationOutcomeError } from '@medplum/core';
+import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
+import type { Appointment, Bundle, OperationDefinition, Slot } from '@medplum/fhirtypes';
+import { getAuthenticatedContext } from '../../context';
+import { withPath } from '../../util/withpath';
+import { buildOutputParameters, parseInputParameters } from './utils/parameters';
+import { validateAllAvailability, validateProposedAppointment } from './utils/scheduling';
+
+const holdOperation = {
+  resourceType: 'OperationDefinition',
+  name: 'hold',
+  status: 'active',
+  kind: 'operation',
+  code: 'hold',
+  resource: ['Appointment'],
+  system: false,
+  type: true,
+  instance: false,
+  parameter: [
+    { use: 'in', name: 'appointment', type: 'Resource', min: 1, max: '1' },
+    { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
+  ],
+} as const satisfies OperationDefinition;
+
+type HoldParameters = {
+  appointment: Appointment;
+};
+
+/**
+ * Handles HTTP requests for the Appointment $hold operation.
+ *
+ * Endpoints:
+ *   [fhir base]/Appointment/$hold
+ *
+ * @param req - The FHIR request.
+ * @returns The FHIR response.
+ */
+export async function appointmentHoldHandler(req: FhirRequest): Promise<FhirResponse> {
+  const ctx = getAuthenticatedContext();
+  const params = parseInputParameters<HoldParameters>(holdOperation, req);
+  const [appointment, slots, healthcareService, schedulingParametersGroup] = await validateProposedAppointment(
+    ctx.repo,
+    withPath(params.appointment, 'Parameters.appointment')
+  );
+
+  // We will write this attribute later, check that we aren't clobbering something that was submitted
+  if (appointment.slot) {
+    throw new OperationOutcomeError(
+      badRequest('Proposed appointment may not have Slot references', 'Parameters.appointment.slot')
+    );
+  }
+
+  // $hold creates slots in "busy-tentative" state
+  for (const slot of slots) {
+    if (slot.status === 'busy') {
+      slot.status = 'busy-tentative';
+    }
+  }
+
+  const createdResources = await ctx.repo.withTransaction(
+    async () => {
+      await validateAllAvailability(ctx.repo, slots, healthcareService, schedulingParametersGroup);
+      const createdSlots = await Promise.all(slots.map((slot) => ctx.repo.createResource<Slot>(slot)));
+      const createdAppointment = await ctx.repo.createResource<Appointment>({
+        ...appointment,
+        slot: createdSlots.map((slot) => createReference(slot)),
+      });
+      return [createdAppointment, ...createdSlots];
+    },
+    { serializable: true }
+  );
+  const bundle: Bundle = {
+    resourceType: 'Bundle',
+    type: 'transaction-response',
+    entry: createdResources.map((resource) => ({ resource })),
+  };
+
+  return [created, buildOutputParameters(holdOperation, bundle)];
+}

--- a/packages/server/src/fhir/operations/hold.ts
+++ b/packages/server/src/fhir/operations/hold.ts
@@ -19,7 +19,7 @@ const holdOperation = {
   type: true,
   instance: false,
   parameter: [
-    { use: 'in', name: 'appointment', type: 'Resource', min: 1, max: '1' },
+    { use: 'in', name: 'appointment', type: 'Appointment', min: 1, max: '1' },
     { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
   ],
 } as const satisfies OperationDefinition;
@@ -48,7 +48,7 @@ export async function appointmentHoldHandler(req: FhirRequest): Promise<FhirResp
   // We will write this attribute later, check that we aren't clobbering something that was submitted
   if (appointment.slot) {
     throw new OperationOutcomeError(
-      badRequest('Proposed appointment may not have Slot references', 'Parameters.appointment.slot')
+      badRequest('Proposed appointment must not have Slot references', 'Parameters.appointment.slot')
     );
   }
 
@@ -62,7 +62,12 @@ export async function appointmentHoldHandler(req: FhirRequest): Promise<FhirResp
   const createdResources = await ctx.repo.withTransaction(
     async () => {
       await validateAllAvailability(ctx.repo, slots, healthcareService, schedulingParametersGroup);
-      const createdSlots = await Promise.all(slots.map((slot) => ctx.repo.createResource<Slot>(slot)));
+
+      const createdSlots: Slot[] = [];
+      for (const slot of slots) {
+        createdSlots.push(await ctx.repo.createResource<Slot>(slot));
+      }
+
       const createdAppointment = await ctx.repo.createResource<Appointment>({
         ...appointment,
         status: 'pending',

--- a/packages/server/src/fhir/operations/hold.ts
+++ b/packages/server/src/fhir/operations/hold.ts
@@ -65,6 +65,7 @@ export async function appointmentHoldHandler(req: FhirRequest): Promise<FhirResp
       const createdSlots = await Promise.all(slots.map((slot) => ctx.repo.createResource<Slot>(slot)));
       const createdAppointment = await ctx.repo.createResource<Appointment>({
         ...appointment,
+        status: 'pending',
         slot: createdSlots.map((slot) => createReference(slot)),
       });
       return [createdAppointment, ...createdSlots];

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -204,11 +204,11 @@ function assertAllMatch(
 }
 
 export function chooseSchedulingParameterGroup(
-  schedules: WithPath<Schedule>[],
+  schedules: WithPath<WithId<Schedule>>[],
   healthcareService: WithPath<WithId<HealthcareService>>
-): Map<Schedule, WithPath<SchedulingParameters>> {
+): Map<WithPath<WithId<Schedule>>, WithPath<SchedulingParameters>> {
   const serviceParams = parseSchedulingParametersExtensions(healthcareService).at(0);
-  const result = new Map<Schedule, WithPath<SchedulingParameters>>();
+  const result = new Map<WithPath<WithId<Schedule>>, WithPath<SchedulingParameters>>();
 
   for (const schedule of schedules) {
     const params = parseSchedulingParametersExtensions(schedule).find((parameters) =>

--- a/packages/server/src/fhir/operations/utils/scheduling.test.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.test.ts
@@ -1,10 +1,17 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { createReference, generateId } from '@medplum/core';
+import { createReference, DEFAULT_MAX_SEARCH_COUNT, generateId } from '@medplum/core';
 import type { HealthcareService, Practitioner, Project, Schedule, Slot } from '@medplum/fhirtypes';
 import type { Interval } from '../../../util/date';
-import { applyExistingSlots, normalizeIntervals, removeAvailability, resolveAvailability } from './scheduling';
+import type { Repository } from '../../repo';
+import {
+  applyExistingSlots,
+  normalizeIntervals,
+  removeAvailability,
+  resolveAvailability,
+  slotsOverlappingInterval,
+} from './scheduling';
 import type { SchedulingParameters } from './scheduling-parameters';
 
 const project: Project = {
@@ -480,6 +487,29 @@ describe('removeAvailability', () => {
     ];
     const blocks = [{ start: new Date('2025-12-01T09:00:00Z'), end: new Date('2025-12-01T12:00:00Z') }];
     expect(removeAvailability(availability, blocks)).toEqual([]);
+  });
+});
+
+describe('slotsOverlappingInterval', () => {
+  test('throws when a full page of DEFAULT_MAX_SEARCH_COUNT slots is returned', async () => {
+    const mockSlot: Slot = {
+      resourceType: 'Slot',
+      status: 'busy',
+      start: '2025-12-01T10:00:00Z',
+      end: '2025-12-01T11:00:00Z',
+      schedule: { reference: `Schedule/${schedule.id}` },
+    };
+    const fullPage = Array.from({ length: DEFAULT_MAX_SEARCH_COUNT }, () => mockSlot);
+    const mockRepo = {
+      searchResources: async () => fullPage,
+    } as unknown as Repository;
+
+    await expect(
+      slotsOverlappingInterval(mockRepo, [schedule as WithId<Schedule>], {
+        start: new Date('2025-12-01'),
+        end: new Date('2025-12-31'),
+      })
+    ).rejects.toThrow('Too many slots found in range');
   });
 });
 

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -11,17 +11,28 @@ import {
   isResource,
   OperationOutcomeError,
   Operator,
+  resolveId,
 } from '@medplum/core';
-import type { CodeableConcept, HealthcareService, Reference, Resource, Schedule, Slot } from '@medplum/fhirtypes';
+import type {
+  Appointment,
+  CodeableConcept,
+  HealthcareService,
+  Reference,
+  Resource,
+  Schedule,
+  Slot,
+} from '@medplum/fhirtypes';
 import assert from 'node:assert';
 import { Temporal } from 'temporal-polyfill';
 import type { Interval } from '../../../util/date';
-import { areIntervalsOverlapping, clamp } from '../../../util/date';
+import { areIntervalsOverlapping, clamp, earliest, latest } from '../../../util/date';
+import { extractReferencesFromCodeableReferenceLike } from '../../../util/servicetype';
 import type { WithPath } from '../../../util/withpath';
-import { copyPaths, getPath } from '../../../util/withpath';
+import { copyPaths, filterWithPaths, getPath, withPath } from '../../../util/withpath';
 import type { Repository } from '../../repo';
 import type { SchedulingParameters } from './scheduling-parameters';
 import { chooseSchedulingParameterGroup } from './scheduling-parameters';
+import { uniqueOn } from './terminology';
 
 // Tricky: support zero-based and one-based indexing by including Sunday on both ends.
 // (Date#getDay() uses zero-based indexing and Temporal#dayOfWeek uses one-based indexing)
@@ -330,6 +341,28 @@ export async function getSchedulingParametersGroup(
   );
 }
 
+// Finds keys that can be used to index into `T` and yield a primitive type
+// that can be compared with strict equality.
+type PrimitiveKey<T> = {
+  [K in keyof T]-?: T[K] extends string | number | boolean | undefined ? K : never;
+}[keyof T];
+
+export function assertAllMatch<T extends object>(
+  objects: WithPath<T>[],
+  attribute: PrimitiveKey<T> & string,
+  msg: string
+): void {
+  if (objects.length <= 1) {
+    return;
+  }
+  const mismatched = objects.find((value) => value[attribute] !== objects[0][attribute]);
+  if (mismatched) {
+    throw new OperationOutcomeError(
+      badRequest(msg, [`${getPath(objects[0])}.${attribute}`, `${getPath(mismatched)}.${attribute}`])
+    );
+  }
+}
+
 export async function slotsOverlappingInterval(
   repo: Repository,
   schedules: (WithId<Schedule> | (Reference<Schedule> & { reference: string }))[],
@@ -365,4 +398,205 @@ export async function slotsOverlappingInterval(
     throw new OperationOutcomeError(badRequest('Too many slots found in range; try searching with smaller bounds'));
   }
   return results;
+}
+
+// Ensures that the input slots match our scheduling parameter constraints
+//
+// Intentionally skipped for now: testing parameters.alignmentInterval and
+// parameters.alignmentOffset. See https://github.com/medplum/medplum/pull/8331.
+function validateSlots(slots: WithPath<Slot>[], parameters: SchedulingParameters): void {
+  // Expect exactly one 'busy' slot with duration matching parameters.duration
+  const busySlots = slots.filter((slot) => slot.status === 'busy');
+  if (busySlots.length !== 1) {
+    throw new OperationOutcomeError(
+      badRequest(
+        `Expected exactly one 'busy' slot per schedule`,
+        slots.map((slot) => getPath(slot))
+      )
+    );
+  }
+  const busySlot = busySlots[0];
+  const busyDurationMinutes = (new Date(busySlot.end).getTime() - new Date(busySlot.start).getTime()) / 60_000;
+  if (busyDurationMinutes !== parameters.duration) {
+    throw new OperationOutcomeError(
+      badRequest('Slot duration does not match scheduling parameters duration', getPath(busySlot))
+    );
+  }
+
+  const busyStartMs = new Date(busySlot.start).getTime();
+  const busyEndMs = new Date(busySlot.end).getTime();
+
+  // If bufferBefore is set, expect one 'busy-unavailable' slot ending at the start of the busy slot
+  if (parameters.bufferBefore > 0) {
+    const bufferBeforeSlots = slots.filter(
+      (slot) => slot.status === 'busy-unavailable' && new Date(slot.end).getTime() === busyStartMs
+    );
+    if (bufferBeforeSlots.length !== 1) {
+      throw new OperationOutcomeError(
+        badRequest(
+          "Expected exactly one 'busy-unavailable' slot ending at the start of the busy slot (bufferBefore)",
+          getPath(busySlot)
+        )
+      );
+    }
+    const bufferBeforeSlot = bufferBeforeSlots[0];
+    const bufferBeforeDurationMinutes =
+      (new Date(bufferBeforeSlot.end).getTime() - new Date(bufferBeforeSlot.start).getTime()) / 60_000;
+    if (bufferBeforeDurationMinutes !== parameters.bufferBefore) {
+      throw new OperationOutcomeError(
+        badRequest(
+          `Buffer-before slot duration (${bufferBeforeDurationMinutes} min) does not match scheduling parameters bufferBefore (${parameters.bufferBefore} min)`,
+          getPath(bufferBeforeSlot)
+        )
+      );
+    }
+  }
+
+  // If bufferAfter is set, expect one 'busy-unavailable' slot starting at the end of the busy slot
+  if (parameters.bufferAfter > 0) {
+    const bufferAfterSlots = slots.filter(
+      (slot) => slot.status === 'busy-unavailable' && new Date(slot.start).getTime() === busyEndMs
+    );
+    if (bufferAfterSlots.length !== 1) {
+      throw new OperationOutcomeError(
+        badRequest(
+          "Expected exactly one 'busy-unavailable' slot starting at the end of the busy slot (bufferAfter)",
+          getPath(busySlot)
+        )
+      );
+    }
+    const bufferAfterSlot = bufferAfterSlots[0];
+    const bufferAfterDurationMinutes =
+      (new Date(bufferAfterSlot.end).getTime() - new Date(bufferAfterSlot.start).getTime()) / 60_000;
+    if (bufferAfterDurationMinutes !== parameters.bufferAfter) {
+      throw new OperationOutcomeError(
+        badRequest(
+          `Buffer-after slot duration (${bufferAfterDurationMinutes} min) does not match scheduling parameters bufferAfter (${parameters.bufferAfter} min)`,
+          getPath(bufferAfterSlot)
+        )
+      );
+    }
+  }
+}
+
+async function validateAvailability(
+  repo: Repository,
+  healthcareService: HealthcareService,
+  schedule: WithId<Schedule>,
+  parameters: SchedulingParameters & { timezone: string },
+  interval: Interval
+): Promise<void> {
+  const existingSlots = await slotsOverlappingInterval(repo, [schedule], interval);
+  let availability = resolveAvailability(parameters, interval, parameters.timezone);
+  availability = applyExistingSlots({
+    availability,
+    slots: existingSlots,
+    range: interval,
+    serviceType: healthcareService.type,
+  });
+  const hasAvailability = availability.some((avail) => avail.start <= interval.start && avail.end >= interval.end);
+  if (!hasAvailability) {
+    // TODO: tie back to specific slot that has problem
+    throw new OperationOutcomeError(badRequest('Requested time slot is not available'));
+  }
+}
+
+export async function validateProposedAppointment(
+  repo: Repository,
+  proposedAppointment: WithPath<Appointment>
+): Promise<
+  [
+    Appointment,
+    WithPath<Slot>[],
+    HealthcareService,
+    Map<WithPath<WithId<Schedule>>, WithPath<SchedulingParameters & { timezone: string }>>,
+  ]
+> {
+  const { contained, ...appointment } = proposedAppointment;
+  const serviceRefs = extractReferencesFromCodeableReferenceLike(appointment.serviceType);
+  if (serviceRefs.length === 0) {
+    throw new OperationOutcomeError(
+      badRequest('Appointment has no service reference', 'Parameters.appointment.serviceType')
+    );
+  }
+  if (serviceRefs.length > 1) {
+    throw new OperationOutcomeError(
+      badRequest('Appointment has too many service references', 'Parameters.appointment.serviceType')
+    );
+  }
+
+  const proposedSlots = filterWithPaths(
+    contained,
+    (r) => isResource<Slot>(r, 'Slot'),
+    `${getPath(proposedAppointment)}.contained`
+  );
+  if (!proposedSlots.length) {
+    throw new OperationOutcomeError(
+      badRequest('Appointment has no contained Slot resources', 'Parameters.appointment')
+    );
+  }
+
+  const busySlots = proposedSlots.filter((slot) => slot.status === 'busy');
+  assertAllMatch(busySlots, 'start', 'Mismatched slot start times');
+  assertAllMatch(busySlots, 'end', 'Mismatched slot end times');
+
+  const scheduleRefs = uniqueOn(
+    proposedSlots.map((slot) => withPath(slot.schedule, `${getPath(slot)}.schedule`)),
+    (ref) => {
+      if (!ref.reference) {
+        throw new OperationOutcomeError(badRequest('Slot missing schedule reference', getPath(ref)));
+      }
+      return ref.reference;
+    }
+  );
+
+  const [schedules, healthcareService] = await Promise.all([
+    repo.readReferences(scheduleRefs).then((schedules) => copyPaths(scheduleRefs, schedules)),
+    repo.readReference(serviceRefs[0]).then((service) => withPath(service, 'HealthcareService')),
+  ]);
+  assertAllLoaded(schedules, 'Schedule load failed');
+
+  const schedulingParameterGroup = await getSchedulingParametersGroup(repo, schedules, healthcareService);
+
+  // Check that scheduling parameters match proposedSlots
+  for (const schedule of schedules) {
+    const parameters = schedulingParameterGroup.get(schedule);
+    assert(parameters);
+
+    const slotsForSchedule = proposedSlots.filter((slot) => resolveId(slot.schedule) === schedule.id);
+    validateSlots(slotsForSchedule, parameters);
+  }
+
+  return [appointment, proposedSlots, healthcareService, schedulingParameterGroup];
+}
+
+export async function validateAllAvailability(
+  repo: Repository,
+  allSlots: WithPath<Slot>[],
+  healthcareService: HealthcareService,
+  schedulingParameterGroup: Map<WithPath<WithId<Schedule>>, WithPath<SchedulingParameters & { timezone: string }>>
+): Promise<void> {
+  const groupedSlots = Object.groupBy(allSlots, (slot) => slot.schedule.reference ?? 'unknown');
+  for (const [schedule, parameters] of schedulingParameterGroup.entries()) {
+    const refstr = getReferenceString(schedule);
+    const slots = groupedSlots[refstr];
+    delete groupedSlots[refstr];
+    assert(slots);
+    const start = earliest(slots.map((slot) => new Date(slot.start)));
+    const end = latest(slots.map((slot) => new Date(slot.end)));
+    assert(start && end);
+    const interval = { start, end };
+    await validateAvailability(repo, healthcareService, schedule, parameters, interval);
+  }
+
+  // Any unprocessed slots represent some kind of error
+  const unprocessedSlots = Object.values(groupedSlots).flat().filter(isDefined);
+  if (unprocessedSlots.length) {
+    throw new OperationOutcomeError(
+      badRequest(
+        'Got slots that did not map to scheduling parameters',
+        unprocessedSlots.map((slot) => getPath(slot))
+      )
+    );
+  }
 }

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -1,12 +1,24 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { badRequest, EMPTY, getExtensionValue, isDefined, isResource, OperationOutcomeError } from '@medplum/core';
-import type { CodeableConcept, Resource, Slot } from '@medplum/fhirtypes';
+import type { WithId } from '@medplum/core';
+import {
+  badRequest,
+  DEFAULT_MAX_SEARCH_COUNT,
+  EMPTY,
+  getExtensionValue,
+  getReferenceString,
+  isDefined,
+  isResource,
+  OperationOutcomeError,
+  Operator,
+} from '@medplum/core';
+import type { CodeableConcept, Reference, Resource, Schedule, Slot } from '@medplum/fhirtypes';
 import { Temporal } from 'temporal-polyfill';
 import type { Interval } from '../../../util/date';
 import { areIntervalsOverlapping, clamp } from '../../../util/date';
 import type { WithPath } from '../../../util/withpath';
 import { getPath } from '../../../util/withpath';
+import type { Repository } from '../../repo';
 import type { SchedulingParameters } from './scheduling-parameters';
 
 // Tricky: support zero-based and one-based indexing by including Sunday on both ends.
@@ -281,4 +293,41 @@ export function assertAllLoaded<T extends Resource>(
   if (invalid) {
     throw new OperationOutcomeError(badRequest(message, getPath(invalid)));
   }
+}
+
+export async function slotsOverlappingInterval(
+  repo: Repository,
+  schedules: (WithId<Schedule> | (Reference<Schedule> & { reference: string }))[],
+  interval: Interval
+): Promise<Slot[]> {
+  const searchStart = interval.start.toISOString();
+  const searchEnd = interval.end.toISOString();
+  const results = await repo.searchResources<Slot>({
+    resourceType: 'Slot',
+    count: DEFAULT_MAX_SEARCH_COUNT,
+    filters: [
+      {
+        code: 'schedule',
+        operator: Operator.EQUALS,
+        value: schedules.map((schedule) => getReferenceString(schedule)).join(','),
+      },
+      {
+        code: 'status',
+        operator: Operator.EQUALS,
+        value: 'busy,busy-tentative,busy-unavailable,free',
+      },
+      {
+        code: '_filter',
+        operator: Operator.EQUALS,
+        value: `((start ge "${searchStart}" and start le "${searchEnd}") or (end ge "${searchStart}" and end le "${searchEnd}") or (start lt "${searchStart}" and end gt "${searchEnd}"))`,
+      },
+    ],
+  });
+
+  // If we filled a full search page of slots, then there may be slots we
+  // didn't fetch that would impact availability. Fail loudly here.
+  if (results.length === DEFAULT_MAX_SEARCH_COUNT) {
+    throw new OperationOutcomeError(badRequest('Too many slots found in range; try searching with smaller bounds'));
+  }
+  return results;
 }

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -12,14 +12,16 @@ import {
   OperationOutcomeError,
   Operator,
 } from '@medplum/core';
-import type { CodeableConcept, Reference, Resource, Schedule, Slot } from '@medplum/fhirtypes';
+import type { CodeableConcept, HealthcareService, Reference, Resource, Schedule, Slot } from '@medplum/fhirtypes';
+import assert from 'node:assert';
 import { Temporal } from 'temporal-polyfill';
 import type { Interval } from '../../../util/date';
 import { areIntervalsOverlapping, clamp } from '../../../util/date';
 import type { WithPath } from '../../../util/withpath';
-import { getPath } from '../../../util/withpath';
+import { copyPaths, getPath } from '../../../util/withpath';
 import type { Repository } from '../../repo';
 import type { SchedulingParameters } from './scheduling-parameters';
+import { chooseSchedulingParameterGroup } from './scheduling-parameters';
 
 // Tricky: support zero-based and one-based indexing by including Sunday on both ends.
 // (Date#getDay() uses zero-based indexing and Temporal#dayOfWeek uses one-based indexing)
@@ -293,6 +295,39 @@ export function assertAllLoaded<T extends Resource>(
   if (invalid) {
     throw new OperationOutcomeError(badRequest(message, getPath(invalid)));
   }
+}
+
+export async function getSchedulingParametersGroup(
+  repo: Repository,
+  schedules: WithPath<WithId<Schedule>>[],
+  healthcareService: WithPath<WithId<HealthcareService>>
+): Promise<Map<WithPath<WithId<Schedule>>, WithPath<SchedulingParameters & { timezone: string }>>> {
+  schedules.forEach((schedule) => {
+    if (schedule.actor.length !== 1) {
+      throw new OperationOutcomeError(
+        badRequest('Scheduling only supported on schedules with exactly one actor', getPath(schedule))
+      );
+    }
+  });
+
+  const actors = await repo
+    .readReferences(schedules.map((schedule) => schedule.actor[0]))
+    .then((actors) => copyPaths(schedules, actors, { suffix: '.actor[0]' }));
+  assertAllLoaded(actors, 'Loading schedule.actor failed');
+
+  const group = chooseSchedulingParameterGroup(schedules, healthcareService);
+
+  return new Map(
+    group.entries().map(([schedule, parameters], idx) => {
+      const actor = actors[idx];
+      assert(actor);
+      const timezone = parameters.timezone ?? getTimeZone(actor);
+      if (!timezone) {
+        throw new OperationOutcomeError(badRequest('No timezone specified', getPath(actor)));
+      }
+      return [schedule, { ...parameters, timezone }];
+    })
+  );
 }
 
 export async function slotsOverlappingInterval(

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -57,6 +57,7 @@ import { getWsBindingTokenHandler } from './operations/getwsbindingtoken';
 import { getWsSubProjectStatsHandler } from './operations/getwssubprojectstats';
 import { getWsSubStatsHandler } from './operations/getwssubstats';
 import { groupExportHandler } from './operations/groupexport';
+import { appointmentHoldHandler } from './operations/hold';
 import { appLaunchHandler } from './operations/launch';
 import { packageInstallHandler } from './operations/packageinstall';
 import { patientEverythingHandler } from './operations/patienteverything';
@@ -389,6 +390,7 @@ function initInternalFhirRouter(): FhirRouter {
   // Appointment Scheduling operations
   router.add('GET', '/Appointment/$find', appointmentFindHandler);
   router.add('POST', '/Appointment/$book', appointmentBookHandler);
+  router.add('POST', '/Appointment/$hold', appointmentHoldHandler);
 
   // PackageRelease $install operation
   router.add('POST', '/PackageRelease/:id/$install', packageInstallHandler);

--- a/packages/server/src/util/date.test.ts
+++ b/packages/server/src/util/date.test.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { addMinutes, areIntervalsOverlapping, clamp } from './date';
+import { addMinutes, areIntervalsOverlapping, clamp, earliest, latest } from './date';
 
 describe('addMinutes', () => {
   test('adds the given number of minutes', () => {
@@ -139,5 +139,39 @@ describe('clamp', () => {
       end: new Date('2026-01-21'),
     };
     expect(clamp(date, interval)).toEqual(date);
+  });
+});
+
+describe('earliest', () => {
+  test('returns undefined for an empty array', () => {
+    expect(earliest([])).toBeUndefined();
+  });
+
+  test('returns the only element when given a single date', () => {
+    const date = new Date('2026-01-10');
+    expect(earliest([date])).toBe(date);
+  });
+
+  test('returns the earliest of multiple dates', () => {
+    expect(earliest([new Date('2026-01-10'), new Date('2026-01-05'), new Date('2026-01-20')])).toEqual(
+      new Date('2026-01-05')
+    );
+  });
+});
+
+describe('latest', () => {
+  test('returns undefined for an empty array', () => {
+    expect(latest([])).toBeUndefined();
+  });
+
+  test('returns the only element when given a single date', () => {
+    const date = new Date('2026-01-10');
+    expect(latest([date])).toBe(date);
+  });
+
+  test('returns the latest of multiple dates', () => {
+    expect(latest([new Date('2026-01-10'), new Date('2026-01-05'), new Date('2026-01-20')])).toEqual(
+      new Date('2026-01-20')
+    );
   });
 });

--- a/packages/server/src/util/date.ts
+++ b/packages/server/src/util/date.ts
@@ -41,9 +41,9 @@ export function clamp(date: Date, interval: Interval): Date {
 }
 
 export function earliest(dates: Date[]): Date | undefined {
-  let min = dates[0];
-  for (const date of dates.slice(1)) {
-    if (date < min) {
+  let min: Date | undefined;
+  for (const date of dates) {
+    if (!min || date < min) {
       min = date;
     }
   }
@@ -51,9 +51,9 @@ export function earliest(dates: Date[]): Date | undefined {
 }
 
 export function latest(dates: Date[]): Date | undefined {
-  let max = dates[0];
-  for (const date of dates.slice(1)) {
-    if (date > max) {
+  let max: Date | undefined;
+  for (const date of dates) {
+    if (!max || date > max) {
       max = date;
     }
   }

--- a/packages/server/src/util/date.ts
+++ b/packages/server/src/util/date.ts
@@ -39,3 +39,23 @@ export function clamp(date: Date, interval: Interval): Date {
   }
   return date;
 }
+
+export function earliest(dates: Date[]): Date | undefined {
+  let min = dates[0];
+  for (const date of dates.slice(1)) {
+    if (date < min) {
+      min = date;
+    }
+  }
+  return min;
+}
+
+export function latest(dates: Date[]): Date | undefined {
+  let max = dates[0];
+  for (const date of dates.slice(1)) {
+    if (date > max) {
+      max = date;
+    }
+  }
+  return max;
+}


### PR DESCRIPTION
This is similar to $book in that it takes a result from `$find` and persists it. There are some minor differences between the two in how the input is manipulated before saving.

I'm taking advantage of the fact that we didn't implement this operation with respect to the early `Schedule/:id/$find` slot-based operation; since that original implementation we have decided that we should reduce the surface area of the API and only offer the more powerful `Appointment/$find` variant (as it can be used for both single-schedule and multi-schedule booking).

This meant that I had a clean slate to start from. I've tried to implement as much as I can in reusable helper functions so that we can easily extend this to `$book` next.