### PR TITLE
fix(server): derive bare-id reference prefix from SearchParameter.target

### DIFF
--- a/packages/core/src/search/details.ts
+++ b/packages/core/src/search/details.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { SearchParameter } from '@medplum/fhirtypes';
+import type { ResourceType, SearchParameter } from '@medplum/fhirtypes';
 import type { Atom } from '../fhirlexer/parse';
 import { InfixOperatorAtom } from '../fhirlexer/parse';
 import { AsAtom, DotAtom, FhirPathAtom, FunctionAtom, IndexerAtom, IsAtom, UnionAtom } from '../fhirpath/atoms';
@@ -29,6 +29,7 @@ export interface SearchParameterDetails {
   readonly elementDefinitions?: InternalSchemaElement[];
   readonly parsedExpression: FhirPathAtom;
   readonly array?: boolean;
+  readonly referenceTargetTypes?: ResourceType[];
 }
 
 interface SearchParameterDetailsBuilder {
@@ -132,13 +133,16 @@ function buildSearchParameterDetails(resourceType: string, searchParam: SearchPa
     parsedExpression = getParsedExpressionForResourceType(resourceType, expression);
   }
 
+  const elementDefinitions = builder.elementDefinitions
+    .map((ed) => ({ ...ed, type: ed.type?.filter((t) => builder.propertyTypes.has(t.code)) }))
+    .filter((ed) => ed.type && ed.type.length > 0);
+
   const result: SearchParameterDetails = {
     type: getSearchParameterType(searchParam, builder.propertyTypes),
-    elementDefinitions: builder.elementDefinitions
-      .map((ed) => ({ ...ed, type: ed.type?.filter((t) => builder.propertyTypes.has(t.code)) }))
-      .filter((ed) => ed.type && ed.type.length > 0),
+    elementDefinitions,
     parsedExpression,
     array: builder.array,
+    referenceTargetTypes: getReferenceTargetTypes(searchParam, elementDefinitions),
   };
   setSearchParameterDetails(resourceType, code, result);
   return result;
@@ -342,4 +346,47 @@ function flattenAtom(atom: Atom): Atom[] {
     }
   }
   return [atom];
+}
+
+/**
+ * Returns the reference target type for a search parameter on a
+ * specific resource type.  Shared search parameters (e.g. `encounter`) may
+ * list multiple targets globally, but the element definition on a concrete
+ * resource (e.g. `DeviceRequest.encounter`) often narrows it to exactly one.
+ *
+ * @param searchParam - The search parameter definition.
+ * @param elementDefs - The element definitions for the resource type.
+ * @returns The target resource types, or undefined if there are zero targets.
+ */
+function getReferenceTargetTypes(
+  searchParam: SearchParameter,
+  elementDefs: InternalSchemaElement[] | undefined
+): ResourceType[] | undefined {
+  // Fast path: the SearchParameter itself has exactly one target type.
+  if (searchParam.target?.length === 1) {
+    return searchParam.target;
+  }
+
+  // Derive from element definitions (resource-specific target profiles).
+  if (elementDefs) {
+    const targetTypes = new Set<string>();
+    for (const ed of elementDefs) {
+      for (const t of ed.type) {
+        if (t.code !== 'Reference' || !t.targetProfile) {
+          continue;
+        }
+        for (const profile of t.targetProfile) {
+          const resourceType = profile.split('/').at(-1);
+          if (resourceType && resourceType !== 'Resource') {
+            targetTypes.add(resourceType);
+          }
+        }
+      }
+    }
+    if (targetTypes.size > 0) {
+      return Array.from(targetTypes) as ResourceType[];
+    }
+  }
+
+  return undefined;
 }

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -26,6 +26,7 @@ import type {
   Communication,
   Composition,
   Condition,
+  DeviceRequest,
   DiagnosticReport,
   Encounter,
   EvidenceVariable,
@@ -38,6 +39,7 @@ import type {
   Patient,
   PlanDefinition,
   Practitioner,
+  PractitionerRole,
   Project,
   Provenance,
   Questionnaire,
@@ -5140,6 +5142,96 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
           parseSearchRequest(`Task?identifier=${identifier}&_sort=_lastUpdated&_cursor=${v2Cursor}`)
         );
         expect(bundleContains(bundle2, task)).toBeUndefined();
+      }));
+  });
+
+  describe('Reference search bare-id prefix derivation', () => {
+    // Verifies that single-target reference search parameters accept bare ids
+    // (per FHIR R4 §3.1.1.4.12 — the spec defines bare `[id]` as the standard
+    // form and reserves `[type]/[id]` for multi-target params). Prior to the
+    // fix, only the `subject`/`patient` columns were prefixed, so spec-compliant
+    // queries like `DeviceRequest?encounter=<uuid>` silently returned zero.
+    test('Single-target reference param: bare uuid matches (DeviceRequest.encounter)', () =>
+      withTestContext(async () => {
+        const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+        const encounter = await repo.createResource<Encounter>({
+          resourceType: 'Encounter',
+          status: 'in-progress',
+          class: { code: 'AMB' },
+          subject: createReference(patient),
+        });
+        const deviceRequest = await repo.createResource<DeviceRequest>({
+          resourceType: 'DeviceRequest',
+          status: 'active',
+          intent: 'order',
+          subject: createReference(patient),
+          encounter: createReference(encounter),
+          codeCodeableConcept: { text: 'Test device' },
+        });
+
+        // Bare uuid form (the spec-compliant form for single-target refs).
+        const bareResult = await repo.search(parseSearchRequest(`DeviceRequest?encounter=${encounter.id}`));
+        expect(bareResult.entry).toHaveLength(1);
+        expect(bareResult.entry?.[0]?.resource?.id).toBe(deviceRequest.id);
+
+        // Control: typed-prefix form still works.
+        const typedResult = await repo.search(parseSearchRequest(`DeviceRequest?encounter=Encounter/${encounter.id}`));
+        expect(typedResult.entry).toHaveLength(1);
+        expect(typedResult.entry?.[0]?.resource?.id).toBe(deviceRequest.id);
+      }));
+
+    test('Single-target reference param: bare uuid matches (PractitionerRole.practitioner)', () =>
+      withTestContext(async () => {
+        const practitioner = await repo.createResource<Practitioner>({ resourceType: 'Practitioner' });
+        const role = await repo.createResource<PractitionerRole>({
+          resourceType: 'PractitionerRole',
+          practitioner: createReference(practitioner),
+        });
+
+        const result = await repo.search(parseSearchRequest(`PractitionerRole?practitioner=${practitioner.id}`));
+        expect(result.entry).toHaveLength(1);
+        expect(result.entry?.[0]?.resource?.id).toBe(role.id);
+      }));
+
+    test('Single-target reference param on array column: bare uuid matches (Encounter.location)', () =>
+      withTestContext(async () => {
+        const location = await repo.createResource<Location>({ resourceType: 'Location', name: randomUUID() });
+        const encounter = await repo.createResource<Encounter>({
+          resourceType: 'Encounter',
+          status: 'in-progress',
+          class: { code: 'AMB' },
+          location: [{ location: createReference(location) }],
+        });
+
+        const result = await repo.search(parseSearchRequest(`Encounter?location=${location.id}`));
+        expect(result.entry).toHaveLength(1);
+        expect(result.entry?.[0]?.resource?.id).toBe(encounter.id);
+      }));
+
+    test('Back-compat: bare uuid on multi-target subject column still defaults to Patient', () =>
+      withTestContext(async () => {
+        // Observation.subject targets [Patient, Group, Device, Location] — multi-target.
+        // The legacy heuristic prepends `Patient/` for bare values; preserved.
+        const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+        const observation = await repo.createResource<Observation>({
+          resourceType: 'Observation',
+          status: 'final',
+          code: { text: 'back-compat probe' },
+          subject: createReference(patient),
+        });
+
+        const result = await repo.search(parseSearchRequest(`Observation?subject=${patient.id}`));
+        expect(result.entry?.some((e) => e.resource?.id === observation.id)).toBe(true);
+      }));
+
+    test('Non-uuid bare value is not rewritten (avoids corrupting unrelated values)', () =>
+      withTestContext(async () => {
+        // Sanity: a value that is neither a uuid nor a typed reference should be
+        // left untouched on a single-target reference column. The search simply
+        // matches nothing — but importantly, it does not throw or get rewritten
+        // into an unintended `Type/not-a-uuid` filter.
+        const result = await repo.search(parseSearchRequest('DeviceRequest?encounter=not-a-uuid'));
+        expect(result.entry ?? []).toHaveLength(0);
       }));
   });
 

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -1381,9 +1381,28 @@ function buildReferenceSearchFilter(
   }
   const column = new Column(table, impl.columnName);
   if (Array.isArray(values)) {
-    values = values.map((v) =>
-      !v.includes('/') && (impl.columnName === 'subject' || impl.columnName === 'patient') ? `Patient/${v}` : v
-    );
+    values = values.map((v) => {
+      if (v.includes('/')) {
+        return v;
+      }
+      // When the search parameter has a single target resource type (the spec's
+      // default for most reference params — see FHIR R4 §3.1.1.4.12), prepend
+      // that type so bare ids match the stored `Type/id` references. Gated on
+      // `isUUID` because Medplum stores its own resource ids as UUIDs; this
+      // avoids rewriting unrelated slashless values (e.g. URNs, identifiers).
+      if (impl.singleTargetType && isUUID(v)) {
+        return `${impl.singleTargetType}/${v}`;
+      }
+      // Back-compat: the `subject` and `patient` columns historically default
+      // to `Patient/` for bare values even when the underlying SearchParameter
+      // is multi-target (e.g. `Observation.subject` -> [Patient, Group,
+      // Device, Location]). Preserved verbatim to avoid breaking callers that
+      // rely on the implicit Patient assumption.
+      if (impl.columnName === 'subject' || impl.columnName === 'patient') {
+        return `Patient/${v}`;
+      }
+      return v;
+    });
   }
   let condition: Condition;
   if (impl.array) {

--- a/packages/server/src/fhir/searchparameter.test.ts
+++ b/packages/server/src/fhir/searchparameter.test.ts
@@ -257,6 +257,14 @@ describe('SearchParameterImplementation', () => {
     expectTokenColumnImplementation(impl);
   });
 
+  test('Task-subject preserves single target legacy behavior', () => {
+    const searchParam = indexedSearchParams.find((e) => e.id === 'Task-subject') as SearchParameter;
+    const impl = getSearchParameterImplementation('Task', searchParam);
+    assertColumnImplementation(impl);
+    expect(impl.columnName).toStrictEqual('subject');
+    expect(impl.singleTargetType).toBeUndefined();
+  });
+
   test.each([
     ['individual-address-country', AddressTable, false],
     ['individual-given', HumanNameTable, true],

--- a/packages/server/src/fhir/searchparameter.ts
+++ b/packages/server/src/fhir/searchparameter.ts
@@ -172,61 +172,15 @@ function buildSearchParameterImplementation(
   const writeable = impl as Writeable<ColumnSearchParameterImplementation>;
   writeable.searchStrategy = 'column';
   writeable.columnName = convertCodeToColumnName(code);
-  if (searchParam.type === 'reference' && impl.type !== SearchParameterType.CANONICAL) {
-    const singleTarget = getSingleReferenceTarget(searchParam, impl);
-    if (singleTarget) {
-      writeable.singleTargetType = singleTarget;
-    }
+  if (
+    searchParam.type === 'reference' &&
+    impl.type !== SearchParameterType.CANONICAL &&
+    impl.referenceTargetTypes?.length === 1
+  ) {
+    writeable.singleTargetType = impl.referenceTargetTypes[0];
   }
 
   return impl;
-}
-
-const HL7_FHIR_STRUCTURE_PREFIX = 'http://hl7.org/fhir/StructureDefinition/';
-
-/**
- * Derives the single reference target type for a search parameter on a
- * specific resource type.  Shared search parameters (e.g. `encounter`) may
- * list multiple targets globally, but the element definition on a concrete
- * resource (e.g. `DeviceRequest.encounter`) often narrows it to exactly one.
- *
- * Returns the target resource type name if exactly one HL7 target profile is
- * found, otherwise `undefined`.
- *
- * @param searchParam - The search parameter definition.
- * @param impl - The search parameter implementation details.
- * @returns The single target resource type, or undefined if there are zero or multiple targets.
- */
-function getSingleReferenceTarget(
-  searchParam: SearchParameter,
-  impl: SearchParameterDetails
-): ResourceType | undefined {
-  // Fast path: the SearchParameter itself already has a single target.
-  if (searchParam.target?.length === 1) {
-    return searchParam.target[0];
-  }
-
-  // Derive from element definitions (resource-specific target profiles).
-  const elementDefs = impl.elementDefinitions;
-  if (elementDefs) {
-    const targetTypes = new Set<string>();
-    for (const ed of elementDefs) {
-      for (const t of ed.type) {
-        if (t.code === 'Reference' && t.targetProfile) {
-          for (const profile of t.targetProfile) {
-            if (profile.startsWith(HL7_FHIR_STRUCTURE_PREFIX)) {
-              targetTypes.add(profile.slice(HL7_FHIR_STRUCTURE_PREFIX.length));
-            }
-          }
-        }
-      }
-    }
-    if (targetTypes.size === 1) {
-      return targetTypes.values().next().value as ResourceType;
-    }
-  }
-
-  return undefined;
 }
 
 /**

--- a/packages/server/src/fhir/searchparameter.ts
+++ b/packages/server/src/fhir/searchparameter.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { SearchParameterDetails } from '@medplum/core';
-import { capitalize, getSearchParameterDetails } from '@medplum/core';
+import { capitalize, getSearchParameterDetails, SearchParameterType } from '@medplum/core';
 import type { ResourceType, SearchParameter } from '@medplum/fhirtypes';
 import { AddressTable } from './lookups/address';
 import { CodingTable } from './lookups/coding';
@@ -23,6 +23,19 @@ export const SearchStrategies = {
 export interface ColumnSearchParameterImplementation extends SearchParameterDetails {
   readonly searchStrategy: typeof SearchStrategies.COLUMN;
   readonly columnName: string;
+  /**
+   * For literal (non-canonical) reference search parameters that resolve to
+   * exactly one target resource type on this resource, the name of that
+   * target type (e.g. `Encounter` for `DeviceRequest.encounter`).
+   *
+   * Derived from the resource's element definition target profiles when the
+   * global SearchParameter has multiple targets but the element narrows to one.
+   * Pre-computed at impl build time so that {@link buildReferenceSearchFilter}
+   * can prepend a `Type/` prefix to spec-compliant bare-id search values
+   * without re-reading the SearchParameter for every query. Undefined for
+   * multi-target references, canonical references, and non-reference params.
+   */
+  readonly singleTargetType?: ResourceType;
 }
 
 export interface LookupTableSearchParameterImplementation extends SearchParameterDetails {
@@ -159,8 +172,61 @@ function buildSearchParameterImplementation(
   const writeable = impl as Writeable<ColumnSearchParameterImplementation>;
   writeable.searchStrategy = 'column';
   writeable.columnName = convertCodeToColumnName(code);
+  if (searchParam.type === 'reference' && impl.type !== SearchParameterType.CANONICAL) {
+    const singleTarget = getSingleReferenceTarget(searchParam, impl);
+    if (singleTarget) {
+      writeable.singleTargetType = singleTarget;
+    }
+  }
 
   return impl;
+}
+
+const HL7_FHIR_STRUCTURE_PREFIX = 'http://hl7.org/fhir/StructureDefinition/';
+
+/**
+ * Derives the single reference target type for a search parameter on a
+ * specific resource type.  Shared search parameters (e.g. `encounter`) may
+ * list multiple targets globally, but the element definition on a concrete
+ * resource (e.g. `DeviceRequest.encounter`) often narrows it to exactly one.
+ *
+ * Returns the target resource type name if exactly one HL7 target profile is
+ * found, otherwise `undefined`.
+ *
+ * @param searchParam - The search parameter definition.
+ * @param impl - The search parameter implementation details.
+ * @returns The single target resource type, or undefined if there are zero or multiple targets.
+ */
+function getSingleReferenceTarget(
+  searchParam: SearchParameter,
+  impl: SearchParameterDetails
+): ResourceType | undefined {
+  // Fast path: the SearchParameter itself already has a single target.
+  if (searchParam.target?.length === 1) {
+    return searchParam.target[0];
+  }
+
+  // Derive from element definitions (resource-specific target profiles).
+  const elementDefs = impl.elementDefinitions;
+  if (elementDefs) {
+    const targetTypes = new Set<string>();
+    for (const ed of elementDefs) {
+      for (const t of ed.type) {
+        if (t.code === 'Reference' && t.targetProfile) {
+          for (const profile of t.targetProfile) {
+            if (profile.startsWith(HL7_FHIR_STRUCTURE_PREFIX)) {
+              targetTypes.add(profile.slice(HL7_FHIR_STRUCTURE_PREFIX.length));
+            }
+          }
+        }
+      }
+    }
+    if (targetTypes.size === 1) {
+      return targetTypes.values().next().value as ResourceType;
+    }
+  }
+
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
Restores #9256

Reverts #9324

This PR restores the original reference search handling implementation while also preserving backwards compatibility for legacy shorthand queries.

Two additional fixes:

1. The original PR included code for backwards compatibility, however it assumed that `singleTargetType` would be false-y, but it could sometimes be populated with `'Resource'`.
2. The original PR did the `ElementDefinition` cross-walk on every write operation, which is a lot of duplicate work per write.  I moved it into `getSearchParameterDetails()`, which is cached and therefore only executed once.

Credit to @AbhiMsft  for the underlying implementation and standards alignment.

Original description:

* fix(server): derive bare-id reference prefix from SearchParameter.target

Closes #9254

Reference search parameters with a single target resource type now accept bare ids (the spec-compliant form per FHIR R4 ┬º3.1.1.4.12). Previously, the bare-id ΓåÆ typed-reference fixup in `buildReferenceSearchFilter` was hard-coded to the `subject` and `patient` columns, so queries like `DeviceRequest?encounter=<uuid>` silently returned an empty bundle.

The new behaviour:

  - For literal (non-canonical) reference search parameters whose underlying `SearchParameter.target` has exactly one entry, the column impl now carries a pre-computed `singleTargetType`. `buildReferenceSearchFilter` uses it to prefix bare UUID values with `Type/` before they hit the WHERE clause.
  - The existing `subject`/`patient` ΓåÆ `Patient/` fallback is preserved verbatim for back-compat on multi-target refs (e.g. `Observation.subject` targets [Patient, Group, Device, Location]).
  - Canonical reference params and non-UUID slashless values are left untouched to avoid corrupting URNs, canonical URLs, and other non-id values.

This mirrors the `searchParam.target?.length === 1` pattern already used by chained search (`parseChainLink`) in the same file.

Tests cover `DeviceRequest.encounter`, `PractitionerRole.practitioner`, the array reference column `Encounter.location`, the typed-prefix control, back-compat for `Observation.subject`, and the non-uuid safety case.



* Fix single-target reference derivation for shared search parameters

Shared search parameters like 'encounter' have multiple global targets (Encounter, EpisodeOfCare), but individual resource types like DeviceRequest.encounter only target Encounter. The previous check (searchParam.target.length === 1) missed these cases, causing bare UUID searches to return zero results.

Now derives the single target type from the resource's element definition targetProfile when the global SearchParameter has multiple targets but the element narrows to exactly one.
