### PR TITLE
Avoid duplicated code from op defs

### DIFF
--- a/packages/server/src/fhir/operations/README.md
+++ b/packages/server/src/fhir/operations/README.md
@@ -26,25 +26,32 @@ Utility functions that use the `OperationDefinition` to automate implementation 
 ### Example: Project $init
 
 ```ts
-import { buildOutputParameters, parseInputParameters } from './utils/parameters';
+import {
+  buildOutputParameters,
+  parseInputParameters,
+  makeOperationDefinitionParameter as param,
+} from './utils/parameters';
 import { created } from '@medplum/core';
 import { Reference } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { makeOperationDefinition } from './definitions';
 
-const operation = makeOperationDefinition({ scope: 'type', resource: 'Project' }, {
-  name: 'project-init',
-  code: 'init',
-  parameter: [
-    // Required param: name (string)
-    { use: 'in', name: 'name', type: 'string', min: 1, max: '1' },
-    // Optional params: owner (Reference), ownerEmail (string)
-    { use: 'in', name: 'owner', type: 'Reference', min: 0, max: '1' },
-    { use: 'in', name: 'ownerEmail', type: 'string', min: 0, max: '1' },
-    // Output parameter: Project
-    { use: 'out', name: 'return', type: 'Project', min: 1, max: '1' },
-  ],
-});
+const projectInitOperation = makeOperationDefinition(
+  { scope: 'type', resource: 'Project' },
+  {
+    name: 'project-init',
+    code: 'init',
+    parameter: [
+      // Required param: name (string)
+      param('in', 'name', 'string', 1, '1'),
+      // Optional params: owner (Reference), ownerEmail (string)
+      param('in', 'owner', 'Reference', 0, '1'),
+      param('in', 'ownerEmail', 'string', 0, '1'),
+      // Output parameter: Project
+      param('out', 'return', 'Project', 1, '1'),
+    ],
+  }
+);
 
 interface ProjectInitParameters {
   name: string;

--- a/packages/server/src/fhir/operations/README.md
+++ b/packages/server/src/fhir/operations/README.md
@@ -28,19 +28,13 @@ Utility functions that use the `OperationDefinition` to automate implementation 
 ```ts
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 import { created } from '@medplum/core';
-import { Reference, OperationDefinition } from '@medplum/fhirtypes';
+import { Reference } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
+import { makeOperationDefinition } from './definitions';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'type', resource: 'Project' }, {
   name: 'project-init',
-  status: 'active',
-  kind: 'operation',
   code: 'init',
-  resource: ['Project'],
-  system: false,
-  type: true, // Available at route /Project/$init only
-  instance: false,
   parameter: [
     // Required param: name (string)
     { use: 'in', name: 'name', type: 'string', min: 1, max: '1' },
@@ -50,7 +44,7 @@ const operation: OperationDefinition = {
     // Output parameter: Project
     { use: 'out', name: 'return', type: 'Project', min: 1, max: '1' },
   ],
-};
+});
 
 interface ProjectInitParameters {
   name: string;

--- a/packages/server/src/fhir/operations/agentbulkstatus.ts
+++ b/packages/server/src/fhir/operations/agentbulkstatus.ts
@@ -2,24 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk, badRequest } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Bundle, OperationDefinition } from '@medplum/fhirtypes';
+import type { Bundle } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { getStatusForAgents } from './agentstatus';
+import { makeOperationDefinition } from './definitions';
 import { getAgentsForRequest, makeResultWrapperEntry } from './utils/agentutils';
 
-export const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+export const operation = makeOperationDefinition({ scope: 'type', resource: 'Agent' }, {
   name: 'agent-bulk-status',
-  status: 'active',
-  kind: 'operation',
   code: 'bulk-status',
-  experimental: true,
-  resource: ['Agent'],
-  system: false,
-  type: true,
-  instance: false,
   parameter: [{ use: 'out', name: 'return', type: 'Bundle', min: 1, max: '1' }],
-};
+});
 
 /**
  * Handles HTTP requests for the Agent $status operation.

--- a/packages/server/src/fhir/operations/agentbulkstatus.ts
+++ b/packages/server/src/fhir/operations/agentbulkstatus.ts
@@ -8,11 +8,14 @@ import { getStatusForAgents } from './agentstatus';
 import { makeOperationDefinition } from './definitions';
 import { getAgentsForRequest, makeResultWrapperEntry } from './utils/agentutils';
 
-export const operation = makeOperationDefinition({ scope: 'type', resource: 'Agent' }, {
-  name: 'agent-bulk-status',
-  code: 'bulk-status',
-  parameter: [{ use: 'out', name: 'return', type: 'Bundle', min: 1, max: '1' }],
-});
+export const operation = makeOperationDefinition(
+  { scope: 'type', resource: 'Agent' },
+  {
+    name: 'agent-bulk-status',
+    code: 'bulk-status',
+    parameter: [{ use: 'out', name: 'return', type: 'Bundle', min: 1, max: '1' }],
+  }
+);
 
 /**
  * Handles HTTP requests for the Agent $status operation.

--- a/packages/server/src/fhir/operations/agentfetchlogs.ts
+++ b/packages/server/src/fhir/operations/agentfetchlogs.ts
@@ -7,14 +7,17 @@ import { makeOperationDefinition } from './definitions';
 import { handleBulkAgentOperation, sendAndHandleAgentRequest } from './utils/agentutils';
 import { parseInputParameters } from './utils/parameters';
 
-export const operation = makeOperationDefinition({ scope: 'type-and-instance', resource: 'Agent' }, {
-  name: 'agent-fetch-logs',
-  code: 'fetch-logs',
-  parameter: [
-    { use: 'in', name: 'limit', type: 'integer', min: 0, max: '1' },
-    { use: 'out', name: 'return', type: 'Parameters', min: 1, max: '1' },
-  ],
-});
+export const operation = makeOperationDefinition(
+  { scope: 'type-and-instance', resource: 'Agent' },
+  {
+    name: 'agent-fetch-logs',
+    code: 'fetch-logs',
+    parameter: [
+      { use: 'in', name: 'limit', type: 'integer', min: 0, max: '1' },
+      { use: 'out', name: 'return', type: 'Parameters', min: 1, max: '1' },
+    ],
+  }
+);
 
 /**
  * Handles HTTP requests for the Agent $fetch-logs operation.

--- a/packages/server/src/fhir/operations/agentfetchlogs.ts
+++ b/packages/server/src/fhir/operations/agentfetchlogs.ts
@@ -2,26 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { AgentLogsResponse, WithId } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Agent, OperationDefinition } from '@medplum/fhirtypes';
+import type { Agent } from '@medplum/fhirtypes';
+import { makeOperationDefinition } from './definitions';
 import { handleBulkAgentOperation, sendAndHandleAgentRequest } from './utils/agentutils';
 import { parseInputParameters } from './utils/parameters';
 
-export const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+export const operation = makeOperationDefinition({ scope: 'type-and-instance', resource: 'Agent' }, {
   name: 'agent-fetch-logs',
-  status: 'active',
-  kind: 'operation',
   code: 'fetch-logs',
-  experimental: true,
-  resource: ['Agent'],
-  system: false,
-  type: true,
-  instance: true,
   parameter: [
     { use: 'in', name: 'limit', type: 'integer', min: 0, max: '1' },
     { use: 'out', name: 'return', type: 'Parameters', min: 1, max: '1' },
   ],
-};
+});
 
 /**
  * Handles HTTP requests for the Agent $fetch-logs operation.

--- a/packages/server/src/fhir/operations/agentreloadconfig.ts
+++ b/packages/server/src/fhir/operations/agentreloadconfig.ts
@@ -2,22 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Agent, OperationDefinition } from '@medplum/fhirtypes';
+import type { Agent } from '@medplum/fhirtypes';
+import { makeOperationDefinition } from './definitions';
 import { handleBulkAgentOperation, sendAndHandleAgentRequest } from './utils/agentutils';
 
-export const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+export const operation = makeOperationDefinition({ scope: 'type-and-instance', resource: 'Agent' }, {
   name: 'agent-reload-config',
-  status: 'active',
-  kind: 'operation',
   code: 'reload-config',
-  experimental: true,
-  resource: ['Agent'],
-  system: false,
-  type: true,
-  instance: true,
   parameter: [{ use: 'out', name: 'return', type: 'Bundle', min: 1, max: '1' }],
-};
+});
 
 /**
  * Handles HTTP requests for the Agent $reload-config operation.

--- a/packages/server/src/fhir/operations/agentreloadconfig.ts
+++ b/packages/server/src/fhir/operations/agentreloadconfig.ts
@@ -6,11 +6,14 @@ import type { Agent } from '@medplum/fhirtypes';
 import { makeOperationDefinition } from './definitions';
 import { handleBulkAgentOperation, sendAndHandleAgentRequest } from './utils/agentutils';
 
-export const operation = makeOperationDefinition({ scope: 'type-and-instance', resource: 'Agent' }, {
-  name: 'agent-reload-config',
-  code: 'reload-config',
-  parameter: [{ use: 'out', name: 'return', type: 'Bundle', min: 1, max: '1' }],
-});
+export const operation = makeOperationDefinition(
+  { scope: 'type-and-instance', resource: 'Agent' },
+  {
+    name: 'agent-reload-config',
+    code: 'reload-config',
+    parameter: [{ use: 'out', name: 'return', type: 'Bundle', min: 1, max: '1' }],
+  }
+);
 
 /**
  * Handles HTTP requests for the Agent $reload-config operation.

--- a/packages/server/src/fhir/operations/agentstats.ts
+++ b/packages/server/src/fhir/operations/agentstats.ts
@@ -2,22 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { AgentStatsResponse, WithId } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Agent, OperationDefinition } from '@medplum/fhirtypes';
+import type { Agent } from '@medplum/fhirtypes';
+import { makeOperationDefinition } from './definitions';
 import { handleBulkAgentOperation, sendAndHandleAgentRequest } from './utils/agentutils';
 
-export const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+export const operation = makeOperationDefinition({ scope: 'type-and-instance', resource: 'Agent' }, {
   name: 'agent-stats',
-  status: 'active',
-  kind: 'operation',
   code: 'stats',
-  experimental: true,
-  resource: ['Agent'],
-  system: false,
-  type: true,
-  instance: true,
   parameter: [{ use: 'out', name: 'return', type: 'Parameters', min: 1, max: '1' }],
-};
+});
 
 /**
  * Handles HTTP requests for the Agent $stats operation.

--- a/packages/server/src/fhir/operations/agentstats.ts
+++ b/packages/server/src/fhir/operations/agentstats.ts
@@ -6,11 +6,14 @@ import type { Agent } from '@medplum/fhirtypes';
 import { makeOperationDefinition } from './definitions';
 import { handleBulkAgentOperation, sendAndHandleAgentRequest } from './utils/agentutils';
 
-export const operation = makeOperationDefinition({ scope: 'type-and-instance', resource: 'Agent' }, {
-  name: 'agent-stats',
-  code: 'stats',
-  parameter: [{ use: 'out', name: 'return', type: 'Parameters', min: 1, max: '1' }],
-});
+export const operation = makeOperationDefinition(
+  { scope: 'type-and-instance', resource: 'Agent' },
+  {
+    name: 'agent-stats',
+    code: 'stats',
+    parameter: [{ use: 'out', name: 'return', type: 'Parameters', min: 1, max: '1' }],
+  }
+);
 
 /**
  * Handles HTTP requests for the Agent $stats operation.

--- a/packages/server/src/fhir/operations/agentstatus.ts
+++ b/packages/server/src/fhir/operations/agentstatus.ts
@@ -12,15 +12,18 @@ import { makeOperationDefinition } from './definitions';
 import { getAgentForRequest } from './utils/agentutils';
 import { buildOutputParameters } from './utils/parameters';
 
-export const operation = makeOperationDefinition({ scope: 'instance', resource: 'Agent' }, {
-  name: 'agent-status',
-  code: 'status',
-  parameter: [
-    { use: 'out', name: 'status', type: 'code', min: 1, max: '1' },
-    { use: 'out', name: 'version', type: 'string', min: 1, max: '1' },
-    { use: 'out', name: 'lastUpdated', type: 'instant', min: 0, max: '1' },
-  ],
-});
+export const operation = makeOperationDefinition(
+  { scope: 'instance', resource: 'Agent' },
+  {
+    name: 'agent-status',
+    code: 'status',
+    parameter: [
+      { use: 'out', name: 'status', type: 'code', min: 1, max: '1' },
+      { use: 'out', name: 'version', type: 'string', min: 1, max: '1' },
+      { use: 'out', name: 'lastUpdated', type: 'instant', min: 0, max: '1' },
+    ],
+  }
+);
 
 /**
  * Handles HTTP requests for the Agent $status operation.

--- a/packages/server/src/fhir/operations/agentstatus.ts
+++ b/packages/server/src/fhir/operations/agentstatus.ts
@@ -3,31 +3,24 @@
 import type { WithId } from '@medplum/core';
 import { allOk, badRequest, isOperationOutcome, normalizeErrorString } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Agent, OperationDefinition, OperationOutcome, Parameters } from '@medplum/fhirtypes';
+import type { Agent, OperationOutcome, Parameters } from '@medplum/fhirtypes';
 import type { AgentInfo } from '../../agent/utils';
 import { AgentConnectionState } from '../../agent/utils';
 import { getAuthenticatedContext } from '../../context';
 import { getCacheRedis } from '../../redis';
+import { makeOperationDefinition } from './definitions';
 import { getAgentForRequest } from './utils/agentutils';
 import { buildOutputParameters } from './utils/parameters';
 
-export const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+export const operation = makeOperationDefinition({ scope: 'instance', resource: 'Agent' }, {
   name: 'agent-status',
-  status: 'active',
-  kind: 'operation',
   code: 'status',
-  experimental: true,
-  resource: ['Agent'],
-  system: false,
-  type: false,
-  instance: true,
   parameter: [
     { use: 'out', name: 'status', type: 'code', min: 1, max: '1' },
     { use: 'out', name: 'version', type: 'string', min: 1, max: '1' },
     { use: 'out', name: 'lastUpdated', type: 'instant', min: 0, max: '1' },
   ],
-};
+});
 
 /**
  * Handles HTTP requests for the Agent $status operation.

--- a/packages/server/src/fhir/operations/agentupgrade.ts
+++ b/packages/server/src/fhir/operations/agentupgrade.ts
@@ -10,16 +10,19 @@ import { parseInputParameters } from './utils/parameters';
 const DEFAULT_UPGRADE_TIMEOUT = 45000;
 const MAX_UPGRADE_TIMEOUT = 56000;
 
-export const operation = makeOperationDefinition({ scope: 'type-and-instance', resource: 'Agent' }, {
-  name: 'agent-upgrade',
-  code: 'upgrade',
-  parameter: [
-    { use: 'in', name: 'version', type: 'string', min: 0, max: '1' },
-    { use: 'in', name: 'timeout', type: 'integer', min: 0, max: '1' },
-    { use: 'in', name: 'force', type: 'boolean', min: 0, max: '1' },
-    { use: 'out', name: 'return', type: 'Bundle', min: 1, max: '1' },
-  ],
-});
+export const operation = makeOperationDefinition(
+  { scope: 'type-and-instance', resource: 'Agent' },
+  {
+    name: 'agent-upgrade',
+    code: 'upgrade',
+    parameter: [
+      { use: 'in', name: 'version', type: 'string', min: 0, max: '1' },
+      { use: 'in', name: 'timeout', type: 'integer', min: 0, max: '1' },
+      { use: 'in', name: 'force', type: 'boolean', min: 0, max: '1' },
+      { use: 'out', name: 'return', type: 'Bundle', min: 1, max: '1' },
+    ],
+  }
+);
 
 /**
  * Handles HTTP requests for the Agent $upgrade operation.

--- a/packages/server/src/fhir/operations/agentupgrade.ts
+++ b/packages/server/src/fhir/operations/agentupgrade.ts
@@ -2,31 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { AgentUpgradeResponse, WithId } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Agent, OperationDefinition } from '@medplum/fhirtypes';
+import type { Agent } from '@medplum/fhirtypes';
+import { makeOperationDefinition } from './definitions';
 import { handleBulkAgentOperation, sendAndHandleAgentRequest } from './utils/agentutils';
 import { parseInputParameters } from './utils/parameters';
 
 const DEFAULT_UPGRADE_TIMEOUT = 45000;
 const MAX_UPGRADE_TIMEOUT = 56000;
 
-export const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+export const operation = makeOperationDefinition({ scope: 'type-and-instance', resource: 'Agent' }, {
   name: 'agent-upgrade',
-  status: 'active',
-  kind: 'operation',
   code: 'upgrade',
-  experimental: true,
-  resource: ['Agent'],
-  system: false,
-  type: true,
-  instance: true,
   parameter: [
     { use: 'in', name: 'version', type: 'string', min: 0, max: '1' },
     { use: 'in', name: 'timeout', type: 'integer', min: 0, max: '1' },
     { use: 'in', name: 'force', type: 'boolean', min: 0, max: '1' },
     { use: 'out', name: 'return', type: 'Bundle', min: 1, max: '1' },
   ],
-};
+});
 
 /**
  * Handles HTTP requests for the Agent $upgrade operation.

--- a/packages/server/src/fhir/operations/ai.ts
+++ b/packages/server/src/fhir/operations/ai.ts
@@ -10,54 +10,57 @@ import { sendFhirResponse } from '../response';
 import { makeOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
 
-const operation = makeOperationDefinition({ scope: 'system' }, {
-  id: 'ai',
-  url: 'https://medplum.com/fhir/OperationDefinition/ai',
-  name: 'ai',
-  code: 'ai',
-  parameter: [
-    {
-      name: 'messages',
-      use: 'in',
-      min: 1,
-      max: '1',
-      type: 'string',
-      documentation: 'JSON string containing the conversation messages array',
-    },
-    {
-      name: 'model',
-      use: 'in',
-      min: 1,
-      max: '1',
-      type: 'string',
-      documentation: 'OpenAI model to use (e.g., gpt-4, gpt-3.5-turbo)',
-    },
-    {
-      name: 'tools',
-      use: 'in',
-      min: 0,
-      max: '1',
-      type: 'string',
-      documentation: 'JSON string containing the tools array (optional)',
-    },
-    {
-      name: 'content',
-      use: 'out',
-      min: 0,
-      max: '1',
-      type: 'string',
-      documentation: 'AI response content',
-    },
-    {
-      name: 'tool_calls',
-      use: 'out',
-      min: 0,
-      max: '1',
-      type: 'string',
-      documentation: 'JSON string containing tool calls array',
-    },
-  ],
-});
+const operation = makeOperationDefinition(
+  { scope: 'system' },
+  {
+    id: 'ai',
+    url: 'https://medplum.com/fhir/OperationDefinition/ai',
+    name: 'ai',
+    code: 'ai',
+    parameter: [
+      {
+        name: 'messages',
+        use: 'in',
+        min: 1,
+        max: '1',
+        type: 'string',
+        documentation: 'JSON string containing the conversation messages array',
+      },
+      {
+        name: 'model',
+        use: 'in',
+        min: 1,
+        max: '1',
+        type: 'string',
+        documentation: 'OpenAI model to use (e.g., gpt-4, gpt-3.5-turbo)',
+      },
+      {
+        name: 'tools',
+        use: 'in',
+        min: 0,
+        max: '1',
+        type: 'string',
+        documentation: 'JSON string containing the tools array (optional)',
+      },
+      {
+        name: 'content',
+        use: 'out',
+        min: 0,
+        max: '1',
+        type: 'string',
+        documentation: 'AI response content',
+      },
+      {
+        name: 'tool_calls',
+        use: 'out',
+        min: 0,
+        max: '1',
+        type: 'string',
+        documentation: 'JSON string containing tool calls array',
+      },
+    ],
+  }
+);
 
 type AIOperationParameters = {
   messages: string;

--- a/packages/server/src/fhir/operations/ai.ts
+++ b/packages/server/src/fhir/operations/ai.ts
@@ -2,25 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk, badRequest, forbidden, isOk, normalizeErrorString, OperationOutcomeError } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { OperationDefinition, ParametersParameter } from '@medplum/fhirtypes';
+import type { ParametersParameter } from '@medplum/fhirtypes';
 import type { Response as ExpressResponse, Request } from 'express';
 import { getAuthenticatedContext } from '../../context';
 import { sendOutcome } from '../outcomes';
 import { sendFhirResponse } from '../response';
+import { makeOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'system' }, {
   id: 'ai',
   url: 'https://medplum.com/fhir/OperationDefinition/ai',
   name: 'ai',
-  status: 'active',
-  kind: 'operation',
   code: 'ai',
-  resource: ['Parameters'],
-  system: false,
-  type: false,
-  instance: false,
   parameter: [
     {
       name: 'messages',
@@ -63,7 +57,7 @@ const operation: OperationDefinition = {
       documentation: 'JSON string containing tool calls array',
     },
   ],
-};
+});
 
 type AIOperationParameters = {
   messages: string;

--- a/packages/server/src/fhir/operations/asyncjobcancel.ts
+++ b/packages/server/src/fhir/operations/asyncjobcancel.ts
@@ -6,12 +6,15 @@ import type { AsyncJob } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { makeOperationDefinition } from './definitions';
 
-export const operation = makeOperationDefinition({ scope: 'instance', resource: 'AsyncJob' }, {
-  id: 'AsyncJob-cancel',
-  name: 'asyncjob-cancel',
-  code: 'cancel',
-  parameter: [{ use: 'out', name: 'return', type: 'OperationOutcome', min: 1, max: '1' }],
-});
+export const operation = makeOperationDefinition(
+  { scope: 'instance', resource: 'AsyncJob' },
+  {
+    id: 'AsyncJob-cancel',
+    name: 'asyncjob-cancel',
+    code: 'cancel',
+    parameter: [{ use: 'out', name: 'return', type: 'OperationOutcome', min: 1, max: '1' }],
+  }
+);
 
 /**
  * Handles HTTP requests for the AsyncJob $cancel operation.

--- a/packages/server/src/fhir/operations/asyncjobcancel.ts
+++ b/packages/server/src/fhir/operations/asyncjobcancel.ts
@@ -2,23 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk, assert, badRequest } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { AsyncJob, OperationDefinition } from '@medplum/fhirtypes';
+import type { AsyncJob } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
+import { makeOperationDefinition } from './definitions';
 
-export const operation: OperationDefinition = {
+export const operation = makeOperationDefinition({ scope: 'instance', resource: 'AsyncJob' }, {
   id: 'AsyncJob-cancel',
-  resourceType: 'OperationDefinition',
   name: 'asyncjob-cancel',
-  status: 'active',
-  kind: 'operation',
   code: 'cancel',
-  experimental: true,
-  resource: ['AsyncJob'],
-  system: false,
-  type: false,
-  instance: true,
   parameter: [{ use: 'out', name: 'return', type: 'OperationOutcome', min: 1, max: '1' }],
-};
+});
 
 /**
  * Handles HTTP requests for the AsyncJob $cancel operation.

--- a/packages/server/src/fhir/operations/binary-presigned-url.ts
+++ b/packages/server/src/fhir/operations/binary-presigned-url.ts
@@ -8,14 +8,17 @@ import { getPresignedUrl } from '../../storage/loader';
 import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
-const operation = makeOperationDefinition({ scope: 'instance', resource: 'Binary' }, {
-  name: 'BinaryPresignedURL',
-  code: 'presigned-url',
-  parameter: [
-    { use: 'in', name: 'upload', type: 'boolean', min: 0, max: '1' },
-    { use: 'out', name: 'url', type: 'uri', min: 1, max: '1' },
-  ],
-});
+const operation = makeOperationDefinition(
+  { scope: 'instance', resource: 'Binary' },
+  {
+    name: 'BinaryPresignedURL',
+    code: 'presigned-url',
+    parameter: [
+      { use: 'in', name: 'upload', type: 'boolean', min: 0, max: '1' },
+      { use: 'out', name: 'url', type: 'uri', min: 1, max: '1' },
+    ],
+  }
+);
 
 type PresignedUrlParams = {
   upload?: boolean;

--- a/packages/server/src/fhir/operations/binary-presigned-url.ts
+++ b/packages/server/src/fhir/operations/binary-presigned-url.ts
@@ -2,27 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 import { AccessPolicyInteraction, allOk, forbidden, OperationOutcomeError, satisfiedAccessPolicy } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Binary, OperationDefinition } from '@medplum/fhirtypes';
+import type { Binary } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { getPresignedUrl } from '../../storage/loader';
+import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'instance', resource: 'Binary' }, {
   name: 'BinaryPresignedURL',
-  status: 'active',
-  kind: 'operation',
   code: 'presigned-url',
-  experimental: true,
-  resource: ['Binary'],
-  system: false,
-  type: false,
-  instance: true,
   parameter: [
     { use: 'in', name: 'upload', type: 'boolean', min: 0, max: '1' },
     { use: 'out', name: 'url', type: 'uri', min: 1, max: '1' },
   ],
-};
+});
 
 type PresignedUrlParams = {
   upload?: boolean;

--- a/packages/server/src/fhir/operations/book.ts
+++ b/packages/server/src/fhir/operations/book.ts
@@ -12,20 +12,13 @@ import {
   Operator,
 } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type {
-  Appointment,
-  Bundle,
-  HealthcareService,
-  OperationDefinition,
-  Patient,
-  Reference,
-  Slot,
-} from '@medplum/fhirtypes';
+import type { Appointment, Bundle, HealthcareService, Patient, Reference, Slot } from '@medplum/fhirtypes';
 import assert from 'node:assert';
 import { getAuthenticatedContext } from '../../context';
 import { addMinutes, areIntervalsOverlapping } from '../../util/date';
 import { getServiceTypeReferences } from '../../util/servicetype';
 import { copyPaths, withPath, withPaths } from '../../util/withpath';
+import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 import {
   applyExistingSlots,
@@ -36,22 +29,18 @@ import {
   slotsOverlappingInterval,
 } from './utils/scheduling';
 
-const bookOperation = {
-  resourceType: 'OperationDefinition',
-  name: 'book',
-  status: 'active',
-  kind: 'operation',
-  code: 'book',
-  resource: ['Appointment'],
-  system: false,
-  type: true,
-  instance: false,
-  parameter: [
-    { use: 'in', name: 'slot', type: 'Resource', min: 1, max: '*' },
-    { use: 'in', name: 'patient-reference', type: 'Reference', min: 0, max: '1' },
-    { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
-  ],
-} as const satisfies OperationDefinition;
+const bookOperation = makeOperationDefinition(
+  { scope: 'type', resource: 'Appointment' },
+  {
+    name: 'book',
+    code: 'book',
+    parameter: [
+      { use: 'in', name: 'slot', type: 'Resource', min: 1, max: '*' },
+      { use: 'in', name: 'patient-reference', type: 'Reference', min: 0, max: '1' },
+      { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
+    ],
+  }
+);
 
 type BookParameters = {
   slot: Slot[];

--- a/packages/server/src/fhir/operations/botinit.ts
+++ b/packages/server/src/fhir/operations/botinit.ts
@@ -11,37 +11,32 @@ import {
   getReferenceString,
 } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type {
-  AccessPolicy,
-  Attachment,
-  Binary,
-  Bot,
-  Project,
-  ProjectMembership,
-  Reference,
-} from '@medplum/fhirtypes';
+import type { AccessPolicy, Attachment, Binary, Bot, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import { Readable } from 'node:stream';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import type { Repository } from '../../fhir/repo';
 import { getGlobalSystemRepo } from '../../fhir/repo';
 import { getBinaryStorage } from '../../storage/loader';
-import { deployBot } from './deploy';
 import { makeOperationDefinition } from './definitions';
+import { deployBot } from './deploy';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
-const botInitOperation = makeOperationDefinition({ scope: 'type', resource: 'Bot' }, {
-  name: 'bot-init',
-  code: 'init',
-  parameter: [
-    { use: 'in', name: 'name', type: 'string', min: 1, max: '1' },
-    { use: 'in', name: 'description', type: 'string', min: 0, max: '1' },
-    { use: 'in', name: 'accessPolicy', type: 'Reference', min: 0, max: '1' },
-    { use: 'in', name: 'sourceCode', type: 'Attachment', min: 0, max: '1' },
-    { use: 'in', name: 'executableCode', type: 'Attachment', min: 0, max: '1' },
-    { use: 'out', name: 'return', type: 'Bot', min: 1, max: '1' },
-  ],
-});
+const botInitOperation = makeOperationDefinition(
+  { scope: 'type', resource: 'Bot' },
+  {
+    name: 'bot-init',
+    code: 'init',
+    parameter: [
+      { use: 'in', name: 'name', type: 'string', min: 1, max: '1' },
+      { use: 'in', name: 'description', type: 'string', min: 0, max: '1' },
+      { use: 'in', name: 'accessPolicy', type: 'Reference', min: 0, max: '1' },
+      { use: 'in', name: 'sourceCode', type: 'Attachment', min: 0, max: '1' },
+      { use: 'in', name: 'executableCode', type: 'Attachment', min: 0, max: '1' },
+      { use: 'out', name: 'return', type: 'Bot', min: 1, max: '1' },
+    ],
+  }
+);
 
 export interface BotInitParameters {
   readonly name: string;

--- a/packages/server/src/fhir/operations/botinit.ts
+++ b/packages/server/src/fhir/operations/botinit.ts
@@ -16,7 +16,6 @@ import type {
   Attachment,
   Binary,
   Bot,
-  OperationDefinition,
   Project,
   ProjectMembership,
   Reference,
@@ -28,18 +27,12 @@ import type { Repository } from '../../fhir/repo';
 import { getGlobalSystemRepo } from '../../fhir/repo';
 import { getBinaryStorage } from '../../storage/loader';
 import { deployBot } from './deploy';
+import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
-const botInitOperation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const botInitOperation = makeOperationDefinition({ scope: 'type', resource: 'Bot' }, {
   name: 'bot-init',
-  status: 'active',
-  kind: 'operation',
   code: 'init',
-  resource: ['Bot'],
-  system: false,
-  type: true,
-  instance: false,
   parameter: [
     { use: 'in', name: 'name', type: 'string', min: 1, max: '1' },
     { use: 'in', name: 'description', type: 'string', min: 0, max: '1' },
@@ -48,7 +41,7 @@ const botInitOperation: OperationDefinition = {
     { use: 'in', name: 'executableCode', type: 'Attachment', min: 0, max: '1' },
     { use: 'out', name: 'return', type: 'Bot', min: 1, max: '1' },
   ],
-};
+});
 
 export interface BotInitParameters {
   readonly name: string;

--- a/packages/server/src/fhir/operations/ccdaexport.ts
+++ b/packages/server/src/fhir/operations/ccdaexport.ts
@@ -6,7 +6,7 @@ import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Binary, OperationDefinition } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import type { PatientSummaryParameters } from './patientsummary';
-import { getPatientSummary, operation as patientSummaryOperation } from './patientsummary';
+import { getPatientSummary, patientSummaryOperation } from './patientsummary';
 import { parseInputParameters } from './utils/parameters';
 
 export const operation = {

--- a/packages/server/src/fhir/operations/claimexport.ts
+++ b/packages/server/src/fhir/operations/claimexport.ts
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk, badRequest, getReferenceString, normalizeErrorString } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Binary, Claim, Media, OperationDefinition } from '@medplum/fhirtypes';
+import type { Binary, Claim, Media } from '@medplum/fhirtypes';
 import { Readable } from 'node:stream';
 import { getAuthenticatedContext } from '../../context';
 import { getBinaryStorage } from '../../storage/loader';
 import { createPdf } from '../../util/pdf';
+import { makeOperationDefinition } from './definitions';
 import { getClaimPDFDocDefinition } from './utils/cms1500pdf';
 import { parseInputParameters } from './utils/parameters';
 
@@ -14,17 +15,9 @@ import { parseInputParameters } from './utils/parameters';
  * Operation definition for the Claim $export operation.
  * This operation exports a claim as a PDF document.
  */
-export const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+export const operation = makeOperationDefinition({ scope: 'instance', resource: 'Claim' }, {
   name: 'claim-export',
-  status: 'active',
-  kind: 'operation',
   code: 'export',
-  experimental: true,
-  resource: ['Claim'],
-  system: false,
-  type: false,
-  instance: true,
   parameter: [
     {
       use: 'in',
@@ -43,7 +36,7 @@ export const operation: OperationDefinition = {
       documentation: 'A Media resource containing the PDF document',
     },
   ],
-};
+});
 
 interface ClaimExportParameters {
   readonly resource: Claim;

--- a/packages/server/src/fhir/operations/claimexport.ts
+++ b/packages/server/src/fhir/operations/claimexport.ts
@@ -15,28 +15,31 @@ import { parseInputParameters } from './utils/parameters';
  * Operation definition for the Claim $export operation.
  * This operation exports a claim as a PDF document.
  */
-export const operation = makeOperationDefinition({ scope: 'instance', resource: 'Claim' }, {
-  name: 'claim-export',
-  code: 'export',
-  parameter: [
-    {
-      use: 'in',
-      name: 'resource',
-      type: 'Resource',
-      min: 1,
-      max: '1',
-      documentation: 'The claim to export',
-    },
-    {
-      use: 'out',
-      name: 'return',
-      type: 'Media',
-      min: 1,
-      max: '1',
-      documentation: 'A Media resource containing the PDF document',
-    },
-  ],
-});
+export const operation = makeOperationDefinition(
+  { scope: 'instance', resource: 'Claim' },
+  {
+    name: 'claim-export',
+    code: 'export',
+    parameter: [
+      {
+        use: 'in',
+        name: 'resource',
+        type: 'Resource',
+        min: 1,
+        max: '1',
+        documentation: 'The claim to export',
+      },
+      {
+        use: 'out',
+        name: 'return',
+        type: 'Media',
+        min: 1,
+        max: '1',
+        documentation: 'A Media resource containing the PDF document',
+      },
+    ],
+  }
+);
 
 interface ClaimExportParameters {
   readonly resource: Claim;

--- a/packages/server/src/fhir/operations/clearallwssubs.ts
+++ b/packages/server/src/fhir/operations/clearallwssubs.ts
@@ -2,23 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk, badRequest, isUUID } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { OperationDefinition, Subscription } from '@medplum/fhirtypes';
+import type { Subscription } from '@medplum/fhirtypes';
 import { requireSuperAdmin } from '../../admin/super';
 import { getActiveSubsKey } from '../../pubsub';
 import { getCacheRedis, getPubSubRedis } from '../../redis';
 import type { CacheEntry } from '../repository/resource-cache';
+import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'system' }, {
   name: 'clear-all-ws-subs',
-  status: 'active',
-  kind: 'operation',
   code: 'clear-all-ws-subs',
-  experimental: true,
-  system: true,
-  type: false,
-  instance: false,
   parameter: [
     {
       use: 'in',
@@ -49,7 +43,7 @@ const operation: OperationDefinition = {
       max: '1',
     },
   ],
-};
+});
 
 export async function clearAllWsSubsHandler(req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();

--- a/packages/server/src/fhir/operations/clearallwssubs.ts
+++ b/packages/server/src/fhir/operations/clearallwssubs.ts
@@ -10,40 +10,43 @@ import type { CacheEntry } from '../repository/resource-cache';
 import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
-const operation = makeOperationDefinition({ scope: 'system' }, {
-  name: 'clear-all-ws-subs',
-  code: 'clear-all-ws-subs',
-  parameter: [
-    {
-      use: 'in',
-      name: 'projectId',
-      type: 'string',
-      min: 0,
-      max: '1',
-    },
-    {
-      use: 'out',
-      name: 'pubSubKeysDeleted',
-      type: 'integer',
-      min: 1,
-      max: '1',
-    },
-    {
-      use: 'out',
-      name: 'cacheKeysDeleted',
-      type: 'integer',
-      min: 1,
-      max: '1',
-    },
-    {
-      use: 'out',
-      name: 'userKeysDeleted',
-      type: 'integer',
-      min: 1,
-      max: '1',
-    },
-  ],
-});
+const operation = makeOperationDefinition(
+  { scope: 'system' },
+  {
+    name: 'clear-all-ws-subs',
+    code: 'clear-all-ws-subs',
+    parameter: [
+      {
+        use: 'in',
+        name: 'projectId',
+        type: 'string',
+        min: 0,
+        max: '1',
+      },
+      {
+        use: 'out',
+        name: 'pubSubKeysDeleted',
+        type: 'integer',
+        min: 1,
+        max: '1',
+      },
+      {
+        use: 'out',
+        name: 'cacheKeysDeleted',
+        type: 'integer',
+        min: 1,
+        max: '1',
+      },
+      {
+        use: 'out',
+        name: 'userKeysDeleted',
+        type: 'integer',
+        min: 1,
+        max: '1',
+      },
+    ],
+  }
+);
 
 export async function clearAllWsSubsHandler(req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();

--- a/packages/server/src/fhir/operations/codesystemimport.ts
+++ b/packages/server/src/fhir/operations/codesystemimport.ts
@@ -3,12 +3,7 @@
 import type { WithId } from '@medplum/core';
 import { OperationOutcomeError, allOk, badRequest, forbidden, normalizeOperationOutcome } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type {
-  CodeSystem,
-  CodeSystemProperty,
-  Coding,
-  OperationDefinitionParameter,
-} from '@medplum/fhirtypes';
+import type { CodeSystem, CodeSystemProperty, Coding, OperationDefinitionParameter } from '@medplum/fhirtypes';
 import type { PoolClient } from 'pg';
 import { getAuthenticatedContext } from '../../context';
 import { Condition, InsertQuery, SelectQuery } from '../sql';
@@ -34,27 +29,30 @@ function makeCodeAttributeParameter(
   };
 }
 
-const operation = makeOperationDefinition({ scope: 'type', resource: 'CodeSystem' }, {
-  name: 'codesystem-import',
-  code: 'import',
-  parameter: [
-    { use: 'in', name: 'system', type: 'uri', min: 0, max: '1' },
-    { use: 'in', name: 'concept', type: 'Coding', min: 0, max: '*' },
-    makeCodeAttributeParameter('property', {
-      name: 'property',
-      type: 'code',
-      min: 1,
-      max: '1',
-    }),
-    makeCodeAttributeParameter('designation', {
-      name: 'language',
-      type: 'code',
-      min: 0,
-      max: '1',
-    }),
-    { use: 'out', name: 'return', type: 'CodeSystem', min: 1, max: '1' },
-  ],
-});
+const operation = makeOperationDefinition(
+  { scope: 'type', resource: 'CodeSystem' },
+  {
+    name: 'codesystem-import',
+    code: 'import',
+    parameter: [
+      { use: 'in', name: 'system', type: 'uri', min: 0, max: '1' },
+      { use: 'in', name: 'concept', type: 'Coding', min: 0, max: '*' },
+      makeCodeAttributeParameter('property', {
+        name: 'property',
+        type: 'code',
+        min: 1,
+        max: '1',
+      }),
+      makeCodeAttributeParameter('designation', {
+        name: 'language',
+        type: 'code',
+        min: 0,
+        max: '1',
+      }),
+      { use: 'out', name: 'return', type: 'CodeSystem', min: 1, max: '1' },
+    ],
+  }
+);
 
 export type ImportedProperty = {
   code: string;

--- a/packages/server/src/fhir/operations/codesystemimport.ts
+++ b/packages/server/src/fhir/operations/codesystemimport.ts
@@ -7,12 +7,12 @@ import type {
   CodeSystem,
   CodeSystemProperty,
   Coding,
-  OperationDefinition,
   OperationDefinitionParameter,
 } from '@medplum/fhirtypes';
 import type { PoolClient } from 'pg';
 import { getAuthenticatedContext } from '../../context';
 import { Condition, InsertQuery, SelectQuery } from '../sql';
+import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 import { findTerminologyResource, parentProperty, selectCoding, uniqueOn } from './utils/terminology';
 
@@ -34,17 +34,9 @@ function makeCodeAttributeParameter(
   };
 }
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'type', resource: 'CodeSystem' }, {
   name: 'codesystem-import',
-  status: 'active',
-  kind: 'operation',
   code: 'import',
-  experimental: true,
-  resource: ['CodeSystem'],
-  system: false,
-  type: true,
-  instance: false,
   parameter: [
     { use: 'in', name: 'system', type: 'uri', min: 0, max: '1' },
     { use: 'in', name: 'concept', type: 'Coding', min: 0, max: '*' },
@@ -62,7 +54,7 @@ const operation: OperationDefinition = {
     }),
     { use: 'out', name: 'return', type: 'CodeSystem', min: 1, max: '1' },
   ],
-};
+});
 
 export type ImportedProperty = {
   code: string;

--- a/packages/server/src/fhir/operations/conceptmapimport.ts
+++ b/packages/server/src/fhir/operations/conceptmapimport.ts
@@ -3,11 +3,7 @@
 import type { TypedValue, WithId } from '@medplum/core';
 import { allOk, append, badRequest, EMPTY, flatMapFilter, forbidden, OperationOutcomeError } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type {
-  Coding,
-  ConceptMap,
-  ConceptMapGroupElementTargetDependsOn,
-} from '@medplum/fhirtypes';
+import type { Coding, ConceptMap, ConceptMapGroupElementTargetDependsOn } from '@medplum/fhirtypes';
 import type { PoolClient } from 'pg';
 import { getAuthenticatedContext } from '../../context';
 import { InsertQuery, SelectQuery, Union } from '../sql';
@@ -15,69 +11,72 @@ import { makeOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
 import { findTerminologyResource, uniqueOn } from './utils/terminology';
 
-const operation = makeOperationDefinition({ scope: 'type-and-instance', resource: 'ConceptMap' }, {
-  name: 'conceptmap-import',
-  code: 'import',
-  affectsState: true,
-  parameter: [
-    { use: 'in', name: 'url', type: 'uri', min: 0, max: '1' },
-    {
-      use: 'in',
-      name: 'mapping',
-      min: 1,
-      max: '*',
-      part: [
-        { use: 'in', name: 'source', type: 'Coding', min: 1, max: '1' },
-        // `target.system` is required; leave `target.code` empty for null map
-        { use: 'in', name: 'target', type: 'Coding', min: 1, max: '1' },
-        // Default value of relationship is `equivalent`, to reduce overhead
-        {
-          use: 'in',
-          name: 'relationship',
-          type: 'code',
-          min: 0,
-          max: '1',
-          binding: {
-            strength: 'required',
-            valueSet: 'http://hl7.org/fhir/ValueSet/concept-map-equivalence',
+const operation = makeOperationDefinition(
+  { scope: 'type-and-instance', resource: 'ConceptMap' },
+  {
+    name: 'conceptmap-import',
+    code: 'import',
+    affectsState: true,
+    parameter: [
+      { use: 'in', name: 'url', type: 'uri', min: 0, max: '1' },
+      {
+        use: 'in',
+        name: 'mapping',
+        min: 1,
+        max: '*',
+        part: [
+          { use: 'in', name: 'source', type: 'Coding', min: 1, max: '1' },
+          // `target.system` is required; leave `target.code` empty for null map
+          { use: 'in', name: 'target', type: 'Coding', min: 1, max: '1' },
+          // Default value of relationship is `equivalent`, to reduce overhead
+          {
+            use: 'in',
+            name: 'relationship',
+            type: 'code',
+            min: 0,
+            max: '1',
+            binding: {
+              strength: 'required',
+              valueSet: 'http://hl7.org/fhir/ValueSet/concept-map-equivalence',
+            },
           },
-        },
-        { use: 'in', name: 'comment', type: 'string', min: 0, max: '1' },
-        {
-          use: 'in',
-          name: 'property',
-          min: 0,
-          max: '*',
-          part: [
-            { use: 'in', name: 'code', type: 'code', min: 1, max: '1' },
-            { use: 'in', name: 'value', type: 'Any', min: 1, max: '1' },
-          ],
-        },
-        {
-          use: 'in',
-          name: 'dependsOn',
-          min: 0,
-          max: '*',
-          part: [
-            { use: 'in', name: 'code', type: 'code', min: 1, max: '1' },
-            { use: 'in', name: 'value', type: 'Any', min: 0, max: '1' },
-          ],
-        },
-        {
-          use: 'in',
-          name: 'product',
-          min: 0,
-          max: '*',
-          part: [
-            { use: 'in', name: 'code', type: 'code', min: 1, max: '1' },
-            { use: 'in', name: 'value', type: 'Any', min: 0, max: '1' },
-          ],
-        },
-      ],
-    },
-    { use: 'out', name: 'return', type: 'ConceptMap', min: 1, max: '1' },
-  ],
-});
+          { use: 'in', name: 'comment', type: 'string', min: 0, max: '1' },
+          {
+            use: 'in',
+            name: 'property',
+            min: 0,
+            max: '*',
+            part: [
+              { use: 'in', name: 'code', type: 'code', min: 1, max: '1' },
+              { use: 'in', name: 'value', type: 'Any', min: 1, max: '1' },
+            ],
+          },
+          {
+            use: 'in',
+            name: 'dependsOn',
+            min: 0,
+            max: '*',
+            part: [
+              { use: 'in', name: 'code', type: 'code', min: 1, max: '1' },
+              { use: 'in', name: 'value', type: 'Any', min: 0, max: '1' },
+            ],
+          },
+          {
+            use: 'in',
+            name: 'product',
+            min: 0,
+            max: '*',
+            part: [
+              { use: 'in', name: 'code', type: 'code', min: 1, max: '1' },
+              { use: 'in', name: 'value', type: 'Any', min: 0, max: '1' },
+            ],
+          },
+        ],
+      },
+      { use: 'out', name: 'return', type: 'ConceptMap', min: 1, max: '1' },
+    ],
+  }
+);
 
 export type ConceptMapImportParameters = {
   url?: string;

--- a/packages/server/src/fhir/operations/conceptmapimport.ts
+++ b/packages/server/src/fhir/operations/conceptmapimport.ts
@@ -7,25 +7,17 @@ import type {
   Coding,
   ConceptMap,
   ConceptMapGroupElementTargetDependsOn,
-  OperationDefinition,
 } from '@medplum/fhirtypes';
 import type { PoolClient } from 'pg';
 import { getAuthenticatedContext } from '../../context';
 import { InsertQuery, SelectQuery, Union } from '../sql';
+import { makeOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
 import { findTerminologyResource, uniqueOn } from './utils/terminology';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'type-and-instance', resource: 'ConceptMap' }, {
   name: 'conceptmap-import',
-  status: 'active',
-  kind: 'operation',
   code: 'import',
-  experimental: true,
-  resource: ['ConceptMap'],
-  system: false,
-  type: true,
-  instance: true,
   affectsState: true,
   parameter: [
     { use: 'in', name: 'url', type: 'uri', min: 0, max: '1' },
@@ -85,7 +77,7 @@ const operation: OperationDefinition = {
     },
     { use: 'out', name: 'return', type: 'ConceptMap', min: 1, max: '1' },
   ],
-};
+});
 
 export type ConceptMapImportParameters = {
   url?: string;

--- a/packages/server/src/fhir/operations/db-column-statistics.ts
+++ b/packages/server/src/fhir/operations/db-column-statistics.ts
@@ -2,28 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk, badRequest, OperationOutcomeError } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { OperationDefinition } from '@medplum/fhirtypes';
 import type { Client, Pool } from 'pg';
 import { requireSuperAdmin } from '../../admin/super';
 import { DatabaseMode, getDatabasePool } from '../../database';
 import { escapeUnicode } from '../../migrations/migrate-utils';
 import { isValidTableName } from '../sql';
+import { makeOperationDefinition } from './definitions';
 import {
   buildOutputParameters,
   makeOperationDefinitionParameter as param,
   parseInputParameters,
 } from './utils/parameters';
 
-const LookupOperation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const LookupOperation = makeOperationDefinition({ scope: 'system' }, {
   name: 'db-column-statistics',
-  status: 'active',
-  kind: 'operation',
   code: 'db-column-statistics',
-  experimental: true,
-  system: true,
-  type: false,
-  instance: false,
   parameter: [
     param('in', 'tableName', 'string', 0, '1'),
     param('out', 'defaultStatisticsTarget', 'integer', 1, '1'),
@@ -50,7 +43,7 @@ const LookupOperation: OperationDefinition = {
       ]),
     ]),
   ],
-};
+});
 
 export async function getColumnStatisticsHandler(req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();

--- a/packages/server/src/fhir/operations/db-column-statistics.ts
+++ b/packages/server/src/fhir/operations/db-column-statistics.ts
@@ -14,36 +14,39 @@ import {
   parseInputParameters,
 } from './utils/parameters';
 
-const LookupOperation = makeOperationDefinition({ scope: 'system' }, {
-  name: 'db-column-statistics',
-  code: 'db-column-statistics',
-  parameter: [
-    param('in', 'tableName', 'string', 0, '1'),
-    param('out', 'defaultStatisticsTarget', 'integer', 1, '1'),
-    param('out', 'table', undefined, 0, '1', [
-      param('out', 'tableName', 'string', 1, '1'),
-      param('out', 'column', undefined, 1, '*', [
-        param('out', 'name', 'string', 1, '1'),
-        param('out', 'statisticsTarget', 'integer', 1, '1'),
-        param('out', 'schemaName', 'string', 1, '1'),
+const LookupOperation = makeOperationDefinition(
+  { scope: 'system' },
+  {
+    name: 'db-column-statistics',
+    code: 'db-column-statistics',
+    parameter: [
+      param('in', 'tableName', 'string', 0, '1'),
+      param('out', 'defaultStatisticsTarget', 'integer', 1, '1'),
+      param('out', 'table', undefined, 0, '1', [
         param('out', 'tableName', 'string', 1, '1'),
-        param('out', 'type', 'string', 1, '1'),
-        param('out', 'notNull', 'boolean', 1, '1'),
-        param('out', 'defaultValue', 'string', 0, '1'),
-        param('out', 'nullFraction', 'decimal', 0, '1'),
-        param('out', 'avgWidth', 'integer', 0, '1'),
-        param('out', 'nDistinct', 'decimal', 0, '1'),
-        param('out', 'mostCommonValues', 'string', 0, '1'),
-        param('out', 'mostCommonFreqs', 'string', 0, '1'),
-        param('out', 'histogramBounds', 'string', 0, '1'),
-        param('out', 'correlation', 'decimal', 0, '1'),
-        param('out', 'mostCommonElems', 'string', 0, '1'),
-        param('out', 'mostCommonElemFreqs', 'string', 0, '1'),
-        param('out', 'elemCountHistogram', 'string', 0, '1'),
+        param('out', 'column', undefined, 1, '*', [
+          param('out', 'name', 'string', 1, '1'),
+          param('out', 'statisticsTarget', 'integer', 1, '1'),
+          param('out', 'schemaName', 'string', 1, '1'),
+          param('out', 'tableName', 'string', 1, '1'),
+          param('out', 'type', 'string', 1, '1'),
+          param('out', 'notNull', 'boolean', 1, '1'),
+          param('out', 'defaultValue', 'string', 0, '1'),
+          param('out', 'nullFraction', 'decimal', 0, '1'),
+          param('out', 'avgWidth', 'integer', 0, '1'),
+          param('out', 'nDistinct', 'decimal', 0, '1'),
+          param('out', 'mostCommonValues', 'string', 0, '1'),
+          param('out', 'mostCommonFreqs', 'string', 0, '1'),
+          param('out', 'histogramBounds', 'string', 0, '1'),
+          param('out', 'correlation', 'decimal', 0, '1'),
+          param('out', 'mostCommonElems', 'string', 0, '1'),
+          param('out', 'mostCommonElemFreqs', 'string', 0, '1'),
+          param('out', 'elemCountHistogram', 'string', 0, '1'),
+        ]),
       ]),
-    ]),
-  ],
-});
+    ],
+  }
+);
 
 export async function getColumnStatisticsHandler(req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();

--- a/packages/server/src/fhir/operations/db-configure-column-statistics.ts
+++ b/packages/server/src/fhir/operations/db-configure-column-statistics.ts
@@ -2,30 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 import { OperationOutcomeError, allOk, badRequest } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { OperationDefinition } from '@medplum/fhirtypes';
 import { requireSuperAdmin } from '../../admin/super';
 import { getShardSystemRepo } from '../repo';
 import { PLACEHOLDER_SHARD_ID } from '../sharding';
 import { isValidColumnName, isValidTableName } from '../sql';
+import { makeOperationDefinition } from './definitions';
 import { makeOperationDefinitionParameter as param, parseInputParameters } from './utils/parameters';
 
-const UpdateOperation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const UpdateOperation = makeOperationDefinition({ scope: 'system' }, {
   name: 'db-configure-column-statistics',
-  status: 'active',
-  kind: 'operation',
   code: 'db-configure-column-statistics',
-  experimental: true,
-  system: true,
-  type: false,
-  instance: false,
   parameter: [
     param('in', 'tableName', 'string', 1, '1'),
     param('in', 'columnNames', 'string', 1, '*'),
     param('in', 'resetToDefault', 'boolean', 1, '1'),
     param('in', 'newStatisticsTarget', 'integer', 0, '1'),
   ],
-};
+});
 
 export async function configureColumnStatisticsHandler(req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();

--- a/packages/server/src/fhir/operations/db-configure-column-statistics.ts
+++ b/packages/server/src/fhir/operations/db-configure-column-statistics.ts
@@ -9,16 +9,19 @@ import { isValidColumnName, isValidTableName } from '../sql';
 import { makeOperationDefinition } from './definitions';
 import { makeOperationDefinitionParameter as param, parseInputParameters } from './utils/parameters';
 
-const UpdateOperation = makeOperationDefinition({ scope: 'system' }, {
-  name: 'db-configure-column-statistics',
-  code: 'db-configure-column-statistics',
-  parameter: [
-    param('in', 'tableName', 'string', 1, '1'),
-    param('in', 'columnNames', 'string', 1, '*'),
-    param('in', 'resetToDefault', 'boolean', 1, '1'),
-    param('in', 'newStatisticsTarget', 'integer', 0, '1'),
-  ],
-});
+const UpdateOperation = makeOperationDefinition(
+  { scope: 'system' },
+  {
+    name: 'db-configure-column-statistics',
+    code: 'db-configure-column-statistics',
+    parameter: [
+      param('in', 'tableName', 'string', 1, '1'),
+      param('in', 'columnNames', 'string', 1, '*'),
+      param('in', 'resetToDefault', 'boolean', 1, '1'),
+      param('in', 'newStatisticsTarget', 'integer', 0, '1'),
+    ],
+  }
+);
 
 export async function configureColumnStatisticsHandler(req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();

--- a/packages/server/src/fhir/operations/db-configure-indexes.ts
+++ b/packages/server/src/fhir/operations/db-configure-indexes.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { accepted, badRequest, concatUrls, OperationOutcomeError } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { OperationDefinition } from '@medplum/fhirtypes';
 import type { Pool, PoolClient } from 'pg';
 import { escapeIdentifier } from 'pg';
 import { requireSuperAdmin } from '../../admin/super';
@@ -12,6 +11,7 @@ import { withLongRunningDatabaseClient } from '../../migrations/migration-utils'
 import { getShardSystemRepo } from '../repo';
 import { PLACEHOLDER_SHARD_ID } from '../sharding';
 import { isValidTableName } from '../sql';
+import { makeOperationDefinition } from './definitions';
 import { AsyncJobExecutor } from './utils/asyncjobexecutor';
 import {
   buildOutputParameters,
@@ -19,16 +19,9 @@ import {
   parseInputParameters,
 } from './utils/parameters';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'system' }, {
   name: 'db-configure-indexes',
-  status: 'active',
-  kind: 'operation',
   code: 'db-configure-indexes',
-  experimental: true,
-  system: true,
-  type: false,
-  instance: false,
   parameter: [
     param('in', 'tableName', 'string', 1, '*'),
     param('in', 'fastUpdateAction', 'string', 0, '1'),
@@ -40,7 +33,7 @@ const operation: OperationDefinition = {
       param('out', 'durationMs', 'integer', 0, '1'),
     ]),
   ],
-};
+});
 
 type InputParameters = {
   tableName: string[];

--- a/packages/server/src/fhir/operations/db-configure-indexes.ts
+++ b/packages/server/src/fhir/operations/db-configure-indexes.ts
@@ -19,21 +19,24 @@ import {
   parseInputParameters,
 } from './utils/parameters';
 
-const operation = makeOperationDefinition({ scope: 'system' }, {
-  name: 'db-configure-indexes',
-  code: 'db-configure-indexes',
-  parameter: [
-    param('in', 'tableName', 'string', 1, '*'),
-    param('in', 'fastUpdateAction', 'string', 0, '1'),
-    param('in', 'fastUpdateValue', 'boolean', 0, '1'),
-    param('in', 'ginPendingListLimitAction', 'string', 0, '1'),
-    param('in', 'ginPendingListLimitValue', 'integer', 0, '1'),
-    param('out', 'action', undefined, 0, '*', [
-      param('out', 'sql', 'string', 1, '1'),
-      param('out', 'durationMs', 'integer', 0, '1'),
-    ]),
-  ],
-});
+const operation = makeOperationDefinition(
+  { scope: 'system' },
+  {
+    name: 'db-configure-indexes',
+    code: 'db-configure-indexes',
+    parameter: [
+      param('in', 'tableName', 'string', 1, '*'),
+      param('in', 'fastUpdateAction', 'string', 0, '1'),
+      param('in', 'fastUpdateValue', 'boolean', 0, '1'),
+      param('in', 'ginPendingListLimitAction', 'string', 0, '1'),
+      param('in', 'ginPendingListLimitValue', 'integer', 0, '1'),
+      param('out', 'action', undefined, 0, '*', [
+        param('out', 'sql', 'string', 1, '1'),
+        param('out', 'durationMs', 'integer', 0, '1'),
+      ]),
+    ],
+  }
+);
 
 type InputParameters = {
   tableName: string[];

--- a/packages/server/src/fhir/operations/dbindexes.ts
+++ b/packages/server/src/fhir/operations/dbindexes.ts
@@ -14,22 +14,25 @@ import {
   parseInputParameters,
 } from './utils/parameters';
 
-const operation = makeOperationDefinition({ scope: 'system' }, {
-  name: 'db-indexes',
-  code: 'db-indexes',
-  parameter: [
-    param('in', 'tableName', 'string', 0, '*'),
-    param('out', 'defaultGinPendingListLimit', 'integer', 1, '1'),
-    param('out', 'index', undefined, 0, '*', [
-      param('out', 'schemaName', 'string', 1, '1'),
-      param('out', 'tableName', 'string', 1, '1'),
-      param('out', 'indexName', 'string', 1, '1'),
-      param('out', 'indexOptions', 'string', 0, '1'),
-      param('out', 'fastUpdate', 'boolean', 0, '1'),
-      param('out', 'ginPendingListLimit', 'integer', 0, '1'),
-    ]),
-  ],
-});
+const operation = makeOperationDefinition(
+  { scope: 'system' },
+  {
+    name: 'db-indexes',
+    code: 'db-indexes',
+    parameter: [
+      param('in', 'tableName', 'string', 0, '*'),
+      param('out', 'defaultGinPendingListLimit', 'integer', 1, '1'),
+      param('out', 'index', undefined, 0, '*', [
+        param('out', 'schemaName', 'string', 1, '1'),
+        param('out', 'tableName', 'string', 1, '1'),
+        param('out', 'indexName', 'string', 1, '1'),
+        param('out', 'indexOptions', 'string', 0, '1'),
+        param('out', 'fastUpdate', 'boolean', 0, '1'),
+        param('out', 'ginPendingListLimit', 'integer', 0, '1'),
+      ]),
+    ],
+  }
+);
 
 interface GinIndexInfo {
   schemaName: string;

--- a/packages/server/src/fhir/operations/dbindexes.ts
+++ b/packages/server/src/fhir/operations/dbindexes.ts
@@ -2,28 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk, badRequest, EMPTY, OperationOutcomeError } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { OperationDefinition } from '@medplum/fhirtypes';
 import type { Pool, PoolClient } from 'pg';
 import { requireSuperAdmin } from '../../admin/super';
 import { DatabaseMode, getDatabasePool } from '../../database';
 import { escapeUnicode } from '../../migrations/migrate-utils';
 import { isValidTableName, replaceNullWithUndefinedInRows, SqlBuilder } from '../sql';
+import { makeOperationDefinition } from './definitions';
 import {
   buildOutputParameters,
   makeOperationDefinitionParameter as param,
   parseInputParameters,
 } from './utils/parameters';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'system' }, {
   name: 'db-indexes',
-  status: 'active',
-  kind: 'operation',
   code: 'db-indexes',
-  experimental: true,
-  system: true,
-  type: false,
-  instance: false,
   parameter: [
     param('in', 'tableName', 'string', 0, '*'),
     param('out', 'defaultGinPendingListLimit', 'integer', 1, '1'),
@@ -36,7 +29,7 @@ const operation: OperationDefinition = {
       param('out', 'ginPendingListLimit', 'integer', 0, '1'),
     ]),
   ],
-};
+});
 
 interface GinIndexInfo {
   schemaName: string;

--- a/packages/server/src/fhir/operations/dbinvalidindexes.ts
+++ b/packages/server/src/fhir/operations/dbinvalidindexes.ts
@@ -2,21 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { OperationDefinition } from '@medplum/fhirtypes';
 import { requireSuperAdmin } from '../../admin/super';
 import { DatabaseMode, getDatabasePool } from '../../database';
+import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters } from './utils/parameters';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'system' }, {
   name: 'db-invalid-indexes',
-  status: 'active',
-  kind: 'operation',
   code: 'db-invalid-indexes',
-  experimental: true,
-  system: true,
-  type: false,
-  instance: false,
   parameter: [
     {
       use: 'out',
@@ -26,7 +19,7 @@ const operation: OperationDefinition = {
       max: '*',
     },
   ],
-};
+});
 
 export async function dbInvalidIndexesHandler(_req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();

--- a/packages/server/src/fhir/operations/dbinvalidindexes.ts
+++ b/packages/server/src/fhir/operations/dbinvalidindexes.ts
@@ -7,19 +7,22 @@ import { DatabaseMode, getDatabasePool } from '../../database';
 import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters } from './utils/parameters';
 
-const operation = makeOperationDefinition({ scope: 'system' }, {
-  name: 'db-invalid-indexes',
-  code: 'db-invalid-indexes',
-  parameter: [
-    {
-      use: 'out',
-      name: 'invalidIndex',
-      type: 'string',
-      min: 0,
-      max: '*',
-    },
-  ],
-});
+const operation = makeOperationDefinition(
+  { scope: 'system' },
+  {
+    name: 'db-invalid-indexes',
+    code: 'db-invalid-indexes',
+    parameter: [
+      {
+        use: 'out',
+        name: 'invalidIndex',
+        type: 'string',
+        min: 0,
+        max: '*',
+      },
+    ],
+  }
+);
 
 export async function dbInvalidIndexesHandler(_req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();

--- a/packages/server/src/fhir/operations/dbschemadiff.ts
+++ b/packages/server/src/fhir/operations/dbschemadiff.ts
@@ -8,19 +8,22 @@ import { generateMigrationActions, writePreDeployActionsToBuilder } from '../../
 import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters } from './utils/parameters';
 
-const operation = makeOperationDefinition({ scope: 'system' }, {
-  name: 'db-schema-diff',
-  code: 'schema-diff',
-  parameter: [
-    {
-      use: 'out',
-      name: 'migrationString',
-      type: 'string',
-      min: 1,
-      max: '1',
-    },
-  ],
-});
+const operation = makeOperationDefinition(
+  { scope: 'system' },
+  {
+    name: 'db-schema-diff',
+    code: 'schema-diff',
+    parameter: [
+      {
+        use: 'out',
+        name: 'migrationString',
+        type: 'string',
+        min: 1,
+        max: '1',
+      },
+    ],
+  }
+);
 
 export async function dbSchemaDiffHandler(_req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();

--- a/packages/server/src/fhir/operations/dbschemadiff.ts
+++ b/packages/server/src/fhir/operations/dbschemadiff.ts
@@ -2,22 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk, FileBuilder } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { OperationDefinition } from '@medplum/fhirtypes';
 import { requireSuperAdmin } from '../../admin/super';
 import { DatabaseMode, getDatabasePool } from '../../database';
 import { generateMigrationActions, writePreDeployActionsToBuilder } from '../../migrations/migrate';
+import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters } from './utils/parameters';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'system' }, {
   name: 'db-schema-diff',
-  status: 'active',
-  kind: 'operation',
   code: 'schema-diff',
-  experimental: true,
-  system: true,
-  type: false,
-  instance: false,
   parameter: [
     {
       use: 'out',
@@ -27,7 +20,7 @@ const operation: OperationDefinition = {
       max: '1',
     },
   ],
-};
+});
 
 export async function dbSchemaDiffHandler(_req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();

--- a/packages/server/src/fhir/operations/dbstats.ts
+++ b/packages/server/src/fhir/operations/dbstats.ts
@@ -7,26 +7,29 @@ import { DatabaseMode, getDatabasePool } from '../../database';
 import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
-const operation = makeOperationDefinition({ scope: 'system' }, {
-  name: 'db-stats',
-  code: 'db-stats',
-  parameter: [
-    {
-      use: 'in',
-      name: 'tableNames',
-      type: 'string',
-      min: 0,
-      max: '1',
-    },
-    {
-      use: 'out',
-      name: 'tableString',
-      type: 'string',
-      min: 1,
-      max: '1',
-    },
-  ],
-});
+const operation = makeOperationDefinition(
+  { scope: 'system' },
+  {
+    name: 'db-stats',
+    code: 'db-stats',
+    parameter: [
+      {
+        use: 'in',
+        name: 'tableNames',
+        type: 'string',
+        min: 0,
+        max: '1',
+      },
+      {
+        use: 'out',
+        name: 'tableString',
+        type: 'string',
+        min: 1,
+        max: '1',
+      },
+    ],
+  }
+);
 
 export async function dbStatsHandler(req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();

--- a/packages/server/src/fhir/operations/dbstats.ts
+++ b/packages/server/src/fhir/operations/dbstats.ts
@@ -2,21 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { OperationDefinition } from '@medplum/fhirtypes';
 import { requireSuperAdmin } from '../../admin/super';
 import { DatabaseMode, getDatabasePool } from '../../database';
+import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'system' }, {
   name: 'db-stats',
-  status: 'active',
-  kind: 'operation',
   code: 'db-stats',
-  experimental: true,
-  system: true,
-  type: false,
-  instance: false,
   parameter: [
     {
       use: 'in',
@@ -33,7 +26,7 @@ const operation: OperationDefinition = {
       max: '1',
     },
   ],
-};
+});
 
 export async function dbStatsHandler(req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();

--- a/packages/server/src/fhir/operations/definitions.ts
+++ b/packages/server/src/fhir/operations/definitions.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { OperationOutcomeError, serverError } from '@medplum/core';
+import { arrayify, OperationOutcomeError, serverError } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import type { Bundle, OperationDefinition, ResourceType, StructureDefinition } from '@medplum/fhirtypes';
 
@@ -16,4 +16,61 @@ export function getOperationDefinition(resourceType: ResourceType, code: string)
     throw new OperationOutcomeError(serverError(new Error('OperationDefinition not found')));
   }
   return opDef;
+}
+
+type OperationDefinitionResource = ResourceType | ResourceType[];
+
+export type OperationDefinitionScope =
+  | { scope: 'system'; resource?: never }
+  | { scope: 'type'; resource: OperationDefinitionResource }
+  | { scope: 'instance'; resource: OperationDefinitionResource }
+  | { scope: 'type-and-instance'; resource: OperationDefinitionResource };
+
+export type MakeOperationDefinitionOptions = Omit<
+  OperationDefinition,
+  'resource' | 'resourceType' | 'kind' | 'status' | 'system' | 'type' | 'instance'
+> & {
+  kind?: OperationDefinition['kind']; // make kind optional since a default is provided
+  status?: OperationDefinition['status']; // make status optional since a default is provided
+};
+
+/**
+ * Creates an OperationDefinition resource from a given scope and partial OperationDefinition object.
+ * The returned OperationDefinition will have the following properties set by default:
+ * - status: 'active'
+ * - kind: 'operation'
+ * - experimental: true
+ * The returned OperationDefinition will have the properties from the operation scope merged with the default properties.
+ * @param operationScope - The scope of the operation definition.
+ * @param options - The options for the operation definition.
+ * @returns The OperationDefinition resource.
+ */
+export function makeOperationDefinition(
+  operationScope: OperationDefinitionScope,
+  options: MakeOperationDefinitionOptions
+): OperationDefinition {
+  const { status = 'active', kind = 'operation', experimental = true, ...operation } = options;
+
+  return {
+    resourceType: 'OperationDefinition',
+    status,
+    kind,
+    experimental,
+    ...operation,
+    ...getOperationScopeFlags(operationScope.scope),
+    resource: arrayify(operationScope.resource),
+  };
+}
+
+const operationScopeFlags = {
+  system: { system: true, type: false, instance: false },
+  type: { system: false, type: true, instance: false },
+  instance: { system: false, type: false, instance: true },
+  'type-and-instance': { system: false, type: true, instance: true },
+} satisfies Record<OperationDefinitionScope['scope'], Pick<OperationDefinition, 'system' | 'type' | 'instance'>>;
+
+function getOperationScopeFlags(
+  scope: OperationDefinitionScope['scope']
+): Pick<OperationDefinition, 'system' | 'type' | 'instance'> {
+  return operationScopeFlags[scope];
 }

--- a/packages/server/src/fhir/operations/explain.ts
+++ b/packages/server/src/fhir/operations/explain.ts
@@ -3,27 +3,21 @@
 import { allOk, parseSearchRequest } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { RepositoryMode } from '@medplum/fhir-router';
-import type { OperationDefinition, Project, Reference } from '@medplum/fhirtypes';
+import type { Project, Reference } from '@medplum/fhirtypes';
 import { requireSuperAdmin } from '../../admin/super';
 import { escapeUnicode } from '../../migrations/migrate-utils';
 import { getCount, getSelectQueryForSearch } from '../search';
 import { SqlBuilder } from '../sql';
+import { makeOperationDefinition } from './definitions';
 import {
   buildOutputParameters,
   makeOperationDefinitionParameter as param,
   parseInputParameters,
 } from './utils/parameters';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'system' }, {
   name: 'db-explain',
-  status: 'active',
-  kind: 'operation',
   code: 'explain',
-  experimental: true,
-  system: true,
-  type: false,
-  instance: false,
   parameter: [
     param('in', 'query', 'string', 1, '1'),
     param('in', 'analyze', 'boolean', 0, '1'),
@@ -35,7 +29,7 @@ const operation: OperationDefinition = {
     param('out', 'countEstimate', 'integer', 0, '1'),
     param('out', 'countAccurate', 'integer', 0, '1'),
   ],
-};
+});
 
 export async function dbExplainHandler(req: FhirRequest): Promise<FhirResponse> {
   const ctx = requireSuperAdmin();

--- a/packages/server/src/fhir/operations/explain.ts
+++ b/packages/server/src/fhir/operations/explain.ts
@@ -15,21 +15,24 @@ import {
   parseInputParameters,
 } from './utils/parameters';
 
-const operation = makeOperationDefinition({ scope: 'system' }, {
-  name: 'db-explain',
-  code: 'explain',
-  parameter: [
-    param('in', 'query', 'string', 1, '1'),
-    param('in', 'analyze', 'boolean', 0, '1'),
-    param('in', 'format', 'string', 0, '1'),
-    param('in', 'count', 'boolean', 0, '1'),
-    param('out', 'query', 'string', 1, '1'),
-    param('out', 'parameters', 'string', 1, '1'),
-    param('out', 'explain', 'string', 1, '1'),
-    param('out', 'countEstimate', 'integer', 0, '1'),
-    param('out', 'countAccurate', 'integer', 0, '1'),
-  ],
-});
+const operation = makeOperationDefinition(
+  { scope: 'system' },
+  {
+    name: 'db-explain',
+    code: 'explain',
+    parameter: [
+      param('in', 'query', 'string', 1, '1'),
+      param('in', 'analyze', 'boolean', 0, '1'),
+      param('in', 'format', 'string', 0, '1'),
+      param('in', 'count', 'boolean', 0, '1'),
+      param('out', 'query', 'string', 1, '1'),
+      param('out', 'parameters', 'string', 1, '1'),
+      param('out', 'explain', 'string', 1, '1'),
+      param('out', 'countEstimate', 'integer', 0, '1'),
+      param('out', 'countAccurate', 'integer', 0, '1'),
+    ],
+  }
+);
 
 export async function dbExplainHandler(req: FhirRequest): Promise<FhirResponse> {
   const ctx = requireSuperAdmin();

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -14,14 +14,7 @@ import {
   resolveId,
 } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type {
-  Appointment,
-  Bundle,
-  HealthcareService,
-  Reference,
-  Schedule,
-  Slot,
-} from '@medplum/fhirtypes';
+import type { Appointment, Bundle, HealthcareService, Reference, Schedule, Slot } from '@medplum/fhirtypes';
 import assert from 'node:assert';
 import { getAuthenticatedContext } from '../../context';
 import { flatMapMax } from '../../util/array';
@@ -41,30 +34,36 @@ import {
 } from './utils/scheduling';
 import { extractCommonParameters } from './utils/scheduling-parameters';
 
-const scheduleFindOperation = makeOperationDefinition({ scope: 'instance', resource: 'Schedule' }, {
-  name: 'find',
-  code: 'find',
-  parameter: [
-    { use: 'in', name: 'start', type: 'dateTime', min: 1, max: '1' },
-    { use: 'in', name: 'end', type: 'dateTime', min: 1, max: '1' },
-    { use: 'in', name: 'service-type-reference', type: 'string', min: 1, max: '1', searchType: 'reference' },
-    { use: 'in', name: '_count', type: 'integer', min: 0, max: '1' },
-    { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
-  ],
-});
+const scheduleFindOperation = makeOperationDefinition(
+  { scope: 'instance', resource: 'Schedule' },
+  {
+    name: 'find',
+    code: 'find',
+    parameter: [
+      { use: 'in', name: 'start', type: 'dateTime', min: 1, max: '1' },
+      { use: 'in', name: 'end', type: 'dateTime', min: 1, max: '1' },
+      { use: 'in', name: 'service-type-reference', type: 'string', min: 1, max: '1', searchType: 'reference' },
+      { use: 'in', name: '_count', type: 'integer', min: 0, max: '1' },
+      { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
+    ],
+  }
+);
 
-const appointmentFindOperation = makeOperationDefinition({ scope: 'type', resource: 'Appointment' }, {
-  name: 'find',
-  code: 'find',
-  parameter: [
-    { use: 'in', name: 'start', type: 'dateTime', min: 1, max: '1' },
-    { use: 'in', name: 'end', type: 'dateTime', min: 1, max: '1' },
-    { use: 'in', name: 'service-type-reference', type: 'string', min: 1, max: '1', searchType: 'reference' },
-    { use: 'in', name: 'schedule', type: 'string', min: 1, max: '*', searchType: 'reference' },
-    { use: 'in', name: '_count', type: 'integer', min: 0, max: '1' },
-    { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
-  ],
-});
+const appointmentFindOperation = makeOperationDefinition(
+  { scope: 'type', resource: 'Appointment' },
+  {
+    name: 'find',
+    code: 'find',
+    parameter: [
+      { use: 'in', name: 'start', type: 'dateTime', min: 1, max: '1' },
+      { use: 'in', name: 'end', type: 'dateTime', min: 1, max: '1' },
+      { use: 'in', name: 'service-type-reference', type: 'string', min: 1, max: '1', searchType: 'reference' },
+      { use: 'in', name: 'schedule', type: 'string', min: 1, max: '*', searchType: 'reference' },
+      { use: 'in', name: '_count', type: 'integer', min: 0, max: '1' },
+      { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
+    ],
+  }
+);
 
 type ScheduleFindParameters = {
   start: string;

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -18,7 +18,6 @@ import type {
   Appointment,
   Bundle,
   HealthcareService,
-  OperationDefinition,
   Reference,
   Schedule,
   Slot,
@@ -30,6 +29,7 @@ import { addMinutes } from '../../util/date';
 import { isCodeableReferenceLikeTo, toCodeableReferenceLike } from '../../util/servicetype';
 import type { WithPath } from '../../util/withpath';
 import { copyPaths, getPath, withPath, withPaths } from '../../util/withpath';
+import { makeOperationDefinition } from './definitions';
 import { findAlignedSlotTimes, overlappingIntervals } from './utils/find';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 import {
@@ -41,16 +41,9 @@ import {
 } from './utils/scheduling';
 import { extractCommonParameters } from './utils/scheduling-parameters';
 
-const scheduleFindOperation = {
-  resourceType: 'OperationDefinition',
+const scheduleFindOperation = makeOperationDefinition({ scope: 'instance', resource: 'Schedule' }, {
   name: 'find',
-  status: 'active',
-  kind: 'operation',
   code: 'find',
-  resource: ['Schedule'],
-  system: false,
-  type: false,
-  instance: true,
   parameter: [
     { use: 'in', name: 'start', type: 'dateTime', min: 1, max: '1' },
     { use: 'in', name: 'end', type: 'dateTime', min: 1, max: '1' },
@@ -58,18 +51,11 @@ const scheduleFindOperation = {
     { use: 'in', name: '_count', type: 'integer', min: 0, max: '1' },
     { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
   ],
-} as const satisfies OperationDefinition;
+});
 
-const appointmentFindOperation = {
-  resourceType: 'OperationDefinition',
+const appointmentFindOperation = makeOperationDefinition({ scope: 'type', resource: 'Appointment' }, {
   name: 'find',
-  status: 'active',
-  kind: 'operation',
   code: 'find',
-  resource: ['Appointment'],
-  system: false,
-  type: true,
-  instance: false,
   parameter: [
     { use: 'in', name: 'start', type: 'dateTime', min: 1, max: '1' },
     { use: 'in', name: 'end', type: 'dateTime', min: 1, max: '1' },
@@ -78,7 +64,7 @@ const appointmentFindOperation = {
     { use: 'in', name: '_count', type: 'integer', min: 0, max: '1' },
     { use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' },
   ],
-} as const satisfies OperationDefinition;
+});
 
 type ScheduleFindParameters = {
   start: string;

--- a/packages/server/src/fhir/operations/getwssubprojectstats.ts
+++ b/packages/server/src/fhir/operations/getwssubprojectstats.ts
@@ -35,26 +35,29 @@ export interface WsSubProjectDetailStats {
   resourceTypes: WsSubResourceTypeDetailStats[];
 }
 
-const projectStatsOperation = makeOperationDefinition({ scope: 'system' }, {
-  name: 'get-ws-sub-project-stats',
-  code: 'get-ws-sub-project-stats',
-  parameter: [
-    {
-      use: 'in',
-      name: 'projectId',
-      type: 'string',
-      min: 1,
-      max: '1',
-    },
-    {
-      use: 'out',
-      name: 'stats',
-      type: 'string',
-      min: 1,
-      max: '1',
-    },
-  ],
-});
+const projectStatsOperation = makeOperationDefinition(
+  { scope: 'system' },
+  {
+    name: 'get-ws-sub-project-stats',
+    code: 'get-ws-sub-project-stats',
+    parameter: [
+      {
+        use: 'in',
+        name: 'projectId',
+        type: 'string',
+        min: 1,
+        max: '1',
+      },
+      {
+        use: 'out',
+        name: 'stats',
+        type: 'string',
+        min: 1,
+        max: '1',
+      },
+    ],
+  }
+);
 
 export async function getWsSubProjectStatsHandler(req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();

--- a/packages/server/src/fhir/operations/getwssubprojectstats.ts
+++ b/packages/server/src/fhir/operations/getwssubprojectstats.ts
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk, badRequest } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { OperationDefinition, ResourceType } from '@medplum/fhirtypes';
+import type { ResourceType } from '@medplum/fhirtypes';
 import { requireSuperAdmin } from '../../admin/super';
 import type { ActiveSubscriptionEntry } from '../../pubsub';
 import { getActiveSubsKey } from '../../pubsub';
 import { getPubSubRedis } from '../../redis';
+import { makeOperationDefinition } from './definitions';
 import { parseActiveSubKey } from './getwssubstats';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
@@ -34,16 +35,9 @@ export interface WsSubProjectDetailStats {
   resourceTypes: WsSubResourceTypeDetailStats[];
 }
 
-const projectStatsOperation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const projectStatsOperation = makeOperationDefinition({ scope: 'system' }, {
   name: 'get-ws-sub-project-stats',
-  status: 'active',
-  kind: 'operation',
   code: 'get-ws-sub-project-stats',
-  experimental: true,
-  system: true,
-  type: false,
-  instance: false,
   parameter: [
     {
       use: 'in',
@@ -60,7 +54,7 @@ const projectStatsOperation: OperationDefinition = {
       max: '1',
     },
   ],
-};
+});
 
 export async function getWsSubProjectStatsHandler(req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();

--- a/packages/server/src/fhir/operations/getwssubstats.ts
+++ b/packages/server/src/fhir/operations/getwssubstats.ts
@@ -2,23 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk, isResourceType } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { OperationDefinition, Project, ResourceType } from '@medplum/fhirtypes';
+import type { Project, ResourceType } from '@medplum/fhirtypes';
 import { requireSuperAdmin } from '../../admin/super';
 import { getAuthenticatedContext } from '../../context';
 import { getActiveSubsKey } from '../../pubsub';
 import { getPubSubRedis } from '../../redis';
+import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters } from './utils/parameters';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'system' }, {
   name: 'get-ws-sub-stats',
-  status: 'active',
-  kind: 'operation',
   code: 'get-ws-sub-stats',
-  experimental: true,
-  system: true,
-  type: false,
-  instance: false,
   parameter: [
     {
       use: 'out',
@@ -28,7 +22,7 @@ const operation: OperationDefinition = {
       max: '1',
     },
   ],
-};
+});
 
 export interface WsSubResourceTypeStats {
   resourceType: string;

--- a/packages/server/src/fhir/operations/getwssubstats.ts
+++ b/packages/server/src/fhir/operations/getwssubstats.ts
@@ -10,19 +10,22 @@ import { getPubSubRedis } from '../../redis';
 import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters } from './utils/parameters';
 
-const operation = makeOperationDefinition({ scope: 'system' }, {
-  name: 'get-ws-sub-stats',
-  code: 'get-ws-sub-stats',
-  parameter: [
-    {
-      use: 'out',
-      name: 'stats',
-      type: 'string',
-      min: 1,
-      max: '1',
-    },
-  ],
-});
+const operation = makeOperationDefinition(
+  { scope: 'system' },
+  {
+    name: 'get-ws-sub-stats',
+    code: 'get-ws-sub-stats',
+    parameter: [
+      {
+        use: 'out',
+        name: 'stats',
+        type: 'string',
+        min: 1,
+        max: '1',
+      },
+    ],
+  }
+);
 
 export interface WsSubResourceTypeStats {
   resourceType: string;

--- a/packages/server/src/fhir/operations/launch.ts
+++ b/packages/server/src/fhir/operations/launch.ts
@@ -2,27 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 import { badRequest, concatUrls, redirect } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { ClientApplication, OperationDefinition, SmartAppLaunch } from '@medplum/fhirtypes';
+import type { ClientApplication, SmartAppLaunch } from '@medplum/fhirtypes';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
+import { makeOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'instance', resource: 'ClientApplication' }, {
   name: 'clientapplication-smart-launch',
-  status: 'active',
-  kind: 'operation',
   code: 'smart-launch',
-  experimental: true,
-  resource: ['ClientApplication'],
-  system: false,
-  type: false,
-  instance: true,
   parameter: [
     { use: 'in', name: 'patient', type: 'uuid', min: 0, max: '1' },
     { use: 'in', name: 'encounter', type: 'uuid', min: 0, max: '1' },
   ],
-};
+});
 
 type LaunchOperationParameters = {
   patient?: string;

--- a/packages/server/src/fhir/operations/launch.ts
+++ b/packages/server/src/fhir/operations/launch.ts
@@ -8,14 +8,17 @@ import { getAuthenticatedContext } from '../../context';
 import { makeOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
 
-const operation = makeOperationDefinition({ scope: 'instance', resource: 'ClientApplication' }, {
-  name: 'clientapplication-smart-launch',
-  code: 'smart-launch',
-  parameter: [
-    { use: 'in', name: 'patient', type: 'uuid', min: 0, max: '1' },
-    { use: 'in', name: 'encounter', type: 'uuid', min: 0, max: '1' },
-  ],
-});
+const operation = makeOperationDefinition(
+  { scope: 'instance', resource: 'ClientApplication' },
+  {
+    name: 'clientapplication-smart-launch',
+    code: 'smart-launch',
+    parameter: [
+      { use: 'in', name: 'patient', type: 'uuid', min: 0, max: '1' },
+      { use: 'in', name: 'encounter', type: 'uuid', min: 0, max: '1' },
+    ],
+  }
+);
 
 type LaunchOperationParameters = {
   patient?: string;

--- a/packages/server/src/fhir/operations/patientsummary.ts
+++ b/packages/server/src/fhir/operations/patientsummary.ts
@@ -56,7 +56,6 @@ import type {
   Immunization,
   MedicationRequest,
   Observation,
-  OperationDefinition,
   OperationDefinitionParameter,
   Organization,
   Patient,
@@ -71,6 +70,7 @@ import type {
 import type { AuthenticatedRequestContext } from '../../context';
 import { getAuthenticatedContext } from '../../context';
 import { getLogger } from '../../logger';
+import { makeOperationDefinition } from './definitions';
 import type { PatientEverythingParameters } from './patienteverything';
 import { getPatientEverything } from './patienteverything';
 import { parseInputParameters } from './utils/parameters';
@@ -83,19 +83,12 @@ export const OBSERVATION_CATEGORY_SYSTEM = `${HTTP_TERMINOLOGY_HL7_ORG}/CodeSyst
 // Patient summary operation
 // https://build.fhir.org/ig/HL7/fhir-ips/OperationDefinition-summary.html
 
-export const operation = {
-  resourceType: 'OperationDefinition',
+export const operation = makeOperationDefinition({ scope: 'type-and-instance', resource: 'Patient' }, {
   id: 'summary',
   name: 'IpsSummary',
   title: 'IPS Summary',
-  status: 'active',
-  kind: 'operation',
   affectsState: false,
   code: 'summary',
-  resource: ['Patient'],
-  system: false,
-  type: true,
-  instance: true,
   parameter: [
     ['author', 'in', 0, 1, 'Reference'],
     ['authoredOn', 'in', 0, 1, 'instant'],
@@ -106,7 +99,7 @@ export const operation = {
     ['profile', 'in', 0, 1, 'canonical'],
     ['return', 'out', 0, 1, 'Bundle'],
   ].map(([name, use, min, max, type]) => ({ name, use, min, max, type }) as OperationDefinitionParameter),
-} satisfies OperationDefinition;
+});
 
 const resourceTypes: ResourceType[] = [
   'Account',

--- a/packages/server/src/fhir/operations/patientsummary.ts
+++ b/packages/server/src/fhir/operations/patientsummary.ts
@@ -56,6 +56,7 @@ import type {
   Immunization,
   MedicationRequest,
   Observation,
+  OperationDefinition,
   OperationDefinitionParameter,
   Organization,
   Patient,
@@ -83,23 +84,27 @@ export const OBSERVATION_CATEGORY_SYSTEM = `${HTTP_TERMINOLOGY_HL7_ORG}/CodeSyst
 // Patient summary operation
 // https://build.fhir.org/ig/HL7/fhir-ips/OperationDefinition-summary.html
 
-export const operation = makeOperationDefinition({ scope: 'type-and-instance', resource: 'Patient' }, {
-  id: 'summary',
-  name: 'IpsSummary',
-  title: 'IPS Summary',
-  affectsState: false,
-  code: 'summary',
-  parameter: [
-    ['author', 'in', 0, 1, 'Reference'],
-    ['authoredOn', 'in', 0, 1, 'instant'],
-    ['start', 'in', 0, 1, 'date'],
-    ['end', 'in', 0, 1, 'date'],
-    ['_since', 'in', 0, 1, 'instant'],
-    ['identifier', 'in', 0, 1, 'string'],
-    ['profile', 'in', 0, 1, 'canonical'],
-    ['return', 'out', 0, 1, 'Bundle'],
-  ].map(([name, use, min, max, type]) => ({ name, use, min, max, type }) as OperationDefinitionParameter),
-});
+export const patientSummaryOperation = makeOperationDefinition(
+  { scope: 'type-and-instance', resource: 'Patient' },
+  {
+    id: 'summary',
+    name: 'IpsSummary',
+    title: 'IPS Summary',
+    affectsState: false,
+    code: 'summary',
+    parameter: [
+      ['author', 'in', 0, 1, 'Reference'],
+      ['authoredOn', 'in', 0, 1, 'instant'],
+      ['start', 'in', 0, 1, 'date'],
+      ['end', 'in', 0, 1, 'date'],
+      ['_since', 'in', 0, 1, 'instant'],
+      ['identifier', 'in', 0, 1, 'string'],
+      ['profile', 'in', 0, 1, 'canonical'],
+      ['return', 'out', 0, 1, 'Bundle'],
+    ].map(([name, use, min, max, type]) => ({ name, use, min, max, type }) as OperationDefinitionParameter),
+  }
+  // cast since this op gets imported elsewhere where its useful to know it definitely has parameters
+) as OperationDefinition & { parameter: OperationDefinitionParameter[] };
 
 const resourceTypes: ResourceType[] = [
   'Account',
@@ -136,7 +141,7 @@ export interface PatientSummaryParameters extends PatientEverythingParameters {
 export async function patientSummaryHandler(req: FhirRequest): Promise<FhirResponse> {
   const ctx = getAuthenticatedContext();
   const { id } = req.params;
-  const params = parseInputParameters<PatientSummaryParameters>(operation, req);
+  const params = parseInputParameters<PatientSummaryParameters>(patientSummaryOperation, req);
   const bundle = await getPatientSummary(ctx, { reference: `Patient/${id}` }, params);
   return [allOk, bundle];
 }

--- a/packages/server/src/fhir/operations/project-rate-limits.ts
+++ b/packages/server/src/fhir/operations/project-rate-limits.ts
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk, arrayify, forbidden, getReferenceString, Operator } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { OperationDefinition, OperationDefinitionParameter, ProjectMembership } from '@medplum/fhirtypes';
+import type { OperationDefinitionParameter, ProjectMembership } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { getRateLimitRedis } from '../../redis';
 import { FHIR_RATE_LIMIT_MEMBERSHIP_PREFIX, FHIR_RATE_LIMIT_PROJECT_PREFIX, getFhirQuotaConfig } from '../fhirquota';
+import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
 const quotaParts: OperationDefinitionParameter[] = [
@@ -15,16 +16,9 @@ const quotaParts: OperationDefinitionParameter[] = [
   { use: 'out', name: 'msBeforeReset', type: 'integer', min: 0, max: '1' },
 ];
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'instance', resource: 'Project' }, {
   name: 'project-rate-limits',
-  status: 'active',
-  kind: 'operation',
   code: 'rate-limits',
-  resource: ['Project'],
-  system: false,
-  type: false,
-  instance: true,
   parameter: [
     { use: 'in', name: 'membershipId', type: 'string', min: 0, max: '*' },
     {
@@ -46,7 +40,7 @@ const operation: OperationDefinition = {
       ],
     },
   ],
-};
+});
 
 type RateLimitsInput = {
   membershipId?: string | string[];

--- a/packages/server/src/fhir/operations/project-rate-limits.ts
+++ b/packages/server/src/fhir/operations/project-rate-limits.ts
@@ -16,31 +16,34 @@ const quotaParts: OperationDefinitionParameter[] = [
   { use: 'out', name: 'msBeforeReset', type: 'integer', min: 0, max: '1' },
 ];
 
-const operation = makeOperationDefinition({ scope: 'instance', resource: 'Project' }, {
-  name: 'project-rate-limits',
-  code: 'rate-limits',
-  parameter: [
-    { use: 'in', name: 'membershipId', type: 'string', min: 0, max: '*' },
-    {
-      use: 'out',
-      name: 'project',
-      min: 1,
-      max: '1',
-      part: [{ use: 'out', name: 'id', type: 'string', min: 1, max: '1' }, ...quotaParts],
-    },
-    {
-      use: 'out',
-      name: 'membership',
-      min: 0,
-      max: '*',
-      part: [
-        { use: 'out', name: 'membershipId', type: 'string', min: 1, max: '1' },
-        { use: 'out', name: 'profile', type: 'Reference', min: 0, max: '1' },
-        ...quotaParts,
-      ],
-    },
-  ],
-});
+const operation = makeOperationDefinition(
+  { scope: 'instance', resource: 'Project' },
+  {
+    name: 'project-rate-limits',
+    code: 'rate-limits',
+    parameter: [
+      { use: 'in', name: 'membershipId', type: 'string', min: 0, max: '*' },
+      {
+        use: 'out',
+        name: 'project',
+        min: 1,
+        max: '1',
+        part: [{ use: 'out', name: 'id', type: 'string', min: 1, max: '1' }, ...quotaParts],
+      },
+      {
+        use: 'out',
+        name: 'membership',
+        min: 0,
+        max: '*',
+        part: [
+          { use: 'out', name: 'membershipId', type: 'string', min: 1, max: '1' },
+          { use: 'out', name: 'profile', type: 'Reference', min: 0, max: '1' },
+          ...quotaParts,
+        ],
+      },
+    ],
+  }
+);
 
 type RateLimitsInput = {
   membershipId?: string | string[];

--- a/packages/server/src/fhir/operations/projectinit.ts
+++ b/packages/server/src/fhir/operations/projectinit.ts
@@ -3,13 +3,7 @@
 import type { ProfileResource, WithId } from '@medplum/core';
 import { badRequest, createReference, created } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type {
-  ClientApplication,
-  Project,
-  ProjectMembership,
-  Reference,
-  User,
-} from '@medplum/fhirtypes';
+import type { ClientApplication, Project, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
 import { randomUUID } from 'node:crypto';
 import { createClient } from '../../admin/client';
 import { createUser } from '../../auth/newuser';
@@ -21,42 +15,25 @@ import { getUserByEmailWithoutProject } from '../../oauth/utils';
 import { getShardSystemRepo } from '../repo';
 import { PLACEHOLDER_SHARD_ID } from '../sharding';
 import { makeOperationDefinition } from './definitions';
-import { buildOutputParameters, parseInputParameters } from './utils/parameters';
+import {
+  buildOutputParameters,
+  makeOperationDefinitionParameter as param,
+  parseInputParameters,
+} from './utils/parameters';
 
-const projectInitOperation = makeOperationDefinition({ scope: 'type', resource: 'Project' }, {
-  name: 'project-init',
-  code: 'init',
-  parameter: [
-    {
-      use: 'in',
-      name: 'name',
-      type: 'string',
-      min: 1,
-      max: '1',
-    },
-    {
-      use: 'in',
-      name: 'owner',
-      type: 'Reference',
-      min: 0,
-      max: '1',
-    },
-    {
-      use: 'in',
-      name: 'ownerEmail',
-      type: 'string',
-      min: 0,
-      max: '1',
-    },
-    {
-      use: 'out',
-      name: 'return',
-      type: 'Project',
-      min: 1,
-      max: '1',
-    },
-  ],
-});
+const projectInitOperation = makeOperationDefinition(
+  { scope: 'type', resource: 'Project' },
+  {
+    name: 'project-init',
+    code: 'init',
+    parameter: [
+      param('in', 'name', 'string', 1, '1'),
+      param('in', 'owner', 'Reference', 0, '1'),
+      param('in', 'ownerEmail', 'string', 0, '1'),
+      param('out', 'return', 'Project', 1, '1'),
+    ],
+  }
+);
 
 interface ProjectInitParameters {
   name: string;

--- a/packages/server/src/fhir/operations/projectinit.ts
+++ b/packages/server/src/fhir/operations/projectinit.ts
@@ -5,7 +5,6 @@ import { badRequest, createReference, created } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type {
   ClientApplication,
-  OperationDefinition,
   Project,
   ProjectMembership,
   Reference,
@@ -21,18 +20,12 @@ import { getLogger } from '../../logger';
 import { getUserByEmailWithoutProject } from '../../oauth/utils';
 import { getShardSystemRepo } from '../repo';
 import { PLACEHOLDER_SHARD_ID } from '../sharding';
+import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
-const projectInitOperation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const projectInitOperation = makeOperationDefinition({ scope: 'type', resource: 'Project' }, {
   name: 'project-init',
-  status: 'active',
-  kind: 'operation',
   code: 'init',
-  resource: ['Project'],
-  system: false,
-  type: true,
-  instance: false,
   parameter: [
     {
       use: 'in',
@@ -63,7 +56,7 @@ const projectInitOperation: OperationDefinition = {
       max: '1',
     },
   ],
-};
+});
 
 interface ProjectInitParameters {
   name: string;

--- a/packages/server/src/fhir/operations/refresh-reference-display.ts
+++ b/packages/server/src/fhir/operations/refresh-reference-display.ts
@@ -7,31 +7,6 @@ import type { Operation } from 'rfc6902';
 import { getAuthenticatedContext } from '../../context';
 import { collectReferences } from '../references';
 
-/*
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
-  name: 'RefreshReferenceDisplayStrings',
-  status: 'active',
-  kind: 'operation',
-  code: 'refresh-reference-display',
-  description: 'Updates the Reference.display field on any references contained in the resource',
-  resource: ['Resource' as ResourceType],
-  system: false,
-  type: false,
-  instance: true,
-  parameter: [
-    {
-      use: 'out',
-      type: 'Resource',
-      name: 'return',
-      min: 1,
-      max: '1',
-      documentation: 'The updated resource',
-    },
-  ],
-};
-*/
-
 export async function refreshReferenceDisplayHandler(req: FhirRequest): Promise<FhirResponse> {
   const { id, resourceType } = req.params;
   if (!id || !resourceType) {

--- a/packages/server/src/fhir/operations/rescope.ts
+++ b/packages/server/src/fhir/operations/rescope.ts
@@ -13,29 +13,25 @@ import {
   parseReference,
 } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { OperationDefinition, Project, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
+import type { Project, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
 import assert from 'node:assert';
 import type { AuthenticatedRequestContext } from '../../context';
 import { getAuthenticatedContext } from '../../context';
+import { makeOperationDefinition } from './definitions';
 import { makeOperationDefinitionParameter as param, parseInputParameters } from './utils/parameters';
 
-export const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
-  name: 'user-rescope',
-  status: 'active',
-  kind: 'operation',
-  code: 'rescope',
-  experimental: true,
-  system: false,
-  type: false,
-  instance: true,
-  resource: ['User'],
-  parameter: [
-    param('in', 'scope', 'code', 1, '1'),
-    param('in', 'project', 'Reference', 0, '1'),
-    param('out', 'return', 'User', 1, '1'),
-  ],
-};
+export const operation = makeOperationDefinition(
+  { scope: 'instance', resource: 'User' },
+  {
+    name: 'user-rescope',
+    code: 'rescope',
+    parameter: [
+      param('in', 'scope', 'code', 1, '1'),
+      param('in', 'project', 'Reference', 0, '1'),
+      param('out', 'return', 'User', 1, '1'),
+    ],
+  }
+);
 
 type RescopeParams = {
   scope: 'project' | 'server';

--- a/packages/server/src/fhir/operations/rotatesecret.ts
+++ b/packages/server/src/fhir/operations/rotatesecret.ts
@@ -8,15 +8,18 @@ import { generateSecret } from '../../oauth/keys';
 import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
-const operation = makeOperationDefinition({ scope: 'instance', resource: 'ClientApplication' }, {
-  name: 'clientapplication-rotate-secret',
-  code: 'rotate-secret',
-  parameter: [
-    { use: 'in', name: 'secret', type: 'string', min: 0, max: '1' },
-    { use: 'in', name: 'retiringSecret', type: 'string', min: 0, max: '1' },
-    { use: 'out', name: 'return', type: 'ClientApplication', min: 1, max: '1' },
-  ],
-});
+const operation = makeOperationDefinition(
+  { scope: 'instance', resource: 'ClientApplication' },
+  {
+    name: 'clientapplication-rotate-secret',
+    code: 'rotate-secret',
+    parameter: [
+      { use: 'in', name: 'secret', type: 'string', min: 0, max: '1' },
+      { use: 'in', name: 'retiringSecret', type: 'string', min: 0, max: '1' },
+      { use: 'out', name: 'return', type: 'ClientApplication', min: 1, max: '1' },
+    ],
+  }
+);
 
 type RotateSecretParameters = {
   secret?: string;

--- a/packages/server/src/fhir/operations/rotatesecret.ts
+++ b/packages/server/src/fhir/operations/rotatesecret.ts
@@ -2,28 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk, badRequest, forbidden, OperationOutcomeError } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { ClientApplication, OperationDefinition } from '@medplum/fhirtypes';
+import type { ClientApplication } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { generateSecret } from '../../oauth/keys';
+import { makeOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'instance', resource: 'ClientApplication' }, {
   name: 'clientapplication-rotate-secret',
-  status: 'active',
-  kind: 'operation',
   code: 'rotate-secret',
-  experimental: true,
-  resource: ['ClientApplication'],
-  system: false,
-  type: false,
-  instance: true,
   parameter: [
     { use: 'in', name: 'secret', type: 'string', min: 0, max: '1' },
     { use: 'in', name: 'retiringSecret', type: 'string', min: 0, max: '1' },
     { use: 'out', name: 'return', type: 'ClientApplication', min: 1, max: '1' },
   ],
-};
+});
 
 type RotateSecretParameters = {
   secret?: string;

--- a/packages/server/src/fhir/operations/set-accounts.ts
+++ b/packages/server/src/fhir/operations/set-accounts.ts
@@ -16,27 +16,21 @@ import {
   parseSearchRequest,
 } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { OperationDefinition, Parameters, Reference, Resource, ResourceType } from '@medplum/fhirtypes';
+import type { Parameters, Reference, Resource, ResourceType } from '@medplum/fhirtypes';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import { addSetAccountsJobData } from '../../workers/set-accounts';
 import type { Repository, SystemRepository } from '../repo';
+import { makeOperationDefinition } from './definitions';
 import { searchPatientCompartment } from './patienteverything';
 import { AsyncJobExecutor } from './utils/asyncjobexecutor';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const operation = makeOperationDefinition({ scope: 'instance', resource: 'Resource' as ResourceType }, {
   id: 'set-accounts',
   name: 'SetAccounts',
-  status: 'active',
-  kind: 'operation',
   code: 'set-accounts',
   description: `Updates account references for the target resource, and optionally any resources in the target's FHIR compartment`,
-  resource: ['Resource' as ResourceType],
-  system: false,
-  type: false,
-  instance: true,
   parameter: [
     {
       use: 'in',
@@ -63,7 +57,7 @@ const operation: OperationDefinition = {
       max: '1',
     },
   ],
-};
+});
 
 export interface SetAccountsParameters {
   accounts: Reference[];

--- a/packages/server/src/fhir/operations/set-accounts.ts
+++ b/packages/server/src/fhir/operations/set-accounts.ts
@@ -26,38 +26,41 @@ import { searchPatientCompartment } from './patienteverything';
 import { AsyncJobExecutor } from './utils/asyncjobexecutor';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
-const operation = makeOperationDefinition({ scope: 'instance', resource: 'Resource' as ResourceType }, {
-  id: 'set-accounts',
-  name: 'SetAccounts',
-  code: 'set-accounts',
-  description: `Updates account references for the target resource, and optionally any resources in the target's FHIR compartment`,
-  parameter: [
-    {
-      use: 'in',
-      name: 'accounts',
-      documentation: 'List of account references to set',
-      type: 'Reference',
-      min: 0,
-      max: '*',
-    },
-    {
-      use: 'in',
-      name: 'propagate',
-      documentation: 'If set, also push changes to other resources in the compartment of the target resource',
-      type: 'boolean',
-      min: 0,
-      max: '1',
-    },
-    {
-      use: 'out',
-      name: 'resourcesUpdated',
-      documentation: 'Number of resources that were updated',
-      type: 'integer',
-      min: 1,
-      max: '1',
-    },
-  ],
-});
+const operation = makeOperationDefinition(
+  { scope: 'instance', resource: 'Resource' as ResourceType },
+  {
+    id: 'set-accounts',
+    name: 'SetAccounts',
+    code: 'set-accounts',
+    description: `Updates account references for the target resource, and optionally any resources in the target's FHIR compartment`,
+    parameter: [
+      {
+        use: 'in',
+        name: 'accounts',
+        documentation: 'List of account references to set',
+        type: 'Reference',
+        min: 0,
+        max: '*',
+      },
+      {
+        use: 'in',
+        name: 'propagate',
+        documentation: 'If set, also push changes to other resources in the compartment of the target resource',
+        type: 'boolean',
+        min: 0,
+        max: '1',
+      },
+      {
+        use: 'out',
+        name: 'resourcesUpdated',
+        documentation: 'Number of resources that were updated',
+        type: 'integer',
+        min: 1,
+        max: '1',
+      },
+    ],
+  }
+);
 
 export interface SetAccountsParameters {
   accounts: Reference[];

--- a/packages/server/src/fhir/operations/update-user-email.ts
+++ b/packages/server/src/fhir/operations/update-user-email.ts
@@ -12,25 +12,18 @@ import {
   Operator,
 } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { OperationDefinition, Project, ProjectMembership, ResourceType, User } from '@medplum/fhirtypes';
+import type { Project, ProjectMembership, ResourceType, User } from '@medplum/fhirtypes';
 import { verifyEmail } from '../../auth/verifyemail';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import { sendEmail } from '../../email/email';
 import { getProjectSystemRepo } from '../repo';
+import { makeOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
 
-const op: OperationDefinition = {
-  resourceType: 'OperationDefinition',
+const op = makeOperationDefinition({ scope: 'instance', resource: 'User' }, {
   name: 'update-user-email',
-  status: 'active',
-  kind: 'operation',
   code: 'update-email',
-  experimental: true,
-  system: false,
-  type: false,
-  instance: true,
-  resource: ['User'],
   parameter: [
     {
       use: 'in',
@@ -65,7 +58,7 @@ const op: OperationDefinition = {
       documentation: 'The updated User resource',
     },
   ],
-};
+});
 
 type InputParams = {
   email: string;

--- a/packages/server/src/fhir/operations/update-user-email.ts
+++ b/packages/server/src/fhir/operations/update-user-email.ts
@@ -21,44 +21,47 @@ import { getProjectSystemRepo } from '../repo';
 import { makeOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
 
-const op = makeOperationDefinition({ scope: 'instance', resource: 'User' }, {
-  name: 'update-user-email',
-  code: 'update-email',
-  parameter: [
-    {
-      use: 'in',
-      name: 'email',
-      type: 'string',
-      min: 1,
-      max: '1',
-      documentation: 'The new email to be set on the User',
-    },
-    {
-      use: 'in',
-      name: 'updateProfileTelecom',
-      type: 'boolean',
-      min: 0,
-      max: '1',
-      documentation: 'If true, add the new email to the associated profile resource',
-    },
-    {
-      use: 'in',
-      name: 'skipEmailVerification',
-      type: 'boolean',
-      min: 0,
-      max: '1',
-      documentation: 'If true, do not send the verification email and mark the email as non-verified',
-    },
-    {
-      use: 'out',
-      name: 'return',
-      type: 'User',
-      min: 1,
-      max: '1',
-      documentation: 'The updated User resource',
-    },
-  ],
-});
+const op = makeOperationDefinition(
+  { scope: 'instance', resource: 'User' },
+  {
+    name: 'update-user-email',
+    code: 'update-email',
+    parameter: [
+      {
+        use: 'in',
+        name: 'email',
+        type: 'string',
+        min: 1,
+        max: '1',
+        documentation: 'The new email to be set on the User',
+      },
+      {
+        use: 'in',
+        name: 'updateProfileTelecom',
+        type: 'boolean',
+        min: 0,
+        max: '1',
+        documentation: 'If true, add the new email to the associated profile resource',
+      },
+      {
+        use: 'in',
+        name: 'skipEmailVerification',
+        type: 'boolean',
+        min: 0,
+        max: '1',
+        documentation: 'If true, do not send the verification email and mark the email as non-verified',
+      },
+      {
+        use: 'out',
+        name: 'return',
+        type: 'User',
+        min: 1,
+        max: '1',
+        documentation: 'The updated User resource',
+      },
+    ],
+  }
+);
 
 type InputParams = {
   email: string;


### PR DESCRIPTION
OperationDefinition are prone to triggering duplicate code detection so introduce a helper to further cut down on the boilerplate.