### PR TITLE
OAuth2 pre-authorized code (magic links)

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -806,6 +806,7 @@ interface RequestState {
  * Standard identifiers: {@link https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-07#name-grant-types}
  * JWT bearer extension: {@link https://datatracker.ietf.org/doc/html/rfc7523}
  * Token exchange extension: {@link https://datatracker.ietf.org/doc/html/rfc8693}
+ * Pre-authorized code: {@link https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-urnietfparamsoauthgrant-typ}
  */
 export const OAuthGrantType = {
   ClientCredentials: 'client_credentials',
@@ -813,6 +814,7 @@ export const OAuthGrantType = {
   RefreshToken: 'refresh_token',
   JwtBearer: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
   TokenExchange: 'urn:ietf:params:oauth:grant-type:token-exchange',
+  PreAuthorizedCode: 'urn:ietf:params:oauth:grant-type:pre-authorized_code',
 } as const;
 export type OAuthGrantType = (typeof OAuthGrantType)[keyof typeof OAuthGrantType];
 

--- a/packages/definitions/src/fhir/r4/fhir.schema.json
+++ b/packages/definitions/src/fhir/r4/fhir.schema.json
@@ -62158,8 +62158,13 @@
             "execute",
             "external",
             "google",
-            "password"
+            "password",
+            "pre-authorized"
           ]
+        },
+        "preAuthorizedCodeHash": {
+          "description": "The hash of the pre-authorized code used to obtain OAuth Pre-Authorized Code Grant.",
+          "$ref": "#/definitions/code"
         },
         "authTime": {
           "description": "Time when the End-User authentication occurred.",
@@ -62195,6 +62200,10 @@
         "mfaVerified": {
           "description": "Whether the user has verified using multi-factor authentication (MFA). This will only be set is the user has MFA enabled (see User.mfaEnrolled).",
           "$ref": "#/definitions/boolean"
+        },
+        "expiresAt": {
+          "description": "The time at which a token will expire for this login.",
+          "$ref": "#/definitions/instant"
         },
         "granted": {
           "description": "Whether a token has been granted for this login.",

--- a/packages/definitions/src/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/src/fhir/r4/profiles-medplum.json
@@ -2713,6 +2713,21 @@
             }
           },
           {
+            "id" : "Login.preAuthorizedCodeHash",
+            "path" : "Login.preAuthorizedCodeHash",
+            "definition" : "The hash of the pre-authorized code used to obtain OAuth Pre-Authorized Code Grant.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "code"
+            }],
+            "base" : {
+              "path" : "Login.preAuthorizedCodeHash",
+              "min" : 0,
+              "max" : "1"
+            }
+          },
+          {
             "id" : "Login.authTime",
             "path" : "Login.authTime",
             "definition" : "Time when the End-User authentication occurred.",
@@ -2832,6 +2847,21 @@
             }],
             "base" : {
               "path" : "Login.mfaVerified",
+              "min" : 0,
+              "max" : "1"
+            }
+          },
+          {
+            "id" : "Login.expiresAt",
+            "path" : "Login.expiresAt",
+            "definition" : "The time at which a token will expire for this login.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "instant"
+            }],
+            "base" : {
+              "path" : "Login.expiresAt",
               "min" : 0,
               "max" : "1"
             }

--- a/packages/definitions/src/fhir/r4/search-parameters-medplum.json
+++ b/packages/definitions/src/fhir/r4/search-parameters-medplum.json
@@ -368,6 +368,23 @@
       }
     },
     {
+      "fullUrl": "https://medplum.com/fhir/SearchParameter/Login-pre-authorized-code-hash",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "Login-pre-authorized-code-hash",
+        "url": "https://medplum.com/fhir/SearchParameter/Login-pre-authorized-code-hash",
+        "version": "4.0.1",
+        "name": "pre-authorized-code-hash",
+        "status": "draft",
+        "publisher": "Medplum",
+        "description": "The pre-authorized code hash of the login",
+        "code": "pre-authorized-code-hash",
+        "base": ["Login"],
+        "type": "token",
+        "expression": "Login.preAuthorizedCodeHash"
+      }
+    },
+    {
       "fullUrl": "https://medplum.com/fhir/SearchParameter/Login-code",
       "resource": {
         "resourceType": "SearchParameter",

--- a/packages/definitions/src/fhir/r4/valuesets-medplum.json
+++ b/packages/definitions/src/fhir/r4/valuesets-medplum.json
@@ -384,6 +384,11 @@
             "code": "password",
             "display": "Password",
             "definition": "Password"
+          },
+          {
+            "code": "pre-authorized",
+            "display": "Pre-authorized",
+            "definition": "Pre-authorized"
           }
         ]
       }

--- a/packages/docs/docs/auth/index.md
+++ b/packages/docs/docs/auth/index.md
@@ -19,11 +19,11 @@ For applications running in a **trusted, back-end environment**, use [_server-si
 
 This category is for user-facing applications that connect directly to Medplum. These applications run in untrusted environments (browsers, native apps) and use **identity providers** to authenticate a user.
 
-| Method                                                         | **Choose to...**                                                                               |
-| :------------------------------------------------------------- | :--------------------------------------------------------------------------------------------- |
-| [Medplum as IDP](/docs/auth/medplum-as-idp)                    | (default) **Get going fast**, and don't have external compliance requirements.                 |
-| [External IDP](/docs/auth/external-identity-providers.mdx)     | Connect to an external IDP, like [Google Auth](/docs/auth/google-auth), Auth0, or AWS Cognito. |
-| [Domain-level IDP](/docs/auth/domain-level-identity-providers) | Use your enterprise, domain-level **corporate identity solution.**                             |
+| Method                                                         | **Choose to...**                                                                                    |
+| :------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------- |
+| [Medplum as IDP](/docs/auth/medplum-as-idp)                    | (default) **Get going fast**, and don't have external compliance requirements.                      |
+| [External IDP](/docs/auth/external-identity-providers.mdx)     | Connect to an external IDP, like [Google Auth](/docs/auth/google-auth), Auth0, or AWS Cognito.      |
+| [Domain-level IDP](/docs/auth/domain-level-identity-providers) | Use your enterprise, domain-level **corporate identity solution.**                                  |
 | [Direct External Auth](/docs/auth/direct-external-auth)        | Authenticate directly with an external IDP token, without a token exchange flow (self-hosted only). |
 
 ## Server-side Authentication
@@ -36,6 +36,8 @@ This category is for back-end services. These applications do not directly authe
 - connect to a CI/CD pipeline
 
 Use the [**Client Credentials Flow**](/docs/auth/client-credentials) to allow your application to use its own client key and secret to obtain a token. When working through proxy API layers, you can [enable on-behalf-of authentication](/docs/auth/on-behalf-of) with client credentials to act on behalf of other entities.
+
+For issuer-initiated workflows such as wallet handoff or magic links, use [**Pre-Authorized Code**](/docs/auth/pre-authorized-code) to mint a one-time code and redeem it at the token endpoint without an authorization redirect.
 
 ---
 

--- a/packages/docs/docs/auth/pre-authorized-code.md
+++ b/packages/docs/docs/auth/pre-authorized-code.md
@@ -1,0 +1,122 @@
+---
+sidebar_position: 11
+tags: [auth]
+---
+
+import ExampleCode from '!!raw-loader!@site/../examples/src/auth/pre-authorized-code.ts';
+import MedplumCodeBlock from '@site/src/components/MedplumCodeBlock';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Pre-Authorized Code
+
+Medplum supports the OAuth 2.0 pre-authorized code grant type, `urn:ietf:params:oauth:grant-type:pre-authorized_code`, as defined by [OpenID for Verifiable Credential Issuance 1.0](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html). This flow is useful for magic links and other issuer-initiated flows where user authentication and consent have already happened before the client asks Medplum for tokens.
+
+## Overview
+
+This flow has two steps:
+
+1. A trusted backend creates a one-time pre-authorized code by calling `/auth/preauthorize`.
+1. The receiving application redeems that code at `/oauth2/token` to obtain Medplum tokens.
+
+Unlike the authorization code flow, this flow does not redirect the user through the authorization endpoint.
+
+## Prerequisites
+
+To use this flow:
+
+- Create a [`ClientApplication`](https://app.medplum.com/ClientApplication) with [Project Admin](/docs/access/admin#project-admin) privileges.
+- Authenticate your backend as that `ClientApplication`, typically with the [Client Credentials Flow](/docs/auth/client-credentials).
+- Include the `X-Medplum-On-Behalf-Of` header when creating the pre-authorized code. This identifies the Medplum user who will receive the resulting token. See [On-Behalf-Of](/docs/auth/on-behalf-of) for details.
+
+:::caution[One-time codes]
+
+Pre-authorized codes are single-use and expire automatically. By default, Medplum issues codes that expire after 1 hour. The maximum allowed lifetime is 24 hours.
+
+:::
+
+## Create a pre-authorized code
+
+Send an authenticated `POST` request to `/auth/preauthorize`.
+
+Request headers:
+
+- `Authorization`: Your `ClientApplication` access token or basic auth credentials
+- `X-Medplum-On-Behalf-Of`: The target `ProjectMembership`, `Practitioner`, `Patient`, or other supported profile reference
+- `Content-Type: application/json`
+
+Request body:
+
+- `clientId`: Required. The target [`ClientApplication`](https://app.medplum.com/ClientApplication) ID.
+- `scope`: Optional. Defaults to `openid`.
+- `nonce`: Optional. If omitted, Medplum generates a random nonce.
+- `expiresIn`: Optional expiration time in seconds. Must be between `1` and `86400`.
+
+Example:
+
+<Tabs groupId="language">
+  <TabItem value="ts" label="TypeScript">
+    <MedplumCodeBlock language="ts" selectBlocks="createPreAuthorizedCode">
+      {ExampleCode}
+    </MedplumCodeBlock>
+  </TabItem>
+  <TabItem value="curl" label="cURL">
+    <MedplumCodeBlock language="bash" selectBlocks="createPreAuthorizedCodeCurl">
+      {ExampleCode}
+    </MedplumCodeBlock>
+  </TabItem>
+</Tabs>
+
+On success, Medplum returns a response like:
+
+```json
+{
+  "preAuthorizedCode": "<ONE_TIME_CODE>",
+  "expiresAt": "2026-05-16T20:15:00.000Z"
+}
+```
+
+You can package this code into a magic link, QR code, or handoff to a wallet or application that will redeem it.
+
+## Redeem the pre-authorized code
+
+To redeem the code, send a form-encoded `POST` request to `/oauth2/token` with:
+
+- `grant_type`: `urn:ietf:params:oauth:grant-type:pre-authorized_code`
+- `client_id`: The [`ClientApplication`](https://app.medplum.com/ClientApplication) ID
+- `pre-authorized_code`: The one-time code returned by `/auth/preauthorize`
+
+Example:
+
+<Tabs groupId="language">
+  <TabItem value="ts" label="TypeScript">
+    <MedplumCodeBlock language="ts" selectBlocks="redeemPreAuthorizedCode">
+      {ExampleCode}
+    </MedplumCodeBlock>
+  </TabItem>
+  <TabItem value="curl" label="cURL">
+    <MedplumCodeBlock language="bash" selectBlocks="redeemPreAuthorizedCodeCurl">
+      {ExampleCode}
+    </MedplumCodeBlock>
+  </TabItem>
+</Tabs>
+
+On success, the response includes a Medplum access token and ID token:
+
+```json
+{
+  "token_type": "Bearer",
+  "access_token": "<ACCESS_TOKEN>",
+  "id_token": "<ID_TOKEN>",
+  "scope": "openid",
+  "expires_in": 3600
+}
+```
+
+## Notes
+
+- Pre-authorized codes can only be redeemed once.
+- If a code is expired, already used, revoked, or presented for the wrong client, Medplum returns an OAuth error response from `/oauth2/token`.
+- Medplum currently supports the pre-authorized code flow without an additional transaction code (`tx_code`).
+
+For more details, see the [OpenID for Verifiable Credential Issuance 1.0 specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html), especially the sections on [Pre-Authorized Code Flow](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-3.5) and [Token Request](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-6.1).

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -270,6 +270,7 @@ const sidebars: SidebarsConfig = {
         { type: 'doc', id: 'auth/mfa' },
         { type: 'doc', id: 'auth/token-exchange' },
         { type: 'doc', id: 'auth/session-management' },
+        { type: 'doc', id: 'auth/pre-authorized-code' },
       ],
     },
     {

--- a/packages/examples/src/auth/pre-authorized-code.ts
+++ b/packages/examples/src/auth/pre-authorized-code.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { MedplumClient } from '@medplum/core';
+
+/*
+// start-block createPreAuthorizedCodeCurl
+curl -X POST 'https://api.medplum.com/auth/preauthorize' \
+  --user "$MY_CLIENT_ID:$MY_CLIENT_SECRET" \
+  -H 'Content-Type: application/json' \
+  -H 'X-Medplum-On-Behalf-Of: Practitioner/00000000-0000-0000-0000-000000000000' \
+  --data-raw '{
+    "clientId": "00000000-0000-0000-0000-000000000000",
+    "scope": "openid",
+    "expiresIn": 3600
+  }'
+// end-block createPreAuthorizedCodeCurl
+*/
+
+/*
+// start-block redeemPreAuthorizedCodeCurl
+curl -X POST 'https://api.medplum.com/oauth2/token' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode 'grant_type=urn:ietf:params:oauth:grant-type:pre-authorized_code' \
+  --data-urlencode 'client_id=00000000-0000-0000-0000-000000000000' \
+  --data-urlencode 'pre-authorized_code=<PRE_AUTHORIZED_CODE>'
+// end-block redeemPreAuthorizedCodeCurl
+*/
+
+const MEDPLUM_BASE_URL = 'https://api.medplum.com/';
+const MY_CLIENT_ID = 'my-client-id';
+const MY_CLIENT_SECRET = 'my-client-secret';
+const ON_BEHALF_OF = 'Practitioner/00000000-0000-0000-0000-000000000000';
+
+// start-block createPreAuthorizedCode
+const medplum = new MedplumClient({
+  baseUrl: MEDPLUM_BASE_URL,
+  clientId: MY_CLIENT_ID,
+  clientSecret: MY_CLIENT_SECRET,
+});
+
+const preAuthResult = await medplum.post(
+  'auth/preauthorize',
+  {
+    clientId: MY_CLIENT_ID,
+    scope: 'openid',
+    expiresIn: 3600,
+    nonce: 'optional-nonce-value',
+  },
+  {
+    headers: {
+      'X-Medplum-On-Behalf-Of': ON_BEHALF_OF,
+    },
+  }
+);
+// end-block createPreAuthorizedCode
+
+// start-block redeemPreAuthorizedCode
+const tokenResponse = await fetch(`${MEDPLUM_BASE_URL}oauth2/token`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/x-www-form-urlencoded',
+  },
+  body: new URLSearchParams({
+    grant_type: 'urn:ietf:params:oauth:grant-type:pre-authorized_code',
+    client_id: MY_CLIENT_ID,
+    'pre-authorized_code': preAuthResult.preAuthorizedCode,
+  }),
+});
+
+const tokens = await tokenResponse.json();
+console.log(tokens.access_token);
+// end-block redeemPreAuthorizedCode

--- a/packages/examples/src/auth/pre-authorized-code.ts
+++ b/packages/examples/src/auth/pre-authorized-code.ts
@@ -46,6 +46,7 @@ const preAuthResult = await medplum.post(
     expiresIn: 3600,
     nonce: 'optional-nonce-value',
   },
+  undefined,
   {
     headers: {
       'X-Medplum-On-Behalf-Of': ON_BEHALF_OF,

--- a/packages/fhirtypes/dist/Login.d.ts
+++ b/packages/fhirtypes/dist/Login.d.ts
@@ -134,7 +134,13 @@ export interface Login {
    * The authentication method used to obtain the code (password or
    * google).
    */
-  authMethod: 'client' | 'exchange' | 'execute' | 'external' | 'google' | 'password';
+  authMethod: 'client' | 'exchange' | 'execute' | 'external' | 'google' | 'password' | 'pre-authorized';
+
+  /**
+   * The hash of the pre-authorized code used to obtain OAuth
+   * Pre-Authorized Code Grant.
+   */
+  preAuthorizedCodeHash?: string;
 
   /**
    * Time when the End-User authentication occurred.
@@ -189,6 +195,11 @@ export interface Login {
    * User.mfaEnrolled).
    */
   mfaVerified?: boolean;
+
+  /**
+   * The time at which a token will expire for this login.
+   */
+  expiresAt?: string;
 
   /**
    * Whether a token has been granted for this login.

--- a/packages/server/src/auth/preauthorize.test.ts
+++ b/packages/server/src/auth/preauthorize.test.ts
@@ -10,6 +10,7 @@ import type { ServerInviteResponse } from '../admin/invite';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import { addTestUser, createTestProject, withTestContext } from '../test.setup';
+import { MAX_PRE_AUTH_CODE_TTL } from './preauthorize';
 
 describe('Pre-authorize', () => {
   const app = express();
@@ -83,6 +84,26 @@ describe('Pre-authorize', () => {
     expect(res.body).toMatchObject(notFound);
   });
 
+  test('Expire time too short', async () => {
+    const res = await request(app)
+      .post('/auth/preauthorize')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .type('json')
+      .send({ clientId: client.id, expiresIn: 0 });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject(badRequest('expiresIn must be a positive integer not exceeding 86400 seconds'));
+  });
+
+  test('Expire time too long', async () => {
+    const res = await request(app)
+      .post('/auth/preauthorize')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .type('json')
+      .send({ clientId: client.id, expiresIn: MAX_PRE_AUTH_CODE_TTL + 1 });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject(badRequest('expiresIn must be a positive integer not exceeding 86400 seconds'));
+  });
+
   test('Success', async () => {
     const res = await request(app)
       .post('/auth/preauthorize')
@@ -92,6 +113,7 @@ describe('Pre-authorize', () => {
       .send({ clientId: client.id });
     expect(res.status).toBe(200);
     expect(res.body.preAuthorizedCode).toBeDefined();
+    expect(res.body.expiresAt).toBeDefined();
     expect(res.body.code).toBeUndefined();
   });
 });

--- a/packages/server/src/auth/preauthorize.test.ts
+++ b/packages/server/src/auth/preauthorize.test.ts
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import { badRequest, getReferenceString, notFound } from '@medplum/core';
+import type { ClientApplication, Project } from '@medplum/fhirtypes';
+import { randomUUID } from 'crypto';
+import express from 'express';
+import request from 'supertest';
+import type { ServerInviteResponse } from '../admin/invite';
+import { initApp, shutdownApp } from '../app';
+import { loadTestConfig } from '../config/loader';
+import { addTestUser, createTestProject, withTestContext } from '../test.setup';
+
+describe('Pre-authorize', () => {
+  const app = express();
+  let project: WithId<Project>;
+  let client: WithId<ClientApplication>;
+  let accessToken: string;
+  let testAccount: ServerInviteResponse & { accessToken: string };
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+
+    await withTestContext(async () => {
+      await initApp(app, config);
+
+      ({ project, client, accessToken } = await createTestProject({
+        membership: { admin: true },
+        withClient: true,
+        withAccessToken: true,
+      }));
+
+      testAccount = await addTestUser(project);
+    });
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test('Requires auth', async () => {
+    const res = await request(app).post('/auth/preauthorize').type('json').send({ clientId: client.id });
+    expect(res.status).toBe(401);
+  });
+
+  test('Requires project admin', async () => {
+    const res = await request(app)
+      .post('/auth/preauthorize')
+      .set('Authorization', `Bearer ${testAccount.accessToken}`)
+      .type('json')
+      .send({ clientId: client.id });
+    expect(res.status).toBe(403);
+  });
+
+  test('Requires clientId', async () => {
+    const res = await request(app)
+      .post('/auth/preauthorize')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .type('json')
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject(badRequest('Client ID is required'));
+  });
+
+  test('Requires onBehalfOfMembership', async () => {
+    const res = await request(app)
+      .post('/auth/preauthorize')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .type('json')
+      .send({ clientId: client.id });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject(badRequest('Pre-authorization requires onBehalfOfMembership'));
+  });
+
+  test('Client not found', async () => {
+    const res = await request(app)
+      .post('/auth/preauthorize')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount.profile))
+      .type('json')
+      .send({ clientId: randomUUID() });
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject(notFound);
+  });
+
+  test('Success', async () => {
+    const res = await request(app)
+      .post('/auth/preauthorize')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount.profile))
+      .type('json')
+      .send({ clientId: client.id });
+    expect(res.status).toBe(200);
+    expect(res.body.preAuthorizedCode).toBeDefined();
+    expect(res.body.code).toBeUndefined();
+  });
+});

--- a/packages/server/src/auth/preauthorize.ts
+++ b/packages/server/src/auth/preauthorize.ts
@@ -9,24 +9,33 @@ import { getAuthenticatedContext } from '../context';
 import { generateSecret } from '../oauth/keys';
 import { makeValidationMiddleware } from '../util/validator';
 
+export const DEFAULT_PRE_AUTH_CODE_TTL = 60 * 60; // 1 hour
+export const MAX_PRE_AUTH_CODE_TTL = 24 * 60 * 60; // 24 hours
+
 export const preAuthorizeValidator = makeValidationMiddleware([
   body('clientId').isUUID().withMessage('Client ID is required'),
+  body('scope').optional().isString().withMessage('Scope must be a string'),
+  body('nonce').optional().isString().withMessage('Nonce must be a string'),
+  body('expiresIn')
+    .optional()
+    .isInt({ min: 1, max: MAX_PRE_AUTH_CODE_TTL })
+    .withMessage(`expiresIn must be a positive integer not exceeding ${MAX_PRE_AUTH_CODE_TTL} seconds`),
 ]);
 
 export async function preAuthorizeHandler(req: Request, res: Response): Promise<void> {
   const { authState, repo } = getAuthenticatedContext();
-
   const { project, membership, onBehalfOfMembership } = authState;
   if (!membership.admin) {
     throw new OperationOutcomeError(forbidden);
   }
-
   if (!onBehalfOfMembership) {
     throw new OperationOutcomeError(badRequest('Pre-authorization requires onBehalfOfMembership'));
   }
 
   const preAuthorizedCode = generateSecret(128);
   const preAuthorizedCodeHash = createHash('sha256').update(preAuthorizedCode).digest('hex');
+  const expiresIn = req.body.expiresIn ?? DEFAULT_PRE_AUTH_CODE_TTL;
+  const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
   const client = await repo.readResource<ClientApplication>('ClientApplication', req.body.clientId);
   const [resourceType, _id] = parseReference(onBehalfOfMembership.profile);
   await repo.getSystemRepo().createResource<Login>({
@@ -38,11 +47,12 @@ export async function preAuthorizeHandler(req: Request, res: Response): Promise<
     membership: createReference(onBehalfOfMembership),
     user: onBehalfOfMembership.user,
     authTime: new Date().toISOString(),
-    preAuthorizedCodeHash,
     scope: req.body.scope || 'openid',
     nonce: req.body.nonce || randomUUID(),
     remoteAddress: req.ip,
     userAgent: req.get('User-Agent'),
+    preAuthorizedCodeHash,
+    expiresAt,
   });
-  res.status(200).json({ preAuthorizedCode });
+  res.status(200).json({ preAuthorizedCode, expiresAt });
 }

--- a/packages/server/src/auth/preauthorize.ts
+++ b/packages/server/src/auth/preauthorize.ts
@@ -25,6 +25,9 @@ export const preAuthorizeValidator = makeValidationMiddleware([
 export async function preAuthorizeHandler(req: Request, res: Response): Promise<void> {
   const { authState, repo } = getAuthenticatedContext();
   const { project, membership, onBehalfOfMembership } = authState;
+  if (project.superAdmin) {
+    throw new OperationOutcomeError(forbidden);
+  }
   if (!membership.admin) {
     throw new OperationOutcomeError(forbidden);
   }

--- a/packages/server/src/auth/preauthorize.ts
+++ b/packages/server/src/auth/preauthorize.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { badRequest, createReference, forbidden, OperationOutcomeError, parseReference } from '@medplum/core';
+import { badRequest, createReference, forbidden, OperationOutcomeError } from '@medplum/core';
 import type { ClientApplication, Login } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import { body } from 'express-validator';
@@ -37,13 +37,11 @@ export async function preAuthorizeHandler(req: Request, res: Response): Promise<
   const expiresIn = req.body.expiresIn ?? DEFAULT_PRE_AUTH_CODE_TTL;
   const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
   const client = await repo.readResource<ClientApplication>('ClientApplication', req.body.clientId);
-  const [resourceType, _id] = parseReference(onBehalfOfMembership.profile);
   await repo.getSystemRepo().createResource<Login>({
     resourceType: 'Login',
     authMethod: 'pre-authorized',
     project: createReference(project),
     client: createReference(client),
-    profileType: resourceType,
     membership: createReference(onBehalfOfMembership),
     user: onBehalfOfMembership.user,
     authTime: new Date().toISOString(),

--- a/packages/server/src/auth/preauthorize.ts
+++ b/packages/server/src/auth/preauthorize.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { badRequest, createReference, forbidden, OperationOutcomeError, parseReference } from '@medplum/core';
+import type { ClientApplication, Login } from '@medplum/fhirtypes';
+import type { Request, Response } from 'express';
+import { body } from 'express-validator';
+import { createHash, randomUUID } from 'node:crypto';
+import { getAuthenticatedContext } from '../context';
+import { generateSecret } from '../oauth/keys';
+import { makeValidationMiddleware } from '../util/validator';
+
+export const preAuthorizeValidator = makeValidationMiddleware([
+  body('clientId').isUUID().withMessage('Client ID is required'),
+]);
+
+export async function preAuthorizeHandler(req: Request, res: Response): Promise<void> {
+  const { authState, repo } = getAuthenticatedContext();
+
+  const { project, membership, onBehalfOfMembership } = authState;
+  if (!membership.admin) {
+    throw new OperationOutcomeError(forbidden);
+  }
+
+  if (!onBehalfOfMembership) {
+    throw new OperationOutcomeError(badRequest('Pre-authorization requires onBehalfOfMembership'));
+  }
+
+  const preAuthorizedCode = generateSecret(128);
+  const preAuthorizedCodeHash = createHash('sha256').update(preAuthorizedCode).digest('hex');
+  const client = await repo.readResource<ClientApplication>('ClientApplication', req.body.clientId);
+  const [resourceType, _id] = parseReference(onBehalfOfMembership.profile);
+  await repo.getSystemRepo().createResource<Login>({
+    resourceType: 'Login',
+    authMethod: 'pre-authorized',
+    project: createReference(project),
+    client: createReference(client),
+    profileType: resourceType,
+    membership: createReference(onBehalfOfMembership),
+    user: onBehalfOfMembership.user,
+    authTime: new Date().toISOString(),
+    preAuthorizedCodeHash,
+    scope: req.body.scope || 'openid',
+    nonce: req.body.nonce || randomUUID(),
+    remoteAddress: req.ip,
+    userAgent: req.get('User-Agent'),
+  });
+  res.status(200).json({ preAuthorizedCode });
+}

--- a/packages/server/src/auth/preauthorize.ts
+++ b/packages/server/src/auth/preauthorize.ts
@@ -25,10 +25,7 @@ export const preAuthorizeValidator = makeValidationMiddleware([
 export async function preAuthorizeHandler(req: Request, res: Response): Promise<void> {
   const { authState, repo } = getAuthenticatedContext();
   const { project, membership, onBehalfOfMembership } = authState;
-  if (project.superAdmin) {
-    throw new OperationOutcomeError(forbidden);
-  }
-  if (!membership.admin) {
+  if (project.superAdmin || !membership.admin) {
     throw new OperationOutcomeError(forbidden);
   }
   if (!onBehalfOfMembership) {

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -16,6 +16,7 @@ import { mfaRouter } from './mfa';
 import { newPatientHandler, newPatientValidator } from './newpatient';
 import { newProjectHandler, newProjectValidator } from './newproject';
 import { newUserHandler, newUserValidator } from './newuser';
+import { preAuthorizeHandler, preAuthorizeValidator } from './preauthorize';
 import { profileHandler, profileValidator } from './profile';
 import { resetPasswordHandler, resetPasswordValidator } from './resetpassword';
 import { revokeHandler, revokeValidator } from './revoke';
@@ -43,6 +44,7 @@ authRouter.post('/verifyemail', verifyEmailValidator, verifyEmailHandler);
 authRouter.post('/google', googleValidator, googleHandler);
 authRouter.post('/exchange', exchangeValidator, exchangeHandler);
 authRouter.post('/revoke', authenticateRequest, revokeValidator, revokeHandler);
+authRouter.post('/preauthorize', authenticateRequest, preAuthorizeValidator, preAuthorizeHandler);
 authRouter.get('/login/:login', statusValidator, statusHandler);
 authRouter.get('/clientinfo/:clientId', clientInfoHandler);
 

--- a/packages/server/src/migrations/data/data-version-manifest.json
+++ b/packages/server/src/migrations/data/data-version-manifest.json
@@ -135,5 +135,8 @@
   },
   "v35": {
     "serverVersion": "5.1.10"
+  },
+  "v36": {
+    "serverVersion": "5.1.12"
   }
 }

--- a/packages/server/src/migrations/data/index.ts
+++ b/packages/server/src/migrations/data/index.ts
@@ -44,3 +44,4 @@ export * as v32 from './v32';
 export * as v33 from './v33';
 export * as v34 from './v34';
 export * as v35 from './v35';
+export * as v36 from './v36';

--- a/packages/server/src/migrations/data/v36.ts
+++ b/packages/server/src/migrations/data/v36.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
+
+import type { PoolClient } from 'pg';
+import { prepareCustomMigrationJobData, runCustomMigration } from '../../workers/post-deploy-migration';
+import * as fns from '../migrate-functions';
+import type { MigrationActionResult } from '../types';
+import type { CustomPostDeployMigration } from './types';
+
+export const migration: CustomPostDeployMigration = {
+  type: 'custom',
+  prepareJobData: (asyncJob) => prepareCustomMigrationJobData(asyncJob),
+  run: async (repo, job, jobData) => runCustomMigration(repo, job, jobData, callback),
+};
+
+// prettier-ignore
+async function callback(client: PoolClient, results: MigrationActionResult[]): Promise<void> {
+  await fns.idempotentCreateIndex(client, results, 'Login_preAuthorizedCodeHash_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "Login_preAuthorizedCodeHash_idx" ON "Login" ("preAuthorizedCodeHash")`);
+}

--- a/packages/server/src/migrations/schema/index.ts
+++ b/packages/server/src/migrations/schema/index.ts
@@ -114,3 +114,4 @@ export * as v102 from './v102';
 export * as v103 from './v103';
 export * as v104 from './v104';
 export * as v105 from './v105';
+export * as v106 from './v106';

--- a/packages/server/src/migrations/schema/v106.ts
+++ b/packages/server/src/migrations/schema/v106.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
+
+import type { PoolClient } from 'pg';
+import * as fns from '../migrate-functions';
+
+// prettier-ignore
+export async function run(client: PoolClient): Promise<void> {
+  const results: { name: string; durationMs: number }[] = []
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "Login" ADD COLUMN IF NOT EXISTS "preAuthorizedCodeHash" TEXT`);
+}

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -2184,6 +2184,46 @@ describe('OAuth2 Token', () => {
     expect(res.body.access_token).toBeDefined();
   });
 
+  test('Pre-authorized code with missing client_id', async () => {
+    const res = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: OAuthGrantType.PreAuthorizedCode,
+      'pre-authorized_code': 'big-long-string',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_request');
+    expect(res.body.error_description).toBe('Missing client_id');
+  });
+
+  test('Pre-authorized code with missing code', async () => {
+    const res = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: OAuthGrantType.PreAuthorizedCode,
+      client_id: client.id,
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_request');
+    expect(res.body.error_description).toBe('Missing pre-authorized_code');
+  });
+
+  test('Pre-authorized code with invalid client_id', async () => {
+    const res = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: OAuthGrantType.PreAuthorizedCode,
+      'pre-authorized_code': 'big-long-string',
+      client_id: 'invalid-client-id',
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test('Pre-authorized code with invalid code', async () => {
+    const res = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: OAuthGrantType.PreAuthorizedCode,
+      client_id: client.id,
+      'pre-authorized_code': 'invalid-code',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_request');
+    expect(res.body.error_description).toBe('Invalid pre-authorized_code');
+  });
+
   test('Pre-authorized code success', async () => {
     const testAccount = await addTestUser(project);
 
@@ -2209,6 +2249,16 @@ describe('OAuth2 Token', () => {
     expect(res2.body.id_token).toBeDefined();
     expect(res2.body.access_token).toBeDefined();
     expect(res2.body.refresh_token).toBeUndefined();
+
+    // Try to use the same pre-authorized code again, should fail since it can only be used once
+    const res3 = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: OAuthGrantType.PreAuthorizedCode,
+      client_id: client.id,
+      'pre-authorized_code': res.body.preAuthorizedCode,
+    });
+    expect(res3.status).toBe(400);
+    expect(res3.body.error).toBe('invalid_request');
+    expect(res3.body.error_description).toBe('Invalid pre-authorized_code');
   });
 });
 

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -6,6 +6,7 @@ import {
   createReference,
   encodeBase64,
   encodeBase64Url,
+  getReferenceString,
   OAuthClientAssertionType,
   OAuthGrantType,
   OAuthTokenType,
@@ -33,7 +34,7 @@ import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
 import type { SystemRepository } from '../fhir/repo';
 import { getProjectSystemRepo } from '../fhir/repo';
-import { createTestProject, generateSelfSignedCert, withTestContext } from '../test.setup';
+import { addTestUser, createTestProject, generateSelfSignedCert, withTestContext } from '../test.setup';
 import { validateClientCert } from './cert';
 import { generateSecret, verifyJwt } from './keys';
 import { hashCode } from './utils';
@@ -80,6 +81,7 @@ describe('OAuth2 Token', () => {
   let config: MedplumServerConfig;
   let project: WithId<Project>;
   let client: WithId<ClientApplication>;
+  let accessToken: string;
   let pkceOptionalClient: ClientApplication;
   let externalAuthClient: ClientApplication;
   let invalidAuthClient: ClientApplication;
@@ -90,7 +92,11 @@ describe('OAuth2 Token', () => {
     await initApp(app, config);
 
     // Create a test project
-    ({ project, client } = await createTestProject({ withClient: true }));
+    ({ project, client, accessToken } = await createTestProject({
+      withAccessToken: true,
+      withClient: true,
+      membership: { admin: true },
+    }));
     systemRepo = await getProjectSystemRepo(project);
 
     // Add secondary secret for testing
@@ -2176,6 +2182,33 @@ describe('OAuth2 Token', () => {
     expect(res.status).toBe(200);
     expect(res.body.error).toBeUndefined();
     expect(res.body.access_token).toBeDefined();
+  });
+
+  test('Pre-authorized code success', async () => {
+    const testAccount = await addTestUser(project);
+
+    const res = await request(app)
+      .post('/auth/preauthorize')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount.profile))
+      .type('json')
+      .send({ clientId: client.id });
+    expect(res.status).toBe(200);
+    expect(res.body.preAuthorizedCode).toBeDefined();
+    expect(res.body.code).toBeUndefined();
+
+    const res2 = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: OAuthGrantType.PreAuthorizedCode,
+      client_id: client.id,
+      'pre-authorized_code': res.body.preAuthorizedCode,
+    });
+    expect(res2.status).toBe(200);
+    expect(res2.body.token_type).toBe('Bearer');
+    expect(res2.body.scope).toBe('openid');
+    expect(res2.body.expires_in).toBe(3600);
+    expect(res2.body.id_token).toBeDefined();
+    expect(res2.body.access_token).toBeDefined();
+    expect(res2.body.refresh_token).toBeUndefined();
   });
 });
 

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -2257,8 +2257,8 @@ describe('OAuth2 Token', () => {
       'pre-authorized_code': res.body.preAuthorizedCode,
     });
     expect(res3.status).toBe(400);
-    expect(res3.body.error).toBe('invalid_request');
-    expect(res3.body.error_description).toBe('Invalid pre-authorized_code');
+    expect(res3.body.error).toBe('invalid_grant');
+    expect(res3.body.error_description).toBe('Token already granted');
   });
 });
 

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -24,7 +24,7 @@ import type {
 import express from 'express';
 import { decodeJwt, generateKeyPair, jwtVerify, SignJWT } from 'jose';
 import fetch from 'node-fetch';
-import { randomUUID, X509Certificate } from 'node:crypto';
+import { createHash, randomUUID, X509Certificate } from 'node:crypto';
 import request from 'supertest';
 import { createClient } from '../admin/client';
 import { inviteUser } from '../admin/invite';
@@ -81,6 +81,7 @@ describe('OAuth2 Token', () => {
   let config: MedplumServerConfig;
   let project: WithId<Project>;
   let client: WithId<ClientApplication>;
+  let adminMembership: WithId<ProjectMembership>;
   let accessToken: string;
   let pkceOptionalClient: ClientApplication;
   let externalAuthClient: ClientApplication;
@@ -92,7 +93,12 @@ describe('OAuth2 Token', () => {
     await initApp(app, config);
 
     // Create a test project
-    ({ project, client, accessToken } = await createTestProject({
+    ({
+      project,
+      client,
+      membership: adminMembership,
+      accessToken,
+    } = await createTestProject({
       withAccessToken: true,
       withClient: true,
       membership: { admin: true },
@@ -2222,6 +2228,35 @@ describe('OAuth2 Token', () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid pre-authorized_code');
+  });
+
+  test('Pre-authorized code expired', async () => {
+    // Create a pre-authorized code that is already expired
+    const preAuthorizedCode = generateSecret(128);
+    const preAuthorizedCodeHash = createHash('sha256').update(preAuthorizedCode).digest('hex');
+    const expiresAt = new Date(Date.now() - 1000).toISOString(); // expired 1 second ago
+    await systemRepo.createResource<Login>({
+      resourceType: 'Login',
+      authMethod: 'pre-authorized',
+      project: createReference(project),
+      client: createReference(client),
+      membership: createReference(adminMembership),
+      user: adminMembership.user,
+      authTime: new Date().toISOString(),
+      scope: 'openid',
+      nonce: randomUUID(),
+      preAuthorizedCodeHash,
+      expiresAt,
+    });
+
+    const res = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: OAuthGrantType.PreAuthorizedCode,
+      client_id: client.id,
+      'pre-authorized_code': preAuthorizedCode,
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_grant');
+    expect(res.body.error_description).toBe('Pre-authorized code expired');
   });
 
   test('Pre-authorized code success', async () => {

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -2216,7 +2216,9 @@ describe('OAuth2 Token', () => {
       'pre-authorized_code': 'big-long-string',
       client_id: 'invalid-client-id',
     });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_client');
+    expect(res.body.error_description).toBe('Invalid client');
   });
 
   test('Pre-authorized code with invalid code', async () => {
@@ -2257,6 +2259,49 @@ describe('OAuth2 Token', () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('invalid_grant');
     expect(res.body.error_description).toBe('Pre-authorized code expired');
+  });
+
+  test('Pre-authorized code IP address restriction', async () => {
+    const testAccount = await addTestUser(project, {
+      resourceType: 'AccessPolicy',
+      resource: [{ resourceType: '*' }],
+      ipAccessRule: [
+        { name: 'Block test', value: '6.6.6.6', action: 'block' },
+        { name: 'Allow by default', value: '*', action: 'allow' },
+      ],
+    });
+
+    const res = await request(app)
+      .post('/auth/preauthorize')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount.profile))
+      .type('json')
+      .send({ clientId: client.id });
+    expect(res.status).toBe(200);
+    expect(res.body.preAuthorizedCode).toBeDefined();
+    expect(res.body.code).toBeUndefined();
+
+    // Login with pre-authorized code from 6.6.6.6
+    // Should fail because of IP address block
+    const res1 = await request(app).post('/oauth2/token').set('X-Forwarded-For', '6.6.6.6').type('form').send({
+      grant_type: OAuthGrantType.PreAuthorizedCode,
+      client_id: client.id,
+      'pre-authorized_code': res.body.preAuthorizedCode,
+    });
+    expect(res1.status).toBe(400);
+    expect(res1.body.error).toBe('invalid_request');
+    expect(res1.body.error_description).toBe('IP address not allowed');
+
+    // Login with pre-authorized code from 5.5.5.5
+    // Should succeed
+    const res2 = await request(app).post('/oauth2/token').set('X-Forwarded-For', '5.5.5.5').type('form').send({
+      grant_type: OAuthGrantType.PreAuthorizedCode,
+      client_id: client.id,
+      'pre-authorized_code': res.body.preAuthorizedCode,
+    });
+    expect(res2.status).toBe(200);
+    expect(res2.body.error).toBeUndefined();
+    expect(res2.body.access_token).toBeDefined();
   });
 
   test('Pre-authorized code success', async () => {

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -469,7 +469,7 @@ async function handlePreAuthorizedCode(req: Request, res: Response): Promise<voi
   }
 
   const systemRepo = getGlobalSystemRepo();
-  const searchResult = await systemRepo.search({
+  const searchResult = await systemRepo.search<Login>({
     resourceType: 'Login',
     filters: [
       {
@@ -480,12 +480,11 @@ async function handlePreAuthorizedCode(req: Request, res: Response): Promise<voi
     ],
   });
 
-  if (!searchResult.entry || searchResult.entry.length === 0) {
+  const login = searchResult?.entry?.[0]?.resource;
+  if (login?.authMethod !== 'pre-authorized') {
     sendTokenError(res, 'invalid_request', 'Invalid pre-authorized_code');
     return;
   }
-
-  const login = searchResult.entry[0].resource as WithId<Login>;
 
   if (login.client?.reference !== `ClientApplication/${clientId}`) {
     sendTokenError(res, 'invalid_request', 'Invalid client');
@@ -497,7 +496,7 @@ async function handlePreAuthorizedCode(req: Request, res: Response): Promise<voi
     return;
   }
 
-  if (login.expiresAt && new Date(login.expiresAt) < new Date()) {
+  if (!login.expiresAt || new Date(login.expiresAt) < new Date()) {
     sendTokenError(res, 'invalid_grant', 'Pre-authorized code expired');
     return;
   }

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -11,6 +11,7 @@ import {
   createReference,
   getStatus,
   isJwt,
+  isString,
   normalizeErrorString,
   normalizeOperationOutcome,
   parseJWTPayload,
@@ -20,7 +21,7 @@ import type { ClientApplication, Login, ProjectMembership, Reference, User } fro
 import type { Request, RequestHandler, Response } from 'express';
 import type { JWTVerifyOptions } from 'jose';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { getUserConfiguration } from '../auth/me';
 import { getProjectIdByClientId } from '../auth/utils';
 import { getConfig } from '../config/loader';
@@ -82,6 +83,9 @@ export const tokenHandler: RequestHandler = async (req: Request, res: Response):
       break;
     case OAuthGrantType.TokenExchange:
       await handleTokenExchange(req, res);
+      break;
+    case OAuthGrantType.PreAuthorizedCode:
+      await handlePreAuthorizedCode(req, res);
       break;
     default:
       sendTokenError(res, 'invalid_request', 'Unsupported grant_type');
@@ -435,6 +439,74 @@ export async function exchangeExternalAuthToken(
     forceUseFirstMembership: true,
     membershipId,
   });
+
+  await sendTokenResponse(res, login, client);
+}
+
+/**
+ * Handles the "Pre-Authorized Code Grant" flow.
+ * See: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-urnietfparamsoauthgrant-typ
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
+ */
+async function handlePreAuthorizedCode(req: Request, res: Response): Promise<void> {
+  const clientId = req.body.client_id;
+  if (!isString(clientId)) {
+    sendTokenError(res, 'invalid_request', 'Missing client_id');
+    return;
+  }
+
+  const preAuthorizedCode = req.body['pre-authorized_code'];
+  if (!isString(preAuthorizedCode)) {
+    sendTokenError(res, 'invalid_request', 'Missing pre-authorized_code');
+    return;
+  }
+
+  const client = await getClientApplication(clientId);
+  if (client.status && client.status !== 'active') {
+    sendTokenError(res, 'invalid_request', 'Invalid client');
+    return;
+  }
+
+  const systemRepo = getGlobalSystemRepo();
+  const searchResult = await systemRepo.search({
+    resourceType: 'Login',
+    filters: [
+      {
+        code: 'pre-authorized-code-hash',
+        operator: Operator.EQUALS,
+        value: createHash('sha256').update(preAuthorizedCode).digest('hex'),
+      },
+    ],
+  });
+
+  if (!searchResult.entry || searchResult.entry.length === 0) {
+    sendTokenError(res, 'invalid_request', 'Invalid code');
+    return;
+  }
+
+  const login = searchResult.entry[0].resource as WithId<Login>;
+
+  if (login.client?.reference !== `ClientApplication/${clientId}`) {
+    sendTokenError(res, 'invalid_request', 'Invalid client');
+    return;
+  }
+
+  if (!login.membership) {
+    sendTokenError(res, 'invalid_request', 'Invalid profile');
+    return;
+  }
+
+  if (login.granted) {
+    await revokeLogin(systemRepo, login);
+    sendTokenError(res, 'invalid_grant', 'Token already granted');
+    return;
+  }
+
+  if (login.revoked) {
+    sendTokenError(res, 'invalid_grant', 'Token revoked');
+    return;
+  }
 
   await sendTokenResponse(res, login, client);
 }

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -462,7 +462,13 @@ async function handlePreAuthorizedCode(req: Request, res: Response): Promise<voi
     return;
   }
 
-  const client = await getClientApplication(clientId);
+  let client;
+  try {
+    client = await getClientApplication(clientId);
+  } catch {
+    sendTokenError(res, 'invalid_client', 'Invalid client');
+    return;
+  }
   if (client.status && client.status !== 'active') {
     sendTokenError(res, 'invalid_request', 'Invalid client');
     return;
@@ -509,6 +515,20 @@ async function handlePreAuthorizedCode(req: Request, res: Response): Promise<voi
 
   if (login.revoked) {
     sendTokenError(res, 'invalid_grant', 'Token revoked');
+    return;
+  }
+
+  login.remoteAddress = req.ip;
+  login.userAgent = req.get('User-Agent');
+
+  try {
+    const membership = await systemRepo.readReference(login.membership);
+    const project = await systemRepo.readReference(membership.project);
+    const userConfig = await getUserConfiguration(systemRepo, project, membership);
+    const accessPolicy = await getAccessPolicyForLogin({ project, login, membership, userConfig });
+    await checkIpAccessRules(login, accessPolicy);
+  } catch (err) {
+    sendTokenError(res, 'invalid_request', normalizeErrorString(err));
     return;
   }
 

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -481,7 +481,7 @@ async function handlePreAuthorizedCode(req: Request, res: Response): Promise<voi
   });
 
   if (!searchResult.entry || searchResult.entry.length === 0) {
-    sendTokenError(res, 'invalid_request', 'Invalid code');
+    sendTokenError(res, 'invalid_request', 'Invalid pre-authorized_code');
     return;
   }
 

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -497,6 +497,11 @@ async function handlePreAuthorizedCode(req: Request, res: Response): Promise<voi
     return;
   }
 
+  if (login.expiresAt && new Date(login.expiresAt) < new Date()) {
+    sendTokenError(res, 'invalid_grant', 'Pre-authorized code expired');
+    return;
+  }
+
   if (login.granted) {
     await revokeLogin(systemRepo, login);
     sendTokenError(res, 'invalid_grant', 'Token already granted');

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -68,7 +68,7 @@ export type CodeChallengeMethod = 'plain' | 'S256';
 export interface LoginRequest {
   readonly email?: string;
   readonly externalId?: string;
-  readonly authMethod: 'password' | 'google' | 'external' | 'exchange';
+  readonly authMethod: Login['authMethod'];
   readonly password?: string;
   readonly scope: string;
   readonly nonce: string;


### PR DESCRIPTION
Implements the [OID4VCI Pre-Authorized Code Grant](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-urnietfparamsoauthgrant-typ) flow as "magic links". An admin creates a short-lived Login via `POST /auth/preauthorize`, receives a plaintext code, and can distribute it to a user who then exchanges it for an access token at `POST /oauth2/token`.

The actual implementation is relatively short.  Most of the PR is tests and docs.

Key files:
* `packages/server/src/auth/preauthorize.ts` - New `/auth/preauthorize` endpoint to generate a code
* `packages/server/src/oauth/token.ts` - New grant type in `/oauth2/token` endpoint to redeem the code

See full discussion: https://github.com/medplum/medplum/discussions/9109