### PR TITLE
Fixes #8835 - prevent duplicate resources in `convertToTransactionBundle`

### DIFF
--- a/packages/core/src/bundle.test.ts
+++ b/packages/core/src/bundle.test.ts
@@ -422,7 +422,7 @@ describe('Bundle tests', () => {
         expect(immunization.patient?.reference).toBe(patientEntry?.fullUrl);
       }
     });
-    
+
     test('Patient with self-referential link does not produce duplicate entries', () => {
       const inputBundle: Bundle = {
         resourceType: 'Bundle',

--- a/packages/core/src/bundle.test.ts
+++ b/packages/core/src/bundle.test.ts
@@ -448,7 +448,7 @@ describe('Bundle tests', () => {
                   type: 'replaces',
                 },
               ],
-            } as Patient,
+            },
           },
         ],
       };
@@ -481,7 +481,7 @@ describe('Bundle tests', () => {
                   type: 'seealso',
                 },
               ],
-            } as Patient,
+            },
           },
         ],
       };

--- a/packages/core/src/bundle.test.ts
+++ b/packages/core/src/bundle.test.ts
@@ -422,6 +422,81 @@ describe('Bundle tests', () => {
         expect(immunization.patient?.reference).toBe(patientEntry?.fullUrl);
       }
     });
+    
+    test('Patient with self-referential link does not produce duplicate entries', () => {
+      const inputBundle: Bundle = {
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [
+          {
+            resource: {
+              resourceType: 'Patient',
+              id: '1',
+              link: [
+                {
+                  extension: [
+                    {
+                      url: 'https://open.epic.com/FHIR/StructureDefinition/patient-merge-target-reference',
+                      valueReference: {
+                        reference: 'Patient/1',
+                      },
+                    },
+                  ],
+                  other: {
+                    reference: 'Patient/2',
+                  },
+                  type: 'replaces',
+                },
+              ],
+            } as Patient,
+          },
+        ],
+      };
+
+      const result = convertToTransactionBundle(inputBundle);
+
+      expect(result.entry).toHaveLength(1);
+      expect(result.entry?.[0]?.request?.method).toBe('POST');
+      expect(result.entry?.[0]?.resource?.resourceType).toBe('Patient');
+    });
+
+    test('Patient self-referential link is remapped to the new urn:uuid', () => {
+      const inputBundle: Bundle = {
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [
+          {
+            resource: {
+              resourceType: 'Patient',
+              id: '1',
+              link: [
+                {
+                  extension: [
+                    {
+                      url: 'https://open.epic.com/FHIR/StructureDefinition/patient-merge-target-reference',
+                      valueReference: { reference: 'Patient/1' },
+                    },
+                  ],
+                  other: { reference: 'Patient/1' },
+                  type: 'seealso',
+                },
+              ],
+            } as Patient,
+          },
+        ],
+      };
+
+      const result = convertToTransactionBundle(inputBundle);
+      expect(result.entry).toHaveLength(1);
+
+      const patientEntry = result.entry?.[0];
+      const patientFullUrl = patientEntry?.fullUrl;
+      expect(patientFullUrl).toMatch(/^urn:uuid:/);
+
+      const patient = patientEntry?.resource as any;
+      expect(patient.link?.[0]?.extension?.[0]?.valueReference?.reference).toBe(patientFullUrl);
+      expect(patient.link?.[0]?.other?.reference).toBe(patientFullUrl);
+    });
   });
 
   describe('convertContainedResourcesToBundle', () => {

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -237,8 +237,8 @@ function buildAdjacencyList(bundle: Bundle): AdjacencyList {
 
     if (fullUrl && entry.resource) {
       findReferences(entry.resource, (reference: string) => {
-        // Add an incoming reference to the adjacency list
-        if (adjacencyList[reference]) {
+        // Skip self-references — a resource referencing itself is not a dependency ordering problem
+        if (reference !== fullUrl && adjacencyList[reference]) {
           adjacencyList[reference].push(fullUrl);
         }
       });


### PR DESCRIPTION
fix: convertToTransactionBundle can create duplicate Patient resources (https://github.com/medplum/medplum/issues/8835)
Fixes https://github.com/medplum/medplum/issues/8835

Signed-off-by: Steven Matthiesen <steven.matthiesen@gmail.com>