### PR TITLE
Provider: Add Appointment confirm button

### DIFF
--- a/examples/medplum-provider/src/components/Calendar.tsx
+++ b/examples/medplum-provider/src/components/Calendar.tsx
@@ -128,6 +128,13 @@ function eventPropGetter(
     result.style.opacity = 0.6;
   }
 
+  // style "pending" appointments with an outlined event
+  if (event.type === 'appointment' && event.appointment.status === 'pending') {
+    result.style.border = '1px solid #228be6'; // blue.6
+    result.style.color = '#228be6'; // blue.6
+    result.style.backgroundColor = 'white';
+  }
+
   return result;
 }
 

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
@@ -3,9 +3,10 @@
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import type { WithId } from '@medplum/core';
-import type { Appointment, Patient } from '@medplum/fhirtypes';
+import type { Appointment, Bundle, Patient, Slot } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
+import type { RenderResult } from '@testing-library/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
@@ -21,6 +22,8 @@ vi.mock('../../utils/encounter', () => ({
 
 describe('AppointmentDetails', () => {
   let medplum: MockClient;
+  const start = '2024-01-15T10:00:00Z';
+  const end = '2024-01-15T10:30:00Z';
 
   beforeEach(async () => {
     medplum = new MockClient();
@@ -29,34 +32,46 @@ describe('AppointmentDetails', () => {
 
   type SetupOptions = {
     appointment: WithId<Appointment>;
-    onUpdate?: (appointment: Appointment) => void;
+    onAppointmentUpdate?: (appointment: Appointment) => void;
+    onSlotUpdate?: (slot: Slot) => void;
   };
 
-  const setup = async (options: SetupOptions): Promise<void> => {
-    const { appointment, onUpdate = vi.fn() } = options;
+  const setup = async (options: SetupOptions): Promise<RenderResult> => {
+    const { appointment, onAppointmentUpdate = vi.fn(), onSlotUpdate = vi.fn() } = options;
 
     // AppointmentDetails uses `useResource` to load patient information; wrap the setup
     // in `act` so that async effect is visible in the rendered result.
+    let result!: RenderResult;
     await act(async () => {
-      return render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <MantineProvider>
-              <Notifications />
-              <AppointmentDetails appointment={appointment} onUpdate={onUpdate} />
-            </MantineProvider>
-          </MedplumProvider>
-        </MemoryRouter>
+      result = render(
+        <AppointmentDetails
+          appointment={appointment}
+          onAppointmentUpdate={onAppointmentUpdate}
+          onSlotUpdate={onSlotUpdate}
+        />,
+        {
+          wrapper: ({ children }) => (
+            <MemoryRouter>
+              <MedplumProvider medplum={medplum}>
+                <MantineProvider>
+                  <Notifications />
+                  {children}
+                </MantineProvider>
+              </MedplumProvider>
+            </MemoryRouter>
+          ),
+        }
       );
     });
+    return result;
   };
 
   const createAppointment = (overrides?: Partial<Appointment>): WithId<Appointment> => ({
     resourceType: 'Appointment',
     id: 'appointment-1',
     status: 'booked',
-    start: '2024-01-15T10:00:00Z',
-    end: '2024-01-15T10:30:00Z',
+    start,
+    end,
     participant: [
       {
         actor: { reference: 'Practitioner/practitioner-1', display: 'Dr. Smith' },
@@ -124,9 +139,9 @@ describe('AppointmentDetails', () => {
   });
 
   describe('Patient Selection', () => {
-    test('calls onUpdate with updated appointment when patient is selected and form submitted', async () => {
+    test('calls onAppointmentUpdate with updated appointment when patient is selected and form submitted', async () => {
       const user = userEvent.setup();
-      const onUpdate = vi.fn();
+      const onAppointmentUpdate = vi.fn();
       const appointment = createAppointment();
 
       // Mock updateResource to return the updated appointment
@@ -142,7 +157,7 @@ describe('AppointmentDetails', () => {
       };
       medplum.updateResource = vi.fn().mockResolvedValue(updatedAppointment);
 
-      await setup({ appointment, onUpdate });
+      await setup({ appointment, onAppointmentUpdate });
 
       // Type in the patient search input (ResourceInput uses a searchbox role)
       const patientInput = screen.getByRole('searchbox');
@@ -171,25 +186,25 @@ describe('AppointmentDetails', () => {
         })
       );
 
-      // Verify onUpdate callback was called
-      expect(onUpdate).toHaveBeenCalledWith(updatedAppointment);
+      // Verify onAppointmentUpdate callback was called
+      expect(onAppointmentUpdate).toHaveBeenCalledWith(updatedAppointment);
     });
 
     test('does not call updateResource when no patient is selected', async () => {
       const user = userEvent.setup();
-      const onUpdate = vi.fn();
+      const onAppointmentUpdate = vi.fn();
       const appointment = createAppointment();
 
       medplum.updateResource = vi.fn();
 
-      await setup({ appointment, onUpdate });
+      await setup({ appointment, onAppointmentUpdate });
 
       // Submit without selecting a patient
       await user.click(screen.getByRole('button', { name: 'Update Appointment' }));
 
       // updateResource should not have been called
       expect(medplum.updateResource).not.toHaveBeenCalled();
-      expect(onUpdate).not.toHaveBeenCalled();
+      expect(onAppointmentUpdate).not.toHaveBeenCalled();
     });
   });
 
@@ -208,7 +223,7 @@ describe('AppointmentDetails', () => {
 
     test('preserves existing participants when adding patient', async () => {
       const user = userEvent.setup();
-      const onUpdate = vi.fn();
+      const onAppointmentUpdate = vi.fn();
       const appointment = createAppointment({
         participant: [
           {
@@ -224,7 +239,7 @@ describe('AppointmentDetails', () => {
 
       medplum.updateResource = vi.fn().mockResolvedValue(appointment);
 
-      await setup({ appointment, onUpdate });
+      await setup({ appointment, onAppointmentUpdate });
 
       // Select a patient (ResourceInput uses a searchbox role)
       const patientInput = screen.getByRole('searchbox');
@@ -273,14 +288,14 @@ describe('AppointmentDetails', () => {
   describe('Error Handling', () => {
     test('handles updateResource failure', async () => {
       const user = userEvent.setup();
-      const onUpdate = vi.fn();
+      const onAppointmentUpdate = vi.fn();
       const appointment = createAppointment();
 
       const updateError = new Error('Network error');
 
       medplum.updateResource = vi.fn().mockRejectedValue(updateError);
 
-      await setup({ appointment, onUpdate });
+      await setup({ appointment, onAppointmentUpdate });
 
       // Select a patient (ResourceInput uses a searchbox role)
       const patientInput = screen.getByRole('searchbox');
@@ -294,9 +309,9 @@ describe('AppointmentDetails', () => {
       // Submit the form - this will cause an unhandled rejection
       await user.click(screen.getByRole('button', { name: 'Update Appointment' }));
 
-      // onUpdate should not have been called since the request failed
+      // onAppointmentUpdate should not have been called since the request failed
       expect(medplum.updateResource).toHaveBeenCalled();
-      expect(onUpdate).not.toHaveBeenCalled();
+      expect(onAppointmentUpdate).not.toHaveBeenCalled();
 
       expect(showErrorNotification).toHaveBeenCalledWith(updateError);
     });
@@ -461,6 +476,8 @@ describe('AppointmentDetails', () => {
     const user = userEvent.setup();
     const appointment = createAppointment();
     const cancelledAppointment = { ...appointment, status: 'cancelled' as const };
+    const onAppointmentUpdate = vi.fn();
+    const onSlotUpdate = vi.fn();
 
     const postPromise = Promise.withResolvers<Appointment>();
     const postMock = vi.fn().mockReturnValue(postPromise.promise);
@@ -469,7 +486,7 @@ describe('AppointmentDetails', () => {
     medplum.invalidateSearches = invalidateSearchesMock;
 
     // click the button
-    await setup({ appointment });
+    const { rerender } = await setup({ appointment, onAppointmentUpdate, onSlotUpdate });
     const button = screen.getByRole('button', { name: /Cancel Visit/i });
     await user.click(button);
 
@@ -490,6 +507,21 @@ describe('AppointmentDetails', () => {
     // it invalidated Appointment and Slot searches on success
     expect(invalidateSearchesMock).toHaveBeenCalledWith('Appointment');
     expect(invalidateSearchesMock).toHaveBeenCalledWith('Slot');
+
+    // it invoked onAppointmentUpdate callback
+    expect(onAppointmentUpdate).toHaveBeenCalledWith(cancelledAppointment);
+
+    // re-render with cancelled appointment
+    await rerender(
+      <AppointmentDetails
+        appointment={cancelledAppointment}
+        onAppointmentUpdate={onAppointmentUpdate}
+        onSlotUpdate={onSlotUpdate}
+      />
+    );
+
+    // cancel button is disabled
+    await waitFor(() => expect(button).toHaveAttribute('data-disabled'));
   });
 
   test('Uncancellable appointment status', async () => {
@@ -504,5 +536,84 @@ describe('AppointmentDetails', () => {
     await waitFor(() => expect(button).toHaveAttribute('data-disabled'));
     await user.hover(button);
     await waitFor(() => screen.getByText(`Can't cancel appointment with status "${status}"`));
+  });
+
+  test('Confirm Visit button', async () => {
+    const user = userEvent.setup();
+    const bookedAppointment = createAppointment();
+    const pendingAppointment = { ...bookedAppointment, status: 'pending' as const };
+    const busySlot: Slot = {
+      resourceType: 'Slot',
+      start,
+      end,
+      status: 'busy',
+      schedule: { reference: 'Schedule/abc123' },
+    };
+    const busyUnavailableSlot: Slot = {
+      resourceType: 'Slot',
+      start,
+      end,
+      status: 'busy-unavailable',
+      schedule: { reference: 'Schedule/abc123' },
+    };
+
+    const onAppointmentUpdate = vi.fn();
+    const onSlotUpdate = vi.fn();
+
+    const postPromise = Promise.withResolvers<Bundle<Appointment | Slot>>();
+    const postMock = vi.fn().mockReturnValue(postPromise.promise);
+    const invalidateSearchesMock = vi.fn();
+    medplum.post = postMock;
+    medplum.invalidateSearches = invalidateSearchesMock;
+
+    // click the button
+    const { rerender } = await setup({
+      appointment: pendingAppointment,
+      onAppointmentUpdate,
+      onSlotUpdate,
+    });
+    const button = screen.getByRole('button', { name: /Confirm Appointment/i });
+    await user.click(button);
+
+    // it invokes the $confirm endpoint
+    await waitFor(() => expect(medplum.post).toHaveBeenCalled());
+    const postUrl = postMock.mock.calls[0][0];
+    expect(postUrl.toString()).toContain(`Appointment/${pendingAppointment.id}/$confirm`);
+
+    // button goes into loading state
+    await waitFor(() => expect(button).toHaveAttribute('data-loading'));
+
+    // resolve the promise
+    postPromise.resolve({
+      resourceType: 'Bundle',
+      type: 'transaction-response',
+      entry: [{ resource: bookedAppointment }, { resource: busySlot }, { resource: busyUnavailableSlot }],
+    });
+
+    // button is no longer loading
+    await waitFor(() => expect(button).not.toHaveAttribute('data-loading'));
+
+    // onAppointmentUpdate was called with the updated appointment
+    expect(onAppointmentUpdate).toHaveBeenCalledWith(bookedAppointment);
+
+    // onSlotUpdate was called with the updated slots
+    expect(onSlotUpdate).toHaveBeenCalledWith(busySlot);
+    expect(onSlotUpdate).toHaveBeenCalledWith(busyUnavailableSlot);
+
+    // it invalidated Appointment and Slot searches on success
+    expect(invalidateSearchesMock).toHaveBeenCalledWith('Appointment');
+    expect(invalidateSearchesMock).toHaveBeenCalledWith('Slot');
+
+    // re-render with booked appointment
+    await rerender(
+      <AppointmentDetails
+        appointment={bookedAppointment}
+        onAppointmentUpdate={onAppointmentUpdate}
+        onSlotUpdate={onSlotUpdate}
+      />
+    );
+
+    // button is not rendered when status is "booked"
+    expect(screen.queryByRole('button', { name: 'Confirm Appointment' })).not.toBeInTheDocument();
   });
 });

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
@@ -3,11 +3,11 @@
 import { Button, Divider, Group, Stack, Text, Tooltip } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import type { WithId } from '@medplum/core';
-import { createReference, formatHumanName, formatPeriod, isReference } from '@medplum/core';
-import type { Appointment, Coding, Patient, PlanDefinition, Practitioner } from '@medplum/fhirtypes';
+import { createReference, EMPTY, formatHumanName, formatPeriod, isReference, isResource } from '@medplum/core';
+import type { Appointment, Bundle, Coding, Patient, PlanDefinition, Practitioner, Slot } from '@medplum/fhirtypes';
 import { CodingInput, Form, MedplumLink, ResourceAvatar, ResourceInput, useMedplum } from '@medplum/react';
 import { useResource } from '@medplum/react-hooks';
-import { IconAlertSquareRounded, IconTrash } from '@tabler/icons-react';
+import { IconAlertSquareRounded, IconFileCheck, IconTrash } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -77,7 +77,8 @@ function UpdateAppointmentForm(props: UpdateAppointmentFormProps): JSX.Element {
 // via $find/$hold to set up an Encounter and apply a plan definition to it.
 export function AppointmentDetails(props: {
   appointment: WithId<Appointment>;
-  onUpdate: (appointment: WithId<Appointment>) => void;
+  onAppointmentUpdate: (appointment: WithId<Appointment>) => void;
+  onSlotUpdate: (slot: WithId<Slot>) => void;
 }): JSX.Element {
   const medplum = useMedplum();
   const [planDefinition, setPlanDefinition] = useState<PlanDefinition | undefined>();
@@ -91,7 +92,7 @@ export function AppointmentDetails(props: {
 
   const patient = useResource(patientRef);
   const navigate = useNavigate();
-  const { appointment, onUpdate } = props;
+  const { appointment, onAppointmentUpdate, onSlotUpdate } = props;
 
   const handleSubmit = useCallback(async () => {
     if (!patient) {
@@ -158,18 +159,48 @@ export function AppointmentDetails(props: {
       );
       medplum.invalidateSearches('Appointment');
       medplum.invalidateSearches('Slot');
-      onUpdate(updated);
+      onAppointmentUpdate(updated);
     } catch (err) {
       showErrorNotification(err);
     } finally {
       setCancelLoading(false);
     }
-  }, [medplum, appointment, cancellable, onUpdate]);
+  }, [medplum, appointment, cancellable, onAppointmentUpdate]);
+
+  const confirmable = appointment.status === 'pending';
+  const [confirmLoading, setConfirmLoading] = useState(false);
+  const handleConfirm = useCallback(async () => {
+    if (!confirmable) {
+      console.error(new Error(`handleConfirm called from non confirmable status '${appointment.status}'`));
+      return;
+    }
+    setConfirmLoading(true);
+    try {
+      const updated = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(
+        medplum.fhirUrl('Appointment', appointment.id, '$confirm')
+      );
+      medplum.invalidateSearches('Appointment');
+      medplum.invalidateSearches('Slot');
+      const updatedResources = updated.entry?.map((entry) => entry.resource) ?? EMPTY;
+      const updatedAppointment = updatedResources.find((res) => isResource<Appointment>(res, 'Appointment'));
+      const updatedSlots = updatedResources.filter((res) => isResource<Slot>(res, 'Slot'));
+      if (updatedAppointment) {
+        onAppointmentUpdate(updatedAppointment);
+      }
+      for (const updatedSlot of updatedSlots) {
+        onSlotUpdate(updatedSlot);
+      }
+    } catch (err) {
+      showErrorNotification(err);
+    } finally {
+      setConfirmLoading(false);
+    }
+  }, [medplum, appointment, confirmable, onAppointmentUpdate, onSlotUpdate]);
 
   return (
     <Stack gap="md">
       <Text size="lg">{formatPeriod({ start: props.appointment.start, end: props.appointment.end })}</Text>
-      {!patientRef && <UpdateAppointmentForm appointment={props.appointment} onUpdate={props.onUpdate} />}
+      {!patientRef && <UpdateAppointmentForm appointment={props.appointment} onUpdate={props.onAppointmentUpdate} />}
 
       {!!patient && (
         <>
@@ -222,6 +253,16 @@ export function AppointmentDetails(props: {
         </>
       )}
       <Divider my="md" />
+      {confirmable && (
+        <Button
+          loading={confirmLoading}
+          onClick={handleConfirm}
+          variant="outline"
+          leftSection={<IconFileCheck size={16} />}
+        >
+          Confirm Appointment
+        </Button>
+      )}
       <Tooltip label={cancelTooltip} disabled={!cancelTooltip}>
         <Button
           loading={cancelLoading}

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
@@ -3,11 +3,11 @@
 import { Button, Divider, Group, Stack, Text, Tooltip } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import type { WithId } from '@medplum/core';
-import { createReference, formatHumanName, formatPeriod, isReference } from '@medplum/core';
-import type { Appointment, Coding, Patient, PlanDefinition, Practitioner } from '@medplum/fhirtypes';
+import { createReference, EMPTY, formatHumanName, formatPeriod, isReference, isResource } from '@medplum/core';
+import type { Appointment, Bundle, Coding, Patient, PlanDefinition, Practitioner, Slot } from '@medplum/fhirtypes';
 import { CodingInput, Form, MedplumLink, ResourceAvatar, ResourceInput, useMedplum } from '@medplum/react';
 import { useResource } from '@medplum/react-hooks';
-import { IconAlertSquareRounded, IconTrash } from '@tabler/icons-react';
+import { IconAlertSquareRounded, IconFileCheck, IconTrash } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -77,7 +77,8 @@ function UpdateAppointmentForm(props: UpdateAppointmentFormProps): JSX.Element {
 // via $find/$hold to set up an Encounter and apply a plan definition to it.
 export function AppointmentDetails(props: {
   appointment: WithId<Appointment>;
-  onUpdate: (appointment: WithId<Appointment>) => void;
+  onAppointmentUpdate: (appointment: WithId<Appointment>) => void;
+  onSlotUpdate: (slot: WithId<Slot>) => void;
 }): JSX.Element {
   const medplum = useMedplum();
   const [planDefinition, setPlanDefinition] = useState<PlanDefinition | undefined>();
@@ -91,7 +92,7 @@ export function AppointmentDetails(props: {
 
   const patient = useResource(patientRef);
   const navigate = useNavigate();
-  const { appointment, onUpdate } = props;
+  const { appointment, onAppointmentUpdate, onSlotUpdate } = props;
 
   const handleSubmit = useCallback(async () => {
     if (!patient) {
@@ -146,11 +147,6 @@ export function AppointmentDetails(props: {
   const [cancelLoading, setCancelLoading] = useState(false);
 
   const handleCancel = useCallback(async () => {
-    if (!cancellable) {
-      console.error(new Error(`handleCancel called from non cancellable status '${appointment.status}'`));
-      return;
-    }
-
     setCancelLoading(true);
     try {
       const updated = await medplum.post<WithId<Appointment>>(
@@ -158,18 +154,48 @@ export function AppointmentDetails(props: {
       );
       medplum.invalidateSearches('Appointment');
       medplum.invalidateSearches('Slot');
-      onUpdate(updated);
+      onAppointmentUpdate(updated);
     } catch (err) {
       showErrorNotification(err);
     } finally {
       setCancelLoading(false);
     }
-  }, [medplum, appointment, cancellable, onUpdate]);
+  }, [medplum, appointment, onAppointmentUpdate]);
+
+  const confirmable = appointment.status === 'pending';
+  const [confirmLoading, setConfirmLoading] = useState(false);
+  const handleConfirm = useCallback(async () => {
+    if (!confirmable) {
+      console.error(new Error(`handleConfirm called from non confirmable status '${appointment.status}'`));
+      return;
+    }
+    setConfirmLoading(true);
+    try {
+      const updated = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(
+        medplum.fhirUrl('Appointment', appointment.id, '$confirm')
+      );
+      medplum.invalidateSearches('Appointment');
+      medplum.invalidateSearches('Slot');
+      const updatedResources = updated.entry?.map((entry) => entry.resource) ?? EMPTY;
+      const updatedAppointment = updatedResources.find((res) => isResource<Appointment>(res, 'Appointment'));
+      const updatedSlots = updatedResources.filter((res) => isResource<Slot>(res, 'Slot'));
+      if (updatedAppointment) {
+        onAppointmentUpdate(updatedAppointment);
+      }
+      for (const updatedSlot of updatedSlots) {
+        onSlotUpdate(updatedSlot);
+      }
+    } catch (err) {
+      showErrorNotification(err);
+    } finally {
+      setConfirmLoading(false);
+    }
+  }, [medplum, appointment, confirmable, onAppointmentUpdate, onSlotUpdate]);
 
   return (
     <Stack gap="md">
       <Text size="lg">{formatPeriod({ start: props.appointment.start, end: props.appointment.end })}</Text>
-      {!patientRef && <UpdateAppointmentForm appointment={props.appointment} onUpdate={props.onUpdate} />}
+      {!patientRef && <UpdateAppointmentForm appointment={props.appointment} onUpdate={props.onAppointmentUpdate} />}
 
       {!!patient && (
         <>
@@ -222,6 +248,16 @@ export function AppointmentDetails(props: {
         </>
       )}
       <Divider my="md" />
+      {confirmable && (
+        <Button
+          loading={confirmLoading}
+          onClick={handleConfirm}
+          variant="outline"
+          leftSection={<IconFileCheck size={16} />}
+        >
+          Confirm Appointment
+        </Button>
+      )}
       <Tooltip label={cancelTooltip} disabled={!cancelTooltip}>
         <Button
           loading={cancelLoading}

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
@@ -207,6 +207,10 @@ export function SchedulePage(): JSX.Element | null {
     [appointmentDetailsHandlers]
   );
 
+  const handleSlotUpdate = useCallback((updated: WithId<Slot>) => {
+    setSlots((state) => (state ?? []).map((existing) => (existing.id === updated.id ? updated : existing)));
+  }, []);
+
   const handleActorChange = useCallback(
     (ref: Reference | undefined) => {
       if (!ref?.reference) {
@@ -299,7 +303,11 @@ export function SchedulePage(): JSX.Element | null {
         h="100%"
       >
         {appointmentDetails && (
-          <AppointmentDetails appointment={appointmentDetails} onUpdate={handleAppointmentUpdate} />
+          <AppointmentDetails
+            appointment={appointmentDetails}
+            onAppointmentUpdate={handleAppointmentUpdate}
+            onSlotUpdate={handleSlotUpdate}
+          />
         )}
       </Drawer>
     </Box>


### PR DESCRIPTION
After using `$hold` (such as from the FooMedical example), an appointment is in the "pending" state.

- Represent "pending" status visually with an outlined style
  <img width="1499" height="1101" alt="Screenshot 2026-05-27 at 9 46 53 AM" src="https://github.com/user-attachments/assets/fbd04544-c0fb-4c68-8ec7-9d8bc604397d" />


- Add a button to invoke `$confirm` for pending appointments
  <img width="1499" height="1101" alt="Screenshot 2026-05-27 at 9 47 00 AM" src="https://github.com/user-attachments/assets/fbb6cd06-335e-4a4c-89ea-ac78b3c3386a" />

