### PR TITLE
Add `Appointment/:id/$confirm` operation

### DIFF
--- a/packages/docs/docs/scheduling/appointment-confirm.md
+++ b/packages/docs/docs/scheduling/appointment-confirm.md
@@ -1,0 +1,165 @@
+# Appointment $confirm
+
+:::info[Alpha]
+
+The `$confirm` operation is currently in alpha.
+
+:::
+
+The `$confirm` operation confirms a held [`Appointment`](/docs/api/fhir/resources/appointment) by atomically setting its status to `booked` and upgrading all `busy-tentative` [`Slot`](/docs/api/fhir/resources/slot) resources it references to `busy` in a single FHIR transaction.
+
+## Booking Lifecycle
+
+`$confirm` is the final step in a hold-then-book flow:
+
+1. **[`$find`](/docs/scheduling/appointment-find)** — Query available time slots
+2. **[`$hold`](/docs/scheduling/appointment-hold)** — Reserve a slot. Creates a `pending` Appointment and `busy-tentative` Slots
+3. **`$confirm`** — Confirm the hold. Transitions the Appointment to `booked` and Slots to `busy`
+
+## Use Cases
+
+- **Patient initiated booking**: A patient can self-schedule a "pending" appointment; staff confirms when accepting it
+- **Staff approval workflow**: A coordinator places a hold on behalf of a patient; a clinician or admin confirms
+- **Automated confirmation**: Programmatically confirm a hold after an external step (e.g., payment or consent) completes
+
+## Invoke the `$confirm` operation
+
+```
+[base]/R4/Appointment/:id/$confirm
+```
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="ts" label="TypeScript">
+
+```typescript
+import { MedplumClient } from '@medplum/core';
+import type { Bundle } from '@medplum/fhirtypes';
+
+const medplum = new MedplumClient();
+
+const bundle = await medplum.post<Bundle>(
+  medplum.fhirUrl('Appointment', 'my-appointment-id', '$confirm')
+);
+```
+
+</TabItem>
+<TabItem value="curl" label="cURL">
+
+```bash
+curl -X POST 'https://api.medplum.com/fhir/R4/Appointment/my-appointment-id/$confirm' \
+  -H "Authorization: Bearer MY_ACCESS_TOKEN"
+```
+
+</TabItem>
+</Tabs>
+
+## Parameters
+
+This operation takes no input parameters. The appointment to confirm is identified by the `id` in the URL.
+
+### Constraints
+
+- The Appointment must have `status: pending` or `status: proposed`. All other statuses are rejected with HTTP 409 Conflict.
+- All `Slot` resources referenced by `Appointment.slot` must exist and be readable by the caller.
+
+## Output
+
+Returns `200 OK` with a `Bundle` of all updated resources:
+
+- One [`Appointment`](/docs/api/fhir/resources/appointment) with `status: booked`
+- One [`Slot`](/docs/api/fhir/resources/slot) per referenced slot that was `busy-tentative` (now `busy`). Slots already in `busy` status are returned unchanged.
+
+### Example Response
+
+```json
+{
+  "resourceType": "Bundle",
+  "type": "transaction-response",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Appointment",
+        "id": "my-appointment-id",
+        "status": "booked",
+        "start": "2026-03-10T09:00:00.000Z",
+        "end": "2026-03-10T10:00:00.000Z",
+        "participant": [
+          { "actor": { "reference": "Practitioner/dr-smith" }, "status": "tentative" },
+          { "actor": { "reference": "Patient/my-patient-id" }, "status": "accepted" }
+        ],
+        "slot": [{ "reference": "Slot/my-slot-id" }]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Slot",
+        "id": "my-slot-id",
+        "status": "busy",
+        "start": "2026-03-10T09:00:00.000Z",
+        "end": "2026-03-10T10:00:00.000Z",
+        "schedule": { "reference": "Schedule/dr-smith-schedule" }
+      }
+    }
+  ]
+}
+```
+
+## Confirmation Logic
+
+`$confirm` performs the following steps atomically inside a database transaction:
+
+1. Reads the Appointment identified by the URL `id`
+2. Validates that the Appointment's `status` is `pending` or `proposed`
+3. Loads all `Slot` resources listed in `Appointment.slot`
+4. Updates any `busy-tentative` Slots to `busy`
+5. Sets the Appointment's `status` to `booked` and saves it
+6. Returns the updated Appointment and Slots in a Bundle
+
+The transaction uses serializable isolation for safety when there are concurrent scheduling operations affecting the same appointment.
+
+## Error Responses
+
+### Appointment Not Found
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [{ "severity": "error", "code": "not-found", "details": { "text": "Not found" } }]
+}
+```
+
+HTTP status: `404`
+
+### Appointment Not in Confirmable State
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [{ "severity": "error", "code": "conflict", "details": { "text": "Appointment cannot be confirmed in 'booked' status" } }]
+}
+```
+
+HTTP status: `409`
+
+### Referenced Slot Not Found
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [{ "severity": "error", "code": "invalid", "details": { "text": "Loading slots failed" } }]
+}
+```
+
+HTTP status: `400`
+
+## Related
+
+- [Appointment `$hold`](/docs/scheduling/appointment-hold) - Place a hold on a slot (the preceding step)
+- [Appointment `$cancel`](/docs/scheduling/appointment-cancel) - Cancel an Appointment
+- [Appointment `$find`](/docs/scheduling/appointment-find) - Find available slots
+- [Scheduling Overview](/docs/scheduling) - High-level scheduling concepts
+- [`Appointment` resource](/docs/api/fhir/resources/appointment)
+- [`Slot` resource](/docs/api/fhir/resources/slot)

--- a/packages/docs/docs/scheduling/appointment-hold.md
+++ b/packages/docs/docs/scheduling/appointment-hold.md
@@ -19,7 +19,7 @@ The `$hold` operation places a hold on one or more schedules by atomically creat
 
 1. **[`$find`](/docs/scheduling/appointment-find)** — Query available time slots. Returns virtual `Appointment` resources with `contained` Slot resources.
 2. **`$hold`** — Submit one of those virtual Appointments to reserve the time. Creates a real `Appointment` (status: `pending`) and `Slot` (status: `busy-tentative`).
-3. **[`$book`](/docs/scheduling/appointment-book)** — Confirm the hold, attach a patient, and transition the `Appointment` to `booked`. *Not yet implemented.*
+3. **[`$confirm`](/docs/scheduling/appointment-confirm)** — Confirm the hold and transition the `Appointment` to `booked`.
 
 ## Use Cases
 
@@ -347,7 +347,8 @@ Returned when the requested time overlaps an existing busy Slot or falls outside
 ## Related
 
 - [Appointment `$find`](/docs/scheduling/appointment-find) - Find available Slots
-- [Appointment `$book`](/docs/scheduling/appointment-book) - Transition Appointment.status from "pending" to "booked" with `$book`
+- [Appointment `$confirm`](/docs/scheduling/appointment-confirm) - Transition Appointment.status from "pending" to "booked"
+- [Appointment `$book`](/docs/scheduling/appointment-book) - Book an appointment in a single step (without a hold)
 - [Defining Availability](/docs/scheduling/defining-availability) - How to configure `SchedulingParameters` on a Schedule
 - [Scheduling Overview](/docs/scheduling) - High-level scheduling concepts
 - [`Appointment` resource](/docs/api/fhir/resources/appointment)

--- a/packages/docs/docs/scheduling/index.md
+++ b/packages/docs/docs/scheduling/index.md
@@ -75,9 +75,10 @@ Once a desired slot has been found, the appointment booking process can be handl
 
 | Operation | Description | Status |
 | --------- | ----------- | ------ |
-| [`$book`](/docs/scheduling/appointment-book) | Book an appointment | **Alpha** |
-| `$hold` | Temporarily hold a slot | **In Development** |
-| `$cancel` | Cancel an appointment | **In Development** |
+| [`$book`](/docs/scheduling/appointment-book) | Book an appointment in one step | **Alpha** |
+| [`$hold`](/docs/scheduling/appointment-hold) | Temporarily hold a slot | **Alpha** |
+| [`$confirm`](/docs/scheduling/appointment-confirm) | Confirm a held appointment | **Alpha** |
+| [`$cancel`](/docs/scheduling/appointment-cancel) | Cancel an appointment | **Alpha** |
 
 ---
 

--- a/packages/server/src/fhir/operations/confirm.test.ts
+++ b/packages/server/src/fhir/operations/confirm.test.ts
@@ -120,18 +120,6 @@ describe('Appointment/:id/$confirm', () => {
     expect(appointments[0]).toMatchObject({ id: appointment.id, status: 'booked' });
   });
 
-  test('Sets appointment status to booked', async () => {
-    const slot = await makeSlot('busy-tentative');
-    const appointment = await makeAppointment('pending', [slot]);
-
-    await request
-      .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
-      .set('Authorization', `Bearer ${project.accessToken}`);
-
-    const updated = await systemRepo.readResource<Appointment>('Appointment', appointment.id);
-    expect(updated.status).toEqual('booked');
-  });
-
   test('Updates busy-tentative slots to busy', async () => {
     const slot = await makeSlot('busy-tentative');
     const appointment = await makeAppointment('pending', [slot]);
@@ -193,7 +181,7 @@ describe('Appointment/:id/$confirm', () => {
   });
 
   test.each(['booked', 'cancelled', 'fulfilled', 'noshow', 'entered-in-error'] as Appointment['status'][])(
-    'Returns 409 for non-confirmable status: %s',
+    'Returns 400 for non-confirmable status: %s',
     async (status) => {
       const appointment = await makeAppointment(status);
 
@@ -210,7 +198,7 @@ describe('Appointment/:id/$confirm', () => {
           },
         ],
       });
-      expect(response.status).toEqual(409);
+      expect(response.status).toEqual(400);
     }
   );
 

--- a/packages/server/src/fhir/operations/confirm.test.ts
+++ b/packages/server/src/fhir/operations/confirm.test.ts
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import { createReference, isDefined, isResource } from '@medplum/core';
+import type { Appointment, Bundle, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
+import express from 'express';
+import supertest from 'supertest';
+import { initApp, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config/loader';
+import { getGlobalSystemRepo } from '../../fhir/repo';
+import type { TestProjectResult } from '../../test.setup';
+import { createTestProject } from '../../test.setup';
+
+const systemRepo = getGlobalSystemRepo();
+const app = express();
+const request = supertest(app);
+
+describe('Appointment/:id/$confirm', () => {
+  let project: TestProjectResult<{ withAccessToken: true }>;
+  let practitioner: WithId<Practitioner>;
+  let schedule: WithId<Schedule>;
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    // try to be more resilient to concurrent tests touching the same tables
+    config.transactionAttempts = 5;
+    await initApp(app, config);
+    project = await createTestProject({ withAccessToken: true });
+
+    practitioner = await systemRepo.createResource<Practitioner>({
+      resourceType: 'Practitioner',
+      meta: { project: project.project.id },
+    });
+
+    schedule = await systemRepo.createResource<Schedule>({
+      resourceType: 'Schedule',
+      actor: [createReference(practitioner)],
+      meta: { project: project.project.id },
+    });
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  async function makeSlot(status: Slot['status'] = 'busy-tentative'): Promise<WithId<Slot>> {
+    return systemRepo.createResource<Slot>({
+      resourceType: 'Slot',
+      status,
+      start: '2026-05-15T14:00:00Z',
+      end: '2026-05-15T15:00:00Z',
+      schedule: createReference(schedule),
+      meta: { project: project.project.id },
+    });
+  }
+
+  async function makeAppointment(
+    status: Appointment['status'],
+    slots: WithId<Slot>[] = []
+  ): Promise<WithId<Appointment>> {
+    // Appointments that are not proposed/cancelled/waitlist require start and end
+    const noStartEnd: Appointment['status'][] = ['proposed', 'cancelled', 'waitlist'];
+    const needsDates = !noStartEnd.includes(status);
+    return systemRepo.createResource<Appointment>({
+      resourceType: 'Appointment',
+      status,
+      ...(needsDates ? { start: '2026-05-15T14:00:00Z', end: '2026-05-15T15:00:00Z' } : {}),
+      participant: [{ actor: createReference(practitioner), status: 'accepted' }],
+      slot: slots.map((slot) => createReference(slot)),
+      meta: { project: project.project.id },
+    });
+  }
+
+  test('Succeeds for a pending appointment', async () => {
+    const slot = await makeSlot('busy-tentative');
+    const appointment = await makeAppointment('pending', [slot]);
+
+    const response = await request
+      .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
+
+    expect(response.body).not.toHaveProperty('issue');
+    expect(response.status).toEqual(200);
+  });
+
+  test('Succeeds for a proposed appointment', async () => {
+    // proposed appointments must have start/end so that confirming to 'booked' passes FHIR validation
+    const appointment = await systemRepo.createResource<Appointment>({
+      resourceType: 'Appointment',
+      status: 'proposed',
+      start: '2026-05-15T14:00:00Z',
+      end: '2026-05-15T15:00:00Z',
+      participant: [{ actor: createReference(practitioner), status: 'accepted' }],
+      meta: { project: project.project.id },
+    });
+
+    const response = await request
+      .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
+
+    expect(response.body).not.toHaveProperty('issue');
+    expect(response.status).toEqual(200);
+  });
+
+  test('Returns a Bundle containing the booked Appointment', async () => {
+    const slot = await makeSlot('busy-tentative');
+    const appointment = await makeAppointment('pending', [slot]);
+
+    const response = await request
+      .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
+
+    expect(response.status).toEqual(200);
+
+    const bundle = response.body as Bundle;
+    const entries = (bundle.entry ?? []).map((e) => e.resource).filter(isDefined);
+
+    const appointments = entries.filter((r) => isResource<Appointment>(r, 'Appointment'));
+    expect(appointments).toHaveLength(1);
+    expect(appointments[0]).toMatchObject({ id: appointment.id, status: 'booked' });
+  });
+
+  test('Sets appointment status to booked', async () => {
+    const slot = await makeSlot('busy-tentative');
+    const appointment = await makeAppointment('pending', [slot]);
+
+    await request
+      .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
+
+    const updated = await systemRepo.readResource<Appointment>('Appointment', appointment.id);
+    expect(updated.status).toEqual('booked');
+  });
+
+  test('Updates busy-tentative slots to busy', async () => {
+    const slot = await makeSlot('busy-tentative');
+    const appointment = await makeAppointment('pending', [slot]);
+
+    const response = await request
+      .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
+
+    expect(response.status).toEqual(200);
+
+    const bundle = response.body as Bundle;
+    const entries = (bundle.entry ?? []).map((e) => e.resource).filter(isDefined);
+    const slots = entries.filter((r) => isResource<Slot>(r, 'Slot'));
+    expect(slots).toHaveLength(1);
+    expect(slots[0]).toMatchObject({ id: slot.id, status: 'busy' });
+  });
+
+  test('Updates multiple busy-tentative slots', async () => {
+    const slot1 = await makeSlot('busy-tentative');
+    const slot2 = await makeSlot('busy-tentative');
+    const appointment = await makeAppointment('pending', [slot1, slot2]);
+
+    const response = await request
+      .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
+
+    expect(response.status).toEqual(200);
+
+    const bundle = response.body as Bundle;
+    const entries = (bundle.entry ?? []).map((e) => e.resource).filter(isDefined);
+    const slots = entries.filter((r) => isResource<Slot>(r, 'Slot'));
+    expect(slots).toHaveLength(2);
+    slots.forEach((s) => expect(s).toHaveProperty('status', 'busy'));
+  });
+
+  test('Does not modify slots that are already busy', async () => {
+    const slot = await makeSlot('busy');
+    const appointment = await makeAppointment('pending', [slot]);
+
+    const response = await request
+      .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
+
+    expect(response.status).toEqual(200);
+
+    const persisted = await systemRepo.readResource<Slot>('Slot', slot.id);
+    expect(persisted.status).toEqual('busy');
+  });
+
+  test('Succeeds for appointment with no slots', async () => {
+    const appointment = await makeAppointment('pending');
+
+    const response = await request
+      .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
+
+    expect(response.body).not.toHaveProperty('issue');
+    expect(response.status).toEqual(200);
+  });
+
+  test.each(['booked', 'cancelled', 'fulfilled', 'noshow', 'entered-in-error'] as Appointment['status'][])(
+    'Returns 409 for non-confirmable status: %s',
+    async (status) => {
+      const appointment = await makeAppointment(status);
+
+      const response = await request
+        .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
+        .set('Authorization', `Bearer ${project.accessToken}`);
+
+      expect(response.body).toMatchObject({
+        resourceType: 'OperationOutcome',
+        issue: [
+          {
+            severity: 'error',
+            details: { text: `Appointment cannot be confirmed in '${status}' status` },
+          },
+        ],
+      });
+      expect(response.status).toEqual(409);
+    }
+  );
+
+  test('Returns 404 when appointment does not exist', async () => {
+    const response = await request
+      .post('/fhir/R4/Appointment/00000000-0000-0000-0000-000000000000/$confirm')
+      .set('Authorization', `Bearer ${project.accessToken}`);
+
+    expect(response.status).toEqual(404);
+  });
+
+  test('Returns 400 when a referenced slot does not exist', async () => {
+    const appointment = await systemRepo.createResource<Appointment>({
+      resourceType: 'Appointment',
+      status: 'pending',
+      start: '2026-05-15T14:00:00Z',
+      end: '2026-05-15T15:00:00Z',
+      participant: [{ actor: createReference(practitioner), status: 'accepted' }],
+      slot: [{ reference: 'Slot/00000000-0000-0000-0000-000000000000' }],
+      meta: { project: project.project.id },
+    });
+
+    const response = await request
+      .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
+      .set('Authorization', `Bearer ${project.accessToken}`);
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toMatchObject({
+      resourceType: 'OperationOutcome',
+      issue: [{ severity: 'error', details: { text: 'Loading slots failed' } }],
+    });
+  });
+});

--- a/packages/server/src/fhir/operations/confirm.ts
+++ b/packages/server/src/fhir/operations/confirm.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { allOk, conflict, OperationOutcomeError } from '@medplum/core';
+import { allOk, badRequest, OperationOutcomeError } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Appointment, Slot } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
@@ -36,7 +36,9 @@ export async function appointmentConfirmHandler(req: FhirRequest): Promise<FhirR
     async () => {
       const appointment = await ctx.repo.readResource<Appointment>('Appointment', appointmentId);
       if (appointment.status !== 'pending' && appointment.status !== 'proposed') {
-        throw new OperationOutcomeError(conflict(`Appointment cannot be confirmed in '${appointment.status}' status`));
+        throw new OperationOutcomeError(
+          badRequest(`Appointment cannot be confirmed in '${appointment.status}' status`)
+        );
       }
 
       // Fetch slots
@@ -47,12 +49,9 @@ export async function appointmentConfirmHandler(req: FhirRequest): Promise<FhirR
 
       // Mark `busy-tentative` slots as `busy`
       const updatedSlots = await Promise.all(
-        slots.map(async (slot) => {
-          if (slot.status === 'busy-tentative') {
-            return ctx.repo.updateResource<Slot>({ ...slot, status: 'busy' });
-          }
-          return slot;
-        })
+        slots.map(async (slot) =>
+          slot.status === 'busy-tentative' ? ctx.repo.updateResource<Slot>({ ...slot, status: 'busy' }) : slot
+        )
       );
 
       // Set appointment.status to `booked`

--- a/packages/server/src/fhir/operations/confirm.ts
+++ b/packages/server/src/fhir/operations/confirm.ts
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { allOk, conflict, OperationOutcomeError } from '@medplum/core';
+import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
+import type { Appointment, Slot } from '@medplum/fhirtypes';
+import { getAuthenticatedContext } from '../../context';
+import { withPaths } from '../../util/withpath';
+import { makeOperationDefinition } from './definitions';
+import { buildOutputParameters } from './utils/parameters';
+import { assertAllLoaded } from './utils/scheduling';
+
+const confirmOperation = makeOperationDefinition(
+  { scope: 'instance', resource: 'Appointment' },
+  {
+    name: 'confirm',
+    code: 'confirm',
+    parameter: [{ use: 'out', name: 'return', type: 'Bundle', min: 0, max: '1' }],
+  }
+);
+
+/**
+ * Handles HTTP requests for the Appointment $confirm operation.
+ *
+ * Marks an Appointment created via `$hold` as "booked".
+ *
+ * Endpoints:
+ *   [fhir base]/Appointment/:id/$confirm
+ *
+ * @param req - The FHIR request.
+ * @returns The FHIR response.
+ */
+export async function appointmentConfirmHandler(req: FhirRequest): Promise<FhirResponse> {
+  const ctx = getAuthenticatedContext();
+  const appointmentId = req.params.id;
+  const updatedResources = await ctx.repo.withTransaction(
+    async () => {
+      const appointment = await ctx.repo.readResource<Appointment>('Appointment', appointmentId);
+      if (appointment.status !== 'pending' && appointment.status !== 'proposed') {
+        throw new OperationOutcomeError(conflict(`Appointment cannot be confirmed in '${appointment.status}' status`));
+      }
+
+      // Fetch slots
+      const slots = await ctx.repo
+        .readReferences(appointment.slot ?? [])
+        .then((slots) => withPaths(slots, 'Appointment.slot'));
+      assertAllLoaded(slots, 'Loading slots failed');
+
+      // Mark `busy-tentative` slots as `busy`
+      const updatedSlots = await Promise.all(
+        slots.map(async (slot) => {
+          if (slot.status === 'busy-tentative') {
+            return ctx.repo.updateResource<Slot>({ ...slot, status: 'busy' });
+          }
+          return slot;
+        })
+      );
+
+      // Set appointment.status to `booked`
+      const updatedAppointment = await ctx.repo.updateResource<Appointment>({ ...appointment, status: 'booked' });
+
+      return [updatedAppointment, ...updatedSlots];
+    },
+    { serializable: true }
+  );
+  const bundle = {
+    resourceType: 'Bundle',
+    type: 'transaction-response',
+    entry: updatedResources.map((resource) => ({ resource })),
+  };
+  return [allOk, buildOutputParameters(confirmOperation, bundle)];
+}

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -36,6 +36,7 @@ import { codeSystemLookupHandler } from './operations/codesystemlookup';
 import { codeSystemValidateCodeHandler } from './operations/codesystemvalidatecode';
 import { conceptMapImportHandler } from './operations/conceptmapimport';
 import { conceptMapTranslateHandler } from './operations/conceptmaptranslate';
+import { appointmentConfirmHandler } from './operations/confirm';
 import { csvHandler } from './operations/csv';
 import { tryCustomOperation } from './operations/custom';
 import { getColumnStatisticsHandler } from './operations/db-column-statistics';
@@ -397,6 +398,7 @@ function initInternalFhirRouter(): FhirRouter {
   router.add('POST', '/Appointment/$book', appointmentBookHandler);
   router.add('POST', '/Appointment/$hold', appointmentHoldHandler);
   router.add('POST', '/Appointment/:id/$cancel', appointmentCancelHandler);
+  router.add('POST', '/Appointment/:id/$confirm', appointmentConfirmHandler);
 
   // PackageRelease $install operation
   router.add('POST', '/PackageRelease/:id/$install', packageInstallHandler);


### PR DESCRIPTION
This operation is invoked for a "pending" appointment created by `$hold`. It updates the appointment to the "booked" status, and updates all associated Slot resources to match.