### PR TITLE
wip(server): audit `findProjectMembership`

### DIFF
--- a/packages/fhir-router/src/repo.test.ts
+++ b/packages/fhir-router/src/repo.test.ts
@@ -152,6 +152,33 @@ describe('MemoryRepository', () => {
     expect(emptyResource).toBeUndefined();
   });
 
+  test('searchOne throwOnMultiple throws when more than one result', async () => {
+    const family = randomUUID();
+    await repo.createResource<Patient>({ resourceType: 'Patient', name: [{ family }] });
+    await repo.createResource<Patient>({ resourceType: 'Patient', name: [{ family }] });
+
+    await expect(
+      repo.searchOne<Patient>(parseSearchRequest('Patient?family=' + family), { throwOnMultiple: true })
+    ).rejects.toThrow(OperationOutcomeError);
+    await expect(
+      repo.searchOne<Patient>(parseSearchRequest('Patient?family=' + family), { throwOnMultiple: true })
+    ).rejects.toThrow('Multiple resources found matching condition');
+
+    // Without throwOnMultiple, returns the first match
+    const resource = await repo.searchOne<Patient>(parseSearchRequest('Patient?family=' + family));
+    expect(resource).toBeDefined();
+  });
+
+  test('searchOne throwOnMultiple does not throw with single result', async () => {
+    const family = randomUUID();
+    const patient = await repo.createResource<Patient>({ resourceType: 'Patient', name: [{ family }] });
+
+    const resource = await repo.searchOne<Patient>(parseSearchRequest('Patient?family=' + family), {
+      throwOnMultiple: true,
+    });
+    expect(resource?.id).toBe(patient.id);
+  });
+
   test('Sort unknown search parameter', async () => {
     for (let i = 0; i < 10; i++) {
       await repo.createResource<Patient>({ resourceType: 'Patient' });

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -36,6 +36,10 @@ export type ReadHistoryOptions = {
   limit?: number;
 };
 
+export type SearchOneOptions = {
+  throwOnMultiple?: boolean;
+};
+
 export const RepositoryMode = {
   READER: 'reader',
   WRITER: 'writer',
@@ -211,10 +215,18 @@ export abstract class FhirRepository<TClient = unknown> {
    *
    * See FHIR search for full details: https://www.hl7.org/fhir/search.html
    * @param searchRequest - The FHIR search request.
+   * @param options - Optional `searchOne` configuration options.
    * @returns Promise to the first search result or undefined.
    */
-  async searchOne<T extends Resource>(searchRequest: SearchRequest<T>): Promise<WithId<T> | undefined> {
-    const bundle = await this.search({ ...searchRequest, count: 1 });
+  async searchOne<T extends Resource>(
+    searchRequest: SearchRequest<T>,
+    options?: SearchOneOptions
+  ): Promise<WithId<T> | undefined> {
+    const count = options?.throwOnMultiple ? 2 : 1;
+    const bundle = await this.search({ ...searchRequest, count });
+    if (options?.throwOnMultiple && (bundle.entry?.length ?? 0) > 1) {
+      throw new OperationOutcomeError(multipleMatches);
+    }
     return bundle.entry?.[0]?.resource;
   }
 

--- a/packages/server/src/workers/utils.test.ts
+++ b/packages/server/src/workers/utils.test.ts
@@ -1,18 +1,32 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { Subscription } from '@medplum/fhirtypes';
+import { createReference, OperationOutcomeError } from '@medplum/core';
+import type { ProjectMembership, Subscription } from '@medplum/fhirtypes';
 import type { Job, Worker } from 'bullmq';
 import { Queue } from 'bullmq';
 import EventEmitter from 'node:events';
+import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
+import { getGlobalSystemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
-import { withTestContext } from '../test.setup';
-import { addVerboseQueueLogging, DefaultQueueRegistry, getWorkerBullmqConfig, isJobSuccessful } from './utils';
+import { createTestProject, withTestContext } from '../test.setup';
+import {
+  addVerboseQueueLogging,
+  DefaultQueueRegistry,
+  findProjectMembership,
+  getWorkerBullmqConfig,
+  isJobSuccessful,
+} from './utils';
 
 describe('worker utils', () => {
   beforeAll(async () => {
-    await loadTestConfig();
+    const config = await loadTestConfig();
+    await initAppServices(config);
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
   });
 
   describe('isJobSuccessful', () => {
@@ -392,5 +406,28 @@ describe('worker utils', () => {
       const result = getWorkerBullmqConfig(config, 'download');
       expect(result).toStrictEqual(config.bullmq);
     });
+  });
+
+  describe('findProjectMembership', () => {
+    test('throws when more than one membership exists for the profile in the project', async () =>
+      withTestContext(async () => {
+        const { project, client } = await createTestProject({ withClient: true });
+        const systemRepo = getGlobalSystemRepo();
+
+        // Create a second ProjectMembership for the same client in the same project
+        await systemRepo.createResource<ProjectMembership>({
+          resourceType: 'ProjectMembership',
+          user: createReference(client),
+          profile: createReference(client),
+          project: createReference(project),
+        });
+
+        await expect(findProjectMembership(project.id, createReference(client))).rejects.toThrow(
+          OperationOutcomeError
+        );
+        await expect(findProjectMembership(project.id, createReference(client))).rejects.toThrow(
+          'Multiple resources found matching condition'
+        );
+      }));
   });
 });

--- a/packages/server/src/workers/utils.test.ts
+++ b/packages/server/src/workers/utils.test.ts
@@ -422,9 +422,7 @@ describe('worker utils', () => {
           project: createReference(project),
         });
 
-        await expect(findProjectMembership(project.id, createReference(client))).rejects.toThrow(
-          OperationOutcomeError
-        );
+        await expect(findProjectMembership(project.id, createReference(client))).rejects.toThrow(OperationOutcomeError);
         await expect(findProjectMembership(project.id, createReference(client))).rejects.toThrow(
           'Multiple resources found matching condition'
         );

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -25,21 +25,24 @@ export function findProjectMembership(
   profile: Reference
 ): Promise<WithId<ProjectMembership> | undefined> {
   const systemRepo = getGlobalSystemRepo();
-  return systemRepo.searchOne<ProjectMembership>({
-    resourceType: 'ProjectMembership',
-    filters: [
-      {
-        code: 'project',
-        operator: Operator.EQUALS,
-        value: `Project/${projectId}`,
-      },
-      {
-        code: 'profile',
-        operator: Operator.EQUALS,
-        value: profile.reference as string,
-      },
-    ],
-  });
+  return systemRepo.searchOne<ProjectMembership>(
+    {
+      resourceType: 'ProjectMembership',
+      filters: [
+        {
+          code: 'project',
+          operator: Operator.EQUALS,
+          value: `Project/${projectId}`,
+        },
+        {
+          code: 'profile',
+          operator: Operator.EQUALS,
+          value: profile.reference as string,
+        },
+      ],
+    },
+    { throwOnMultiple: true }
+  );
 }
 
 export function isJobSuccessful(subscription: Subscription, status: number): boolean {


### PR DESCRIPTION
Fixes #9026

The most problematic spot remaining where we assume 1 profile resource = 1 project membership is in subscription bots...

When `runAsUser` is `true`, we call `findProjectMembership` on `meta.author` of the resource, which is non-deterministic whenever a user's profile has more than 1 `ProjectMembership` to the given project...

See: https://github.com/medplum/medplum/blob/derrick-audit-findprojectmembership/packages/server/src/workers/subscription.ts#L876

Theoretically we could thread through the membership of the user through to the job, but we should probably assess whether this may overly complicate other features in the future