### PR TITLE
Fixes #9276 - unified external auth

### DIFF
--- a/packages/core/src/base-schema.json
+++ b/packages/core/src/base-schema.json
@@ -4291,6 +4291,20 @@
             "code": "boolean"
           }
         ]
+      },
+      "identitySource": {
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
+      },
+      "identityMappingMode": {
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
       }
     }
   }

--- a/packages/definitions/src/fhir/r4/fhir.schema.json
+++ b/packages/definitions/src/fhir/r4/fhir.schema.json
@@ -62870,6 +62870,23 @@
         "useSubject": {
           "description": "Optional flag to use the subject field instead of the email field.",
           "$ref": "#/definitions/boolean"
+        },
+        "identitySource": {
+          "description": "External credential field used to identify the user.",
+          "enum": [
+            "email",
+            "subject",
+            "fhir-user"
+          ]
+        },
+        "identityMappingMode": {
+          "description": "Medplum identity mapping target.",
+          "enum": [
+            "user-email",
+            "user-external-id",
+            "project-membership-external-id",
+            "project-membership-profile"
+          ]
         }
       },
       "additionalProperties": false,

--- a/packages/definitions/src/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/src/fhir/r4/profiles-medplum.json
@@ -5465,6 +5465,46 @@
               "min" : 0,
               "max" : "1"
             }
+          },
+          {
+            "id" : "IdentityProvider.identitySource",
+            "path" : "IdentityProvider.identitySource",
+            "short" : "External credential field used to identify the user.",
+            "definition" : "External credential field used to identify the user.",
+            "min" : 0,
+            "max" : "1",
+            "base" : {
+              "path" : "IdentityProvider.identitySource",
+              "min" : 0,
+              "max" : "1"
+            },
+            "type" : [{
+              "code" : "code"
+            }],
+            "binding" : {
+              "strength" : "required",
+              "valueSet" : "https://medplum.com/fhir/ValueSet/identity-provider-identity-source|4.0.1"
+            }
+          },
+          {
+            "id" : "IdentityProvider.identityMappingMode",
+            "path" : "IdentityProvider.identityMappingMode",
+            "short" : "Medplum identity mapping target.",
+            "definition" : "Medplum identity mapping target.",
+            "min" : 0,
+            "max" : "1",
+            "base" : {
+              "path" : "IdentityProvider.identityMappingMode",
+              "min" : 0,
+              "max" : "1"
+            },
+            "type" : [{
+              "code" : "code"
+            }],
+            "binding" : {
+              "strength" : "required",
+              "valueSet" : "https://medplum.com/fhir/ValueSet/identity-provider-identity-mapping-mode|4.0.1"
+            }
           }
         ]
       }

--- a/packages/definitions/src/fhir/r4/valuesets-medplum.json
+++ b/packages/definitions/src/fhir/r4/valuesets-medplum.json
@@ -836,6 +836,111 @@
       }
     },
     {
+      "fullUrl": "https://medplum.com/fhir/CodeSystem/identity-provider-identity-source",
+      "resource": {
+        "resourceType": "CodeSystem",
+        "id": "identity-provider-identity-source",
+        "url": "https://medplum.com/fhir/CodeSystem/identity-provider-identity-source",
+        "name": "IdentityProviderIdentitySource",
+        "title": "Identity Provider Identity Source",
+        "status": "active",
+        "description": "External credential fields used to identify a user.",
+        "valueSet": "https://medplum.com/fhir/ValueSet/identity-provider-identity-source",
+        "content": "complete",
+        "concept": [
+          {
+            "code": "email",
+            "display": "Email",
+            "definition": "Use the email claim from the external identity provider."
+          },
+          {
+            "code": "subject",
+            "display": "Subject",
+            "definition": "Use the subject claim from the external identity provider."
+          },
+          {
+            "code": "fhir-user",
+            "display": "FHIR User",
+            "definition": "Use the fhirUser claim from the external identity provider."
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "https://medplum.com/fhir/ValueSet/identity-provider-identity-source",
+      "resource": {
+        "resourceType": "ValueSet",
+        "id": "identity-provider-identity-source",
+        "url": "https://medplum.com/fhir/ValueSet/identity-provider-identity-source",
+        "name": "IdentityProviderIdentitySource",
+        "title": "Identity Provider Identity Source",
+        "status": "active",
+        "description": "External credential fields used to identify a user.",
+        "compose": {
+          "include": [
+            {
+              "system": "https://medplum.com/fhir/CodeSystem/identity-provider-identity-source"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "https://medplum.com/fhir/CodeSystem/identity-provider-identity-mapping-mode",
+      "resource": {
+        "resourceType": "CodeSystem",
+        "id": "identity-provider-identity-mapping-mode",
+        "url": "https://medplum.com/fhir/CodeSystem/identity-provider-identity-mapping-mode",
+        "name": "IdentityProviderIdentityMappingMode",
+        "title": "Identity Provider Identity Mapping Mode",
+        "status": "active",
+        "description": "Medplum identity mapping targets for external identity providers.",
+        "valueSet": "https://medplum.com/fhir/ValueSet/identity-provider-identity-mapping-mode",
+        "content": "complete",
+        "concept": [
+          {
+            "code": "user-email",
+            "display": "User Email",
+            "definition": "Map the external identity to a User by email address."
+          },
+          {
+            "code": "user-external-id",
+            "display": "User External ID",
+            "definition": "Map the external identity to a User by external ID."
+          },
+          {
+            "code": "project-membership-external-id",
+            "display": "Project Membership External ID",
+            "definition": "Map the external identity to a ProjectMembership by external ID."
+          },
+          {
+            "code": "project-membership-profile",
+            "display": "Project Membership Profile",
+            "definition": "Map the external identity to a ProjectMembership by profile reference."
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "https://medplum.com/fhir/ValueSet/identity-provider-identity-mapping-mode",
+      "resource": {
+        "resourceType": "ValueSet",
+        "id": "identity-provider-identity-mapping-mode",
+        "url": "https://medplum.com/fhir/ValueSet/identity-provider-identity-mapping-mode",
+        "name": "IdentityProviderIdentityMappingMode",
+        "title": "Identity Provider Identity Mapping Mode",
+        "status": "active",
+        "description": "Medplum identity mapping targets for external identity providers.",
+        "compose": {
+          "include": [
+            {
+              "system": "https://medplum.com/fhir/CodeSystem/identity-provider-identity-mapping-mode"
+            }
+          ]
+        }
+      }
+    },
+    {
       "fullUrl": "https://medplum.com/fhir/CodeSystem/client-application-status",
       "resource": {
         "resourceType": "CodeSystem",

--- a/packages/fhirtypes/dist/IdentityProvider.d.ts
+++ b/packages/fhirtypes/dist/IdentityProvider.d.ts
@@ -62,4 +62,14 @@ export interface IdentityProvider {
    * Optional flag to use the subject field instead of the email field.
    */
   useSubject?: boolean;
+
+  /**
+   * External credential field used to identify the user.
+   */
+  identitySource?: 'email' | 'subject' | 'fhir-user';
+
+  /**
+   * Medplum identity mapping target.
+   */
+  identityMappingMode?: 'user-email' | 'user-external-id' | 'project-membership-external-id' | 'project-membership-profile';
 }

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -18,7 +18,7 @@
     "compare": "tsx src/compare.ts",
     "docs": "tsx src/docs.ts && cd ../.. && git apply packages/generator/src/ONC-compliance-text.patch && git apply packages/generator/src/medication-recommendations.patch",
     "fhirtypes": "tsx src/index.ts && cd ../fhirtypes && tsc",
-    "generate": "npm run valuesets && npm run fhirtypes && npm run jsonschema && npm run baseschema && npm run mockclient && npm run docs",
+    "generate": "npm run valuesets && npm run fhirtypes && npm run jsonschema && npm run baseschema && npm run mockclient",
     "jsonschema": "tsx src/jsonschema.ts && npx prettier ../definitions/dist/fhir/r4/fhir.schema.json --write",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/server/src/auth/external.test.ts
+++ b/packages/server/src/auth/external.test.ts
@@ -10,7 +10,7 @@ import request from 'supertest';
 import { createClient } from '../admin/client';
 import { inviteUser } from '../admin/invite';
 import { initApp, shutdownApp } from '../app';
-import { loadTestConfig } from '../config/loader';
+import { getConfig, loadTestConfig } from '../config/loader';
 import type { SystemRepository } from '../fhir/repo';
 import { getProjectSystemRepo } from '../fhir/repo';
 import { withTestContext } from '../test.setup';
@@ -81,7 +81,11 @@ describe('External', () => {
       // Update client application with external auth
       await systemRepo.updateResource<ClientApplication>({
         ...externalAuthClient,
-        identityProvider,
+        identityProvider: {
+          ...identityProvider,
+          identitySource: 'email',
+          identityMappingMode: 'user-email',
+        },
       });
 
       // Invite user with external ID
@@ -228,6 +232,38 @@ describe('External', () => {
     expect(redirect.searchParams.get('login')).toBeTruthy();
   });
 
+  test('Server config identity provider success', async () => {
+    const issuer = `https://${randomUUID()}.example.com`;
+    const config = getConfig();
+    const externalAuthProviders = config.externalAuthProviders;
+    config.externalAuthProviders = [{ issuer, identityProvider }];
+
+    try {
+      const url = appendQueryParams('/auth/external', {
+        code: randomUUID(),
+        state: JSON.stringify({ issuer }),
+      });
+
+      // Mock the external identity provider
+      (fetch as unknown as jest.Mock).mockImplementation(() => ({
+        ok: true,
+        status: 200,
+        json: () => buildTokens(email),
+      }));
+
+      // Simulate the external identity provider callback
+      const res = await request(app).get(url);
+      expect(res.status).toBe(302);
+
+      const redirect = new URL(res.header.location);
+      expect(redirect.host).toStrictEqual('localhost:3000');
+      expect(redirect.pathname).toStrictEqual('/signin');
+      expect(redirect.searchParams.get('login')).toBeTruthy();
+    } finally {
+      config.externalAuthProviders = externalAuthProviders;
+    }
+  });
+
   test('ClientApplication success', async () => {
     const url = appendQueryParams('/auth/external', {
       code: randomUUID(),
@@ -366,7 +402,8 @@ describe('External', () => {
         ...client,
         identityProvider: {
           ...identityProvider,
-          useSubject: true,
+          identitySource: 'subject',
+          identityMappingMode: 'project-membership-external-id',
         },
       });
 

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -5,6 +5,7 @@ import {
   concatUrls,
   ContentType,
   encodeBase64,
+  isString,
   OAuthGrantType,
   OAuthTokenAuthMethod,
   OperationOutcomeError,
@@ -213,7 +214,10 @@ async function resolveExternalLoginIdentity(
   const identityMappingMode = getIdentityMappingMode(idp);
 
   if (identitySource === 'email' && identityMappingMode === 'user-email') {
-    const email = (userInfo.email as string | undefined)?.toLowerCase();
+    let email: string | undefined;
+    if (isString(userInfo.email)) {
+      email = userInfo.email.toLowerCase();
+    }
     if (!email) {
       throw new OperationOutcomeError(badRequest('External token does not contain email address'));
     }
@@ -221,7 +225,10 @@ async function resolveExternalLoginIdentity(
   }
 
   if (identitySource === 'subject' && identityMappingMode === 'project-membership-external-id') {
-    const externalId = userInfo.sub as string | undefined;
+    let externalId: string | undefined;
+    if (isString(userInfo.sub)) {
+      externalId = userInfo.sub;
+    }
     if (!externalId) {
       throw new OperationOutcomeError(badRequest('External token does not contain subject'));
     }
@@ -232,10 +239,12 @@ async function resolveExternalLoginIdentity(
 }
 
 function getIdentitySource(idp: IdentityProvider): IdentitySource {
+  // Fallback to preserve legacy behavior
   return idp.identitySource ?? (idp.useSubject ? 'subject' : 'email');
 }
 
 function getIdentityMappingMode(idp: IdentityProvider): IdentityMappingMode {
+  // Fallback to preserve legacy behavior
   return idp.identityMappingMode ?? (idp.useSubject ? 'project-membership-external-id' : 'user-email');
 }
 

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -30,6 +30,7 @@ import { getDomainConfiguration } from './method';
 
 export interface ExternalAuthState {
   domain?: string;
+  issuer?: string;
   projectId?: string;
   clientId?: string;
   scope?: string;
@@ -39,6 +40,14 @@ export interface ExternalAuthState {
   codeChallengeMethod?: CodeChallengeMethod;
   redirectUri?: string;
   returnTo?: string;
+}
+
+type IdentitySource = NonNullable<IdentityProvider['identitySource']>;
+type IdentityMappingMode = NonNullable<IdentityProvider['identityMappingMode']>;
+
+interface ExternalLoginIdentity {
+  email?: string;
+  externalId?: string;
 }
 
 export async function externalCallbackHandler(req: Request, res: Response): Promise<void> {
@@ -75,23 +84,18 @@ export async function externalCallbackHandler(req: Request, res: Response): Prom
 
   const userInfo = await verifyExternalCode(idp, code, body.codeChallenge);
 
-  let email: string | undefined = undefined;
-  let externalId: string | undefined = undefined;
-  if (idp.useSubject) {
-    externalId = userInfo.sub as string | undefined;
-    if (!externalId) {
-      sendOutcome(res, badRequest('External token does not contain subject'));
+  let identity: ExternalLoginIdentity;
+  try {
+    identity = await resolveExternalLoginIdentity(idp, userInfo);
+  } catch (err) {
+    if (err instanceof OperationOutcomeError) {
+      sendOutcome(res, err.outcome);
       return;
     }
-  } else {
-    email = (userInfo.email as string | undefined)?.toLowerCase();
-    if (!email) {
-      sendOutcome(res, badRequest('External token does not contain email address'));
-      return;
-    }
+    throw err;
   }
 
-  if (body.domain && !email?.endsWith('@' + body.domain)) {
+  if (body.domain && !identity.email?.endsWith('@' + body.domain)) {
     sendOutcome(res, badRequest('Email address does not match domain'));
     return;
   }
@@ -107,8 +111,8 @@ export async function externalCallbackHandler(req: Request, res: Response): Prom
 
   const login = await tryLogin({
     authMethod: 'external',
-    email,
-    externalId,
+    email: identity.email,
+    externalId: identity.externalId,
     projectId,
     clientId: body.clientId,
     scope: body.scope ?? 'openid offline_access',
@@ -194,7 +198,45 @@ async function getIdentityProvider(
     idp = domainConfig.identityProvider;
   }
 
+  if (!idp && state.issuer) {
+    idp = getConfig().externalAuthProviders?.find((provider) => provider.issuer === state.issuer)?.identityProvider;
+  }
+
   return { idp, client };
+}
+
+async function resolveExternalLoginIdentity(
+  idp: IdentityProvider,
+  userInfo: Record<string, unknown>
+): Promise<ExternalLoginIdentity> {
+  const identitySource = getIdentitySource(idp);
+  const identityMappingMode = getIdentityMappingMode(idp);
+
+  if (identitySource === 'email' && identityMappingMode === 'user-email') {
+    const email = (userInfo.email as string | undefined)?.toLowerCase();
+    if (!email) {
+      throw new OperationOutcomeError(badRequest('External token does not contain email address'));
+    }
+    return { email };
+  }
+
+  if (identitySource === 'subject' && identityMappingMode === 'project-membership-external-id') {
+    const externalId = userInfo.sub as string | undefined;
+    if (!externalId) {
+      throw new OperationOutcomeError(badRequest('External token does not contain subject'));
+    }
+    return { externalId };
+  }
+
+  throw new OperationOutcomeError(badRequest('Unsupported identity provider configuration'));
+}
+
+function getIdentitySource(idp: IdentityProvider): IdentitySource {
+  return idp.identitySource ?? (idp.useSubject ? 'subject' : 'email');
+}
+
+function getIdentityMappingMode(idp: IdentityProvider): IdentityMappingMode {
+  return idp.identityMappingMode ?? (idp.useSubject ? 'project-membership-external-id' : 'user-email');
 }
 
 /**

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { ClientApplication, Project, ProjectSetting } from '@medplum/fhirtypes';
+import type { ClientApplication, IdentityProvider, Project, ProjectSetting } from '@medplum/fhirtypes';
 import type { KeepJobs } from 'bullmq';
 
 export interface MedplumServerConfig {
@@ -289,7 +289,9 @@ export interface MedplumBullmqConfig {
 
 export interface MedplumExternalAuthConfig {
   readonly issuer: string;
-  readonly userInfoUrl: string;
+  /** @deprecated Use identityProvider.userInfoUrl instead. */
+  readonly userInfoUrl?: string;
+  readonly identityProvider?: IdentityProvider;
 }
 
 export type WorkerName =

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -1230,7 +1230,11 @@ async function tryExternalAuthLogin(
 
   // Validate the token against the external IDP's userinfo endpoint
   try {
-    await getExternalUserInfo(externalAuthConfig.userInfoUrl, accessToken);
+    const userInfoUrl = externalAuthConfig.identityProvider?.userInfoUrl ?? externalAuthConfig.userInfoUrl;
+    if (!userInfoUrl) {
+      return undefined;
+    }
+    await getExternalUserInfo(userInfoUrl, accessToken, externalAuthConfig.identityProvider);
   } catch (err: any) {
     getLogger().warn('Failed to get external user info', err);
     return undefined;


### PR DESCRIPTION
Fixes #9276

This is an incremental step toward unifying Medplum external authentication flows behind the existing `IdentityProvider` type and `/auth/external` callback.

This PR does **not** attempt to replace Google auth or the existing bearer-token external auth flow yet. It lays groundwork for a shared external auth model while preserving existing behavior.

## What Changed

- Added new `IdentityProvider` fields:
  - `identitySource`
  - `identityMappingMode`
- Added CodeSystem / ValueSet definitions for the new enum values.
- Updated `/auth/external` to resolve external identity using the new two-axis model:
  - `identitySource`: which claim/value to read from the external credentials
  - `identityMappingMode`: which Medplum identity concept to map that value to
- Preserved legacy behavior:
  - Existing email-based external auth maps to `User.email`
  - Existing `useSubject` auth maps to `ProjectMembership.externalId`
  - `useSubject` remains supported as legacy shorthand
- Extended server config external auth provider shape:
  - `MedplumExternalAuthConfig.identityProvider?: IdentityProvider`
  - `MedplumExternalAuthConfig.userInfoUrl` is retained as deprecated legacy config
- Added support for `/auth/external` to select a server-configured identity provider using `state.issuer`.

## Compatibility

Backwards compatibility is intended to be preserved.

Existing configurations without `identitySource` or `identityMappingMode` continue to use legacy interpretation:

- `useSubject: true` implies:
  - `identitySource = "subject"`
  - `identityMappingMode = "project-membership-external-id"`
- no `useSubject` implies:
  - `identitySource = "email"`
  - `identityMappingMode = "user-email"`

Legacy `externalAuthProviders[].userInfoUrl` remains supported for existing bearer-token external auth.

## Larger Plan

The long-term goal is to unify Medplum's external auth implementations:

- Google auth
- DomainConfiguration external auth
- ClientApplication external auth
- server-level `externalAuthProviders`
- bearer-token external auth

The intended end state is a shared flow:

1. Resolve an `IdentityProvider`
2. Validate external credentials
3. Normalize external claims
4. Resolve Medplum identity according to configured mapping mode
5. Create a Medplum `Login`
6. Let existing membership/profile selection complete the login

## Still in progress

- Google auth is not yet refactored into the shared `/auth/external` internals.
- `project-membership-profile` / `fhirUser` mapping is not yet implemented for `/auth/external`.
- Server-scoped subject mapping is not implemented yet.

For server-scoped subject mapping, we should avoid using `User.externalId` because it is deprecated. A likely future direction is mapping `{issuer, sub}` to `User.identifier`, but that needs a separate design pass.

- ID token cryptographic validation in generic external auth remains unchanged.
- The existing server-level bearer-token auth flow is only lightly adapted to the new config shape; it is not fully unified yet.
