### PR TITLE
WIP: feat(data warehouse): provision S3 Tables Iceberg warehouse tables on migrate

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -14,6 +14,7 @@ import {
   getPreDeployMigration,
 } from './migrations/migration-utils';
 import { getPreDeployMigrationVersions, MigrationVersion } from './migrations/migration-versions';
+import { runS3TablesWarehouseMigrationsIfNeeded } from './migrations/s3-tables-warehouse/run-s3-tables-warehouse-migrations';
 import { getServerVersion } from './util/version';
 
 export const DatabaseMode = {
@@ -47,6 +48,7 @@ export async function initDatabase(serverConfig: MedplumServerConfig): Promise<v
 
   if (serverConfig.database.runMigrations !== false) {
     await runMigrations(pool);
+    await runS3TablesWarehouseMigrationsIfNeeded(serverConfig);
   }
 
   if (serverConfig.readonlyDatabase) {

--- a/packages/server/src/migrations/s3-tables-warehouse/run-s3-tables-warehouse-migrations.test.ts
+++ b/packages/server/src/migrations/s3-tables-warehouse/run-s3-tables-warehouse-migrations.test.ts
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { MedplumServerConfig } from '../../config/types';
+import { runS3TablesWarehouseMigrationsIfNeeded } from './run-s3-tables-warehouse-migrations';
+import * as tableNames from './warehouse-table-names';
+
+jest.mock('./s3-tables-client', () => ({
+  createS3TablesClient: jest.fn(() => ({ send: jest.fn() })),
+  ensureNamespaceExists: jest.fn().mockResolvedValue(undefined),
+  ensureWarehouseHistoryIcebergTable: jest.fn().mockResolvedValue('skipped'),
+}));
+
+const dwClient: {
+  ensureNamespaceExists: jest.Mock;
+  ensureWarehouseHistoryIcebergTable: jest.Mock;
+} = jest.requireMock('./s3-tables-client');
+
+describe('runS3TablesWarehouseMigrationsIfNeeded', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('no-op when dataWarehouse is absent', async () => {
+    const config = { database: { runMigrations: true }, awsRegion: 'us-east-1' } as unknown as MedplumServerConfig;
+    await runS3TablesWarehouseMigrationsIfNeeded(config);
+    expect(dwClient.ensureNamespaceExists).not.toHaveBeenCalled();
+  });
+
+  test('no-op when data warehouse disabled', async () => {
+    const config = {
+      database: { runMigrations: true },
+      awsRegion: 'us-east-1',
+      dataWarehouse: { enabled: false },
+    } as unknown as MedplumServerConfig;
+    await runS3TablesWarehouseMigrationsIfNeeded(config);
+    expect(dwClient.ensureNamespaceExists).not.toHaveBeenCalled();
+  });
+
+  test('no-op when sink is local', async () => {
+    const config = {
+      database: { runMigrations: true },
+      awsRegion: 'us-east-1',
+      dataWarehouse: { enabled: true, sink: 'local', cron: '0 * * * *', localBasePath: '/tmp/dw' },
+    } as unknown as MedplumServerConfig;
+    await runS3TablesWarehouseMigrationsIfNeeded(config);
+    expect(dwClient.ensureNamespaceExists).not.toHaveBeenCalled();
+  });
+
+  test('throws when enabled but cron missing', async () => {
+    const config = {
+      database: { runMigrations: true },
+      awsRegion: 'us-east-1',
+      dataWarehouse: { enabled: true, sink: 's3tables', awsS3TableArn: 'arn:aws:s3tables:us-east-1:1:bucket/x' },
+    } as unknown as MedplumServerConfig;
+    await expect(runS3TablesWarehouseMigrationsIfNeeded(config)).rejects.toThrow('dataWarehouse.cron is required');
+  });
+
+  test('ensures namespace and tables when s3tables enabled', async () => {
+    const spy = jest.spyOn(tableNames, 'getWarehouseSyncPostgresTableNames').mockReturnValue(['Patient_History']);
+    try {
+      const config = {
+        database: { runMigrations: true },
+        awsRegion: 'us-east-1',
+        dataWarehouse: {
+          enabled: true,
+          sink: 's3tables',
+          awsS3TableArn: 'arn:aws:s3tables:us-east-1:123456789012:bucket/test',
+          namespace: 'analytics',
+          cron: '0 * * * *',
+        },
+      } as unknown as MedplumServerConfig;
+      await runS3TablesWarehouseMigrationsIfNeeded(config);
+      expect(dwClient.ensureNamespaceExists).toHaveBeenCalledWith(
+        expect.anything(),
+        'arn:aws:s3tables:us-east-1:123456789012:bucket/test',
+        'analytics'
+      );
+      expect(dwClient.ensureWarehouseHistoryIcebergTable).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/server/src/migrations/s3-tables-warehouse/run-s3-tables-warehouse-migrations.ts
+++ b/packages/server/src/migrations/s3-tables-warehouse/run-s3-tables-warehouse-migrations.ts
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { MedplumServerConfig } from '../../config/types';
+import { globalLogger } from '../../logger';
+import { createS3TablesClient, ensureNamespaceExists, ensureWarehouseHistoryIcebergTable } from './s3-tables-client';
+import {
+  DEFAULT_WAREHOUSE_NAMESPACE,
+  getWarehouseSyncPostgresTableNames,
+  resolveWarehouseSourcesFromPostgresTableNames,
+} from './warehouse-table-names';
+
+const PROVISION_CONCURRENCY = 8;
+
+/** Narrow config slice expected once `dataWarehouse` is introduced by server config (separate feature PR). */
+export interface DataWarehouseConfigSlice {
+  enabled?: boolean;
+  sink?: 's3tables' | 'local';
+  awsS3TableArn?: string;
+  namespace?: string;
+  cron?: string;
+  localBasePath?: string;
+}
+
+type ServerConfigWithOptionalWarehouse = MedplumServerConfig & { dataWarehouse?: DataWarehouseConfigSlice };
+
+/**
+ * After Postgres schema migrations, provision managed S3 Tables Iceberg namespaces and `_History` tables
+ * required by the data warehouse sync worker. Idempotent; skipped when `database.runMigrations` is false,
+ * `dataWarehouse` is absent/disabled, or sink is `local`.
+ *
+ * @param serverConfig - Loaded Medplum server configuration (may include optional `dataWarehouse` from a future PR).
+ */
+export async function runS3TablesWarehouseMigrationsIfNeeded(serverConfig: MedplumServerConfig): Promise<void> {
+  const config = serverConfig as ServerConfigWithOptionalWarehouse;
+  const dw = config.dataWarehouse;
+  if (!dw?.enabled) {
+    return;
+  }
+
+  if (!dw.cron?.trim()) {
+    throw new Error('dataWarehouse.cron is required when dataWarehouse.enabled is true');
+  }
+
+  const sink = dw.sink ?? 's3tables';
+  if (sink !== 's3tables' && sink !== 'local') {
+    throw new Error('dataWarehouse.sink must be "s3tables" or "local"');
+  }
+  if (sink === 'local') {
+    return;
+  }
+
+  const tableBucketArn = dw.awsS3TableArn;
+  if (!tableBucketArn?.trim()) {
+    throw new Error('dataWarehouse.awsS3TableArn is required when dataWarehouse.sink is "s3tables"');
+  }
+
+  const namespace = dw.namespace?.trim() || DEFAULT_WAREHOUSE_NAMESPACE;
+  const client = createS3TablesClient(config.awsRegion);
+
+  await ensureNamespaceExists(client, tableBucketArn, namespace);
+
+  const sources = resolveWarehouseSourcesFromPostgresTableNames(getWarehouseSyncPostgresTableNames());
+  const started = Date.now();
+  let created = 0;
+  let skipped = 0;
+
+  for (let i = 0; i < sources.length; i += PROVISION_CONCURRENCY) {
+    const slice = sources.slice(i, i + PROVISION_CONCURRENCY);
+    const results = await Promise.all(
+      slice.map((spec) => ensureWarehouseHistoryIcebergTable(client, tableBucketArn, namespace, spec.icebergTable))
+    );
+    for (const r of results) {
+      if (r === 'created') {
+        created++;
+      } else {
+        skipped++;
+      }
+    }
+  }
+
+  globalLogger.info('S3 Tables warehouse tables ensured', {
+    namespace,
+    tables: sources.length,
+    created,
+    skipped,
+    durationMs: Date.now() - started,
+  });
+}

--- a/packages/server/src/migrations/s3-tables-warehouse/s3-tables-client.test.ts
+++ b/packages/server/src/migrations/s3-tables-warehouse/s3-tables-client.test.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { CreateTableCommand, GetTableCommand } from '@aws-sdk/client-s3tables';
+import { ensureWarehouseHistoryIcebergTable } from './s3-tables-client';
+
+describe('s3-tables-client ensureWarehouseHistoryIcebergTable', () => {
+  test('returns skipped when table already exists', async () => {
+    const send = jest.fn().mockResolvedValue({});
+    const client = { send } as any;
+    const result = await ensureWarehouseHistoryIcebergTable(
+      client,
+      'arn:aws:s3tables:us-east-1:123456789012:bucket/test',
+      'default',
+      'patient_history'
+    );
+    expect(result).toBe('skipped');
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][0]).toBeInstanceOf(GetTableCommand);
+  });
+
+  test('creates table when GetTable returns NotFoundException', async () => {
+    const notFound = Object.assign(new Error('not found'), { name: 'NotFoundException' });
+    const send = jest.fn().mockRejectedValueOnce(notFound).mockResolvedValueOnce({});
+    const client = { send } as any;
+    const result = await ensureWarehouseHistoryIcebergTable(
+      client,
+      'arn:aws:s3tables:us-east-1:123456789012:bucket/test',
+      'default',
+      'patient_history'
+    );
+    expect(result).toBe('created');
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send.mock.calls[0][0]).toBeInstanceOf(GetTableCommand);
+    expect(send.mock.calls[1][0]).toBeInstanceOf(CreateTableCommand);
+  });
+});

--- a/packages/server/src/migrations/s3-tables-warehouse/s3-tables-client.ts
+++ b/packages/server/src/migrations/s3-tables-warehouse/s3-tables-client.ts
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  CreateNamespaceCommand,
+  CreateTableCommand,
+  GetTableCommand,
+  OpenTableFormat,
+  S3TablesClient,
+} from '@aws-sdk/client-s3tables';
+import { buildMedplumWarehouseHistoryIcebergMetadata } from './warehouse-iceberg-metadata';
+
+export function createS3TablesClient(region: string): S3TablesClient {
+  return new S3TablesClient({ region });
+}
+
+export async function tableExists(
+  s3TablesClient: S3TablesClient,
+  tableBucketArn: string,
+  namespace: string,
+  tableName: string
+): Promise<boolean> {
+  try {
+    await s3TablesClient.send(
+      new GetTableCommand({
+        tableBucketARN: tableBucketArn,
+        namespace,
+        name: tableName,
+      })
+    );
+    return true;
+  } catch (error: any) {
+    if (typeof error?.name === 'string' && error.name === 'NotFoundException') {
+      return false;
+    } else {
+      throw error;
+    }
+  }
+}
+
+export async function ensureNamespaceExists(
+  s3TablesClient: S3TablesClient,
+  tableBucketArn: string,
+  namespace: string
+): Promise<void> {
+  try {
+    await s3TablesClient.send(
+      new CreateNamespaceCommand({
+        tableBucketARN: tableBucketArn,
+        namespace: [namespace],
+      })
+    );
+  } catch (error: any) {
+    if (typeof error?.name === 'string' && (error.name.includes('Conflict') || error.name.includes('AlreadyExists'))) {
+      return;
+    }
+    throw error;
+  }
+}
+
+export type EnsureWarehouseIcebergTableResult = 'created' | 'skipped';
+
+/**
+ * Ensures a single managed Iceberg table exists for Medplum `_History` warehouse sync (idempotent).
+ *
+ * @param s3TablesClient - AWS S3 Tables client for the table bucket region.
+ * @param tableBucketArn - Table bucket ARN (`dataWarehouse.awsS3TableArn`).
+ * @param namespace - Iceberg namespace in the table bucket.
+ * @param icebergTableName - Lowercased Iceberg table name (e.g. `patient_history`).
+ * @returns Whether a new table was created or an existing table was left in place.
+ */
+export async function ensureWarehouseHistoryIcebergTable(
+  s3TablesClient: S3TablesClient,
+  tableBucketArn: string,
+  namespace: string,
+  icebergTableName: string
+): Promise<EnsureWarehouseIcebergTableResult> {
+  if (await tableExists(s3TablesClient, tableBucketArn, namespace, icebergTableName)) {
+    return 'skipped';
+  }
+
+  try {
+    await s3TablesClient.send(
+      new CreateTableCommand({
+        tableBucketARN: tableBucketArn,
+        namespace,
+        name: icebergTableName,
+        format: OpenTableFormat.ICEBERG,
+        metadata: { iceberg: buildMedplumWarehouseHistoryIcebergMetadata() },
+      })
+    );
+    return 'created';
+  } catch (error: any) {
+    const errorName = typeof error?.name === 'string' ? error.name : '';
+    if (errorName.includes('Conflict') || errorName === 'ConflictException') {
+      if (await tableExists(s3TablesClient, tableBucketArn, namespace, icebergTableName)) {
+        return 'skipped';
+      }
+    }
+    throw error;
+  }
+}

--- a/packages/server/src/migrations/s3-tables-warehouse/warehouse-iceberg-metadata.test.ts
+++ b/packages/server/src/migrations/s3-tables-warehouse/warehouse-iceberg-metadata.test.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { buildMedplumWarehouseHistoryIcebergMetadata, WAREHOUSE_ICEBERG_FIELD_IDS } from './warehouse-iceberg-metadata';
+
+describe('warehouse-iceberg-metadata', () => {
+  test('buildMedplumWarehouseHistoryIcebergMetadata matches sync column layout', () => {
+    const meta = buildMedplumWarehouseHistoryIcebergMetadata();
+    const fields = meta.schema?.fields ?? [];
+    expect(fields.map((f) => f?.name)).toEqual(['id', 'version_id', 'content', 'last_updated', 'project_id']);
+    expect(fields.map((f) => f?.id)).toEqual([
+      WAREHOUSE_ICEBERG_FIELD_IDS.id,
+      WAREHOUSE_ICEBERG_FIELD_IDS.version_id,
+      WAREHOUSE_ICEBERG_FIELD_IDS.content,
+      WAREHOUSE_ICEBERG_FIELD_IDS.last_updated,
+      WAREHOUSE_ICEBERG_FIELD_IDS.project_id,
+    ]);
+    const parts = meta.partitionSpec?.fields ?? [];
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toMatchObject({
+      sourceId: WAREHOUSE_ICEBERG_FIELD_IDS.project_id,
+      transform: 'identity',
+      name: 'project_id',
+    });
+    expect(parts[1]).toMatchObject({
+      sourceId: WAREHOUSE_ICEBERG_FIELD_IDS.last_updated,
+      transform: 'day',
+      name: 'last_updated_day',
+    });
+  });
+});

--- a/packages/server/src/migrations/s3-tables-warehouse/warehouse-iceberg-metadata.ts
+++ b/packages/server/src/migrations/s3-tables-warehouse/warehouse-iceberg-metadata.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { IcebergMetadata } from '@aws-sdk/client-s3tables';
+
+/**
+ * Stable Iceberg field IDs for the warehouse `_History` layout.
+ * Partition fields reference these IDs; names align with DuckDB `INSERT` from the data warehouse sync.
+ */
+export const WAREHOUSE_ICEBERG_FIELD_IDS = {
+  id: 1,
+  version_id: 2,
+  content: 3,
+  last_updated: 4,
+  project_id: 5,
+} as const;
+
+/**
+ * Iceberg metadata (schema + partition spec) for managed S3 Tables backing Medplum `_History` sync.
+ *
+ * @returns Iceberg metadata accepted by `CreateTableCommand` for format `ICEBERG`.
+ */
+export function buildMedplumWarehouseHistoryIcebergMetadata(): IcebergMetadata {
+  const ids = WAREHOUSE_ICEBERG_FIELD_IDS;
+  return {
+    schema: {
+      fields: [
+        { id: ids.id, name: 'id', type: 'string', required: true },
+        { id: ids.version_id, name: 'version_id', type: 'string', required: true },
+        { id: ids.content, name: 'content', type: 'string', required: false },
+        { id: ids.last_updated, name: 'last_updated', type: 'timestamptz', required: true },
+        { id: ids.project_id, name: 'project_id', type: 'string', required: false },
+      ],
+    },
+    partitionSpec: {
+      specId: 0,
+      fields: [
+        { sourceId: ids.project_id, transform: 'identity', name: 'project_id' },
+        { sourceId: ids.last_updated, transform: 'day', name: 'last_updated_day' },
+      ],
+    },
+  };
+}

--- a/packages/server/src/migrations/s3-tables-warehouse/warehouse-table-names.ts
+++ b/packages/server/src/migrations/s3-tables-warehouse/warehouse-table-names.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { getResourceTypes } from '@medplum/core';
+
+/** Default Iceberg catalog namespace when `dataWarehouse.namespace` is unset (matches warehouse sync). */
+export const DEFAULT_WAREHOUSE_NAMESPACE = 'default';
+
+export interface WarehouseSourceTable {
+  readonly postgresTable: string;
+  readonly icebergTable: string;
+  readonly tableKey: string;
+}
+
+/**
+ * Postgres history table names for all indexed repository resource types (`{ResourceType}_History`).
+ *
+ * @returns Non-empty list of Postgres `_History` table identifiers.
+ */
+export function getWarehouseSyncPostgresTableNames(): string[] {
+  return getResourceTypes().map((resourceType) => `${resourceType}_History`);
+}
+
+export function toIcebergTableName(tableIdentifier: string): string {
+  return tableIdentifier.toLowerCase();
+}
+
+export function resolveWarehouseSourcesFromPostgresTableNames(tableNames: string[]): WarehouseSourceTable[] {
+  const resolved: WarehouseSourceTable[] = [];
+  for (const raw of tableNames) {
+    const postgresTable = raw.trim();
+    if (!postgresTable) {
+      continue;
+    }
+    const icebergTable = toIcebergTableName(postgresTable);
+    resolved.push({ postgresTable, icebergTable, tableKey: icebergTable });
+  }
+
+  if (resolved.length === 0) {
+    throw new Error('At least one Postgres table name is required when using --table');
+  }
+
+  return [...new Map(resolved.map((s) => [s.postgresTable, s])).values()];
+}


### PR DESCRIPTION
Run idempotent S3 Tables namespace and table creation after Postgres
migrations when dataWarehouse is enabled with the s3tables sink, using
a self-contained migrations module and @aws-sdk/client-s3tables.
