### PR TITLE
Vendor JSON Patch library

### DIFF
--- a/packages/core/src/patch/README.md
+++ b/packages/core/src/patch/README.md
@@ -1,0 +1,2 @@
+The code in this directory is a vendored copy of https://github.com/chbrown/rfc6902
+as of 2026-05-28 under the MIT license, with any subsequent changes owned by Medplum.

--- a/packages/core/src/patch/arrays.test.ts
+++ b/packages/core/src/patch/arrays.test.ts
@@ -1,0 +1,49 @@
+/* eslint-disable header/header */
+/*
+ * Copyright © 2014-2021 Christopher Brown <io@henrian.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import { applyPatch, createPatch } from './index';
+import { clone } from './util';
+
+test.each([
+  [['A', 'Z', 'Z'], ['A']],
+  [
+    ['A', 'B'],
+    ['B', 'A'],
+  ],
+  [[], ['A', 'B']],
+  [
+    ['B', 'A', 'M'],
+    ['M', 'A', 'A'],
+  ],
+  [['A', 'A', 'R'], []],
+  [
+    ['A', 'B', 'C'],
+    ['B', 'C', 'D'],
+  ],
+  [
+    ['A', 'C'],
+    ['A', 'B', 'C'],
+  ],
+  [
+    ['A', 'B', 'C'],
+    ['A', 'Z'],
+  ],
+])(`diff+patch: [%j] => [%j]`, (input, expected) => {
+  const patch = createPatch(input, expected);
+  const actual_output = clone(input);
+  applyPatch(actual_output, patch);
+  expect(actual_output).toStrictEqual(expected);
+});

--- a/packages/core/src/patch/createTests.test.ts
+++ b/packages/core/src/patch/createTests.test.ts
@@ -1,0 +1,164 @@
+/* eslint-disable header/header */
+/*
+ * Copyright © 2014-2021 Christopher Brown <io@henrian.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import type {
+  AddOperation,
+  CopyOperation,
+  MoveOperation,
+  RemoveOperation,
+  ReplaceOperation,
+  TestOperation,
+} from './diff';
+import { applyPatch, createTests } from './index';
+
+test('simple patch', () => {
+  // > For example, given the JSON document
+  const obj = { itemCodes: ['123', '456', '789'] };
+
+  // > and the following patch
+  const patch: RemoveOperation[] = [{ op: 'remove', path: '/itemCodes/1' }];
+
+  // > should generate the following test
+  const expected: TestOperation[] = [{ op: 'test', path: '/itemCodes/1', value: '456' }];
+
+  const actual = createTests(obj, patch);
+  expect(actual).toStrictEqual(expected);
+
+  const actualApply = applyPatch(obj, actual);
+  expect(actualApply).toStrictEqual([null]);
+});
+
+test('complex patch', () => {
+  // > For example, given the JSON document
+  const obj = {
+    items: [
+      {
+        code: '123',
+        description: 'item # 123',
+        componentCodes: ['456', '789'],
+      },
+      {
+        code: '456',
+        description: 'item # 456',
+        componentCodes: ['789'],
+      },
+      {
+        code: '789',
+        description: 'item # 789',
+        componentCodes: [],
+      },
+    ],
+  };
+
+  // > and the following patch
+  const patch: RemoveOperation[] = [{ op: 'remove', path: '/items/1' }];
+
+  // > should generate the following test
+  const expected: TestOperation[] = [
+    {
+      op: 'test',
+      path: '/items/1',
+      value: {
+        code: '456',
+        description: 'item # 456',
+        componentCodes: ['789'],
+      },
+    },
+  ];
+
+  const actual = createTests(obj, patch);
+  expect(actual).toStrictEqual(expected);
+
+  const actualApply = applyPatch(obj, actual);
+  expect(actualApply).toStrictEqual([null]);
+});
+
+test('simple patch with add', () => {
+  // > For example, given the JSON document
+  const obj = { itemCodes: ['123', '456', '789'] };
+
+  // > and the following patch
+  const patch: AddOperation[] = [{ op: 'add', path: '/itemCodes/-', value: 'abc' }];
+
+  // > should generate the following test
+  const expected: TestOperation[] = [];
+
+  const actual = createTests(obj, patch);
+  expect(actual).toStrictEqual(expected);
+});
+
+test('simple patch with move', () => {
+  // > For example, given the JSON document
+  const obj = { itemCodes: ['123', '456', '789'], alternateItemCodes: ['abc'] };
+
+  // > and the following patch
+  const patch: MoveOperation[] = [{ op: 'move', from: '/itemCodes/1', path: '/alternateItemCodes/0' }];
+
+  // > should generate the following test
+  const expected: TestOperation[] = [
+    { op: 'test', path: '/alternateItemCodes/0', value: 'abc' },
+    { op: 'test', path: '/itemCodes/1', value: '456' },
+  ];
+
+  const actual = createTests(obj, patch);
+  expect(actual).toStrictEqual(expected);
+
+  const actualApply = applyPatch(obj, actual);
+  expect(actualApply).toStrictEqual([null, null]);
+});
+
+test('simple patch with copy', () => {
+  // > For example, given the JSON document
+  const obj = { itemCodes: ['123', '456', '789'], alternateItemCodes: [] };
+
+  // > and the following patch
+  const patch: CopyOperation[] = [
+    {
+      op: 'copy',
+      from: '/itemCodes/1',
+      path: '/alternateItemCodes/0',
+    },
+  ];
+
+  // > should generate the following test
+  const expected: TestOperation[] = [
+    { op: 'test', path: '/alternateItemCodes/0', value: undefined },
+    { op: 'test', path: '/itemCodes/1', value: '456' },
+  ];
+
+  const actual = createTests(obj, patch);
+  expect(actual).toStrictEqual(expected);
+
+  const actualApply = applyPatch(obj, actual);
+  expect(actualApply).toStrictEqual([null, null]);
+});
+
+test('simple patch with replace', () => {
+  // > For example, given the JSON document
+  const obj = { itemCodes: ['123', '456', '789'] };
+
+  // > and the following patch
+  const patch: ReplaceOperation[] = [{ op: 'replace', path: '/itemCodes/1', value: 'abc' }];
+
+  // > should generate the following test
+  const expected: TestOperation[] = [{ op: 'test', path: '/itemCodes/1', value: '456' }];
+
+  const actual = createTests(obj, patch);
+  expect(actual).toStrictEqual(expected);
+
+  const actualApply = applyPatch(obj, actual);
+  expect(actualApply).toStrictEqual([null]);
+});

--- a/packages/core/src/patch/diff.ts
+++ b/packages/core/src/patch/diff.ts
@@ -1,0 +1,414 @@
+/* eslint-disable header/header */
+/*
+ * Copyright © 2014-2021 Christopher Brown <io@henrian.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import type { Pointer } from './pointer'; // we only need this for type inference
+import { hasOwnProperty, objectType } from './util';
+
+/*
+All diff* functions should return a list of operations, often empty.
+
+Each operation should be an object with two to four fields:
+* `op`: the name of the operation; one of "add", "remove", "replace", "move",
+  "copy", or "test".
+* `path`: a JSON pointer string
+* `from`: a JSON pointer string
+* `value`: a JSON value
+
+The different operations have different arguments.
+* "add": [`path`, `value`]
+* "remove": [`path`]
+* "replace": [`path`, `value`]
+* "move": [`from`, `path`]
+* "copy": [`from`, `path`]
+* "test": [`path`, `value`]
+
+Currently this only really differentiates between Arrays, Objects, and
+Everything Else, which is pretty much just what JSON substantially
+differentiates between.
+*/
+
+export interface AddOperation {
+  op: 'add';
+  path: string;
+  value: any;
+}
+export interface RemoveOperation {
+  op: 'remove';
+  path: string;
+}
+export interface ReplaceOperation {
+  op: 'replace';
+  path: string;
+  value: any;
+}
+export interface MoveOperation {
+  op: 'move';
+  from: string;
+  path: string;
+}
+export interface CopyOperation {
+  op: 'copy';
+  from: string;
+  path: string;
+}
+export interface TestOperation {
+  op: 'test';
+  path: string;
+  value: any;
+}
+
+export type Operation =
+  | AddOperation
+  | RemoveOperation
+  | ReplaceOperation
+  | MoveOperation
+  | CopyOperation
+  | TestOperation;
+
+export function isDestructive({ op }: Operation): boolean {
+  return op === 'remove' || op === 'replace' || op === 'copy' || op === 'move';
+}
+
+export type Diff = (input: any, output: any, ptr: Pointer) => Operation[];
+/**
+ * VoidableDiff exists to allow the user to provide a partial diff(...) function,
+ * falling back to the built-in diffAny(...) function if the user-provided function
+ * returns void.
+ */
+export type VoidableDiff = (input: any, output: any, ptr: Pointer) => Operation[] | undefined;
+
+/**
+ * List the keys in `minuend` that are not in `subtrahend`.
+ *
+ * A key is only considered if it is both 1) an own-property (o.hasOwnProperty(k))
+ * of the object, and 2) has a value that is not undefined. This is to match JSON
+ * semantics, where JSON object serialization drops keys with undefined values.
+ *
+ * @param minuend - Object of interest
+ * @param subtrahend - Object of comparison
+ * @returns Array of keys that are in `minuend` but not in `subtrahend`.
+ */
+export function subtract(minuend: { [index: string]: any }, subtrahend: { [index: string]: any }): string[] {
+  const keys: string[] = [];
+  for (const key in minuend) {
+    if (
+      hasOwnProperty.call(minuend, key) &&
+      minuend[key] !== undefined &&
+      !(hasOwnProperty.call(subtrahend, key) && subtrahend[key] !== undefined)
+    ) {
+      keys.push(key);
+    }
+  }
+  return keys;
+}
+
+/**
+ * List the keys that shared by all `objects`.
+ *
+ * The semantics of what constitutes a "key" is described in {@link subtract}.
+ *
+ * @param objects - Array of objects to compare
+ * @returns Array of keys that are in ("own-properties" of) every object in `objects`.
+ */
+export function intersection(objects: ArrayLike<{ [index: string]: any }>): string[] {
+  const length = objects.length;
+  // prepare empty counter to keep track of how many objects each key occurred in
+  const counter: { [index: string]: number } = {};
+  // go through each object and increment the counter for each key in that object
+  for (let i = 0; i < length; i++) {
+    const object = objects[i];
+    for (const key in object) {
+      if (hasOwnProperty.call(object, key) && object[key] !== undefined) {
+        counter[key] = (counter[key] || 0) + 1;
+      }
+    }
+  }
+  // now delete all keys from the counter that were not seen in every object
+  for (const key in counter) {
+    if (counter[key] < length) {
+      delete counter[key];
+    }
+  }
+  // finally, extract whatever keys remain in the counter
+  return Object.keys(counter);
+}
+
+/**
+ * List the keys that shared by all `a` and `b`.
+ *
+ * The semantics of what constitutes a "key" is described in {@link subtract}.
+ *
+ * @param a - First object to compare
+ * @param b - Second object to compare
+ * @returns Array of keys that are in ("own-properties" of) `a` and `b`.
+ */
+function intersection2(a: { [index: string]: any }, b: { [index: string]: any }): string[] {
+  const keys: string[] = [];
+  for (const key in a) {
+    if (hasOwnProperty.call(a, key) && a[key] !== undefined && hasOwnProperty.call(b, key) && b[key] !== undefined) {
+      keys.push(key);
+    }
+  }
+  return keys;
+}
+
+interface ArrayAdd {
+  op: 'add';
+  index: number;
+  value: any;
+}
+interface ArrayRemove {
+  op: 'remove';
+  index: number;
+}
+interface ArrayReplace {
+  op: 'replace';
+  index: number;
+  original: any;
+  value: any;
+}
+/**
+ * These are not proper Operation objects, but will be converted into
+ * Operation objects eventually. {index} indicates the actual target position,
+ * never 'end-of-array'
+ */
+type ArrayOperation = ArrayAdd | ArrayRemove | ArrayReplace;
+function isArrayAdd(array_operation: ArrayOperation): array_operation is ArrayAdd {
+  return array_operation.op === 'add';
+}
+function isArrayRemove(array_operation: ArrayOperation): array_operation is ArrayRemove {
+  return array_operation.op === 'remove';
+}
+
+interface DynamicAlternative {
+  operations: ArrayOperation[];
+  /** Indicates the total cost of getting to this position. */
+  cost: number;
+}
+
+function appendArrayOperation(base: DynamicAlternative, operation: ArrayOperation): DynamicAlternative {
+  return {
+    // the new operation must be pushed on the end
+    operations: base.operations.concat(operation),
+    cost: base.cost + 1,
+  };
+}
+
+/**
+ * Calculate the shortest sequence of operations to get from `input` to `output`,
+ * using a dynamic programming implementation of the Levenshtein distance algorithm.
+ *
+ * To get from the input ABC to the output AZ we could just delete all the input
+ * and say "insert A, insert Z" and be done with it. That's what we do if the
+ * input is empty. But we can be smarter.
+ *
+ *           output
+ *                A   Z
+ *                -   -
+ *           [0]  1   2
+ * input A |  1  [0]  1
+ *       B |  2  [1]  1
+ *       C |  3   2  [2]
+ *
+ * 1) start at 0,0 (+0)
+ * 2) keep A (+0)
+ * 3) remove B (+1)
+ * 4) replace C with Z (+1)
+ *
+ * If the `input` (source) is empty, they'll all be in the top row, resulting in an
+ * array of 'add' operations.
+ * If the `output` (target) is empty, everything will be in the left column,
+ * resulting in an array of 'remove' operations.
+ *
+ * @param input - The original array.
+ * @param output - The target array.
+ * @param ptr - JSON Pointer.
+ * @param diff - Diff function.
+ * @returns A list of add/remove/replace operations.
+ */
+export function diffArrays<T>(input: T[], output: T[], ptr: Pointer, diff: Diff = diffAny): Operation[] {
+  // set up cost matrix (very simple initialization: just a map)
+  const max_length = Math.max(input.length, output.length);
+  const memo = new Map<number, DynamicAlternative>([[0, { operations: [], cost: 0 }]]);
+
+  /**
+   * Calculate the cheapest sequence of operations required to get from
+   * input.slice(0, i) to output.slice(0, j).
+   * There may be other valid sequences with the same cost, but none cheaper.
+   *
+   * @param i - The row in the layout above
+   * @param j - The column in the layout above
+   * @returns An object containing a list of operations, along with the total cost of applying them
+   *    (+1 for each add/remove/replace operation)
+   */
+  function dist(i: number, j: number): DynamicAlternative {
+    // memoized
+    const memo_key = i * max_length + j;
+    let memoized = memo.get(memo_key);
+    if (memoized === undefined) {
+      // TODO: this !diff(...).length usage could/should be lazy
+      if (i > 0 && j > 0 && !diff(input[i - 1], output[j - 1], ptr.add(String(i - 1))).length) {
+        // equal (no operations => no cost)
+        memoized = dist(i - 1, j - 1);
+      } else {
+        const alternatives: DynamicAlternative[] = [];
+        if (i > 0) {
+          // NOT topmost row
+          const remove_base = dist(i - 1, j);
+          const remove_operation: ArrayRemove = {
+            op: 'remove',
+            index: i - 1,
+          };
+          alternatives.push(appendArrayOperation(remove_base, remove_operation));
+        }
+        if (j > 0) {
+          // NOT leftmost column
+          const add_base = dist(i, j - 1);
+          const add_operation: ArrayAdd = {
+            op: 'add',
+            index: i - 1,
+            value: output[j - 1],
+          };
+          alternatives.push(appendArrayOperation(add_base, add_operation));
+        }
+        if (i > 0 && j > 0) {
+          // TABLE MIDDLE
+          // supposing we replaced it, compute the rest of the costs:
+          const replace_base = dist(i - 1, j - 1);
+          // okay, the general plan is to replace it, but we can be smarter,
+          // recursing into the structure and replacing only part of it if
+          // possible, but to do so we'll need the original value
+          const replace_operation: ArrayReplace = {
+            op: 'replace',
+            index: i - 1,
+            original: input[i - 1],
+            value: output[j - 1],
+          };
+          alternatives.push(appendArrayOperation(replace_base, replace_operation));
+        }
+        // the only other case, i === 0 && j === 0, has already been memoized
+
+        // the meat of the algorithm:
+        // sort by cost to find the lowest one (might be several ties for lowest)
+        // [4, 6, 7, 1, 2].sort((a, b) => a - b) -> [ 1, 2, 4, 6, 7 ]
+        const best = alternatives.sort((a, b) => a.cost - b.cost)[0];
+        memoized = best;
+      }
+      memo.set(memo_key, memoized);
+    }
+    return memoized;
+  }
+  // handle weird objects masquerading as Arrays that don't have proper length
+  // properties by using 0 for everything but positive numbers
+  const input_length = isNaN(input.length) || input.length <= 0 ? 0 : input.length;
+  const output_length = isNaN(output.length) || output.length <= 0 ? 0 : output.length;
+  const array_operations = dist(input_length, output_length).operations;
+  const [padded_operations] = array_operations.reduce<[Operation[], number]>(
+    ([operations, padding], array_operation) => {
+      if (isArrayAdd(array_operation)) {
+        const padded_index = array_operation.index + 1 + padding;
+        const index_token = padded_index < input_length + padding ? String(padded_index) : '-';
+        const operation = {
+          op: array_operation.op,
+          path: ptr.add(index_token).toString(),
+          value: array_operation.value,
+        };
+        // padding++ // maybe only if array_operation.index > -1 ?
+        return [operations.concat(operation), padding + 1];
+      } else if (isArrayRemove(array_operation)) {
+        const operation = {
+          op: array_operation.op,
+          path: ptr.add(String(array_operation.index + padding)).toString(),
+        };
+        // padding--
+        return [operations.concat(operation), padding - 1];
+      } else {
+        // replace
+        const replace_ptr = ptr.add(String(array_operation.index + padding));
+        const replace_operations = diff(array_operation.original, array_operation.value, replace_ptr);
+        return [operations.concat(...replace_operations), padding];
+      }
+    },
+    [[], 0]
+  );
+  return padded_operations;
+}
+
+export function diffObjects(input: any, output: any, ptr: Pointer, diff: Diff = diffAny): Operation[] {
+  // if a key is in input but not output -> remove it
+  const operations: Operation[] = [];
+  subtract(input, output).forEach((key) => {
+    operations.push({ op: 'remove', path: ptr.add(key).toString() });
+  });
+  // if a key is in output but not input -> add it
+  subtract(output, input).forEach((key) => {
+    operations.push({ op: 'add', path: ptr.add(key).toString(), value: output[key] });
+  });
+  // if a key is in both, diff it recursively
+  intersection2(input, output).forEach((key) => {
+    operations.push(...diff(input[key], output[key], ptr.add(key)));
+  });
+  return operations;
+}
+
+/**
+ * `diffAny()` returns an empty array if `input` and `output` are materially equal
+ * (i.e., would produce equivalent JSON); otherwise it produces an array of patches
+ * that would transform `input` into `output`.
+ *
+ * > Here, "equal" means that the value at the target location and the
+ * > value conveyed by "value" are of the same JSON type, and that they
+ * > are considered equal by the following rules for that type:
+ * > o  strings: are considered equal if they contain the same number of
+ * >    Unicode characters and their code points are byte-by-byte equal.
+ * > o  numbers: are considered equal if their values are numerically
+ * >    equal.
+ * > o  arrays: are considered equal if they contain the same number of
+ * >    values, and if each value can be considered equal to the value at
+ * >    the corresponding position in the other array, using this list of
+ * >    type-specific rules.
+ * > o  objects: are considered equal if they contain the same number of
+ * >    members, and if each member can be considered equal to a member in
+ * >    the other object, by comparing their keys (as strings) and their
+ * >    values (using this list of type-specific rules).
+ * > o  literals (false, true, and null): are considered equal if they are
+ * >    the same.
+ *
+ * @param input - The original value.
+ * @param output - The target value.
+ * @param ptr - JSON Pointer.
+ * @param diff - Diff function.
+ * @returns The list of operations to get form the original to target value.
+ */
+export function diffAny(input: any, output: any, ptr: Pointer, diff: Diff = diffAny): Operation[] {
+  // strict equality handles literals, numbers, and strings (a sufficient but not necessary cause)
+  if (input === output) {
+    return [];
+  }
+  const input_type = objectType(input);
+  const output_type = objectType(output);
+  if (input_type === 'array' && output_type === 'array') {
+    return diffArrays(input, output, ptr, diff);
+  }
+  if (input_type === 'object' && output_type === 'object') {
+    return diffObjects(input, output, ptr, diff);
+  }
+  // at this point we know that input and output are materially different;
+  // could be array -> object, object -> array, boolean -> undefined,
+  // number -> string, or some other combination, but nothing that can be split
+  // up into multiple patches: so `output` must replace `input` wholesale.
+  return [{ op: 'replace', path: ptr.toString(), value: output }];
+}

--- a/packages/core/src/patch/index.ts
+++ b/packages/core/src/patch/index.ts
@@ -1,0 +1,132 @@
+/* eslint-disable header/header */
+/*
+ * Copyright © 2014-2021 Christopher Brown <io@henrian.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import { Pointer } from './pointer';
+export { Pointer };
+
+import type { Diff, Operation, TestOperation, VoidableDiff } from './diff';
+import { diffAny, isDestructive } from './diff';
+import type { InvalidOperationError, MissingError, Options, TestError } from './patch';
+import { apply } from './patch';
+
+export type { Operation, Options, TestOperation };
+export type Patch = Operation[];
+
+/**
+ * Apply a 'application/json-patch+json'-type patch to an object.
+ *
+ * `patch` *must* be an array of operations.
+ *
+ * > Operation objects MUST have exactly one "op" member, whose value
+ * > indicates the operation to perform.  Its value MUST be one of "add",
+ * > "remove", "replace", "move", "copy", or "test"; other values are
+ * > errors.
+ *
+ * This method mutates the target object in-place.
+ *
+ * @param object - The object to apply the patch to
+ * @param patch - Array of operations to apply
+ * @param options - Optional customization of patch application behavior
+ * @returns list of results, one for each operation: `null` indicated success,
+ *     otherwise, the result will be an instance of one of the Error classes.
+ */
+export function applyPatch(
+  object: any,
+  patch: Operation[],
+  options?: Options
+): (null | MissingError | InvalidOperationError | TestError)[] {
+  return patch.map((operation) => apply(object, operation, options));
+}
+
+function wrapVoidableDiff(diff: VoidableDiff): Diff {
+  function wrappedDiff(input: any, output: any, ptr: Pointer): Operation[] {
+    const custom_patch = diff(input, output, ptr);
+    // ensure an array is always returned
+    return Array.isArray(custom_patch) ? custom_patch : diffAny(input, output, ptr, wrappedDiff);
+  }
+  return wrappedDiff;
+}
+
+/**
+ * Produce a 'application/json-patch+json'-type patch to get from one object to
+ * another.
+ *
+ * This does not alter `input` or `output` unless they have a property getter with
+ * side-effects (which is not a good idea anyway).
+ *
+ * `diff` is called on each pair of comparable non-primitive nodes in the
+ * `input`/`output` object trees, producing nested patches. Return `undefined`
+ * to fall back to default behaviour.
+ *
+ * Returns list of operations to perform on `input` to produce `output`.
+ *
+ * @param input - The input value.
+ * @param output - The target value.
+ * @param diff - Optional diff function.
+ * @returns The list of patch operations.
+ */
+export function createPatch(input: any, output: any, diff?: VoidableDiff): Operation[] {
+  const ptr = new Pointer();
+  // a new Pointer gets a default path of [''] if not specified
+  return (diff ? wrapVoidableDiff(diff) : diffAny)(input, output, ptr);
+}
+
+/**
+ * Create a test operation based on `input`'s current evaluation of the JSON
+ * Pointer `path`; if such a pointer cannot be resolved, returns undefined.
+ *
+ * @param input - The input value.
+ * @param path - The path to create a test for.
+ * @returns A test operation, if a value exists at the given path.
+ */
+function createTest(input: any, path: string): TestOperation | undefined {
+  const endpoint = Pointer.fromJSON(path).evaluate(input);
+  if (endpoint !== undefined) {
+    return { op: 'test', path, value: endpoint.value };
+  }
+  return undefined;
+}
+
+/**
+ * Produce an 'application/json-patch+json'-type list of tests, to verify that
+ * existing values in an object are identical to the those captured at some
+ * checkpoint (whenever this function is called).
+ *
+ * This does not alter `input` or `output` unless they have a property getter with
+ * side-effects (which is not a good idea anyway).
+ *
+ * Returns list of test operations.
+ *
+ * @param input - The input value.
+ * @param patch - The list of patch operations.
+ * @returns A list of test operations corresponding to the current values.
+ */
+export function createTests(input: any, patch: Operation[]): TestOperation[] {
+  const tests = new Array<TestOperation>();
+  patch.filter(isDestructive).forEach((operation) => {
+    const pathTest = createTest(input, operation.path);
+    if (pathTest) {
+      tests.push(pathTest);
+    }
+    if ('from' in operation) {
+      const fromTest = createTest(input, operation.from);
+      if (fromTest) {
+        tests.push(fromTest);
+      }
+    }
+  });
+  return tests;
+}

--- a/packages/core/src/patch/issues.test.ts
+++ b/packages/core/src/patch/issues.test.ts
@@ -1,0 +1,260 @@
+/* eslint-disable header/header */
+/*
+ * Copyright © 2014-2021 Christopher Brown <io@henrian.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import type { Operation, VoidableDiff } from './diff';
+import { applyPatch, createPatch } from './index';
+import type { Pointer } from './pointer';
+import { clone } from './util';
+
+function checkRoundtrip(
+  input: any,
+  output: any,
+  expected_patch: Operation[],
+  diff?: VoidableDiff,
+  actual_patch: Operation[] = createPatch(input, output, diff)
+): void {
+  expect(actual_patch).toStrictEqual(expected_patch);
+  const actual_output = clone(input);
+  const patch_results = applyPatch(actual_output, actual_patch);
+  expect(actual_output).toEqual(output);
+  expect(patch_results.length).toStrictEqual(actual_patch.length);
+  expect(patch_results.every((result) => result === null)).toBeTruthy();
+}
+
+test('issues/3', () => {
+  const input = { arr: ['1', '2', '2'] };
+  const output = { arr: ['1'] };
+  const expected_patch: Operation[] = [
+    { op: 'remove', path: '/arr/1' },
+    { op: 'remove', path: '/arr/1' },
+  ];
+  checkRoundtrip(input, output, expected_patch);
+});
+
+test('issues/4', () => {
+  const input = ['A', 'B'];
+  const output = ['B', 'A'];
+  const expected_patch: Operation[] = [
+    { op: 'add', path: '/0', value: 'B' },
+    { op: 'remove', path: '/2' },
+  ];
+  checkRoundtrip(input, output, expected_patch);
+});
+
+test('issues/5', () => {
+  const input: string[] = [];
+  const output = ['A', 'B'];
+  const expected_patch: Operation[] = [
+    { op: 'add', path: '/-', value: 'A' },
+    { op: 'add', path: '/-', value: 'B' },
+  ];
+  checkRoundtrip(input, output, expected_patch);
+});
+
+test('issues/9', () => {
+  const input = [{ A: 1, B: 2 }, { C: 3 }];
+  const output = [{ A: 1, B: 20 }, { C: 3 }];
+  const expected_patch: Operation[] = [{ op: 'replace', path: '/0/B', value: 20 }];
+  checkRoundtrip(input, output, expected_patch);
+});
+
+test('issues/12', () => {
+  const input = { name: 'ABC', repositories: ['a', 'e'] };
+  const output = { name: 'ABC', repositories: ['a', 'b', 'c', 'd', 'e'] };
+  const expected_patch: Operation[] = [
+    { op: 'add', path: '/repositories/1', value: 'b' },
+    { op: 'add', path: '/repositories/2', value: 'c' },
+    { op: 'add', path: '/repositories/3', value: 'd' },
+  ];
+  checkRoundtrip(input, output, expected_patch);
+});
+
+test('issues/15', () => {
+  const customDiff: VoidableDiff = (input: any, output: any, ptr: Pointer) => {
+    if (input instanceof Date && output instanceof Date && input.valueOf() !== output.valueOf()) {
+      return [{ op: 'replace', path: ptr.toString(), value: output }];
+    }
+    return undefined;
+  };
+  const input = { date: new Date(0) };
+  const output = { date: new Date(1) };
+  const expected_patch: Operation[] = [{ op: 'replace', path: '/date', value: new Date(1) }];
+  checkRoundtrip(input, output, expected_patch, customDiff);
+});
+
+test('issues/15/array', () => {
+  const customDiff: VoidableDiff = (input: any, output: any, ptr: Pointer) => {
+    if (input instanceof Date && output instanceof Date && input.valueOf() !== output.valueOf()) {
+      return [{ op: 'replace', path: ptr.toString(), value: output }];
+    }
+    return undefined;
+  };
+  const input = [new Date(0)];
+  const output = [new Date(1)];
+  const expected_patch: Operation[] = [{ op: 'replace', path: '/0', value: new Date(1) }];
+  checkRoundtrip(input, output, expected_patch, customDiff);
+});
+
+test('issues/29', () => {
+  // Custom diff function that short-circuits recursion when the last token
+  // in the current pointer is the key "stop_recursing", such that that key's
+  // values are compared as primitives rather than objects/arrays.
+  const customDiff: VoidableDiff = (input: any, output: any, ptr: Pointer) => {
+    if (ptr.tokens[ptr.tokens.length - 1] === 'stop_recursing') {
+      // do not compare arrays, replace instead
+      return [{ op: 'replace', path: ptr.toString(), value: output }];
+    }
+    return undefined;
+  };
+
+  const input = {
+    normal: ['a', 'b'],
+    stop_recursing: ['a', 'b'],
+  };
+  const output = {
+    normal: ['a'],
+    stop_recursing: ['a'],
+  };
+  const expected_patch: Operation[] = [
+    { op: 'remove', path: '/normal/1' },
+    { op: 'replace', path: '/stop_recursing', value: ['a'] },
+  ];
+  const actual_patch = createPatch(input, output, customDiff);
+  checkRoundtrip(input, output, expected_patch, undefined, actual_patch);
+
+  const nested_input = { root: input };
+  const nested_output = { root: output };
+  const nested_expected_patch: Operation[] = [
+    { op: 'remove', path: '/root/normal/1' },
+    { op: 'replace', path: '/root/stop_recursing', value: ['a'] },
+  ];
+  const nested_actual_patch = createPatch(nested_input, nested_output, customDiff);
+  checkRoundtrip(nested_input, nested_output, nested_expected_patch, undefined, nested_actual_patch);
+});
+
+test('issues/32', () => {
+  const input = 'a';
+  const output = 'b';
+  const expected_patch: Operation[] = [{ op: 'replace', path: '', value: 'b' }];
+  const actual_patch = createPatch(input, output);
+  expect(actual_patch).toStrictEqual(expected_patch);
+  const actual_output = clone(input);
+  const results = applyPatch(input, actual_patch);
+  expect(actual_output).toStrictEqual('a');
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+test('issues/33', () => {
+  const object = { root: { 0: 4 } };
+  const array = { root: [4] };
+  checkRoundtrip(object, array, [{ op: 'replace', path: '/root', value: [4] }]);
+  checkRoundtrip(array, object, [{ op: 'replace', path: '/root', value: { 0: 4 } }]);
+});
+
+test('issues/34', () => {
+  const input = [3, 4];
+  const output = [3, 4];
+  delete output[0];
+  const expected_patch: Operation[] = [{ op: 'replace', path: '/0', value: undefined }];
+  checkRoundtrip(input, output, expected_patch);
+});
+
+test('issues/35', () => {
+  const input = { name: 'bob', image: undefined, cat: null };
+  const output = { name: 'bob', image: 'foo.jpg', cat: 'nikko' };
+  const expected_patch: Operation[] = [
+    { op: 'add', path: '/image', value: 'foo.jpg' },
+    { op: 'replace', path: '/cat', value: 'nikko' },
+  ];
+  checkRoundtrip(input, output, expected_patch);
+});
+
+test('issues/36', () => {
+  const input = [undefined, 'B']; // same as: const input = ['A', 'B']; delete input[0]
+  const output = ['A', 'B'];
+  const expected_patch: Operation[] = [
+    // could also be {op: 'add', ...} -- the spec isn't clear on what constitutes existence for arrays
+    { op: 'replace', path: '/0', value: 'A' },
+  ];
+  checkRoundtrip(input, output, expected_patch);
+});
+
+test('issues/37', () => {
+  const value = { id: 'chbrown' };
+  const patch_results = applyPatch(value, [{ op: 'copy', from: '/id', path: '/name' }]);
+  const expected_value = { id: 'chbrown', name: 'chbrown' };
+  expect(value).toStrictEqual(expected_value);
+  expect(patch_results.every((result) => result === null)).toBeTruthy();
+});
+
+test('issues/38', () => {
+  const value = {
+    current: { timestamp: 23 },
+    history: [],
+  };
+  const patch_results = applyPatch(value, [
+    { op: 'copy', from: '/current', path: '/history/-' },
+    { op: 'replace', path: '/current/timestamp', value: 24 },
+    { op: 'copy', from: '/current', path: '/history/-' },
+  ]);
+  const expected_value = {
+    current: { timestamp: 24 },
+    history: [{ timestamp: 23 }, { timestamp: 24 }],
+  };
+  expect(value).toStrictEqual(expected_value);
+  expect(patch_results.every((result) => result === null)).toBeTruthy();
+});
+
+test('issues/44', () => {
+  const value = {};
+  const author = { firstName: 'Chris' };
+  const patch_results = applyPatch(value, [
+    { op: 'add', path: '/author', value: author },
+    { op: 'add', path: '/author/lastName', value: 'Brown' },
+  ]);
+  const expected_value = {
+    author: { firstName: 'Chris', lastName: 'Brown' },
+  };
+  expect(value).toStrictEqual(expected_value);
+  expect(patch_results.every((result) => result === null)).toBeTruthy();
+  expect(author).toStrictEqual({ firstName: 'Chris' });
+});
+
+test('issues/76', () => {
+  expect(({} as any).polluted).toBeUndefined();
+  const value = {};
+  applyPatch(value, [{ op: 'add', path: '/__proto__/polluted', value: 'Hello!' }]);
+  expect(({} as any).polluted).toBeUndefined();
+});
+
+test('issues/78', () => {
+  const user: any = { firstName: 'Chris' };
+  const patch_results = applyPatch(user, [{ op: 'add', path: '/createdAt', value: new Date('2010-08-10T22:10:48Z') }]);
+  expect(patch_results.every((result) => result === null)).toBeTruthy();
+  expect(user['createdAt'].getTime()).toStrictEqual(1281478248000);
+});
+
+test('issues/97', () => {
+  const commits: any[] = [];
+  const user = { firstName: 'Chris', commits: ['80f1243'] };
+  const patch_results = applyPatch(user, [
+    { op: 'replace', path: '/commits', value: commits },
+    { op: 'add', path: '/commits/-', value: '5d565c8' },
+  ]);
+  expect(patch_results.every((result) => result === null)).toBeTruthy();
+  expect(user).toStrictEqual({ firstName: 'Chris', commits: ['5d565c8'] });
+  expect(commits).toHaveLength(0);
+});

--- a/packages/core/src/patch/patch.test.ts
+++ b/packages/core/src/patch/patch.test.ts
@@ -1,0 +1,171 @@
+/* eslint-disable header/header */
+/*
+ * Copyright © 2014-2021 Christopher Brown <io@henrian.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import { applyPatch } from './index';
+
+test('broken add', () => {
+  const user = { id: 'chbrown' };
+  const results = applyPatch(user, [{ op: 'add', path: '/a/b', value: 1 }]);
+  expect(user).toStrictEqual({ id: 'chbrown' });
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+test('broken add (array does not exist)', () => {
+  const user = { id: 'chbrown' };
+  const results = applyPatch(user, [{ op: 'add', path: '/tag/-', value: 1 }]);
+  expect(user).toStrictEqual({ id: 'chbrown' });
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+test('working add (array exists)', () => {
+  const user = { id: 'chbrown', tag: [] };
+  const results = applyPatch(user, [{ op: 'add', path: '/tag/-', value: 123 }]);
+  expect(results).toStrictEqual([null]);
+  expect(user).toStrictEqual({ id: 'chbrown', tag: [123] });
+});
+
+test('working add (array exists and non-empty)', () => {
+  const user = { id: 'chbrown', tag: [999] };
+  const results = applyPatch(user, [{ op: 'add', path: '/tag/-', value: 123 }]);
+  expect(results).toStrictEqual([null]);
+  expect(user).toStrictEqual({ id: 'chbrown', tag: [999, 123] });
+});
+
+test('broken remove', () => {
+  const user = { id: 'chbrown' };
+  const results = applyPatch(user, [{ op: 'remove', path: '/name' }]);
+  expect(user).toStrictEqual({ id: 'chbrown' });
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+test('broken replace', () => {
+  const user = { id: 'chbrown' };
+  const results = applyPatch(user, [{ op: 'replace', path: '/name', value: 1 }]);
+  expect(user).toStrictEqual({ id: 'chbrown' });
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+test('broken replace (array)', () => {
+  const users = [{ id: 'chbrown' }];
+  const results = applyPatch(users, [{ op: 'replace', path: '/1', value: { id: 'chbrown2' } }]);
+  // cf. issues/36
+  expect(users).toStrictEqual([{ id: 'chbrown' }]);
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+test('broken move (from)', () => {
+  const user = { id: 'chbrown' };
+  const results = applyPatch(user, [{ op: 'move', from: '/name', path: '/id' }]);
+  expect(user).toStrictEqual({ id: 'chbrown' });
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+test('broken move (path)', () => {
+  const user = { id: 'chbrown' };
+  const results = applyPatch(user, [{ op: 'move', from: '/id', path: '/a/b' }]);
+  expect(user).toStrictEqual({ id: 'chbrown' });
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+test('broken copy (from)', () => {
+  const user = { id: 'chbrown' };
+  const results = applyPatch(user, [{ op: 'copy', from: '/name', path: '/id' }]);
+  expect(user).toStrictEqual({ id: 'chbrown' });
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+test('broken copy (path)', () => {
+  const user = { id: 'chbrown' };
+  const results = applyPatch(user, [{ op: 'copy', from: '/id', path: '/a/b' }]);
+  expect(user).toStrictEqual({ id: 'chbrown' });
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+// Option: implicitArrayCreation
+
+test('creates missing top-level array', () => {
+  const object = {};
+  const results = applyPatch(object, [{ op: 'add', path: '/identifier/-', value: { system: 'mrn' } }], {
+    implicitArrayCreation: true,
+  });
+  expect(results).toStrictEqual([null]);
+  expect(object).toStrictEqual({ identifier: [{ system: 'mrn' }] });
+});
+
+test('creates missing nested array when parent exists', () => {
+  const object = { meta: {} };
+  const results = applyPatch(object, [{ op: 'add', path: '/meta/tag/-', value: 'x' }], { implicitArrayCreation: true });
+  expect(results).toStrictEqual([null]);
+  expect(object).toStrictEqual({ meta: { tag: ['x'] } });
+});
+
+test('multiple appends to created array', () => {
+  const object = { meta: {} };
+  const results = applyPatch(
+    object,
+    [
+      { op: 'add', path: '/meta/tag/-', value: 'a' },
+      { op: 'add', path: '/meta/tag/-', value: 'b' },
+    ],
+    { implicitArrayCreation: true }
+  );
+  expect(results).toStrictEqual([null, null]);
+  expect(object).toStrictEqual({ meta: { tag: ['a', 'b'] } });
+});
+
+test('fails when parent object missing', () => {
+  const object = {};
+  const results = applyPatch(object, [{ op: 'add', path: '/meta/tag/-', value: 'x' }], { implicitArrayCreation: true });
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+test('fails when parent is not object (value)', () => {
+  const object = { meta: true };
+  const results = applyPatch(object, [{ op: 'add', path: '/meta/tag/-', value: 'x' }], { implicitArrayCreation: true });
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+test('fails when parent is not object (array)', () => {
+  const object = { meta: [] };
+  const results = applyPatch(object, [{ op: 'add', path: '/meta/tag/-', value: 'x' }], { implicitArrayCreation: true });
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+test('fails when parent is not object (null)', () => {
+  const object = { meta: null };
+  const results = applyPatch(object, [{ op: 'add', path: '/meta/tag/-', value: 'x' }], { implicitArrayCreation: true });
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+test('fails on existing non-array property (value)', () => {
+  const object = { a: 1 };
+  const results = applyPatch(object, [{ op: 'add', path: '/a/-', value: 2 }], { implicitArrayCreation: true });
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+test('fails on existing non-array property (object)', () => {
+  const object = { a: { b: 2 } };
+  const results = applyPatch(object, [{ op: 'add', path: '/a/-', value: 2 }], { implicitArrayCreation: true });
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});
+
+test('fails on non-terminal /-', () => {
+  const object = {};
+  const results = applyPatch(object, [{ op: 'add', path: '/list/-/name', value: 'x' }], {
+    implicitArrayCreation: true,
+  });
+  expect(results.map((r) => r?.name)).toStrictEqual(['MissingError']);
+});

--- a/packages/core/src/patch/patch.ts
+++ b/packages/core/src/patch/patch.ts
@@ -1,0 +1,320 @@
+/* eslint-disable header/header */
+/*
+ * Copyright © 2014-2021 Christopher Brown <io@henrian.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import type {
+  AddOperation,
+  CopyOperation,
+  MoveOperation,
+  Operation,
+  RemoveOperation,
+  ReplaceOperation,
+  TestOperation,
+} from './diff';
+import { diffAny } from './diff';
+import { Pointer } from './pointer';
+import { clone, objectType } from './util';
+
+export interface Options {
+  /**
+   * When true, "add" operations with path ending in "/-" will implicitly
+   * create an empty array where possible.
+   *
+   * For example, with this option enabled, for the object `{live: true}`,
+   * the operation `add "/tag/-" 123` will result in `{live: true, tag: [123]}`.
+   * Subsequent operations behave normally: another `add "/tag/-" 456` will result
+   * in `{live: true, tag: [123, 456]}`.
+   *
+   * If the indicated array property already exists but is not an array, this will
+   * produce an error.
+   *
+   * Only the leaf array will be inferred; missing parent objects will still
+   * produce errors.
+   */
+  implicitArrayCreation?: boolean;
+}
+
+export class MissingError extends Error {
+  path: string;
+
+  constructor(path: string) {
+    super(`Value required at path: ${path}`);
+    this.path = path;
+    this.name = 'MissingError';
+  }
+}
+
+export class TestError extends Error {
+  actual: any;
+  expected: any;
+
+  constructor(actual: any, expected: any) {
+    super(`Test failed: ${actual} != ${expected}`);
+    this.actual = actual;
+    this.expected = expected;
+    this.name = 'TestError';
+  }
+}
+
+function _add(object: any, key: string, value: any): void {
+  if (Array.isArray(object)) {
+    // `key` must be an index
+    if (key === '-') {
+      object.push(value);
+    } else {
+      const index = parseInt(key, 10);
+      object.splice(index, 0, value);
+    }
+  } else {
+    object[key] = value;
+  }
+}
+
+function _remove(object: any, key: string): void {
+  if (Array.isArray(object)) {
+    // '-' syntax doesn't make sense when removing
+    const index = parseInt(key, 10);
+    object.splice(index, 1);
+  } else {
+    // not sure what the proper behavior is when path = ''
+    delete object[key];
+  }
+}
+
+/**
+ * >  o  If the target location specifies an array index, a new value is
+ * >     inserted into the array at the specified index.
+ * >  o  If the target location specifies an object member that does not
+ * >     already exist, a new member is added to the object.
+ * >  o  If the target location specifies an object member that does exist,
+ * >     that member's value is replaced.
+ *
+ * @param object - The object being patched.
+ * @param operation - The operation to perform on the object.
+ * @param options - Optional params.
+ * @returns null on success, or error if one occurred.
+ */
+export function add(object: any, operation: AddOperation, options?: Options): MissingError | null {
+  const pointer = Pointer.fromJSON(operation.path);
+  // Handle implicit array creation for terminal "/-" paths
+  if (options?.implicitArrayCreation && pointer.tokens[pointer.tokens.length - 1] === '-') {
+    // Try to evaluate the parent (the array itself)
+    const parentEndpoint = pointer.parent().evaluate(object);
+    // If the array property doesn't exist but its parent does,
+    // and this parent is a plain object (not an array),
+    // create an (empty) array that we will add to below.
+    if (parentEndpoint.value === undefined && objectType(parentEndpoint.parent) === 'object') {
+      parentEndpoint.parent[parentEndpoint.key] = [];
+    }
+  }
+
+  const endpoint = pointer.evaluate(object);
+  // it's not exactly a "MissingError" in the same way that `remove` is -- more like a MissingParent, or something
+  if (endpoint.parent === undefined) {
+    return new MissingError(operation.path);
+  }
+
+  // When using implicitArrayCreation, validate that "/-" targets are actually arrays
+  if (options?.implicitArrayCreation && endpoint.key === '-' && !Array.isArray(endpoint.parent)) {
+    return new MissingError(operation.path);
+  }
+
+  _add(endpoint.parent, endpoint.key, clone(operation.value));
+  return null;
+}
+
+/**
+ * > The "remove" operation removes the value at the target location.
+ * > The target location MUST exist for the operation to be successful.
+ *
+ * @param object - The object being patched.
+ * @param operation - The operation to perform on the object.
+ * @param _options - Optional params.
+ * @returns null on success, or error if one occurred.
+ */
+export function remove(object: any, operation: RemoveOperation, _options?: Options): MissingError | null {
+  // endpoint has parent, key, and value properties
+  const endpoint = Pointer.fromJSON(operation.path).evaluate(object);
+  if (endpoint.value === undefined) {
+    return new MissingError(operation.path);
+  }
+  // not sure what the proper behavior is when path = ''
+  _remove(endpoint.parent, endpoint.key);
+  return null;
+}
+
+/**
+ * > The "replace" operation replaces the value at the target location
+ * > with a new value.  The operation object MUST contain a "value" member
+ * > whose content specifies the replacement value.
+ * > The target location MUST exist for the operation to be successful.
+ *
+ * > This operation is functionally identical to a "remove" operation for
+ * > a value, followed immediately by an "add" operation at the same
+ * > location with the replacement value.
+ *
+ * Even more simply, it's like the add operation with an existence check.
+ *
+ * @param object - The object being patched.
+ * @param operation - The operation to perform on the object.
+ * @param _options - Optional params.
+ * @returns null on success, or error if one occurred.
+ */
+export function replace(object: any, operation: ReplaceOperation, _options?: Options): MissingError | null {
+  const endpoint = Pointer.fromJSON(operation.path).evaluate(object);
+  if (endpoint.parent === null) {
+    return new MissingError(operation.path);
+  }
+  // this existence check treats arrays as a special case
+  if (Array.isArray(endpoint.parent)) {
+    if (parseInt(endpoint.key, 10) >= endpoint.parent.length) {
+      return new MissingError(operation.path);
+    }
+  } else if (endpoint.value === undefined) {
+    return new MissingError(operation.path);
+  }
+  endpoint.parent[endpoint.key] = clone(operation.value);
+  return null;
+}
+
+/**
+ * > The "move" operation removes the value at a specified location and
+ * > adds it to the target location.
+ * > The operation object MUST contain a "from" member, which is a string
+ * > containing a JSON Pointer value that references the location in the
+ * > target document to move the value from.
+ * > This operation is functionally identical to a "remove" operation on
+ * > the "from" location, followed immediately by an "add" operation at
+ * > the target location with the value that was just removed.
+ *
+ * > The "from" location MUST NOT be a proper prefix of the "path"
+ * > location; i.e., a location cannot be moved into one of its children.
+ *
+ * TODO: throw if the check described in the previous paragraph fails.
+ *
+ * @param object - The object being patched.
+ * @param operation - The operation to perform on the object.
+ * @param _options - Optional params.
+ * @returns null on success, or error if one occurred.
+ */
+export function move(object: any, operation: MoveOperation, _options?: Options): MissingError | null {
+  const from_endpoint = Pointer.fromJSON(operation.from).evaluate(object);
+  if (from_endpoint.value === undefined) {
+    return new MissingError(operation.from);
+  }
+  const endpoint = Pointer.fromJSON(operation.path).evaluate(object);
+  if (endpoint.parent === undefined) {
+    return new MissingError(operation.path);
+  }
+  _remove(from_endpoint.parent, from_endpoint.key);
+  _add(endpoint.parent, endpoint.key, from_endpoint.value);
+  return null;
+}
+
+/**
+ * > The "copy" operation copies the value at a specified location to the
+ * > target location.
+ * > The operation object MUST contain a "from" member, which is a string
+ * > containing a JSON Pointer value that references the location in the
+ * > target document to copy the value from.
+ * > The "from" location MUST exist for the operation to be successful.
+ *
+ * > This operation is functionally identical to an "add" operation at the
+ * > target location using the value specified in the "from" member.
+ *
+ * Alternatively, it's like 'move' without the 'remove'.
+ *
+ * @param object - The object being patched.
+ * @param operation - The operation to perform on the object.
+ * @param _options - Optional params.
+ * @returns null on success, or error if one occurred.
+ */
+export function copy(object: any, operation: CopyOperation, _options?: Options): MissingError | null {
+  const from_endpoint = Pointer.fromJSON(operation.from).evaluate(object);
+  if (from_endpoint.value === undefined) {
+    return new MissingError(operation.from);
+  }
+  const endpoint = Pointer.fromJSON(operation.path).evaluate(object);
+  if (endpoint.parent === undefined) {
+    return new MissingError(operation.path);
+  }
+  _add(endpoint.parent, endpoint.key, clone(from_endpoint.value));
+  return null;
+}
+
+/**
+ * > The "test" operation tests that a value at the target location is
+ * > equal to a specified value.
+ * > The operation object MUST contain a "value" member that conveys the
+ * > value to be compared to the target location's value.
+ * > The target location MUST be equal to the "value" value for the
+ * > operation to be considered successful.
+ *
+ * @param object - The object being patched.
+ * @param operation - The add operation to perform on the object.
+ * @param _options - Optional params.
+ * @returns null on success, or error if one occurred.
+ */
+export function test(object: any, operation: TestOperation, _options?: Options): TestError | null {
+  const endpoint = Pointer.fromJSON(operation.path).evaluate(object);
+  // TODO: this diffAny(...).length usage could/should be lazy
+  if (diffAny(endpoint.value, operation.value, new Pointer()).length) {
+    return new TestError(endpoint.value, operation.value);
+  }
+  return null;
+}
+
+export class InvalidOperationError extends Error {
+  operation: Operation;
+
+  constructor(operation: Operation) {
+    super(`Invalid operation: ${operation.op}`);
+    this.operation = operation;
+    this.name = 'InvalidOperationError';
+  }
+}
+
+/**
+ * Switch on `operation.op`, applying the corresponding patch function for each
+ * case to `object`.
+ *
+ * @param object - The object being patched.
+ * @param operation - The operation to perform on the object.
+ * @param options - Optional params.
+ * @returns null on success, or error if one occurred.
+ */
+export function apply(
+  object: any,
+  operation: Operation,
+  options?: Options
+): MissingError | InvalidOperationError | TestError | null {
+  switch (operation.op) {
+    case 'add':
+      return add(object, operation, options);
+    case 'remove':
+      return remove(object, operation, options);
+    case 'replace':
+      return replace(object, operation, options);
+    case 'move':
+      return move(object, operation, options);
+    case 'copy':
+      return copy(object, operation, options);
+    case 'test':
+      return test(object, operation, options);
+    default:
+      return new InvalidOperationError(operation);
+  }
+}

--- a/packages/core/src/patch/pointer.test.ts
+++ b/packages/core/src/patch/pointer.test.ts
@@ -1,0 +1,123 @@
+/* eslint-disable header/header */
+/*
+ * Copyright © 2014-2021 Christopher Brown <io@henrian.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import { Pointer } from './pointer';
+import { clone } from './util';
+
+test('Pointer.fromJSON empty', () => {
+  expect(() => Pointer.fromJSON('')).not.toThrow();
+});
+test('Pointer.fromJSON slash', () => {
+  expect(() => Pointer.fromJSON('/')).not.toThrow();
+});
+test('Pointer.fromJSON invalid', () => {
+  expect(() => Pointer.fromJSON('a')).toThrow('Invalid JSON Pointer');
+});
+
+test('Pointer.parent', () => {
+  const pointer = Pointer.fromJSON('/abc/-');
+  const parent = pointer.parent();
+  expect(parent.toString()).toStrictEqual('/abc');
+  const grandParent = parent.parent();
+  expect(grandParent.toString()).toStrictEqual('');
+  const greatGrandParent = grandParent.parent();
+  expect(greatGrandParent.toString()).toStrictEqual('');
+});
+
+const example = { bool: false, arr: [10, 20, 30], obj: { a: 'A', b: 'B' } };
+
+test('Pointer#get bool', () => {
+  expect(Pointer.fromJSON('/bool').get(example)).toStrictEqual(false);
+});
+test('Pointer#get array', () => {
+  expect(Pointer.fromJSON('/arr/1').get(example)).toStrictEqual(20);
+});
+test('Pointer#get object', () => {
+  expect(Pointer.fromJSON('/obj/b').get(example)).toStrictEqual('B');
+});
+test('Pointer#push', () => {
+  const pointer = Pointer.fromJSON('/obj');
+  pointer.push('a');
+  expect(pointer.toString()).toStrictEqual('/obj/a');
+});
+test('Pointer#get∘push', () => {
+  const pointer = Pointer.fromJSON('/obj');
+  pointer.push('a');
+  expect(pointer.get(example)).toStrictEqual('A');
+});
+
+test('Pointer#set bool', () => {
+  const input = { bool: true };
+  Pointer.fromJSON('/bool').set(input, false);
+  expect(input.bool).toStrictEqual(false);
+});
+
+test('Pointer#set array middle', () => {
+  const input: any = { arr: ['10', '20', '30'] };
+  Pointer.fromJSON('/arr/1').set(input, 0);
+  expect(input.arr[1]).toStrictEqual(0);
+});
+
+test('Pointer#set array beyond', () => {
+  const input: any = { arr: ['10', '20', '30'] };
+  Pointer.fromJSON('/arr/3').set(input, 40);
+  expect(input.arr[3]).toStrictEqual(40);
+});
+
+test('Pointer#set top-level', () => {
+  const input: any = { obj: { a: 'A', b: 'B' } };
+  const original = clone(input);
+  Pointer.fromJSON('').set(input, { other: { c: 'C' } });
+  expect(input).toStrictEqual(original);
+  // You might think, well, why? Why shouldn't we do it and then have a test:
+  // t.deepEqual(input, {other: {c: 'C'}}, 'should replace whole object')
+  // And true, we could hack that by removing the current properties and setting the new ones,
+  // but that only works for the case of object-replacing-object;
+  // the following is just as valid (though clearly impossible)...
+  Pointer.fromJSON('').set(input, 'root');
+  expect(input).toStrictEqual(original);
+  // ...and it'd be weird to have it work for one but not the other.
+  // See Issue #92 for more discussion of this limitation / behavior.
+});
+
+test('Pointer#set object existing', () => {
+  const input = { obj: { a: 'A', b: 'B' } };
+  Pointer.fromJSON('/obj/b').set(input, 'BBB');
+  expect(input.obj.b).toStrictEqual('BBB');
+});
+
+test('Pointer#set object new', () => {
+  const input: any = { obj: { a: 'A', b: 'B' } };
+  Pointer.fromJSON('/obj/c').set(input, 'C');
+  expect(input.obj.c).toStrictEqual('C');
+});
+
+test('Pointer#set deep object new', () => {
+  const input: any = { obj: { subobj: { a: 'A', b: 'B' } } };
+  Pointer.fromJSON('/obj/subobj/c').set(input, 'C');
+  expect(input.obj.subobj.c).toStrictEqual('C');
+});
+
+test('Pointer#set not found', () => {
+  const input: any = { obj: { a: 'A', b: 'B' } };
+  const original = clone(input);
+  Pointer.fromJSON('/notfound/c').set(input, 'C');
+  expect(input).toStrictEqual(original);
+  Pointer.fromJSON('/obj/notfound/c').set(input, 'C');
+  expect(input).toStrictEqual(original);
+  Pointer.fromJSON('/notfound/subobj/c').set(input, 'C');
+  expect(input).toStrictEqual(original);
+});

--- a/packages/core/src/patch/pointer.ts
+++ b/packages/core/src/patch/pointer.ts
@@ -1,0 +1,150 @@
+/* eslint-disable header/header */
+/*
+ * Copyright © 2014-2021 Christopher Brown <io@henrian.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * Unescape token part of a JSON Pointer string
+ *
+ * `token` should *not* contain any '/' characters.
+ *
+ * > Evaluation of each reference token begins by decoding any escaped
+ * > character sequence.  This is performed by first transforming any
+ * > occurrence of the sequence '~1' to '/', and then transforming any
+ * > occurrence of the sequence '~0' to '~'.  By performing the
+ * > substitutions in this order, an implementation avoids the error of
+ * > turning '~01' first into '~1' and then into '/', which would be
+ * > incorrect (the string '~01' correctly becomes '~1' after
+ * > transformation).
+ *
+ * Here's my take:
+ *
+ * ~1 is unescaped with higher priority than ~0 because it is a lower-order escape character.
+ * I say "lower order" because '/' needs escaping due to the JSON Pointer serialization technique.
+ * Whereas, '~' is escaped because escaping '/' uses the '~' character.
+ *
+ * @param token - The token to unescape.
+ * @returns The unescaped token.
+ */
+export function unescapeToken(token: string): string {
+  return token.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+/**
+ * Escape token part of a JSON Pointer string
+ *
+ * > '~' needs to be encoded as '~0' and '/'
+ * > needs to be encoded as '~1' when these characters appear in a
+ * > reference token.
+ *
+ * This is the exact inverse of `unescapeToken()`, so the reverse replacements must take place in reverse order.
+ *
+ * @param token - The token to escape.
+ * @returns The escaped token.
+ */
+export function escapeToken(token: string): string {
+  return token.replace(/~/g, '~0').replace(/\//g, '~1');
+}
+
+export interface PointerEvaluation {
+  parent: any;
+  key: string;
+  value: any;
+}
+
+/**
+ * JSON Pointer representation
+ */
+export class Pointer {
+  tokens: string[];
+
+  constructor(tokens = ['']) {
+    this.tokens = tokens;
+  }
+
+  /**
+   * @param path - The JSON path: *must* be a properly escaped string.
+   * @returns The JSON pointer object.
+   */
+  static fromJSON(path: string): Pointer {
+    const tokens = path.split('/').map(unescapeToken);
+    if (tokens[0] !== '') {
+      throw new Error(`Invalid JSON Pointer: ${path}`);
+    }
+    return new Pointer(tokens);
+  }
+  toString(): string {
+    return this.tokens.map(escapeToken).join('/');
+  }
+
+  /**
+   * Returns an object with 'parent', 'key', and 'value' properties.
+   * In the special case that this Pointer's path == "",
+   * this object will be {parent: null, key: '', value: object}.
+   * Otherwise, parent and key will have the property such that parent[key] == value.
+   *
+   * @param object - The object against which to evaluate the pointer.
+   * @returns The evaluation result.
+   */
+  evaluate(object: any): PointerEvaluation {
+    let parent: any = null;
+    let key = '';
+    let value = object;
+    for (let i = 1, l = this.tokens.length; i < l; i++) {
+      parent = value;
+      key = this.tokens[i];
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        continue;
+      }
+      // not sure if this the best way to handle non-existant paths...
+      value = parent?.[key];
+    }
+    return { parent, key, value };
+  }
+  get(object: any): any {
+    return this.evaluate(object).value;
+  }
+  set(object: any, value: any): void {
+    const endpoint = this.evaluate(object);
+    if (endpoint.parent) {
+      endpoint.parent[endpoint.key] = value;
+    }
+  }
+  push(token: string): void {
+    // mutable
+    this.tokens.push(token);
+  }
+
+  /**
+   * @param token - The token to add to the pointer.
+   * @returns An updated pointer.
+   */
+  add(token: string): Pointer {
+    const tokens = this.tokens.concat(String(token));
+    return new Pointer(tokens);
+  }
+
+  /**
+   * Create a new Pointer representing the parent of this one.
+   *
+   * The parent of the empty pointer is the empty pointer.
+   *
+   * @returns The parent pointer.
+   */
+  parent(): Pointer {
+    const tokens = this.tokens.length > 1 ? this.tokens.slice(0, -1) : [''];
+    return new Pointer(tokens);
+  }
+}

--- a/packages/core/src/patch/spec.test.ts
+++ b/packages/core/src/patch/spec.test.ts
@@ -1,0 +1,617 @@
+/* eslint-disable header/header */
+/*
+ * Copyright © 2014-2021 Christopher Brown <io@henrian.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import type { AddOperation, Operation } from './diff';
+import { applyPatch, createPatch } from './index';
+import { Pointer } from './pointer';
+import { clone } from './util';
+
+interface Spec {
+  name: string;
+  input: any;
+  patch: Operation[];
+  output: any;
+  results: (string | null)[];
+  diffable: boolean;
+}
+
+// const spec_data = yaml.load(readFileSync(join(__dirname, 'spec.yaml'), { encoding: 'utf8' })) as Spec[];
+const specData: Spec[] = [
+  {
+    name: 'A.1. Adding an Object Member',
+    input: {
+      foo: 'bar',
+    },
+    patch: [
+      {
+        op: 'add',
+        path: '/baz',
+        value: 'qux',
+      },
+    ],
+    output: {
+      baz: 'qux',
+      foo: 'bar',
+    },
+    results: [null],
+    diffable: true,
+  },
+  {
+    name: 'A.2. Adding an Array Element',
+    input: {
+      foo: ['bar', 'baz'],
+    },
+    patch: [
+      {
+        op: 'add',
+        path: '/foo/1',
+        value: 'qux',
+      },
+    ],
+    output: {
+      foo: ['bar', 'qux', 'baz'],
+    },
+    results: [null],
+    diffable: true,
+  },
+  {
+    name: 'A.3. Removing an Object Member',
+    input: {
+      baz: 'qux',
+      foo: 'bar',
+    },
+    patch: [
+      {
+        op: 'remove',
+        path: '/baz',
+      },
+    ],
+    output: {
+      foo: 'bar',
+    },
+    results: [null],
+    diffable: true,
+  },
+  {
+    name: 'A.4. Removing an Array Element',
+    input: {
+      foo: ['bar', 'qux', 'baz'],
+    },
+    patch: [
+      {
+        op: 'remove',
+        path: '/foo/1',
+      },
+    ],
+    output: {
+      foo: ['bar', 'baz'],
+    },
+    results: [null],
+    diffable: true,
+  },
+  {
+    name: 'A.5. Replacing a Value',
+    input: {
+      baz: 'qux',
+      foo: 'bar',
+    },
+    patch: [
+      {
+        op: 'replace',
+        path: '/baz',
+        value: 'boo',
+      },
+    ],
+    output: {
+      baz: 'boo',
+      foo: 'bar',
+    },
+    results: [null],
+    diffable: true,
+  },
+  {
+    name: 'A.6. Moving a Value',
+    input: {
+      foo: {
+        bar: 'baz',
+        waldo: 'fred',
+      },
+      qux: {
+        corge: 'grault',
+      },
+    },
+    patch: [
+      {
+        op: 'move',
+        from: '/foo/waldo',
+        path: '/qux/thud',
+      },
+    ],
+    output: {
+      foo: {
+        bar: 'baz',
+      },
+      qux: {
+        corge: 'grault',
+        thud: 'fred',
+      },
+    },
+    results: [null],
+    diffable: false,
+  },
+  {
+    name: 'A.7. Moving an Array Element',
+    input: {
+      foo: ['all', 'grass', 'cows', 'eat'],
+    },
+    patch: [
+      {
+        op: 'move',
+        from: '/foo/1',
+        path: '/foo/3',
+      },
+    ],
+    output: {
+      foo: ['all', 'cows', 'eat', 'grass'],
+    },
+    results: [null],
+    diffable: false,
+  },
+  {
+    name: 'A.8. Testing a Value: Success',
+    input: {
+      baz: 'qux',
+      foo: ['a', 2, 'c'],
+    },
+    patch: [
+      {
+        op: 'test',
+        path: '/baz',
+        value: 'qux',
+      },
+      {
+        op: 'test',
+        path: '/foo/1',
+        value: 2,
+      },
+    ],
+    output: {
+      baz: 'qux',
+      foo: ['a', 2, 'c'],
+    },
+    results: [null, null],
+    diffable: true,
+  },
+  {
+    name: 'A.9. Testing a Value: Error',
+    input: {
+      baz: 'qux',
+    },
+    patch: [
+      {
+        op: 'test',
+        path: '/baz',
+        value: 'bar',
+      },
+    ],
+    output: {
+      baz: 'qux',
+    },
+    results: ['TestError'],
+    diffable: false,
+  },
+  {
+    name: 'A.10. Adding a Nested Member Object',
+    input: {
+      foo: 'bar',
+    },
+    patch: [
+      {
+        op: 'add',
+        path: '/child',
+        value: {
+          grandchild: {},
+        },
+      },
+    ],
+    output: {
+      foo: 'bar',
+      child: {
+        grandchild: {},
+      },
+    },
+    results: [null],
+    diffable: true,
+  },
+  {
+    name: 'A.11. Ignoring Unrecognized Elements',
+    input: {
+      foo: 'bar',
+    },
+    patch: [
+      {
+        op: 'add',
+        path: '/baz',
+        value: 'qux',
+        xyz: 123,
+      } as AddOperation,
+    ],
+    output: {
+      foo: 'bar',
+      baz: 'qux',
+    },
+    results: [null],
+    diffable: false,
+  },
+  {
+    name: 'A.12. Adding to a Nonexistent Target',
+    input: {
+      foo: 'bar',
+    },
+    patch: [
+      {
+        op: 'add',
+        path: '/baz/bat',
+        value: 'qux',
+      },
+    ],
+    output: {
+      foo: 'bar',
+    },
+    results: ['MissingError'],
+    diffable: false,
+  },
+  {
+    name: 'A.13.2 Invalid JSON Patch Document',
+    input: {
+      foo: 'bar',
+    },
+    patch: [
+      {
+        op: 'transcend',
+        path: '/baz',
+        value: 'qux',
+      } as unknown as Operation,
+    ],
+    output: {
+      foo: 'bar',
+    },
+    results: ['InvalidOperationError'],
+    diffable: false,
+  },
+  {
+    name: 'A.14. ~ Escape Ordering',
+    input: {
+      '/': 9,
+      '~1': 10,
+    },
+    patch: [
+      {
+        op: 'test',
+        path: '/~01',
+        value: 10,
+      },
+    ],
+    output: {
+      '/': 9,
+      '~1': 10,
+    },
+    results: [null],
+    diffable: true,
+  },
+  {
+    name: 'A.15. Comparing Strings and Numbers',
+    input: {
+      '/': 9,
+      '~1': 10,
+    },
+    patch: [
+      {
+        op: 'test',
+        path: '/~01',
+        value: '10',
+      },
+    ],
+    output: {
+      '/': 9,
+      '~1': 10,
+    },
+    results: ['TestError'],
+    diffable: false,
+  },
+  {
+    name: 'A.16. Adding an Array Value',
+    input: {
+      foo: ['bar'],
+    },
+    patch: [
+      {
+        op: 'add',
+        path: '/foo/-',
+        value: ['abc', 'def'],
+      },
+    ],
+    output: {
+      foo: ['bar', ['abc', 'def']],
+    },
+    results: [null],
+    diffable: true,
+  },
+  {
+    name: 'Test types (failure)',
+    input: {
+      whole: 3,
+      ish: '3.14',
+      parts: [3, 141, 592, 654],
+      exact: false,
+      natural: null,
+      approximation: 'true',
+      float: {
+        significand: 314,
+        exponent: -2,
+      },
+    },
+    output: {
+      whole: 3,
+      ish: '3.14',
+      parts: [3, 141, 592, 654],
+      exact: false,
+      natural: null,
+      approximation: 'true',
+      float: {
+        significand: 314,
+        exponent: -2,
+      },
+    },
+    patch: [
+      {
+        op: 'test',
+        path: '/whole',
+        value: '3',
+      },
+      {
+        op: 'test',
+        path: '/ish',
+        value: 3.14,
+      },
+      {
+        op: 'test',
+        path: '/parts',
+        value: '3,141,592,654',
+      },
+      {
+        op: 'test',
+        path: '/parts/3',
+        value: 654.001,
+      },
+      {
+        op: 'test',
+        path: '/natural',
+      } as Operation,
+      {
+        op: 'test',
+        path: '/approximation',
+        value: true,
+      },
+      {
+        op: 'test',
+        path: '/float',
+        value: [
+          ['significand', 314],
+          ['exponent', -2],
+        ],
+      },
+    ],
+    results: ['TestError', 'TestError', 'TestError', 'TestError', 'TestError', 'TestError', 'TestError'],
+    diffable: false,
+  },
+  {
+    name: 'Test types (success)',
+    input: {
+      whole: 3,
+      ish: '3.14',
+      parts: [3, 141, 592, 654],
+      exact: false,
+      natural: null,
+      approximation: 'true',
+      float: {
+        significand: 314,
+        exponent: -2,
+      },
+    },
+    output: {
+      whole: 3,
+      ish: '3.14',
+      parts: [3, 141, 592, 654],
+      exact: false,
+      natural: null,
+      approximation: 'true',
+      float: {
+        significand: 314,
+        exponent: -2,
+      },
+    },
+    patch: [
+      {
+        op: 'test',
+        path: '/whole',
+        value: 3,
+      },
+      {
+        op: 'test',
+        path: '/ish',
+        value: '3.14',
+      },
+      {
+        op: 'test',
+        path: '/parts',
+        value: [3, 141, 592, 654],
+      },
+      {
+        op: 'test',
+        path: '/parts/3',
+        value: 654,
+      },
+      {
+        op: 'test',
+        path: '/natural',
+        value: null,
+      },
+      {
+        op: 'test',
+        path: '/approximation',
+        value: 'true',
+      },
+      {
+        op: 'test',
+        path: '/float',
+        value: {
+          significand: 314,
+          exponent: -2,
+        },
+      },
+    ],
+    results: [null, null, null, null, null, null, null],
+    diffable: true,
+  },
+  {
+    name: 'Array vs. Object',
+    input: {
+      repositories: ['amulet', 'flickr-with-uploads'],
+    },
+    output: {
+      repositories: {},
+    },
+    patch: [
+      {
+        op: 'replace',
+        path: '/repositories',
+        value: {},
+      },
+    ],
+    results: [null],
+    diffable: true,
+  },
+];
+
+test('JSON Pointer - rfc-examples', () => {
+  // > For example, given the JSON document
+  const obj = {
+    foo: ['bar', 'baz'],
+    '': 0,
+    'a/b': 1,
+    'c%d': 2,
+    'e^f': 3,
+    'g|h': 4,
+    'i\\j': 5,
+    "k'l": 6,
+    ' ': 7,
+    'm~n': 8,
+  };
+
+  // > The following JSON strings evaluate to the accompanying values
+  const pointers = [
+    { path: '', expected: obj },
+    { path: '/foo', expected: ['bar', 'baz'] },
+    { path: '/foo/0', expected: 'bar' },
+    { path: '/', expected: 0 },
+    { path: '/a~1b', expected: 1 },
+    { path: '/c%d', expected: 2 },
+    { path: '/e^f', expected: 3 },
+    { path: '/g|h', expected: 4 },
+    { path: '/i\\j', expected: 5 },
+    { path: "/k'l", expected: 6 },
+    { path: '/ ', expected: 7 },
+    { path: '/m~0n', expected: 8 },
+  ];
+
+  pointers.forEach((pointer) => {
+    const actual = Pointer.fromJSON(pointer.path).evaluate(obj).value;
+    expect(actual).toStrictEqual(pointer.expected);
+  });
+});
+
+test('JSON Pointer - package example', () => {
+  const obj = {
+    first: 'chris',
+    last: 'brown',
+    github: {
+      account: {
+        id: 'chbrown',
+        handle: '@chbrown',
+      },
+      repos: ['amulet', 'twilight', 'rfc6902'],
+      stars: [
+        {
+          owner: 'raspberrypi',
+          repo: 'userland',
+        },
+        {
+          owner: 'angular',
+          repo: 'angular.js',
+        },
+      ],
+    },
+    'github/account': 'deprecated',
+  };
+
+  const pointers = [
+    { path: '/first', expected: 'chris' },
+    { path: '/github~1account', expected: 'deprecated' },
+    { path: '/github/account/handle', expected: '@chbrown' },
+    { path: '/github/repos', expected: ['amulet', 'twilight', 'rfc6902'] },
+    { path: '/github/repos/2', expected: 'rfc6902' },
+    { path: '/github/stars/0/repo', expected: 'userland' },
+  ];
+
+  pointers.forEach((pointer) => {
+    const actual = Pointer.fromJSON(pointer.path).evaluate(obj).value;
+    expect(actual).toStrictEqual(pointer.expected);
+  });
+});
+
+test('Specification format', () => {
+  expect(specData).toHaveLength(19);
+  // use sorted values and sort() to emulate set equality
+  const props = ['diffable', 'input', 'name', 'output', 'patch', 'results'];
+  specData.forEach((spec) => {
+    expect(Object.keys(spec).sort()).toStrictEqual(props);
+  });
+});
+
+// take the input, apply the patch, and check the actual result against the
+// expected output
+test.each(specData)(`patch $name`, (spec) => {
+  // patch operations are applied to object in-place
+  const actual = clone(spec.input);
+  const expected = spec.output;
+  const results = applyPatch(actual, spec.patch);
+  expect(actual).toStrictEqual(expected);
+  // since errors are object instances, reduce them to strings to match
+  // the spec's results, which has the type `Array<string | null>`
+  const results_names = results.map((error) => (error ? error.name : error));
+  expect(results_names).toStrictEqual(spec.results);
+});
+
+test.each(specData.filter((s) => s.diffable))(`diff $name`, (spec) => {
+  // we read this separately because patch is destructive and it's easier just to start with a blank slate
+  // ignore spec items that are marked as not diffable
+  // perform diff (create patch = list of operations) and check result against non-test patches in spec
+  const actual = createPatch(spec.input, spec.output);
+  const expected = spec.patch.filter((operation) => operation.op !== 'test');
+  expect(actual).toStrictEqual(expected);
+});

--- a/packages/core/src/patch/util.ts
+++ b/packages/core/src/patch/util.ts
@@ -1,0 +1,78 @@
+/* eslint-disable header/header */
+/*
+ * Copyright © 2014-2021 Christopher Brown <io@henrian.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+export const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+export function objectType(object: any): string {
+  if (object === undefined) {
+    return 'undefined';
+  }
+  if (object === null) {
+    return 'null';
+  }
+  if (Array.isArray(object)) {
+    return 'array';
+  }
+  return typeof object;
+}
+
+function isNonPrimitive(value: any): value is object {
+  // loose-equality checking for null is faster than strict checking for each of null/undefined/true/false
+  // checking null first, then calling typeof, is faster than vice-versa
+  return value && typeof value === 'object';
+}
+
+/**
+ * Recursively copy a value.
+ *
+ * @param source - should be a JavaScript primitive, Array, Date, or (plain old) Object.
+ * @returns copy of source where every Array and Object have been recursively
+ *         reconstructed from their constituent elements
+ */
+export function clone<T>(source: T): T {
+  if (!isNonPrimitive(source)) {
+    // short-circuiting is faster than a single return
+    return source;
+  }
+  // x.constructor == Array is the fastest way to check if x is an Array
+  if (source.constructor === Array) {
+    // construction via imperative for-loop is faster than source.map(arrayVsObject)
+    const length = (source as any[]).length;
+    // setting the Array length during construction is faster than just `[]` or `new Array()`
+    const arrayTarget: any = new Array(length);
+    for (let i = 0; i < length; i++) {
+      arrayTarget[i] = clone(source[i]);
+    }
+    return arrayTarget;
+  }
+  // Date
+  if (source.constructor === Date) {
+    const dateTarget: any = new Date(+source);
+    return dateTarget;
+  }
+  // Object
+  const objectTarget: any = {};
+  // declaring the variable (with const) inside the loop is faster
+  for (const key in source) {
+    // hasOwnProperty costs a bit of performance, but it's semantically necessary
+    // using a global helper is MUCH faster than calling source.hasOwnProperty(key)
+    if (hasOwnProperty.call(source, key)) {
+      objectTarget[key] = clone(source[key]);
+    }
+  }
+  return objectTarget;
+}


### PR DESCRIPTION
Vendors our current JSON Patch library into `@medplum/core` to allow consistent patching implementations across server and client, including for future use with FHIRPath Patch.  This is nearly a verbatim copy, with minor adjustments made to conform with Medplum coding standards and linters