### PR TITLE
feat(auth): support POST-style userinfo for non-OIDC IdPs (GCIP/Firebase)

### DIFF
--- a/packages/definitions/src/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/src/fhir/r4/profiles-medplum.json
@@ -5369,6 +5369,54 @@
               "min" : 0,
               "max" : "1"
             }
+          },
+          {
+            "id" : "IdentityProvider.userInfoTokenField",
+            "path" : "IdentityProvider.userInfoTokenField",
+            "short" : "Optional field name for token in POST-style userinfo requests.",
+            "definition" : "When set, the userinfo request will use POST with a JSON body instead of GET with a Bearer header. The token will be placed in the body under this field name (e.g. 'idToken' for Google Cloud Identity Platform / Firebase).",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "string"
+            }],
+            "base" : {
+              "path" : "IdentityProvider.userInfoTokenField",
+              "min" : 0,
+              "max" : "1"
+            }
+          },
+          {
+            "id" : "IdentityProvider.userInfoApiKey",
+            "path" : "IdentityProvider.userInfoApiKey",
+            "short" : "Optional API key appended as ?key= to the userinfo URL.",
+            "definition" : "When set, appended as a 'key' query parameter to the userinfo URL. Required by some identity providers such as Google Cloud Identity Platform / Firebase.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "string"
+            }],
+            "base" : {
+              "path" : "IdentityProvider.userInfoApiKey",
+              "min" : 0,
+              "max" : "1"
+            }
+          },
+          {
+            "id" : "IdentityProvider.userInfoResponsePath",
+            "path" : "IdentityProvider.userInfoResponsePath",
+            "short" : "Optional dot-separated path to unwrap claims from the userinfo response.",
+            "definition" : "Dot-separated path used to extract the claims object from a nested userinfo response body (e.g. 'users.0' for Google Cloud Identity Platform / Firebase, whose response shape is { users: [{ email, localId, ... }] }).",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "string"
+            }],
+            "base" : {
+              "path" : "IdentityProvider.userInfoResponsePath",
+              "min" : 0,
+              "max" : "1"
+            }
           }
         ]
       }

--- a/packages/fhirtypes/dist/IdentityProvider.d.ts
+++ b/packages/fhirtypes/dist/IdentityProvider.d.ts
@@ -51,4 +51,24 @@ export interface IdentityProvider {
    * Optional flag to use the subject field instead of the email field.
    */
   useSubject?: boolean;
+
+  /**
+   * When set, the userinfo request will use POST with a JSON body instead of GET with a Bearer
+   * header. The token will be placed in the body under this field name (e.g. 'idToken' for
+   * Google Cloud Identity Platform / Firebase).
+   */
+  userInfoTokenField?: string;
+
+  /**
+   * When set, appended as a 'key' query parameter to the userinfo URL. Required by some identity
+   * providers such as Google Cloud Identity Platform / Firebase.
+   */
+  userInfoApiKey?: string;
+
+  /**
+   * Dot-separated path used to extract the claims object from a nested userinfo response body
+   * (e.g. 'users.0' for Google Cloud Identity Platform / Firebase, whose response shape is
+   * { users: [{ email, localId, ... }] }).
+   */
+  userInfoResponsePath?: string;
 }

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -83,6 +83,7 @@ describe('OAuth2 Token', () => {
   let pkceOptionalClient: ClientApplication;
   let externalAuthClient: ClientApplication;
   let invalidAuthClient: ClientApplication;
+  let gcipAuthClient: ClientApplication;
   let systemRepo: SystemRepository;
 
   beforeAll(async () => {
@@ -144,6 +145,23 @@ describe('OAuth2 Token', () => {
         userInfoUrl: 'https://example.com/oauth2/userinfo',
         clientId: '123',
         clientSecret: '456',
+      },
+    });
+
+    // Create a GCIP external auth client (POST-style userinfo)
+    gcipAuthClient = await createClient(systemRepo, {
+      project,
+      name: 'GCIP Auth Client',
+      redirectUri,
+      identityProvider: {
+        authorizeUrl: 'https://example.com/oauth2/authorize',
+        tokenUrl: 'https://example.com/oauth2/token',
+        userInfoUrl: 'https://identitytoolkit.googleapis.com/v1/accounts:lookup',
+        clientId: 'gcip-client-id',
+        clientSecret: 'gcip-client-secret',
+        userInfoTokenField: 'idToken',
+        userInfoApiKey: 'fake-api-key',
+        userInfoResponsePath: 'users.0',
       },
     });
 
@@ -2012,6 +2030,81 @@ describe('OAuth2 Token', () => {
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid user info URL - check your identity provider configuration');
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test('Token exchange GCIP POST-style userinfo success', async () => {
+    (fetch as unknown as jest.Mock).mockImplementation((url: string, options: RequestInit) => {
+      expect(url).toContain('key=fake-api-key');
+      expect(options.method).toBe('POST');
+      expect(JSON.parse(options.body as string)).toMatchObject({ idToken: 'gcip-id-token' });
+      return {
+        status: 200,
+        json: () => ({ users: [{ email, localId: 'firebase-uid-123' }] }),
+        headers: { get: () => ContentType.JSON },
+      };
+    });
+
+    const res = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: OAuthGrantType.TokenExchange,
+      subject_token_type: OAuthTokenType.AccessToken,
+      client_id: gcipAuthClient.id,
+      subject_token: 'gcip-id-token',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.access_token).toBeTruthy();
+  });
+
+  test('Token exchange GCIP POST-style userinfo failure', async () => {
+    (fetch as unknown as jest.Mock).mockImplementation(() => ({
+      status: 400,
+      headers: { get: () => ContentType.JSON },
+    }));
+
+    const res = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: OAuthGrantType.TokenExchange,
+      subject_token_type: OAuthTokenType.AccessToken,
+      client_id: gcipAuthClient.id,
+      subject_token: 'invalid-token',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_request');
+  });
+
+  test('Token exchange userInfoApiKey appended to URL', async () => {
+    let capturedUrl = '';
+    (fetch as unknown as jest.Mock).mockImplementation((url: string) => {
+      capturedUrl = url;
+      return {
+        status: 200,
+        json: () => ({ users: [{ email, localId: 'firebase-uid-123' }] }),
+        headers: { get: () => ContentType.JSON },
+      };
+    });
+
+    await request(app).post('/oauth2/token').type('form').send({
+      grant_type: OAuthGrantType.TokenExchange,
+      subject_token_type: OAuthTokenType.AccessToken,
+      client_id: gcipAuthClient.id,
+      subject_token: 'gcip-id-token',
+    });
+    expect(capturedUrl).toContain('key=fake-api-key');
+  });
+
+  test('Token exchange userInfoResponsePath unwraps nested claims', async () => {
+    (fetch as unknown as jest.Mock).mockImplementation(() => ({
+      status: 200,
+      json: () => ({ users: [{ email, localId: 'firebase-uid-456' }] }),
+      headers: { get: () => ContentType.JSON },
+    }));
+
+    const res = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: OAuthGrantType.TokenExchange,
+      subject_token_type: OAuthTokenType.AccessToken,
+      client_id: gcipAuthClient.id,
+      subject_token: 'gcip-id-token',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.access_token).toBeTruthy();
   });
 
   test('FHIRcast scopes added to client credentials flow', async () => {

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -845,15 +845,32 @@ export async function getExternalUserInfo(
     throw new OperationOutcomeError(badRequest('Invalid user info URL - check your identity provider configuration'));
   }
 
+  if (idp?.userInfoApiKey) {
+    const url = new URL(userInfoUrl);
+    url.searchParams.set('key', idp.userInfoApiKey);
+    userInfoUrl = url.toString();
+  }
+
   let response;
   try {
-    response = await fetch(userInfoUrl, {
-      method: 'GET',
-      headers: {
-        Accept: ContentType.JSON,
-        Authorization: `Bearer ${externalAccessToken}`,
-      },
-    });
+    if (idp?.userInfoTokenField) {
+      response = await fetch(userInfoUrl, {
+        method: 'POST',
+        headers: {
+          Accept: ContentType.JSON,
+          'Content-Type': ContentType.JSON,
+        },
+        body: JSON.stringify({ [idp.userInfoTokenField]: externalAccessToken }),
+      });
+    } else {
+      response = await fetch(userInfoUrl, {
+        method: 'GET',
+        headers: {
+          Accept: ContentType.JSON,
+          Authorization: `Bearer ${externalAccessToken}`,
+        },
+      });
+    }
   } catch (err: any) {
     log.warn('Error while verifying external auth code', err);
     throw new OperationOutcomeError(badRequest('Failed to verify code - check your identity provider configuration'));
@@ -870,18 +887,27 @@ export async function getExternalUserInfo(
   }
 
   const contentType = response.headers.get('content-type');
+  let claims: Record<string, unknown>;
   try {
     if (contentType?.includes(ContentType.JSON)) {
-      return await response.json();
+      claims = await response.json();
     } else if (contentType?.includes(ContentType.JWT)) {
-      return parseJWTPayload(await response.text());
+      claims = parseJWTPayload(await response.text());
+    } else {
+      throw new OperationOutcomeError(badRequest(`Failed to verify code - unsupported content type: ${contentType}`));
     }
   } catch (err: any) {
     log.warn('Failed to verify external authorization code', err);
     throw new OperationOutcomeError(badRequest('Failed to verify code - check your identity provider configuration'));
   }
 
-  throw new OperationOutcomeError(badRequest(`Failed to verify code - unsupported content type: ${contentType}`));
+  if (idp?.userInfoResponsePath) {
+    for (const key of idp.userInfoResponsePath.split('.')) {
+      claims = claims[key] as Record<string, unknown>;
+    }
+  }
+
+  return claims;
 }
 
 interface ValidationAssertion {


### PR DESCRIPTION
## Summary

Medplum's token exchange flow (RFC 8693) hard-codes a `GET + Authorization: Bearer` contract when calling an external IdP's userinfo endpoint. This is incompatible with **Google Cloud Identity Platform (GCIP) / Firebase email-password authentication**, which requires:

```
POST https://identitytoolkit.googleapis.com/v1/accounts:lookup?key=<API_KEY>
Content-Type: application/json

{ "idToken": "<firebase-idToken>" }
```

This pattern also differs in response shape — GCIP returns `{ users: [{ email, localId, ... }] }` rather than a flat claims object.

### Changes

Adds three optional fields to `IdentityProvider`:

| Field | Type | Purpose |
|---|---|---|
| `userInfoTokenField` | `string` | Switches to `POST` and places the token in the JSON body under this key (e.g. `"idToken"`) |
| `userInfoApiKey` | `string` | Appended as `?key=<value>` query param on the userinfo URL |
| `userInfoResponsePath` | `string` | Dot-separated path to unwrap nested claims (e.g. `"users.0"`) |

All fields are optional. The existing `GET + Bearer` behavior is **unchanged** when they are absent — no impact on current Auth0, Okta, or standard OIDC configurations.

### GCIP configuration example

```json
{
  "userInfoUrl": "https://identitytoolkit.googleapis.com/v1/accounts:lookup",
  "userInfoTokenField": "idToken",
  "userInfoApiKey": "YOUR_FIREBASE_API_KEY",
  "userInfoResponsePath": "users.0"
}
```

> **Note on `userInfoApiKey` security:** Firebase API keys are public identifiers by design — they are embedded in every Firebase client app's JavaScript bundle. The security of the `accounts:lookup` call comes from the validity of the `idToken` (a short-lived JWT signed by Google), not the API key.

### Files changed

- `packages/definitions/src/fhir/r4/profiles-medplum.json` — 3 new element definitions on `IdentityProvider` StructureDefinition
- `packages/fhirtypes/dist/IdentityProvider.d.ts` — generated types updated to match
- `packages/server/src/oauth/utils.ts` — `getExternalUserInfo` branched to support POST-style verification and response unwrapping
- `packages/server/src/oauth/token.test.ts` — 4 new test cases covering GCIP POST flow, API key appending, response path unwrapping, and failure handling

## Test plan

- [ ] Existing token exchange tests (`Token exchange JSON success`, `Token exchange JWT success`, etc.) pass without modification
- [ ] New test `Token exchange GCIP POST-style userinfo success` — verifies POST is used, token goes in body, API key in URL, `users.0` path unwrapped
- [ ] New test `Token exchange GCIP POST-style userinfo failure` — verifies 400 propagated correctly
- [ ] New test `Token exchange userInfoApiKey appended to URL` — verifies `?key=` present in captured URL
- [ ] New test `Token exchange userInfoResponsePath unwraps nested claims` — verifies email resolved from nested response

🤖 Generated with [Claude Code](https://claude.com/claude-code)