### PR TITLE
Fix `act()` warnings in provider tests

### DIFF
--- a/examples/medplum-provider/src/components/ChargeItem/ChargeItemList.test.tsx
+++ b/examples/medplum-provider/src/components/ChargeItem/ChargeItemList.test.tsx
@@ -242,9 +242,7 @@ describe('ChargeItemList', () => {
     expect(cptInput).toBeDefined();
 
     // Type in CPT code input
-    await act(async () => {
-      await user.type(cptInput, '99214');
-    });
+    await user.type(cptInput, '99214');
 
     // Wait for valueSetExpand to be called
     await waitFor(
@@ -282,9 +280,7 @@ describe('ChargeItemList', () => {
     expect(definitionInput).toBeDefined();
 
     // Type in definition input
-    await act(async () => {
-      await user.type(definitionInput, 'Test');
-    });
+    await user.type(definitionInput, 'Test');
 
     // Wait for searchResources to be called
     await waitFor(

--- a/examples/medplum-provider/src/components/encounter/BillingTab.test.tsx
+++ b/examples/medplum-provider/src/components/encounter/BillingTab.test.tsx
@@ -535,9 +535,7 @@ describe('BillingTab', () => {
     expect(cptInput).toBeDefined();
 
     // Type in CPT code input
-    await act(async () => {
-      await user.type(cptInput, '99214');
-    });
+    await user.type(cptInput, '99214');
 
     // Wait for valueSetExpand to be called
     await waitFor(
@@ -574,9 +572,7 @@ describe('BillingTab', () => {
     expect(definitionInput).toBeDefined();
 
     // Type in definition input
-    await act(async () => {
-      await user.type(definitionInput, 'Test');
-    });
+    await user.type(definitionInput, 'Test');
 
     // Wait for searchResources to be called
     await waitFor(

--- a/examples/medplum-provider/src/components/encounter/EncounterChart.test.tsx
+++ b/examples/medplum-provider/src/components/encounter/EncounterChart.test.tsx
@@ -75,11 +75,13 @@ describe('EncounterChart', () => {
     );
   };
 
-  test('renders loading spinner initially', () => {
+  test('renders loading spinner initially', async () => {
     setup();
     // The Loading component renders a spinner, not text
     const loader = document.querySelector('.mantine-Loader-root');
     expect(loader).toBeInTheDocument();
+    // Drain pending async state updates so they don't escape the test
+    await act(async () => {});
   });
 
   test('renders encounter header after loading', async () => {

--- a/examples/medplum-provider/src/components/insurance/CoverageRequestInbox.test.tsx
+++ b/examples/medplum-provider/src/components/insurance/CoverageRequestInbox.test.tsx
@@ -261,10 +261,11 @@ describe('CoverageRequestInbox', () => {
 
   describe('Check Eligibility button', () => {
     test('shows error notification when the eligibility bot is not configured', async () => {
+      const user = userEvent.setup();
       medplum.searchOne = vi.fn().mockResolvedValue(undefined) as typeof medplum.searchOne;
       await setup(medplum, { coverageId: COVERAGE_ID });
 
-      screen.getByRole('button', { name: 'Check Eligibility' }).click();
+      await user.click(screen.getByRole('button', { name: 'Check Eligibility' }));
 
       await waitFor(() =>
         expect(screen.getByText(/To enable Insurance Eligibility please contact support/)).toBeInTheDocument()
@@ -272,6 +273,7 @@ describe('CoverageRequestInbox', () => {
     });
 
     test('shows error notification when no PractitionerRole is found for the current user', async () => {
+      const user = userEvent.setup();
       medplum.searchOne = vi.fn().mockImplementation((resourceType: string) => {
         if (resourceType === 'Bot') {
           return Promise.resolve(mockBot);
@@ -280,7 +282,7 @@ describe('CoverageRequestInbox', () => {
       }) as typeof medplum.searchOne;
       await setup(medplum, { coverageId: COVERAGE_ID });
 
-      screen.getByRole('button', { name: 'Check Eligibility' }).click();
+      await user.click(screen.getByRole('button', { name: 'Check Eligibility' }));
 
       await waitFor(() =>
         expect(screen.getByText(/No PractitionerRole found for the assigned practitioner/)).toBeInTheDocument()

--- a/examples/medplum-provider/src/components/schedule/CreateVisit.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateVisit.test.tsx
@@ -259,9 +259,7 @@ describe('CreateVisit', () => {
       });
 
       const classInput = await screen.findByLabelText(/Class/i);
-      await act(async () => {
-        await user.click(classInput);
-      });
+      await user.click(classInput);
 
       expect(classInput).toBeInTheDocument();
     });

--- a/examples/medplum-provider/src/pages/encounter/EncounterModal.test.tsx
+++ b/examples/medplum-provider/src/pages/encounter/EncounterModal.test.tsx
@@ -100,11 +100,13 @@ describe('EncounterModal', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
-  test('Displays care template section', () => {
+  test('Displays care template section', async () => {
     setup();
 
     expect(screen.getByText('Apply care template')).toBeInTheDocument();
     expect(screen.getByText(/You can select template for new encounter/i)).toBeInTheDocument();
+    // Drain pending async state updates (e.g. ResourceInput default value resolution)
+    await act(async () => {});
   });
 
   test('Form fields can be populated with values', async () => {

--- a/examples/medplum-provider/src/pages/encounter/EncounterModal.test.tsx
+++ b/examples/medplum-provider/src/pages/encounter/EncounterModal.test.tsx
@@ -83,9 +83,7 @@ describe('EncounterModal', () => {
     });
 
     const createButton = screen.getByRole('button', { name: /Create Encounter/i });
-    await act(async () => {
-      await user.click(createButton);
-    });
+    await user.click(createButton);
 
     await waitFor(() => {
       expect(screen.getByText('Please fill out required fields.')).toBeInTheDocument();
@@ -171,9 +169,7 @@ describe('EncounterModal', () => {
 
     // The error notification will show when trying to create without filling required fields
     const createButton = screen.getByRole('button', { name: /Create Encounter/i });
-    await act(async () => {
-      await user.click(createButton);
-    });
+    await user.click(createButton);
 
     // Should show validation error - use getAllByText since there may be multiple
     await waitFor(() => {
@@ -274,9 +270,7 @@ describe('EncounterModal', () => {
 
     // Should show validation error when trying to create without patient
     const createButton = screen.getByRole('button', { name: /Create Encounter/i });
-    await act(async () => {
-      await user.click(createButton);
-    });
+    await user.click(createButton);
 
     // Use getAllByText since there may be multiple validation messages
     await waitFor(() => {

--- a/examples/medplum-provider/src/pages/labs/OrderLabsPage.test.tsx
+++ b/examples/medplum-provider/src/pages/labs/OrderLabsPage.test.tsx
@@ -125,7 +125,7 @@ describe('OrderLabsPage', () => {
     );
   }
 
-  test('Renders form fields', () => {
+  test('Renders form fields', async () => {
     setup();
 
     expect(screen.getByText('Requester')).toBeInTheDocument();
@@ -136,6 +136,8 @@ describe('OrderLabsPage', () => {
     expect(screen.getByText('Order notes')).toBeInTheDocument();
     expect(screen.getByText('Specimen collection time')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Submit Order' })).toBeInTheDocument();
+    // Drain pending async state updates (e.g. ResourceInput defaultValue resolution)
+    await act(async () => {});
   });
 
   test('Loads patient when patientId is provided', async () => {
@@ -156,7 +158,7 @@ describe('OrderLabsPage', () => {
     expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
   });
 
-  test('Shows test metadata cards when tests are selected', () => {
+  test('Shows test metadata cards when tests are selected', async () => {
     const mockTest: TestCoding = {
       code: 'TEST001',
       display: 'Complete Blood Count',
@@ -173,6 +175,8 @@ describe('OrderLabsPage', () => {
 
     // Test metadata cards should be rendered (component will render them)
     expect(screen.getByText('Selected tests')).toBeInTheDocument();
+    // Drain pending async state updates (e.g. ResourceInput defaultValue resolution)
+    await act(async () => {});
   });
 
   test('Shows coverage input when patient is set', async () => {
@@ -357,10 +361,12 @@ describe('OrderLabsPage', () => {
     );
   });
 
-  test('Renders specimen collection date time input', () => {
+  test('Renders specimen collection date time input', async () => {
     setup();
 
     expect(screen.getByText('Specimen collection time')).toBeInTheDocument();
     expect(screen.getByText('Specimen collection time')).toBeInTheDocument();
+    // Drain pending async state updates (e.g. ResourceInput defaultValue resolution)
+    await act(async () => {});
   });
 });


### PR DESCRIPTION
These emit a bunch of noise into the test output. Let's clean it up.

Co-Authored-By: Claude Sonnet 4.6