### PR TITLE
Fixes #9182 - www-authenticate: bearer

### DIFF
--- a/packages/server/src/oauth/middleware.test.ts
+++ b/packages/server/src/oauth/middleware.test.ts
@@ -76,7 +76,7 @@ describe('Auth middleware', () => {
 
   test('No auth header', async () => {
     const res = await request(app).get('/fhir/R4/Patient');
-    expect(res.header['www-authenticate']).toBeUndefined();
+    expect(res.header['www-authenticate']).toBe(`Bearer realm="${getConfig().baseUrl}"`);
     expect(res.status).toBe(401);
   });
 
@@ -99,11 +99,13 @@ describe('Auth middleware', () => {
   test('Invalid bearer token', async () => {
     const res = await request(app).get('/fhir/R4/Patient').set('Authorization', 'Bearer foo');
     expect(res.status).toBe(401);
+    expect(res.header['www-authenticate']).toBe(`Bearer realm="${getConfig().baseUrl}"`);
   });
 
   test('Basic auth empty string', async () => {
     const res = await request(app).get('/fhir/R4/Patient').set('Authorization', 'Basic ');
     expect(res.status).toBe(401);
+    expect(res.header['www-authenticate']).toBe(`Basic realm="${getConfig().baseUrl}"`);
   });
 
   test('Basic auth malformed string', async () => {

--- a/packages/server/src/oauth/middleware.ts
+++ b/packages/server/src/oauth/middleware.ts
@@ -34,9 +34,9 @@ export function authenticateRequest(req: Request, res: Response, next: NextFunct
   if (ctx instanceof AuthenticatedRequestContext) {
     next();
   } else {
-    if (res.req.query[PROMPT_BASIC_AUTH_PARAM]) {
-      res.set('WWW-Authenticate', `Basic realm="${getConfig().baseUrl}"`);
-    }
+    const requestAuthScheme = req.headers.authorization?.split(' ')[0] ?? 'Bearer';
+    const responseAuthScheme = res.req.query[PROMPT_BASIC_AUTH_PARAM] ? 'Basic' : requestAuthScheme;
+    res.set('WWW-Authenticate', `${responseAuthScheme} realm="${getConfig().baseUrl}"`);
     next(new OperationOutcomeError(unauthorized));
   }
 }


### PR DESCRIPTION
Adds `WWW-Authenticate: Bearer` on 401

We have tried setting `WWW-Authenticate` header in the past, and had challenges with unwanted browser behavior.  See: https://github.com/medplum/medplum/pulls?q=is%3Apr+%22WWW-Authenticate%22+is%3Aclosed+

This new model uses `WWW-Authenticate: Bearer`, not `Basic`, which allegedly should avoid the browser UX challenges.

Fixes #9182 - see the ticket for more details