### PR TITLE
docs(health-gorilla): document access policy needs for non-admin practitioners

### DIFF
--- a/packages/docs/docs/access/access-policies.md
+++ b/packages/docs/docs/access/access-policies.md
@@ -274,6 +274,10 @@ The AccessPolicy below grants access to all `Observation` resources that belong 
 
 The FHIR `Binary` resource is a special case. It is used to store arbitrary binary data, such as images or documents. Unlike other resources, `Binary` resources are not searchable, and therefore do not have search parameters, and therefore cannot use the `criteria` field in an `AccessPolicy`.
 
+:::caution[`criteria` is silently ignored on Binary]
+Because `Binary` has no search parameters, Medplum's policy matcher short-circuits any `criteria` you put on a `Binary` rule and treats it as an unconditional match. A rule like `{ "resourceType": "Binary", "criteria": "Binary?_compartment=Organization/abc" }` therefore grants project-wide access to Binaries — not the scoped access you might expect. Use `securityContext` for scoping instead.
+:::
+
 To control access to `Binary` resources, you must use the `securityContext` field. This field is a reference to another resource, such as a `Patient`, `Practitioner`, or `Organization`, that defines the context in which the binary data is relevant.
 
 See [Binary Security Context](/docs/access/binary-security-context) for more information on how to use the `securityContext` field to control access to `Binary` resources.
@@ -650,6 +654,64 @@ This update allows for more granular control and visibility in RBAC implementati
 - **Client-Side**
   - The introduction of AccessPolicy.basedOn allows for client-side changes based on the user's group/policy.
   - This is especially useful for Role-Based Access Control (RBAC) implementations where different users may have varying access levels.
+
+## Gotchas
+
+A few subtle behaviors that aren't obvious from a first read of the policy resource, but that
+will bite you if you don't know them.
+
+### `Binary` rules ignore criteria
+
+Already noted above — `{ "resourceType": "Binary", "criteria": "..." }` matches every Binary in
+the project regardless of the criteria, because `Binary` has no search parameters for the matcher
+to evaluate. Use [`securityContext`](/docs/access/binary-security-context) for scoping instead.
+
+### `ProjectMembership` rules don't apply to non-admins
+
+The Medplum server applies an additional filter (`applyProjectAdminAccessPolicy`) that strips any
+`ProjectMembership` rules from policies attached to non-admin users. As a result, you cannot grant
+a non-admin user read or write access to `ProjectMembership` resources via an `AccessPolicy` —
+managing memberships always requires `admin: true` on the user's own `ProjectMembership`.
+
+### Resource rules with no `compartment` and no `criteria` skip filtering entirely
+
+A resource rule like `{ "resourceType": "Organization", "readonly": true }` (no `compartment`,
+no `criteria`) grants project-wide access to that resource type. The query builder takes an
+early-return path and adds no filter to search queries. This is fine for shared, non-PHI resource
+types (`CodeSystem`, `ValueSet`, etc.) but is rarely what you want for clinical data — always
+scope with `compartment` or `criteria` for those.
+
+### `%organization` substitutes a `Reference`; use `%organization.id` for ids
+
+If you parameterize a policy with `valueReference: { reference: "Organization/abc-123" }` named
+`organization`, the substitution rules are:
+
+- `%organization` → `Organization/abc-123` (the full reference string)
+- `%organization.id` → `abc-123` (just the id portion)
+
+When writing reference-based search criteria, prefix the resource type explicitly. For example,
+to scope to organizations whose `partOf` points at the user's organization:
+
+```json
+{ "resourceType": "Organization", "criteria": "Organization?partof=Organization/%organization.id" }
+```
+
+The naive form `partof=%organization` does not bind reliably for reference matching across all
+search-parameter types — spelling the resource type explicitly avoids the issue.
+
+### A resource is not in its own compartment
+
+`Organization?_compartment=%organization` will _not_ match the practitioner's own organization,
+because Medplum doesn't add an organization to its own `meta.compartment`. To grant a user read
+access to their own organization, match by id:
+
+```json
+{ "resourceType": "Organization", "readonly": true, "criteria": "Organization?_id=%organization.id" }
+```
+
+Combine with a `partof=` rule to also pick up sub-orgs (e.g. lab contracts) under the
+organization. See the [Health Gorilla access policy guide](/docs/integration/health-gorilla/access-policy)
+for a worked example.
 
 ## Related Resources
 

--- a/packages/docs/docs/integration/health-gorilla/access-policy.md
+++ b/packages/docs/docs/integration/health-gorilla/access-policy.md
@@ -1,0 +1,214 @@
+---
+sidebar_position: 3
+sidebar_label: Access Policy for Practitioners
+---
+
+# Access Policy for Practitioners
+
+This guide lists the [`AccessPolicy`](/docs/api/fhir/medplum/accesspolicy) rules a non-admin
+practitioner needs to send Health Gorilla lab orders and read results back. Each rule is paired
+with the operation it unblocks so you can add only what you need.
+
+:::info[Why this matters]
+Project admins (`ProjectMembership.admin = true`) bypass per-resource access policy checks. If your
+team has been operating with admin enabled, the access policy doesn't actually constrain anything —
+the moment you switch a practitioner to non-admin, every missing rule below surfaces as a `403
+Forbidden` from a different operation in the lab order pipeline.
+:::
+
+## How Health Gorilla bots run
+
+The two bots referenced throughout the integration —
+`health-gorilla-labs/send-to-health-gorilla` and `health-gorilla-labs/autocomplete` — are
+configured with `runAsUser: true`. That flag means the bot executes against Medplum using the
+**calling practitioner's** access policy, not a privileged service account. Every read, write, and
+sub-bot invocation the bot performs goes through your practitioner's policy.
+
+This is intentional: data the bot creates (`ServiceRequest`, `Specimen`, `DocumentReference`,
+`Binary` attachments, etc.) is automatically scoped to the practitioner's organization via the
+account-inheritance rules described in [Compartments](/docs/access/access-policies#compartments).
+The flip side: every resource the bot touches must be permitted by the practitioner's access
+policy.
+
+The HG bots themselves typically live in a Medplum project that is **linked** to your project
+rather than in your project directly. Read access still flows through your policy — you'll need a
+`Bot` rule scoped to the two HG identifiers, which Medplum resolves across linked projects.
+
+## The minimum policy
+
+The policy below covers the full lab order lifecycle for a practitioner who belongs to a single
+organization. It assumes a `provider_organization` parameter is set on the
+[`ProjectMembership.access[]`](/docs/api/fhir/medplum/projectmembership) entry — see
+[Parameterized Policies](/docs/access/access-policies#parameterized-policies).
+
+```json
+{
+  "resourceType": "AccessPolicy",
+  "name": "Practitioner — Health Gorilla",
+  "compartment": { "reference": "%provider_organization" },
+  "resource": [
+    { "resourceType": "Patient", "criteria": "Patient?_compartment=%provider_organization" },
+    { "resourceType": "ServiceRequest", "criteria": "ServiceRequest?_compartment=%provider_organization" },
+    { "resourceType": "DiagnosticReport", "criteria": "DiagnosticReport?_compartment=%provider_organization" },
+    { "resourceType": "DocumentReference", "criteria": "DocumentReference?_compartment=%provider_organization" },
+    { "resourceType": "Specimen", "criteria": "Specimen?_compartment=%provider_organization" },
+    { "resourceType": "QuestionnaireResponse", "criteria": "QuestionnaireResponse?_compartment=%provider_organization" },
+    { "resourceType": "RequestGroup", "criteria": "RequestGroup?_compartment=%provider_organization" },
+    { "resourceType": "Coverage", "criteria": "Coverage?_compartment=%provider_organization" },
+    { "resourceType": "Binary" },
+    {
+      "resourceType": "Bot",
+      "readonly": true,
+      "criteria": "Bot?identifier=https://www.medplum.com/integrations/bot-identifier|health-gorilla-labs/send-to-health-gorilla,https://www.medplum.com/integrations/bot-identifier|health-gorilla-labs/autocomplete"
+    },
+    {
+      "resourceType": "Organization",
+      "readonly": true,
+      "criteria": "Organization?_id=%provider_organization.id"
+    },
+    {
+      "resourceType": "Organization",
+      "readonly": true,
+      "criteria": "Organization?partof=Organization/%provider_organization.id"
+    },
+    { "resourceType": "CodeSystem", "readonly": true },
+    { "resourceType": "ValueSet", "readonly": true },
+    { "resourceType": "Practitioner", "readonly": true },
+    { "resourceType": "Questionnaire", "readonly": true }
+  ]
+}
+```
+
+## What each rule unblocks
+
+### Resources written by the order bundle
+
+[`createLabOrderBundle`](https://www.npmjs.com/package/@medplum/health-gorilla-core) (and the
+`useHealthGorillaLabOrder` hook) produces a `transaction` Bundle containing:
+
+| Resource | Why it's needed |
+| --- | --- |
+| `ServiceRequest` | The parent order (with `meta.profile = MedplumHealthGorillaOrder`) plus one child SR per test. |
+| `QuestionnaireResponse` | One per test that has Ask-On-Order-Entry questions answered. |
+| `Specimen` | Optional — only when `specimenCollectedDateTime` is supplied. |
+| `Coverage` | Optional — only when `billTo === 'insurance'`. |
+| `DiagnosticReport` | Created by the bot when results come back. |
+| `DocumentReference` | Wraps the requisition PDF and other HG-side documents. |
+
+All of these get the practitioner's organization stamped onto `meta.account` automatically — so
+`_compartment=%provider_organization` is the right scoping.
+
+### `Binary` — special-cased
+
+The `send-to-health-gorilla` bot calls `medplum.createAttachment(...)` after a successful
+transmission, which creates one or more `Binary` resources for the requisition document and
+specimen labels. Without a `Binary` rule, the bot fails with:
+
+```
+OperationOutcomeError: Forbidden
+  at Ht.createAttachment ...
+  at downloadHealthGorillaDocument ...
+```
+
+`Binary` resources have no FHIR search parameters, so any `criteria` you put on the rule is
+ignored — see [Binaries](/docs/access/access-policies#binaries). An unconstrained
+`{ "resourceType": "Binary" }` rule grants project-wide access; for tighter control, use
+[`securityContext`](/docs/access/binary-security-context).
+
+### `Bot` — scoped to the two HG identifiers
+
+`Bot/$execute` requires read access on the bot resource itself. The two HG bots both live under
+the well-known `https://www.medplum.com/integrations/bot-identifier` system. Listing both values
+in a single comma-separated `identifier=` filter scopes the rule precisely:
+
+```json
+{
+  "resourceType": "Bot",
+  "readonly": true,
+  "criteria": "Bot?identifier=https://www.medplum.com/integrations/bot-identifier|health-gorilla-labs/send-to-health-gorilla,https://www.medplum.com/integrations/bot-identifier|health-gorilla-labs/autocomplete"
+}
+```
+
+This permits invoking the HG bots without granting the practitioner access to any other Bot in the
+project. Add new identifiers to the comma-separated list as more HG bots are introduced.
+
+### `Organization` — three rules to cover three cases
+
+A practitioner needs to read three kinds of `Organization` resources:
+
+1. **Their own practice.** Organizations don't appear in their own
+   `meta.compartment`, so a plain `_compartment` filter won't match the practitioner's own
+   organization. Match by id instead:
+
+   ```json
+   { "resourceType": "Organization", "readonly": true, "criteria": "Organization?_id=%provider_organization.id" }
+   ```
+
+2. **Sub-orgs of their practice** — typically the per-practice lab contracts whose
+   `partOf` points at the practice. The criteria string must spell out the resource type
+   explicitly; substituting `%provider_organization` directly does **not** bind for reference
+   matching.
+
+   ```json
+   { "resourceType": "Organization", "readonly": true, "criteria": "Organization?partof=Organization/%provider_organization.id" }
+   ```
+
+3. **Imported organizations in the patient's compartment** — for example, a primary care
+   provider attached to an imported patient bundle. These get `meta.account =
+   Organization/<practice>` via the patient's account propagation, so a standard `_compartment`
+   filter applies:
+
+   ```json
+   { "resourceType": "Organization", "readonly": true, "criteria": "Organization?_compartment=%provider_organization" }
+   ```
+
+   Note this rule only fires once your import path actually propagates the practice into
+   `meta.accounts` on each imported resource (call `Patient/<id>/$set-accounts` with
+   `propagate: true`).
+
+### `CodeSystem` and `ValueSet` — terminology lookups
+
+`ValueSet/$expand` (used by ICD-10 diagnosis pickers, LOINC test pickers, etc.) needs read access
+on the `ValueSet` itself and on the `CodeSystem`s it composes from. Both are project-wide,
+non-PHI resources, so unscoped `readonly: true` rules are appropriate.
+
+## The Health Gorilla "tenant" Organization
+
+The send-order bot rejects orders whose `performingLabAccountNumber` extension doesn't match an
+account number HG has on file for the requesting practice. The practice (sometimes called the
+"tenant" by HG) is identified by an `Organization` resource that conforms to the
+`MedplumHealthGorillaTenant` profile:
+
+```
+https://medplum.com/profiles/integrations/health-gorilla/StructureDefinition/MedplumHealthGorillaTenant
+```
+
+The profile requires:
+
+- `name` (1..1)
+- `telecom` with at least one `system: phone` entry
+- `address` with `line`, `city`, `state`, `postalCode`
+
+If the practice Organization is missing any of these, HG rejects with:
+
+```
+Provided account number 87659430 is not on the list of account numbers assigned to this practice
+```
+
+even when the account number is correct. Conform the practice Organization to the profile, then
+re-submit.
+
+## Operational checklist
+
+Before flipping a practitioner from `admin: true` to `admin: false`:
+
+1. Attach the policy above (or a project-specific equivalent) via `ProjectMembership.access[]`,
+   parameterized to the practitioner's organization.
+2. Verify the practitioner can still read the two HG bots (try `searchTestCatalog` from the
+   front-end or `Bot/$execute?identifier=...` directly).
+3. Verify `ValueSet/$expand` succeeds for the diagnosis picker.
+4. Submit a test lab order end-to-end against the HG sandbox and confirm the requisition `Binary`
+   gets attached without a `Forbidden`.
+
+Skip step 1 and the bot's `403`s will be your first feedback signal, but the others won't surface
+until a clinician actually tries to place an order.

--- a/packages/docs/docs/integration/health-gorilla/sending-orders.md
+++ b/packages/docs/docs/integration/health-gorilla/sending-orders.md
@@ -6,6 +6,8 @@ sidebar_position: 1
 
 :::info[Prerequisites]
 For a vendor-neutral overview of diagnostic ordering concepts and the FHIR data model, see [Labs & Imaging](/docs/labs-imaging) and [Order Labs and Imaging](/docs/labs-imaging/ordering-labs-imaging).
+
+For the AccessPolicy rules a non-admin practitioner needs to send orders end-to-end (Bot read, Binary write, Organization scoping, terminology lookups, etc.), see [Access Policy for Practitioners](./access-policy).
 :::
 
 This guide explains how laboratory orders work in the Medplum-Health Gorilla labs integration.


### PR DESCRIPTION
## Summary

When migrating a Liza Health team practitioner from project admin to non-admin (so the access policy actually constrains them), every missing rule in the Health Gorilla send-order pipeline surfaced as a different opaque `Forbidden` from a different bot or operation. The information needed to assemble a working policy was scattered across the source — `runAsUser` on the bot, `Binary`'s special-cased matcher, `applyProjectAdminAccessPolicy` stripping `ProjectMembership` rules, the lack-of-self-compartment quirk on `Organization` — but not reflected in the docs.

This PR collects what we learned into:

1. **A new page** `docs/integration/health-gorilla/access-policy.md` with a complete worked policy and one-paragraph explanations of why each rule is there. Includes a section on the `MedplumHealthGorillaTenant` profile and the symptom you see when an org doesn't conform (the `account number not on the list of account numbers assigned to this practice` rejection).

2. **Four targeted "Gotchas"** added to `docs/access/access-policies.md`:
   - `Binary` rules silently ignore `criteria`.
   - `ProjectMembership` rules don't apply to non-admins.
   - Resource rules with neither `compartment` nor `criteria` skip filtering.
   - `%organization` vs `%organization.id` substitution and the `partof=Organization/%organization.id` quirk.
   - "A resource is not in its own compartment" — why `Organization?_compartment=%organization` doesn't match the user's own org.

3. **Cross-links** between `sending-orders.md` and the new access-policy page.

## Why draft

Posting as draft to invite a maintainer to validate the framing — particularly:
- That my read of `runAsUser: true` and the linked-project resolution for HG bots is what you'd want to communicate to integrators.
- That the `%organization.id` form (vs naive `%organization`) is the recommended pattern.
- That the gotchas are accurate (e.g., the `applyProjectAdminAccessPolicy` stripping behavior — that one came from reading server source, happy to drop or rephrase if I'm wrong about the precedent).

Happy to adjust tone, scope, or split into multiple PRs if you'd prefer.

## DCO

All commits signed off (`git commit -s`).