### PR TITLE
fix(core,react-hooks): don't refresh subs if unauthenticated

### DIFF
--- a/packages/core/src/subscriptions/index.test.ts
+++ b/packages/core/src/subscriptions/index.test.ts
@@ -298,6 +298,25 @@ describe('SubscriptionManager', () => {
       expect(receivedBundle).toStrictEqual(sentBundle);
     });
 
+    test('should not bind or create resources while unauthenticated', async () => {
+      await wsServer.connected;
+
+      const getProfileSpy = vi.spyOn(medplum, 'getProfile').mockReturnValue(undefined);
+      const createSpy = vi.spyOn(medplum, 'createResource');
+
+      const emitter = defaultManager.addCriteria('Communication');
+      expect(emitter).toBeInstanceOf(SubscriptionEmitter);
+
+      // Give any async rebind a chance to run — it should be skipped while unauthenticated
+      await sleep(50);
+
+      // No Subscription resource is created and no $get-ws-binding-token call is made
+      expect(createSpy).not.toHaveBeenCalled();
+
+      getProfileSpy.mockRestore();
+      createSpy.mockRestore();
+    });
+
     test('should emit `error` when token or url missing from `Subscription/$get-ws-binding-token` operation', async () => {
       const originalError = console.error;
       console.error = vi.fn();

--- a/packages/core/src/subscriptions/index.ts
+++ b/packages/core/src/subscriptions/index.ts
@@ -419,6 +419,12 @@ export class SubscriptionManager {
     if (this.ws.readyState !== WebSocket.OPEN) {
       return;
     }
+    // If a user is not logged in, skip the rebind. Attempting it would 401 on
+    // $get-ws-binding-token. The entry stays idle and will be picked up by
+    // refreshAllSubscriptions once a connection is (re)established while authenticated.
+    if (!this.medplum.getProfile()) {
+      return;
+    }
     // Only subscribe idle entries — connecting/active/refreshing entries already have an operation in progress,
     // and removed entries are dead
     if (criteriaEntry.state !== 'idle') {
@@ -528,6 +534,10 @@ export class SubscriptionManager {
   }
 
   private checkTokenExpirations(): void {
+    // Don't attempt token refreshes while unauthenticated — they would 401 in a loop.
+    if (!this.isAuthenticated()) {
+      return;
+    }
     const now = Date.now();
     for (const mapEntry of this.criteriaEntries.values()) {
       for (const criteriaEntry of getAllEntries(mapEntry)) {

--- a/packages/core/src/subscriptions/index.ts
+++ b/packages/core/src/subscriptions/index.ts
@@ -535,7 +535,7 @@ export class SubscriptionManager {
 
   private checkTokenExpirations(): void {
     // Don't attempt token refreshes while unauthenticated — they would 401 in a loop.
-    if (!this.isAuthenticated()) {
+    if (!this.medplum.getProfile()) {
       return;
     }
     const now = Date.now();

--- a/packages/react-hooks/src/useSubscription/useSubscription.test.tsx
+++ b/packages/react-hooks/src/useSubscription/useSubscription.test.tsx
@@ -482,6 +482,30 @@ describe('useSubscription()', () => {
     expect(lastFromCb4?.id).toEqual(id4);
   });
 
+  test('Is a no-op when unauthenticated', async () => {
+    const profile = medplum.getProfile();
+    const getProfileSpy = jest.spyOn(medplum, 'getProfile').mockReturnValue(undefined);
+    const subscribeSpy = jest.spyOn(medplum, 'subscribeToCriteria');
+
+    setup(<TestComponent criteria="Communication" />);
+
+    // No subscription should be created while unauthenticated
+    expect(subscribeSpy).not.toHaveBeenCalled();
+    expect(medplum.getSubscriptionManager().getCriteriaCount()).toEqual(0);
+
+    // Once authenticated, the hook should subscribe
+    getProfileSpy.mockReturnValue(profile);
+    act(() => {
+      medplum.dispatchEvent({ type: 'change' });
+    });
+
+    expect(subscribeSpy).toHaveBeenCalledWith('Communication', undefined);
+    expect(medplum.getSubscriptionManager().getCriteriaCount()).toEqual(1);
+
+    getProfileSpy.mockRestore();
+    subscribeSpy.mockRestore();
+  });
+
   test('WebSocket disconnects and reconnects', async () => {
     let lastFromCb: Bundle | undefined;
     const id = generateId();

--- a/packages/react-hooks/src/useSubscription/useSubscription.ts
+++ b/packages/react-hooks/src/useSubscription/useSubscription.ts
@@ -92,7 +92,10 @@ export function useSubscription(
     }
 
     let shouldSubscribe = false;
-    if (prevCriteriaRef.current !== effectiveCriteria || !deepEquals(prevMemoizedSubPropsRef.current, memoizedSubProps)) {
+    if (
+      prevCriteriaRef.current !== effectiveCriteria ||
+      !deepEquals(prevMemoizedSubPropsRef.current, memoizedSubProps)
+    ) {
       shouldSubscribe = true;
     }
 

--- a/packages/react-hooks/src/useSubscription/useSubscription.ts
+++ b/packages/react-hooks/src/useSubscription/useSubscription.ts
@@ -4,7 +4,7 @@ import type { SubscriptionEmitter, SubscriptionEventMap } from '@medplum/core';
 import { deepEquals } from '@medplum/core';
 import type { Bundle, Subscription } from '@medplum/fhirtypes';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
+import { useMedplum, useMedplumProfile } from '../MedplumProvider/MedplumProvider.context';
 
 const SUBSCRIPTION_DEBOUNCE_MS = 3000;
 
@@ -44,6 +44,12 @@ export function useSubscription(
   options?: UseSubscriptionOptions
 ): void {
   const medplum = useMedplum();
+  const profile = useMedplumProfile();
+  // When the user is not authenticated, the subscription becomes a no-op. Subscribing would
+  // create a `Subscription` resource and request a WebSocket binding token, both of which 401
+  // without a profile. Treating criteria as `undefined` skips all subscription work; when the
+  // user authenticates, `profile` changes and the effect re-runs to subscribe.
+  const effectiveCriteria = profile ? criteria : undefined;
   const [emitter, setEmitter] = useState<SubscriptionEmitter>();
   // We don't memoize the entire options object since it contains callbacks and if the callbacks change identity, we don't want to trigger a resubscribe to criteria
   const [memoizedSubProps, setMemoizedSubProps] = useState(options?.subscriptionProps);
@@ -86,7 +92,7 @@ export function useSubscription(
     }
 
     let shouldSubscribe = false;
-    if (prevCriteriaRef.current !== criteria || !deepEquals(prevMemoizedSubPropsRef.current, memoizedSubProps)) {
+    if (prevCriteriaRef.current !== effectiveCriteria || !deepEquals(prevMemoizedSubPropsRef.current, memoizedSubProps)) {
       shouldSubscribe = true;
     }
 
@@ -95,25 +101,25 @@ export function useSubscription(
     }
 
     // Set prev criteria and options to latest after checking them
-    prevCriteriaRef.current = criteria;
+    prevCriteriaRef.current = effectiveCriteria;
     prevMemoizedSubPropsRef.current = memoizedSubProps;
 
     // We do this after as to not immediately trigger re-render
-    if (shouldSubscribe && criteria) {
-      setEmitter(medplum.subscribeToCriteria(criteria, memoizedSubProps));
-    } else if (!criteria) {
+    if (shouldSubscribe && effectiveCriteria) {
+      setEmitter(medplum.subscribeToCriteria(effectiveCriteria, memoizedSubProps));
+    } else if (!effectiveCriteria) {
       setEmitter(undefined);
     }
 
     return () => {
       unsubTimerRef.current = setTimeout(() => {
         setEmitter(undefined);
-        if (criteria) {
-          medplum.unsubscribeFromCriteria(criteria, memoizedSubProps);
+        if (effectiveCriteria) {
+          medplum.unsubscribeFromCriteria(effectiveCriteria, memoizedSubProps);
         }
       }, SUBSCRIPTION_DEBOUNCE_MS);
     };
-  }, [medplum, criteria, memoizedSubProps]);
+  }, [medplum, effectiveCriteria, memoizedSubProps]);
 
   const emitterCallback = useCallback((event: SubscriptionEventMap['message']) => {
     callbackRef.current?.(event.payload);


### PR DESCRIPTION
It's currently possible that if a developer does not guard against unauthed access to component which mount `useSubscription` that unauthenticated requests to create subscriptions could be automatically attempted and cause noisy errors. This PR should clean that up by making the `useSubscription` hook no-op when unauthenticated.

Separately but related, we also now check that a user is authenticated before attempting to refresh subscriptions that have tokens which will expire soon (or maybe already expired while a tab was backgrounded).