### PR TITLE
Stop sharing lambda clients across requests

### DIFF
--- a/packages/server/src/cloud/aws/lambda.ts
+++ b/packages/server/src/cloud/aws/lambda.ts
@@ -7,19 +7,22 @@ import {
   ResourceConflictException,
   ResourceNotFoundException,
 } from '@aws-sdk/client-lambda';
+import { ConfiguredRetryStrategy } from '@smithy/util-retry';
 import { getConfig } from '../../config/loader';
 import { getLogger } from '../../logger';
 
-let managementClient: LambdaClient;
 /**
  * Creates a new AWS Lambda client with a custom retry strategy.
  * @returns A configured LambdaClient.
  */
 export function getBotManagementLambdaClient(): LambdaClient {
-  if (!managementClient) {
-    managementClient = new LambdaClient({ region: getConfig().awsRegion });
-  }
-  return managementClient;
+  return new LambdaClient({
+    region: getConfig().awsRegion,
+    retryStrategy: new ConfiguredRetryStrategy(
+      5, // max attempts
+      (attempt: number) => 500 * 2 ** attempt // Exponential backoff
+    ),
+  });
 }
 
 export interface DeleteLambdaVersionOptions {


### PR DESCRIPTION
The changed seems to have increased the increased the likelyhood of rate limiting on lambda management requests.