### PR TITLE
Handle broken images due to malware scanner

### DIFF
--- a/packages/react/src/AttachmentDisplay/AttachmentDisplay.tsx
+++ b/packages/react/src/AttachmentDisplay/AttachmentDisplay.tsx
@@ -6,6 +6,7 @@ import type { Attachment } from '@medplum/fhirtypes';
 import { useCachedBinaryUrl } from '@medplum/react-hooks';
 import type { JSX } from 'react';
 import { CcdaDisplay } from '../CcdaDisplay/CcdaDisplay';
+import { ScannedImage } from './ScannedImage';
 
 export interface AttachmentDisplayProps {
   readonly value?: Attachment;
@@ -23,7 +24,7 @@ export function AttachmentDisplay(props: AttachmentDisplayProps): JSX.Element | 
   return (
     <div data-testid="attachment-display">
       {contentType?.startsWith('image/') && (
-        <img data-testid="attachment-image" style={{ maxWidth: props.maxWidth }} src={url} alt={title} />
+        <ScannedImage data-testid="attachment-image" style={{ maxWidth: props.maxWidth }} src={url} alt={title} />
       )}
       {contentType?.startsWith('video/') && (
         <video data-testid="attachment-video" style={{ maxWidth: props.maxWidth }} controls={true}>

--- a/packages/react/src/AttachmentDisplay/ScannedImage.test.tsx
+++ b/packages/react/src/AttachmentDisplay/ScannedImage.test.tsx
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { act, fireEvent, render, screen } from '../test-utils/render';
+import { ScannedImage } from './ScannedImage';
+
+describe('ScannedImage', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('retries after an image load error', () => {
+    render(<ScannedImage alt="Scanned document" src="https://example.com/image.jpg" />);
+
+    fireEvent.error(screen.getByAltText('Scanned document'));
+
+    expect(document.querySelector('.mantine-Loader-root')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByAltText('Scanned document')).toBeInTheDocument();
+  });
+
+  test('shows a placeholder after the final retry fails', () => {
+    render(<ScannedImage alt="Scanned document" src="https://example.com/image.jpg" maxRetries={1} />);
+
+    fireEvent.error(screen.getByAltText('Scanned document'));
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    fireEvent.error(screen.getByAltText('Scanned document'));
+
+    expect(screen.getByText('Image unavailable')).toBeInTheDocument();
+  });
+
+  test('clears the retry timer on unmount', () => {
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+    const { unmount } = render(<ScannedImage alt="Scanned document" src="https://example.com/image.jpg" />);
+
+    fireEvent.error(screen.getByAltText('Scanned document'));
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+});

--- a/packages/react/src/AttachmentDisplay/ScannedImage.tsx
+++ b/packages/react/src/AttachmentDisplay/ScannedImage.tsx
@@ -3,7 +3,7 @@
 
 import { Loader } from '@mantine/core';
 import type { DetailedHTMLProps, ImgHTMLAttributes, JSX } from 'react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export interface ScannedImageProps extends DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> {
   readonly maxRetries?: number;
@@ -12,7 +12,16 @@ export interface ScannedImageProps extends DetailedHTMLProps<ImgHTMLAttributes<H
 export function ScannedImage(props: ScannedImageProps): JSX.Element {
   const { maxRetries = 5, ...rest } = props;
   const [attempt, setAttempt] = useState(0);
-  const [status, setStatus] = useState<'loading' | 'loaded' | 'waiting' | 'failed'>('loading');
+  const [status, setStatus] = useState<'fetching' | 'backoff' | 'loaded' | 'failed'>('fetching');
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== undefined) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   const handleError = (): void => {
     if (attempt >= maxRetries) {
@@ -20,13 +29,14 @@ export function ScannedImage(props: ScannedImageProps): JSX.Element {
       return;
     }
 
-    setStatus('waiting');
+    setStatus('backoff');
 
     // Exponential backoff: 1s, 2s, 4s, 8s, 16s
     const delay = Math.min(1000 * 2 ** attempt, 16000);
-    setTimeout(() => {
+    timeoutRef.current = setTimeout(() => {
       setAttempt((a) => a + 1);
-      setStatus('loading');
+      setStatus('fetching');
+      timeoutRef.current = undefined;
     }, delay);
   };
 
@@ -34,7 +44,7 @@ export function ScannedImage(props: ScannedImageProps): JSX.Element {
     return <div className="image-placeholder">Image unavailable</div>;
   }
 
-  if (status === 'waiting') {
+  if (status === 'backoff') {
     return <Loader />;
   }
 

--- a/packages/react/src/AttachmentDisplay/ScannedImage.tsx
+++ b/packages/react/src/AttachmentDisplay/ScannedImage.tsx
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { Loader } from '@mantine/core';
+import type { DetailedHTMLProps, ImgHTMLAttributes, JSX } from 'react';
+import { useState } from 'react';
+
+export interface ScannedImageProps extends DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> {
+  readonly maxRetries?: number;
+}
+
+export function ScannedImage(props: ScannedImageProps): JSX.Element {
+  const { maxRetries = 5, ...rest } = props;
+  const [attempt, setAttempt] = useState(0);
+  const [status, setStatus] = useState<'loading' | 'loaded' | 'waiting' | 'failed'>('loading');
+
+  const handleError = (): void => {
+    if (attempt >= maxRetries) {
+      setStatus('failed');
+      return;
+    }
+
+    setStatus('waiting');
+
+    // Exponential backoff: 1s, 2s, 4s, 8s, 16s
+    const delay = Math.min(1000 * 2 ** attempt, 16000);
+    setTimeout(() => {
+      setAttempt((a) => a + 1);
+      setStatus('loading');
+    }, delay);
+  };
+
+  if (status === 'failed') {
+    return <div className="image-placeholder">Image unavailable</div>;
+  }
+
+  if (status === 'waiting') {
+    return <Loader />;
+  }
+
+  return <img onLoad={() => setStatus('loaded')} onError={handleError} {...rest} />;
+}


### PR DESCRIPTION
When using [AWS GuardDuty Malware Protection for S3](https://docs.aws.amazon.com/guardduty/latest/ug/gdu-malware-protection-s3.html), a newly uploaded image might not be available for a few seconds.

Before this PR, the Medplum `<AttachmentDisplay>` component would simply display a broken image element, because the first attempt would fail with HTTP 403.

After this PR, the `<AttachmentDisplay>` component will detect the 403 and retry up to 5 times, and display a spinner in place.

Demo:

https://github.com/user-attachments/assets/8db9bc1b-968e-49e7-aa29-bd0c122ce776


