### PR TITLE
fix(server): don't refresh if membership inactive

### DIFF
--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -1175,7 +1175,7 @@ describe('OAuth2 Token', () => {
       refresh_token: res2.body.refresh_token,
     });
     expect(res3.status).toBe(400);
-    expect(res3.body.error).toBe('invalid_grant');
+    expect(res3.body.error).toBe('access_denied');
     expect(res3.body.error_description).toBe('Profile not active');
   });
 

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -1123,6 +1123,61 @@ describe('OAuth2 Token', () => {
     expect(res3.body.error_description).toBe('Token revoked');
   });
 
+  test('Refresh token membership inactive', async () => {
+    // Use a dedicated user so deactivating the membership does not affect other tests
+    const inactiveEmail = `test-${randomUUID()}@example.com`;
+    const inactivePassword = 'test-password';
+    await inviteUser({
+      project,
+      resourceType: 'Practitioner',
+      firstName: 'Test',
+      lastName: 'Test',
+      email: inactiveEmail,
+      password: inactivePassword,
+    });
+
+    const res = await request(app).post('/auth/login').type('json').send({
+      email: inactiveEmail,
+      password: inactivePassword,
+      codeChallenge: 'xyz',
+      codeChallengeMethod: 'plain',
+      scope: 'openid offline_access',
+    });
+    expect(res.status).toBe(200);
+
+    const res2 = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: 'authorization_code',
+      code: res.body.code,
+      code_verifier: 'xyz',
+    });
+    expect(res2.status).toBe(200);
+    expect(res2.body.refresh_token).toBeDefined();
+
+    // Find the login
+    const loginBundle = await systemRepo.search<Login>(parseSearchRequest('Login?code=' + res.body.code));
+    expect(loginBundle.entry).toHaveLength(1);
+
+    // Deactivate the membership
+    const login = loginBundle.entry?.[0]?.resource as Login;
+    const membership = await systemRepo.readReference<ProjectMembership>(
+      login.membership as Reference<ProjectMembership>
+    );
+    await withTestContext(() =>
+      systemRepo.updateResource({
+        ...membership,
+        active: false,
+      })
+    );
+
+    const res3 = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: 'refresh_token',
+      refresh_token: res2.body.refresh_token,
+    });
+    expect(res3.status).toBe(400);
+    expect(res3.body.error).toBe('invalid_grant');
+    expect(res3.body.error_description).toBe('Profile not active');
+  });
+
   test('Refresh token Basic auth success', async () => {
     const res = await request(app).post('/auth/login').type('json').send({
       email,

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -19,6 +19,7 @@ import type {
   Login,
   Project,
   ProjectMembership,
+  Reference,
   SmartAppLaunch,
 } from '@medplum/fhirtypes';
 import express from 'express';

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -302,7 +302,7 @@ async function handleRefreshToken(req: Request, res: Response): Promise<void> {
 
   if (login.membership) {
     const membership = await systemRepo.readReference<ProjectMembership>(
-      login.membership as Reference<ProjectMembership>
+      login.membership
     );
     if (membership.active === false) {
       sendTokenError(res, 'invalid_grant', 'Profile not active');

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -301,9 +301,7 @@ async function handleRefreshToken(req: Request, res: Response): Promise<void> {
   }
 
   if (login.membership) {
-    const membership = await systemRepo.readReference<ProjectMembership>(
-      login.membership
-    );
+    const membership = await systemRepo.readReference<ProjectMembership>(login.membership);
     if (membership.active === false) {
       sendTokenError(res, 'invalid_grant', 'Profile not active');
       return;

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -300,6 +300,16 @@ async function handleRefreshToken(req: Request, res: Response): Promise<void> {
     return;
   }
 
+  if (login.membership) {
+    const membership = await systemRepo.readReference<ProjectMembership>(
+      login.membership as Reference<ProjectMembership>
+    );
+    if (membership.active === false) {
+      sendTokenError(res, 'invalid_grant', 'Profile not active');
+      return;
+    }
+  }
+
   // Use a timing-safe-equal here so that we don't expose timing information which could be
   // used to infer the secret value
   if (!timingSafeEqualStr(login.refreshSecret, claims.refresh_secret)) {

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -303,7 +303,7 @@ async function handleRefreshToken(req: Request, res: Response): Promise<void> {
   if (login.membership) {
     const membership = await systemRepo.readReference<ProjectMembership>(login.membership);
     if (membership.active === false) {
-      sendTokenError(res, 'invalid_grant', 'Profile not active');
+      sendTokenError(res, 'access_denied', 'Profile not active');
       return;
     }
   }


### PR DESCRIPTION
Prevents users with an inactive ProjectMembership but a non-revoked / expired refresh token from spamming with 401s. Previously we would give an access token anyways, which the client would attempt to use and immediately receive a 401, triggering another refresh, in a tight loop