### PR TITLE
Provider: Use Appointment-based scheduling flow

### DIFF
--- a/examples/medplum-provider/src/components/schedule/BookAppointmentForm.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/BookAppointmentForm.test.tsx
@@ -17,13 +17,15 @@ vi.mock('../../utils/notifications');
 describe('BookAppointmentForm', () => {
   let medplum: MockClient;
 
-  const slot: Slot = {
-    resourceType: 'Slot',
-    id: 'slot-1',
-    start: '2026-02-20T13:00:00Z',
-    end: '2026-02-20T13:30:00Z',
-    schedule: { reference: 'Schedule/schedule-1' },
-    status: 'free',
+  const start = '2026-02-20T13:00:00Z';
+  const end = '2026-02-20T13:30:00Z';
+  const appointment: Appointment = {
+    resourceType: 'Appointment',
+    id: 'appointment-1',
+    status: 'proposed',
+    start,
+    end,
+    participant: [],
   };
 
   beforeEach(() => {
@@ -43,7 +45,7 @@ describe('BookAppointmentForm', () => {
           <MedplumProvider medplum={medplum}>
             <MantineProvider>
               <Notifications />
-              <BookAppointmentForm slot={slot} onSuccess={onSuccess} />
+              <BookAppointmentForm appointment={appointment} onSuccess={onSuccess} />
             </MantineProvider>
           </MedplumProvider>
         </MemoryRouter>
@@ -58,7 +60,7 @@ describe('BookAppointmentForm', () => {
     expect(screen.getByRole('button', { name: 'Create Appointment' })).toBeInTheDocument();
   });
 
-  test('displays the slot time period', async () => {
+  test('displays the appointment time period', async () => {
     await setup();
 
     expect(screen.getByText(/2026/)).toBeInTheDocument();
@@ -90,8 +92,8 @@ describe('BookAppointmentForm', () => {
             resourceType: 'Appointment',
             id: 'appointment-1',
             status: 'booked',
-            start: slot.start,
-            end: slot.end,
+            start,
+            end,
             participant: [],
           },
         },
@@ -100,8 +102,8 @@ describe('BookAppointmentForm', () => {
             resourceType: 'Slot',
             id: 'slot-1',
             status: 'busy',
-            start: slot.start,
-            end: slot.end,
+            start,
+            end,
             schedule: { reference: 'Schedule/schedule-1' },
           },
         },
@@ -129,13 +131,21 @@ describe('BookAppointmentForm', () => {
       new URL('https://example.com/fhir/R4/Appointment/$book'),
       expect.objectContaining({
         resourceType: 'Parameters',
-        parameter: expect.arrayContaining([
-          { name: 'slot', resource: slot },
+        parameter: [
           {
-            name: 'patient-reference',
-            valueReference: expect.objectContaining({ reference: `Patient/${HomerSimpson.id}` }),
+            name: 'appointment',
+            resource: expect.objectContaining({
+              resourceType: 'Appointment',
+              participant: expect.arrayContaining([
+                expect.objectContaining({
+                  actor: expect.objectContaining({ reference: `Patient/${HomerSimpson.id}` }),
+                  status: 'needs-action',
+                  required: 'required',
+                }),
+              ]),
+            }),
           },
-        ]),
+        ],
       })
     );
   });
@@ -148,8 +158,8 @@ describe('BookAppointmentForm', () => {
       resourceType: 'Appointment',
       id: 'appointment-1',
       status: 'booked',
-      start: slot.start,
-      end: slot.end,
+      start,
+      end,
       participant: [],
     };
 
@@ -157,8 +167,8 @@ describe('BookAppointmentForm', () => {
       resourceType: 'Slot',
       id: 'slot-1',
       status: 'busy',
-      start: slot.start,
-      end: slot.end,
+      start,
+      end,
       schedule: { reference: 'Schedule/schedule-1' },
     };
 
@@ -166,7 +176,7 @@ describe('BookAppointmentForm', () => {
       resourceType: 'Slot',
       id: 'slot-2',
       status: 'busy-unavailable',
-      start: slot.end,
+      start,
       end: '2026-02-01T13:45:00Z',
       schedule: { reference: 'Schedule/schedule-1' },
     };

--- a/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
@@ -11,7 +11,7 @@ import { showErrorNotification } from '../../utils/notifications';
 import { SchedulingTransientIdentifier } from '../../utils/scheduling';
 
 type BookAppointmentFormProps = {
-  slot: Slot;
+  appointment: Appointment;
   onSuccess?: (result: { appointments: WithId<Appointment>[]; slots: WithId<Slot>[] }) => void;
 };
 
@@ -20,27 +20,33 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
   const [patient, setPatient] = useState<Patient | undefined>(undefined);
   const [loading, setLoading] = useState(false);
 
-  const { slot, onSuccess } = props;
+  const { appointment, onSuccess } = props;
 
-  const bookSlot = useCallback(
+  const bookAppointment = useCallback(
     async (patient: Patient) => {
       setLoading(true);
 
+      // merge patient into participants list
+      const booking = {
+        ...appointment,
+        participant: [
+          ...appointment.participant,
+          {
+            actor: createReference(patient),
+            status: 'needs-action',
+            required: 'required',
+          },
+        ],
+      } satisfies Appointment;
+
       // Remove any transient identifiers we added for use in the UI before submitting
-      const bookSlot = { ...slot };
-      SchedulingTransientIdentifier.remove(bookSlot);
+      SchedulingTransientIdentifier.remove(booking);
 
       try {
-        const data = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(
-          medplum.fhirUrl('Appointment', '$book'),
-          {
-            resourceType: 'Parameters',
-            parameter: [
-              { name: 'slot', resource: bookSlot },
-              { name: 'patient-reference', valueReference: createReference(patient) },
-            ],
-          }
-        );
+        const data = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(medplum.fhirUrl('Appointment', '$book'), {
+          resourceType: 'Parameters',
+          parameter: [{ name: 'appointment', resource: booking }],
+        });
         medplum.invalidateSearches('Appointment');
         medplum.invalidateSearches('Slot');
 
@@ -57,19 +63,20 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
         setLoading(false);
       }
     },
-    [medplum, slot, onSuccess]
+    [medplum, appointment, onSuccess]
   );
 
   const handleSubmit = useCallback(async () => {
     if (!patient) {
       return;
     }
+
     try {
-      await bookSlot(patient);
+      await bookAppointment(patient);
     } catch (error) {
       showErrorNotification(error);
     }
-  }, [patient, bookSlot]);
+  }, [patient, bookAppointment]);
 
   const choosePatient = useCallback((patient: Resource | undefined) => {
     if (patient && patient.resourceType !== 'Patient') {
@@ -81,7 +88,7 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
   return (
     <Form onSubmit={handleSubmit}>
       <Stack gap="md">
-        <Text size="lg">{formatPeriod({ start: props.slot.start, end: props.slot.end })}</Text>
+        <Text size="lg">{formatPeriod({ start: props.appointment.start, end: props.appointment.end })}</Text>
         <ResourceInput
           label="Patient"
           resourceType="Patient"

--- a/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
@@ -43,10 +43,13 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
       SchedulingTransientIdentifier.remove(booking);
 
       try {
-        const data = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(medplum.fhirUrl('Appointment', '$book'), {
-          resourceType: 'Parameters',
-          parameter: [{ name: 'appointment', resource: booking }],
-        });
+        const data = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(
+          medplum.fhirUrl('Appointment', '$book'),
+          {
+            resourceType: 'Parameters',
+            parameter: [{ name: 'appointment', resource: booking }],
+          }
+        );
         medplum.invalidateSearches('Appointment');
         medplum.invalidateSearches('Slot');
 

--- a/examples/medplum-provider/src/pages/schedule/FindPane.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/FindPane.test.tsx
@@ -35,22 +35,22 @@ describe('FindPane', () => {
     end: new Date('2024-01-21T23:59:59Z'),
   };
 
-  const mockSlots: Slot[] = [
+  const mockAppointments: Appointment[] = [
     {
-      resourceType: 'Slot',
-      id: 'slot-1',
-      schedule: { reference: 'Schedule/schedule-1' },
-      status: 'free',
+      resourceType: 'Appointment',
+      id: 'appointment-1',
+      status: 'proposed',
       start: '2024-01-16T10:00:00Z',
       end: '2024-01-16T10:30:00Z',
+      participant: [],
     },
     {
-      resourceType: 'Slot',
-      id: 'slot-2',
-      schedule: { reference: 'Schedule/schedule-1' },
-      status: 'free',
+      resourceType: 'Appointment',
+      id: 'appointment-2',
+      status: 'proposed',
       start: '2024-01-16T11:00:00Z',
       end: '2024-01-16T11:30:00Z',
+      participant: [],
     },
   ];
 
@@ -66,7 +66,7 @@ describe('FindPane', () => {
           Promise.resolve({
             resourceType: 'Bundle',
             type: 'searchset',
-            entry: mockSlots.map((slot) => ({ resource: slot })),
+            entry: mockAppointments.map((appointment) => ({ resource: appointment })),
           })
         );
       }
@@ -105,9 +105,7 @@ describe('FindPane', () => {
   type SetupOptions = {
     schedule?: WithId<Schedule>;
     range?: { start: Date; end: Date };
-    onChange?: (slots: Slot[]) => void;
     onSuccess?: (results: { appointments: Appointment[]; slots: Slot[] }) => void;
-    slots?: Slot[];
   };
 
   const setup = (options: SetupOptions = {}): ReturnType<typeof render> => {
@@ -164,27 +162,36 @@ describe('FindPane', () => {
   });
 
   describe('HealthcareService Selection', () => {
-    test('fetches slots when a service type is selected', async () => {
+    test('fetches appointments when a service type is selected', async () => {
       const user = userEvent.setup();
-      const onChange = vi.fn();
 
       await act(async () => {
-        setup({ onChange });
+        setup();
       });
 
       await user.click(screen.getByText('Annual Checkup'));
 
-      // check that $find was called
+      // check that Appointment/$find was called
       expect(medplum.get).toHaveBeenCalledWith(
-        expect.stringContaining('Schedule/schedule-1/$find'),
+        expect.objectContaining({ href: expect.stringContaining('Appointment/$find') }),
         expect.any(Object)
       );
 
       // check that it was called with the service-type-reference parameter
       expect(medplum.get).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `service-type-reference=${encodeURIComponent(`HealthcareService/${healthcareService.id}`)}`
-        ),
+        expect.objectContaining({
+          href: expect.stringContaining(
+            `service-type-reference=${encodeURIComponent(`HealthcareService/${healthcareService.id}`)}`
+          ),
+        }),
+        expect.any(Object)
+      );
+
+      // check that the schedule reference is included
+      expect(medplum.get).toHaveBeenCalledWith(
+        expect.objectContaining({
+          href: expect.stringContaining(`schedule=${encodeURIComponent('Schedule/schedule-1')}`),
+        }),
         expect.any(Object)
       );
     });
@@ -202,19 +209,19 @@ describe('FindPane', () => {
       expect(screen.queryByText('Schedule…')).not.toBeInTheDocument();
     });
 
-    test('displays slot buttons after selection', async () => {
+    test('displays appointment buttons after selection', async () => {
       const user = userEvent.setup();
 
       await act(async () => {
-        setup({ slots: mockSlots });
+        setup();
       });
 
       await user.click(screen.getByText('Annual Checkup'));
 
-      // Slots should be rendered as buttons with formatted date/time
+      // Appointments should be rendered as buttons with formatted date/time
       const buttons = screen.getAllByRole('button');
 
-      // 1 dismiss button + 2 slot buttons
+      // 1 dismiss button + 2 appointment buttons
       expect(buttons.length).toEqual(3);
     });
   });
@@ -278,39 +285,39 @@ describe('FindPane', () => {
     });
   });
 
-  describe('Slot Selection', () => {
-    test('Displays a form for the chosen slot', async () => {
+  describe('Appointment Selection', () => {
+    test('Displays a form for the chosen appointment', async () => {
       const user = userEvent.setup();
       const onSuccess = vi.fn();
 
       await act(async () => {
-        setup({ slots: mockSlots, onSuccess });
+        setup({ onSuccess });
       });
 
       // Select a service type first
       await user.click(screen.getByText('Annual Checkup'));
 
       await waitFor(() => {
-        // Find slot buttons (they contain formatted datetime)
-        const slotButtons = screen.getAllByRole('button').filter((btn) => btn.textContent?.includes('2024'));
-        expect(slotButtons.length).toBeGreaterThan(0);
+        // Find appointment buttons (they contain formatted datetime)
+        const appointmentButtons = screen.getAllByRole('button').filter((btn) => btn.textContent?.includes('2024'));
+        expect(appointmentButtons.length).toBeGreaterThan(0);
       });
 
-      // Click on a slot button
-      const slotButtons = screen.getAllByRole('button').filter((btn) => btn.textContent?.includes('2024'));
-      expect(slotButtons).not.toHaveLength(0);
-      await user.click(slotButtons[0]);
+      // Click on an appointment button
+      const appointmentButtons = screen.getAllByRole('button').filter((btn) => btn.textContent?.includes('2024'));
+      expect(appointmentButtons).not.toHaveLength(0);
+      await user.click(appointmentButtons[0]);
 
       // See creation form become visible
       expect(screen.getByRole('button', { name: 'Create Appointment' })).toBeInTheDocument();
 
-      // Dismissing the form takes us back to the slot choices
+      // Dismissing the form takes us back to the appointment choices
       const dismissButton = screen.getByLabelText('Clear selection');
       expect(dismissButton).toBeInTheDocument();
       await user.click(dismissButton);
 
-      const slotButtons2 = screen.getAllByRole('button').filter((btn) => btn.textContent?.includes('2024'));
-      expect(slotButtons2).not.toHaveLength(0);
+      const appointmentButtons2 = screen.getAllByRole('button').filter((btn) => btn.textContent?.includes('2024'));
+      expect(appointmentButtons2).not.toHaveLength(0);
     });
   });
 
@@ -350,8 +357,8 @@ describe('FindPane', () => {
         .map((call) => call[0])
         .find((url) => url.toString().includes('$find'));
 
-      expect(callUrl).toContain('start=');
-      expect(callUrl).toContain('end=');
+      expect(callUrl?.href).toContain('start=');
+      expect(callUrl?.href).toContain('end=');
     });
   });
 
@@ -413,7 +420,7 @@ describe('FindPane', () => {
 
       await user.click(screen.getByText('Annual Checkup'));
       expect(medplum.get).toHaveBeenCalledWith(
-        expect.any(String),
+        expect.objectContaining({ href: expect.stringContaining('$find') }),
         expect.objectContaining({ signal: expect.any(AbortSignal) })
       );
     });

--- a/examples/medplum-provider/src/pages/schedule/FindPane.tsx
+++ b/examples/medplum-provider/src/pages/schedule/FindPane.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Button, Group, Stack, Title } from '@mantine/core';
 import type { WithId } from '@medplum/core';
-import { EMPTY, formatDateTime, isDefined } from '@medplum/core';
+import { EMPTY, formatDateTime, getReferenceString, isDefined } from '@medplum/core';
 import type { Appointment, Bundle, HealthcareService, Schedule, Slot } from '@medplum/fhirtypes';
 import { CodeableConceptDisplay, useMedplum } from '@medplum/react';
 import { IconChevronRight, IconX } from '@tabler/icons-react';
@@ -45,8 +45,8 @@ function HealthcareServiceDisplay(props: { value: HealthcareService }): JSX.Elem
 // See https://www.medplum.com/docs/scheduling/defining-availability for details.
 export function FindPane(props: FindPaneProps): JSX.Element | null {
   const medplum = useMedplum();
-  const [slots, setSlots] = useState<readonly Slot[] | undefined>(undefined);
-  const [chosenSlot, setChosenSlot] = useState<Slot | undefined>(undefined);
+  const [appointments, setAppointments] = useState<readonly Appointment[] | undefined>(undefined);
+  const [chosenAppointment, setChosenAppointment] = useState<Appointment | undefined>(undefined);
   const [selectedHealthcareService, setSelectedHealthcareService] = useState<WithId<HealthcareService> | undefined>();
   const { schedule, range, onSuccess } = props;
 
@@ -85,7 +85,7 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
     }
   }, [scheduleableServices]);
 
-  // Ensure that we are searching for slots in the future by at least 30 minutes.
+  // Ensure that we are searching for appointments in the future by at least 30 minutes.
   const earliestSchedulable = useSchedulingStartsAt({ minimumNoticeMinutes: 30 });
 
   useEffect(() => {
@@ -102,14 +102,15 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
     let completed = false;
     const controller = new AbortController();
     const signal = controller.signal;
-    const params = new URLSearchParams({
-      start,
-      end,
-      'service-type-reference': `HealthcareService/${selectedHealthcareService.id}`,
-    });
+
+    const url = medplum.fhirUrl('Appointment', '$find');
+    url.searchParams.append('start', start);
+    url.searchParams.append('end', end);
+    url.searchParams.append('service-type-reference', getReferenceString(selectedHealthcareService));
+    url.searchParams.append('schedule', getReferenceString(schedule));
 
     medplum
-      .get<Bundle<Slot>>(`fhir/R4/Schedule/${schedule.id}/$find?${params}`, { signal })
+      .get<Bundle<Appointment>>(url, { signal })
       .then(
         (bundle) => {
           if (signal.aborted) {
@@ -117,9 +118,9 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
           }
           if (bundle.entry) {
             bundle.entry.forEach((entry) => entry.resource && SchedulingTransientIdentifier.set(entry.resource));
-            setSlots(bundle.entry.map((entry) => entry.resource).filter(isDefined));
+            setAppointments(bundle.entry.map((entry) => entry.resource).filter(isDefined));
           } else {
-            setSlots([]);
+            setAppointments([]);
           }
         },
         (error) => {
@@ -140,14 +141,14 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
 
   const handleDismiss = useCallback(() => {
     setSelectedHealthcareService(undefined);
-    setSlots(EMPTY);
+    setAppointments(EMPTY);
   }, []);
 
   const handleBookSuccess = useCallback(
     (results: { appointments: WithId<Appointment>[]; slots: WithId<Slot>[] }) => {
       setSelectedHealthcareService(undefined);
-      setSlots([]);
-      setChosenSlot(undefined);
+      setAppointments([]);
+      setChosenAppointment(undefined);
       onSuccess(results);
     },
     [onSuccess]
@@ -157,18 +158,18 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
     return null;
   }
 
-  if (selectedHealthcareService && chosenSlot) {
+  if (selectedHealthcareService && chosenAppointment) {
     return (
       <Stack gap="sm" justify="flex-start" className={props.className}>
         <Title order={4}>
           <Group justify="space-between">
             <HealthcareServiceDisplay value={selectedHealthcareService} />
-            <Button variant="subtle" onClick={() => setChosenSlot(undefined)} aria-label="Clear selection">
+            <Button variant="subtle" onClick={() => setChosenAppointment(undefined)} aria-label="Clear selection">
               <IconX size={20} />
             </Button>
           </Group>
         </Title>
-        <BookAppointmentForm slot={chosenSlot} onSuccess={handleBookSuccess} />
+        <BookAppointmentForm appointment={chosenAppointment} onSuccess={handleBookSuccess} />
       </Stack>
     );
   }
@@ -186,15 +187,15 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
             )}
           </Group>
         </Title>
-        {(slots ?? EMPTY).map((slot) => (
+        {(appointments ?? EMPTY).map((appointment) => (
           <Button
-            key={SchedulingTransientIdentifier.get(slot)}
+            key={SchedulingTransientIdentifier.get(appointment)}
             variant="outline"
             color="gray.3"
             styles={(theme) => ({ label: { fontWeight: 'normal', color: theme.colors.gray[9] } })}
-            onClick={() => setChosenSlot(slot)}
+            onClick={() => setChosenAppointment(appointment)}
           >
-            {formatDateTime(slot.start)}
+            {formatDateTime(appointment.start)}
           </Button>
         ))}
       </Stack>

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
@@ -419,14 +419,14 @@ describe('$find/$book component integration tests', () => {
 
     // Mock $find operation
     const originalGet = medplum.get.bind(medplum);
-    const mockFindSlots: Slot[] = [
+    const mockFindAppointments: Appointment[] = [
       {
-        resourceType: 'Slot',
-        id: 'find-slot-1',
-        schedule: createReference(DrAliceSmithSchedule),
-        status: 'free',
+        resourceType: 'Appointment',
+        id: 'find-appointment-1',
+        status: 'proposed',
         start: slotStart,
         end: slotEnd,
+        participant: [],
       },
     ];
     vi.spyOn(medplum, 'get').mockImplementation((url, options) => {
@@ -435,8 +435,8 @@ describe('$find/$book component integration tests', () => {
           Promise.resolve({
             resourceType: 'Bundle',
             type: 'searchset',
-            entry: mockFindSlots.map((slot) => ({ resource: slot })),
-          } satisfies Bundle<Slot>)
+            entry: mockFindAppointments.map((appointment) => ({ resource: appointment })),
+          } satisfies Bundle<Appointment>)
         );
       }
       return originalGet(url, options);
@@ -494,7 +494,7 @@ describe('$find/$book component integration tests', () => {
     // Pane header shows selected service type
     expect(screen.getByText('Annual Checkup')).toBeInTheDocument();
 
-    // Click on a slot button from the find pane
+    // Click on an appointment button from the find pane
     const slotButtons = screen.getAllByText(/1\/16\/2024/);
     expect(slotButtons.length).toEqual(1);
     await user.click(slotButtons[0]);


### PR DESCRIPTION
This paves the way for multi-schedule operations - we're using endpoints that are capable of taking multiple schedules and booking atomically.

The original `/Schedule/:id/$find` endpoint is going to be removed at the end of the Scheduling Alpha period. The intent is to simplify the API surface area by only providing the more powerful `/Appointment/$find` API. This prepares the Provider app for that future transition.