### PR TITLE
Fixes #9183 - offline_access when refresh_token in grant_types

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -503,7 +503,7 @@ export interface BaseLoginRequest {
 export interface EmailPasswordLoginRequest extends BaseLoginRequest {
   readonly email: string;
   readonly password: string;
-  /** @deprecated Use scope of "offline" or "offline_access" instead. */
+  /** @deprecated Use "offline_access" scope instead. */
   readonly remember?: boolean;
 }
 

--- a/packages/definitions/src/fhir/r4/fhir.schema.json
+++ b/packages/definitions/src/fhir/r4/fhir.schema.json
@@ -61936,6 +61936,20 @@
           },
           "type": "array"
         },
+        "grantType": {
+          "description": "Optional OAuth grant type for the client application. This specifies the allowed grant types for the client application.",
+          "items": {
+            "$ref": "#/definitions/string"
+          },
+          "type": "array"
+        },
+        "responseType": {
+          "description": "Optional OAuth response type for the client application. This specifies the allowed response types for the client application.",
+          "items": {
+            "$ref": "#/definitions/string"
+          },
+          "type": "array"
+        },
         "defaultScope": {
           "description": "Optional default OAuth scope for the client application. This scope is used when the client application does not specify a scope in the authorization request.",
           "items": {

--- a/packages/definitions/src/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/src/fhir/r4/profiles-medplum.json
@@ -1050,6 +1050,36 @@
             }
           },
           {
+            "id" : "ClientApplication.grantType",
+            "path" : "ClientApplication.grantType",
+            "definition" : "Optional OAuth grant type for the client application. This specifies the allowed grant types for the client application.",
+            "min" : 0,
+            "max" : "*",
+            "type" : [{
+              "code" : "string"
+            }],
+            "base": {
+              "path" : "ClientApplication.grantType",
+              "min" : 0,
+              "max" : "*"
+            }
+          },
+          {
+            "id" : "ClientApplication.responseType",
+            "path" : "ClientApplication.responseType",
+            "definition" : "Optional OAuth response type for the client application. This specifies the allowed response types for the client application.",
+            "min" : 0,
+            "max" : "*",
+            "type" : [{
+              "code" : "string"
+            }],
+            "base": {
+              "path" : "ClientApplication.responseType",
+              "min" : 0,
+              "max" : "*"
+            }
+          },
+          {
             "id" : "ClientApplication.defaultScope",
             "path" : "ClientApplication.defaultScope",
             "definition" : "Optional default OAuth scope for the client application. This scope is used when the client application does not specify a scope in the authorization request.",

--- a/packages/fhirtypes/dist/ClientApplication.d.ts
+++ b/packages/fhirtypes/dist/ClientApplication.d.ts
@@ -182,6 +182,18 @@ export interface ClientApplication {
   allowedOrigin?: string[];
 
   /**
+   * Optional OAuth grant type for the client application. This specifies
+   * the allowed grant types for the client application.
+   */
+  grantType?: string[];
+
+  /**
+   * Optional OAuth response type for the client application. This
+   * specifies the allowed response types for the client application.
+   */
+  responseType?: string[];
+
+  /**
    * Optional default OAuth scope for the client application. This scope is
    * used when the client application does not specify a scope in the
    * authorization request.

--- a/packages/server/src/admin/client.ts
+++ b/packages/server/src/admin/client.ts
@@ -2,14 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
 import { createReference, singularize } from '@medplum/core';
-import type {
-  AccessPolicy,
-  ClientApplication,
-  IdentityProvider,
-  Project,
-  ProjectMembership,
-  Reference,
-} from '@medplum/fhirtypes';
+import type { AccessPolicy, ClientApplication, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import { body } from 'express-validator';
 import { getAuthenticatedContext } from '../context';
@@ -38,47 +31,34 @@ export async function createClientHandler(req: Request, res: Response): Promise<
   res.status(201).json(client);
 }
 
-export interface CreateClientRequest {
+export interface CreateClientRequest extends Partial<ClientApplication> {
   readonly project: Project;
-  readonly name: string;
-  readonly description?: string;
-  readonly redirectUris?: string[];
   readonly accessPolicy?: Reference<AccessPolicy>;
-  readonly identityProvider?: IdentityProvider;
-  readonly accessTokenLifetime?: string;
-  readonly refreshTokenLifetime?: string;
-
-  /** @deprecated Use redirectUris instead */
-  readonly redirectUri?: string;
 }
 
 export async function createClient(repo: Repository, request: CreateClientRequest): Promise<WithId<ClientApplication>> {
+  const { project, accessPolicy, ...rest } = request;
+
   const systemRepo = repo.getSystemRepo();
   const client = await systemRepo.createResource<ClientApplication>({
     meta: {
-      project: request.project.id,
+      project: project.id,
       author: repo.getConfig().author,
     },
     resourceType: 'ClientApplication',
-    name: request.name,
     secret: generateSecret(32),
-    description: request.description,
-    redirectUri: request.redirectUri,
-    redirectUris: request.redirectUris,
-    identityProvider: request.identityProvider,
-    accessTokenLifetime: request.accessTokenLifetime,
-    refreshTokenLifetime: request.refreshTokenLifetime,
+    ...rest,
   });
 
   await systemRepo.createResource<ProjectMembership>({
     meta: {
-      project: request.project.id,
+      project: project.id,
     },
     resourceType: 'ProjectMembership',
-    project: createReference(request.project),
+    project: createReference(project),
     user: createReference(client),
     profile: createReference(client),
-    accessPolicy: request.accessPolicy,
+    accessPolicy: accessPolicy,
   });
 
   return client;

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -22,6 +22,7 @@ import { getClientRedirectUri } from '../oauth/clients';
 import type { CodeChallengeMethod } from '../oauth/utils';
 import { getClientApplication, tryLogin } from '../oauth/utils';
 import { getDomainConfiguration } from './method';
+import { getScopeString } from './utils';
 
 /*
  * External authentication callback
@@ -111,7 +112,7 @@ export async function externalCallbackHandler(req: Request, res: Response): Prom
     externalId,
     projectId,
     clientId: body.clientId,
-    scope: body.scope ?? 'openid offline',
+    scope: getScopeString(body.scope, client),
     nonce: body.nonce ?? randomUUID(),
     launchId: body.launch,
     codeChallenge: body.codeChallenge,

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -22,7 +22,6 @@ import { getClientRedirectUri } from '../oauth/clients';
 import type { CodeChallengeMethod } from '../oauth/utils';
 import { getClientApplication, tryLogin } from '../oauth/utils';
 import { getDomainConfiguration } from './method';
-import { getScopeString } from './utils';
 
 /*
  * External authentication callback
@@ -112,7 +111,7 @@ export async function externalCallbackHandler(req: Request, res: Response): Prom
     externalId,
     projectId,
     clientId: body.clientId,
-    scope: getScopeString(body.scope, client),
+    scope: body.scope ?? 'openid offline_access',
     nonce: body.nonce ?? randomUUID(),
     launchId: body.launch,
     codeChallenge: body.codeChallenge,

--- a/packages/server/src/auth/google.ts
+++ b/packages/server/src/auth/google.ts
@@ -15,7 +15,7 @@ import type { GoogleCredentialClaims } from '../oauth/utils';
 import { getUserByEmail, tryLogin } from '../oauth/utils';
 import { makeValidationMiddleware } from '../util/validator';
 import { isExternalAuth } from './method';
-import { getProjectIdByClientId, getScopeString, sendLoginResult } from './utils';
+import { getProjectIdByClientId, sendLoginResult } from './utils';
 
 /*
  * Integrating Google Sign-In into your web app
@@ -127,7 +127,7 @@ export async function googleHandler(req: Request, res: Response): Promise<void> 
     projectId,
     clientId,
     resourceType,
-    scope: getScopeString(req.body.scope),
+    scope: req.body.scope ?? 'openid offline_access',
     nonce: req.body.nonce || randomUUID(),
     launchId: req.body.launch,
     codeChallenge: req.body.codeChallenge,

--- a/packages/server/src/auth/google.ts
+++ b/packages/server/src/auth/google.ts
@@ -15,7 +15,7 @@ import type { GoogleCredentialClaims } from '../oauth/utils';
 import { getUserByEmail, tryLogin } from '../oauth/utils';
 import { makeValidationMiddleware } from '../util/validator';
 import { isExternalAuth } from './method';
-import { getProjectIdByClientId, sendLoginResult } from './utils';
+import { getProjectIdByClientId, getScopeString, sendLoginResult } from './utils';
 
 /*
  * Integrating Google Sign-In into your web app
@@ -127,7 +127,7 @@ export async function googleHandler(req: Request, res: Response): Promise<void> 
     projectId,
     clientId,
     resourceType,
-    scope: req.body.scope || 'openid offline',
+    scope: getScopeString(req.body.scope),
     nonce: req.body.nonce || randomUUID(),
     launchId: req.body.launch,
     codeChallenge: req.body.codeChallenge,

--- a/packages/server/src/auth/login.test.ts
+++ b/packages/server/src/auth/login.test.ts
@@ -290,7 +290,7 @@ describe('Login', () => {
     const res8 = await request(app).post('/auth/login').type('json').send({
       email: memberEmail,
       password: 'my-new-password',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
@@ -305,7 +305,7 @@ describe('Login', () => {
     });
     expect(res9.status).toBe(200);
     expect(res9.body.token_type).toBe('Bearer');
-    expect(res9.body.scope).toBe('openid offline');
+    expect(res9.body.scope).toBe('openid offline_access');
     expect(res9.body.expires_in).toBe(3600);
     expect(res9.body.id_token).toBeDefined();
     expect(res9.body.access_token).toBeDefined();
@@ -376,7 +376,7 @@ describe('Login', () => {
     const res8 = await request(app).post('/auth/login').type('json').send({
       email,
       password,
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
     expect(res8.status).toBe(400);
     expect(res8.body).toMatchObject({
@@ -419,7 +419,7 @@ describe('Login', () => {
     const res1 = await request(app).post('/auth/login').type('json').send({
       email,
       password,
-      scope: 'openid offline',
+      scope: 'openid offline_access',
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
@@ -433,7 +433,7 @@ describe('Login', () => {
       resourceType: 'Practitioner',
       email,
       password,
-      scope: 'openid offline',
+      scope: 'openid offline_access',
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
@@ -446,7 +446,7 @@ describe('Login', () => {
       resourceType: 'Patient',
       email,
       password,
-      scope: 'openid offline',
+      scope: 'openid offline_access',
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
@@ -475,7 +475,7 @@ describe('Login', () => {
     const res1 = await request(app).post('/auth/login').type('json').send({
       email,
       password,
-      scope: 'openid offline',
+      scope: 'openid offline_access',
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
@@ -487,7 +487,7 @@ describe('Login', () => {
     const res2 = await request(app).post('/auth/login').type('json').send({
       email: email.toLowerCase(),
       password,
-      scope: 'openid offline',
+      scope: 'openid offline_access',
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
@@ -534,7 +534,7 @@ describe('Login', () => {
     const res = await request(app).post('/auth/login').type('json').send({
       email,
       password,
-      scope: 'openid offline',
+      scope: 'openid offline_access',
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
       projectId: project.id,

--- a/packages/server/src/auth/register.ts
+++ b/packages/server/src/auth/register.ts
@@ -7,7 +7,7 @@ import { randomUUID } from 'node:crypto';
 import { createProject } from '../fhir/operations/projectinit';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { getAuthTokens, getUserByEmailWithoutProject, tryLogin } from '../oauth/utils';
-import { bcryptHashPassword } from './utils';
+import { bcryptHashPassword, getScopeString } from './utils';
 
 /*
  * This is a utility method for creating a Project, Profile, and ProjectMembership.
@@ -61,7 +61,7 @@ export async function registerNew(request: RegisterRequest): Promise<RegisterRes
 
   const login = await tryLogin({
     authMethod: 'password',
-    scope: request.scope ?? 'openid offline',
+    scope: getScopeString(request.scope),
     nonce: randomUUID(),
     email: email,
     password: password,

--- a/packages/server/src/auth/register.ts
+++ b/packages/server/src/auth/register.ts
@@ -7,7 +7,7 @@ import { randomUUID } from 'node:crypto';
 import { createProject } from '../fhir/operations/projectinit';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { getAuthTokens, getUserByEmailWithoutProject, tryLogin } from '../oauth/utils';
-import { bcryptHashPassword, getScopeString } from './utils';
+import { bcryptHashPassword } from './utils';
 
 /*
  * This is a utility method for creating a Project, Profile, and ProjectMembership.
@@ -61,7 +61,7 @@ export async function registerNew(request: RegisterRequest): Promise<RegisterRes
 
   const login = await tryLogin({
     authMethod: 'password',
-    scope: getScopeString(request.scope),
+    scope: request.scope ?? 'openid offline_access',
     nonce: randomUUID(),
     email: email,
     password: password,

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -3,7 +3,6 @@
 import type { ProfileResource, WithId } from '@medplum/core';
 import { badRequest, createReference, OperationOutcomeError, Operator, resolveId } from '@medplum/core';
 import type {
-  ClientApplication,
   ContactPoint,
   Login,
   OperationOutcome,
@@ -278,16 +277,4 @@ export function validateRecaptcha(projectValidation?: (p: Project) => OperationO
     }
     next();
   };
-}
-
-export function getScopeString(requestedScope: string | undefined, client?: ClientApplication): string {
-  if (requestedScope) {
-    return requestedScope;
-  }
-
-  if (client?.defaultScope) {
-    return client.defaultScope.join(' ');
-  }
-
-  return 'openid offline_access';
 }

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -3,6 +3,7 @@
 import type { ProfileResource, WithId } from '@medplum/core';
 import { badRequest, createReference, OperationOutcomeError, Operator, resolveId } from '@medplum/core';
 import type {
+  ClientApplication,
   ContactPoint,
   Login,
   OperationOutcome,
@@ -277,4 +278,16 @@ export function validateRecaptcha(projectValidation?: (p: Project) => OperationO
     }
     next();
   };
+}
+
+export function getScopeString(requestedScope: string | undefined, client?: ClientApplication): string {
+  if (requestedScope) {
+    return requestedScope;
+  }
+
+  if (client?.defaultScope) {
+    return client.defaultScope.join(' ');
+  }
+
+  return 'openid offline_access';
 }

--- a/packages/server/src/fhir/fhirquota.test.ts
+++ b/packages/server/src/fhir/fhirquota.test.ts
@@ -184,7 +184,7 @@ describe('FHIR Rate Limits', () => {
     const loginRes = await request(app).post('/auth/login').type('json').send({
       email,
       password,
-      scope: 'openid offline',
+      scope: 'openid offline_access',
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });

--- a/packages/server/src/oauth/README.md
+++ b/packages/server/src/oauth/README.md
@@ -195,7 +195,7 @@ Be sure to logout between each test by visiting <http://host.docker.internal:810
 
 In "EHR Launch Sequence":
 
-Make sure "Scopes" includes "fhirUser launch launch/patient offline*access openid profile user/*._ patient/_.\_"
+Make sure "Scopes" includes "fhirUser launch launch/patient offline_access openid profile user/*._ patient/_.\_"
 
 Launch URL's:
 

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -705,13 +705,13 @@ describe('OAuth2 Token', () => {
     expect(res2.body.refresh_token).toBeDefined();
   });
 
-  test('Authorization code token success with refresh using scope=offline', async () => {
+  test('Authorization code token success with refresh using scope=offline_access', async () => {
     const res = await request(app).post('/auth/login').type('json').send({
       email,
       password,
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
     expect(res.status).toBe(200);
 
@@ -722,7 +722,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res2.status).toBe(200);
     expect(res2.body.token_type).toBe('Bearer');
-    expect(res2.body.scope).toBe('openid offline');
+    expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
     expect(res2.body.id_token).toBeDefined();
     expect(res2.body.access_token).toBeDefined();
@@ -854,7 +854,7 @@ describe('OAuth2 Token', () => {
       password,
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
     expect(res.status).toBe(200);
 
@@ -865,7 +865,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res2.status).toBe(200);
     expect(res2.body.token_type).toBe('Bearer');
-    expect(res2.body.scope).toBe('openid offline');
+    expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
     expect(res2.body.id_token).toBeDefined();
     expect(res2.body.access_token).toBeDefined();
@@ -877,7 +877,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res3.status).toBe(200);
     expect(res3.body.token_type).toBe('Bearer');
-    expect(res3.body.scope).toBe('openid offline');
+    expect(res3.body.scope).toBe('openid offline_access');
     expect(res3.body.expires_in).toBe(3600);
     expect(res3.body.id_token).toBeDefined();
     expect(res3.body.access_token).toBeDefined();
@@ -923,7 +923,7 @@ describe('OAuth2 Token', () => {
       password,
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
     expect(res.status).toBe(200);
 
@@ -934,7 +934,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res2.status).toBe(200);
     expect(res2.body.token_type).toBe('Bearer');
-    expect(res2.body.scope).toBe('openid offline');
+    expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
     expect(res2.body.id_token).toBeDefined();
     expect(res2.body.access_token).toBeDefined();
@@ -966,7 +966,7 @@ describe('OAuth2 Token', () => {
       clientId: client.id,
       codeChallenge: codeHash,
       codeChallengeMethod: 'S256',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
     expect(res.status).toBe(200);
 
@@ -988,7 +988,7 @@ describe('OAuth2 Token', () => {
       clientId: client.id,
       codeChallenge: codeHash,
       codeChallengeMethod: 'S256',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
     expect(res.status).toBe(200);
 
@@ -999,7 +999,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res2.status).toBe(200);
     expect(res2.body.token_type).toBe('Bearer');
-    expect(res2.body.scope).toBe('openid offline');
+    expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
     expect(res2.body.id_token).toBeDefined();
     expect(res2.body.access_token).toBeDefined();
@@ -1011,7 +1011,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res3.status).toBe(200);
     expect(res3.body.token_type).toBe('Bearer');
-    expect(res3.body.scope).toBe('openid offline');
+    expect(res3.body.scope).toBe('openid offline_access');
     expect(res3.body.expires_in).toBe(3600);
     expect(res3.body.id_token).toBeDefined();
     expect(res3.body.access_token).toBeDefined();
@@ -1024,7 +1024,7 @@ describe('OAuth2 Token', () => {
       password,
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
     expect(res.status).toBe(200);
 
@@ -1035,7 +1035,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res2.status).toBe(200);
     expect(res2.body.token_type).toBe('Bearer');
-    expect(res2.body.scope).toBe('openid offline');
+    expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
     expect(res2.body.id_token).toBeDefined();
     expect(res2.body.access_token).toBeDefined();
@@ -1070,7 +1070,7 @@ describe('OAuth2 Token', () => {
       clientId: client.id,
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
     expect(res.status).toBe(200);
 
@@ -1081,7 +1081,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res2.status).toBe(200);
     expect(res2.body.token_type).toBe('Bearer');
-    expect(res2.body.scope).toBe('openid offline');
+    expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
     expect(res2.body.id_token).toBeDefined();
     expect(res2.body.access_token).toBeDefined();
@@ -1097,7 +1097,7 @@ describe('OAuth2 Token', () => {
       });
     expect(res3.status).toBe(200);
     expect(res3.body.token_type).toBe('Bearer');
-    expect(res3.body.scope).toBe('openid offline');
+    expect(res3.body.scope).toBe('openid offline_access');
     expect(res3.body.expires_in).toBe(3600);
     expect(res3.body.id_token).toBeDefined();
     expect(res3.body.access_token).toBeDefined();
@@ -1111,7 +1111,7 @@ describe('OAuth2 Token', () => {
       clientId: client.id,
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
     expect(res.status).toBe(200);
 
@@ -1122,7 +1122,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res2.status).toBe(200);
     expect(res2.body.token_type).toBe('Bearer');
-    expect(res2.body.scope).toBe('openid offline');
+    expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
     expect(res2.body.id_token).toBeDefined();
     expect(res2.body.access_token).toBeDefined();
@@ -1148,7 +1148,7 @@ describe('OAuth2 Token', () => {
       clientId: client.id,
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
     expect(res.status).toBe(200);
 
@@ -1159,7 +1159,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res2.status).toBe(200);
     expect(res2.body.token_type).toBe('Bearer');
-    expect(res2.body.scope).toBe('openid offline');
+    expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
     expect(res2.body.id_token).toBeDefined();
     expect(res2.body.access_token).toBeDefined();
@@ -1185,7 +1185,7 @@ describe('OAuth2 Token', () => {
       clientId: client.id,
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
     expect(res.status).toBe(200);
 
@@ -1196,7 +1196,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res2.status).toBe(200);
     expect(res2.body.token_type).toBe('Bearer');
-    expect(res2.body.scope).toBe('openid offline');
+    expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
     expect(res2.body.id_token).toBeDefined();
     expect(res2.body.access_token).toBeDefined();
@@ -1229,7 +1229,7 @@ describe('OAuth2 Token', () => {
       clientId: client.id,
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
     expect(res.status).toBe(200);
 
@@ -1241,7 +1241,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res2.status).toBe(200);
     expect(res2.body.token_type).toBe('Bearer');
-    expect(res2.body.scope).toBe('openid offline');
+    expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
     expect(res2.body.id_token).toBeDefined();
     expect(res2.body.access_token).toBeDefined();
@@ -1254,7 +1254,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res3.status).toBe(200);
     expect(res3.body.token_type).toBe('Bearer');
-    expect(res3.body.scope).toBe('openid offline');
+    expect(res3.body.scope).toBe('openid offline_access');
     expect(res3.body.expires_in).toBe(3600);
     expect(res3.body.id_token).toBeDefined();
     expect(res3.body.access_token).toBeDefined();
@@ -1267,7 +1267,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res4.status).toBe(200);
     expect(res4.body.token_type).toBe('Bearer');
-    expect(res4.body.scope).toBe('openid offline');
+    expect(res4.body.scope).toBe('openid offline_access');
     expect(res4.body.expires_in).toBe(3600);
     expect(res4.body.id_token).toBeDefined();
     expect(res4.body.access_token).toBeDefined();
@@ -1299,7 +1299,7 @@ describe('OAuth2 Token', () => {
       password,
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
     expect(res.status).toBe(200);
 
@@ -1308,12 +1308,12 @@ describe('OAuth2 Token', () => {
       client_id: validLifetimeClient.id,
       code: res.body.code,
       code_verifier: 'xyz',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
 
     expect(res2.status).toBe(200);
     expect(res2.body.token_type).toBe('Bearer');
-    expect(res2.body.scope).toBe('openid offline');
+    expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(60);
     expect(res2.body.id_token).toBeDefined();
     expect(res2.body.access_token).toBeDefined();
@@ -1363,7 +1363,7 @@ describe('OAuth2 Token', () => {
       password,
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
     expect(res.status).toBe(200);
 
@@ -1372,12 +1372,12 @@ describe('OAuth2 Token', () => {
       client_id: validLifetimeClient.id,
       code: res.body.code,
       code_verifier: 'xyz',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
 
     expect(res2.status).toBe(200);
     expect(res2.body.token_type).toBe('Bearer');
-    expect(res2.body.scope).toBe('openid offline');
+    expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
     expect(res2.body.id_token).toBeDefined();
     expect(res2.body.access_token).toBeDefined();
@@ -1438,7 +1438,7 @@ describe('OAuth2 Token', () => {
       clientId: client.id,
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
-      scope: 'openid offline',
+      scope: 'openid offline_access',
     });
     expect(res.status).toBe(200);
 
@@ -1450,7 +1450,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res2.status).toBe(200);
     expect(res2.body.token_type).toBe('Bearer');
-    expect(res2.body.scope).toBe('openid offline');
+    expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.patient).toStrictEqual(testPatient.profile.id);
   });
 
@@ -2062,7 +2062,7 @@ describe('OAuth2 Token', () => {
       password,
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
-      scope: 'openid offline', // Request offline access
+      scope: 'openid offline_access', // Request offline_access access
     });
     expect(res.status).toBe(200);
 
@@ -2073,11 +2073,55 @@ describe('OAuth2 Token', () => {
     });
     expect(res2.status).toBe(200);
     expect(res2.body.token_type).toBe('Bearer');
-    expect(res2.body.scope).toBe('openid offline');
+    expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
     expect(res2.body.id_token).toBeDefined();
     expect(res2.body.access_token).toBeDefined();
     expect(res2.body.refresh_token).toBeUndefined();
+  });
+
+  test('Grant types refresh_token should include refresh token', async () => {
+    const client = await createClient(systemRepo, {
+      project,
+      name: 'Test Client with Refresh Token',
+      refreshTokenLifetime: '60s',
+      grantType: [OAuthGrantType.AuthorizationCode, OAuthGrantType.RefreshToken],
+    });
+
+    // Create a test user
+    const email = `test-${randomUUID()}@example.com`;
+    const password = 'test-password';
+    await inviteUser({
+      project,
+      resourceType: 'Practitioner',
+      firstName: 'Test',
+      lastName: 'Test',
+      email,
+      password,
+    });
+
+    const res = await request(app).post('/auth/login').type('json').send({
+      email,
+      password,
+      codeChallenge: 'xyz',
+      codeChallengeMethod: 'plain',
+      scope: 'openid', // Do not request offline_access access
+      clientId: client.id,
+    });
+    expect(res.status).toBe(200);
+
+    const res2 = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: 'authorization_code',
+      code: res.body.code,
+      code_verifier: 'xyz',
+    });
+    expect(res2.status).toBe(200);
+    expect(res2.body.token_type).toBe('Bearer');
+    expect(res2.body.scope).toBe('openid');
+    expect(res2.body.expires_in).toBe(3600);
+    expect(res2.body.id_token).toBeDefined();
+    expect(res2.body.access_token).toBeDefined();
+    expect(res2.body.refresh_token).toBeDefined();
   });
 
   test('mTLS error on client not found', async () => {

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -705,13 +705,13 @@ describe('OAuth2 Token', () => {
     expect(res2.body.refresh_token).toBeDefined();
   });
 
-  test('Authorization code token success with refresh using scope=offline_access', async () => {
+  test('Authorization code token success with refresh using scope=offline', async () => {
     const res = await request(app).post('/auth/login').type('json').send({
       email,
       password,
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
-      scope: 'openid offline_access',
+      scope: 'openid offline',
     });
     expect(res.status).toBe(200);
 
@@ -722,7 +722,7 @@ describe('OAuth2 Token', () => {
     });
     expect(res2.status).toBe(200);
     expect(res2.body.token_type).toBe('Bearer');
-    expect(res2.body.scope).toBe('openid offline_access');
+    expect(res2.body.scope).toBe('openid offline');
     expect(res2.body.expires_in).toBe(3600);
     expect(res2.body.id_token).toBeDefined();
     expect(res2.body.access_token).toBeDefined();

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -428,7 +428,7 @@ export async function exchangeExternalAuthToken(
     externalId,
     projectId,
     clientId,
-    scope: req.body.scope || 'openid offline',
+    scope: req.body.scope || 'openid offline_access',
     nonce: req.body.nonce || randomUUID(),
     remoteAddress: req.ip,
     userAgent: req.get('User-Agent'),

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -820,7 +820,7 @@ function includeRefreshToken(request: LoginRequest, client: ClientApplication | 
   // There are two ways that a client can indicate that it wants refresh tokens:
   // 1. Include "offline_access" in the scope of the authorization request
   // 2. Include "refresh_token" in the grant types of the client application registration
-  return client?.grantType?.includes('refresh_token') || scopeArray?.includes('offline_access');
+  return !!(client?.grantType?.includes('refresh_token') || scopeArray?.includes('offline_access'));
 }
 
 export function normalizeUserInfoUrl(userInfoUrl: string): string {

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -86,7 +86,7 @@ export interface LoginRequest {
   readonly origin?: string;
   readonly pictureUrl?: string;
   readonly forceUseFirstMembership?: boolean;
-  /** @deprecated Use scope of "offline" or "offline_access" instead. */
+  /** @deprecated Use "offline_access" scope instead. */
   readonly remember?: boolean;
 }
 
@@ -178,7 +178,7 @@ export async function tryLogin(request: LoginRequest): Promise<WithId<Login>> {
 
   await authenticate(request, user);
 
-  const refreshSecret = includeRefreshToken(request) ? generateSecret(32) : undefined;
+  const refreshSecret = includeRefreshToken(request, client) ? generateSecret(32) : undefined;
 
   const login = await systemRepo.createResource<Login>({
     resourceType: 'Login',
@@ -799,20 +799,28 @@ export function timingSafeEqualStr(a: string | undefined, b: string | undefined)
 /**
  * Determines if the login request should include a refresh token.
  * @param request - The login request.
+ * @param client - The client application.
  * @returns True if the login should include a refresh token.
  */
-function includeRefreshToken(request: LoginRequest): boolean {
+function includeRefreshToken(request: LoginRequest, client: ClientApplication | undefined): boolean {
   // Deprecated legacy "remember" flag
   if (request.remember) {
+    getLogger().warn('LoginRequest.remember is deprecated, use "offline_access" instead');
     return true;
   }
 
-  // Check for offline scope
-  // Google calls it "offline": https://developers.google.com/identity/protocols/oauth2/web-server#offline
-  // Auth0 calls it "offline_access": https://auth0.com/docs/secure/tokens/refresh-tokens/get-refresh-tokens
-  // We support both
-  const scopeArray = request.scope.split(' ');
-  return scopeArray.includes('offline') || scopeArray.includes('offline_access');
+  const scopeArray = request.scope?.split(' ');
+  if (scopeArray?.includes('offline')) {
+    // Historically, we supported "offline" as the scope for refresh tokens, but that is not the standard.
+    // Google called it "offline": https://developers.google.com/identity/protocols/oauth2/web-server#offline
+    getLogger().warn('Scope "offline" is deprecated, use "offline_access" instead');
+    return true;
+  }
+
+  // There are two ways that a client can indicate that it wants refresh tokens:
+  // 1. Include "offline_access" in the scope of the authorization request
+  // 2. Include "refresh_token" in the grant types of the client application registration
+  return client?.grantType?.includes('refresh_token') || scopeArray?.includes('offline_access');
 }
 
 export function normalizeUserInfoUrl(userInfoUrl: string): string {


### PR DESCRIPTION
The immediate motivation here is to enable refresh tokens via `grant_types` so that Claude MCP integration can get refresh tokens.

1. Added `grantType` and `responseType` to `ClientApplication`
2. Include refresh tokens when `ClientApplication.grantType` includes `refresh_token`
3. Drive-by fix: marked `'offline'` scope as deprecated, and changed them all to `'offline_access'`, which is more standard
4. Drive-by fix: added logging for deprecated `'offline'` scope and deprecated `remember` flag
5. Drive-by fix: fixed some client test utilities to support all `ClientApplication` fields

See https://github.com/medplum/medplum/issues/9183 for more details