### PR TITLE
testing(generator): migrate @medplum/generator from Jest to Vitest

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "mockclient": "tsx src/mockclient.ts && npx prettier ../mock/src/mocks/*.json --write",
-    "test": "jest",
+    "test": "vitest run",
     "valuesets": "tsx src/valuesets.ts"
   },
   "devDependencies": {

--- a/packages/generator/tsconfig.json
+++ b/packages/generator/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["jest", "node"],
+    "types": ["node", "vitest/globals"],
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/generator/vite.config.ts
+++ b/packages/generator/vite.config.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});


### PR DESCRIPTION

## Summary

Migrates `@medplum/generator` from Jest to Vitest.

## Changes

- Add `vite.config.ts`, `vitest run` script, `vitest/globals` in tsconfig
- Remove `jest.config.json`

## Testing
No change.