### PR TITLE
docs: add Spaces feature documentation for Medplum Provider

### DIFF
--- a/packages/docs/docs/ai/ai-operation.md
+++ b/packages/docs/docs/ai/ai-operation.md
@@ -447,3 +447,4 @@ if (toolCallsParam?.valueString) {
 - [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling)
 - [Medplum Project Features](/docs/access/projects)
 - [AI and Medplum](/docs/ai)
+- [Spaces in Medplum Provider](/docs/provider/spaces) — a worked example of `$ai` plus tool calling driving an in-app assistant

--- a/packages/docs/docs/ai/index.md
+++ b/packages/docs/docs/ai/index.md
@@ -115,6 +115,7 @@ Explore our dedicated integrations to learn more:
 
 - **[Medplum `$ai` ](/docs/ai/ai-operation):** The FHIR-compliant operation for integrating with large language models (LLMs) and enabling conversational AI within healthcare applications.
 - **[Medplum AI (MCP)](/docs/ai/mcp):** Connect with Medplum's MCP integration to enable AI models to securely access and interact with healthcare data using FHIR standards.
+- **[Spaces (Medplum Provider)](/docs/provider/spaces):** An example implementation of an in-app AI assistant in the Provider app, built on `$ai` and a four-bot pipeline that translates natural language into FHIR API calls, summarizes results, and renders generated charts.
 - **[AWS Textract](/docs/ai/aws):** Extract and analyze text from clinical documents, faxes, and other unstructured data sources.
 - **[AWS Comprehend Medical](/docs/ai/aws):** Uncover valuable insights from clinical text, identifying medical conditions, medications, and treatments.
 

--- a/packages/docs/docs/provider/index.md
+++ b/packages/docs/docs/provider/index.md
@@ -52,7 +52,7 @@ The following sections outline the primary functionality of the Medplum Provider
 - [How Spaces Works](./provider/spaces#how-spaces-works)
 - [Prerequisites](./provider/spaces#prerequisites)
 - [The Agent Loop](./provider/spaces#the-agent-loop)
-- [Customizing The Translator System Prompt](./provider/spaces#customizing-the-translator-system-prompt)
+- [Customizing System Prompts](./provider/spaces#customizing-system-prompts)
 
 #### Documentation Coming Soon:
 

--- a/packages/docs/docs/provider/index.md
+++ b/packages/docs/docs/provider/index.md
@@ -47,6 +47,13 @@ The following sections outline the primary functionality of the Medplum Provider
 - [Documenting Visits](./provider/visits#documenting-visits)
 - [Setting Up Care Templates (via Medplum App)](./provider/visits#setting-up-care-templates-via-medplum-app)
 
+#### [Spaces](./provider/spaces)
+
+- [How Spaces Works](./provider/spaces#how-spaces-works)
+- [Prerequisites](./provider/spaces#prerequisites)
+- [The Agent Loop](./provider/spaces#the-agent-loop)
+- [Customizing The Translator System Prompt](./provider/spaces#customizing-the-translator-system-prompt)
+
 #### Documentation Coming Soon:
 
 - Tasks

--- a/packages/docs/docs/provider/spaces.mdx
+++ b/packages/docs/docs/provider/spaces.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 500
 title: Spaces
 tags: [provider, ai, spaces, bots, communications]
 keywords: [Spaces, $ai, OpenAI, FHIR agent, AI assistant, Medplum Provider, ai-fhir-request-tools]

--- a/packages/docs/docs/provider/spaces.mdx
+++ b/packages/docs/docs/provider/spaces.mdx
@@ -22,21 +22,15 @@ The feature is reachable at `/Spaces/Communication` in the Provider app. It is g
 
 Spaces is not a single AI call. Each user prompt drives a short pipeline of bots and a tool-use loop:
 
-```
-User message
-   │
-   ▼
-ai-fhir-request-tools  ── translator bot
-   │  returns: tool_calls[]   and a visualize flag
-   ▼
-Provider UI executes each fhir_request directly against the FHIR API
-   │  loop up to 10 iterations
-   ▼
-ai-resource-summary-sse  ── streaming summary bot
-   │
-   ├── visualize=false ──▶ stream text into the chat
-   │
-   └── visualize=true  ──▶ ai-component-generator-sse  ──▶ JSX Chart() component
+```mermaid
+flowchart TD
+  U[User message] --> T[ai-fhir-request-tools<br/>translator bot]
+  T -->|tool_calls + visualize flag| X[Provider UI executes each<br/>fhir_request against the FHIR API]
+  X -->|loop up to 10 iterations| T
+  T -->|no tool calls| S[ai-resource-summary-sse<br/>streaming summary bot]
+  S -->|visualize = false| O1[Stream text into the chat]
+  S -->|visualize = true| V[ai-component-generator-sse<br/>chart generator bot]
+  V --> O2[JSX Chart component<br/>rendered in side panel]
 ```
 
 Three things to keep in mind:

--- a/packages/docs/docs/provider/spaces.mdx
+++ b/packages/docs/docs/provider/spaces.mdx
@@ -7,8 +7,6 @@ keywords: [Spaces, $ai, OpenAI, FHIR agent, AI assistant, Medplum Provider, ai-f
 
 import ExampleCode from '!!raw-loader!@site/../examples/src/provider/spaces-examples.ts';
 import MedplumCodeBlock from '@site/src/components/MedplumCodeBlock';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Spaces
 
@@ -60,52 +58,45 @@ Three things to keep in mind:
 
 ### Enable Project Features
 
-The project must list both `ai` and `bots` in `Project.features`. The Provider app's Spaces page short-circuits if either is missing, and the `$ai` operation rejects the request server-side if `ai` is not enabled.
+Spaces requires the `ai` and `bots` features on your Medplum project. Both are disabled by default. Contact info@medplum.com to enable them on your account; project administrators cannot toggle these features directly.
 
-<Tabs groupId="language">
-  <TabItem value="ts" label="Typescript">
-    <MedplumCodeBlock language="ts" selectBlocks="enableFeaturesTs">{ExampleCode}</MedplumCodeBlock>
-  </TabItem>
-  <TabItem value="cli" label="CLI">
-    <MedplumCodeBlock language="bash" selectBlocks="enableFeaturesCli">{ExampleCode}</MedplumCodeBlock>
-  </TabItem>
-</Tabs>
-
-See [Project Features](/docs/access/projects) for the full list of toggles.
+The Provider app's Spaces page short-circuits if either feature is missing, and the `$ai` operation rejects the request server-side if `ai` is not enabled.
 
 ### Configure The OpenAI API Key
 
-Add your OpenAI key as a project secret named `OPENAI_API_KEY`. The `$ai` operation reads it from `Project.secret` on every call and forwards it to OpenAI's chat completions endpoint. It is never sent to the client.
+Add your OpenAI key as a project secret named `OPENAI_API_KEY`. The `$ai` operation reads it from the project on every call and forwards it to OpenAI's chat completions endpoint. It is never sent to the client.
 
-<Tabs groupId="language">
-  <TabItem value="ts" label="Typescript">
-    <MedplumCodeBlock language="ts" selectBlocks="addOpenAiSecretTs">{ExampleCode}</MedplumCodeBlock>
-  </TabItem>
-  <TabItem value="cli" label="CLI">
-    <MedplumCodeBlock language="bash" selectBlocks="addOpenAiSecretCli">{ExampleCode}</MedplumCodeBlock>
-  </TabItem>
-</Tabs>
+You must be a project administrator to add secrets. In the [Medplum App](https://app.medplum.com):
+
+1. Open Project Admin (left sidebar, or [app.medplum.com/admin/project](https://app.medplum.com/admin/project)).
+2. Click the Secrets tab.
+3. Click Add and enter `OPENAI_API_KEY` as the name, `string` as the type, and your OpenAI key as the value.
+
+See [Bot Secrets](/docs/bots/bot-secrets) for the same workflow described in more detail.
 
 :::caution
 If the key is missing, the `$ai` operation returns `OpenAI API key not configured in project secrets` and every Spaces turn fails. Set this before deploying the bots.
 :::
 
-### Deploy The Four Bots
+### Deploy The Spaces Bots
 
-Spaces depends on four bots. All four are addressed by `Identifier` (system `https://www.medplum.com/bots`), so the Provider UI does not need to know their resource IDs.
+Spaces depends on three bots that ship under [`examples/medplum-demo-bots/src/spaces-bots`](https://github.com/medplum/medplum/tree/main/examples/medplum-demo-bots/src/spaces-bots) and are already registered in that project's `medplum.config.json`. The Provider UI resolves each one by `Identifier` (system `https://www.medplum.com/bots`), so the identifier values below are load-bearing.
 
-| Identifier Value             | Source File                                                                                                                                                                                       | Role                                                                       |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `ai-fhir-request-tools`      | [`fhir-translator-bot.ts`](https://github.com/medplum/medplum/blob/main/examples/medplum-demo-bots/src/spaces-bots/fhir-translator-bot.ts)                                                         | Translator. Emits `fhir_request` tool calls and a `visualize` flag.        |
-| `ai-resource-summary`        | [`fhir-summary-bot.ts`](https://github.com/medplum/medplum/blob/main/examples/medplum-demo-bots/src/spaces-bots/fhir-summary-bot.ts)                                                              | Non-streaming summary fallback.                                            |
-| `ai-resource-summary-sse`    | [`fhir-summary-bot.ts`](https://github.com/medplum/medplum/blob/main/examples/medplum-demo-bots/src/spaces-bots/fhir-summary-bot.ts)                                                              | Primary streaming summary path. Server-Sent Events.                        |
-| `ai-component-generator-sse` | [`fhir-visualizer-bot.ts`](https://github.com/medplum/medplum/blob/main/examples/medplum-demo-bots/src/spaces-bots/fhir-visualizer-bot.ts)                                                        | Streaming Recharts / Mantine `Chart()` JSX generation.                     |
+| Identifier Value             | Source File                                                                                                                                       | Role                                                                  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `ai-fhir-request-tools`      | [`fhir-translator-bot.ts`](https://github.com/medplum/medplum/blob/main/examples/medplum-demo-bots/src/spaces-bots/fhir-translator-bot.ts)         | Translator. Emits `fhir_request` tool calls and a `visualize` flag.   |
+| `ai-resource-summary-sse`    | [`fhir-summary-bot.ts`](https://github.com/medplum/medplum/blob/main/examples/medplum-demo-bots/src/spaces-bots/fhir-summary-bot.ts)               | Streaming summary bot (Server-Sent Events).                           |
+| `ai-component-generator-sse` | [`fhir-visualizer-bot.ts`](https://github.com/medplum/medplum/blob/main/examples/medplum-demo-bots/src/spaces-bots/fhir-visualizer-bot.ts)         | Streaming Recharts / Mantine `Chart()` JSX generation.                |
 
-Deploy each one with the Medplum CLI. Use the identifier values from the table above so the Provider UI can resolve them.
+To deploy:
 
-<MedplumCodeBlock language="bash" selectBlocks="deployBotsCli">{ExampleCode}</MedplumCodeBlock>
+1. Clone [the demo-bots project](https://github.com/medplum/medplum/tree/main/examples/medplum-demo-bots) (or copy the `spaces-bots` directory and the matching entries from `medplum.config.json` into your own bot project).
+2. Build and deploy each bot following [Bot Basics](/docs/bots/bot-basics) and [Bots In Production](/docs/bots/bots-in-production).
+3. After deployment, open each [`Bot`](/docs/api/fhir/medplum/bot) resource in the Medplum App and add an `identifier` entry whose `system` is `https://www.medplum.com/bots` and whose `value` matches the table above. The Provider UI uses this identifier to find the bot, so a missing or mistyped value silently breaks the feature.
 
-See [Bot Basics](/docs/bots/bot-basics) and [Bots In Production](/docs/bots/bots-in-production) for general bot deployment guidance.
+:::note
+The non-streaming `ai-resource-summary` bot is referenced in the Provider source as a fallback path, but the shipping UI always uses the streaming variant. You only need to deploy a non-streaming summary bot if you fork the Provider app to disable streaming.
+:::
 
 ### Seed The Translator System Prompt
 

--- a/packages/docs/docs/provider/spaces.mdx
+++ b/packages/docs/docs/provider/spaces.mdx
@@ -96,10 +96,6 @@ To deploy:
 2. Build and deploy each bot following [Bot Basics](/docs/bots/bot-basics) and [Bots In Production](/docs/bots/bots-in-production).
 3. After deployment, open each [`Bot`](/docs/api/fhir/medplum/bot) resource in the Medplum App and add an `identifier` entry whose `system` is `https://www.medplum.com/bots` and whose `value` matches the table above. The Provider UI uses this identifier to find the bot, so a missing or mistyped value silently breaks the feature.
 
-:::note
-The non-streaming `ai-resource-summary` bot is referenced in the Provider source as a fallback path, but the shipping UI always uses the streaming variant. You only need to deploy a non-streaming summary bot if you fork the Provider app to disable streaming.
-:::
-
 ### Author System Prompt Communications
 
 Each of the three Spaces bots loads its system prompt from a [`Communication`](/docs/api/fhir/resources/communication) resource at request time, not from code. These prompts are operator-authored content. They decide what Spaces does in your clinic: its tone, what it refuses, which FHIR-call strategies the translator prefers, how aggressively the summary bot narrates, which chart types the visualizer reaches for. Treat writing them as part of building the feature, not as a setup step that copies a canned recipe.
@@ -108,7 +104,7 @@ Three Communications are required, one per bot. The identifier system is `http:/
 
 | Bot                          | Prompt Communication `identifier.value` | Payload Shape                                                                                                                                                                                                                  |
 | ---------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ai-fhir-request-tools`      | `ai-fhir-request-tools`                 | `payload[0]` is the system prompt. `payload[1]` is a profile-context template; any `{{ref}}` is replaced at request time with the requester's reference string (for example, `Practitioner/abc-123`) and appended to the prompt. |
+| `ai-fhir-request-tools`      | `ai-fhir-request-tools`                 | Both payloads are required. `payload[0]` is the system prompt. `payload[1]` is a profile-context template; any `{{ref}}` is replaced at request time with the requester's reference string (for example, `Practitioner/abc-123`) and appended to the prompt. |
 | `ai-resource-summary-sse`    | `ai-resource-summary-sse`               | `payload[0]` is the system prompt. No profile-context template.                                                                                                                                                                |
 | `ai-component-generator-sse` | `ai-component-generator-sse`            | `payload[0]` is the system prompt. No profile-context template.                                                                                                                                                                |
 
@@ -153,9 +149,9 @@ One per turn (user, assistant, tool). Each is linked to its topic by `partOf`.
 
 <MedplumCodeBlock language="ts" selectBlocks="loadConversationMessagesTs">{ExampleCode}</MedplumCodeBlock>
 
-## The Four Bots
+## The Bots
 
-All four bots are thin wrappers over [`$ai`](/docs/ai/ai-operation). They accept a `Parameters` resource with a `messages` JSON array and a `model` string, and they return a `Parameters` resource the Provider UI can consume directly.
+All three bots are thin wrappers over [`$ai`](/docs/ai/ai-operation). They accept a `Parameters` resource with a `messages` JSON array and a `model` string, and they return a `Parameters` resource the Provider UI can consume directly.
 
 ### FHIR Translator Bot
 
@@ -166,7 +162,7 @@ Inputs:
 | Parameter  | Type          | Required | Description                                                                  |
 | ---------- | ------------- | -------- | ---------------------------------------------------------------------------- |
 | `messages` | `valueString` | Yes      | JSON-encoded conversation history (OpenAI chat format).                      |
-| `model`    | `valueString` | No       | OpenAI model to use. Defaults to `gpt-4` if omitted.                         |
+| `model`    | `valueString` | No       | OpenAI model to use. Defaults to `gpt-4` if omitted. The shipping Provider UI always passes a model from the chat-input dropdown, so this default only applies when you invoke the bot directly. |
 
 Outputs: `content` (string, may be null when the model only returns tool calls), `tool_calls` (JSON array of `{ id, function: { name, arguments } }`), and `visualize` (boolean).
 
@@ -176,11 +172,11 @@ The translator is the only bot that loops. The Provider UI re-invokes it after e
 
 ### FHIR Summary Bot
 
-`ai-resource-summary` (non-streaming) and `ai-resource-summary-sse` (streaming). Takes the conversation history after the loop has finished and produces a plain-language narration of the resources the translator pulled. The streaming variant is the path the Provider UI uses by default; the non-streaming one is a fallback.
+`ai-resource-summary-sse`. Takes the conversation history after the loop has finished and produces a streaming, plain-language narration of the resources the translator pulled.
 
 Inputs: same `messages` and `model` parameters as the translator.
 
-Outputs: `content` (the narration), streamed as SSE chunks when the streaming variant is invoked.
+Outputs: `content` (the narration), streamed as SSE chunks.
 
 ### FHIR Visualizer Bot
 

--- a/packages/docs/docs/provider/spaces.mdx
+++ b/packages/docs/docs/provider/spaces.mdx
@@ -22,16 +22,14 @@ The feature is reachable at `/Spaces/Communication` in the Provider app. It is g
 
 The translator bot can issue any FHIR request the requester's AccessPolicy permits, so the practical capability surface is broad. Typical prompts fall into a few categories:
 
-| Category               | Example Prompts                                                                                                                              |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| Search and lookup      | "Find the patient John Smith." "Which patients are scheduled with Dr. Chen this week?"                                                       |
-| Clinical summary       | "Summarize Maria Garcia's last three encounters." "What medications is this patient on?"                                                     |
-| Visualize trends       | "Show a growth chart for this patient." "Plot hemoglobin A1c over the last two years."                                                       |
-| Operational reporting  | "Chart provider utilization across the clinic for the past month." "How many lab orders did we place last week?"                             |
-| Schedule and tasks     | "Schedule a follow-up with Dr. Patel next Tuesday at 10am." "Create a task to fax the imaging report to the referring provider."             |
-| Orders and updates     | "Order a CBC for this patient." "Place a referral to cardiology." "Update the patient's phone number to 555-0142."                           |
+- Search and lookup – "Find the patient John Smith." "Which patients are scheduled with Dr. Chen this week?"
+- Clinical summary – "Summarize Maria Garcia's last three encounters." "What medications is this patient on?"
+- Visualize trends – "Show a growth chart for this patient." "Plot hemoglobin A1c over the last two years."
+- Operational reporting – "Chart provider utilization across the clinic for the past month." "How many lab orders did we place last week?"
+- Schedule and tasks – "Schedule a follow-up with Dr. Patel next Tuesday at 10am." "Create a task to fax the imaging report to the referring provider."
+- Orders and updates – "Order a CBC for this patient." "Place a referral to cardiology." "Update the patient's phone number to 555-0142."
 
-The first four rows are read-only and end at the summary bot. The visualization and reporting prompts additionally invoke the visualizer bot to render an interactive chart in the side panel. The last two rows trigger live FHIR writes through the same loop.
+The first four bullets are read-only and end at the summary bot. The visualization and reporting prompts additionally invoke the visualizer bot to render an interactive chart in the side panel. The last two bullets trigger live FHIR writes through the same loop.
 
 :::caution
 Writes happen as soon as the loop reaches them. Treat clinically significant prompts (orders, referrals, status changes) the same way you would any draft – review the resulting resource before relying on it, and consider scoping the `ai` feature to AccessPolicies that do not include write access to high-risk resource types.

--- a/packages/docs/docs/provider/spaces.mdx
+++ b/packages/docs/docs/provider/spaces.mdx
@@ -1,0 +1,245 @@
+---
+sidebar_position: 6
+title: Spaces
+tags: [provider, ai, spaces, bots, communications]
+keywords: [Spaces, $ai, OpenAI, FHIR agent, AI assistant, Medplum Provider, ai-fhir-request-tools]
+---
+
+import ExampleCode from '!!raw-loader!@site/../examples/src/provider/spaces-examples.ts';
+import MedplumCodeBlock from '@site/src/components/MedplumCodeBlock';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Spaces
+
+Spaces is the in-app AI assistant in [Medplum Provider](https://provider.medplum.com). A user types a question in natural language; under the hood a chain of Medplum [bots](/docs/bots) translates the question into FHIR API calls, executes them against the project, summarizes the results in the chat, and optionally renders a generated chart inside the same view.
+
+Spaces is shipped as an example implementation. The Provider app source lives in [`examples/medplum-provider`](https://github.com/medplum/medplum/tree/main/examples/medplum-provider) and the bot source in [`examples/medplum-demo-bots/src/spaces-bots`](https://github.com/medplum/medplum/tree/main/examples/medplum-demo-bots/src/spaces-bots). Use this page to set Spaces up in your own project, understand what it does behind the chat input, and tune the parts that are designed to be tuned.
+
+The feature is reachable at `/Spaces/Communication` in the Provider app. It is gated on the project having both the `ai` and `bots` features enabled.
+
+## How Spaces Works
+
+Spaces is not a single AI call. Each user prompt drives a short pipeline of bots and a tool-use loop:
+
+```
+User message
+   │
+   ▼
+ai-fhir-request-tools  ── translator bot
+   │  returns: tool_calls[]   and a visualize flag
+   ▼
+Provider UI executes each fhir_request directly against the FHIR API
+   │  loop up to 10 iterations
+   ▼
+ai-resource-summary-sse  ── streaming summary bot
+   │
+   ├── visualize=false ──▶ stream text into the chat
+   │
+   └── visualize=true  ──▶ ai-component-generator-sse  ──▶ JSX Chart() component
+```
+
+Three things to keep in mind:
+
+- The Provider UI, not the bots, executes the FHIR requests that the translator suggests. Every request runs under the signed-in user's access policies, so the assistant can never read or write resources the user could not access directly.
+- The bots are the only thing that talks to OpenAI. The browser never sees the OpenAI API key. All AI traffic flows through the server-side [`$ai` operation](/docs/ai/ai-operation), which reads the key from project secrets.
+- Conversation history is persisted as [`Communication`](/docs/api/fhir/resources/communication) resources, so transcripts are searchable, auditable, and survive a page reload.
+
+## Prerequisites
+
+### Enable Project Features
+
+The project must list both `ai` and `bots` in `Project.features`. The Provider app's Spaces page short-circuits if either is missing, and the `$ai` operation rejects the request server-side if `ai` is not enabled.
+
+<Tabs groupId="language">
+  <TabItem value="ts" label="Typescript">
+    <MedplumCodeBlock language="ts" selectBlocks="enableFeaturesTs">{ExampleCode}</MedplumCodeBlock>
+  </TabItem>
+  <TabItem value="cli" label="CLI">
+    <MedplumCodeBlock language="bash" selectBlocks="enableFeaturesCli">{ExampleCode}</MedplumCodeBlock>
+  </TabItem>
+</Tabs>
+
+See [Project Features](/docs/access/projects) for the full list of toggles.
+
+### Configure The OpenAI API Key
+
+Add your OpenAI key as a project secret named `OPENAI_API_KEY`. The `$ai` operation reads it from `Project.secret` on every call and forwards it to OpenAI's chat completions endpoint. It is never sent to the client.
+
+<Tabs groupId="language">
+  <TabItem value="ts" label="Typescript">
+    <MedplumCodeBlock language="ts" selectBlocks="addOpenAiSecretTs">{ExampleCode}</MedplumCodeBlock>
+  </TabItem>
+  <TabItem value="cli" label="CLI">
+    <MedplumCodeBlock language="bash" selectBlocks="addOpenAiSecretCli">{ExampleCode}</MedplumCodeBlock>
+  </TabItem>
+</Tabs>
+
+:::caution
+If the key is missing, the `$ai` operation returns `OpenAI API key not configured in project secrets` and every Spaces turn fails. Set this before deploying the bots.
+:::
+
+### Deploy The Four Bots
+
+Spaces depends on four bots. All four are addressed by `Identifier` (system `https://www.medplum.com/bots`), so the Provider UI does not need to know their resource IDs.
+
+| Identifier Value             | Source File                                                                                                                                                                                       | Role                                                                       |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `ai-fhir-request-tools`      | [`fhir-translator-bot.ts`](https://github.com/medplum/medplum/blob/main/examples/medplum-demo-bots/src/spaces-bots/fhir-translator-bot.ts)                                                         | Translator. Emits `fhir_request` tool calls and a `visualize` flag.        |
+| `ai-resource-summary`        | [`fhir-summary-bot.ts`](https://github.com/medplum/medplum/blob/main/examples/medplum-demo-bots/src/spaces-bots/fhir-summary-bot.ts)                                                              | Non-streaming summary fallback.                                            |
+| `ai-resource-summary-sse`    | [`fhir-summary-bot.ts`](https://github.com/medplum/medplum/blob/main/examples/medplum-demo-bots/src/spaces-bots/fhir-summary-bot.ts)                                                              | Primary streaming summary path. Server-Sent Events.                        |
+| `ai-component-generator-sse` | [`fhir-visualizer-bot.ts`](https://github.com/medplum/medplum/blob/main/examples/medplum-demo-bots/src/spaces-bots/fhir-visualizer-bot.ts)                                                        | Streaming Recharts / Mantine `Chart()` JSX generation.                     |
+
+Deploy each one with the Medplum CLI. Use the identifier values from the table above so the Provider UI can resolve them.
+
+<MedplumCodeBlock language="bash" selectBlocks="deployBotsCli">{ExampleCode}</MedplumCodeBlock>
+
+See [Bot Basics](/docs/bots/bot-basics) and [Bots In Production](/docs/bots/bots-in-production) for general bot deployment guidance.
+
+### Seed The Translator System Prompt
+
+The translator bot does not embed its system prompt in code. It loads it from a [`Communication`](/docs/api/fhir/resources/communication) resource at request time. This makes the prompt editable without redeploying the bot. The Communication must exist before the first user message or the translator throws.
+
+The contract is:
+
+- Identifier: system `http://medplum.com/ai-spaces`, value `ai-fhir-request-tools`.
+- `payload[0].contentString` is the system prompt sent to OpenAI.
+- `payload[1].contentString` is a profile-context template. Any `{{ref}}` placeholder is replaced at request time with the requester's reference string (for example, `Practitioner/abc-123`) and appended to the system prompt.
+
+<MedplumCodeBlock language="ts" selectBlocks="seedSystemPromptTs">{ExampleCode}</MedplumCodeBlock>
+
+## Conversation Data Model
+
+Each conversation in Spaces is a small tree of [`Communication`](/docs/api/fhir/resources/communication) resources. Splitting the thread header from each turn keeps the agent loop recoverable mid-iteration and lets the history sidebar list conversations with a single search.
+
+### Topic Communication
+
+One per conversation. Created on the user's first message.
+
+| Field            | Value                                                                            |
+| ---------------- | -------------------------------------------------------------------------------- |
+| `identifier`     | system `http://medplum.com/ai-message`, value `ai-message-topic`                 |
+| `sender`         | Reference to the user who started the conversation                               |
+| `status`         | `in-progress`                                                                    |
+| `topic.text`     | First 100 characters of the user's first message, used as the sidebar title      |
+| `note[0].text`   | JSON-encoded `{ "model": "..." }` capturing the model chosen for the conversation |
+
+<MedplumCodeBlock language="ts" selectBlocks="loadRecentTopicsTs">{ExampleCode}</MedplumCodeBlock>
+
+The Provider UI filters by `sender` so users only see their own conversations in the sidebar. Adjust this filter in your own UI if you need a shared inbox.
+
+### Message Communications
+
+One per turn (user, assistant, tool). Each is linked to its topic by `partOf`.
+
+| Field                       | Value                                                                                                                                                                                              |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `identifier`                | system `http://medplum.com/ai-message`, value `ai-message`                                                                                                                                          |
+| `partOf[0].reference`       | `Communication/<topic-id>`                                                                                                                                                                          |
+| `status`                    | `completed`                                                                                                                                                                                         |
+| `payload[0].contentString`  | JSON of `{ role, content, tool_calls, tool_call_id, resources, componentCode, sequenceNumber }`                                                                                                     |
+
+`sequenceNumber` is the source of truth for ordering; `_lastUpdated` is only used for pagination. The Provider UI persists every tool call and tool response on its own message so a mid-loop failure leaves a readable transcript.
+
+<MedplumCodeBlock language="ts" selectBlocks="loadConversationMessagesTs">{ExampleCode}</MedplumCodeBlock>
+
+## The Four Bots
+
+All four bots are thin wrappers over [`$ai`](/docs/ai/ai-operation). They accept a `Parameters` resource with a `messages` JSON array and a `model` string, and they return a `Parameters` resource the Provider UI can consume directly.
+
+### FHIR Translator Bot
+
+`ai-fhir-request-tools`. Converts the conversation history into one or more `fhir_request` tool calls. Each call carries an HTTP method (`GET` / `POST` / `PUT` / `DELETE`), a FHIR path, and an optional body. The bot also reports a `visualize` boolean, derived from the tool-call arguments, that tells the UI whether the final answer should be rendered as a chart.
+
+Inputs:
+
+| Parameter  | Type          | Required | Description                                                                  |
+| ---------- | ------------- | -------- | ---------------------------------------------------------------------------- |
+| `messages` | `valueString` | Yes      | JSON-encoded conversation history (OpenAI chat format).                      |
+| `model`    | `valueString` | No       | OpenAI model to use. Defaults to `gpt-4` if omitted.                         |
+
+Outputs: `content` (string, may be null when the model only returns tool calls), `tool_calls` (JSON array of `{ id, function: { name, arguments } }`), and `visualize` (boolean).
+
+The translator is the only bot that loops. The Provider UI re-invokes it after every batch of tool calls until the model decides it has enough context to answer.
+
+<MedplumCodeBlock language="ts" selectBlocks="invokeTranslatorBotTs">{ExampleCode}</MedplumCodeBlock>
+
+### FHIR Summary Bot
+
+`ai-resource-summary` (non-streaming) and `ai-resource-summary-sse` (streaming). Takes the conversation history after the loop has finished and produces a plain-language narration of the resources the translator pulled. The streaming variant is the path the Provider UI uses by default; the non-streaming one is a fallback.
+
+Inputs: same `messages` and `model` parameters as the translator.
+
+Outputs: `content` (the narration), streamed as SSE chunks when the streaming variant is invoked.
+
+### FHIR Visualizer Bot
+
+`ai-component-generator-sse`. Only invoked when the translator set `visualize=true` at least once during the loop. Receives the resolved FHIR resources and produces a self-contained `function Chart()` React component, streamed to the UI inside a fenced code block. The generated component uses pre-scoped [Recharts](https://recharts.org) primitives (line, bar, area, pie, scatter, composed) and [Mantine](https://mantine.dev) layout primitives — no `import` statements required.
+
+Inputs: `messages`, `model`, and `fhirData` (`valueString`, JSON array of resolved FHIR resources collected during the loop).
+
+Outputs: a streamed JSX code block that the Provider UI parses with a small streaming code extractor and renders in the right-hand panel of the chat view.
+
+## The Agent Loop
+
+Spaces is a true ReAct-style agent, not a single OpenAI round trip. Per user prompt, the translator may chain several FHIR calls before producing a final answer.
+
+The loop in [`spaceMessaging.ts`](https://github.com/medplum/medplum/blob/main/examples/medplum-provider/src/utils/spaceMessaging.ts) runs like this:
+
+1. Invoke the translator with the current conversation.
+2. If it returns no tool calls, exit the loop with its `content` as the final answer.
+3. If it returns tool calls, execute each `fhir_request` against the FHIR API (`GET` / `POST` / `PUT` / `DELETE`), append the responses to the conversation, and go back to step 1.
+
+While the loop runs the UI surfaces the active call as `Step N: <METHOD> <path>` so users can see what the model is doing in real time.
+
+### Iteration Cap
+
+The loop is capped at `MAX_AGENT_ITERATIONS = 10`. When the cap is hit, the loop short-circuits to the summary bot and the response is appended with a note telling the user the request reached the processing limit. Increasing the cap lets the agent answer more complex chained questions; decreasing it bounds per-prompt cost.
+
+### Adjusting The Cap
+
+Because Spaces ships as an example implementation, the cap is a constant in the Provider source, not a runtime setting. To change it, fork [`examples/medplum-provider`](https://github.com/medplum/medplum/tree/main/examples/medplum-provider) and edit `MAX_AGENT_ITERATIONS` in `src/utils/spaceMessaging.ts`.
+
+:::tip
+If you find users routinely hitting the cap, tighten the translator system prompt first. Many long loops come from the model fetching adjacent data it does not need.
+:::
+
+### Streaming Behavior
+
+The summary and visualizer bots stream their output as Server-Sent Events from OpenAI through `$ai` to the browser, so users see the narration appear word-by-word and the chart code render as it is generated. Tool calls run only on the non-streaming path — this is a constraint of OpenAI's streaming protocol, surfaced in the [`$ai` operation docs](/docs/ai/ai-operation).
+
+### Model Selection
+
+The Provider UI exposes a model selector in the chat input. The chosen model flows through to every bot via the `model` parameter and on to `$ai`. The dropdown contents are a UI concern; change it in [`ChatInput.tsx`](https://github.com/medplum/medplum/blob/main/examples/medplum-provider/src/pages/spaces/ChatInput.tsx) if you want to expose different models. The bots themselves are model-agnostic — they pass whatever string they are given.
+
+## Customizing The Translator System Prompt
+
+The Communication that backs the translator's system prompt is the supported customization point. Edit it, and the next user message uses the new prompt — no bot redeploy required.
+
+<MedplumCodeBlock language="ts" selectBlocks="updateSystemPromptTs">{ExampleCode}</MedplumCodeBlock>
+
+Recommendations:
+
+- Keep the instruction telling the model to use `fhir_request` for every FHIR operation. Removing it lets the model invent results.
+- Append domain-specific guidance rather than rewriting the whole prompt. For example, "when the user asks about vitals, prefer Observation searches that include both code and date".
+- Use `payload[1]` for anything that depends on the requester. The `{{ref}}` placeholder is replaced at request time, which is the only piece of per-user context the bot has by default.
+
+:::caution
+A prompt that contradicts the tool schema (for example, telling the model not to call any tools) will break the loop in subtle ways — the translator returns plain text, the summary bot gets no tool responses to narrate, and the chat shows a generic "I was unable to generate a response" message. Test prompt changes against a few representative user questions before rolling them out.
+:::
+
+## Security And Cost
+
+- The OpenAI API key lives only in `Project.secret`. The browser cannot read it, and bots receive it only inside their handler scope.
+- AccessPolicy applies to every FHIR request the loop executes. The assistant cannot read or write resources the requester is not entitled to. Audit-sensitive deployments should also restrict which `Practitioner` accounts have the `ai` feature exposed in their session.
+- Every loop iteration is one OpenAI call. A user asking a multi-hop question can drive five to ten model calls per prompt. Monitor your OpenAI usage dashboard and consider rate-limiting the bot endpoints in production.
+- All Spaces activity is recorded as standard FHIR [`AuditEvent`](/docs/api/fhir/resources/auditevent) resources, the same way every other Medplum write is.
+
+## See Also
+
+- [Medplum `$ai` Operation](/docs/ai/ai-operation) — the underlying FHIR operation that wraps OpenAI
+- [Medplum AI (MCP)](/docs/ai/mcp) — an alternative AI surface for tools that speak MCP
+- [Bot Basics](/docs/bots/bot-basics) — bot fundamentals and deployment
+- [Bot Secrets](/docs/bots/bot-secrets) — accessing project secrets from a bot
+- [Project Features](/docs/access/projects) — enabling the `ai` and `bots` flags
+- [Communication](/docs/api/fhir/resources/communication) FHIR resource API — conversation storage

--- a/packages/docs/docs/provider/spaces.mdx
+++ b/packages/docs/docs/provider/spaces.mdx
@@ -14,6 +14,8 @@ Spaces is the in-app AI assistant in [Medplum Provider](https://provider.medplum
 
 Spaces is shipped as an example implementation. The Provider app source lives in [`examples/medplum-provider`](https://github.com/medplum/medplum/tree/main/examples/medplum-provider) and the bot source in [`examples/medplum-demo-bots/src/spaces-bots`](https://github.com/medplum/medplum/tree/main/examples/medplum-demo-bots/src/spaces-bots). Use this page to set Spaces up in your own project, understand what it does behind the chat input, and tune the parts that are designed to be tuned.
 
+The assistant's behavior – what it says, what it refuses, which FHIR strategies it uses, how it summarizes, what charts it favors – is determined by three [`Communication`](/docs/api/fhir/resources/communication) resources that you author for your deployment. Spaces ships without canonical prompts on purpose: the right behavior depends on what your clinic plans to use the feature for. See [Author System Prompt Communications](#author-system-prompt-communications) below.
+
 The feature is reachable at `/Spaces/Communication` in the Provider app. It is gated on the project having both the `ai` and `bots` features enabled.
 
 ## What You Can Do With Spaces
@@ -98,17 +100,23 @@ To deploy:
 The non-streaming `ai-resource-summary` bot is referenced in the Provider source as a fallback path, but the shipping UI always uses the streaming variant. You only need to deploy a non-streaming summary bot if you fork the Provider app to disable streaming.
 :::
 
-### Seed The Translator System Prompt
+### Author System Prompt Communications
 
-The translator bot does not embed its system prompt in code. It loads it from a [`Communication`](/docs/api/fhir/resources/communication) resource at request time. This makes the prompt editable without redeploying the bot. The Communication must exist before the first user message or the translator throws.
+Each of the three Spaces bots loads its system prompt from a [`Communication`](/docs/api/fhir/resources/communication) resource at request time, not from code. These prompts are operator-authored content. They decide what Spaces does in your clinic: its tone, what it refuses, which FHIR-call strategies the translator prefers, how aggressively the summary bot narrates, which chart types the visualizer reaches for. Treat writing them as part of building the feature, not as a setup step that copies a canned recipe.
 
-The contract is:
+Three Communications are required, one per bot. The identifier system is `http://medplum.com/ai-spaces`; the value matches the bot identifier value used by the Provider UI.
 
-- Identifier: system `http://medplum.com/ai-spaces`, value `ai-fhir-request-tools`.
-- `payload[0].contentString` is the system prompt sent to OpenAI.
-- `payload[1].contentString` is a profile-context template. Any `{{ref}}` placeholder is replaced at request time with the requester's reference string (for example, `Practitioner/abc-123`) and appended to the system prompt.
+| Bot                          | Prompt Communication `identifier.value` | Payload Shape                                                                                                                                                                                                                  |
+| ---------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ai-fhir-request-tools`      | `ai-fhir-request-tools`                 | `payload[0]` is the system prompt. `payload[1]` is a profile-context template; any `{{ref}}` is replaced at request time with the requester's reference string (for example, `Practitioner/abc-123`) and appended to the prompt. |
+| `ai-resource-summary-sse`    | `ai-resource-summary-sse`               | `payload[0]` is the system prompt. No profile-context template.                                                                                                                                                                |
+| `ai-component-generator-sse` | `ai-component-generator-sse`            | `payload[0]` is the system prompt. No profile-context template.                                                                                                                                                                |
 
-<MedplumCodeBlock language="ts" selectBlocks="seedSystemPromptTs">{ExampleCode}</MedplumCodeBlock>
+If any Communication is missing, the corresponding bot throws (`"... system prompt is not available"`) and that part of the loop fails: a missing translator prompt stops the user's message; a missing summary prompt leaves the chat without narration; a missing visualizer prompt leaves the chart panel empty.
+
+The example below seeds all three Communications. The bodies are thin but functional – the loop will run end-to-end so you can verify wiring – they are not production prompts. Replace each `payload[0].contentString` with text authored for your deployment before exposing Spaces to users.
+
+<MedplumCodeBlock language="ts" selectBlocks="seedSystemPromptsTs">{ExampleCode}</MedplumCodeBlock>
 
 ## Conversation Data Model
 
@@ -214,20 +222,20 @@ The summary and visualizer bots stream their output as Server-Sent Events from O
 
 The Provider UI exposes a model selector in the chat input. The chosen model flows through to every bot via the `model` parameter and on to `$ai`. The dropdown contents are a UI concern; change it in [`ChatInput.tsx`](https://github.com/medplum/medplum/blob/main/examples/medplum-provider/src/pages/spaces/ChatInput.tsx) if you want to expose different models. The bots themselves are model-agnostic – they pass whatever string they are given.
 
-## Customizing The Translator System Prompt
+## Customizing System Prompts
 
-The Communication that backs the translator's system prompt is the supported customization point. Edit it, and the next user message uses the new prompt – no bot redeploy required.
+Spaces' behavior – when it calls FHIR, how it phrases summaries, which chart types it reaches for – is determined almost entirely by the three system-prompt Communications, not by the bot code (the bots are thin wrappers around `$ai`). To change behavior, edit `payload[0].contentString` on the relevant Communication. The next user message picks up the new prompt without a bot redeploy.
 
 <MedplumCodeBlock language="ts" selectBlocks="updateSystemPromptTs">{ExampleCode}</MedplumCodeBlock>
 
-Recommendations:
+Guidance per bot:
 
-- Keep the instruction telling the model to use `fhir_request` for every FHIR operation. Removing it lets the model invent results.
-- Append domain-specific guidance rather than rewriting the whole prompt. For example, "when the user asks about vitals, prefer Observation searches that include both code and date".
-- Use `payload[1]` for anything that depends on the requester. The `{{ref}}` placeholder is replaced at request time, which is the only piece of per-user context the bot has by default.
+- Translator (`ai-fhir-request-tools`). Keep the instruction telling the model to use the `fhir_request` tool for every FHIR operation – removing it lets the model invent results. Append clinic-specific guidance rather than rewriting the whole prompt. Use `payload[1]` for anything that depends on the requester; `{{ref}}` is the only per-user context the bot has by default.
+- Summary (`ai-resource-summary-sse`). Tune narration depth, terminology, and whether the bot mentions resource IDs or sticks to clinical content. This prompt also sets the tone users hear most.
+- Visualizer (`ai-component-generator-sse`). Bias toward specific chart types or labelling conventions for your specialty, and remind the model that only the pre-scoped Recharts and Mantine components are available – it must not write `import` statements.
 
 :::caution
-A prompt that contradicts the tool schema (for example, telling the model not to call any tools) will break the loop in subtle ways – the translator returns plain text, the summary bot gets no tool responses to narrate, and the chat shows a generic "I was unable to generate a response" message. Test prompt changes against a few representative user questions before rolling them out.
+A prompt that contradicts the tool schema (for example, telling the translator not to call any tools) will break the loop in subtle ways – the translator returns plain text, the summary bot gets no tool responses to narrate, and the chat shows a generic "I was unable to generate a response" message. Test prompt changes against representative user questions before rolling them out.
 :::
 
 ## Security And Cost

--- a/packages/docs/docs/provider/spaces.mdx
+++ b/packages/docs/docs/provider/spaces.mdx
@@ -18,6 +18,25 @@ Spaces is shipped as an example implementation. The Provider app source lives in
 
 The feature is reachable at `/Spaces/Communication` in the Provider app. It is gated on the project having both the `ai` and `bots` features enabled.
 
+## What You Can Do With Spaces
+
+The translator bot can issue any FHIR request the requester's AccessPolicy permits, so the practical capability surface is broad. Typical prompts fall into a few categories:
+
+| Category               | Example Prompts                                                                                                                              |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Search and lookup      | "Find the patient John Smith." "Which patients are scheduled with Dr. Chen this week?"                                                       |
+| Clinical summary       | "Summarize Maria Garcia's last three encounters." "What medications is this patient on?"                                                     |
+| Visualize trends       | "Show a growth chart for this patient." "Plot hemoglobin A1c over the last two years."                                                       |
+| Operational reporting  | "Chart provider utilization across the clinic for the past month." "How many lab orders did we place last week?"                             |
+| Schedule and tasks     | "Schedule a follow-up with Dr. Patel next Tuesday at 10am." "Create a task to fax the imaging report to the referring provider."             |
+| Orders and updates     | "Order a CBC for this patient." "Place a referral to cardiology." "Update the patient's phone number to 555-0142."                           |
+
+The first four rows are read-only and end at the summary bot. The visualization and reporting prompts additionally invoke the visualizer bot to render an interactive chart in the side panel. The last two rows trigger live FHIR writes through the same loop.
+
+:::caution
+Writes happen as soon as the loop reaches them. Treat clinically significant prompts (orders, referrals, status changes) the same way you would any draft – review the resulting resource before relying on it, and consider scoping the `ai` feature to AccessPolicies that do not include write access to high-risk resource types.
+:::
+
 ## How Spaces Works
 
 Spaces is not a single AI call. Each user prompt drives a short pipeline of bots and a tool-use loop:
@@ -168,7 +187,7 @@ Outputs: `content` (the narration), streamed as SSE chunks when the streaming va
 
 ### FHIR Visualizer Bot
 
-`ai-component-generator-sse`. Only invoked when the translator set `visualize=true` at least once during the loop. Receives the resolved FHIR resources and produces a self-contained `function Chart()` React component, streamed to the UI inside a fenced code block. The generated component uses pre-scoped [Recharts](https://recharts.org) primitives (line, bar, area, pie, scatter, composed) and [Mantine](https://mantine.dev) layout primitives — no `import` statements required.
+`ai-component-generator-sse`. Only invoked when the translator set `visualize=true` at least once during the loop. Receives the resolved FHIR resources and produces a self-contained `function Chart()` React component, streamed to the UI inside a fenced code block. The generated component uses pre-scoped [Recharts](https://recharts.org) primitives (line, bar, area, pie, scatter, composed) and [Mantine](https://mantine.dev) layout primitives – no `import` statements required.
 
 Inputs: `messages`, `model`, and `fhirData` (`valueString`, JSON array of resolved FHIR resources collected during the loop).
 
@@ -200,15 +219,15 @@ If you find users routinely hitting the cap, tighten the translator system promp
 
 ### Streaming Behavior
 
-The summary and visualizer bots stream their output as Server-Sent Events from OpenAI through `$ai` to the browser, so users see the narration appear word-by-word and the chart code render as it is generated. Tool calls run only on the non-streaming path — this is a constraint of OpenAI's streaming protocol, surfaced in the [`$ai` operation docs](/docs/ai/ai-operation).
+The summary and visualizer bots stream their output as Server-Sent Events from OpenAI through `$ai` to the browser, so users see the narration appear word-by-word and the chart code render as it is generated. Tool calls run only on the non-streaming path – this is a constraint of OpenAI's streaming protocol, surfaced in the [`$ai` operation docs](/docs/ai/ai-operation).
 
 ### Model Selection
 
-The Provider UI exposes a model selector in the chat input. The chosen model flows through to every bot via the `model` parameter and on to `$ai`. The dropdown contents are a UI concern; change it in [`ChatInput.tsx`](https://github.com/medplum/medplum/blob/main/examples/medplum-provider/src/pages/spaces/ChatInput.tsx) if you want to expose different models. The bots themselves are model-agnostic — they pass whatever string they are given.
+The Provider UI exposes a model selector in the chat input. The chosen model flows through to every bot via the `model` parameter and on to `$ai`. The dropdown contents are a UI concern; change it in [`ChatInput.tsx`](https://github.com/medplum/medplum/blob/main/examples/medplum-provider/src/pages/spaces/ChatInput.tsx) if you want to expose different models. The bots themselves are model-agnostic – they pass whatever string they are given.
 
 ## Customizing The Translator System Prompt
 
-The Communication that backs the translator's system prompt is the supported customization point. Edit it, and the next user message uses the new prompt — no bot redeploy required.
+The Communication that backs the translator's system prompt is the supported customization point. Edit it, and the next user message uses the new prompt – no bot redeploy required.
 
 <MedplumCodeBlock language="ts" selectBlocks="updateSystemPromptTs">{ExampleCode}</MedplumCodeBlock>
 
@@ -219,7 +238,7 @@ Recommendations:
 - Use `payload[1]` for anything that depends on the requester. The `{{ref}}` placeholder is replaced at request time, which is the only piece of per-user context the bot has by default.
 
 :::caution
-A prompt that contradicts the tool schema (for example, telling the model not to call any tools) will break the loop in subtle ways — the translator returns plain text, the summary bot gets no tool responses to narrate, and the chat shows a generic "I was unable to generate a response" message. Test prompt changes against a few representative user questions before rolling them out.
+A prompt that contradicts the tool schema (for example, telling the model not to call any tools) will break the loop in subtle ways – the translator returns plain text, the summary bot gets no tool responses to narrate, and the chat shows a generic "I was unable to generate a response" message. Test prompt changes against a few representative user questions before rolling them out.
 :::
 
 ## Security And Cost
@@ -231,9 +250,9 @@ A prompt that contradicts the tool schema (for example, telling the model not to
 
 ## See Also
 
-- [Medplum `$ai` Operation](/docs/ai/ai-operation) — the underlying FHIR operation that wraps OpenAI
-- [Medplum AI (MCP)](/docs/ai/mcp) — an alternative AI surface for tools that speak MCP
-- [Bot Basics](/docs/bots/bot-basics) — bot fundamentals and deployment
-- [Bot Secrets](/docs/bots/bot-secrets) — accessing project secrets from a bot
-- [Project Features](/docs/access/projects) — enabling the `ai` and `bots` flags
-- [Communication](/docs/api/fhir/resources/communication) FHIR resource API — conversation storage
+- [Medplum `$ai` Operation](/docs/ai/ai-operation) – the underlying FHIR operation that wraps OpenAI
+- [Medplum AI (MCP)](/docs/ai/mcp) – an alternative AI surface for tools that speak MCP
+- [Bot Basics](/docs/bots/bot-basics) – bot fundamentals and deployment
+- [Bot Secrets](/docs/bots/bot-secrets) – accessing project secrets from a bot
+- [Project Features](/docs/access/projects) – enabling the `ai` and `bots` flags
+- [Communication](/docs/api/fhir/resources/communication) FHIR resource API – conversation storage

--- a/packages/examples/src/provider/spaces-examples.ts
+++ b/packages/examples/src/provider/spaces-examples.ts
@@ -13,20 +13,18 @@ import type { Communication, Parameters } from '@medplum/fhirtypes';
 
 const medplum = new MedplumClient();
 
-// start-block seedSystemPromptTs
-// One-time setup: create the Communication that holds the translator's system
-// prompt and profile-context template. payload[0] is the system prompt;
-// payload[1] is a profile-context template where {{ref}} is substituted with
-// the requester's reference string at request time.
+// start-block seedSystemPromptsTs
+// One-time setup: create the three Communications that hold the system prompts
+// for the translator, summary, and visualizer bots. The bodies below are a
+// thin wiring skeleton - the loop runs end-to-end with these in place, but
+// you should replace each payload[0].contentString with prompts authored for
+// your deployment before exposing Spaces to users.
+
+// Translator: produces the fhir_request tool calls that drive the loop.
 await medplum.createResource<Communication>({
   resourceType: 'Communication',
   status: 'completed',
-  identifier: [
-    {
-      system: 'http://medplum.com/ai-spaces',
-      value: 'ai-fhir-request-tools',
-    },
-  ],
+  identifier: [{ system: 'http://medplum.com/ai-spaces', value: 'ai-fhir-request-tools' }],
   payload: [
     {
       contentString: [
@@ -34,15 +32,49 @@ await medplum.createResource<Communication>({
         'Use the fhir_request tool for every FHIR operation - never invent results.',
         'For updates, first GET the resource, then PUT the modified full resource.',
         'Set visualize=true on the tool call when the result should be a chart',
-        '(e.g. growth trends, lab values over time, observation series).',
+        '(for example trends or values over time).',
       ].join('\n'),
     },
     {
+      // payload[1] is a profile-context template; {{ref}} is replaced at request
+      // time with the requester's reference string (e.g. Practitioner/abc-123).
       contentString: 'The requester is {{ref}}. Scope queries to data they are entitled to see.',
     },
   ],
 });
-// end-block seedSystemPromptTs
+
+// Summary: narrates the FHIR responses the translator collected.
+await medplum.createResource<Communication>({
+  resourceType: 'Communication',
+  status: 'completed',
+  identifier: [{ system: 'http://medplum.com/ai-spaces', value: 'ai-resource-summary-sse' }],
+  payload: [
+    {
+      contentString: [
+        'You translate FHIR response bundles into clear, human-readable summaries.',
+        'Lead with the most clinically relevant detail. Be concise.',
+        'If the response is an empty bundle, say so plainly and suggest what to try next.',
+      ].join('\n'),
+    },
+  ],
+});
+
+// Visualizer: produces a self-contained Chart() React component when asked.
+await medplum.createResource<Communication>({
+  resourceType: 'Communication',
+  status: 'completed',
+  identifier: [{ system: 'http://medplum.com/ai-spaces', value: 'ai-component-generator-sse' }],
+  payload: [
+    {
+      contentString: [
+        'You generate a self-contained function Chart() React component that visualizes FHIR data.',
+        'Use only the Recharts and Mantine components already in scope - do not write import statements.',
+        'Prefer LineChart or AreaChart for trends over time and BarChart or PieChart for categorical counts.',
+      ].join('\n'),
+    },
+  ],
+});
+// end-block seedSystemPromptsTs
 
 // start-block updateSystemPromptTs
 // To tune the translator at runtime, edit payload[0].contentString on the

--- a/packages/examples/src/provider/spaces-examples.ts
+++ b/packages/examples/src/provider/spaces-examples.ts
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Code samples for /docs/provider/spaces.mdx.
+// Each example has up to three blocks: <name>Ts (live TypeScript), <name>Cli
+// (commented `medplum` CLI invocation), <name>Curl (commented HTTP request).
+// Non-TypeScript blocks live inside /* */ comments so this file still compiles.
+
+// start-block imports
+import { MedplumClient } from '@medplum/core';
+import type { Communication, Parameters, Project } from '@medplum/fhirtypes';
+// end-block imports
+
+const medplum = new MedplumClient();
+
+// start-block enableFeaturesTs
+// Read the current project, then patch its features list.
+const project = await medplum.searchOne('Project');
+if (!project?.id) {
+  throw new Error('No accessible Project found');
+}
+const existingFeatures = project.features ?? [];
+const required: NonNullable<Project['features']> = ['ai', 'bots'];
+const features = Array.from(new Set([...existingFeatures, ...required])) as NonNullable<Project['features']>;
+await medplum.updateResource<Project>({ ...project, features });
+// end-block enableFeaturesTs
+
+/*
+// start-block enableFeaturesCli
+medplum project update --features ai,bots
+// end-block enableFeaturesCli
+*/
+
+// start-block addOpenAiSecretTs
+// Add OPENAI_API_KEY to the project secret list.
+const projectForSecret = await medplum.searchOne('Project');
+if (!projectForSecret?.id) {
+  throw new Error('No accessible Project found');
+}
+const otherSecrets = (projectForSecret.secret ?? []).filter((s) => s.name !== 'OPENAI_API_KEY');
+await medplum.updateResource<Project>({
+  ...projectForSecret,
+  secret: [...otherSecrets, { name: 'OPENAI_API_KEY', valueString: 'sk-...' }],
+});
+// end-block addOpenAiSecretTs
+
+/*
+// start-block addOpenAiSecretCli
+medplum project secret set OPENAI_API_KEY 'sk-...'
+// end-block addOpenAiSecretCli
+*/
+
+/*
+// start-block deployBotsCli
+# From examples/medplum-demo-bots, deploy each Spaces bot with its identifier.
+# Repeat for each of the four bots; replace <bot-name> with the source filename
+# and <identifier-value> with the identifier value from the table.
+medplum bot create \
+  --name '<bot-name>' \
+  --source 'src/spaces-bots/<bot-name>.ts' \
+  --identifier 'https://www.medplum.com/bots|<identifier-value>'
+
+medplum bot deploy '<bot-name>'
+// end-block deployBotsCli
+*/
+
+// start-block seedSystemPromptTs
+// One-time setup: create the Communication that holds the translator's system
+// prompt and profile-context template. payload[0] is the system prompt;
+// payload[1] is a profile-context template where {{ref}} is substituted with
+// the requester's reference string at request time.
+await medplum.createResource<Communication>({
+  resourceType: 'Communication',
+  status: 'completed',
+  identifier: [
+    {
+      system: 'http://medplum.com/ai-spaces',
+      value: 'ai-fhir-request-tools',
+    },
+  ],
+  payload: [
+    {
+      contentString: [
+        'You are a FHIR data assistant for Medplum.',
+        'Use the fhir_request tool for every FHIR operation - never invent results.',
+        'For updates, first GET the resource, then PUT the modified full resource.',
+        'Set visualize=true on the tool call when the result should be a chart',
+        '(e.g. growth trends, lab values over time, observation series).',
+      ].join('\n'),
+    },
+    {
+      contentString: 'The requester is {{ref}}. Scope queries to data they are entitled to see.',
+    },
+  ],
+});
+// end-block seedSystemPromptTs
+
+// start-block updateSystemPromptTs
+// To tune the translator at runtime, edit payload[0].contentString on the
+// existing Communication. The next user message picks up the new prompt
+// without redeploying any bot.
+const existing = await medplum.searchOne('Communication', {
+  identifier: 'http://medplum.com/ai-spaces|ai-fhir-request-tools',
+});
+if (existing?.id) {
+  await medplum.updateResource<Communication>({
+    ...existing,
+    payload: [
+      {
+        contentString: [
+          'You are a FHIR data assistant for Medplum.',
+          'Use the fhir_request tool for every FHIR operation.',
+          'When the user asks about vitals, prefer Observation searches that include both code and date.',
+        ].join('\n'),
+      },
+      existing.payload?.[1] ?? { contentString: 'The requester is {{ref}}.' },
+    ],
+  });
+}
+// end-block updateSystemPromptTs
+
+// start-block loadRecentTopicsTs
+// Topic headers carry identifier ai-message-topic. The Provider UI filters by
+// the current user's reference so each user only sees their own conversations.
+const profile = await medplum.getProfile();
+const topics = await medplum.searchResources('Communication', {
+  identifier: 'http://medplum.com/ai-message|ai-message-topic',
+  sender: profile?.id ? `${profile.resourceType}/${profile.id}` : '',
+  _sort: '-_lastUpdated',
+  _count: '10',
+});
+console.log(topics);
+// end-block loadRecentTopicsTs
+
+// start-block loadConversationMessagesTs
+// Each turn is a child Communication linked via partOf. payload[0].contentString
+// is JSON of { role, content, tool_calls, tool_call_id, resources, componentCode, sequenceNumber }.
+const topicId = 'example-topic-id';
+const messages = await medplum.searchResources('Communication', {
+  'part-of': `Communication/${topicId}`,
+  _sort: '_lastUpdated',
+  _count: '100',
+});
+const turns = messages
+  .filter((m) => m.payload?.[0]?.contentString)
+  .map((m) => JSON.parse(m.payload?.[0]?.contentString as string))
+  .sort((a, b) => (a.sequenceNumber ?? 0) - (b.sequenceNumber ?? 0));
+console.log(turns);
+// end-block loadConversationMessagesTs
+
+// start-block invokeTranslatorBotTs
+// Direct invocation of the translator bot. The Provider UI does this on every
+// loop iteration; you only need this snippet to build your own client.
+const translatorResponse = await medplum.executeBot(
+  { system: 'https://www.medplum.com/bots', value: 'ai-fhir-request-tools' },
+  {
+    resourceType: 'Parameters',
+    parameter: [
+      {
+        name: 'messages',
+        valueString: JSON.stringify([{ role: 'user', content: 'Find the patient named John Smith' }]),
+      },
+      { name: 'model', valueString: 'gpt-4' },
+    ],
+  } satisfies Parameters
+);
+console.log(translatorResponse);
+// end-block invokeTranslatorBotTs

--- a/packages/examples/src/provider/spaces-examples.ts
+++ b/packages/examples/src/provider/spaces-examples.ts
@@ -8,61 +8,10 @@
 
 // start-block imports
 import { MedplumClient } from '@medplum/core';
-import type { Communication, Parameters, Project } from '@medplum/fhirtypes';
+import type { Communication, Parameters } from '@medplum/fhirtypes';
 // end-block imports
 
 const medplum = new MedplumClient();
-
-// start-block enableFeaturesTs
-// Read the current project, then patch its features list.
-const project = await medplum.searchOne('Project');
-if (!project?.id) {
-  throw new Error('No accessible Project found');
-}
-const existingFeatures = project.features ?? [];
-const required: NonNullable<Project['features']> = ['ai', 'bots'];
-const features = Array.from(new Set([...existingFeatures, ...required]));
-await medplum.updateResource<Project>({ ...project, features });
-// end-block enableFeaturesTs
-
-/*
-// start-block enableFeaturesCli
-medplum project update --features ai,bots
-// end-block enableFeaturesCli
-*/
-
-// start-block addOpenAiSecretTs
-// Add OPENAI_API_KEY to the project secret list.
-const projectForSecret = await medplum.searchOne('Project');
-if (!projectForSecret?.id) {
-  throw new Error('No accessible Project found');
-}
-const otherSecrets = (projectForSecret.secret ?? []).filter((s) => s.name !== 'OPENAI_API_KEY');
-await medplum.updateResource<Project>({
-  ...projectForSecret,
-  secret: [...otherSecrets, { name: 'OPENAI_API_KEY', valueString: 'sk-...' }],
-});
-// end-block addOpenAiSecretTs
-
-/*
-// start-block addOpenAiSecretCli
-medplum project secret set OPENAI_API_KEY 'sk-...'
-// end-block addOpenAiSecretCli
-*/
-
-/*
-// start-block deployBotsCli
-# From examples/medplum-demo-bots, deploy each Spaces bot with its identifier.
-# Repeat for each of the four bots; replace <bot-name> with the source filename
-# and <identifier-value> with the identifier value from the table.
-medplum bot create \
-  --name '<bot-name>' \
-  --source 'src/spaces-bots/<bot-name>.ts' \
-  --identifier 'https://www.medplum.com/bots|<identifier-value>'
-
-medplum bot deploy '<bot-name>'
-// end-block deployBotsCli
-*/
 
 // start-block seedSystemPromptTs
 // One-time setup: create the Communication that holds the translator's system

--- a/packages/examples/src/provider/spaces-examples.ts
+++ b/packages/examples/src/provider/spaces-examples.ts
@@ -21,7 +21,7 @@ if (!project?.id) {
 }
 const existingFeatures = project.features ?? [];
 const required: NonNullable<Project['features']> = ['ai', 'bots'];
-const features = Array.from(new Set([...existingFeatures, ...required])) as NonNullable<Project['features']>;
+const features = Array.from(new Set([...existingFeatures, ...required]));
 await medplum.updateResource<Project>({ ...project, features });
 // end-block enableFeaturesTs
 


### PR DESCRIPTION
## Summary

- New page at `/docs/provider/spaces` documenting the Spaces in-app AI assistant in the Provider app as an example implementation. Covers setup (`ai`/`bots` features, `OPENAI_API_KEY` secret, deploying the four bots, seeding the translator system-prompt Communication), the `Communication`-based conversation data model, the four-bot pipeline, the ReAct-style agent loop (including the `MAX_AGENT_ITERATIONS = 10` constant and how to adjust it), and the supported translator-prompt customization point.
- Companion code examples at `packages/examples/src/provider/spaces-examples.ts` with `// start-block` / `// end-block` markers, rendered via `MedplumCodeBlock`. Setup commands use TS/CLI tabs per the docs formatting guide.
- Cross-links: promoted Spaces out of "Documentation Coming Soon" in the Provider index, added a Spaces bullet under "AI Solutions with Medplum" in `/docs/ai`, and added a backlink from `/docs/ai/ai-operation` "Related Documentation".

## Test plan

- [x] `npx tsc --noEmit` in `packages/examples` — clean
- [x] `npm run build` in `packages/docs` — succeeds; `build/docs/provider/spaces.html` generated, no errors on the new page
- [x] Manual review of the architecture diagram, the agent-loop explanation, and the "supported customization" framing for the translator system prompt
- [x] Visual check by running `npm run start` in `packages/docs` and confirming the page appears in the Provider sidebar at position 6 (after Visits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)