### PR TITLE
Add lab account number to provider lab order form

### DIFF
--- a/examples/medplum-provider/src/pages/labs/OrderLabsPage.tsx
+++ b/examples/medplum-provider/src/pages/labs/OrderLabsPage.tsx
@@ -75,6 +75,7 @@ export function OrderLabsPage(props: OrderLabsPageProps): JSX.Element {
     updateBillingInformation,
     setSpecimenCollectedDateTime,
     setOrderNotes,
+    setPerformingLabAccountNumber,
     createOrderBundle,
   } = labOrderReturn;
 
@@ -176,6 +177,10 @@ export function OrderLabsPage(props: OrderLabsPageProps): JSX.Element {
               patient={patient}
               performingLab={performingLab}
               error={createError?.validation?.performingLab}
+            />
+            <TextInput
+              label="Account number"
+              onChange={(e) => setPerformingLabAccountNumber(e.currentTarget.value || undefined)}
             />
             <div>
               <AsyncAutocomplete<TestCoding>

--- a/examples/medplum-provider/src/pages/labs/OrderLabsPage.tsx
+++ b/examples/medplum-provider/src/pages/labs/OrderLabsPage.tsx
@@ -179,7 +179,7 @@ export function OrderLabsPage(props: OrderLabsPageProps): JSX.Element {
               error={createError?.validation?.performingLab}
             />
             <TextInput
-              label="Account number"
+              label="Lab account number"
               onChange={(e) => setPerformingLabAccountNumber(e.currentTarget.value || undefined)}
             />
             <div>


### PR DESCRIPTION
Simple change to include the lab account number as a value you can pass in when ordering labs via Medplum Provider.