### PR TITLE
Delete old versions of all lambda bots

### DIFF
--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -389,6 +389,14 @@ export class BackEnd extends Construct {
           resources: [`arn:aws:lambda:${region}:${accountNumber}:function:medplum-bot-lambda-*`],
         }),
 
+        // Lambda: List functions
+        // https://docs.aws.amazon.com/lambda/latest/dg/permissions-user-function.html
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['lambda:ListFunctions'],
+          resources: ['*'],
+        }),
+
         // Lambda layers: List layer versions
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,

--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -8,6 +8,7 @@ import { randomUUID } from 'node:crypto';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
+import { LAMBDA_NAME_REGEX_PATTERN } from '../cloud/aws/deploy';
 import { loadTestConfig } from '../config/loader';
 import { Repository } from '../fhir/repo';
 import { minCursorBasedSearchPageSize } from '../fhir/search';
@@ -19,6 +20,8 @@ import { rebuildR4ValueSets } from '../seeds/valuesets';
 import { createTestProject, waitForAsyncJob, withTestContext } from '../test.setup';
 import type { CronJobData } from '../workers/cron';
 import { getCronQueue } from '../workers/cron';
+import type { LambdaCleanerJobData } from '../workers/lambda-cleaner';
+import { getLambdaCleanerQueue } from '../workers/lambda-cleaner';
 import type { ReindexJobData } from '../workers/reindex';
 import { getReindexQueue } from '../workers/reindex';
 
@@ -753,6 +756,65 @@ describe('Super Admin routes', () => {
       expect(endTimestamp).toBeLessThanOrEqual(expectedMaxTime);
     }
   );
+
+  test('Lambda cleaner require async', async () => {
+    const res = await request(app)
+      .post('/admin/super/lambda-cleaner')
+      .set('Authorization', 'Bearer ' + adminAccessToken)
+      .type('json')
+      .send({});
+
+    expect(res.status).toStrictEqual(400);
+    expect(res.body.issue[0].details.text).toBe('Operation requires "Prefer: respond-async"');
+  });
+
+  test('Lambda cleaner enqueues job', async () => {
+    const queue = getLambdaCleanerQueue() as any;
+    queue.add.mockClear();
+
+    const res = await request(app)
+      .post('/admin/super/lambda-cleaner')
+      .set('Authorization', 'Bearer ' + adminAccessToken)
+      .set('Prefer', 'respond-async')
+      .type('json')
+      .send({
+        keepLatest: 2,
+        deleteConcurrency: 3,
+        dryRun: false,
+      });
+
+    expect(res.status).toStrictEqual(202);
+    expect(res.headers['content-location']).toBeDefined();
+    expect(queue.add).toHaveBeenCalledWith(
+      'LambdaCleanerJob',
+      expect.objectContaining<Partial<LambdaCleanerJobData>>({
+        options: {
+          nameRegex: LAMBDA_NAME_REGEX_PATTERN,
+          keepLatest: 2,
+          deleteConcurrency: 3,
+          dryRun: false,
+        },
+      })
+    );
+  });
+
+  test('Lambda cleaner rejects invalid args', async () => {
+    const queue = getLambdaCleanerQueue() as any;
+    queue.add.mockClear();
+
+    const res = await request(app)
+      .post('/admin/super/lambda-cleaner')
+      .set('Authorization', 'Bearer ' + adminAccessToken)
+      .set('Prefer', 'respond-async')
+      .type('json')
+      .send({
+        keepLatest: 0,
+        deleteConcurrency: 0,
+      });
+
+    expect(res.status).toStrictEqual(400);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
 
   test('Set password access denied', async () => {
     const res = await request(app)

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -18,6 +18,7 @@ import { Router } from 'express';
 import { body, checkExact, validationResult } from 'express-validator';
 import { assert } from 'node:console';
 import { setPassword } from '../auth/setpassword';
+import { LAMBDA_NAME_REGEX_PATTERN } from '../cloud/aws/deploy';
 import { getConfig } from '../config/loader';
 import type { AuthenticatedRequestContext } from '../context';
 import { getAuthenticatedContext } from '../context';
@@ -39,6 +40,8 @@ import { rebuildR4SearchParameters } from '../seeds/searchparameters';
 import { rebuildR4StructureDefinitions } from '../seeds/structuredefinitions';
 import { rebuildR4ValueSets } from '../seeds/valuesets';
 import { reloadCronBots, removeBullMQJobByKey } from '../workers/cron';
+import type { LambdaCleanerOptions } from '../workers/lambda-cleaner';
+import { addLambdaCleanerJobData } from '../workers/lambda-cleaner';
 import { addPostDeployMigrationJobData, prepareDynamicMigrationJobData } from '../workers/post-deploy-migration';
 import type { ReindexJobOptions } from '../workers/reindex';
 import { addReindexJob } from '../workers/reindex';
@@ -219,6 +222,57 @@ superAdminRouter.post(
     await exec.init(asyncJobUrl.toString());
     await exec.run(async (asyncJob) => {
       await addReindexJob(resourceTypes as ResourceType[], asyncJob, opts);
+    });
+
+    const { baseUrl } = getConfig();
+    sendOutcome(res, accepted(exec.getContentLocation(baseUrl)));
+  }
+);
+
+// to delete old versions of AWS Lambda functions matching a name pattern.
+superAdminRouter.post(
+  '/lambda-cleaner',
+  [
+    body('keepLatest').optional().isInt({ min: 1, max: 10 }).withMessage('keepLatest must be an integer from 1 to 10'),
+    body('deleteConcurrency')
+      .optional()
+      .isInt({ min: 1, max: 50 })
+      .withMessage('deleteConcurrency must be an integer from 1 to 10'),
+    body('dryRun').optional().isBoolean().withMessage('dryRun must be a boolean').toBoolean(),
+    checkExact(),
+  ],
+  async (req: Request, res: Response) => {
+    requireSuperAdmin();
+    requireAsync(req);
+
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      sendOutcome(res, invalidRequest(errors));
+      return;
+    }
+
+    const options: LambdaCleanerOptions = {
+      nameRegex: LAMBDA_NAME_REGEX_PATTERN,
+      keepLatest: req.body.keepLatest === undefined ? undefined : Number(req.body.keepLatest),
+      deleteConcurrency: req.body.deleteConcurrency === undefined ? undefined : Number(req.body.deleteConcurrency),
+      dryRun: req.body.dryRun === undefined ? true : Boolean(req.body.dryRun),
+    };
+
+    const queryForUrl: Record<string, string> = removeEmptyStrings({
+      nameRegex: options.nameRegex,
+      keepLatest: options.keepLatest?.toString(),
+      deleteConcurrency: options.deleteConcurrency?.toString(),
+      dryRun: (options.dryRun ?? true).toString(),
+    });
+
+    const asyncJobUrl = new URL(`${req.protocol}://${req.get('host') + req.originalUrl}`);
+    asyncJobUrl.search = getQueryString(queryForUrl);
+
+    const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID);
+    const exec = new AsyncJobExecutor(systemRepo);
+    await exec.init(asyncJobUrl.toString());
+    await exec.run(async (asyncJob) => {
+      await addLambdaCleanerJobData({ asyncJob, options });
     });
 
     const { baseUrl } = getConfig();
@@ -562,10 +616,10 @@ function requireAsync(req: Request): void {
   }
 }
 
-function removeEmptyStrings(record: Record<string, string>): Record<string, string> {
+function removeEmptyStrings(record: Record<string, string | undefined>): Record<string, string> {
   const cleaned: Record<string, string> = {};
   for (const [key, value] of Object.entries(record)) {
-    if (value !== '') {
+    if (value !== undefined && value !== '') {
       cleaned[key] = value;
     }
   }

--- a/packages/server/src/cloud/aws/deploy.ts
+++ b/packages/server/src/cloud/aws/deploy.ts
@@ -1,14 +1,11 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { GetFunctionConfigurationCommandOutput } from '@aws-sdk/client-lambda';
+import type { GetFunctionConfigurationCommandOutput, LambdaClient } from '@aws-sdk/client-lambda';
 import {
   CreateFunctionCommand,
-  DeleteFunctionCommand,
   GetFunctionCommand,
   GetFunctionConfigurationCommand,
-  LambdaClient,
   ListLayerVersionsCommand,
-  ListVersionsByFunctionCommand,
   PackageType,
   ResourceConflictException,
   ResourceNotFoundException,
@@ -17,19 +14,19 @@ import {
 } from '@aws-sdk/client-lambda';
 import { normalizeErrorString, sleep } from '@medplum/core';
 import type { Bot } from '@medplum/fhirtypes';
-import { ConfiguredRetryStrategy } from '@smithy/util-retry';
 import JSZip from 'jszip';
 import { getJsFileExtension } from '../../bots/utils';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import { getLogger, globalLogger } from '../../logger';
+import { createLambdaClient, deleteOldLambdaVersions } from './lambda';
 
 export const LAMBDA_RUNTIME = 'nodejs22.x';
 export const LAMBDA_HANDLER = 'index.handler';
 export const LAMBDA_MEMORY = 1024;
 export const DEFAULT_LAMBDA_TIMEOUT = 10;
 export const MAX_LAMBDA_TIMEOUT = 900; // 60 * 15 (15 mins)
-export const LAMBDA_VERSIONS_TO_KEEP = 2;
+const LAMBDA_VERSIONS_TO_KEEP = 2;
 
 const CJS_PREFIX = `const { ContentType, Hl7Message, MedplumClient } = require("@medplum/core");
 const PdfPrinter = require("pdfmake");
@@ -119,19 +116,8 @@ export function getLambdaNameForBot(bot: Bot): string {
   return `medplum-bot-lambda-${bot.id}`;
 }
 
-/**
- * Creates a new AWS Lambda client with a custom retry strategy.
- * @returns A configured LambdaClient.
- */
-export function createLambdaClient(): LambdaClient {
-  return new LambdaClient({
-    region: getConfig().awsRegion,
-    retryStrategy: new ConfiguredRetryStrategy(
-      5, // max attempts
-      (attempt: number) => 500 * 2 ** attempt // Exponential backoff
-    ),
-  });
-}
+export const LAMBDA_NAME_REGEX_PATTERN =
+  '^medplum-bot-lambda-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
 
 export async function getLambdaTimeoutForBot(bot: Bot): Promise<number> {
   const client = createLambdaClient();
@@ -178,7 +164,7 @@ export async function deployLambdaInternal(
     await updateLambda(bot, client, name, zipFile);
     const { project } = getAuthenticatedContext();
     // Don't block on delete since this could take a while
-    deleteOldLambdaVersions(client, name).catch((err) => {
+    deleteOldLambdaVersions(client, name, { dryRun: false, keepLatest: LAMBDA_VERSIONS_TO_KEEP }).catch((err) => {
       globalLogger.error('Error occurred while deleting old Lambdas', {
         projectId: project.id,
         name,
@@ -187,42 +173,6 @@ export async function deployLambdaInternal(
     });
   } else {
     await createLambda(bot, client, name, zipFile);
-  }
-}
-
-/**
- * Deletes published lambda versions older than the most recent `LAMBDA_VERSIONS_TO_KEEP` versions.
- * Always preserves the unpublished `$LATEST` qualifier.
- * @param client - The AWS Lambda client.
- * @param name - The lambda name.
- */
-export async function deleteOldLambdaVersions(client: LambdaClient, name: string): Promise<void> {
-  const log = getLogger();
-  const versions: number[] = [];
-  let marker: string | undefined;
-  do {
-    const response = await client.send(new ListVersionsByFunctionCommand({ FunctionName: name, Marker: marker }));
-    for (const v of response.Versions ?? []) {
-      const parsed = Number(v.Version);
-      if (Number.isInteger(parsed)) {
-        versions.push(parsed);
-      }
-    }
-    marker = response.NextMarker;
-  } while (marker);
-
-  const toDelete = versions.toSorted((a, b) => b - a).slice(LAMBDA_VERSIONS_TO_KEEP);
-  if (toDelete.length === 0) {
-    return;
-  }
-
-  log.info('Cleaning up old lambda versions', { name, versions: toDelete });
-  for (const version of toDelete) {
-    try {
-      await client.send(new DeleteFunctionCommand({ FunctionName: name, Qualifier: String(version) }));
-    } catch (err) {
-      log.warn('Failed to delete old lambda version', { name, version, err: normalizeErrorString(err) });
-    }
   }
 }
 

--- a/packages/server/src/cloud/aws/lambda.ts
+++ b/packages/server/src/cloud/aws/lambda.ts
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import {
+  DeleteFunctionCommand,
+  LambdaClient,
+  ListAliasesCommand,
+  ListVersionsByFunctionCommand,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-lambda';
+import { ConfiguredRetryStrategy } from '@smithy/util-retry';
+import { getConfig } from '../../config/loader';
+import { getLogger } from '../../logger';
+
+/**
+ * Creates a new AWS Lambda client with a custom retry strategy.
+ * @returns A configured LambdaClient.
+ */
+export function createLambdaClient(): LambdaClient {
+  return new LambdaClient({
+    region: getConfig().awsRegion,
+    retryStrategy: new ConfiguredRetryStrategy(
+      5, // max attempts
+      (attempt: number) => 500 * 2 ** attempt // Exponential backoff
+    ),
+  });
+}
+
+export interface DeleteLambdaVersionOptions {
+  readonly dryRun: boolean;
+  readonly keepLatest?: number;
+  readonly deleteConcurrency?: number;
+}
+
+export interface DeleteOldLambdaVersionStats {
+  functionsWithDeleteCandidates: number;
+  publishedVersionsScanned: number;
+  aliasProtectedVersions: number;
+  versionsPlanned: number;
+  versionsDeleted: number;
+  versionsNotFound: number;
+}
+
+/**
+ * Deletes old published versions of an AWS Lambda function.
+ * @param client - The AWS Lambda client.
+ * @param functionName - The name of the function to delete versions for.
+ * @param options - The options for the delete.
+ * @param stats - (Optional) If provided, the stats object will be updated with the results of the delete.
+ */
+export async function deleteOldLambdaVersions(
+  client: LambdaClient,
+  functionName: string,
+  options: DeleteLambdaVersionOptions,
+  stats?: DeleteOldLambdaVersionStats
+): Promise<void> {
+  const keepLatest = options.keepLatest ?? 1;
+  const deleteConcurrency = options.deleteConcurrency ?? 2;
+
+  if (keepLatest < 1) {
+    throw new Error('keepLatest must be at least 1');
+  }
+
+  const aliasVersions = await listAliasVersions(client, functionName);
+  const keepVersions = new Set<string>(aliasVersions);
+
+  const versions = await listPublishedVersions(client, functionName);
+  for (let i = 0; i < keepLatest; i++) {
+    keepVersions.add(versions[i]);
+  }
+
+  const deleteCandidates = versions.filter((v) => !keepVersions.has(v));
+  if (stats) {
+    stats.publishedVersionsScanned += versions.length;
+    stats.aliasProtectedVersions += aliasVersions.size;
+    stats.versionsPlanned += deleteCandidates.length;
+  }
+
+  if (deleteCandidates.length === 0) {
+    return;
+  }
+
+  if (stats) {
+    stats.functionsWithDeleteCandidates++;
+  }
+
+  if (options.dryRun) {
+    for (const version of deleteCandidates) {
+      getLogger().info('Would delete Lambda function version', { functionName, version });
+    }
+    return;
+  }
+
+  await runWithConcurrency(deleteCandidates, deleteConcurrency, async (version) => {
+    const result = await deleteLambdaVersion(client, functionName, version);
+    if (stats) {
+      if (result === 'deleted') {
+        stats.versionsDeleted++;
+      } else {
+        stats.versionsNotFound++;
+      }
+    }
+  });
+}
+
+/**
+ * Lists all published versions of a Lambda function.
+ * @param client - The AWS Lambda client.
+ * @param functionName - The name of the function to list versions for.
+ * @returns A list of published version numbers sorted in descending order.
+ */
+async function listPublishedVersions(client: LambdaClient, functionName: string): Promise<string[]> {
+  const versions: string[] = [];
+  let marker: string | undefined;
+
+  do {
+    const response = await client.send(
+      new ListVersionsByFunctionCommand({ FunctionName: functionName, Marker: marker })
+    );
+    marker = response.NextMarker;
+
+    for (const version of response.Versions ?? []) {
+      if (version.Version && version.Version !== '$LATEST') {
+        versions.push(version.Version);
+      }
+    }
+  } while (marker);
+
+  return versions.sort((a, b) => Number(b) - Number(a));
+}
+
+const SKIP_ALIAS_VERSIONS = true;
+const EMPTY_SET = new Set<string>();
+async function listAliasVersions(client: LambdaClient, functionName: string): Promise<Set<string>> {
+  if (SKIP_ALIAS_VERSIONS) {
+    return EMPTY_SET;
+  }
+
+  const versions = new Set<string>();
+  let marker: string | undefined;
+
+  do {
+    const response = await client.send(new ListAliasesCommand({ FunctionName: functionName, Marker: marker }));
+    marker = response.NextMarker;
+
+    for (const alias of response.Aliases ?? []) {
+      if (alias.FunctionVersion) {
+        versions.add(alias.FunctionVersion);
+      }
+      for (const version of Object.keys(alias.RoutingConfig?.AdditionalVersionWeights ?? {})) {
+        versions.add(version);
+      }
+    }
+  } while (marker);
+
+  return versions;
+}
+
+async function deleteLambdaVersion(
+  client: LambdaClient,
+  functionName: string,
+  version: string
+): Promise<'deleted' | 'not-found'> {
+  try {
+    await client.send(new DeleteFunctionCommand({ FunctionName: functionName, Qualifier: version }));
+    getLogger().info('Deleted Lambda function version', { functionName, version });
+    return 'deleted';
+  } catch (err) {
+    if (err instanceof ResourceNotFoundException) {
+      getLogger().info('Lambda function version already deleted', { functionName, version });
+      return 'not-found';
+    }
+
+    throw err;
+  }
+}
+
+async function runWithConcurrency<T>(
+  jobs: T[],
+  concurrency: number,
+  callback: (job: T) => Promise<void>
+): Promise<void> {
+  let nextIndex = 0;
+  const workerCount = Math.min(jobs.length, concurrency);
+
+  // invoke and wait for `workerCount` while loop workers to complete
+  // each worker processes items off the `items` queue one at a time until the queue is empty
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < jobs.length) {
+        const job = jobs[nextIndex++];
+        await callback(job);
+      }
+    })
+  );
+}

--- a/packages/server/src/cloud/aws/lambda.ts
+++ b/packages/server/src/cloud/aws/lambda.ts
@@ -3,8 +3,8 @@
 import {
   DeleteFunctionCommand,
   LambdaClient,
-  ListAliasesCommand,
   ListVersionsByFunctionCommand,
+  ResourceConflictException,
   ResourceNotFoundException,
 } from '@aws-sdk/client-lambda';
 import { ConfiguredRetryStrategy } from '@smithy/util-retry';
@@ -34,10 +34,10 @@ export interface DeleteLambdaVersionOptions {
 export interface DeleteOldLambdaVersionStats {
   functionsWithDeleteCandidates: number;
   publishedVersionsScanned: number;
-  aliasProtectedVersions: number;
   versionsPlanned: number;
   versionsDeleted: number;
   versionsNotFound: number;
+  versionsHasAlias: number;
 }
 
 /**
@@ -60,9 +60,7 @@ export async function deleteOldLambdaVersions(
     throw new Error('keepLatest must be at least 1');
   }
 
-  const aliasVersions = await listAliasVersions(client, functionName);
-  const keepVersions = new Set<string>(aliasVersions);
-
+  const keepVersions = new Set<string>();
   const versions = await listPublishedVersions(client, functionName);
   for (let i = 0; i < keepLatest; i++) {
     keepVersions.add(versions[i]);
@@ -71,7 +69,6 @@ export async function deleteOldLambdaVersions(
   const deleteCandidates = versions.filter((v) => !keepVersions.has(v));
   if (stats) {
     stats.publishedVersionsScanned += versions.length;
-    stats.aliasProtectedVersions += aliasVersions.size;
     stats.versionsPlanned += deleteCandidates.length;
   }
 
@@ -92,12 +89,22 @@ export async function deleteOldLambdaVersions(
 
   await runWithConcurrency(deleteCandidates, deleteConcurrency, async (version) => {
     const result = await deleteLambdaVersion(client, functionName, version);
-    if (stats) {
-      if (result === 'deleted') {
+    if (!stats) {
+      return;
+    }
+    switch (result) {
+      case 'deleted':
         stats.versionsDeleted++;
-      } else {
+        break;
+      case 'not-found':
         stats.versionsNotFound++;
-      }
+        break;
+      case 'has-alias':
+        stats.versionsHasAlias++;
+        break;
+      default:
+        result satisfies never;
+        throw new Error('Unknown deleteLambdaVersion result', { cause: result });
     }
   });
 }
@@ -128,38 +135,11 @@ async function listPublishedVersions(client: LambdaClient, functionName: string)
   return versions.sort((a, b) => Number(b) - Number(a));
 }
 
-const SKIP_ALIAS_VERSIONS = true;
-const EMPTY_SET = new Set<string>();
-async function listAliasVersions(client: LambdaClient, functionName: string): Promise<Set<string>> {
-  if (SKIP_ALIAS_VERSIONS) {
-    return EMPTY_SET;
-  }
-
-  const versions = new Set<string>();
-  let marker: string | undefined;
-
-  do {
-    const response = await client.send(new ListAliasesCommand({ FunctionName: functionName, Marker: marker }));
-    marker = response.NextMarker;
-
-    for (const alias of response.Aliases ?? []) {
-      if (alias.FunctionVersion) {
-        versions.add(alias.FunctionVersion);
-      }
-      for (const version of Object.keys(alias.RoutingConfig?.AdditionalVersionWeights ?? {})) {
-        versions.add(version);
-      }
-    }
-  } while (marker);
-
-  return versions;
-}
-
 async function deleteLambdaVersion(
   client: LambdaClient,
   functionName: string,
   version: string
-): Promise<'deleted' | 'not-found'> {
+): Promise<'deleted' | 'not-found' | 'has-alias'> {
   try {
     await client.send(new DeleteFunctionCommand({ FunctionName: functionName, Qualifier: version }));
     getLogger().info('Deleted Lambda function version', { functionName, version });
@@ -168,6 +148,10 @@ async function deleteLambdaVersion(
     if (err instanceof ResourceNotFoundException) {
       getLogger().info('Lambda function version already deleted', { functionName, version });
       return 'not-found';
+    } else if (err instanceof ResourceConflictException) {
+      // Unable to delete version because the following aliases reference it: [<alias>]
+      getLogger().info('Lambda function version already in use', { functionName, version });
+      return 'has-alias';
     }
 
     throw err;

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -289,7 +289,8 @@ export type WorkerName =
   | 'reindex'
   | 'batch'
   | 'post-deploy-migration'
-  | 'set-accounts';
+  | 'set-accounts'
+  | 'lambda-cleaner';
 
 export interface MedplumWorkersConfig {
   /**

--- a/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
+++ b/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
@@ -47,7 +47,7 @@ export class AsyncJobExecutor {
    * @param callback - The callback to execute.
    * @returns A promise that resolves when the job is completed or fails.
    */
-  async startAsync(callback: (job: AsyncJob) => Promise<any>): Promise<AsyncJob | undefined> {
+  async startAsync(callback: (job: AsyncJob) => Promise<any>): Promise<WithId<AsyncJob>> {
     const log = getLogger();
     if (!this.resource) {
       throw new Error('AsyncJob missing');
@@ -102,11 +102,11 @@ export class AsyncJobExecutor {
     return output ?? undefined;
   }
 
-  async completeJob(output?: Parameters): Promise<AsyncJob> {
+  async completeJob(output?: Parameters): Promise<WithId<AsyncJob>> {
     if (!this.resource) {
       throw new Error('Cannot completeJob since AsyncJob is not specified');
     }
-    let updatedJob: AsyncJob = {
+    let updatedJob: WithId<AsyncJob> = {
       ...this.resource,
       status: 'completed',
       transactionTime: new Date().toISOString(),
@@ -127,7 +127,7 @@ export class AsyncJobExecutor {
     }
   }
 
-  async failJob(err?: Error, output?: Parameters): Promise<AsyncJob> {
+  async failJob(err?: Error, output?: Parameters): Promise<WithId<AsyncJob>> {
     if (!this.resource) {
       throw new Error('Cannot failJob since AsyncJob is not specified');
     }
@@ -139,7 +139,7 @@ export class AsyncJobExecutor {
       throw err;
     }
 
-    const failedJob: AsyncJob = {
+    const failedJob: WithId<AsyncJob> = {
       ...this.resource,
       status: 'error',
       transactionTime: new Date().toISOString(),

--- a/packages/server/src/workers/index.ts
+++ b/packages/server/src/workers/index.ts
@@ -8,6 +8,7 @@ import { initBatchWorker } from './batch';
 import { initCronWorker } from './cron';
 import { addDispatchJobs, initDispatchWorker } from './dispatch';
 import { initDownloadWorker } from './download';
+import { initLambdaCleanerWorker } from './lambda-cleaner';
 import { initPostDeployMigrationWorker } from './post-deploy-migration';
 import { initReindexWorker } from './reindex';
 import { initSetAccountsWorker } from './set-accounts';
@@ -24,6 +25,7 @@ const workerDefs: { name: WorkerName; init: WorkerInitializer }[] = [
   { name: 'batch', init: initBatchWorker },
   { name: 'post-deploy-migration', init: initPostDeployMigrationWorker },
   { name: 'set-accounts', init: initSetAccountsWorker },
+  { name: 'lambda-cleaner', init: initLambdaCleanerWorker },
 ];
 
 /**

--- a/packages/server/src/workers/lambda-cleaner.test.ts
+++ b/packages/server/src/workers/lambda-cleaner.test.ts
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import {
+  DeleteFunctionCommand,
+  LambdaClient,
+  ListAliasesCommand,
+  ListFunctionsCommand,
+  ListVersionsByFunctionCommand,
+} from '@aws-sdk/client-lambda';
+import type { AwsClientStub } from 'aws-sdk-client-mock';
+import { mockClient } from 'aws-sdk-client-mock';
+import 'aws-sdk-client-mock-jest';
+import { loadTestConfig } from '../config/loader';
+import { execLambdaCleanerJob } from './lambda-cleaner';
+
+describe('Lambda version cleanup worker', () => {
+  let mockLambdaClient: AwsClientStub<LambdaClient>;
+
+  beforeAll(async () => {
+    await loadTestConfig();
+  });
+
+  beforeEach(() => {
+    mockLambdaClient = mockClient(LambdaClient);
+  });
+
+  afterEach(() => {
+    mockLambdaClient.restore();
+  });
+
+  test('cleanupLambdaVersions deletes old matching function versions', async () => {
+    mockLambdaClient.on(ListFunctionsCommand).resolves({
+      Functions: [
+        { FunctionName: 'medplum-bot-lambda-a' },
+        { FunctionName: 'other-function' },
+        { FunctionName: 'medplum-bot-lambda-b' },
+      ],
+    });
+    mockLambdaClient.on(ListVersionsByFunctionCommand).callsFake(({ FunctionName }) => {
+      if (FunctionName === 'medplum-bot-lambda-a') {
+        return {
+          Versions: [{ Version: '$LATEST' }, { Version: '1' }, { Version: '2' }, { Version: '3' }, { Version: '4' }],
+        };
+      }
+      if (FunctionName === 'medplum-bot-lambda-b') {
+        return {
+          Versions: [{ Version: '$LATEST' }, { Version: '1' }, { Version: '2' }],
+        };
+      }
+      throw new Error(`Unexpected function: ${FunctionName}`);
+    });
+    mockLambdaClient.on(ListAliasesCommand).callsFake(({ FunctionName }) => {
+      if (FunctionName === 'medplum-bot-lambda-a') {
+        return {
+          Aliases: [
+            {
+              Name: 'prod',
+              FunctionVersion: '3',
+              RoutingConfig: { AdditionalVersionWeights: { '2': 0.1 } },
+            },
+          ],
+        };
+      }
+      return { Aliases: [] };
+    });
+    mockLambdaClient.on(DeleteFunctionCommand).resolves({});
+
+    const summary = await execLambdaCleanerJob(
+      {
+        nameRegex: '^medplum-bot-lambda-*',
+        keepLatest: 1,
+        deleteConcurrency: 2,
+        dryRun: false,
+      },
+      new LambdaClient({ region: 'us-east-1' })
+    );
+
+    expect(summary).toMatchObject({
+      options: {
+        nameRegex: '^medplum-bot-lambda-*',
+        keepLatest: 1,
+        deleteConcurrency: 2,
+        dryRun: false,
+      },
+      functionsScanned: 3,
+      functionsMatched: 2,
+      functionsWithDeleteCandidates: 2,
+      publishedVersionsScanned: 6,
+      aliasProtectedVersions: 0,
+      versionsPlanned: 4,
+      versionsDeleted: 4,
+      versionsNotFound: 0,
+      durationMs: expect.any(Number),
+    });
+
+    expect(mockLambdaClient).toHaveReceivedCommandTimes(ListAliasesCommand, 0);
+    expect(mockLambdaClient).toHaveReceivedCommandTimes(DeleteFunctionCommand, 4);
+    expect(mockLambdaClient).toHaveReceivedCommandWith(DeleteFunctionCommand, {
+      FunctionName: 'medplum-bot-lambda-a',
+      Qualifier: '1',
+    });
+    expect(mockLambdaClient).toHaveReceivedCommandWith(DeleteFunctionCommand, {
+      FunctionName: 'medplum-bot-lambda-b',
+      Qualifier: '1',
+    });
+  });
+
+  test('cleanupLambdaVersions dry run does not delete', async () => {
+    mockLambdaClient.on(ListFunctionsCommand).resolves({
+      Functions: [{ FunctionName: 'medplum-bot-lambda-a' }],
+    });
+    mockLambdaClient.on(ListVersionsByFunctionCommand).resolves({
+      Versions: [{ Version: '$LATEST' }, { Version: '1' }, { Version: '2' }],
+    });
+    mockLambdaClient.on(ListAliasesCommand).resolves({ Aliases: [] });
+    mockLambdaClient.on(DeleteFunctionCommand).resolves({});
+
+    const summary = await execLambdaCleanerJob(
+      {
+        nameRegex: '^medplum-bot-lambda-[a-z]$',
+        keepLatest: 1,
+        dryRun: true,
+      },
+      new LambdaClient({ region: 'us-east-1' })
+    );
+
+    expect(summary.versionsPlanned).toBe(1);
+    expect(summary.versionsDeleted).toBe(0);
+    expect(mockLambdaClient).toHaveReceivedCommandTimes(DeleteFunctionCommand, 0);
+  });
+});

--- a/packages/server/src/workers/lambda-cleaner.test.ts
+++ b/packages/server/src/workers/lambda-cleaner.test.ts
@@ -6,6 +6,8 @@ import {
   ListAliasesCommand,
   ListFunctionsCommand,
   ListVersionsByFunctionCommand,
+  ResourceConflictException,
+  ResourceNotFoundException,
 } from '@aws-sdk/client-lambda';
 import type { AwsClientStub } from 'aws-sdk-client-mock';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -63,7 +65,16 @@ describe('Lambda version cleanup worker', () => {
       }
       return { Aliases: [] };
     });
-    mockLambdaClient.on(DeleteFunctionCommand).resolves({});
+    // mockLambdaClient.on(DeleteFunctionCommand).resolves({});
+    mockLambdaClient.on(DeleteFunctionCommand).callsFake(({ FunctionName, Qualifier }) => {
+      if (FunctionName === 'medplum-bot-lambda-a' && Qualifier === '2') {
+        throw new ResourceConflictException({ $metadata: {}, message: 'Version has an alias' });
+      }
+      if (FunctionName === 'medplum-bot-lambda-b' && Qualifier === '1') {
+        throw new ResourceNotFoundException({ $metadata: {}, message: 'Version not found' });
+      }
+      return {};
+    });
 
     const summary = await execLambdaCleanerJob(
       {
@@ -86,10 +97,10 @@ describe('Lambda version cleanup worker', () => {
       functionsMatched: 2,
       functionsWithDeleteCandidates: 2,
       publishedVersionsScanned: 6,
-      aliasProtectedVersions: 0,
       versionsPlanned: 4,
-      versionsDeleted: 4,
-      versionsNotFound: 0,
+      versionsDeleted: 2,
+      versionsNotFound: 1,
+      versionsHasAlias: 1,
       durationMs: expect.any(Number),
     });
 

--- a/packages/server/src/workers/lambda-cleaner.test.ts
+++ b/packages/server/src/workers/lambda-cleaner.test.ts
@@ -12,14 +12,25 @@ import {
 import type { AwsClientStub } from 'aws-sdk-client-mock';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
+import type { Job } from 'bullmq';
+import assert from 'node:assert';
+import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
-import { execLambdaCleanerJob } from './lambda-cleaner';
+import { AsyncJobExecutor } from '../fhir/operations/utils/asyncjobexecutor';
+import { getShardSystemRepo } from '../fhir/repo';
+import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
+import type { LambdaCleanerJobData } from './lambda-cleaner';
+import { execLambdaCleanerJob, lambdaCleanerJobProcessor } from './lambda-cleaner';
 
 describe('Lambda version cleanup worker', () => {
   let mockLambdaClient: AwsClientStub<LambdaClient>;
 
   beforeAll(async () => {
-    await loadTestConfig();
+    const config = await loadTestConfig();
+    await initAppServices(config);
+  });
+  afterAll(async () => {
+    await shutdownApp();
   });
 
   beforeEach(() => {
@@ -76,33 +87,22 @@ describe('Lambda version cleanup worker', () => {
       return {};
     });
 
-    const summary = await execLambdaCleanerJob(
-      {
-        nameRegex: '^medplum-bot-lambda-*',
-        keepLatest: 1,
-        deleteConcurrency: 2,
-        dryRun: false,
+    const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID);
+    const exec = new AsyncJobExecutor(systemRepo);
+    const asyncJob = await exec.init('/some-url');
+    const job = {
+      data: {
+        asyncJob,
+        options: { nameRegex: '^medplum-bot-lambda-*', keepLatest: 1, deleteConcurrency: 2, dryRun: false },
       },
-      new LambdaClient({ region: 'us-east-1' })
-    );
+    } as unknown as Job<LambdaCleanerJobData>;
+    const updatedAsyncJob = await lambdaCleanerJobProcessor(job);
 
-    expect(summary).toMatchObject({
-      options: {
-        nameRegex: '^medplum-bot-lambda-*',
-        keepLatest: 1,
-        deleteConcurrency: 2,
-        dryRun: false,
-      },
-      functionsScanned: 3,
-      functionsMatched: 2,
-      functionsWithDeleteCandidates: 2,
-      publishedVersionsScanned: 6,
-      versionsPlanned: 4,
-      versionsDeleted: 2,
-      versionsNotFound: 1,
-      versionsHasAlias: 1,
-      durationMs: expect.any(Number),
-    });
+    const output = updatedAsyncJob.output;
+    assert(output);
+    expect(output.parameter?.find((p) => p.name === 'versionsDeleted')?.valueInteger).toBe(2);
+    expect(output.parameter?.find((p) => p.name === 'versionsNotFound')?.valueInteger).toBe(1);
+    expect(output.parameter?.find((p) => p.name === 'versionsHasAlias')?.valueInteger).toBe(1);
 
     expect(mockLambdaClient).toHaveReceivedCommandTimes(ListAliasesCommand, 0);
     expect(mockLambdaClient).toHaveReceivedCommandTimes(DeleteFunctionCommand, 4);
@@ -135,8 +135,26 @@ describe('Lambda version cleanup worker', () => {
       new LambdaClient({ region: 'us-east-1' })
     );
 
-    expect(summary.versionsPlanned).toBe(1);
-    expect(summary.versionsDeleted).toBe(0);
+    expect(summary).toStrictEqual({
+      options: {
+        nameRegex: '^medplum-bot-lambda-[a-z]$',
+        keepLatest: 1,
+        dryRun: true,
+        deleteConcurrency: 5,
+      },
+      publishedVersionsScanned: 2,
+      functionsScanned: 1,
+      functionsWithDeleteCandidates: 1,
+      functionsMatched: 1,
+      versionsPlanned: 1,
+      versionsDeleted: 0,
+      versionsNotFound: 0,
+      versionsHasAlias: 0,
+      durationMs: expect.any(Number),
+    });
+
+    // expect(summary.versionsPlanned).toBe(1);
+    // expect(summary.versionsDeleted).toBe(0);
     expect(mockLambdaClient).toHaveReceivedCommandTimes(DeleteFunctionCommand, 0);
   });
 });

--- a/packages/server/src/workers/lambda-cleaner.ts
+++ b/packages/server/src/workers/lambda-cleaner.ts
@@ -3,6 +3,7 @@
 import type { LambdaClient } from '@aws-sdk/client-lambda';
 import { ListFunctionsCommand } from '@aws-sdk/client-lambda';
 import type { WithId } from '@medplum/core';
+import { EMPTY } from '@medplum/core';
 import type { AsyncJob, Parameters, ParametersParameter } from '@medplum/fhirtypes';
 import type { Job, QueueBaseOptions } from 'bullmq';
 import { Queue, Worker } from 'bullmq';
@@ -59,7 +60,7 @@ export const initLambdaCleanerWorker: WorkerInitializer = (config, options?: Wor
   let worker: Worker<LambdaCleanerJobData> | undefined;
   if (options?.workerEnabled !== false) {
     const workerConfig = getWorkerBullmqConfig(config, 'lambda-cleaner');
-    worker = new Worker<LambdaCleanerJobData>(LambdaCleanerQueueName, (job) => jobProcessor(job), {
+    worker = new Worker<LambdaCleanerJobData>(LambdaCleanerQueueName, (job) => lambdaCleanerJobProcessor(job), {
       ...defaultOptions,
       concurrency: 1,
       ...workerConfig,
@@ -86,10 +87,10 @@ export async function addLambdaCleanerJobData(jobData: LambdaCleanerJobData): Pr
   return queue.add('LambdaCleanerJob', jobData);
 }
 
-async function jobProcessor(job: Job<LambdaCleanerJobData>): Promise<void> {
+export async function lambdaCleanerJobProcessor(job: Job<LambdaCleanerJobData>): Promise<WithId<AsyncJob>> {
   const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID);
   const exec = new AsyncJobExecutor(systemRepo, job.data.asyncJob);
-  await exec.startAsync(async () => {
+  return exec.startAsync(async () => {
     const summary = await execLambdaCleanerJob(job.data.options);
     return formatSummary(summary);
   });
@@ -126,19 +127,15 @@ export async function execLambdaCleanerJob(
     const response = await lambdaClient.send(new ListFunctionsCommand({ Marker: marker }));
     marker = response.NextMarker;
 
-    for (const lambdaFunction of response.Functions ?? []) {
+    for (const lambdaFunction of response.Functions ?? EMPTY) {
       const functionName = lambdaFunction.FunctionName;
-      if (!functionName) {
-        continue;
+      if (functionName) {
+        summary.functionsScanned++;
+        if (nameRegex.test(functionName)) {
+          summary.functionsMatched++;
+          await deleteOldLambdaVersions(lambdaClient, functionName, options, summary);
+        }
       }
-      summary.functionsScanned++;
-
-      if (!nameRegex.test(functionName)) {
-        continue;
-      }
-
-      summary.functionsMatched++;
-      await deleteOldLambdaVersions(lambdaClient, functionName, options, summary);
     }
   } while (marker);
 
@@ -162,7 +159,7 @@ function formatSummary(summary: LambdaCleanerSummary): Parameters {
     { name: 'versionsDeleted', valueInteger: stats.versionsDeleted },
     { name: 'versionsNotFound', valueInteger: stats.versionsNotFound },
     { name: 'versionsHasAlias', valueInteger: stats.versionsHasAlias },
-    { name: 'duration', valueQuantity: { value: stats.durationMs, code: 'ms' } },
+    { name: 'durationMs', valueQuantity: { value: stats.durationMs, code: 'ms' } },
   ];
 
   return {

--- a/packages/server/src/workers/lambda-cleaner.ts
+++ b/packages/server/src/workers/lambda-cleaner.ts
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { LambdaClient } from '@aws-sdk/client-lambda';
+import { ListFunctionsCommand } from '@aws-sdk/client-lambda';
+import type { WithId } from '@medplum/core';
+import type { AsyncJob, Parameters, ParametersParameter } from '@medplum/fhirtypes';
+import type { Job, QueueBaseOptions } from 'bullmq';
+import { Queue, Worker } from 'bullmq';
+import type { DeleteOldLambdaVersionStats } from '../cloud/aws/lambda';
+import { createLambdaClient, deleteOldLambdaVersions } from '../cloud/aws/lambda';
+import { AsyncJobExecutor } from '../fhir/operations/utils/asyncjobexecutor';
+import { getShardSystemRepo } from '../fhir/repo';
+import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
+import { globalLogger } from '../logger';
+import type { WorkerInitializer, WorkerInitializerOptions } from './utils';
+import { addVerboseQueueLogging, getBullmqRedisConnectionOptions, getWorkerBullmqConfig, queueRegistry } from './utils';
+
+export interface LambdaCleanerOptions {
+  readonly nameRegex: string;
+  readonly keepLatest?: number;
+  readonly deleteConcurrency?: number;
+  readonly dryRun?: boolean;
+}
+
+interface ResolvedLambdaCleanerOptions extends LambdaCleanerOptions {
+  readonly keepLatest: number;
+  readonly deleteConcurrency: number;
+  readonly dryRun: boolean;
+}
+
+const DEFAULT_KEEP_LATEST = 1;
+const DEFAULT_DELETE_CONCURRENCY = 5;
+const DEFAULT_DRY_RUN = true;
+
+export interface LambdaCleanerJobData {
+  readonly asyncJob: WithId<AsyncJob>;
+  readonly options: LambdaCleanerOptions;
+}
+
+export interface LambdaCleanerSummary extends DeleteOldLambdaVersionStats {
+  readonly options: LambdaCleanerOptions;
+  functionsScanned: number;
+  functionsMatched: number;
+  durationMs: number;
+}
+
+export const LambdaCleanerQueueName = 'LambdaCleanerQueue';
+
+export const initLambdaCleanerWorker: WorkerInitializer = (config, options?: WorkerInitializerOptions) => {
+  const defaultOptions: QueueBaseOptions = {
+    connection: getBullmqRedisConnectionOptions(config),
+  };
+
+  const queue = new Queue<LambdaCleanerJobData>(LambdaCleanerQueueName, {
+    ...defaultOptions,
+    defaultJobOptions: { attempts: 1 },
+  });
+
+  let worker: Worker<LambdaCleanerJobData> | undefined;
+  if (options?.workerEnabled !== false) {
+    const workerConfig = getWorkerBullmqConfig(config, 'lambda-cleaner');
+    worker = new Worker<LambdaCleanerJobData>(LambdaCleanerQueueName, (job) => jobProcessor(job), {
+      ...defaultOptions,
+      concurrency: 1,
+      ...workerConfig,
+    });
+    addVerboseQueueLogging<LambdaCleanerJobData>(queue, worker, (job) => ({
+      asyncJob: `AsyncJob/${job.data.asyncJob.id}`,
+      nameRegex: job.data.options.nameRegex,
+      dryRun: job.data.options.dryRun,
+    }));
+  }
+
+  return { queue, worker, name: LambdaCleanerQueueName };
+};
+
+export function getLambdaCleanerQueue(): Queue<LambdaCleanerJobData> | undefined {
+  return queueRegistry.get(LambdaCleanerQueueName);
+}
+
+export async function addLambdaCleanerJobData(jobData: LambdaCleanerJobData): Promise<Job<LambdaCleanerJobData>> {
+  const queue = getLambdaCleanerQueue();
+  if (!queue) {
+    throw new Error(`Job queue ${LambdaCleanerQueueName} not available`);
+  }
+  return queue.add('LambdaCleanerJob', jobData);
+}
+
+async function jobProcessor(job: Job<LambdaCleanerJobData>): Promise<void> {
+  const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID);
+  const exec = new AsyncJobExecutor(systemRepo, job.data.asyncJob);
+  await exec.startAsync(async () => {
+    const summary = await execLambdaCleanerJob(job.data.options);
+    return formatSummary(summary);
+  });
+}
+
+export async function execLambdaCleanerJob(
+  inputOptions: LambdaCleanerOptions,
+  client?: LambdaClient
+): Promise<LambdaCleanerSummary> {
+  const options: ResolvedLambdaCleanerOptions = {
+    nameRegex: inputOptions.nameRegex,
+    keepLatest: inputOptions.keepLatest ?? DEFAULT_KEEP_LATEST,
+    deleteConcurrency: inputOptions.deleteConcurrency ?? DEFAULT_DELETE_CONCURRENCY,
+    dryRun: inputOptions.dryRun ?? DEFAULT_DRY_RUN,
+  };
+  const lambdaClient = client ?? createLambdaClient();
+  const startTime = Date.now();
+  const summary: LambdaCleanerSummary = {
+    options,
+    functionsScanned: 0,
+    functionsMatched: 0,
+    functionsWithDeleteCandidates: 0,
+    publishedVersionsScanned: 0,
+    aliasProtectedVersions: 0,
+    versionsPlanned: 0,
+    versionsDeleted: 0,
+    versionsNotFound: 0,
+    durationMs: 0,
+  };
+
+  const nameRegex = new RegExp(options.nameRegex);
+  let marker: string | undefined;
+  do {
+    const response = await lambdaClient.send(new ListFunctionsCommand({ Marker: marker }));
+    marker = response.NextMarker;
+
+    for (const lambdaFunction of response.Functions ?? []) {
+      const functionName = lambdaFunction.FunctionName;
+      if (!functionName) {
+        continue;
+      }
+      summary.functionsScanned++;
+
+      if (!nameRegex.test(functionName)) {
+        continue;
+      }
+
+      summary.functionsMatched++;
+      await deleteOldLambdaVersions(lambdaClient, functionName, options, summary);
+    }
+  } while (marker);
+
+  summary.durationMs = Date.now() - startTime;
+  globalLogger.info('Lambda cleaner completed', summary);
+  return summary;
+}
+
+function formatSummary(summary: LambdaCleanerSummary): Parameters {
+  const { options, ...stats } = summary;
+  const parameters: ParametersParameter[] = [
+    { name: 'options.nameRegex', valueString: options.nameRegex },
+    { name: 'options.keepLatest', valueInteger: options.keepLatest },
+    { name: 'options.deleteConcurrency', valueInteger: options.deleteConcurrency },
+    { name: 'options.dryRun', valueBoolean: options.dryRun },
+    { name: 'functionsScanned', valueInteger: stats.functionsScanned },
+    { name: 'functionsMatched', valueInteger: stats.functionsMatched },
+    { name: 'functionsWithDeleteCandidates', valueInteger: stats.functionsWithDeleteCandidates },
+    { name: 'publishedVersionsScanned', valueInteger: stats.publishedVersionsScanned },
+    { name: 'aliasProtectedVersions', valueInteger: stats.aliasProtectedVersions },
+    { name: 'versionsPlanned', valueInteger: stats.versionsPlanned },
+    { name: 'versionsDeleted', valueInteger: stats.versionsDeleted },
+    { name: 'versionsNotFound', valueInteger: stats.versionsNotFound },
+    { name: 'duration', valueQuantity: { value: stats.durationMs, code: 'ms' } },
+  ];
+
+  return {
+    resourceType: 'Parameters',
+    parameter: parameters,
+  };
+}

--- a/packages/server/src/workers/lambda-cleaner.ts
+++ b/packages/server/src/workers/lambda-cleaner.ts
@@ -113,10 +113,10 @@ export async function execLambdaCleanerJob(
     functionsMatched: 0,
     functionsWithDeleteCandidates: 0,
     publishedVersionsScanned: 0,
-    aliasProtectedVersions: 0,
     versionsPlanned: 0,
     versionsDeleted: 0,
     versionsNotFound: 0,
+    versionsHasAlias: 0,
     durationMs: 0,
   };
 
@@ -158,10 +158,10 @@ function formatSummary(summary: LambdaCleanerSummary): Parameters {
     { name: 'functionsMatched', valueInteger: stats.functionsMatched },
     { name: 'functionsWithDeleteCandidates', valueInteger: stats.functionsWithDeleteCandidates },
     { name: 'publishedVersionsScanned', valueInteger: stats.publishedVersionsScanned },
-    { name: 'aliasProtectedVersions', valueInteger: stats.aliasProtectedVersions },
     { name: 'versionsPlanned', valueInteger: stats.versionsPlanned },
     { name: 'versionsDeleted', valueInteger: stats.versionsDeleted },
     { name: 'versionsNotFound', valueInteger: stats.versionsNotFound },
+    { name: 'versionsHasAlias', valueInteger: stats.versionsHasAlias },
     { name: 'duration', valueQuantity: { value: stats.durationMs, code: 'ms' } },
   ];
 

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -214,7 +214,7 @@ function getFinishedJobFieldsForLogging(job: Job): Record<string, string | numbe
 export function addVerboseQueueLogging<TDataType>(
   queue: Queue,
   worker: Worker,
-  getJobDataLoggingFields?: (job: Job<TDataType>) => Record<string, string | number | undefined>
+  getJobDataLoggingFields?: (job: Job<TDataType>) => Record<string, string | number | boolean | undefined>
 ): void {
   worker.on('active', (job, prev) => {
     globalLogger.info(`${queue.name} worker: active`, {


### PR DESCRIPTION
This builds on #9167 by scanning all lambda functions and performing old version cleanup as needed.

TODO before merging:

- [ ] Deploy CDK change

Output from a test [run on staging](https://app.staging.medplum.dev/AsyncJob/3fb1f688-6a5e-4c23-a4d9-a135196bd73c/json) including a Bot that had an aliased version:

```sh
npx medplum --base-url https://api.staging.medplum.dev \
    post --prefer-async admin/super/lambda-cleaner '{"dryRun":false}'
```

```json
{
  "resourceType": "AsyncJob",
  "status": "completed",
  "request": "https://api.staging.medplum.dev/admin/super/lambda-cleaner?nameRegex=%5Emedplum-bot-lambda-%5B0-9a-f%5D%7B8%7D-%5B0-9a-f%5D%7B4%7D-%5B0-9a-f%5D%7B4%7D-%5B0-9a-f%5D%7B4%7D-%5B0-9a-f%5D%7B12%7D%24&dryRun=false",
  "requestTime": "2026-05-11T20:40:35.729Z",
  "id": "3fb1f688-6a5e-4c23-a4d9-a135196bd73c",
  "meta": {
    "versionId": "ef14f8d8-a4d4-4f66-832d-20f00e1caf91",
    "lastUpdated": "2026-05-11T20:40:41.406Z",
    "author": {
      "reference": "system"
    }
  },
  "transactionTime": "2026-05-11T20:40:41.405Z",
  "output": {
    "resourceType": "Parameters",
    "parameter": [
      {
        "name": "options.nameRegex",
        "valueString": "^medplum-bot-lambda-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
      },
      {
        "name": "options.keepLatest",
        "valueInteger": 1
      },
      {
        "name": "options.deleteConcurrency",
        "valueInteger": 5
      },
      {
        "name": "options.dryRun",
        "valueBoolean": false
      },
      {
        "name": "functionsScanned",
        "valueInteger": 81
      },
      {
        "name": "functionsMatched",
        "valueInteger": 79
      },
      {
        "name": "functionsWithDeleteCandidates",
        "valueInteger": 1
      },
      {
        "name": "publishedVersionsScanned",
        "valueInteger": 81
      },
      {
        "name": "versionsPlanned",
        "valueInteger": 2
      },
      {
        "name": "versionsDeleted",
        "valueInteger": 1
      },
      {
        "name": "versionsNotFound",
        "valueInteger": 0
      },
      {
        "name": "versionsHasAlias",
        "valueInteger": 1
      },
      {
        "name": "duration",
        "valueQuantity": {
          "value": 5648,
          "code": "ms"
        }
      }
    ]
  }
}
```
Impact lambda version before/after
### Before
<img width="751" height="242" alt="Screenshot 2026-05-11 at 1 40 31 PM" src="https://github.com/user-attachments/assets/cc5cc04f-f941-4cac-ac06-a638b8b08da9" />

### After
<img width="740" height="205" alt="Screenshot 2026-05-11 at 1 40 41 PM" src="https://github.com/user-attachments/assets/392e1c50-b9bf-493e-8613-6bbb12f48d30" />
