### PR TITLE
Provider encounter creation: link appointment.slot

### DIFF
--- a/examples/medplum-provider/src/utils/encounter.test.ts
+++ b/examples/medplum-provider/src/utils/encounter.test.ts
@@ -83,7 +83,7 @@ describe('encounter utils', () => {
       const start = new Date('2025-01-01T10:00:00Z');
       const end = new Date('2025-01-01T10:30:00Z');
 
-      await createAppointment(medplum, start, end, patient, practitioner, schedule);
+      const appointment = await createAppointment(medplum, start, end, patient, practitioner, schedule);
 
       const slotCreations = createdResources.filter((r) => r.resourceType === 'Slot');
       expect(slotCreations).toHaveLength(1);
@@ -94,6 +94,9 @@ describe('encounter utils', () => {
         end: end.toISOString(),
         schedule: { reference: 'Schedule/sched-1' },
       });
+
+      // appointment.slot holds a reference to the created slot
+      expect(appointment.slot).toMatchObject([{ reference: `Slot/${slotCreations[0].id}` }]);
     });
 
     test('does not create a Slot when schedule is not provided', async () => {
@@ -104,14 +107,14 @@ describe('encounter utils', () => {
         return result;
       });
 
-      await createAppointment(
+      const appointment = await createAppointment(
         medplum,
         new Date('2025-01-01T10:00:00Z'),
         new Date('2025-01-01T10:30:00Z'),
         patient,
         practitioner
       );
-
+      expect(appointment.slot).toBeUndefined();
       expect(createdResources.filter((r) => r.resourceType === 'Slot')).toHaveLength(0);
     });
   });

--- a/examples/medplum-provider/src/utils/encounter.ts
+++ b/examples/medplum-provider/src/utils/encounter.ts
@@ -14,6 +14,7 @@ import type {
   Reference,
   Schedule,
   ServiceRequest,
+  Slot,
   Task,
 } from '@medplum/fhirtypes';
 
@@ -27,11 +28,26 @@ export async function createAppointment(
 ): Promise<Appointment> {
   const practitionerRef = isResource(practitioner) ? createReference(practitioner) : practitioner;
 
+  // If we have a schedule reference, add a busy slot to prevent future
+  // scheduling operations (such as $find or $book) from thinking this
+  // time is free.
+  let slot: WithId<Slot> | undefined = undefined;
+  if (schedule) {
+    slot = await medplum.createResource({
+      resourceType: 'Slot',
+      start: start.toISOString(),
+      end: end.toISOString(),
+      schedule: createReference(schedule),
+      status: 'busy',
+    });
+  }
+
   const appointment = await medplum.createResource({
     resourceType: 'Appointment',
     status: 'booked',
     start: start.toISOString(),
     end: end.toISOString(),
+    slot: slot ? [createReference(slot)] : undefined,
     participant: [
       {
         actor: createReference(patient),
@@ -43,19 +59,6 @@ export async function createAppointment(
       },
     ],
   });
-
-  // If we have a schedule reference, add a busy slot to prevent future
-  // scheduling operations (such as $find or $book) from thinking this
-  // time is free.
-  if (schedule) {
-    await medplum.createResource({
-      resourceType: 'Slot',
-      start: start.toISOString(),
-      end: end.toISOString(),
-      schedule: createReference(schedule),
-      status: 'busy',
-    });
-  }
 
   return appointment;
 }


### PR DESCRIPTION
When clicking on the calendar to schedule a visit, we are creating a `Slot` resource, but we weren't linking it to the `Appointment` resource we created.

This prevents the slot from being cleared if the appointment is cancelled, leaving an unexpected availability block on the practitioner's calendar.