### PR TITLE
Add $book support for proposed appointment input

### DIFF
--- a/packages/docs/docs/scheduling/appointment-book.md
+++ b/packages/docs/docs/scheduling/appointment-book.md
@@ -257,21 +257,12 @@ The transaction uses serializable isolation to prevent double-booking under conc
 
 ## Error Responses
 
-### Time No Longer Available
+### Time Not Available
 
 ```json
 {
   "resourceType": "OperationOutcome",
-  "issue": [{ "severity": "error", "code": "conflict", "details": { "text": "Requested time slot is no longer available" } }]
-}
-```
-
-### No Availability Found
-
-```json
-{
-  "resourceType": "OperationOutcome",
-  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "No availability found at this time" } }]
+  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "Requested time slot is not available" } }]
 }
 ```
 
@@ -281,15 +272,6 @@ The transaction uses serializable isolation to prevent double-booking under conc
 {
   "resourceType": "OperationOutcome",
   "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "Mismatched slot start times" } }]
-}
-```
-
-### No Matching Scheduling Parameters
-
-```json
-{
-  "resourceType": "OperationOutcome",
-  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "No matching scheduling parameters found" } }]
 }
 ```
 

--- a/packages/docs/docs/scheduling/appointment-book.md
+++ b/packages/docs/docs/scheduling/appointment-book.md
@@ -3,11 +3,16 @@ sidebar_label: Appointment $book
 sidebar_position: 3
 ---
 
+import ExampleCode from '!!raw-loader!@site/../examples/src/scheduling/book.ts';
+import MedplumCodeBlock from '@site/src/components/MedplumCodeBlock';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Appointment $book
 
 :::info[Alpha]
 
-The `$book` operation is currently in alpha. It supports only Schedules with a single actor.
+The `$book` operation is currently in alpha.
 
 :::
 
@@ -15,7 +20,7 @@ The `$book` operation books an [`Appointment`](/docs/api/fhir/resources/appointm
 
 ## Use Cases
 
-- **Single-provider booking**: Book a patient into an open slot returned by [`$find`](/docs/scheduling/appointment-find)
+- **Direct booking**: Book an appointment directly from a `$find` result, without a prior hold
 - **Multi-resource booking**: Simultaneously book multiple Schedules (e.g., surgeon + OR room + anesthesiologist) for the same appointment time
 - **Programmatic scheduling**: Automate appointment creation from external systems while respecting provider availability rules
 
@@ -25,103 +30,12 @@ The `$book` operation books an [`Appointment`](/docs/api/fhir/resources/appointm
 [base]/R4/Appointment/$book
 ```
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 <Tabs>
 <TabItem value="ts" label="TypeScript">
-
-```typescript
-import { MedplumClient } from '@medplum/core';
-import type { Appointment, Bundle, Parameters, Slot } from '@medplum/fhirtypes';
-
-const medplum = new MedplumClient();
-
-const result = await medplum.post(
-  medplum.fhirUrl('Appointment', '$book'),
-  {
-    resourceType: 'Parameters',
-    parameter: [
-      {
-        name: 'slot',
-        resource: {
-          resourceType: 'Slot',
-          status: 'free',
-          start: '2026-03-10T09:00:00.000Z',
-          end: '2026-03-10T10:00:00.000Z',
-          schedule: { reference: 'Schedule/my-schedule-id' },
-          serviceType: [
-            {
-              coding: [{ code: 'inital-visit' }],
-              extension: [
-                url: 'https://medplum.com/fhir/service-type-reference',
-                valueReference: { reference: "HealthcareService/my-healthcareservice-id"}
-              ]
-            }
-          ]
-        } satisfies Slot,
-      },
-      {
-        name: 'patient-reference',
-        valueReference: { reference: 'Patient/my-patient-id' },
-      },
-    ],
-  }
-) as Parameters;
-
-const bundle = result.parameter?.[0]?.resource as Bundle;
-const appointment = bundle.entry
-  ?.find((e) => e.resource?.resourceType === 'Appointment')
-  ?.resource as Appointment;
-```
-
-For multi-resource bookings, add additional `slot` parameters — one per Schedule:
-
-```typescript
-const result = await medplum.post(
-  medplum.fhirUrl('Appointment', '$book'),
-  {
-    resourceType: 'Parameters',
-    parameter: [
-      {
-        name: 'slot',
-        resource: {
-          resourceType: 'Slot',
-          status: 'free',
-          start: '2026-03-11T08:00:00.000Z',
-          end: '2026-03-11T10:00:00.000Z',
-          schedule: { reference: 'Schedule/surgeon-schedule-id' },
-          serviceType: [{
-            coding: [{ code: 'bariatric-surgery' }],
-            extension: [
-              url: 'https://medplum.com/fhir/service-type-reference',
-              valueReference: { reference: "HealthcareService/my-healthcareservice-id"}
-            ]
-          }],
-        } satisfies Slot,
-      },
-      {
-        name: 'slot',
-        resource: {
-          resourceType: 'Slot',
-          status: 'free',
-          start: '2026-03-11T08:00:00.000Z',
-          end: '2026-03-11T10:00:00.000Z',
-          schedule: { reference: 'Schedule/or-room-schedule-id' },
-          serviceType: [{
-            coding: [{ code: 'bariatric-surgery' }],
-            extension: [
-              url: 'https://medplum.com/fhir/service-type-reference',
-              valueReference: { reference: "HealthcareService/my-healthcareservice-id"}
-            ]
-          }],
-        } satisfies Slot,
-      },
-    ],
-  }
-) as Parameters;
-```
-
+  <MedplumCodeBlock language="ts" selectBlocks="bookOne">
+    {ExampleCode}
+  </MedplumCodeBlock>
 </TabItem>
 <TabItem value="curl" label="cURL">
 
@@ -133,25 +47,40 @@ curl -X POST 'https://api.medplum.com/fhir/R4/Appointment/$book' \
     "resourceType": "Parameters",
     "parameter": [
       {
-        "name": "slot",
+        "name": "appointment",
         "resource": {
-          "resourceType": "Slot",
-          "status": "free",
+          "resourceType": "Appointment",
+          "status": "proposed",
           "start": "2026-03-10T09:00:00.000Z",
           "end": "2026-03-10T10:00:00.000Z",
-          "schedule": { "reference": "Schedule/my-schedule-id" }
-          "serviceType": [{
-            "coding": [{ "code": "bariatric-surgery" }],
-            "extension": [
-              "url": 'https://medplum.com/fhir/service-type-reference',
-              "valueReference": { "reference": "HealthcareService/my-healthcareservice-id"}
-            ]
-          }],
+          "serviceType": [
+            {
+              "coding": [{ "code": "initial-visit" }],
+              "extension": [
+                {
+                  "url": "https://medplum.com/fhir/service-type-reference",
+                  "valueReference": { "reference": "HealthcareService/my-healthcareservice-id" }
+                }
+              ]
+            }
+          ],
+          "participant": [
+            {
+              "actor": { "reference": "Practitioner/dr-smith" },
+              "required": "required",
+              "status": "needs-action"
+            }
+          ],
+          "contained": [
+            {
+              "resourceType": "Slot",
+              "status": "busy",
+              "schedule": { "reference": "Schedule/dr-smith-schedule" },
+              "start": "2026-03-10T09:00:00.000Z",
+              "end": "2026-03-10T10:00:00.000Z"
+            }
+          ]
         }
-      },
-      {
-        "name": "patient-reference",
-        "valueReference": { "reference": "Patient/my-patient-id" }
       }
     ]
   }'
@@ -162,110 +91,46 @@ curl -X POST 'https://api.medplum.com/fhir/R4/Appointment/$book' \
 
 ## Parameters
 
-| Name               | Type        | Description                                                                                                                                                | Required |
-| ------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `slot`             | `Resource`  | A `Slot` resource describing the desired booking time. Must include `start`, `end`, `schedule`, and `serviceType`. Repeatable for multi-resource bookings. | Yes (1+) |
-| `patient-reference`| `Reference` | Reference to a [`Patient`](/docs/api/fhir/resources/patient) to include as a participant on the Appointment                                                | No       |
+| Name          | Type          | Description                                                                                                                                                   | Required |
+| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `appointment` | `Appointment` | A proposed `Appointment` resource (e.g. from `$find`). Must include `start`, `end`, and `serviceType`. Must have `Slot` resources in `contained`.             | Yes      |
 
-### Multi-resource Bookings
+### Appointment Input
 
-Pass multiple `slot` parameters (one per Schedule) to book all resources atomically. All slots must share the same `start` time, `end` time, and `serviceType`.
-
-```json
-{
-  "resourceType": "Parameters",
-  "parameter": [
-    {
-      "name": "slot",
-      "resource": {
-        "resourceType": "Slot",
-        "status": "free",
-        "start": "2026-03-11T08:00:00.000Z",
-        "end": "2026-03-11T10:00:00.000Z",
-        "schedule": { "reference": "Schedule/surgeon-schedule-id" },
-        "serviceType": [{
-          "coding": [{ "code": "bariatric-surgery" }]
-          "extension": [
-            "url": 'https://medplum.com/fhir/service-type-reference',
-            "valueReference": { "reference": "HealthcareService/my-healthcareservice-id"}
-          ]
-        }]
-      }
-    },
-    {
-      "name": "slot",
-      "resource": {
-        "resourceType": "Slot",
-        "status": "free",
-        "start": "2026-03-11T08:00:00.000Z",
-        "end": "2026-03-11T10:00:00.000Z",
-        "schedule": { "reference": "Schedule/or-room-schedule-id" }
-        "serviceType": [{
-          "coding": [{ "code": "bariatric-surgery" }]
-          "extension": [
-            "url": 'https://medplum.com/fhir/service-type-reference',
-            "valueReference": { "reference": "HealthcareService/my-healthcareservice-id"}
-          ]
-        }]
-      }
-    }
-  ]
-}
-```
-
-### Constraints
-
-- All `slot` parameters must have matching `start`, `end` , and `serviceType` attributes
-- Each referenced Schedule must have exactly **one actor**
-- Each actor must have a timezone defined via the `http://hl7.org/fhir/StructureDefinition/timezone` extension
-- The requested time must match a valid slot duration from the Schedule's `SchedulingParameters`
-- No existing busy Slots may overlap the requested time window (including buffer windows)
-- The `serviceType` attribute must reference the HealthcareService you are trying to schedule
-
-The easiest way to meet these requirements is to use a result from a [`$find` operation](/docs/scheduling/appointment-find).
-
-## Output
-
-Returns `201 Created` with a [`Parameters`](/docs/api/fhir/resources/parameters) resource wrapping a `Bundle` containing all persisted resources:
-
-- One [`Appointment`](/docs/api/fhir/resources/appointment) with `status: booked`
-- One `Slot` per input slot parameter with `status: busy`
-- Zero or more buffer `Slot` resources with `status: busy-unavailable` (created automatically from `bufferBefore`/`bufferAfter` settings on the Schedule)
-
-### Example Response
+The `appointment` parameter accepts a proposed `Appointment` resource, exactly as returned by [`$find`](/docs/scheduling/appointment-find). The Appointment must include `contained` Slot resources that describe which Schedules to book.
 
 ```json
 {
   "resourceType": "Parameters",
   "parameter": [
     {
-      "name": "return",
+      "name": "appointment",
       "resource": {
-        "resourceType": "Bundle",
-        "type": "searchset",
-        "entry": [
+        "resourceType": "Appointment",
+        "status": "proposed",
+        "start": "2026-03-10T09:00:00.000Z",
+        "end": "2026-03-10T10:00:00.000Z",
+        "serviceType": [
           {
-            "resource": {
-              "resourceType": "Appointment",
-              "id": "new-appointment-id",
-              "status": "booked",
-              "start": "2026-03-10T09:00:00.000Z",
-              "end": "2026-03-10T10:00:00.000Z",
-              "participant": [
-                { "actor": { "reference": "Practitioner/dr-smith" }, "status": "tentative" },
-                { "actor": { "reference": "Patient/my-patient-id" }, "status": "accepted" }
-              ]
-            }
-          },
+            "coding": [{ "code": "initial-visit" }],
+            "extension": [
+              {
+                "url": "https://medplum.com/fhir/service-type-reference",
+                "valueReference": { "reference": "HealthcareService/my-healthcareservice-id" }
+              }
+            ]
+          }
+        ],
+        "participant": [
+          { "actor": { "reference": "Practitioner/dr-smith" }, "required": "required", "status": "needs-action" }
+        ],
+        "contained": [
           {
-            "resource": {
-              "resourceType": "Slot",
-              "id": "booked-slot-id",
-              "status": "busy",
-              "start": "2026-03-10T09:00:00.000Z",
-              "end": "2026-03-10T10:00:00.000Z",
-              "schedule": { "reference": "Schedule/my-schedule-id" }
-            }
+            "resourceType": "Slot",
+            "status": "busy",
+            "schedule": { "reference": "Schedule/dr-smith-schedule" },
+            "start": "2026-03-10T09:00:00.000Z",
+            "end": "2026-03-10T10:00:00.000Z"
           }
         ]
       }
@@ -274,9 +139,112 @@ Returns `201 Created` with a [`Parameters`](/docs/api/fhir/resources/parameters)
 }
 ```
 
+For multi-resource bookings, include multiple Slot resources in `Appointment.contained`:
+
+```json
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "appointment",
+      "resource": {
+        "resourceType": "Appointment",
+        "status": "proposed",
+        "start": "2026-03-11T08:00:00.000Z",
+        "end": "2026-03-11T10:00:00.000Z",
+        "serviceType": [
+          {
+            "coding": [{ "code": "bariatric-surgery" }],
+            "extension": [
+              {
+                "url": "https://medplum.com/fhir/service-type-reference",
+                "valueReference": { "reference": "HealthcareService/my-healthcareservice-id" }
+              }
+            ]
+          }
+        ],
+        "participant": [
+          { "actor": { "reference": "Practitioner/dr-smith" }, "required": "required", "status": "needs-action" },
+          { "actor": { "reference": "Location/or-room-1" }, "required": "required", "status": "needs-action" }
+        ],
+        "contained": [
+          {
+            "resourceType": "Slot",
+            "status": "busy",
+            "schedule": { "reference": "Schedule/surgeon-schedule-id" },
+            "start": "2026-03-11T08:00:00.000Z",
+            "end": "2026-03-11T10:00:00.000Z"
+          },
+          {
+            "resourceType": "Slot",
+            "status": "busy",
+            "schedule": { "reference": "Schedule/or-room-schedule-id" },
+            "start": "2026-03-11T08:00:00.000Z",
+            "end": "2026-03-11T10:00:00.000Z"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+### Constraints
+
+- Each referenced Schedule must have exactly **one actor**
+- Each actor must have a timezone defined via the `http://hl7.org/fhir/StructureDefinition/timezone` extension
+- The requested time must match a valid slot duration from the Schedule's `SchedulingParameters`
+- No existing busy Slots may overlap the requested time window (including buffer windows)
+- The `serviceType` attribute must reference the HealthcareService you are trying to schedule via the `https://medplum.com/fhir/service-type-reference` extension
+- The input `Appointment` must not already contain `slot` references (these are set by `$book`)
+
+The easiest way to meet these requirements is to use a result from a [`$find` operation](/docs/scheduling/appointment-find).
+
+## Output
+
+Returns `201 Created` with a [`Bundle`](/docs/api/fhir/resources/bundle) wrapping all persisted resources:
+
+- One [`Appointment`](/docs/api/fhir/resources/appointment) with `status: "booked"`
+- One `Slot` per contained Slot with `status: "busy"`
+- Zero or more buffer `Slot` resources with `status: "busy-unavailable"` (when `bufferBefore` or `bufferAfter` scheduling parameters are set)
+
+### Example Response
+
+```json
+{
+  "resourceType": "Bundle",
+  "type": "transaction-response",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Appointment",
+        "id": "new-appointment-id",
+        "status": "booked",
+        "start": "2026-03-10T09:00:00.000Z",
+        "end": "2026-03-10T10:00:00.000Z",
+        "participant": [
+          { "actor": { "reference": "Practitioner/dr-smith" }, "status": "tentative" }
+        ],
+        "slot": [{ "reference": "Slot/booked-slot-id" }]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Slot",
+        "id": "booked-slot-id",
+        "status": "busy",
+        "start": "2026-03-10T09:00:00.000Z",
+        "end": "2026-03-10T10:00:00.000Z",
+        "schedule": { "reference": "Schedule/dr-smith-schedule" }
+      }
+    }
+  ]
+}
+```
+
 ## Booking Logic
 
-`$book` performs the following steps inside a serializable transaction:
+`$book` performs the following steps atomically inside a database transaction:
 
 1. Validates that each proposed Slot's start/end matches a valid slot duration defined in the Schedule's `SchedulingParameters`
 2. Loads existing Slots in the time window (including buffer margins) for each Schedule
@@ -337,6 +305,7 @@ The transaction uses serializable isolation to prevent double-booking under conc
 ## Related
 
 - [Appointment `$find`](/docs/scheduling/appointment-find) - Find available Slots before booking
+- [Appointment `$hold`](/docs/scheduling/appointment-hold) - Optionally reserve a slot before confirming
 - [Defining Availability](/docs/scheduling/defining-availability) - How to configure `SchedulingParameters` on a Schedule
 - [Scheduling Overview](/docs/scheduling) - High-level scheduling concepts
 - [`Appointment` resource](/docs/api/fhir/resources/appointment)

--- a/packages/examples/src/scheduling/book.ts
+++ b/packages/examples/src/scheduling/book.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// start-block bookOne
+import { isResource, MedplumClient } from '@medplum/core';
+import type { Appointment, Bundle, Slot } from '@medplum/fhirtypes';
+
+const medplum = new MedplumClient();
+
+// 1. Find available appointments
+const findUrl = medplum.fhirUrl('Appointment', '$find');
+findUrl.searchParams.append('start', '2026-03-10T00:00:00Z');
+findUrl.searchParams.append('end', '2026-03-10T23:59:59Z');
+findUrl.searchParams.append('service-type-reference', 'HealthcareService/my-healthcare-service-id');
+findUrl.searchParams.append('schedule', 'Schedule/my-schedule-id');
+const findBundle = (await medplum.get<Bundle<Appointment>>(findUrl)) as Bundle;
+
+// 2. Pick a proposed appointment from the results
+const proposedAppointment = findBundle.entry?.[0]?.resource as Appointment;
+
+// 3. Book it
+const bundle = await medplum.post<Bundle<Appointment | Slot>>(medplum.fhirUrl('Appointment', '$book'), {
+  resourceType: 'Parameters',
+  parameter: [
+    {
+      name: 'appointment',
+      resource: proposedAppointment,
+    },
+  ],
+});
+
+// Use the newly created Appointment resource
+const appointment = bundle.entry?.map((e) => e.resource)?.find((e) => isResource<Appointment>(e, 'Appointment'));
+// end-block bookOne
+
+console.log(appointment);

--- a/packages/server/src/fhir/operations/book.test.ts
+++ b/packages/server/src/fhir/operations/book.test.ts
@@ -1310,6 +1310,49 @@ describe('Appointment/$book', () => {
         issue: [{ details: { text: 'Proposed appointment must not have Slot references' } }],
       });
     });
+
+    test('rejects when the proposed appointment is outside of any availability window', async () => {
+      const schedule = await makeSchedule({ actor: practitioner1 });
+      const start = '2026-01-16T14:00:00Z';
+      const end = '2026-01-16T15:00:00Z';
+
+      const response = await request
+        .post('/fhir/R4/Appointment/$book')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send(appointmentParam({ schedule, start, end }));
+
+      expect(response.status).toEqual(400);
+      expect(response.body).toMatchObject({
+        resourceType: 'OperationOutcome',
+        issue: [{ details: { text: 'Requested time slot is not available' } }],
+      });
+    });
+
+    test('rejects when the proposed appointment conflicts with an existing slot', async () => {
+      const schedule = await makeSchedule({ actor: practitioner1 });
+      const start = '2026-01-15T14:00:00Z';
+      const end = '2026-01-15T15:00:00Z';
+
+      await systemRepo.createResource<Slot>({
+        resourceType: 'Slot',
+        start,
+        end,
+        status: 'busy',
+        schedule: createReference(schedule),
+        meta: { project: project.project.id },
+      });
+
+      const response = await request
+        .post('/fhir/R4/Appointment/$book')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send(appointmentParam({ schedule, start, end }));
+
+      expect(response.status).toEqual(400);
+      expect(response.body).toMatchObject({
+        resourceType: 'OperationOutcome',
+        issue: [{ details: { text: 'Requested time slot is not available' } }],
+      });
+    });
   });
 
   describe('Loading schedulingParameters from HealthcareService', () => {

--- a/packages/server/src/fhir/operations/book.test.ts
+++ b/packages/server/src/fhir/operations/book.test.ts
@@ -1115,6 +1115,203 @@ describe('Appointment/$book', () => {
     ]);
   });
 
+  describe('with appointment parameter', () => {
+    function appointmentParam(opts: { schedule: WithId<Schedule>; start: string; end: string }): object {
+      return {
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              status: 'proposed',
+              start: opts.start,
+              end: opts.end,
+              serviceType: toCodeableReferenceLike(officeVisitService),
+              participant: [{ actor: opts.schedule.actor[0], status: 'tentative' }],
+              contained: [
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(opts.schedule),
+                  start: opts.start,
+                  end: opts.end,
+                } satisfies Slot,
+              ],
+            } satisfies Appointment,
+          },
+        ],
+      };
+    }
+
+    test('creates a booked Appointment and busy Slots', async () => {
+      const schedule = await makeSchedule({ actor: practitioner1 });
+      const start = '2026-01-15T14:00:00Z';
+      const end = '2026-01-15T15:00:00Z';
+
+      const response = await request
+        .post('/fhir/R4/Appointment/$book')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send(appointmentParam({ schedule, start, end }));
+
+      expect(response.body).not.toHaveProperty('issue');
+      expect(response.status).toEqual(201);
+
+      const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
+
+      const appointments = entries.filter(isAppointment);
+      expect(appointments).toHaveLength(1);
+      expect(appointments[0]).toHaveProperty('status', 'booked');
+      expect(appointments[0]).toHaveProperty('start', start);
+      expect(appointments[0]).toHaveProperty('end', end);
+      expect(appointments[0]).not.toHaveProperty('contained');
+
+      const slots = entries.filter(isSlot);
+      expect(slots).toHaveLength(1);
+      expect(slots[0]).toHaveProperty('status', 'busy');
+      expect(appointments[0]).toHaveProperty('slot', [createReference(slots[0])]);
+    });
+
+    test('rejects when both appointment and slot are provided', async () => {
+      const schedule = await makeSchedule({ actor: practitioner1 });
+      const start = '2026-01-15T14:00:00Z';
+      const end = '2026-01-15T15:00:00Z';
+
+      const response = await request
+        .post('/fhir/R4/Appointment/$book')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'appointment',
+              resource: {
+                resourceType: 'Appointment',
+                status: 'proposed',
+                start,
+                end,
+                serviceType: toCodeableReferenceLike(officeVisitService),
+                participant: [{ actor: createReference(practitioner1), status: 'tentative' }],
+                contained: [
+                  {
+                    resourceType: 'Slot',
+                    status: 'busy',
+                    schedule: createReference(schedule),
+                    start,
+                    end,
+                  } satisfies Slot,
+                ],
+              } satisfies Appointment,
+            },
+            {
+              name: 'slot',
+              resource: {
+                resourceType: 'Slot',
+                schedule: createReference(schedule),
+                start,
+                end,
+                status: 'free',
+                serviceType: [officeVisit],
+              } satisfies Slot,
+            },
+          ],
+        });
+
+      expect(response.status).toEqual(400);
+      expect(response.body).toMatchObject({
+        resourceType: 'OperationOutcome',
+        issue: [{ details: { text: 'Received exclusive parameters `slot` and `appointment`' } }],
+      });
+    });
+
+    test('rejects when patient-reference is provided alongside appointment', async () => {
+      const schedule = await makeSchedule({ actor: practitioner1 });
+      const start = '2026-01-15T14:00:00Z';
+      const end = '2026-01-15T15:00:00Z';
+
+      const response = await request
+        .post('/fhir/R4/Appointment/$book')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'appointment',
+              resource: {
+                resourceType: 'Appointment',
+                status: 'proposed',
+                start,
+                end,
+                serviceType: toCodeableReferenceLike(officeVisitService),
+                participant: [{ actor: createReference(practitioner1), status: 'tentative' }],
+                contained: [
+                  {
+                    resourceType: 'Slot',
+                    status: 'busy',
+                    schedule: createReference(schedule),
+                    start,
+                    end,
+                  } satisfies Slot,
+                ],
+              } satisfies Appointment,
+            },
+            {
+              name: 'patient-reference',
+              valueReference: createReference(patient),
+            },
+          ],
+        });
+
+      expect(response.status).toEqual(400);
+      expect(response.body).toMatchObject({
+        resourceType: 'OperationOutcome',
+        issue: [{ details: { text: '`patient-reference` parameter not allowed with `appointment` parameter' } }],
+      });
+    });
+
+    test('rejects a proposed appointment that already has slot references', async () => {
+      const schedule = await makeSchedule({ actor: practitioner1 });
+      const start = '2026-01-15T14:00:00Z';
+      const end = '2026-01-15T15:00:00Z';
+
+      const response = await request
+        .post('/fhir/R4/Appointment/$book')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'appointment',
+              resource: {
+                resourceType: 'Appointment',
+                status: 'proposed',
+                start,
+                end,
+                serviceType: toCodeableReferenceLike(officeVisitService),
+                participant: [{ actor: createReference(practitioner1), status: 'tentative' }],
+                slot: [{ reference: 'Slot/already-set' }],
+                contained: [
+                  {
+                    resourceType: 'Slot',
+                    status: 'busy',
+                    schedule: createReference(schedule),
+                    start,
+                    end,
+                  } satisfies Slot,
+                ],
+              } satisfies Appointment,
+            },
+          ],
+        });
+
+      expect(response.status).toEqual(400);
+      expect(response.body).toMatchObject({
+        resourceType: 'OperationOutcome',
+        issue: [{ details: { text: 'Proposed appointment must not have Slot references' } }],
+      });
+    });
+  });
+
   describe('Loading schedulingParameters from HealthcareService', () => {
     async function makeHealthcareService(serviceType: CodeableConcept, duration: number): Promise<void> {
       await systemRepo.createResource<HealthcareService>({
@@ -1497,6 +1694,65 @@ describe('scheduling flow integration test', () => {
 
   afterAll(async () => {
     await shutdownApp();
+  });
+
+  test('a proposed appointment from Appointment/$find can be used as input to $book', async () => {
+    const practitioner = await systemRepo.createResource<Practitioner>({
+      resourceType: 'Practitioner',
+      meta: { project: project.project.id },
+      extension: [{ url: 'http://hl7.org/fhir/StructureDefinition/timezone', valueCode: 'America/Phoenix' }],
+    });
+
+    const schedule = await systemRepo.createResource<Schedule>({
+      resourceType: 'Schedule',
+      meta: { project: project.project.id },
+      actor: [createReference(practitioner)],
+      serviceType: toCodeableReferenceLike(service),
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+          extension: [
+            threeDayAvailability,
+            { url: 'duration', valueDuration: { value: 60, unit: 'min' } },
+            { url: 'service', valueReference: createReference(service) },
+          ],
+        },
+      ],
+    });
+
+    const findResponse = await request
+      .get('/fhir/R4/Appointment/$find')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .query({
+        start: new Date('2026-01-28T07:00:00.000-07:00').toISOString(),
+        end: new Date('2026-01-28T12:00:00.000-07:00').toISOString(),
+        'service-type-reference': `HealthcareService/${service.id}`,
+        schedule: `Schedule/${schedule.id}`,
+      });
+
+    expect(findResponse.body).not.toHaveProperty('issue');
+    expect(findResponse.status).toBe(200);
+    expect(findResponse.body.entry?.length).toBeGreaterThan(0);
+
+    const proposedAppointment: Appointment = findResponse.body.entry[1].resource;
+    expect(proposedAppointment.status).toBe('proposed');
+
+    const bookResponse = await request
+      .post('/fhir/R4/Appointment/$book')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'appointment', resource: proposedAppointment }],
+      });
+
+    expect(bookResponse.body).not.toHaveProperty('issue');
+    expect(bookResponse.status).toBe(201);
+
+    const entries = ((bookResponse.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
+    const appointments = entries.filter(isAppointment);
+    expect(appointments).toHaveLength(1);
+    expect(appointments[0]).toHaveProperty('status', 'booked');
+    expect(appointments[0]).not.toHaveProperty('contained');
   });
 
   test('a slot from $find can be used as input to $book', async () => {

--- a/packages/server/src/fhir/operations/book.ts
+++ b/packages/server/src/fhir/operations/book.ts
@@ -25,6 +25,7 @@ import {
   assertAllLoaded,
   assertAllMatch,
   getSchedulingParametersGroup,
+  persistProposedAppointment,
   resolveAvailability,
   slotsOverlappingInterval,
 } from './utils/scheduling';
@@ -35,7 +36,8 @@ const bookOperation = makeOperationDefinition(
     name: 'book',
     code: 'book',
     parameter: [
-      { use: 'in', name: 'slot', type: 'Resource', min: 1, max: '*' },
+      { use: 'in', name: 'appointment', type: 'Appointment', min: 0, max: '1' },
+      { use: 'in', name: 'slot', type: 'Resource', min: 0, max: '*' },
       { use: 'in', name: 'patient-reference', type: 'Reference', min: 0, max: '1' },
       { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
     ],
@@ -43,6 +45,7 @@ const bookOperation = makeOperationDefinition(
 );
 
 type BookParameters = {
+  appointment?: Appointment;
   slot: Slot[];
   'patient-reference'?: Reference<Patient>;
 };
@@ -59,6 +62,20 @@ function serviceTypeTokens(slots: Slot[]): string[] {
   return [...tokenSet.values()];
 }
 
+async function bookFromProposedAppointmentHandler(proposedAppointment: Appointment): Promise<FhirResponse> {
+  const ctx = getAuthenticatedContext();
+  const bundle = await persistProposedAppointment(
+    ctx.repo,
+    withPath(proposedAppointment, 'Parameters.appointment'),
+    (appointment, _slots) => {
+      // Create appointment with "booked" status
+      appointment.status = 'booked';
+    }
+  );
+
+  return [created, buildOutputParameters(bookOperation, bundle)];
+}
+
 /**
  * Handles HTTP requests for the Appointment $book operation.
  *
@@ -71,6 +88,20 @@ function serviceTypeTokens(slots: Slot[]): string[] {
 export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResponse> {
   const ctx = getAuthenticatedContext();
   const params = parseInputParameters<BookParameters>(bookOperation, req);
+
+  if (params.appointment) {
+    if (params.slot.length) {
+      throw new OperationOutcomeError(badRequest('Received exclusive parameters `slot` and `appointment`'));
+    }
+    if (params['patient-reference']) {
+      throw new OperationOutcomeError(
+        badRequest('`patient-reference` parameter not allowed with `appointment` parameter')
+      );
+    }
+
+    return bookFromProposedAppointmentHandler(params.appointment);
+  }
+
   const proposedSlots = withPaths(params.slot, 'Parameters.slot');
 
   assertAllMatch(proposedSlots, 'start', 'Mismatched slot start times');
@@ -78,6 +109,10 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
   const { start, end } = proposedSlots[0];
   const startDate = new Date(start);
   const endDate = new Date(end);
+
+  // We intend to remove the older `Slot` based approach beyond here, probably
+  // around when we transition into the scheduling "beta" milestone. For now
+  // we support the original implementation path as well.
 
   if (params['patient-reference']) {
     // validate that the patient reference exists and is visible to the caller

--- a/packages/server/src/fhir/operations/book.ts
+++ b/packages/server/src/fhir/operations/book.ts
@@ -24,8 +24,8 @@ import {
   applyExistingSlots,
   assertAllLoaded,
   assertAllMatch,
+  createProposedAppointment,
   getSchedulingParametersGroup,
-  persistProposedAppointment,
   resolveAvailability,
   slotsOverlappingInterval,
 } from './utils/scheduling';
@@ -64,7 +64,7 @@ function serviceTypeTokens(slots: Slot[]): string[] {
 
 async function bookFromProposedAppointmentHandler(proposedAppointment: Appointment): Promise<FhirResponse> {
   const ctx = getAuthenticatedContext();
-  const bundle = await persistProposedAppointment(
+  const bundle = await createProposedAppointment(
     ctx.repo,
     withPath(proposedAppointment, 'Parameters.appointment'),
     (appointment, _slots) => {

--- a/packages/server/src/fhir/operations/hold.ts
+++ b/packages/server/src/fhir/operations/hold.ts
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { badRequest, created, createReference, OperationOutcomeError } from '@medplum/core';
+import { created } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Appointment, Bundle, OperationDefinition, Slot } from '@medplum/fhirtypes';
+import type { Appointment, OperationDefinition } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { withPath } from '../../util/withpath';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
-import { validateAllAvailability, validateProposedAppointment } from './utils/scheduling';
+import { persistProposedAppointment } from './utils/scheduling';
 
 const holdOperation = {
   resourceType: 'OperationDefinition',
@@ -40,48 +40,21 @@ type HoldParameters = {
 export async function appointmentHoldHandler(req: FhirRequest): Promise<FhirResponse> {
   const ctx = getAuthenticatedContext();
   const params = parseInputParameters<HoldParameters>(holdOperation, req);
-  const [appointment, slots, healthcareService, schedulingParametersGroup] = await validateProposedAppointment(
+  const bundle = await persistProposedAppointment(
     ctx.repo,
-    withPath(params.appointment, 'Parameters.appointment')
-  );
+    withPath(params.appointment, 'Parameters.appointment'),
+    (appointment, slots) => {
+      // Create appointment with "pending" status
+      appointment.status = 'pending';
 
-  // We will write this attribute later, check that we aren't clobbering something that was submitted
-  if (appointment.slot) {
-    throw new OperationOutcomeError(
-      badRequest('Proposed appointment must not have Slot references', 'Parameters.appointment.slot')
-    );
-  }
-
-  // $hold creates slots in "busy-tentative" state
-  for (const slot of slots) {
-    if (slot.status === 'busy') {
-      slot.status = 'busy-tentative';
-    }
-  }
-
-  const createdResources = await ctx.repo.withTransaction(
-    async () => {
-      await validateAllAvailability(ctx.repo, slots, healthcareService, schedulingParametersGroup);
-
-      const createdSlots: Slot[] = [];
-      for (const slot of slots) {
-        createdSlots.push(await ctx.repo.createResource<Slot>(slot));
-      }
-
-      const createdAppointment = await ctx.repo.createResource<Appointment>({
-        ...appointment,
-        status: 'pending',
-        slot: createdSlots.map((slot) => createReference(slot)),
+      // $hold creates slots with "busy-tentative" status
+      slots.forEach((slot) => {
+        if (slot.status === 'busy') {
+          slot.status = 'busy-tentative';
+        }
       });
-      return [createdAppointment, ...createdSlots];
-    },
-    { serializable: true }
+    }
   );
-  const bundle: Bundle = {
-    resourceType: 'Bundle',
-    type: 'transaction-response',
-    entry: createdResources.map((resource) => ({ resource })),
-  };
 
   return [created, buildOutputParameters(holdOperation, bundle)];
 }

--- a/packages/server/src/fhir/operations/hold.ts
+++ b/packages/server/src/fhir/operations/hold.ts
@@ -6,7 +6,7 @@ import type { Appointment, OperationDefinition } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { withPath } from '../../util/withpath';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
-import { persistProposedAppointment } from './utils/scheduling';
+import { createProposedAppointment } from './utils/scheduling';
 
 const holdOperation = {
   resourceType: 'OperationDefinition',
@@ -40,7 +40,7 @@ type HoldParameters = {
 export async function appointmentHoldHandler(req: FhirRequest): Promise<FhirResponse> {
   const ctx = getAuthenticatedContext();
   const params = parseInputParameters<HoldParameters>(holdOperation, req);
-  const bundle = await persistProposedAppointment(
+  const bundle = await createProposedAppointment(
     ctx.repo,
     withPath(params.appointment, 'Parameters.appointment'),
     (appointment, slots) => {
@@ -48,11 +48,11 @@ export async function appointmentHoldHandler(req: FhirRequest): Promise<FhirResp
       appointment.status = 'pending';
 
       // $hold creates slots with "busy-tentative" status
-      slots.forEach((slot) => {
+      for (const slot of slots) {
         if (slot.status === 'busy') {
           slot.status = 'busy-tentative';
         }
-      });
+      }
     }
   );
 

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -603,7 +603,7 @@ export async function validateAllAvailability(
   }
 }
 
-export async function persistProposedAppointment(
+export async function createProposedAppointment(
   repo: Repository,
   proposedAppointment: WithPath<Appointment>,
   customizer: (appointment: Appointment, slots: Slot[]) => void

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -3,6 +3,7 @@
 import type { WithId } from '@medplum/core';
 import {
   badRequest,
+  createReference,
   DEFAULT_MAX_SEARCH_COUNT,
   EMPTY,
   getExtensionValue,
@@ -15,6 +16,7 @@ import {
 } from '@medplum/core';
 import type {
   Appointment,
+  Bundle,
   CodeableConcept,
   HealthcareService,
   Reference,
@@ -599,4 +601,43 @@ export async function validateAllAvailability(
       )
     );
   }
+}
+
+export async function persistProposedAppointment(
+  repo: Repository,
+  proposedAppointment: WithPath<Appointment>,
+  customizer: (appointment: Appointment, slots: Slot[]) => void
+): Promise<Bundle<Appointment | Slot>> {
+  const [appointment, slots, healthcareService, schedulingParametersGroup] = await validateProposedAppointment(
+    repo,
+    proposedAppointment
+  );
+
+  // We will write this attribute later, check that we aren't clobbering something that was submitted
+  if (appointment.slot) {
+    throw new OperationOutcomeError(
+      badRequest('Proposed appointment must not have Slot references', `${getPath(proposedAppointment)}.slot`)
+    );
+  }
+
+  customizer(appointment, slots);
+
+  const createdResources = await repo.withTransaction(
+    async () => {
+      await validateAllAvailability(repo, slots, healthcareService, schedulingParametersGroup);
+      const createdSlots = await Promise.all(slots.map((slot) => repo.createResource<Slot>(slot)));
+      const createdAppointment = await repo.createResource<Appointment>({
+        ...appointment,
+        slot: createdSlots.map((slot) => createReference(slot)),
+      });
+      return [createdAppointment, ...createdSlots];
+    },
+    { serializable: true }
+  );
+
+  return {
+    resourceType: 'Bundle',
+    type: 'transaction-response',
+    entry: createdResources.map((resource) => ({ resource })),
+  };
 }


### PR DESCRIPTION
In [#8793](https://github.com/medplum/medplum/pull/8793) we added a $find endpoint for multi-schedule searching that returns proposed Appointment resources. Here we teach `$book` to accept an `appointment` parameter; by passing an individual result from `$find` in that parameter, we can atomically create all the appropriate Slot and Appointment resources.

This is almost identical to the `$hold` endpoint, so we extract most of the logic into a shared helper. It has a callback that allows each endpoint to customize the resources it is about to save just before it creates them. This makes the difference between the two extremely clear to discern.