### PR TITLE
Various oauth2 fixes for spec compliance

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -26,9 +26,11 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+    allowedHosts: true,
   },
   preview: {
     port: 3000,
+    allowedHosts: true,
   },
   publicDir: 'static',
   build: {

--- a/packages/react/src/ContactPointInput/ContactPointInput.tsx
+++ b/packages/react/src/ContactPointInput/ContactPointInput.tsx
@@ -72,7 +72,7 @@ export function ContactPointInput(props: ContactPointInputProps): JSX.Element {
         onChange={(e) =>
           setSystem(e.currentTarget.value as 'url' | 'phone' | 'fax' | 'email' | 'pager' | 'sms' | 'other')
         }
-        data={['', 'email', 'phone', 'fax', 'pager', 'sms', 'other']}
+        data={['', 'email', 'phone', 'fax', 'pager', 'sms', 'url', 'other']}
         error={getErrorsForInput(outcome, errorPath + '.system')}
       />
       <NativeSelect

--- a/packages/server/src/oauth/README.md
+++ b/packages/server/src/oauth/README.md
@@ -8,23 +8,77 @@ OpenID Implementer's Guide: https://openid.net/specs/openid-connect-basic-1_0.ht
 
 For both local and production testing, setup your Practitioner profile with all of the OpenID user info properties:
 
-| User info property    | Practitioner property | Example value |
-| --------------------- | --------------------- | ------------- |
-| name                  | name[0]               | Alice         |
-| given_name            | name[0].given[0]      |               |
-| middle_name           | name[0].given[0]      |               |
-| family_name           | name[0].family        |               |
-| gender                | name[0].gender        |               |
-| picture               | photo[0].url          |               |
-| preferred_username    |                       |               |
-| nickname              |                       |               |
-| website               |                       |               |
-| zoneinfo              |                       |               |
-| email                 | telecom               |               |
-| email_verified        |                       |               |
-| phone_number          | telecom               |               |
-| phone_number_verified |                       |               |
-| address               | address               |               |
+| User info property    | Practitioner property       | Example value |
+| --------------------- | --------------------------- | ------------- |
+| name                  | name[0]                     | Alice         |
+| given_name            | name[0].given[0]            |               |
+| middle_name           | name[0].given[0]            |               |
+| family_name           | name[0].family              |               |
+| gender                | name[0].gender              |               |
+| picture               | photo[0].url                |               |
+| preferred_username    | telecom                     |               |
+| nickname              | name.where(use='nickname')  |               |
+| website               | telecom.where(system='url') |               |
+| zoneinfo              | extension                   |               |
+| email                 | telecom                     |               |
+| email_verified        |                             |               |
+| phone_number          | telecom                     |               |
+| phone_number_verified |                             |               |
+| address               | address                     |               |
+
+For example:
+
+```json
+{
+  "resourceType": "Practitioner",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/timezone",
+      "valueCode": "US/Pacific"
+    }
+  ],
+  "birthDate": "1982-06-05",
+  "gender": "male",
+  "name": [
+    {
+      "use": "official",
+      "given": ["Homer", "J"],
+      "family": "Simpson"
+    },
+    {
+      "use": "nickname",
+      "given": ["Homer"]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "email",
+      "use": "work",
+      "value": "homer.simpson@example.com"
+    },
+    {
+      "system": "url",
+      "use": "work",
+      "value": "https://www.example.com/"
+    }
+  ],
+  "address": [
+    {
+      "line": ["742 Evergreen Terrace"],
+      "city": "Springfield",
+      "state": "IL",
+      "postalCode": "12345"
+    }
+  ],
+  "photo": [
+    {
+      "contentType": "image/webp",
+      "url": "Binary/123",
+      "title": "homer-simpson.webp"
+    }
+  ]
+}
+```
 
 ## Test against OpenID Conformance Suite locally
 
@@ -33,90 +87,59 @@ Follow these instructions to setup your local dev environment with the Conforman
 Requirements:
 
 - The Conformance Suite running in Docker must be able to access the Medplum API server
-  - That means that the Medplum API server cannot simply use "localhost"
-  - Instead, we will use `host.docker.internal`
 - The Medplum API server cookies require HTTPS
-  - That means we cannot simply use `vite` and `tsx`
-  - Instead, we will use [Caddy](https://caddyserver.com/) for an easy localhost HTTPS proxy
+- That means that the Medplum API server cannot simply use "localhost"
+- Instead, we will use ngrok to create a public URL that tunnels to our local dev environment, and configure the Medplum API server to use that URL as its base URL
 
-The Medplum OpenID configuration requires HTTPS. We recommend using .
+The Medplum OpenID configuration requires HTTPS. We recommend using ngrok for this purpose. We recommend using multiple tunnels: one for the API server and one for the app server. This allows the Conformance Suite to access the API server directly, without going through the app server.
 
-| Service | HTTP address                     | HTTPS address                     |
-| ------- | -------------------------------- | --------------------------------- |
-| api     | http://host.docker.internal/8103 | https://host.docker.internal/8104 |
-| app     | http://localhost:3000            | https://localhost:8106            |
+For the purposes of this example, we will use the following ngrok URLs:
+
+- API server: https://api.ngrok.medplum.dev
+- App server: https://app.ngrok.medplum.dev
 
 ### Update the app config
 
 Open `packages/app/.env`
 
-Add or replace the `MEDPLUM_BASE_URL` environment variable with `https://host.docker.internal:8104/`
+Add or replace the `MEDPLUM_BASE_URL` environment variable with `https://api.ngrok.medplum.dev/`
 
 ```
-MEDPLUM_BASE_URL=https://host.docker.internal:8104/
+MEDPLUM_BASE_URL=https://api.ngrok.medplum.dev/
 ```
 
 ### Update the server config
 
 Open `packages/server/medplum.config.json`
 
-Replace all instances of `http://localhost:8103/` with `https://host.docker.internal:8104/`
+Replace all instances of `http://localhost:8103/` with `https://api.ngrok.medplum.dev/`
 
-Replace all instances of `http://localhost:3000/` with `https://localhost:8106/`
+Replace all instances of `http://localhost:3000/` with `https://app.ngrok.medplum.dev/`
 
-The result should look something like this:
+### Setup ngrok
 
-```json
-{
-  "port": 8103,
-  "baseUrl": "https://host.docker.internal:8104/",
-  "issuer": "https://host.docker.internal:8104/",
-  "audience": "https://host.docker.internal:8104/",
-  "jwksUrl": "https://host.docker.internal:8104/.well-known/jwks.json",
-  "authorizeUrl": "https://host.docker.internal:8104/oauth2/authorize",
-  "tokenUrl": "https://host.docker.internal:8104/oauth2/token",
-  "userInfoUrl": "https://host.docker.internal:8104/oauth2/userinfo",
-  "appBaseUrl": "https://localhost:8106",
-  "binaryStorage": "file:./binary/",
-  "storageBaseUrl": "https://host.docker.internal:8104/storage/",
-  "database": {
-    "host": "localhost",
-    "port": 5432,
-    "dbname": "medplum",
-    "username": "medplum",
-    "password": "medplum"
-  },
-  "redis": {
-    "host": "localhost",
-    "port": 6379,
-    "password": "medplum"
-  }
-}
+For example:
+
+```yaml
+# ~/.config/ngrok/ngrok.yml
+version: 3
+
+agent:
+  authtoken: YOUR_NGROK_AUTH_TOKEN
+
+endpoints:
+  - name: app
+    url: https://app.ngrok.medplum.dev
+    upstream:
+      url: http://localhost:3000
+
+  - name: api
+    url: https://api.ngrok.medplum.dev
+    upstream:
+      url: http://localhost:8103
 ```
 
-### Setup Caddy
-
-First, download and install Caddy: https://caddyserver.com/download
-
-Next, create a `Caddyfile` with the following contents:
-
-```
-localhost:8104 {
-  reverse_proxy 127.0.0.1:8103
-  tls internal
-}
-
-localhost:8106 {
-  reverse_proxy 127.0.0.1:8105
-  tls internal
-}
-```
-
-Now you can run Caddy with `caddy run`
-
-Test the Medplum API server URL: <https://host.docker.internal:8104/>
-
-Test the Medplum app URL: <https://localhost:8106/>
+Then run `ngrok start --all` to start the tunnels.
 
 ### Setup the OpenID project
 
@@ -132,18 +155,23 @@ Make note of the client IDs and client secrets
 
 https://gitlab.com/openid/conformance-suite/-/wikis/Developers/Build-&-Run
 
+Download docker-compose-prebuilt.yml into an empty directory:
+
 ```bash
-git clone git@gitlab.com:openid/conformance-suite.git
-cd conformance-suite
-mvn clean package
-docker-compose up
+curl -O https://gitlab.com/openid/conformance-suite/-/raw/master/docker-compose-prebuilt.yml
+```
+
+Start the stack:
+
+```bash
+docker compose -f docker-compose-prebuilt.yml up
 ```
 
 Open browser to <https://localhost.emobix.co.uk:8443/>
 
 Test the Docker localhost URL: <http://host.docker.internal:8103/>
 
-Be sure to logout between each test by visiting <http://host.docker.internal:8103/oauth2/logout>
+Be sure to logout between each test by visiting <https://api.ngrok.medplum.dev/oauth2/logout>
 
 ### OpenID notes
 
@@ -159,7 +187,7 @@ Set the "Redirect URI" to "https://localhost.emobix.co.uk:8443/test/a/medplum/ca
   - description: medplum
   - publish: No
 - Server
-  - discoveryUrl: http://host.docker.internal:8103/.well-known/openid-configuration
+  - discoveryUrl: https://api.ngrok.medplum.dev/.well-known/openid-configuration
   - login_hint:
 - Client:
   - client_id: CLIENT_ID_1
@@ -195,7 +223,7 @@ Be sure to logout between each test by visiting <http://host.docker.internal:810
 
 In "EHR Launch Sequence":
 
-Make sure "Scopes" includes "fhirUser launch launch/patient offline_access openid profile user/*._ patient/_.\_"
+Make sure "Scopes" includes "fhirUser launch launch/patient offline*access openid profile user/\*.* patient/\_.\_"
 
 Launch URL's:
 
@@ -213,4 +241,4 @@ http://localhost:4567/inferno/oauth2/static/launch?iss=http%3A%2F%2Fhost.docker.
 Launch URI: https://inferno.healthit.gov/suites/custom/smart/launch
 Redirect URI: https://inferno.healthit.gov/suites/custom/smart/redirect
 
-https://inferno.healthit.gov/suites/custom/smart/launch?iss=https%3A%2F%2Fcody.medplum.dev%2Ffhir%2FR4&launch=xyz1234
+https://inferno.healthit.gov/suites/custom/smart/launch?iss=https%3A%2F%2Fngrok.medplum.dev%2Ffhir%2FR4&launch=xyz1234

--- a/packages/server/src/oauth/README.md
+++ b/packages/server/src/oauth/README.md
@@ -37,7 +37,7 @@ For example:
       "valueCode": "US/Pacific"
     }
   ],
-  "birthDate": "1982-06-05",
+  "birthDate": "1970-01-01",
   "gender": "male",
   "name": [
     {
@@ -223,7 +223,11 @@ Be sure to logout between each test by visiting <http://host.docker.internal:810
 
 In "EHR Launch Sequence":
 
-Make sure "Scopes" includes "fhirUser launch launch/patient offline*access openid profile user/\*.* patient/\_.\_"
+Make sure "Scopes" includes:
+
+```
+fhirUser launch launch/patient offline_access openid profile user/*.* patient/*.*
+```
 
 Launch URL's:
 

--- a/packages/server/src/oauth/userinfo.test.ts
+++ b/packages/server/src/oauth/userinfo.test.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { ContentType } from '@medplum/core';
-import type { ContactPoint } from '@medplum/fhirtypes';
+import type { WithId } from '@medplum/core';
+import { ContentType, getReferenceString } from '@medplum/core';
+import type { ContactPoint, Project } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
@@ -9,13 +10,17 @@ import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config/loader';
 import { getProjectSystemRepo } from '../fhir/repo';
-
-const app = express();
+import { addTestUser, createTestProject } from '../test.setup';
 
 describe('OAuth2 UserInfo', () => {
+  const app = express();
+  let project: WithId<Project>;
+
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initApp(app, config);
+
+    ({ project } = await createTestProject());
   });
 
   afterAll(async () => {
@@ -220,5 +225,120 @@ describe('OAuth2 UserInfo', () => {
     expect(res3.body.email).toBeUndefined();
     expect(res3.body.phone_number).toBeUndefined();
     expect(res3.body.address).toBeUndefined();
+  });
+
+  test('Profile with empty resource', async () => {
+    const testUser = await addTestUser(project, { scope: 'openid profile email phone address' });
+    const { user, profile, accessToken } = testUser;
+
+    const res1 = await request(app)
+      .put(`/fhir/R4/${getReferenceString(profile)}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        resourceType: profile.resourceType,
+        id: profile.id,
+      });
+    expect(res1.status).toBe(200);
+
+    const res3 = await request(app).get(`/oauth2/userinfo`).set('Authorization', `Bearer ${accessToken}`);
+    expect(res3.status).toBe(200);
+    expect(res3.body.sub).toStrictEqual(user.id);
+    expect(res3.body.email).toStrictEqual(user.email);
+    expect(res3.body.profile).toStrictEqual(getReferenceString(profile));
+    expect(res3.body.name).toBeUndefined();
+    expect(res3.body.given_name).toBeUndefined();
+    expect(res3.body.middle_name).toBeUndefined();
+    expect(res3.body.family_name).toBeUndefined();
+    expect(res3.body.phone_number).toBeUndefined();
+    expect(res3.body.address).toBeUndefined();
+  });
+
+  test('Profile with full resource', async () => {
+    const testUser = await addTestUser(project, { scope: 'openid profile email phone address' });
+    const { user, profile, accessToken } = testUser;
+
+    const res1 = await request(app)
+      .put(`/fhir/R4/${getReferenceString(profile)}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        resourceType: profile.resourceType,
+        id: profile.id,
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/StructureDefinition/timezone',
+            valueCode: 'US/Pacific',
+          },
+        ],
+        birthDate: '1970-01-01',
+        gender: 'male',
+        name: [
+          {
+            use: 'official',
+            given: ['Homer', 'J'],
+            family: 'Simpson',
+          },
+          {
+            use: 'nickname',
+            given: ['Homie'],
+          },
+        ],
+        telecom: [
+          {
+            system: 'email',
+            use: 'work',
+            value: 'homer.simpson@example.com',
+          },
+          {
+            system: 'email',
+            use: 'work',
+            value: 'homer.simpson@example.com',
+          },
+          {
+            system: 'url',
+            use: 'work',
+            value: 'https://www.example.com/',
+          },
+        ],
+        address: [
+          {
+            line: ['742 Evergreen Terrace'],
+            city: 'Springfield',
+            state: 'IL',
+            postalCode: '12345',
+          },
+        ],
+        photo: [
+          {
+            contentType: 'image/webp',
+            url: 'Binary/123',
+            title: 'homer-simpson.webp',
+          },
+        ],
+      });
+    expect(res1.status).toBe(200);
+
+    const res3 = await request(app).get(`/oauth2/userinfo`).set('Authorization', `Bearer ${accessToken}`);
+    expect(res3.status).toBe(200);
+    expect(res3.body.sub).toStrictEqual(user.id);
+    expect(res3.body.email).toStrictEqual(user.email);
+    expect(res3.body.profile).toStrictEqual(getReferenceString(profile));
+    expect(res3.body.name).toStrictEqual('Homer J Simpson');
+    expect(res3.body.family_name).toStrictEqual('Simpson');
+    expect(res3.body.given_name).toStrictEqual('Homer');
+    expect(res3.body.middle_name).toStrictEqual('J');
+    expect(res3.body.birthdate).toStrictEqual('1970-01-01');
+    expect(res3.body.gender).toStrictEqual('male');
+    expect(res3.body.picture).toStrictEqual('Binary/123');
+    expect(res3.body.nickname).toStrictEqual('Homie');
+    expect(res3.body.website).toStrictEqual('https://www.example.com/');
+    expect(res3.body.preferred_username).toStrictEqual('homer.simpson');
+    expect(res3.body.zoneinfo).toStrictEqual('US/Pacific');
+    expect(res3.body.address).toStrictEqual({
+      formatted: '742 Evergreen Terrace, Springfield, IL, 12345',
+      street_address: '742 Evergreen Terrace',
+      locality: 'Springfield',
+      region: 'IL',
+      postal_code: '12345',
+    });
   });
 });

--- a/packages/server/src/oauth/userinfo.ts
+++ b/packages/server/src/oauth/userinfo.ts
@@ -9,6 +9,7 @@ import {
   getDateProperty,
   getExtensionValue,
   getReferenceString,
+  HTTP_HL7_ORG,
 } from '@medplum/core';
 import type { Bot, ClientApplication, Reference, User } from '@medplum/fhirtypes';
 import type { Request, RequestHandler, Response } from 'express';
@@ -59,36 +60,23 @@ function buildProfile(userInfo: Record<string, any>, profile: ProfileResource | 
     return;
   }
 
-  userInfo.birthdate = profile.birthDate;
-  userInfo.gender = profile.gender ?? '';
-  userInfo.picture = profile.photo?.[0]?.url ?? '';
-
   const humanName = profile.name?.[0];
   if (humanName) {
     userInfo.name = formatHumanName(humanName);
     userInfo.family_name = formatFamilyName(humanName);
 
     const givenNameParts = formatGivenName(humanName).split(' ');
-    userInfo.given_name = givenNameParts[0] ?? '';
-    userInfo.middle_name = givenNameParts.slice(1).join(' ') ?? '';
-  } else {
-    userInfo.name = '';
-    userInfo.family_name = '';
-    userInfo.given_name = '';
-    userInfo.middle_name = '';
+    userInfo.given_name = givenNameParts[0];
+    userInfo.middle_name = givenNameParts.slice(1).join(' ');
   }
 
-  const nickname = profile.name?.find((n) => n.use === 'nickname');
-  userInfo.nickname = nickname ? formatHumanName(nickname) : '';
-
-  const website = profile.telecom?.find((cp) => cp.system === 'url')?.value;
-  userInfo.website = website ?? '';
-
-  const email = profile.telecom?.find((cp) => cp.system === 'email')?.value;
-  userInfo.preferred_username = email ? email.split('@')[0] : '';
-
-  const preferredTimeZone = getExtensionValue(profile, 'http://hl7.org/fhir/StructureDefinition/timezone');
-  userInfo.zoneinfo = preferredTimeZone ?? '';
+  userInfo.birthdate = profile.birthDate;
+  userInfo.gender = profile.gender;
+  userInfo.picture = profile.photo?.[0]?.url;
+  userInfo.nickname = profile.name?.find((n) => n.use === 'nickname')?.given?.[0];
+  userInfo.website = profile.telecom?.find((cp) => cp.system === 'url')?.value;
+  userInfo.preferred_username = profile.telecom?.find((cp) => cp.system === 'email')?.value?.split('@')[0];
+  userInfo.zoneinfo = getExtensionValue(profile, `${HTTP_HL7_ORG}/fhir/StructureDefinition/timezone`);
 }
 
 function buildEmail(
@@ -121,6 +109,11 @@ function buildAddress(userInfo: Record<string, any>, profile: ProfileResource | 
   if (address) {
     userInfo.address = {
       formatted: formatAddress(address),
+      street_address: address.line?.join(' '),
+      locality: address.city,
+      region: address.state,
+      postal_code: address.postalCode,
+      country: address.country,
     };
   }
 }

--- a/packages/server/src/oauth/userinfo.ts
+++ b/packages/server/src/oauth/userinfo.ts
@@ -7,6 +7,7 @@ import {
   formatGivenName,
   formatHumanName,
   getDateProperty,
+  getExtensionValue,
   getReferenceString,
 } from '@medplum/core';
 import type { Bot, ClientApplication, Reference, User } from '@medplum/fhirtypes';
@@ -24,7 +25,7 @@ export const userInfoHandler: RequestHandler = async (_req: Request, res: Respon
   const user = await ctx.systemRepo.readReference(ctx.login.user as Reference<User>);
   const profile = await ctx.repo.readReference(ctx.profile);
   const userInfo: Record<string, any> = {
-    sub: profile.id,
+    sub: user.id,
   };
 
   const scopes = ctx.login.scope?.split(' ');
@@ -47,27 +48,47 @@ export const userInfoHandler: RequestHandler = async (_req: Request, res: Respon
 function buildProfile(userInfo: Record<string, any>, profile: ProfileResource | Bot | ClientApplication): void {
   userInfo.profile = getReferenceString(profile);
   userInfo.locale = 'en-US';
-  userInfo.birthdate = 'birthDate' in profile ? profile.birthDate : '';
 
   const lastUpdated = getDateProperty(profile.meta?.lastUpdated);
   if (lastUpdated) {
     userInfo.updated_at = lastUpdated.getTime() / 1000;
   }
 
-  const humanName = typeof profile.name === 'object' ? profile.name?.[0] : undefined;
-  if (humanName) {
-    userInfo.name = formatHumanName(humanName);
-    userInfo.given_name = formatGivenName(humanName);
-    userInfo.middle_name = '';
-    userInfo.family_name = formatFamilyName(humanName);
+  if (profile.resourceType !== 'Patient' && profile.resourceType !== 'Practitioner') {
+    // The rest of the profile information is only available for Patient and Practitioner resources
+    return;
   }
 
-  userInfo.website = '';
-  userInfo.zoneinfo = '';
-  userInfo.gender = '';
-  userInfo.preferred_username = '';
-  userInfo.picture = '';
-  userInfo.nickname = '';
+  userInfo.birthdate = profile.birthDate;
+  userInfo.gender = profile.gender ?? '';
+  userInfo.picture = profile.photo?.[0]?.url ?? '';
+
+  const humanName = profile.name?.[0];
+  if (humanName) {
+    userInfo.name = formatHumanName(humanName);
+    userInfo.family_name = formatFamilyName(humanName);
+
+    const givenNameParts = formatGivenName(humanName).split(' ');
+    userInfo.given_name = givenNameParts[0] ?? '';
+    userInfo.middle_name = givenNameParts.slice(1).join(' ') ?? '';
+  } else {
+    userInfo.name = '';
+    userInfo.family_name = '';
+    userInfo.given_name = '';
+    userInfo.middle_name = '';
+  }
+
+  const nickname = profile.name?.find((n) => n.use === 'nickname');
+  userInfo.nickname = nickname ? formatHumanName(nickname) : '';
+
+  const website = profile.telecom?.find((cp) => cp.system === 'url')?.value;
+  userInfo.website = website ?? '';
+
+  const email = profile.telecom?.find((cp) => cp.system === 'email')?.value;
+  userInfo.preferred_username = email ? email.split('@')[0] : '';
+
+  const preferredTimeZone = getExtensionValue(profile, 'http://hl7.org/fhir/StructureDefinition/timezone');
+  userInfo.zoneinfo = preferredTimeZone ?? '';
 }
 
 function buildEmail(

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -180,6 +180,7 @@ export async function addTestUser(
   options?: {
     accessPolicy?: AccessPolicy;
     resourceType?: 'Practitioner' | 'Patient';
+    scope?: string;
   }
 ): Promise<ServerInviteResponse & { accessToken: string }> {
   let accessPolicy = options?.accessPolicy;
@@ -214,7 +215,7 @@ export async function addTestUser(
     authMethod: 'password',
     email,
     password,
-    scope: 'openid',
+    scope: options?.scope ?? 'openid',
     nonce: 'nonce',
     projectId: project.id,
   });


### PR DESCRIPTION
Preparing to apply for OAuth2 / Open ID Connect certification.

It has been a while since I ran the conformance tests.  The tool has changed a little, and our docs were out of date.  

The only functional change is that we need to demonstrate we can return all user info fields, so this adds support for: 

- `middle_name`
- `nickname`
- `preferred_username`
- `website`
- `zoneinfo`

After that, we're mostly green on the conformance suite:

<img width="1890" height="1753" alt="image" src="https://github.com/user-attachments/assets/ce8d563e-58b2-402a-a067-8e5d1054b628" />
