### PR TITLE
medplum-provider: hide Get Started screen via project setting

### DIFF
--- a/examples/medplum-provider/src/App.tsx
+++ b/examples/medplum-provider/src/App.tsx
@@ -67,8 +67,11 @@ export function App(): JSX.Element | null {
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const project = medplum.getProject();
-  const setupDisabledByProject = project?.setting?.find((s) => s.name === HIDE_GET_STARTED_SETTING)?.valueBoolean === true;
-  const [setupDismissedByUser, setSetupDismissedByUser] = useState(() => localStorage.getItem(SETUP_DISMISSED_KEY) === 'true');
+  const setupDisabledByProject =
+    project?.setting?.find((s) => s.name === HIDE_GET_STARTED_SETTING)?.valueBoolean === true;
+  const [setupDismissedByUser, setSetupDismissedByUser] = useState(
+    () => localStorage.getItem(SETUP_DISMISSED_KEY) === 'true'
+  );
   const setupDismissed = setupDisabledByProject || setupDismissedByUser;
   const { hasAccess: hasDoseSpot } = useDoseSpotAccess();
   const membership = medplum.getProjectMembership();

--- a/examples/medplum-provider/src/App.tsx
+++ b/examples/medplum-provider/src/App.tsx
@@ -24,6 +24,7 @@ import { useDoseSpotAccess } from './hooks/useDoseSpotAccess';
 import './index.css';
 
 const SETUP_DISMISSED_KEY = 'medplum-provider-setup-completed';
+const HIDE_GET_STARTED_SETTING = 'hideGetStarted';
 
 import { EncounterChartPage } from './pages/encounter/EncounterChartPage';
 import { EncounterModal } from './pages/encounter/EncounterModal';
@@ -65,14 +66,17 @@ export function App(): JSX.Element | null {
   const doseSpotCount = useDoseSpotNotifications();
   const location = useLocation();
   const [searchParams] = useSearchParams();
-  const [setupDismissed, setSetupDismissed] = useState(() => localStorage.getItem(SETUP_DISMISSED_KEY) === 'true');
+  const project = medplum.getProject();
+  const setupDisabledByProject = project?.setting?.find((s) => s.name === HIDE_GET_STARTED_SETTING)?.valueBoolean === true;
+  const [setupDismissedByUser, setSetupDismissedByUser] = useState(() => localStorage.getItem(SETUP_DISMISSED_KEY) === 'true');
+  const setupDismissed = setupDisabledByProject || setupDismissedByUser;
   const { hasAccess: hasDoseSpot } = useDoseSpotAccess();
   const membership = medplum.getProjectMembership();
   const hasScriptSure = hasScriptSureIdentifier(membership);
 
   const handleDismissSetup = (): void => {
     localStorage.setItem(SETUP_DISMISSED_KEY, 'true');
-    setSetupDismissed(true);
+    setSetupDismissedByUser(true);
   };
 
   if (medplum.isLoading()) {


### PR DESCRIPTION
## Summary

- Adds a `hideGetStarted` project setting that, when set to `true` in the project's public settings, suppresses the Get Started screen and sidebar link for all project members
- Per-user localStorage dismissal continues to work as before — either mechanism can hide the screen
- Setting name is extracted to a constant (`HIDE_GET_STARTED_SETTING`) for discoverability

To enable, a project admin adds a setting via the Medplum admin UI (`Project > Settings`):
```
name: hideGetStarted
valueBoolean: true
```

Fixes #9251

## Test plan

- [ ] With no project setting, Get Started screen appears for new users as before
- [ ] With `hideGetStarted: true` in project settings, Get Started link is absent from sidebar and `/` redirects to patient list
- [ ] Per-user localStorage dismiss still works when project setting is absent