### PR TITLE
Fixed the RECAPTCHA_SITE_KEY always being reverted to the default

### DIFF
--- a/packages/app/docker-entrypoint.sh
+++ b/packages/app/docker-entrypoint.sh
@@ -7,7 +7,7 @@ set -e
 : ${MEDPLUM_BASE_URL:="http://localhost:8103/"}
 : ${MEDPLUM_CLIENT_ID:=""}
 : ${GOOGLE_CLIENT_ID:=""}
-: ${RECAPTCHA_SITE_KEY:="6LfHdsYdAAAAAC0uLnnRrDrhcXnziiUwKd8VtLNq"}
+: ${RECAPTCHA_SITE_KEY="6LfHdsYdAAAAAC0uLnnRrDrhcXnziiUwKd8VtLNq"}
 : ${MEDPLUM_REGISTER_ENABLED:="true"}
 : ${MEDPLUM_AWS_TEXTRACT_ENABLED:="true"}
 


### PR DESCRIPTION
Closes [8615](https://github.com/medplum/medplum/issues/8615).