### PR TITLE
Add $cancel Scheduling operation

### DIFF
--- a/packages/docs/docs/scheduling/appointment-cancel.md
+++ b/packages/docs/docs/scheduling/appointment-cancel.md
@@ -17,7 +17,7 @@ The `$cancel` operation cancels an [`Appointment`](/docs/api/fhir/resources/appo
 ## Invoke the `$cancel` operation
 
 ```
-[base]/R4/Appointment/$cancel
+[base]/R4/Appointment/:id/$cancel
 ```
 
 import Tabs from '@theme/Tabs';
@@ -28,45 +28,21 @@ import TabItem from '@theme/TabItem';
 
 ```typescript
 import { MedplumClient } from '@medplum/core';
-import type { Appointment, Bundle, Parameters } from '@medplum/fhirtypes';
+import type { Appointment } from '@medplum/fhirtypes';
 
 const medplum = new MedplumClient();
 
-const result = await medplum.post(
-  medplum.fhirUrl('Appointment', '$cancel'),
-  {
-    resourceType: 'Parameters',
-    parameter: [
-      {
-        name: 'appointment-reference',
-        valueReference: { reference: 'Appointment/my-appointment-id' },
-      },
-    ],
-  }
-) as Parameters;
-
-const bundle = result.parameter?.[0]?.resource as Bundle;
-const appointment = bundle.entry
-  ?.find((e) => e.resource?.resourceType === 'Appointment')
-  ?.resource as Appointment;
+const appointment = await medplum.post<Appointment>(
+  medplum.fhirUrl('Appointment', 'my-appointment-id', '$cancel')
+);
 ```
 
 </TabItem>
 <TabItem value="curl" label="cURL">
 
 ```bash
-curl -X POST 'https://api.medplum.com/fhir/R4/Appointment/$cancel' \
-  -H "Content-Type: application/fhir+json" \
-  -H "Authorization: Bearer MY_ACCESS_TOKEN" \
-  -d '{
-    "resourceType": "Parameters",
-    "parameter": [
-      {
-        "name": "appointment-reference",
-        "valueReference": { "reference": "Appointment/my-appointment-id" }
-      }
-    ]
-  }'
+curl -X POST 'https://api.medplum.com/fhir/R4/Appointment/my-appointment-id/$cancel' \
+  -H "Authorization: Bearer MY_ACCESS_TOKEN"
 ```
 
 </TabItem>
@@ -74,9 +50,7 @@ curl -X POST 'https://api.medplum.com/fhir/R4/Appointment/$cancel' \
 
 ## Parameters
 
-| Name                     | Type        | Description                                                                                    | Required |
-| ------------------------ | ----------- | ---------------------------------------------------------------------------------------------- | -------- |
-| `appointment-reference`  | `Reference` | Reference to the [`Appointment`](/docs/api/fhir/resources/appointment) to cancel               | Yes      |
+This operation takes no input parameters. The appointment to cancel is identified by the `id` in the URL.
 
 ### Constraints
 
@@ -85,7 +59,7 @@ curl -X POST 'https://api.medplum.com/fhir/R4/Appointment/$cancel' \
 
 ## Output
 
-Returns `200 OK` with a [`Parameters`](/docs/api/fhir/resources/parameters) resource wrapping a `Bundle` containing the updated Appointment:
+Returns `200 OK` with the updated [`Appointment`](/docs/api/fhir/resources/appointment) resource directly:
 
 - One [`Appointment`](/docs/api/fhir/resources/appointment) with `status: cancelled`
 
@@ -95,30 +69,14 @@ All `Slot` resources that were referenced by the Appointment are deleted and do 
 
 ```json
 {
-  "resourceType": "Parameters",
-  "parameter": [
-    {
-      "name": "return",
-      "resource": {
-        "resourceType": "Bundle",
-        "type": "transaction-response",
-        "entry": [
-          {
-            "resource": {
-              "resourceType": "Appointment",
-              "id": "my-appointment-id",
-              "status": "cancelled",
-              "start": "2026-03-10T09:00:00.000Z",
-              "end": "2026-03-10T10:00:00.000Z",
-              "participant": [
-                { "actor": { "reference": "Practitioner/dr-smith" }, "status": "tentative" },
-                { "actor": { "reference": "Patient/my-patient-id" }, "status": "accepted" }
-              ]
-            }
-          }
-        ]
-      }
-    }
+  "resourceType": "Appointment",
+  "id": "my-appointment-id",
+  "status": "cancelled",
+  "start": "2026-03-10T09:00:00.000Z",
+  "end": "2026-03-10T10:00:00.000Z",
+  "participant": [
+    { "actor": { "reference": "Practitioner/dr-smith" }, "status": "tentative" },
+    { "actor": { "reference": "Patient/my-patient-id" }, "status": "accepted" }
   ]
 }
 ```
@@ -127,12 +85,12 @@ All `Slot` resources that were referenced by the Appointment are deleted and do 
 
 `$cancel` performs the following steps inside a serializable transaction:
 
-1. Reads the referenced Appointment
+1. Reads the Appointment identified by the URL `id`
 2. Loads all `Slot` resources listed in `Appointment.slot`
 3. Validates that the Appointment's `status` is `booked` or `pending`
 4. Sets the Appointment's `status` to `cancelled` and saves it
 5. Deletes all referenced Slots
-6. Returns the updated Appointment in the response Bundle
+6. Returns the updated Appointment
 
 The transaction uses serializable isolation for safety when there are concurrent scheduling operations affecting the same appointment.
 
@@ -162,15 +120,6 @@ The transaction uses serializable isolation for safety when there are concurrent
 {
   "resourceType": "OperationOutcome",
   "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "Loading slots failed" } }]
-}
-```
-
-### Missing Required Parameter
-
-```json
-{
-  "resourceType": "OperationOutcome",
-  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "Expected at least 1 value(s) for required input parameter 'appointment-reference'" } }]
 }
 ```
 

--- a/packages/docs/docs/scheduling/appointment-cancel.md
+++ b/packages/docs/docs/scheduling/appointment-cancel.md
@@ -1,0 +1,183 @@
+# Appointment $cancel
+
+:::info[Alpha]
+
+The `$cancel` operation is currently in alpha.
+
+:::
+
+The `$cancel` operation cancels an [`Appointment`](/docs/api/fhir/resources/appointment) by atomically setting its status to `cancelled` and deleting all [`Slot`](/docs/api/fhir/resources/slot) resources it references in a single FHIR transaction.
+
+## Use Cases
+
+- **Patient-initiated cancellation**: Cancel a scheduled appointment at the patient's request and free the provider's time
+- **Staff-initiated cancellation**: Cancel an appointment from an admin or scheduling workflow
+- **Automated cancellation**: Programmatically cancel appointments based on external triggers (e.g., provider unavailability, EHR integration)
+
+## Invoke the `$cancel` operation
+
+```
+[base]/R4/Appointment/$cancel
+```
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="ts" label="TypeScript">
+
+```typescript
+import { MedplumClient } from '@medplum/core';
+import type { Appointment, Bundle, Parameters } from '@medplum/fhirtypes';
+
+const medplum = new MedplumClient();
+
+const result = await medplum.post(
+  medplum.fhirUrl('Appointment', '$cancel'),
+  {
+    resourceType: 'Parameters',
+    parameter: [
+      {
+        name: 'appointment-reference',
+        valueReference: { reference: 'Appointment/my-appointment-id' },
+      },
+    ],
+  }
+) as Parameters;
+
+const bundle = result.parameter?.[0]?.resource as Bundle;
+const appointment = bundle.entry
+  ?.find((e) => e.resource?.resourceType === 'Appointment')
+  ?.resource as Appointment;
+```
+
+</TabItem>
+<TabItem value="curl" label="cURL">
+
+```bash
+curl -X POST 'https://api.medplum.com/fhir/R4/Appointment/$cancel' \
+  -H "Content-Type: application/fhir+json" \
+  -H "Authorization: Bearer MY_ACCESS_TOKEN" \
+  -d '{
+    "resourceType": "Parameters",
+    "parameter": [
+      {
+        "name": "appointment-reference",
+        "valueReference": { "reference": "Appointment/my-appointment-id" }
+      }
+    ]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+## Parameters
+
+| Name                     | Type        | Description                                                                                    | Required |
+| ------------------------ | ----------- | ---------------------------------------------------------------------------------------------- | -------- |
+| `appointment-reference`  | `Reference` | Reference to the [`Appointment`](/docs/api/fhir/resources/appointment) to cancel               | Yes      |
+
+### Constraints
+
+- The Appointment must have `status: booked` or `status: pending`. All other statuses are rejected.
+- All `Slot` resources referenced by `Appointment.slot` must exist and be readable by the caller.
+
+## Output
+
+Returns `200 OK` with a [`Parameters`](/docs/api/fhir/resources/parameters) resource wrapping a `Bundle` containing the updated Appointment:
+
+- One [`Appointment`](/docs/api/fhir/resources/appointment) with `status: cancelled`
+
+All `Slot` resources that were referenced by the Appointment are deleted and do not appear in the response.
+
+### Example Response
+
+```json
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "return",
+      "resource": {
+        "resourceType": "Bundle",
+        "type": "transaction-response",
+        "entry": [
+          {
+            "resource": {
+              "resourceType": "Appointment",
+              "id": "my-appointment-id",
+              "status": "cancelled",
+              "start": "2026-03-10T09:00:00.000Z",
+              "end": "2026-03-10T10:00:00.000Z",
+              "participant": [
+                { "actor": { "reference": "Practitioner/dr-smith" }, "status": "tentative" },
+                { "actor": { "reference": "Patient/my-patient-id" }, "status": "accepted" }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+## Cancellation Logic
+
+`$cancel` performs the following steps inside a serializable transaction:
+
+1. Reads the referenced Appointment
+2. Loads all `Slot` resources listed in `Appointment.slot`
+3. Validates that the Appointment's `status` is `booked` or `pending`
+4. Sets the Appointment's `status` to `cancelled` and saves it
+5. Deletes all referenced Slots
+6. Returns the updated Appointment in the response Bundle
+
+The transaction uses serializable isolation for safety when there are concurrent scheduling operations affecting the same appointment.
+
+## Error Responses
+
+### Appointment Not Found
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [{ "severity": "error", "code": "not-found", "details": { "text": "Not found" } }]
+}
+```
+
+### Appointment Not in Cancelable State
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "Appointment is not in cancelable state due to status" } }]
+}
+```
+
+### Referenced Slot Not Found
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "Loading slots failed" } }]
+}
+```
+
+### Missing Required Parameter
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "Expected at least 1 value(s) for required input parameter 'appointment-reference'" } }]
+}
+```
+
+## Related
+
+- [Appointment `$book`](/docs/scheduling/appointment-book) - Book an Appointment (the inverse operation)
+- [Appointment `$find`](/docs/scheduling/appointment-find) - Find available slots
+- [Scheduling Overview](/docs/scheduling) - High-level scheduling concepts
+- [`Appointment` resource](/docs/api/fhir/resources/appointment)
+- [`Slot` resource](/docs/api/fhir/resources/slot)

--- a/packages/docs/docs/scheduling/appointment-cancel.md
+++ b/packages/docs/docs/scheduling/appointment-cancel.md
@@ -152,7 +152,7 @@ The transaction uses serializable isolation for safety when there are concurrent
 ```json
 {
   "resourceType": "OperationOutcome",
-  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "Appointment is not in cancelable state due to status" } }]
+  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "Appointment cannot be canceled in 'arrived' status" } }]
 }
 ```
 

--- a/packages/server/src/fhir/operations/book.test.ts
+++ b/packages/server/src/fhir/operations/book.test.ts
@@ -69,6 +69,8 @@ describe('Appointment/$book', () => {
 
   beforeAll(async () => {
     const config = await loadTestConfig();
+    // try to be more resilient to concurrent tests touching the same tables
+    config.transactionAttempts = 5;
     await initApp(app, config);
     project = await createTestProject({ withAccessToken: true });
     practitioner1 = await makePractitioner({ timezone: 'America/New_York' });
@@ -1474,6 +1476,8 @@ describe('scheduling flow integration test', () => {
 
   beforeAll(async () => {
     const config = await loadTestConfig();
+    // try to be more resilient to concurrent tests touching the same tables
+    config.transactionAttempts = 5;
     await initApp(app, config);
     project = await createTestProject({ withAccessToken: true });
   });

--- a/packages/server/src/fhir/operations/cancel.test.ts
+++ b/packages/server/src/fhir/operations/cancel.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
 import { createReference, parseSearchRequest } from '@medplum/core';
-import type { Appointment, Bundle, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
+import type { Appointment, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
 import express from 'express';
 import supertest from 'supertest';
 import { initApp, shutdownApp } from '../../app';
@@ -74,12 +74,8 @@ describe('Appointment/$cancel', () => {
     const appointment = await makeAppointment('booked', [slot]);
 
     const response = await request
-      .post('/fhir/R4/Appointment/$cancel')
-      .set('Authorization', `Bearer ${project.accessToken}`)
-      .send({
-        resourceType: 'Parameters',
-        parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
-      });
+      .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toEqual(200);
@@ -90,38 +86,25 @@ describe('Appointment/$cancel', () => {
     const appointment = await makeAppointment('pending', [slot]);
 
     const response = await request
-      .post('/fhir/R4/Appointment/$cancel')
-      .set('Authorization', `Bearer ${project.accessToken}`)
-      .send({
-        resourceType: 'Parameters',
-        parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
-      });
+      .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toEqual(200);
   });
 
-  test('Returns Bundle with cancelled appointment', async () => {
+  test('Returns cancelled appointment', async () => {
     const slot = await makeSlot();
     const appointment = await makeAppointment('booked', [slot]);
 
     const response = await request
-      .post('/fhir/R4/Appointment/$cancel')
-      .set('Authorization', `Bearer ${project.accessToken}`)
-      .send({
-        resourceType: 'Parameters',
-        parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
-      });
+      .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toEqual(200);
 
-    const bundle = response.body as Bundle;
-    expect(bundle).toHaveProperty('resourceType', 'Bundle');
-    expect(bundle).toHaveProperty('type', 'transaction-response');
-    expect(bundle.entry).toHaveLength(1);
-
-    const updated = bundle.entry?.[0]?.resource as Appointment;
+    const updated = response.body as Appointment;
     expect(updated).toMatchObject({ resourceType: 'Appointment', id: appointment.id, status: 'cancelled' });
   });
 
@@ -130,12 +113,8 @@ describe('Appointment/$cancel', () => {
     const appointment = await makeAppointment('booked', [slot]);
 
     const response = await request
-      .post('/fhir/R4/Appointment/$cancel')
-      .set('Authorization', `Bearer ${project.accessToken}`)
-      .send({
-        resourceType: 'Parameters',
-        parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
-      });
+      .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toEqual(200);
@@ -150,12 +129,8 @@ describe('Appointment/$cancel', () => {
     const appointment = await makeAppointment('booked', [slot1, slot2]);
 
     const response = await request
-      .post('/fhir/R4/Appointment/$cancel')
-      .set('Authorization', `Bearer ${project.accessToken}`)
-      .send({
-        resourceType: 'Parameters',
-        parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
-      });
+      .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toEqual(200);
@@ -168,12 +143,8 @@ describe('Appointment/$cancel', () => {
     const appointment = await makeAppointment('booked');
 
     const response = await request
-      .post('/fhir/R4/Appointment/$cancel')
-      .set('Authorization', `Bearer ${project.accessToken}`)
-      .send({
-        resourceType: 'Parameters',
-        parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
-      });
+      .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toEqual(200);
@@ -185,12 +156,8 @@ describe('Appointment/$cancel', () => {
       const appointment = await makeAppointment(status);
 
       const response = await request
-        .post('/fhir/R4/Appointment/$cancel')
-        .set('Authorization', `Bearer ${project.accessToken}`)
-        .send({
-          resourceType: 'Parameters',
-          parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
-        });
+        .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
+        .set('Authorization', `Bearer ${project.accessToken}`);
 
       expect(response.body).toMatchObject({
         resourceType: 'OperationOutcome',
@@ -208,28 +175,10 @@ describe('Appointment/$cancel', () => {
 
   test('Returns 404 when appointment does not exist', async () => {
     const response = await request
-      .post('/fhir/R4/Appointment/$cancel')
-      .set('Authorization', `Bearer ${project.accessToken}`)
-      .send({
-        resourceType: 'Parameters',
-        parameter: [
-          {
-            name: 'appointment-reference',
-            valueReference: { reference: 'Appointment/00000000-0000-0000-0000-000000000000' },
-          },
-        ],
-      });
+      .post('/fhir/R4/Appointment/00000000-0000-0000-0000-000000000000/$cancel')
+      .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.status).toEqual(404);
-  });
-
-  test('Returns 400 when appointment-reference parameter is missing', async () => {
-    const response = await request
-      .post('/fhir/R4/Appointment/$cancel')
-      .set('Authorization', `Bearer ${project.accessToken}`)
-      .send({ resourceType: 'Parameters', parameter: [] });
-
-    expect(response.status).toEqual(400);
   });
 
   test('Returns 400 when a referenced slot does not exist', async () => {
@@ -244,12 +193,8 @@ describe('Appointment/$cancel', () => {
     });
 
     const response = await request
-      .post('/fhir/R4/Appointment/$cancel')
-      .set('Authorization', `Bearer ${project.accessToken}`)
-      .send({
-        resourceType: 'Parameters',
-        parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
-      });
+      .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.status).toEqual(400);
     expect(response.body).toMatchObject({

--- a/packages/server/src/fhir/operations/cancel.test.ts
+++ b/packages/server/src/fhir/operations/cancel.test.ts
@@ -45,8 +45,8 @@ describe('Appointment/$cancel', () => {
     return systemRepo.createResource<Slot>({
       resourceType: 'Slot',
       status: 'busy',
-      start: '2026-01-15T14:00:00Z',
-      end: '2026-01-15T15:00:00Z',
+      start: '2026-05-15T14:00:00Z',
+      end: '2026-05-15T15:00:00Z',
       schedule: createReference(schedule),
       meta: { project: project.project.id },
     });
@@ -62,7 +62,7 @@ describe('Appointment/$cancel', () => {
     return systemRepo.createResource<Appointment>({
       resourceType: 'Appointment',
       status,
-      ...(needsDates ? { start: '2026-01-15T14:00:00Z', end: '2026-01-15T15:00:00Z' } : {}),
+      ...(needsDates ? { start: '2026-05-15T14:00:00Z', end: '2026-05-15T15:00:00Z' } : {}),
       participant: [{ actor: createReference(practitioner), status: 'accepted' }],
       slot: slots.map((slot) => createReference(slot)),
       meta: { project: project.project.id },
@@ -185,8 +185,8 @@ describe('Appointment/$cancel', () => {
     const appointment = await systemRepo.createResource<Appointment>({
       resourceType: 'Appointment',
       status: 'booked',
-      start: '2026-01-15T14:00:00Z',
-      end: '2026-01-15T15:00:00Z',
+      start: '2026-05-15T14:00:00Z',
+      end: '2026-05-15T15:00:00Z',
       participant: [{ actor: createReference(practitioner), status: 'accepted' }],
       slot: [{ reference: 'Slot/00000000-0000-0000-0000-000000000000' }],
       meta: { project: project.project.id },

--- a/packages/server/src/fhir/operations/cancel.test.ts
+++ b/packages/server/src/fhir/operations/cancel.test.ts
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import { createReference, parseSearchRequest } from '@medplum/core';
+import type { Appointment, Bundle, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
+import express from 'express';
+import supertest from 'supertest';
+import { initApp, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config/loader';
+import { getGlobalSystemRepo } from '../../fhir/repo';
+import type { TestProjectResult } from '../../test.setup';
+import { createTestProject } from '../../test.setup';
+
+const systemRepo = getGlobalSystemRepo();
+const app = express();
+const request = supertest(app);
+
+describe('Appointment/$cancel', () => {
+  let project: TestProjectResult<{ withAccessToken: true }>;
+  let practitioner: WithId<Practitioner>;
+  let schedule: WithId<Schedule>;
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initApp(app, config);
+    project = await createTestProject({ withAccessToken: true });
+
+    practitioner = await systemRepo.createResource<Practitioner>({
+      resourceType: 'Practitioner',
+      meta: { project: project.project.id },
+    });
+
+    schedule = await systemRepo.createResource<Schedule>({
+      resourceType: 'Schedule',
+      actor: [createReference(practitioner)],
+      meta: { project: project.project.id },
+    });
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  async function makeSlot(): Promise<WithId<Slot>> {
+    return systemRepo.createResource<Slot>({
+      resourceType: 'Slot',
+      status: 'busy',
+      start: '2026-01-15T14:00:00Z',
+      end: '2026-01-15T15:00:00Z',
+      schedule: createReference(schedule),
+      meta: { project: project.project.id },
+    });
+  }
+
+  async function makeAppointment(
+    status: Appointment['status'],
+    slots: WithId<Slot>[] = []
+  ): Promise<WithId<Appointment>> {
+    // Appointments that are not proposed/cancelled/waitlist require start and end
+    const noStartEnd: Appointment['status'][] = ['proposed', 'cancelled', 'waitlist'];
+    const needsDates = !noStartEnd.includes(status);
+    return systemRepo.createResource<Appointment>({
+      resourceType: 'Appointment',
+      status,
+      ...(needsDates ? { start: '2026-01-15T14:00:00Z', end: '2026-01-15T15:00:00Z' } : {}),
+      participant: [{ actor: createReference(practitioner), status: 'accepted' }],
+      slot: slots.map((slot) => createReference(slot)),
+      meta: { project: project.project.id },
+    });
+  }
+
+  test('Succeeds for a booked appointment', async () => {
+    const slot = await makeSlot();
+    const appointment = await makeAppointment('booked', [slot]);
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$cancel')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
+      });
+
+    expect(response.body).not.toHaveProperty('issue');
+    expect(response.status).toEqual(200);
+  });
+
+  test('Succeeds for a pending appointment', async () => {
+    const slot = await makeSlot();
+    const appointment = await makeAppointment('pending', [slot]);
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$cancel')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
+      });
+
+    expect(response.body).not.toHaveProperty('issue');
+    expect(response.status).toEqual(200);
+  });
+
+  test('Returns Bundle with cancelled appointment', async () => {
+    const slot = await makeSlot();
+    const appointment = await makeAppointment('booked', [slot]);
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$cancel')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
+      });
+
+    expect(response.body).not.toHaveProperty('issue');
+    expect(response.status).toEqual(200);
+
+    const bundle = response.body as Bundle;
+    expect(bundle).toHaveProperty('resourceType', 'Bundle');
+    expect(bundle).toHaveProperty('type', 'transaction-response');
+    expect(bundle.entry).toHaveLength(1);
+
+    const updated = bundle.entry?.[0]?.resource as Appointment;
+    expect(updated).toMatchObject({ resourceType: 'Appointment', id: appointment.id, status: 'cancelled' });
+  });
+
+  test('Deletes the referenced slot', async () => {
+    const slot = await makeSlot();
+    const appointment = await makeAppointment('booked', [slot]);
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$cancel')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
+      });
+
+    expect(response.body).not.toHaveProperty('issue');
+    expect(response.status).toEqual(200);
+
+    const remaining = await systemRepo.searchResources<Slot>(parseSearchRequest(`Slot?_id=${slot.id}`));
+    expect(remaining).toHaveLength(0);
+  });
+
+  test('Deletes multiple slots', async () => {
+    const slot1 = await makeSlot();
+    const slot2 = await makeSlot();
+    const appointment = await makeAppointment('booked', [slot1, slot2]);
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$cancel')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
+      });
+
+    expect(response.body).not.toHaveProperty('issue');
+    expect(response.status).toEqual(200);
+
+    const remaining = await systemRepo.searchResources<Slot>(parseSearchRequest(`Slot?_id=${slot1.id},${slot2.id}`));
+    expect(remaining).toHaveLength(0);
+  });
+
+  test('Succeeds for appointment with no slots', async () => {
+    const appointment = await makeAppointment('booked');
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$cancel')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
+      });
+
+    expect(response.body).not.toHaveProperty('issue');
+    expect(response.status).toEqual(200);
+  });
+
+  test.each(['cancelled', 'fulfilled', 'noshow', 'entered-in-error'] as Appointment['status'][])(
+    'Returns 400 for non-cancelable status: %s',
+    async (status) => {
+      const appointment = await makeAppointment(status);
+
+      const response = await request
+        .post('/fhir/R4/Appointment/$cancel')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send({
+          resourceType: 'Parameters',
+          parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
+        });
+
+      expect(response.body).toMatchObject({
+        resourceType: 'OperationOutcome',
+        issue: [
+          {
+            severity: 'error',
+            code: 'invalid',
+            details: { text: 'Appointment is not in cancelable state due to status' },
+          },
+        ],
+      });
+      expect(response.status).toEqual(400);
+    }
+  );
+
+  test('Returns 404 when appointment does not exist', async () => {
+    const response = await request
+      .post('/fhir/R4/Appointment/$cancel')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment-reference',
+            valueReference: { reference: 'Appointment/00000000-0000-0000-0000-000000000000' },
+          },
+        ],
+      });
+
+    expect(response.status).toEqual(404);
+  });
+
+  test('Returns 400 when appointment-reference parameter is missing', async () => {
+    const response = await request
+      .post('/fhir/R4/Appointment/$cancel')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({ resourceType: 'Parameters', parameter: [] });
+
+    expect(response.status).toEqual(400);
+  });
+
+  test('Returns 400 when a referenced slot does not exist', async () => {
+    const appointment = await systemRepo.createResource<Appointment>({
+      resourceType: 'Appointment',
+      status: 'booked',
+      start: '2026-01-15T14:00:00Z',
+      end: '2026-01-15T15:00:00Z',
+      participant: [{ actor: createReference(practitioner), status: 'accepted' }],
+      slot: [{ reference: 'Slot/00000000-0000-0000-0000-000000000000' }],
+      meta: { project: project.project.id },
+    });
+
+    const response = await request
+      .post('/fhir/R4/Appointment/$cancel')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'appointment-reference', valueReference: createReference(appointment) }],
+      });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toMatchObject({
+      resourceType: 'OperationOutcome',
+      issue: [{ severity: 'error', code: 'invalid', details: { text: 'Loading slots failed' } }],
+    });
+  });
+});

--- a/packages/server/src/fhir/operations/cancel.test.ts
+++ b/packages/server/src/fhir/operations/cancel.test.ts
@@ -22,6 +22,8 @@ describe('Appointment/$cancel', () => {
 
   beforeAll(async () => {
     const config = await loadTestConfig();
+    // try to be more resilient to concurrent tests touching the same tables
+    config.transactionAttempts = 5;
     await initApp(app, config);
     project = await createTestProject({ withAccessToken: true });
 

--- a/packages/server/src/fhir/operations/cancel.test.ts
+++ b/packages/server/src/fhir/operations/cancel.test.ts
@@ -165,7 +165,7 @@ describe('Appointment/$cancel', () => {
           {
             severity: 'error',
             code: 'invalid',
-            details: { text: 'Appointment is not in cancelable state due to status' },
+            details: { text: `Appointment cannot be canceled in '${status}' status` },
           },
         ],
       });

--- a/packages/server/src/fhir/operations/cancel.ts
+++ b/packages/server/src/fhir/operations/cancel.ts
@@ -3,7 +3,7 @@
 
 import { allOk, badRequest, OperationOutcomeError } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Appointment, Bundle, OperationDefinition, Reference } from '@medplum/fhirtypes';
+import type { Appointment, OperationDefinition } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { withPaths } from '../../util/withpath';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
@@ -17,34 +17,30 @@ const cancelOperation = {
   code: 'cancel',
   resource: ['Appointment'],
   system: false,
-  type: true,
-  instance: false,
-  parameter: [
-    { use: 'in', name: 'appointment-reference', type: 'Reference', min: 1, max: '1' },
-    { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
-  ],
+  type: false,
+  instance: true,
+  parameter: [{ use: 'out', name: 'return', type: 'Appointment', min: 1, max: '1' }],
 } as const satisfies OperationDefinition;
 
-type CancelParameters = {
-  'appointment-reference': Reference<Appointment>;
-};
+type CancelParameters = {};
 
 /**
  * Handles HTTP requests for the Appointment $cancel operation.
  *
  * Endpoints:
- *   [fhir base]/Appointment/$cancel
+ *   [fhir base]/Appointment/:id/$cancel
  *
  * @param req - The FHIR request.
  * @returns The FHIR response.
  */
 export async function appointmentCancelHandler(req: FhirRequest): Promise<FhirResponse> {
   const ctx = getAuthenticatedContext();
-  const params = parseInputParameters<CancelParameters>(cancelOperation, req);
+  parseInputParameters<CancelParameters>(cancelOperation, req);
+  const appointmentId = req.params.id;
 
-  const updatedResources = await ctx.repo.withTransaction(
+  const updatedAppointment = await ctx.repo.withTransaction(
     async () => {
-      const appointment = await ctx.repo.readReference(params['appointment-reference']);
+      const appointment = await ctx.repo.readResource<Appointment>('Appointment', appointmentId);
       const slots = await ctx.repo
         .readReferences(appointment.slot ?? [])
         .then((slots) => withPaths(slots, 'appointment.slot'));
@@ -58,16 +54,10 @@ export async function appointmentCancelHandler(req: FhirRequest): Promise<FhirRe
 
       const updatedAppointment = await ctx.repo.updateResource(appointment);
       await Promise.all(slots.map((slot) => ctx.repo.deleteResource('Slot', slot.id)));
-      return [updatedAppointment];
+      return updatedAppointment;
     },
     { serializable: true }
   );
 
-  const bundle: Bundle = {
-    resourceType: 'Bundle',
-    type: 'transaction-response',
-    entry: updatedResources.map((resource) => ({ resource })),
-  };
-
-  return [allOk, buildOutputParameters(cancelOperation, bundle)];
+  return [allOk, buildOutputParameters(cancelOperation, updatedAppointment)];
 }

--- a/packages/server/src/fhir/operations/cancel.ts
+++ b/packages/server/src/fhir/operations/cancel.ts
@@ -3,24 +3,21 @@
 
 import { allOk, badRequest, OperationOutcomeError } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Appointment, OperationDefinition } from '@medplum/fhirtypes';
+import type { Appointment } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { withPaths } from '../../util/withpath';
+import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 import { assertAllLoaded } from './utils/scheduling';
 
-const cancelOperation = {
-  resourceType: 'OperationDefinition',
-  name: 'cancel',
-  status: 'active',
-  kind: 'operation',
-  code: 'cancel',
-  resource: ['Appointment'],
-  system: false,
-  type: false,
-  instance: true,
-  parameter: [{ use: 'out', name: 'return', type: 'Appointment', min: 1, max: '1' }],
-} as const satisfies OperationDefinition;
+const cancelOperation = makeOperationDefinition(
+  { scope: 'instance', resource: 'Appointment' },
+  {
+    name: 'cancel',
+    code: 'cancel',
+    parameter: [{ use: 'out', name: 'return', type: 'Appointment', min: 1, max: '1' }],
+  }
+);
 
 type CancelParameters = {};
 

--- a/packages/server/src/fhir/operations/cancel.ts
+++ b/packages/server/src/fhir/operations/cancel.ts
@@ -47,7 +47,7 @@ export async function appointmentCancelHandler(req: FhirRequest): Promise<FhirRe
       assertAllLoaded(slots, 'Loading slots failed');
 
       if (appointment.status !== 'pending' && appointment.status !== 'booked') {
-        throw new OperationOutcomeError(badRequest('Appointment is not in cancelable state due to status'));
+        throw new OperationOutcomeError(badRequest(`Appointment cannot be canceled in '${appointment.status}' status`));
       }
 
       appointment.status = 'cancelled';

--- a/packages/server/src/fhir/operations/cancel.ts
+++ b/packages/server/src/fhir/operations/cancel.ts
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { allOk, badRequest, OperationOutcomeError } from '@medplum/core';
+import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
+import type { Appointment, Bundle, OperationDefinition, Reference } from '@medplum/fhirtypes';
+import { getAuthenticatedContext } from '../../context';
+import { withPaths } from '../../util/withpath';
+import { buildOutputParameters, parseInputParameters } from './utils/parameters';
+import { assertAllLoaded } from './utils/scheduling';
+
+const cancelOperation = {
+  resourceType: 'OperationDefinition',
+  name: 'cancel',
+  status: 'active',
+  kind: 'operation',
+  code: 'cancel',
+  resource: ['Appointment'],
+  system: false,
+  type: true,
+  instance: false,
+  parameter: [
+    { use: 'in', name: 'appointment-reference', type: 'Reference', min: 1, max: '1' },
+    { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
+  ],
+} as const satisfies OperationDefinition;
+
+type CancelParameters = {
+  'appointment-reference': Reference<Appointment>;
+};
+
+/**
+ * Handles HTTP requests for the Appointment $cancel operation.
+ *
+ * Endpoints:
+ *   [fhir base]/Appointment/$cancel
+ *
+ * @param req - The FHIR request.
+ * @returns The FHIR response.
+ */
+export async function appointmentCancelHandler(req: FhirRequest): Promise<FhirResponse> {
+  const ctx = getAuthenticatedContext();
+  const params = parseInputParameters<CancelParameters>(cancelOperation, req);
+
+  const updatedResources = await ctx.repo.withTransaction(
+    async () => {
+      const appointment = await ctx.repo.readReference(params['appointment-reference']);
+      const slots = await ctx.repo
+        .readReferences(appointment.slot ?? [])
+        .then((slots) => withPaths(slots, 'appointment.slot'));
+      assertAllLoaded(slots, 'Loading slots failed');
+
+      if (appointment.status !== 'pending' && appointment.status !== 'booked') {
+        throw new OperationOutcomeError(badRequest('Appointment is not in cancelable state due to status'));
+      }
+
+      appointment.status = 'cancelled';
+
+      const updatedAppointment = await ctx.repo.updateResource(appointment);
+      await Promise.all(slots.map((slot) => ctx.repo.deleteResource('Slot', slot.id)));
+      return [updatedAppointment];
+    },
+    { serializable: true }
+  );
+
+  const bundle: Bundle = {
+    resourceType: 'Bundle',
+    type: 'transaction-response',
+    entry: updatedResources.map((resource) => ({ resource })),
+  };
+
+  return [allOk, buildOutputParameters(cancelOperation, bundle)];
+}

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -26,6 +26,7 @@ import { asyncJobCancelHandler } from './operations/asyncjobcancel';
 import { binaryPresignedUrlHandler } from './operations/binary-presigned-url';
 import { appointmentBookHandler } from './operations/book';
 import { botInitHandler } from './operations/botinit';
+import { appointmentCancelHandler } from './operations/cancel';
 import { ccdaExportHandler } from './operations/ccdaexport';
 import { chargeItemDefinitionApplyHandler } from './operations/chargeitemdefinitionapply';
 import { claimExportGetHandler, claimExportPostHandler } from './operations/claimexport';
@@ -395,6 +396,7 @@ function initInternalFhirRouter(): FhirRouter {
   router.add('GET', '/Appointment/$find', appointmentFindHandler);
   router.add('POST', '/Appointment/$book', appointmentBookHandler);
   router.add('POST', '/Appointment/$hold', appointmentHoldHandler);
+  router.add('POST', '/Appointment/$cancel', appointmentCancelHandler);
 
   // PackageRelease $install operation
   router.add('POST', '/PackageRelease/:id/$install', packageInstallHandler);

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -396,7 +396,7 @@ function initInternalFhirRouter(): FhirRouter {
   router.add('GET', '/Appointment/$find', appointmentFindHandler);
   router.add('POST', '/Appointment/$book', appointmentBookHandler);
   router.add('POST', '/Appointment/$hold', appointmentHoldHandler);
-  router.add('POST', '/Appointment/$cancel', appointmentCancelHandler);
+  router.add('POST', '/Appointment/:id/$cancel', appointmentCancelHandler);
 
   // PackageRelease $install operation
   router.add('POST', '/PackageRelease/:id/$install', packageInstallHandler);


### PR DESCRIPTION
Adds the `/Appointment/$cancel` FHIR operation, which cancels a booked or pending appointment by setting its status to cancelled and deleting all referenced Slot resources in a serializable transaction.

Resolves: #7691