### PR TITLE
Repository resource type access tracking

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@
 **/ccda/testdata/**/*
 **/mock/src/mocks/**/*.json
 **/packages/definitions/src/fhir/**/*
+packages/server/binary/**/*

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -599,5 +599,5 @@ export function invalidSearchOperator(operator: Operator, searchParameterCodeOrI
 }
 
 export function getSearchResourceTypes(searchRequest: SearchRequest): Iterable<ResourceType> {
-  return searchRequest.types ? searchRequest.types : [searchRequest.resourceType];
+  return searchRequest.types ?? [searchRequest.resourceType];
 }

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -597,3 +597,7 @@ export function invalidSearchOperator(operator: Operator, searchParameterCodeOrI
   }
   return badRequest(`Invalid operator ${operator} for ${searchParameterCodeOrId}`);
 }
+
+export function getSearchResourceTypes(searchRequest: SearchRequest): Iterable<ResourceType> {
+  return searchRequest.types ? searchRequest.types : [searchRequest.resourceType];
+}

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -598,6 +598,6 @@ export function invalidSearchOperator(operator: Operator, searchParameterCodeOrI
   return badRequest(`Invalid operator ${operator} for ${searchParameterCodeOrId}`);
 }
 
-export function getSearchResourceTypes(searchRequest: SearchRequest): Iterable<ResourceType> {
+export function getSearchResourceTypes(searchRequest: SearchRequest): ResourceType[] {
   return searchRequest.types ?? [searchRequest.resourceType];
 }

--- a/packages/fhir-router/src/batch.test.ts
+++ b/packages/fhir-router/src/batch.test.ts
@@ -1568,4 +1568,117 @@ describe('Batch', () => {
       expect(bundle.entry?.[1]?.response?.status).toStrictEqual('400');
     });
   });
+
+  describe('Transaction resource type tracking', () => {
+    test('Gathers resource types from transaction entries', async () => {
+      // Pre-create resources so the patch/delete/read entries succeed within the transaction
+      const serviceRequest = await repo.createResource<ServiceRequest>({
+        resourceType: 'ServiceRequest',
+        status: 'active',
+        intent: 'order',
+        subject: { display: 'Test' },
+      });
+      const observation = await repo.createResource<Observation>({
+        resourceType: 'Observation',
+        status: 'final',
+        code: { text: 'test' },
+      });
+      const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+
+      const spy = vi.spyOn(repo, 'withTransaction');
+      try {
+        const bundle = await processBatch(req, repo, router, {
+          resourceType: 'Bundle',
+          type: 'transaction',
+          entry: [
+            {
+              // create: type derived from the route (URL)
+              request: { method: 'POST', url: 'Organization' },
+              resource: { resourceType: 'Organization', name: 'Test Org' },
+            },
+            {
+              // PATCH: type comes from the URL, NOT the Parameters payload
+              request: { method: 'PATCH', url: 'ServiceRequest/' + serviceRequest.id },
+              resource: {
+                resourceType: 'Parameters',
+                parameter: [
+                  {
+                    name: 'operation',
+                    part: [
+                      { name: 'op', valueCode: 'replace' },
+                      { name: 'path', valueString: '/status' },
+                      { name: 'value', valueString: '"completed"' },
+                    ],
+                  },
+                ],
+              },
+            },
+            {
+              // DELETE: no entry.resource at all; type comes from the URL
+              request: { method: 'DELETE', url: 'Observation/' + observation.id },
+            },
+            {
+              // read: no entry.resource; type comes from the URL
+              request: { method: 'GET', url: 'Patient/' + patient.id },
+            },
+          ],
+        });
+
+        expect(bundle.type).toStrictEqual('transaction-response');
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        const { resourceTypes } = spy.mock.calls[0][1];
+        expect(Array.from(resourceTypes).sort()).toStrictEqual([
+          'Observation',
+          'Organization',
+          'Patient',
+          'ServiceRequest',
+        ]);
+        // The PATCH target type is recorded, not the Binary/Parameters payload
+        expect(Array.from(resourceTypes)).not.toContain('Parameters');
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    test('De-duplicates repeated resource types', async () => {
+      const patient1 = await repo.createResource<Patient>({ resourceType: 'Patient' });
+      const patient2 = await repo.createResource<Patient>({ resourceType: 'Patient' });
+
+      const spy = vi.spyOn(repo, 'withTransaction');
+      try {
+        await processBatch(req, repo, router, {
+          resourceType: 'Bundle',
+          type: 'transaction',
+          entry: [
+            { request: { method: 'GET', url: 'Patient/' + patient1.id } },
+            { request: { method: 'GET', url: 'Patient/' + patient2.id } },
+            { request: { method: 'POST', url: 'Patient' }, resource: { resourceType: 'Patient' } },
+          ],
+        });
+
+        const { resourceTypes } = spy.mock.calls[0][1];
+        expect(Array.from(resourceTypes)).toStrictEqual(['Patient']);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    test('Skips system-level entries with no resource type', async () => {
+      const spy = vi.spyOn(repo, 'withTransaction');
+      try {
+        // search-system has no resourceType route param, so it is under-reported
+        await processBatch(req, repo, router, {
+          resourceType: 'Bundle',
+          type: 'transaction',
+          entry: [{ request: { method: 'GET', url: '?_type=Observation' } }],
+        });
+
+        const { resourceTypes } = spy.mock.calls[0][1];
+        expect(Array.from(resourceTypes)).toStrictEqual([]);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
 });

--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -201,7 +201,10 @@ export class BatchProcessor {
           this.state = cloneState(preTransactionState);
           return this.processEntriesAndBuild();
         }),
-      { serializable: bundleInfo.requiresStrongTransaction }
+      {
+        serializable: bundleInfo.requiresStrongTransaction,
+        resourceTypes: [], // TODO: Determine resource types from bundle
+      }
     );
   }
 

--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -18,6 +18,7 @@ import type {
   OperationOutcome,
   ParametersParameter,
   Resource,
+  ResourceType,
 } from '@medplum/fhirtypes';
 import type { IncomingHttpHeaders } from 'node:http';
 import type { FhirRequest, FhirRouteHandler, FhirRouteMetadata, FhirRouter, RestInteraction } from './fhirrouter';
@@ -29,13 +30,17 @@ const maxSerializableTransactionEntries = 8;
 
 const localBundleReference = /urn(:|%3A)uuid(:|%3A)[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
 
-type BundleEntryIdentity = { placeholder: string; reference: string };
+interface BundleEntryIdentity {
+  placeholder: string;
+  reference: string;
+}
 
-export type BundlePreprocessInfo = {
+export interface BundlePreprocessInfo {
   ordering: number[];
   requiresStrongTransaction: boolean;
   updates: number;
-};
+  resourceTypes: Set<ResourceType>;
+}
 
 /**
  * The durable, JSON-serializable state produced by preprocessing a batch bundle. This is
@@ -203,7 +208,7 @@ export class BatchProcessor {
         }),
       {
         serializable: bundleInfo.requiresStrongTransaction,
-        resourceTypes: [], // TODO: Determine resource types from bundle
+        resourceTypes: bundleInfo.resourceTypes,
       }
     );
   }
@@ -251,6 +256,7 @@ export class BatchProcessor {
       bundle: this.bundle,
       bundleInfo: {
         ordering: this.bundleInfo.ordering,
+        resourceTypes: this.bundleInfo.resourceTypes,
         requiresStrongTransaction: this.bundleInfo.requiresStrongTransaction,
         updates: this.bundleInfo.updates,
       },
@@ -384,6 +390,7 @@ export class BatchProcessor {
       'history-instance': [],
     };
     const seenIdentities = new Set<string>();
+    const resourceTypes = new Set<ResourceType>();
     let requiresStrongTransaction = false;
     let updates = 0;
 
@@ -412,6 +419,17 @@ export class BatchProcessor {
           badRequest(`Invalid REST interaction in batch: ${entry.request?.method} ${entry.request?.url}`)
         );
       }
+
+      // Track the resource type touched by this entry, derived from the parsed route.
+      // The URL is used rather than entry.resource since reads/deletes have no resource
+      // and PATCH carries a Binary/Parameters payload instead of the target resource.
+      // System-level interactions (search-system, history-system, nested bundles) have no
+      // resource type and are skipped. GraphQL and custom operations can touch arbitrary
+      // resource types that are not derivable from the URL, so they are under-reported here.
+      const entryResourceType = route?.params?.resourceType as ResourceType | undefined;
+      if (entryResourceType) {
+        resourceTypes.add(entryResourceType);
+      }
       if (interaction === 'create' && entry.request?.ifNoneExist) {
         // Conditional create requires strong (serializable) transaction to
         // guarantee uniqueness of created resource
@@ -438,6 +456,7 @@ export class BatchProcessor {
       ordering,
       requiresStrongTransaction,
       updates,
+      resourceTypes,
     };
   }
 

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -36,8 +36,10 @@ export type ReadHistoryOptions = {
   limit?: number;
 };
 
+type ResourceTypeInput = ResourceType | readonly ResourceType[] | ReadonlySet<ResourceType>;
+
 export interface TransactionOptions {
-  readonly resourceTypes: Iterable<ResourceType>;
+  readonly resourceTypes: ResourceTypeInput;
   readonly serializable?: boolean;
 }
 

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -12,6 +12,7 @@ import {
   deepClone,
   evalFhirPath,
   generateId,
+  getSearchResourceTypes,
   globalSchema,
   matchesSearchRequest,
   multipleMatches,
@@ -20,7 +21,7 @@ import {
   preconditionFailed,
   stringify,
 } from '@medplum/core';
-import type { Bundle, OperationOutcome, Parameters, Reference, Resource } from '@medplum/fhirtypes';
+import type { Bundle, OperationOutcome, Parameters, Reference, Resource, ResourceType } from '@medplum/fhirtypes';
 
 export type CreateResourceOptions = {
   assignedId?: boolean;
@@ -34,6 +35,11 @@ export type ReadHistoryOptions = {
   offset?: number;
   limit?: number;
 };
+
+export interface TransactionOptions {
+  readonly resourceTypes: Iterable<ResourceType>;
+  readonly serializable?: boolean;
+}
 
 export const RepositoryMode = {
   READER: 'reader',
@@ -195,10 +201,12 @@ export abstract class FhirRepository {
    * Runs a callback function within a transaction.
    *
    * @param callback - The callback function to be run within a transaction.
+   * @param options - The transaction options.
+   * @returns The result of the callback function.
    */
   abstract withTransaction<TResult>(
     callback: (txRepo: this) => Promise<TResult>,
-    options?: { serializable?: boolean }
+    options: TransactionOptions
   ): Promise<TResult>;
 
   /**
@@ -280,7 +288,10 @@ export abstract class FhirRepository {
         const createdResource = await txRepo.createResource(resource, options);
         return { resource: createdResource, outcome: created };
       },
-      { serializable: true } // Requires strong transactional guarantees to ensure unique resource creation
+      {
+        resourceTypes: getSearchResourceTypes(search),
+        serializable: true, // serializable to ensure unique resource creation
+      }
     );
   }
 
@@ -340,7 +351,7 @@ export abstract class FhirRepository {
         const updated = await txRepo.updateResource({ ...resource, id: existing.id }, options);
         return { resource: updated, outcome: allOk };
       },
-      { serializable: true }
+      { serializable: true, resourceTypes: getSearchResourceTypes(search) }
     );
   }
 
@@ -374,7 +385,7 @@ export abstract class FhirRepository {
         const resource = matches[0];
         await txRepo.deleteResource(resource.resourceType, resource.id);
       },
-      { serializable: true }
+      { serializable: true, resourceTypes: getSearchResourceTypes(search) }
     );
   }
 
@@ -395,7 +406,7 @@ export abstract class FhirRepository {
         const resource = matches[0];
         return txRepo.patchResource(resource.resourceType, resource.id, patch);
       },
-      { serializable: true }
+      { serializable: true, resourceTypes: getSearchResourceTypes(search) }
     );
   }
 }

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -141,7 +141,11 @@ export async function inviteUser(request: ServerInviteRequest): Promise<ServerIn
 
         return txRepo.conditionalCreate(userResource, searchRequest);
       },
-      { serializable: true }
+      {
+        resourceTypes: ['ProjectMembership', 'User'],
+        source: 'inviteUser.upsertUser',
+        serializable: true,
+      }
     );
     user = result;
     existingUser = !isCreated(outcome);
@@ -469,7 +473,11 @@ async function upsertProjectMembership(
         return createProjectMembership(txRepo, user, project, profile, partialMembership);
       }
     },
-    { serializable: true }
+    {
+      resourceTypes: ['ProjectMembership', profile.resourceType],
+      source: 'upsertProjectMembership',
+      serializable: true,
+    }
   );
 
   return membership;

--- a/packages/server/src/admin/project.ts
+++ b/packages/server/src/admin/project.ts
@@ -159,30 +159,27 @@ projectAdminRouter.delete('/:projectId/members/:membershipId', async (req: Reque
   // Check if the user is project-scoped (has a project field matching the current project)
   if (user.project?.reference === getReferenceString(ctx.project)) {
     // Wrap search and delete operations in a transaction
-    await systemRepo.withTransaction(async (txRepo) => {
-      // Check if there are other ProjectMemberships for this user
-      // (search before deleting to get accurate count)
-      const otherMemberships = await txRepo.searchResources<ProjectMembership>({
-        resourceType: 'ProjectMembership',
-        filters: [
-          {
-            code: 'user',
-            operator: Operator.EQUALS,
-            value: getReferenceString(user),
-          },
-        ],
-        count: 2,
-      });
+    await systemRepo.withTransaction(
+      async (txRepo) => {
+        // Check if there are other ProjectMemberships for this user
+        // (search before deleting to get accurate count)
+        const otherMemberships = await txRepo.searchResources<ProjectMembership>({
+          resourceType: 'ProjectMembership',
+          filters: [{ code: 'user', operator: Operator.EQUALS, value: getReferenceString(user) }],
+          count: 2,
+        });
 
-      // Delete the ProjectMembership
-      await txRepo.deleteResource('ProjectMembership', membershipId);
+        // Delete the ProjectMembership
+        await txRepo.deleteResource('ProjectMembership', membershipId);
 
-      // Delete the User resource if it's project-scoped and this was their only membership
-      // (project-scoped users should only have memberships in one project)
-      if (otherMemberships.length === 1 && otherMemberships[0].id === membershipId) {
-        await txRepo.deleteResource('User', user.id);
-      }
-    });
+        // Delete the User resource if it's project-scoped and this was their only membership
+        // (project-scoped users should only have memberships in one project)
+        if (otherMemberships.length === 1 && otherMemberships[0].id === membershipId) {
+          await txRepo.deleteResource('User', user.id);
+        }
+      },
+      { resourceTypes: ['ProjectMembership', 'User'], source: 'projectAdmin.deleteMember' }
+    );
   } else {
     // User is not project-scoped, just delete the ProjectMembership
     await ctx.repo.deleteResource('ProjectMembership', membershipId);

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -511,7 +511,14 @@ superAdminRouter.post(
 
     const startTime = Date.now();
     const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be an input to this route
-    await systemRepo.getDatabaseClient(DatabaseMode.WRITER).query(query);
+    await systemRepo
+      .getDatabaseClient({
+        mode: DatabaseMode.WRITER,
+        operation: 'write',
+        resourceTypes: [],
+        source: 'admin.super.updateTableSettings',
+      })
+      .query(query);
     globalLogger.info('[Super Admin]: Table settings updated', {
       tableName: req.body.tableName,
       settings: req.body.settings,
@@ -562,7 +569,14 @@ superAdminRouter.post(
     await sendAsyncResponse(req, res, async () => {
       const startTime = Date.now();
       const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be an input to this route
-      await systemRepo.getDatabaseClient(DatabaseMode.WRITER).query(query);
+      await systemRepo
+        .getDatabaseClient({
+          mode: DatabaseMode.WRITER,
+          operation: 'write',
+          resourceTypes: [],
+          source: 'admin.super.vacuum',
+        })
+        .query(query);
       globalLogger.info('[Super Admin]: Vacuum completed', {
         tableNames: req.body.tableNames,
         vacuum,

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -24,6 +24,7 @@ import { DatabaseMode, getDatabasePool } from '../database';
 import { AsyncJobExecutor, sendAsyncResponse } from '../fhir/operations/utils/asyncjobexecutor';
 import { invalidRequest, sendOutcome } from '../fhir/outcomes';
 import { getShardSystemRepo, Repository } from '../fhir/repo';
+import { repoAccess } from '../fhir/repository/access-tracker';
 import { minCursorBasedSearchPageSize } from '../fhir/search';
 import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
 import { isValidTableName } from '../fhir/sql';
@@ -511,14 +512,11 @@ superAdminRouter.post(
 
     const startTime = Date.now();
     const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be an input to this route
-    await systemRepo
-      .getDatabaseClient({
-        mode: DatabaseMode.WRITER,
-        operation: 'write',
-        resourceTypes: [],
-        source: 'admin.super.updateTableSettings',
-      })
-      .query(query);
+    await systemRepo.executeRawSql(
+      query,
+      undefined,
+      repoAccess.sqlWriteConfig({ source: 'superAdminRouter.tableSettings' })
+    );
     globalLogger.info('[Super Admin]: Table settings updated', {
       tableName: req.body.tableName,
       settings: req.body.settings,
@@ -569,14 +567,11 @@ superAdminRouter.post(
     await sendAsyncResponse(req, res, async () => {
       const startTime = Date.now();
       const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be an input to this route
-      await systemRepo
-        .getDatabaseClient({
-          mode: DatabaseMode.WRITER,
-          operation: 'write',
-          resourceTypes: [],
-          source: 'admin.super.vacuum',
-        })
-        .query(query);
+      await systemRepo.executeRawSql(
+        query,
+        undefined,
+        repoAccess.sqlWriteConfig({ source: 'superAdminRouter.vacuum' })
+      );
       globalLogger.info('[Super Admin]: Vacuum completed', {
         tableNames: req.body.tableNames,
         vacuum,

--- a/packages/server/src/auth/verifyemail.ts
+++ b/packages/server/src/auth/verifyemail.ts
@@ -38,10 +38,13 @@ export async function verifyEmailHandler(req: Request, res: Response): Promise<v
 
   const user = await systemRepo.readReference(securityRequest.user);
 
-  await systemRepo.withTransaction(async (txRepo) => {
-    await txRepo.updateResource<User>({ ...user, emailVerified: true });
-    await txRepo.updateResource<UserSecurityRequest>({ ...securityRequest, used: true });
-  });
+  await systemRepo.withTransaction(
+    async (txRepo) => {
+      await txRepo.updateResource<User>({ ...user, emailVerified: true });
+      await txRepo.updateResource<UserSecurityRequest>({ ...securityRequest, used: true });
+    },
+    { resourceTypes: ['User', 'UserSecurityRequest'], source: 'verifyEmailHandler' }
+  );
 
   if (securityRequest.redirectUri) {
     // Send a "redirect", but don't actually follow it, because the client may want to handle the redirect themselves (e.g. in a React app).

--- a/packages/server/src/fhir/batch/checkpoint-store.test.ts
+++ b/packages/server/src/fhir/batch/checkpoint-store.test.ts
@@ -19,7 +19,7 @@ describe('BatchCheckpointStore', () => {
   function makeInitialState(): BatchInitialState {
     return {
       bundle: { resourceType: 'Bundle', type: 'batch', entry: [{ request: { method: 'GET', url: 'Patient' } }] },
-      bundleInfo: { ordering: [0], requiresStrongTransaction: false, updates: 0 },
+      bundleInfo: { ordering: [0], resourceTypes: new Set(['Patient']), requiresStrongTransaction: false, updates: 0 },
       resolvedIdentities: { 'urn:uuid:abc': 'Patient/123' },
       preprocessResults: {},
     };

--- a/packages/server/src/fhir/batch/checkpoint-store.ts
+++ b/packages/server/src/fhir/batch/checkpoint-store.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { ILogger } from '@medplum/core';
 import { ContentType, normalizeErrorString } from '@medplum/core';
-import type { BatchInitialState } from '@medplum/fhir-router';
-import type { Bundle, BundleEntry } from '@medplum/fhirtypes';
+import type { BatchInitialState, BundlePreprocessInfo } from '@medplum/fhir-router';
+import type { Bundle, BundleEntry, ResourceType } from '@medplum/fhirtypes';
 import { getBinaryStorage } from '../../storage/loader';
 import { readStreamToString } from '../../util/streams';
 
@@ -97,10 +97,16 @@ export class BatchCheckpointStore {
 
   /**
    * Persists the initial state produced by preprocessing. Written once, before processing entries.
+   * `bundleInfo.resourceTypes` is a `Set`, which `JSON.stringify` would silently drop, so it is
+   * persisted as an array and revived in {@link loadInitialState}.
    * @param state - The durable initial state.
    */
   async saveInitialState(state: BatchInitialState): Promise<void> {
-    await this.writeFile(this.stateKey(), ContentType.JSON, JSON.stringify(state));
+    const persisted: PersistedInitialState = {
+      ...state,
+      bundleInfo: { ...state.bundleInfo, resourceTypes: Array.from(state.bundleInfo.resourceTypes) },
+    };
+    await this.writeFile(this.stateKey(), ContentType.JSON, JSON.stringify(persisted));
   }
 
   /**
@@ -108,7 +114,11 @@ export class BatchCheckpointStore {
    * @returns The durable initial state.
    */
   async loadInitialState(): Promise<BatchInitialState> {
-    return JSON.parse(await this.readFile(this.stateKey())) as BatchInitialState;
+    const persisted = JSON.parse(await this.readFile(this.stateKey())) as PersistedInitialState;
+    return {
+      ...persisted,
+      bundleInfo: { ...persisted.bundleInfo, resourceTypes: new Set(persisted.bundleInfo.resourceTypes) },
+    };
   }
 
   /**
@@ -199,6 +209,12 @@ export class BatchCheckpointStore {
       });
     }
   }
+}
+
+/** The JSON-safe on-disk form of {@link BatchInitialState}. */
+interface PersistedInitialState extends Omit<BatchInitialState, 'bundleInfo'> {
+  // TODO{v5.2} make resourceTypes required
+  bundleInfo: Omit<BundlePreprocessInfo, 'resourceTypes'> & { resourceTypes?: ResourceType[] };
 }
 
 interface RunWithConcurrencyOptions {

--- a/packages/server/src/fhir/lookups/reference.test.ts
+++ b/packages/server/src/fhir/lookups/reference.test.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import type { Observation, Patient, ServiceRequest } from '@medplum/fhirtypes';
+import type { Observation, Patient, ResourceType, ServiceRequest } from '@medplum/fhirtypes';
 import { randomUUID } from 'node:crypto';
 import { vi } from 'vitest';
 import { initAppServices, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
 import { DatabaseMode } from '../../database';
+import type { ExecuteSqlOptions } from '../repo';
 import { getGlobalSystemRepo } from '../repo';
 import { lookupTables } from '../searchparameter';
 import type { ReferenceTableRow } from './reference';
@@ -34,6 +35,17 @@ describe('ReferenceTable', () => {
     return a.code.localeCompare(b.code);
   }
 
+  function getReferenceTestClient(
+    resourceTypes: Partial<ExecuteSqlOptions> & { resourceTypes: ResourceType[] }
+  ): ReturnType<typeof systemRepo.getDatabaseClient> {
+    return systemRepo.getDatabaseClient({
+      ...resourceTypes,
+      mode: DatabaseMode.WRITER,
+      operation: 'write',
+      source: 'reference.test',
+    });
+  }
+
   describe('getColumnName', () => {
     test('throws not implemented error', () => {
       expect(() => refTable.getColumnName()).toThrow('ReferenceTable.getColumnName not implemented');
@@ -42,14 +54,14 @@ describe('ReferenceTable', () => {
 
   describe('getExistingRows', () => {
     test('returns empty array for empty resources', async () => {
-      const rows = await refTable.getExistingRows(systemRepo.getDatabaseClient(DatabaseMode.WRITER), []);
+      const rows = await refTable.getExistingRows(getReferenceTestClient({ resourceTypes: ['Observation'] }), []);
       expect(rows).toEqual([]);
     });
   });
 
   describe('batchInsertRows', () => {
     test('returns early for empty values without querying DB', async () => {
-      const client = systemRepo.getDatabaseClient(DatabaseMode.WRITER);
+      const client = getReferenceTestClient({ resourceTypes: ['Observation'] });
       const querySpy = vi.spyOn(client, 'query');
 
       await refTable.batchInsertRows(client, 'Observation', []);
@@ -61,7 +73,7 @@ describe('ReferenceTable', () => {
 
   describe('batchIndexResources', () => {
     test('returns early for empty resources array', async () => {
-      const client = systemRepo.getDatabaseClient(DatabaseMode.WRITER);
+      const client = getReferenceTestClient({ resourceTypes: ['Observation'] });
       const querySpy = vi.spyOn(client, 'query');
 
       // Should not throw and should return early
@@ -83,7 +95,9 @@ describe('ReferenceTable', () => {
         code: { coding: [{ system: 'http://loinc.org', code: '3141-9' }] },
       });
 
-      const createRows = await refTable.getExistingRows(systemRepo.getDatabaseClient(DatabaseMode.WRITER), [obs]);
+      const createRows = await refTable.getExistingRows(getReferenceTestClient({ resourceTypes: [obs.resourceType] }), [
+        obs,
+      ]);
       expect(createRows).toHaveLength(2);
       expect(createRows.sort(sortFn)).toStrictEqual([
         {
@@ -104,7 +118,9 @@ describe('ReferenceTable', () => {
         encounter: { reference: 'Encounter/' + encounterId },
       });
 
-      const updateRows = await refTable.getExistingRows(systemRepo.getDatabaseClient(DatabaseMode.WRITER), [obs]);
+      const updateRows = await refTable.getExistingRows(getReferenceTestClient({ resourceTypes: [obs.resourceType] }), [
+        obs,
+      ]);
       expect(updateRows).toHaveLength(3);
       expect(updateRows.sort(sortFn)).toStrictEqual([
         {
@@ -125,7 +141,9 @@ describe('ReferenceTable', () => {
       ]);
 
       await systemRepo.deleteResource('Observation', obs.id);
-      const deleteRows = await refTable.getExistingRows(systemRepo.getDatabaseClient(DatabaseMode.WRITER), [obs]);
+      const deleteRows = await refTable.getExistingRows(getReferenceTestClient({ resourceTypes: ['Observation'] }), [
+        obs,
+      ]);
       expect(deleteRows).toHaveLength(0);
     });
 
@@ -143,7 +161,11 @@ describe('ReferenceTable', () => {
       };
 
       await expect(
-        refTable.batchIndexResources(systemRepo.getDatabaseClient(DatabaseMode.WRITER), [obs, patient], true)
+        refTable.batchIndexResources(
+          getReferenceTestClient({ resourceTypes: [obs.resourceType, patient.resourceType] }),
+          [obs, patient],
+          true
+        )
       ).rejects.toThrow('batchIndexResources must be called with resources of the same type: Patient vs Observation');
     });
 
@@ -163,7 +185,7 @@ describe('ReferenceTable', () => {
         status: 'final', // Change something else, not the reference
       });
 
-      const rows = await refTable.getExistingRows(systemRepo.getDatabaseClient(DatabaseMode.WRITER), [obs]);
+      const rows = await refTable.getExistingRows(getReferenceTestClient({ resourceTypes: [obs.resourceType] }), [obs]);
       expect(rows).toHaveLength(2);
       expect(rows.sort(sortFn)).toStrictEqual([
         {
@@ -197,11 +219,19 @@ describe('ReferenceTable', () => {
 
       // This should process all resources with yielding between batches
       await expect(
-        refTable.batchIndexResources(systemRepo.getDatabaseClient(DatabaseMode.WRITER), resources, true, batchSize)
+        refTable.batchIndexResources(
+          getReferenceTestClient({ resourceTypes: [resources[0].resourceType] }),
+          resources,
+          true,
+          batchSize
+        )
       ).resolves.toBeUndefined();
 
       // Verify at least one resource was indexed
-      const rows = await refTable.getExistingRows(systemRepo.getDatabaseClient(DatabaseMode.WRITER), [resources[0]]);
+      const rows = await refTable.getExistingRows(
+        getReferenceTestClient({ resourceTypes: [resources[0].resourceType] }),
+        [resources[0]]
+      );
       expect(rows.length).toBeGreaterThan(0);
     });
   });
@@ -221,7 +251,7 @@ describe('ReferenceTable', () => {
       });
 
       await expect(
-        refTable.batchIndexResources(systemRepo.getDatabaseClient(DatabaseMode.WRITER), [obs], true)
+        refTable.batchIndexResources(getReferenceTestClient({ resourceTypes: [obs.resourceType] }), [obs], true)
       ).rejects.toThrow('Test extraction error');
 
       extractValuesSpy.mockRestore();
@@ -248,7 +278,10 @@ describe('ReferenceTable', () => {
 
       // The requester reference uses a local reference to contained resource
       // This tests that references are properly extracted
-      const rows = await refTable.getExistingRows(systemRepo.getDatabaseClient(DatabaseMode.WRITER), [serviceRequest]);
+      const rows = await refTable.getExistingRows(
+        getReferenceTestClient({ resourceTypes: [serviceRequest.resourceType] }),
+        [serviceRequest]
+      );
       expect(rows.length).toBeGreaterThan(0);
 
       // Verify the subject reference was indexed (patient reference)
@@ -264,7 +297,9 @@ describe('ReferenceTable', () => {
         name: [{ text: 'Test Patient' }],
       });
 
-      const rows = await refTable.getExistingRows(systemRepo.getDatabaseClient(DatabaseMode.WRITER), [patient]);
+      const rows = await refTable.getExistingRows(getReferenceTestClient({ resourceTypes: [patient.resourceType] }), [
+        patient,
+      ]);
       // Patient with no references should have no reference rows
       expect(rows).toHaveLength(0);
     });

--- a/packages/server/src/fhir/lookups/reference.test.ts
+++ b/packages/server/src/fhir/lookups/reference.test.ts
@@ -6,10 +6,10 @@ import { randomUUID } from 'node:crypto';
 import { vi } from 'vitest';
 import { initAppServices, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
-import { DatabaseMode } from '../../database';
-import type { ExecuteSqlOptions } from '../repo';
 import { getGlobalSystemRepo } from '../repo';
+import { repoAccess } from '../repository/access-tracker';
 import { lookupTables } from '../searchparameter';
+import type { PgQueryable } from '../sql';
 import type { ReferenceTableRow } from './reference';
 import { ReferenceTable } from './reference';
 
@@ -35,15 +35,8 @@ describe('ReferenceTable', () => {
     return a.code.localeCompare(b.code);
   }
 
-  function getReferenceTestClient(
-    resourceTypes: Partial<ExecuteSqlOptions> & { resourceTypes: ResourceType[] }
-  ): ReturnType<typeof systemRepo.getDatabaseClient> {
-    return systemRepo.getDatabaseClient({
-      ...resourceTypes,
-      mode: DatabaseMode.WRITER,
-      operation: 'write',
-      source: 'reference.test',
-    });
+  function getReferenceTestClient(resourceTypes: ResourceType | ResourceType[]): PgQueryable {
+    return systemRepo.getDatabaseClient(repoAccess.sqlWrite(resourceTypes));
   }
 
   describe('getColumnName', () => {
@@ -54,14 +47,14 @@ describe('ReferenceTable', () => {
 
   describe('getExistingRows', () => {
     test('returns empty array for empty resources', async () => {
-      const rows = await refTable.getExistingRows(getReferenceTestClient({ resourceTypes: ['Observation'] }), []);
+      const rows = await refTable.getExistingRows(getReferenceTestClient('Observation'), []);
       expect(rows).toEqual([]);
     });
   });
 
   describe('batchInsertRows', () => {
     test('returns early for empty values without querying DB', async () => {
-      const client = getReferenceTestClient({ resourceTypes: ['Observation'] });
+      const client = getReferenceTestClient('Observation');
       const querySpy = vi.spyOn(client, 'query');
 
       await refTable.batchInsertRows(client, 'Observation', []);
@@ -73,7 +66,7 @@ describe('ReferenceTable', () => {
 
   describe('batchIndexResources', () => {
     test('returns early for empty resources array', async () => {
-      const client = getReferenceTestClient({ resourceTypes: ['Observation'] });
+      const client = getReferenceTestClient('Observation');
       const querySpy = vi.spyOn(client, 'query');
 
       // Should not throw and should return early
@@ -95,9 +88,7 @@ describe('ReferenceTable', () => {
         code: { coding: [{ system: 'http://loinc.org', code: '3141-9' }] },
       });
 
-      const createRows = await refTable.getExistingRows(getReferenceTestClient({ resourceTypes: [obs.resourceType] }), [
-        obs,
-      ]);
+      const createRows = await refTable.getExistingRows(getReferenceTestClient(obs.resourceType), [obs]);
       expect(createRows).toHaveLength(2);
       expect(createRows.sort(sortFn)).toStrictEqual([
         {
@@ -118,9 +109,7 @@ describe('ReferenceTable', () => {
         encounter: { reference: 'Encounter/' + encounterId },
       });
 
-      const updateRows = await refTable.getExistingRows(getReferenceTestClient({ resourceTypes: [obs.resourceType] }), [
-        obs,
-      ]);
+      const updateRows = await refTable.getExistingRows(getReferenceTestClient(obs.resourceType), [obs]);
       expect(updateRows).toHaveLength(3);
       expect(updateRows.sort(sortFn)).toStrictEqual([
         {
@@ -141,9 +130,7 @@ describe('ReferenceTable', () => {
       ]);
 
       await systemRepo.deleteResource('Observation', obs.id);
-      const deleteRows = await refTable.getExistingRows(getReferenceTestClient({ resourceTypes: ['Observation'] }), [
-        obs,
-      ]);
+      const deleteRows = await refTable.getExistingRows(getReferenceTestClient('Observation'), [obs]);
       expect(deleteRows).toHaveLength(0);
     });
 
@@ -162,7 +149,7 @@ describe('ReferenceTable', () => {
 
       await expect(
         refTable.batchIndexResources(
-          getReferenceTestClient({ resourceTypes: [obs.resourceType, patient.resourceType] }),
+          getReferenceTestClient([obs.resourceType, patient.resourceType]),
           [obs, patient],
           true
         )
@@ -185,7 +172,7 @@ describe('ReferenceTable', () => {
         status: 'final', // Change something else, not the reference
       });
 
-      const rows = await refTable.getExistingRows(getReferenceTestClient({ resourceTypes: [obs.resourceType] }), [obs]);
+      const rows = await refTable.getExistingRows(getReferenceTestClient(obs.resourceType), [obs]);
       expect(rows).toHaveLength(2);
       expect(rows.sort(sortFn)).toStrictEqual([
         {
@@ -219,19 +206,11 @@ describe('ReferenceTable', () => {
 
       // This should process all resources with yielding between batches
       await expect(
-        refTable.batchIndexResources(
-          getReferenceTestClient({ resourceTypes: [resources[0].resourceType] }),
-          resources,
-          true,
-          batchSize
-        )
+        refTable.batchIndexResources(getReferenceTestClient(resources[0].resourceType), resources, true, batchSize)
       ).resolves.toBeUndefined();
 
       // Verify at least one resource was indexed
-      const rows = await refTable.getExistingRows(
-        getReferenceTestClient({ resourceTypes: [resources[0].resourceType] }),
-        [resources[0]]
-      );
+      const rows = await refTable.getExistingRows(getReferenceTestClient(resources[0].resourceType), [resources[0]]);
       expect(rows.length).toBeGreaterThan(0);
     });
   });
@@ -250,9 +229,9 @@ describe('ReferenceTable', () => {
         throw extractError;
       });
 
-      await expect(
-        refTable.batchIndexResources(getReferenceTestClient({ resourceTypes: [obs.resourceType] }), [obs], true)
-      ).rejects.toThrow('Test extraction error');
+      await expect(refTable.batchIndexResources(getReferenceTestClient(obs.resourceType), [obs], true)).rejects.toThrow(
+        'Test extraction error'
+      );
 
       extractValuesSpy.mockRestore();
     });
@@ -278,10 +257,9 @@ describe('ReferenceTable', () => {
 
       // The requester reference uses a local reference to contained resource
       // This tests that references are properly extracted
-      const rows = await refTable.getExistingRows(
-        getReferenceTestClient({ resourceTypes: [serviceRequest.resourceType] }),
-        [serviceRequest]
-      );
+      const rows = await refTable.getExistingRows(getReferenceTestClient(serviceRequest.resourceType), [
+        serviceRequest,
+      ]);
       expect(rows.length).toBeGreaterThan(0);
 
       // Verify the subject reference was indexed (patient reference)
@@ -297,9 +275,7 @@ describe('ReferenceTable', () => {
         name: [{ text: 'Test Patient' }],
       });
 
-      const rows = await refTable.getExistingRows(getReferenceTestClient({ resourceTypes: [patient.resourceType] }), [
-        patient,
-      ]);
+      const rows = await refTable.getExistingRows(getReferenceTestClient(patient.resourceType), [patient]);
       // Patient with no references should have no reference rows
       expect(rows).toHaveLength(0);
     });

--- a/packages/server/src/fhir/operations/cancel.ts
+++ b/packages/server/src/fhir/operations/cancel.ts
@@ -54,7 +54,11 @@ export async function appointmentCancelHandler(req: FhirRequest): Promise<FhirRe
       await Promise.all(slots.map((slot) => txRepo.deleteResource('Slot', slot.id)));
       return updatedAppointment;
     },
-    { serializable: true }
+    {
+      resourceTypes: ['Appointment', 'Slot'],
+      source: 'appointmentCancelHandler',
+      serializable: true,
+    }
   );
 
   return [allOk, buildOutputParameters(cancelOperation, updatedAppointment)];

--- a/packages/server/src/fhir/operations/codesystemimport.ts
+++ b/packages/server/src/fhir/operations/codesystemimport.ts
@@ -105,6 +105,9 @@ export async function codeSystemImportHandler(req: FhirRequest): Promise<FhirRes
 
   try {
     await repo.withTransaction(async (txRepo) => {
+      // `importCodeSystem` does not read/write any resource tables, only derivative tables, so we can
+      // drop down to utilizing a raw database client here and opt-out of resource type access tracking
+      // TODO: this should probably report access of "CodeSystem" to the access tracker.
       const db = txRepo.getDatabaseClient(DatabaseMode.WRITER);
       await importCodeSystem(db, codeSystem, params.concept, params.property, params.designation);
     });

--- a/packages/server/src/fhir/operations/codesystemimport.ts
+++ b/packages/server/src/fhir/operations/codesystemimport.ts
@@ -5,7 +5,7 @@ import { OperationOutcomeError, allOk, badRequest, forbidden, normalizeOperation
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { CodeSystem, CodeSystemProperty, Coding, OperationDefinitionParameter } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
-import { DatabaseMode } from '../../database';
+import { repoAccess } from '../repository/access-tracker';
 import type { PgQueryable } from '../sql';
 import { Condition, InsertQuery, SelectQuery } from '../sql';
 import { makeOperationDefinition } from './definitions';
@@ -107,12 +107,9 @@ export async function codeSystemImportHandler(req: FhirRequest): Promise<FhirRes
     await repo.withTransaction(
       async (txRepo) => {
         // `importCodeSystem` operates only on CodeSystem derivative tables
-        const db = txRepo.getDatabaseClient({
-          mode: DatabaseMode.WRITER,
-          operation: 'write',
-          resourceTypes: ['CodeSystem'],
-          source: 'codeSystemImportHandler.client',
-        });
+        const db = txRepo.getDatabaseClient(
+          repoAccess.sqlWrite('CodeSystem', { source: 'codeSystemImportHandler.client' })
+        );
         await importCodeSystem(db, codeSystem, params.concept, params.property, params.designation);
       },
       { resourceTypes: ['CodeSystem'], source: 'codeSystemImportHandler' }

--- a/packages/server/src/fhir/operations/codesystemimport.ts
+++ b/packages/server/src/fhir/operations/codesystemimport.ts
@@ -104,13 +104,19 @@ export async function codeSystemImportHandler(req: FhirRequest): Promise<FhirRes
   }
 
   try {
-    await repo.withTransaction(async (txRepo) => {
-      // `importCodeSystem` does not read/write any resource tables, only derivative tables, so we can
-      // drop down to utilizing a raw database client here and opt-out of resource type access tracking
-      // TODO: this should probably report access of "CodeSystem" to the access tracker.
-      const db = txRepo.getDatabaseClient(DatabaseMode.WRITER);
-      await importCodeSystem(db, codeSystem, params.concept, params.property, params.designation);
-    });
+    await repo.withTransaction(
+      async (txRepo) => {
+        // `importCodeSystem` operates only on CodeSystem derivative tables
+        const db = txRepo.getDatabaseClient({
+          mode: DatabaseMode.WRITER,
+          operation: 'write',
+          resourceTypes: ['CodeSystem'],
+          source: 'codeSystemImportHandler.client',
+        });
+        await importCodeSystem(db, codeSystem, params.concept, params.property, params.designation);
+      },
+      { resourceTypes: ['CodeSystem'], source: 'codeSystemImportHandler' }
+    );
   } catch (err) {
     return [normalizeOperationOutcome(err)];
   }

--- a/packages/server/src/fhir/operations/conceptmapimport.ts
+++ b/packages/server/src/fhir/operations/conceptmapimport.ts
@@ -120,6 +120,9 @@ export async function conceptMapImportHandler(req: FhirRequest): Promise<FhirRes
   }
 
   await repo.withTransaction(async (txRepo) => {
+    // `importConceptMap` does not read/write any resource tables, only derivative tables, so we can
+    // drop down to utilizing a raw database client here and opt-out of resource type access tracking
+    // TODO: this should probably report access of "ConceptMap" to the access tracker.
     const db = txRepo.getDatabaseClient(DatabaseMode.WRITER);
     return importConceptMap(db, conceptMap, params.mapping);
   });

--- a/packages/server/src/fhir/operations/conceptmapimport.ts
+++ b/packages/server/src/fhir/operations/conceptmapimport.ts
@@ -119,13 +119,19 @@ export async function conceptMapImportHandler(req: FhirRequest): Promise<FhirRes
     return [badRequest('ConceptMap to import into must be specified', `Parameters.parameter.where(name = 'url')`)];
   }
 
-  await repo.withTransaction(async (txRepo) => {
-    // `importConceptMap` does not read/write any resource tables, only derivative tables, so we can
-    // drop down to utilizing a raw database client here and opt-out of resource type access tracking
-    // TODO: this should probably report access of "ConceptMap" to the access tracker.
-    const db = txRepo.getDatabaseClient(DatabaseMode.WRITER);
-    return importConceptMap(db, conceptMap, params.mapping);
-  });
+  await repo.withTransaction(
+    async (txRepo) => {
+      // `importConceptMap` operates only on ConceptMap derivative tables
+      const db = txRepo.getDatabaseClient({
+        mode: DatabaseMode.WRITER,
+        operation: 'write',
+        resourceTypes: ['ConceptMap'],
+        source: 'conceptMapImportHandler.client',
+      });
+      await importConceptMap(db, conceptMap, params.mapping);
+    },
+    { resourceTypes: ['ConceptMap'], source: 'conceptMapImportHandler' }
+  );
   return [allOk, conceptMap];
 }
 

--- a/packages/server/src/fhir/operations/conceptmapimport.ts
+++ b/packages/server/src/fhir/operations/conceptmapimport.ts
@@ -5,7 +5,7 @@ import { allOk, append, badRequest, EMPTY, flatMapFilter, forbidden, OperationOu
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Coding, ConceptMap, ConceptMapGroupElementTargetDependsOn } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
-import { DatabaseMode } from '../../database';
+import { repoAccess } from '../repository/access-tracker';
 import type { PgQueryable } from '../sql';
 import { InsertQuery, SelectQuery, Union } from '../sql';
 import { makeOperationDefinition } from './definitions';
@@ -122,12 +122,9 @@ export async function conceptMapImportHandler(req: FhirRequest): Promise<FhirRes
   await repo.withTransaction(
     async (txRepo) => {
       // `importConceptMap` operates only on ConceptMap derivative tables
-      const db = txRepo.getDatabaseClient({
-        mode: DatabaseMode.WRITER,
-        operation: 'write',
-        resourceTypes: ['ConceptMap'],
-        source: 'conceptMapImportHandler.client',
-      });
+      const db = txRepo.getDatabaseClient(
+        repoAccess.sqlWrite('ConceptMap', { source: 'conceptMapImportHandler.client' })
+      );
       await importConceptMap(db, conceptMap, params.mapping);
     },
     { resourceTypes: ['ConceptMap'], source: 'conceptMapImportHandler' }

--- a/packages/server/src/fhir/operations/confirm.ts
+++ b/packages/server/src/fhir/operations/confirm.ts
@@ -60,7 +60,7 @@ export async function appointmentConfirmHandler(req: FhirRequest): Promise<FhirR
 
       return [updatedAppointment, ...updatedSlots];
     },
-    { serializable: true }
+    { serializable: true, resourceTypes: ['Appointment', 'Slot'], source: 'appointmentConfirm' }
   );
   const bundle = {
     resourceType: 'Bundle',

--- a/packages/server/src/fhir/operations/db-configure-column-statistics.ts
+++ b/packages/server/src/fhir/operations/db-configure-column-statistics.ts
@@ -62,20 +62,26 @@ export async function configureColumnStatisticsHandler(req: FhirRequest): Promis
   }
 
   const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be an input to this handler
-  await systemRepo.withTransaction(async (txRepo) => {
-    for (const columnName of params.columnNames) {
-      // table and column names cannot be parameterized, so string interpolate after validating inputs
-      const query = `ALTER TABLE "${params.tableName}" ALTER COLUMN "${columnName}" SET STATISTICS ${newStatisticsTarget}`;
-      await txRepo.executeRawSql(query, [], {
-        mode: DatabaseMode.WRITER,
-        operation: 'write',
-        // this may alter resource type tables, but do not specify since this is an
-        // administrative operation where the desired shard/database was specified as an input to this handler
-        resourceTypes: [],
-        source: 'configureColumnStatisticsHandler',
-      });
+  await systemRepo.withTransaction(
+    async (txRepo) => {
+      for (const columnName of params.columnNames) {
+        // table and column names cannot be parameterized, so string interpolate after validating inputs
+        const query = `ALTER TABLE "${params.tableName}" ALTER COLUMN "${columnName}" SET STATISTICS ${newStatisticsTarget}`;
+        await txRepo.executeRawSql(query, [], {
+          mode: DatabaseMode.WRITER,
+          operation: 'write',
+          // this may alter resource type tables, but do not specify since this is an
+          // administrative operation where the desired shard/database was specified as an input to this handler
+          resourceTypes: [],
+          source: 'configureColumnStatisticsHandler',
+        });
+      }
+    },
+    {
+      resourceTypes: [],
+      source: 'configureColumnStatisticsHandler.transaction',
     }
-  });
+  );
 
   return [allOk];
 }

--- a/packages/server/src/fhir/operations/db-configure-column-statistics.ts
+++ b/packages/server/src/fhir/operations/db-configure-column-statistics.ts
@@ -63,11 +63,17 @@ export async function configureColumnStatisticsHandler(req: FhirRequest): Promis
 
   const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be an input to this handler
   await systemRepo.withTransaction(async (txRepo) => {
-    const client = txRepo.getDatabaseClient(DatabaseMode.WRITER);
     for (const columnName of params.columnNames) {
-      await client.query(
-        'ALTER TABLE "' + params.tableName + '" ALTER COLUMN "' + columnName + '" SET STATISTICS ' + newStatisticsTarget
-      );
+      // table and column names cannot be parameterized, so string interpolate after validating inputs
+      const query = `ALTER TABLE "${params.tableName}" ALTER COLUMN "${columnName}" SET STATISTICS ${newStatisticsTarget}`;
+      await txRepo.executeRawSql(query, [], {
+        mode: DatabaseMode.WRITER,
+        operation: 'write',
+        // this may alter resource type tables, but do not specify since this is an
+        // administrative operation where the desired shard/database was specified as an input to this handler
+        resourceTypes: [],
+        source: 'configureColumnStatisticsHandler',
+      });
     }
   });
 

--- a/packages/server/src/fhir/operations/db-configure-column-statistics.ts
+++ b/packages/server/src/fhir/operations/db-configure-column-statistics.ts
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { OperationOutcomeError, allOk, badRequest } from '@medplum/core';
+import { EMPTY, OperationOutcomeError, allOk, badRequest } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { requireSuperAdmin } from '../../context';
-import { DatabaseMode } from '../../database';
 import { getShardSystemRepo } from '../repo';
+import { repoAccess } from '../repository/access-tracker';
 import { PLACEHOLDER_SHARD_ID } from '../sharding';
 import { isValidColumnName, isValidTableName } from '../sql';
 import { makeOperationDefinition } from './definitions';
@@ -67,20 +67,14 @@ export async function configureColumnStatisticsHandler(req: FhirRequest): Promis
       for (const columnName of params.columnNames) {
         // table and column names cannot be parameterized, so string interpolate after validating inputs
         const query = `ALTER TABLE "${params.tableName}" ALTER COLUMN "${columnName}" SET STATISTICS ${newStatisticsTarget}`;
-        await txRepo.executeRawSql(query, [], {
-          mode: DatabaseMode.WRITER,
-          operation: 'write',
-          // this may alter resource type tables, but do not specify since this is an
-          // administrative operation where the desired shard/database was specified as an input to this handler
-          resourceTypes: [],
-          source: 'configureColumnStatisticsHandler',
-        });
+        await txRepo.executeRawSql(
+          query,
+          undefined,
+          repoAccess.sqlWriteConfig({ source: 'configureColumnStatisticsHandler' })
+        );
       }
     },
-    {
-      resourceTypes: [],
-      source: 'configureColumnStatisticsHandler.transaction',
-    }
+    { resourceTypes: EMPTY, source: 'configureColumnStatisticsHandler.transaction' }
   );
 
   return [allOk];

--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -14,9 +14,9 @@ import type {
   ValueSetExpansionContains,
 } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
-import { DatabaseMode } from '../../database';
 import { getLogger } from '../../logger';
 import type { Repository } from '../repo';
+import { repoAccess } from '../repository/access-tracker';
 import type { PgQueryable } from '../sql';
 import {
   Column,
@@ -242,12 +242,10 @@ async function includeInExpansion(
   codeSystem: WithId<CodeSystem>,
   params: ValueSetExpandParameters
 ): Promise<void> {
-  const db = getAuthenticatedContext().repo.getDatabaseClient({
-    mode: DatabaseMode.READER,
-    operation: 'read',
-    resourceTypes: ['CodeSystem'], // used on non resource type tables derived from CodeSystem, like Coding and CodeSystem_Property
-    source: 'expand.includeInExpansion',
-  });
+  const db = getAuthenticatedContext().repo.getDatabaseClient(
+    // for non resource tables derived from CodeSystem, e.g. Coding and CodeSystem_Property
+    repoAccess.sqlRead('CodeSystem', { source: 'expand.includeInExpansion' })
+  );
   await hydrateCodeSystemProperties(db, codeSystem);
 
   const query = expansionQuery(include, codeSystem, params);

--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -245,7 +245,7 @@ async function includeInExpansion(
   const db = getAuthenticatedContext().repo.getDatabaseClient({
     mode: DatabaseMode.READER,
     operation: 'read',
-    resourceTypes: ['CodeSystem'],
+    resourceTypes: ['CodeSystem'], // used on non resource type tables derived from CodeSystem, like Coding and CodeSystem_Property
     source: 'expand.includeInExpansion',
   });
   await hydrateCodeSystemProperties(db, codeSystem);

--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -242,7 +242,12 @@ async function includeInExpansion(
   codeSystem: WithId<CodeSystem>,
   params: ValueSetExpandParameters
 ): Promise<void> {
-  const db = getAuthenticatedContext().repo.getDatabaseClient(DatabaseMode.READER);
+  const db = getAuthenticatedContext().repo.getDatabaseClient({
+    mode: DatabaseMode.READER,
+    operation: 'read',
+    resourceTypes: ['CodeSystem'],
+    source: 'expand.includeInExpansion',
+  });
   await hydrateCodeSystemProperties(db, codeSystem);
 
   const query = expansionQuery(include, codeSystem, params);

--- a/packages/server/src/fhir/operations/explain.ts
+++ b/packages/server/src/fhir/operations/explain.ts
@@ -5,6 +5,7 @@ import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { RepositoryMode } from '@medplum/fhir-router';
 import type { Project, Reference } from '@medplum/fhirtypes';
 import { requireSuperAdmin } from '../../context';
+import { DatabaseMode } from '../../database';
 import { escapeUnicode } from '../../migrations/migrate-utils';
 import { getCount, getSelectQueryForSearch } from '../search';
 import { SqlBuilder } from '../sql';
@@ -65,8 +66,13 @@ export async function dbExplainHandler(req: FhirRequest): Promise<FhirResponse> 
     selectQuery.explain.push('format json');
   }
 
-  const { result, countResult } = await repo.withStatementTimeout({ timeoutMs: 0 }, async (client) => {
-    const result = await selectQuery.execute(client);
+  const { result, countResult } = await repo.withStatementTimeout({ timeoutMs: 0 }, async () => {
+    const result = await repo.executeSql<{ 'QUERY PLAN': string[] }>(selectQuery, {
+      mode: DatabaseMode.READER,
+      operation: 'read',
+      resourceTypes: searchReq.types ?? [searchReq.resourceType],
+      source: 'dbExplainHandler',
+    });
     const countResult = params.count ? await getCount(repo, searchReq, { forceAccurate: true }) : undefined;
     return { result, countResult };
   });

--- a/packages/server/src/fhir/operations/explain.ts
+++ b/packages/server/src/fhir/operations/explain.ts
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { allOk, parseSearchRequest } from '@medplum/core';
+import { allOk, getSearchResourceTypes, parseSearchRequest } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { RepositoryMode } from '@medplum/fhir-router';
 import type { Project, Reference } from '@medplum/fhirtypes';
 import { requireSuperAdmin } from '../../context';
-import { DatabaseMode } from '../../database';
 import { escapeUnicode } from '../../migrations/migrate-utils';
+import { repoAccess } from '../repository/access-tracker';
 import { getCount, getSelectQueryForSearch } from '../search';
 import { SqlBuilder } from '../sql';
 import { makeOperationDefinition } from './definitions';
@@ -67,12 +67,10 @@ export async function dbExplainHandler(req: FhirRequest): Promise<FhirResponse> 
   }
 
   const { result, countResult } = await repo.withStatementTimeout({ timeoutMs: 0 }, async () => {
-    const result = await repo.executeSql<{ 'QUERY PLAN': string[] }>(selectQuery, {
-      mode: DatabaseMode.READER,
-      operation: 'read',
-      resourceTypes: searchReq.types ?? [searchReq.resourceType],
-      source: 'dbExplainHandler',
-    });
+    const result = await repo.executeSql<{ 'QUERY PLAN': string[] }>(
+      selectQuery,
+      repoAccess.sqlRead(getSearchResourceTypes(searchReq), { source: 'dbExplainHandler' })
+    );
     const countResult = params.count ? await getCount(repo, searchReq, { forceAccurate: true }) : undefined;
     return { result, countResult };
   });

--- a/packages/server/src/fhir/operations/expunge.ts
+++ b/packages/server/src/fhir/operations/expunge.ts
@@ -4,9 +4,12 @@ import {
   accepted,
   AccessPolicyInteraction,
   allOk,
+  badRequest,
   concatUrls,
   forbidden,
   getResourceTypes,
+  isResourceType,
+  OperationOutcomeError,
   Operator,
 } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
@@ -31,6 +34,9 @@ export async function expungeHandler(req: FhirRequest): Promise<FhirResponse> {
   }
 
   const { resourceType, id } = req.params;
+  if (!isResourceType(resourceType)) {
+    throw new OperationOutcomeError(badRequest('Invalid resource type'), { cause: resourceType });
+  }
   const { everything } = req.query;
   if (resourceType === 'Project' || everything === 'true') {
     // Only super admins can expunge a project other than the current project.

--- a/packages/server/src/fhir/operations/projectinit.ts
+++ b/packages/server/src/fhir/operations/projectinit.ts
@@ -139,74 +139,77 @@ export async function createProject(
 
   log.info('Project creation request received', { name: projectName });
 
-  return systemRepo.withTransaction(async (txRepo) => {
-    // Pre-generate the project ID so the default access policies (which reference the project via
-    // meta.project) can be created first, then the Project can be created in a single write with its
-    // default policies already set.
-    const projectId = txRepo.generateId();
+  return systemRepo.withTransaction(
+    async (txRepo) => {
+      // Pre-generate the project ID so the default access policies (which reference the project via
+      // meta.project) can be created first, then the Project can be created in a single write with its
+      // default policies already set.
+      const projectId = txRepo.generateId();
 
-    const patientAccessPolicy = await createPatientCompartmentAccessPolicy(
-      txRepo,
-      projectId,
-      'Default Patient Access Policy'
-    );
-    const relatedPersonAccessPolicy = await createPatientCompartmentAccessPolicy(
-      txRepo,
-      projectId,
-      'Default RelatedPerson Access Policy'
-    );
-    const adminAccessPolicy = await createAdminAccessPolicy(txRepo, projectId, 'Default Admin Access Policy');
-    const practitionerAccessPolicy = await createPractitionerAccessPolicy(
-      txRepo,
-      projectId,
-      'Default Practitioner Access Policy'
-    );
-
-    const project = await txRepo.createResource<Project>(
-      {
-        resourceType: 'Project',
-        id: projectId,
-        name: projectName,
-        owner: admin ? createReference(admin) : undefined,
-        strictMode: true,
-        features: config.defaultProjectFeatures,
-        systemSetting: config.defaultProjectSystemSetting,
-        defaultPatientAccessPolicy: createReference(patientAccessPolicy),
-        defaultAccessPolicies: [
-          { profileType: 'Patient', accessPolicy: createReference(patientAccessPolicy) },
-          { profileType: 'RelatedPerson', accessPolicy: createReference(relatedPersonAccessPolicy) },
-          { profileType: 'Admin', accessPolicy: createReference(adminAccessPolicy) },
-          { profileType: 'Practitioner', accessPolicy: createReference(practitionerAccessPolicy) },
-        ],
-      },
-      { assignedId: true }
-    );
-
-    log.info('Project created', {
-      id: project.id,
-      name: projectName,
-    });
-
-    const client = await createClient(txRepo, {
-      project,
-      name: project.name + ' Default Client',
-      description: 'Default client for ' + project.name,
-    });
-
-    if (admin) {
-      const profile = await createProfile(
+      const patientAccessPolicy = await createPatientCompartmentAccessPolicy(
         txRepo,
-        project,
-        'Practitioner',
-        admin.firstName,
-        admin.lastName,
-        admin.email
+        projectId,
+        'Default Patient Access Policy'
       );
-      const membership = await createProjectMembership(txRepo, admin, project, profile, { admin: true });
-      return { project, profile, membership, client };
-    }
-    return { project, client };
-  });
+      const relatedPersonAccessPolicy = await createPatientCompartmentAccessPolicy(
+        txRepo,
+        projectId,
+        'Default RelatedPerson Access Policy'
+      );
+      const adminAccessPolicy = await createAdminAccessPolicy(txRepo, projectId, 'Default Admin Access Policy');
+      const practitionerAccessPolicy = await createPractitionerAccessPolicy(
+        txRepo,
+        projectId,
+        'Default Practitioner Access Policy'
+      );
+
+      const project = await txRepo.createResource<Project>(
+        {
+          resourceType: 'Project',
+          id: projectId,
+          name: projectName,
+          owner: admin ? createReference(admin) : undefined,
+          strictMode: true,
+          features: config.defaultProjectFeatures,
+          systemSetting: config.defaultProjectSystemSetting,
+          defaultPatientAccessPolicy: createReference(patientAccessPolicy),
+          defaultAccessPolicies: [
+            { profileType: 'Patient', accessPolicy: createReference(patientAccessPolicy) },
+            { profileType: 'RelatedPerson', accessPolicy: createReference(relatedPersonAccessPolicy) },
+            { profileType: 'Admin', accessPolicy: createReference(adminAccessPolicy) },
+            { profileType: 'Practitioner', accessPolicy: createReference(practitionerAccessPolicy) },
+          ],
+        },
+        { assignedId: true }
+      );
+
+      log.info('Project created', {
+        id: project.id,
+        name: projectName,
+      });
+
+      const client = await createClient(txRepo, {
+        project,
+        name: project.name + ' Default Client',
+        description: 'Default client for ' + project.name,
+      });
+
+      if (admin) {
+        const profile = await createProfile(
+          txRepo,
+          project,
+          'Practitioner',
+          admin.firstName,
+          admin.lastName,
+          admin.email
+        );
+        const membership = await createProjectMembership(txRepo, admin, project, profile, { admin: true });
+        return { project, profile, membership, client };
+      }
+      return { project, client };
+    },
+    { resourceTypes: ['Project', 'AccessPolicy', 'ClientApplication', 'Practitioner', 'ProjectMembership'] }
+  );
 }
 
 async function createPatientCompartmentAccessPolicy(

--- a/packages/server/src/fhir/operations/rebuild-base-definitions.ts
+++ b/packages/server/src/fhir/operations/rebuild-base-definitions.ts
@@ -132,22 +132,25 @@ async function replaceExisting<T extends Resource & { url?: string }>(
   projectId: string
 ): Promise<WithId<T>> {
   const systemRepo = repo.getSystemRepo();
-  return systemRepo.withTransaction(async (systemRepo) => {
-    if (resource.url) {
-      const bundle = await systemRepo.search({
-        resourceType: resource.resourceType,
-        filters: [
-          { code: 'url', operator: Operator.EQUALS, value: resource.url },
-          { code: '_project', operator: Operator.EQUALS, value: projectId },
-        ],
-      });
-      for (const entry of bundle.entry ?? EMPTY) {
-        const existing = entry.resource as WithId<T>;
-        await systemRepo.deleteResource(existing.resourceType, existing.id);
+  return systemRepo.withTransaction(
+    async (systemRepo) => {
+      if (resource.url) {
+        const bundle = await systemRepo.search({
+          resourceType: resource.resourceType,
+          filters: [
+            { code: 'url', operator: Operator.EQUALS, value: resource.url },
+            { code: '_project', operator: Operator.EQUALS, value: projectId },
+          ],
+        });
+        for (const entry of bundle.entry ?? EMPTY) {
+          const existing = entry.resource as WithId<T>;
+          await systemRepo.deleteResource(existing.resourceType, existing.id);
+        }
       }
-    }
-    return systemRepo.createResource(cleanSeedResource(resource));
-  });
+      return systemRepo.createResource(cleanSeedResource(resource));
+    },
+    { resourceTypes: resource.resourceType, source: 'rebuild-base-definitions.replaceExisting' }
+  );
 }
 
 function cleanSeedResource<T extends Resource>(resource: T): T {

--- a/packages/server/src/fhir/operations/refresh-reference-display.ts
+++ b/packages/server/src/fhir/operations/refresh-reference-display.ts
@@ -16,30 +16,33 @@ export async function refreshReferenceDisplayHandler(req: FhirRequest): Promise<
   }
 
   const { repo } = getAuthenticatedContext();
-  const updated = await repo.ensureInTransaction(async (txRepo) => {
-    const resource = await txRepo.readResource(resourceType, id);
+  const updated = await repo.ensureInTransaction(
+    async (txRepo) => {
+      const resource = await txRepo.readResource(resourceType, id);
 
-    const referenceMap = collectReferences(resource);
-    const references: TypedValueWithPath[] = [];
-    for (const path of Object.keys(referenceMap)) {
-      references.push(...referenceMap[path]);
-    }
-    const resolved = await txRepo.readReferences(references.map((r) => r.value));
+      const referenceMap = collectReferences(resource);
+      const references: TypedValueWithPath[] = [];
+      for (const path of Object.keys(referenceMap)) {
+        references.push(...referenceMap[path]);
+      }
+      const resolved = await txRepo.readReferences(references.map((r) => r.value));
 
-    const patch: Operation[] = [];
-    for (let i = 0; i < resolved.length; i++) {
-      const resource = resolved[i];
-      if (resource instanceof Error) {
-        continue;
+      const patch: Operation[] = [];
+      for (let i = 0; i < resolved.length; i++) {
+        const resource = resolved[i];
+        if (resource instanceof Error) {
+          continue;
+        }
+
+        const path = pathToJSONPointer(references[i].path) + '/display';
+        const value = getDisplayString(resource);
+        patch.push({ op: 'add', path, value });
       }
 
-      const path = pathToJSONPointer(references[i].path) + '/display';
-      const value = getDisplayString(resource);
-      patch.push({ op: 'add', path, value });
-    }
-
-    return txRepo.patchResource(resourceType, id, patch);
-  });
+      return txRepo.patchResource(resourceType, id, patch);
+    },
+    { resourceTypes: [resourceType], source: 'refreshReferenceDisplayHandler' }
+  );
 
   return [allOk, updated];
 }

--- a/packages/server/src/fhir/operations/rescope.ts
+++ b/packages/server/src/fhir/operations/rescope.ts
@@ -172,7 +172,11 @@ async function rescopeUserToProject(
         project: targetRef,
       });
     },
-    { serializable: true } // We need serializable here since if a new project membership is added for this user, we want this tx to fail
+    {
+      resourceTypes: ['Project', 'ProjectMembership', 'User'],
+      source: 'rescopeUserToProject',
+      serializable: true, // if a new project membership is added for this user, we want this tx to fail
+    }
   );
 }
 
@@ -187,15 +191,18 @@ async function rescopeUserToProject(
 async function rescopeUserToServer(ctx: AuthenticatedRequestContext, user: WithId<User>): Promise<WithId<User>> {
   const systemRepo = ctx.systemRepo;
 
-  return systemRepo.withTransaction(async (txRepo) => {
-    const rereadUser = await txRepo.readResource<User>('User', user.id);
-    if (!rereadUser.project) {
-      throw new OperationOutcomeError(badRequest('User is already server-scoped'));
-    }
+  return systemRepo.withTransaction(
+    async (txRepo) => {
+      const rereadUser = await txRepo.readResource<User>('User', user.id);
+      if (!rereadUser.project) {
+        throw new OperationOutcomeError(badRequest('User is already server-scoped'));
+      }
 
-    delete rereadUser.project;
-    delete rereadUser.meta?.project;
+      delete rereadUser.project;
+      delete rereadUser.meta?.project;
 
-    return txRepo.updateResource(rereadUser);
-  });
+      return txRepo.updateResource(rereadUser);
+    },
+    { resourceTypes: ['User'], source: 'rescopeUserToServer' }
+  );
 }

--- a/packages/server/src/fhir/operations/rotatesecret.ts
+++ b/packages/server/src/fhir/operations/rotatesecret.ts
@@ -51,25 +51,28 @@ export async function rotateSecretHandler(req: FhirRequest): Promise<FhirRespons
 
   // Patch using system repo since the secret fields should not generally be user-writeable
   const systemRepo = ctx.systemRepo;
-  const clientApp = await systemRepo.withTransaction(async (txRepo) => {
-    let clientApp = await txRepo.readResource<ClientApplication>('ClientApplication', req.params.id);
-    if (params.secret && params.secret === clientApp.secret) {
-      clientApp = await txRepo.updateResource({
-        ...clientApp,
-        secret: generateSecret(32), // Generate new secret
-        retiringSecret: clientApp.secret, // Rotate existing secret to "retiring" slot
-      });
-    } else if (params.retiringSecret && params.retiringSecret === clientApp.retiringSecret) {
-      clientApp = await txRepo.updateResource({
-        ...clientApp,
-        retiringSecret: undefined, // Remove rotated secret after it's been retired
-      });
-    } else {
-      throw new OperationOutcomeError(badRequest('Provided secret does not match client'));
-    }
+  const clientApp = await systemRepo.withTransaction(
+    async (txRepo) => {
+      let clientApp = await txRepo.readResource<ClientApplication>('ClientApplication', req.params.id);
+      if (params.secret && params.secret === clientApp.secret) {
+        clientApp = await txRepo.updateResource({
+          ...clientApp,
+          secret: generateSecret(32), // Generate new secret
+          retiringSecret: clientApp.secret, // Rotate existing secret to "retiring" slot
+        });
+      } else if (params.retiringSecret && params.retiringSecret === clientApp.retiringSecret) {
+        clientApp = await txRepo.updateResource({
+          ...clientApp,
+          retiringSecret: undefined, // Remove rotated secret after it's been retired
+        });
+      } else {
+        throw new OperationOutcomeError(badRequest('Provided secret does not match client'));
+      }
 
-    return clientApp;
-  });
+      return clientApp;
+    },
+    { resourceTypes: 'ClientApplication', source: 'rotateSecretHandler' }
+  );
 
   return [allOk, buildOutputParameters(operation, clientApp)];
 }

--- a/packages/server/src/fhir/operations/subsumes.ts
+++ b/packages/server/src/fhir/operations/subsumes.ts
@@ -78,7 +78,12 @@ export async function isSubsumed(
 ): Promise<boolean> {
   const { repo } = getAuthenticatedContext();
   const base = selectCoding(codeSystem.id, baseCode);
-  const db = repo.getDatabaseClient(DatabaseMode.READER);
+  const db = repo.getDatabaseClient({
+    mode: DatabaseMode.READER,
+    operation: 'read',
+    resourceTypes: ['CodeSystem'],
+    source: 'subsumes.isA',
+  });
 
   const parentProperty = await resolveProperty(db, codeSystem, getParentProperty(codeSystem));
   if (!parentProperty) {

--- a/packages/server/src/fhir/operations/subsumes.ts
+++ b/packages/server/src/fhir/operations/subsumes.ts
@@ -5,7 +5,7 @@ import { allOk, badRequest } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { CodeSystem } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
-import { DatabaseMode } from '../../database';
+import { repoAccess } from '../repository/access-tracker';
 import { getOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 import {
@@ -78,12 +78,8 @@ export async function isSubsumed(
 ): Promise<boolean> {
   const { repo } = getAuthenticatedContext();
   const base = selectCoding(codeSystem.id, baseCode);
-  const db = repo.getDatabaseClient({
-    mode: DatabaseMode.READER,
-    operation: 'read',
-    resourceTypes: ['CodeSystem'], // used on non resource type tables derived from CodeSystem
-    source: 'subsumes.isA',
-  });
+  // used on non resource type tables derived from CodeSystem
+  const db = repo.getDatabaseClient(repoAccess.sqlRead('CodeSystem', { source: 'isSubsumed' }));
 
   const parentProperty = await resolveProperty(db, codeSystem, getParentProperty(codeSystem));
   if (!parentProperty) {

--- a/packages/server/src/fhir/operations/subsumes.ts
+++ b/packages/server/src/fhir/operations/subsumes.ts
@@ -81,7 +81,7 @@ export async function isSubsumed(
   const db = repo.getDatabaseClient({
     mode: DatabaseMode.READER,
     operation: 'read',
-    resourceTypes: ['CodeSystem'],
+    resourceTypes: ['CodeSystem'], // used on non resource type tables derived from CodeSystem
     source: 'subsumes.isA',
   });
 

--- a/packages/server/src/fhir/operations/update-user-email.ts
+++ b/packages/server/src/fhir/operations/update-user-email.ts
@@ -86,88 +86,94 @@ export async function updateUserEmailOperation(req: FhirRequest): Promise<FhirRe
 
 async function updateUser(userId: string, params: InputParams, project: WithId<Project>): Promise<User> {
   const systemRepo = await getProjectSystemRepo(project);
-  return systemRepo.withTransaction(async (txRepo) => {
-    let user = await txRepo.readResource<User>('User', userId);
-    if (!project.superAdmin && user.project?.reference !== getReferenceString(project)) {
-      throw new OperationOutcomeError(forbidden);
-    }
-    if (params.updateProfileTelecom && !user.project) {
-      throw new OperationOutcomeError(badRequest('Cannot update profile of server-scoped User'));
-    }
-
-    const oldEmail = user.email;
-    user.email = params.email;
-    user.emailVerified = false;
-    user = await txRepo.updateResource(user);
-
-    if (!params.skipEmailVerification) {
-      const { id, secret } = await verifyEmail(txRepo, user);
-      const url = concatUrls(getConfig().appBaseUrl, `verifyemail/${id}/${secret}`);
-
-      // Use the target user's own project for project-level SMTP configuration.
-      // A super admin may be operating across projects, so the caller's project is not authoritative.
-      let emailProject: WithId<Project> | undefined;
-      if (user.project) {
-        emailProject =
-          user.project.reference === getReferenceString(project)
-            ? project
-            : await getGlobalSystemRepo().readReference<Project>(user.project);
+  return systemRepo.withTransaction(
+    async (txRepo) => {
+      let user = await txRepo.readResource<User>('User', userId);
+      if (!project.superAdmin && user.project?.reference !== getReferenceString(project)) {
+        throw new OperationOutcomeError(forbidden);
+      }
+      if (params.updateProfileTelecom && !user.project) {
+        throw new OperationOutcomeError(badRequest('Cannot update profile of server-scoped User'));
       }
 
-      await sendEmail(
-        txRepo,
-        {
-          to: params.email,
-          subject: 'Medplum Email Address Updated',
-          text: [
-            'We received a request to update the email address associated with your Medplum account.',
-            '',
-            'Please click on the following link to verify your ability to receive emails:',
-            '',
-            url,
-            '',
-            'If you received this in error, you can safely ignore it.',
-            '',
-            'Thank you,',
-            'Medplum',
-            '',
-          ].join('\n'),
-        },
-        emailProject
-      );
-    }
+      const oldEmail = user.email;
+      user.email = params.email;
+      user.emailVerified = false;
+      user = await txRepo.updateResource(user);
 
-    if (params.updateProfileTelecom && user.project?.reference) {
-      // Get membership for Project-scoped User
-      const membership = await txRepo.searchOne<ProjectMembership>({
-        resourceType: 'ProjectMembership',
-        filters: [
-          { code: 'user', operator: Operator.EQUALS, value: getReferenceString(user) },
-          { code: 'project', operator: Operator.EQUALS, value: user.project.reference },
-        ],
-      });
+      if (!params.skipEmailVerification) {
+        const { id, secret } = await verifyEmail(txRepo, user);
+        const url = concatUrls(getConfig().appBaseUrl, `verifyemail/${id}/${secret}`);
 
-      if (membership) {
-        const profile = await txRepo.readReference(membership.profile);
-        if (profileTypesWithTelecom.includes(profile.resourceType)) {
-          let telecom = (profile as ProfileResource).telecom;
-          // Add new email if not already present
-          if (!telecom?.some((contact) => contact.system === 'email' && contact.value === params.email)) {
-            telecom = append(telecom, { use: 'work', system: 'email', value: params.email });
+        // Use the target user's own project for project-level SMTP configuration.
+        // A super admin may be operating across projects, so the caller's project is not authoritative.
+        let emailProject: WithId<Project> | undefined;
+        if (user.project) {
+          emailProject =
+            user.project.reference === getReferenceString(project)
+              ? project
+              : await getGlobalSystemRepo().readReference<Project>(user.project);
+        }
+
+        await sendEmail(
+          txRepo,
+          {
+            to: params.email,
+            subject: 'Medplum Email Address Updated',
+            text: [
+              'We received a request to update the email address associated with your Medplum account.',
+              '',
+              'Please click on the following link to verify your ability to receive emails:',
+              '',
+              url,
+              '',
+              'If you received this in error, you can safely ignore it.',
+              '',
+              'Thank you,',
+              'Medplum',
+              '',
+            ].join('\n'),
+          },
+          emailProject
+        );
+      }
+
+      if (params.updateProfileTelecom && user.project?.reference) {
+        // Get membership for Project-scoped User
+        const membership = await txRepo.searchOne<ProjectMembership>({
+          resourceType: 'ProjectMembership',
+          filters: [
+            { code: 'user', operator: Operator.EQUALS, value: getReferenceString(user) },
+            { code: 'project', operator: Operator.EQUALS, value: user.project.reference },
+          ],
+        });
+
+        if (membership) {
+          const profile = await txRepo.readReference(membership.profile);
+          if (profileTypesWithTelecom.includes(profile.resourceType)) {
+            let telecom = (profile as ProfileResource).telecom;
+            // Add new email if not already present
+            if (!telecom?.some((contact) => contact.system === 'email' && contact.value === params.email)) {
+              telecom = append(telecom, { use: 'work', system: 'email', value: params.email });
+            }
+
+            // Mark instances of the previous email as old
+            const previous = telecom.find((contact) => contact.value === oldEmail && contact.system === 'email');
+            if (previous) {
+              previous.use = 'old';
+            }
+            (profile as ProfileResource).telecom = telecom;
+
+            await txRepo.updateResource(profile);
           }
-
-          // Mark instances of the previous email as old
-          const previous = telecom.find((contact) => contact.value === oldEmail && contact.system === 'email');
-          if (previous) {
-            previous.use = 'old';
-          }
-          (profile as ProfileResource).telecom = telecom;
-
-          await txRepo.updateResource(profile);
         }
       }
-    }
 
-    return user;
-  });
+      return user;
+    },
+    {
+      resourceTypes: ['ProjectMembership', 'User', 'UserSecurityRequest', ...profileTypesWithTelecom],
+      source: 'updateUserEmail.updateUser',
+    }
+  );
 }

--- a/packages/server/src/fhir/operations/update-user-email.ts
+++ b/packages/server/src/fhir/operations/update-user-email.ts
@@ -17,6 +17,7 @@ import { verifyEmail } from '../../auth/verifyemail';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import { sendEmail } from '../../email/email';
+import type { Repository } from '../repo';
 import { getGlobalSystemRepo, getProjectSystemRepo } from '../repo';
 import { makeOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
@@ -151,20 +152,7 @@ async function updateUser(userId: string, params: InputParams, project: WithId<P
         if (membership) {
           const profile = await txRepo.readReference(membership.profile);
           if (profileTypesWithTelecom.includes(profile.resourceType)) {
-            let telecom = (profile as ProfileResource).telecom;
-            // Add new email if not already present
-            if (!telecom?.some((contact) => contact.system === 'email' && contact.value === params.email)) {
-              telecom = append(telecom, { use: 'work', system: 'email', value: params.email });
-            }
-
-            // Mark instances of the previous email as old
-            const previous = telecom.find((contact) => contact.value === oldEmail && contact.system === 'email');
-            if (previous) {
-              previous.use = 'old';
-            }
-            (profile as ProfileResource).telecom = telecom;
-
-            await txRepo.updateResource(profile);
+            await updateProfileTelecom(txRepo, profile as WithId<ProfileResource>, oldEmail, params.email);
           }
         }
       }
@@ -176,4 +164,29 @@ async function updateUser(userId: string, params: InputParams, project: WithId<P
       source: 'updateUserEmail.updateUser',
     }
   );
+}
+
+async function updateProfileTelecom(
+  repo: Repository,
+  profile: WithId<ProfileResource>,
+  oldEmail: string | undefined,
+  newEmail: string
+): Promise<WithId<ProfileResource>> {
+  let telecom = profile.telecom;
+  // Add new email if not already present
+  if (!telecom?.some((contact) => contact.system === 'email' && contact.value === newEmail)) {
+    telecom = append(telecom, { use: 'work', system: 'email', value: newEmail });
+  }
+
+  // Mark instances of the previous email as old
+  if (oldEmail) {
+    for (const contact of telecom) {
+      if (contact.system === 'email' && contact.value === oldEmail) {
+        contact.use = 'old';
+      }
+    }
+  }
+  profile.telecom = telecom;
+
+  return repo.updateResource(profile);
 }

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -748,7 +748,7 @@ export async function createProposedAppointment(
       });
       return [createdAppointment, ...createdSlots];
     },
-    { serializable: true }
+    { serializable: true, resourceTypes: ['Appointment', 'Slot'], source: 'createProposedAppointment' }
   );
 
   return {

--- a/packages/server/src/fhir/operations/valuesetvalidatecode.ts
+++ b/packages/server/src/fhir/operations/valuesetvalidatecode.ts
@@ -123,7 +123,12 @@ async function findIncludedCode(
     return candidates.find((c) => include.concept?.some((i) => i.code === c.code));
   } else if (include.filter) {
     const codeSystem = await findTerminologyResource<CodeSystem>(repo, 'CodeSystem', include.system);
-    const db = repo.getDatabaseClient(DatabaseMode.READER);
+    const db = repo.getDatabaseClient({
+      mode: DatabaseMode.READER,
+      operation: 'read',
+      resourceTypes: ['CodeSystem'],
+      source: 'valuesetvalidatecode.includeHasCoding',
+    });
     await hydrateCodeSystemProperties(db, codeSystem);
 
     for (const coding of candidates) {
@@ -147,7 +152,12 @@ async function satisfies(
   codeSystem: WithId<CodeSystem>
 ): Promise<boolean> {
   const { logger, repo } = getAuthenticatedContext();
-  const db = repo.getDatabaseClient(DatabaseMode.READER);
+  const db = repo.getDatabaseClient({
+    mode: DatabaseMode.READER,
+    operation: 'read',
+    resourceTypes: ['CodeSystem'],
+    source: 'valuesetvalidatecode.satisfies',
+  });
   let query = selectCoding(codeSystem.id, code);
 
   switch (filter.op) {

--- a/packages/server/src/fhir/operations/valuesetvalidatecode.ts
+++ b/packages/server/src/fhir/operations/valuesetvalidatecode.ts
@@ -13,8 +13,8 @@ import type {
   ValueSetComposeIncludeFilter,
 } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
-import { DatabaseMode } from '../../database';
 import type { Repository } from '../repo';
+import { repoAccess } from '../repository/access-tracker';
 import { validateCoding } from './codesystemvalidatecode';
 import { getOperationDefinition } from './definitions';
 import { hydrateCodeSystemProperties } from './expand';
@@ -123,12 +123,10 @@ async function findIncludedCode(
     return candidates.find((c) => include.concept?.some((i) => i.code === c.code));
   } else if (include.filter) {
     const codeSystem = await findTerminologyResource<CodeSystem>(repo, 'CodeSystem', include.system);
-    const db = repo.getDatabaseClient({
-      mode: DatabaseMode.READER,
-      operation: 'read',
-      resourceTypes: ['CodeSystem'], // // used on non resource type tables derived from CodeSystem
-      source: 'valuesetvalidatecode.includeHasCoding',
-    });
+    // used on non resource type tables derived from CodeSystem
+    const db = repo.getDatabaseClient(
+      repoAccess.sqlRead('CodeSystem', { source: 'valuesetvalidatecode.includeHasCoding' })
+    );
     await hydrateCodeSystemProperties(db, codeSystem);
 
     for (const coding of candidates) {
@@ -152,12 +150,7 @@ async function satisfies(
   codeSystem: WithId<CodeSystem>
 ): Promise<boolean> {
   const { logger, repo } = getAuthenticatedContext();
-  const db = repo.getDatabaseClient({
-    mode: DatabaseMode.READER,
-    operation: 'read',
-    resourceTypes: ['CodeSystem'],
-    source: 'valuesetvalidatecode.satisfies',
-  });
+  const db = repo.getDatabaseClient(repoAccess.sqlRead('CodeSystem', { source: 'valuesetvalidatecode.satisfies' }));
   let query = selectCoding(codeSystem.id, code);
 
   switch (filter.op) {

--- a/packages/server/src/fhir/operations/valuesetvalidatecode.ts
+++ b/packages/server/src/fhir/operations/valuesetvalidatecode.ts
@@ -126,7 +126,7 @@ async function findIncludedCode(
     const db = repo.getDatabaseClient({
       mode: DatabaseMode.READER,
       operation: 'read',
-      resourceTypes: ['CodeSystem'],
+      resourceTypes: ['CodeSystem'], // // used on non resource type tables derived from CodeSystem
       source: 'valuesetvalidatecode.includeHasCoding',
     });
     await hydrateCodeSystemProperties(db, codeSystem);

--- a/packages/server/src/fhir/precommit.ts
+++ b/packages/server/src/fhir/precommit.ts
@@ -174,14 +174,18 @@ function getTargetResourceTypes(element: InternalSchemaElement | undefined): Res
  * @throws {OperationOutcomeError} When the resource cannot be deleted because of a critical reference.
  */
 async function checkReferencesForDelete(repo: Repository, resource: WithId<Resource>): Promise<void> {
-  const db = repo.getDatabaseClient(DatabaseMode.WRITER);
   const checkForCriticalRefs = new SelectQuery('ProjectMembership_References')
     .column('resourceId')
     .where('targetId', '=', resource.id)
     .where('code', 'IN', criticalProjectMembershipReferences)
     .limit(1);
 
-  const results = await checkForCriticalRefs.execute(db);
+  const results = await repo.executeSql<{ resourceId: string }>(checkForCriticalRefs, {
+    mode: DatabaseMode.WRITER,
+    operation: 'read',
+    resourceTypes: ['ProjectMembership', resource.resourceType],
+    source: 'precommit.checkReferencesForDelete',
+  });
   if (results.length) {
     throw new OperationOutcomeError(
       badRequest(

--- a/packages/server/src/fhir/precommit.ts
+++ b/packages/server/src/fhir/precommit.ts
@@ -183,7 +183,7 @@ async function checkReferencesForDelete(repo: Repository, resource: WithId<Resou
   const results = await repo.executeSql<{ resourceId: string }>(checkForCriticalRefs, {
     mode: DatabaseMode.WRITER,
     operation: 'read',
-    resourceTypes: ['ProjectMembership', resource.resourceType],
+    resourceTypes: ['ProjectMembership'],
     source: 'precommit.checkReferencesForDelete',
   });
   if (results.length) {

--- a/packages/server/src/fhir/precommit.ts
+++ b/packages/server/src/fhir/precommit.ts
@@ -21,6 +21,7 @@ import { DatabaseMode } from '../database';
 import { getLogger } from '../logger';
 import { findProjectMembership } from '../workers/utils';
 import type { Repository } from './repo';
+import { repoAccess } from './repository/access-tracker';
 import { SelectQuery } from './sql';
 
 export const PRE_COMMIT_SUBSCRIPTION_URL = 'https://medplum.com/fhir/StructureDefinition/pre-commit-bot';
@@ -180,12 +181,10 @@ async function checkReferencesForDelete(repo: Repository, resource: WithId<Resou
     .where('code', 'IN', criticalProjectMembershipReferences)
     .limit(1);
 
-  const results = await repo.executeSql<{ resourceId: string }>(checkForCriticalRefs, {
-    mode: DatabaseMode.WRITER,
-    operation: 'read',
-    resourceTypes: ['ProjectMembership'],
-    source: 'precommit.checkReferencesForDelete',
-  });
+  const results = await repo.executeSql<{ resourceId: string }>(
+    checkForCriticalRefs,
+    repoAccess.sqlRead('ProjectMembership', { mode: DatabaseMode.WRITER, source: 'precommit.checkReferencesForDelete' })
+  );
   if (results.length) {
     throw new OperationOutcomeError(
       badRequest(

--- a/packages/server/src/fhir/references.ts
+++ b/packages/server/src/fhir/references.ts
@@ -8,13 +8,14 @@ import {
   crawlTypedValueAsync,
   createReference,
   createStructureIssue,
+  isResourceType,
   normalizeErrorString,
   OperationOutcomeError,
   parseSearchRequest,
   PropertyType,
   toTypedValue,
 } from '@medplum/core';
-import type { OperationOutcomeIssue, Reference, Resource } from '@medplum/fhirtypes';
+import type { OperationOutcomeIssue, Reference, Resource, ResourceType } from '@medplum/fhirtypes';
 import { randomUUID } from 'node:crypto';
 import type { Repository } from './repo';
 
@@ -178,4 +179,15 @@ export async function replaceConditionalReferences<T extends Resource>(repo: Rep
   );
 
   return resource;
+}
+
+export function getResourceTypesFromReferences(references: Iterable<Reference>): ResourceType[] {
+  const resourceTypes = new Set<ResourceType>();
+  for (const reference of references) {
+    const resourceType = reference.reference?.split('/')[0];
+    if (resourceType && isResourceType(resourceType)) {
+      resourceTypes.add(resourceType);
+    }
+  }
+  return Array.from(resourceTypes);
 }

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -48,6 +48,7 @@ import { AuditEventOutcome, createAuditEvent, ReadInteraction, RestfulOperationT
 import * as workersModule from '../workers';
 import { getRepoForLogin } from './accesspolicy';
 import { getGlobalSystemRepo, getProjectSystemRepo, getShardSystemRepo, Repository } from './repo';
+import type { PgQueryable } from './sql';
 import { SelectQuery } from './sql';
 import * as tokenColumnModule from './token-column';
 
@@ -424,10 +425,16 @@ describe('FHIR Repo', () => {
     const project = await systemRepo.createResource<Project>({ resourceType: 'Project', name: 'Split Tx Project' });
     const patient = await systemRepo.createResource<Patient>({ resourceType: 'Patient' });
 
-    await systemRepo.withTransaction(async (txRepo) => {
-      await txRepo.readResource('Patient', patient.id);
-      await txRepo.getSystemRepo().readResource('Project', project.id);
-    });
+    await systemRepo.withTransaction(
+      async (txRepo) => {
+        await txRepo.readResource('Patient', patient.id);
+        await txRepo.getSystemRepo().readResource('Project', project.id);
+      },
+      {
+        resourceTypes: ['Patient', 'Project'],
+        source: 'repo.test.mixedTransactionAccess',
+      }
+    );
 
     expect(infoSpy).toHaveBeenCalledWith(
       '[RepoSplit] Mixed transaction access',
@@ -1384,21 +1391,42 @@ describe('FHIR Repo', () => {
       return patients;
     }
 
-    async function countRows(tableName: string, id: string): Promise<number> {
+    async function countRows(db: PgQueryable, tableName: string, id: string): Promise<number> {
       const query = new SelectQuery(tableName).column('id').where('id', '=', id);
-      return (await query.execute(systemRepo.getDatabaseClient(DatabaseMode.READER))).length;
+      return (
+        await query.execute(
+          systemRepo.getDatabaseClient({
+            mode: DatabaseMode.READER,
+            operation: 'read',
+            resourceTypes: ['Patient'],
+            source: 'repo.test.countRows',
+          })
+        )
+      ).length;
     }
 
     async function expectPatientExpunged(patient: WithId<Patient>): Promise<void> {
       await expect(systemRepo.readResource('Patient', patient.id)).rejects.toThrow();
-      expect(await countRows('Patient', patient.id)).toStrictEqual(0);
-      expect(await countRows('Patient_History', patient.id)).toStrictEqual(0);
+      const db = systemRepo.getDatabaseClient({
+        mode: DatabaseMode.READER,
+        operation: 'read',
+        resourceTypes: ['Patient'],
+        source: 'repo.test.countRows',
+      });
+      expect(await countRows(db, 'Patient', patient.id)).toStrictEqual(0);
+      expect(await countRows(db, 'Patient_History', patient.id)).toStrictEqual(0);
     }
 
     async function expectPatientPresent(patient: WithId<Patient>): Promise<void> {
       expect((await systemRepo.readResource('Patient', patient.id)).id).toStrictEqual(patient.id);
-      expect(await countRows('Patient', patient.id)).toStrictEqual(1);
-      expect(await countRows('Patient_History', patient.id)).toBeGreaterThan(0);
+      const db = systemRepo.getDatabaseClient({
+        mode: DatabaseMode.READER,
+        operation: 'read',
+        resourceTypes: ['Patient'],
+        source: 'repo.test.countRows',
+      });
+      expect(await countRows(db, 'Patient', patient.id)).toStrictEqual(1);
+      expect(await countRows(db, 'Patient_History', patient.id)).toBeGreaterThan(0);
     }
 
     async function expectPatientsExpunged(...patients: WithId<Patient>[]): Promise<void> {
@@ -1782,7 +1810,12 @@ describe('FHIR Repo', () => {
 
   async function getProjectIdColumn(id: string): Promise<string | null> {
     const projectIdQuery = new SelectQuery('User').column('projectId').where('id', '=', id);
-    const client = systemRepo.getDatabaseClient(DatabaseMode.WRITER);
+    const client = systemRepo.getDatabaseClient({
+      mode: DatabaseMode.WRITER,
+      operation: 'read',
+      resourceTypes: ['User'],
+      source: 'repo.test.getProjectIdColumn',
+    });
     return (await projectIdQuery.execute(client))[0].projectId;
   }
 
@@ -1834,10 +1867,17 @@ describe('FHIR Repo', () => {
       { async: true },
       async () => {
         const startTime = Date.now();
-        await repo.withTransaction(async (txRepo) => {
-          await txRepo.createResource({ resourceType: 'Patient' });
-          expect(Date.now() - startTime).toBeLessThan(100);
-        });
+        await repo.withTransaction(
+          async (txRepo) => {
+            await txRepo.createResource({ resourceType: 'Patient' });
+            expect(Date.now() - startTime).toBeLessThan(100);
+          },
+          {
+            source: 'repo.test.asyncQuotaDelay',
+
+            resourceTypes: ['Patient'],
+          }
+        );
         expect(Date.now() - startTime).toBeGreaterThan(100);
       }
     );
@@ -1860,17 +1900,30 @@ describe('FHIR Repo', () => {
       }
 
       let finishedTransaction = false;
-      await repo.withTransaction(async (txRepo) => {
-        const client = txRepo.getDatabaseClient(DatabaseMode.WRITER);
-        const querySpy = spyOnQuery(client);
-        await txRepo.createResource(patient);
-        const calls = querySpy.mock.calls;
-        expect(calls.filter((c) => c[0].includes('INSERT INTO "Patient"'))).toHaveLength(1);
-        expect(calls.filter((c) => c[0].includes('INSERT INTO "Patient_History"'))).toHaveLength(1);
-        expect(calls.filter((c) => c[0].includes('INSERT INTO "Patient_References"')).length).toBeGreaterThanOrEqual(2);
-        querySpy.mockRestore();
-        finishedTransaction = true;
-      });
+      await repo.withTransaction(
+        async (txRepo) => {
+          const client = txRepo.getDatabaseClient({
+            mode: DatabaseMode.WRITER,
+            operation: 'write',
+            resourceTypes: ['Patient'],
+            source: 'repo.test.insertReferenceBatching.client',
+          });
+          const querySpy = spyOnQuery(client);
+          await txRepo.createResource(patient);
+          const calls = querySpy.mock.calls;
+          expect(calls.filter((c) => c[0].includes('INSERT INTO "Patient"'))).toHaveLength(1);
+          expect(calls.filter((c) => c[0].includes('INSERT INTO "Patient_History"'))).toHaveLength(1);
+          expect(calls.filter((c) => c[0].includes('INSERT INTO "Patient_References"')).length).toBeGreaterThanOrEqual(
+            2
+          );
+          querySpy.mockRestore();
+          finishedTransaction = true;
+        },
+        {
+          resourceTypes: ['Patient'],
+          source: 'repo.test.insertReferenceBatching',
+        }
+      );
       expect(finishedTransaction).toBe(true);
     }));
 
@@ -1885,7 +1938,12 @@ describe('FHIR Repo', () => {
 
       const versionQuery = new SelectQuery('Patient').column('__version').where('id', '=', patient.id);
 
-      const client = repo.getDatabaseClient(DatabaseMode.WRITER);
+      const client = repo.getDatabaseClient({
+        mode: DatabaseMode.WRITER,
+        operation: 'write',
+        resourceTypes: ['Patient'],
+        source: 'repo.test.versionColumn',
+      });
       expect((await versionQuery.execute(client))[0].__version).toStrictEqual(Repository.VERSION);
 
       // Simulate the resource being at an older version

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -43,7 +43,7 @@ import { r4ProjectId, systemResourceProjectId } from '../constants';
 import { runInAuthenticatedContext } from '../context';
 import { DatabaseMode, getDatabasePool } from '../database';
 import { getLogger } from '../logger';
-import { bundleContains, createTestProject, spyOnQuery, withTestContext } from '../test.setup';
+import { bundleContains, createTestProject, mockStdoutWrite, spyOnQuery, withTestContext } from '../test.setup';
 import { AuditEventOutcome, createAuditEvent, ReadInteraction, RestfulOperationType } from '../util/auditevent';
 import * as workersModule from '../workers';
 import { getRepoForLogin } from './accesspolicy';
@@ -60,8 +60,11 @@ describe('FHIR Repo', () => {
 
   let testProjectRepo: Repository;
   let systemRepo: Repository;
+  let stdoutSpy: MockInstance<typeof process.stdout.write>;
 
   beforeAll(async () => {
+    stdoutSpy = mockStdoutWrite();
+
     const config = await loadTestConfig();
     await initAppServices(config);
 
@@ -82,6 +85,7 @@ describe('FHIR Repo', () => {
 
   afterAll(async () => {
     await shutdownApp();
+    stdoutSpy.mockRestore();
   });
 
   test('getRepoForLogin', async () => {
@@ -387,9 +391,9 @@ describe('FHIR Repo', () => {
         layer: 'cache',
         operation: 'read',
         source: 'repo.getCacheEntries',
-        specialResourceTypes: ['Project'],
-        otherResourceTypes: ['Patient'],
-        resourceTypes: ['Patient', 'Project'],
+        specialResourceTypes: expect.toEqualUnordered(['Project']),
+        otherResourceTypes: expect.toEqualUnordered(['Patient']),
+        resourceTypes: expect.toEqualUnordered(['Patient', 'Project']),
       })
     );
   });
@@ -413,9 +417,9 @@ describe('FHIR Repo', () => {
         layer: 'sql',
         operation: 'read',
         source: 'search.getSearchEntries',
-        specialResourceTypes: ['Project'],
-        otherResourceTypes: ['Patient'],
-        resourceTypes: ['Patient', 'Project'],
+        specialResourceTypes: expect.toEqualUnordered(['Project']),
+        otherResourceTypes: expect.toEqualUnordered(['Patient']),
+        resourceTypes: expect.toEqualUnordered(['Patient', 'Project']),
       })
     );
   });
@@ -441,10 +445,10 @@ describe('FHIR Repo', () => {
       expect.objectContaining({
         scope: 'transaction',
         status: 'committed',
-        specialResourceTypes: ['Project'],
-        otherResourceTypes: ['Patient'],
-        readResourceTypes: ['Patient', 'Project'],
-        writeResourceTypes: [],
+        specialResourceTypes: expect.toEqualUnordered(['Project']),
+        otherResourceTypes: expect.toEqualUnordered(['Patient']),
+        readResourceTypes: expect.toEqualUnordered(['Patient', 'Project']),
+        writeResourceTypes: expect.toEqualUnordered([]),
       })
     );
   });

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -48,7 +48,7 @@ import { AuditEventOutcome, createAuditEvent, ReadInteraction, RestfulOperationT
 import * as workersModule from '../workers';
 import { getRepoForLogin } from './accesspolicy';
 import { getGlobalSystemRepo, getProjectSystemRepo, getShardSystemRepo, Repository } from './repo';
-import type { PgQueryable } from './sql';
+import { repoAccess } from './repository/access-tracker';
 import { SelectQuery } from './sql';
 import * as tokenColumnModule from './token-column';
 
@@ -1103,13 +1103,15 @@ describe('FHIR Repo', () => {
       expect(history2.entry?.[0]?.request?.method).toStrictEqual('DELETE');
       expect(history2.entry?.[0]?.request?.url).toStrictEqual(`Patient/${patient.id}`);
 
-      const tombstoneRows = await new SelectQuery('Patient_History')
-        .column('versionId')
-        .column('content')
-        .where('id', '=', patient.id)
-        .orderBy('lastUpdated', true)
-        .limit(1)
-        .execute(systemRepo.getDatabaseClient(DatabaseMode.READER));
+      const tombstoneRows = await systemRepo.sqlRead(
+        new SelectQuery('Patient_History')
+          .column('versionId')
+          .column('content')
+          .where('id', '=', patient.id)
+          .orderBy('lastUpdated', true)
+          .limit(1),
+        'Patient'
+      );
       expect(tombstoneRows).toHaveLength(1);
       const deleteVersionId = tombstoneRows[0].versionId as string;
       const tombstone = JSON.parse(tombstoneRows[0].content as string);
@@ -1404,42 +1406,21 @@ describe('FHIR Repo', () => {
       return patients;
     }
 
-    async function countRows(db: PgQueryable, tableName: string, id: string): Promise<number> {
+    async function countRows(tableName: string, id: string): Promise<number> {
       const query = new SelectQuery(tableName).column('id').where('id', '=', id);
-      return (
-        await query.execute(
-          systemRepo.getDatabaseClient({
-            mode: DatabaseMode.READER,
-            operation: 'read',
-            resourceTypes: ['Patient'],
-            source: 'repo.test.countRows',
-          })
-        )
-      ).length;
+      return (await systemRepo.sqlRead(query, 'Patient')).length;
     }
 
     async function expectPatientExpunged(patient: WithId<Patient>): Promise<void> {
       await expect(systemRepo.readResource('Patient', patient.id)).rejects.toThrow();
-      const db = systemRepo.getDatabaseClient({
-        mode: DatabaseMode.READER,
-        operation: 'read',
-        resourceTypes: ['Patient'],
-        source: 'repo.test.countRows',
-      });
-      expect(await countRows(db, 'Patient', patient.id)).toStrictEqual(0);
-      expect(await countRows(db, 'Patient_History', patient.id)).toStrictEqual(0);
+      expect(await countRows('Patient', patient.id)).toStrictEqual(0);
+      expect(await countRows('Patient_History', patient.id)).toStrictEqual(0);
     }
 
     async function expectPatientPresent(patient: WithId<Patient>): Promise<void> {
       expect((await systemRepo.readResource('Patient', patient.id)).id).toStrictEqual(patient.id);
-      const db = systemRepo.getDatabaseClient({
-        mode: DatabaseMode.READER,
-        operation: 'read',
-        resourceTypes: ['Patient'],
-        source: 'repo.test.countRows',
-      });
-      expect(await countRows(db, 'Patient', patient.id)).toStrictEqual(1);
-      expect(await countRows(db, 'Patient_History', patient.id)).toBeGreaterThan(0);
+      expect(await countRows('Patient', patient.id)).toStrictEqual(1);
+      expect(await countRows('Patient_History', patient.id)).toBeGreaterThan(0);
     }
 
     async function expectPatientsExpunged(...patients: WithId<Patient>[]): Promise<void> {
@@ -1823,13 +1804,7 @@ describe('FHIR Repo', () => {
 
   async function getProjectIdColumn(id: string): Promise<string | null> {
     const projectIdQuery = new SelectQuery('User').column('projectId').where('id', '=', id);
-    const client = systemRepo.getDatabaseClient({
-      mode: DatabaseMode.WRITER,
-      operation: 'read',
-      resourceTypes: ['User'],
-      source: 'repo.test.getProjectIdColumn',
-    });
-    return (await projectIdQuery.execute(client))[0].projectId;
+    return (await systemRepo.sqlRead(projectIdQuery, 'User', { mode: DatabaseMode.WRITER }))[0].projectId;
   }
 
   test('Super admin can edit User.meta.project', async () =>
@@ -1915,12 +1890,7 @@ describe('FHIR Repo', () => {
       let finishedTransaction = false;
       await repo.withTransaction(
         async (txRepo) => {
-          const client = txRepo.getDatabaseClient({
-            mode: DatabaseMode.WRITER,
-            operation: 'write',
-            resourceTypes: ['Patient'],
-            source: 'repo.test.insertReferenceBatching.client',
-          });
+          const client = txRepo.getDatabaseClient(repoAccess.sqlWrite('Patient'));
           const querySpy = spyOnQuery(client);
           await txRepo.createResource(patient);
           const calls = querySpy.mock.calls;
@@ -1950,38 +1920,41 @@ describe('FHIR Repo', () => {
       });
 
       const versionQuery = new SelectQuery('Patient').column('__version').where('id', '=', patient.id);
+      const readVersion = async (): Promise<number> =>
+        (await repo.sqlRead(versionQuery, 'Patient', { mode: DatabaseMode.WRITER }))[0].__version;
+      const setVersion = async (version: number): Promise<void> => {
+        await repo.executeRawSql(
+          'UPDATE "Patient" SET __version = $1 WHERE id = $2',
+          [version, patient.id],
+          repoAccess.sqlWrite('Patient')
+        );
+      };
 
-      const client = repo.getDatabaseClient({
-        mode: DatabaseMode.WRITER,
-        operation: 'write',
-        resourceTypes: ['Patient'],
-        source: 'repo.test.versionColumn',
-      });
-      expect((await versionQuery.execute(client))[0].__version).toStrictEqual(Repository.VERSION);
+      expect(await readVersion()).toStrictEqual(Repository.VERSION);
 
       // Simulate the resource being at an older version
       const OLDER_VERSION = Repository.VERSION - 1;
-      await client.query('UPDATE "Patient" SET __version = $1 WHERE id = $2', [OLDER_VERSION, patient.id]);
-      expect((await versionQuery.execute(client))[0].__version).toStrictEqual(OLDER_VERSION);
+      await setVersion(OLDER_VERSION);
+      expect(await readVersion()).toStrictEqual(OLDER_VERSION);
 
       // noop update should not change the version
       await repo.updateResource<Patient>(patient);
-      expect((await versionQuery.execute(client))[0].__version).toStrictEqual(OLDER_VERSION);
+      expect(await readVersion()).toStrictEqual(OLDER_VERSION);
 
       // meaningful update should change the version
       await repo.updateResource<Patient>({
         ...patient,
         name: [{ given: ['Bob'], family: 'Smith' }],
       });
-      expect((await versionQuery.execute(client))[0].__version).toStrictEqual(Repository.VERSION);
+      expect(await readVersion()).toStrictEqual(Repository.VERSION);
 
       // Simulate the resource being at an older version
-      await client.query('UPDATE "Patient" SET __version = $1 WHERE id = $2', [OLDER_VERSION, patient.id]);
-      expect((await versionQuery.execute(client))[0].__version).toStrictEqual(OLDER_VERSION);
+      await setVersion(OLDER_VERSION);
+      expect(await readVersion()).toStrictEqual(OLDER_VERSION);
 
       // reindex SHOULD change the version
       await repo.reindexResource('Patient', patient.id);
-      expect((await versionQuery.execute(client))[0].__version).toStrictEqual(Repository.VERSION);
+      expect(await readVersion()).toStrictEqual(Repository.VERSION);
     });
   });
 

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -1243,6 +1243,15 @@ describe('FHIR Repo', () => {
     }
   });
 
+  test('Reindex mixed resource types not allowed', async () => {
+    await expect(() =>
+      systemRepo.reindexResources([
+        { resourceType: 'Patient', id: randomUUID() },
+        { resourceType: 'Practitioner', id: randomUUID() },
+      ])
+    ).rejects.toThrow('All resources must be of the same type');
+  });
+
   test('Reindex resource errors logged', async () => {
     const patient1 = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -372,6 +372,76 @@ describe('FHIR Repo', () => {
     expect((results[5] as OperationOutcomeError).outcome.id).toBe('not-found');
   });
 
+  test('Logs mixed cache access for readReferences across split resource types', async () => {
+    const infoSpy = vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+    const project = await systemRepo.createResource<Project>({ resourceType: 'Project', name: 'Split Cache Project' });
+    const patient = await systemRepo.createResource<Patient>({ resourceType: 'Patient' });
+
+    await systemRepo.readReferences([{ reference: `Project/${project.id}` }, { reference: `Patient/${patient.id}` }]);
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[RepoSplit] Mixed resource access',
+      expect.objectContaining({
+        scope: 'statement',
+        layer: 'cache',
+        operation: 'read',
+        source: 'repo.getCacheEntries',
+        specialResourceTypes: ['Project'],
+        otherResourceTypes: ['Patient'],
+        resourceTypes: ['Patient', 'Project'],
+      })
+    );
+  });
+
+  test('Logs mixed SQL access for multi-type search across split resource types', async () => {
+    const infoSpy = vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+    await systemRepo.createResource<Project>({ resourceType: 'Project', name: 'Split Search Project' });
+    await systemRepo.createResource<Patient>({ resourceType: 'Patient' });
+
+    await systemRepo.search({
+      resourceType: 'Patient',
+      types: ['Project', 'Patient'],
+      count: 10,
+      offset: 0,
+    });
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[RepoSplit] Mixed resource access',
+      expect.objectContaining({
+        scope: 'statement',
+        layer: 'sql',
+        operation: 'read',
+        source: 'search.getSearchEntries',
+        specialResourceTypes: ['Project'],
+        otherResourceTypes: ['Patient'],
+        resourceTypes: ['Patient', 'Project'],
+      })
+    );
+  });
+
+  test('Logs mixed transaction access across repo and system repo', async () => {
+    const infoSpy = vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+    const project = await systemRepo.createResource<Project>({ resourceType: 'Project', name: 'Split Tx Project' });
+    const patient = await systemRepo.createResource<Patient>({ resourceType: 'Patient' });
+
+    await systemRepo.withTransaction(async (txRepo) => {
+      await txRepo.readResource('Patient', patient.id);
+      await txRepo.getSystemRepo().readResource('Project', project.id);
+    });
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[RepoSplit] Mixed transaction access',
+      expect.objectContaining({
+        scope: 'transaction',
+        status: 'committed',
+        specialResourceTypes: ['Project'],
+        otherResourceTypes: ['Patient'],
+        readResourceTypes: ['Patient', 'Project'],
+        writeResourceTypes: [],
+      })
+    );
+  });
+
   describe('Read history', () => {
     const versions: Record<string, WithId<Patient>> = {};
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -64,6 +64,7 @@ import type {
 import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import { Readable } from 'node:stream';
+import type { QueryResult, QueryResultRow } from 'pg';
 import { getConfig } from '../config/loader';
 import { syntheticR4Project } from '../constants';
 import { AuthenticatedRequestContext, tryGetRequestContext } from '../context';
@@ -101,7 +102,8 @@ import { clamp, makeOperationDefinitionParameter, parseParametersFromDefinitions
 import { getPatients } from './patient';
 import { preCommitValidation } from './precommit';
 import { getResourceTypesFromReferences, replaceConditionalReferences, validateResourceReferences } from './references';
-import type { ExecuteSqlOptions, TransactionSqlOptions } from './repository/access-tracker';
+import type { ExecuteSqlOptions, ResourceTypeInput, TransactionSqlOptions } from './repository/access-tracker';
+import { repoAccess } from './repository/access-tracker';
 import { removeField } from './repository/field-utils';
 import { removeCachedProfile } from './repository/profile-cache';
 import type { ConnectionScope, StatementTimeoutOptions } from './repository/repository-connection';
@@ -417,19 +419,55 @@ export class Repository extends FhirRepository implements Disposable {
       await limiter?.consume(points);
     }
   }
-  async executeSql<T = any>(
-    query: { execute(conn: PgQueryable): Promise<T[]> },
+
+  async sqlRead<R extends QueryResultRow = any>(
+    query: { execute(conn: PgQueryable): Promise<R[]> },
+    resourceTypes: ResourceTypeInput,
+    options?: { mode?: DatabaseMode; source?: string }
+  ): Promise<R[]> {
+    return this.executeSql(query, {
+      resourceTypes,
+      operation: 'read',
+      mode: options?.mode ?? DatabaseMode.READER,
+      source: options?.source,
+    });
+  }
+
+  async sqlWrite<R extends QueryResultRow = any>(
+    query: { execute(conn: PgQueryable): Promise<R[]> },
+    resourceTypes: ResourceTypeInput,
+    options?: { source?: string }
+  ): Promise<R[]> {
+    return this.executeSql(query, {
+      resourceTypes,
+      operation: 'write',
+      mode: DatabaseMode.WRITER,
+      source: options?.source,
+    });
+  }
+
+  async executeSql<R extends QueryResultRow = any>(
+    query: { execute(conn: PgQueryable): Promise<R[]> },
     options: ExecuteSqlOptions
-  ): Promise<T[]> {
+  ): Promise<R[]> {
     this.assertUsable();
     return query.execute(this.getDatabaseClient(options));
   }
 
-  async executeRawSql<T = any>(query: string, params: any[], options: ExecuteSqlOptions): Promise<T[]> {
+  async executeRawSql<R extends QueryResultRow = any>(
+    query: string,
+    params: any[] | undefined,
+    options: ExecuteSqlOptions
+  ): Promise<R[]> {
     return this.executeSql(
       {
-        execute: async (conn) => {
-          const result = await conn.query(query, params);
+        execute: async (conn): Promise<R[]> => {
+          let result: QueryResult<R>;
+          if (params) {
+            result = await conn.query(query, params);
+          } else {
+            result = await conn.query(query);
+          }
           return result.rows;
         },
       },
@@ -583,12 +621,7 @@ export class Repository extends FhirRepository implements Disposable {
 
     this.addSecurityFilters(builder, resourceType, AccessPolicyInteraction.READ);
 
-    const rows = await this.executeSql<{ content: string; deleted: boolean }>(builder, {
-      mode: DatabaseMode.READER,
-      operation: 'read',
-      resourceTypes: [resourceType as ResourceType],
-      source: 'repo.readResourceFromDatabase',
-    });
+    const rows = await this.sqlRead<{ content: string; deleted: boolean }>(builder, resourceType as ResourceType);
     if (rows.length === 0) {
       throw new OperationOutcomeError(notFound);
     }
@@ -733,7 +766,7 @@ export class Repository extends FhirRepository implements Disposable {
         }
       }
 
-      const rows = await this.executeSql<{
+      const rows = await this.sqlRead<{
         versionId: string;
         id: string;
         content?: string;
@@ -748,22 +781,13 @@ export class Repository extends FhirRepository implements Disposable {
           .orderBy('lastUpdated', true)
           .limit(clamp(0, options?.limit ?? 100, DEFAULT_MAX_SEARCH_COUNT))
           .offset(Math.max(0, options?.offset ?? 0)),
-        {
-          mode: DatabaseMode.READER,
-          operation: 'read',
-          resourceTypes: [resourceType],
-          source: 'repo.readHistory.rows',
-        }
+        resourceType,
+        { source: 'repo.readHistory' }
       );
 
-      const countRows = await this.executeSql<{ count: number }>(
+      const countRows = await this.sqlRead<{ count: number }>(
         new SelectQuery(resourceType + '_History').raw('COUNT(*)::int AS "count"').where('id', '=', id),
-        {
-          mode: DatabaseMode.READER,
-          operation: 'read',
-          resourceTypes: [resourceType],
-          source: 'repo.readHistory.count',
-        }
+        resourceType
       );
 
       const totalCount = countRows[0].count;
@@ -841,14 +865,10 @@ export class Repository extends FhirRepository implements Disposable {
         }
       }
 
-      const rows = await this.executeSql<{ content: string }>(
+      const rows = await this.sqlRead<{ content: string }>(
         new SelectQuery(resourceType + '_History').column('content').where('id', '=', id).where('versionId', '=', vid),
-        {
-          mode: DatabaseMode.READER,
-          operation: 'read',
-          resourceTypes: [resourceType],
-          source: 'repo.readVersion',
-        }
+        resourceType,
+        { source: 'repo.readVersion' }
       );
 
       if (rows.length === 0) {
@@ -881,8 +901,7 @@ export class Repository extends FhirRepository implements Disposable {
       if (options?.ifMatch) {
         // Conditional update requires transaction
         result = await this.withTransaction((txRepo) => txRepo.updateResourceImpl(resource, false, options), {
-          resourceTypes: [resource.resourceType],
-          source: 'repo.updateResource.ifMatch',
+          resourceTypes: resource.resourceType,
         });
       } else {
         result = await this.updateResourceImpl(resource, false, options);
@@ -1364,14 +1383,11 @@ export class Repository extends FhirRepository implements Disposable {
               author: txRepo.getAuthor(),
             });
 
-            await txRepo.executeSql(new InsertQuery(resourceType, [columns]).mergeOnConflict(), {
-              mode: DatabaseMode.WRITER,
-              operation: 'write',
-              resourceTypes: [resourceType],
-              source: 'repo.deleteResource.resource',
+            await txRepo.sqlWrite(new InsertQuery(resourceType, [columns]).mergeOnConflict(), resourceType, {
+              source: 'repo.deleteResource',
             });
 
-            await txRepo.executeSql(
+            await txRepo.sqlWrite(
               new InsertQuery(resourceType + '_History', [
                 {
                   id,
@@ -1380,12 +1396,7 @@ export class Repository extends FhirRepository implements Disposable {
                   content: historyContent,
                 },
               ]),
-              {
-                mode: DatabaseMode.WRITER,
-                operation: 'write',
-                resourceTypes: [resourceType],
-                source: 'repo.deleteResource.resource',
-              }
+              resourceType
             );
 
             await txRepo.deleteFromLookupTables(resource);
@@ -1506,10 +1517,7 @@ export class Repository extends FhirRepository implements Disposable {
         if (projectId) {
           deleteQuery.where('projectId', '=', projectId);
         }
-        const deleteResult = await txRepo.executeSql<{ id: string }>(deleteQuery, {
-          mode: DatabaseMode.WRITER,
-          operation: 'write',
-          resourceTypes: [resourceType],
+        const deleteResult = await txRepo.sqlWrite<{ id: string }>(deleteQuery, resourceType, {
           source: 'repo.expungeResources.resource',
         });
         if (deleteResult.length === 0) {
@@ -1523,12 +1531,7 @@ export class Repository extends FhirRepository implements Disposable {
           await txRepo.deleteFromLookupTables({ resourceType, id: res.id } as WithId<Resource>);
         }
 
-        await txRepo.executeSql(new DeleteQuery(resourceType + '_History').where('id', 'IN', deletedIds), {
-          mode: DatabaseMode.WRITER,
-          operation: 'write',
-          resourceTypes: [resourceType],
-          source: 'repo.expungeResources.history',
-        });
+        await txRepo.sqlWrite(new DeleteQuery(resourceType + '_History').where('id', 'IN', deletedIds), resourceType);
         await txRepo.postCommit(() => txRepo.deleteCacheEntries(resourceType, deletedIds));
         return deletedIds;
       },
@@ -1554,12 +1557,7 @@ export class Repository extends FhirRepository implements Disposable {
       throw new OperationOutcomeError(forbidden);
     }
 
-    const client = this.getDatabaseClient({
-      mode: DatabaseMode.WRITER,
-      operation: 'write',
-      resourceTypes: [resourceType],
-      source: 'repo.purgeResources.lookupTables',
-    });
+    const client = this.getDatabaseClient(repoAccess.sqlWrite(resourceType, { source: 'repo.purgeResources' }));
 
     // Delete from lookup tables first
     // These operations use the main resource table for lastUpdated, so must come first
@@ -1567,18 +1565,8 @@ export class Repository extends FhirRepository implements Disposable {
       await lookupTable.purgeValuesBefore(client, resourceType, before);
     }
 
-    await this.executeSql(new DeleteQuery(resourceType).where('lastUpdated', '<=', before), {
-      mode: DatabaseMode.WRITER,
-      operation: 'write',
-      resourceTypes: [resourceType],
-      source: 'repo.purgeResources.resource',
-    });
-    await this.executeSql(new DeleteQuery(resourceType + '_History').where('lastUpdated', '<=', before), {
-      mode: DatabaseMode.WRITER,
-      operation: 'write',
-      resourceTypes: [resourceType],
-      source: 'repo.purgeResources.history',
-    });
+    await this.sqlWrite(new DeleteQuery(resourceType).where('lastUpdated', '<=', before), resourceType);
+    await this.sqlWrite(new DeleteQuery(resourceType + '_History').where('lastUpdated', '<=', before), resourceType);
   }
 
   async search<T extends Resource>(
@@ -1808,10 +1796,7 @@ export class Repository extends FhirRepository implements Disposable {
    */
   protected async writeResource(resource: Resource): Promise<void> {
     const row = buildResourceRow(resource, Repository.VERSION);
-    await this.executeSql(new InsertQuery(resource.resourceType, [row]).mergeOnConflict(), {
-      mode: DatabaseMode.WRITER,
-      operation: 'write',
-      resourceTypes: [resource.resourceType],
+    await this.sqlWrite(new InsertQuery(resource.resourceType, [row]).mergeOnConflict(), resource.resourceType, {
       source: 'repo.writeResource',
     });
   }
@@ -1821,15 +1806,13 @@ export class Repository extends FhirRepository implements Disposable {
       return;
     }
 
-    await this.executeSql(
+    await this.sqlWrite(
       new InsertQuery(
         resources[0].resourceType,
         resources.map((r) => buildResourceRow(r, Repository.VERSION))
       ).mergeOnConflict(),
+      resources[0].resourceType,
       {
-        mode: DatabaseMode.WRITER,
-        operation: 'write',
-        resourceTypes: [resources[0].resourceType],
         source: 'repo.batchWriteResources',
       }
     );
@@ -1844,7 +1827,7 @@ export class Repository extends FhirRepository implements Disposable {
     const meta = resource.meta as Meta;
     const content = stringify(resource);
 
-    await this.executeSql(
+    await this.sqlWrite(
       new InsertQuery(resourceType + '_History', [
         {
           id: resource.id,
@@ -1853,12 +1836,7 @@ export class Repository extends FhirRepository implements Disposable {
           content,
         },
       ]),
-      {
-        mode: DatabaseMode.WRITER,
-        operation: 'write',
-        resourceTypes: [resourceType],
-        source: 'repo.writeResourceVersion',
-      }
+      resourceType
     );
   }
 
@@ -1922,12 +1900,9 @@ export class Repository extends FhirRepository implements Disposable {
    * @param create - If true, then the resource is being created.
    */
   protected async writeLookupTables(resource: WithId<Resource>, create: boolean): Promise<void> {
-    const client = this.getDatabaseClient({
-      mode: DatabaseMode.WRITER,
-      operation: 'write',
-      resourceTypes: [resource.resourceType],
-      source: 'repo.writeLookupTables',
-    });
+    const client = this.getDatabaseClient(
+      repoAccess.sqlWrite(resource.resourceType, { source: 'repo.writeLookupTables' })
+    );
     for (const lookupTable of lookupTables) {
       await lookupTable.indexResource(client, resource, create);
     }
@@ -1937,12 +1912,9 @@ export class Repository extends FhirRepository implements Disposable {
     if (!resources.length) {
       return;
     }
-    const client = this.getDatabaseClient({
-      mode: DatabaseMode.WRITER,
-      operation: 'write',
-      resourceTypes: [resources[0].resourceType],
-      source: 'repo.batchWriteLookupTables',
-    });
+    const client = this.getDatabaseClient(
+      repoAccess.sqlWrite(resources[0].resourceType, { source: 'repo.batchWriteLookupTables' })
+    );
     for (const lookupTable of lookupTables) {
       await lookupTable.batchIndexResources(client, resources, create);
     }
@@ -1953,12 +1925,9 @@ export class Repository extends FhirRepository implements Disposable {
    * @param resource - The resource to delete.
    */
   protected async deleteFromLookupTables(resource: WithId<Resource>): Promise<void> {
-    const client = this.getDatabaseClient({
-      mode: DatabaseMode.WRITER,
-      operation: 'write',
-      resourceTypes: [resource.resourceType],
-      source: 'repo.deleteFromLookupTables',
-    });
+    const client = this.getDatabaseClient(
+      repoAccess.sqlWrite(resource.resourceType, { source: 'repo.deleteFromLookupTables' })
+    );
     for (const lookupTable of lookupTables) {
       await lookupTable.deleteValuesForResource(client, resource);
     }
@@ -2371,6 +2340,9 @@ export class Repository extends FhirRepository implements Disposable {
   }
 
   /**
+   * @deprecated Use {@link sqlRead}, {@link sqlWrite},
+   * {@link executeSql}, etc. to facilitate resource-type routing.
+   *
    * Returns a query-capable database client.
    * Use this method when you don't care if you're in a transaction or not.
    * For example, use this method for "read by ID".
@@ -2434,7 +2406,7 @@ export class Repository extends FhirRepository implements Disposable {
     if (this.connection.isInTransaction()) {
       return undefined;
     }
-    this.connection.recordResourceAccess('cache', 'read', [resourceType], 'repo.getCacheEntry');
+    this.connection.recordResourceAccess('cache', 'read', resourceType, 'repo.getCacheEntry');
     return getResourceCacheEntry<T>(resourceType, id);
   }
 
@@ -2472,7 +2444,7 @@ export class Repository extends FhirRepository implements Disposable {
       return;
     }
 
-    this.connection.recordResourceAccess('cache', 'write', [resource.resourceType], 'repo.setCacheEntry');
+    this.connection.recordResourceAccess('cache', 'write', resource.resourceType, 'repo.setCacheEntry');
     await setResourceCacheEntry(resource);
   }
 
@@ -2488,7 +2460,7 @@ export class Repository extends FhirRepository implements Disposable {
       return;
     }
 
-    this.connection.recordResourceAccess('cache', 'write', [resourceType], 'repo.deleteCacheEntry');
+    this.connection.recordResourceAccess('cache', 'write', resourceType, 'repo.deleteCacheEntry');
     await deleteResourceCacheEntry(resourceType, id);
   }
 
@@ -2504,7 +2476,7 @@ export class Repository extends FhirRepository implements Disposable {
       return;
     }
 
-    this.connection.recordResourceAccess('cache', 'write', [resourceType], 'repo.deleteCacheEntries');
+    this.connection.recordResourceAccess('cache', 'write', resourceType, 'repo.deleteCacheEntries');
     await deleteResourceCacheEntries(resourceType, ids);
   }
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -102,7 +102,7 @@ import { getPatients } from './patient';
 import { preCommitValidation } from './precommit';
 import { replaceConditionalReferences, validateResourceReferences } from './references';
 import type { ExecuteSqlOptions, TransactionSqlOptions } from './repository/access-tracker';
-import { getLocalReferenceResourceTypes } from './repository/access-tracker';
+import { getResourceTypesFromReferences } from './repository/access-tracker';
 import { removeField } from './repository/field-utils';
 import { removeCachedProfile } from './repository/profile-cache';
 import type { ConnectionScope, StatementTimeoutOptions } from './repository/repository-connection';
@@ -2449,7 +2449,7 @@ export class Repository extends FhirRepository implements Disposable {
     this.connection.recordResourceAccess(
       'cache',
       'read',
-      getLocalReferenceResourceTypes(references),
+      getResourceTypesFromReferences(references),
       'repo.getCacheEntries'
     );
     return getResourceCacheEntries(references);

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -64,7 +64,6 @@ import type {
 import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import { Readable } from 'node:stream';
-import type { PoolClient } from 'pg';
 import { getConfig } from '../config/loader';
 import { syntheticR4Project } from '../constants';
 import { AuthenticatedRequestContext, tryGetRequestContext } from '../context';
@@ -102,6 +101,8 @@ import { clamp, makeOperationDefinitionParameter, parseParametersFromDefinitions
 import { getPatients } from './patient';
 import { preCommitValidation } from './precommit';
 import { replaceConditionalReferences, validateResourceReferences } from './references';
+import type { RepositoryAccessOperation } from './repository/access-tracker';
+import { getLocalReferenceResourceTypes } from './repository/access-tracker';
 import { removeField } from './repository/field-utils';
 import { removeCachedProfile } from './repository/profile-cache';
 import type { ConnectionScope, StatementTimeoutOptions } from './repository/repository-connection';
@@ -253,6 +254,13 @@ export interface ResendSubscriptionsOptions extends InteractionOptions {
 
 export interface ProcessAllResourcesOptions {
   delayBetweenPagesMs?: number;
+}
+
+export interface ExecuteSqlOptions {
+  readonly mode: DatabaseMode;
+  readonly operation: RepositoryAccessOperation;
+  readonly resourceTypes: Iterable<ResourceType>;
+  readonly source: string;
 }
 
 function addSyntheticR4ProjectIfMissing(context: RepositoryContext): void {
@@ -417,6 +425,26 @@ export class Repository extends FhirRepository implements Disposable {
       await limiter?.consume(points);
     }
   }
+  async executeSql<T = any>(
+    query: { execute(conn: PgQueryable): Promise<T[]> },
+    options: ExecuteSqlOptions
+  ): Promise<T[]> {
+    this.assertUsable();
+    this.connection.recordResourceAccess('sql', options.operation, options.resourceTypes, options.source);
+    return query.execute(this.getDatabaseClient(options.mode));
+  }
+
+  async executeRawSql<T = any>(query: string, params: any[], options: ExecuteSqlOptions): Promise<T[]> {
+    return this.executeSql(
+      {
+        execute: async (conn) => {
+          const result = await conn.query(query, params);
+          return result.rows;
+        },
+      },
+      options
+    );
+  }
 
   private resourceCap(): ResourceCap | undefined {
     const context = tryGetRequestContext();
@@ -564,7 +592,12 @@ export class Repository extends FhirRepository implements Disposable {
 
     this.addSecurityFilters(builder, resourceType, AccessPolicyInteraction.READ);
 
-    const rows = await builder.execute(this.getDatabaseClient(DatabaseMode.READER));
+    const rows = await this.executeSql<{ content: string; deleted: boolean }>(builder, {
+      mode: DatabaseMode.READER,
+      operation: 'read',
+      resourceTypes: [resourceType as ResourceType],
+      source: 'repo.readResourceFromDatabase',
+    });
     if (rows.length === 0) {
       throw new OperationOutcomeError(notFound);
     }
@@ -573,7 +606,7 @@ export class Repository extends FhirRepository implements Disposable {
       throw new OperationOutcomeError(gone);
     }
 
-    const resource = JSON.parse(rows[0].content as string) as WithId<T>;
+    const resource = JSON.parse(rows[0].content) as WithId<T>;
 
     if (!this.connection.isInTransaction()) {
       // Only set cache entry if not in a transaction
@@ -709,28 +742,45 @@ export class Repository extends FhirRepository implements Disposable {
         }
       }
 
-      const rows = await new SelectQuery(resourceType + '_History')
-        .column('versionId')
-        .column('id')
-        .column('content')
-        .column('lastUpdated')
-        .where('id', '=', id)
-        .orderBy('lastUpdated', true)
-        .limit(clamp(0, options?.limit ?? 100, DEFAULT_MAX_SEARCH_COUNT))
-        .offset(Math.max(0, options?.offset ?? 0))
-        .execute(this.getDatabaseClient(DatabaseMode.READER));
+      const rows = await this.executeSql<{
+        versionId: string;
+        id: string;
+        content?: string;
+        lastUpdated?: string;
+      }>(
+        new SelectQuery(resourceType + '_History')
+          .column('versionId')
+          .column('id')
+          .column('content')
+          .column('lastUpdated')
+          .where('id', '=', id)
+          .orderBy('lastUpdated', true)
+          .limit(clamp(0, options?.limit ?? 100, DEFAULT_MAX_SEARCH_COUNT))
+          .offset(Math.max(0, options?.offset ?? 0)),
+        {
+          mode: DatabaseMode.READER,
+          operation: 'read',
+          resourceTypes: [resourceType],
+          source: 'repo.readHistory.rows',
+        }
+      );
 
-      const countRows = await new SelectQuery(resourceType + '_History')
-        .raw('COUNT(*)::int AS "count"')
-        .where('id', '=', id)
-        .execute(this.getDatabaseClient(DatabaseMode.READER));
+      const countRows = await this.executeSql<{ count: number }>(
+        new SelectQuery(resourceType + '_History').raw('COUNT(*)::int AS "count"').where('id', '=', id),
+        {
+          mode: DatabaseMode.READER,
+          operation: 'read',
+          resourceTypes: [resourceType],
+          source: 'repo.readHistory.count',
+        }
+      );
 
-      const totalCount = countRows[0].count as number;
+      const totalCount = countRows[0].count;
 
       const entries: BundleEntry<T>[] = [];
 
       for (const row of rows) {
-        const parsed = parseHistoryContent(row.content as string);
+        const parsed = parseHistoryContent(row.content);
         const isDeleted = parsed.meta?.deleted;
         const resource = !isDeleted ? this.removeHiddenFields(parsed as T) : undefined;
         const outcome: OperationOutcome = !isDeleted
@@ -800,17 +850,21 @@ export class Repository extends FhirRepository implements Disposable {
         }
       }
 
-      const rows = await new SelectQuery(resourceType + '_History')
-        .column('content')
-        .where('id', '=', id)
-        .where('versionId', '=', vid)
-        .execute(this.getDatabaseClient(DatabaseMode.READER));
+      const rows = await this.executeSql<{ content: string }>(
+        new SelectQuery(resourceType + '_History').column('content').where('id', '=', id).where('versionId', '=', vid),
+        {
+          mode: DatabaseMode.READER,
+          operation: 'read',
+          resourceTypes: [resourceType],
+          source: 'repo.readVersion',
+        }
+      );
 
       if (rows.length === 0) {
         throw new OperationOutcomeError(notFound);
       }
 
-      const parsed = parseHistoryContent(rows[0].content as string);
+      const parsed = parseHistoryContent(rows[0].content);
       // FHIR vread of a delete version returns 410 Gone with no resource body.
       if (parsed.meta?.deleted) {
         throw new OperationOutcomeError(gone);
@@ -1297,19 +1351,31 @@ export class Repository extends FhirRepository implements Disposable {
             author: txRepo.getAuthor(),
           });
 
-          const client = txRepo.getDatabaseClient(DatabaseMode.WRITER);
-          await new InsertQuery(resourceType, [columns]).mergeOnConflict().execute(client);
+          await txRepo.executeSql(new InsertQuery(resourceType, [columns]).mergeOnConflict(), {
+            mode: DatabaseMode.WRITER,
+            operation: 'write',
+            resourceTypes: [resourceType],
+            source: 'repo.deleteResource.resource',
+          });
 
-          await new InsertQuery(resourceType + '_History', [
+          await txRepo.executeSql(
+            new InsertQuery(resourceType + '_History', [
+              {
+                id,
+                versionId,
+                lastUpdated: columns.lastUpdated,
+                content: historyContent,
+              },
+            ]),
             {
-              id,
-              versionId,
-              lastUpdated: columns.lastUpdated,
-              content: historyContent,
-            },
-          ]).execute(client);
+              mode: DatabaseMode.WRITER,
+              operation: 'write',
+              resourceTypes: [resourceType],
+              source: 'repo.deleteResource.history',
+            }
+          );
 
-          await txRepo.deleteFromLookupTables(client, resource);
+          await txRepo.deleteFromLookupTables(resource);
 
           const durationMs = Date.now() - startTime;
 
@@ -1392,7 +1458,7 @@ export class Repository extends FhirRepository implements Disposable {
    * @param resourceType - The FHIR resource type.
    * @param id - The resource ID.
    */
-  async expungeResource(resourceType: string, id: string): Promise<void> {
+  async expungeResource(resourceType: ResourceType, id: string): Promise<void> {
     this.assertUsable();
     await this.expungeResources(resourceType, [id]);
   }
@@ -1403,7 +1469,7 @@ export class Repository extends FhirRepository implements Disposable {
    * @param resourceType - The FHIR resource type.
    * @param ids - The resource IDs.
    */
-  async expungeResources(resourceType: string, ids: string[]): Promise<void> {
+  async expungeResources(resourceType: ResourceType, ids: string[]): Promise<void> {
     this.assertUsable();
     if (!this.isSuperAdmin() && !this.isProjectAdmin()) {
       throw new OperationOutcomeError(forbidden);
@@ -1422,8 +1488,12 @@ export class Repository extends FhirRepository implements Disposable {
         if (projectId) {
           deleteQuery.where('projectId', '=', projectId);
         }
-        const client = txRepo.getDatabaseClient(DatabaseMode.WRITER);
-        const deleteResult = await deleteQuery.execute<{ id: string }>(client);
+        const deleteResult = await txRepo.executeSql<{ id: string }>(deleteQuery, {
+          mode: DatabaseMode.WRITER,
+          operation: 'write',
+          resourceTypes: [resourceType],
+          source: 'repo.expungeResources.resource',
+        });
         if (deleteResult.length === 0) {
           return [];
         }
@@ -1432,10 +1502,15 @@ export class Repository extends FhirRepository implements Disposable {
         for (let i = 0; i < deleteResult.length; i++) {
           const res = deleteResult[i];
           deletedIds[i] = res.id;
-          await txRepo.deleteFromLookupTables(client, { resourceType, id: res.id } as WithId<Resource>);
+          await txRepo.deleteFromLookupTables({ resourceType, id: res.id } as WithId<Resource>);
         }
 
-        await new DeleteQuery(resourceType + '_History').where('id', 'IN', deletedIds).execute(client);
+        await txRepo.executeSql(new DeleteQuery(resourceType + '_History').where('id', 'IN', deletedIds), {
+          mode: DatabaseMode.WRITER,
+          operation: 'write',
+          resourceTypes: [resourceType],
+          source: 'repo.expungeResources.history',
+        });
         await txRepo.postCommit(() => txRepo.deleteCacheEntries(resourceType, deletedIds));
         return deletedIds;
       },
@@ -1469,8 +1544,18 @@ export class Repository extends FhirRepository implements Disposable {
       await lookupTable.purgeValuesBefore(client, resourceType, before);
     }
 
-    await new DeleteQuery(resourceType).where('lastUpdated', '<=', before).execute(client);
-    await new DeleteQuery(resourceType + '_History').where('lastUpdated', '<=', before).execute(client);
+    await this.executeSql(new DeleteQuery(resourceType).where('lastUpdated', '<=', before), {
+      mode: DatabaseMode.WRITER,
+      operation: 'write',
+      resourceTypes: [resourceType],
+      source: 'repo.purgeResources.resource',
+    });
+    await this.executeSql(new DeleteQuery(resourceType + '_History').where('lastUpdated', '<=', before), {
+      mode: DatabaseMode.WRITER,
+      operation: 'write',
+      resourceTypes: [resourceType],
+      source: 'repo.purgeResources.history',
+    });
   }
 
   async search<T extends Resource>(
@@ -1699,22 +1784,32 @@ export class Repository extends FhirRepository implements Disposable {
    * @param resource - The resource.
    */
   protected async writeResource(resource: Resource): Promise<void> {
-    const client = this.getDatabaseClient(DatabaseMode.WRITER);
     const row = buildResourceRow(resource, Repository.VERSION);
-    await new InsertQuery(resource.resourceType, [row]).mergeOnConflict().execute(client);
+    await this.executeSql(new InsertQuery(resource.resourceType, [row]).mergeOnConflict(), {
+      mode: DatabaseMode.WRITER,
+      operation: 'write',
+      resourceTypes: [resource.resourceType],
+      source: 'repo.writeResource',
+    });
   }
 
   protected async batchWriteResources(resources: Resource[]): Promise<void> {
     if (!resources.length) {
       return;
     }
-    const client = this.getDatabaseClient(DatabaseMode.WRITER);
-    await new InsertQuery(
-      resources[0].resourceType,
-      resources.map((r) => buildResourceRow(r, Repository.VERSION))
-    )
-      .mergeOnConflict()
-      .execute(client);
+
+    await this.executeSql(
+      new InsertQuery(
+        resources[0].resourceType,
+        resources.map((r) => buildResourceRow(r, Repository.VERSION))
+      ).mergeOnConflict(),
+      {
+        mode: DatabaseMode.WRITER,
+        operation: 'write',
+        resourceTypes: [resources[0].resourceType],
+        source: 'repo.batchWriteResources',
+      }
+    );
   }
 
   /**
@@ -1726,15 +1821,22 @@ export class Repository extends FhirRepository implements Disposable {
     const meta = resource.meta as Meta;
     const content = stringify(resource);
 
-    const client = this.getDatabaseClient(DatabaseMode.WRITER);
-    await new InsertQuery(resourceType + '_History', [
+    await this.executeSql(
+      new InsertQuery(resourceType + '_History', [
+        {
+          id: resource.id,
+          versionId: meta.versionId,
+          lastUpdated: meta.lastUpdated,
+          content,
+        },
+      ]),
       {
-        id: resource.id,
-        versionId: meta.versionId,
-        lastUpdated: meta.lastUpdated,
-        content,
-      },
-    ]).execute(client);
+        mode: DatabaseMode.WRITER,
+        operation: 'write',
+        resourceTypes: [resourceType],
+        source: 'repo.writeResourceVersion',
+      }
+    );
   }
 
   /**
@@ -1812,10 +1914,10 @@ export class Repository extends FhirRepository implements Disposable {
 
   /**
    * Deletes values from lookup tables.
-   * @param client - The database client inside the transaction.
    * @param resource - The resource to delete.
    */
-  protected async deleteFromLookupTables(client: PgQueryable, resource: WithId<Resource>): Promise<void> {
+  protected async deleteFromLookupTables(resource: WithId<Resource>): Promise<void> {
+    const client = this.getDatabaseClient(DatabaseMode.WRITER);
     for (const lookupTable of lookupTables) {
       await lookupTable.deleteValuesForResource(client, resource);
     }
@@ -2261,7 +2363,7 @@ export class Repository extends FhirRepository implements Disposable {
 
   async withStatementTimeout<TResult>(
     options: StatementTimeoutOptions,
-    callback: (client: PoolClient) => Promise<TResult>
+    callback: () => Promise<TResult>
   ): Promise<TResult> {
     this.assertUsable();
     if (!this.ownsConnection) {
@@ -2287,13 +2389,14 @@ export class Repository extends FhirRepository implements Disposable {
    * @returns The cache entry if found; otherwise, undefined.
    */
   private async getCacheEntry<T extends Resource>(
-    resourceType: string,
+    resourceType: ResourceType,
     id: string
   ): Promise<CacheEntry<WithId<T>> | undefined> {
     // No cache access allowed mid-transaction
     if (this.connection.isInTransaction()) {
       return undefined;
     }
+    this.connection.recordResourceAccess('cache', 'read', [resourceType], 'repo.getCacheEntry');
     return getResourceCacheEntry<T>(resourceType, id);
   }
 
@@ -2308,6 +2411,12 @@ export class Repository extends FhirRepository implements Disposable {
       return new Array(references.length);
     }
 
+    this.connection.recordResourceAccess(
+      'cache',
+      'read',
+      getLocalReferenceResourceTypes(references),
+      'repo.getCacheEntries'
+    );
     return getResourceCacheEntries(references);
   }
 
@@ -2325,6 +2434,7 @@ export class Repository extends FhirRepository implements Disposable {
       return;
     }
 
+    this.connection.recordResourceAccess('cache', 'write', [resource.resourceType], 'repo.setCacheEntry');
     await setResourceCacheEntry(resource);
   }
 
@@ -2333,13 +2443,14 @@ export class Repository extends FhirRepository implements Disposable {
    * @param resourceType - The resource type.
    * @param id - The resource ID.
    */
-  private async deleteCacheEntry(resourceType: string, id: string): Promise<void> {
+  private async deleteCacheEntry(resourceType: ResourceType, id: string): Promise<void> {
     // No cache access allowed mid-transaction
     if (this.connection.isInTransaction()) {
       await this.postCommit(() => this.deleteCacheEntry(resourceType, id));
       return;
     }
 
+    this.connection.recordResourceAccess('cache', 'write', [resourceType], 'repo.deleteCacheEntry');
     await deleteResourceCacheEntry(resourceType, id);
   }
 
@@ -2348,13 +2459,14 @@ export class Repository extends FhirRepository implements Disposable {
    * @param resourceType - The resource type.
    * @param ids - The resource IDs.
    */
-  private async deleteCacheEntries(resourceType: string, ids: string[]): Promise<void> {
+  private async deleteCacheEntries(resourceType: ResourceType, ids: string[]): Promise<void> {
     // No cache access allowed mid-transaction
     if (this.connection.isInTransaction()) {
       await this.postCommit(() => this.deleteCacheEntries(resourceType, ids));
       return;
     }
 
+    this.connection.recordResourceAccess('cache', 'write', [resourceType], 'repo.deleteCacheEntries');
     await deleteResourceCacheEntries(resourceType, ids);
   }
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -101,7 +101,7 @@ import { clamp, makeOperationDefinitionParameter, parseParametersFromDefinitions
 import { getPatients } from './patient';
 import { preCommitValidation } from './precommit';
 import { replaceConditionalReferences, validateResourceReferences } from './references';
-import type { RepositoryAccessOperation } from './repository/access-tracker';
+import type { ExecuteSqlOptions, TransactionSqlOptions } from './repository/access-tracker';
 import { getLocalReferenceResourceTypes } from './repository/access-tracker';
 import { removeField } from './repository/field-utils';
 import { removeCachedProfile } from './repository/profile-cache';
@@ -131,8 +131,6 @@ import { lookupTables } from './searchparameter';
 import { GLOBAL_SHARD_ID } from './sharding';
 import type { Expression, PgQueryable } from './sql';
 import { Condition, DeleteQuery, Disjunction, InsertQuery, SelectQuery } from './sql';
-
-export type { StatementTimeoutOptions } from './repository/repository-connection';
 
 /**
  * The RepositoryContext interface defines standard metadata for repository actions.
@@ -256,12 +254,7 @@ export interface ProcessAllResourcesOptions {
   delayBetweenPagesMs?: number;
 }
 
-export interface ExecuteSqlOptions {
-  readonly mode: DatabaseMode;
-  readonly operation: RepositoryAccessOperation;
-  readonly resourceTypes: Iterable<ResourceType>;
-  readonly source: string;
-}
+export type { ExecuteSqlOptions, TransactionSqlOptions } from './repository/access-tracker';
 
 function addSyntheticR4ProjectIfMissing(context: RepositoryContext): void {
   if (context.projects && !context.projects.some((project) => project.id === syntheticR4Project.id)) {
@@ -431,7 +424,7 @@ export class Repository extends FhirRepository implements Disposable {
   ): Promise<T[]> {
     this.assertUsable();
     this.connection.recordResourceAccess('sql', options.operation, options.resourceTypes, options.source);
-    return query.execute(this.getDatabaseClient(options.mode));
+    return query.execute(this.getDatabaseClient(options));
   }
 
   async executeRawSql<T = any>(query: string, params: any[], options: ExecuteSqlOptions): Promise<T[]> {
@@ -889,7 +882,10 @@ export class Repository extends FhirRepository implements Disposable {
       let result: WithId<T>;
       if (options?.ifMatch) {
         // Conditional update requires transaction
-        result = await this.withTransaction((txRepo) => txRepo.updateResourceImpl(resource, false, options));
+        result = await this.withTransaction((txRepo) => txRepo.updateResourceImpl(resource, false, options), {
+          resourceTypes: [resource.resourceType],
+          source: 'repo.updateResource.ifMatch',
+        });
       } else {
         result = await this.updateResourceImpl(resource, false, options);
       }
@@ -1132,11 +1128,14 @@ export class Repository extends FhirRepository implements Disposable {
    * @param create - If true, then the resource is being created.
    */
   private async writeToDatabase<T extends WithId<Resource>>(resource: T, create: boolean): Promise<void> {
-    await this.ensureInTransaction(async (txRepo) => {
-      await txRepo.writeResource(resource);
-      await txRepo.writeResourceVersion(resource);
-      await txRepo.writeLookupTables(resource, create);
-    });
+    await this.ensureInTransaction(
+      async (txRepo) => {
+        await txRepo.writeResource(resource);
+        await txRepo.writeResourceVersion(resource);
+        await txRepo.writeLookupTables(resource, create);
+      },
+      { resourceTypes: resource.resourceType, source: 'repo.writeToDatabase' }
+    );
   }
 
   /**
@@ -1205,10 +1204,13 @@ export class Repository extends FhirRepository implements Disposable {
       throw new OperationOutcomeError(forbidden);
     }
 
-    await this.withTransaction(async (txRepo) => {
-      const resource = await txRepo.readResourceImpl<T>(resourceType, id);
-      return txRepo.reindexResources([resource]);
-    });
+    await this.withTransaction(
+      async (txRepo) => {
+        const resource = await txRepo.readResourceImpl<T>(resourceType, id);
+        return txRepo.reindexResources([resource]);
+      },
+      { resourceTypes: resourceType, source: 'repo.reindexResource' }
+    );
   }
 
   /**
@@ -1221,6 +1223,13 @@ export class Repository extends FhirRepository implements Disposable {
     this.assertUsable();
     if (!this.isSuperAdmin()) {
       throw new OperationOutcomeError(forbidden);
+    }
+    const resourceType = resources[0]?.resourceType;
+    for (let i = 1; i < resources.length; i++) {
+      if (resources[i].resourceType !== resourceType) {
+        // TODO add test for varyings types
+        throw new OperationOutcomeError(badRequest('All resources must be of the same type'));
+      }
     }
 
     // Since the page size could be relatively large (1k+), preferring a simple for loop with re-used variables
@@ -1236,10 +1245,13 @@ export class Repository extends FhirRepository implements Disposable {
       }
     }
 
-    await this.ensureInTransaction(async (txRepo) => {
-      await txRepo.batchWriteLookupTables(resources, false);
-      await txRepo.batchWriteResources(resources);
-    });
+    await this.ensureInTransaction(
+      async (txRepo) => {
+        await txRepo.batchWriteLookupTables(resources, false);
+        await txRepo.batchWriteResources(resources);
+      },
+      { resourceTypes: resourceType, source: 'repo.reindexResources' }
+    );
   }
 
   /**
@@ -1334,56 +1346,59 @@ export class Repository extends FhirRepository implements Disposable {
       }
 
       if (!this.isCacheOnly(resource)) {
-        await this.ensureInTransaction(async (txRepo) => {
-          // FHIR logical delete: retain history and append a new deleted version. Instance
-          // reads and vread of that version return HTTP 410 Gone; prior versions stay readable.
-          const versionId = txRepo.generateId();
-          const lastUpdated = new Date();
+        await this.ensureInTransaction(
+          async (txRepo) => {
+            // FHIR logical delete: retain history and append a new deleted version. Instance
+            // reads and vread of that version return HTTP 410 Gone; prior versions stay readable.
+            const versionId = txRepo.generateId();
+            const lastUpdated = new Date();
 
-          // Main table: empty content with deleted=true so search/read return 410, not 404.
-          const columns = buildDeletedResourceRow(resource, lastUpdated);
+            // Main table: empty content with deleted=true so search/read return 410, not 404.
+            const columns = buildDeletedResourceRow(resource, lastUpdated);
 
-          // History table: minimal tombstone (resourceType, id, meta.deleted) for auditing and
-          // warehouse sync. Public history bundles still omit the body and return 410 per spec.
-          const historyContent = buildDeleteHistoryContent(resource, {
-            versionId,
-            lastUpdated,
-            author: txRepo.getAuthor(),
-          });
+            // History table: minimal tombstone (resourceType, id, meta.deleted) for auditing and
+            // warehouse sync. Public history bundles still omit the body and return 410 per spec.
+            const historyContent = buildDeleteHistoryContent(resource, {
+              versionId,
+              lastUpdated,
+              author: txRepo.getAuthor(),
+            });
 
-          await txRepo.executeSql(new InsertQuery(resourceType, [columns]).mergeOnConflict(), {
-            mode: DatabaseMode.WRITER,
-            operation: 'write',
-            resourceTypes: [resourceType],
-            source: 'repo.deleteResource.resource',
-          });
-
-          await txRepo.executeSql(
-            new InsertQuery(resourceType + '_History', [
-              {
-                id,
-                versionId,
-                lastUpdated: columns.lastUpdated,
-                content: historyContent,
-              },
-            ]),
-            {
+            await txRepo.executeSql(new InsertQuery(resourceType, [columns]).mergeOnConflict(), {
               mode: DatabaseMode.WRITER,
               operation: 'write',
               resourceTypes: [resourceType],
-              source: 'repo.deleteResource.history',
-            }
-          );
+              source: 'repo.deleteResource.resource',
+            });
 
-          await txRepo.deleteFromLookupTables(resource);
+            await txRepo.executeSql(
+              new InsertQuery(resourceType + '_History', [
+                {
+                  id,
+                  versionId,
+                  lastUpdated: columns.lastUpdated,
+                  content: historyContent,
+                },
+              ]),
+              {
+                mode: DatabaseMode.WRITER,
+                operation: 'write',
+                resourceTypes: [resourceType],
+                source: 'repo.deleteResource.resource',
+              }
+            );
 
-          const durationMs = Date.now() - startTime;
+            await txRepo.deleteFromLookupTables(resource);
 
-          // Delete auditing via AuditEvent; FHIR does not require a searchable Provenance per delete.
-          await txRepo.postCommit(async () => {
-            txRepo.logEvent(DeleteInteraction, AuditEventOutcome.Success, undefined, { resource, durationMs });
-          });
-        });
+            const durationMs = Date.now() - startTime;
+
+            // Delete auditing via AuditEvent; FHIR does not require a searchable Provenance per delete.
+            await txRepo.postCommit(async () => {
+              txRepo.logEvent(DeleteInteraction, AuditEventOutcome.Success, undefined, { resource, durationMs });
+            });
+          },
+          { resourceTypes: resourceType, source: 'repo.deleteResource' }
+        );
       }
 
       if (!this.context.skipBackgroundJobs) {
@@ -1412,36 +1427,39 @@ export class Repository extends FhirRepository implements Disposable {
 
     const startTime = Date.now();
     try {
-      return await this.ensureInTransaction(async (txRepo) => {
-        const resource = await txRepo.readResourceFromDatabase<T>(resourceType, id);
+      return await this.ensureInTransaction(
+        async (txRepo) => {
+          const resource = await txRepo.readResourceFromDatabase<T>(resourceType, id);
 
-        if (resource.resourceType !== resourceType) {
-          throw new OperationOutcomeError(badRequest('Incorrect resource type'));
-        }
-        if (resource.id !== id) {
-          throw new OperationOutcomeError(badRequest('Incorrect ID'));
-        }
+          if (resource.resourceType !== resourceType) {
+            throw new OperationOutcomeError(badRequest('Incorrect resource type'));
+          }
+          if (resource.id !== id) {
+            throw new OperationOutcomeError(badRequest('Incorrect ID'));
+          }
 
-        if (Array.isArray(patch)) {
-          patchObject(resource, patch);
-        } else if (patch.parameter) {
-          const params = parseParametersFromDefinitions(
-            patchOperationDefinition.parameter as OperationDefinitionParameter[],
-            patch.parameter
-          );
-          fhirpathPatchTypedValue(toTypedValue(resource), params.operation as FhirPathPatch[]);
-        } else {
-          return resource; // No patch present, return unmodified
-        }
+          if (Array.isArray(patch)) {
+            patchObject(resource, patch);
+          } else if (patch.parameter) {
+            const params = parseParametersFromDefinitions(
+              patchOperationDefinition.parameter as OperationDefinitionParameter[],
+              patch.parameter
+            );
+            fhirpathPatchTypedValue(toTypedValue(resource), params.operation as FhirPathPatch[]);
+          } else {
+            return resource; // No patch present, return unmodified
+          }
 
-        const result = await txRepo.updateResourceImpl(resource, false, options);
-        const durationMs = Date.now() - startTime;
+          const result = await txRepo.updateResourceImpl(resource, false, options);
+          const durationMs = Date.now() - startTime;
 
-        await txRepo.postCommit(async () => {
-          txRepo.logEvent(PatchInteraction, AuditEventOutcome.Success, undefined, { resource: result, durationMs });
-        });
-        return result;
-      });
+          await txRepo.postCommit(async () => {
+            txRepo.logEvent(PatchInteraction, AuditEventOutcome.Success, undefined, { resource: result, durationMs });
+          });
+          return result;
+        },
+        { resourceTypes: resourceType, source: 'repo.patchResource' }
+      );
     } catch (err) {
       const durationMs = Date.now() - startTime;
       this.logEvent(PatchInteraction, AuditEventOutcome.MinorFailure, err, {
@@ -1514,7 +1532,7 @@ export class Repository extends FhirRepository implements Disposable {
         await txRepo.postCommit(() => txRepo.deleteCacheEntries(resourceType, deletedIds));
         return deletedIds;
       },
-      { serializable: true }
+      { serializable: true, resourceTypes: resourceType, source: 'repo.expungeResources' }
     );
     incrementCounter(
       `medplum.fhir.interaction.delete.count`,
@@ -1536,7 +1554,12 @@ export class Repository extends FhirRepository implements Disposable {
       throw new OperationOutcomeError(forbidden);
     }
 
-    const client = this.getDatabaseClient(DatabaseMode.WRITER);
+    const client = this.getDatabaseClient({
+      mode: DatabaseMode.WRITER,
+      operation: 'write',
+      resourceTypes: [resourceType],
+      source: 'repo.purgeResources.lookupTables',
+    });
 
     // Delete from lookup tables first
     // These operations use the main resource table for lastUpdated, so must come first
@@ -1899,14 +1922,24 @@ export class Repository extends FhirRepository implements Disposable {
    * @param create - If true, then the resource is being created.
    */
   protected async writeLookupTables(resource: WithId<Resource>, create: boolean): Promise<void> {
-    const client = this.getDatabaseClient(DatabaseMode.WRITER);
+    const client = this.getDatabaseClient({
+      mode: DatabaseMode.WRITER,
+      operation: 'write',
+      resourceTypes: [resource.resourceType],
+      source: 'repo.writeLookupTables',
+    });
     for (const lookupTable of lookupTables) {
       await lookupTable.indexResource(client, resource, create);
     }
   }
 
   protected async batchWriteLookupTables<T extends Resource>(resources: WithId<T>[], create: boolean): Promise<void> {
-    const client = this.getDatabaseClient(DatabaseMode.WRITER);
+    const client = this.getDatabaseClient({
+      mode: DatabaseMode.WRITER,
+      operation: 'write',
+      resourceTypes: [resources[0].resourceType],
+      source: 'repo.batchWriteLookupTables',
+    });
     for (const lookupTable of lookupTables) {
       await lookupTable.batchIndexResources(client, resources, create);
     }
@@ -1917,7 +1950,12 @@ export class Repository extends FhirRepository implements Disposable {
    * @param resource - The resource to delete.
    */
   protected async deleteFromLookupTables(resource: WithId<Resource>): Promise<void> {
-    const client = this.getDatabaseClient(DatabaseMode.WRITER);
+    const client = this.getDatabaseClient({
+      mode: DatabaseMode.WRITER,
+      operation: 'write',
+      resourceTypes: [resource.resourceType],
+      source: 'repo.deleteFromLookupTables',
+    });
     for (const lookupTable of lookupTables) {
       await lookupTable.deleteValuesForResource(client, resource);
     }
@@ -2335,17 +2373,17 @@ export class Repository extends FhirRepository implements Disposable {
    * For example, use this method for "read by ID".
    * At runtime, this can be backed by a pool client or a pool, but the public type
    * intentionally only exposes query operations.
-   * @param mode - The database mode.
+   * @param options - SQL execution metadata.
    * @returns The database client.
    */
-  getDatabaseClient(mode: DatabaseMode): PgQueryable {
+  getDatabaseClient(options: ExecuteSqlOptions): PgQueryable {
     this.assertUsable();
-    return this.connection.getDatabaseClient(this.connectionScope, mode);
+    return this.connection.getDatabaseClient(this.connectionScope, options);
   }
 
   async withTransaction<TResult>(
     callback: (repo: this) => Promise<TResult>,
-    options?: { serializable?: boolean }
+    options: TransactionSqlOptions
   ): Promise<TResult> {
     this.assertUsable();
     return this.connection.withTransaction(
@@ -2366,9 +2404,6 @@ export class Repository extends FhirRepository implements Disposable {
     callback: () => Promise<TResult>
   ): Promise<TResult> {
     this.assertUsable();
-    if (!this.ownsConnection) {
-      throw new Error('Cannot set statement timeout on a borrowed repository connection');
-    }
     return this.connection.withStatementTimeout(options, callback);
   }
 
@@ -2470,13 +2505,17 @@ export class Repository extends FhirRepository implements Disposable {
     await deleteResourceCacheEntries(resourceType, ids);
   }
 
-  async ensureInTransaction<TResult>(callback: (repo: this) => Promise<TResult>): Promise<TResult> {
+  async ensureInTransaction<TResult>(
+    callback: (repo: this) => Promise<TResult>,
+    options: TransactionSqlOptions
+  ): Promise<TResult> {
     this.assertUsable();
     if (this.connection.isInTransaction()) {
+      this.connection.recordResourceAccess('sql', 'transaction', options.resourceTypes, options.source);
       return callback(this);
     }
 
-    return this.withTransaction(callback);
+    return this.withTransaction(callback, options);
   }
 
   getConfig(): Readonly<RepositoryContext> {

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -100,9 +100,8 @@ import { FhirQuotaCost } from './fhirquota';
 import { clamp, makeOperationDefinitionParameter, parseParametersFromDefinitions } from './operations/utils/parameters';
 import { getPatients } from './patient';
 import { preCommitValidation } from './precommit';
-import { replaceConditionalReferences, validateResourceReferences } from './references';
+import { getResourceTypesFromReferences, replaceConditionalReferences, validateResourceReferences } from './references';
 import type { ExecuteSqlOptions, TransactionSqlOptions } from './repository/access-tracker';
-import { getResourceTypesFromReferences } from './repository/access-tracker';
 import { removeField } from './repository/field-utils';
 import { removeCachedProfile } from './repository/profile-cache';
 import type { ConnectionScope, StatementTimeoutOptions } from './repository/repository-connection';
@@ -423,7 +422,6 @@ export class Repository extends FhirRepository implements Disposable {
     options: ExecuteSqlOptions
   ): Promise<T[]> {
     this.assertUsable();
-    this.connection.recordResourceAccess('sql', options.operation, options.resourceTypes, options.source);
     return query.execute(this.getDatabaseClient(options));
   }
 
@@ -1224,10 +1222,12 @@ export class Repository extends FhirRepository implements Disposable {
     if (!this.isSuperAdmin()) {
       throw new OperationOutcomeError(forbidden);
     }
-    const resourceType = resources[0]?.resourceType;
+    if (!resources.length) {
+      return;
+    }
+    const resourceType = resources[0].resourceType;
     for (let i = 1; i < resources.length; i++) {
       if (resources[i].resourceType !== resourceType) {
-        // TODO add test for varyings types
         throw new OperationOutcomeError(badRequest('All resources must be of the same type'));
       }
     }
@@ -1934,6 +1934,9 @@ export class Repository extends FhirRepository implements Disposable {
   }
 
   protected async batchWriteLookupTables<T extends Resource>(resources: WithId<T>[], create: boolean): Promise<void> {
+    if (!resources.length) {
+      return;
+    }
     const client = this.getDatabaseClient({
       mode: DatabaseMode.WRITER,
       operation: 'write',

--- a/packages/server/src/fhir/repository/access-tracker.ts
+++ b/packages/server/src/fhir/repository/access-tracker.ts
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { isResourceType } from '@medplum/core';
+import type { Reference, ResourceType } from '@medplum/fhirtypes';
+import { getLogger } from '../../logger';
+
+export type RepositoryAccessLayer = 'sql' | 'cache';
+export type RepositoryAccessOperation = 'read' | 'write';
+
+type TransactionAccessFrame = {
+  sqlReadCount: number;
+  sqlWriteCount: number;
+  cacheReadCount: number;
+  cacheWriteCount: number;
+  readResourceTypes: Set<ResourceType>;
+  writeResourceTypes: Set<ResourceType>;
+  specialResourceTypes: Set<ResourceType>;
+  otherResourceTypes: Set<ResourceType>;
+  sources: Set<string>;
+};
+
+const splitTrackedResourceTypes = new Set<ResourceType>(['Project', 'ProjectMembership', 'User']);
+
+export function createRepositoryAccessTracker(): RepositoryAccessTracker {
+  return new RepositoryAccessTracker();
+}
+
+export class RepositoryAccessTracker {
+  readonly transactionFrames: TransactionAccessFrame[] = [];
+
+  getCurrentTransactionFrame(): TransactionAccessFrame | undefined {
+    return this.transactionFrames[this.transactionFrames.length - 1];
+  }
+
+  private hasTrackedTransaction(): boolean {
+    return this.transactionFrames.length > 0;
+  }
+
+  pushTransactionFrame(): void {
+    this.transactionFrames.push(createTransactionAccessFrame());
+  }
+
+  popTransactionFrame(): TransactionAccessFrame {
+    const frame = this.transactionFrames.pop();
+    if (!frame) {
+      throw new Error('No transaction frame');
+    }
+    return frame;
+  }
+
+  mergeLastTransactionFrame(): void {
+    const popped = this.popTransactionFrame();
+    const current = this.getCurrentTransactionFrame();
+    if (!current) {
+      throw new Error('No current transaction frame');
+    }
+    mergeTransactionAccessFrame(current, popped);
+  }
+
+  clearTransactionFrames(): void {
+    this.transactionFrames.length = 0;
+  }
+
+  logTransactionAccess(frame: TransactionAccessFrame, status: 'committed' | 'rolled_back'): void {
+    if (!frame.specialResourceTypes.size || !frame.otherResourceTypes.size) {
+      return;
+    }
+
+    getLogger().info('[RepoSplit] Mixed transaction access', {
+      scope: 'transaction',
+      status,
+      specialResourceTypes: [...frame.specialResourceTypes].sort(),
+      otherResourceTypes: [...frame.otherResourceTypes].sort(),
+      readResourceTypes: [...frame.readResourceTypes].sort(),
+      writeResourceTypes: [...frame.writeResourceTypes].sort(),
+      sqlReadCount: frame.sqlReadCount,
+      sqlWriteCount: frame.sqlWriteCount,
+      cacheReadCount: frame.cacheReadCount,
+      cacheWriteCount: frame.cacheWriteCount,
+      sources: [...frame.sources].sort(),
+    });
+  }
+
+  recordResourceAccess(
+    layer: RepositoryAccessLayer,
+    operation: RepositoryAccessOperation,
+    resourceTypes: Iterable<ResourceType>,
+    source: string
+  ): void {
+    const access = partitionResourceTypes(resourceTypes);
+    if (access.all.length === 0) {
+      return;
+    }
+
+    if (access.special.length > 0 && access.other.length > 0) {
+      getLogger().info('[RepoSplit] Mixed resource access', {
+        scope: 'statement',
+        layer,
+        operation,
+        source,
+        inTransaction: this.hasTrackedTransaction(),
+        specialResourceTypes: access.special,
+        otherResourceTypes: access.other,
+        resourceTypes: access.all,
+      });
+    }
+
+    const frame = this.getCurrentTransactionFrame();
+    if (!frame) {
+      return;
+    }
+
+    if (layer === 'sql') {
+      if (operation === 'read') {
+        frame.sqlReadCount++;
+      } else {
+        frame.sqlWriteCount++;
+      }
+    } else if (operation === 'read') {
+      frame.cacheReadCount++;
+    } else {
+      frame.cacheWriteCount++;
+    }
+
+    const resourceTypeSet = operation === 'read' ? frame.readResourceTypes : frame.writeResourceTypes;
+    for (const resourceType of access.all) {
+      resourceTypeSet.add(resourceType);
+    }
+    for (const resourceType of access.special) {
+      frame.specialResourceTypes.add(resourceType);
+    }
+    for (const resourceType of access.other) {
+      frame.otherResourceTypes.add(resourceType);
+    }
+    frame.sources.add(source);
+  }
+}
+
+function createTransactionAccessFrame(): TransactionAccessFrame {
+  return {
+    sqlReadCount: 0,
+    sqlWriteCount: 0,
+    cacheReadCount: 0,
+    cacheWriteCount: 0,
+    readResourceTypes: new Set<ResourceType>(),
+    writeResourceTypes: new Set<ResourceType>(),
+    specialResourceTypes: new Set<ResourceType>(),
+    otherResourceTypes: new Set<ResourceType>(),
+    sources: new Set<string>(),
+  };
+}
+
+function partitionResourceTypes(resourceTypes: Iterable<ResourceType>): {
+  all: ResourceType[];
+  special: ResourceType[];
+  other: ResourceType[];
+} {
+  const all = new Set<ResourceType>();
+  const special = new Set<ResourceType>();
+  const other = new Set<ResourceType>();
+
+  for (const resourceType of resourceTypes) {
+    if (!resourceType) {
+      continue;
+    }
+    all.add(resourceType);
+    if (splitTrackedResourceTypes.has(resourceType)) {
+      special.add(resourceType);
+    } else {
+      other.add(resourceType);
+    }
+  }
+
+  return {
+    all: [...all].sort(),
+    special: [...special].sort(),
+    other: [...other].sort(),
+  };
+}
+
+function mergeTransactionAccessFrame(target: TransactionAccessFrame, source: TransactionAccessFrame): void {
+  target.sqlReadCount += source.sqlReadCount;
+  target.sqlWriteCount += source.sqlWriteCount;
+  target.cacheReadCount += source.cacheReadCount;
+  target.cacheWriteCount += source.cacheWriteCount;
+
+  for (const resourceType of source.readResourceTypes) {
+    target.readResourceTypes.add(resourceType);
+  }
+  for (const resourceType of source.writeResourceTypes) {
+    target.writeResourceTypes.add(resourceType);
+  }
+  for (const resourceType of source.specialResourceTypes) {
+    target.specialResourceTypes.add(resourceType);
+  }
+  for (const resourceType of source.otherResourceTypes) {
+    target.otherResourceTypes.add(resourceType);
+  }
+  for (const sourceName of source.sources) {
+    target.sources.add(sourceName);
+  }
+}
+
+export function getLocalReferenceResourceTypes(references: Reference[]): ResourceType[] {
+  const resourceTypes = new Set<ResourceType>();
+  for (const reference of references) {
+    const resourceType = reference.reference?.split('/')[0];
+    if (resourceType && isResourceType(resourceType)) {
+      resourceTypes.add(resourceType);
+    }
+  }
+  return [...resourceTypes].sort();
+}

--- a/packages/server/src/fhir/repository/access-tracker.ts
+++ b/packages/server/src/fhir/repository/access-tracker.ts
@@ -44,7 +44,7 @@ export class RepositoryAccessTracker {
   readonly transactionFrames: TransactionAccessFrame[] = [];
 
   getCurrentTransactionFrame(): TransactionAccessFrame | undefined {
-    return this.transactionFrames[this.transactionFrames.length - 1];
+    return this.transactionFrames.at(-1);
   }
 
   private hasTrackedTransaction(): boolean {
@@ -84,15 +84,15 @@ export class RepositoryAccessTracker {
     getLogger().info('[RepoSplit] Mixed transaction access', {
       scope: 'transaction',
       status,
-      specialResourceTypes: [...frame.specialResourceTypes].sort(),
-      otherResourceTypes: [...frame.otherResourceTypes].sort(),
-      readResourceTypes: [...frame.readResourceTypes].sort(),
-      writeResourceTypes: [...frame.writeResourceTypes].sort(),
+      specialResourceTypes: Array.from(frame.specialResourceTypes),
+      otherResourceTypes: Array.from(frame.otherResourceTypes),
+      readResourceTypes: Array.from(frame.readResourceTypes),
+      writeResourceTypes: Array.from(frame.writeResourceTypes),
       sqlReadCount: frame.sqlReadCount,
       sqlWriteCount: frame.sqlWriteCount,
       cacheReadCount: frame.cacheReadCount,
       cacheWriteCount: frame.cacheWriteCount,
-      sources: [...frame.sources].sort(),
+      sources: Array.from(frame.sources),
     });
   }
 
@@ -103,57 +103,63 @@ export class RepositoryAccessTracker {
     source: string
   ): void {
     const access = partitionResourceTypes(resourceTypes);
-    if (access.all.length === 0) {
+    if (access.all.size === 0) {
       return;
     }
 
-    if (access.special.length > 0 && access.other.length > 0) {
+    if (access.special.size > 0 && access.other.size > 0) {
       getLogger().info('[RepoSplit] Mixed resource access', {
         scope: 'statement',
         layer,
         operation,
         source,
         inTransaction: this.hasTrackedTransaction(),
-        specialResourceTypes: access.special,
-        otherResourceTypes: access.other,
-        resourceTypes: access.all,
+        specialResourceTypes: Array.from(access.special),
+        otherResourceTypes: Array.from(access.other),
+        resourceTypes: Array.from(access.all),
       });
     }
 
     const frame = this.getCurrentTransactionFrame();
-    if (!frame) {
-      return;
+    if (frame) {
+      updateTransactionAccessFrame(frame, layer, operation, source, access);
     }
+  }
+}
 
+function updateTransactionAccessFrame(
+  frame: TransactionAccessFrame,
+  layer: RepositoryAccessLayer,
+  operation: RepositoryAccessOperation,
+  source: string,
+  access: ResourceTypePartition
+): void {
+  if (operation === 'read') {
     if (layer === 'sql') {
-      if (operation === 'read') {
-        frame.sqlReadCount++;
-      } else if (operation === 'write') {
-        frame.sqlWriteCount++;
-      }
-    } else if (operation === 'read') {
+      frame.sqlReadCount++;
+    } else {
       frame.cacheReadCount++;
+    }
+    for (const resourceType of access.all) {
+      frame.readResourceTypes.add(resourceType);
+    }
+  } else if (operation === 'write') {
+    if (layer === 'sql') {
+      frame.sqlWriteCount++;
     } else {
       frame.cacheWriteCount++;
     }
-
-    if (operation === 'read') {
-      for (const resourceType of access.all) {
-        frame.readResourceTypes.add(resourceType);
-      }
-    } else if (operation === 'write') {
-      for (const resourceType of access.all) {
-        frame.writeResourceTypes.add(resourceType);
-      }
+    for (const resourceType of access.all) {
+      frame.writeResourceTypes.add(resourceType);
     }
-    for (const resourceType of access.special) {
-      frame.specialResourceTypes.add(resourceType);
-    }
-    for (const resourceType of access.other) {
-      frame.otherResourceTypes.add(resourceType);
-    }
-    frame.sources.add(source);
   }
+  for (const resourceType of access.special) {
+    frame.specialResourceTypes.add(resourceType);
+  }
+  for (const resourceType of access.other) {
+    frame.otherResourceTypes.add(resourceType);
+  }
+  frame.sources.add(source);
 }
 
 function createTransactionAccessFrame(): TransactionAccessFrame {
@@ -170,19 +176,18 @@ function createTransactionAccessFrame(): TransactionAccessFrame {
   };
 }
 
-function partitionResourceTypes(resourceTypes: Iterable<ResourceType>): {
-  all: ResourceType[];
-  special: ResourceType[];
-  other: ResourceType[];
-} {
+type ResourceTypePartition = {
+  readonly all: Set<ResourceType>;
+  readonly special: Set<ResourceType>;
+  readonly other: Set<ResourceType>;
+};
+
+function partitionResourceTypes(resourceTypes: Iterable<ResourceType>): ResourceTypePartition {
   const all = new Set<ResourceType>();
   const special = new Set<ResourceType>();
   const other = new Set<ResourceType>();
 
   for (const resourceType of resourceTypes) {
-    if (!resourceType) {
-      continue;
-    }
     all.add(resourceType);
     if (splitTrackedResourceTypes.has(resourceType)) {
       special.add(resourceType);
@@ -191,11 +196,7 @@ function partitionResourceTypes(resourceTypes: Iterable<ResourceType>): {
     }
   }
 
-  return {
-    all: [...all].sort(),
-    special: [...special].sort(),
-    other: [...other].sort(),
-  };
+  return { all, special, other };
 }
 
 function mergeTransactionAccessFrame(target: TransactionAccessFrame, source: TransactionAccessFrame): void {
@@ -221,7 +222,7 @@ function mergeTransactionAccessFrame(target: TransactionAccessFrame, source: Tra
   }
 }
 
-export function getLocalReferenceResourceTypes(references: Reference[]): ResourceType[] {
+export function getResourceTypesFromReferences(references: Reference[]): ResourceType[] {
   const resourceTypes = new Set<ResourceType>();
   for (const reference of references) {
     const resourceType = reference.reference?.split('/')[0];
@@ -229,5 +230,5 @@ export function getLocalReferenceResourceTypes(references: Reference[]): Resourc
       resourceTypes.add(resourceType);
     }
   }
-  return [...resourceTypes].sort();
+  return Array.from(resourceTypes);
 }

--- a/packages/server/src/fhir/repository/access-tracker.ts
+++ b/packages/server/src/fhir/repository/access-tracker.ts
@@ -2,11 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { isResourceType } from '@medplum/core';
+import type { TransactionOptions } from '@medplum/fhir-router';
 import type { Reference, ResourceType } from '@medplum/fhirtypes';
+import type { DatabaseMode } from '../../database';
 import { getLogger } from '../../logger';
 
 export type RepositoryAccessLayer = 'sql' | 'cache';
-export type RepositoryAccessOperation = 'read' | 'write';
+export type RepositoryAccessOperation = 'read' | 'write' | 'transaction' | 'configuration';
+
+export interface RepositoryAccessOptions {
+  readonly resourceTypes: Iterable<ResourceType>;
+  readonly source: string;
+}
+
+export interface ExecuteSqlOptions extends RepositoryAccessOptions {
+  readonly operation: RepositoryAccessOperation;
+  readonly mode: DatabaseMode;
+}
+
+export interface TransactionSqlOptions extends RepositoryAccessOptions, TransactionOptions {}
 
 type TransactionAccessFrame = {
   sqlReadCount: number;
@@ -114,7 +128,7 @@ export class RepositoryAccessTracker {
     if (layer === 'sql') {
       if (operation === 'read') {
         frame.sqlReadCount++;
-      } else {
+      } else if (operation === 'write') {
         frame.sqlWriteCount++;
       }
     } else if (operation === 'read') {
@@ -123,9 +137,14 @@ export class RepositoryAccessTracker {
       frame.cacheWriteCount++;
     }
 
-    const resourceTypeSet = operation === 'read' ? frame.readResourceTypes : frame.writeResourceTypes;
-    for (const resourceType of access.all) {
-      resourceTypeSet.add(resourceType);
+    if (operation === 'read') {
+      for (const resourceType of access.all) {
+        frame.readResourceTypes.add(resourceType);
+      }
+    } else if (operation === 'write') {
+      for (const resourceType of access.all) {
+        frame.writeResourceTypes.add(resourceType);
+      }
     }
     for (const resourceType of access.special) {
       frame.specialResourceTypes.add(resourceType);

--- a/packages/server/src/fhir/repository/access-tracker.ts
+++ b/packages/server/src/fhir/repository/access-tracker.ts
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { isResourceType } from '@medplum/core';
 import type { TransactionOptions } from '@medplum/fhir-router';
-import type { Reference, ResourceType } from '@medplum/fhirtypes';
+import type { ResourceType } from '@medplum/fhirtypes';
 import type { DatabaseMode } from '../../database';
 import { getLogger } from '../../logger';
 
@@ -35,10 +34,6 @@ type TransactionAccessFrame = {
 };
 
 const splitTrackedResourceTypes = new Set<ResourceType>(['Project', 'ProjectMembership', 'User']);
-
-export function createRepositoryAccessTracker(): RepositoryAccessTracker {
-  return new RepositoryAccessTracker();
-}
 
 export class RepositoryAccessTracker {
   readonly transactionFrames: TransactionAccessFrame[] = [];
@@ -220,15 +215,4 @@ function mergeTransactionAccessFrame(target: TransactionAccessFrame, source: Tra
   for (const sourceName of source.sources) {
     target.sources.add(sourceName);
   }
-}
-
-export function getResourceTypesFromReferences(references: Reference[]): ResourceType[] {
-  const resourceTypes = new Set<ResourceType>();
-  for (const reference of references) {
-    const resourceType = reference.reference?.split('/')[0];
-    if (resourceType && isResourceType(resourceType)) {
-      resourceTypes.add(resourceType);
-    }
-  }
-  return Array.from(resourceTypes);
 }

--- a/packages/server/src/fhir/repository/access-tracker.ts
+++ b/packages/server/src/fhir/repository/access-tracker.ts
@@ -3,15 +3,20 @@
 
 import type { TransactionOptions } from '@medplum/fhir-router';
 import type { ResourceType } from '@medplum/fhirtypes';
-import type { DatabaseMode } from '../../database';
+import { DatabaseMode } from '../../database';
 import { getLogger } from '../../logger';
 
 export type RepositoryAccessLayer = 'sql' | 'cache';
 export type RepositoryAccessOperation = 'read' | 'write' | 'transaction' | 'configuration';
 
+export type NormalizedResourceTypes = ReadonlySet<ResourceType>;
+export type ResourceTypeInput = ResourceType | readonly ResourceType[] | NormalizedResourceTypes;
+
 export interface RepositoryAccessOptions {
-  readonly resourceTypes: Iterable<ResourceType>;
-  readonly source: string;
+  /** The resource types involved in the operation */
+  readonly resourceTypes: ResourceTypeInput;
+  /** Short label identifying the call site (e.g. `repo.readResourceFromDatabase`) */
+  readonly source?: string;
 }
 
 export interface ExecuteSqlOptions extends RepositoryAccessOptions {
@@ -67,8 +72,20 @@ export class RepositoryAccessTracker {
     mergeTransactionAccessFrame(current, popped);
   }
 
-  clearTransactionFrames(): void {
-    this.transactionFrames.length = 0;
+  /**
+   * Folds every live transaction frame into a single aggregate frame, empties the stack, and
+   * returns the aggregate (or undefined if no frames were live). Used on abnormal termination —
+   * e.g. when ROLLBACK itself fails and the whole transaction is torn down at once — where the
+   * normal per-level commit/rollback bookkeeping cannot run. Inner savepoint frames may still be
+   * unmerged at that point (a failed `ROLLBACK TO SAVEPOINT` skips {@link mergeLastTransactionFrame}),
+   * so they are folded in here to give the caller the full picture for a final log.
+   * @returns The aggregate of all live frames, or undefined if the stack was empty.
+   */
+  collapseTransactionFrames(): TransactionAccessFrame | undefined {
+    while (this.transactionFrames.length > 1) {
+      this.mergeLastTransactionFrame();
+    }
+    return this.transactionFrames.pop();
   }
 
   logTransactionAccess(frame: TransactionAccessFrame, status: 'committed' | 'rolled_back'): void {
@@ -94,8 +111,8 @@ export class RepositoryAccessTracker {
   recordResourceAccess(
     layer: RepositoryAccessLayer,
     operation: RepositoryAccessOperation,
-    resourceTypes: Iterable<ResourceType>,
-    source: string
+    resourceTypes: ReadonlySet<ResourceType>,
+    source: string | undefined
   ): void {
     const access = partitionResourceTypes(resourceTypes);
     if (access.all.size === 0) {
@@ -120,13 +137,17 @@ export class RepositoryAccessTracker {
       updateTransactionAccessFrame(frame, layer, operation, source, access);
     }
   }
+
+  static normalizeResourceTypes(input: ResourceTypeInput): ReadonlySet<ResourceType> {
+    return typeof input === 'string' ? new Set([input]) : new Set(input);
+  }
 }
 
 function updateTransactionAccessFrame(
   frame: TransactionAccessFrame,
   layer: RepositoryAccessLayer,
   operation: RepositoryAccessOperation,
-  source: string,
+  source: string | undefined,
   access: ResourceTypePartition
 ): void {
   if (operation === 'read') {
@@ -154,7 +175,9 @@ function updateTransactionAccessFrame(
   for (const resourceType of access.other) {
     frame.otherResourceTypes.add(resourceType);
   }
-  frame.sources.add(source);
+  if (source) {
+    frame.sources.add(source);
+  }
 }
 
 function createTransactionAccessFrame(): TransactionAccessFrame {
@@ -177,7 +200,7 @@ type ResourceTypePartition = {
   readonly other: Set<ResourceType>;
 };
 
-function partitionResourceTypes(resourceTypes: Iterable<ResourceType>): ResourceTypePartition {
+function partitionResourceTypes(resourceTypes: ReadonlySet<ResourceType>): ResourceTypePartition {
   const all = new Set<ResourceType>();
   const special = new Set<ResourceType>();
   const other = new Set<ResourceType>();
@@ -194,25 +217,101 @@ function partitionResourceTypes(resourceTypes: Iterable<ResourceType>): Resource
   return { all, special, other };
 }
 
+const setsToMerge = ['readResourceTypes', 'writeResourceTypes', 'specialResourceTypes', 'otherResourceTypes'] as const;
+
 function mergeTransactionAccessFrame(target: TransactionAccessFrame, source: TransactionAccessFrame): void {
   target.sqlReadCount += source.sqlReadCount;
   target.sqlWriteCount += source.sqlWriteCount;
   target.cacheReadCount += source.cacheReadCount;
   target.cacheWriteCount += source.cacheWriteCount;
 
-  for (const resourceType of source.readResourceTypes) {
-    target.readResourceTypes.add(resourceType);
+  for (const set of setsToMerge) {
+    for (const item of source[set]) {
+      target[set].add(item);
+    }
   }
-  for (const resourceType of source.writeResourceTypes) {
-    target.writeResourceTypes.add(resourceType);
-  }
-  for (const resourceType of source.specialResourceTypes) {
-    target.specialResourceTypes.add(resourceType);
-  }
-  for (const resourceType of source.otherResourceTypes) {
-    target.otherResourceTypes.add(resourceType);
-  }
+
   for (const sourceName of source.sources) {
     target.sources.add(sourceName);
   }
 }
+
+/**
+ * Factory helpers for the {@link ExecuteSqlOptions} passed to `Repository.getDatabaseClient` /
+ * `Repository.executeSql`. Each helper records the resource types and intent of an access so the
+ * shard-boundary tracking sees it.
+ */
+export const repoAccess = {
+  /**
+   * Use when reading resources (read-by-id, history, search, count, etc.).
+   * Pass the resource type(s) the query selects from so the access is attributed correctly.
+   * Defaults to DatabaseMode.READER which can be overridden as needed, which should be rare.
+   * @param resourceTypes - The resource type(s) the query reads.
+   * @param options - Optional overrides.
+   * @param options.mode - The database mode to use (default: DatabaseMode.READER).
+   * @param options.source - Short label identifying the call site (e.g. `repo.readResource`).
+   * @returns Options describing the read access.
+   */
+  sqlRead: (
+    resourceTypes: ResourceTypeInput,
+    options?: { mode?: DatabaseMode; source?: string }
+  ): ExecuteSqlOptions => {
+    return {
+      mode: options?.mode ?? DatabaseMode.READER,
+      operation: 'read',
+      resourceTypes,
+      source: options?.source,
+    };
+  },
+
+  /**
+   * Use when writing resources (INSERT/UPDATE/DELETE on a resource and its
+   * history/lookup tables). Always uses DatabaseMode.WRITER.
+   * @param resourceTypes - The resource type(s) the query writes.
+   * @param options - Optional overrides.
+   * @param options.source - Short label identifying the call site (e.g. `repo.updateResource`).
+   * @returns Options describing the write access.
+   */
+  sqlWrite: (resourceTypes: ResourceTypeInput, options?: { source?: string }): ExecuteSqlOptions => {
+    return {
+      mode: DatabaseMode.WRITER,
+      operation: 'write',
+      resourceTypes,
+      source: options?.source,
+    };
+  },
+
+  /**
+   * Use when acquiring a READER client only to issue session/transaction configuration — e.g.
+   * `SET statement_timeout = 2000` — rather than to read resource data. No resources should be read.
+   * @param options - Optional overrides.
+   * @param options.source - Short label identifying the call site.
+   * @returns Options describing the reader configuration access.
+   */
+  sqlReadConfig: (options?: { source?: string }): ExecuteSqlOptions => {
+    return {
+      mode: DatabaseMode.READER,
+      operation: 'configuration',
+      resourceTypes: new Set(),
+      source: options?.source,
+    };
+  },
+
+  /**
+   * Use when acquiring the WRITER client only to issue configuration statements — e.g.
+   * `set_config('statement_timeout', ..., true)` inside a transaction — rather than to read or
+   * write resource data. Like {@link repoAccess.sqlReadConfig} but on the writer (the connection a
+   * transaction is pinned to). Carries no resource types, so nothing is recorded against tracking.
+   * @param options - Optional overrides.
+   * @param options.source - Short label identifying the call site.
+   * @returns Options describing the writer configuration access.
+   */
+  sqlWriteConfig: (options?: { source?: string }): ExecuteSqlOptions => {
+    return {
+      mode: DatabaseMode.WRITER,
+      operation: 'configuration',
+      resourceTypes: new Set(),
+      source: options?.source,
+    };
+  },
+};

--- a/packages/server/src/fhir/repository/method-guards.test.ts
+++ b/packages/server/src/fhir/repository/method-guards.test.ts
@@ -11,6 +11,7 @@ import { DatabaseMode } from '../../database';
 import { createTestProject, withTestContext } from '../../test.setup';
 import type { Repository } from '../repo';
 import { SelectQuery } from '../sql';
+import { repoAccess } from './access-tracker';
 
 type MemberKind = 'method' | 'getter' | 'setter';
 
@@ -114,13 +115,18 @@ const guardedInvocations: MethodInvocation[] = [
   {
     name: 'getDatabaseClient',
     kind: 'method',
-    invoke: (repo) =>
-      repo.getDatabaseClient({
-        mode: DatabaseMode.WRITER,
-        operation: 'write',
-        resourceTypes: [],
-        source: 'repo-guard.test',
-      }),
+    invoke: (repo) => repo.getDatabaseClient(repoAccess.sqlWriteConfig()),
+  },
+  {
+    name: 'sqlRead',
+    kind: 'method',
+    invoke: (repo) => repo.sqlRead(new SelectQuery('Patient').column('id').limit(0), 'Patient'),
+  },
+  {
+    name: 'sqlWrite',
+    kind: 'method',
+    // not actually writing anything, just testing the guard
+    invoke: (repo) => repo.sqlWrite(new SelectQuery('Patient').column('id').limit(0), 'Patient'),
   },
   {
     name: 'executeSql',
@@ -412,14 +418,7 @@ describe('transaction-scoped repository guards', () => {
       const cloned = repo.clone();
       cloned[Symbol.dispose]();
 
-      expect(() =>
-        cloned.getDatabaseClient({
-          mode: DatabaseMode.WRITER,
-          operation: 'write',
-          resourceTypes: [],
-          source: 'repo-guard.test',
-        })
-      ).toThrow('Already closed');
+      expect(() => cloned.getDatabaseClient(repoAccess.sqlWriteConfig())).toThrow('Already closed');
       await expect(cloned.createResource<Patient>({ resourceType: 'Patient' })).rejects.toThrow('Already closed');
       await expect(
         cloned.withTransaction(async () => undefined, { resourceTypes: [], source: 'repo-guard.test' })

--- a/packages/server/src/fhir/repository/method-guards.test.ts
+++ b/packages/server/src/fhir/repository/method-guards.test.ts
@@ -10,6 +10,7 @@ import { loadTestConfig } from '../../config/loader';
 import { DatabaseMode } from '../../database';
 import { createTestProject, withTestContext } from '../../test.setup';
 import type { Repository } from '../repo';
+import { SelectQuery } from '../sql';
 
 type MemberKind = 'method' | 'getter' | 'setter';
 
@@ -111,6 +112,28 @@ const guardedInvocations: MethodInvocation[] = [
   { name: 'getSystemRepo', kind: 'method', invoke: (repo) => repo.getSystemRepo() },
   { name: 'setMode', kind: 'method', invoke: (repo) => repo.setMode('reader') },
   { name: 'getDatabaseClient', kind: 'method', invoke: (repo) => repo.getDatabaseClient(DatabaseMode.WRITER) },
+  {
+    name: 'executeSql',
+    kind: 'method',
+    invoke: (repo) =>
+      repo.executeSql(new SelectQuery('Patient').column('id').limit(0), {
+        mode: DatabaseMode.WRITER,
+        operation: 'read',
+        resourceTypes: ['Patient'],
+        source: 'test',
+      }),
+  },
+  {
+    name: 'executeRawSql',
+    kind: 'method',
+    invoke: (repo) =>
+      repo.executeRawSql('SELECT 1', [], {
+        mode: DatabaseMode.WRITER,
+        operation: 'read',
+        resourceTypes: [],
+        source: 'test',
+      }),
+  },
   { name: 'withTransaction', kind: 'method', invoke: (repo) => repo.withTransaction(async () => undefined) },
   { name: 'withOverrideConfig', kind: 'method', invoke: (repo) => repo.withOverrideConfig({ extendedMode: true }) },
   {

--- a/packages/server/src/fhir/repository/method-guards.test.ts
+++ b/packages/server/src/fhir/repository/method-guards.test.ts
@@ -111,7 +111,17 @@ const guardedPatient: WithId<Patient> = { resourceType: 'Patient', id: NIL };
 const guardedInvocations: MethodInvocation[] = [
   { name: 'getSystemRepo', kind: 'method', invoke: (repo) => repo.getSystemRepo() },
   { name: 'setMode', kind: 'method', invoke: (repo) => repo.setMode('reader') },
-  { name: 'getDatabaseClient', kind: 'method', invoke: (repo) => repo.getDatabaseClient(DatabaseMode.WRITER) },
+  {
+    name: 'getDatabaseClient',
+    kind: 'method',
+    invoke: (repo) =>
+      repo.getDatabaseClient({
+        mode: DatabaseMode.WRITER,
+        operation: 'write',
+        resourceTypes: [],
+        source: 'repo-guard.test',
+      }),
+  },
   {
     name: 'executeSql',
     kind: 'method',
@@ -134,7 +144,11 @@ const guardedInvocations: MethodInvocation[] = [
         source: 'test',
       }),
   },
-  { name: 'withTransaction', kind: 'method', invoke: (repo) => repo.withTransaction(async () => undefined) },
+  {
+    name: 'withTransaction',
+    kind: 'method',
+    invoke: (repo) => repo.withTransaction(async () => undefined, { resourceTypes: [], source: 'repo-guard.test' }),
+  },
   { name: 'withOverrideConfig', kind: 'method', invoke: (repo) => repo.withOverrideConfig({ extendedMode: true }) },
   {
     name: 'withStatementTimeout',
@@ -143,7 +157,11 @@ const guardedInvocations: MethodInvocation[] = [
   },
   { name: 'preCommit', kind: 'method', invoke: (repo) => repo.preCommit(async () => undefined) },
   { name: 'postCommit', kind: 'method', invoke: (repo) => repo.postCommit(async () => undefined) },
-  { name: 'ensureInTransaction', kind: 'method', invoke: (repo) => repo.ensureInTransaction(async () => undefined) },
+  {
+    name: 'ensureInTransaction',
+    kind: 'method',
+    invoke: (repo) => repo.ensureInTransaction(async () => undefined, { resourceTypes: [], source: 'repo-guard.test' }),
+  },
   { name: 'recordFhirQuota', kind: 'method', invoke: (repo) => repo.recordFhirQuota(1) },
 
   // Reads
@@ -369,17 +387,20 @@ describe('transaction-scoped repository guards', () => {
       withTestContext(async () => {
         const cloned = repo.clone();
         let observedError: unknown;
-        await cloned.withTransaction(async () => {
-          try {
-            // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies parent repo rejection.
-            const result = entry.invoke(cloned);
-            if (result instanceof Promise) {
-              await result;
+        await cloned.withTransaction(
+          async () => {
+            try {
+              // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies parent repo rejection.
+              const result = entry.invoke(cloned);
+              if (result instanceof Promise) {
+                await result;
+              }
+            } catch (err) {
+              observedError = err;
             }
-          } catch (err) {
-            observedError = err;
-          }
-        });
+          },
+          { resourceTypes: [], source: 'repo-guard.test' }
+        );
         expect(observedError).toBeInstanceOf(Error);
         expect((observedError as Error).message).toContain('transaction-scoped repository');
       })
@@ -391,9 +412,18 @@ describe('transaction-scoped repository guards', () => {
       const cloned = repo.clone();
       cloned[Symbol.dispose]();
 
-      expect(() => cloned.getDatabaseClient(DatabaseMode.WRITER)).toThrow('Already closed');
+      expect(() =>
+        cloned.getDatabaseClient({
+          mode: DatabaseMode.WRITER,
+          operation: 'write',
+          resourceTypes: [],
+          source: 'repo-guard.test',
+        })
+      ).toThrow('Already closed');
       await expect(cloned.createResource<Patient>({ resourceType: 'Patient' })).rejects.toThrow('Already closed');
-      await expect(cloned.withTransaction(async () => undefined)).rejects.toThrow('Already closed');
+      await expect(
+        cloned.withTransaction(async () => undefined, { resourceTypes: [], source: 'repo-guard.test' })
+      ).rejects.toThrow('Already closed');
     }));
 });
 

--- a/packages/server/src/fhir/repository/repository-connection.ts
+++ b/packages/server/src/fhir/repository/repository-connection.ts
@@ -11,7 +11,12 @@ import { DatabaseMode, getDatabasePool } from '../../database';
 import { getLogger } from '../../logger';
 import type { PgQueryable, TransactionIsolationLevel } from '../sql';
 import { isPoolClient, isRetryableTransactionError, normalizeDatabaseError } from '../sql';
-import type { RepositoryAccessLayer, RepositoryAccessOperation } from './access-tracker';
+import type {
+  ExecuteSqlOptions,
+  RepositoryAccessLayer,
+  RepositoryAccessOperation,
+  TransactionSqlOptions,
+} from './access-tracker';
 import { createRepositoryAccessTracker } from './access-tracker';
 import type { TransactionIdleStatus, TransactionIdleTrackerOptions } from './transaction-idle-tracker';
 import { TransactionIdleTracker } from './transaction-idle-tracker';
@@ -248,21 +253,22 @@ export class RepositoryConnection implements Disposable {
    * If in a transaction, then returns the transaction client (PoolClient).
    * Otherwise, returns the pool (Pool).
    * @param scope - The scope of the database client.
-   * @param mode - The database mode.
+   * @param options - SQL execution metadata.
    * @returns The database client.
    */
-  getDatabaseClient(scope: ConnectionScope, mode: DatabaseMode): PgQueryable {
+  getDatabaseClient(scope: ConnectionScope, options: ExecuteSqlOptions): PgQueryable {
+    this.recordResourceAccess('sql', options.operation, options.resourceTypes, options.source);
     this.assertNotClosed();
     this.assertScope(scope);
     if (this.conn) {
       // A held client might be pinned outside a transaction, but it still has one physical
       // database role. Do not let writer work accidentally run on a reader connection.
-      this.assertConnectionMode(mode);
+      this.assertConnectionMode(options.mode);
       return this.conn;
     }
     this.assertCanAcquireConnection();
-    this.promoteRepositoryMode(mode);
-    return getDatabasePool(this._mode === RepositoryMode.WRITER ? DatabaseMode.WRITER : mode);
+    this.promoteRepositoryMode(options.mode);
+    return getDatabasePool(this.mode === RepositoryMode.WRITER ? DatabaseMode.WRITER : options.mode);
   }
 
   /**
@@ -300,6 +306,13 @@ export class RepositoryConnection implements Disposable {
     if (this.pinDepth > 0 && !err) {
       return;
     }
+
+    // releasing while a transaction is still active is a no-op when there is no error
+    // since the transaction is still in progress and the connection must be held until it ends
+    if (this.isInTransaction() && !err) {
+      return;
+    }
+
     const releaseErr = err || this.discardOnRelease;
     if (this.ownsClient) {
       const conn = this.conn;
@@ -328,18 +341,31 @@ export class RepositoryConnection implements Disposable {
     options: StatementTimeoutOptions,
     callback: () => Promise<TResult>
   ): Promise<TResult> {
+    let isLocal = false;
+
     await this.withConnectionStateLock(async () => {
       this.assertNotClosed();
-      this.assertOwnsClient();
       if (this.isInTransaction()) {
-        throw new Error('Cannot set statement timeout during an active transaction');
+        isLocal = true;
+      } else {
+        // when not in a transaction, don't allow changing the config of a borrowed connection since
+        // that would mean it gets returned to the owner in a different state than it was when borrowed
+        // this may be too restrictive, but hold the line for now
+        this.assertOwnsClient('Cannot set statement timeout on a borrowed connection');
       }
 
       const client = await this.getConnection(options.mode ?? DatabaseMode.WRITER);
 
-      await client.query(`SELECT set_config('statement_timeout', $1, false)`, [String(options.timeoutMs)]);
+      await client.query(`SELECT set_config('statement_timeout', $1, $2)`, [String(options.timeoutMs), isLocal]);
       this.pinDepth++;
-      this.discardOnRelease = true;
+      // A session-level SET (isLocal === false) leaves statement_timeout changed on the physical
+      // connection with no reliable way to restore its prior value, so the connection is dirty and
+      // must be discarded rather than returned to the pool. A transaction-local SET (isLocal === true)
+      // is reverted automatically by Postgres when the transaction ends, leaving the connection clean,
+      // so there is nothing to discard.
+      if (!isLocal) {
+        this.discardOnRelease = true;
+      }
     });
 
     try {
@@ -348,7 +374,7 @@ export class RepositoryConnection implements Disposable {
     } finally {
       await this.withConnectionStateLock(async () => {
         this.pinDepth--;
-        if (this.pinDepth === 0) {
+        if (!isLocal && this.pinDepth === 0 && !this.isInTransaction()) {
           this.releaseConnection();
         }
       });
@@ -460,7 +486,7 @@ export class RepositoryConnection implements Disposable {
   async withTransaction<TResult>(
     scope: ConnectionScope,
     callback: (txScope: ConnectionScope) => Promise<TResult>,
-    options?: { serializable?: boolean }
+    options: TransactionSqlOptions
   ): Promise<TResult> {
     this.assertNotClosed();
     const isolationLevel = options?.serializable ? 'SERIALIZABLE' : 'REPEATABLE READ';
@@ -482,6 +508,7 @@ export class RepositoryConnection implements Disposable {
             serializable: options?.serializable ?? false,
           });
         }
+        this.recordResourceAccess('sql', 'transaction', options.resourceTypes, options.source);
         const result = await callback(txScope);
         await this.commitTransaction(txScope);
         if (attempt > 0) {
@@ -763,9 +790,9 @@ export class RepositoryConnection implements Disposable {
     }
   }
 
-  private assertOwnsClient(): void {
+  private assertOwnsClient(errorMessage?: string): void {
     if (!this.ownsClient) {
-      throw new Error('Does not own database client');
+      throw new Error(errorMessage ?? 'Does not own database client');
     }
   }
 

--- a/packages/server/src/fhir/repository/repository-connection.ts
+++ b/packages/server/src/fhir/repository/repository-connection.ts
@@ -17,7 +17,7 @@ import type {
   RepositoryAccessOperation,
   TransactionSqlOptions,
 } from './access-tracker';
-import { createRepositoryAccessTracker } from './access-tracker';
+import { RepositoryAccessTracker } from './access-tracker';
 import type { TransactionIdleStatus, TransactionIdleTrackerOptions } from './transaction-idle-tracker';
 import { TransactionIdleTracker } from './transaction-idle-tracker';
 
@@ -107,7 +107,7 @@ export class RepositoryConnection implements Disposable {
   private readonly rootScope: RootScope;
   private currentScope: Scope;
 
-  private readonly accessTracker = createRepositoryAccessTracker();
+  private readonly accessTracker = new RepositoryAccessTracker();
 
   /**
    * Creates a connection that owns any PoolClient it acquires.

--- a/packages/server/src/fhir/repository/repository-connection.ts
+++ b/packages/server/src/fhir/repository/repository-connection.ts
@@ -3,6 +3,7 @@
 import type { OperationOutcomeError } from '@medplum/core';
 import { normalizeErrorString, sleep } from '@medplum/core';
 import { RepositoryMode } from '@medplum/fhir-router';
+import type { ResourceType } from '@medplum/fhirtypes';
 import assert from 'node:assert';
 import type { PoolClient } from 'pg';
 import { getConfig } from '../../config/loader';
@@ -10,6 +11,8 @@ import { DatabaseMode, getDatabasePool } from '../../database';
 import { getLogger } from '../../logger';
 import type { PgQueryable, TransactionIsolationLevel } from '../sql';
 import { isPoolClient, isRetryableTransactionError, normalizeDatabaseError } from '../sql';
+import type { RepositoryAccessLayer, RepositoryAccessOperation } from './access-tracker';
+import { createRepositoryAccessTracker } from './access-tracker';
 import type { TransactionIdleStatus, TransactionIdleTrackerOptions } from './transaction-idle-tracker';
 import { TransactionIdleTracker } from './transaction-idle-tracker';
 
@@ -98,6 +101,8 @@ export class RepositoryConnection implements Disposable {
 
   private readonly rootScope: RootScope;
   private currentScope: Scope;
+
+  private readonly accessTracker = createRepositoryAccessTracker();
 
   /**
    * Creates a connection that owns any PoolClient it acquires.
@@ -226,6 +231,15 @@ export class RepositoryConnection implements Disposable {
     return false;
   }
 
+  recordResourceAccess(
+    layer: RepositoryAccessLayer,
+    operation: RepositoryAccessOperation,
+    resourceTypes: Iterable<ResourceType>,
+    source: string
+  ): void {
+    this.accessTracker.recordResourceAccess(layer, operation, resourceTypes, source);
+  }
+
   /**
    * Returns a database client.
    * Use this method when you don't care if you're in a transaction or not.
@@ -312,9 +326,9 @@ export class RepositoryConnection implements Disposable {
 
   async withStatementTimeout<TResult>(
     options: StatementTimeoutOptions,
-    callback: (client: PoolClient) => Promise<TResult>
+    callback: () => Promise<TResult>
   ): Promise<TResult> {
-    const client = await this.withConnectionStateLock(async () => {
+    await this.withConnectionStateLock(async () => {
       this.assertNotClosed();
       this.assertOwnsClient();
       if (this.isInTransaction()) {
@@ -326,12 +340,11 @@ export class RepositoryConnection implements Disposable {
       await client.query(`SELECT set_config('statement_timeout', $1, false)`, [String(options.timeoutMs)]);
       this.pinDepth++;
       this.discardOnRelease = true;
-      return client;
     });
 
     try {
       // invoking the callback must happen outside of the connection state lock to avoid deadlocks
-      return await callback(client);
+      return await callback();
     } finally {
       await this.withConnectionStateLock(async () => {
         this.pinDepth--;
@@ -601,6 +614,7 @@ export class RepositoryConnection implements Disposable {
       }
       const txScope = createScope(nextDepth === 1 ? 'transaction' : 'savepoint', this.currentScope);
       this.currentScope = txScope;
+      this.accessTracker.pushTransactionFrame();
       return { client, scope: txScope };
     });
   }
@@ -633,6 +647,8 @@ export class RepositoryConnection implements Disposable {
 
         this.transactionIsolationLevel = undefined;
         this.releaseConnection();
+        const frame = this.accessTracker.popTransactionFrame();
+        this.accessTracker.logTransactionAccess(frame, 'committed');
       } else {
         assert(this.currentScope.kind === 'savepoint');
         assert(this.currentScope.parent.kind !== 'root');
@@ -645,6 +661,7 @@ export class RepositoryConnection implements Disposable {
         this.currentScope.parent.preCommitCallbacks.push(...this.currentScope.preCommitCallbacks);
         this.currentScope.parent.postCommitCallbacks.push(...this.currentScope.postCommitCallbacks);
         this.currentScope = this.currentScope.parent;
+        this.accessTracker.mergeLastTransactionFrame();
       }
     });
 
@@ -692,7 +709,7 @@ export class RepositoryConnection implements Disposable {
           this.currentScope = this.currentScope.parent;
         }
         this.transactionIsolationLevel = undefined;
-
+        this.accessTracker.clearTransactionFrames();
         // Pass the original triggering error so the client is released with the right root cause.
         this.releaseConnection(error);
         return;
@@ -709,6 +726,10 @@ export class RepositoryConnection implements Disposable {
       if (isOuter) {
         this.transactionIsolationLevel = undefined;
         this.releaseConnection(error);
+        const frame = this.accessTracker.popTransactionFrame();
+        this.accessTracker.logTransactionAccess(frame, 'rolled_back');
+      } else {
+        this.accessTracker.mergeLastTransactionFrame();
       }
     });
   }

--- a/packages/server/src/fhir/repository/repository-connection.ts
+++ b/packages/server/src/fhir/repository/repository-connection.ts
@@ -3,7 +3,6 @@
 import type { OperationOutcomeError } from '@medplum/core';
 import { normalizeErrorString, sleep } from '@medplum/core';
 import { RepositoryMode } from '@medplum/fhir-router';
-import type { ResourceType } from '@medplum/fhirtypes';
 import assert from 'node:assert';
 import type { PoolClient } from 'pg';
 import { getConfig } from '../../config/loader';
@@ -13,8 +12,11 @@ import type { PgQueryable, TransactionIsolationLevel } from '../sql';
 import { isPoolClient, isRetryableTransactionError, normalizeDatabaseError } from '../sql';
 import type {
   ExecuteSqlOptions,
+  NormalizedResourceTypes,
   RepositoryAccessLayer,
   RepositoryAccessOperation,
+  RepositoryAccessOptions,
+  ResourceTypeInput,
   TransactionSqlOptions,
 } from './access-tracker';
 import { RepositoryAccessTracker } from './access-tracker';
@@ -239,10 +241,11 @@ export class RepositoryConnection implements Disposable {
   recordResourceAccess(
     layer: RepositoryAccessLayer,
     operation: RepositoryAccessOperation,
-    resourceTypes: Iterable<ResourceType>,
-    source: string
+    resourceTypes: ResourceTypeInput,
+    source: string | undefined
   ): void {
-    this.accessTracker.recordResourceAccess(layer, operation, resourceTypes, source);
+    const normalizedResourceTypes = RepositoryAccessTracker.normalizeResourceTypes(resourceTypes);
+    this.accessTracker.recordResourceAccess(layer, operation, normalizedResourceTypes, source);
   }
 
   /**
@@ -736,7 +739,13 @@ export class RepositoryConnection implements Disposable {
           this.currentScope = this.currentScope.parent;
         }
         this.transactionIsolationLevel = undefined;
-        this.accessTracker.clearTransactionFrames();
+        // The transaction died as a whole, so the per-level commit/rollback logging never runs.
+        // Collapse whatever frames are still live into one and emit the rolled_back transaction
+        // record here so a mixed-access transaction is still surfaced on the dead-connection path.
+        const frame = this.accessTracker.collapseTransactionFrames();
+        if (frame) {
+          this.accessTracker.logTransactionAccess(frame, 'rolled_back');
+        }
         // Pass the original triggering error so the client is released with the right root cause.
         this.releaseConnection(error);
         return;
@@ -917,5 +926,16 @@ export class RepositoryConnection implements Disposable {
     if (this.closed) {
       throw new Error('Already closed');
     }
+  }
+
+  static noramlizeResourceTypes(input: ResourceTypeInput): NormalizedResourceTypes {
+    return RepositoryAccessTracker.normalizeResourceTypes(input);
+  }
+
+  static normalizeOptions<T extends RepositoryAccessOptions>(opts: T): T & { resourceTypes: NormalizedResourceTypes } {
+    return {
+      ...opts,
+      resourceTypes: RepositoryAccessTracker.normalizeResourceTypes(opts.resourceTypes),
+    };
   }
 }

--- a/packages/server/src/fhir/repository/transaction-idle-tracker.test.ts
+++ b/packages/server/src/fhir/repository/transaction-idle-tracker.test.ts
@@ -46,10 +46,18 @@ describe('TransactionIdleTracker', () => {
       const recordHistogramValueSpy = vi.spyOn(otelModule, 'recordHistogramValue').mockImplementation(() => true);
 
       try {
-        await repo.withTransaction(async (txRepo) => {
-          const client = txRepo.getDatabaseClient(DatabaseMode.WRITER);
-          await client.query('SELECT 1');
-        });
+        await repo.withTransaction(
+          async (txRepo) => {
+            const client = txRepo.getDatabaseClient({
+              mode: DatabaseMode.WRITER,
+              operation: 'write',
+              resourceTypes: [],
+              source: 'test.transactionIdleTracker.getDatabaseClient',
+            });
+            await client.query('SELECT 1');
+          },
+          { resourceTypes: [], source: 'test.transactionIdleTracker.noMetrics' }
+        );
 
         expect(query.mock.calls.map(([sql]) => sql)).toStrictEqual([
           'BEGIN ISOLATION LEVEL REPEATABLE READ',
@@ -91,12 +99,20 @@ describe('TransactionIdleTracker', () => {
     const recordHistogramValueSpy = vi.spyOn(otelModule, 'recordHistogramValue').mockImplementation(() => true);
 
     try {
-      await repo.withTransaction(async (txRepo) => {
-        const client = txRepo.getDatabaseClient(DatabaseMode.WRITER);
-        await new Promise<void>((resolve, reject) => {
-          client.query('SELECT 1', (err) => (err ? reject(err) : resolve()));
-        });
-      });
+      await repo.withTransaction(
+        async (txRepo) => {
+          const client = txRepo.getDatabaseClient({
+            mode: DatabaseMode.WRITER,
+            operation: 'write',
+            resourceTypes: [],
+            source: 'test.transactionIdleTracker.getDatabaseClient',
+          });
+          await new Promise<void>((resolve, reject) => {
+            client.query('SELECT 1', (err) => (err ? reject(err) : resolve()));
+          });
+        },
+        { resourceTypes: [], source: 'test.transactionIdleTracker.callbackStyle' }
+      );
 
       expect(client.query).toBe(query);
       expect(warnSpy).not.toHaveBeenCalledWith(TransactionIdleTracker.LOG_HIGH_IDLE_TIME_MSG, expect.anything());
@@ -127,10 +143,13 @@ describe('TransactionIdleTracker', () => {
 
     try {
       await expect(
-        repo.withTransaction(async () => {
-          now += 10;
-          throw new Error('work failed');
-        })
+        repo.withTransaction(
+          async () => {
+            now += 10;
+            throw new Error('work failed');
+          },
+          { resourceTypes: [], source: 'test.transactionIdleTracker.rolledBack' }
+        )
       ).rejects.toThrow('work failed');
 
       expect(recordHistogramValueSpy).toHaveBeenCalledWith(TransactionIdleTracker.OTEL_TOTAL_METRIC_NAME, 10, {
@@ -181,15 +200,26 @@ describe('TransactionIdleTracker', () => {
     const recordHistogramValueSpy = vi.spyOn(otelModule, 'recordHistogramValue').mockImplementation(() => true);
 
     try {
-      await repo.withTransaction(async (txRepo) => {
-        now += 30;
-        await txRepo.withTransaction(async (nestedTxRepo) => {
-          now += 20;
-          const client = nestedTxRepo.getDatabaseClient(DatabaseMode.WRITER);
-          await client.query('SELECT 1');
-        });
-        now += 10;
-      });
+      await repo.withTransaction(
+        async (txRepo) => {
+          now += 30;
+          await txRepo.withTransaction(
+            async (nestedTxRepo) => {
+              now += 20;
+              const client = nestedTxRepo.getDatabaseClient({
+                mode: DatabaseMode.WRITER,
+                operation: 'write',
+                resourceTypes: [],
+                source: 'test.transactionIdleTracker.getDatabaseClient',
+              });
+              await client.query('SELECT 1');
+            },
+            { resourceTypes: [], source: 'test.transactionIdleTracker.nestedIdle' }
+          );
+          now += 10;
+        },
+        { resourceTypes: [], source: 'test.transactionIdleTracker.nestedIdle' }
+      );
 
       expect(recordHistogramValueSpy).not.toHaveBeenCalled();
       expect(warnSpy).not.toHaveBeenCalledWith(TransactionIdleTracker.LOG_HIGH_IDLE_TIME_MSG, expect.anything());
@@ -197,15 +227,26 @@ describe('TransactionIdleTracker', () => {
       now = 0;
       query.mockClear();
 
-      await repo.withTransaction(async (txRepo) => {
-        now += 20;
-        await txRepo.withTransaction(async (nestedTxRepo) => {
-          const client = nestedTxRepo.getDatabaseClient(DatabaseMode.WRITER);
-          now += 5;
-          await client.query('SELECT 1');
-        });
-        now += 50;
-      });
+      await repo.withTransaction(
+        async (txRepo) => {
+          now += 20;
+          await txRepo.withTransaction(
+            async (nestedTxRepo) => {
+              const client = nestedTxRepo.getDatabaseClient({
+                mode: DatabaseMode.WRITER,
+                operation: 'write',
+                resourceTypes: [],
+                source: 'test.transactionIdleTracker.getDatabaseClient',
+              });
+              now += 5;
+              await client.query('SELECT 1');
+            },
+            { resourceTypes: [], source: 'test.transactionIdleTracker.nestedIdle' }
+          );
+          now += 50;
+        },
+        { resourceTypes: [], source: 'test.transactionIdleTracker.nestedIdle' }
+      );
 
       expect(query.mock.calls.map(([sql]) => sql)).toStrictEqual([
         'BEGIN ISOLATION LEVEL REPEATABLE READ',

--- a/packages/server/src/fhir/repository/transaction-idle-tracker.test.ts
+++ b/packages/server/src/fhir/repository/transaction-idle-tracker.test.ts
@@ -8,6 +8,7 @@ import { DatabaseMode } from '../../database';
 import { getLogger } from '../../logger';
 import * as otelModule from '../../otel/otel';
 import { getShardSystemRepo } from '../repo';
+import { repoAccess } from './access-tracker';
 import { RepositoryConnection } from './repository-connection';
 import { TransactionIdleTracker } from './transaction-idle-tracker';
 
@@ -48,15 +49,10 @@ describe('TransactionIdleTracker', () => {
       try {
         await repo.withTransaction(
           async (txRepo) => {
-            const client = txRepo.getDatabaseClient({
-              mode: DatabaseMode.WRITER,
-              operation: 'write',
-              resourceTypes: [],
-              source: 'test.transactionIdleTracker.getDatabaseClient',
-            });
+            const client = txRepo.getDatabaseClient(repoAccess.sqlWriteConfig());
             await client.query('SELECT 1');
           },
-          { resourceTypes: [], source: 'test.transactionIdleTracker.noMetrics' }
+          { resourceTypes: [] }
         );
 
         expect(query.mock.calls.map(([sql]) => sql)).toStrictEqual([
@@ -101,17 +97,12 @@ describe('TransactionIdleTracker', () => {
     try {
       await repo.withTransaction(
         async (txRepo) => {
-          const client = txRepo.getDatabaseClient({
-            mode: DatabaseMode.WRITER,
-            operation: 'write',
-            resourceTypes: [],
-            source: 'test.transactionIdleTracker.getDatabaseClient',
-          });
+          const client = txRepo.getDatabaseClient(repoAccess.sqlWriteConfig());
           await new Promise<void>((resolve, reject) => {
             client.query('SELECT 1', (err) => (err ? reject(err) : resolve()));
           });
         },
-        { resourceTypes: [], source: 'test.transactionIdleTracker.callbackStyle' }
+        { resourceTypes: [] }
       );
 
       expect(client.query).toBe(query);
@@ -148,7 +139,7 @@ describe('TransactionIdleTracker', () => {
             now += 10;
             throw new Error('work failed');
           },
-          { resourceTypes: [], source: 'test.transactionIdleTracker.rolledBack' }
+          { resourceTypes: [] }
         )
       ).rejects.toThrow('work failed');
 
@@ -206,19 +197,14 @@ describe('TransactionIdleTracker', () => {
           await txRepo.withTransaction(
             async (nestedTxRepo) => {
               now += 20;
-              const client = nestedTxRepo.getDatabaseClient({
-                mode: DatabaseMode.WRITER,
-                operation: 'write',
-                resourceTypes: [],
-                source: 'test.transactionIdleTracker.getDatabaseClient',
-              });
+              const client = nestedTxRepo.getDatabaseClient(repoAccess.sqlWriteConfig());
               await client.query('SELECT 1');
             },
-            { resourceTypes: [], source: 'test.transactionIdleTracker.nestedIdle' }
+            { resourceTypes: [] }
           );
           now += 10;
         },
-        { resourceTypes: [], source: 'test.transactionIdleTracker.nestedIdle' }
+        { resourceTypes: [] }
       );
 
       expect(recordHistogramValueSpy).not.toHaveBeenCalled();
@@ -232,20 +218,15 @@ describe('TransactionIdleTracker', () => {
           now += 20;
           await txRepo.withTransaction(
             async (nestedTxRepo) => {
-              const client = nestedTxRepo.getDatabaseClient({
-                mode: DatabaseMode.WRITER,
-                operation: 'write',
-                resourceTypes: [],
-                source: 'test.transactionIdleTracker.getDatabaseClient',
-              });
+              const client = nestedTxRepo.getDatabaseClient(repoAccess.sqlWriteConfig());
               now += 5;
               await client.query('SELECT 1');
             },
-            { resourceTypes: [], source: 'test.transactionIdleTracker.nestedIdle' }
+            { resourceTypes: [] }
           );
           now += 50;
         },
-        { resourceTypes: [], source: 'test.transactionIdleTracker.nestedIdle' }
+        { resourceTypes: [] }
       );
 
       expect(query.mock.calls.map(([sql]) => sql)).toStrictEqual([

--- a/packages/server/src/fhir/repository/transaction.test.ts
+++ b/packages/server/src/fhir/repository/transaction.test.ts
@@ -25,7 +25,9 @@ import * as workersModule from '../../workers';
 import type { Repository, SystemRepository } from '../repo';
 import { getShardSystemRepo } from '../repo';
 import { RepositoryConnection } from '../repository/repository-connection';
+import type { PgQueryable } from '../sql';
 import { PostgresError } from '../sql';
+import { repoAccess } from './access-tracker';
 
 const TRANSACTION_SCOPE_ERROR =
   'Repository is in an active transaction; use the transaction-scoped repository passed to the callback';
@@ -58,12 +60,7 @@ describe('FHIR Repo Transactions', () => {
           expect(txRepo).not.toBe(repo);
           expect(() =>
             // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies parent repo rejection.
-            repo.getDatabaseClient({
-              mode: DatabaseMode.WRITER,
-              operation: 'write',
-              resourceTypes: [],
-              source: 'test.withTransaction.parentRepo',
-            })
+            repo.getDatabaseClient(repoAccess.sqlWriteConfig())
           ).toThrow(TRANSACTION_SCOPE_ERROR);
           // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies parent repo rejection.
           await expect(repo.createResource<Patient>({ resourceType: 'Patient' })).rejects.toThrow(
@@ -261,12 +258,7 @@ describe('FHIR Repo Transactions', () => {
                 await expectPatientVisible(nestedRepo, patient1?.id);
                 await expectPatientVisible(nestedRepo, patient2?.id);
 
-                const db = nestedRepo.getDatabaseClient({
-                  mode: DatabaseMode.READER,
-                  operation: 'read',
-                  resourceTypes: [],
-                  source: 'test.transaction.getDatabaseClient',
-                });
+                const db = nestedRepo.getDatabaseClient(repoAccess.sqlReadConfig());
                 await expect(db.query(`SELECT * FROM "TableDoesNotExist"`)).rejects.toMatchObject({
                   message: 'relation "TableDoesNotExist" does not exist',
                 });
@@ -464,14 +456,7 @@ describe('FHIR Repo Transactions', () => {
             source: 'test.releasedNestedRepo.locked',
           });
 
-          expect(() =>
-            releasedRepo.getDatabaseClient({
-              mode: DatabaseMode.WRITER,
-              operation: 'write',
-              resourceTypes: [],
-              source: 'test.transaction.getDatabaseClient',
-            })
-          ).toThrow(SAVEPOINT_RELEASED_ERROR);
+          expect(() => releasedRepo.getDatabaseClient(repoAccess.sqlWriteConfig())).toThrow(SAVEPOINT_RELEASED_ERROR);
           await expect(releasedRepo.createResource<Patient>({ resourceType: 'Patient' })).rejects.toThrow(
             SAVEPOINT_RELEASED_ERROR
           );
@@ -563,12 +548,7 @@ describe('FHIR Repo Transactions', () => {
 
       await repo.withTransaction(
         async (txRepo) => {
-          const client = txRepo.getDatabaseClient({
-            mode: DatabaseMode.WRITER,
-            operation: 'write',
-            resourceTypes: [],
-            source: 'test.transaction.getDatabaseClient',
-          });
+          const client = txRepo.getDatabaseClient(repoAccess.sqlWriteConfig());
           const querySpy = spyOnQuery(client);
           try {
             await txRepo
@@ -1050,12 +1030,7 @@ describe('FHIR Repo Transactions', () => {
     await expect(
       repo.withTransaction(
         async (txRepo) => {
-          const client = txRepo.getDatabaseClient({
-            mode: DatabaseMode.WRITER,
-            operation: 'write',
-            resourceTypes: [],
-            source: 'test.transaction.getDatabaseClient',
-          });
+          const client = txRepo.getDatabaseClient(repoAccess.sqlWriteConfig());
           querySpy = spyOnQuery(client).mockImplementation(() => {
             // Simulates a session killed by idle_in_transaction_session_timeout: every query
             // issued on the client — including the ROLLBACK the error handler sends — rejects.
@@ -1092,39 +1067,70 @@ describe('FHIR Repo Transactions', () => {
     errorSpy.mockRestore();
   });
 
+  test('withTransaction logs mixed access as rolled_back when rollback fails on a dead backend', async () => {
+    const infoSpy = vi.spyOn(getLogger(), 'info').mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(getLogger(), 'warn').mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(getLogger(), 'error').mockImplementation(() => undefined);
+    let querySpy: MockInstance | undefined;
+
+    await expect(
+      repo.withTransaction(
+        async (txRepo) => {
+          const client = txRepo.getDatabaseClient(repoAccess.sqlWriteConfig());
+          querySpy = spyOnQuery(client).mockImplementation(() => {
+            const terminationErr = Object.assign(
+              new Error('terminating connection due to idle-in-transaction timeout'),
+              { code: '57P01' }
+            );
+            throw terminationErr;
+          });
+          await client.query('SELECT 1');
+        },
+        // Declaring a special (Project) + other (Patient) type seeds the frame as mixed, so the
+        // teardown must still emit the transaction-level log even though ROLLBACK itself fails.
+        { resourceTypes: ['Patient', 'Project'], source: 'test.withTransaction.deadBackendMixed' }
+      )
+    ).rejects.toThrow('terminating connection due to idle-in-transaction timeout');
+
+    assert(querySpy);
+
+    // Bookkeeping must be fully reset so the repo is safe for future use
+    expect((repo as any).connection.transactionDepth).toBe(0);
+    expect((repo as any).connection.conn).toBeUndefined();
+    // The dead transaction's frame stack must be drained, not leaked
+    expect((repo as any).connection.accessTracker.transactionFrames).toHaveLength(0);
+
+    // The mixed-access transaction is surfaced as rolled_back rather than silently dropped
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[RepoSplit] Mixed transaction access',
+      expect.objectContaining({
+        scope: 'transaction',
+        status: 'rolled_back',
+        specialResourceTypes: ['Project'],
+        otherResourceTypes: ['Patient'],
+      })
+    );
+
+    querySpy.mockRestore();
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
   test('withStatementTimeout pins connection and discards it after callback', async () => {
-    let escapedClient: PoolClient | undefined;
+    let escapedClient: PgQueryable | undefined;
     await repo.withStatementTimeout({ timeoutMs: 0 }, async () => {
-      const client = repo.getDatabaseClient({
-        mode: DatabaseMode.WRITER,
-        operation: 'write',
-        resourceTypes: [],
-        source: 'test.withStatementTimeout.pins',
-      }) as PoolClient;
+      const client = repo.getDatabaseClient(repoAccess.sqlWriteConfig());
       escapedClient = client;
       await repo.withTransaction(
         async (txRepo) => {
-          expect(
-            txRepo.getDatabaseClient({
-              mode: DatabaseMode.WRITER,
-              operation: 'write',
-              resourceTypes: [],
-              source: 'test.withStatementTimeout.pins',
-            })
-          ).toBe(client);
+          expect(txRepo.getDatabaseClient(repoAccess.sqlWriteConfig())).toBe(client);
         },
         { resourceTypes: [], source: 'test.withStatementTimeout.pins' }
       );
     });
     assert(escapedClient);
-    expect(
-      repo.getDatabaseClient({
-        mode: DatabaseMode.WRITER,
-        operation: 'write',
-        resourceTypes: [],
-        source: 'test.withStatementTimeout.pins',
-      })
-    ).not.toBe(escapedClient);
+    expect(repo.getDatabaseClient(repoAccess.sqlWriteConfig())).not.toBe(escapedClient);
   });
 
   test('withStatementTimeout rejects on borrowed repository connections but succeeds within transactions', async () => {
@@ -1315,69 +1321,22 @@ describe('FHIR Repo Transactions', () => {
         // disposing a derived transaction repo does not dispose the main txnRepo
         const derivedTxnRepo = txnRepo.withOverrideConfig({ extendedMode: false });
         derivedTxnRepo[Symbol.dispose]();
-        expect(() =>
-          derivedTxnRepo.getDatabaseClient({
-            mode: DatabaseMode.WRITER,
-            operation: 'write',
-            resourceTypes: [],
-            source: 'test.transaction.getDatabaseClient',
-          })
-        ).toThrow('Already closed');
+        expect(() => derivedTxnRepo.getDatabaseClient(repoAccess.sqlWriteConfig())).toThrow('Already closed');
 
-        const client = txnRepo.getDatabaseClient({
-          mode: DatabaseMode.WRITER,
-          operation: 'write',
-          resourceTypes: [],
-          source: 'test.transaction.getDatabaseClient',
-        });
+        const client = txnRepo.getDatabaseClient(repoAccess.sqlWriteConfig());
         assert(client);
 
         const systemRepo = txnRepo.getSystemRepo();
         const overrideRepo = txnRepo.withOverrideConfig({ extendedMode: false });
 
-        expect(
-          systemRepo.getDatabaseClient({
-            mode: DatabaseMode.WRITER,
-            operation: 'write',
-            resourceTypes: [],
-            source: 'test.transaction.getDatabaseClient',
-          })
-        ).toBe(client);
-        expect(
-          overrideRepo.getDatabaseClient({
-            mode: DatabaseMode.WRITER,
-            operation: 'write',
-            resourceTypes: [],
-            source: 'test.transaction.getDatabaseClient',
-          })
-        ).toBe(client);
+        expect(systemRepo.getDatabaseClient(repoAccess.sqlWriteConfig())).toBe(client);
+        expect(overrideRepo.getDatabaseClient(repoAccess.sqlWriteConfig())).toBe(client);
 
         // disposing the main txnRepo does not close derived repos
         txnRepo[Symbol.dispose]();
-        expect(() =>
-          txnRepo.getDatabaseClient({
-            mode: DatabaseMode.WRITER,
-            operation: 'write',
-            resourceTypes: [],
-            source: 'test.transaction.getDatabaseClient',
-          })
-        ).toThrow('Already closed');
-        expect(
-          systemRepo.getDatabaseClient({
-            mode: DatabaseMode.WRITER,
-            operation: 'write',
-            resourceTypes: [],
-            source: 'test.transaction.getDatabaseClient',
-          })
-        ).toBe(client);
-        expect(
-          overrideRepo.getDatabaseClient({
-            mode: DatabaseMode.WRITER,
-            operation: 'write',
-            resourceTypes: [],
-            source: 'test.transaction.getDatabaseClient',
-          })
-        ).toBe(client);
+        expect(() => txnRepo.getDatabaseClient(repoAccess.sqlWriteConfig())).toThrow('Already closed');
+        expect(systemRepo.getDatabaseClient(repoAccess.sqlWriteConfig())).toBe(client);
+        expect(overrideRepo.getDatabaseClient(repoAccess.sqlWriteConfig())).toBe(client);
 
         escapedTxnRepo = txnRepo;
         escapedTxnSystemRepo = systemRepo;
@@ -1395,30 +1354,9 @@ describe('FHIR Repo Transactions', () => {
     const closedTxnOverrideRepo = escapedTxnOverrideRepo;
 
     // After the transaction commits, both the txnRepo and derived repos are all closed.
-    expect(() =>
-      closedTxnRepo.getDatabaseClient({
-        mode: DatabaseMode.WRITER,
-        operation: 'write',
-        resourceTypes: [],
-        source: 'test.transaction.getDatabaseClient',
-      })
-    ).toThrow('Already closed');
-    expect(() =>
-      closedTxnSystemRepo.getDatabaseClient({
-        mode: DatabaseMode.WRITER,
-        operation: 'write',
-        resourceTypes: [],
-        source: 'test.transaction.getDatabaseClient',
-      })
-    ).toThrow('Already closed');
-    expect(() =>
-      closedTxnOverrideRepo.getDatabaseClient({
-        mode: DatabaseMode.WRITER,
-        operation: 'write',
-        resourceTypes: [],
-        source: 'test.transaction.getDatabaseClient',
-      })
-    ).toThrow('Already closed');
+    expect(() => closedTxnRepo.getDatabaseClient(repoAccess.sqlWriteConfig())).toThrow('Already closed');
+    expect(() => closedTxnSystemRepo.getDatabaseClient(repoAccess.sqlWriteConfig())).toThrow('Already closed');
+    expect(() => closedTxnOverrideRepo.getDatabaseClient(repoAccess.sqlWriteConfig())).toThrow('Already closed');
   });
 
   test('withTransaction rejects a writer client that is not a PoolClient', async () => {
@@ -1589,12 +1527,7 @@ describe('FHIR Repo Transactions', () => {
             // The parent repo should also be blocked for ordinary repository/database operations, not
             // only for nested withTransaction calls.
             // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies parent repo rejection.
-            repo.getDatabaseClient({
-              mode: DatabaseMode.WRITER,
-              operation: 'write',
-              resourceTypes: [],
-              source: 'test.transaction.getDatabaseClient',
-            });
+            repo.getDatabaseClient(repoAccess.sqlWriteConfig());
           } catch (err) {
             parentDatabaseClientError = err;
           }
@@ -1669,24 +1602,12 @@ describe('FHIR Repo Transactions', () => {
       let checked = false;
       await repo.withTransaction(
         async (txRepo) => {
-          const client = txRepo.getDatabaseClient({
-            mode: DatabaseMode.WRITER,
-            operation: 'write',
-            resourceTypes: [],
-            source: 'test.transaction.getDatabaseClient',
-          });
+          const client = txRepo.getDatabaseClient(repoAccess.sqlWriteConfig());
           // starting a transaction will have pinned a connection to `txRepo`.
           // so ensure that cloning after that pinning does not propagate the pinned connection
           // to the cloned repository.
-          const clonedRepo1 = txRepo.clone();
-          expect(
-            clonedRepo1.getDatabaseClient({
-              mode: DatabaseMode.WRITER,
-              operation: 'write',
-              resourceTypes: [],
-              source: 'test.transaction.getDatabaseClient',
-            })
-          ).not.toBe(client);
+          const clonedTxRepo = txRepo.clone();
+          expect(clonedTxRepo.getDatabaseClient(repoAccess.sqlWriteConfig())).not.toBe(client);
           checked = true;
         },
         { resourceTypes: [], source: 'test.clone.noSharedConnection' }

--- a/packages/server/src/fhir/repository/transaction.test.ts
+++ b/packages/server/src/fhir/repository/transaction.test.ts
@@ -49,55 +49,77 @@ describe('FHIR Repo Transactions', () => {
 
   test('withTransaction parent repo unusable during transaction callback', () =>
     withTestContext(async () => {
-      const patient = await repo.withTransaction(async (txRepo) => {
-        // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies scoped repo identity.
-        const alias = repo;
-        expect(txRepo).not.toBe(alias);
-        // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies scoped repo identity.
-        expect(txRepo).not.toBe(repo);
-        // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies parent repo rejection.
-        expect(() => repo.getDatabaseClient(DatabaseMode.WRITER)).toThrow(TRANSACTION_SCOPE_ERROR);
-        // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies parent repo rejection.
-        await expect(repo.createResource<Patient>({ resourceType: 'Patient' })).rejects.toThrow(
-          TRANSACTION_SCOPE_ERROR
-        );
-        return txRepo.createResource<Patient>({ resourceType: 'Patient' });
-      });
+      const patient = await repo.withTransaction(
+        async (txRepo) => {
+          // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies scoped repo identity.
+          const alias = repo;
+          expect(txRepo).not.toBe(alias);
+          // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies scoped repo identity.
+          expect(txRepo).not.toBe(repo);
+          expect(() =>
+            // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies parent repo rejection.
+            repo.getDatabaseClient({
+              mode: DatabaseMode.WRITER,
+              operation: 'write',
+              resourceTypes: [],
+              source: 'test.withTransaction.parentRepo',
+            })
+          ).toThrow(TRANSACTION_SCOPE_ERROR);
+          // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies parent repo rejection.
+          await expect(repo.createResource<Patient>({ resourceType: 'Patient' })).rejects.toThrow(
+            TRANSACTION_SCOPE_ERROR
+          );
+          return txRepo.createResource<Patient>({ resourceType: 'Patient' });
+        },
+        {
+          resourceTypes: ['Patient'],
+          source: 'test.withTransaction',
+        }
+      );
       await expectPatientVisible(repo, patient.id);
     }));
 
   test('ensureInTransaction callback must use the scoped repository when starting transaction', () =>
     withTestContext(async () => {
-      const patient = await repo.ensureInTransaction(async (txRepo) => {
-        // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies scoped repo identity.
-        expect(txRepo).not.toBe(repo);
-        // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies parent repo rejection.
-        await expect(repo.createResource<Patient>({ resourceType: 'Patient' })).rejects.toThrow(
-          TRANSACTION_SCOPE_ERROR
-        );
-        return txRepo.createResource<Patient>({ resourceType: 'Patient' });
-      });
+      const patient = await repo.ensureInTransaction(
+        async (txRepo) => {
+          // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies scoped repo identity.
+          expect(txRepo).not.toBe(repo);
+          // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies parent repo rejection.
+          await expect(repo.createResource<Patient>({ resourceType: 'Patient' })).rejects.toThrow(
+            TRANSACTION_SCOPE_ERROR
+          );
+          return txRepo.createResource<Patient>({ resourceType: 'Patient' });
+        },
+        { resourceTypes: ['Patient'], source: 'test.ensureInTransaction' }
+      );
       await expectPatientVisible(repo, patient.id);
     }));
 
   test('ensureInTransaction passes the current repository inside transaction', () =>
     withTestContext(async () => {
-      await repo.withTransaction(async (txRepo) => {
-        const patient = await txRepo.ensureInTransaction(async (ensuredRepo) => {
-          // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies scoped repo identity.
-          expect(ensuredRepo).toBe(txRepo);
-          return ensuredRepo.createResource<Patient>({ resourceType: 'Patient' });
-        });
+      await repo.withTransaction(
+        async (txRepo) => {
+          const patient = await txRepo.ensureInTransaction(
+            async (ensuredRepo) => {
+              // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies scoped repo identity.
+              expect(ensuredRepo).toBe(txRepo);
+              return ensuredRepo.createResource<Patient>({ resourceType: 'Patient' });
+            },
+            { resourceTypes: ['Patient'], source: 'test.ensureInTransaction.passesCurrent' }
+          );
 
-        expect(patient).toBeDefined();
-      });
+          expect(patient).toBeDefined();
+        },
+        { resourceTypes: ['Patient'], source: 'test.ensureInTransaction.passesCurrent' }
+      );
     }));
 
   test('withTransaction rejects concurrent calls', async () => {
     const cb1 = vi.fn().mockReturnValue('first success');
     const cb2 = vi.fn().mockReturnValue('second success');
-    const promise1 = repo.withTransaction(cb1);
-    const promise2 = repo.withTransaction(cb2);
+    const promise1 = repo.withTransaction(cb1, { resourceTypes: [], source: 'test.withTransaction.concurrent' });
+    const promise2 = repo.withTransaction(cb2, { resourceTypes: [], source: 'test.withTransaction.concurrent' });
 
     const [result1, result2] = await Promise.allSettled([promise1, promise2]);
     assert(result1.status === 'fulfilled');
@@ -114,16 +136,19 @@ describe('FHIR Repo Transactions', () => {
       let patient: WithId<Patient> | undefined;
 
       await expect(
-        repo.withTransaction(async (txRepo) => {
-          // Create one patient
-          // This will initially succeed, but should then be rolled back
-          patient = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
-          await expectPatientVisible(txRepo, patient.id);
+        repo.withTransaction(
+          async (txRepo) => {
+            // Create one patient
+            // This will initially succeed, but should then be rolled back
+            patient = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
+            await expectPatientVisible(txRepo, patient.id);
 
-          // Now try to create a malformed patient
-          // This will fail, and should rollback the entire transaction
-          await txRepo.createResource({ resourceType: 'Patient', foo: 'bar' } as unknown as Patient);
-        })
+            // Now try to create a malformed patient
+            // This will fail, and should rollback the entire transaction
+            await txRepo.createResource({ resourceType: 'Patient', foo: 'bar' } as unknown as Patient);
+          },
+          { resourceTypes: ['Patient'], source: 'test.transaction.rollback' }
+        )
       ).rejects.toMatchObject(
         new OperationOutcomeError({
           resourceType: 'OperationOutcome',
@@ -148,12 +173,18 @@ describe('FHIR Repo Transactions', () => {
       let patient1: Patient | undefined;
       let patient2: Patient | undefined;
 
-      await repo.withTransaction(async (txRepo) => {
-        patient1 = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
-        patient2 = await txRepo.withTransaction(async (nestedRepo) => {
-          return nestedRepo.createResource<Patient>({ resourceType: 'Patient' });
-        });
-      });
+      await repo.withTransaction(
+        async (txRepo) => {
+          patient1 = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
+          patient2 = await txRepo.withTransaction(
+            async (nestedRepo) => {
+              return nestedRepo.createResource<Patient>({ resourceType: 'Patient' });
+            },
+            { resourceTypes: ['Patient'], source: 'test.nestedTransaction.commit' }
+          );
+        },
+        { resourceTypes: ['Patient'], source: 'test.nestedTransaction.commit' }
+      );
       await expectPatientVisible(repo, patient1?.id);
       await expectPatientVisible(repo, patient2?.id);
     }));
@@ -164,41 +195,47 @@ describe('FHIR Repo Transactions', () => {
       let patient2: Patient | undefined;
 
       // Start an outer transaction - this should succeed
-      await repo.withTransaction(async (txRepo) => {
-        // Create one patient
-        // This will initially succeed, and should not be rolled back
-        patient1 = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
+      await repo.withTransaction(
+        async (txRepo) => {
+          // Create one patient
+          // This will initially succeed, and should not be rolled back
+          patient1 = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
 
-        // Start an inner transaction - this will be rolled back
-        await expect(
-          txRepo.withTransaction(async (nestedRepo) => {
-            patient2 = await nestedRepo.createResource<Patient>({ resourceType: 'Patient' });
-            await expectPatientVisible(nestedRepo, patient1?.id);
-            await expectPatientVisible(nestedRepo, patient2?.id);
+          // Start an inner transaction - this will be rolled back
+          await expect(
+            txRepo.withTransaction(
+              async (nestedRepo) => {
+                patient2 = await nestedRepo.createResource<Patient>({ resourceType: 'Patient' });
+                await expectPatientVisible(nestedRepo, patient1?.id);
+                await expectPatientVisible(nestedRepo, patient2?.id);
 
-            // Now try to create a malformed patient
-            // This will fail, and should rollback the entire transaction
-            await nestedRepo.createResource({ resourceType: 'Patient', foo: 'bar' } as unknown as Patient);
-          })
-        ).rejects.toMatchObject(
-          new OperationOutcomeError({
-            resourceType: 'OperationOutcome',
-            issue: [
-              {
-                severity: 'error',
-                code: 'structure',
-                details: {
-                  text: 'Invalid additional property "foo"',
-                },
-                expression: ['Patient.foo'],
+                // Now try to create a malformed patient
+                // This will fail, and should rollback the entire transaction
+                await nestedRepo.createResource({ resourceType: 'Patient', foo: 'bar' } as unknown as Patient);
               },
-            ],
-          })
-        );
+              { resourceTypes: ['Patient'], source: 'test.nestedTransaction.rollback' }
+            )
+          ).rejects.toMatchObject(
+            new OperationOutcomeError({
+              resourceType: 'OperationOutcome',
+              issue: [
+                {
+                  severity: 'error',
+                  code: 'structure',
+                  details: {
+                    text: 'Invalid additional property "foo"',
+                  },
+                  expression: ['Patient.foo'],
+                },
+              ],
+            })
+          );
 
-        await expectPatientVisible(txRepo, patient1?.id);
-        await expectPatientAbsent(txRepo, patient2?.id);
-      });
+          await expectPatientVisible(txRepo, patient1?.id);
+          await expectPatientAbsent(txRepo, patient2?.id);
+        },
+        { resourceTypes: ['Patient'], source: 'test.nestedTransaction.rollback' }
+      );
     }));
 
   test('Nested transaction rollback from DB error', () =>
@@ -207,31 +244,42 @@ describe('FHIR Repo Transactions', () => {
       let patient2: Patient | undefined;
 
       // Start an outer transaction - this should succeed
-      await repo.withTransaction(async (txRepo) => {
-        // Create one patient
-        // This will initially succeed, and should not be rolled back
-        patient1 = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
-        expect(patient1).toBeDefined();
+      await repo.withTransaction(
+        async (txRepo) => {
+          // Create one patient
+          // This will initially succeed, and should not be rolled back
+          patient1 = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
+          expect(patient1).toBeDefined();
 
-        // Start an inner transaction - this will be rolled back
-        await expect(
-          txRepo.withTransaction(async (nestedRepo) => {
-            patient2 = await nestedRepo.createResource<Patient>({ resourceType: 'Patient' });
-            expect(patient2).toBeDefined();
+          // Start an inner transaction - this will be rolled back
+          await expect(
+            txRepo.withTransaction(
+              async (nestedRepo) => {
+                patient2 = await nestedRepo.createResource<Patient>({ resourceType: 'Patient' });
+                expect(patient2).toBeDefined();
 
-            await expectPatientVisible(nestedRepo, patient1?.id);
-            await expectPatientVisible(nestedRepo, patient2?.id);
+                await expectPatientVisible(nestedRepo, patient1?.id);
+                await expectPatientVisible(nestedRepo, patient2?.id);
 
-            const db = nestedRepo.getDatabaseClient(DatabaseMode.READER);
-            await expect(db.query(`SELECT * FROM "TableDoesNotExist"`)).rejects.toMatchObject({
-              message: 'relation "TableDoesNotExist" does not exist',
-            });
-          })
-        ).rejects.toThrow('current transaction is aborted, commands ignored until end of transaction block');
+                const db = nestedRepo.getDatabaseClient({
+                  mode: DatabaseMode.READER,
+                  operation: 'read',
+                  resourceTypes: [],
+                  source: 'test.transaction.getDatabaseClient',
+                });
+                await expect(db.query(`SELECT * FROM "TableDoesNotExist"`)).rejects.toMatchObject({
+                  message: 'relation "TableDoesNotExist" does not exist',
+                });
+              },
+              { resourceTypes: ['Patient'], source: 'test.nestedTransaction.rollbackDbError' }
+            )
+          ).rejects.toThrow('current transaction is aborted, commands ignored until end of transaction block');
 
-        await expectPatientVisible(txRepo, patient1?.id);
-        await expectPatientAbsent(txRepo, patient2?.id, { outcome: notFound });
-      });
+          await expectPatientVisible(txRepo, patient1?.id);
+          await expectPatientAbsent(txRepo, patient2?.id, { outcome: notFound });
+        },
+        { resourceTypes: ['Patient'], source: 'test.nestedTransaction.rollbackDbError' }
+      );
 
       await expectPatientVisible(repo, patient1?.id);
       await expectPatientAbsent(repo, patient2?.id, { outcome: notFound });
@@ -243,13 +291,16 @@ describe('FHIR Repo Transactions', () => {
   ])('Post-commit callback on $name', ({ shouldRollback }) =>
     withTestContext(async () => {
       const callback = vi.fn();
-      const txn = repo.withTransaction(async (txRepo) => {
-        await txRepo.postCommit(callback);
-        expect(callback).not.toHaveBeenCalled();
-        if (shouldRollback) {
-          throw new Error('Roll it back!');
-        }
-      });
+      const txn = repo.withTransaction(
+        async (txRepo) => {
+          await txRepo.postCommit(callback);
+          expect(callback).not.toHaveBeenCalled();
+          if (shouldRollback) {
+            throw new Error('Roll it back!');
+          }
+        },
+        { resourceTypes: [], source: 'test.postCommit.callback' }
+      );
 
       if (shouldRollback) {
         await expect(txn).rejects.toThrow('Roll it back!');
@@ -282,9 +333,12 @@ describe('FHIR Repo Transactions', () => {
 
       let patient: WithId<Patient> | undefined;
       try {
-        await compartmentRepo.withTransaction(async (txRepo) => {
-          patient = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
-        });
+        await compartmentRepo.withTransaction(
+          async (txRepo) => {
+            patient = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
+          },
+          { resourceTypes: ['Patient'], source: 'test.transaction.postCommitAuditEvent' }
+        );
         assert(patient);
         await waitFor(async () => {
           assert(patient);
@@ -309,25 +363,31 @@ describe('FHIR Repo Transactions', () => {
       const errorSpy = vi.spyOn(getLogger(), 'error').mockImplementation(() => {});
       const postCommitCb = vi.fn();
       try {
-        await repo.withTransaction(async (txRepo) => {
-          await txRepo.postCommit(() => postCommitCb('first'));
-          await txRepo.withTransaction(async (nestedRepo) => {
-            await nestedRepo.postCommit(async () => {
-              postCommitCb('second');
-              // Registered while post-commit callbacks are being processed, so it is
-              // invoked immediately (depth-first) rather than queued
-              await nestedRepo.postCommit(() => {
-                postCommitCb('third');
-              });
-            });
+        await repo.withTransaction(
+          async (txRepo) => {
+            await txRepo.postCommit(() => postCommitCb('first'));
+            await txRepo.withTransaction(
+              async (nestedRepo) => {
+                await nestedRepo.postCommit(async () => {
+                  postCommitCb('second');
+                  // Registered while post-commit callbacks are being processed, so it is
+                  // invoked immediately (depth-first) rather than queued
+                  await nestedRepo.postCommit(() => {
+                    postCommitCb('third');
+                  });
+                });
+                expect(postCommitCb).not.toHaveBeenCalled();
+              },
+              { resourceTypes: [], source: 'test.nestedTransaction.postCommit' }
+            );
             expect(postCommitCb).not.toHaveBeenCalled();
-          });
-          expect(postCommitCb).not.toHaveBeenCalled();
-          await txRepo.postCommit(async () => {
-            postCommitCb('fourth');
-            await txRepo.postCommit(() => postCommitCb('fifth'));
-          });
-        });
+            await txRepo.postCommit(async () => {
+              postCommitCb('fourth');
+              await txRepo.postCommit(() => postCommitCb('fifth'));
+            });
+          },
+          { resourceTypes: [], source: 'test.nestedTransaction.postCommit' }
+        );
         expect(postCommitCb.mock.calls.map(([arg]) => arg)).toStrictEqual([
           'first',
           'second',
@@ -346,14 +406,20 @@ describe('FHIR Repo Transactions', () => {
       let nestedPatient: WithId<Patient> | undefined;
       let postCommitPatient: WithId<Patient> | undefined;
 
-      await repo.withTransaction(async (txRepo) => {
-        await txRepo.withTransaction(async (nestedRepo) => {
-          nestedPatient = await nestedRepo.createResource<Patient>({ resourceType: 'Patient' });
-          await nestedRepo.postCommit(async () => {
-            postCommitPatient = await nestedRepo.createResource<Patient>({ resourceType: 'Patient' });
-          });
-        });
-      });
+      await repo.withTransaction(
+        async (txRepo) => {
+          await txRepo.withTransaction(
+            async (nestedRepo) => {
+              nestedPatient = await nestedRepo.createResource<Patient>({ resourceType: 'Patient' });
+              await nestedRepo.postCommit(async () => {
+                postCommitPatient = await nestedRepo.createResource<Patient>({ resourceType: 'Patient' });
+              });
+            },
+            { resourceTypes: ['Patient'], source: 'test.releasedNestedRepo.postCommitWrite' }
+          );
+        },
+        { resourceTypes: ['Patient'], source: 'test.releasedNestedRepo.postCommitWrite' }
+      );
 
       // Post-commit callbacks run before the outer withTransaction resolves, and errors
       // in them are logged rather than thrown, so assert the write actually happened
@@ -367,73 +433,109 @@ describe('FHIR Repo Transactions', () => {
       let nestedPatient: WithId<Patient> | undefined;
       let preCommitPatient: WithId<Patient> | undefined;
 
-      await repo.withTransaction(async (txRepo) => {
-        await txRepo.withTransaction(async (nestedRepo) => {
-          nestedPatient = await nestedRepo.createResource<Patient>({ resourceType: 'Patient' });
-          // Mirrors how validateResourceReferences reads through the registering repo
-          await nestedRepo.preCommit(async () => {
-            assert(nestedPatient);
-            preCommitPatient = await nestedRepo.readResource<Patient>('Patient', nestedPatient.id);
-          });
-        });
-        // Pre-commit callbacks only run when the outermost transaction commits
-        expect(preCommitPatient).toBeUndefined();
-      });
+      await repo.withTransaction(
+        async (txRepo) => {
+          await txRepo.withTransaction(
+            async (nestedRepo) => {
+              nestedPatient = await nestedRepo.createResource<Patient>({ resourceType: 'Patient' });
+              // Mirrors how validateResourceReferences reads through the registering repo
+              await nestedRepo.preCommit(async () => {
+                assert(nestedPatient);
+                preCommitPatient = await nestedRepo.readResource<Patient>('Patient', nestedPatient.id);
+              });
+            },
+            { resourceTypes: ['Patient'], source: 'test.releasedNestedRepo.preCommitRead' }
+          );
+          // Pre-commit callbacks only run when the outermost transaction commits
+          expect(preCommitPatient).toBeUndefined();
+        },
+        { resourceTypes: ['Patient'], source: 'test.releasedNestedRepo.preCommitRead' }
+      );
 
       expect(preCommitPatient?.id).toStrictEqual(nestedPatient?.id);
     }));
 
   test('Released nested repo is locked until the outer transaction begins committing', () =>
     withTestContext(async () => {
-      await repo.withTransaction(async (txRepo) => {
-        const releasedRepo = await txRepo.withTransaction(async (nestedRepo) => nestedRepo);
+      await repo.withTransaction(
+        async (txRepo) => {
+          const releasedRepo = await txRepo.withTransaction(async (nestedRepo) => nestedRepo, {
+            resourceTypes: [],
+            source: 'test.releasedNestedRepo.locked',
+          });
 
-        expect(() => releasedRepo.getDatabaseClient(DatabaseMode.WRITER)).toThrow(SAVEPOINT_RELEASED_ERROR);
-        await expect(releasedRepo.createResource<Patient>({ resourceType: 'Patient' })).rejects.toThrow(
-          SAVEPOINT_RELEASED_ERROR
-        );
-        await expect(releasedRepo.withTransaction(async () => undefined)).rejects.toThrow(SAVEPOINT_RELEASED_ERROR);
-        await expect(releasedRepo.preCommit(async () => undefined)).rejects.toThrow(SAVEPOINT_RELEASED_ERROR);
-        await expect(releasedRepo.postCommit(async () => undefined)).rejects.toThrow(SAVEPOINT_RELEASED_ERROR);
+          expect(() =>
+            releasedRepo.getDatabaseClient({
+              mode: DatabaseMode.WRITER,
+              operation: 'write',
+              resourceTypes: [],
+              source: 'test.transaction.getDatabaseClient',
+            })
+          ).toThrow(SAVEPOINT_RELEASED_ERROR);
+          await expect(releasedRepo.createResource<Patient>({ resourceType: 'Patient' })).rejects.toThrow(
+            SAVEPOINT_RELEASED_ERROR
+          );
+          await expect(
+            releasedRepo.withTransaction(async () => undefined, {
+              resourceTypes: [],
+              source: 'test.releasedNestedRepo.locked',
+            })
+          ).rejects.toThrow(SAVEPOINT_RELEASED_ERROR);
+          await expect(releasedRepo.preCommit(async () => undefined)).rejects.toThrow(SAVEPOINT_RELEASED_ERROR);
+          await expect(releasedRepo.postCommit(async () => undefined)).rejects.toThrow(SAVEPOINT_RELEASED_ERROR);
 
-        // The outer transaction-scoped repo remains fully usable
-        const patient = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
-        await expectPatientVisible(txRepo, patient.id);
-      });
+          // The outer transaction-scoped repo remains fully usable
+          const patient = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
+          await expectPatientVisible(txRepo, patient.id);
+        },
+        { resourceTypes: ['Patient'], source: 'test.releasedNestedRepo.locked' }
+      );
     }));
 
   test('Retry executes post-commit hook once from outer transaction', async () => {
     const postCommit = vi.fn();
     let shouldError = true;
 
-    await repo.withTransaction(async (txRepo) => {
-      await txRepo.postCommit(postCommit);
-      expect(postCommit).not.toHaveBeenCalled();
+    await repo.withTransaction(
+      async (txRepo) => {
+        await txRepo.postCommit(postCommit);
+        expect(postCommit).not.toHaveBeenCalled();
 
-      await txRepo.withTransaction(async () => {
-        if (shouldError) {
-          shouldError = false;
-          throw Object.assign(new Error('serialization failure'), { code: PostgresError.SerializationFailure });
-        }
-      });
-      expect(postCommit).not.toHaveBeenCalled();
-    });
+        await txRepo.withTransaction(
+          async () => {
+            if (shouldError) {
+              shouldError = false;
+              throw Object.assign(new Error('serialization failure'), { code: PostgresError.SerializationFailure });
+            }
+          },
+          { resourceTypes: [], source: 'test.retry.postCommitOnce' }
+        );
+        expect(postCommit).not.toHaveBeenCalled();
+      },
+      { resourceTypes: [], source: 'test.retry.postCommitOnce' }
+    );
     expect(postCommit).toHaveBeenCalledTimes(1);
   });
 
   test('Retry should not execute post-commit hook from rollback', async () => {
     const postCommit = vi.fn();
 
-    await repo.withTransaction(async (txRepo) => {
-      try {
-        await txRepo.withTransaction(async (nestedRepo) => {
-          await nestedRepo.postCommit(postCommit);
-          throw Object.assign(new Error('serialization failure'), { code: PostgresError.SerializationFailure });
-        });
-      } catch {
-        // Ignore error
-      }
-    });
+    await repo.withTransaction(
+      async (txRepo) => {
+        try {
+          await txRepo.withTransaction(
+            async (nestedRepo) => {
+              await nestedRepo.postCommit(postCommit);
+              throw Object.assign(new Error('serialization failure'), { code: PostgresError.SerializationFailure });
+            },
+            { resourceTypes: [], source: 'test.retry.noPostCommitOnRollback' }
+          );
+        } catch {
+          // Ignore error
+        }
+      },
+      { resourceTypes: [], source: 'test.retry.noPostCommitOnRollback' }
+    );
 
     expect(postCommit).toHaveBeenCalledTimes(0);
   });
@@ -443,10 +545,13 @@ describe('FHIR Repo Transactions', () => {
       const callback = vi.fn();
       let callsBeforeCommit: number | undefined;
 
-      await repo.withTransaction(async (txRepo) => {
-        await txRepo.getSystemRepo().postCommit(callback);
-        callsBeforeCommit = callback.mock.calls.length;
-      });
+      await repo.withTransaction(
+        async (txRepo) => {
+          await txRepo.getSystemRepo().postCommit(callback);
+          callsBeforeCommit = callback.mock.calls.length;
+        },
+        { resourceTypes: [], source: 'test.getSystemRepo.sharesPostCommit' }
+      );
 
       expect(callsBeforeCommit).toStrictEqual(0);
       expect(callback).toHaveBeenCalledTimes(1);
@@ -456,18 +561,28 @@ describe('FHIR Repo Transactions', () => {
     withTestContext(async () => {
       let queries: string[] = [];
 
-      await repo.withTransaction(async (txRepo) => {
-        const client = txRepo.getDatabaseClient(DatabaseMode.WRITER);
-        const querySpy = spyOnQuery(client);
-        try {
-          await txRepo.getSystemRepo().withTransaction(async () => undefined);
-        } finally {
-          queries = querySpy.mock.calls.map(([query]) =>
-            typeof query === 'string' ? query : (query as { text: string }).text
-          );
-          querySpy.mockRestore();
-        }
-      });
+      await repo.withTransaction(
+        async (txRepo) => {
+          const client = txRepo.getDatabaseClient({
+            mode: DatabaseMode.WRITER,
+            operation: 'write',
+            resourceTypes: [],
+            source: 'test.transaction.getDatabaseClient',
+          });
+          const querySpy = spyOnQuery(client);
+          try {
+            await txRepo
+              .getSystemRepo()
+              .withTransaction(async () => undefined, { resourceTypes: [], source: 'test.getSystemRepo.nests' });
+          } finally {
+            queries = querySpy.mock.calls.map(([query]) =>
+              typeof query === 'string' ? query : (query as { text: string }).text
+            );
+            querySpy.mockRestore();
+          }
+        },
+        { resourceTypes: [], source: 'test.getSystemRepo.nests' }
+      );
       // only a savepoint, no commit
       expect(queries).toStrictEqual(['SAVEPOINT sp2', 'RELEASE SAVEPOINT sp2']);
     }));
@@ -475,16 +590,19 @@ describe('FHIR Repo Transactions', () => {
   test('getSystemRepo() defers cache writes while parent transaction is active', () =>
     withTestContext(async () => {
       let cacheReadDuringTransaction = false;
-      const patient = await repo.withTransaction(async (txRepo) => {
-        const created = await txRepo.getSystemRepo().createResource<Patient>({ resourceType: 'Patient' });
-        try {
-          await systemRepo.readResource<Patient>('Patient', created.id, { checkCacheOnly: true });
-          cacheReadDuringTransaction = true;
-        } catch {
-          cacheReadDuringTransaction = false;
-        }
-        return created;
-      });
+      const patient = await repo.withTransaction(
+        async (txRepo) => {
+          const created = await txRepo.getSystemRepo().createResource<Patient>({ resourceType: 'Patient' });
+          try {
+            await systemRepo.readResource<Patient>('Patient', created.id, { checkCacheOnly: true });
+            cacheReadDuringTransaction = true;
+          } catch {
+            cacheReadDuringTransaction = false;
+          }
+          return created;
+        },
+        { resourceTypes: ['Patient'], source: 'test.getSystemRepo.defersCacheWrites' }
+      );
 
       expect(cacheReadDuringTransaction).toBe(false);
       await expect(systemRepo.readResource('Patient', patient.id, { checkCacheOnly: true })).resolves.toBeDefined();
@@ -495,13 +613,16 @@ describe('FHIR Repo Transactions', () => {
       const callbackFn = vi.fn();
       let patient: WithId<Patient> | undefined;
       await expect(
-        repo.withTransaction(async (txRepo) => {
-          const clonedRepo = txRepo.clone();
-          patient = await clonedRepo.createResource<Patient>({ resourceType: 'Patient' });
-          await clonedRepo.postCommit(callbackFn);
-          expect(callbackFn).toHaveBeenCalledTimes(1);
-          throw new Error('rollback clone transaction');
-        })
+        repo.withTransaction(
+          async (txRepo) => {
+            const clonedRepo = txRepo.clone();
+            patient = await clonedRepo.createResource<Patient>({ resourceType: 'Patient' });
+            await clonedRepo.postCommit(callbackFn);
+            expect(callbackFn).toHaveBeenCalledTimes(1);
+            throw new Error('rollback clone transaction');
+          },
+          { resourceTypes: ['Patient'], source: 'test.clone.noSharedState' }
+        )
       ).rejects.toThrow('rollback clone transaction');
 
       expect(callbackFn).toHaveBeenCalledTimes(1);
@@ -533,37 +654,43 @@ describe('FHIR Repo Transactions', () => {
       8. RepositoryConnection.withTransaction() treats 40001 as retryable, rolls back tx2, starts a fresh transaction, reruns tx2 callback and succeeds.
       */
 
-      const tx1 = repo.clone().withTransaction(async (txRepo) => {
-        log('tx1 start');
-        try {
-          await txRepo.updateResource({ ...existing, gender: 'unknown' });
-        } catch (err) {
-          log('tx1 update error');
-          throw err;
-        }
-        tx1UpdateFinished.resolve(undefined);
-        log('tx1 after update');
-        await allowTx1Commit.promise;
-        log('tx1 committing');
-        return 'tx1 success';
-      });
+      const tx1 = repo.clone().withTransaction(
+        async (txRepo) => {
+          log('tx1 start');
+          try {
+            await txRepo.updateResource({ ...existing, gender: 'unknown' });
+          } catch (err) {
+            log('tx1 update error');
+            throw err;
+          }
+          tx1UpdateFinished.resolve(undefined);
+          log('tx1 after update');
+          await allowTx1Commit.promise;
+          log('tx1 committing');
+          return 'tx1 success';
+        },
+        { resourceTypes: ['Patient'], source: 'test.conflictingConcurrentWrites' }
+      );
 
       await tx1UpdateFinished.promise;
 
-      const tx2 = repo.clone().withTransaction(async (txRepo) => {
-        log('tx2 start');
-        await txRepo.readResource('Patient', existing.id);
-        tx2SnapshotTaken.resolve(undefined);
-        try {
-          await txRepo.updateResource({ ...existing, deceasedBoolean: false });
-        } catch (err) {
-          log('tx2 update error');
-          throw err;
-        }
-        log('tx2 after update');
-        log('tx2 committing');
-        return 'tx2 success';
-      });
+      const tx2 = repo.clone().withTransaction(
+        async (txRepo) => {
+          log('tx2 start');
+          await txRepo.readResource('Patient', existing.id);
+          tx2SnapshotTaken.resolve(undefined);
+          try {
+            await txRepo.updateResource({ ...existing, deceasedBoolean: false });
+          } catch (err) {
+            log('tx2 update error');
+            throw err;
+          }
+          log('tx2 after update');
+          log('tx2 committing');
+          return 'tx2 success';
+        },
+        { resourceTypes: ['Patient'], source: 'test.conflictingConcurrentWrites' }
+      );
 
       await tx2SnapshotTaken.promise;
 
@@ -625,7 +752,11 @@ describe('FHIR Repo Transactions', () => {
           tx1CreateFinished.resolve(undefined);
           await allowTx1Commit.promise;
         },
-        { serializable: isolation === 'serializable' }
+        {
+          serializable: isolation === 'serializable',
+          resourceTypes: ['Patient'],
+          source: 'test.conflictingConditionalCreates',
+        }
       );
       await tx1CreateFinished.promise;
 
@@ -640,7 +771,11 @@ describe('FHIR Repo Transactions', () => {
           tx2CreateFinished.resolve(undefined);
           await allowTx2Commit.promise;
         },
-        { serializable: isolation === 'serializable' }
+        {
+          serializable: isolation === 'serializable',
+          resourceTypes: ['Patient'],
+          source: 'test.conflictingConditionalCreates',
+        }
       );
       await tx2CreateFinished.promise;
 
@@ -689,14 +824,17 @@ describe('FHIR Repo Transactions', () => {
       });
 
       // Simulate patch operation with long delay in the middle to ensure conflict
-      const tx1 = repo.clone().withTransaction(async (txRepo) => {
-        log('tx1 search');
-        const found = await txRepo.readResource<Patient>(existing.resourceType, existing.id);
-        tx1SearchFinished.resolve(undefined);
-        await allowTx1Update.promise;
-        log('tx1 update');
-        return txRepo.updateResource({ ...found, gender: 'other' });
-      });
+      const tx1 = repo.clone().withTransaction(
+        async (txRepo) => {
+          log('tx1 search');
+          const found = await txRepo.readResource<Patient>(existing.resourceType, existing.id);
+          tx1SearchFinished.resolve(undefined);
+          await allowTx1Update.promise;
+          log('tx1 update');
+          return txRepo.updateResource({ ...found, gender: 'other' });
+        },
+        { resourceTypes: ['Patient'], source: 'test.conflictingUpdateWithPatch' }
+      );
 
       await tx1SearchFinished.promise;
       const tx2Patient = await repo.clone().updateResource({ ...existing, deceasedBoolean: false });
@@ -761,9 +899,13 @@ describe('FHIR Repo Transactions', () => {
       });
 
       if (expectedError) {
-        await expect(repo.withTransaction(txFn)).rejects.toThrow(expectedError);
+        await expect(
+          repo.withTransaction(txFn, { resourceTypes: [], source: 'test.retry.transactionConflict' })
+        ).rejects.toThrow(expectedError);
       } else {
-        await expect(repo.withTransaction(txFn)).resolves.toStrictEqual(expectedResult);
+        await expect(
+          repo.withTransaction(txFn, { resourceTypes: [], source: 'test.retry.transactionConflict' })
+        ).resolves.toStrictEqual(expectedResult);
       }
       expect(txFn).toHaveBeenCalledTimes(expectedCalls);
     })
@@ -810,25 +952,29 @@ describe('FHIR Repo Transactions', () => {
         const outerTx = vi.fn(async (txRepo): Promise<boolean> => {
           outerRepos.push(txRepo);
           if (!catchNestedError) {
-            return txRepo.withTransaction(txFn);
+            return txRepo.withTransaction(txFn, { resourceTypes: [], source: 'test.retry.nested' });
           }
           try {
-            await txRepo.withTransaction(txFn);
+            await txRepo.withTransaction(txFn, { resourceTypes: [], source: 'test.retry.nested' });
             return true;
-          } catch (_) {
+          } catch {
             return false;
           }
         });
 
         if (expectedError) {
-          await expect(repo.withTransaction(outerTx)).rejects.toThrow(expectedError);
+          await expect(
+            repo.withTransaction(outerTx, { resourceTypes: [], source: 'test.retry.nested' })
+          ).rejects.toThrow(expectedError);
         } else {
-          await expect(repo.withTransaction(outerTx)).resolves.toStrictEqual(expectedResult);
+          await expect(
+            repo.withTransaction(outerTx, { resourceTypes: [], source: 'test.retry.nested' })
+          ).resolves.toStrictEqual(expectedResult);
         }
         expect(txFn).toHaveBeenCalledTimes(expectedTxCalls);
         expect(outerTx).toHaveBeenCalledTimes(expectedOuterCalls);
         expect(outerRepos).toHaveLength(expectedOuterCalls);
-        expect(outerRepos.map((r) => r.isClosed())).toStrictEqual(Array(expectedOuterCalls).fill(true));
+        expect(outerRepos.map((r) => r.isClosed())).toStrictEqual(new Array(expectedOuterCalls).fill(true));
       })
   );
 
@@ -838,17 +984,20 @@ describe('FHIR Repo Transactions', () => {
       const patients: WithId<Patient>[] = [];
       let shouldError = true;
 
-      const createdPatient = await repo.withTransaction(async (txRepo) => {
-        const patient = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
-        patients.push(patient);
+      const createdPatient = await repo.withTransaction(
+        async (txRepo) => {
+          const patient = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
+          patients.push(patient);
 
-        if (shouldError) {
-          shouldError = false;
-          throw Object.assign(new Error('serialization failure'), { code: PostgresError.SerializationFailure });
-        }
+          if (shouldError) {
+            shouldError = false;
+            throw Object.assign(new Error('serialization failure'), { code: PostgresError.SerializationFailure });
+          }
 
-        return patient;
-      });
+          return patient;
+        },
+        { resourceTypes: ['Patient'], source: 'test.retry.afterCreate' }
+      );
 
       expect(patients).toHaveLength(2);
       expect(createdPatient).toEqual(patients[1]);
@@ -899,18 +1048,29 @@ describe('FHIR Repo Transactions', () => {
     let querySpy: MockInstance | undefined;
 
     await expect(
-      repo.withTransaction(async (txRepo) => {
-        const client = txRepo.getDatabaseClient(DatabaseMode.WRITER);
-        querySpy = spyOnQuery(client).mockImplementation(() => {
-          // Simulates a session killed by idle_in_transaction_session_timeout: every query
-          // issued on the client — including the ROLLBACK the error handler sends — rejects.
-          const terminationErr = Object.assign(new Error('terminating connection due to idle-in-transaction timeout'), {
-            code: '57P01',
+      repo.withTransaction(
+        async (txRepo) => {
+          const client = txRepo.getDatabaseClient({
+            mode: DatabaseMode.WRITER,
+            operation: 'write',
+            resourceTypes: [],
+            source: 'test.transaction.getDatabaseClient',
           });
-          throw terminationErr;
-        });
-        await client.query('SELECT 1');
-      })
+          querySpy = spyOnQuery(client).mockImplementation(() => {
+            // Simulates a session killed by idle_in_transaction_session_timeout: every query
+            // issued on the client — including the ROLLBACK the error handler sends — rejects.
+            const terminationErr = Object.assign(
+              new Error('terminating connection due to idle-in-transaction timeout'),
+              {
+                code: '57P01',
+              }
+            );
+            throw terminationErr;
+          });
+          await client.query('SELECT 1');
+        },
+        { resourceTypes: [], source: 'test.withTransaction.deadBackendRollback' }
+      )
     ).rejects.toThrow('terminating connection due to idle-in-transaction timeout');
 
     assert(querySpy);
@@ -934,22 +1094,53 @@ describe('FHIR Repo Transactions', () => {
 
   test('withStatementTimeout pins connection and discards it after callback', async () => {
     let escapedClient: PoolClient | undefined;
-    await repo.withStatementTimeout({ timeoutMs: 0 }, async (client) => {
+    await repo.withStatementTimeout({ timeoutMs: 0 }, async () => {
+      const client = repo.getDatabaseClient({
+        mode: DatabaseMode.WRITER,
+        operation: 'write',
+        resourceTypes: [],
+        source: 'test.withStatementTimeout.pins',
+      }) as PoolClient;
       escapedClient = client;
-      await repo.withTransaction(async (txRepo) => {
-        expect(txRepo.getDatabaseClient(DatabaseMode.WRITER)).toBe(client);
-      });
+      await repo.withTransaction(
+        async (txRepo) => {
+          expect(
+            txRepo.getDatabaseClient({
+              mode: DatabaseMode.WRITER,
+              operation: 'write',
+              resourceTypes: [],
+              source: 'test.withStatementTimeout.pins',
+            })
+          ).toBe(client);
+        },
+        { resourceTypes: [], source: 'test.withStatementTimeout.pins' }
+      );
     });
     assert(escapedClient);
-    expect(repo.getDatabaseClient(DatabaseMode.WRITER)).not.toBe(escapedClient);
+    expect(
+      repo.getDatabaseClient({
+        mode: DatabaseMode.WRITER,
+        operation: 'write',
+        resourceTypes: [],
+        source: 'test.withStatementTimeout.pins',
+      })
+    ).not.toBe(escapedClient);
   });
 
-  test('withStatementTimeout rejects borrowed repository connections', async () => {
-    await repo.withTransaction(async (txRepo) => {
-      await expect(
-        txRepo.getSystemRepo().withStatementTimeout({ timeoutMs: 0 }, async () => undefined)
-      ).rejects.toThrow('borrowed repository connection');
-    });
+  test('withStatementTimeout rejects on borrowed repository connections but succeeds within transactions', async () => {
+    const query = vi.fn(async (_sql: string) => ({ rows: [] }));
+    const client = { query, release: vi.fn() } as unknown as PoolClient;
+    const borrowedClientRepo = createBorrowedRepo(client);
+    await expect(borrowedClientRepo.withStatementTimeout({ timeoutMs: 0 }, async () => undefined)).rejects.toThrow(
+      'Cannot set statement timeout on a borrowed connection'
+    );
+
+    await borrowedClientRepo.withTransaction(
+      async (txRepo) => {
+        await expect(txRepo.withStatementTimeout({ timeoutMs: 0 }, async () => 5)).resolves.toBe(5);
+      },
+      { resourceTypes: [], source: 'test.withStatementTimeout.rejectsBorrowed' }
+    );
   });
 
   test('withStatementTimeout prevents writer operations on a pinned reader connection', async () => {
@@ -959,7 +1150,12 @@ describe('FHIR Repo Transactions', () => {
       await repo.withStatementTimeout({ timeoutMs: 0, mode: DatabaseMode.READER }, async () => {
         // The timeout wrapper pins one physical reader client. A nested transaction
         // must not silently reuse that reader client for writer work.
-        await expect(repo.withTransaction(async () => undefined)).rejects.toThrow('reader database connection');
+        await expect(
+          repo.withTransaction(async () => undefined, {
+            resourceTypes: [],
+            source: 'test.withStatementTimeout.pinnedReader',
+          })
+        ).rejects.toThrow('reader database connection');
         reachedEnd = true;
       });
       expect(reachedEnd).toBe(true);
@@ -974,14 +1170,17 @@ describe('FHIR Repo Transactions', () => {
       readerRepo.setMode(RepositoryMode.READER);
       expect(readerRepo.mode).toBe(RepositoryMode.READER);
 
-      await readerRepo.withTransaction(async (txRepo) => {
-        // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies mode promotion on the shared connection.
-        expect(readerRepo.mode).toBe(RepositoryMode.WRITER);
-        expect(txRepo.mode).toBe(RepositoryMode.WRITER);
-        expect(() => txRepo.setMode(RepositoryMode.READER)).toThrow('Cannot set repository mode to reader');
-        expect(txRepo.mode).toBe(RepositoryMode.WRITER);
-        await txRepo.createResource<Patient>({ resourceType: 'Patient' });
-      });
+      await readerRepo.withTransaction(
+        async (txRepo) => {
+          // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies mode promotion on the shared connection.
+          expect(readerRepo.mode).toBe(RepositoryMode.WRITER);
+          expect(txRepo.mode).toBe(RepositoryMode.WRITER);
+          expect(() => txRepo.setMode(RepositoryMode.READER)).toThrow('Cannot set repository mode to reader');
+          expect(txRepo.mode).toBe(RepositoryMode.WRITER);
+          await txRepo.createResource<Patient>({ resourceType: 'Patient' });
+        },
+        { resourceTypes: ['Patient'], source: 'test.withTransaction.promotesReader' }
+      );
 
       expect(readerRepo.mode).toBe(RepositoryMode.WRITER);
     }));
@@ -1003,18 +1202,24 @@ describe('FHIR Repo Transactions', () => {
 
     try {
       await expect(
-        borrowedClientRepo.withTransaction(async () => {
-          throw new Error('work failed');
-        })
+        borrowedClientRepo.withTransaction(
+          async () => {
+            throw new Error('work failed');
+          },
+          { resourceTypes: [], source: 'test.borrowedConnection.noReacquire' }
+        )
       ).rejects.toThrow('work failed');
 
       // The repository only borrowed this PoolClient, so it drops its local reference
       // after the fatal rollback path but never releases a client it does not own.
       expect(client.release).not.toHaveBeenCalled();
 
-      await expect(borrowedClientRepo.withTransaction(async () => undefined)).rejects.toThrow(
-        'Borrowed repository connection is no longer available'
-      );
+      await expect(
+        borrowedClientRepo.withTransaction(async () => undefined, {
+          resourceTypes: [],
+          source: 'test.borrowedConnection.noReacquire',
+        })
+      ).rejects.toThrow('Borrowed repository connection is no longer available');
     } finally {
       warnSpy.mockRestore();
       errorSpy.mockRestore();
@@ -1032,7 +1237,12 @@ describe('FHIR Repo Transactions', () => {
     const txnCallback = vi.fn();
 
     try {
-      await expect(borrowedClientRepo.withTransaction(txnCallback)).rejects.toThrow('begin failed');
+      await expect(
+        borrowedClientRepo.withTransaction(txnCallback, {
+          resourceTypes: [],
+          source: 'test.withTransaction.beginFails',
+        })
+      ).rejects.toThrow('begin failed');
       expect(txnCallback).not.toHaveBeenCalled();
 
       // BEGIN never succeeded, so the in-memory state must not claim an active
@@ -1057,11 +1267,15 @@ describe('FHIR Repo Transactions', () => {
     const borrowedClientRepo = createBorrowedRepo(client);
     await borrowedClientRepo.withTransaction(
       async (txRepo) => {
-        await expect(txRepo.withTransaction(async () => undefined, { serializable: true })).rejects.toThrow(
-          'Cannot start SERIALIZABLE transaction inside active REPEATABLE READ transaction'
-        );
+        await expect(
+          txRepo.withTransaction(async () => undefined, {
+            serializable: true,
+            resourceTypes: [],
+            source: 'test.withTransaction.rejectsIsolationUpgrade',
+          })
+        ).rejects.toThrow('Cannot start SERIALIZABLE transaction inside active REPEATABLE READ transaction');
       },
-      { serializable: false }
+      { serializable: false, resourceTypes: [], source: 'test.withTransaction.rejectsIsolationUpgrade' }
     );
 
     expect(query.mock.calls.map(([sql]) => sql)).toStrictEqual(['BEGIN ISOLATION LEVEL REPEATABLE READ', 'COMMIT']);
@@ -1076,9 +1290,12 @@ describe('FHIR Repo Transactions', () => {
     const borrowedClientRepo = createBorrowedRepo(client);
     await borrowedClientRepo.withTransaction(
       async (txRepo) => {
-        await txRepo.withTransaction(async () => undefined);
+        await txRepo.withTransaction(async () => undefined, {
+          resourceTypes: [],
+          source: 'test.withTransaction.weakerIsolation',
+        });
       },
-      { serializable: true }
+      { serializable: true, resourceTypes: [], source: 'test.withTransaction.weakerIsolation' }
     );
 
     expect(query.mock.calls.map(([sql]) => sql)).toStrictEqual([
@@ -1093,31 +1310,81 @@ describe('FHIR Repo Transactions', () => {
     let escapedTxnRepo: Repository | undefined;
     let escapedTxnSystemRepo: Repository | undefined;
     let escapedTxnOverrideRepo: Repository | undefined;
-    await repo.withTransaction(async (txnRepo) => {
-      // disposing a derived transaction repo does not dispose the main txnRepo
-      const derivedTxnRepo = txnRepo.withOverrideConfig({ extendedMode: false });
-      derivedTxnRepo[Symbol.dispose]();
-      expect(() => derivedTxnRepo.getDatabaseClient(DatabaseMode.WRITER)).toThrow('Already closed');
+    await repo.withTransaction(
+      async (txnRepo) => {
+        // disposing a derived transaction repo does not dispose the main txnRepo
+        const derivedTxnRepo = txnRepo.withOverrideConfig({ extendedMode: false });
+        derivedTxnRepo[Symbol.dispose]();
+        expect(() =>
+          derivedTxnRepo.getDatabaseClient({
+            mode: DatabaseMode.WRITER,
+            operation: 'write',
+            resourceTypes: [],
+            source: 'test.transaction.getDatabaseClient',
+          })
+        ).toThrow('Already closed');
 
-      const client = txnRepo.getDatabaseClient(DatabaseMode.WRITER);
-      assert(client);
+        const client = txnRepo.getDatabaseClient({
+          mode: DatabaseMode.WRITER,
+          operation: 'write',
+          resourceTypes: [],
+          source: 'test.transaction.getDatabaseClient',
+        });
+        assert(client);
 
-      const systemRepo = txnRepo.getSystemRepo();
-      const overrideRepo = txnRepo.withOverrideConfig({ extendedMode: false });
+        const systemRepo = txnRepo.getSystemRepo();
+        const overrideRepo = txnRepo.withOverrideConfig({ extendedMode: false });
 
-      expect(systemRepo.getDatabaseClient(DatabaseMode.WRITER)).toBe(client);
-      expect(overrideRepo.getDatabaseClient(DatabaseMode.WRITER)).toBe(client);
+        expect(
+          systemRepo.getDatabaseClient({
+            mode: DatabaseMode.WRITER,
+            operation: 'write',
+            resourceTypes: [],
+            source: 'test.transaction.getDatabaseClient',
+          })
+        ).toBe(client);
+        expect(
+          overrideRepo.getDatabaseClient({
+            mode: DatabaseMode.WRITER,
+            operation: 'write',
+            resourceTypes: [],
+            source: 'test.transaction.getDatabaseClient',
+          })
+        ).toBe(client);
 
-      // disposing the main txnRepo does not close derived repos
-      txnRepo[Symbol.dispose]();
-      expect(() => txnRepo.getDatabaseClient(DatabaseMode.WRITER)).toThrow('Already closed');
-      expect(systemRepo.getDatabaseClient(DatabaseMode.WRITER)).toBe(client);
-      expect(overrideRepo.getDatabaseClient(DatabaseMode.WRITER)).toBe(client);
+        // disposing the main txnRepo does not close derived repos
+        txnRepo[Symbol.dispose]();
+        expect(() =>
+          txnRepo.getDatabaseClient({
+            mode: DatabaseMode.WRITER,
+            operation: 'write',
+            resourceTypes: [],
+            source: 'test.transaction.getDatabaseClient',
+          })
+        ).toThrow('Already closed');
+        expect(
+          systemRepo.getDatabaseClient({
+            mode: DatabaseMode.WRITER,
+            operation: 'write',
+            resourceTypes: [],
+            source: 'test.transaction.getDatabaseClient',
+          })
+        ).toBe(client);
+        expect(
+          overrideRepo.getDatabaseClient({
+            mode: DatabaseMode.WRITER,
+            operation: 'write',
+            resourceTypes: [],
+            source: 'test.transaction.getDatabaseClient',
+          })
+        ).toBe(client);
 
-      escapedTxnRepo = txnRepo;
-      escapedTxnSystemRepo = systemRepo;
-      escapedTxnOverrideRepo = overrideRepo;
-    });
+        escapedTxnRepo = txnRepo;
+        escapedTxnSystemRepo = systemRepo;
+        escapedTxnOverrideRepo = overrideRepo;
+      },
+      { resourceTypes: [], source: 'test.derivedTransactionScopedRepos' }
+    );
 
     assert(escapedTxnRepo);
     assert(escapedTxnSystemRepo);
@@ -1128,9 +1395,30 @@ describe('FHIR Repo Transactions', () => {
     const closedTxnOverrideRepo = escapedTxnOverrideRepo;
 
     // After the transaction commits, both the txnRepo and derived repos are all closed.
-    expect(() => closedTxnRepo.getDatabaseClient(DatabaseMode.WRITER)).toThrow('Already closed');
-    expect(() => closedTxnSystemRepo.getDatabaseClient(DatabaseMode.WRITER)).toThrow('Already closed');
-    expect(() => closedTxnOverrideRepo.getDatabaseClient(DatabaseMode.WRITER)).toThrow('Already closed');
+    expect(() =>
+      closedTxnRepo.getDatabaseClient({
+        mode: DatabaseMode.WRITER,
+        operation: 'write',
+        resourceTypes: [],
+        source: 'test.transaction.getDatabaseClient',
+      })
+    ).toThrow('Already closed');
+    expect(() =>
+      closedTxnSystemRepo.getDatabaseClient({
+        mode: DatabaseMode.WRITER,
+        operation: 'write',
+        resourceTypes: [],
+        source: 'test.transaction.getDatabaseClient',
+      })
+    ).toThrow('Already closed');
+    expect(() =>
+      closedTxnOverrideRepo.getDatabaseClient({
+        mode: DatabaseMode.WRITER,
+        operation: 'write',
+        resourceTypes: [],
+        source: 'test.transaction.getDatabaseClient',
+      })
+    ).toThrow('Already closed');
   });
 
   test('withTransaction rejects a writer client that is not a PoolClient', async () => {
@@ -1142,9 +1430,12 @@ describe('FHIR Repo Transactions', () => {
     const errorSpy = vi.spyOn(getLogger(), 'error').mockImplementation(() => {});
 
     try {
-      await expect(borrowedClientRepo.withTransaction(async () => undefined)).rejects.toThrow(
-        'Transactions require a dedicated PoolClient'
-      );
+      await expect(
+        borrowedClientRepo.withTransaction(async () => undefined, {
+          resourceTypes: [],
+          source: 'test.withTransaction.rejectsNonPoolClient',
+        })
+      ).rejects.toThrow('Transactions require a dedicated PoolClient');
       expect(query).not.toHaveBeenCalled();
     } finally {
       errorSpy.mockRestore();
@@ -1174,28 +1465,37 @@ describe('FHIR Repo Transactions', () => {
     const errorSpy = vi.spyOn(getLogger(), 'error').mockImplementation(() => {});
 
     try {
-      await borrowedClientRepo.withTransaction(async (txRepo) => {
-        const txRepo2 = txRepo.getSystemRepo();
-        const nestedCallback2 = vi.fn();
+      await borrowedClientRepo.withTransaction(
+        async (txRepo) => {
+          const txRepo2 = txRepo.getSystemRepo();
+          const nestedCallback2 = vi.fn();
 
-        const tx1 = txRepo.withTransaction(async () => {
-          await finishFirstNestedTransaction.promise;
-        });
-        await savepointIssued.promise;
+          const tx1 = txRepo.withTransaction(
+            async () => {
+              await finishFirstNestedTransaction.promise;
+            },
+            { resourceTypes: [], source: 'test.concurrentNestedTransaction' }
+          );
+          await savepointIssued.promise;
 
-        // While the first nested begin is suspended, a sibling repo sharing the connection
-        // attempts to start its own transaction. It passes its initial usability check since
-        // the new scope is not yet published, so the connection state lock must force it to
-        // wait for the first begin, after which it is rejected without issuing any SQL.
-        const tx2 = txRepo2.withTransaction(nestedCallback2);
-        allowSavepoint.resolve(undefined);
-        await expect(tx2).rejects.toThrow(TRANSACTION_SCOPE_ERROR);
-        expect(nestedCallback2).not.toHaveBeenCalled();
-        expect(queries).toStrictEqual(['BEGIN ISOLATION LEVEL REPEATABLE READ', 'SAVEPOINT sp2']);
+          // While the first nested begin is suspended, a sibling repo sharing the connection
+          // attempts to start its own transaction. It passes its initial usability check since
+          // the new scope is not yet published, so the connection state lock must force it to
+          // wait for the first begin, after which it is rejected without issuing any SQL.
+          const tx2 = txRepo2.withTransaction(nestedCallback2, {
+            resourceTypes: [],
+            source: 'test.concurrentNestedTransaction',
+          });
+          allowSavepoint.resolve(undefined);
+          await expect(tx2).rejects.toThrow(TRANSACTION_SCOPE_ERROR);
+          expect(nestedCallback2).not.toHaveBeenCalled();
+          expect(queries).toStrictEqual(['BEGIN ISOLATION LEVEL REPEATABLE READ', 'SAVEPOINT sp2']);
 
-        finishFirstNestedTransaction.resolve(undefined);
-        await tx1;
-      });
+          finishFirstNestedTransaction.resolve(undefined);
+          await tx1;
+        },
+        { resourceTypes: [], source: 'test.concurrentNestedTransaction' }
+      );
 
       expect(queries).toStrictEqual([
         'BEGIN ISOLATION LEVEL REPEATABLE READ',
@@ -1222,15 +1522,18 @@ describe('FHIR Repo Transactions', () => {
     const repo = createBorrowedRepo(client);
 
     const result = await Promise.race([
-      repo.withTransaction(async (txRepo) => {
-        await txRepo.preCommit(async () => {
-          // Pre-commit callbacks are allowed to start their own nested transaction.
-          // If the outer commit held connectionStateLock while running callbacks, this nested
-          // transaction would wait for the lock while the outer commit waited for the callback.
-          await txRepo.withTransaction(precommit);
-        });
-        return 'completed';
-      }),
+      repo.withTransaction(
+        async (txRepo) => {
+          await txRepo.preCommit(async () => {
+            // Pre-commit callbacks are allowed to start their own nested transaction.
+            // If the outer commit held connectionStateLock while running callbacks, this nested
+            // transaction would wait for the lock while the outer commit waited for the callback.
+            await txRepo.withTransaction(precommit, { resourceTypes: [], source: 'test.preCommit.noDeadlock' });
+          });
+          return 'completed';
+        },
+        { resourceTypes: [], source: 'test.preCommit.noDeadlock' }
+      ),
       new Promise((resolve) => {
         // The broken implementation deadlocks, so the race gives the test a bounded failure mode.
         setTimeout(() => resolve('timed out'), 100);
@@ -1250,14 +1553,17 @@ describe('FHIR Repo Transactions', () => {
   test('pre-commit callbacks can add additional pre-commit callbacks', async () => {
     const preCommitEntries: string[] = [];
 
-    await repo.withTransaction(async (txRepo) => {
-      await txRepo.preCommit(async () => {
-        preCommitEntries.push('first');
+    await repo.withTransaction(
+      async (txRepo) => {
         await txRepo.preCommit(async () => {
-          preCommitEntries.push('second');
+          preCommitEntries.push('first');
+          await txRepo.preCommit(async () => {
+            preCommitEntries.push('second');
+          });
         });
-      });
-    });
+      },
+      { resourceTypes: [], source: 'test.preCommit.addsAdditional' }
+    );
 
     expect(preCommitEntries).toStrictEqual(['first', 'second']);
   });
@@ -1276,28 +1582,39 @@ describe('FHIR Repo Transactions', () => {
     let parentTransactionError: unknown;
     let parentDatabaseClientError: unknown;
 
-    await repo.withTransaction(async (txRepo) => {
-      await txRepo.preCommit(async () => {
-        try {
-          // The parent repo should also be blocked for ordinary repository/database operations, not
-          // only for nested withTransaction calls.
-          // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies parent repo rejection.
-          repo.getDatabaseClient(DatabaseMode.WRITER);
-        } catch (err) {
-          parentDatabaseClientError = err;
-        }
+    await repo.withTransaction(
+      async (txRepo) => {
+        await txRepo.preCommit(async () => {
+          try {
+            // The parent repo should also be blocked for ordinary repository/database operations, not
+            // only for nested withTransaction calls.
+            // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies parent repo rejection.
+            repo.getDatabaseClient({
+              mode: DatabaseMode.WRITER,
+              operation: 'write',
+              resourceTypes: [],
+              source: 'test.transaction.getDatabaseClient',
+            });
+          } catch (err) {
+            parentDatabaseClientError = err;
+          }
 
-        try {
-          // A pre-commit callback runs before the outer COMMIT. Starting a transaction through the
-          // original repo here used to create SAVEPOINT sp2 and convert the outer commit into a
-          // savepoint release. Only the transaction-scoped repo is allowed to nest in this window.
-          // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies parent repo rejection.
-          await repo.withTransaction(async () => undefined);
-        } catch (err) {
-          parentTransactionError = err;
-        }
-      });
-    });
+          try {
+            // A pre-commit callback runs before the outer COMMIT. Starting a transaction through the
+            // original repo here used to create SAVEPOINT sp2 and convert the outer commit into a
+            // savepoint release. Only the transaction-scoped repo is allowed to nest in this window.
+            // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies parent repo rejection.
+            await repo.withTransaction(async () => undefined, {
+              resourceTypes: [],
+              source: 'test.parentRepo.cannotStartDuringPreCommit',
+            });
+          } catch (err) {
+            parentTransactionError = err;
+          }
+        });
+      },
+      { resourceTypes: [], source: 'test.parentRepo.cannotStartDuringPreCommit' }
+    );
 
     expect(parentTransactionError).toEqual(expect.any(Error));
     expect((parentTransactionError as Error).message).toContain('transaction-scoped repository');
@@ -1312,19 +1629,22 @@ describe('FHIR Repo Transactions', () => {
     const finalPostCommit = vi.fn();
 
     const error = new Error('Post-commit hook failed');
-    const promise = repo.withTransaction(async (txRepo) => {
-      await txRepo.postCommit(async () => {
-        throw new Error('Post-commit hook failed');
-      });
-      await txRepo.postCommit(async () => {
-        // eslint-disable-next-line no-throw-literal
-        throw 'Post-commit hook failed with string';
-      });
-      await txRepo.postCommit(finalPostCommit);
-      if (mode === 'rollback') {
-        throw new Error('Transaction failed');
-      }
-    });
+    const promise = repo.withTransaction(
+      async (txRepo) => {
+        await txRepo.postCommit(async () => {
+          throw new Error('Post-commit hook failed');
+        });
+        await txRepo.postCommit(async () => {
+          // eslint-disable-next-line no-throw-literal
+          throw 'Post-commit hook failed with string';
+        });
+        await txRepo.postCommit(finalPostCommit);
+        if (mode === 'rollback') {
+          throw new Error('Transaction failed');
+        }
+      },
+      { resourceTypes: [], source: 'test.postCommit.handling' }
+    );
 
     if (mode === 'commit') {
       await promise;
@@ -1347,15 +1667,30 @@ describe('FHIR Repo Transactions', () => {
       // const { repo } = await createTestProject({ withRepo: true });
 
       let checked = false;
-      await repo.withTransaction(async (txRepo) => {
-        const client = txRepo.getDatabaseClient(DatabaseMode.WRITER);
-        // starting a transaction will have pinned a connection to `txRepo`.
-        // so ensure that cloning after that pinning does not propagate the pinned connection
-        // to the cloned repository.
-        const clonedRepo1 = txRepo.clone();
-        expect(clonedRepo1.getDatabaseClient(DatabaseMode.WRITER)).not.toBe(client);
-        checked = true;
-      });
+      await repo.withTransaction(
+        async (txRepo) => {
+          const client = txRepo.getDatabaseClient({
+            mode: DatabaseMode.WRITER,
+            operation: 'write',
+            resourceTypes: [],
+            source: 'test.transaction.getDatabaseClient',
+          });
+          // starting a transaction will have pinned a connection to `txRepo`.
+          // so ensure that cloning after that pinning does not propagate the pinned connection
+          // to the cloned repository.
+          const clonedRepo1 = txRepo.clone();
+          expect(
+            clonedRepo1.getDatabaseClient({
+              mode: DatabaseMode.WRITER,
+              operation: 'write',
+              resourceTypes: [],
+              source: 'test.transaction.getDatabaseClient',
+            })
+          ).not.toBe(client);
+          checked = true;
+        },
+        { resourceTypes: [], source: 'test.clone.noSharedConnection' }
+      );
       expect(checked).toBe(true);
     }));
 });

--- a/packages/server/src/fhir/resource-cap.ts
+++ b/packages/server/src/fhir/resource-cap.ts
@@ -8,15 +8,17 @@ import {
   projectAdminResourceTypes,
   protectedResourceTypes,
 } from '@medplum/core';
+import type { ResourceType } from '@medplum/fhirtypes';
 import type Redis from 'ioredis';
 import { RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
-import { DatabaseMode, getDatabasePool } from '../database';
+import { DatabaseMode } from '../database';
 import type { AuthState } from '../oauth/middleware';
+import { getRepoForLogin } from './accesspolicy';
 import { SelectQuery, Union } from './sql';
 
 const ONE_DAY = 60 * 60 * 24;
 
-let countedResourceTypes: string[] | undefined;
+let countedResourceTypes: ResourceType[] | undefined;
 
 export class ResourceCap {
   private readonly limiter: RateLimiterRedis;
@@ -24,6 +26,7 @@ export class ResourceCap {
 
   private current?: RateLimiterRes;
   private readonly enabled: boolean;
+  private readonly authState: AuthState;
   private readonly logger: Logger;
 
   private initPromise?: Promise<void>;
@@ -36,7 +39,7 @@ export class ResourceCap {
       duration: ONE_DAY,
     });
     this.projectKey = authState.project.id;
-
+    this.authState = authState;
     this.logger = logger;
     this.enabled = authState.project.systemSetting?.find((s) => s.name === 'enableResourceCap')?.valueBoolean === true;
   }
@@ -48,11 +51,17 @@ export class ResourceCap {
 
     let currentStatus = await this.limiter.get(this.projectKey);
     if (!currentStatus) {
+      const repo = await getRepoForLogin(this.authState, true);
       const subqueries = countedResourceTypes.map((rt) =>
         new SelectQuery(rt).raw(`COUNT(*)::int as "count"`).where('projectId', '=', this.projectKey)
       );
       const query = new SelectQuery('combined', new Union(...subqueries)).column('count');
-      const tableCounts = await query.execute(getDatabasePool(DatabaseMode.READER));
+      const tableCounts = await repo.executeSql<{ count: number }>(query, {
+        mode: DatabaseMode.READER,
+        operation: 'read',
+        resourceTypes: countedResourceTypes,
+        source: 'resourceCap.init',
+      });
       const totalCount = tableCounts.reduce((sum, row) => sum + row.count, 0);
       currentStatus = await this.limiter.set(this.projectKey, totalCount, ONE_DAY);
     }

--- a/packages/server/src/fhir/resource-cap.ts
+++ b/packages/server/src/fhir/resource-cap.ts
@@ -11,9 +11,9 @@ import {
 import type { ResourceType } from '@medplum/fhirtypes';
 import type Redis from 'ioredis';
 import { RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
-import { DatabaseMode } from '../database';
 import type { AuthState } from '../oauth/middleware';
 import { getRepoForLogin } from './accesspolicy';
+import { repoAccess } from './repository/access-tracker';
 import { SelectQuery, Union } from './sql';
 
 const ONE_DAY = 60 * 60 * 24;
@@ -56,12 +56,10 @@ export class ResourceCap {
         new SelectQuery(rt).raw(`COUNT(*)::int as "count"`).where('projectId', '=', this.projectKey)
       );
       const query = new SelectQuery('combined', new Union(...subqueries)).column('count');
-      const tableCounts = await repo.executeSql<{ count: number }>(query, {
-        mode: DatabaseMode.READER,
-        operation: 'read',
-        resourceTypes: countedResourceTypes,
-        source: 'resourceCap.init',
-      });
+      const tableCounts = await repo.executeSql<{ count: number }>(
+        query,
+        repoAccess.sqlRead(countedResourceTypes, { source: 'resourceCap.init' })
+      );
       const totalCount = tableCounts.reduce((sum, row) => sum + row.count, 0);
       currentStatus = await this.limiter.set(this.projectKey, totalCount, ONE_DAY);
     }

--- a/packages/server/src/fhir/resource-cap.ts
+++ b/packages/server/src/fhir/resource-cap.ts
@@ -51,7 +51,7 @@ export class ResourceCap {
 
     let currentStatus = await this.limiter.get(this.projectKey);
     if (!currentStatus) {
-      const repo = await getRepoForLogin(this.authState, true);
+      using repo = await getRepoForLogin(this.authState, true);
       const subqueries = countedResourceTypes.map((rt) =>
         new SelectQuery(rt).raw(`COUNT(*)::int as "count"`).where('projectId', '=', this.projectKey)
       );

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -58,10 +58,10 @@ import type { MockInstance } from 'vitest';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
-import { DatabaseMode } from '../database';
 import { bundleContains, createTestProject, withTestContext } from '../test.setup';
 import type { SystemRepository } from './repo';
 import { getGlobalSystemRepo, Repository } from './repo';
+import { repoAccess } from './repository/access-tracker';
 import type { ChainedSearchLink } from './search';
 import { clampEstimateCount, Direction, getCount, parseChainedParameter } from './search';
 import type { TokenColumnSearchParameterImplementation } from './searchparameter';
@@ -5474,15 +5474,7 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
   describe('discourage sequential scans', () => {
     let querySpy: MockInstance;
     beforeEach(() => {
-      querySpy = vi.spyOn(
-        repo.getDatabaseClient({
-          mode: DatabaseMode.READER,
-          operation: 'read',
-          resourceTypes: [],
-          source: 'search.test',
-        }),
-        'query'
-      );
+      querySpy = vi.spyOn(repo.getDatabaseClient(repoAccess.sqlReadConfig()), 'query');
     });
 
     afterEach(() => {
@@ -5828,12 +5820,7 @@ describe.each([true, false])('systemRepo', (rangeSearch) => {
         new SelectQuery('Patient').column('__version').where('id', '=', id);
 
       // patient1 at OLDER_VERSION, patient2 at Repository.VERSION
-      const client = systemRepo.getDatabaseClient({
-        mode: DatabaseMode.WRITER,
-        operation: 'write',
-        resourceTypes: ['Patient'],
-        source: 'search.test.maxResourceVersion',
-      });
+      const client = systemRepo.getDatabaseClient(repoAccess.sqlWrite('Patient'));
       const OLDER_VERSION = Repository.VERSION - 1;
       await client.query('UPDATE "Patient" SET __version = $1 WHERE id = $2', [OLDER_VERSION, patient1.id]);
       expect((await getVersionQuery(patient1.id).execute(client))[0].__version).toStrictEqual(OLDER_VERSION);

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -5474,7 +5474,15 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
   describe('discourage sequential scans', () => {
     let querySpy: MockInstance;
     beforeEach(() => {
-      querySpy = vi.spyOn(repo.getDatabaseClient(DatabaseMode.READER), 'query');
+      querySpy = vi.spyOn(
+        repo.getDatabaseClient({
+          mode: DatabaseMode.READER,
+          operation: 'read',
+          resourceTypes: [],
+          source: 'search.test',
+        }),
+        'query'
+      );
     });
 
     afterEach(() => {
@@ -5496,8 +5504,6 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       expect(querySpy).toHaveBeenNthCalledWith(1, expect.stringContaining('SET enable_seqscan = off'));
       expect(querySpy).toHaveBeenNthCalledWith(2, expect.stringContaining('SELECT'), expect.anything());
       expect(querySpy).toHaveBeenNthCalledWith(3, expect.stringContaining('RESET enable_seqscan'));
-
-      querySpy.mockRestore();
     });
 
     test('config.fhirSearchMinLimit', async () => {
@@ -5512,7 +5518,6 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       await repo.search(parseSearchRequest('Patient?identifier=123&_count=1'));
       expect(querySpy).toHaveBeenCalledTimes(1);
       expect(querySpy).toHaveBeenNthCalledWith(1, expect.stringMatching(/LIMIT 39$/), expect.anything());
-      querySpy.mockClear();
     });
   });
 });
@@ -5823,7 +5828,12 @@ describe.each([true, false])('systemRepo', (rangeSearch) => {
         new SelectQuery('Patient').column('__version').where('id', '=', id);
 
       // patient1 at OLDER_VERSION, patient2 at Repository.VERSION
-      const client = systemRepo.getDatabaseClient(DatabaseMode.WRITER);
+      const client = systemRepo.getDatabaseClient({
+        mode: DatabaseMode.WRITER,
+        operation: 'write',
+        resourceTypes: ['Patient'],
+        source: 'search.test.maxResourceVersion',
+      });
       const OLDER_VERSION = Repository.VERSION - 1;
       await client.query('UPDATE "Patient" SET __version = $1 WHERE id = $2', [OLDER_VERSION, patient1.id]);
       expect((await getVersionQuery(patient1.id).execute(client))[0].__version).toStrictEqual(OLDER_VERSION);

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -98,6 +98,8 @@ interface Cursor {
   excludedIds?: string[];
 }
 
+type TrackedResourceTypes = Set<ResourceType>;
+
 /** Linking direction for chained search. */
 export const Direction = {
   FORWARD: 1,
@@ -131,8 +133,9 @@ export async function searchImpl<T extends Resource>(
   let rowCount = undefined;
   let nextResource: T | undefined;
   if (searchRequest.count > 0) {
-    const builder = getSelectQueryForSearch(repo, searchRequest, options);
-    ({ entry, rowCount, nextResource } = await getSearchEntries<T>(repo, searchRequest, builder));
+    const trackedResourceTypes = new Set<ResourceType>();
+    const builder = getSelectQueryForSearch(repo, searchRequest, { ...options, trackedResourceTypes });
+    ({ entry, rowCount, nextResource } = await getSearchEntries<T>(repo, searchRequest, builder, trackedResourceTypes));
   }
 
   let total = undefined;
@@ -161,10 +164,12 @@ export async function searchByReferenceImpl<T extends Resource>(
   // Hold on to references to parts of the SelectQuery that need to be modified per reference value
   const referenceConditions: Condition[] = [];
   const referenceColumns: Column[] = [];
+  const trackedResourceTypes = new Set<ResourceType>();
 
   const searchQuery = getSelectQueryForSearch(repo, searchRequest, {
     addColumns: true,
     limitModifier: 0,
+    trackedResourceTypes,
     resourceTypeQueryCallback: (resourceType, builder) => {
       const param = getSearchParameter(resourceType, referenceField);
       if (param?.type !== 'reference') {
@@ -204,7 +209,12 @@ export async function searchByReferenceImpl<T extends Resource>(
   const rows: {
     content: string;
     ref: string;
-  }[] = await unionAllBuilder.execute(repo.getDatabaseClient(DatabaseMode.READER));
+  }[] = await repo.executeSql(unionAllBuilder, {
+    mode: DatabaseMode.READER,
+    operation: 'read',
+    resourceTypes: trackedResourceTypes,
+    source: 'search.searchByReference',
+  });
 
   const results: Record<string, WithId<T>[]> = Object.create(null);
   for (const ref of referenceValues) {
@@ -316,12 +326,14 @@ export function getSelectQueryForSearch<T extends Resource>(
  * @param repo - The repository.
  * @param searchRequest - The search request.
  * @param builder - The `SelectQuery` builder that is ready to execute.
+ * @param trackedResourceTypes - Resource types involved in the logical query.
  * @returns The bundle entries for the search result.
  */
 async function getSearchEntries<T extends Resource>(
   repo: Repository,
   searchRequest: SearchRequestWithCountAndOffset<T>,
-  builder: SelectQuery
+  builder: SelectQuery,
+  trackedResourceTypes: TrackedResourceTypes
 ): Promise<{ entry: BundleEntry<WithId<T>>[]; rowCount: number; nextResource?: T }> {
   const config = getConfig();
   const originalLimit = builder.limit_;
@@ -338,7 +350,12 @@ async function getSearchEntries<T extends Resource>(
       // just massively inflates the cost of a sequential scan to the planner.
       await client.query('SET enable_seqscan = off');
     }
-    rows = await builder.execute(client);
+    rows = await repo.executeSql(builder, {
+      mode: DatabaseMode.READER,
+      operation: 'read',
+      resourceTypes: trackedResourceTypes,
+      source: 'search.getSearchEntries',
+    });
   } finally {
     if (config.fhirSearchDiscourageSeqScan) {
       await client.query('RESET enable_seqscan');
@@ -396,6 +413,8 @@ interface GetBaseSelectQueryOptions {
   resourceTypeQueryCallback?: (resourceType: SearchRequest['resourceType'], builder: SelectQuery) => void;
   /** The maximum resource version to include in the search. If zero is specified, only resources with a NULL version are included. */
   maxResourceVersion?: number;
+  /** Resource types involved in the logical search query. */
+  trackedResourceTypes?: TrackedResourceTypes;
 }
 function getBaseSelectQuery(
   repo: Repository,
@@ -425,6 +444,7 @@ function getBaseSelectQueryForResourceType(
   searchRequest: SearchRequest,
   opts?: GetBaseSelectQueryOptions
 ): SelectQuery {
+  opts?.trackedResourceTypes?.add(resourceType);
   const builder = new SelectQuery(resourceType);
   const addColumns = opts?.addColumns !== false;
   const idColumn = new Column(resourceType, 'id');
@@ -441,7 +461,7 @@ function getBaseSelectQueryForResourceType(
     repo.addDeletedFilter(builder);
   }
   repo.addSecurityFilters(builder, resourceType, AccessPolicyInteraction.SEARCH);
-  addSearchFilters(repo, builder, resourceType, searchRequest);
+  addSearchFilters(repo, builder, resourceType, searchRequest, opts?.trackedResourceTypes);
   if (opts?.resourceTypeQueryCallback) {
     opts.resourceTypeQueryCallback(resourceType, builder);
   }
@@ -579,8 +599,9 @@ async function getSearchIncludeEntries(
         count: DEFAULT_MAX_SEARCH_COUNT,
         offset: 0,
       };
-      const query = getSelectQueryForSearch(repo, searchRequest);
-      return getSearchEntries(repo, searchRequest, query);
+      const trackedResourceTypes = new Set<ResourceType>();
+      const query = getSelectQueryForSearch(repo, searchRequest, { trackedResourceTypes });
+      return getSearchEntries(repo, searchRequest, query, trackedResourceTypes);
     });
 
     const searchResults = await Promise.all(canonicalSearches);
@@ -650,8 +671,9 @@ async function getSearchRevIncludeEntries(
     offset: 0,
   };
 
-  const query = getSelectQueryForSearch(repo, searchRequest);
-  const entries = (await getSearchEntries(repo, searchRequest, query)).entry;
+  const trackedResourceTypes = new Set<ResourceType>();
+  const query = getSelectQueryForSearch(repo, searchRequest, { trackedResourceTypes });
+  const entries = (await getSearchEntries(repo, searchRequest, query, trackedResourceTypes)).entry;
   for (const entry of entries) {
     entry.search = { mode: 'include' };
   }
@@ -916,7 +938,8 @@ export async function getCount(
  * @returns The total number of matching results.
  */
 async function getAccurateCount(repo: Repository, searchRequest: SearchRequest): Promise<number> {
-  const builder = getBaseSelectQuery(repo, searchRequest, { addColumns: false });
+  const trackedResourceTypes = new Set<ResourceType>();
+  const builder = getBaseSelectQuery(repo, searchRequest, { addColumns: false, trackedResourceTypes });
 
   if (builder.joins.length > 0) {
     builder.raw(`COUNT (DISTINCT "${searchRequest.resourceType}"."id")::int AS "count"`);
@@ -924,8 +947,13 @@ async function getAccurateCount(repo: Repository, searchRequest: SearchRequest):
     builder.raw('COUNT(*)::int AS "count"');
   }
 
-  const rows = await builder.execute(repo.getDatabaseClient(DatabaseMode.READER));
-  return rows[0].count as number;
+  const rows = await repo.executeSql<{ count: number }>(builder, {
+    mode: DatabaseMode.READER,
+    operation: 'read',
+    resourceTypes: trackedResourceTypes,
+    source: 'search.getAccurateCount',
+  });
+  return rows[0].count;
 }
 
 /**
@@ -937,12 +965,18 @@ async function getAccurateCount(repo: Repository, searchRequest: SearchRequest):
  * @returns The total number of matching results.
  */
 async function getEstimateCount(repo: Repository, searchRequest: SearchRequest): Promise<number> {
-  const builder = getBaseSelectQuery(repo, searchRequest);
+  const trackedResourceTypes = new Set<ResourceType>();
+  const builder = getBaseSelectQuery(repo, searchRequest, { trackedResourceTypes });
   builder.explain = true;
 
   // See: https://wiki.postgresql.org/wiki/Count_estimate
   // This parses the query plan to find the estimated number of rows.
-  const rows = await builder.execute(repo.getDatabaseClient(DatabaseMode.READER));
+  const rows = await repo.executeSql<{ 'QUERY PLAN': string }>(builder, {
+    mode: DatabaseMode.READER,
+    operation: 'read',
+    resourceTypes: trackedResourceTypes,
+    source: 'search.getEstimateCount',
+  });
   for (const row of rows) {
     const queryPlan = row['QUERY PLAN'];
     const match = /rows=(\d+)/.exec(queryPlan);
@@ -979,14 +1013,16 @@ export function clampEstimateCount(searchRequest: SearchRequest, estimateCount: 
  * @param selectQuery - The select query builder.
  * @param resourceType - The type of resources requested.
  * @param searchRequest - The search request.
+ * @param trackedResourceTypes - Resource types involved in the logical query.
  */
 function addSearchFilters(
   repo: Repository,
   selectQuery: SelectQuery,
   resourceType: ResourceType,
-  searchRequest: SearchRequest
+  searchRequest: SearchRequest,
+  trackedResourceTypes?: TrackedResourceTypes
 ): void {
-  const expr = buildSearchExpression(repo, selectQuery, resourceType, searchRequest);
+  const expr = buildSearchExpression(repo, selectQuery, resourceType, searchRequest, trackedResourceTypes);
   if (expr) {
     selectQuery.predicate.expressions.push(expr);
   }
@@ -1000,11 +1036,19 @@ export function buildSearchExpression(
   repo: Repository,
   selectQuery: SelectQuery,
   resourceType: ResourceType,
-  searchRequest: SearchRequest
+  searchRequest: SearchRequest,
+  trackedResourceTypes?: TrackedResourceTypes
 ): Expression | undefined {
   const expressions: Expression[] = [];
   for (const filter of searchRequest.filters ?? EMPTY) {
-    const expr = buildSearchFilterExpression(repo, selectQuery, resourceType, resourceType, filter);
+    const expr = buildSearchFilterExpression(
+      repo,
+      selectQuery,
+      resourceType,
+      resourceType,
+      filter,
+      trackedResourceTypes
+    );
     expressions.push(expr);
   }
   if (expressions.length === 0) {
@@ -1023,6 +1067,7 @@ export function buildSearchExpression(
  * @param resourceType - The type of resources requested.
  * @param table - The resource table.
  * @param filter - The search filter.
+ * @param trackedResourceTypes - Resource types involved in the logical query.
  * @returns The search query where expression
  */
 function buildSearchFilterExpression(
@@ -1030,7 +1075,8 @@ function buildSearchFilterExpression(
   selectQuery: SelectQuery,
   resourceType: ResourceType,
   table: string,
-  filter: Filter
+  filter: Filter,
+  trackedResourceTypes?: TrackedResourceTypes
 ): Expression {
   if (typeof filter.value !== 'string') {
     throw new OperationOutcomeError(badRequest('Search filter value must be a string'));
@@ -1042,10 +1088,17 @@ function buildSearchFilterExpression(
 
   if (isChainedSearchFilter(filter)) {
     const chain = parseChainedParameter(resourceType, filter);
-    return buildChainedSearch(repo, selectQuery, resourceType, chain);
+    return buildChainedSearch(repo, selectQuery, resourceType, chain, trackedResourceTypes);
   }
 
-  const specialParamExpression = trySpecialSearchParameter(repo, selectQuery, resourceType, table, filter);
+  const specialParamExpression = trySpecialSearchParameter(
+    repo,
+    selectQuery,
+    resourceType,
+    table,
+    filter,
+    trackedResourceTypes
+  );
   if (specialParamExpression) {
     return specialParamExpression;
   }
@@ -1154,6 +1207,7 @@ function buildNormalSearchFilterExpression(
  * @param resourceType - The type of resources requested.
  * @param table - The resource table.
  * @param filter - The search filter.
+ * @param trackedResourceTypes - Resource types involved in the logical query.
  * @returns True if the search parameter is a special code.
  */
 function trySpecialSearchParameter(
@@ -1161,7 +1215,8 @@ function trySpecialSearchParameter(
   selectQuery: SelectQuery,
   resourceType: ResourceType,
   table: string,
-  filter: Filter
+  filter: Filter,
+  trackedResourceTypes?: TrackedResourceTypes
 ): Expression | undefined {
   switch (filter.code) {
     case '_id':
@@ -1238,7 +1293,7 @@ function trySpecialSearchParameter(
     }
     case '_filter': {
       const filterExpr = parseFilterParameter(filter.value);
-      return buildFilterParameterExpression(repo, selectQuery, resourceType, table, filterExpr);
+      return buildFilterParameterExpression(repo, selectQuery, resourceType, table, filterExpr, trackedResourceTypes);
     }
 
     default:
@@ -1251,14 +1306,38 @@ function buildFilterParameterExpression(
   selectQuery: SelectQuery,
   resourceType: ResourceType,
   table: string,
-  filterExpression: FhirFilterExpression
+  filterExpression: FhirFilterExpression,
+  trackedResourceTypes?: TrackedResourceTypes
 ): Expression {
   if (filterExpression instanceof FhirFilterNegation) {
-    return new Negation(buildFilterParameterExpression(repo, selectQuery, resourceType, table, filterExpression.child));
+    return new Negation(
+      buildFilterParameterExpression(
+        repo,
+        selectQuery,
+        resourceType,
+        table,
+        filterExpression.child,
+        trackedResourceTypes
+      )
+    );
   } else if (filterExpression instanceof FhirFilterConnective) {
-    return buildFilterParameterConnective(repo, selectQuery, resourceType, table, filterExpression);
+    return buildFilterParameterConnective(
+      repo,
+      selectQuery,
+      resourceType,
+      table,
+      filterExpression,
+      trackedResourceTypes
+    );
   } else if (filterExpression instanceof FhirFilterComparison) {
-    return buildFilterParameterComparison(repo, selectQuery, resourceType, table, filterExpression);
+    return buildFilterParameterComparison(
+      repo,
+      selectQuery,
+      resourceType,
+      table,
+      filterExpression,
+      trackedResourceTypes
+    );
   } else {
     throw new OperationOutcomeError(badRequest('Unknown filter expression type'));
   }
@@ -1269,11 +1348,19 @@ function buildFilterParameterConnective(
   selectQuery: SelectQuery,
   resourceType: ResourceType,
   table: string,
-  filterConnective: FhirFilterConnective
+  filterConnective: FhirFilterConnective,
+  trackedResourceTypes?: TrackedResourceTypes
 ): Expression {
   const expressions = [
-    buildFilterParameterExpression(repo, selectQuery, resourceType, table, filterConnective.left),
-    buildFilterParameterExpression(repo, selectQuery, resourceType, table, filterConnective.right),
+    buildFilterParameterExpression(repo, selectQuery, resourceType, table, filterConnective.left, trackedResourceTypes),
+    buildFilterParameterExpression(
+      repo,
+      selectQuery,
+      resourceType,
+      table,
+      filterConnective.right,
+      trackedResourceTypes
+    ),
   ];
   return filterConnective.keyword === 'and' ? new Conjunction(expressions) : new Disjunction(expressions);
 }
@@ -1283,13 +1370,21 @@ function buildFilterParameterComparison(
   selectQuery: SelectQuery,
   resourceType: ResourceType,
   table: string,
-  filterComparison: FhirFilterComparison
+  filterComparison: FhirFilterComparison,
+  trackedResourceTypes?: TrackedResourceTypes
 ): Expression {
-  return buildSearchFilterExpression(repo, selectQuery, resourceType, table, {
-    code: filterComparison.path,
-    operator: filterComparison.operator,
-    value: filterComparison.value,
-  });
+  return buildSearchFilterExpression(
+    repo,
+    selectQuery,
+    resourceType,
+    table,
+    {
+      code: filterComparison.path,
+      operator: filterComparison.operator,
+      value: filterComparison.value,
+    },
+    trackedResourceTypes
+  );
 }
 
 /**
@@ -1699,10 +1794,16 @@ function buildChainedSearch(
   repo: Repository,
   selectQuery: SelectQuery,
   resourceType: string,
-  param: ChainedSearchParameter
+  param: ChainedSearchParameter,
+  trackedResourceTypes?: TrackedResourceTypes
 ): Expression {
   if (param.chain.length > 3) {
     throw new OperationOutcomeError(badRequest('Search chains longer than three links are not currently supported'));
+  }
+
+  for (const link of param.chain) {
+    trackedResourceTypes?.add(link.originType as ResourceType);
+    trackedResourceTypes?.add(link.targetType as ResourceType);
   }
 
   // Special case: single-link chain of the form param._id=<id> can be rewritten as param=ResourceType/<id>
@@ -1711,14 +1812,21 @@ function buildChainedSearch(
   if (param.chain.length === 1 && param.filter?.code === '_id' && param.chain[0].direction === Direction.FORWARD) {
     const { targetType, code } = param.chain[0];
     const targetId = param.filter.value;
-    return buildSearchFilterExpression(repo, selectQuery, resourceType as ResourceType, resourceType, {
-      code,
-      operator: param.filter.operator,
-      value: `${targetType}/${targetId}`,
-    });
+    return buildSearchFilterExpression(
+      repo,
+      selectQuery,
+      resourceType as ResourceType,
+      resourceType,
+      {
+        code,
+        operator: param.filter.operator,
+        value: `${targetType}/${targetId}`,
+      },
+      trackedResourceTypes
+    );
   }
 
-  return buildChainedSearchUsingReferenceTable(repo, selectQuery, param);
+  return buildChainedSearchUsingReferenceTable(repo, selectQuery, param, trackedResourceTypes);
 }
 
 /**
@@ -1729,12 +1837,14 @@ function buildChainedSearch(
  * @param repo - The repository.
  * @param selectQuery - The select query builder.
  * @param param - The chained search parameter.
+ * @param trackedResourceTypes - Resource types involved in the logical query.
  * @returns The WHERE clause expression for the final chained filter.
  */
 function buildChainedSearchUsingReferenceTable(
   repo: Repository,
   selectQuery: SelectQuery,
-  param: ChainedSearchParameter
+  param: ChainedSearchParameter,
+  trackedResourceTypes?: TrackedResourceTypes
 ): Expression {
   let link = param.chain[0];
   validateSearchResourceType(repo, link.targetType as ResourceType);
@@ -1769,7 +1879,14 @@ function buildChainedSearchUsingReferenceTable(
   innerQuery
     .where(new Column(currentTable, 'id'), '!=', null)
     .whereExpr(
-      buildSearchFilterExpression(repo, innerQuery, link.targetType as ResourceType, currentTable, param.filter)
+      buildSearchFilterExpression(
+        repo,
+        innerQuery,
+        link.targetType as ResourceType,
+        currentTable,
+        param.filter,
+        trackedResourceTypes
+      )
     );
   return new SqlFunction('EXISTS', [innerQuery]);
 }

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -342,7 +342,12 @@ async function getSearchEntries<T extends Resource>(
     builder.limit(config.fhirSearchMinLimit);
   }
 
-  const client = repo.getDatabaseClient(DatabaseMode.READER);
+  const client = repo.getDatabaseClient({
+    mode: DatabaseMode.READER,
+    operation: 'read',
+    resourceTypes: trackedResourceTypes,
+    source: 'search.getSearchEntries.statementConfig',
+  });
   let rows: any[];
   try {
     if (config.fhirSearchDiscourageSeqScan) {

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -47,10 +47,10 @@ import type {
 } from '@medplum/fhirtypes';
 import { getConfig } from '../config/loader';
 import { systemResourceProjectId } from '../constants';
-import { DatabaseMode } from '../database';
 import { clamp } from './operations/utils/parameters';
 import { addRangeColumnsOrderBy, buildRangeColumnsSearchFilter } from './range-column';
 import type { Repository } from './repo';
+import { repoAccess } from './repository/access-tracker';
 import { parseHistoryContent } from './repository/row-builder';
 import { getFullUrl } from './response';
 import type { ColumnSearchParameterImplementation } from './searchparameter';
@@ -209,12 +209,10 @@ export async function searchByReferenceImpl<T extends Resource>(
   const rows: {
     content: string;
     ref: string;
-  }[] = await repo.executeSql(unionAllBuilder, {
-    mode: DatabaseMode.READER,
-    operation: 'read',
-    resourceTypes: trackedResourceTypes,
-    source: 'search.searchByReference',
-  });
+  }[] = await repo.executeSql(
+    unionAllBuilder,
+    repoAccess.sqlRead(trackedResourceTypes, { source: 'search.searchByReference' })
+  );
 
   const results: Record<string, WithId<T>[]> = Object.create(null);
   for (const ref of referenceValues) {
@@ -342,28 +340,27 @@ async function getSearchEntries<T extends Resource>(
     builder.limit(config.fhirSearchMinLimit);
   }
 
-  const client = repo.getDatabaseClient({
-    mode: DatabaseMode.READER,
-    operation: 'configuration',
-    resourceTypes: [],
-    source: 'search.getSearchEntries.statementConfig',
-  });
-  let rows: any[];
+  let rows: { id: string; content: string; lastUpdated?: Date }[];
   try {
     if (config.fhirSearchDiscourageSeqScan) {
       // Despite the name, this doesn't truly remove the possibility of a sequential scan,
       // just massively inflates the cost of a sequential scan to the planner.
-      await client.query('SET enable_seqscan = off');
+      await repo.executeRawSql(
+        'SET enable_seqscan = off',
+        undefined,
+        repoAccess.sqlReadConfig({ source: 'search.getSearchEntries.setSeqScan' })
+      );
     }
-    rows = await repo.executeSql(builder, {
-      mode: DatabaseMode.READER,
-      operation: 'read',
-      resourceTypes: trackedResourceTypes,
+    rows = await repo.sqlRead<(typeof rows)[number]>(builder, trackedResourceTypes, {
       source: 'search.getSearchEntries',
     });
   } finally {
     if (config.fhirSearchDiscourageSeqScan) {
-      await client.query('RESET enable_seqscan');
+      await repo.executeRawSql(
+        'RESET enable_seqscan',
+        undefined,
+        repoAccess.sqlReadConfig({ source: 'search.getSearchEntries.resetSeqScan' })
+      );
     }
   }
 
@@ -371,7 +368,7 @@ async function getSearchEntries<T extends Resource>(
   const resources: WithId<T>[] = [];
   for (let i = 0; i < rowCount; i++) {
     const row = rows[i];
-    const parsed = parseHistoryContent(row.content as string);
+    const parsed = parseHistoryContent(row.content);
     if (!parsed.meta?.deleted) {
       resources.push(parsed as WithId<T>);
     } else {
@@ -952,12 +949,10 @@ async function getAccurateCount(repo: Repository, searchRequest: SearchRequest):
     builder.raw('COUNT(*)::int AS "count"');
   }
 
-  const rows = await repo.executeSql<{ count: number }>(builder, {
-    mode: DatabaseMode.READER,
-    operation: 'read',
-    resourceTypes: trackedResourceTypes,
-    source: 'search.getAccurateCount',
-  });
+  const rows = await repo.executeSql<{ count: number }>(
+    builder,
+    repoAccess.sqlRead(trackedResourceTypes, { source: 'search.getAccurateCount' })
+  );
   return rows[0].count;
 }
 
@@ -976,12 +971,10 @@ async function getEstimateCount(repo: Repository, searchRequest: SearchRequest):
 
   // See: https://wiki.postgresql.org/wiki/Count_estimate
   // This parses the query plan to find the estimated number of rows.
-  const rows = await repo.executeSql<{ 'QUERY PLAN': string }>(builder, {
-    mode: DatabaseMode.READER,
-    operation: 'read',
-    resourceTypes: trackedResourceTypes,
-    source: 'search.getEstimateCount',
-  });
+  const rows = await repo.executeSql<{ 'QUERY PLAN': string }>(
+    builder,
+    repoAccess.sqlRead(trackedResourceTypes, { source: 'search.getEstimateCount' })
+  );
   for (const row of rows) {
     const queryPlan = row['QUERY PLAN'];
     const match = /rows=(\d+)/.exec(queryPlan);
@@ -1383,11 +1376,7 @@ function buildFilterParameterComparison(
     selectQuery,
     resourceType,
     table,
-    {
-      code: filterComparison.path,
-      operator: filterComparison.operator,
-      value: filterComparison.value,
-    },
+    { code: filterComparison.path, operator: filterComparison.operator, value: filterComparison.value },
     trackedResourceTypes
   );
 }
@@ -1822,11 +1811,7 @@ function buildChainedSearch(
       selectQuery,
       resourceType as ResourceType,
       resourceType,
-      {
-        code,
-        operator: param.filter.operator,
-        value: `${targetType}/${targetId}`,
-      },
+      { code, operator: param.filter.operator, value: `${targetType}/${targetId}` },
       trackedResourceTypes
     );
   }

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -344,8 +344,8 @@ async function getSearchEntries<T extends Resource>(
 
   const client = repo.getDatabaseClient({
     mode: DatabaseMode.READER,
-    operation: 'read',
-    resourceTypes: trackedResourceTypes,
+    operation: 'configuration',
+    resourceTypes: [],
     source: 'search.getSearchEntries.statementConfig',
   });
   let rows: any[];

--- a/packages/server/src/migrations/migration-utils.ts
+++ b/packages/server/src/migrations/migration-utils.ts
@@ -160,7 +160,7 @@ export async function preparePostDeployMigrationAsyncJob(
 
       return asyncJob;
     },
-    { serializable: true }
+    { serializable: true, resourceTypes: 'AsyncJob', source: 'preparePostDeployMigrationAsyncJob' }
   );
 }
 

--- a/packages/server/src/seed.test.ts
+++ b/packages/server/src/seed.test.ts
@@ -9,6 +9,7 @@ import type { OutputAction } from './fhir/operations/db-configure-indexes';
 import { configureGinIndexes, vacuumTable } from './fhir/operations/db-configure-indexes';
 import type { SystemRepository } from './fhir/repo';
 import { getGlobalSystemRepo } from './fhir/repo';
+import { repoAccess } from './fhir/repository/access-tracker';
 import { SelectQuery } from './fhir/sql';
 import { globalLogger } from './logger';
 import { getPostDeployVersion, getPreDeployVersion } from './migration-sql';
@@ -79,12 +80,9 @@ describe('Seed', () => {
       // and then vacuum the tables to clear any existing pending list entries.
       const actions: OutputAction[] = [];
       const tables = ['Appointment', 'Appointment_References', 'Slot', 'Slot_References'];
-      const client = repo.getDatabaseClient({
-        mode: DatabaseMode.WRITER,
-        operation: 'write',
-        resourceTypes: ['Appointment', 'Slot'],
-        source: 'seed.test.configureIndexes',
-      });
+      const client = repo.getDatabaseClient(
+        repoAccess.sqlWrite(['Appointment', 'Slot'], { source: 'seed.test.configureIndexes' })
+      );
       await configureGinIndexes(client, actions, tables, { fastUpdate: false });
       for (const table of tables) {
         await vacuumTable(client, actions, table);

--- a/packages/server/src/seed.test.ts
+++ b/packages/server/src/seed.test.ts
@@ -79,7 +79,12 @@ describe('Seed', () => {
       // and then vacuum the tables to clear any existing pending list entries.
       const actions: OutputAction[] = [];
       const tables = ['Appointment', 'Appointment_References', 'Slot', 'Slot_References'];
-      const client = repo.getDatabaseClient(DatabaseMode.WRITER);
+      const client = repo.getDatabaseClient({
+        mode: DatabaseMode.WRITER,
+        operation: 'write',
+        resourceTypes: ['Appointment', 'Slot'],
+        source: 'seed.test.configureIndexes',
+      });
       await configureGinIndexes(client, actions, tables, { fastUpdate: false });
       for (const table of tables) {
         await vacuumTable(client, actions, table);

--- a/packages/server/src/seed.ts
+++ b/packages/server/src/seed.ts
@@ -24,24 +24,39 @@ export async function seedDatabase(config: MedplumServerConfig): Promise<void> {
     return;
   }
 
-  await systemRepo.withTransaction(async (txRepo) => {
-    await createSuperAdmin(txRepo, config);
+  await systemRepo.withTransaction(
+    async (txRepo) => {
+      await createSuperAdmin(txRepo, config);
 
-    globalLogger.info('Building structure definitions...');
-    let startTime = Date.now();
-    await rebuildR4StructureDefinitions(txRepo);
-    globalLogger.info('Finished building structure definitions', { durationMs: Date.now() - startTime });
+      globalLogger.info('Building structure definitions...');
+      let startTime = Date.now();
+      await rebuildR4StructureDefinitions(txRepo);
+      globalLogger.info('Finished building structure definitions', { durationMs: Date.now() - startTime });
 
-    globalLogger.info('Building value sets...');
-    startTime = Date.now();
-    await rebuildR4ValueSets(txRepo);
-    globalLogger.info('Finished building value sets', { durationMs: Date.now() - startTime });
+      globalLogger.info('Building value sets...');
+      startTime = Date.now();
+      await rebuildR4ValueSets(txRepo);
+      globalLogger.info('Finished building value sets', { durationMs: Date.now() - startTime });
 
-    globalLogger.info('Building search parameters...');
-    startTime = Date.now();
-    await rebuildR4SearchParameters(txRepo);
-    globalLogger.info('Finished building search parameters', { durationMs: Date.now() - startTime });
-  });
+      globalLogger.info('Building search parameters...');
+      startTime = Date.now();
+      await rebuildR4SearchParameters(txRepo);
+      globalLogger.info('Finished building search parameters', { durationMs: Date.now() - startTime });
+    },
+    {
+      resourceTypes: [
+        'ClientApplication',
+        'Practitioner',
+        'Project',
+        'ProjectMembership',
+        'SearchParameter',
+        'StructureDefinition',
+        'User',
+        'ValueSet',
+      ],
+      source: 'seedDatabase',
+    }
+  );
 }
 
 async function createSuperAdmin(systemRepo: SystemRepository, config: MedplumServerConfig): Promise<void> {

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -302,6 +302,31 @@ export {
 } from './test.setup.fetch';
 
 /**
+ * Spies on `process.stdout.write` and swallows everything written to it, keeping
+ * log output (from any `Logger` instance) out of the terminal during a test.
+ *
+ * Because all loggers ultimately write through `process.stdout.write`, this silences
+ * `globalLogger` and any request-context logger alike, without altering logger
+ * behavior or having to mock individual log methods.
+ *
+ * The returned spy must be restored once the test (or suite) finishes, e.g.:
+ *
+ * ```ts
+ * let stdoutSpy: vi.SpyInstance;
+ * beforeEach(() => { stdoutSpy = mockStdoutWrite(); });
+ * afterEach(() => { stdoutSpy.mockRestore(); });
+ * ```
+ *
+ * Note: this suppresses the terminal output only. To assert on what was logged,
+ * spy on the relevant logger method directly (e.g. `vi.spyOn(getLogger(), 'info')`).
+ *
+ * @returns The spy installed on `process.stdout.write`; call `mockRestore()` to undo.
+ */
+export function mockStdoutWrite(): MockInstance<typeof process.stdout.write> {
+  return vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+}
+
+/**
  * Returns true if the resource is in an entry in the bundle.
  * @param bundle - A bundle of resources.
  * @param resource - The resource to search for.

--- a/packages/server/src/workers/reindex.test.ts
+++ b/packages/server/src/workers/reindex.test.ts
@@ -783,7 +783,12 @@ describe('Reindex Worker', () => {
         identifier: [{ system: idSystem, value: mrn }],
       });
 
-      const client = repo.getDatabaseClient(DatabaseMode.WRITER);
+      const client = repo.getDatabaseClient({
+        mode: DatabaseMode.WRITER,
+        operation: 'write',
+        resourceTypes: ['Patient'],
+        source: 'reindex.test',
+      });
       const getVersionQuery = (id: string[]): SelectQuery =>
         new SelectQuery('Patient').column('id').column('__version').where('id', 'IN', id);
       await client.query('UPDATE "Patient" SET __version = $1 WHERE id = $2', [OLDER_VERSION, outdatedPatient.id]);

--- a/packages/server/src/workers/reindex.test.ts
+++ b/packages/server/src/workers/reindex.test.ts
@@ -24,6 +24,7 @@ import { loadTestConfig } from '../config/loader';
 import { DatabaseMode, getDatabasePool } from '../database';
 import type { SystemRepository } from '../fhir/repo';
 import { Repository } from '../fhir/repo';
+import { repoAccess } from '../fhir/repository/access-tracker';
 import { SelectQuery } from '../fhir/sql';
 import { globalLogger } from '../logger';
 import { createTestProject, withQueryInterceptor, withTestContext } from '../test.setup';
@@ -783,12 +784,7 @@ describe('Reindex Worker', () => {
         identifier: [{ system: idSystem, value: mrn }],
       });
 
-      const client = repo.getDatabaseClient({
-        mode: DatabaseMode.WRITER,
-        operation: 'write',
-        resourceTypes: ['Patient'],
-        source: 'reindex.test',
-      });
+      const client = repo.getDatabaseClient(repoAccess.sqlWrite('Patient'));
       const getVersionQuery = (id: string[]): SelectQuery =>
         new SelectQuery('Patient').column('id').column('__version').where('id', 'IN', id);
       await client.query('UPDATE "Patient" SET __version = $1 WHERE id = $2', [OLDER_VERSION, outdatedPatient.id]);

--- a/packages/server/src/workers/reindex.ts
+++ b/packages/server/src/workers/reindex.ts
@@ -19,6 +19,7 @@ import { DatabaseMode, getDatabasePool, getDefaultStatementTimeout } from '../da
 import { AsyncJobExecutor } from '../fhir/operations/utils/asyncjobexecutor';
 import type { SystemRepository } from '../fhir/repo';
 import { getShardSystemRepo } from '../fhir/repo';
+import { repoAccess } from '../fhir/repository/access-tracker';
 import { minCursorBasedSearchPageSize } from '../fhir/search';
 import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
 import { globalLogger } from '../logger';
@@ -323,21 +324,24 @@ export class ReindexJob {
         ORDER BY "Task"."lastUpdated" LIMIT 501
         ```
         */
-          const conn = txRepo.getDatabaseClient({
-            mode: DatabaseMode.WRITER,
-            operation: 'configuration',
-            resourceTypes: [],
-            source: 'ReindexJobExecutor.processIteration',
-          });
+          const sqlOpts = repoAccess.sqlWriteConfig({ source: 'ReindexJobExecutor.processIteration' });
           let bundle: Bundle<WithId<Resource>>;
           try {
-            await conn.query(`SELECT set_config('statement_timeout', $1, true)`, [String(searchStatementTimeout)]);
+            await txRepo.executeRawSql(
+              `SELECT set_config('statement_timeout', $1, true)`,
+              [String(searchStatementTimeout)],
+              sqlOpts
+            );
             bundle = await txRepo.search(searchRequest, { maxResourceVersion });
           } finally {
             if (upsertStatementTimeout === 'DEFAULT') {
-              await conn.query(`RESET statement_timeout`);
+              await txRepo.executeRawSql(`RESET statement_timeout`, undefined, sqlOpts);
             } else {
-              await conn.query(`SELECT set_config('statement_timeout', $1, true)`, [String(upsertStatementTimeout)]);
+              await txRepo.executeRawSql(
+                `SELECT set_config('statement_timeout', $1, true)`,
+                [String(upsertStatementTimeout)],
+                sqlOpts
+              );
             }
           }
           if (bundle.entry?.length) {

--- a/packages/server/src/workers/reindex.ts
+++ b/packages/server/src/workers/reindex.ts
@@ -304,8 +304,9 @@ export class ReindexJob {
     let cursor = '';
     let nextTimestamp = new Date(0).toISOString();
     try {
-      await systemRepo.withTransaction(async (txRepo) => {
-        /*
+      await systemRepo.withTransaction(
+        async (txRepo) => {
+          /*
         When a ReindexJob needs to scan a very large table for resources to reindex,
         but most/all have already been reindexed, the search will scan the most/all of table
         before finding any results with a query such as the following. Depending on factors
@@ -322,30 +323,37 @@ export class ReindexJob {
         ORDER BY "Task"."lastUpdated" LIMIT 501
         ```
         */
-        const conn = txRepo.getDatabaseClient(DatabaseMode.WRITER);
-        let bundle: Bundle<WithId<Resource>>;
-        try {
-          await conn.query(`SELECT set_config('statement_timeout', $1, true)`, [String(searchStatementTimeout)]);
-          bundle = await txRepo.search(searchRequest, { maxResourceVersion });
-        } finally {
-          if (upsertStatementTimeout === 'DEFAULT') {
-            await conn.query(`RESET statement_timeout`);
-          } else {
-            await conn.query(`SELECT set_config('statement_timeout', $1, true)`, [String(upsertStatementTimeout)]);
+          const conn = txRepo.getDatabaseClient({
+            mode: DatabaseMode.WRITER,
+            operation: 'configuration',
+            resourceTypes: [],
+            source: 'ReindexJobExecutor.processIteration',
+          });
+          let bundle: Bundle<WithId<Resource>>;
+          try {
+            await conn.query(`SELECT set_config('statement_timeout', $1, true)`, [String(searchStatementTimeout)]);
+            bundle = await txRepo.search(searchRequest, { maxResourceVersion });
+          } finally {
+            if (upsertStatementTimeout === 'DEFAULT') {
+              await conn.query(`RESET statement_timeout`);
+            } else {
+              await conn.query(`SELECT set_config('statement_timeout', $1, true)`, [String(upsertStatementTimeout)]);
+            }
           }
-        }
-        if (bundle.entry?.length) {
-          const resources = bundle.entry.map((e) => e.resource as WithId<Resource>);
-          await txRepo.reindexResources(resources);
-          newCount += resources.length;
-          nextTimestamp = bundle.entry.at(-1)?.resource?.meta?.lastUpdated ?? nextTimestamp;
-        }
+          if (bundle.entry?.length) {
+            const resources = bundle.entry.map((e) => e.resource as WithId<Resource>);
+            await txRepo.reindexResources(resources);
+            newCount += resources.length;
+            nextTimestamp = bundle.entry.at(-1)?.resource?.meta?.lastUpdated ?? nextTimestamp;
+          }
 
-        const nextLink = bundle.link?.find((link) => link.relation === 'next');
-        if (nextLink) {
-          cursor = parseSearchRequest(nextLink.url).cursor ?? '';
-        }
-      });
+          const nextLink = bundle.link?.find((link) => link.relation === 'next');
+          if (nextLink) {
+            cursor = parseSearchRequest(nextLink.url).cursor ?? '';
+          }
+        },
+        { resourceTypes: resourceType, source: 'ReindexJobExecutor.processIteration' }
+      );
     } catch (err: any) {
       return { count: newCount, cursor, nextTimestamp, err, errSearchRequest: searchRequest };
     }

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -958,18 +958,21 @@ async function autoDisableSubscription(
       { op: 'add', path: '/error', value: errorMessage },
     ];
 
-    await systemRepo.withTransaction(async (txRepo) => {
-      await txRepo.patchResource('Subscription', subscription.id, patch);
+    await systemRepo.withTransaction(
+      async (txRepo) => {
+        await txRepo.patchResource('Subscription', subscription.id, patch);
 
-      await createSubscriptionAuditEvent(
-        txRepo,
-        subscription,
-        new Date().toISOString(),
-        AuditEventOutcome.SeriousFailure,
-        errorMessage,
-        subscription
-      );
-    });
+        await createSubscriptionAuditEvent(
+          txRepo,
+          subscription,
+          new Date().toISOString(),
+          AuditEventOutcome.SeriousFailure,
+          errorMessage,
+          subscription
+        );
+      },
+      { resourceTypes: ['AuditEvent', 'Subscription'], source: 'autoDisableSubscription' }
+    );
 
     await clearSubscriptionFailures(subscription.id);
 


### PR DESCRIPTION
**Note**: This PR is chained on #9285 since they both touch the same parts of Repository and related code.

Add resource-type access tracking to the FHIR repository

This branch instruments the server's FHIR repository layer to record which resource types are touched by every database and cache operation, with the goal of identifying transactions that mix "special" platform resource types (Project, ProjectMembership, User) with ordinary resource types. This is groundwork for a future effort to split the repository/datastore (logged under the [RepoSplit] tag). Down the road, having this resource type access metadata will enable enforcement of sharding boundaries by throwing when violations are detected rather than just logging.

### What changed

New access-tracking layer (packages/server/src/fhir/repository/access-tracker.ts)
- Adds RepositoryAccessTracker, which partitions accessed resource types into "special" (Project, ProjectMembership, User) vs. "other" and maintains a stack of per-transaction frames (counts of SQL/cache reads & writes, the resource types touched, and the calling source).
- Frames follow the transaction lifecycle: pushed on BEGIN/savepoint, merged on nested commit/rollback, popped on outer commit/rollback, and cleared on connection reset.
- Emits structured getLogger().info('[RepoSplit]...') logs at the statement level (when a single op mixes special + other types) and at the transaction level (when a committed/rolled-back transaction touched both classes).
- Exposes getResourceTypesFromReferences() helper.

Repository connection (repository-connection.ts)
- getDatabaseClient(mode) --> getDatabaseClient(options), where options carry { operation, mode, resourceTypes, source }, and each call records access.
- withTransaction now requires TransactionSqlOptions (resource types + source) and no longer passes the raw PoolClient to callbacks; withStatementTimeout similarly drops the client param.
- withStatementTimeout is relaxed to allow use inside an active transaction (using set_config(..., is_local=true)), instead of throwing; it still guards against mutating a borrowed connection's config. assertOwnsClient takes an optional
custom message.

fhir-router (batch.ts, repo.ts, core/search.ts)
- Introduces TransactionOptions { resourceTypes, serializable? }; FhirRepository.withTransaction now takes it as a required argument.
- Batch/transaction preprocessing collects the set of resource types from parsed routes (documented limitations: system-level interactions, GraphQL, and custom operations are under-reported).
- Conditional create/update/delete/patch pass the search's resource types via the new getSearchResourceTypes() helper in @medplum/core.

Repo & search wiring (repo.ts, search.ts)
- Every getDatabaseClient, withTransaction, and withStatementTimeout call site now supplies resourceTypes and a descriptive source string (e.g. repo.writeToDatabase, search.getSearchEntries).
- Search query building threads a trackedResourceTypes set through select/filter/chained-search construction so chained and _type-multi searches accumulate all involved resource types.

Callers updated to satisfy the new signatures: admin (invite/project/super), auth (verifyemail), value-set/code-system/concept-map operations, scheduling (book/cancel), expunge, rescope, rotatesecret, update-user-email, refresh-reference-display, explain, db-configure-column-statistics, reindex, subscription worker, seed, and migration utils.

Tests & helpers
- Adds mockStdoutWrite() test helper to suppress logger output.
- Updates repo.test.ts, transaction.test.ts, repo-guard.test.ts, search.test.ts, reference.test.ts, reindex.test.ts, and batch.test.ts for the new APIs, plus new coverage for batch resource-type collection and access logging.

Notes

- The tracking is observational (logging only) and does not change query behavior or transaction semantics.
- Resource-type coverage for GraphQL and custom operations is intentionally incomplete and noted in code comments.

