### PR TITLE
Website: restructure navbar IA — split Resources, add FAQ to footer

### DIFF
--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -144,20 +144,47 @@ const config: Config = {
       },
       items: [
         {
-          to: '/products',
-          label: 'Products',
+          to: '/platform',
+          label: 'Platform',
           position: 'left',
         },
         {
-          to: '/solutions',
+          // Label clicks through to /solutions; the dropdown surfaces Case
+          // Studies as a related destination without duplicating the overview link.
+          type: 'dropdown',
           label: 'Solutions',
           position: 'left',
+          to: '/solutions',
+          items: [{ label: 'Case Studies', to: '/case-studies' }],
         },
         {
-          type: 'doc',
-          docId: 'home',
+          // Clicking the label defaults to /docs (the primary destination).
+          // The dropdown groups developer-facing resources at one click rather
+          // than elevating Storybook/Knowledge Base to the same level as Docs.
+          type: 'dropdown',
+          label: 'Developers',
           position: 'left',
+          to: '/docs',
+          items: [
+            { type: 'doc', docId: 'home', label: 'Docs' },
+            { label: 'GitHub', to: 'https://github.com/medplum/medplum' },
+            { label: 'Storybook', to: 'https://storybook.medplum.com' },
+            { label: 'Discord', to: 'https://discord.gg/medplum' },
+            { label: 'Knowledge Base', to: 'https://linen.medplum.com' },
+          ],
+        },
+        {
+          // Generic / non-developer resources. Compliance lives here for the
+          // buyer audience; the same /docs/compliance page is also reachable
+          // via Docs for engineers.
+          type: 'dropdown',
           label: 'Resources',
+          position: 'left',
+          items: [
+            { label: 'Blog', to: '/blog' },
+            { label: 'Compliance', to: '/docs/compliance' },
+            { label: 'Open Source', to: '/open-source' },
+          ],
         },
         {
           to: '/pricing',
@@ -184,7 +211,7 @@ const config: Config = {
           title: 'Developers',
           items: [
             {
-              label: 'Getting started',
+              label: 'Quickstart',
               to: '/docs/tutorials',
             },
             {
@@ -207,6 +234,10 @@ const config: Config = {
             {
               label: 'Case Studies',
               to: '/case-studies',
+            },
+            {
+              label: 'FAQ',
+              to: '/faq',
             },
             {
               label: 'Discord',


### PR DESCRIPTION
## Summary

Reorganizes the top navigation per [Maddy's review on #9217](https://github.com/medplum/medplum/pull/9217). Previously a single Resources dropdown held Docs, FAQ, Case Studies, Blog, GitHub, Storybook, Discord, and Knowledge Base — flat list, no audience separation, Storybook and Knowledge Base elevated to the same level as official Docs.

**New navbar:**

| Item | Click goes to | Dropdown items |
|---|---|---|
| **Platform** | \`/platform\` | — |
| **Solutions** | \`/solutions\` | Case Studies |
| **Developers** | **\`/docs\`** | Docs · GitHub · Storybook · Discord · Knowledge Base |
| **Resources** | (dropdown only) | Blog · Compliance · Open Source |
| **Pricing** | \`/pricing\` | — |

**Footer:** FAQ added to the Community column (per Maddy — FAQ isn't polished enough for top-of-site placement yet).

## ⚠ Depends on companion PRs

This PR's navbar links reference \`/platform\`, \`/faq\`, and the new \`/solutions\` content that ship in separate PRs. CI **will fail** standalone with broken-link errors until those land. The companion PRs:

- Platform page — separate PR
- Solutions page — separate PR
- FAQ page — #9222

Once those three merge, this PR will build cleanly and can land.

## What changed in each item

- **Solutions → dropdown**: was a single link. Label click still goes to \`/solutions\`; the dropdown surfaces Case Studies (was buried in the footer).
- **Developers → new dropdown**: replaces the developer-y items from the old Resources. Label click defaults to \`/docs\` so developer docs are still one click from the homepage.
- **Resources → repurposed**: now non-developer content only (Blog, Compliance, Open Source). Trimmed from 8 items to 3.
- **FAQ moved to footer**: no top-nav placement.

## Test plan

After dependencies merge:
- [ ] \`npm run build\` passes
- [ ] Click each navbar item — verify Solutions → /solutions, Developers → /docs, Resources opens dropdown without label-click navigation
- [ ] Hover Solutions → dropdown shows Case Studies
- [ ] Hover Developers → dropdown shows Docs at top, then GitHub/Storybook/Discord/Knowledge Base
- [ ] Footer → FAQ link reaches \`/faq\`
- [ ] Mobile/responsive check on the dropdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)