### PR TITLE
Added order set sync bot trigger after importing example order set

### DIFF
--- a/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
+++ b/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
@@ -18,6 +18,7 @@ import { showNotification } from '@mantine/notifications';
 import { convertToTransactionBundle } from '@medplum/core';
 import type { Bundle, BundleEntry } from '@medplum/fhirtypes';
 import { MedplumLink, useMedplum } from '@medplum/react';
+import { SCRIPTSURE_ORDERSET_SYNC_BOT } from '@medplum/scriptsure-react';
 import {
   IconApps,
   IconArrowUpRight,
@@ -128,6 +129,13 @@ export function GetStartedPage(): JSX.Element {
 
       const resourceCount =
         result.entry?.filter((entry: BundleEntry) => entry.response?.status?.startsWith('2')).length || 0;
+
+      const pdLocation = result.entry?.find((e) => e.response?.location?.startsWith('PlanDefinition/'))?.response
+        ?.location;
+      const pdId = pdLocation?.split('/')[1];
+      if (pdId) {
+        await medplum.executeBot(SCRIPTSURE_ORDERSET_SYNC_BOT, { planDefinitionId: pdId });
+      }
 
       showNotification({
         color: 'green',

--- a/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
+++ b/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
@@ -17,8 +17,8 @@ import {
 import { showNotification } from '@mantine/notifications';
 import { convertToTransactionBundle } from '@medplum/core';
 import type { Bundle, BundleEntry } from '@medplum/fhirtypes';
-import { useSyncOrderSet } from '@medplum/react-hooks';
 import { MedplumLink, useMedplum } from '@medplum/react';
+import { useSyncOrderSet } from '@medplum/react-hooks';
 import {
   IconApps,
   IconArrowUpRight,

--- a/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
+++ b/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
@@ -17,8 +17,8 @@ import {
 import { showNotification } from '@mantine/notifications';
 import { convertToTransactionBundle } from '@medplum/core';
 import type { Bundle, BundleEntry } from '@medplum/fhirtypes';
+import { useSyncOrderSet } from '@medplum/react-hooks';
 import { MedplumLink, useMedplum } from '@medplum/react';
-import { SCRIPTSURE_ORDERSET_SYNC_BOT } from '@medplum/scriptsure-react';
 import {
   IconApps,
   IconArrowUpRight,
@@ -44,6 +44,7 @@ import classes from './GetStartedPage.module.css';
 
 export function GetStartedPage(): JSX.Element {
   const medplum = useMedplum();
+  const syncOrderSet = useSyncOrderSet();
   const [importingPatient, setImportingPatient] = useState(false);
   const [importingVisit, setImportingVisit] = useState(false);
   const [importingIcd10, setImportingIcd10] = useState(false);
@@ -134,7 +135,7 @@ export function GetStartedPage(): JSX.Element {
         ?.location;
       const pdId = pdLocation?.split('/')[1];
       if (pdId) {
-        await medplum.executeBot(SCRIPTSURE_ORDERSET_SYNC_BOT, { planDefinitionId: pdId });
+        await syncOrderSet(pdId);
       }
 
       showNotification({
@@ -147,7 +148,7 @@ export function GetStartedPage(): JSX.Element {
     } finally {
       setImportingOrderSet(false);
     }
-  }, [medplum]);
+  }, [medplum, syncOrderSet]);
 
   const integrations = [
     { src: '/img/integrations/labcorp.png', alt: 'Labcorp', left: 20, top: 20, zIndex: 1, rotation: -2 },

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -15,5 +15,6 @@ export * from './useQuestionnaireForm/utils';
 export * from './useResource/useResource';
 export * from './useSearch/useSearch';
 export * from './useSubscription/useSubscription';
+export * from './useSyncOrderSet/useSyncOrderSet';
 export * from './useThreadInbox/useThreadInbox';
 export * from './useWhisper/useWhisper';

--- a/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.test.tsx
+++ b/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.test.tsx
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { OperationOutcome } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { act, renderHook } from '@testing-library/react';
+import type { JSX, ReactNode } from 'react';
+import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
+import { useSyncOrderSet } from './useSyncOrderSet';
+
+const OPERATION_URL = 'fhir/R4/PlanDefinition/$sync-orderset';
+
+function wrapper(medplum: MockClient) {
+  return function Wrapper(props: { children: ReactNode }): JSX.Element {
+    return <MedplumProvider medplum={medplum}>{props.children}</MedplumProvider>;
+  };
+}
+
+describe('useSyncOrderSet', () => {
+  test('POSTs planDefinitionId to $sync-orderset', async () => {
+    const medplum = new MockClient();
+    const post = jest.spyOn(medplum, 'post').mockResolvedValue({ resourceType: 'Parameters', parameter: [] });
+
+    const { result } = renderHook(() => useSyncOrderSet(), { wrapper: wrapper(medplum) });
+
+    await act(async () => {
+      await result.current('plan-def-123');
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    const [calledUrl, body] = post.mock.calls[0];
+    expect(calledUrl.toString()).toContain(OPERATION_URL);
+    expect(body).toEqual({ planDefinitionId: 'plan-def-123' });
+  });
+
+  test('silently no-ops when operation is not deployed (not-found)', async () => {
+    const medplum = new MockClient();
+    const notFound: OperationOutcome = {
+      resourceType: 'OperationOutcome',
+      issue: [{ severity: 'error', code: 'not-found', diagnostics: 'Operation not found' }],
+    };
+    jest.spyOn(medplum, 'post').mockRejectedValue(notFound);
+
+    const { result } = renderHook(() => useSyncOrderSet(), { wrapper: wrapper(medplum) });
+
+    await act(async () => {
+      // Should resolve without throwing
+      await expect(result.current('plan-def-123')).resolves.toBeUndefined();
+    });
+  });
+
+  test('re-throws non-not-found errors', async () => {
+    const medplum = new MockClient();
+    const serverError: OperationOutcome = {
+      resourceType: 'OperationOutcome',
+      issue: [{ severity: 'error', code: 'exception', diagnostics: 'Internal server error' }],
+    };
+    jest.spyOn(medplum, 'post').mockRejectedValue(serverError);
+
+    const { result } = renderHook(() => useSyncOrderSet(), { wrapper: wrapper(medplum) });
+
+    await act(async () => {
+      await expect(result.current('plan-def-123')).rejects.toMatchObject({ resourceType: 'OperationOutcome' });
+    });
+  });
+});

--- a/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.ts
+++ b/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { isOperationOutcome } from '@medplum/core';
+import { useCallback } from 'react';
+import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
+
+/**
+ * Vendor-neutral React hook that syncs a Medplum `PlanDefinition` (type=order-set)
+ * to the configured e-prescribing vendor via the `$sync-orderset` custom FHIR operation
+ * (`POST /fhir/R4/PlanDefinition/$sync-orderset`).
+ *
+ * Silently no-ops when the operation is not deployed (i.e. no e-prescribing vendor
+ * is configured for the project), so callers do not need to guard against missing
+ * integrations.
+ *
+ * @returns A stable `syncOrderSet(planDefinitionId)` callback.
+ */
+export function useSyncOrderSet(): (planDefinitionId: string) => Promise<void> {
+  const medplum = useMedplum();
+
+  return useCallback(
+    async (planDefinitionId: string): Promise<void> => {
+      try {
+        await medplum.post(medplum.fhirUrl('PlanDefinition', '$sync-orderset'), { planDefinitionId });
+      } catch (err: unknown) {
+        // If the operation isn't deployed, silently skip — project has no e-prescribing vendor configured.
+        if (isOperationOutcome(err) && err.issue?.some((i) => i.code === 'not-found')) {
+          return;
+        }
+        throw err;
+      }
+    },
+    [medplum]
+  );
+}

--- a/packages/scriptsure-react/src/common.ts
+++ b/packages/scriptsure-react/src/common.ts
@@ -85,11 +85,6 @@ export const SCRIPTSURE_ADD_PATIENT_PHARMACY_BOT: Identifier = {
   value: 'scriptsure-add-patient-pharmacy-bot',
 };
 
-export const SCRIPTSURE_ORDERSET_SYNC_BOT: Identifier = {
-  system: MEDPLUM_BOT_SYSTEM,
-  value: 'scriptsure-orderset-sync-bot',
-};
-
 export const SCRIPTSURE_PATIENT_ID_SYSTEM = 'https://scriptsure.com/patient-id';
 
 /** Base URL for ScriptSure-specific extensions on in-memory Medication resources (e.g. `/sig`). */

--- a/packages/scriptsure-react/src/common.ts
+++ b/packages/scriptsure-react/src/common.ts
@@ -85,6 +85,11 @@ export const SCRIPTSURE_ADD_PATIENT_PHARMACY_BOT: Identifier = {
   value: 'scriptsure-add-patient-pharmacy-bot',
 };
 
+export const SCRIPTSURE_ORDERSET_SYNC_BOT: Identifier = {
+  system: MEDPLUM_BOT_SYSTEM,
+  value: 'scriptsure-orderset-sync-bot',
+};
+
 export const SCRIPTSURE_PATIENT_ID_SYSTEM = 'https://scriptsure.com/patient-id';
 
 /** Base URL for ScriptSure-specific extensions on in-memory Medication resources (e.g. `/sig`). */


### PR DESCRIPTION
Simple PR to trigger the order set sync bot after importing our example order set in the "Getting Started" tab. This makes the new order set automatically sync into DAW upon import. 