### PR TITLE
SMART Health Cards and Links

### DIFF
--- a/packages/server/src/fhir/operations/definitions.ts
+++ b/packages/server/src/fhir/operations/definitions.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { arrayify, OperationOutcomeError, serverError } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
-import type { Bundle, OperationDefinition, ResourceType, StructureDefinition } from '@medplum/fhirtypes';
+import type { Bundle, OperationDefinition, Parameters, ResourceType, StructureDefinition } from '@medplum/fhirtypes';
 
 const operationDefinitions = (
   readJson('fhir/r4/profiles-resources.json') as Bundle<StructureDefinition | OperationDefinition>
@@ -73,4 +73,17 @@ function getOperationScopeFlags(
   scope: OperationDefinitionScope['scope']
 ): Pick<OperationDefinition, 'system' | 'type' | 'instance'> {
   return operationScopeFlags[scope];
+}
+
+export function makeParameters(values: Record<string, string | boolean | undefined>): Parameters {
+  const parameters: Parameters = { resourceType: 'Parameters', parameter: [] };
+  for (const [name, value] of Object.entries(values)) {
+    if (value === undefined) {
+      continue;
+    }
+    parameters.parameter?.push(
+      typeof value === 'boolean' ? { name, valueBoolean: value } : { name, valueString: value }
+    );
+  }
+  return parameters;
 }

--- a/packages/server/src/fhir/operations/definitions.ts
+++ b/packages/server/src/fhir/operations/definitions.ts
@@ -74,4 +74,3 @@ function getOperationScopeFlags(
 ): Pick<OperationDefinition, 'system' | 'type' | 'instance'> {
   return operationScopeFlags[scope];
 }
-

--- a/packages/server/src/fhir/operations/definitions.ts
+++ b/packages/server/src/fhir/operations/definitions.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { arrayify, OperationOutcomeError, serverError } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
-import type { Bundle, OperationDefinition, Parameters, ResourceType, StructureDefinition } from '@medplum/fhirtypes';
+import type { Bundle, OperationDefinition, ResourceType, StructureDefinition } from '@medplum/fhirtypes';
 
 const operationDefinitions = (
   readJson('fhir/r4/profiles-resources.json') as Bundle<StructureDefinition | OperationDefinition>
@@ -75,15 +75,3 @@ function getOperationScopeFlags(
   return operationScopeFlags[scope];
 }
 
-export function makeParameters(values: Record<string, string | boolean | undefined>): Parameters {
-  const parameters: Parameters = { resourceType: 'Parameters', parameter: [] };
-  for (const [name, value] of Object.entries(values)) {
-    if (value === undefined) {
-      continue;
-    }
-    parameters.parameter?.push(
-      typeof value === 'boolean' ? { name, valueBoolean: value } : { name, valueString: value }
-    );
-  }
-  return parameters;
-}

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { ContentType } from '@medplum/core';
+import { badRequest, ContentType } from '@medplum/core';
 import type { Bundle, Parameters, Patient } from '@medplum/fhirtypes';
 import express from 'express';
 import type { KeyLike } from 'jose';
@@ -70,7 +70,7 @@ describe('SMART Health operations', () => {
     expect(getBooleanParameter(verifyFileResponse.body, 'valid')).toBe(true);
   });
 
-  test('Rejects invalid SMART Health Cards', async () => {
+  test('Detects invalid SMART Health Cards', async () => {
     const patient = await createPatient();
     const expiredResponse = await request(app)
       .post(`/fhir/R4/Patient/${patient.id}/$generate-smart-health-card`)
@@ -93,26 +93,24 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({});
-    expect(missingInputResponse.status).toBe(200);
-    expect(getBooleanParameter(missingInputResponse.body, 'valid')).toBe(false);
-    expect(getStringParameter(missingInputResponse.body, 'error')).toContain('Expected credential');
+    expect(missingInputResponse.status).toBe(400);
+    expect(missingInputResponse.body).toMatchObject(badRequest('Expected credential, shcUri, or file'));
 
     const invalidQrResponse = await request(app)
       .post('/fhir/R4/$verify-smart-health-card')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ shcUri: 'shc:/123' });
-    expect(invalidQrResponse.status).toBe(200);
-    expect(getBooleanParameter(invalidQrResponse.body, 'valid')).toBe(false);
-    expect(getStringParameter(invalidQrResponse.body, 'error')).toContain('numeric encoding');
+    expect(invalidQrResponse.status).toBe(400);
+    expect(invalidQrResponse.body).toMatchObject(badRequest('Invalid SMART Health Card numeric encoding'));
 
     const invalidFileResponse = await request(app)
       .post('/fhir/R4/$verify-smart-health-card')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ file: JSON.stringify({ verifiableCredential: [] }) });
-    expect(invalidFileResponse.status).toBe(200);
-    expect(getBooleanParameter(invalidFileResponse.body, 'valid')).toBe(false);
+    expect(invalidFileResponse.status).toBe(400);
+    expect(invalidFileResponse.body).toMatchObject(badRequest('Expected credential, shcUri, or file'));
 
     const missingPatientResponse = await request(app)
       .post('/fhir/R4/Patient/not-found/$generate-smart-health-card')
@@ -149,7 +147,6 @@ describe('SMART Health operations', () => {
       .send({ credential });
     expect(verifyResponse.status).toBe(200);
     expect(getBooleanParameter(verifyResponse.body, 'valid')).toBe(true);
-    expect(getBooleanParameter(verifyResponse.body, 'signatureValid')).toBe(true);
     expect(getBooleanParameter(verifyResponse.body, 'issuerTrusted')).toBe(false);
     expect(getBooleanParameter(verifyResponse.body, 'verified')).toBe(false);
     expect(fetchSpy).toHaveBeenCalledWith(new URL('https://issuer.example.com/.well-known/jwks.json'), {

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -29,7 +29,7 @@ describe('SMART Health operations', () => {
       .post(`/fhir/R4/Patient/${patient.id}/$generate-smart-health-card`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
-      .send({ includeQrCode: true });
+      .send({ _type: 'Patient', includeQrCode: true });
     expect(generateResponse.status).toBe(200);
 
     const credential = getStringParameter(generateResponse.body, 'credential');
@@ -49,6 +49,74 @@ describe('SMART Health operations', () => {
     const bundle = JSON.parse(getStringParameter(verifyResponse.body, 'fhirBundle')) as Bundle;
     expect(bundle.resourceType).toBe('Bundle');
     expect(bundle.entry?.some((entry) => entry.resource?.resourceType === 'Patient')).toBe(true);
+
+    const verifyShcUriResponse = await request(app)
+      .post('/fhir/R4/$verify-smart-health-card')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ shcUri: getStringParameter(generateResponse.body, 'shcUri') });
+    expect(verifyShcUriResponse.status).toBe(200);
+    expect(getBooleanParameter(verifyShcUriResponse.body, 'valid')).toBe(true);
+
+    const verifyFileResponse = await request(app)
+      .post('/fhir/R4/$verify-smart-health-card')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ file: getStringParameter(generateResponse.body, 'file') });
+    expect(verifyFileResponse.status).toBe(200);
+    expect(getBooleanParameter(verifyFileResponse.body, 'valid')).toBe(true);
+  });
+
+  test('Rejects invalid SMART Health Cards', async () => {
+    const patient = await createPatient();
+    const expiredResponse = await request(app)
+      .post(`/fhir/R4/Patient/${patient.id}/$generate-smart-health-card`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ exp: Math.floor(Date.now() / 1000) - 60 });
+    expect(expiredResponse.status).toBe(200);
+
+    const expiredVerifyResponse = await request(app)
+      .post('/fhir/R4/$verify-smart-health-card')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ credential: getStringParameter(expiredResponse.body, 'credential') });
+    expect(expiredVerifyResponse.status).toBe(200);
+    expect(getBooleanParameter(expiredVerifyResponse.body, 'valid')).toBe(false);
+    expect(getStringParameter(expiredVerifyResponse.body, 'error')).toContain('expired');
+
+    const missingInputResponse = await request(app)
+      .post('/fhir/R4/$verify-smart-health-card')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({});
+    expect(missingInputResponse.status).toBe(200);
+    expect(getBooleanParameter(missingInputResponse.body, 'valid')).toBe(false);
+    expect(getStringParameter(missingInputResponse.body, 'error')).toContain('Expected credential');
+
+    const invalidQrResponse = await request(app)
+      .post('/fhir/R4/$verify-smart-health-card')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ shcUri: 'shc:/123' });
+    expect(invalidQrResponse.status).toBe(200);
+    expect(getBooleanParameter(invalidQrResponse.body, 'valid')).toBe(false);
+    expect(getStringParameter(invalidQrResponse.body, 'error')).toContain('numeric encoding');
+
+    const invalidFileResponse = await request(app)
+      .post('/fhir/R4/$verify-smart-health-card')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ file: JSON.stringify({ verifiableCredential: [] }) });
+    expect(invalidFileResponse.status).toBe(200);
+    expect(getBooleanParameter(invalidFileResponse.body, 'valid')).toBe(false);
+
+    const missingPatientResponse = await request(app)
+      .post('/fhir/R4/Patient/not-found/$generate-smart-health-card')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({});
+    expect(missingPatientResponse.status).toBe(400);
   });
 
   test('Generate manifest and resolve SMART Health Link', async () => {
@@ -83,6 +151,108 @@ describe('SMART Health operations', () => {
 
     const fhirResources = JSON.parse(getStringParameter(resolveResponse.body, 'fhirResources')) as Bundle[];
     expect(fhirResources[0]?.resourceType).toBe('Bundle');
+
+    const viewerResolveResponse = await request(app)
+      .post('/fhir/R4/$resolve-smart-health-link')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ shlink: `https://viewer.example/#${shlink}`, recipient: 'Test Recipient', passcode: '123456' });
+    expect(viewerResolveResponse.status).toBe(200);
+    expect(getBooleanParameter(viewerResolveResponse.body, 'valid')).toBe(true);
+  });
+
+  test('Rejects invalid SMART Health Links', async () => {
+    const patient = await createPatient();
+    const passcodeResponse = await request(app)
+      .post(`/fhir/R4/Patient/${patient.id}/$generate-smart-health-link`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ _type: 'Patient', passcode: '123456', includeQrCode: true });
+    expect(passcodeResponse.status).toBe(200);
+    expect(getStringParameter(passcodeResponse.body, 'qrCodeDataUrl')).toMatch(/^data:image\/png;base64,/);
+
+    const manifestUrl = new URL(getStringParameter(passcodeResponse.body, 'manifestUrl'));
+    const missingPasscodeManifestResponse = await request(app)
+      .post(manifestUrl.pathname)
+      .set('Content-Type', ContentType.JSON)
+      .send({ recipient: 'Test Recipient' });
+    expect(missingPasscodeManifestResponse.status).toBe(400);
+    expect(missingPasscodeManifestResponse.body.error).toContain('passcode');
+
+    const wrongPasscodeResolveResponse = await request(app)
+      .post('/fhir/R4/$resolve-smart-health-link')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({
+        shlink: getStringParameter(passcodeResponse.body, 'shlink'),
+        recipient: 'Test Recipient',
+        passcode: 'wrong',
+      });
+    expect(wrongPasscodeResolveResponse.status).toBe(200);
+    expect(getBooleanParameter(wrongPasscodeResolveResponse.body, 'valid')).toBe(false);
+    expect(getStringParameter(wrongPasscodeResolveResponse.body, 'error')).toContain('passcode');
+
+    const missingManifestResponse = await request(app)
+      .post('/fhir/R4/.well-known/smart-health-links/not-found/manifest.json')
+      .set('Content-Type', ContentType.JSON)
+      .send({});
+    expect(missingManifestResponse.status).toBe(404);
+
+    const expiredResponse = await request(app)
+      .post(`/fhir/R4/Patient/${patient.id}/$generate-smart-health-link`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ exp: Math.floor(Date.now() / 1000) - 60 });
+    expect(expiredResponse.status).toBe(200);
+
+    const expiredResolveResponse = await request(app)
+      .post('/fhir/R4/$resolve-smart-health-link')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ shlink: getStringParameter(expiredResponse.body, 'shlink') });
+    expect(expiredResolveResponse.status).toBe(200);
+    expect(getBooleanParameter(expiredResolveResponse.body, 'valid')).toBe(false);
+    expect(getStringParameter(expiredResolveResponse.body, 'error')).toContain('expired');
+
+    const invalidUriResponse = await request(app)
+      .post('/fhir/R4/$resolve-smart-health-link')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ shlink: 'https://example.com/no-link' });
+    expect(invalidUriResponse.status).toBe(200);
+    expect(getBooleanParameter(invalidUriResponse.body, 'valid')).toBe(false);
+    expect(getStringParameter(invalidUriResponse.body, 'error')).toContain('Invalid SMART Health Link URI');
+
+    const invalidPayloadResponse = await request(app)
+      .post('/fhir/R4/$resolve-smart-health-link')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ shlink: 'shlink:/e30' });
+    expect(invalidPayloadResponse.status).toBe(200);
+    expect(getBooleanParameter(invalidPayloadResponse.body, 'valid')).toBe(false);
+    expect(getStringParameter(invalidPayloadResponse.body, 'error')).toContain('Invalid SMART Health Link payload');
+
+    const unknownGeneratedLinkResponse = await request(app)
+      .post('/fhir/R4/$resolve-smart-health-link')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({
+        shlink: encodeShlinkPayload({
+          url: 'https://example.com/fhir/R4/.well-known/smart-health-links/not-found/manifest.json',
+          key: '0000000000000000000000000000000000000000000',
+          v: 1,
+        }),
+      });
+    expect(unknownGeneratedLinkResponse.status).toBe(200);
+    expect(getBooleanParameter(unknownGeneratedLinkResponse.body, 'valid')).toBe(false);
+    expect(getStringParameter(unknownGeneratedLinkResponse.body, 'error')).toContain('Medplum-generated');
+
+    const missingPatientResponse = await request(app)
+      .post('/fhir/R4/Patient/not-found/$generate-smart-health-link')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({});
+    expect(missingPatientResponse.status).toBe(400);
   });
 });
 
@@ -106,4 +276,8 @@ function getBooleanParameter(parameters: Parameters, name: string): boolean {
   const value = parameters.parameter?.find((p) => p.name === name)?.valueBoolean;
   expect(value).toBeDefined();
   return value as boolean;
+}
+
+function encodeShlinkPayload(payload: object): string {
+  return `shlink:/${Buffer.from(JSON.stringify(payload)).toString('base64url')}`;
 }

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -3,6 +3,9 @@
 import { ContentType } from '@medplum/core';
 import type { Bundle, Parameters, Patient } from '@medplum/fhirtypes';
 import express from 'express';
+import type { KeyLike } from 'jose';
+import { CompactSign, exportJWK, generateKeyPair } from 'jose';
+import { deflateRawSync } from 'node:zlib';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
@@ -117,6 +120,59 @@ describe('SMART Health operations', () => {
       .set('Content-Type', ContentType.JSON)
       .send({});
     expect(missingPatientResponse.status).toBe(400);
+  });
+
+  test('Verifies external SMART Health Card signatures without trusting issuer', async () => {
+    const issuer = 'https://issuer.example.com';
+    const { privateKey, publicKey } = await generateKeyPair('ES256', { extractable: true });
+    const publicJwk = await exportJWK(publicKey);
+    publicJwk.alg = 'ES256';
+    publicJwk.kid = 'external-key';
+    publicJwk.use = 'sig';
+
+    const credential = await createSmartHealthCardCredential({
+      issuer,
+      keyId: publicJwk.kid,
+      privateKey,
+      bundle: { resourceType: 'Bundle', type: 'collection' },
+    });
+
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ keys: [publicJwk] }),
+    } as Response);
+
+    const verifyResponse = await request(app)
+      .post('/fhir/R4/$verify-smart-health-card')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ credential });
+    expect(verifyResponse.status).toBe(200);
+    expect(getBooleanParameter(verifyResponse.body, 'valid')).toBe(true);
+    expect(getBooleanParameter(verifyResponse.body, 'signatureValid')).toBe(true);
+    expect(getBooleanParameter(verifyResponse.body, 'issuerTrusted')).toBe(false);
+    expect(getBooleanParameter(verifyResponse.body, 'verified')).toBe(false);
+    expect(fetchSpy).toHaveBeenCalledWith(new URL('https://issuer.example.com/.well-known/jwks.json'), {
+      redirect: 'error',
+      signal: expect.any(AbortSignal),
+    });
+
+    fetchSpy.mockRestore();
+
+    const insecureCredential = await createSmartHealthCardCredential({
+      issuer: 'http://issuer.example.com',
+      keyId: publicJwk.kid,
+      privateKey,
+      bundle: { resourceType: 'Bundle', type: 'collection' },
+    });
+    const insecureVerifyResponse = await request(app)
+      .post('/fhir/R4/$verify-smart-health-card')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ credential: insecureCredential });
+    expect(insecureVerifyResponse.status).toBe(200);
+    expect(getBooleanParameter(insecureVerifyResponse.body, 'valid')).toBe(false);
+    expect(getStringParameter(insecureVerifyResponse.body, 'error')).toContain('HTTPS');
   });
 
   test('Generate manifest and resolve SMART Health Link', async () => {
@@ -280,4 +336,26 @@ function getBooleanParameter(parameters: Parameters, name: string): boolean {
 
 function encodeShlinkPayload(payload: object): string {
   return `shlink:/${Buffer.from(JSON.stringify(payload)).toString('base64url')}`;
+}
+
+async function createSmartHealthCardCredential(options: {
+  issuer: string;
+  keyId: string;
+  privateKey: KeyLike;
+  bundle: Bundle;
+}): Promise<string> {
+  const payload = {
+    iss: options.issuer,
+    nbf: Math.floor(Date.now() / 1000),
+    vc: {
+      type: ['https://smarthealth.cards#health-card'],
+      credentialSubject: {
+        fhirVersion: '4.0.1',
+        fhirBundle: options.bundle,
+      },
+    },
+  };
+  return new CompactSign(deflateRawSync(Buffer.from(JSON.stringify(payload))))
+    .setProtectedHeader({ alg: 'ES256', kid: options.keyId, zip: 'DEF' })
+    .sign(options.privateKey);
 }

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { ContentType } from '@medplum/core';
+import type { Bundle, Parameters, Patient } from '@medplum/fhirtypes';
+import express from 'express';
+import request from 'supertest';
+import { initApp, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config/loader';
+import { initTestAuth } from '../../test.setup';
+
+const app = express();
+let accessToken: string;
+
+describe('SMART Health operations', () => {
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initApp(app, config);
+    accessToken = await initTestAuth();
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test('Generate and verify SMART Health Card', async () => {
+    const patient = await createPatient();
+
+    const generateResponse = await request(app)
+      .post(`/fhir/R4/Patient/${patient.id}/$generate-smart-health-card`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ includeQrCode: true });
+    expect(generateResponse.status).toBe(200);
+
+    const credential = getStringParameter(generateResponse.body, 'credential');
+    expect(credential.split('.')).toHaveLength(3);
+    expect(getStringParameter(generateResponse.body, 'shcUri')).toMatch(/^shc:\//);
+    expect(getStringParameter(generateResponse.body, 'file')).toContain('verifiableCredential');
+    expect(getStringParameter(generateResponse.body, 'qrCodeDataUrl')).toMatch(/^data:image\/png;base64,/);
+
+    const verifyResponse = await request(app)
+      .post('/fhir/R4/$verify-smart-health-card')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ credential });
+    expect(verifyResponse.status).toBe(200);
+    expect(getBooleanParameter(verifyResponse.body, 'valid')).toBe(true);
+
+    const bundle = JSON.parse(getStringParameter(verifyResponse.body, 'fhirBundle')) as Bundle;
+    expect(bundle.resourceType).toBe('Bundle');
+    expect(bundle.entry?.some((entry) => entry.resource?.resourceType === 'Patient')).toBe(true);
+  });
+
+  test('Generate manifest and resolve SMART Health Link', async () => {
+    const patient = await createPatient();
+
+    const generateResponse = await request(app)
+      .post(`/fhir/R4/Patient/${patient.id}/$generate-smart-health-link`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ passcode: '123456', label: 'Test Link' });
+    expect(generateResponse.status).toBe(200);
+
+    const shlink = getStringParameter(generateResponse.body, 'shlink');
+    expect(shlink).toMatch(/^shlink:\//);
+
+    const manifestUrl = new URL(getStringParameter(generateResponse.body, 'manifestUrl'));
+    const manifestResponse = await request(app)
+      .post(manifestUrl.pathname)
+      .set('Content-Type', ContentType.JSON)
+      .send({ recipient: 'Test Recipient', passcode: '123456' });
+    expect(manifestResponse.status).toBe(200);
+    expect(manifestResponse.body.files).toHaveLength(1);
+    expect(manifestResponse.body.files[0].embedded).toBeDefined();
+
+    const resolveResponse = await request(app)
+      .post('/fhir/R4/$resolve-smart-health-link')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ shlink, recipient: 'Test Recipient', passcode: '123456' });
+    expect(resolveResponse.status).toBe(200);
+    expect(getBooleanParameter(resolveResponse.body, 'valid')).toBe(true);
+
+    const fhirResources = JSON.parse(getStringParameter(resolveResponse.body, 'fhirResources')) as Bundle[];
+    expect(fhirResources[0]?.resourceType).toBe('Bundle');
+  });
+});
+
+async function createPatient(): Promise<Patient> {
+  const response = await request(app)
+    .post('/fhir/R4/Patient')
+    .set('Authorization', 'Bearer ' + accessToken)
+    .set('Content-Type', ContentType.FHIR_JSON)
+    .send({ resourceType: 'Patient', name: [{ given: ['Alice'], family: 'Smith' }] });
+  expect(response.status).toBe(201);
+  return response.body as Patient;
+}
+
+function getStringParameter(parameters: Parameters, name: string): string {
+  const value = parameters.parameter?.find((p) => p.name === name)?.valueString;
+  expect(value).toBeDefined();
+  return value as string;
+}
+
+function getBooleanParameter(parameters: Parameters, name: string): boolean {
+  const value = parameters.parameter?.find((p) => p.name === name)?.valueBoolean;
+  expect(value).toBeDefined();
+  return value as boolean;
+}

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -172,6 +172,32 @@ describe('SMART Health operations', () => {
     expect(getStringParameter(insecureVerifyResponse.body, 'error')).toContain('HTTPS');
   });
 
+  test('Rejects SMART Health Card issuer hosts with private IPv6 addresses', async () => {
+    const { privateKey } = await generateKeyPair('ES256');
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Unexpected fetch'));
+
+    for (const issuer of ['https://[fd12:3456::1]', 'https://[fc00::1]']) {
+      const credential = await createSmartHealthCardCredential({
+        issuer,
+        keyId: 'private-ipv6-key',
+        privateKey,
+        bundle: { resourceType: 'Bundle', type: 'collection' },
+      });
+
+      const verifyResponse = await request(app)
+        .post('/fhir/R4/$verify-smart-health-card')
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Content-Type', ContentType.JSON)
+        .send({ credential });
+      expect(verifyResponse.status).toBe(200);
+      expect(getBooleanParameter(verifyResponse.body, 'valid')).toBe(false);
+      expect(getStringParameter(verifyResponse.body, 'error')).toContain('Unsafe SMART Health Card issuer host');
+    }
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
   test('Generate manifest and resolve SMART Health Link', async () => {
     const patient = await createPatient();
 

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -303,6 +303,15 @@ describe('SMART Health operations', () => {
     expect(getBooleanParameter(invalidUriResponse.body, 'valid')).toBe(false);
     expect(getStringParameter(invalidUriResponse.body, 'error')).toContain('Invalid SMART Health Link URI');
 
+    const nonStringShlinkResponse = await request(app)
+      .post('/fhir/R4/$resolve-smart-health-link')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON)
+      .send({ shlink: 123 });
+    expect(nonStringShlinkResponse.status).toBe(200);
+    expect(getBooleanParameter(nonStringShlinkResponse.body, 'valid')).toBe(false);
+    expect(getStringParameter(nonStringShlinkResponse.body, 'error')).toContain('Expected shlink to be a string');
+
     const invalidPayloadResponse = await request(app)
       .post('/fhir/R4/$resolve-smart-health-link')
       .set('Authorization', 'Bearer ' + accessToken)

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -118,7 +118,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({});
-    expect(missingPatientResponse.status).toBe(400);
+    expect(missingPatientResponse.status).toBe(404);
   });
 
   test('Verifies external SMART Health Card signatures without trusting issuer', async () => {
@@ -341,7 +341,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({});
-    expect(missingPatientResponse.status).toBe(400);
+    expect(missingPatientResponse.status).toBe(404);
   });
 });
 

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -40,6 +40,7 @@ describe('SMART Health operations', () => {
     expect(getStringParameter(generateResponse.body, 'shcUri')).toMatch(/^shc:\//);
     expect(getStringParameter(generateResponse.body, 'file')).toContain('verifiableCredential');
     expect(getStringParameter(generateResponse.body, 'qrCodeDataUrl')).toMatch(/^data:image\/png;base64,/);
+    expect(getStringParameter(generateResponse.body, 'keyId')).toBeDefined();
 
     const verifyResponse = await request(app)
       .post('/fhir/R4/$verify-smart-health-card')

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -150,6 +150,7 @@ export async function verifySmartHealthCardHandler(req: FhirRequest): Promise<Fh
   let issuerTrusted: boolean | undefined = undefined;
   let header: ProtectedHeaderParameters | undefined = undefined;
   let valid = true;
+  let error: string | undefined = undefined;
 
   try {
     ({ issuerTrusted } = await verifySmartHealthCardCredential(credential));
@@ -157,6 +158,7 @@ export async function verifySmartHealthCardHandler(req: FhirRequest): Promise<Fh
   } catch (err) {
     getLogger().warn('SMART Health Card validation failed', { err });
     valid = false;
+    error = normalizeErrorString(err);
   }
 
   return [
@@ -168,6 +170,7 @@ export async function verifySmartHealthCardHandler(req: FhirRequest): Promise<Fh
       issuer: unverifiedPayload.iss,
       keyId: header?.kid,
       fhirBundle: JSON.stringify(unverifiedPayload.vc.credentialSubject.fhirBundle),
+      error,
     }),
   ];
 }

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -3,13 +3,14 @@
 import { allOk, badRequest, normalizeErrorString, OAuthSigningAlgorithm } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Bundle, Patient, Resource } from '@medplum/fhirtypes';
-import type { JWK, KeyLike } from 'jose';
+import type { JWK, KeyLike, ProtectedHeaderParameters } from 'jose';
 import { CompactSign, compactVerify, decodeProtectedHeader, importJWK } from 'jose';
 import { isIP } from 'node:net';
 import { deflateRawSync, inflateRawSync } from 'node:zlib';
 import QRCode from 'qrcode';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
+import { getLogger } from '../../logger';
 import { getJwks, getSigningKey } from '../../oauth/keys';
 import { makeOperationDefinition, makeParameters } from './definitions';
 import { getPatientEverything } from './patienteverything';
@@ -80,7 +81,6 @@ export const verifySmartHealthCardOperation = makeOperationDefinition(
       { use: 'in', name: 'shcUri', type: 'string', min: 0, max: '1' },
       { use: 'in', name: 'file', type: 'string', min: 0, max: '1' },
       { use: 'out', name: 'valid', type: 'boolean', min: 1, max: '1' },
-      { use: 'out', name: 'signatureValid', type: 'boolean', min: 0, max: '1' },
       { use: 'out', name: 'issuerTrusted', type: 'boolean', min: 0, max: '1' },
       { use: 'out', name: 'verified', type: 'boolean', min: 0, max: '1' },
       { use: 'out', name: 'issuer', type: 'uri', min: 0, max: '1' },
@@ -91,6 +91,15 @@ export const verifySmartHealthCardOperation = makeOperationDefinition(
   }
 );
 
+/**
+ * Handles the Patient/$generate-smart-health-card operation.
+ *
+ * Builds a Patient/$everything bundle for the requested patient, signs it as a SMART Health Card credential, and
+ * returns the credential in JWS, SHC URI, and SMART Health Card file formats.
+ *
+ * @param req - FHIR request containing the patient ID and optional parameters for filtering, expiration, and QR code generation.
+ * @returns FHIR response containing the generated SMART Health Card credential in multiple formats and related metadata.
+ */
 export async function generateSmartHealthCardHandler(req: FhirRequest): Promise<FhirResponse> {
   try {
     const ctx = getAuthenticatedContext();
@@ -125,30 +134,52 @@ export async function generateSmartHealthCardHandler(req: FhirRequest): Promise<
   }
 }
 
+/**
+ * Handles the system-level $verify-smart-health-card operation.
+ *
+ * Reads a SMART Health Card credential from one of the supported input formats, verifies the signature when possible,
+ * and returns the decoded issuer, key ID, and FHIR Bundle details.
+ *
+ * @param req - FHIR request containing the SMART Health Card credential in one of the supported input formats.
+ * @returns FHIR response containing the verification results, including validity, issuer trust, and decoded payload details.
+ */
 export async function verifySmartHealthCardHandler(req: FhirRequest): Promise<FhirResponse> {
-  try {
-    const params = parseInputParameters<VerifySmartHealthCardParams>(verifySmartHealthCardOperation, req);
-    const credential = readSmartHealthCardCredential(params);
-    const { payload, issuerTrusted } = await verifySmartHealthCardCredential(credential);
-    const header = decodeProtectedHeader(credential);
+  const params = parseInputParameters<VerifySmartHealthCardParams>(verifySmartHealthCardOperation, req);
+  const credential = readSmartHealthCardCredential(params);
+  const unverifiedPayload = decodeSmartHealthCardPayload(credential);
+  let issuerTrusted: boolean | undefined = undefined;
+  let header: ProtectedHeaderParameters | undefined = undefined;
+  let valid = true;
 
-    return [
-      allOk,
-      makeParameters({
-        valid: true,
-        signatureValid: true,
-        issuerTrusted,
-        verified: issuerTrusted,
-        issuer: payload.iss,
-        keyId: header.kid,
-        fhirBundle: JSON.stringify(payload.vc.credentialSubject.fhirBundle),
-      }),
-    ];
+  try {
+    ({ issuerTrusted } = await verifySmartHealthCardCredential(credential));
+    header = decodeProtectedHeader(credential);
   } catch (err) {
-    return [allOk, makeParameters({ valid: false, error: normalizeErrorString(err) })];
+    getLogger().warn('SMART Health Card validation failed', { err });
+    valid = false;
   }
+
+  return [
+    allOk,
+    makeParameters({
+      valid,
+      issuerTrusted,
+      verified: issuerTrusted,
+      issuer: unverifiedPayload.iss,
+      keyId: header?.kid,
+      fhirBundle: JSON.stringify(unverifiedPayload.vc.credentialSubject.fhirBundle),
+    }),
+  ];
 }
 
+/**
+ * Creates a compressed JWS credential containing the given FHIR Bundle as a SMART Health Card Verifiable Credential.
+ *
+ * @param bundle - FHIR Bundle to embed in the credential subject.
+ * @param issuer - Issuer URL to place in the JWT `iss` claim.
+ * @param exp - Optional expiration time as a NumericDate value in seconds since the Unix epoch.
+ * @returns Compact JWS string for the signed SMART Health Card credential.
+ */
 async function createSmartHealthCardCredential(bundle: Bundle, issuer: string, exp?: number): Promise<string> {
   const key = getSmartHealthCardSigningKey();
   const payload: SmartHealthCardJwt = {
@@ -169,6 +200,12 @@ async function createSmartHealthCardCredential(bundle: Bundle, issuer: string, e
     .sign(key.privateKey);
 }
 
+/**
+ * Verifies a SMART Health Card credential signature and validates the decoded payload claims.
+ *
+ * @param credential - Compact JWS credential to verify.
+ * @returns The decoded SMART Health Card JWT payload and whether the credential came from a trusted issuer.
+ */
 async function verifySmartHealthCardCredential(
   credential: string
 ): Promise<{ payload: SmartHealthCardJwt; issuerTrusted: boolean }> {
@@ -184,6 +221,13 @@ async function verifySmartHealthCardCredential(
   return { payload: jwt, issuerTrusted };
 }
 
+/**
+ * Validates SMART Health Card JWT claims and embedded FHIR metadata.
+ *
+ * @param payload - Decoded SMART Health Card JWT payload to validate.
+ * @param options - Validation options, including whether to require the configured issuer.
+ * @param options.requireTrustedIssuer - When true, requires the JWT `iss` claim to match the configured issuer URL; otherwise, allows any issuer.
+ */
 function validateSmartHealthCardPayload(
   payload: SmartHealthCardJwt,
   options: { requireTrustedIssuer?: boolean } = {}
@@ -209,6 +253,12 @@ function validateSmartHealthCardPayload(
   }
 }
 
+/**
+ * Extracts the compact JWS credential from supported verification input parameters.
+ *
+ * @param params - Verification parameters containing either `credential`, `shcUri`, or SMART Health Card file JSON.
+ * @returns Compact JWS credential string.
+ */
 function readSmartHealthCardCredential(params: VerifySmartHealthCardParams): string {
   if (params.credential) {
     return params.credential;
@@ -226,10 +276,22 @@ function readSmartHealthCardCredential(params: VerifySmartHealthCardParams): str
   throw new Error('Expected credential, shcUri, or file');
 }
 
+/**
+ * Wraps a SMART Health Card credential in the standard file export shape.
+ *
+ * @param credential - Compact JWS credential to include in the file payload.
+ * @returns SMART Health Card file object with a `verifiableCredential` array.
+ */
 function writeSmartHealthCardFile(credential: string): { verifiableCredential: string[] } {
   return { verifiableCredential: [credential] };
 }
 
+/**
+ * Encodes a compact JWS credential as an `shc:/` SMART Health Card URI.
+ *
+ * @param credential - Compact JWS credential to numerically encode.
+ * @returns SMART Health Card URI string.
+ */
 function encodeSmartHealthCardUri(credential: string): string {
   return (
     'shc:/' +
@@ -246,6 +308,12 @@ function encodeSmartHealthCardUri(credential: string): string {
   );
 }
 
+/**
+ * Decodes a SMART Health Card URI or numeric payload back into a compact JWS credential.
+ *
+ * @param uri - `shc:/` URI or bare numeric SMART Health Card encoding.
+ * @returns Compact JWS credential string.
+ */
 function decodeSmartHealthCardUri(uri: string): string {
   const numeric = uri.startsWith('shc:/') ? uri.substring(5) : uri;
   if (!/^\d+$/.test(numeric) || numeric.length % 2 !== 0) {
@@ -258,6 +326,11 @@ function decodeSmartHealthCardUri(uri: string): string {
   return result;
 }
 
+/**
+ * Resolves the local private signing key and key ID for SMART Health Card issuance.
+ *
+ * @returns Private key and `kid` used to sign SMART Health Card credentials.
+ */
 function getSmartHealthCardSigningKey(): SmartHealthCardSigningKey {
   const jwk = getSmartHealthCardSigningJwk();
   return {
@@ -266,6 +339,11 @@ function getSmartHealthCardSigningKey(): SmartHealthCardSigningKey {
   };
 }
 
+/**
+ * Finds the local JWK metadata for the configured SMART Health Card signing algorithm.
+ *
+ * @returns JWK containing the signing key metadata.
+ */
 function getSmartHealthCardSigningJwk(): JWK {
   const jwk = getJwks().keys.find((key) => key.alg === SHC_SIGNING_ALG);
   if (!jwk?.kid) {
@@ -274,6 +352,12 @@ function getSmartHealthCardSigningJwk(): JWK {
   return jwk;
 }
 
+/**
+ * Decodes a SMART Health Card credential payload without verifying its signature.
+ *
+ * @param credential - Compact JWS credential to decode.
+ * @returns Decoded SMART Health Card JWT payload.
+ */
 function decodeSmartHealthCardPayload(credential: string): SmartHealthCardJwt {
   const [headerPart, payloadPart] = credential.split('.');
   if (!headerPart || !payloadPart) {
@@ -285,6 +369,15 @@ function decodeSmartHealthCardPayload(credential: string): SmartHealthCardJwt {
   return JSON.parse(Buffer.from(bytes).toString('utf8')) as SmartHealthCardJwt;
 }
 
+/**
+ * Resolves the public key needed to verify a SMART Health Card credential.
+ *
+ * Uses a matching local JWK when available; otherwise, fetches the issuer JWKS after issuer host validation.
+ *
+ * @param credential - Compact JWS credential whose protected header contains the key ID.
+ * @param issuer - Issuer URL from the unverified credential payload.
+ * @returns Public key and whether the issuer matches the configured local issuer.
+ */
 async function getSmartHealthCardPublicKey(
   credential: string,
   issuer: string
@@ -312,6 +405,12 @@ async function getSmartHealthCardPublicKey(
   return { publicKey: (await importJWK(externalJwk, SHC_SIGNING_ALG)) as KeyLike, issuerTrusted: false };
 }
 
+/**
+ * Fetches external SMART Health Card issuer JWKS from the standard well-known URL.
+ *
+ * @param issuer - External issuer URL to query.
+ * @returns JWK array from the issuer JWKS document.
+ */
 async function getExternalSmartHealthCardJwks(issuer: string): Promise<JWK[]> {
   const issuerUrl = new URL(issuer);
   if (issuerUrl.protocol !== 'https:') {
@@ -329,6 +428,12 @@ async function getExternalSmartHealthCardJwks(issuer: string): Promise<JWK[]> {
   return jwks.keys ?? [];
 }
 
+/**
+ * Checks whether a hostname should be rejected for outbound SMART Health Card JWKS lookup.
+ *
+ * @param hostname - Hostname from an external issuer URL.
+ * @returns True when the hostname is localhost, link-local, loopback, private, or otherwise unsafe.
+ */
 function isUnsafeHostname(hostname: string): boolean {
   const ipVersion = isIP(hostname);
   if (ipVersion === 0) {

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -228,7 +228,7 @@ function encodeSmartHealthCardUri(credential: string): string {
     credential
       .split('')
       .map((char) => {
-        const value = char.charCodeAt(0) - 45;
+        const value = (char.codePointAt(0) as number) - 45;
         if (value < 0 || value > 77) {
           throw new Error(`Invalid SMART Health Card JWS character: ${char}`);
         }
@@ -245,7 +245,7 @@ function decodeSmartHealthCardUri(uri: string): string {
   }
   let result = '';
   for (let i = 0; i < numeric.length; i += 2) {
-    result += String.fromCharCode(Number.parseInt(numeric.substring(i, i + 2), 10) + 45);
+    result += String.fromCodePoint(Number.parseInt(numeric.substring(i, i + 2), 10) + 45);
   }
   return result;
 }

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk, badRequest, normalizeErrorString, OAuthSigningAlgorithm } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Bundle, Parameters, Patient, Resource } from '@medplum/fhirtypes';
+import type { Bundle, Patient, Resource } from '@medplum/fhirtypes';
 import type { JWK, KeyLike } from 'jose';
 import { CompactSign, compactVerify, decodeProtectedHeader, importJWK } from 'jose';
 import { isIP } from 'node:net';
@@ -11,14 +11,13 @@ import QRCode from 'qrcode';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import { getJwks, getSigningKey } from '../../oauth/keys';
-import { makeOperationDefinition } from './definitions';
+import { makeOperationDefinition, makeParameters } from './definitions';
 import { getPatientEverything } from './patienteverything';
 import { parseInputParameters } from './utils/parameters';
 
 const SHC_VC_TYPE = ['https://smarthealth.cards#health-card'];
 const FHIR_VERSION = '4.0.1';
 const SHC_SIGNING_ALG = OAuthSigningAlgorithm.ES256;
-const jwksCache = new Map<string, JWK[]>();
 
 interface SmartHealthCardSigningKey {
   privateKey: KeyLike;
@@ -322,18 +321,12 @@ async function getExternalSmartHealthCardJwks(issuer: string): Promise<JWK[]> {
     throw new Error('Unsafe SMART Health Card issuer host');
   }
   const jwksUrl = new URL('/.well-known/jwks.json', issuerUrl);
-  const cached = jwksCache.get(jwksUrl.toString());
-  if (cached) {
-    return cached;
-  }
   const response = await fetch(jwksUrl, { redirect: 'error', signal: AbortSignal.timeout(5000) });
   if (!response.ok) {
     throw new Error(`SMART Health Card issuer JWKS request failed: ${response.status}`);
   }
   const jwks = (await response.json()) as { keys?: JWK[] };
-  const keys = jwks.keys ?? [];
-  jwksCache.set(jwksUrl.toString(), keys);
-  return keys;
+  return jwks.keys ?? [];
 }
 
 function isUnsafeHostname(hostname: string): boolean {
@@ -345,17 +338,4 @@ function isUnsafeHostname(hostname: string): boolean {
     return /^(10\.|127\.|169\.254\.|172\.(1[6-9]|2\d|3[0-1])\.|192\.168\.)/.test(hostname);
   }
   return hostname === '::1' || hostname.toLowerCase().startsWith('fe80:') || hostname.toLowerCase().startsWith('fc');
-}
-
-function makeParameters(values: Record<string, string | boolean | undefined>): Parameters {
-  const parameters: Parameters = { resourceType: 'Parameters', parameter: [] };
-  for (const [name, value] of Object.entries(values)) {
-    if (value === undefined) {
-      continue;
-    }
-    parameters.parameter?.push(
-      typeof value === 'boolean' ? { name, valueBoolean: value } : { name, valueString: value }
-    );
-  }
-  return parameters;
 }

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -1,27 +1,25 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { allOk, badRequest, normalizeErrorString } from '@medplum/core';
+import { allOk, badRequest, normalizeErrorString, OAuthSigningAlgorithm } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Bundle, Parameters, Patient, Resource } from '@medplum/fhirtypes';
 import type { JWK, KeyLike } from 'jose';
-import { calculateJwkThumbprint, CompactSign, compactVerify, exportJWK, generateKeyPair } from 'jose';
+import { CompactSign, compactVerify, decodeProtectedHeader, importJWK } from 'jose';
 import { deflateRawSync, inflateRawSync } from 'node:zlib';
 import QRCode from 'qrcode';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
+import { getJwks, getSigningKey } from '../../oauth/keys';
 import { makeOperationDefinition } from './definitions';
 import { getPatientEverything } from './patienteverything';
 import { parseInputParameters } from './utils/parameters';
 
 const SHC_VC_TYPE = ['https://smarthealth.cards#health-card'];
 const FHIR_VERSION = '4.0.1';
-
-let signingKeyPromise: Promise<SmartHealthCardSigningKey> | undefined;
+const SHC_SIGNING_ALG = OAuthSigningAlgorithm.ES256;
 
 interface SmartHealthCardSigningKey {
   privateKey: KeyLike;
-  publicKey: KeyLike;
-  publicJwk: JWK;
   kid: string;
 }
 
@@ -115,7 +113,7 @@ export async function generateSmartHealthCardHandler(req: FhirRequest): Promise<
         file,
         qrCodeDataUrl,
         issuer,
-        keyId: (await getSmartHealthCardSigningKey()).kid,
+        keyId: getSmartHealthCardSigningKey().kid,
       }),
     ];
   } catch (err) {
@@ -128,7 +126,7 @@ export async function verifySmartHealthCardHandler(req: FhirRequest): Promise<Fh
     const params = parseInputParameters<VerifySmartHealthCardParams>(verifySmartHealthCardOperation, req);
     const credential = readSmartHealthCardCredential(params);
     const payload = await verifySmartHealthCardCredential(credential);
-    const header = JSON.parse(Buffer.from(credential.split('.')[0], 'base64url').toString('utf8')) as { kid?: string };
+    const header = decodeProtectedHeader(credential);
 
     return [
       allOk,
@@ -145,7 +143,7 @@ export async function verifySmartHealthCardHandler(req: FhirRequest): Promise<Fh
 }
 
 async function createSmartHealthCardCredential(bundle: Bundle, issuer: string, exp?: number): Promise<string> {
-  const key = await getSmartHealthCardSigningKey();
+  const key = getSmartHealthCardSigningKey();
   const payload: SmartHealthCardJwt = {
     iss: issuer,
     nbf: Math.floor(Date.now() / 1000),
@@ -160,18 +158,15 @@ async function createSmartHealthCardCredential(bundle: Bundle, issuer: string, e
   };
   const compressedPayload = deflateRawSync(Buffer.from(JSON.stringify(payload)));
   return new CompactSign(compressedPayload)
-    .setProtectedHeader({ alg: 'ES256', kid: key.kid, zip: 'DEF' })
+    .setProtectedHeader({ alg: SHC_SIGNING_ALG, kid: key.kid, zip: 'DEF' })
     .sign(key.privateKey);
 }
 
 async function verifySmartHealthCardCredential(credential: string): Promise<SmartHealthCardJwt> {
-  const key = await getSmartHealthCardSigningKey();
-  const { payload, protectedHeader } = await compactVerify(credential, key.publicKey);
-  if (protectedHeader.alg !== 'ES256') {
+  const publicKey = await getSmartHealthCardPublicKey(credential);
+  const { payload, protectedHeader } = await compactVerify(credential, publicKey);
+  if (protectedHeader.alg !== SHC_SIGNING_ALG) {
     throw new Error('Unsupported SMART Health Card signing algorithm');
-  }
-  if (protectedHeader.kid !== key.kid) {
-    throw new Error('Untrusted SMART Health Card key');
   }
   const bytes = protectedHeader.zip === 'DEF' ? inflateRawSync(payload) : payload;
   const jwt = JSON.parse(Buffer.from(bytes).toString('utf8')) as SmartHealthCardJwt;
@@ -250,18 +245,35 @@ function decodeSmartHealthCardUri(uri: string): string {
   return result;
 }
 
-async function getSmartHealthCardSigningKey(): Promise<SmartHealthCardSigningKey> {
-  signingKeyPromise ??= generateSmartHealthCardSigningKey();
-  return signingKeyPromise;
+function getSmartHealthCardSigningKey(): SmartHealthCardSigningKey {
+  const jwk = getSmartHealthCardSigningJwk();
+  return {
+    privateKey: getSigningKey(SHC_SIGNING_ALG),
+    kid: jwk.kid as string,
+  };
 }
 
-async function generateSmartHealthCardSigningKey(): Promise<SmartHealthCardSigningKey> {
-  const { privateKey, publicKey } = await generateKeyPair('ES256', { extractable: true });
-  const publicJwk = await exportJWK(publicKey);
-  publicJwk.alg = 'ES256';
-  publicJwk.use = 'sig';
-  const kid = await calculateJwkThumbprint(publicJwk, 'sha256');
-  return { privateKey, publicKey, publicJwk, kid };
+function getSmartHealthCardSigningJwk(): JWK {
+  const jwk = getJwks().keys.find((key) => key.alg === SHC_SIGNING_ALG);
+  if (!jwk?.kid) {
+    throw new Error(`Signing key not found for alg: ${SHC_SIGNING_ALG}`);
+  }
+  return jwk;
+}
+
+async function getSmartHealthCardPublicKey(credential: string): Promise<KeyLike> {
+  const header = decodeProtectedHeader(credential);
+  if (header.alg !== SHC_SIGNING_ALG) {
+    throw new Error('Unsupported SMART Health Card signing algorithm');
+  }
+  if (!header.kid) {
+    throw new Error('Missing SMART Health Card key ID');
+  }
+  const jwk = getJwks().keys.find((key) => key.kid === header.kid && key.alg === SHC_SIGNING_ALG);
+  if (!jwk) {
+    throw new Error('Untrusted SMART Health Card key');
+  }
+  return importJWK(jwk, SHC_SIGNING_ALG) as Promise<KeyLike>;
 }
 
 function makeParameters(values: Record<string, string | boolean | undefined>): Parameters {

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -5,6 +5,7 @@ import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Bundle, Parameters, Patient, Resource } from '@medplum/fhirtypes';
 import type { JWK, KeyLike } from 'jose';
 import { CompactSign, compactVerify, decodeProtectedHeader, importJWK } from 'jose';
+import { isIP } from 'node:net';
 import { deflateRawSync, inflateRawSync } from 'node:zlib';
 import QRCode from 'qrcode';
 import { getConfig } from '../../config/loader';
@@ -17,6 +18,7 @@ import { parseInputParameters } from './utils/parameters';
 const SHC_VC_TYPE = ['https://smarthealth.cards#health-card'];
 const FHIR_VERSION = '4.0.1';
 const SHC_SIGNING_ALG = OAuthSigningAlgorithm.ES256;
+const jwksCache = new Map<string, JWK[]>();
 
 interface SmartHealthCardSigningKey {
   privateKey: KeyLike;
@@ -79,6 +81,9 @@ export const verifySmartHealthCardOperation = makeOperationDefinition(
       { use: 'in', name: 'shcUri', type: 'string', min: 0, max: '1' },
       { use: 'in', name: 'file', type: 'string', min: 0, max: '1' },
       { use: 'out', name: 'valid', type: 'boolean', min: 1, max: '1' },
+      { use: 'out', name: 'signatureValid', type: 'boolean', min: 0, max: '1' },
+      { use: 'out', name: 'issuerTrusted', type: 'boolean', min: 0, max: '1' },
+      { use: 'out', name: 'verified', type: 'boolean', min: 0, max: '1' },
       { use: 'out', name: 'issuer', type: 'uri', min: 0, max: '1' },
       { use: 'out', name: 'keyId', type: 'string', min: 0, max: '1' },
       { use: 'out', name: 'fhirBundle', type: 'string', min: 0, max: '1' },
@@ -125,13 +130,16 @@ export async function verifySmartHealthCardHandler(req: FhirRequest): Promise<Fh
   try {
     const params = parseInputParameters<VerifySmartHealthCardParams>(verifySmartHealthCardOperation, req);
     const credential = readSmartHealthCardCredential(params);
-    const payload = await verifySmartHealthCardCredential(credential);
+    const { payload, issuerTrusted } = await verifySmartHealthCardCredential(credential);
     const header = decodeProtectedHeader(credential);
 
     return [
       allOk,
       makeParameters({
         valid: true,
+        signatureValid: true,
+        issuerTrusted,
+        verified: issuerTrusted,
         issuer: payload.iss,
         keyId: header.kid,
         fhirBundle: JSON.stringify(payload.vc.credentialSubject.fhirBundle),
@@ -162,21 +170,27 @@ async function createSmartHealthCardCredential(bundle: Bundle, issuer: string, e
     .sign(key.privateKey);
 }
 
-async function verifySmartHealthCardCredential(credential: string): Promise<SmartHealthCardJwt> {
-  const publicKey = await getSmartHealthCardPublicKey(credential);
+async function verifySmartHealthCardCredential(
+  credential: string
+): Promise<{ payload: SmartHealthCardJwt; issuerTrusted: boolean }> {
+  const unverifiedPayload = decodeSmartHealthCardPayload(credential);
+  const { publicKey, issuerTrusted } = await getSmartHealthCardPublicKey(credential, unverifiedPayload.iss);
   const { payload, protectedHeader } = await compactVerify(credential, publicKey);
   if (protectedHeader.alg !== SHC_SIGNING_ALG) {
     throw new Error('Unsupported SMART Health Card signing algorithm');
   }
   const bytes = protectedHeader.zip === 'DEF' ? inflateRawSync(payload) : payload;
   const jwt = JSON.parse(Buffer.from(bytes).toString('utf8')) as SmartHealthCardJwt;
-  validateSmartHealthCardPayload(jwt);
-  return jwt;
+  validateSmartHealthCardPayload(jwt, { requireTrustedIssuer: issuerTrusted });
+  return { payload: jwt, issuerTrusted };
 }
 
-function validateSmartHealthCardPayload(payload: SmartHealthCardJwt): void {
+function validateSmartHealthCardPayload(
+  payload: SmartHealthCardJwt,
+  options: { requireTrustedIssuer?: boolean } = {}
+): void {
   const now = Math.floor(Date.now() / 1000);
-  if (payload.iss !== getConfig().issuer) {
+  if (options.requireTrustedIssuer && payload.iss !== getConfig().issuer) {
     throw new Error('Untrusted SMART Health Card issuer');
   }
   if (typeof payload.nbf !== 'number' || payload.nbf > now) {
@@ -261,7 +275,21 @@ function getSmartHealthCardSigningJwk(): JWK {
   return jwk;
 }
 
-async function getSmartHealthCardPublicKey(credential: string): Promise<KeyLike> {
+function decodeSmartHealthCardPayload(credential: string): SmartHealthCardJwt {
+  const [headerPart, payloadPart] = credential.split('.');
+  if (!headerPart || !payloadPart) {
+    throw new Error('Invalid SMART Health Card credential');
+  }
+  const header = decodeProtectedHeader(credential);
+  const payload = Buffer.from(payloadPart, 'base64url');
+  const bytes = header.zip === 'DEF' ? inflateRawSync(payload) : payload;
+  return JSON.parse(Buffer.from(bytes).toString('utf8')) as SmartHealthCardJwt;
+}
+
+async function getSmartHealthCardPublicKey(
+  credential: string,
+  issuer: string
+): Promise<{ publicKey: KeyLike; issuerTrusted: boolean }> {
   const header = decodeProtectedHeader(credential);
   if (header.alg !== SHC_SIGNING_ALG) {
     throw new Error('Unsupported SMART Health Card signing algorithm');
@@ -269,11 +297,54 @@ async function getSmartHealthCardPublicKey(credential: string): Promise<KeyLike>
   if (!header.kid) {
     throw new Error('Missing SMART Health Card key ID');
   }
-  const jwk = getJwks().keys.find((key) => key.kid === header.kid && key.alg === SHC_SIGNING_ALG);
-  if (!jwk) {
-    throw new Error('Untrusted SMART Health Card key');
+  const localJwk = getJwks().keys.find((key) => key.kid === header.kid && key.alg === SHC_SIGNING_ALG);
+  if (localJwk) {
+    return {
+      publicKey: (await importJWK(localJwk, SHC_SIGNING_ALG)) as KeyLike,
+      issuerTrusted: issuer === getConfig().issuer,
+    };
   }
-  return importJWK(jwk, SHC_SIGNING_ALG) as Promise<KeyLike>;
+  const externalJwk = (await getExternalSmartHealthCardJwks(issuer)).find(
+    (key) => key.kid === header.kid && key.alg === SHC_SIGNING_ALG
+  );
+  if (!externalJwk) {
+    throw new Error('SMART Health Card key not found');
+  }
+  return { publicKey: (await importJWK(externalJwk, SHC_SIGNING_ALG)) as KeyLike, issuerTrusted: false };
+}
+
+async function getExternalSmartHealthCardJwks(issuer: string): Promise<JWK[]> {
+  const issuerUrl = new URL(issuer);
+  if (issuerUrl.protocol !== 'https:') {
+    throw new Error('External SMART Health Card issuer must use HTTPS');
+  }
+  if (isUnsafeHostname(issuerUrl.hostname)) {
+    throw new Error('Unsafe SMART Health Card issuer host');
+  }
+  const jwksUrl = new URL('/.well-known/jwks.json', issuerUrl);
+  const cached = jwksCache.get(jwksUrl.toString());
+  if (cached) {
+    return cached;
+  }
+  const response = await fetch(jwksUrl, { redirect: 'error', signal: AbortSignal.timeout(5000) });
+  if (!response.ok) {
+    throw new Error(`SMART Health Card issuer JWKS request failed: ${response.status}`);
+  }
+  const jwks = (await response.json()) as { keys?: JWK[] };
+  const keys = jwks.keys ?? [];
+  jwksCache.set(jwksUrl.toString(), keys);
+  return keys;
+}
+
+function isUnsafeHostname(hostname: string): boolean {
+  const ipVersion = isIP(hostname);
+  if (ipVersion === 0) {
+    return ['localhost', 'localhost.localdomain'].includes(hostname.toLowerCase());
+  }
+  if (ipVersion === 4) {
+    return /^(10\.|127\.|169\.254\.|172\.(1[6-9]|2\d|3[0-1])\.|192\.168\.)/.test(hostname);
+  }
+  return hostname === '::1' || hostname.toLowerCase().startsWith('fe80:') || hostname.toLowerCase().startsWith('fc');
 }
 
 function makeParameters(values: Record<string, string | boolean | undefined>): Parameters {

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { allOk, badRequest, normalizeErrorString } from '@medplum/core';
+import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
+import type { Bundle, Parameters, Patient, Resource } from '@medplum/fhirtypes';
+import type { JWK, KeyLike } from 'jose';
+import { calculateJwkThumbprint, CompactSign, compactVerify, exportJWK, generateKeyPair } from 'jose';
+import { deflateRawSync, inflateRawSync } from 'node:zlib';
+import QRCode from 'qrcode';
+import { getConfig } from '../../config/loader';
+import { getAuthenticatedContext } from '../../context';
+import { makeOperationDefinition } from './definitions';
+import { getPatientEverything } from './patienteverything';
+import { parseInputParameters } from './utils/parameters';
+
+const SHC_VC_TYPE = ['https://smarthealth.cards#health-card'];
+const FHIR_VERSION = '4.0.1';
+
+let signingKeyPromise: Promise<SmartHealthCardSigningKey> | undefined;
+
+interface SmartHealthCardSigningKey {
+  privateKey: KeyLike;
+  publicKey: KeyLike;
+  publicJwk: JWK;
+  kid: string;
+}
+
+interface SmartHealthCardJwt {
+  iss: string;
+  nbf: number;
+  exp?: number;
+  vc: {
+    type: string[];
+    credentialSubject: {
+      fhirVersion: string;
+      fhirBundle: Bundle;
+    };
+  };
+}
+
+interface GenerateSmartHealthCardParams {
+  _type?: string;
+  exp?: number;
+  includeQrCode?: boolean;
+}
+
+interface VerifySmartHealthCardParams {
+  credential?: string;
+  shcUri?: string;
+  file?: string;
+}
+
+export const generateSmartHealthCardOperation = makeOperationDefinition(
+  { scope: 'instance', resource: 'Patient' },
+  {
+    name: 'GenerateSmartHealthCard',
+    code: 'generate-smart-health-card',
+    affectsState: false,
+    parameter: [
+      { use: 'in', name: '_type', type: 'string', min: 0, max: '1' },
+      { use: 'in', name: 'exp', type: 'integer', min: 0, max: '1' },
+      { use: 'in', name: 'includeQrCode', type: 'boolean', min: 0, max: '1' },
+      { use: 'out', name: 'credential', type: 'string', min: 1, max: '1' },
+      { use: 'out', name: 'shcUri', type: 'uri', min: 1, max: '1' },
+      { use: 'out', name: 'file', type: 'string', min: 1, max: '1' },
+      { use: 'out', name: 'qrCodeDataUrl', type: 'string', min: 0, max: '1' },
+      { use: 'out', name: 'issuer', type: 'uri', min: 1, max: '1' },
+      { use: 'out', name: 'keyId', type: 'string', min: 1, max: '1' },
+    ],
+  }
+);
+
+export const verifySmartHealthCardOperation = makeOperationDefinition(
+  { scope: 'system' },
+  {
+    name: 'VerifySmartHealthCard',
+    code: 'verify-smart-health-card',
+    affectsState: false,
+    parameter: [
+      { use: 'in', name: 'credential', type: 'string', min: 0, max: '1' },
+      { use: 'in', name: 'shcUri', type: 'string', min: 0, max: '1' },
+      { use: 'in', name: 'file', type: 'string', min: 0, max: '1' },
+      { use: 'out', name: 'valid', type: 'boolean', min: 1, max: '1' },
+      { use: 'out', name: 'issuer', type: 'uri', min: 0, max: '1' },
+      { use: 'out', name: 'keyId', type: 'string', min: 0, max: '1' },
+      { use: 'out', name: 'fhirBundle', type: 'string', min: 0, max: '1' },
+      { use: 'out', name: 'error', type: 'string', min: 0, max: '1' },
+    ],
+  }
+);
+
+export async function generateSmartHealthCardHandler(req: FhirRequest): Promise<FhirResponse> {
+  try {
+    const ctx = getAuthenticatedContext();
+    const patient = await ctx.repo.readResource<Patient>('Patient', req.params.id);
+    const params = parseInputParameters<GenerateSmartHealthCardParams>(generateSmartHealthCardOperation, req);
+    const bundle = await getPatientEverything(ctx.repo, patient, {
+      _count: 1000,
+      _type: params._type
+        ?.split(',')
+        .map((s) => s.trim() as Resource['resourceType'])
+        .filter(Boolean),
+    });
+    const issuer = getConfig().issuer;
+    const credential = await createSmartHealthCardCredential(bundle, issuer, params.exp);
+    const shcUri = encodeSmartHealthCardUri(credential);
+    const file = JSON.stringify(writeSmartHealthCardFile(credential));
+    const qrCodeDataUrl = params.includeQrCode ? await QRCode.toDataURL(shcUri) : undefined;
+
+    return [
+      allOk,
+      makeParameters({
+        credential,
+        shcUri,
+        file,
+        qrCodeDataUrl,
+        issuer,
+        keyId: (await getSmartHealthCardSigningKey()).kid,
+      }),
+    ];
+  } catch (err) {
+    return [badRequest(normalizeErrorString(err))];
+  }
+}
+
+export async function verifySmartHealthCardHandler(req: FhirRequest): Promise<FhirResponse> {
+  try {
+    const params = parseInputParameters<VerifySmartHealthCardParams>(verifySmartHealthCardOperation, req);
+    const credential = readSmartHealthCardCredential(params);
+    const payload = await verifySmartHealthCardCredential(credential);
+    const header = JSON.parse(Buffer.from(credential.split('.')[0], 'base64url').toString('utf8')) as { kid?: string };
+
+    return [
+      allOk,
+      makeParameters({
+        valid: true,
+        issuer: payload.iss,
+        keyId: header.kid,
+        fhirBundle: JSON.stringify(payload.vc.credentialSubject.fhirBundle),
+      }),
+    ];
+  } catch (err) {
+    return [allOk, makeParameters({ valid: false, error: normalizeErrorString(err) })];
+  }
+}
+
+async function createSmartHealthCardCredential(bundle: Bundle, issuer: string, exp?: number): Promise<string> {
+  const key = await getSmartHealthCardSigningKey();
+  const payload: SmartHealthCardJwt = {
+    iss: issuer,
+    nbf: Math.floor(Date.now() / 1000),
+    exp,
+    vc: {
+      type: SHC_VC_TYPE,
+      credentialSubject: {
+        fhirVersion: FHIR_VERSION,
+        fhirBundle: bundle,
+      },
+    },
+  };
+  const compressedPayload = deflateRawSync(Buffer.from(JSON.stringify(payload)));
+  return new CompactSign(compressedPayload)
+    .setProtectedHeader({ alg: 'ES256', kid: key.kid, zip: 'DEF' })
+    .sign(key.privateKey);
+}
+
+async function verifySmartHealthCardCredential(credential: string): Promise<SmartHealthCardJwt> {
+  const key = await getSmartHealthCardSigningKey();
+  const { payload, protectedHeader } = await compactVerify(credential, key.publicKey);
+  if (protectedHeader.alg !== 'ES256') {
+    throw new Error('Unsupported SMART Health Card signing algorithm');
+  }
+  if (protectedHeader.kid !== key.kid) {
+    throw new Error('Untrusted SMART Health Card key');
+  }
+  const bytes = protectedHeader.zip === 'DEF' ? inflateRawSync(payload) : payload;
+  const jwt = JSON.parse(Buffer.from(bytes).toString('utf8')) as SmartHealthCardJwt;
+  validateSmartHealthCardPayload(jwt);
+  return jwt;
+}
+
+function validateSmartHealthCardPayload(payload: SmartHealthCardJwt): void {
+  const now = Math.floor(Date.now() / 1000);
+  if (payload.iss !== getConfig().issuer) {
+    throw new Error('Untrusted SMART Health Card issuer');
+  }
+  if (typeof payload.nbf !== 'number' || payload.nbf > now) {
+    throw new Error('SMART Health Card is not yet valid');
+  }
+  if (payload.exp !== undefined && payload.exp <= now) {
+    throw new Error('SMART Health Card has expired');
+  }
+  if (!payload.vc?.type?.includes(SHC_VC_TYPE[0])) {
+    throw new Error('Invalid SMART Health Card credential type');
+  }
+  if (payload.vc.credentialSubject.fhirVersion !== FHIR_VERSION) {
+    throw new Error('Unsupported SMART Health Card FHIR version');
+  }
+  if (payload.vc.credentialSubject.fhirBundle?.resourceType !== 'Bundle') {
+    throw new Error('Missing SMART Health Card FHIR Bundle');
+  }
+}
+
+function readSmartHealthCardCredential(params: VerifySmartHealthCardParams): string {
+  if (params.credential) {
+    return params.credential;
+  }
+  if (params.shcUri) {
+    return decodeSmartHealthCardUri(params.shcUri);
+  }
+  if (params.file) {
+    const parsed = JSON.parse(params.file) as { verifiableCredential?: string[] };
+    const credential = parsed.verifiableCredential?.[0];
+    if (credential) {
+      return credential;
+    }
+  }
+  throw new Error('Expected credential, shcUri, or file');
+}
+
+function writeSmartHealthCardFile(credential: string): { verifiableCredential: string[] } {
+  return { verifiableCredential: [credential] };
+}
+
+function encodeSmartHealthCardUri(credential: string): string {
+  return (
+    'shc:/' +
+    credential
+      .split('')
+      .map((char) => {
+        const value = char.charCodeAt(0) - 45;
+        if (value < 0 || value > 77) {
+          throw new Error(`Invalid SMART Health Card JWS character: ${char}`);
+        }
+        return value.toString().padStart(2, '0');
+      })
+      .join('')
+  );
+}
+
+function decodeSmartHealthCardUri(uri: string): string {
+  const numeric = uri.startsWith('shc:/') ? uri.substring(5) : uri;
+  if (!/^\d+$/.test(numeric) || numeric.length % 2 !== 0) {
+    throw new Error('Invalid SMART Health Card numeric encoding');
+  }
+  let result = '';
+  for (let i = 0; i < numeric.length; i += 2) {
+    result += String.fromCharCode(Number.parseInt(numeric.substring(i, i + 2), 10) + 45);
+  }
+  return result;
+}
+
+async function getSmartHealthCardSigningKey(): Promise<SmartHealthCardSigningKey> {
+  signingKeyPromise ??= generateSmartHealthCardSigningKey();
+  return signingKeyPromise;
+}
+
+async function generateSmartHealthCardSigningKey(): Promise<SmartHealthCardSigningKey> {
+  const { privateKey, publicKey } = await generateKeyPair('ES256', { extractable: true });
+  const publicJwk = await exportJWK(publicKey);
+  publicJwk.alg = 'ES256';
+  publicJwk.use = 'sig';
+  const kid = await calculateJwkThumbprint(publicJwk, 'sha256');
+  return { privateKey, publicKey, publicJwk, kid };
+}
+
+function makeParameters(values: Record<string, string | boolean | undefined>): Parameters {
+  const parameters: Parameters = { resourceType: 'Parameters', parameter: [] };
+  for (const [name, value] of Object.entries(values)) {
+    if (value === undefined) {
+      continue;
+    }
+    parameters.parameter?.push(
+      typeof value === 'boolean' ? { name, valueBoolean: value } : { name, valueString: value }
+    );
+  }
+  return parameters;
+}

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -228,9 +228,7 @@ async function verifySmartHealthCardCredential(
     throw new Error('Unsupported SMART Health Card signing algorithm');
   }
   const bytes =
-    protectedHeader.zip === 'DEF'
-      ? await inflateRaw(payload, { maxOutputLength: SHC_MAX_DECOMPRESSED_SIZE })
-      : payload;
+    protectedHeader.zip === 'DEF' ? await inflateRaw(payload, { maxOutputLength: SHC_MAX_DECOMPRESSED_SIZE }) : payload;
   const jwt = JSON.parse(Buffer.from(bytes).toString('utf8')) as SmartHealthCardJwt;
   validateSmartHealthCardPayload(jwt, { requireTrustedIssuer: issuerTrusted });
   return { payload: jwt, issuerTrusted };

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -1,24 +1,32 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { allOk, badRequest, normalizeErrorString, OAuthSigningAlgorithm } from '@medplum/core';
+import { allOk, normalizeErrorString, OAuthSigningAlgorithm } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Bundle, Patient, Resource } from '@medplum/fhirtypes';
 import type { JWK, KeyLike, ProtectedHeaderParameters } from 'jose';
 import { CompactSign, compactVerify, decodeProtectedHeader, importJWK } from 'jose';
 import { isIP } from 'node:net';
-import { deflateRawSync, inflateRawSync } from 'node:zlib';
+import { promisify } from 'node:util';
+import { deflateRaw as deflateRawCb, inflateRaw as inflateRawCb } from 'node:zlib';
 import QRCode from 'qrcode';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import { getLogger } from '../../logger';
 import { getJwks, getSigningKey } from '../../oauth/keys';
-import { makeOperationDefinition, makeParameters } from './definitions';
+import { makeOperationDefinition } from './definitions';
 import { getPatientEverything } from './patienteverything';
-import { parseInputParameters } from './utils/parameters';
+import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
 const SHC_VC_TYPE = ['https://smarthealth.cards#health-card'];
 const FHIR_VERSION = '4.0.1';
 const SHC_SIGNING_ALG = OAuthSigningAlgorithm.ES256;
+
+// Upper bound on the decompressed size of a SMART Health Card payload. Guards against decompression bombs in
+// attacker-supplied credentials, since the payload is inflated before its signature can be verified.
+const SHC_MAX_DECOMPRESSED_SIZE = 8 * 1024 * 1024;
+
+const deflateRaw = promisify(deflateRawCb);
+const inflateRaw = promisify(inflateRawCb);
 
 interface SmartHealthCardSigningKey {
   privateKey: KeyLike;
@@ -101,37 +109,33 @@ export const verifySmartHealthCardOperation = makeOperationDefinition(
  * @returns FHIR response containing the generated SMART Health Card credential in multiple formats and related metadata.
  */
 export async function generateSmartHealthCardHandler(req: FhirRequest): Promise<FhirResponse> {
-  try {
-    const ctx = getAuthenticatedContext();
-    const patient = await ctx.repo.readResource<Patient>('Patient', req.params.id);
-    const params = parseInputParameters<GenerateSmartHealthCardParams>(generateSmartHealthCardOperation, req);
-    const bundle = await getPatientEverything(ctx.repo, patient, {
-      _count: 1000,
-      _type: params._type
-        ?.split(',')
-        .map((s) => s.trim() as Resource['resourceType'])
-        .filter(Boolean),
-    });
-    const issuer = getConfig().issuer;
-    const { credential, keyId } = await createSmartHealthCardCredential(bundle, issuer, params.exp);
-    const shcUri = encodeSmartHealthCardUri(credential);
-    const file = JSON.stringify(writeSmartHealthCardFile(credential));
-    const qrCodeDataUrl = params.includeQrCode ? await QRCode.toDataURL(shcUri) : undefined;
+  const ctx = getAuthenticatedContext();
+  const patient = await ctx.repo.readResource<Patient>('Patient', req.params.id);
+  const params = parseInputParameters<GenerateSmartHealthCardParams>(generateSmartHealthCardOperation, req);
+  const bundle = await getPatientEverything(ctx.repo, patient, {
+    _count: 1000,
+    _type: params._type
+      ?.split(',')
+      .map((s) => s.trim() as Resource['resourceType'])
+      .filter(Boolean),
+  });
+  const issuer = getConfig().issuer;
+  const { credential, keyId } = await createSmartHealthCardCredential(bundle, issuer, params.exp);
+  const shcUri = encodeSmartHealthCardUri(credential);
+  const file = JSON.stringify(writeSmartHealthCardFile(credential));
+  const qrCodeDataUrl = params.includeQrCode ? await QRCode.toDataURL(shcUri) : undefined;
 
-    return [
-      allOk,
-      makeParameters({
-        credential,
-        shcUri,
-        file,
-        qrCodeDataUrl,
-        issuer,
-        keyId,
-      }),
-    ];
-  } catch (err) {
-    return [badRequest(normalizeErrorString(err))];
-  }
+  return [
+    allOk,
+    buildOutputParameters(generateSmartHealthCardOperation, {
+      credential,
+      shcUri,
+      file,
+      qrCodeDataUrl,
+      issuer,
+      keyId,
+    }),
+  ];
 }
 
 /**
@@ -146,24 +150,24 @@ export async function generateSmartHealthCardHandler(req: FhirRequest): Promise<
 export async function verifySmartHealthCardHandler(req: FhirRequest): Promise<FhirResponse> {
   const params = parseInputParameters<VerifySmartHealthCardParams>(verifySmartHealthCardOperation, req);
   const credential = readSmartHealthCardCredential(params);
-  const unverifiedPayload = decodeSmartHealthCardPayload(credential);
+  const unverifiedPayload = await decodeSmartHealthCardPayload(credential);
   let issuerTrusted: boolean | undefined = undefined;
   let header: ProtectedHeaderParameters | undefined = undefined;
-  let valid = true;
+  let valid = false;
   let error: string | undefined = undefined;
 
   try {
     ({ issuerTrusted } = await verifySmartHealthCardCredential(credential));
     header = decodeProtectedHeader(credential);
+    valid = true;
   } catch (err) {
     getLogger().warn('SMART Health Card validation failed', { err });
-    valid = false;
     error = normalizeErrorString(err);
   }
 
   return [
     allOk,
-    makeParameters({
+    buildOutputParameters(verifySmartHealthCardOperation, {
       valid,
       issuerTrusted,
       verified: issuerTrusted,
@@ -201,7 +205,7 @@ async function createSmartHealthCardCredential(
       },
     },
   };
-  const compressedPayload = deflateRawSync(Buffer.from(JSON.stringify(payload)));
+  const compressedPayload = await deflateRaw(Buffer.from(JSON.stringify(payload)));
   const credential = await new CompactSign(compressedPayload)
     .setProtectedHeader({ alg: SHC_SIGNING_ALG, kid: key.kid, zip: 'DEF' })
     .sign(key.privateKey);
@@ -217,13 +221,16 @@ async function createSmartHealthCardCredential(
 async function verifySmartHealthCardCredential(
   credential: string
 ): Promise<{ payload: SmartHealthCardJwt; issuerTrusted: boolean }> {
-  const unverifiedPayload = decodeSmartHealthCardPayload(credential);
+  const unverifiedPayload = await decodeSmartHealthCardPayload(credential);
   const { publicKey, issuerTrusted } = await getSmartHealthCardPublicKey(credential, unverifiedPayload.iss);
   const { payload, protectedHeader } = await compactVerify(credential, publicKey);
   if (protectedHeader.alg !== SHC_SIGNING_ALG) {
     throw new Error('Unsupported SMART Health Card signing algorithm');
   }
-  const bytes = protectedHeader.zip === 'DEF' ? inflateRawSync(payload) : payload;
+  const bytes =
+    protectedHeader.zip === 'DEF'
+      ? await inflateRaw(payload, { maxOutputLength: SHC_MAX_DECOMPRESSED_SIZE })
+      : payload;
   const jwt = JSON.parse(Buffer.from(bytes).toString('utf8')) as SmartHealthCardJwt;
   validateSmartHealthCardPayload(jwt, { requireTrustedIssuer: issuerTrusted });
   return { payload: jwt, issuerTrusted };
@@ -366,14 +373,15 @@ function getSmartHealthCardSigningJwk(): JWK {
  * @param credential - Compact JWS credential to decode.
  * @returns Decoded SMART Health Card JWT payload.
  */
-function decodeSmartHealthCardPayload(credential: string): SmartHealthCardJwt {
+async function decodeSmartHealthCardPayload(credential: string): Promise<SmartHealthCardJwt> {
   const [headerPart, payloadPart] = credential.split('.');
   if (!headerPart || !payloadPart) {
     throw new Error('Invalid SMART Health Card credential');
   }
   const header = decodeProtectedHeader(credential);
   const payload = Buffer.from(payloadPart, 'base64url');
-  const bytes = header.zip === 'DEF' ? inflateRawSync(payload) : payload;
+  const bytes =
+    header.zip === 'DEF' ? await inflateRaw(payload, { maxOutputLength: SHC_MAX_DECOMPRESSED_SIZE }) : payload;
   return JSON.parse(Buffer.from(bytes).toString('utf8')) as SmartHealthCardJwt;
 }
 

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -455,5 +455,7 @@ function isUnsafeHostname(hostname: string): boolean {
   if (ipVersion === 4) {
     return /^(10\.|127\.|169\.254\.|172\.(1[6-9]|2\d|3[0-1])\.|192\.168\.)/.test(ipHostname);
   }
-  return ipHostname === '::1' || ipHostname.startsWith('fe80:') || ipHostname.startsWith('fc') || ipHostname.startsWith('fd');
+  return (
+    ipHostname === '::1' || ipHostname.startsWith('fe80:') || ipHostname.startsWith('fc') || ipHostname.startsWith('fd')
+  );
 }

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -438,12 +438,17 @@ async function getExternalSmartHealthCardJwks(issuer: string): Promise<JWK[]> {
  * @returns True when the hostname is localhost, link-local, loopback, private, or otherwise unsafe.
  */
 function isUnsafeHostname(hostname: string): boolean {
-  const ipVersion = isIP(hostname);
+  const normalizedHostname = hostname.toLowerCase();
+  const ipHostname =
+    normalizedHostname.startsWith('[') && normalizedHostname.endsWith(']')
+      ? normalizedHostname.slice(1, -1)
+      : normalizedHostname;
+  const ipVersion = isIP(ipHostname);
   if (ipVersion === 0) {
-    return ['localhost', 'localhost.localdomain'].includes(hostname.toLowerCase());
+    return ['localhost', 'localhost.localdomain'].includes(normalizedHostname);
   }
   if (ipVersion === 4) {
-    return /^(10\.|127\.|169\.254\.|172\.(1[6-9]|2\d|3[0-1])\.|192\.168\.)/.test(hostname);
+    return /^(10\.|127\.|169\.254\.|172\.(1[6-9]|2\d|3[0-1])\.|192\.168\.)/.test(ipHostname);
   }
-  return hostname === '::1' || hostname.toLowerCase().startsWith('fe80:') || hostname.toLowerCase().startsWith('fc');
+  return ipHostname === '::1' || ipHostname.startsWith('fe80:') || ipHostname.startsWith('fc') || ipHostname.startsWith('fd');
 }

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -69,7 +69,7 @@ export const generateSmartHealthCardOperation = makeOperationDefinition(
       { use: 'in', name: 'exp', type: 'integer', min: 0, max: '1' },
       { use: 'in', name: 'includeQrCode', type: 'boolean', min: 0, max: '1' },
       { use: 'out', name: 'credential', type: 'string', min: 1, max: '1' },
-      { use: 'out', name: 'shcUri', type: 'uri', min: 1, max: '1' },
+      { use: 'out', name: 'shcUri', type: 'string', min: 1, max: '1' },
       { use: 'out', name: 'file', type: 'string', min: 1, max: '1' },
       { use: 'out', name: 'qrCodeDataUrl', type: 'string', min: 0, max: '1' },
       { use: 'out', name: 'issuer', type: 'uri', min: 1, max: '1' },

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -113,7 +113,7 @@ export async function generateSmartHealthCardHandler(req: FhirRequest): Promise<
         .filter(Boolean),
     });
     const issuer = getConfig().issuer;
-    const credential = await createSmartHealthCardCredential(bundle, issuer, params.exp);
+    const { credential, keyId } = await createSmartHealthCardCredential(bundle, issuer, params.exp);
     const shcUri = encodeSmartHealthCardUri(credential);
     const file = JSON.stringify(writeSmartHealthCardFile(credential));
     const qrCodeDataUrl = params.includeQrCode ? await QRCode.toDataURL(shcUri) : undefined;
@@ -126,7 +126,7 @@ export async function generateSmartHealthCardHandler(req: FhirRequest): Promise<
         file,
         qrCodeDataUrl,
         issuer,
-        keyId: getSmartHealthCardSigningKey().kid,
+        keyId,
       }),
     ];
   } catch (err) {
@@ -181,9 +181,13 @@ export async function verifySmartHealthCardHandler(req: FhirRequest): Promise<Fh
  * @param bundle - FHIR Bundle to embed in the credential subject.
  * @param issuer - Issuer URL to place in the JWT `iss` claim.
  * @param exp - Optional expiration time as a NumericDate value in seconds since the Unix epoch.
- * @returns Compact JWS string for the signed SMART Health Card credential.
+ * @returns Compact JWS string for the signed SMART Health Card credential and the signing key ID.
  */
-async function createSmartHealthCardCredential(bundle: Bundle, issuer: string, exp?: number): Promise<string> {
+async function createSmartHealthCardCredential(
+  bundle: Bundle,
+  issuer: string,
+  exp?: number
+): Promise<{ credential: string; keyId: string }> {
   const key = getSmartHealthCardSigningKey();
   const payload: SmartHealthCardJwt = {
     iss: issuer,
@@ -198,9 +202,10 @@ async function createSmartHealthCardCredential(bundle: Bundle, issuer: string, e
     },
   };
   const compressedPayload = deflateRawSync(Buffer.from(JSON.stringify(payload)));
-  return new CompactSign(compressedPayload)
+  const credential = await new CompactSign(compressedPayload)
     .setProtectedHeader({ alg: SHC_SIGNING_ALG, kid: key.kid, zip: 'DEF' })
     .sign(key.privateKey);
+  return { credential, keyId: key.kid };
 }
 
 /**

--- a/packages/server/src/fhir/operations/smarthealthlinks.ts
+++ b/packages/server/src/fhir/operations/smarthealthlinks.ts
@@ -1,0 +1,269 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { allOk, badRequest, concatUrls, ContentType, normalizeErrorString } from '@medplum/core';
+import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
+import type { Bundle, Parameters, Patient, Resource } from '@medplum/fhirtypes';
+import type { Request, Response } from 'express';
+import { base64url, compactDecrypt, CompactEncrypt } from 'jose';
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import QRCode from 'qrcode';
+import { getConfig } from '../../config/loader';
+import { getAuthenticatedContext } from '../../context';
+import { makeOperationDefinition } from './definitions';
+import { getPatientEverything } from './patienteverything';
+import { parseInputParameters } from './utils/parameters';
+
+const SHL_CONTENT_TYPE_FHIR_JSON = 'application/fhir+json';
+
+interface GenerateSmartHealthLinkParams {
+  _type?: string;
+  exp?: number;
+  label?: string;
+  passcode?: string;
+  includeQrCode?: boolean;
+}
+
+interface ResolveSmartHealthLinkParams {
+  shlink?: string;
+  recipient?: string;
+  passcode?: string;
+}
+
+interface SmartHealthLinkPayload {
+  url: string;
+  key: string;
+  exp?: number;
+  flag?: string;
+  label?: string;
+  v: 1;
+}
+
+interface SmartHealthLinkRecord {
+  id: string;
+  projectId: string;
+  patientReference: string;
+  payload: SmartHealthLinkPayload;
+  passcodeHash?: string;
+  files: SmartHealthLinkManifestFile[];
+}
+
+interface SmartHealthLinkManifestFile {
+  contentType: typeof SHL_CONTENT_TYPE_FHIR_JSON;
+  embedded: string;
+  lastUpdated: string;
+}
+
+const smartHealthLinkRecords = new Map<string, SmartHealthLinkRecord>();
+
+export const generateSmartHealthLinkOperation = makeOperationDefinition(
+  { scope: 'instance', resource: 'Patient' },
+  {
+    name: 'GenerateSmartHealthLink',
+    code: 'generate-smart-health-link',
+    affectsState: true,
+    parameter: [
+      { use: 'in', name: '_type', type: 'string', min: 0, max: '1' },
+      { use: 'in', name: 'exp', type: 'integer', min: 0, max: '1' },
+      { use: 'in', name: 'label', type: 'string', min: 0, max: '1' },
+      { use: 'in', name: 'passcode', type: 'string', min: 0, max: '1' },
+      { use: 'in', name: 'includeQrCode', type: 'boolean', min: 0, max: '1' },
+      { use: 'out', name: 'shlink', type: 'string', min: 1, max: '1' },
+      { use: 'out', name: 'manifestUrl', type: 'uri', min: 1, max: '1' },
+      { use: 'out', name: 'qrCodeDataUrl', type: 'string', min: 0, max: '1' },
+      { use: 'out', name: 'id', type: 'id', min: 1, max: '1' },
+    ],
+  }
+);
+
+export const resolveSmartHealthLinkOperation = makeOperationDefinition(
+  { scope: 'system' },
+  {
+    name: 'ResolveSmartHealthLink',
+    code: 'resolve-smart-health-link',
+    affectsState: false,
+    parameter: [
+      { use: 'in', name: 'shlink', type: 'string', min: 1, max: '1' },
+      { use: 'in', name: 'recipient', type: 'string', min: 0, max: '1' },
+      { use: 'in', name: 'passcode', type: 'string', min: 0, max: '1' },
+      { use: 'out', name: 'valid', type: 'boolean', min: 1, max: '1' },
+      { use: 'out', name: 'manifest', type: 'string', min: 0, max: '1' },
+      { use: 'out', name: 'fhirResources', type: 'string', min: 0, max: '1' },
+      { use: 'out', name: 'error', type: 'string', min: 0, max: '1' },
+    ],
+  }
+);
+
+export async function generateSmartHealthLinkHandler(req: FhirRequest): Promise<FhirResponse> {
+  try {
+    const ctx = getAuthenticatedContext();
+    const patient = await ctx.repo.readResource<Patient>('Patient', req.params.id);
+    const params = parseInputParameters<GenerateSmartHealthLinkParams>(generateSmartHealthLinkOperation, req);
+    const bundle = await getPatientEverything(ctx.repo, patient, {
+      _count: 1000,
+      _type: params._type
+        ?.split(',')
+        .map((s) => s.trim() as Resource['resourceType'])
+        .filter(Boolean),
+    });
+    const key = base64url.encode(randomBytes(32));
+    const id = randomUUID();
+    const manifestUrl = concatUrls(getConfig().baseUrl, `/fhir/R4/.well-known/smart-health-links/${id}/manifest.json`);
+    const payload: SmartHealthLinkPayload = {
+      url: manifestUrl,
+      key,
+      exp: params.exp,
+      flag: params.passcode ? 'P' : undefined,
+      label: params.label,
+      v: 1,
+    };
+    const encryptedBundle = await encryptSmartHealthLinkFile(bundle, key);
+    smartHealthLinkRecords.set(id, {
+      id,
+      projectId: ctx.project.id,
+      patientReference: `Patient/${patient.id}`,
+      payload,
+      passcodeHash: params.passcode ? hashPasscode(params.passcode) : undefined,
+      files: [
+        {
+          contentType: SHL_CONTENT_TYPE_FHIR_JSON,
+          embedded: encryptedBundle,
+          lastUpdated: new Date().toISOString(),
+        },
+      ],
+    });
+    const shlink = encodeSmartHealthLink(payload);
+    const qrCodeDataUrl = params.includeQrCode ? await QRCode.toDataURL(shlink) : undefined;
+    return [allOk, makeParameters({ shlink, manifestUrl, qrCodeDataUrl, id })];
+  } catch (err) {
+    return [badRequest(normalizeErrorString(err))];
+  }
+}
+
+export async function resolveSmartHealthLinkHandler(req: FhirRequest): Promise<FhirResponse> {
+  try {
+    const params = parseInputParameters<ResolveSmartHealthLinkParams>(resolveSmartHealthLinkOperation, req);
+    const result = await resolveGeneratedSmartHealthLink(params.shlink as string, params.passcode);
+    return [
+      allOk,
+      makeParameters({
+        valid: true,
+        manifest: JSON.stringify(result.manifest),
+        fhirResources: JSON.stringify(result.fhirResources),
+      }),
+    ];
+  } catch (err) {
+    return [allOk, makeParameters({ valid: false, error: normalizeErrorString(err) })];
+  }
+}
+
+export async function smartHealthLinkManifestHandler(req: Request, res: Response): Promise<void> {
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const record = smartHealthLinkRecords.get(id);
+  if (!record) {
+    res.status(404).json({ error: 'SMART Health Link not found' });
+    return;
+  }
+  const passcode = typeof req.body?.passcode === 'string' ? req.body.passcode : undefined;
+  const outcome = validateSmartHealthLinkRecord(record, passcode);
+  if (outcome) {
+    res.status(400).json({ error: outcome });
+    return;
+  }
+  res.status(200).contentType(ContentType.JSON).json(buildSmartHealthLinkManifest(record));
+}
+
+async function resolveGeneratedSmartHealthLink(
+  shlink: string,
+  passcode?: string
+): Promise<{ manifest: object; fhirResources: Resource[] }> {
+  const payload = parseSmartHealthLink(shlink);
+  const id = getSmartHealthLinkId(payload.url);
+  const record = id ? smartHealthLinkRecords.get(id) : undefined;
+  if (!record) {
+    throw new Error('Only Medplum-generated SMART Health Links are supported by this prototype');
+  }
+  const outcome = validateSmartHealthLinkRecord(record, passcode);
+  if (outcome) {
+    throw new Error(outcome);
+  }
+  const manifest = buildSmartHealthLinkManifest(record);
+  const fhirResources: Resource[] = [];
+  for (const file of record.files) {
+    const { contentType, plaintext } = await decryptSmartHealthLinkFile(file.embedded, payload.key);
+    if (contentType === SHL_CONTENT_TYPE_FHIR_JSON) {
+      fhirResources.push(JSON.parse(plaintext) as Resource);
+    }
+  }
+  return { manifest, fhirResources };
+}
+
+async function encryptSmartHealthLinkFile(bundle: Bundle, key: string): Promise<string> {
+  const plaintext = Buffer.from(JSON.stringify(bundle));
+  return new CompactEncrypt(plaintext)
+    .setProtectedHeader({ alg: 'dir', enc: 'A256GCM', cty: SHL_CONTENT_TYPE_FHIR_JSON })
+    .encrypt(base64url.decode(key));
+}
+
+async function decryptSmartHealthLinkFile(
+  jwe: string,
+  key: string
+): Promise<{ contentType: string | undefined; plaintext: string }> {
+  const { plaintext, protectedHeader } = await compactDecrypt(jwe, base64url.decode(key));
+  return { contentType: protectedHeader.cty, plaintext: Buffer.from(plaintext).toString('utf8') };
+}
+
+function buildSmartHealthLinkManifest(record: SmartHealthLinkRecord): object {
+  return {
+    status: 'finalized',
+    files: record.files,
+  };
+}
+
+function validateSmartHealthLinkRecord(record: SmartHealthLinkRecord, passcode?: string): string | undefined {
+  const now = Math.floor(Date.now() / 1000);
+  if (record.payload.exp !== undefined && record.payload.exp <= now) {
+    return 'SMART Health Link has expired';
+  }
+  if (record.payload.flag?.includes('P') && (!passcode || hashPasscode(passcode) !== record.passcodeHash)) {
+    return 'Invalid SMART Health Link passcode';
+  }
+  return undefined;
+}
+
+function encodeSmartHealthLink(payload: SmartHealthLinkPayload): string {
+  return `shlink:/${base64url.encode(Buffer.from(JSON.stringify(payload)))}`;
+}
+
+function parseSmartHealthLink(input: string): SmartHealthLinkPayload {
+  const raw = input.includes('#shlink:/') ? input.substring(input.indexOf('#shlink:/') + 1) : input;
+  if (!raw.startsWith('shlink:/')) {
+    throw new Error('Invalid SMART Health Link URI');
+  }
+  const payload = JSON.parse(Buffer.from(base64url.decode(raw.substring('shlink:/'.length))).toString('utf8'));
+  if (payload?.v !== 1 || typeof payload.url !== 'string' || typeof payload.key !== 'string') {
+    throw new Error('Invalid SMART Health Link payload');
+  }
+  return payload as SmartHealthLinkPayload;
+}
+
+function getSmartHealthLinkId(manifestUrl: string): string | undefined {
+  const match = manifestUrl.match(/\/smart-health-links\/([^/]+)\/manifest\.json$/);
+  return match?.[1];
+}
+
+function hashPasscode(passcode: string): string {
+  return createHash('sha256').update(passcode).digest('hex');
+}
+
+function makeParameters(values: Record<string, string | boolean | undefined>): Parameters {
+  const parameters: Parameters = { resourceType: 'Parameters', parameter: [] };
+  for (const [name, value] of Object.entries(values)) {
+    if (value === undefined) {
+      continue;
+    }
+    parameters.parameter?.push(
+      typeof value === 'boolean' ? { name, valueBoolean: value } : { name, valueString: value }
+    );
+  }
+  return parameters;
+}

--- a/packages/server/src/fhir/operations/smarthealthlinks.ts
+++ b/packages/server/src/fhir/operations/smarthealthlinks.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { allOk, badRequest, concatUrls, ContentType, normalizeErrorString } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Bundle, Parameters, Patient, Resource } from '@medplum/fhirtypes';
+import type { Bundle, Patient, Resource } from '@medplum/fhirtypes';
 import bcrypt from 'bcrypt';
 import type { Request, Response } from 'express';
 import { base64url, compactDecrypt, CompactEncrypt } from 'jose';
@@ -10,12 +10,12 @@ import { randomBytes, randomUUID } from 'node:crypto';
 import QRCode from 'qrcode';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
-import { makeOperationDefinition } from './definitions';
+import { makeOperationDefinition, makeParameters } from './definitions';
 import { getPatientEverything } from './patienteverything';
 import { parseInputParameters } from './utils/parameters';
 
 const SHL_CONTENT_TYPE_FHIR_JSON = 'application/fhir+json';
-const SHL_PASSCODE_BCRYPT_ROUNDS = 12;
+const SHL_PASSCODE_BCRYPT_ROUNDS = 10;
 
 interface GenerateSmartHealthLinkParams {
   _type?: string;
@@ -260,17 +260,4 @@ function getSmartHealthLinkId(manifestUrl: string): string | undefined {
 
 function hashPasscode(passcode: string): Promise<string> {
   return bcrypt.hash(passcode, SHL_PASSCODE_BCRYPT_ROUNDS);
-}
-
-function makeParameters(values: Record<string, string | boolean | undefined>): Parameters {
-  const parameters: Parameters = { resourceType: 'Parameters', parameter: [] };
-  for (const [name, value] of Object.entries(values)) {
-    if (value === undefined) {
-      continue;
-    }
-    parameters.parameter?.push(
-      typeof value === 'boolean' ? { name, valueBoolean: value } : { name, valueString: value }
-    );
-  }
-  return parameters;
 }

--- a/packages/server/src/fhir/operations/smarthealthlinks.ts
+++ b/packages/server/src/fhir/operations/smarthealthlinks.ts
@@ -254,7 +254,7 @@ function parseSmartHealthLink(input: string): SmartHealthLinkPayload {
 }
 
 function getSmartHealthLinkId(manifestUrl: string): string | undefined {
-  const match = manifestUrl.match(/\/smart-health-links\/([^/]+)\/manifest\.json$/);
+  const match = /\/smart-health-links\/([^/]+)\/manifest\.json$/.exec(manifestUrl);
   return match?.[1];
 }
 

--- a/packages/server/src/fhir/operations/smarthealthlinks.ts
+++ b/packages/server/src/fhir/operations/smarthealthlinks.ts
@@ -3,9 +3,10 @@
 import { allOk, badRequest, concatUrls, ContentType, normalizeErrorString } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Bundle, Parameters, Patient, Resource } from '@medplum/fhirtypes';
+import bcrypt from 'bcrypt';
 import type { Request, Response } from 'express';
 import { base64url, compactDecrypt, CompactEncrypt } from 'jose';
-import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import { randomBytes, randomUUID } from 'node:crypto';
 import QRCode from 'qrcode';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
@@ -14,6 +15,7 @@ import { getPatientEverything } from './patienteverything';
 import { parseInputParameters } from './utils/parameters';
 
 const SHL_CONTENT_TYPE_FHIR_JSON = 'application/fhir+json';
+const SHL_PASSCODE_BCRYPT_ROUNDS = 12;
 
 interface GenerateSmartHealthLinkParams {
   _type?: string;
@@ -122,7 +124,7 @@ export async function generateSmartHealthLinkHandler(req: FhirRequest): Promise<
       projectId: ctx.project.id,
       patientReference: `Patient/${patient.id}`,
       payload,
-      passcodeHash: params.passcode ? hashPasscode(params.passcode) : undefined,
+      passcodeHash: params.passcode ? await hashPasscode(params.passcode) : undefined,
       files: [
         {
           contentType: SHL_CONTENT_TYPE_FHIR_JSON,
@@ -164,7 +166,7 @@ export async function smartHealthLinkManifestHandler(req: Request, res: Response
     return;
   }
   const passcode = typeof req.body?.passcode === 'string' ? req.body.passcode : undefined;
-  const outcome = validateSmartHealthLinkRecord(record, passcode);
+  const outcome = await validateSmartHealthLinkRecord(record, passcode);
   if (outcome) {
     res.status(400).json({ error: outcome });
     return;
@@ -182,7 +184,7 @@ async function resolveGeneratedSmartHealthLink(
   if (!record) {
     throw new Error('Only Medplum-generated SMART Health Links are supported by this prototype');
   }
-  const outcome = validateSmartHealthLinkRecord(record, passcode);
+  const outcome = await validateSmartHealthLinkRecord(record, passcode);
   if (outcome) {
     throw new Error(outcome);
   }
@@ -219,13 +221,18 @@ function buildSmartHealthLinkManifest(record: SmartHealthLinkRecord): object {
   };
 }
 
-function validateSmartHealthLinkRecord(record: SmartHealthLinkRecord, passcode?: string): string | undefined {
+async function validateSmartHealthLinkRecord(
+  record: SmartHealthLinkRecord,
+  passcode?: string
+): Promise<string | undefined> {
   const now = Math.floor(Date.now() / 1000);
   if (record.payload.exp !== undefined && record.payload.exp <= now) {
     return 'SMART Health Link has expired';
   }
-  if (record.payload.flag?.includes('P') && (!passcode || hashPasscode(passcode) !== record.passcodeHash)) {
-    return 'Invalid SMART Health Link passcode';
+  if (record.payload.flag?.includes('P')) {
+    if (!passcode || !record.passcodeHash || !(await bcrypt.compare(passcode, record.passcodeHash))) {
+      return 'Invalid SMART Health Link passcode';
+    }
   }
   return undefined;
 }
@@ -251,8 +258,8 @@ function getSmartHealthLinkId(manifestUrl: string): string | undefined {
   return match?.[1];
 }
 
-function hashPasscode(passcode: string): string {
-  return createHash('sha256').update(passcode).digest('hex');
+function hashPasscode(passcode: string): Promise<string> {
+  return bcrypt.hash(passcode, SHL_PASSCODE_BCRYPT_ROUNDS);
 }
 
 function makeParameters(values: Record<string, string | boolean | undefined>): Parameters {

--- a/packages/server/src/fhir/operations/smarthealthlinks.ts
+++ b/packages/server/src/fhir/operations/smarthealthlinks.ts
@@ -70,7 +70,7 @@ export const generateSmartHealthLinkOperation = makeOperationDefinition(
       { use: 'in', name: 'passcode', type: 'string', min: 0, max: '1' },
       { use: 'in', name: 'includeQrCode', type: 'boolean', min: 0, max: '1' },
       { use: 'out', name: 'shlink', type: 'string', min: 1, max: '1' },
-      { use: 'out', name: 'manifestUrl', type: 'uri', min: 1, max: '1' },
+      { use: 'out', name: 'manifestUrl', type: 'string', min: 1, max: '1' },
       { use: 'out', name: 'qrCodeDataUrl', type: 'string', min: 0, max: '1' },
       { use: 'out', name: 'id', type: 'id', min: 1, max: '1' },
     ],

--- a/packages/server/src/fhir/operations/smarthealthlinks.ts
+++ b/packages/server/src/fhir/operations/smarthealthlinks.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { allOk, badRequest, concatUrls, ContentType, isString, normalizeErrorString } from '@medplum/core';
+import { allOk, concatUrls, ContentType, isString, normalizeErrorString } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Bundle, Patient, Resource } from '@medplum/fhirtypes';
 import bcrypt from 'bcrypt';
@@ -10,9 +10,9 @@ import { randomBytes, randomUUID } from 'node:crypto';
 import QRCode from 'qrcode';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
-import { makeOperationDefinition, makeParameters } from './definitions';
+import { makeOperationDefinition } from './definitions';
 import { getPatientEverything } from './patienteverything';
-import { parseInputParameters } from './utils/parameters';
+import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
 const SHL_CONTENT_TYPE_FHIR_JSON = 'application/fhir+json';
 const SHL_PASSCODE_BCRYPT_ROUNDS = 10;
@@ -96,49 +96,45 @@ export const resolveSmartHealthLinkOperation = makeOperationDefinition(
 );
 
 export async function generateSmartHealthLinkHandler(req: FhirRequest): Promise<FhirResponse> {
-  try {
-    const ctx = getAuthenticatedContext();
-    const patient = await ctx.repo.readResource<Patient>('Patient', req.params.id);
-    const params = parseInputParameters<GenerateSmartHealthLinkParams>(generateSmartHealthLinkOperation, req);
-    const bundle = await getPatientEverything(ctx.repo, patient, {
-      _count: 1000,
-      _type: params._type
-        ?.split(',')
-        .map((s) => s.trim() as Resource['resourceType'])
-        .filter(Boolean),
-    });
-    const key = base64url.encode(randomBytes(32));
-    const id = randomUUID();
-    const manifestUrl = concatUrls(getConfig().baseUrl, `/fhir/R4/.well-known/smart-health-links/${id}/manifest.json`);
-    const payload: SmartHealthLinkPayload = {
-      url: manifestUrl,
-      key,
-      exp: params.exp,
-      flag: params.passcode ? 'P' : undefined,
-      label: params.label,
-      v: 1,
-    };
-    const encryptedBundle = await encryptSmartHealthLinkFile(bundle, key);
-    smartHealthLinkRecords.set(id, {
-      id,
-      projectId: ctx.project.id,
-      patientReference: `Patient/${patient.id}`,
-      payload,
-      passcodeHash: params.passcode ? await hashPasscode(params.passcode) : undefined,
-      files: [
-        {
-          contentType: SHL_CONTENT_TYPE_FHIR_JSON,
-          embedded: encryptedBundle,
-          lastUpdated: new Date().toISOString(),
-        },
-      ],
-    });
-    const shlink = encodeSmartHealthLink(payload);
-    const qrCodeDataUrl = params.includeQrCode ? await QRCode.toDataURL(shlink) : undefined;
-    return [allOk, makeParameters({ shlink, manifestUrl, qrCodeDataUrl, id })];
-  } catch (err) {
-    return [badRequest(normalizeErrorString(err))];
-  }
+  const ctx = getAuthenticatedContext();
+  const patient = await ctx.repo.readResource<Patient>('Patient', req.params.id);
+  const params = parseInputParameters<GenerateSmartHealthLinkParams>(generateSmartHealthLinkOperation, req);
+  const bundle = await getPatientEverything(ctx.repo, patient, {
+    _count: 1000,
+    _type: params._type
+      ?.split(',')
+      .map((s) => s.trim() as Resource['resourceType'])
+      .filter(Boolean),
+  });
+  const key = base64url.encode(randomBytes(32));
+  const id = randomUUID();
+  const manifestUrl = concatUrls(getConfig().baseUrl, `/fhir/R4/.well-known/smart-health-links/${id}/manifest.json`);
+  const payload: SmartHealthLinkPayload = {
+    url: manifestUrl,
+    key,
+    exp: params.exp,
+    flag: params.passcode ? 'P' : undefined,
+    label: params.label,
+    v: 1,
+  };
+  const encryptedBundle = await encryptSmartHealthLinkFile(bundle, key);
+  smartHealthLinkRecords.set(id, {
+    id,
+    projectId: ctx.project.id,
+    patientReference: `Patient/${patient.id}`,
+    payload,
+    passcodeHash: params.passcode ? await hashPasscode(params.passcode) : undefined,
+    files: [
+      {
+        contentType: SHL_CONTENT_TYPE_FHIR_JSON,
+        embedded: encryptedBundle,
+        lastUpdated: new Date().toISOString(),
+      },
+    ],
+  });
+  const shlink = encodeSmartHealthLink(payload);
+  const qrCodeDataUrl = params.includeQrCode ? await QRCode.toDataURL(shlink) : undefined;
+  return [allOk, buildOutputParameters(generateSmartHealthLinkOperation, { shlink, manifestUrl, qrCodeDataUrl, id })];
 }
 
 export async function resolveSmartHealthLinkHandler(req: FhirRequest): Promise<FhirResponse> {
@@ -150,14 +146,14 @@ export async function resolveSmartHealthLinkHandler(req: FhirRequest): Promise<F
     const result = await resolveGeneratedSmartHealthLink(params.shlink, params.passcode);
     return [
       allOk,
-      makeParameters({
+      buildOutputParameters(resolveSmartHealthLinkOperation, {
         valid: true,
         manifest: JSON.stringify(result.manifest),
         fhirResources: JSON.stringify(result.fhirResources),
       }),
     ];
   } catch (err) {
-    return [allOk, makeParameters({ valid: false, error: normalizeErrorString(err) })];
+    return [allOk, buildOutputParameters(resolveSmartHealthLinkOperation, { valid: false, error: normalizeErrorString(err) })];
   }
 }
 
@@ -245,7 +241,8 @@ function encodeSmartHealthLink(payload: SmartHealthLinkPayload): string {
 }
 
 function parseSmartHealthLink(input: string): SmartHealthLinkPayload {
-  const raw = input.includes('#shlink:/') ? input.substring(input.indexOf('#shlink:/') + 1) : input;
+  const fragmentIndex = input.indexOf('#shlink:/');
+  const raw = fragmentIndex === -1 ? input : input.substring(fragmentIndex + 1);
   if (!raw.startsWith('shlink:/')) {
     throw new Error('Invalid SMART Health Link URI');
   }

--- a/packages/server/src/fhir/operations/smarthealthlinks.ts
+++ b/packages/server/src/fhir/operations/smarthealthlinks.ts
@@ -153,7 +153,10 @@ export async function resolveSmartHealthLinkHandler(req: FhirRequest): Promise<F
       }),
     ];
   } catch (err) {
-    return [allOk, buildOutputParameters(resolveSmartHealthLinkOperation, { valid: false, error: normalizeErrorString(err) })];
+    return [
+      allOk,
+      buildOutputParameters(resolveSmartHealthLinkOperation, { valid: false, error: normalizeErrorString(err) }),
+    ];
   }
 }
 

--- a/packages/server/src/fhir/operations/smarthealthlinks.ts
+++ b/packages/server/src/fhir/operations/smarthealthlinks.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { allOk, badRequest, concatUrls, ContentType, normalizeErrorString } from '@medplum/core';
+import { allOk, badRequest, concatUrls, ContentType, isString, normalizeErrorString } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Bundle, Patient, Resource } from '@medplum/fhirtypes';
 import bcrypt from 'bcrypt';
@@ -144,7 +144,10 @@ export async function generateSmartHealthLinkHandler(req: FhirRequest): Promise<
 export async function resolveSmartHealthLinkHandler(req: FhirRequest): Promise<FhirResponse> {
   try {
     const params = parseInputParameters<ResolveSmartHealthLinkParams>(resolveSmartHealthLinkOperation, req);
-    const result = await resolveGeneratedSmartHealthLink(params.shlink as string, params.passcode);
+    if (!isString(params.shlink)) {
+      throw new Error('Expected shlink to be a string');
+    }
+    const result = await resolveGeneratedSmartHealthLink(params.shlink, params.passcode);
     return [
       allOk,
       makeParameters({

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -75,6 +75,12 @@ import { userRescopeOperation } from './operations/rescope';
 import { resourceGraphHandler } from './operations/resourcegraph';
 import { rotateSecretHandler } from './operations/rotatesecret';
 import { setAccountsHandler } from './operations/set-accounts';
+import { generateSmartHealthCardHandler, verifySmartHealthCardHandler } from './operations/smarthealthcards';
+import {
+  generateSmartHealthLinkHandler,
+  resolveSmartHealthLinkHandler,
+  smartHealthLinkManifestHandler,
+} from './operations/smarthealthlinks';
 import { structureDefinitionExpandProfileHandler } from './operations/structuredefinitionexpandprofile';
 import { codeSystemSubsumesOperation } from './operations/subsumes';
 import { updateUserEmailOperation } from './operations/update-user-email';
@@ -169,6 +175,7 @@ publicRoutes.get(['/$versions', '/%24versions'], (_req: Request, res: Response) 
 // See: https://build.fhir.org/ig/HL7/smart-app-launch/conformance.html#sample-request
 publicRoutes.get('/.well-known/smart-configuration', smartConfigurationHandler);
 publicRoutes.get('/.well-known/smart-styles.json', smartStylingHandler);
+publicRoutes.post('/.well-known/smart-health-links/:id/manifest.json', smartHealthLinkManifestHandler);
 
 // Protected routes require authentication
 const protectedRoutes = Router().use(authenticateRequest);
@@ -372,6 +379,14 @@ function initInternalFhirRouter(): FhirRouter {
   // Patient $ccda-export operation
   router.add('GET', '/Patient/:id/$ccda-export', ccdaExportHandler);
   router.add('POST', '/Patient/:id/$ccda-export', ccdaExportHandler);
+
+  // SMART Health Cards operations
+  router.add('POST', '/Patient/:id/$generate-smart-health-card', generateSmartHealthCardHandler);
+  router.add('POST', '/$verify-smart-health-card', verifySmartHealthCardHandler);
+
+  // SMART Health Links operations
+  router.add('POST', '/Patient/:id/$generate-smart-health-link', generateSmartHealthLinkHandler);
+  router.add('POST', '/$resolve-smart-health-link', resolveSmartHealthLinkHandler);
 
   // QuestionnaireResponse $extract operation
   router.add('GET', '/QuestionnaireResponse/:id/$extract', extractHandler);

--- a/packages/server/src/oauth/keys.test.ts
+++ b/packages/server/src/oauth/keys.test.ts
@@ -218,6 +218,15 @@ describe('Keys', () => {
     expect(generateSecret(32)).toHaveLength(64);
   });
 
+  test('Get signing key by algorithm', async () => {
+    const config = await loadTestConfig();
+    await initKeys(config);
+
+    expect(getSigningKey()).toBeDefined();
+    expect(getSigningKey('ES256')).toBeDefined();
+    expect(() => getSigningKey('none')).toThrow('Signing key not found for alg: none');
+  });
+
   test('Generate access token with email', async () => {
     const config = await loadTestConfig();
     await initKeys(config);

--- a/packages/server/src/oauth/keys.ts
+++ b/packages/server/src/oauth/keys.ts
@@ -93,14 +93,17 @@ const DEFAULT_REFRESH_LIFETIME = '2w';
 
 let issuer: string | undefined;
 const publicKeys: Record<string, KeyLike> = {};
+const allSigningKeys: Record<string, KeyLike> = {};
 const jwks: { keys: JWK[] } = { keys: [] };
 let jsonWebKey: JsonWebKey | undefined;
-let signingKey: KeyLike | undefined;
+let jsonWebKeys: JsonWebKey[] = [];
+let defaultSigningKey: KeyLike | undefined;
 
 export async function initKeys(config: MedplumServerConfig): Promise<void> {
   issuer = undefined;
   jsonWebKey = undefined;
-  signingKey = undefined;
+  jsonWebKeys = [];
+  defaultSigningKey = undefined;
   jwks.keys = [];
 
   if (!config) {
@@ -117,8 +120,6 @@ export async function initKeys(config: MedplumServerConfig): Promise<void> {
     resourceType: 'JsonWebKey',
     filters: [{ code: 'active', operator: Operator.EQUALS, value: 'true' }],
   });
-
-  let jsonWebKeys: JsonWebKey[] | undefined;
 
   if (searchResult.length > 0) {
     globalLogger.info(`Loaded ${searchResult.length} key(s) from the database`);
@@ -163,14 +164,15 @@ export async function initKeys(config: MedplumServerConfig): Promise<void> {
 
     // Convert from JWK to PKCS and add to the collection of public keys
     publicKeys[jwk.id as string] = (await importJWK(publicKey)) as KeyLike;
+    allSigningKeys[jwk.id as string] = (await importJWK({
+      ...(jwk as JWK),
+      use: 'sig',
+    })) as KeyLike;
   }
 
   // Use the first key as the signing key
   jsonWebKey = jsonWebKeys[0];
-  signingKey = (await importJWK({
-    ...(jsonWebKey as JWK),
-    use: 'sig',
-  })) as KeyLike;
+  defaultSigningKey = allSigningKeys[jsonWebKey.id as string];
 }
 
 /**
@@ -184,10 +186,23 @@ export function getJwks(): { keys: JWK[] } {
 
 /**
  * Returns the current signing key.
+ * @param alg - Optional signing algorithm.  If not provided, the default signing key will be returned.
  * @returns The current signing key.
  */
-export function getSigningKey(): KeyLike {
-  return signingKey as KeyLike;
+export function getSigningKey(alg?: string): KeyLike {
+  if (!alg) {
+    if (!defaultSigningKey) {
+      throw new Error('Signing key not initialized');
+    }
+    return defaultSigningKey;
+  }
+
+  const jwk = jsonWebKeys.find((key) => (key.alg ?? LEGACY_DEFAULT_ALG) === alg);
+  const key = jwk?.id ? allSigningKeys[jwk.id] : undefined;
+  if (!key) {
+    throw new Error(`Signing key not found for alg: ${alg}`);
+  }
+  return key;
 }
 
 /**
@@ -242,7 +257,7 @@ export function generateRefreshToken(claims: MedplumRefreshTokenClaims, lifetime
  * @returns Promise to generate and sign the JWT.
  */
 async function generateJwt(exp: string, claims: JWTPayload): Promise<string> {
-  if (!jsonWebKey || !signingKey || !issuer) {
+  if (!jsonWebKey || !defaultSigningKey || !issuer) {
     throw new Error('Signing key not initialized');
   }
 
@@ -263,7 +278,7 @@ async function generateJwt(exp: string, claims: JWTPayload): Promise<string> {
     .setIssuer(issuer)
     .setAudience(claims.aud ?? (claims.client_id as string))
     .setExpirationTime(exp)
-    .sign(signingKey);
+    .sign(defaultSigningKey);
 }
 
 /**


### PR DESCRIPTION
Adds initial Medplum server support for SMART Health Cards and SMART Health Links as FHIR operations.

https://build.fhir.org/ig/HL7/smart-health-cards-and-links/

New operations:

- `POST /fhir/R4/Patient/:id/$generate-smart-health-card`
- `POST /fhir/R4/$verify-smart-health-card`
- `POST /fhir/R4/Patient/:id/$generate-smart-health-link`
- `POST /fhir/R4/$resolve-smart-health-link`

Also adds a public generated-SHL manifest endpoint:

- `POST /fhir/R4/.well-known/smart-health-links/:id/manifest.json`

# Changes

- Added SMART Health Card generation from a patient compartment bundle.
- Added SHC output artifacts:
  - compact JWS credential
  - `shc:/` numeric URI
  - `.smart-health-card` JSON file content
  - optional QR code data URL
- Added SHC verification for:
  - compact JWS credentials
  - `shc:/` numeric values
  - `.smart-health-card` file JSON
- Reused existing OAuth signing key infrastructure for SHC signing.
  - `getSigningKey(alg?)` now optionally returns the first active key matching an algorithm.
  - SHC generation uses the active `ES256` key from existing `JsonWebKey` resources.
  - This removes the original prototype's ephemeral in-memory signing key.
- Added external SHC verification support.
  - Local Medplum JWKS is checked first.
  - External issuer JWKS is fetched from `https://issuer/.well-known/jwks.json`.
  - Verification response distinguishes:
    - `signatureValid`
    - `issuerTrusted`
    - `verified`
- Added initial SMART Health Link generation and resolution.
  - Generates `shlink:/` payloads.
  - Encrypts bundled FHIR JSON as JWE `dir` + `A256GCM`.
  - Supports optional passcode protection with `bcrypt`.
  - Serves manifests for Medplum-generated links.
  - Resolves Medplum-generated links and returns decrypted FHIR resources.
- Added focused tests for happy paths, failure paths, external SHC verification, key selection, and passcode behavior.

# Notes / Limitations

This is still an initial server-side prototype, not a complete production rollout.

- SHL persistence is currently in-memory.
- SHL encrypted files are embedded in the manifest rather than stored durably in Binary/storage.
- SHL external resolution is not implemented yet.
- SHC external issuer trust is intentionally conservative:
  - External signatures can validate cryptographically.
  - External issuers are not marked trusted.
  - `verified` is only true for Medplum-trusted issuer/key combinations.
- External JWKS fetching has first-pass safety controls:
  - HTTPS only
  - no redirects
  - timeout
  - basic localhost/private IP literal rejection
  - DNS private-range resolution checks should be added before treating this as hardened remote fetch infrastructure.

