### PR TITLE
Support server-scoped Patient users in invite endpoint

### DIFF
--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -1428,4 +1428,117 @@ describe('Admin Invite', () => {
     expect(normalizeErrorString(res.body)).toContain('Access policy');
     expect(normalizeErrorString(res.body)).toContain('does not exist');
   });
+
+  test('Invite Patient with scope: server creates server-scoped user', async () => {
+    const { project, accessToken } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Alice',
+        lastName: 'Smith',
+        projectName: 'Alice Project',
+        email: `alice${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+
+    const bobEmail = `bob${randomUUID()}@example.com`;
+    const res = await request(app)
+      .post('/admin/projects/' + project.id + '/invite')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'Patient',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email: bobEmail,
+        scope: 'server',
+        sendEmail: false,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.resourceType).toBe('ProjectMembership');
+
+    // Server-scoped user should NOT be visible from the project context
+    const res2 = await request(app)
+      .get('/fhir/R4/User?email=' + bobEmail)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res2.status).toBe(200);
+    expect(res2.body.resourceType).toBe('Bundle');
+    expect(res2.body.entry).toBeUndefined();
+  });
+
+  test('Invite Patient without scope defaults to project-scoped', async () => {
+    const { project, accessToken } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Alice',
+        lastName: 'Smith',
+        projectName: 'Alice Project',
+        email: `alice${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+
+    const bobEmail = `bob${randomUUID()}@example.com`;
+    const res = await request(app)
+      .post('/admin/projects/' + project.id + '/invite')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'Patient',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email: bobEmail,
+        sendEmail: false,
+      });
+
+    expect(res.status).toBe(200);
+
+    // Project-scoped user should be visible from the project context
+    const res2 = await request(app)
+      .get('/fhir/R4/User?email=' + bobEmail)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res2.status).toBe(200);
+    const user = res2.body.entry[0].resource;
+    expect(user.resourceType).toBe('User');
+    expect(user.project?.reference).toBe(getReferenceString(project));
+  });
+
+  test('Invite Patient with scope: server - conflict with existing project-scoped Patient', async () => {
+    const { project, accessToken } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Alice',
+        lastName: 'Smith',
+        projectName: 'Alice Project',
+        email: `alice${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+
+    const bobEmail = `bob${randomUUID()}@example.com`;
+
+    // Invite Bob first as project-scoped Patient
+    const res1 = await request(app)
+      .post('/admin/projects/' + project.id + '/invite')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'Patient',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email: bobEmail,
+        sendEmail: false,
+      });
+    expect(res1.status).toBe(200);
+
+    // Invite Bob again as server-scoped Patient - should fail (different scope, same project)
+    const res2 = await request(app)
+      .post('/admin/projects/' + project.id + '/invite')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'Patient',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email: bobEmail,
+        scope: 'server',
+        sendEmail: false,
+      });
+    expect(res2.status).toBe(409);
+    expect(normalizeErrorString(res2.body)).toStrictEqual('User is already a member of this project');
+  });
 });

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -160,12 +160,11 @@ async function makeUserResource(request: ServerInviteRequest): Promise<User> {
   const password = request.password ?? generateSecret(16);
   const passwordHash = await bcryptHashPassword(password);
 
+  // Default scoping: Patients are project-scoped, Practitioners/RelatedPersons are server-scoped.
+  // Either default can be overridden with scope: 'project' | 'server'.
+  // Users with an externalId are always project-scoped regardless of resourceType.
   let project: Reference<Project> | undefined = undefined;
-  if (request.resourceType === 'Patient' || externalId || scope === 'project') {
-    // Users can optionally be scoped to a project.
-    // We force users to be scoped to a project if:
-    // 1) They are a patient
-    // 2) They are a practitioner with an externalId
+  if ((request.resourceType === 'Patient' && scope !== 'server') || externalId || scope === 'project') {
     project = createReference(request.project);
   }
 


### PR DESCRIPTION
## Summary

- Patients invited via `/admin/projects/:projectId/invite` default to project-scoped (existing behavior preserved)
- Practitioners/RelatedPersons default to server-scoped (existing behavior preserved)
- **New:** callers can now pass `scope: 'server'` when inviting a `Patient` to create a server-scoped user, mirroring how `scope: 'project'` already works for Practitioners

## Changes

**`packages/server/src/admin/invite.ts`** — one-line condition change in `makeUserResource`:
```diff
- if (request.resourceType === 'Patient' || externalId || scope === 'project') {
+ if ((request.resourceType === 'Patient' && scope !== 'server') || externalId || scope === 'project') {
```

Note: `externalId` still forces project-scoped regardless of `resourceType` or `scope`.

**`packages/server/src/admin/invite.test.ts`** — three new tests:
1. `scope: 'server'` on a Patient creates a server-scoped user (not visible from project context)
2. No `scope` on a Patient defaults to project-scoped (visible from project context, `user.project` set)
3. `scope: 'server'` on a Patient when a project-scoped Patient with the same email already has a membership → 409 conflict (existing conflict-detection logic applies)

## Reviewer notes

No changes to `InviteRequest` in `@medplum/core` — `scope: 'project' | 'server'` was already there, just not respected for `Patient` resourceType.