### PR TITLE
Add clarification on Bots with ProjectMemberships

### DIFF
--- a/packages/app/src/admin/BotsPage.tsx
+++ b/packages/app/src/admin/BotsPage.tsx
@@ -13,24 +13,22 @@ export function BotsPage(): JSX.Element {
         profileTypeOptions={[{ label: 'Bot', value: 'Bot' }]}
         fields={['user', 'profile', 'accessPolicy', 'userConfiguration', 'active', 'admin']}
         toolbarLeft={
-          <>
-            <Paper withBorder p="sm" radius="sm" maw={520}>
-              <Text size="sm" c="dimmed">
-                Please note that this list is limited to Bots that have a ProjectMembership. Bots that are run as user
-                commonly do not have a ProjectMembership, and are not included, such as most Bots in Medplum-managed
-                integrations. For a complete list of Bots, see <MedplumLink to="/Bot">Bots</MedplumLink>. For more
-                information, see{' '}
-                <Anchor
-                  href="https://www.medplum.com/docs/bots/bot-run-as-user"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  running Bots as user
-                </Anchor>
-                .
-              </Text>
-            </Paper>
-          </>
+          <Paper withBorder p="sm" radius="sm" maw={520}>
+            <Text size="sm" c="dimmed">
+              Please note that this list is limited to Bots that have a ProjectMembership. Bots that are run as user
+              commonly do not have a ProjectMembership, and are not included, such as most Bots in Medplum-managed
+              integrations. For a complete list of Bots, see <MedplumLink to="/Bot">Bots</MedplumLink>. For more
+              information, see{' '}
+              <Anchor
+                href="https://www.medplum.com/docs/bots/bot-run-as-user"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                running Bots as user
+              </Anchor>
+              .
+            </Text>
+          </Paper>
         }
         toolbarRight={
           <Anchor href="https://www.medplum.com/docs/bots" target="_blank" rel="noopener noreferrer" size="sm">

--- a/packages/app/src/admin/BotsPage.tsx
+++ b/packages/app/src/admin/BotsPage.tsx
@@ -16,9 +16,18 @@ export function BotsPage(): JSX.Element {
           <>
             <Paper withBorder p="sm" radius="sm" maw={520}>
               <Text size="sm" c="dimmed">
-                Please note that this list is limited to Bots that have a ProjectMembership. Bots that are run as user commonly do not have a ProjectMembership, and are not included, 
-                such as most Bots in Medplum-managed integrations. For a complete list of Bots, see <MedplumLink to="/Bot">Bots</MedplumLink>.
-                For more information, see <Anchor href="https://www.medplum.com/docs/bots/bot-run-as-user" target="_blank" rel="noopener noreferrer">running Bots as user</Anchor>.
+                Please note that this list is limited to Bots that have a ProjectMembership. Bots that are run as user
+                commonly do not have a ProjectMembership, and are not included, such as most Bots in Medplum-managed
+                integrations. For a complete list of Bots, see <MedplumLink to="/Bot">Bots</MedplumLink>. For more
+                information, see{' '}
+                <Anchor
+                  href="https://www.medplum.com/docs/bots/bot-run-as-user"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  running Bots as user
+                </Anchor>
+                .
               </Text>
             </Paper>
           </>

--- a/packages/app/src/admin/BotsPage.tsx
+++ b/packages/app/src/admin/BotsPage.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Group, Title } from '@mantine/core';
+import { Anchor, Group, Paper, Text, Title } from '@mantine/core';
 import { MedplumLink } from '@medplum/react';
 import type { JSX } from 'react';
 import { MemberTable } from './MembersTable';
@@ -8,10 +8,26 @@ import { MemberTable } from './MembersTable';
 export function BotsPage(): JSX.Element {
   return (
     <>
-      <Title>Bots</Title>
+      <Title>ProjectMemberships by Bot</Title>
       <MemberTable
         profileTypeOptions={[{ label: 'Bot', value: 'Bot' }]}
         fields={['user', 'profile', 'accessPolicy', 'userConfiguration', 'active', 'admin']}
+        toolbarLeft={
+          <>
+            <Paper withBorder p="sm" radius="sm" maw={520}>
+              <Text size="sm" c="dimmed">
+                Please note that this list is limited to Bots that have a ProjectMembership. Bots that are run as user commonly do not have a ProjectMembership, and are not included, 
+                such as most Bots in Medplum-managed integrations. For a complete list of Bots, see <MedplumLink to="/Bot">Bots</MedplumLink>.
+                For more information, see <Anchor href="https://www.medplum.com/docs/bots/bot-run-as-user" target="_blank" rel="noopener noreferrer">running Bots as user</Anchor>.
+              </Text>
+            </Paper>
+          </>
+        }
+        toolbarRight={
+          <Anchor href="https://www.medplum.com/docs/bots" target="_blank" rel="noopener noreferrer" size="sm">
+            Learn more about Bots
+          </Anchor>
+        }
       />
       <Group justify="flex-end">
         <MedplumLink to={`/admin/bots/new`}>Create new bot</MedplumLink>

--- a/packages/app/src/admin/ClientsPage.tsx
+++ b/packages/app/src/admin/ClientsPage.tsx
@@ -8,7 +8,7 @@ import { MemberTable } from './MembersTable';
 export function ClientsPage(): JSX.Element {
   return (
     <>
-      <Title>Client Applications</Title>
+      <Title>ProjectMemberships by ClientApplication</Title>
       <MemberTable
         profileTypeOptions={[{ label: 'ClientApplication', value: 'ClientApplication' }]}
         fields={['user', 'profile', 'accessPolicy', 'userConfiguration', 'active', 'admin']}

--- a/packages/app/src/admin/MembersTable.tsx
+++ b/packages/app/src/admin/MembersTable.tsx
@@ -48,12 +48,18 @@ export function MemberTable(props: MemberTableProps): JSX.Element {
     });
   }
 
+  const showSegmentedControl = props.profileTypeOptions.length > 1;
+  const showToolbar =
+    showSegmentedControl || props.toolbarLeft !== undefined || props.toolbarRight !== undefined;
+
   return (
     <>
-      {props.profileTypeOptions.length > 1 && (
+      {showToolbar && (
         <Group justify="space-between" align="center" mb="md" wrap="nowrap">
           <Group gap="md" wrap="nowrap">
-            <SegmentedControl value={profileType} onChange={handleProfileTypeChange} data={props.profileTypeOptions} />
+            {showSegmentedControl && (
+              <SegmentedControl value={profileType} onChange={handleProfileTypeChange} data={props.profileTypeOptions} />
+            )}
             {props.toolbarLeft}
           </Group>
           {props.toolbarRight}

--- a/packages/app/src/admin/MembersTable.tsx
+++ b/packages/app/src/admin/MembersTable.tsx
@@ -49,8 +49,7 @@ export function MemberTable(props: MemberTableProps): JSX.Element {
   }
 
   const showSegmentedControl = props.profileTypeOptions.length > 1;
-  const showToolbar =
-    showSegmentedControl || props.toolbarLeft !== undefined || props.toolbarRight !== undefined;
+  const showToolbar = showSegmentedControl || props.toolbarLeft !== undefined || props.toolbarRight !== undefined;
 
   return (
     <>
@@ -58,7 +57,11 @@ export function MemberTable(props: MemberTableProps): JSX.Element {
         <Group justify="space-between" align="center" mb="md" wrap="nowrap">
           <Group gap="md" wrap="nowrap">
             {showSegmentedControl && (
-              <SegmentedControl value={profileType} onChange={handleProfileTypeChange} data={props.profileTypeOptions} />
+              <SegmentedControl
+                value={profileType}
+                onChange={handleProfileTypeChange}
+                data={props.profileTypeOptions}
+              />
             )}
             {props.toolbarLeft}
           </Group>


### PR DESCRIPTION
<img width="978" height="374" alt="Screenshot 2026-05-07 at 11 59 06 AM" src="https://github.com/user-attachments/assets/6b87c535-e7ea-4def-a1bc-55b156202799" />

Eliminate confusion when users don't see all Bots listed under the Bots tab. 