### PR TITLE
Document Alpha/Beta feature expectations

### DIFF
--- a/examples/medplum-provider/src/components/AlphaBanner.module.css
+++ b/examples/medplum-provider/src/components/AlphaBanner.module.css
@@ -8,3 +8,7 @@
   color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-8));
   font-weight: 600;
 }
+
+.content {
+  flex-grow: 1;
+}

--- a/examples/medplum-provider/src/components/AlphaBanner.tsx
+++ b/examples/medplum-provider/src/components/AlphaBanner.tsx
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { BoxProps } from '@mantine/core';
-import { Box, Group, Pill } from '@mantine/core';
+import { Box, Button, Group, Pill } from '@mantine/core';
+import { IconExternalLink } from '@tabler/icons-react';
 import cx from 'clsx';
 import type { JSX } from 'react';
 import classes from './AlphaBanner.module.css';
+import { DocsLink } from './DocsLink';
 
 interface AlphaBannerProps extends BoxProps {
   children: React.ReactNode;
@@ -16,7 +18,10 @@ export function AlphaBanner(props: AlphaBannerProps): JSX.Element {
     <Box p="sm" {...boxProps} className={cx(classes.alphaBanner, className)}>
       <Group gap="md">
         <Pill className={classes.alphaPill}>Alpha</Pill>
-        <span>{children}</span>
+        <span className={classes.content}>{children}</span>
+        <Button variant="transparent" component={DocsLink} path="compliance/alpha-beta">
+          <IconExternalLink size={20} />
+        </Button>
       </Group>
     </Box>
   );

--- a/packages/docs/docs/agent/index.md
+++ b/packages/docs/docs/agent/index.md
@@ -224,7 +224,7 @@ HL7 Feeds can be extremely high volume, and before you go live with a high-volum
 
 - [HL7 v2](https://www.hl7.org): A widely used low-level message protocol for healthcare data exchange.
 - [DICOM](https://www.dicomstandard.org/): A protocol used for storing metadata about medical images. Currently, Medplum supports the C-STORE and C-ECHO operations. Support for other DICOM operations such C-FIND, C-GET, and C-MOVE is coming soon.
-- [ASTM](https://www.astm.org/): Used to transfer data between clinical instruments and computer systems. ASTM support is still in alpha.
+- [ASTM](https://www.astm.org/): Used to transfer data between clinical instruments and computer systems. ASTM support is still in [alpha](/docs/compliance/alpha-beta).
 
 ## See also
 

--- a/packages/docs/docs/compliance/alpha-beta.md
+++ b/packages/docs/docs/compliance/alpha-beta.md
@@ -1,0 +1,87 @@
+# Alpha & Beta Features
+
+Some Medplum features are released before they reach general availability (GA). This page explains what the **Alpha** and **Beta** labels mean, what guarantees apply at each stage, and what you are opting in to when you build on a pre-GA feature.
+
+## Stability Stages
+
+| Stage           | API stability                                    | Breaking changes                                                           | Production use         |
+|-----------------|--------------------------------------------------|----------------------------------------------------------------------------|------------------------|
+| **Alpha**       | Experimental — subject to change at any time     | May occur in any release, including patch releases, without advance notice | Not recommended        |
+| **Beta**        | Mostly stable — significant changes are unlikely | Announced in release notes with ≥ one minor version of lead time           | Permitted with caution |
+| **GA (Stable)** | Stable — full semver guarantees apply            | Only in major releases, with ≥ 30 days written notice                      | Fully supported        |
+
+## Alpha
+
+A feature tagged **Alpha** is an early preview. It is functional enough to be useful for exploration or prototyping, but it is not yet complete.
+
+**What this means in practice:**
+
+- The API shape, request/response schema, and behavior can change between any two releases — including weekly patch releases — without a migration guide.
+- The feature may be disabled, renamed, or removed entirely if the design direction changes.
+- There is no SLA on availability or correctness for alpha features.
+- Alpha features are not covered by Medplum's deprecation policy (which only applies to GA features).
+
+**How alpha is marked:**
+
+- Documentation pages carry an `Alpha` admonition at the top.
+- Status columns in overview tables show **Alpha**.
+- TypeScript APIs may be annotated `@experimental` in TSDoc.
+
+**Who should use alpha features:**
+
+Alpha features are intended for developers who want to give early feedback or who are willing to track changes closely. Do not base production workflows or compliance-sensitive integrations on alpha features.
+
+This is the stage when feedback can be most rapidly incorporated, so we encourage Medplum users to test features at this stage and let us know when we can make their usage easier/better.
+
+## Beta
+
+A feature tagged **Beta** has stabilized enough that the core contract is unlikely to change, but it has not yet completed the full validation required for GA.
+
+**What this means in practice:**
+
+- Breaking changes are possible but will be called out in the release notes for the minor version that introduces them.
+- Medplum will provide a migration path (documentation, scripts, or a compatibility shim) for any breaking change made during beta.
+- The feature is not yet covered by the standard deprecation policy, but Medplum will make reasonable effort to avoid removal without notice.
+- Performance, scalability, or edge-case behavior may still be rough.
+
+**How beta is marked:**
+
+- Documentation pages carry a `Beta` admonition or a `(Beta)` label in the sidebar.
+- Status columns in overview tables show **Beta**.
+
+**Who should use beta features:**
+
+Beta features are appropriate for production use in non-critical workflows where you can absorb an occasional breaking change across minor versions. If your workflow is compliance-sensitive or involves patient-facing data pipelines, wait for GA unless you have capacity to track and respond to changes.
+
+At this stage there is still an opportunity to incorporate significant community feedback. We want to hear from users to make any adjustments before the feature enters the strict GA release cycle.
+
+## General availability (GA / Stable)
+
+Once a feature reaches general availability it is governed by the full [Medplum Version Policy](/docs/compliance/versions). In summary:
+
+- Breaking changes are concentrated into annual major releases and announced ≥ 30 days in advance.
+- A feature marked `@deprecated` in minor _N_ will not be removed until major _N + 1_.
+- ONC certification, HIPAA compliance programs, and enterprise SLAs only apply to GA features.
+
+## Graduation path
+
+Features generally progress **Alpha → Beta → GA**. There is no fixed timeline for graduation; it depends on API stability, test coverage, operator feedback, and production validation. Medplum publishes graduation announcements in GitHub release notes and the `#announcements` Discord channel.
+
+A feature can also be **retired** from alpha or beta without reaching GA if the approach is abandoned. In that case, Medplum will post a notice in the release notes and, where practical, document migration options.
+
+## Quick reference
+
+| Signal                              | Where you see it                  | Stage                               |
+|-------------------------------------|-----------------------------------|-------------------------------------|
+| `:::info[Alpha]` admonition in docs | Doc page header                   | Alpha                               |
+| `(Alpha)` in sidebar label          | Docs sidebar                      | Alpha                               |
+| **Alpha** in a status table         | Docs overview table               | Alpha                               |
+| `@experimental` TSDoc tag           | TypeScript source / API reference | Alpha                               |
+| `:::info[Beta]` admonition in docs  | Doc page header                   | Beta                                |
+| `(Beta)` in heading or sidebar      | Docs pages                        | Beta                                |
+| No stability label                  | Docs and source                   | GA                                  |
+| `@deprecated` TSDoc tag             | TypeScript source / API reference | Scheduled for removal in next major |
+
+## Feedback
+
+If you are using an alpha or beta feature and encounter a bug, an API design issue, or a missing capability, please [open a GitHub issue](https://github.com/medplum/medplum/issues).

--- a/packages/docs/docs/compliance/alpha-beta.md
+++ b/packages/docs/docs/compliance/alpha-beta.md
@@ -1,84 +1,60 @@
 # Alpha & Beta Features
 
-Some Medplum features are released before they reach general availability (GA). This page explains what the **Alpha** and **Beta** labels mean, what guarantees apply at each stage, and what you are opting in to when you build on a pre-GA feature.
+Some Medplum features are released before they reach general availability (GA). This page explains what the **Alpha** and **Beta** labels mean and what to expect when building on pre-GA features.
 
 ## Stability Stages
 
-| Stage           | API stability                                    | Breaking changes                                                           | Production use         |
-|-----------------|--------------------------------------------------|----------------------------------------------------------------------------|------------------------|
-| **Alpha**       | Experimental — subject to change at any time     | May occur in any release, including patch releases, without advance notice | Not recommended        |
-| **Beta**        | Mostly stable — significant changes are unlikely | Announced in release notes with ≥ one minor version of lead time           | Permitted with caution |
-| **GA (Stable)** | Stable — full semver guarantees apply            | Only in major releases, with ≥ 30 days written notice                      | Fully supported        |
+| Stage           | API stability                                    | Breaking changes                                      | Recommended usage                        |
+|-----------------|--------------------------------------------------|-------------------------------------------------------|------------------------------------------|
+| **Alpha**       | Experimental — subject to change at any time     | May occur in any release without advance notice       | Prototyping and early validation         |
+| **Beta**        | Mostly stable — core contract unlikely to change | Possible, with advance notice where practical         | Production use with caution              |
+| **GA (Stable)** | Stable — full semver guarantees apply            | Concentrated in major releases, announced in advance  | Production use, fully supported          |
 
 ## Alpha
 
-A feature tagged **Alpha** is an early preview. It is functional enough to be useful for exploration or prototyping, but it is not yet complete.
+Medplum develops in the open. Alpha features are available publicly so that developers can experiment early and provide feedback before APIs are finalized.
 
 **What this means in practice:**
 
-- The API shape, request/response schema, and behavior can change between any two releases — including weekly patch releases — without a migration guide.
-- The feature may be disabled, renamed, or removed entirely if the design direction changes.
-- There is no SLA on availability or correctness for alpha features.
-- Alpha features are not covered by Medplum's deprecation policy (which only applies to GA features).
+- The API shape, request/response schema, and behavior can change between any two releases without a migration guide.
+- The feature may be disabled, renamed, or removed if the design direction changes.
+- Alpha features are not covered by Medplum's deprecation policy.
 
-**How alpha is marked:**
+Alpha features are intended for developers who want to give early feedback or who are willing to track changes closely. This is the stage when feedback can be most rapidly incorporated — we encourage users to test and share their experience.
 
-- Documentation pages carry an `Alpha` admonition at the top.
-- Status columns in overview tables show **Alpha**.
-- TypeScript APIs may be annotated `@experimental` in TSDoc.
-
-**Who should use alpha features:**
-
-Alpha features are intended for developers who want to give early feedback or who are willing to track changes closely. Do not base production workflows or compliance-sensitive integrations on alpha features.
-
-This is the stage when feedback can be most rapidly incorporated, so we encourage Medplum users to test features at this stage and let us know when we can make their usage easier/better.
+**How alpha is marked:** Documentation pages carry an `Alpha` admonition; TypeScript APIs may be annotated `@experimental`.
 
 ## Beta
 
-A feature tagged **Beta** has stabilized enough that the core contract is unlikely to change, but it has not yet completed the full validation required for GA.
+A feature tagged **Beta** has a stable core contract but has not yet completed full validation for GA.
 
 **What this means in practice:**
 
-- Breaking changes are possible but will be called out in the release notes for the minor version that introduces them.
-- Medplum will provide a migration path (documentation, scripts, or a compatibility shim) for any breaking change made during beta.
-- The feature is not yet covered by the standard deprecation policy, but Medplum will make reasonable effort to avoid removal without notice.
-- Performance, scalability, or edge-case behavior may still be rough.
+- Breaking changes are possible but will be noted in release notes, and Medplum will make reasonable effort to provide a migration path.
+- Performance or edge-case behavior may still be rough.
 
-**How beta is marked:**
+Beta features are appropriate for production use in non-critical workflows where you can absorb an occasional breaking change. We want to hear from users before a feature enters the strict GA release cycle.
 
-- Documentation pages carry a `Beta` admonition or a `(Beta)` label in the sidebar.
-- Status columns in overview tables show **Beta**.
+**How beta is marked:** Documentation pages carry a `Beta` admonition or a `(Beta)` label.
 
-**Who should use beta features:**
+## General Availability (GA / Stable)
 
-Beta features are appropriate for production use in non-critical workflows where you can absorb an occasional breaking change across minor versions. If your workflow is compliance-sensitive or involves patient-facing data pipelines, wait for GA unless you have capacity to track and respond to changes.
-
-At this stage there is still an opportunity to incorporate significant community feedback. We want to hear from users to make any adjustments before the feature enters the strict GA release cycle.
-
-## General availability (GA / Stable)
-
-Once a feature reaches general availability it is governed by the full [Medplum Version Policy](/docs/compliance/versions). In summary:
-
-- Breaking changes are concentrated into annual major releases and announced ≥ 30 days in advance.
-- A feature marked `@deprecated` in minor _N_ will not be removed until major _N + 1_.
-- ONC certification, HIPAA compliance programs, and enterprise SLAs only apply to GA features.
+Once a feature reaches GA it is governed by the full [Medplum Version Policy](/docs/compliance/versions): breaking changes are concentrated into major releases and announced in advance.
 
 ## Graduation path
 
-Features generally progress **Alpha → Beta → GA**. There is no fixed timeline for graduation; it depends on API stability, test coverage, operator feedback, and production validation. Medplum publishes graduation announcements in GitHub release notes and the `#announcements` Discord channel.
+Features generally progress **Alpha → Beta → GA**. There is no fixed timeline; graduation depends on API stability, test coverage, operator feedback, and production validation. Graduation announcements are published in GitHub release notes and the `#announcements` Discord channel.
 
-A feature can also be **retired** from alpha or beta without reaching GA if the approach is abandoned. In that case, Medplum will post a notice in the release notes and, where practical, document migration options.
+A feature can also be **retired** from alpha or beta without reaching GA. Medplum will post a notice in the release notes and, where practical, document migration options.
 
 ## Quick reference
 
 | Signal                              | Where you see it                  | Stage                               |
 |-------------------------------------|-----------------------------------|-------------------------------------|
 | `:::info[Alpha]` admonition in docs | Doc page header                   | Alpha                               |
-| `(Alpha)` in sidebar label          | Docs sidebar                      | Alpha                               |
 | **Alpha** in a status table         | Docs overview table               | Alpha                               |
 | `@experimental` TSDoc tag           | TypeScript source / API reference | Alpha                               |
 | `:::info[Beta]` admonition in docs  | Doc page header                   | Beta                                |
-| `(Beta)` in heading or sidebar      | Docs pages                        | Beta                                |
 | No stability label                  | Docs and source                   | GA                                  |
 | `@deprecated` TSDoc tag             | TypeScript source / API reference | Scheduled for removal in next major |
 

--- a/packages/docs/docs/compliance/versions.md
+++ b/packages/docs/docs/compliance/versions.md
@@ -79,12 +79,14 @@ All Medplum components are released in lockstep with the same version number:
 - Must be deployed sequentially (cannot skip minor versions)
 - Include backwards-compatible feature additions and improvements
 - _The `medplum upgrade` / `medplum aws upgrade` tool automatically chains sequential minors (e.g., 5.0 → 5.3) and supports transactional rollback._
+- May include breaking changes in [features tagged as Alpha or Beta](./alpha-beta)
 
 ### Patch Versions (X.Y.Z)
 
 - Released approximately weekly
 - Include bug fixes and non-breaking feature additions
 - Can be deployed directly without intermediate steps
+- May include breaking changes in [features tagged as Alpha](./alpha-beta)
 
 ### Security Patch SLA
 

--- a/packages/docs/docs/integration/electronic-prior-auth.md
+++ b/packages/docs/docs/integration/electronic-prior-auth.md
@@ -4,8 +4,10 @@ sidebar_position: 100
 
 # Electronic Prior Auth
 
-:::info[]
-Medplum CMS-0057-F Electronic Prior Auth is currently in alpha.
+:::info[Alpha]
+
+Medplum CMS-0057-F Electronic Prior Auth is currently in [alpha](/docs/compliance/alpha-beta).
+
 :::
 
 This document describes the recommended process for establishing connectivity and beginning CRD (Coverage Requirements Discovery) testing with Medplum.

--- a/packages/docs/docs/scheduling/appointment-book.md
+++ b/packages/docs/docs/scheduling/appointment-book.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 :::info[Alpha]
 
-The `$book` operation is currently in alpha.
+The `$book` operation is currently in [alpha](/docs/compliance/alpha-beta).
 
 :::
 

--- a/packages/docs/docs/scheduling/appointment-cancel.md
+++ b/packages/docs/docs/scheduling/appointment-cancel.md
@@ -2,7 +2,7 @@
 
 :::info[Alpha]
 
-The `$cancel` operation is currently in alpha.
+The `$cancel` operation is currently in [alpha](/docs/compliance/alpha-beta).
 
 :::
 

--- a/packages/docs/docs/scheduling/appointment-confirm.md
+++ b/packages/docs/docs/scheduling/appointment-confirm.md
@@ -2,7 +2,7 @@
 
 :::info[Alpha]
 
-The `$confirm` operation is currently in alpha.
+The `$confirm` operation is currently in [alpha](/docs/compliance/alpha-beta).
 
 :::
 

--- a/packages/docs/docs/scheduling/appointment-find.md
+++ b/packages/docs/docs/scheduling/appointment-find.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 :::info[Alpha]
 
-The `$find` operation is currently in alpha.
+The `$find` operation is currently in [alpha](/docs/compliance/alpha-beta).
 
 :::
 

--- a/packages/docs/docs/scheduling/appointment-hold.md
+++ b/packages/docs/docs/scheduling/appointment-hold.md
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 :::info[Alpha]
 
-The `$hold` operation is currently in alpha.
+The `$hold` operation is currently in [alpha](/docs/compliance/alpha-beta).
 
 :::
 

--- a/packages/docs/docs/scheduling/defining-availability.md
+++ b/packages/docs/docs/scheduling/defining-availability.md
@@ -3,7 +3,13 @@ sidebar_label: Defining Availability (Alpha)
 sidebar_position: 10
 ---
 
-# Defining Availability (Alpha)
+# Defining Availability
+
+:::info[Alpha]
+
+Medplum Scheduling APIs are currently in [alpha](/docs/compliance/alpha-beta).
+
+:::
 
 This guide covers how to configure availability using the `SchedulingParameters` extension — at both the actor level (per Schedule) and the service type level (via HealthcareService). It covers scheduling constraints, override behavior, timezone handling, and multi-resource scheduling patterns.
 

--- a/packages/docs/docs/scheduling/index.md
+++ b/packages/docs/docs/scheduling/index.md
@@ -3,8 +3,10 @@ import MedplumCodeBlock from '@site/src/components/MedplumCodeBlock';
 
 # Scheduling
 
-:::info[]
-Medplum Scheduling is currently in alpha.
+:::info[Alpha]
+
+Medplum Scheduling is currently in [alpha](/docs/compliance/alpha-beta).
+
 :::
 
 Welcome to the Medplum Scheduling documentation. We currently support a range of scheduling operations that are available via the FHIR API. The following sections walk through the FHIR resources that are used to model scheduling and how the operations interact with them.

--- a/packages/server/src/fhir/operations/book.ts
+++ b/packages/server/src/fhir/operations/book.ts
@@ -82,6 +82,7 @@ async function bookFromProposedAppointmentHandler(proposedAppointment: Appointme
  * Endpoints:
  *   [fhir base]/Appointment/$book
  *
+ * @experimental - Scheduling Alpha API
  * @param req - The FHIR request.
  * @returns The FHIR response.
  */
@@ -101,6 +102,10 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
 
     return bookFromProposedAppointmentHandler(params.appointment);
   }
+
+  // The code path below was deprecated during the Scheduling Alpha window. It is retained
+  // for a brief time to allow users to transition to the new `appointment` input format.
+  ctx.logger.info('Deprecated $book slot handler invoked');
 
   const proposedSlots = withPaths(params.slot, 'Parameters.slot');
 

--- a/packages/server/src/fhir/operations/cancel.ts
+++ b/packages/server/src/fhir/operations/cancel.ts
@@ -27,6 +27,7 @@ type CancelParameters = {};
  * Endpoints:
  *   [fhir base]/Appointment/:id/$cancel
  *
+ * @experimental - Scheduling Alpha API
  * @param req - The FHIR request.
  * @returns The FHIR response.
  */

--- a/packages/server/src/fhir/operations/confirm.ts
+++ b/packages/server/src/fhir/operations/confirm.ts
@@ -26,6 +26,7 @@ const confirmOperation = makeOperationDefinition(
  * Endpoints:
  *   [fhir base]/Appointment/:id/$confirm
  *
+ * @experimental - Scheduling Alpha API
  * @param req - The FHIR request.
  * @returns The FHIR response.
  */

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -285,6 +285,7 @@ async function handler(params: {
  * Endpoints:
  *   [fhir base]/Schedule/[id]/$find
  *
+ * @deprecated - use Appointment/$find instead.
  * @param req - The FHIR request.
  * @returns The FHIR response.
  */
@@ -324,6 +325,7 @@ export async function scheduleFindHandler(req: FhirRequest): Promise<FhirRespons
  * Endpoints:
  *   [fhir base]/Appointment/$find
  *
+ * @experimental - Scheduling Alpha API
  * @param req - The FHIR request.
  * @returns The FHIR response.
  */

--- a/packages/server/src/fhir/operations/hold.ts
+++ b/packages/server/src/fhir/operations/hold.ts
@@ -34,6 +34,7 @@ type HoldParameters = {
  * Endpoints:
  *   [fhir base]/Appointment/$hold
  *
+ * @experimental - Scheduling Alpha API
  * @param req - The FHIR request.
  * @returns The FHIR response.
  */


### PR DESCRIPTION
- include a link to the page from Provider's `AlphaBanner` component.
- update Scheduling operations with TSDoc `@experimental` annotations
- update "Alpha" admonitions around docs with link to alpha/beta definitions