### PR TITLE
Serialize transaction state transitions

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -1703,6 +1703,238 @@ describe('FHIR Repo', () => {
     ]);
   });
 
+  test('withTransactionStateLock serializes concurrent transaction begins', async () => {
+    const beginIssued = Promise.withResolvers<undefined>();
+    const allowBegin = Promise.withResolvers<undefined>();
+    const finishFirstTransaction = Promise.withResolvers<undefined>();
+    const secondCallbackStarted = Promise.withResolvers<undefined>();
+    const queries: string[] = [];
+    let beginCount = 0;
+    const query = jest.fn(async (sql: string) => {
+      queries.push(sql);
+      if (sql === 'BEGIN ISOLATION LEVEL REPEATABLE READ' && ++beginCount === 1) {
+        // Pause the first BEGIN before beginTransaction can publish transactionDepth = 1.
+        beginIssued.resolve(undefined);
+        await allowBegin.promise;
+      }
+      return { rows: [] };
+    });
+    const client = {
+      query,
+      release: jest.fn(),
+    } as unknown as PoolClient;
+    const repo = getShardSystemRepo(
+      'test-shard',
+      RepositoryConnection.borrowClient(client, { mode: DatabaseMode.WRITER })
+    );
+
+    const tx1 = repo.withTransaction(async () => {
+      await finishFirstTransaction.promise;
+    });
+    await beginIssued.promise;
+
+    // Start a second transaction while the first transaction is suspended in BEGIN. Without the state
+    // lock, this second call can observe transactionDepth = 0 and incorrectly issue another BEGIN.
+    const tx2 = repo.withTransaction(async () => {
+      secondCallbackStarted.resolve(undefined);
+    });
+    // Let the second transaction run any queued promise continuations. If it is not blocked by the
+    // lock, it will append its own SQL before this assertion.
+    await allowPendingMicrotasks();
+
+    // The second begin must wait until the first BEGIN has completed and published transactionDepth.
+    expect(queries).toStrictEqual(['BEGIN ISOLATION LEVEL REPEATABLE READ']);
+
+    allowBegin.resolve(undefined);
+    await secondCallbackStarted.promise;
+    finishFirstTransaction.resolve(undefined);
+    await Promise.all([tx1, tx2]);
+
+    expect(queries).toStrictEqual([
+      'BEGIN ISOLATION LEVEL REPEATABLE READ',
+      'SAVEPOINT sp2',
+      'RELEASE SAVEPOINT sp2',
+      'COMMIT',
+    ]);
+  });
+
+  test('withTransactionStateLock serializes concurrent transaction commits', async () => {
+    const firstStarted = Promise.withResolvers<undefined>();
+    const secondStarted = Promise.withResolvers<undefined>();
+    const finishTransactions = Promise.withResolvers<undefined>();
+    const releaseSavepointIssued = Promise.withResolvers<undefined>();
+    const allowReleaseSavepoint = Promise.withResolvers<undefined>();
+    const queries: string[] = [];
+    let releaseSavepointCount = 0;
+    const query = jest.fn(async (sql: string) => {
+      queries.push(sql);
+      if (sql === 'RELEASE SAVEPOINT sp2' && ++releaseSavepointCount === 1) {
+        // Hold the inner commit in the database call before transactionDepth is decremented.
+        releaseSavepointIssued.resolve(undefined);
+        await allowReleaseSavepoint.promise;
+      }
+      return { rows: [] };
+    });
+    const client = {
+      query,
+      release: jest.fn(),
+    } as unknown as PoolClient;
+    const repo = getShardSystemRepo(
+      'test-shard',
+      RepositoryConnection.borrowClient(client, { mode: DatabaseMode.WRITER })
+    );
+
+    const tx1 = repo.withTransaction(async () => {
+      firstStarted.resolve(undefined);
+      await secondStarted.promise;
+      await finishTransactions.promise;
+    });
+    await firstStarted.promise;
+
+    const tx2 = repo.withTransaction(async () => {
+      secondStarted.resolve(undefined);
+      await finishTransactions.promise;
+    });
+    await secondStarted.promise;
+
+    expect(queries).toStrictEqual(['BEGIN ISOLATION LEVEL REPEATABLE READ', 'SAVEPOINT sp2']);
+    finishTransactions.resolve(undefined);
+    await releaseSavepointIssued.promise;
+    // Both transaction callbacks have finished. Yield so the second commit path can attempt to run;
+    // it must not issue COMMIT until the first RELEASE SAVEPOINT has decremented transactionDepth.
+    await allowPendingMicrotasks();
+
+    // The other commit path must wait until transactionDepth is decremented after RELEASE SAVEPOINT.
+    expect(queries).toStrictEqual(['BEGIN ISOLATION LEVEL REPEATABLE READ', 'SAVEPOINT sp2', 'RELEASE SAVEPOINT sp2']);
+
+    allowReleaseSavepoint.resolve(undefined);
+    await Promise.all([tx1, tx2]);
+
+    expect(queries).toStrictEqual([
+      'BEGIN ISOLATION LEVEL REPEATABLE READ',
+      'SAVEPOINT sp2',
+      'RELEASE SAVEPOINT sp2',
+      'COMMIT',
+    ]);
+  });
+
+  test('withTransactionStateLock serializes concurrent transaction rollbacks', async () => {
+    const firstStarted = Promise.withResolvers<undefined>();
+    const secondStarted = Promise.withResolvers<undefined>();
+    const failTransactions = Promise.withResolvers<undefined>();
+    const rollbackSavepointIssued = Promise.withResolvers<undefined>();
+    const allowRollbackSavepoint = Promise.withResolvers<undefined>();
+    const queries: string[] = [];
+    let rollbackSavepointCount = 0;
+    const query = jest.fn(async (sql: string) => {
+      queries.push(sql);
+      if (sql === 'ROLLBACK TO SAVEPOINT sp2' && ++rollbackSavepointCount === 1) {
+        // Hold the inner rollback in the database call before transactionDepth is decremented.
+        rollbackSavepointIssued.resolve(undefined);
+        await allowRollbackSavepoint.promise;
+      }
+      return { rows: [] };
+    });
+    const client = {
+      query,
+      release: jest.fn(),
+    } as unknown as PoolClient;
+    const repo = getShardSystemRepo(
+      'test-shard',
+      RepositoryConnection.borrowClient(client, { mode: DatabaseMode.WRITER })
+    );
+    const errorSpy = jest.spyOn(getLogger(), 'error').mockImplementation(() => {});
+
+    try {
+      const tx1 = repo
+        .withTransaction(async () => {
+          firstStarted.resolve(undefined);
+          await secondStarted.promise;
+          await failTransactions.promise;
+          throw new Error('first rollback');
+        })
+        .catch((err) => err);
+      await firstStarted.promise;
+
+      const tx2 = repo
+        .withTransaction(async () => {
+          secondStarted.resolve(undefined);
+          await failTransactions.promise;
+          throw new Error('second rollback');
+        })
+        .catch((err) => err);
+      await secondStarted.promise;
+
+      expect(queries).toStrictEqual(['BEGIN ISOLATION LEVEL REPEATABLE READ', 'SAVEPOINT sp2']);
+      failTransactions.resolve(undefined);
+      await rollbackSavepointIssued.promise;
+      // Both transaction callbacks have failed. Yield so the second rollback path can attempt to run;
+      // it must not issue ROLLBACK until the savepoint rollback has updated transactionDepth.
+      await allowPendingMicrotasks();
+
+      // The other rollback path must wait until transactionDepth is decremented after ROLLBACK TO SAVEPOINT.
+      expect(queries).toStrictEqual([
+        'BEGIN ISOLATION LEVEL REPEATABLE READ',
+        'SAVEPOINT sp2',
+        'ROLLBACK TO SAVEPOINT sp2',
+      ]);
+
+      allowRollbackSavepoint.resolve(undefined);
+      const results = await Promise.all([tx1, tx2]);
+
+      expect(results).toEqual([expect.any(Error), expect.any(Error)]);
+      expect(queries).toStrictEqual([
+        'BEGIN ISOLATION LEVEL REPEATABLE READ',
+        'SAVEPOINT sp2',
+        'ROLLBACK TO SAVEPOINT sp2',
+        'ROLLBACK',
+      ]);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  test('processing pre-commit callbacks does not deadlock a transaction', async () => {
+    const queries: string[] = [];
+    const query = jest.fn(async (sql: string) => {
+      queries.push(sql);
+      return { rows: [] };
+    });
+    const client = {
+      query,
+      release: jest.fn(),
+    } as unknown as PoolClient;
+    const repo = getShardSystemRepo(
+      'test-shard',
+      RepositoryConnection.borrowClient(client, { mode: DatabaseMode.WRITER })
+    );
+
+    const result = await Promise.race([
+      repo
+        .withTransaction(async () => {
+          await repo.preCommit(async () => {
+            // Pre-commit callbacks are allowed to start their own nested transaction.
+            // If the outer commit held transactionStateLock while running callbacks, this nested
+            // transaction would wait for the lock while the outer commit waited for the callback.
+            await repo.withTransaction(async () => undefined);
+          });
+        })
+        .then(() => 'completed'),
+      new Promise((resolve) => {
+        // The broken implementation deadlocks, so the race gives the test a bounded failure mode.
+        setTimeout(() => resolve('timed out'), 100);
+      }),
+    ]);
+
+    expect(result).toBe('completed');
+    expect(queries).toStrictEqual([
+      'BEGIN ISOLATION LEVEL REPEATABLE READ',
+      'SAVEPOINT sp2',
+      'RELEASE SAVEPOINT sp2',
+      'COMMIT',
+    ]);
+  });
+
   test.each(['commit', 'rollback'])('Post-commit handling on %s', async (mode) => {
     const repo = systemRepo;
     const loggerErrorSpy = jest.spyOn(getLogger(), 'error').mockImplementation(() => {});
@@ -1974,4 +2206,13 @@ function shuffleString(s: string): string {
     arr[j] = temp;
   }
   return arr.join('');
+}
+
+// Some transaction race tests need to make a negative assertion: a competing async path has had a
+// chance to resume, but it must not issue SQL while the transaction state lock is held.
+async function allowPendingMicrotasks(): Promise<void> {
+  // Yield twice so already-queued promise continuations, and continuations queued by those
+  // continuations, can run far enough to issue SQL if the lock is missing.
+  await Promise.resolve();
+  await Promise.resolve();
 }

--- a/packages/server/src/fhir/repository/repository-connection.ts
+++ b/packages/server/src/fhir/repository/repository-connection.ts
@@ -193,15 +193,16 @@ export class RepositoryConnection implements Disposable {
   ): Promise<TResult> {
     this.assertNotClosed();
     const isolationLevel = options?.serializable ? 'SERIALIZABLE' : 'REPEATABLE READ';
-    this.assertCompatibleTransactionIsolationLevel(isolationLevel);
 
     const config = getConfig();
     const transactionAttempts = config.transactionAttempts ?? defaultTransactionAttempts;
     let error: OperationOutcomeError | undefined;
     for (let attempt = 0; attempt < transactionAttempts; attempt++) {
       const attemptStartTime = Date.now();
+      let transactionStarted = false;
       try {
         const client = await this.beginTransaction(isolationLevel);
+        transactionStarted = true;
         const result = await callback(client);
         await this.commitTransaction();
         if (attempt > 0) {
@@ -219,7 +220,9 @@ export class RepositoryConnection implements Disposable {
         error = operationOutcomeError;
 
         // Ensure transaction is rolled back before attempting any retry
-        await this.rollbackTransaction(operationOutcomeError);
+        if (transactionStarted) {
+          await this.rollbackTransaction(operationOutcomeError);
+        }
         if (this.transactionDepth || !isRetryableTransactionError(operationOutcomeError)) {
           break; // Fall through to throw statement outside of the loop
         }
@@ -261,100 +264,147 @@ export class RepositoryConnection implements Disposable {
     throw error;
   }
 
-  private async beginTransaction(isolationLevel: TransactionIsolationLevel): Promise<PoolClient> {
-    this.assertNotClosed();
-    const nextDepth = this.transactionDepth + 1;
-    const conn = await this.getConnection(DatabaseMode.WRITER);
+  /**
+   * tail of a FIFO queue for transaction state change requests.
+   */
+  private transactionStateLock: Promise<undefined> = Promise.resolve(undefined);
+
+  /**
+   * Serializes the small critical sections that reads/writes transaction
+   * state and issues the matching transaction SQL commands:
+   * - read/write transactionDepth
+   * - choose COMMIT vs RELEASE SAVEPOINT
+   * - clear/pop callback frames
+   * - release connection state
+   * @param callback - The callback to execute with the transaction state lock.
+   * @returns Passthrough result of the callback.
+   */
+  private async withTransactionStateLock<T>(callback: () => Promise<T>): Promise<T> {
+    // capture the current tail of the queue
+    const previous = this.transactionStateLock;
+
+    // create a new unresolved promise and make it the new queue tail immediately
+    const { promise, resolve } = Promise.withResolvers<undefined>();
+    this.transactionStateLock = promise;
+
+    // Wait previous request resolves
+    await previous;
+    // current request owns the lock.
+
     try {
-      if (nextDepth === 1) {
-        await conn.query('BEGIN ISOLATION LEVEL ' + isolationLevel);
-      } else {
-        await conn.query('SAVEPOINT sp' + nextDepth);
-      }
-    } catch (err) {
-      if (nextDepth === 1) {
-        // If BEGIN itself fails, no transaction exists to roll back. Drop the client
-        // with the original error so pg-pool does not return a questionable session.
-        this.releaseConnection(err instanceof Error ? err : true);
-      }
-      throw err;
+      return await callback();
+    } finally {
+      // release the lock
+      resolve(undefined);
     }
-    // Publish transaction state only after Postgres confirms BEGIN/SAVEPOINT.
-    if (nextDepth === 1) {
-      this.transactionIsolationLevel = isolationLevel;
-    }
-    this.transactionDepth = nextDepth;
-    this.pushCallbackFrame();
-    return conn;
+  }
+
+  private async beginTransaction(isolationLevel: TransactionIsolationLevel): Promise<PoolClient> {
+    return this.withTransactionStateLock(async () => {
+      this.assertNotClosed();
+      this.assertCompatibleTransactionIsolationLevel(isolationLevel);
+      const nextDepth = this.transactionDepth + 1;
+      const conn = await this.getConnection(DatabaseMode.WRITER);
+      try {
+        if (nextDepth === 1) {
+          await conn.query('BEGIN ISOLATION LEVEL ' + isolationLevel);
+        } else {
+          await conn.query('SAVEPOINT sp' + nextDepth);
+        }
+      } catch (err) {
+        if (nextDepth === 1) {
+          // If BEGIN itself fails, no transaction exists to roll back. Drop the client
+          // with the original error so pg-pool does not return a questionable session.
+          this.releaseConnection(err instanceof Error ? err : true);
+        }
+        throw err;
+      }
+      // Publish transaction state only after Postgres confirms BEGIN/SAVEPOINT.
+      if (nextDepth === 1) {
+        this.transactionIsolationLevel = isolationLevel;
+      }
+      this.transactionDepth = nextDepth;
+      this.pushCallbackFrame();
+      return conn;
+    });
   }
 
   private async commitTransaction(): Promise<void> {
-    this.assertInTransaction();
-    const conn = await this.getConnection(DatabaseMode.WRITER);
-    if (this.transactionDepth === 1) {
+    const shouldProcessPreCommit = await this.withTransactionStateLock(async () => {
+      this.assertInTransaction();
+      return this.transactionDepth === 1;
+    });
+
+    // processPreCommit needs to be invoked outside of the transaction state lock to avoid deadlocks
+    // since it could involve transactions
+    if (shouldProcessPreCommit) {
       await this.processPreCommit();
-      await conn.query('COMMIT');
-      this.transactionDepth = 0;
-      this.transactionIsolationLevel = undefined;
-      this.releaseConnection();
-      this.clearCallbackStack();
+    }
+
+    const shouldProcessPostCommit = await this.withTransactionStateLock(async () => {
+      this.assertInTransaction();
+      const conn = await this.getConnection(DatabaseMode.WRITER);
+      if (this.transactionDepth === 1) {
+        await conn.query('COMMIT');
+        this.transactionDepth = 0;
+        this.transactionIsolationLevel = undefined;
+        this.releaseConnection();
+        this.clearCallbackStack();
+        return true;
+      } else {
+        // If RELEASE SAVEPOINT fails (e.g. transaction in aborted state), let the error propagate.
+        // withTransaction's catch will invoke rollbackTransaction, which can run ROLLBACK TO SAVEPOINT
+        // even against an aborted transaction to recover — aborting here would discard work the outer
+        // scope can still commit. rollbackTransaction's own catch handles the truly-dead-connection case.
+        await conn.query('RELEASE SAVEPOINT sp' + this.transactionDepth);
+        this.transactionDepth--; // safe to decrement since assertInTransaction() ensures transactionDepth > 0
+        this.popCallbackFrame();
+        return false;
+      }
+    });
+
+    if (shouldProcessPostCommit) {
       await this.processPostCommit();
-    } else {
-      // If RELEASE SAVEPOINT fails (e.g. transaction in aborted state), let the error propagate.
-      // withTransaction's catch will invoke rollbackTransaction, which can run ROLLBACK TO SAVEPOINT
-      // even against an aborted transaction to recover — aborting here would discard work the outer
-      // scope can still commit. rollbackTransaction's own catch handles the truly-dead-connection case.
-      await conn.query('RELEASE SAVEPOINT sp' + this.transactionDepth);
-      this.transactionDepth--; // safe to decrement since assertInTransaction() ensures transactionDepth > 0
-      this.popCallbackFrame();
     }
   }
 
   private async rollbackTransaction(error: Error): Promise<void> {
-    // Tolerate being called after state has already been reset (e.g. when a prior
-    // cleanup path in commit/rollback fully aborted the transaction on a dead connection).
-    if (this.transactionDepth === 0) {
-      return;
-    }
-    const conn = await this.getConnection(DatabaseMode.WRITER);
-    const isOuter = this.transactionDepth === 1;
-    try {
-      if (isOuter) {
-        await conn.query('ROLLBACK');
-      } else {
-        await conn.query('ROLLBACK TO SAVEPOINT sp' + this.transactionDepth);
+    return this.withTransactionStateLock(async () => {
+      // Tolerate being called after state has already been reset (e.g. when a prior
+      // cleanup path in commit/rollback fully aborted the transaction on a dead connection).
+      if (this.transactionDepth === 0) {
+        return;
       }
-    } catch (rollbackErr) {
-      // ROLLBACK itself failed — connection is almost certainly dead (e.g. killed by
-      // idle_in_transaction_session_timeout). Pass the original triggering error to
-      // abortTransaction so the client is released with the right root cause.
-      getLogger().warn('Error rolling back transaction', {
-        err: normalizeErrorString(rollbackErr),
-        originalErr: normalizeErrorString(error),
-      });
-      this.abortTransaction(error);
-      return;
-    }
-    this.transactionDepth--; // safe to decrement since early return if transactionDepth === 0
-    this.truncateCommitCallbacks();
-    if (isOuter) {
-      this.transactionIsolationLevel = undefined;
-      this.releaseConnection(error);
-    }
-  }
+      const conn = await this.getConnection(DatabaseMode.WRITER);
+      const isOuter = this.transactionDepth === 1;
+      try {
+        if (isOuter) {
+          await conn.query('ROLLBACK');
+        } else {
+          await conn.query('ROLLBACK TO SAVEPOINT sp' + this.transactionDepth);
+        }
+      } catch (rollbackErr) {
+        // ROLLBACK itself failed — connection is effectively dead (e.g. killed by idle_in_transaction_session_timeout).
+        getLogger().warn('Error rolling back transaction', {
+          err: normalizeErrorString(rollbackErr),
+          originalErr: normalizeErrorString(error),
+        });
 
-  /**
-   * Fully abort the transaction hierarchy: reset depth, drop pending pre/post-commit
-   * callbacks, and release the connection with an error so pg-pool discards it.
-   * Invoked from commit/rollback error paths when further recovery on the current
-   * connection is not possible.
-   * @param err - The error that triggered the abort; forwarded to `release()`.
-   */
-  private abortTransaction(err: Error): void {
-    this.transactionDepth = 0;
-    this.transactionIsolationLevel = undefined;
-    this.clearCallbackStack();
-    this.releaseConnection(err);
+        // abort the transaction
+        this.transactionDepth = 0;
+        this.transactionIsolationLevel = undefined;
+        this.clearCallbackStack();
+        // Pass the original triggering error so the client is released with the right root cause.
+        this.releaseConnection(error);
+        return;
+      }
+      this.transactionDepth--; // safe to decrement since early return if transactionDepth === 0
+      this.truncateCommitCallbacks();
+      if (isOuter) {
+        this.transactionIsolationLevel = undefined;
+        this.releaseConnection(error);
+      }
+    });
   }
 
   private endTransaction(): void {


### PR DESCRIPTION
This is the first of two steps to improve transaction management. Serializes the critical moments of transaction management within RepositoryConnection such that competing `withTransaction` cannot clobber eachother.

Fixes #9244 