### PR TITLE
feat(server): record authenticating ClientApplication on AuditEvent.agent[]

### DIFF
--- a/packages/server/src/fhir/accesspolicy.ts
+++ b/packages/server/src/fhir/accesspolicy.ts
@@ -99,6 +99,7 @@ export async function getRepoForLogin(authState: AuthState, extendedMode?: boole
     checkReferencesOnWrite: project.checkReferencesOnWrite,
     validateTerminology: project.features?.includes('validate-terminology'),
     onBehalfOf: authState.onBehalfOf ? createReference(authState.onBehalfOf) : undefined,
+    client: login.client,
   });
 }
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -53,6 +53,7 @@ import type {
   Binary,
   Bundle,
   BundleEntry,
+  ClientApplication,
   Meta,
   OperationOutcome,
   Project,
@@ -154,6 +155,17 @@ export interface RepositoryContext {
    * This value will be included in every resource as meta.onBehalfOf.
    */
   onBehalfOf?: Reference;
+
+  /**
+   * The authenticating ClientApplication for the current login, when present.
+   * This is the application that obtained the access token, which may differ
+   * from the acting `author` (e.g. when using `X-Medplum-On-Behalf-Of`, or for
+   * a SMART on FHIR app acting on behalf of a user). It is recorded as an
+   * additional non-requestor `agent[]` participant on per-interaction AuditEvents
+   * so the audit trail captures which client performed an action.
+   * Absent on the pure `client_credentials` / system paths.
+   */
+  client?: Reference<ClientApplication>;
 
   remoteAddress?: string;
 
@@ -2072,6 +2084,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
         resource,
         searchQuery: query,
         durationMs: options?.durationMs,
+        client: this.context.client,
       }
     );
     logAuditEvent(auditEvent);

--- a/packages/server/src/util/auditevent.test.ts
+++ b/packages/server/src/util/auditevent.test.ts
@@ -8,11 +8,13 @@ import type { BotExecutionRequest } from '../bots/types';
 import { loadTestConfig } from '../config/loader';
 import { globalLogger } from '../logger';
 import {
+  ApplicationAgentType,
   AuditEventOutcome,
   createAuditEvent,
   createBotAuditEvent,
   CreateInteraction,
   logAuditEvent,
+  ReadInteraction,
   RestfulOperationType,
 } from './auditevent';
 
@@ -80,6 +82,65 @@ describe('AuditEvent utils', () => {
     expect(auditLog).not.toContain('User');
   });
 
+  test('Appends authenticating client as a non-requestor agent', async () => {
+    await loadTestConfig();
+
+    const auditEvent = createAuditEvent(
+      RestfulOperationType,
+      ReadInteraction,
+      randomUUID(),
+      { reference: 'Practitioner/user-123' },
+      undefined,
+      AuditEventOutcome.Success,
+      { client: { reference: 'ClientApplication/agent-client' } }
+    );
+
+    expect(auditEvent.agent).toHaveLength(2);
+    expect(auditEvent.agent?.[0]).toMatchObject({
+      who: { reference: 'Practitioner/user-123' },
+      requestor: true,
+    });
+    expect(auditEvent.agent?.[1]).toMatchObject({
+      who: { reference: 'ClientApplication/agent-client' },
+      requestor: false,
+      type: { coding: [ApplicationAgentType] },
+    });
+  });
+
+  test('Does not duplicate client agent when client is the actor', async () => {
+    await loadTestConfig();
+
+    // client_credentials: the client is itself the author/actor (agent[0]).
+    const clientRef = { reference: 'ClientApplication/agent-client' };
+    const auditEvent = createAuditEvent(
+      RestfulOperationType,
+      ReadInteraction,
+      randomUUID(),
+      clientRef,
+      undefined,
+      AuditEventOutcome.Success,
+      { client: clientRef }
+    );
+
+    expect(auditEvent.agent).toHaveLength(1);
+    expect(auditEvent.agent?.[0]).toMatchObject({ who: clientRef, requestor: true });
+  });
+
+  test('Omits client agent when no client is present', async () => {
+    await loadTestConfig();
+
+    const auditEvent = createAuditEvent(
+      RestfulOperationType,
+      ReadInteraction,
+      randomUUID(),
+      { reference: 'Practitioner/user-123' },
+      undefined,
+      AuditEventOutcome.Success
+    );
+
+    expect(auditEvent.agent).toHaveLength(1);
+  });
+
   test.each<Bot['auditEventTrigger']>(['never', 'on-error', 'on-output'])(
     'Skips creating audit event with `%s` trigger',
     async (trigger) => {
@@ -105,6 +166,9 @@ describe('AuditEvent utils', () => {
   );
 
   test('Logs Bot output', async () => {
+    const config = await loadTestConfig();
+    config.logAuditEvents = true;
+
     const bot: WithId<Bot> = {
       resourceType: 'Bot',
       id: randomUUID(),

--- a/packages/server/src/util/auditevent.ts
+++ b/packages/server/src/util/auditevent.ts
@@ -4,9 +4,11 @@ import type { ProfileResource } from '@medplum/core';
 import { append, createReference, flatMapFilter, isResource, isResourceWithId, resolveId } from '@medplum/core';
 import type {
   AuditEvent,
+  AuditEventAgent,
   AuditEventAgentNetwork,
   AuditEventEntity,
   Bot,
+  ClientApplication,
   Coding,
   Extension,
   Practitioner,
@@ -35,6 +37,17 @@ import { globalLogger } from '../logger';
  * See: https://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_D.html
  */
 export const DicomCodeSystem = 'http://dicom.nema.org/resources/ontology/DCM';
+
+/**
+ * DICOM "Application" participant role, used to label an `AuditEvent.agent` that
+ * represents the authenticating software/application rather than a human user.
+ * See: https://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html
+ */
+export const ApplicationAgentType: Coding = {
+  system: DicomCodeSystem,
+  code: '110150',
+  display: 'Application',
+};
 
 /**
  * AuditEvent type code system.
@@ -179,6 +192,13 @@ export function createAuditEvent(
     resource?: Resource | Reference;
     searchQuery?: string;
     durationMs?: number;
+    /**
+     * The authenticating ClientApplication, recorded as an additional non-requestor
+     * `agent[]` participant when it differs from `who` (the acting profile). This
+     * captures the delegated client on on-behalf-of and SMART-on-FHIR interactions,
+     * where the client would otherwise be absent from the audit trail.
+     */
+    client?: Reference<ClientApplication>;
   }
 ): AuditEvent {
   const config = getConfig();
@@ -205,6 +225,27 @@ export function createAuditEvent(
     extension = append(extension, buildDurationExtension(options.durationMs));
   }
 
+  const agent: AuditEventAgent[] = [
+    {
+      who: applyOptionalRedaction(who) as Reference<Practitioner>,
+      requestor: true,
+      network,
+    },
+  ];
+
+  // Record the authenticating ClientApplication as an additional non-requestor
+  // agent when it differs from the acting profile. This captures the delegated
+  // client on on-behalf-of and SMART-on-FHIR interactions, where it would
+  // otherwise be absent from the audit trail. When the client is itself the
+  // actor (e.g. client_credentials), it is already `agent[0]`, so skip it.
+  if (options?.client?.reference && options.client.reference !== who?.reference) {
+    agent.push({
+      who: applyOptionalRedaction(options.client) as Reference<ClientApplication>,
+      requestor: false,
+      type: { coding: [ApplicationAgentType] },
+    });
+  }
+
   const auditEvent: AuditEvent = {
     resourceType: 'AuditEvent',
     meta: { project: projectId },
@@ -213,13 +254,7 @@ export function createAuditEvent(
     action: AuditEventActionLookup[subtype.code],
     recorded: new Date().toISOString(),
     source: { observer: { identifier: { value: config.baseUrl } } },
-    agent: [
-      {
-        who: applyOptionalRedaction(who) as Reference<Practitioner>,
-        requestor: true,
-        network,
-      },
-    ],
+    agent,
     outcome,
     outcomeDesc: options?.description,
     entity,


### PR DESCRIPTION
Closes #9332

## Summary

The per-interaction `AuditEvent` Medplum auto-generates records a **single** `agent` — the resource author/profile — and never records the authenticating `ClientApplication`. Under `X-Medplum-On-Behalf-Of` the acting client disappears entirely, leaving the event indistinguishable from the user acting directly; the same gap applies to SMART-on-FHIR apps acting on behalf of a user. For reads there is no resource `meta` fallback, so there's no record of which client acted.

This PR threads the authenticating `ClientApplication` (`login.client`) through the repository context and records it as an additional **non-requestor** `agent[]` participant on the per-interaction path — generalizing the dual-agent attribution `createBotAuditEvent` already produces.

## Changes

- `RepositoryContext` gains an optional `client?: Reference<ClientApplication>`.
- `getRepoForLogin` populates it from `authState.login.client`.
- `createAuditEvent` accepts an optional `client` and **appends** it as a non-requestor agent with the DICOM `Application` role coding (`110150`).
- `logEvent` passes `this.context.client` through.

## Behavior

```jsonc
"agent": [
  { "who": { "reference": "Practitioner/<user>" }, "requestor": true },
  {
    "who": { "reference": "ClientApplication/<client>" },
    "requestor": false,
    "type": { "coding": [{ "system": "http://dicom.nema.org/resources/ontology/DCM", "code": "110150", "display": "Application" }] }
  }
]
```

- **Backward compatible:** `agent[0]` is unchanged (still the actor, `requestor: true`), so consumers assuming `agent[0]` is the actor are unaffected.
- The client agent is **appended only when it differs from the actor** — so `client_credentials` (where the client *is* the author) doesn't get a duplicate, and the pure system path (no `login.client`) is unaffected.
- Covers reads/searches (when `saveAuditEvents` is enabled), on-behalf-of, SMART-on-FHIR consent flows, and bot FHIR interactions — all share this path.

## Tests

- Unit tests in `auditevent.test.ts` covering: client appended as second agent; no duplicate when client is the actor; omitted when absent.
- (Drive-by) made the existing `Logs Bot output` test self-sufficient — it relied on leaked global config from an earlier test.

## Open question for maintainers

Issue #9332 raised whether this should be gated behind config / `X-Medplum: extended` to preserve the single-agent default. I've implemented it ungated since the change is additive and `agent[0]` is preserved, but happy to gate it if you'd prefer. The optional secondary suggestion in the issue (recording the granted SMART scope on the AuditEvent) is **not** included here to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)