### PR TITLE
Fix auto syncing order set

### DIFF
--- a/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.test.tsx
+++ b/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { OperationOutcome } from '@medplum/fhirtypes';
+import { OperationOutcomeError } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { act, renderHook } from '@testing-library/react';
 import type { JSX, ReactNode } from 'react';
@@ -34,32 +34,34 @@ describe('useSyncOrderSet', () => {
 
   test('silently no-ops when operation is not deployed (not-found)', async () => {
     const medplum = new MockClient();
-    const notFound: OperationOutcome = {
-      resourceType: 'OperationOutcome',
-      issue: [{ severity: 'error', code: 'not-found', diagnostics: 'Operation not found' }],
-    };
-    jest.spyOn(medplum, 'post').mockRejectedValue(notFound);
+    jest.spyOn(medplum, 'post').mockRejectedValue(
+      new OperationOutcomeError({
+        resourceType: 'OperationOutcome',
+        issue: [{ severity: 'error', code: 'not-found', diagnostics: 'Operation not found' }],
+      })
+    );
 
     const { result } = renderHook(() => useSyncOrderSet(), { wrapper: wrapper(medplum) });
 
     await act(async () => {
-      // Should resolve without throwing
       await expect(result.current('plan-def-123')).resolves.toBeUndefined();
     });
   });
 
   test('re-throws non-not-found errors', async () => {
     const medplum = new MockClient();
-    const serverError: OperationOutcome = {
-      resourceType: 'OperationOutcome',
-      issue: [{ severity: 'error', code: 'exception', diagnostics: 'Internal server error' }],
-    };
-    jest.spyOn(medplum, 'post').mockRejectedValue(serverError);
+    jest.spyOn(medplum, 'post').mockRejectedValue(
+      new OperationOutcomeError({
+        resourceType: 'OperationOutcome',
+        issue: [{ severity: 'error', code: 'exception', diagnostics: 'Internal server error' }],
+      })
+    );
 
     const { result } = renderHook(() => useSyncOrderSet(), { wrapper: wrapper(medplum) });
 
     await act(async () => {
-      await expect(result.current('plan-def-123')).rejects.toMatchObject({ resourceType: 'OperationOutcome' });
+      await expect(result.current('plan-def-123')).rejects.toBeInstanceOf(OperationOutcomeError);
     });
   });
 });
+

--- a/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.test.tsx
+++ b/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.test.tsx
@@ -64,4 +64,3 @@ describe('useSyncOrderSet', () => {
     });
   });
 });
-

--- a/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.ts
+++ b/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.ts
@@ -33,4 +33,3 @@ export function useSyncOrderSet(): (planDefinitionId: string) => Promise<void> {
     [medplum]
   );
 }
-

--- a/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.ts
+++ b/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { isOperationOutcome } from '@medplum/core';
+import { OperationOutcomeError } from '@medplum/core';
 import { useCallback } from 'react';
 import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
 
@@ -24,7 +24,7 @@ export function useSyncOrderSet(): (planDefinitionId: string) => Promise<void> {
         await medplum.post(medplum.fhirUrl('PlanDefinition', '$sync-orderset'), { planDefinitionId });
       } catch (err: unknown) {
         // If the operation isn't deployed, silently skip — project has no e-prescribing vendor configured.
-        if (isOperationOutcome(err) && err.issue?.some((i) => i.code === 'not-found')) {
+        if (err instanceof OperationOutcomeError && err.outcome.issue?.some((i) => i.code === 'not-found')) {
           return;
         }
         throw err;
@@ -33,3 +33,4 @@ export function useSyncOrderSet(): (planDefinitionId: string) => Promise<void> {
     [medplum]
   );
 }
+


### PR DESCRIPTION
[Last PR](https://github.com/medplum/medplum/pull/9307) that got merged didn't actually swallow the "not-found" error when a user doesn't have the `$sync-orderset` set (i.e. ScriptSure hasn't been deployed in their project yet). This is a fix to ensure it does happen. 