### PR TITLE
Disable GIN Fastupdate on Appointment, Slot in tests

### DIFF
--- a/packages/server/src/fhir/operations/book.test.ts
+++ b/packages/server/src/fhir/operations/book.test.ts
@@ -172,6 +172,7 @@ describe('Appointment/$book', () => {
           },
         ],
       });
+    expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toEqual(201);
   });
 
@@ -642,6 +643,7 @@ describe('Appointment/$book', () => {
       });
 
     if (succeeds) {
+      expect(response.body).not.toHaveProperty('issue');
       expect(response.status).toEqual(201);
     } else {
       expect(response.status).toEqual(400);
@@ -825,6 +827,7 @@ describe('Appointment/$book', () => {
             },
           ],
         });
+      expect(response.body).not.toHaveProperty('issue');
       expect(response.status).toEqual(201);
     }
   );
@@ -1229,13 +1232,13 @@ describe('Appointment/$book', () => {
           ],
         });
 
-      expect(response.status).toEqual(400);
       expect(response.body).toMatchObject({
         resourceType: 'OperationOutcome',
         issue: [
           { severity: 'error', code: 'invalid', details: { text: 'Multiple matching HealthcareServices found' } },
         ],
       });
+      expect(response.status).toEqual(400);
     });
 
     test('fails when booking outside HealthcareService availability', async () => {
@@ -1395,7 +1398,6 @@ describe('Appointment/$book', () => {
         ],
       });
 
-    expect(response.status).toEqual(400);
     expect(response.body).toHaveProperty('issue', [
       {
         severity: 'error',
@@ -1405,6 +1407,7 @@ describe('Appointment/$book', () => {
         },
       },
     ]);
+    expect(response.status).toEqual(400);
   });
 
   test('when the service type has no system attribute', async () => {
@@ -1461,6 +1464,7 @@ describe('Appointment/$book', () => {
           },
         ],
       });
+    expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toEqual(201);
   });
 });

--- a/packages/server/src/fhir/operations/book.ts
+++ b/packages/server/src/fhir/operations/book.ts
@@ -177,10 +177,10 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
     healthcareService = healthcareServices[0];
   }
 
-  const bufferSlots: Slot[] = [];
-
   const createdResources = await ctx.repo.withTransaction(
     async () => {
+      const bufferSlots: Slot[] = [];
+
       await Promise.all(
         proposedSlots.map(async (proposedSlot) => {
           const scheduleRefString = getReferenceString(proposedSlot.schedule);

--- a/packages/server/src/fhir/operations/db-configure-indexes.ts
+++ b/packages/server/src/fhir/operations/db-configure-indexes.ts
@@ -50,7 +50,7 @@ type InputParameters = {
   ginPendingListLimitValue?: number;
 };
 
-type OutputAction = {
+export type OutputAction = {
   sql: string;
   durationMs?: number;
 };
@@ -125,7 +125,7 @@ type GinIndexConfig = {
   ginPendingListLimit?: 'reset' | number;
 };
 
-async function configureGinIndexes(
+export async function configureGinIndexes(
   client: PoolClient | Pool,
   actions: OutputAction[],
   tableNames: string[],
@@ -215,7 +215,11 @@ async function configureGinIndexes(
   }
 }
 
-async function vacuumTable(client: PoolClient | Pool, actions: OutputAction[], tableName: string): Promise<void> {
+export async function vacuumTable(
+  client: PoolClient | Pool,
+  actions: OutputAction[],
+  tableName: string
+): Promise<void> {
   const sql = `VACUUM ${escapeIdentifier(tableName)}`;
   const startTime = Date.now();
   await client.query(sql);

--- a/packages/server/src/seed.test.ts
+++ b/packages/server/src/seed.test.ts
@@ -4,6 +4,8 @@ import type { Project } from '@medplum/fhirtypes';
 import { initAppServices, shutdownApp } from './app';
 import { loadTestConfig } from './config/loader';
 import { DatabaseMode, getDatabasePool } from './database';
+import type { OutputAction } from './fhir/operations/db-configure-indexes';
+import { configureGinIndexes, vacuumTable } from './fhir/operations/db-configure-indexes';
 import type { SystemRepository } from './fhir/repo';
 import { getGlobalSystemRepo } from './fhir/repo';
 import { SelectQuery } from './fhir/sql';
@@ -63,8 +65,17 @@ describe('Seed', () => {
     console.log(`${new Date().toISOString()} - Initializing app services`);
     await initAppServices(config);
     await withTestContext(async () => {
+      const repo = getGlobalSystemRepo();
       // Run post-deploy migrations synchronously
-      await synchronouslyRunAllPendingPostDeployMigrations(getGlobalSystemRepo());
+      await synchronouslyRunAllPendingPostDeployMigrations(repo);
+
+      const actions: OutputAction[] = [];
+      const tables = ['Appointment', 'Appointment_References', 'Slot', 'Slot_References'];
+      const client = repo.getDatabaseClient(DatabaseMode.WRITER);
+      await configureGinIndexes(client, actions, tables, { fastUpdate: false });
+      for (const table of tables) {
+        await vacuumTable(client, actions, table);
+      }
     });
   });
 

--- a/packages/server/src/seed.test.ts
+++ b/packages/server/src/seed.test.ts
@@ -69,6 +69,13 @@ describe('Seed', () => {
       // Run post-deploy migrations synchronously
       await synchronouslyRunAllPendingPostDeployMigrations(repo);
 
+      // Scheduling features use serializable transactions that touch these
+      // tables. The `fastUpdate` feature can cause seemingly unrelated transactions
+      // to append to the same "pending list", which can cause transaction
+      // failures.
+      //
+      // Here we update the indexes on Appointment and Slot tables to disable `fastUpdate`,
+      // and then vacuum the tables to clear any existing pending list entries.
       const actions: OutputAction[] = [];
       const tables = ['Appointment', 'Appointment_References', 'Slot', 'Slot_References'];
       const client = repo.getDatabaseClient(DatabaseMode.WRITER);


### PR DESCRIPTION
While working on scheduling tests that are exercising endpoints using serializable transactions, I'm seeing CI failing irregularly with "could not serialize access due to read/write dependencies among transactions". I'm surprised because the tests shouldn't be conflicting with each other (they are touching distinct rows), but it seems like Postgres can sometimes end up locking more than I expected.

@MattLong suggested that FastUpdate could be the culprit - the default GIN index uses this feature, which can push all the updates to a table into a single pending list, which could cause this kind of problem. In this commit we turn off the fastUpdate feature for these tables in the test environment.

Includes some other scheduling test updates:
- Fixes a $book implementation issue where references to objects can leak across transaction retries.
- Improves $book tests to check `response.body.issue` before `response.status` to provide more helpful errors on test failure