### PR TITLE
Require HTTPS for rest-hook Subscription URLs by default

### DIFF
--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -201,6 +201,9 @@ export interface MedplumServerConfig {
    * Optional flag to require email verification before allowing users to create projects.
    */
   requireVerifiedEmailForProjectCreation?: boolean;
+
+  /** Optional flag to allow rest-hook Subscriptions to send requests to insecure HTTP URLs. */
+  allowInsecureRestHookUrl?: boolean;
 }
 
 export interface SubscriptionAutoDisableTrigger {

--- a/packages/server/src/config/utils.ts
+++ b/packages/server/src/config/utils.ts
@@ -160,6 +160,7 @@ export function isFloatConfig(_key: string): boolean {
 }
 
 const booleanKeys = new Set([
+  'allowInsecureRestHookUrl',
   'botCustomFunctionsEnabled',
   'database.ssl.rejectUnauthorized',
   'database.ssl.require',

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -537,6 +537,71 @@ describe('Subscription Worker', () => {
       await expect(findAndExecSubscriptionJob(patient, 'create')).rejects.toThrow('Job not found');
     }));
 
+  test('Reject insecure rest-hook URLs by default', () =>
+    withTestContext(async () => {
+      const subscription = await repo.createResource<Subscription>({
+        resourceType: 'Subscription',
+        reason: 'test',
+        status: 'active',
+        criteria: 'Patient',
+        channel: {
+          type: 'rest-hook',
+          endpoint: 'http://example.com/subscription',
+        },
+      });
+      expect(subscription).toBeDefined();
+
+      const patient = await repo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['Alice'], family: 'Smith' }],
+      });
+      expect(patient).toBeDefined();
+
+      await expect(findAndExecSubscriptionJob(patient, 'create')).rejects.toThrow('HTTPS is required');
+      expect(fetch).not.toHaveBeenCalled();
+    }));
+
+  test('Allow insecure rest-hook URLs when configured', () =>
+    withTestContext(async () => {
+      const url = 'http://example.com/subscription';
+      const savedConfig = getConfig().allowInsecureRestHookUrl;
+      getConfig().allowInsecureRestHookUrl = true;
+
+      try {
+        const subscription = await repo.createResource<Subscription>({
+          resourceType: 'Subscription',
+          reason: 'test',
+          status: 'active',
+          criteria: 'Patient',
+          channel: {
+            type: 'rest-hook',
+            endpoint: url,
+          },
+        });
+        expect(subscription).toBeDefined();
+
+        const patient = await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Smith' }],
+        });
+        expect(patient).toBeDefined();
+
+        (fetch as unknown as jest.Mock).mockImplementation(() => ({ status: 200 }));
+
+        await findAndExecSubscriptionJob(patient, 'create');
+
+        expect(fetch).toHaveBeenCalledWith(
+          url,
+          expect.objectContaining({
+            method: 'POST',
+            body: stringify(patient),
+          })
+        );
+      } finally {
+        getConfig().allowInsecureRestHookUrl = savedConfig;
+      }
+    }));
+
   // Skip test
   test.skip('Ignore subscriptions with missing criteria', () =>
     withTestContext(async () => {

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -40,6 +40,7 @@ import fetch from 'node-fetch';
 import { createHmac } from 'node:crypto';
 import type { Operation } from 'rfc6902';
 import { executeBot } from '../bots/execute';
+import { getConfig } from '../config/loader';
 import type { SubscriptionAutoDisableTrigger } from '../config/types';
 import { WEBSOCKET_SUB_PUBLISH_CHANNEL } from '../constants';
 import { getRequestContext, runInAuthenticatedContext, tryGetRequestContext, tryRunInRequestContext } from '../context';
@@ -730,6 +731,7 @@ async function sendRestHook(
     systemRepo = getGlobalSystemRepo(); // SHARDING is global correct if no project?
   }
   try {
+    validateRestHookUrl(url);
     log.info('Sending rest hook', {
       url,
       subscriptionId: subscription.id,
@@ -785,6 +787,25 @@ async function sendRestHook(
   if (error) {
     throw error;
   }
+}
+
+function validateRestHookUrl(url: string): void {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    throw new Error('Invalid rest-hook URL: must be an absolute HTTPS URL');
+  }
+
+  if (parsedUrl.protocol === 'https:') {
+    return;
+  }
+
+  if (parsedUrl.protocol === 'http:' && getConfig().allowInsecureRestHookUrl) {
+    return;
+  }
+
+  throw new Error('Invalid rest-hook URL: HTTPS is required unless allowInsecureRestHookUrl is enabled');
 }
 
 /**


### PR DESCRIPTION
- Require `https://` endpoints for `Subscription` rest-hook delivery by default
- Add `allowInsecureRestHookUrl` server config override for self-hosted deployments that still need `http://` webhooks
- Add subscription worker tests for default HTTP rejection and explicit insecure URL opt-in