### PR TITLE
Soft-delete draft MR on order-medication failure

### DIFF
--- a/examples/medplum-provider/src/pages/meds/OrderMedicationPage.test.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderMedicationPage.test.tsx
@@ -3,7 +3,11 @@
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import type { MedicationOrderRequest, MedicationOrderResponse } from '@medplum/core';
-import type { Medication } from '@medplum/fhirtypes';
+import {
+  MEDICATION_REQUEST_STATUS_REASON_RESPONSE_NOT_RECEIVED,
+  MEDICATION_REQUEST_STATUS_REASON_SYSTEM,
+} from '@medplum/core';
+import type { Medication, MedicationRequest } from '@medplum/fhirtypes';
 import { DrAliceSmith, HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import type * as ScriptSureReactModule from '@medplum/scriptsure-react';
@@ -59,7 +63,7 @@ describe('OrderMedicationPage', () => {
     expect(screen.getByRole('tab', { name: 'Order set' })).toBeInTheDocument();
   });
 
-  test('deletes the draft MedicationRequest when the order bot fails', async () => {
+  test('soft-deletes the draft MedicationRequest (status=unknown + statusReason) when the order bot fails', async () => {
     const medplum = new MockClient();
     medplum.setProfile(DrAliceSmith);
 
@@ -73,12 +77,13 @@ describe('OrderMedicationPage', () => {
     };
     searchMedicationsMock.mockResolvedValue([searchHit]);
 
-    // Bot call rejects after the draft MR is created — exercise the cleanup branch.
+    // Bot call rejects after the draft MR is created — exercise the soft-delete branch.
     orderMedicationMock.mockImplementation(async (_input: MedicationOrderRequest): Promise<MedicationOrderResponse> => {
       throw ORDER_MEDICATION_REJECTION;
     });
 
     const createSpy = vi.spyOn(medplum, 'createResource');
+    const updateSpy = vi.spyOn(medplum, 'updateResource');
     const deleteSpy = vi.spyOn(medplum, 'deleteResource');
 
     const user = userEvent.setup();
@@ -116,15 +121,29 @@ describe('OrderMedicationPage', () => {
       expect(orderMedicationMock).toHaveBeenCalledTimes(1);
     });
 
-    // The draft MedicationRequest should have been created, then deleted, with matching ids.
+    // The draft MedicationRequest should have been created with status='draft'.
     const createdMrCall = createSpy.mock.calls.find((c) => {
       const r = c[0] as { resourceType?: string; status?: string } | undefined;
       return r?.resourceType === 'MedicationRequest' && r?.status === 'draft';
     });
     expect(createdMrCall).toBeDefined();
 
+    // ...and then *soft*-deleted via updateResource — flipped to status='unknown' with the
+    // canonical 'response-not-received' statusReason so vendor webhooks can reconcile later.
+    // See wiki/medplum/medication-request-lifecycle.md.
     await waitFor(() => {
-      expect(deleteSpy).toHaveBeenCalledWith('MedicationRequest', expect.any(String));
+      const softDeleted = updateSpy.mock.calls
+        .map((c) => c[0] as MedicationRequest | undefined)
+        .find((r) => r?.resourceType === 'MedicationRequest' && r?.status === 'unknown');
+      expect(softDeleted).toBeDefined();
+      expect(softDeleted?.statusReason?.coding?.[0]).toMatchObject({
+        system: MEDICATION_REQUEST_STATUS_REASON_SYSTEM,
+        code: MEDICATION_REQUEST_STATUS_REASON_RESPONSE_NOT_RECEIVED,
+      });
     });
+
+    // And the legacy hard-delete path must NOT fire — that would erase the orphan record
+    // and remove the only handle vendor reconciliation has.
+    expect(deleteSpy).not.toHaveBeenCalledWith('MedicationRequest', expect.any(String));
   });
 });

--- a/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
@@ -20,6 +20,7 @@ import {
 } from '@mantine/core';
 import type { MedicationOrderDrugInput, MedplumClient, WithId } from '@medplum/core';
 import {
+  buildMedicationRequestResponseLostStatusReason,
   createReference,
   getCodeBySystem,
   getExtensionValue,
@@ -914,13 +915,22 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
 
       onOrderComplete?.({ launchUrl: res.launchUrl, medicationRequestId: res.medicationRequestId });
     } catch (e) {
-      // The bot call (or downstream FHIR write) failed after the draft MR was created.
-      // Clean up the orphan draft so the MedicationsPage doesn't grow stale "draft" rows
-      // for every aborted attempt. We swallow delete failures so the original error
-      // is the one the user sees.
+      // The order-medication operation (or its downstream FHIR write) failed after
+      // the draft MR was created. We *soft*-delete instead of hard-deleting because
+      // the vendor side may have actually accepted (and even transmitted) the
+      // prescription before the response was lost — hard-deleting would leave us
+      // with a real-world Rx and no local record to reconcile against the vendor
+      // webhook. Mark the MR as `unknown` + statusReason so MedicationsPage filters
+      // can hide it from the active list while inbound reconciliation still has a
+      // resource to address. PUT is idempotent on retry. Failures here are
+      // swallowed so the original error is the one the user sees.
       if (createdMr?.id) {
         try {
-          await medplum.deleteResource('MedicationRequest', createdMr.id);
+          await medplum.updateResource<MedicationRequest>({
+            ...createdMr,
+            status: 'unknown',
+            statusReason: buildMedicationRequestResponseLostStatusReason(),
+          });
         } catch {
           // ignore - we still want to surface the original error
         }

--- a/packages/core/src/medication-order-utils.test.ts
+++ b/packages/core/src/medication-order-utils.test.ts
@@ -12,6 +12,9 @@ import type {
 import {
   INVALID_MEDICATION_ORDER_RESPONSE,
   INVALID_MEDICATION_ORDER_SET_RESPONSE,
+  MEDICATION_REQUEST_STATUS_REASON_RESPONSE_NOT_RECEIVED,
+  MEDICATION_REQUEST_STATUS_REASON_SYSTEM,
+  buildMedicationRequestResponseLostStatusReason,
   getMedicationOrderIframeUrl,
   getPendingMedicationOrderId,
   getPendingMedicationOrderStatus,
@@ -149,6 +152,39 @@ describe('MedicationOrder getters', () => {
       subject: { reference: 'Patient/1' },
     } satisfies MedicationRequest;
     expect(getMedicationOrderIframeUrl(mr, TEST_EXT)).toBeUndefined();
+  });
+});
+
+describe('MedicationRequest soft-delete (response-not-received)', () => {
+  test('MEDICATION_REQUEST_STATUS_REASON_SYSTEM is a stable canonical URL', () => {
+    expect(MEDICATION_REQUEST_STATUS_REASON_SYSTEM).toBe(
+      'https://medplum.com/fhir/CodeSystem/medication-request-status-reason'
+    );
+  });
+
+  test('MEDICATION_REQUEST_STATUS_REASON_RESPONSE_NOT_RECEIVED is the canonical code', () => {
+    expect(MEDICATION_REQUEST_STATUS_REASON_RESPONSE_NOT_RECEIVED).toBe('response-not-received');
+  });
+
+  test('buildMedicationRequestResponseLostStatusReason emits canonical system + code with human-readable display + text', () => {
+    const reason = buildMedicationRequestResponseLostStatusReason();
+    expect(reason).toEqual({
+      coding: [
+        {
+          system: MEDICATION_REQUEST_STATUS_REASON_SYSTEM,
+          code: MEDICATION_REQUEST_STATUS_REASON_RESPONSE_NOT_RECEIVED,
+          display: 'Order-medication response not received',
+        },
+      ],
+      text: expect.stringMatching(/vendor-side state is unknown/),
+    });
+  });
+
+  test('buildMedicationRequestResponseLostStatusReason returns a fresh object each call (callers may mutate)', () => {
+    const a = buildMedicationRequestResponseLostStatusReason();
+    const b = buildMedicationRequestResponseLostStatusReason();
+    expect(a).not.toBe(b);
+    expect(a.coding).not.toBe(b.coding);
   });
 });
 

--- a/packages/core/src/medication-order-utils.ts
+++ b/packages/core/src/medication-order-utils.ts
@@ -1,7 +1,13 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { CodeableConcept, Medication, MedicationRequest, Parameters, ParametersParameter } from '@medplum/fhirtypes';
+import type {
+  CodeableConcept,
+  Medication,
+  MedicationRequest,
+  Parameters,
+  ParametersParameter,
+} from '@medplum/fhirtypes';
 import { isResource } from './types';
 import { getExtensionValue, getIdentifier } from './utils';
 

--- a/packages/core/src/medication-order-utils.ts
+++ b/packages/core/src/medication-order-utils.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Medication, MedicationRequest, Parameters, ParametersParameter } from '@medplum/fhirtypes';
+import type { CodeableConcept, Medication, MedicationRequest, Parameters, ParametersParameter } from '@medplum/fhirtypes';
 import { isResource } from './types';
 import { getExtensionValue, getIdentifier } from './utils';
 
@@ -22,6 +22,53 @@ export const INVALID_MEDICATION_SEARCH_RESPONSE = 'Invalid response from medicat
  * Stable error when an order-set widget-url response is missing `launchUrl`.
  */
 export const INVALID_MEDICATION_ORDER_SET_RESPONSE = 'Invalid response from order-set bot';
+
+/**
+ * Canonical CodeSystem URL for `MedicationRequest.statusReason` values stamped
+ * by Medplum-managed order flows when a draft MR has to be retired without a
+ * confirmed vendor outcome.
+ *
+ * Downstream reconciliation (vendor webhook bots, audit reports) should match
+ * `statusReason.coding[?(@.system==MEDICATION_REQUEST_STATUS_REASON_SYSTEM)]`
+ * to recognize records that originated from this soft-delete path rather than
+ * a clinician decision.
+ */
+export const MEDICATION_REQUEST_STATUS_REASON_SYSTEM =
+  'https://medplum.com/fhir/CodeSystem/medication-request-status-reason';
+
+/**
+ * Code stamped on `MedicationRequest.statusReason` when an order-medication
+ * operation never returned a verifiable response — the vendor side may have
+ * created (and sent) the prescription, or it may have rejected the request, and
+ * we cannot tell from the client. Used in place of a hard `DELETE` so the
+ * record stays addressable for later reconciliation against vendor webhooks.
+ */
+export const MEDICATION_REQUEST_STATUS_REASON_RESPONSE_NOT_RECEIVED = 'response-not-received';
+
+/**
+ * Builds the `statusReason` CodeableConcept used when soft-deleting a draft
+ * `MedicationRequest` whose vendor-side outcome is unknown (see
+ * {@link MEDICATION_REQUEST_STATUS_REASON_RESPONSE_NOT_RECEIVED}).
+ *
+ * Paired with `status: 'unknown'` (a valid FHIR R4 MedicationRequest status),
+ * this is the standard shape every order-medication caller should write when
+ * `orderMedication(...)` throws after the draft MR has been created.
+ *
+ * @returns A `CodeableConcept` carrying our canonical system + code and a
+ *   human-readable `text` summary.
+ */
+export function buildMedicationRequestResponseLostStatusReason(): CodeableConcept {
+  return {
+    coding: [
+      {
+        system: MEDICATION_REQUEST_STATUS_REASON_SYSTEM,
+        code: MEDICATION_REQUEST_STATUS_REASON_RESPONSE_NOT_RECEIVED,
+        display: 'Order-medication response not received',
+      },
+    ],
+    text: 'The order-medication operation did not return a verifiable response; vendor-side state is unknown.',
+  };
+}
 
 /**
  * Vendor-neutral drug line for {@link MedicationOrderRequest}.


### PR DESCRIPTION
When `$order-medication` throws after the draft `MedicationRequest` has been created, hard-deleting the orphan record races against vendor acceptance — if the vendor side already created (and possibly transmitted) the prescription before the response was lost, we lose the only local handle that an inbound vendor webhook can use to reconcile.

Replace the hard `DELETE` in `OrderMedicationPage.submitSingle`'s `catch` branch with `updateResource({ ...mr, status: 'unknown', statusReason })`. The `statusReason` carries a canonical CodeableConcept built by the new `buildMedicationRequestResponseLostStatusReason()` helper in `@medplum/core/medication-order-utils`, which exports two new constants:

  - `MEDICATION_REQUEST_STATUS_REASON_SYSTEM` (`https://medplum.com/fhir/CodeSystem/medication-request-status-reason`)
  - `MEDICATION_REQUEST_STATUS_REASON_RESPONSE_NOT_RECEIVED` (`'response-not-received'`)

`status: 'unknown'` is a valid FHIR R4 MedicationRequest status; PUT is idempotent so retries are safe; update failures are still swallowed so the user sees the original error. The compound flow is untouched (it doesn't pre-create a draft MR). `MedicationsPage` filters that hide non-active prescriptions must treat `'unknown'` as inactive alongside `'draft'`; vendor webhook bots that observe an order whose pending-id matches an MR with this `statusReason` coding should transition it to the live status.

Closes the first deferred row from PR #8999 review comment r3276980997.

Tests:
- packages/core: 4 new tests for the new constants + helper shape, system stability, code stability, and fresh-object-per-call (35/35).
- medplum-provider: existing failure-path test rewritten to assert \`updateResource\` was called with \`status: 'unknown'\` + the canonical \`statusReason.coding[0]\` system/code, and that \`deleteResource\` is *not* called (30/30).