### PR TITLE
DoseSpot sync button fix

### DIFF
--- a/examples/medplum-provider/src/pages/patient/MedicationsPage.test.tsx
+++ b/examples/medplum-provider/src/pages/patient/MedicationsPage.test.tsx
@@ -22,6 +22,17 @@ function createDoseSpotMembership(): ReturnType<MockClient['getProjectMembership
   };
 }
 
+function createScriptSureMembership(): ReturnType<MockClient['getProjectMembership']> {
+  return {
+    resourceType: 'ProjectMembership',
+    id: 'test-membership',
+    project: { reference: 'Project/test' },
+    user: { reference: 'User/test' },
+    profile: { reference: 'Practitioner/test' },
+    identifier: [{ system: 'https://scriptsure.com', value: '12345' }],
+  };
+}
+
 /**
  * Build an empty MedicationRequest search Bundle so the new server-side search path
  * (`medplum.search('MedicationRequest', ...)` returning a Bundle with `total`) is
@@ -95,7 +106,10 @@ describe('MedicationsPage', () => {
   });
 
   test('Renders medication tabs and order action', async () => {
-    await setup(`/Patient/${HomerSimpson.id}/MedicationRequest`);
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'search').mockResolvedValue(emptyMrBundle(0));
+    vi.spyOn(medplum, 'getProjectMembership').mockReturnValue(createScriptSureMembership());
+    await setup(`/Patient/${HomerSimpson.id}/MedicationRequest`, medplum);
     expect(await screen.findByText('Active')).toBeInTheDocument();
     expect(await screen.findByText('Draft')).toBeInTheDocument();
     expect(await screen.findByText('Completed')).toBeInTheDocument();
@@ -192,34 +206,23 @@ describe('MedicationsPage', () => {
     });
   });
 
-  test('Does not show DoseSpot sync button without DoseSpot identifier', async () => {
-    await setup(`/Patient/${HomerSimpson.id}/MedicationRequest`);
-    expect(await screen.findByText('Active')).toBeInTheDocument();
-    expect(screen.queryByText('DoseSpot sync')).not.toBeInTheDocument();
-  });
-
-  test('Shows DoseSpot sync button with DoseSpot identifier', async () => {
+  test('Does not trigger DoseSpot sync without DoseSpot identifier', async () => {
     const medplum = new MockClient();
     vi.spyOn(medplum, 'search').mockResolvedValue(emptyMrBundle(0));
-    vi.spyOn(medplum, 'getProjectMembership').mockReturnValue(createDoseSpotMembership());
+    const executeBotSpy = vi.spyOn(medplum, 'executeBot').mockResolvedValue({});
 
     await setup(`/Patient/${HomerSimpson.id}/MedicationRequest`, medplum);
-    expect(await screen.findByText('DoseSpot sync')).toBeInTheDocument();
+    expect(await screen.findByText('Active')).toBeInTheDocument();
+    expect(executeBotSpy).not.toHaveBeenCalled();
   });
 
-  test('DoseSpot sync button triggers bot execution', async () => {
+  test('DoseSpot sync calls all three bots automatically on mount', async () => {
     const medplum = new MockClient();
     vi.spyOn(medplum, 'search').mockResolvedValue(emptyMrBundle(0));
     vi.spyOn(medplum, 'getProjectMembership').mockReturnValue(createDoseSpotMembership());
     const executeBotSpy = vi.spyOn(medplum, 'executeBot').mockResolvedValue({});
 
     await setup(`/Patient/${HomerSimpson.id}/MedicationRequest`, medplum);
-    expect(await screen.findByText('DoseSpot sync')).toBeInTheDocument();
-
-    const syncButton = screen.getByText('DoseSpot sync');
-    await act(async () => {
-      fireEvent.click(syncButton);
-    });
 
     await waitFor(() => {
       expect(executeBotSpy).toHaveBeenCalledTimes(3);

--- a/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
@@ -196,7 +196,7 @@ export function MedicationsPage(): JSX.Element {
     }
   }, [patientId, fetchData]);
 
-const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const getOrderUrl = useCallback(
     (order: MedicationRequest): string => {

--- a/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
@@ -196,7 +196,10 @@ export function MedicationsPage(): JSX.Element {
     }
   }, [patientId, fetchData]);
 
-const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const fetchDataRef = useRef(fetchData);
+  fetchDataRef.current = fetchData;
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const getOrderUrl = useCallback(
     (order: MedicationRequest): string => {
@@ -263,7 +266,7 @@ const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
             autoClose: 3000,
           });
           medplum.invalidateSearches('MedicationRequest');
-          await fetchData();
+          await fetchDataRef.current();
         }
       } catch (err) {
         if (!cancelled) {
@@ -275,8 +278,7 @@ const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
     return () => {
       cancelled = true;
     };
-    // fetchData is intentionally excluded — including it would re-trigger the sync on every tab/page change.
-  }, [hasDoseSpot, medplum, patient?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [hasDoseSpot, medplum, patient?.id]);
 
   const handleOrderMedicationComplete = useCallback(
     async (result: { launchUrl: string; medicationRequestId?: string }): Promise<void> => {

--- a/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
@@ -227,7 +227,7 @@ export function MedicationsPage(): JSX.Element {
 
   useEffect(() => {
     if (!hasDoseSpot || !patient?.id) {
-      return;
+      return undefined;
     }
     const today = new Date().toISOString().split('T')[0];
     const notificationId = 'dosespot-sync';
@@ -278,7 +278,7 @@ export function MedicationsPage(): JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, [hasDoseSpot, patient?.id]);
+  }, [hasDoseSpot, medplum, patient?.id]);
 
   const handleOrderMedicationComplete = useCallback(
     async (result: { launchUrl: string; medicationRequestId?: string }): Promise<void> => {

--- a/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
@@ -244,8 +244,16 @@ export function MedicationsPage(): JSX.Element {
       .executeBot(DOSESPOT_PATIENT_SYNC_BOT, { patientId: patient.id })
       .then(() =>
         Promise.all([
-          medplum.executeBot(DOSESPOT_PRESCRIPTIONS_SYNC_BOT, { patientId: patient.id as string, start: today, end: today }),
-          medplum.executeBot(DOSESPOT_MEDICATION_HISTORY_BOT, { patientId: patient.id as string, start: today, end: today }),
+          medplum.executeBot(DOSESPOT_PRESCRIPTIONS_SYNC_BOT, {
+            patientId: patient.id as string,
+            start: today,
+            end: today,
+          }),
+          medplum.executeBot(DOSESPOT_MEDICATION_HISTORY_BOT, {
+            patientId: patient.id as string,
+            start: today,
+            end: today,
+          }),
         ])
       )
       .then(() => {

--- a/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
@@ -196,6 +196,9 @@ export function MedicationsPage(): JSX.Element {
     }
   }, [patientId, fetchData]);
 
+  const fetchDataRef = useRef(fetchData);
+  fetchDataRef.current = fetchData;
+
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const getOrderUrl = useCallback(
@@ -257,7 +260,7 @@ export function MedicationsPage(): JSX.Element {
             autoClose: 3000,
           });
           medplum.invalidateSearches('MedicationRequest');
-          fetchData().catch(showErrorNotification);
+          fetchDataRef.current().catch(showErrorNotification);
         }
       })
       .catch((err: unknown) => {

--- a/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
@@ -16,8 +16,8 @@ import {
   Text,
   Tooltip,
 } from '@mantine/core';
-import { showNotification, updateNotification } from '@mantine/notifications';
-import { getReferenceString, normalizeErrorString } from '@medplum/core';
+import { hideNotification, showNotification, updateNotification } from '@mantine/notifications';
+import { getReferenceString } from '@medplum/core';
 import {
   DOSESPOT_MEDICATION_HISTORY_BOT,
   DOSESPOT_PATIENT_SYNC_BOT,
@@ -196,10 +196,7 @@ export function MedicationsPage(): JSX.Element {
     }
   }, [patientId, fetchData]);
 
-  const fetchDataRef = useRef(fetchData);
-  fetchDataRef.current = fetchData;
-
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const getOrderUrl = useCallback(
     (order: MedicationRequest): string => {
@@ -240,10 +237,10 @@ export function MedicationsPage(): JSX.Element {
       autoClose: false,
       withCloseButton: false,
     });
-    medplum
-      .executeBot(DOSESPOT_PATIENT_SYNC_BOT, { patientId: patient.id })
-      .then(() =>
-        Promise.all([
+    (async () => {
+      try {
+        await medplum.executeBot(DOSESPOT_PATIENT_SYNC_BOT, { patientId: patient.id });
+        await Promise.all([
           medplum.executeBot(DOSESPOT_PRESCRIPTIONS_SYNC_BOT, {
             patientId: patient.id as string,
             start: today,
@@ -254,9 +251,7 @@ export function MedicationsPage(): JSX.Element {
             start: today,
             end: today,
           }),
-        ])
-      )
-      .then(() => {
+        ]);
         if (!cancelled) {
           updateNotification({
             id: notificationId,
@@ -268,25 +263,20 @@ export function MedicationsPage(): JSX.Element {
             autoClose: 3000,
           });
           medplum.invalidateSearches('MedicationRequest');
-          fetchDataRef.current().catch(showErrorNotification);
+          await fetchData();
         }
-      })
-      .catch((err: unknown) => {
+      } catch (err) {
         if (!cancelled) {
-          updateNotification({
-            id: notificationId,
-            loading: false,
-            color: 'red',
-            title: 'Error syncing with DoseSpot',
-            message: normalizeErrorString(err),
-            autoClose: 5000,
-          });
+          hideNotification(notificationId);
+          showErrorNotification(err);
         }
-      });
+      }
+    })().catch(showErrorNotification);
     return () => {
       cancelled = true;
     };
-  }, [hasDoseSpot, medplum, patient?.id]);
+    // fetchData is intentionally excluded — including it would re-trigger the sync on every tab/page change.
+  }, [hasDoseSpot, medplum, patient?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleOrderMedicationComplete = useCallback(
     async (result: { launchUrl: string; medicationRequestId?: string }): Promise<void> => {

--- a/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
@@ -3,11 +3,9 @@
 import {
   ActionIcon,
   Box,
-  Button,
   Divider,
   Flex,
   Group,
-  Loader,
   Modal,
   Pagination,
   Paper,
@@ -18,7 +16,7 @@ import {
   Text,
   Tooltip,
 } from '@mantine/core';
-import { showNotification } from '@mantine/notifications';
+import { showNotification, updateNotification } from '@mantine/notifications';
 import { getReferenceString, normalizeErrorString } from '@medplum/core';
 import {
   DOSESPOT_MEDICATION_HISTORY_BOT,
@@ -37,7 +35,7 @@ import type { MedTab } from '../../components/meds/MedListItem';
 import { MedListItem } from '../../components/meds/MedListItem';
 import { MedSelectEmpty } from '../../components/meds/MedSelectEmpty';
 import { PrescriptionIFrameModal } from '../../components/meds/PrescriptionIFrameModal';
-import { hasDoseSpotIdentifier } from '../../components/utils';
+import { hasDoseSpotIdentifier, hasScriptSureIdentifier } from '../../components/utils';
 import { usePatient } from '../../hooks/usePatient';
 import { showErrorNotification } from '../../utils/notifications';
 import { OrderMedicationPage } from '../meds/OrderMedicationPage';
@@ -145,7 +143,7 @@ export function MedicationsPage(): JSX.Element {
   const patientReference = useMemo(() => (patient ? getReferenceString(patient) : undefined), [patient]);
   const membership = medplum.getProjectMembership();
   const hasDoseSpot = hasDoseSpotIdentifier(membership);
-  const [syncing, setSyncing] = useState(false);
+  const hasScriptSure = hasScriptSureIdentifier(membership);
 
   const fetchOrders = useCallback(async (): Promise<void> => {
     if (!patientReference) {
@@ -224,36 +222,60 @@ export function MedicationsPage(): JSX.Element {
     };
   }, [medicationRequestId, orderFromList, medplum]);
 
-  const handleDoseSpotSync = useCallback(async (): Promise<void> => {
-    if (!patient?.id) {
+  useEffect(() => {
+    if (!hasDoseSpot || !patient?.id) {
       return;
     }
-    setSyncing(true);
     const today = new Date().toISOString().split('T')[0];
-    try {
-      await medplum.executeBot(DOSESPOT_PATIENT_SYNC_BOT, { patientId: patient.id });
-      await Promise.all([
-        medplum.executeBot(DOSESPOT_PRESCRIPTIONS_SYNC_BOT, { patientId: patient.id, start: today, end: today }),
-        medplum.executeBot(DOSESPOT_MEDICATION_HISTORY_BOT, { patientId: patient.id, start: today, end: today }),
-      ]);
-      showNotification({
-        color: 'green',
-        icon: '✓',
-        title: 'Successfully synced prescriptions and medications with DoseSpot',
-        message: '',
+    const notificationId = 'dosespot-sync';
+    let cancelled = false;
+    showNotification({
+      id: notificationId,
+      loading: true,
+      title: 'Syncing with DoseSpot',
+      message: '',
+      autoClose: false,
+      withCloseButton: false,
+    });
+    medplum
+      .executeBot(DOSESPOT_PATIENT_SYNC_BOT, { patientId: patient.id })
+      .then(() =>
+        Promise.all([
+          medplum.executeBot(DOSESPOT_PRESCRIPTIONS_SYNC_BOT, { patientId: patient.id as string, start: today, end: today }),
+          medplum.executeBot(DOSESPOT_MEDICATION_HISTORY_BOT, { patientId: patient.id as string, start: today, end: today }),
+        ])
+      )
+      .then(() => {
+        if (!cancelled) {
+          updateNotification({
+            id: notificationId,
+            loading: false,
+            color: 'green',
+            icon: '✓',
+            title: 'Successfully synced prescriptions and medications with DoseSpot',
+            message: '',
+            autoClose: 3000,
+          });
+          medplum.invalidateSearches('MedicationRequest');
+          fetchData().catch(showErrorNotification);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          updateNotification({
+            id: notificationId,
+            loading: false,
+            color: 'red',
+            title: 'Error syncing with DoseSpot',
+            message: normalizeErrorString(err),
+            autoClose: 5000,
+          });
+        }
       });
-      medplum.invalidateSearches('MedicationRequest');
-      await fetchData();
-    } catch (err) {
-      showNotification({
-        color: 'red',
-        title: 'Error syncing with DoseSpot',
-        message: normalizeErrorString(err),
-      });
-    } finally {
-      setSyncing(false);
-    }
-  }, [medplum, patient, fetchData]);
+    return () => {
+      cancelled = true;
+    };
+  }, [hasDoseSpot, patient?.id]);
 
   const handleOrderMedicationComplete = useCallback(
     async (result: { launchUrl: string; medicationRequestId?: string }): Promise<void> => {
@@ -329,29 +351,20 @@ export function MedicationsPage(): JSX.Element {
                   </Tabs>
                 </Group>
                 <Group gap="xs">
-                  {hasDoseSpot && (
-                    <Button
-                      size="xs"
-                      variant="light"
-                      leftSection={syncing ? <Loader size={14} /> : undefined}
-                      disabled={syncing}
-                      onClick={() => handleDoseSpotSync().catch(showErrorNotification)}
-                    >
-                      {syncing ? 'Syncing…' : 'DoseSpot sync'}
-                    </Button>
+                  {hasScriptSure && (
+                    <Tooltip label="Order medication" position="bottom" openDelay={500}>
+                      <ActionIcon
+                        radius="xl"
+                        variant="filled"
+                        color="blue"
+                        size={32}
+                        aria-label="Order medication"
+                        onClick={() => setNewOrderModalOpened(true)}
+                      >
+                        <IconPlus size={16} />
+                      </ActionIcon>
+                    </Tooltip>
                   )}
-                  <Tooltip label="Order medication" position="bottom" openDelay={500}>
-                    <ActionIcon
-                      radius="xl"
-                      variant="filled"
-                      color="blue"
-                      size={32}
-                      aria-label="Order medication"
-                      onClick={() => setNewOrderModalOpened(true)}
-                    >
-                      <IconPlus size={16} />
-                    </ActionIcon>
-                  </Tooltip>
                 </Group>
               </Flex>
             </Paper>


### PR DESCRIPTION
The DoseSpot sync button was rendering weirdly in medplum provider. This PR removes the button entirely and automatically runs sync on `Meds` tab render. 