### PR TITLE
Added vmcontext bots security note

### DIFF
--- a/packages/server/src/bots/vmcontext.ts
+++ b/packages/server/src/bots/vmcontext.ts
@@ -19,6 +19,31 @@ import { MockConsole } from '../util/console';
 import { readStreamToString } from '../util/streams';
 import type { BotExecutionContext, BotExecutionResult } from './types';
 
+/*
+ * SECURITY NOTE: VMContext Bots execute administrator-provided JavaScript inside
+ * a Node.js VM context. This is intentionally powerful and must be treated as
+ * unsafe for untrusted code.
+ *
+ * This execution mode is intended for:
+ *
+ * 1. Local development and testing, where the developer already controls the
+ * server process and could run arbitrary Node.js code directly.
+ *
+ * 2. Highly restricted production deployments where only trusted system
+ * administrators can create or update Bot executable code, and where the
+ * server is configured accordingly.
+ *
+ * This feature is disabled unless explicitly enabled by server configuration
+ * (`vmContextBotsEnabled`). It is not intended to be a sandbox boundary for
+ * hostile users, multi-tenant user-submitted code, or arbitrary third-party
+ * JavaScript execution.
+ *
+ * Security reports about this file should take that threat model into account.
+ * If untrusted users are able to install or modify Bots in a production system,
+ * that is a deployment/access-control issue and VMContext Bots should not be
+ * enabled in that environment.
+ */
+
 export const DEFAULT_VM_CONTEXT_TIMEOUT = 10000;
 
 /**


### PR DESCRIPTION
Adds a security note to the VMContext Bot execution engine documenting the intended threat model and deployment assumptions.

This code executes administrator-provided JavaScript inside a Node.js VM context and is intentionally powerful. While the feature is documented elsewhere, the threat model was not clearly stated in the implementation itself.

## Motivation

Recently we've received multiple security reports flagging this file as arbitrary code execution. The reports are technically correct in the sense that VMContext Bots execute code, but they often miss the intended deployment model:

* VMContext Bots are disabled unless explicitly enabled by server configuration.
* They are primarily intended for local development and testing.
* In production, they are only appropriate in environments where Bot installation and modification are restricted to trusted administrators.
* They are not intended to provide isolation for untrusted user-supplied code.

Adding this context directly to the source code makes the design intent more explicit for maintainers, auditors, and security reviewers.

## Functional Changes

None.

This PR adds documentation only and does not change behavior.
