### PR TITLE
Fixes #9039 - Server option to require verified email address

### DIFF
--- a/packages/app/src/RegisterPage.tsx
+++ b/packages/app/src/RegisterPage.tsx
@@ -5,12 +5,13 @@ import { Document, Logo, RegisterForm, useMedplum } from '@medplum/react';
 import { IconAlertCircle } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import { getConfig, isRegisterEnabled } from './config';
 
 export function RegisterPage(): JSX.Element | null {
   const medplum = useMedplum();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const config = getConfig();
 
   useEffect(() => {
@@ -40,6 +41,7 @@ export function RegisterPage(): JSX.Element | null {
       }}
       googleClientId={config.googleClientId}
       recaptchaSiteKey={config.recaptchaSiteKey}
+      login={searchParams.get('login') || undefined}
     >
       <Logo size={32} />
       <Title order={3} py="lg">

--- a/packages/app/src/VerifyEmailPage.test.tsx
+++ b/packages/app/src/VerifyEmailPage.test.tsx
@@ -39,7 +39,7 @@ describe('VerifyEmailPage', () => {
       fireEvent.click(screen.getByRole('button'));
     });
 
-    expect(screen.getByTestId('success')).toBeInTheDocument();
+    expect(await screen.findByTestId('success')).toBeInTheDocument();
     expect(postSpy).toHaveBeenCalledWith('auth/verifyemail', { id, secret });
   });
 });

--- a/packages/app/src/VerifyEmailPage.tsx
+++ b/packages/app/src/VerifyEmailPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Button, Flex, Group, Stack, Title } from '@mantine/core';
-import { normalizeOperationOutcome } from '@medplum/core';
+import { Flex, Group, Stack, Title } from '@mantine/core';
+import { locationUtils, normalizeOperationOutcome } from '@medplum/core';
 import type { OperationOutcome } from '@medplum/fhirtypes';
 import {
   Document,
@@ -9,6 +9,7 @@ import {
   Logo,
   MedplumLink,
   OperationOutcomeAlert,
+  SubmitButton,
   getIssuesForExpression,
   useMedplum,
 } from '@medplum/react';
@@ -27,16 +28,19 @@ export function VerifyEmailPage(): JSX.Element {
     <Document width={450}>
       <OperationOutcomeAlert issues={issues} />
       <Form
-        onSubmit={() => {
+        onSubmit={async () => {
           setOutcome(undefined);
-          const body = {
-            id,
-            secret,
-          };
-          medplum
-            .post('auth/verifyemail', body)
-            .then(() => setSuccess(true))
-            .catch((err) => setOutcome(normalizeOperationOutcome(err)));
+          try {
+            const outcome = await medplum.post<OperationOutcome>('auth/verifyemail', { id, secret });
+            const uri = outcome.issue[0].details?.coding?.find((c) => c.system === 'urn:ietf:rfc:3986')?.code;
+            if (uri) {
+              locationUtils.assign(uri);
+            } else {
+              setSuccess(true);
+            }
+          } catch (err) {
+            setOutcome(normalizeOperationOutcome(err));
+          }
         }}
       >
         <Flex direction="column" align="center" justify="center">
@@ -49,8 +53,8 @@ export function VerifyEmailPage(): JSX.Element {
               In order to sign in, click the button below to verify your ability to receive email at the address this
               link was sent to.
             </p>
-            <Group justify="flex-end" mt="xl">
-              <Button type="submit">Verify email</Button>
+            <Group justify="center" mt="xl">
+              <SubmitButton>Verify email</SubmitButton>
             </Group>
           </Stack>
         )}

--- a/packages/app/src/VerifyEmailPage.tsx
+++ b/packages/app/src/VerifyEmailPage.tsx
@@ -31,8 +31,8 @@ export function VerifyEmailPage(): JSX.Element {
         onSubmit={async () => {
           setOutcome(undefined);
           try {
-            const outcome = await medplum.post<OperationOutcome | undefined>('auth/verifyemail', { id, secret });
-            const uri = outcome?.issue?.[0]?.details?.coding?.find((c) => c.system === 'urn:ietf:rfc:3986')?.code;
+            const result = await medplum.post<OperationOutcome | undefined>('auth/verifyemail', { id, secret });
+            const uri = result?.issue?.[0]?.details?.coding?.find((c) => c.system === 'urn:ietf:rfc:3986')?.code;
             if (uri) {
               locationUtils.assign(uri);
             } else {

--- a/packages/app/src/VerifyEmailPage.tsx
+++ b/packages/app/src/VerifyEmailPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Flex, Group, Stack, Title } from '@mantine/core';
-import { locationUtils, normalizeOperationOutcome } from '@medplum/core';
+import { getOutcomeRedirectUrl, locationUtils, normalizeOperationOutcome } from '@medplum/core';
 import type { OperationOutcome } from '@medplum/fhirtypes';
 import {
   Document,
@@ -32,7 +32,7 @@ export function VerifyEmailPage(): JSX.Element {
           setOutcome(undefined);
           try {
             const result = await medplum.post<OperationOutcome | undefined>('auth/verifyemail', { id, secret });
-            const uri = result?.issue?.[0]?.details?.coding?.find((c) => c.system === 'urn:ietf:rfc:3986')?.code;
+            const uri = getOutcomeRedirectUrl(result);
             if (uri) {
               locationUtils.assign(uri);
             } else {

--- a/packages/app/src/VerifyEmailPage.tsx
+++ b/packages/app/src/VerifyEmailPage.tsx
@@ -31,8 +31,8 @@ export function VerifyEmailPage(): JSX.Element {
         onSubmit={async () => {
           setOutcome(undefined);
           try {
-            const outcome = await medplum.post<OperationOutcome>('auth/verifyemail', { id, secret });
-            const uri = outcome.issue[0].details?.coding?.find((c) => c.system === 'urn:ietf:rfc:3986')?.code;
+            const outcome = await medplum.post<OperationOutcome | undefined>('auth/verifyemail', { id, secret });
+            const uri = outcome?.issue?.[0]?.details?.coding?.find((c) => c.system === 'urn:ietf:rfc:3986')?.code;
             if (uri) {
               locationUtils.assign(uri);
             } else {

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -223,10 +223,6 @@ describe('Client', () => {
     mockEnvironment.getBuffer.mockReturnValue(undefined);
   });
 
-  afterAll(() => {
-    Object.defineProperty(globalThis.window, 'sessionStorage', { value: undefined });
-  });
-
   test('Constructor', () => {
     expect(
       () =>
@@ -465,7 +461,6 @@ describe('Client', () => {
   test('Clear', () => {
     const client = new MedplumClient({ fetch: mockFetch(200, {}) });
     expect(() => client.clear()).not.toThrow();
-    expect(sessionStorage.length).toStrictEqual(0);
   });
 
   test('SignOut', async () => {
@@ -735,7 +730,7 @@ describe('Client', () => {
       );
       expect(result).toMatch(/https:\/\/auth\.example\.com\/authorize\?.+scope=/);
 
-      const codeVerifier = sessionStorage.getItem('codeVerifier');
+      const codeVerifier = localStorage.getItem('codeVerifier');
       expect(codeVerifier).toHaveLength(128);
 
       const { searchParams } = new URL(result);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3981,8 +3981,6 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     const codeVerifier = getRandomString().slice(0, 128);
     this.storage.setString('codeVerifier', codeVerifier);
 
-    console.log('CODY startPkce', { pkceState, codeVerifier });
-
     try {
       const arrayHash = await encryptSHA256(codeVerifier);
       const codeChallenge = arrayBufferToBase64(arrayHash)

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -517,7 +517,6 @@ export interface NewUserRequest {
   readonly remember?: boolean;
   readonly projectId?: string;
   readonly clientId?: string;
-  readonly redirectUri?: string;
 }
 
 export interface NewProjectRequest {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -543,6 +543,7 @@ export interface GoogleLoginRequest extends BaseLoginRequest {
 
 export interface LoginAuthenticationResponse {
   readonly login: string;
+  readonly emailVerificationRequired?: boolean;
   readonly mfaEnrollRequired?: boolean;
   readonly mfaRequired?: boolean;
   readonly enrollQrCode?: string;

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -512,11 +512,12 @@ export interface NewUserRequest {
   readonly lastName: string;
   readonly email: string;
   readonly password: string;
-  readonly recaptchaToken: string;
+  readonly recaptchaToken?: string;
   readonly recaptchaSiteKey?: string;
   readonly remember?: boolean;
   readonly projectId?: string;
   readonly clientId?: string;
+  readonly redirectUri?: string;
 }
 
 export interface NewProjectRequest {
@@ -1204,9 +1205,6 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    */
   clear(): void {
     this.storage.clear();
-    if (isBrowserEnvironment()) {
-      sessionStorage.clear();
-    }
     this.clearActiveLogin();
   }
 
@@ -3977,10 +3975,12 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    */
   async startPkce(): Promise<{ codeChallengeMethod: CodeChallengeMethod; codeChallenge: string }> {
     const pkceState = getRandomString();
-    sessionStorage.setItem('pkceState', pkceState);
+    this.storage.setString('pkceState', pkceState);
 
     const codeVerifier = getRandomString().slice(0, 128);
-    sessionStorage.setItem('codeVerifier', codeVerifier);
+    this.storage.setString('codeVerifier', codeVerifier);
+
+    console.log('CODY startPkce', { pkceState, codeVerifier });
 
     try {
       const arrayHash = await encryptSHA256(codeVerifier);
@@ -4005,7 +4005,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     const loginRequest = await this.ensureCodeChallenge(loginParams ?? {});
     const url = new URL(this.authorizeUrl);
     url.searchParams.set('response_type', 'code');
-    url.searchParams.set('state', sessionStorage.getItem('pkceState') as string);
+    url.searchParams.set('state', this.storage.getString('pkceState') as string);
     url.searchParams.set('client_id', loginRequest.clientId ?? (this.clientId as string));
     url.searchParams.set('redirect_uri', loginRequest.redirectUri ?? locationUtils.getOrigin());
     url.searchParams.set('code_challenge_method', loginRequest.codeChallengeMethod as string);
@@ -4030,11 +4030,9 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       redirect_uri: loginParams?.redirectUri ?? locationUtils.getOrigin(),
     };
 
-    if (typeof sessionStorage !== 'undefined') {
-      const codeVerifier = sessionStorage.getItem('codeVerifier');
-      if (codeVerifier) {
-        tokenParams.code_verifier = codeVerifier;
-      }
+    const codeVerifier = this.storage.getString('codeVerifier');
+    if (codeVerifier) {
+      tokenParams.code_verifier = codeVerifier;
     }
 
     return this.fetchTokens(tokenParams);

--- a/packages/core/src/outcomes.test.ts
+++ b/packages/core/src/outcomes.test.ts
@@ -10,6 +10,7 @@ import {
   conflict,
   created,
   forbidden,
+  getOutcomeRedirectUrl,
   getStatus,
   gone,
   isAccepted,
@@ -19,6 +20,7 @@ import {
   isNotFound,
   isOk,
   isOperationOutcome,
+  isRedirect,
   multipleMatches,
   normalizeErrorString,
   notFound,
@@ -26,6 +28,7 @@ import {
   operationOutcomeToString,
   preconditionFailed,
   redirect,
+  redirectOk,
   serverError,
   serverTimeout,
   tooManyRequests,
@@ -97,6 +100,7 @@ describe('Outcomes', () => {
     [created, 201],
     [accepted('https://example.com'), 202],
     [redirect(new URL('http://example.com')), 302],
+    [redirectOk(new URL('http://example.com')), 200],
     [notModified, 304],
     [badRequest('bad'), 400],
     [unauthorized, 401],
@@ -186,5 +190,17 @@ describe('Outcomes', () => {
         ],
       })
     ).toStrictEqual('Supplied Patient is unknown.');
+  });
+
+  test('Redirect', () => {
+    const r1 = redirect(new URL('http://example.com/'));
+    expect(isOk(r1)).toBe(false);
+    expect(isRedirect(r1)).toBe(true);
+    expect(getOutcomeRedirectUrl(r1)).toBe('http://example.com/');
+
+    const r2 = redirectOk(new URL('http://example.com/'));
+    expect(isOk(r2)).toBe(true);
+    expect(isRedirect(r2)).toBe(false);
+    expect(getOutcomeRedirectUrl(r2)).toBe('http://example.com/');
   });
 });

--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -325,6 +325,14 @@ export function redirect(url: URL): OperationOutcome {
   };
 }
 
+export function redirectOk(url: URL): OperationOutcome {
+  return { ...redirect(url), id: OK_ID };
+}
+
+export function getOutcomeRedirectUrl(outcome: OperationOutcome | undefined): string | undefined {
+  return outcome?.issue?.[0]?.details?.coding?.find((c) => c.system === 'urn:ietf:rfc:3986')?.code;
+}
+
 export function businessRule(key: string, message: string): OperationOutcome {
   return {
     resourceType: 'OperationOutcome',

--- a/packages/react/src/auth/RegisterForm.tsx
+++ b/packages/react/src/auth/RegisterForm.tsx
@@ -14,6 +14,7 @@ import { NewUserForm } from './NewUserForm';
 
 export interface RegisterFormProps {
   readonly type: 'patient' | 'project';
+  readonly login?: string;
   readonly projectId?: string;
   readonly clientId?: string;
   readonly googleClientId?: string;
@@ -25,8 +26,9 @@ export interface RegisterFormProps {
 export function RegisterForm(props: RegisterFormProps): JSX.Element {
   const { type, projectId, clientId, googleClientId, recaptchaSiteKey, onSuccess } = props;
   const medplum = useMedplum();
-  const [login, setLogin] = useState<string>();
+  const [login, setLogin] = useState<string | undefined>(props.login);
   const [outcome, setOutcome] = useState<OperationOutcome>();
+  const [emailVerificationRequired, setEmailVerificationRequired] = useState<boolean>(false);
 
   useEffect(() => {
     if (type === 'patient' && login) {
@@ -44,8 +46,12 @@ export function RegisterForm(props: RegisterFormProps): JSX.Element {
         .processCode(response.code)
         .then(() => onSuccess())
         .catch((err) => setOutcome(normalizeOperationOutcome(err)));
-    } else if (response.login) {
+    }
+    if (response.login) {
       setLogin(response.login);
+    }
+    if (response.emailVerificationRequired) {
+      setEmailVerificationRequired(true);
     }
   }
 
@@ -65,7 +71,10 @@ export function RegisterForm(props: RegisterFormProps): JSX.Element {
           {props.children}
         </NewUserForm>
       )}
-      {login && type === 'project' && <NewProjectForm login={login} handleAuthResponse={handleAuthResponse} />}
+      {emailVerificationRequired && <div>Please verify your email address to continue.</div>}
+      {login && !emailVerificationRequired && type === 'project' && (
+        <NewProjectForm login={login} handleAuthResponse={handleAuthResponse} />
+      )}
     </Document>
   );
 }

--- a/packages/react/src/auth/RegisterForm.tsx
+++ b/packages/react/src/auth/RegisterForm.tsx
@@ -71,7 +71,9 @@ export function RegisterForm(props: RegisterFormProps): JSX.Element {
           {props.children}
         </NewUserForm>
       )}
-      {emailVerificationRequired && <div>Please verify your email address to continue.</div>}
+      {emailVerificationRequired && (
+        <div>Please check your email for a verification link. Click the link to continue setting up your account.</div>
+      )}
       {login && !emailVerificationRequired && type === 'project' && (
         <NewProjectForm login={login} handleAuthResponse={handleAuthResponse} />
       )}

--- a/packages/server/src/auth/newproject.test.ts
+++ b/packages/server/src/auth/newproject.test.ts
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { badRequest, Operator } from '@medplum/core';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import { pwnedPassword } from 'hibp';
 import fetch from 'node-fetch';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
-import { loadTestConfig } from '../config/loader';
+import { getConfig, loadTestConfig } from '../config/loader';
+import { getGlobalSystemRepo } from '../fhir/repo';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 
 jest.mock('hibp');
@@ -25,6 +27,7 @@ describe('New project', () => {
   });
 
   beforeEach(async () => {
+    getConfig().requireVerifiedEmailForProjectCreation = undefined;
     (fetch as unknown as jest.Mock).mockClear();
     (pwnedPassword as unknown as jest.Mock).mockClear();
     setupPwnedPasswordMock(pwnedPassword as unknown as jest.Mock, 0);
@@ -292,5 +295,58 @@ describe('New project', () => {
     expect(res5.body.data).toBeDefined();
     expect(res5.body.data.PatientList).toBeDefined();
     expect(res5.body.data.PatientList.length).toStrictEqual(0);
+  });
+
+  test('Require verified email - rejected', async () => {
+    getConfig().requireVerifiedEmailForProjectCreation = true;
+
+    const res1 = await request(app)
+      .post('/auth/newuser')
+      .type('json')
+      .send({
+        firstName: 'Alexander',
+        lastName: 'Hamilton',
+        email: `alex${randomUUID()}@example.com`,
+        password: 'password!@#',
+        recaptchaToken: 'xyz',
+        codeChallenge: 'xyz',
+        codeChallengeMethod: 'plain',
+      });
+    expect(res1.status).toBe(200);
+
+    const res2 = await request(app).post('/auth/newproject').type('json').send({
+      login: res1.body.login,
+      projectName: 'Hamilton Project',
+    });
+    expect(res2.status).toBe(400);
+    expect(res2.body).toMatchObject(badRequest('Email verification is required to create a project'));
+  });
+
+  test('Require verified email - allowed', async () => {
+    getConfig().requireVerifiedEmailForProjectCreation = true;
+
+    const email = `alex${randomUUID()}@example.com`;
+    const res1 = await request(app).post('/auth/newuser').type('json').send({
+      firstName: 'Alexander',
+      lastName: 'Hamilton',
+      email,
+      password: 'password!@#',
+      recaptchaToken: 'xyz',
+      codeChallenge: 'xyz',
+      codeChallengeMethod: 'plain',
+    });
+    expect(res1.status).toBe(200);
+
+    const systemRepo = getGlobalSystemRepo();
+    await systemRepo.conditionalPatch(
+      { resourceType: 'User', filters: [{ code: 'email', operator: Operator.EXACT, value: email }] },
+      [{ op: 'add', path: '/emailVerified', value: true }]
+    );
+
+    const res2 = await request(app).post('/auth/newproject').type('json').send({
+      login: res1.body.login,
+      projectName: 'Hamilton Project',
+    });
+    expect(res2.status).toBe(200);
   });
 });

--- a/packages/server/src/auth/newproject.ts
+++ b/packages/server/src/auth/newproject.ts
@@ -4,6 +4,7 @@ import { badRequest } from '@medplum/core';
 import type { Login, Reference, User } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import { body } from 'express-validator';
+import { getConfig } from '../config/loader';
 import { createProject } from '../fhir/operations/projectinit';
 import { sendOutcome } from '../fhir/outcomes';
 import { getGlobalSystemRepo } from '../fhir/repo';
@@ -37,8 +38,14 @@ export async function newProjectHandler(req: Request, res: Response): Promise<vo
     return;
   }
 
-  const projectName = req.body.projectName;
   const user = await systemRepo.readReference<User>(login.user as Reference<User>);
+
+  if (getConfig().requireVerifiedEmailForProjectCreation && !user.emailVerified) {
+    sendOutcome(res, badRequest('Email verification is required to create a project'));
+    return;
+  }
+
+  const projectName = req.body.projectName;
   const { membership } = await createProject(projectName, user);
   const updatedLogin = await setLoginMembership(login, membership);
   await sendLoginResult(res, updatedLogin);

--- a/packages/server/src/auth/newuser.test.ts
+++ b/packages/server/src/auth/newuser.test.ts
@@ -28,6 +28,7 @@ describe('New user', () => {
 
   beforeEach(() => {
     getConfig().registerEnabled = undefined;
+    getConfig().requireVerifiedEmailForProjectCreation = undefined;
   });
 
   afterAll(async () => {
@@ -58,6 +59,7 @@ describe('New user', () => {
     expect(res.status).toBe(200);
     expect(res.body.login).toBeDefined();
     expect(res.body.code).toBeUndefined();
+    expect(res.body.emailVerificationRequired).toStrictEqual(false);
   });
 
   test('Register disabled', async () => {
@@ -625,5 +627,25 @@ describe('New user', () => {
     expect(res.status).toBe(200);
     expect(res.body.login).toBeDefined();
     expect(res.body.code).toBeUndefined();
+  });
+
+  test('Require email verification for new project', async () => {
+    getConfig().requireVerifiedEmailForProjectCreation = true;
+    const res = await request(app)
+      .post('/auth/newuser')
+      .type('json')
+      .send({
+        firstName: 'Alexander',
+        lastName: 'Hamilton',
+        email: `alex${randomUUID()}@example.com`,
+        password: 'password!@#',
+        recaptchaToken: 'xyz',
+        projectId: 'new',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.login).toBeDefined();
+    expect(res.body.code).toBeUndefined();
+    expect(res.body.emailVerificationRequired).toBe(true);
   });
 });

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -91,12 +91,12 @@ export async function newUserHandler(req: Request, res: Response): Promise<void>
       allowNoMembership: true,
     });
 
+    let emailVerificationRequired = false;
     if (config.requireVerifiedEmailForProjectCreation && projectId === 'new') {
       await sendVerificationEmail(user, login);
-      res.status(200).json({ login: login.id, emailVerificationRequired: true });
-    } else {
-      res.status(200).json({ login: login.id });
+      emailVerificationRequired = true;
     }
+    res.status(200).json({ login: login.id, emailVerificationRequired });
   } catch (err) {
     sendOutcome(res, normalizeOperationOutcome(err));
   }
@@ -129,10 +129,6 @@ export async function createUser(request: NewUserRequest): Promise<WithId<User>>
 }
 
 async function sendVerificationEmail(user: WithId<User>, login: WithId<Login>): Promise<void> {
-  if (!getConfig().requireVerifiedEmailForProjectCreation) {
-    return;
-  }
-
   const redirectUri = concatUrls(getConfig().appBaseUrl, `register?login=${login.id}`);
   const { id, secret } = await verifyEmail(user, redirectUri);
   const url = concatUrls(getConfig().appBaseUrl, `verifyemail/${id}/${secret}`);

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -1,19 +1,21 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { NewUserRequest, WithId } from '@medplum/core';
-import { badRequest, normalizeOperationOutcome } from '@medplum/core';
-import type { ClientApplication, User } from '@medplum/fhirtypes';
+import { badRequest, concatUrls, normalizeOperationOutcome } from '@medplum/core';
+import type { ClientApplication, Login, User } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import { body } from 'express-validator';
 import { pwnedPassword } from 'hibp';
 import { randomUUID } from 'node:crypto';
 import { getConfig } from '../config/loader';
+import { sendEmail } from '../email/email';
 import { sendOutcome } from '../fhir/outcomes';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
 import { getUserByEmailInProject, getUserByEmailWithoutProject, tryLogin } from '../oauth/utils';
 import { makeValidationMiddleware } from '../util/validator';
-import { bcryptHashPassword } from './utils';
+import { bcryptHashPassword, sendLoginResult } from './utils';
+import { verifyEmail } from './verifyemail';
 
 export const newUserValidator = makeValidationMiddleware([
   body('firstName').isLength({ min: 1, max: 128 }).withMessage('First name must be between 1 and 128 characters'),
@@ -71,7 +73,7 @@ export async function newUserHandler(req: Request, res: Response): Promise<void>
   }
 
   try {
-    await createUser({ ...req.body, email } as NewUserRequest);
+    const user = await createUser({ ...req.body, email } as NewUserRequest);
 
     const login = await tryLogin({
       authMethod: 'password',
@@ -88,13 +90,15 @@ export async function newUserHandler(req: Request, res: Response): Promise<void>
       userAgent: req.get('User-Agent'),
       allowNoMembership: true,
     });
-    res.status(200).json({ login: login.id });
+
+    await sendVerificationEmail(user, login);
+    await sendLoginResult(res, login);
   } catch (err) {
     sendOutcome(res, normalizeOperationOutcome(err));
   }
 }
 
-export async function createUser(request: Omit<NewUserRequest, 'recaptchaToken'>): Promise<WithId<User>> {
+export async function createUser(request: NewUserRequest): Promise<WithId<User>> {
   const { firstName, lastName, email, password, projectId } = request;
 
   const numPwns = await pwnedPassword(password);
@@ -115,6 +119,35 @@ export async function createUser(request: Omit<NewUserRequest, 'recaptchaToken'>
     passwordHash,
     project: projectId && projectId !== 'new' ? { reference: `Project/${projectId}` } : undefined,
   });
+
   globalLogger.info('User created', { id: result.id, email });
   return result;
+}
+
+async function sendVerificationEmail(user: WithId<User>, login: WithId<Login>): Promise<void> {
+  if (!getConfig().requireVerifiedEmail) {
+    return;
+  }
+
+  const redirectUri = concatUrls(getConfig().appBaseUrl, `register?login=${login.id}`);
+  const { id, secret } = await verifyEmail(user, redirectUri);
+  const url = concatUrls(getConfig().appBaseUrl, `verifyemail/${id}/${secret}`);
+  const systemRepo = getGlobalSystemRepo();
+  await sendEmail(systemRepo, {
+    to: user.email,
+    subject: 'Medplum Email Verification',
+    text: [
+      'We received a request to create a Medplum account using this email address.',
+      '',
+      'Please click the following link to verify your email address:',
+      '',
+      url,
+      '',
+      'If you received this in error, you can safely ignore it.',
+      '',
+      'Thank you,',
+      'Medplum',
+      '',
+    ].join('\n'),
+  });
 }

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -14,7 +14,7 @@ import { getGlobalSystemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
 import { getUserByEmailInProject, getUserByEmailWithoutProject, tryLogin } from '../oauth/utils';
 import { makeValidationMiddleware } from '../util/validator';
-import { bcryptHashPassword, sendLoginResult } from './utils';
+import { bcryptHashPassword } from './utils';
 import { verifyEmail } from './verifyemail';
 
 export const newUserValidator = makeValidationMiddleware([
@@ -91,8 +91,12 @@ export async function newUserHandler(req: Request, res: Response): Promise<void>
       allowNoMembership: true,
     });
 
-    await sendVerificationEmail(user, login);
-    await sendLoginResult(res, login);
+    if (config.requireVerifiedEmailForProjectCreation && projectId === 'new') {
+      await sendVerificationEmail(user, login);
+      res.status(200).json({ login: login.id, emailVerificationRequired: true });
+    } else {
+      res.status(200).json({ login: login.id });
+    }
   } catch (err) {
     sendOutcome(res, normalizeOperationOutcome(err));
   }
@@ -125,7 +129,7 @@ export async function createUser(request: NewUserRequest): Promise<WithId<User>>
 }
 
 async function sendVerificationEmail(user: WithId<User>, login: WithId<Login>): Promise<void> {
-  if (!getConfig().requireVerifiedEmail) {
+  if (!getConfig().requireVerifiedEmailForProjectCreation) {
     return;
   }
 

--- a/packages/server/src/auth/register.ts
+++ b/packages/server/src/auth/register.ts
@@ -38,6 +38,7 @@ export interface RegisterResponse {
 
 /**
  * Registers a new user and/or new project.
+ * This method is now only used in tests! Do not use this method in production code!
  * @param request - The register request.
  * @returns The registration response.
  */

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -86,14 +86,8 @@ export async function createProjectMembership(
  * @param login - The login details.
  */
 export async function sendLoginResult(res: Response, login: Login): Promise<void> {
-  const config = getConfig();
   const systemRepo = getGlobalSystemRepo();
   const user = await systemRepo.readReference<User>(login.user as Reference<User>);
-
-  if (config.requireVerifiedEmail && !user.emailVerified) {
-    res.status(200).json({ login: login.id, emailVerificationRequired: true });
-    return;
-  }
 
   if (user.mfaRequired && !user.mfaEnrolled && login.authMethod === 'password' && !login.mfaVerified) {
     const accountName = `Medplum - ${user.email}`;

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -86,8 +86,14 @@ export async function createProjectMembership(
  * @param login - The login details.
  */
 export async function sendLoginResult(res: Response, login: Login): Promise<void> {
+  const config = getConfig();
   const systemRepo = getGlobalSystemRepo();
   const user = await systemRepo.readReference<User>(login.user as Reference<User>);
+
+  if (config.requireVerifiedEmail && !user.emailVerified) {
+    res.status(200).json({ login: login.id, emailVerificationRequired: true });
+    return;
+  }
 
   if (user.mfaRequired && !user.mfaEnrolled && login.authMethod === 'password' && !login.mfaVerified) {
     const accountName = `Medplum - ${user.email}`;

--- a/packages/server/src/auth/verifyemail.ts
+++ b/packages/server/src/auth/verifyemail.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { allOk, badRequest, createReference, redirect, resolveId } from '@medplum/core';
+import { allOk, badRequest, createReference, redirectOk, resolveId } from '@medplum/core';
 import type { User, UserSecurityRequest } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import { body } from 'express-validator';
@@ -44,7 +44,7 @@ export async function verifyEmailHandler(req: Request, res: Response): Promise<v
 
   if (securityRequest.redirectUri) {
     // Send a "redirect", but don't actually follow it, because the client may want to handle the redirect themselves (e.g. in a React app).
-    sendOutcome(res, { ...redirect(new URL(securityRequest.redirectUri)), id: 'ok' });
+    sendOutcome(res, redirectOk(new URL(securityRequest.redirectUri)));
   } else {
     sendOutcome(res, allOk);
   }

--- a/packages/server/src/auth/verifyemail.ts
+++ b/packages/server/src/auth/verifyemail.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { allOk, badRequest, createReference, resolveId } from '@medplum/core';
+import { allOk, badRequest, createReference, redirect, resolveId } from '@medplum/core';
 import type { User, UserSecurityRequest } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import { body } from 'express-validator';
@@ -42,18 +42,23 @@ export async function verifyEmailHandler(req: Request, res: Response): Promise<v
     await systemRepo.updateResource<UserSecurityRequest>({ ...securityRequest, used: true });
   });
 
-  sendOutcome(res, allOk);
+  if (securityRequest.redirectUri) {
+    // Send a "redirect", but don't actually follow it, because the client may want to handle the redirect themselves (e.g. in a React app).
+    sendOutcome(res, { ...redirect(new URL(securityRequest.redirectUri)), id: 'ok' });
+  } else {
+    sendOutcome(res, allOk);
+  }
 }
 
 /**
- * Creates a "verify email" for the user.
- * Returns the URL to the email verification request.
+ * Creates a "verify email" request for the user.
+ * Returns the created UserSecurityRequest, which contains the secret that should be sent in the verification email.
  * @param user - The user to create the request for.
  * @param redirectUri - Optional URI for redirection to the client application.
- * @returns The URL to reset the password.
+ * @returns The created UserSecurityRequest.
  */
 export async function verifyEmail(user: User, redirectUri?: string): Promise<WithId<UserSecurityRequest>> {
-  // Create the password change request
+  // Create the email verification request
   const systemRepo = getGlobalSystemRepo();
   return systemRepo.createResource<UserSecurityRequest>({
     resourceType: 'UserSecurityRequest',

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -190,12 +190,9 @@ export interface MedplumServerConfig {
   aiRealtimeTranscriptionUrl?: string;
 
   /**
-   * Optional flag to require email verification before allowing users to log in or register.
-   * Default is `false` to avoid accidentally locking users out of their accounts, but setting this to `true` is recommended for production deployments.
-   * If enabled, users must verify their email address before they can log in or register. This is done by sending a verification email with a link that the user must click to verify their email address.
-   * The link contains a secret that is validated by the server when the user clicks the link. If the secret is valid, the user's email is marked as verified and they can log in or register successfully.
+   * Optional flag to require email verification before allowing users to create projects.
    */
-  requireVerifiedEmail?: boolean;
+  requireVerifiedEmailForProjectCreation?: boolean;
 }
 
 export interface SubscriptionAutoDisableTrigger {

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -188,6 +188,14 @@ export interface MedplumServerConfig {
    * Default is `wss://api.openai.com/v1/realtime?intent=transcription`.
    */
   aiRealtimeTranscriptionUrl?: string;
+
+  /**
+   * Optional flag to require email verification before allowing users to log in or register.
+   * Default is `false` to avoid accidentally locking users out of their accounts, but setting this to `true` is recommended for production deployments.
+   * If enabled, users must verify their email address before they can log in or register. This is done by sending a verification email with a link that the user must click to verify their email address.
+   * The link contains a secret that is validated by the server when the user clicks the link. If the secret is valid, the user's email is marked as verified and they can log in or register successfully.
+   */
+  requireVerifiedEmail?: boolean;
 }
 
 export interface SubscriptionAutoDisableTrigger {

--- a/packages/server/src/fhir/operations/update-user-email.ts
+++ b/packages/server/src/fhir/operations/update-user-email.ts
@@ -112,7 +112,7 @@ async function updateUser(userId: string, params: InputParams, project: WithId<P
         to: params.email,
         subject: 'Medplum Email Address Updated',
         text: [
-          'A request to update the email address associated with your Medplum account.',
+          'We received a request to update the email address associated with your Medplum account.',
           '',
           'Please click on the following link to verify your ability to receive emails:',
           '',

--- a/packages/server/src/fhir/outcomes.ts
+++ b/packages/server/src/fhir/outcomes.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { append, ContentType, EMPTY, getStatus, isAccepted, isRedirect } from '@medplum/core';
+import { append, ContentType, EMPTY, getOutcomeRedirectUrl, getStatus, isAccepted, isRedirect } from '@medplum/core';
 import type { Extension, OperationOutcome } from '@medplum/fhirtypes';
 import type { Response } from 'express';
 import type { Result, ValidationError } from 'express-validator';
@@ -41,7 +41,7 @@ export function sendOutcome(res: Response, outcome: OperationOutcome): Response 
     res.set('Content-Location', outcome.issue[0].diagnostics);
   }
   if (isRedirect(outcome)) {
-    const uri = outcome.issue[0].details?.coding?.find((c) => c.system === 'urn:ietf:rfc:3986')?.code;
+    const uri = getOutcomeRedirectUrl(outcome);
     if (uri) {
       res.set('Location', uri);
     }

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -482,6 +482,7 @@ export async function setLoginMembership(
   // Everything checks out, update the login
   const updatedLogin: Login = {
     ...login,
+    project: createReference(project),
     membership: createReference(membership),
   };
 


### PR DESCRIPTION
Adds an optional server configuration setting (`requireVerifiedEmailForProjectCreation`) that requires users to verify their email address before creating a new project via the self-registration flow.

**This setting does NOT affect:**
- New users created through the Invite flow
- Logins for existing users

### How it works

**Registration flow with verification enabled:**

1. User submits the registration form → `POST /auth/newuser` with `projectId: 'new'`
2. Server creates the user + login, sends a verification email, and returns `{ login, emailVerificationRequired: true }` (instead of proceeding to project creation)
3. UI shows an instructional message: *"Please check your email for a verification link…"*
4. User clicks the link in the email → `/verifyemail/<id>/<secret>`
5. User clicks "Verify email" → `POST /auth/verifyemail` marks `user.emailVerified = true` and returns a redirect URI
6. UI follows the redirect back to `/register?login=<loginId>`
7. User enters a project name and completes registration via `POST /auth/newproject`

### Configuration

Set in `medplum.config.json`:

```json
{
  "requireVerifiedEmailForProjectCreation": true
}
```

Default is `false` (opt-in, no change in behavior for existing deployments).

### Technical notes

- `UserSecurityRequest` (type `verify-email`) is reused from the existing `$update-email` operation — no new FHIR resource type needed
- PKCE state (`pkceState`, `codeVerifier`) was migrated from `sessionStorage` to `MedplumClient.storage` (localStorage by default). This allows the PKCE flow to survive the cross-tab redirect introduced by email verification. **This is a behavioral change for all PKCE flows** — the verifier now persists across sessions rather than being cleared on tab close
- Verification links do not expire (consistent with existing password-reset behavior)
- The `/auth/verifyemail` handler returns an `OperationOutcome` with HTTP 200 (rather than a true 302 redirect) so the React SPA can extract the URI and navigate without a full-page reload
- `oauth/utils.ts`: `setLoginMembership` now correctly sets `login.project` alongside `login.membership` (bug fix bundled in this PR)

Fixes #9039