### PR TITLE
fhircast-v3.0.0/R4

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -38,6 +38,7 @@ import { sendOutcome } from './fhir/outcomes';
 import { fhirRouter } from './fhir/routes';
 import { loadStructureDefinitions } from './fhir/structure';
 import { fhircastSTU2Router, fhircastSTU3Router } from './fhircast/routes';
+import { fhircastR4Router } from './fhircast-r4/routes';
 import { cleanupReservedDatabaseConnections, healthcheckHandler } from './healthcheck';
 import { cleanupHeartbeat, initHeartbeat } from './heartbeat';
 import { hl7BodyParser } from './hl7/parser';
@@ -234,6 +235,7 @@ export async function initApp(app: Express, config: MedplumServerConfig): Promis
   apiRouter.use('/fhir/R4/', fhirRouter);
   apiRouter.use('/fhircast/STU2/', fhircastSTU2Router);
   apiRouter.use('/fhircast/STU3/', fhircastSTU3Router);
+  apiRouter.use('/fhircast/R4/', fhircastR4Router);
   apiRouter.use('/keyvalue/v1/', keyValueRouter);
   apiRouter.use('/oauth2/', oauthRouter);
   apiRouter.use('/scim/v2/', scimRouter);

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -38,7 +38,7 @@ import { sendOutcome } from './fhir/outcomes';
 import { fhirRouter } from './fhir/routes';
 import { loadStructureDefinitions } from './fhir/structure';
 import { fhircastSTU2Router, fhircastSTU3Router } from './fhircast/routes';
-import { fhircastR4Router } from './fhircast-r4/routes';
+import { fhircastR4Router, FHIRCAST_R4_MOUNT_PATH } from './fhircast-r4/routes';
 import { cleanupReservedDatabaseConnections, healthcheckHandler } from './healthcheck';
 import { cleanupHeartbeat, initHeartbeat } from './heartbeat';
 import { hl7BodyParser } from './hl7/parser';
@@ -235,7 +235,8 @@ export async function initApp(app: Express, config: MedplumServerConfig): Promis
   apiRouter.use('/fhir/R4/', fhirRouter);
   apiRouter.use('/fhircast/STU2/', fhircastSTU2Router);
   apiRouter.use('/fhircast/STU3/', fhircastSTU3Router);
-  apiRouter.use('/fhircast/R4/', fhircastR4Router);
+  apiRouter.use(FHIRCAST_R4_MOUNT_PATH, fhircastR4Router);
+  apiRouter.use('/hub', fhircastR4Router); // OHIF compat alias → /api/hub
   apiRouter.use('/keyvalue/v1/', keyValueRouter);
   apiRouter.use('/oauth2/', oauthRouter);
   apiRouter.use('/scim/v2/', scimRouter);

--- a/packages/server/src/cors.ts
+++ b/packages/server/src/cors.ts
@@ -42,6 +42,7 @@ function isOriginAllowed(origin: string | undefined): boolean {
 const prefixes = [
   '/.well-known/',
   '/admin/',
+  '/api/hub',
   '/auth/',
   '/cds-services',
   '/email/',

--- a/packages/server/src/fhir/metadata.ts
+++ b/packages/server/src/fhir/metadata.ts
@@ -225,7 +225,7 @@ function buildRest(config: MedplumServerConfig): CapabilityStatementRest[] {
           extension: [
             {
               url: 'hub.url',
-              valueUrl: `${config.baseUrl}fhircast/STU3`,
+              valueUrl: `${config.baseUrl}fhircast/R4`,
             },
           ],
           url: 'http://hl7.org/fhir/uv/fhircast/StructureDefinition/fhircast-configuration-extension',

--- a/packages/server/src/fhir/metadata.ts
+++ b/packages/server/src/fhir/metadata.ts
@@ -21,6 +21,7 @@ import type {
 } from '@medplum/fhirtypes';
 import { getConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
+import { getFhircastHubUrl } from '../fhircast-r4/routes';
 
 /**
  * The base CapabilityStatement that seeds the server generated statement.
@@ -225,7 +226,7 @@ function buildRest(config: MedplumServerConfig): CapabilityStatementRest[] {
           extension: [
             {
               url: 'hub.url',
-              valueUrl: `${config.baseUrl}fhircast/R4`,
+              valueUrl: getFhircastHubUrl(config.baseUrl),
             },
           ],
           url: 'http://hl7.org/fhir/uv/fhircast/StructureDefinition/fhircast-configuration-extension',

--- a/packages/server/src/fhircast-r4/context-store.ts
+++ b/packages/server/src/fhircast-r4/context-store.ts
@@ -1,0 +1,377 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { CurrentContext, FhircastAnchorResourceType, FhircastEventPayload, FhircastEventName } from '@medplum/core';
+import { generateId, badRequest, OperationOutcomeError, isResource, EMPTY, append } from '@medplum/core';
+import type { Bundle, BundleEntry, Resource } from '@medplum/fhirtypes';
+import { getCacheRedis } from '../redis';
+import { getLogger } from '../logger';
+import { RedisKeys } from './types';
+
+// Lua script for atomic compare-and-set on context updates.
+// KEYS[1] = context key
+// ARGV[1] = expected versionId
+// ARGV[2] = new context JSON
+// Returns: 1 on success, 0 on version mismatch, -1 if no context exists
+const COMPARE_AND_SET_LUA = `
+local current = redis.call('GET', KEYS[1])
+if not current then
+  return -1
+end
+local decoded = cjson.decode(current)
+if decoded['context.versionId'] ~= ARGV[1] then
+  return 0
+end
+redis.call('SET', KEYS[1], ARGV[2])
+return 1
+`;
+
+const RESOURCE_TYPE_LOWER_TO_VALID: Record<string, FhircastAnchorResourceType> = {
+  patient: 'Patient',
+  imagingstudy: 'ImagingStudy',
+  encounter: 'Encounter',
+  diagnosticreport: 'DiagnosticReport',
+};
+
+/**
+ * Extract the anchor resource type from an event name.
+ * E.g. "Patient-open" -> "Patient", "DiagnosticReport-update" -> "DiagnosticReport"
+ */
+export function extractAnchorResourceType(eventName: string): FhircastAnchorResourceType {
+  const lowered = eventName.split('-')[0].toLowerCase();
+  const resourceType = RESOURCE_TYPE_LOWER_TO_VALID[lowered];
+  if (!resourceType) {
+    throw new OperationOutcomeError(badRequest(`Invalid anchor resource type in event: ${eventName}`));
+  }
+  return resourceType;
+}
+
+/**
+ * Get the current context for a topic.
+ */
+export async function getCurrentContext(
+  projectId: string,
+  topic: string
+): Promise<CurrentContext<FhircastAnchorResourceType> | undefined> {
+  const key = RedisKeys.topicCurrentContext(projectId, topic);
+  const value = await getCacheRedis().get(key);
+  if (!value) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    getLogger().error('[FHIRcast R4] Failed to parse current context', { projectId, topic });
+    return undefined;
+  }
+}
+
+/**
+ * Set the current context for a topic.
+ */
+export async function setCurrentContext(
+  projectId: string,
+  topic: string,
+  context: CurrentContext<FhircastAnchorResourceType>
+): Promise<void> {
+  const key = RedisKeys.topicCurrentContext(projectId, topic);
+  await getCacheRedis().set(key, JSON.stringify(context));
+}
+
+/**
+ * Atomically update the current context with compare-and-set.
+ * Returns true if the update succeeded, false if version mismatch.
+ * Throws if no context exists.
+ */
+export async function compareAndSetContext(
+  projectId: string,
+  topic: string,
+  expectedVersionId: string,
+  newContext: CurrentContext<FhircastAnchorResourceType>
+): Promise<boolean> {
+  const key = RedisKeys.topicCurrentContext(projectId, topic);
+  const result = await getCacheRedis().eval(COMPARE_AND_SET_LUA, 1, key, expectedVersionId, JSON.stringify(newContext));
+
+  if (result === -1) {
+    throw new OperationOutcomeError(badRequest('No context currently open for this topic'));
+  }
+  return result === 1;
+}
+
+/**
+ * Clear the current context for a topic.
+ */
+export async function clearCurrentContext(projectId: string, topic: string): Promise<void> {
+  const key = RedisKeys.topicCurrentContext(projectId, topic);
+  await getCacheRedis().del(key);
+}
+
+/**
+ * Store a context for later retrieval (DiagnosticReport multi-context).
+ */
+export async function storeContext(
+  projectId: string,
+  topic: string,
+  resourceId: string,
+  context: CurrentContext<FhircastAnchorResourceType>
+): Promise<void> {
+  const key = RedisKeys.topicContextStorage(projectId, topic);
+  await getCacheRedis().hset(key, resourceId, JSON.stringify(context));
+}
+
+/**
+ * Fetch a stored context by resource ID.
+ */
+export async function fetchStoredContext(
+  projectId: string,
+  topic: string,
+  resourceId: string
+): Promise<CurrentContext<FhircastAnchorResourceType> | undefined> {
+  const key = RedisKeys.topicContextStorage(projectId, topic);
+  const value = await getCacheRedis().hget(key, resourceId);
+  if (!value) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Remove a stored context.
+ */
+export async function removeStoredContext(projectId: string, topic: string, resourceId: string): Promise<void> {
+  const key = RedisKeys.topicContextStorage(projectId, topic);
+  await getCacheRedis().hdel(key, resourceId);
+}
+
+/**
+ * Remove all stored contexts for a topic.
+ */
+export async function clearStoredContexts(projectId: string, topic: string): Promise<void> {
+  const key = RedisKeys.topicContextStorage(projectId, topic);
+  await getCacheRedis().del(key);
+}
+
+/**
+ * Handle an open context change request.
+ * Returns the updated event payload with context.versionId set.
+ */
+export async function handleOpenEvent(
+  projectId: string,
+  event: FhircastEventPayload
+): Promise<void> {
+  const topic = event['hub.topic'];
+  const anchorResourceType = extractAnchorResourceType(event['hub.event']);
+
+  // If there's a current context that is DiagnosticReport, store it before replacing
+  const currentContext = await getCurrentContext(projectId, topic);
+  if (currentContext?.['context.type'] === 'DiagnosticReport') {
+    const report = currentContext.context.find((ctx) => ctx.key === 'report')?.resource;
+    if (isResource(report, 'DiagnosticReport') && report.id) {
+      await storeContext(projectId, topic, report.id, currentContext);
+    }
+  }
+
+  // Check if we have a stored context for a DiagnosticReport being reopened
+  if (anchorResourceType === 'DiagnosticReport') {
+    const anchorReport = (event.context as Array<{ key: string; resource: Resource }>).find(
+      (ctx) => ctx.key === 'report'
+    )?.resource;
+
+    if (anchorReport?.id) {
+      const storedContext = await fetchStoredContext(projectId, topic, anchorReport.id);
+      if (storedContext) {
+        await setCurrentContext(projectId, topic, storedContext);
+        event['context.versionId'] = storedContext['context.versionId'];
+        return;
+      }
+    }
+  }
+
+  // Create new context
+  event['context.versionId'] = generateId();
+
+  if (anchorResourceType === 'DiagnosticReport') {
+    await setCurrentContext(projectId, topic, {
+      'context.type': 'DiagnosticReport',
+      context: [
+        ...event.context,
+        {
+          key: 'content',
+          resource: { id: generateId(), resourceType: 'Bundle', type: 'collection' },
+        },
+      ],
+      'context.versionId': event['context.versionId'],
+    } as CurrentContext<'DiagnosticReport'>);
+  } else {
+    await setCurrentContext(projectId, topic, {
+      'context.type': anchorResourceType,
+      context: event.context,
+      'context.versionId': event['context.versionId'],
+    } as CurrentContext<typeof anchorResourceType>);
+  }
+}
+
+/**
+ * Handle a close context change request.
+ */
+export async function handleCloseEvent(
+  projectId: string,
+  event: FhircastEventPayload
+): Promise<void> {
+  const topic = event['hub.topic'];
+
+  // If closing a DiagnosticReport, clean up its stored context
+  const report = (event.context as Array<{ key: string; resource: Resource }>).find(
+    (ctx) => ctx.key === 'report'
+  )?.resource;
+
+  if (report?.id) {
+    await removeStoredContext(projectId, topic, report.id);
+  }
+
+  // Clear the current context
+  await clearCurrentContext(projectId, topic);
+}
+
+/**
+ * Handle an update context change request (DiagnosticReport-update).
+ * Validates version ID, processes Bundle operations, updates context atomically.
+ * Returns the prior version ID on success.
+ */
+export async function handleUpdateEvent(
+  projectId: string,
+  event: FhircastEventPayload
+): Promise<string> {
+  const topic = event['hub.topic'];
+  const currentContext = await getCurrentContext(projectId, topic);
+
+  if (!currentContext || currentContext['context.type'] !== 'DiagnosticReport') {
+    throw new OperationOutcomeError(badRequest('No DiagnosticReport currently open for this topic'));
+  }
+
+  const priorVersionId = currentContext['context.versionId'];
+
+  // Version check
+  if (event['context.versionId'] !== priorVersionId) {
+    throw new OperationOutcomeError(
+      badRequest(
+        `Version mismatch: expected '${priorVersionId}', received '${event['context.versionId'] || '(empty)'}'`
+      )
+    );
+  }
+
+  // Extract and validate updates bundle
+  const updates = event.context.find(
+    (ctx: { key: string; resource?: Resource }) => ctx.key === 'updates'
+  )?.resource as Bundle | undefined;
+
+  if (!updates) {
+    throw new OperationOutcomeError(badRequest('Update event requires an updates bundle in the context'));
+  }
+
+  // Process the update bundle
+  processUpdateBundle(updates, currentContext as CurrentContext<'DiagnosticReport'>);
+
+  // Generate new version
+  const newVersionId = generateId();
+  event['context.priorVersionId'] = priorVersionId;
+  currentContext['context.versionId'] = newVersionId;
+  event['context.versionId'] = newVersionId;
+
+  // Atomic context update
+  const success = await compareAndSetContext(projectId, topic, priorVersionId, currentContext);
+  if (!success) {
+    throw new OperationOutcomeError(badRequest('Concurrent context modification detected'));
+  }
+
+  return priorVersionId;
+}
+
+/**
+ * Process PUT/DELETE entries in an update bundle against the content bundle.
+ */
+function processUpdateBundle(updatesBundle: Bundle, currentContext: CurrentContext<'DiagnosticReport'>): void {
+  const contentBundle = currentContext.context.find((ctx) => ctx.key === 'content')?.resource as Bundle;
+
+  for (const entry of updatesBundle?.entry ?? EMPTY) {
+    switch (entry.request?.method) {
+      case 'PUT':
+        processUpdateBundlePutEntry(entry, contentBundle);
+        break;
+      case 'DELETE':
+        processUpdateBundleDeleteEntry(entry, contentBundle, currentContext);
+        break;
+      case undefined:
+        throw new OperationOutcomeError(badRequest('Update bundle contains entry with missing request.method'));
+      default:
+        throw new OperationOutcomeError(
+          badRequest(
+            `Update bundle contains entry with unsupported request.method '${entry.request?.method}', only 'PUT' and 'DELETE' are supported`
+          )
+        );
+    }
+  }
+}
+
+function processUpdateBundlePutEntry(entry: BundleEntry, contentBundle: Bundle): void {
+  if (!entry.resource) {
+    throw new OperationOutcomeError(badRequest('Missing resource in update bundle PUT entry'));
+  }
+
+  const upsertedResource = entry.resource;
+  const matchingIndex = contentBundle.entry?.findIndex((e) => e.resource?.id === upsertedResource.id);
+
+  if (matchingIndex === undefined || matchingIndex === -1) {
+    contentBundle.entry = append(contentBundle.entry, { resource: upsertedResource });
+  } else {
+    (contentBundle.entry as BundleEntry[])[matchingIndex].resource = upsertedResource;
+  }
+}
+
+function processUpdateBundleDeleteEntry(
+  entry: BundleEntry,
+  contentBundle: Bundle,
+  currentContext: CurrentContext<'DiagnosticReport'>
+): void {
+  if (!entry.fullUrl) {
+    throw new OperationOutcomeError(badRequest('DELETE entry in update bundle missing fullUrl'));
+  }
+
+  // Extract resource ID from fullUrl (e.g. "Observation/abc-123" -> "abc-123")
+  const parts = entry.fullUrl.split('/');
+  const resourceId = parts[parts.length - 1];
+  if (!resourceId) {
+    throw new OperationOutcomeError(badRequest('fullUrl in DELETE entry is not a resolvable reference'));
+  }
+
+  // Check content bundle first
+  const entryIndex = contentBundle.entry?.findIndex((e) => e.resource?.id === resourceId);
+  if (entryIndex !== undefined && entryIndex !== -1) {
+    contentBundle.entry = (contentBundle.entry as BundleEntry[]).filter((e) => e.resource?.id !== resourceId);
+  } else if (currentContext.context.some((ctx) => ctx.resource?.id === resourceId)) {
+    throw new OperationOutcomeError(badRequest('Cannot delete a resource that is part of the original open context'));
+  } else {
+    throw new OperationOutcomeError(badRequest('Cannot delete resource not currently in the content bundle'));
+  }
+}
+
+/**
+ * Handle a select event (DiagnosticReport-select).
+ * Validates that the referenced DiagnosticReport is the current context.
+ */
+export async function handleSelectEvent(
+  projectId: string,
+  event: FhircastEventPayload
+): Promise<void> {
+  const topic = event['hub.topic'];
+  const currentContext = await getCurrentContext(projectId, topic);
+
+  if (!currentContext || currentContext['context.type'] !== 'DiagnosticReport') {
+    throw new OperationOutcomeError(badRequest('No DiagnosticReport currently open for this topic'));
+  }
+  // Select events are passed through - no context modification needed
+}

--- a/packages/server/src/fhircast-r4/context-store.ts
+++ b/packages/server/src/fhircast-r4/context-store.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { CurrentContext, FhircastAnchorResourceType, FhircastEventPayload, FhircastEventName } from '@medplum/core';
+import type { CurrentContext, FhircastAnchorResourceType, FhircastEventPayload } from '@medplum/core';
 import { generateId, badRequest, OperationOutcomeError, isResource, EMPTY, append } from '@medplum/core';
 import type { Bundle, BundleEntry, Resource } from '@medplum/fhirtypes';
 import { getCacheRedis } from '../redis';
@@ -265,8 +265,8 @@ export async function handleUpdateEvent(
   }
 
   // Extract and validate updates bundle
-  const updates = event.context.find(
-    (ctx: { key: string; resource?: Resource }) => ctx.key === 'updates'
+  const updates = (event.context as Array<{ key: string; resource?: Resource }>).find(
+    (ctx) => ctx.key === 'updates'
   )?.resource as Bundle | undefined;
 
   if (!updates) {

--- a/packages/server/src/fhircast-r4/event-bus.ts
+++ b/packages/server/src/fhircast-r4/event-bus.ts
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FhircastMessagePayload } from '@medplum/core';
+import { generateId } from '@medplum/core';
+import type { OperationOutcome } from '@medplum/fhirtypes';
+import { publish } from '../pubsub';
+import { getLogger } from '../logger';
+import { getSubscribersForEvent } from './subscriptions';
+import { RedisKeys } from './types';
+import type { SubscriberRecord, SyncErrorContext } from './types';
+
+/**
+ * Publish a FHIRcast event to all subscribers of a topic that are subscribed to this event type.
+ *
+ * Unlike the old hub's fire-and-forget approach, this function:
+ * 1. Filters subscribers by their event subscriptions
+ * 2. Publishes to the Redis channel (which the WebSocket handler forwards to filtered subscribers)
+ * 3. Returns the list of subscribers who should receive the event (for ack tracking)
+ */
+export async function publishEvent(
+  projectId: string,
+  payload: FhircastMessagePayload
+): Promise<SubscriberRecord[]> {
+  const topic = payload.event['hub.topic'];
+  const eventName = payload.event['hub.event'];
+  const channel = RedisKeys.topicChannel(projectId, topic);
+
+  // Get subscribers filtered by event
+  const subscribers = await getSubscribersForEvent(projectId, topic, eventName);
+
+  if (subscribers.length === 0) {
+    getLogger().debug('[FHIRcast R4] No subscribers for event', { projectId, topic, eventName });
+    return [];
+  }
+
+  // Publish to Redis channel
+  // The WebSocket handler will filter per-subscriber based on their event list
+  const message = JSON.stringify({
+    ...payload,
+    _meta: {
+      eventName,
+      projectId,
+      topic,
+    },
+  });
+
+  await publish(channel, message);
+
+  getLogger().info('[FHIRcast R4] Event published', {
+    projectId,
+    topic,
+    eventName,
+    eventId: payload.id,
+    subscriberCount: subscribers.length,
+  });
+
+  return subscribers;
+}
+
+/**
+ * Publish a SyncError event to subscribers that are subscribed to 'syncerror'.
+ *
+ * Per spec: "SyncError events distributed only to Subscribers which have subscribed to them"
+ */
+export async function publishSyncError(
+  projectId: string,
+  topic: string,
+  operationOutcome: OperationOutcome,
+  triggeringEventName?: string
+): Promise<void> {
+  const syncErrorPayload: FhircastMessagePayload = {
+    timestamp: new Date().toISOString(),
+    id: generateId(),
+    event: {
+      'hub.topic': topic,
+      'hub.event': 'syncerror',
+      context: [
+        {
+          key: 'operationoutcome',
+          resource: operationOutcome,
+        } as SyncErrorContext,
+      ],
+    },
+  };
+
+  const channel = RedisKeys.topicChannel(projectId, topic);
+  const message = JSON.stringify({
+    ...syncErrorPayload,
+    _meta: {
+      eventName: 'syncerror',
+      projectId,
+      topic,
+    },
+  });
+
+  await publish(channel, message);
+
+  getLogger().warn('[FHIRcast R4] SyncError published', {
+    projectId,
+    topic,
+    triggeringEventName,
+    outcomeText: operationOutcome.issue?.[0]?.diagnostics,
+  });
+}
+
+/**
+ * Create a SyncError OperationOutcome for a subscriber timeout.
+ */
+export function createTimeoutSyncError(
+  subscriberName: string | undefined,
+  eventId: string,
+  eventName: string
+): OperationOutcome {
+  return {
+    resourceType: 'OperationOutcome',
+    issue: [
+      {
+        severity: 'warning',
+        code: 'timeout',
+        diagnostics: `Subscriber${subscriberName ? ` '${subscriberName}'` : ''} did not respond to event '${eventName}' (id: ${eventId}) within timeout period`,
+      },
+    ],
+  };
+}
+
+/**
+ * Create a SyncError OperationOutcome for a subscriber refusal (4xx/5xx response).
+ */
+export function createRefusalSyncError(
+  subscriberName: string | undefined,
+  eventId: string,
+  eventName: string,
+  status: string
+): OperationOutcome {
+  return {
+    resourceType: 'OperationOutcome',
+    issue: [
+      {
+        severity: 'warning',
+        code: 'processing',
+        diagnostics: `Subscriber${subscriberName ? ` '${subscriberName}'` : ''} refused event '${eventName}' (id: ${eventId}) with status ${status}`,
+      },
+    ],
+  };
+}
+
+/**
+ * Create a SyncError OperationOutcome for an abnormal WebSocket close.
+ */
+export function createDisconnectSyncError(
+  subscriberName: string | undefined,
+  closeCode: number
+): OperationOutcome {
+  return {
+    resourceType: 'OperationOutcome',
+    issue: [
+      {
+        severity: 'warning',
+        code: 'transient',
+        diagnostics: `Subscriber${subscriberName ? ` '${subscriberName}'` : ''} disconnected abnormally (WebSocket close code: ${closeCode})`,
+      },
+    ],
+  };
+}
+
+/**
+ * Publish a heartbeat event to a topic.
+ */
+export async function publishHeartbeat(
+  projectId: string,
+  topic: string,
+  periodSeconds: number
+): Promise<void> {
+  // Heartbeat is not in FhircastEventName but is defined in the spec.
+  // Use a plain object to avoid the type constraint.
+  const heartbeatPayload = {
+    timestamp: new Date().toISOString(),
+    id: generateId(),
+    event: {
+      'hub.topic': topic,
+      'hub.event': 'heartbeat',
+      context: [{ key: 'period', decimal: `${periodSeconds}` }],
+    },
+  };
+
+  const channel = RedisKeys.topicChannel(projectId, topic);
+  const message = JSON.stringify({
+    ...heartbeatPayload,
+    _meta: {
+      eventName: 'heartbeat',
+      projectId,
+      topic,
+    },
+  });
+
+  await publish(channel, message).catch((err: Error) => {
+    getLogger().error('[FHIRcast R4] Failed to publish heartbeat', {
+      projectId,
+      topic,
+      error: err.message,
+    });
+  });
+}

--- a/packages/server/src/fhircast-r4/routes.test.ts
+++ b/packages/server/src/fhircast-r4/routes.test.ts
@@ -1,15 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { FhircastMessagePayload, WithId } from '@medplum/core';
 import {
   ContentType,
-  createReference,
-  generateId,
-  getReferenceString,
   serializeFhircastSubscriptionRequest,
 } from '@medplum/core';
-import type { DiagnosticReport, Observation, Patient, Project } from '@medplum/fhirtypes';
 import express from 'express';
 import type { Server } from 'node:http';
 import { randomUUID } from 'node:crypto';
@@ -19,13 +14,12 @@ import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
 import { createTestProject, withTestContext } from '../test.setup';
 
-const R4_BASE_ROUTE = '/fhircast/R4';
+const R4_BASE_ROUTE = '/fhircast/hub';
 
 describe('FHIRcast R4 routes', () => {
   let app: express.Express;
   let config: MedplumServerConfig;
   let server: Server;
-  let project: WithId<Project>;
   let accessToken: string;
 
   beforeAll(async () => {
@@ -39,7 +33,6 @@ describe('FHIRcast R4 routes', () => {
     );
 
     accessToken = result.accessToken;
-    project = result.project;
 
     await new Promise<void>((resolve) => {
       server.listen(0, 'localhost', 8520, resolve);

--- a/packages/server/src/fhircast-r4/routes.test.ts
+++ b/packages/server/src/fhircast-r4/routes.test.ts
@@ -1,0 +1,522 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FhircastMessagePayload, WithId } from '@medplum/core';
+import {
+  ContentType,
+  createReference,
+  generateId,
+  getReferenceString,
+  serializeFhircastSubscriptionRequest,
+} from '@medplum/core';
+import type { DiagnosticReport, Observation, Patient, Project } from '@medplum/fhirtypes';
+import express from 'express';
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import request from 'superwstest';
+import { initApp, shutdownApp } from '../app';
+import { loadTestConfig } from '../config/loader';
+import type { MedplumServerConfig } from '../config/types';
+import { createTestProject, withTestContext } from '../test.setup';
+
+const R4_BASE_ROUTE = '/fhircast/R4';
+
+describe('FHIRcast R4 routes', () => {
+  let app: express.Express;
+  let config: MedplumServerConfig;
+  let server: Server;
+  let project: WithId<Project>;
+  let accessToken: string;
+
+  beforeAll(async () => {
+    app = express();
+    config = await loadTestConfig();
+    config.heartbeatEnabled = false;
+    server = await initApp(app, config);
+
+    const result = await withTestContext(() =>
+      createTestProject({ membership: { admin: true }, withAccessToken: true })
+    );
+
+    accessToken = result.accessToken;
+    project = result.project;
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, 'localhost', 8520, resolve);
+    });
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  // ==========================================================================
+  // Well-known configuration
+  // ==========================================================================
+
+  test('Get well-known configuration', async () => {
+    const res = await request(server).get(`${R4_BASE_ROUTE}/.well-known/fhircast-configuration`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.eventsSupported).toBeDefined();
+    expect(res.body.eventsSupported).toContain('Patient-open');
+    expect(res.body.eventsSupported).toContain('DiagnosticReport-update');
+    expect(res.body.getCurrentSupport).toBe(true);
+    expect(res.body.websocketSupport).toBe(true);
+    expect(res.body.webhookSupport).toBe(false);
+    expect(res.body.fhircastVersion).toBe('STU3');
+  });
+
+  // ==========================================================================
+  // Subscription - JSON body (backwards compatible)
+  // ==========================================================================
+
+  test('Subscribe with JSON body', async () => {
+    const res = await request(server)
+      .post(R4_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        'hub.channel.type': 'websocket',
+        'hub.mode': 'subscribe',
+        'hub.topic': 'test-topic-json',
+        'hub.events': 'Patient-open,Patient-close',
+      });
+
+    expect(res.status).toBe(202);
+    expect(res.body['hub.channel.endpoint']).toBeDefined();
+    expect(res.body['hub.channel.endpoint']).toMatch(/ws.*\/ws\/fhircast-r4\//);
+  });
+
+  // ==========================================================================
+  // Subscription - URL-encoded body (spec-compliant)
+  // ==========================================================================
+
+  test('Subscribe with URL-encoded body', async () => {
+    const res = await request(server)
+      .post(R4_BASE_ROUTE)
+      .set('Content-Type', ContentType.FORM_URL_ENCODED)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send(
+        serializeFhircastSubscriptionRequest({
+          mode: 'subscribe',
+          channelType: 'websocket',
+          topic: 'test-topic-urlenc',
+          events: ['Patient-open', 'Patient-close'],
+        })
+      );
+
+    expect(res.status).toBe(202);
+    expect(res.body['hub.channel.endpoint']).toBeDefined();
+    expect(res.body['hub.channel.endpoint']).toMatch(/ws.*\/ws\/fhircast-r4\//);
+  });
+
+  // ==========================================================================
+  // Subscription - auth required
+  // ==========================================================================
+
+  test('Subscribe without auth returns 401', async () => {
+    const res = await request(server)
+      .post(R4_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .send({
+        'hub.channel.type': 'websocket',
+        'hub.mode': 'subscribe',
+        'hub.topic': 'topic',
+        'hub.events': 'Patient-open',
+      });
+
+    expect(res.status).toBe(401);
+  });
+
+  // ==========================================================================
+  // Subscription - validation
+  // ==========================================================================
+
+  test('Subscribe missing hub.channel.type', async () => {
+    const res = await request(server)
+      .post(R4_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        'hub.mode': 'subscribe',
+        'hub.topic': 'topic',
+        'hub.events': 'Patient-open',
+      });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('Subscribe invalid hub.channel.type', async () => {
+    const res = await request(server)
+      .post(R4_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        'hub.channel.type': 'webhook',
+        'hub.mode': 'subscribe',
+        'hub.topic': 'topic',
+        'hub.events': 'Patient-open',
+      });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('Subscribe invalid hub.mode', async () => {
+    const res = await request(server)
+      .post(R4_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        'hub.channel.type': 'websocket',
+        'hub.mode': 'xyz',
+        'hub.topic': 'topic',
+        'hub.events': 'Patient-open',
+      });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('Subscribe missing hub.topic', async () => {
+    const res = await request(server)
+      .post(R4_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        'hub.channel.type': 'websocket',
+        'hub.mode': 'subscribe',
+        'hub.events': 'Patient-open',
+      });
+
+    expect(res.status).toBe(400);
+  });
+
+  // ==========================================================================
+  // Subscribing twice yields same endpoint
+  // ==========================================================================
+
+  test('Subscribing twice to the same topic yields same endpoint', async () => {
+    const topic = randomUUID();
+
+    const res1 = await request(server)
+      .post(R4_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        'hub.channel.type': 'websocket',
+        'hub.mode': 'subscribe',
+        'hub.topic': topic,
+        'hub.events': 'Patient-open',
+      });
+
+    const res2 = await request(server)
+      .post(R4_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        'hub.channel.type': 'websocket',
+        'hub.mode': 'subscribe',
+        'hub.topic': topic,
+        'hub.events': 'Patient-open',
+      });
+
+    expect(res1.status).toBe(202);
+    expect(res2.status).toBe(202);
+    expect(res1.body['hub.channel.endpoint']).toBe(res2.body['hub.channel.endpoint']);
+  });
+
+  // ==========================================================================
+  // GetCurrentContext
+  // ==========================================================================
+
+  test('GetCurrentContext with no context returns empty', async () => {
+    const topic = randomUUID();
+
+    const res = await request(server)
+      .get(`${R4_BASE_ROUTE}/${topic}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      'context.type': '',
+      context: [],
+    });
+  });
+
+  // ==========================================================================
+  // Context change - Patient-open
+  // ==========================================================================
+
+  test('Patient-open context change', async () => {
+    const topic = randomUUID();
+    const patientId = randomUUID();
+
+    // Subscribe first
+    await request(server)
+      .post(R4_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        'hub.channel.type': 'websocket',
+        'hub.mode': 'subscribe',
+        'hub.topic': topic,
+        'hub.events': 'Patient-open',
+      });
+
+    // Send context change
+    const res = await request(server)
+      .post(R4_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        timestamp: new Date().toISOString(),
+        id: randomUUID(),
+        event: {
+          'hub.topic': topic,
+          'hub.event': 'Patient-open',
+          context: [
+            {
+              key: 'patient',
+              resource: { resourceType: 'Patient', id: patientId },
+            },
+          ],
+        },
+      });
+
+    expect(res.status).toBe(202);
+
+    // Verify context was set
+    const contextRes = await request(server)
+      .get(`${R4_BASE_ROUTE}/${topic}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+
+    expect(contextRes.status).toBe(200);
+    expect(contextRes.body['context.type']).toBe('Patient');
+    expect(contextRes.body['context.versionId']).toBeDefined();
+    expect(contextRes.body.context).toHaveLength(1);
+  });
+
+  // ==========================================================================
+  // Context change via /:topic route
+  // ==========================================================================
+
+  test('Context change via /:topic route', async () => {
+    const topic = randomUUID();
+    const patientId = randomUUID();
+
+    const res = await request(server)
+      .post(`${R4_BASE_ROUTE}/${topic}`)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        timestamp: new Date().toISOString(),
+        id: randomUUID(),
+        event: {
+          'hub.topic': topic,
+          'hub.event': 'Patient-open',
+          context: [
+            {
+              key: 'patient',
+              resource: { resourceType: 'Patient', id: patientId },
+            },
+          ],
+        },
+      });
+
+    expect(res.status).toBe(202);
+  });
+
+  // ==========================================================================
+  // DiagnosticReport lifecycle
+  // ==========================================================================
+
+  test('DiagnosticReport open creates content bundle', async () => {
+    const topic = randomUUID();
+    const reportId = randomUUID();
+    const patientId = randomUUID();
+
+    // Open DiagnosticReport
+    const res = await request(server)
+      .post(`${R4_BASE_ROUTE}/${topic}`)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        timestamp: new Date().toISOString(),
+        id: randomUUID(),
+        event: {
+          'hub.topic': topic,
+          'hub.event': 'DiagnosticReport-open',
+          context: [
+            {
+              key: 'report',
+              resource: { resourceType: 'DiagnosticReport', id: reportId, status: 'preliminary', code: {} },
+            },
+            {
+              key: 'patient',
+              resource: { resourceType: 'Patient', id: patientId },
+            },
+          ],
+        },
+      });
+
+    expect(res.status).toBe(202);
+
+    // Verify context includes content bundle
+    const contextRes = await request(server)
+      .get(`${R4_BASE_ROUTE}/${topic}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+
+    expect(contextRes.status).toBe(200);
+    expect(contextRes.body['context.type']).toBe('DiagnosticReport');
+    expect(contextRes.body['context.versionId']).toBeDefined();
+
+    const content = contextRes.body.context.find((c: any) => c.key === 'content');
+    expect(content).toBeDefined();
+    expect(content.resource.resourceType).toBe('Bundle');
+    expect(content.resource.type).toBe('collection');
+  });
+
+  test('DiagnosticReport-update with version mismatch returns 400', async () => {
+    const topic = randomUUID();
+    const reportId = randomUUID();
+    const patientId = randomUUID();
+
+    // Open DiagnosticReport
+    await request(server)
+      .post(`${R4_BASE_ROUTE}/${topic}`)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        timestamp: new Date().toISOString(),
+        id: randomUUID(),
+        event: {
+          'hub.topic': topic,
+          'hub.event': 'DiagnosticReport-open',
+          context: [
+            {
+              key: 'report',
+              resource: { resourceType: 'DiagnosticReport', id: reportId, status: 'preliminary', code: {} },
+            },
+            {
+              key: 'patient',
+              resource: { resourceType: 'Patient', id: patientId },
+            },
+          ],
+        },
+      });
+
+    // Try update with wrong version ID
+    const res = await request(server)
+      .post(`${R4_BASE_ROUTE}/${topic}`)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        timestamp: new Date().toISOString(),
+        id: randomUUID(),
+        event: {
+          'hub.topic': topic,
+          'hub.event': 'DiagnosticReport-update',
+          'context.versionId': 'wrong-version',
+          context: [
+            {
+              key: 'report',
+              reference: { reference: `DiagnosticReport/${reportId}` },
+            },
+            {
+              key: 'updates',
+              resource: {
+                resourceType: 'Bundle',
+                type: 'transaction',
+                entry: [],
+              },
+            },
+          ],
+        },
+      });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('DiagnosticReport close clears context', async () => {
+    const topic = randomUUID();
+    const reportId = randomUUID();
+    const patientId = randomUUID();
+
+    // Open
+    await request(server)
+      .post(`${R4_BASE_ROUTE}/${topic}`)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        timestamp: new Date().toISOString(),
+        id: randomUUID(),
+        event: {
+          'hub.topic': topic,
+          'hub.event': 'DiagnosticReport-open',
+          context: [
+            {
+              key: 'report',
+              resource: { resourceType: 'DiagnosticReport', id: reportId, status: 'preliminary', code: {} },
+            },
+            {
+              key: 'patient',
+              resource: { resourceType: 'Patient', id: patientId },
+            },
+          ],
+        },
+      });
+
+    // Close
+    await request(server)
+      .post(`${R4_BASE_ROUTE}/${topic}`)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        timestamp: new Date().toISOString(),
+        id: randomUUID(),
+        event: {
+          'hub.topic': topic,
+          'hub.event': 'DiagnosticReport-close',
+          context: [
+            {
+              key: 'report',
+              resource: { resourceType: 'DiagnosticReport', id: reportId, status: 'preliminary', code: {} },
+            },
+            {
+              key: 'patient',
+              resource: { resourceType: 'Patient', id: patientId },
+            },
+          ],
+        },
+      });
+
+    // Verify empty context
+    const contextRes = await request(server)
+      .get(`${R4_BASE_ROUTE}/${topic}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+
+    expect(contextRes.status).toBe(200);
+    expect(contextRes.body).toMatchObject({
+      'context.type': '',
+      context: [],
+    });
+  });
+
+  // ==========================================================================
+  // Invalid context change request
+  // ==========================================================================
+
+  test('Context change with missing event returns 400', async () => {
+    const res = await request(server)
+      .post(R4_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        timestamp: new Date().toISOString(),
+        id: randomUUID(),
+        // missing event
+      });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/server/src/fhircast-r4/routes.ts
+++ b/packages/server/src/fhircast-r4/routes.ts
@@ -17,6 +17,14 @@ import { trackEventAcks } from './sync-error';
 import type { EventCategory } from './types';
 import { getEventCategory, isFhircastMessagePayload, SUPPORTED_EVENTS } from './types';
 
+/** The mount path for this router. */
+export const FHIRCAST_R4_MOUNT_PATH = '/fhircast/hub/';
+
+/** Build the full public hub URL from a base URL. */
+export function getFhircastHubUrl(baseUrl: string): string {
+  return `${baseUrl}fhircast/hub`;
+}
+
 export const fhircastR4Router = Router();
 
 // ============================================================================
@@ -102,7 +110,7 @@ protectedRoutes.post('/:topic', async (req: Request, res: Response) => {
 protectedRoutes.get('/:topic', async (req: Request, res: Response) => {
   try {
     const { project } = getAuthenticatedContext();
-    const topic = req.params.topic;
+    const topic = req.params.topic as string;
 
     const currentContext = await getCurrentContext(project.id, topic);
     if (!currentContext) {

--- a/packages/server/src/fhircast-r4/routes.ts
+++ b/packages/server/src/fhircast-r4/routes.ts
@@ -1,0 +1,336 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FhircastEventPayload, FhircastMessagePayload } from '@medplum/core';
+import { badRequest, getWebSocketUrl, normalizeErrorString, OperationOutcomeError, serverError } from '@medplum/core';
+import type { Request, Response } from 'express';
+import { Router } from 'express';
+import { getConfig } from '../config/loader';
+import { getAuthenticatedContext } from '../context';
+import { sendOutcome } from '../fhir/outcomes';
+import { getLogger } from '../logger';
+import { authenticateRequest } from '../oauth/middleware';
+import { getOrCreateEndpoint, addSubscriber, removeSubscriber, updateSubscriberEvents } from './subscriptions';
+import { getCurrentContext, handleOpenEvent, handleCloseEvent, handleUpdateEvent, handleSelectEvent } from './context-store';
+import { publishEvent } from './event-bus';
+import { trackEventAcks } from './sync-error';
+import type { EventCategory } from './types';
+import { getEventCategory, isFhircastMessagePayload, SUPPORTED_EVENTS } from './types';
+
+export const fhircastR4Router = Router();
+
+// ============================================================================
+// Public routes (no auth required)
+// ============================================================================
+
+const publicRoutes = Router();
+fhircastR4Router.use(publicRoutes);
+
+/**
+ * .well-known/fhircast-configuration endpoint
+ * Returns hub capabilities per FHIRcast spec.
+ */
+publicRoutes.get('/.well-known/fhircast-configuration', (_req: Request, res: Response) => {
+  res.status(200).json({
+    eventsSupported: [...SUPPORTED_EVENTS],
+    getCurrentSupport: true,
+    websocketSupport: true,
+    webhookSupport: false,
+    fhircastVersion: 'STU3',
+  });
+});
+
+// ============================================================================
+// Protected routes (require authentication)
+// ============================================================================
+
+const protectedRoutes = Router().use(authenticateRequest);
+fhircastR4Router.use(protectedRoutes);
+
+/**
+ * POST / — Subscription request (URL-encoded) or context change (JSON)
+ *
+ * Per spec:
+ * - Subscription: Content-Type: application/x-www-form-urlencoded
+ * - Context change: Content-Type: application/fhir+json
+ *
+ * We also accept JSON for subscriptions (for backwards compatibility / easier testing).
+ */
+protectedRoutes.post('/', async (req: Request, res: Response) => {
+  try {
+    // Determine if this is a subscription request or context change request
+    if (isSubscriptionRequest(req)) {
+      await handleSubscriptionRequest(req, res);
+    } else if (isContextChangeRequest(req)) {
+      await handleContextChangeRequest(req, res);
+    } else {
+      sendOutcome(res, badRequest('Request must be a subscription (URL-encoded) or context change (FHIR+JSON)'));
+    }
+  } catch (err) {
+    if (err instanceof OperationOutcomeError) {
+      sendOutcome(res, err.outcome);
+      return;
+    }
+    getLogger().error('[FHIRcast R4] Unhandled error in POST /', { error: normalizeErrorString(err) });
+    sendOutcome(res, serverError(err instanceof Error ? err : new Error(String(err))));
+  }
+});
+
+/**
+ * POST /:topic — Context change request for a specific topic
+ * Content-Type: application/fhir+json
+ */
+protectedRoutes.post('/:topic', async (req: Request, res: Response) => {
+  try {
+    await handleContextChangeRequest(req, res);
+  } catch (err) {
+    if (err instanceof OperationOutcomeError) {
+      sendOutcome(res, err.outcome);
+      return;
+    }
+    getLogger().error('[FHIRcast R4] Unhandled error in POST /:topic', { error: normalizeErrorString(err) });
+    sendOutcome(res, serverError(err instanceof Error ? err : new Error(String(err))));
+  }
+});
+
+/**
+ * GET /:topic — GetCurrentContext
+ * Returns the current context for a topic.
+ *
+ * Per spec: https://build.fhir.org/ig/HL7/fhircast-docs/2-9-GetCurrentContext.html
+ */
+protectedRoutes.get('/:topic', async (req: Request, res: Response) => {
+  try {
+    const { project } = getAuthenticatedContext();
+    const topic = req.params.topic;
+
+    const currentContext = await getCurrentContext(project.id, topic);
+    if (!currentContext) {
+      // Per spec: empty context when no context is established
+      res.status(200).json({
+        'context.type': '',
+        context: [],
+      });
+      return;
+    }
+
+    res.status(200).json(currentContext);
+  } catch (err) {
+    if (err instanceof OperationOutcomeError) {
+      sendOutcome(res, err.outcome);
+      return;
+    }
+    getLogger().error('[FHIRcast R4] Unhandled error in GET /:topic', { error: normalizeErrorString(err) });
+    sendOutcome(res, serverError(err instanceof Error ? err : new Error(String(err))));
+  }
+});
+
+// ============================================================================
+// Request type detection
+// ============================================================================
+
+function isSubscriptionRequest(req: Request): boolean {
+  const contentType = req.headers['content-type'] || '';
+
+  // URL-encoded subscription
+  if (contentType.includes('application/x-www-form-urlencoded')) {
+    return true;
+  }
+
+  // JSON subscription (has hub.mode but no event)
+  if (req.body && req.body['hub.mode'] && !req.body.event) {
+    return true;
+  }
+
+  return false;
+}
+
+function isContextChangeRequest(req: Request): boolean {
+  // Has FHIRcast event structure
+  if (req.body && req.body.id && req.body.event && req.body.timestamp) {
+    return true;
+  }
+  return false;
+}
+
+// ============================================================================
+// Subscription handling
+// ============================================================================
+
+async function handleSubscriptionRequest(req: Request, res: Response): Promise<void> {
+  const ctx = getAuthenticatedContext();
+
+  // Parse subscription fields from either URL-encoded or JSON body
+  const channelType = req.body['hub.channel.type'];
+  const mode = req.body['hub.mode'] as string;
+  const topic = req.body['hub.topic'] as string;
+  const events = req.body['hub.events'] as string;
+  const leaseSeconds = req.body['hub.lease_seconds'] ? parseInt(req.body['hub.lease_seconds'], 10) : undefined;
+  const subscriberName = req.body['subscriber.name'] as string | undefined;
+  const existingEndpoint = req.body['hub.channel.endpoint'] as string | undefined;
+
+  // Validate required fields
+  if (!channelType) {
+    sendOutcome(res, badRequest('Missing hub.channel.type'));
+    return;
+  }
+  if (channelType !== 'websocket') {
+    sendOutcome(res, badRequest('Invalid hub.channel.type: must be "websocket"'));
+    return;
+  }
+  if (!mode) {
+    sendOutcome(res, badRequest('Missing hub.mode'));
+    return;
+  }
+  if (!topic) {
+    sendOutcome(res, badRequest('Missing hub.topic'));
+    return;
+  }
+
+  if (mode === 'subscribe') {
+    await handleSubscribe(ctx, req, res, topic, events, leaseSeconds, subscriberName, existingEndpoint);
+  } else if (mode === 'unsubscribe') {
+    await handleUnsubscribe(ctx, res, topic, existingEndpoint);
+  } else {
+    sendOutcome(res, badRequest(`Invalid hub.mode: '${mode}', must be 'subscribe' or 'unsubscribe'`));
+  }
+}
+
+async function handleSubscribe(
+  ctx: ReturnType<typeof getAuthenticatedContext>,
+  _req: Request,
+  res: Response,
+  topic: string,
+  events: string | undefined,
+  leaseSeconds: number | undefined,
+  subscriberName: string | undefined,
+  existingEndpoint: string | undefined
+): Promise<void> {
+  // Events are conditional per spec - required for new subscriptions
+  if (!events && !existingEndpoint) {
+    sendOutcome(res, badRequest('Missing hub.events for new subscription'));
+    return;
+  }
+
+  const projectId = ctx.project.id;
+
+  // Get or create endpoint
+  let endpoint: string;
+  try {
+    endpoint = await getOrCreateEndpoint(projectId, topic);
+  } catch (err) {
+    getLogger().error('[FHIRcast R4] Failed to get endpoint', {
+      topic,
+      error: normalizeErrorString(err),
+    });
+    sendOutcome(res, serverError(new Error('Failed to get endpoint for topic')));
+    return;
+  }
+
+  // Register or update subscription
+  if (existingEndpoint) {
+    // Re-subscription with existing endpoint - update events
+    const updated = await updateSubscriberEvents(projectId, topic, endpoint, events || '', leaseSeconds);
+    if (!updated) {
+      // New subscription on existing endpoint
+      await addSubscriber(projectId, topic, endpoint, events || '', subscriberName, leaseSeconds);
+    }
+  } else {
+    await addSubscriber(projectId, topic, endpoint, events || '', subscriberName, leaseSeconds);
+  }
+
+  // Return WebSocket endpoint URL
+  const config = getConfig();
+  res.status(202).json({
+    'hub.channel.endpoint': getWebSocketUrl(config.baseUrl, `/ws/fhircast-r4/${endpoint}`),
+  });
+}
+
+async function handleUnsubscribe(
+  ctx: ReturnType<typeof getAuthenticatedContext>,
+  res: Response,
+  topic: string,
+  endpointUrl: string | undefined
+): Promise<void> {
+  if (!endpointUrl) {
+    sendOutcome(res, badRequest('Missing hub.channel.endpoint for unsubscribe'));
+    return;
+  }
+
+  const projectId = ctx.project.id;
+
+  // Extract endpoint ID from WSS URL
+  const endpointParts = endpointUrl.split('/');
+  const endpoint = endpointParts[endpointParts.length - 1];
+
+  await removeSubscriber(projectId, topic, endpoint);
+
+  // Return the endpoint in response per spec
+  res.status(202).json({
+    'hub.channel.endpoint': endpointUrl,
+  });
+}
+
+// ============================================================================
+// Context change handling
+// ============================================================================
+
+/**
+ * Event dispatch table: maps event categories to handlers.
+ * Replaces the fragile string suffix matching in the old hub.
+ */
+const EVENT_HANDLERS: Record<EventCategory, (projectId: string, event: FhircastEventPayload) => Promise<void>> = {
+  open: handleOpenEvent,
+  close: handleCloseEvent,
+  update: async (projectId, event) => {
+    await handleUpdateEvent(projectId, event);
+  },
+  select: handleSelectEvent,
+  other: async () => {
+    // Default: no context modification needed (e.g. userlogout, userhibernate)
+  },
+};
+
+async function handleContextChangeRequest(req: Request, res: Response): Promise<void> {
+  const ctx = getAuthenticatedContext();
+  const body = req.body;
+
+  // Validate basic structure
+  if (!isFhircastMessagePayload(body)) {
+    sendOutcome(res, badRequest('Invalid context change request: missing id, timestamp, or event'));
+    return;
+  }
+
+  const payload = body as FhircastMessagePayload;
+  const { event } = payload;
+
+  // Validate event fields
+  if (!event['hub.topic']) {
+    sendOutcome(res, badRequest('Missing event["hub.topic"]'));
+    return;
+  }
+  if (!event['hub.event']) {
+    sendOutcome(res, badRequest('Missing event["hub.event"]'));
+    return;
+  }
+  if (!event.context) {
+    sendOutcome(res, badRequest('Missing event.context'));
+    return;
+  }
+
+  const projectId = ctx.project.id;
+  const category = getEventCategory(event['hub.event']);
+  const handler = EVENT_HANDLERS[category];
+
+  // Execute the context handler (may modify event payload in-place with versionId)
+  await handler(projectId, event);
+
+  // Publish the event to subscribers
+  const subscribers = await publishEvent(projectId, payload);
+
+  // Start ack tracking: 10-second timeout per subscriber, SyncError on timeout/refusal
+  trackEventAcks(payload.id, event['hub.event'], subscribers);
+
+  // Per spec: return 202 Accepted
+  res.status(202).json({ success: true });
+}

--- a/packages/server/src/fhircast-r4/subscriptions.ts
+++ b/packages/server/src/fhircast-r4/subscriptions.ts
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { generateId } from '@medplum/core';
+import { getCacheRedis } from '../redis';
+import { getLogger } from '../logger';
+import type { SubscriberRecord } from './types';
+import { DEFAULT_CONFIG, RedisKeys, subscriberWantsEvent } from './types';
+
+/**
+ * Manages FHIRcast R4 subscriptions in Redis.
+ *
+ * Subscriptions are stored in a Redis hash per topic:
+ *   Key: medplum:fhircast-r4:project:{projectId}:topic:{topic}:subs
+ *   Field: endpoint ID
+ *   Value: JSON-serialized SubscriberRecord
+ *
+ * A reverse mapping from endpoint to projectId:topic is maintained for WebSocket lookups:
+ *   Key: medplum:fhircast-r4:endpoint:{endpoint}:topic
+ *   Value: "projectId:topic"
+ */
+
+/**
+ * Generate or retrieve the WebSocket endpoint for a topic.
+ * Uses Redis MULTI for atomicity (setnx + get).
+ */
+export async function getOrCreateEndpoint(projectId: string, topic: string): Promise<string> {
+  const endpointKey = RedisKeys.topicEndpoint(projectId, topic);
+  const redis = getCacheRedis();
+
+  const results = await redis.multi().setnx(endpointKey, generateId()).get(endpointKey).exec();
+
+  if (!results || results.length !== 2) {
+    throw new Error('Redis returned unexpected results for endpoint generation');
+  }
+
+  const [err, endpoint] = results[1];
+  if (err) {
+    throw err;
+  }
+
+  const endpointStr = endpoint as string;
+
+  // Maintain reverse mapping: endpoint -> projectId:topic
+  const mappingKey = RedisKeys.endpointMapping(endpointStr);
+  await redis.setnx(mappingKey, `${projectId}:${topic}`);
+
+  return endpointStr;
+}
+
+/**
+ * Register a new subscriber for a topic.
+ */
+export async function addSubscriber(
+  projectId: string,
+  topic: string,
+  endpoint: string,
+  events: string,
+  subscriberName?: string,
+  leaseSeconds?: number
+): Promise<SubscriberRecord> {
+  const record: SubscriberRecord = {
+    endpoint,
+    topic,
+    projectId,
+    events,
+    subscriberName,
+    leaseSeconds: leaseSeconds ?? DEFAULT_CONFIG.defaultLeaseSeconds,
+    subscribedAt: Date.now(),
+  };
+
+  const subsKey = RedisKeys.topicSubscribers(projectId, topic);
+  await getCacheRedis().hset(subsKey, endpoint, JSON.stringify(record));
+
+  getLogger().info('[FHIRcast R4] Subscriber added', {
+    projectId,
+    topic,
+    endpoint,
+    events,
+    subscriberName,
+  });
+
+  return record;
+}
+
+/**
+ * Remove a subscriber from a topic.
+ */
+export async function removeSubscriber(projectId: string, topic: string, endpoint: string): Promise<void> {
+  const subsKey = RedisKeys.topicSubscribers(projectId, topic);
+  await getCacheRedis().hdel(subsKey, endpoint);
+
+  // Clean up reverse mapping
+  const mappingKey = RedisKeys.endpointMapping(endpoint);
+  await getCacheRedis().del(mappingKey);
+
+  getLogger().info('[FHIRcast R4] Subscriber removed', { projectId, topic, endpoint });
+}
+
+/**
+ * Get all subscribers for a topic.
+ */
+export async function getSubscribers(projectId: string, topic: string): Promise<SubscriberRecord[]> {
+  const subsKey = RedisKeys.topicSubscribers(projectId, topic);
+  const all = await getCacheRedis().hgetall(subsKey);
+
+  const subscribers: SubscriberRecord[] = [];
+  for (const [, value] of Object.entries(all)) {
+    try {
+      subscribers.push(JSON.parse(value));
+    } catch {
+      getLogger().error('[FHIRcast R4] Failed to parse subscriber record', { value });
+    }
+  }
+  return subscribers;
+}
+
+/**
+ * Get a specific subscriber by endpoint.
+ */
+export async function getSubscriber(
+  projectId: string,
+  topic: string,
+  endpoint: string
+): Promise<SubscriberRecord | undefined> {
+  const subsKey = RedisKeys.topicSubscribers(projectId, topic);
+  const value = await getCacheRedis().hget(subsKey, endpoint);
+  if (!value) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Get subscribers for a topic that are subscribed to a specific event.
+ * Per spec: event filtering is case-insensitive.
+ */
+export async function getSubscribersForEvent(
+  projectId: string,
+  topic: string,
+  eventName: string
+): Promise<SubscriberRecord[]> {
+  const all = await getSubscribers(projectId, topic);
+  return all.filter((sub) => subscriberWantsEvent(sub.events, eventName));
+}
+
+/**
+ * Update a subscriber's event list (re-subscription).
+ * Per spec: "Each subsequent and verified request SHALL override previous subscription state"
+ */
+export async function updateSubscriberEvents(
+  projectId: string,
+  topic: string,
+  endpoint: string,
+  events: string,
+  leaseSeconds?: number
+): Promise<SubscriberRecord | undefined> {
+  const existing = await getSubscriber(projectId, topic, endpoint);
+  if (!existing) {
+    return undefined;
+  }
+
+  const updated: SubscriberRecord = {
+    ...existing,
+    events,
+    leaseSeconds: leaseSeconds ?? existing.leaseSeconds,
+    subscribedAt: Date.now(),
+  };
+
+  const subsKey = RedisKeys.topicSubscribers(projectId, topic);
+  await getCacheRedis().hset(subsKey, endpoint, JSON.stringify(updated));
+
+  return updated;
+}
+
+/**
+ * Resolve an endpoint ID to its projectId and topic.
+ */
+export async function resolveEndpoint(endpoint: string): Promise<{ projectId: string; topic: string } | undefined> {
+  const mappingKey = RedisKeys.endpointMapping(endpoint);
+  const value = await getCacheRedis().get(mappingKey);
+  if (!value) {
+    return undefined;
+  }
+
+  const colonIndex = value.indexOf(':');
+  if (colonIndex === -1) {
+    return undefined;
+  }
+
+  return {
+    projectId: value.substring(0, colonIndex),
+    topic: value.substring(colonIndex + 1),
+  };
+}
+
+/**
+ * Check if a topic has any active subscribers.
+ */
+export async function hasSubscribers(projectId: string, topic: string): Promise<boolean> {
+  const subsKey = RedisKeys.topicSubscribers(projectId, topic);
+  const count = await getCacheRedis().hlen(subsKey);
+  return count > 0;
+}
+
+/**
+ * Clean up all subscriptions for a topic.
+ */
+export async function cleanupTopicSubscriptions(projectId: string, topic: string): Promise<void> {
+  const subscribers = await getSubscribers(projectId, topic);
+
+  // Clean up reverse mappings
+  const pipeline = getCacheRedis().pipeline();
+  for (const sub of subscribers) {
+    pipeline.del(RedisKeys.endpointMapping(sub.endpoint));
+  }
+  pipeline.del(RedisKeys.topicSubscribers(projectId, topic));
+  await pipeline.exec();
+
+  getLogger().info('[FHIRcast R4] Cleaned up topic subscriptions', {
+    projectId,
+    topic,
+    subscriberCount: subscribers.length,
+  });
+}

--- a/packages/server/src/fhircast-r4/sync-error.ts
+++ b/packages/server/src/fhircast-r4/sync-error.ts
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { getLogger } from '../logger';
+import { removeSubscriber } from './subscriptions';
+import { publishSyncError, createTimeoutSyncError, createRefusalSyncError, createDisconnectSyncError } from './event-bus';
+import type { SubscriberRecord, SubscriberResponse } from './types';
+import { DEFAULT_CONFIG } from './types';
+
+/**
+ * Map of eventId -> Map<endpoint, PendingAckEntry>
+ * Tracks which subscribers we're waiting on for acknowledgment.
+ */
+interface PendingAckEntry {
+  subscriber: SubscriberRecord;
+  timer: ReturnType<typeof setTimeout>;
+  resolve: (response: SubscriberResponse | null) => void;
+}
+
+const pendingAcks = new Map<string, Map<string, PendingAckEntry>>();
+
+/**
+ * Registered callback to close a WebSocket for a given endpoint.
+ * Set by the WebSocket layer via `registerCloseSocketCallback`.
+ * This avoids the routes layer needing to import from the ws layer.
+ */
+let closeSocketCallback: ((endpoint: string) => void) | undefined;
+
+/**
+ * Register the callback used to close WebSocket connections for non-responsive subscribers.
+ * Called once by the WebSocket handler during initialization.
+ */
+export function registerCloseSocketCallback(callback: (endpoint: string) => void): void {
+  closeSocketCallback = callback;
+}
+
+/**
+ * Register pending acknowledgments for an event.
+ * Sets up 10-second timers per subscriber.
+ *
+ * Per spec:
+ * - Subscriber does not respond within 10 seconds → SyncError
+ * - Hub SHALL unsubscribe the non-responsive subscriber
+ */
+export function trackEventAcks(
+  eventId: string,
+  eventName: string,
+  subscribers: SubscriberRecord[]
+): void {
+  if (subscribers.length === 0) {
+    return;
+  }
+
+  const entryMap = new Map<string, PendingAckEntry>();
+  pendingAcks.set(eventId, entryMap);
+
+  for (const subscriber of subscribers) {
+    let resolve: (response: SubscriberResponse | null) => void;
+    const promise = new Promise<SubscriberResponse | null>((r) => {
+      resolve = r;
+    });
+
+    const timer = setTimeout(async () => {
+      // Timeout - subscriber didn't respond in time
+      getLogger().warn('[FHIRcast R4] Subscriber ack timeout', {
+        eventId,
+        eventName,
+        endpoint: subscriber.endpoint,
+        subscriberName: subscriber.subscriberName,
+      });
+
+      // Remove from pending
+      entryMap.delete(subscriber.endpoint);
+      if (entryMap.size === 0) {
+        pendingAcks.delete(eventId);
+      }
+
+      // Generate SyncError
+      const outcome = createTimeoutSyncError(subscriber.subscriberName, eventId, eventName);
+      await publishSyncError(subscriber.projectId, subscriber.topic, outcome, eventName);
+
+      // Unsubscribe the non-responsive subscriber
+      await removeSubscriber(subscriber.projectId, subscriber.topic, subscriber.endpoint);
+      if (closeSocketCallback) {
+        closeSocketCallback(subscriber.endpoint);
+      }
+
+      resolve!(null);
+    }, DEFAULT_CONFIG.ackTimeoutMs);
+
+    entryMap.set(subscriber.endpoint, {
+      subscriber,
+      timer,
+      resolve: resolve!,
+    });
+
+    // Handle the response when it arrives
+    promise.then(async (response) => {
+      if (!response) {
+        return; // Timeout already handled
+      }
+
+      const statusCode = parseInt(response.status, 10);
+
+      // 2xx = success
+      if (statusCode >= 200 && statusCode < 300) {
+        getLogger().debug('[FHIRcast R4] Subscriber ack success', {
+          eventId,
+          endpoint: subscriber.endpoint,
+          status: response.status,
+        });
+        return;
+      }
+
+      // 4xx or 5xx = refusal → SyncError
+      getLogger().warn('[FHIRcast R4] Subscriber refused event', {
+        eventId,
+        eventName,
+        endpoint: subscriber.endpoint,
+        status: response.status,
+      });
+
+      const outcome = createRefusalSyncError(subscriber.subscriberName, eventId, eventName, response.status);
+      await publishSyncError(subscriber.projectId, subscriber.topic, outcome, eventName);
+    }).catch((err) => {
+      getLogger().error('[FHIRcast R4] Error processing subscriber response', { error: String(err) });
+    });
+  }
+}
+
+/**
+ * Process a subscriber's response to an event notification.
+ * Called by the WebSocket handler when it receives a { id, status } message.
+ */
+export function handleSubscriberResponse(endpoint: string, response: SubscriberResponse): boolean {
+  const entryMap = pendingAcks.get(response.id);
+  if (!entryMap) {
+    return false; // No pending ack for this event ID
+  }
+
+  const entry = entryMap.get(endpoint);
+  if (!entry) {
+    return false; // No pending ack for this endpoint
+  }
+
+  // Clear the timeout
+  clearTimeout(entry.timer);
+
+  // Remove from pending
+  entryMap.delete(endpoint);
+  if (entryMap.size === 0) {
+    pendingAcks.delete(response.id);
+  }
+
+  // Resolve the promise
+  entry.resolve(response);
+  return true;
+}
+
+/**
+ * Handle an abnormal WebSocket close for a subscriber.
+ * Per spec: Generate SyncError when close code is not 1000 (normal) or 1001 (going away).
+ */
+export async function handleAbnormalClose(
+  subscriber: SubscriberRecord,
+  closeCode: number
+): Promise<void> {
+  // Don't generate SyncError for normal closes
+  if (closeCode === 1000 || closeCode === 1001) {
+    return;
+  }
+
+  getLogger().warn('[FHIRcast R4] Abnormal WebSocket close', {
+    endpoint: subscriber.endpoint,
+    closeCode,
+    subscriberName: subscriber.subscriberName,
+  });
+
+  const outcome = createDisconnectSyncError(subscriber.subscriberName, closeCode);
+  await publishSyncError(subscriber.projectId, subscriber.topic, outcome);
+}
+
+/**
+ * Clean up all pending acks for an endpoint (e.g. when WebSocket closes).
+ */
+export function cleanupPendingAcks(endpoint: string): void {
+  for (const [eventId, entryMap] of pendingAcks) {
+    const entry = entryMap.get(endpoint);
+    if (entry) {
+      clearTimeout(entry.timer);
+      entryMap.delete(endpoint);
+      if (entryMap.size === 0) {
+        pendingAcks.delete(eventId);
+      }
+    }
+  }
+}
+
+/**
+ * Get the count of pending acks (for testing/debugging).
+ */
+export function getPendingAckCount(): number {
+  let count = 0;
+  for (const entryMap of pendingAcks.values()) {
+    count += entryMap.size;
+  }
+  return count;
+}

--- a/packages/server/src/fhircast-r4/types.test.ts
+++ b/packages/server/src/fhircast-r4/types.test.ts
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  getEventCategory,
+  subscriberWantsEvent,
+  isFhircastMessagePayload,
+  isSubscriberResponse,
+  RedisKeys,
+  parseProjectAndTopic,
+} from './types';
+
+describe('FHIRcast R4 types', () => {
+  describe('getEventCategory', () => {
+    test('open events', () => {
+      expect(getEventCategory('Patient-open')).toBe('open');
+      expect(getEventCategory('DiagnosticReport-open')).toBe('open');
+      expect(getEventCategory('ImagingStudy-open')).toBe('open');
+      expect(getEventCategory('Encounter-open')).toBe('open');
+    });
+
+    test('close events', () => {
+      expect(getEventCategory('Patient-close')).toBe('close');
+      expect(getEventCategory('DiagnosticReport-close')).toBe('close');
+    });
+
+    test('update events', () => {
+      expect(getEventCategory('DiagnosticReport-update')).toBe('update');
+    });
+
+    test('select events', () => {
+      expect(getEventCategory('DiagnosticReport-select')).toBe('select');
+    });
+
+    test('other events', () => {
+      expect(getEventCategory('syncerror')).toBe('other');
+      expect(getEventCategory('heartbeat')).toBe('other');
+      expect(getEventCategory('userlogout')).toBe('other');
+    });
+  });
+
+  describe('subscriberWantsEvent', () => {
+    test('single event match', () => {
+      expect(subscriberWantsEvent('Patient-open', 'Patient-open')).toBe(true);
+    });
+
+    test('single event no match', () => {
+      expect(subscriberWantsEvent('Patient-open', 'Patient-close')).toBe(false);
+    });
+
+    test('multiple events match', () => {
+      expect(subscriberWantsEvent('Patient-open,Patient-close', 'Patient-close')).toBe(true);
+    });
+
+    test('case insensitive', () => {
+      expect(subscriberWantsEvent('patient-open', 'Patient-open')).toBe(true);
+      expect(subscriberWantsEvent('Patient-open', 'patient-open')).toBe(true);
+    });
+
+    test('with spaces', () => {
+      expect(subscriberWantsEvent('Patient-open, Patient-close', 'Patient-close')).toBe(true);
+    });
+  });
+
+  describe('isFhircastMessagePayload', () => {
+    test('valid payload', () => {
+      expect(
+        isFhircastMessagePayload({
+          timestamp: '2024-01-01T00:00:00Z',
+          id: 'test-id',
+          event: {
+            'hub.topic': 'test-topic',
+            'hub.event': 'Patient-open',
+            context: [],
+          },
+        })
+      ).toBe(true);
+    });
+
+    test('null', () => {
+      expect(isFhircastMessagePayload(null)).toBe(false);
+    });
+
+    test('missing fields', () => {
+      expect(isFhircastMessagePayload({ id: 'test' })).toBe(false);
+      expect(isFhircastMessagePayload({ timestamp: '2024', id: 'test' })).toBe(false);
+    });
+
+    test('missing event fields', () => {
+      expect(
+        isFhircastMessagePayload({
+          timestamp: '2024',
+          id: 'test',
+          event: { 'hub.topic': 'topic' },
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('isSubscriberResponse', () => {
+    test('valid response', () => {
+      expect(isSubscriberResponse({ id: 'test-id', status: '200' })).toBe(true);
+    });
+
+    test('invalid - missing id', () => {
+      expect(isSubscriberResponse({ status: '200' })).toBe(false);
+    });
+
+    test('invalid - missing status', () => {
+      expect(isSubscriberResponse({ id: 'test-id' })).toBe(false);
+    });
+
+    test('invalid - non-string status', () => {
+      expect(isSubscriberResponse({ id: 'test-id', status: 200 })).toBe(false);
+    });
+
+    test('null', () => {
+      expect(isSubscriberResponse(null)).toBe(false);
+    });
+  });
+
+  describe('RedisKeys', () => {
+    test('topicSubscribers', () => {
+      expect(RedisKeys.topicSubscribers('proj1', 'topic1')).toBe(
+        'medplum:fhircast-r4:project:proj1:topic:topic1:subs'
+      );
+    });
+
+    test('endpointMapping', () => {
+      expect(RedisKeys.endpointMapping('ep1')).toBe('medplum:fhircast-r4:endpoint:ep1:topic');
+    });
+
+    test('topicCurrentContext', () => {
+      expect(RedisKeys.topicCurrentContext('proj1', 'topic1')).toBe(
+        'medplum:fhircast-r4:project:proj1:topic:topic1:latest'
+      );
+    });
+
+    test('topicChannel', () => {
+      expect(RedisKeys.topicChannel('proj1', 'topic1')).toBe('fhircast-r4:proj1:topic1');
+    });
+
+    test('keys do not collide with old hub', () => {
+      const oldKey = 'medplum:fhircast:project:proj1:topic:topic1:latest';
+      const newKey = RedisKeys.topicCurrentContext('proj1', 'topic1');
+      expect(newKey).not.toBe(oldKey);
+      expect(newKey).toContain('fhircast-r4');
+    });
+  });
+
+  describe('parseProjectAndTopic', () => {
+    test('valid string', () => {
+      expect(parseProjectAndTopic('proj1:topic1')).toEqual({
+        projectId: 'proj1',
+        topic: 'topic1',
+      });
+    });
+
+    test('topic with colon', () => {
+      expect(parseProjectAndTopic('proj1:topic:with:colons')).toEqual({
+        projectId: 'proj1',
+        topic: 'topic:with:colons',
+      });
+    });
+
+    test('no colon', () => {
+      expect(parseProjectAndTopic('nocolon')).toBeUndefined();
+    });
+  });
+});

--- a/packages/server/src/fhircast-r4/types.ts
+++ b/packages/server/src/fhircast-r4/types.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { FhircastEventName, FhircastMessagePayload } from '@medplum/core';
+import type { FhircastMessagePayload } from '@medplum/core';
 import type { OperationOutcome } from '@medplum/fhirtypes';
 
 /**

--- a/packages/server/src/fhircast-r4/types.ts
+++ b/packages/server/src/fhircast-r4/types.ts
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FhircastEventName, FhircastMessagePayload } from '@medplum/core';
+import type { OperationOutcome } from '@medplum/fhirtypes';
+
+/**
+ * Per-subscriber state stored in Redis and tracked in-memory by WebSocket connections.
+ */
+export interface SubscriberRecord {
+  /** The unique WebSocket endpoint ID for this subscriber. */
+  readonly endpoint: string;
+  /** The topic this subscriber is subscribed to. */
+  readonly topic: string;
+  /** The project ID for this subscriber. */
+  readonly projectId: string;
+  /** Comma-separated list of events this subscriber is subscribed to. */
+  readonly events: string;
+  /** Optional human-readable subscriber name (sent in SyncError notifications). */
+  readonly subscriberName?: string;
+  /** Lease duration in seconds. */
+  readonly leaseSeconds: number;
+  /** Timestamp (ms) when the subscription was created. */
+  readonly subscribedAt: number;
+}
+
+/**
+ * WebSocket subscription confirmation message.
+ * Sent by hub to subscriber after WebSocket connection is established.
+ * See: https://build.fhir.org/ig/HL7/fhircast-docs/2-4-Subscribing.html
+ */
+export interface SubscriptionConfirmation {
+  'hub.mode': 'subscribe';
+  'hub.topic': string;
+  'hub.events': string;
+  'hub.lease_seconds': number;
+}
+
+/**
+ * WebSocket subscription denial message.
+ * Sent by hub when subscription is denied or unsubscribed.
+ */
+export interface SubscriptionDenial {
+  'hub.mode': 'denied';
+  'hub.topic': string;
+  'hub.events': string;
+  'hub.reason'?: string;
+}
+
+/**
+ * Subscriber acknowledgment response sent over WebSocket.
+ * See: https://build.fhir.org/ig/HL7/fhircast-docs/2-5-ReceiveEventNotification.html
+ */
+export interface SubscriberResponse {
+  /** Event ID from the notification. */
+  id: string;
+  /** Numeric HTTP status code as string (e.g. "200", "409"). */
+  status: string;
+}
+
+/**
+ * Pending acknowledgment tracker for a single event notification.
+ */
+export interface PendingAck {
+  /** The event ID we're waiting for acknowledgment of. */
+  readonly eventId: string;
+  /** The endpoint of the subscriber we're waiting on. */
+  readonly endpoint: string;
+  /** Timer handle for the 10-second timeout. */
+  readonly timer: ReturnType<typeof setTimeout>;
+  /** Resolve function for the pending promise. */
+  readonly resolve: (response: SubscriberResponse) => void;
+}
+
+/**
+ * Event handler entry in the dispatch table.
+ */
+export type EventCategory = 'open' | 'close' | 'update' | 'select' | 'other';
+
+/**
+ * Maps event names to their categories for dispatch.
+ */
+export function getEventCategory(eventName: string): EventCategory {
+  const lower = eventName.toLowerCase();
+  if (lower.endsWith('-open')) {
+    return 'open';
+  }
+  if (lower.endsWith('-close')) {
+    return 'close';
+  }
+  if (lower.endsWith('-update')) {
+    return 'update';
+  }
+  if (lower.endsWith('-select')) {
+    return 'select';
+  }
+  return 'other';
+}
+
+/**
+ * Check whether a subscriber's event filter includes a given event.
+ * Per spec: "Hubs and Subscribers SHALL be case insensitive for event-names"
+ */
+export function subscriberWantsEvent(subscriberEvents: string, eventName: string): boolean {
+  const normalizedEvent = eventName.toLowerCase();
+  const subscribedEvents = subscriberEvents.split(',').map((e) => e.trim().toLowerCase());
+  return subscribedEvents.includes(normalizedEvent);
+}
+
+/**
+ * SyncError event context with OperationOutcome.
+ */
+export interface SyncErrorContext {
+  key: 'operationoutcome';
+  resource: OperationOutcome;
+}
+
+/**
+ * Configuration for the FHIRcast R4 hub.
+ */
+export interface FhircastR4Config {
+  /** Ack timeout in milliseconds (default: 10000). */
+  ackTimeoutMs: number;
+  /** WebSocket ping interval in milliseconds (default: 30000). */
+  pingIntervalMs: number;
+  /** Maximum missed pongs before closing connection (default: 3). */
+  maxMissedPongs: number;
+  /** Default lease seconds for subscriptions (default: 3600). */
+  defaultLeaseSeconds: number;
+}
+
+export const DEFAULT_CONFIG: FhircastR4Config = {
+  ackTimeoutMs: 10_000,
+  pingIntervalMs: 30_000,
+  maxMissedPongs: 3,
+  defaultLeaseSeconds: 3600,
+};
+
+/**
+ * The set of events supported by this hub.
+ */
+export const SUPPORTED_EVENTS: readonly string[] = [
+  'syncerror',
+  'heartbeat',
+  'userlogout',
+  'userhibernate',
+  'Patient-open',
+  'Patient-close',
+  'ImagingStudy-open',
+  'ImagingStudy-close',
+  'Encounter-open',
+  'Encounter-close',
+  'DiagnosticReport-open',
+  'DiagnosticReport-close',
+  'DiagnosticReport-select',
+  'DiagnosticReport-update',
+];
+
+/**
+ * Type guard for FhircastMessagePayload.
+ */
+export function isFhircastMessagePayload(obj: unknown): obj is FhircastMessagePayload {
+  if (!obj || typeof obj !== 'object') {
+    return false;
+  }
+  const payload = obj as Record<string, unknown>;
+  return (
+    typeof payload.timestamp === 'string' &&
+    typeof payload.id === 'string' &&
+    typeof payload.event === 'object' &&
+    payload.event !== null &&
+    typeof (payload.event as Record<string, unknown>)['hub.topic'] === 'string' &&
+    typeof (payload.event as Record<string, unknown>)['hub.event'] === 'string'
+  );
+}
+
+/**
+ * Type guard for SubscriberResponse.
+ */
+export function isSubscriberResponse(obj: unknown): obj is SubscriberResponse {
+  if (!obj || typeof obj !== 'object') {
+    return false;
+  }
+  const resp = obj as Record<string, unknown>;
+  return typeof resp.id === 'string' && typeof resp.status === 'string';
+}
+
+/**
+ * Redis key helpers for the R4 hub. Uses `fhircast-r4` prefix to avoid collisions
+ * with the existing `fhircast` prefix used by STU2/STU3.
+ */
+export const RedisKeys = {
+  /** Hash storing all subscriber records for a topic. Field = endpoint, Value = JSON SubscriberRecord. */
+  topicSubscribers(projectId: string, topic: string): string {
+    return `medplum:fhircast-r4:project:${projectId}:topic:${topic}:subs`;
+  },
+  /** Maps endpoint ID to "projectId:topic". */
+  endpointMapping(endpoint: string): string {
+    return `medplum:fhircast-r4:endpoint:${endpoint}:topic`;
+  },
+  /** Current context for a topic. */
+  topicCurrentContext(projectId: string, topic: string): string {
+    return `medplum:fhircast-r4:project:${projectId}:topic:${topic}:latest`;
+  },
+  /** Hash storing archived contexts for a topic (DiagnosticReport multi-context). */
+  topicContextStorage(projectId: string, topic: string): string {
+    return `medplum:fhircast-r4:project:${projectId}:topic:${topic}:contexts`;
+  },
+  /** Redis pub/sub channel for a topic. */
+  topicChannel(projectId: string, topic: string): string {
+    return `fhircast-r4:${projectId}:${topic}`;
+  },
+  /** Endpoint key for topic endpoint generation (atomic setnx). */
+  topicEndpoint(projectId: string, topic: string): string {
+    return `medplum:fhircast-r4:project:${projectId}:topic:${topic}:endpoint`;
+  },
+} as const;
+
+/**
+ * Parse a "projectId:topic" string from Redis.
+ */
+export function parseProjectAndTopic(value: string): { projectId: string; topic: string } | undefined {
+  const colonIndex = value.indexOf(':');
+  if (colonIndex === -1) {
+    return undefined;
+  }
+  return {
+    projectId: value.substring(0, colonIndex),
+    topic: value.substring(colonIndex + 1),
+  };
+}

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -27,6 +27,7 @@ import { getProjectIdByClientId } from '../auth/utils';
 import { getConfig } from '../config/loader';
 import { getAccessPolicyForLogin } from '../fhir/accesspolicy';
 import { getGlobalSystemRepo } from '../fhir/repo';
+import { getFhircastHubUrl } from '../fhircast-r4/routes';
 import { getTopicForUser } from '../fhircast/utils';
 import { validateClientCert } from './cert';
 import type { MedplumRefreshTokenClaims } from './keys';
@@ -795,7 +796,7 @@ async function sendTokenResponse(res: Response, login: WithId<Login>, client?: C
       sendTokenError(res, normalizeErrorString(err));
       return;
     }
-    fhircastProps['hub.url'] = `${config.baseUrl}fhircast/R4`;
+    fhircastProps['hub.url'] = getFhircastHubUrl(config.baseUrl);
     fhircastProps['hub.topic'] = topic;
   }
 

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -795,7 +795,7 @@ async function sendTokenResponse(res: Response, login: WithId<Login>, client?: C
       sendTokenError(res, normalizeErrorString(err));
       return;
     }
-    fhircastProps['hub.url'] = `${config.baseUrl}fhircast/STU3`; // TODO: Figure out how to handle the split between STU2 and STU3...
+    fhircastProps['hub.url'] = `${config.baseUrl}fhircast/R4`;
     fhircastProps['hub.topic'] = topic;
   }
 

--- a/packages/server/src/ws/fhircast-r4.test.ts
+++ b/packages/server/src/ws/fhircast-r4.test.ts
@@ -51,7 +51,7 @@ describe('FHIRcast R4 WebSocket', () => {
 
         // Subscribe with URL-encoded body (spec-compliant)
         const res1 = await request(server)
-          .post('/fhircast/R4')
+          .post('/fhircast/hub')
           .set('Content-Type', ContentType.FORM_URL_ENCODED)
           .set('Authorization', 'Bearer ' + accessToken)
           .send(
@@ -82,7 +82,7 @@ describe('FHIRcast R4 WebSocket', () => {
           .exec(async () => {
             // Publish a Patient-open event
             const res2 = await request(server)
-              .post(`/fhircast/R4/${topic}`)
+              .post(`/fhircast/hub/${topic}`)
               .set('Content-Type', ContentType.JSON)
               .set('Authorization', 'Bearer ' + accessToken)
               .send({
@@ -121,7 +121,7 @@ describe('FHIRcast R4 WebSocket', () => {
         const topic = randomUUID();
 
         const res1 = await request(server)
-          .post('/fhircast/R4')
+          .post('/fhircast/hub')
           .set('Content-Type', ContentType.FORM_URL_ENCODED)
           .set('Authorization', 'Bearer ' + accessToken)
           .send(
@@ -207,7 +207,7 @@ describe('FHIRcast R4 WebSocket', () => {
 
         // Subscribe
         const res1 = await request(server)
-          .post('/fhircast/R4')
+          .post('/fhircast/hub')
           .set('Content-Type', ContentType.FORM_URL_ENCODED)
           .set('Authorization', 'Bearer ' + accessToken)
           .send(
@@ -234,7 +234,7 @@ describe('FHIRcast R4 WebSocket', () => {
           .exec(async () => {
             // Open DiagnosticReport 1
             const res = await request(server)
-              .post('/fhircast/R4')
+              .post('/fhircast/hub')
               .set('Content-Type', ContentType.JSON)
               .set('Authorization', 'Bearer ' + accessToken)
               .send({
@@ -260,7 +260,7 @@ describe('FHIRcast R4 WebSocket', () => {
           .exec(async () => {
             // Update DiagnosticReport 1 — add Observation
             const res = await request(server)
-              .post('/fhircast/R4')
+              .post('/fhircast/hub')
               .set('Content-Type', ContentType.JSON)
               .set('Authorization', 'Bearer ' + accessToken)
               .send({
@@ -303,7 +303,7 @@ describe('FHIRcast R4 WebSocket', () => {
           .exec(async () => {
             // Open DiagnosticReport 2 (suspends report 1)
             const res = await request(server)
-              .post('/fhircast/R4')
+              .post('/fhircast/hub')
               .set('Content-Type', ContentType.JSON)
               .set('Authorization', 'Bearer ' + accessToken)
               .send({
@@ -328,7 +328,7 @@ describe('FHIRcast R4 WebSocket', () => {
           .exec(async () => {
             // Reopen DiagnosticReport 1 — should restore content
             const res = await request(server)
-              .post('/fhircast/R4')
+              .post('/fhircast/hub')
               .set('Content-Type', ContentType.JSON)
               .set('Authorization', 'Bearer ' + accessToken)
               .send({
@@ -354,7 +354,7 @@ describe('FHIRcast R4 WebSocket', () => {
           .exec(async () => {
             // Close DiagnosticReport 1
             const res = await request(server)
-              .post('/fhircast/R4')
+              .post('/fhircast/hub')
               .set('Content-Type', ContentType.JSON)
               .set('Authorization', 'Bearer ' + accessToken)
               .send({
@@ -378,7 +378,7 @@ describe('FHIRcast R4 WebSocket', () => {
           .exec(async () => {
             // Verify empty context
             const res = await request(server)
-              .get(`/fhircast/R4/${topic}`)
+              .get(`/fhircast/hub/${topic}`)
               .set('Authorization', 'Bearer ' + accessToken);
             expect(res.status).toBe(200);
             expect(res.body).toMatchObject({ 'context.type': '', context: [] });
@@ -393,7 +393,7 @@ describe('FHIRcast R4 WebSocket', () => {
 
         // Subscribe
         const res1 = await request(server)
-          .post('/fhircast/R4')
+          .post('/fhircast/hub')
           .set('Content-Type', ContentType.JSON)
           .set('Authorization', 'Bearer ' + accessToken)
           .send({
@@ -407,7 +407,7 @@ describe('FHIRcast R4 WebSocket', () => {
 
         // Unsubscribe
         const res2 = await request(server)
-          .post('/fhircast/R4')
+          .post('/fhircast/hub')
           .set('Content-Type', ContentType.JSON)
           .set('Authorization', 'Bearer ' + accessToken)
           .send({

--- a/packages/server/src/ws/fhircast-r4.test.ts
+++ b/packages/server/src/ws/fhircast-r4.test.ts
@@ -1,0 +1,424 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FhircastMessagePayload, WithId } from '@medplum/core';
+import {
+  ContentType,
+  createReference,
+  generateId,
+  getReferenceString,
+  serializeFhircastSubscriptionRequest,
+} from '@medplum/core';
+import type { DiagnosticReport, Observation, Patient } from '@medplum/fhirtypes';
+import type { Express } from 'express';
+import express from 'express';
+import { randomUUID } from 'node:crypto';
+import type { Server } from 'node:http';
+import request from 'superwstest';
+import { initApp, shutdownApp } from '../app';
+import { loadTestConfig } from '../config/loader';
+import type { MedplumServerConfig } from '../config/types';
+import { globalLogger } from '../logger';
+import { initTestAuth, withTestContext } from '../test.setup';
+
+describe('FHIRcast R4 WebSocket', () => {
+  describe('Basic flow', () => {
+    let app: Express;
+    let config: MedplumServerConfig;
+    let server: Server;
+    let accessToken: string;
+
+    beforeAll(async () => {
+      console.log = jest.fn();
+      app = express();
+      config = await loadTestConfig();
+      config.heartbeatEnabled = false;
+      server = await initApp(app, config);
+      accessToken = await initTestAuth({ membership: { admin: true } });
+      await new Promise<void>((resolve) => {
+        server.listen(0, 'localhost', 8521, resolve);
+      });
+    });
+
+    afterAll(async () => {
+      await shutdownApp();
+    });
+
+    test('Subscribe and receive event via WebSocket', () =>
+      withTestContext(async () => {
+        const topic = randomUUID();
+        const patientId = randomUUID();
+
+        // Subscribe with URL-encoded body (spec-compliant)
+        const res1 = await request(server)
+          .post('/fhircast/R4')
+          .set('Content-Type', ContentType.FORM_URL_ENCODED)
+          .set('Authorization', 'Bearer ' + accessToken)
+          .send(
+            serializeFhircastSubscriptionRequest({
+              mode: 'subscribe',
+              channelType: 'websocket',
+              topic,
+              events: ['Patient-open'],
+            })
+          );
+
+        expect(res1.status).toBe(202);
+        const endpoint = res1.body['hub.channel.endpoint'];
+        expect(endpoint).toMatch(/ws.*\/ws\/fhircast-r4\//);
+
+        const pathname = new URL(endpoint).pathname;
+
+        await request(server)
+          .ws(pathname)
+          .expectJson((obj) => {
+            // Subscription confirmation per spec
+            expect(obj['hub.mode']).toBe('subscribe');
+            expect(obj['hub.topic']).toBe(topic);
+            expect(obj['hub.events']).toBe('Patient-open');
+            expect(obj['hub.lease_seconds']).toBeDefined();
+            expect(typeof obj['hub.lease_seconds']).toBe('number');
+          })
+          .exec(async () => {
+            // Publish a Patient-open event
+            const res2 = await request(server)
+              .post(`/fhircast/R4/${topic}`)
+              .set('Content-Type', ContentType.JSON)
+              .set('Authorization', 'Bearer ' + accessToken)
+              .send({
+                timestamp: new Date().toISOString(),
+                id: randomUUID(),
+                event: {
+                  'hub.topic': topic,
+                  'hub.event': 'Patient-open',
+                  context: [
+                    {
+                      key: 'patient',
+                      resource: {
+                        resourceType: 'Patient',
+                        id: patientId,
+                      },
+                    },
+                  ],
+                },
+              });
+            expect(res2.status).toBe(202);
+          })
+          .expectJson((obj) => {
+            // Received event notification
+            expect(obj.event['hub.topic']).toBe(topic);
+            expect(obj.event['hub.event']).toBe('Patient-open');
+            expect(obj.event['context.versionId']).toBeDefined();
+          })
+          // Send ack response per spec
+          .sendJson({ id: randomUUID(), status: '200' })
+          .close()
+          .expectClosed();
+      }));
+
+    test('WebSocket confirmation has correct format', () =>
+      withTestContext(async () => {
+        const topic = randomUUID();
+
+        const res1 = await request(server)
+          .post('/fhircast/R4')
+          .set('Content-Type', ContentType.FORM_URL_ENCODED)
+          .set('Authorization', 'Bearer ' + accessToken)
+          .send(
+            serializeFhircastSubscriptionRequest({
+              mode: 'subscribe',
+              channelType: 'websocket',
+              topic,
+              events: ['Patient-open', 'Patient-close', 'ImagingStudy-open'],
+            })
+          );
+
+        const pathname = new URL(res1.body['hub.channel.endpoint']).pathname;
+
+        await request(server)
+          .ws(pathname)
+          .expectJson((obj) => {
+            // Verify confirmation matches spec exactly
+            expect(obj).toMatchObject({
+              'hub.mode': 'subscribe',
+              'hub.topic': topic,
+              'hub.events': 'Patient-open,Patient-close,ImagingStudy-open',
+              'hub.lease_seconds': expect.any(Number),
+            });
+
+            // Verify no extra non-spec fields
+            expect(obj['hub.callback']).toBeUndefined();
+            expect(obj['hub.channel']).toBeUndefined();
+            expect(obj['hub.secret']).toBeUndefined();
+            expect(obj['hub.subscriber']).toBeUndefined();
+          })
+          .close()
+          .expectClosed();
+      }));
+
+    test('Invalid endpoint sends denial and closes', () =>
+      withTestContext(async () => {
+        const errorSpy = jest.spyOn(globalLogger, 'error');
+        const fakeEndpoint = randomUUID();
+
+        await request(server)
+          .ws(`/ws/fhircast-r4/${fakeEndpoint}`)
+          .expectJson((obj) => {
+            expect(obj['hub.mode']).toBe('denied');
+            expect(obj['hub.reason']).toBe('invalid endpoint');
+          })
+          .expectClosed();
+
+        errorSpy.mockRestore();
+      }));
+
+    test('DiagnosticReport suspend-resume via WebSocket', () =>
+      withTestContext(async () => {
+        const topic = randomUUID();
+
+        const patient1: WithId<Patient> = {
+          id: generateId(),
+          resourceType: 'Patient',
+          name: [{ use: 'official', given: ['Frodo'], family: 'Baggins' }],
+        };
+        const report1: WithId<DiagnosticReport> = {
+          id: generateId(),
+          resourceType: 'DiagnosticReport',
+          status: 'preliminary',
+          code: { coding: [{ system: 'http://loinc.org', code: '19005-8' }] },
+        };
+        const observation1: WithId<Observation> = {
+          id: generateId(),
+          resourceType: 'Observation',
+          status: 'preliminary',
+          code: { coding: [{ system: 'http://www.radlex.org', code: 'RID49690' }] },
+        };
+        const patient2: WithId<Patient> = {
+          id: generateId(),
+          resourceType: 'Patient',
+          name: [{ use: 'official', given: ['Bilbo'], family: 'Baggins' }],
+        };
+        const report2: WithId<DiagnosticReport> = {
+          id: generateId(),
+          resourceType: 'DiagnosticReport',
+          status: 'preliminary',
+          code: { coding: [{ system: 'http://loinc.org', code: '19005-8' }] },
+        };
+
+        // Subscribe
+        const res1 = await request(server)
+          .post('/fhircast/R4')
+          .set('Content-Type', ContentType.FORM_URL_ENCODED)
+          .set('Authorization', 'Bearer ' + accessToken)
+          .send(
+            serializeFhircastSubscriptionRequest({
+              mode: 'subscribe',
+              channelType: 'websocket',
+              topic,
+              events: ['DiagnosticReport-open', 'DiagnosticReport-close', 'DiagnosticReport-update'],
+            })
+          );
+
+        const pathname = new URL(res1.body['hub.channel.endpoint']).pathname;
+
+        let lastVersionId: string | undefined;
+        let report1VersionId: string | undefined;
+
+        await request(server)
+          .ws(pathname)
+          .expectJson((obj) => {
+            // Confirmation
+            expect(obj['hub.mode']).toBe('subscribe');
+            expect(obj['hub.topic']).toBe(topic);
+          })
+          .exec(async () => {
+            // Open DiagnosticReport 1
+            const res = await request(server)
+              .post('/fhircast/R4')
+              .set('Content-Type', ContentType.JSON)
+              .set('Authorization', 'Bearer ' + accessToken)
+              .send({
+                timestamp: new Date().toISOString(),
+                id: randomUUID(),
+                event: {
+                  'hub.topic': topic,
+                  'hub.event': 'DiagnosticReport-open',
+                  context: [
+                    { key: 'report', resource: report1 },
+                    { key: 'patient', resource: patient1 },
+                  ],
+                },
+              });
+            expect(res.status).toBe(202);
+          })
+          .expectJson((obj: FhircastMessagePayload<'DiagnosticReport-open'>) => {
+            expect(obj.event['hub.event']).toBe('DiagnosticReport-open');
+            expect(obj.event['context.versionId']).toBeDefined();
+            lastVersionId = obj.event['context.versionId'];
+          })
+          .sendJson({ id: generateId(), status: '200' })
+          .exec(async () => {
+            // Update DiagnosticReport 1 — add Observation
+            const res = await request(server)
+              .post('/fhircast/R4')
+              .set('Content-Type', ContentType.JSON)
+              .set('Authorization', 'Bearer ' + accessToken)
+              .send({
+                timestamp: new Date().toISOString(),
+                id: randomUUID(),
+                event: {
+                  'hub.topic': topic,
+                  'hub.event': 'DiagnosticReport-update',
+                  'context.versionId': lastVersionId,
+                  context: [
+                    { key: 'report', reference: createReference(report1) },
+                    { key: 'patient', reference: createReference(patient1) },
+                    {
+                      key: 'updates',
+                      resource: {
+                        id: generateId(),
+                        resourceType: 'Bundle',
+                        type: 'transaction',
+                        entry: [
+                          {
+                            request: { method: 'PUT', url: getReferenceString(observation1) },
+                            resource: observation1,
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              } satisfies FhircastMessagePayload<'DiagnosticReport-update'>);
+            expect(res.status).toBe(202);
+          })
+          .expectJson((obj: FhircastMessagePayload<'DiagnosticReport-update'>) => {
+            expect(obj.event['hub.event']).toBe('DiagnosticReport-update');
+            expect(obj.event['context.versionId']).toBeDefined();
+            expect(obj.event['context.versionId']).not.toBe(lastVersionId); // New version
+            lastVersionId = obj.event['context.versionId'];
+            report1VersionId = lastVersionId;
+          })
+          .sendJson({ id: generateId(), status: '200' })
+          .exec(async () => {
+            // Open DiagnosticReport 2 (suspends report 1)
+            const res = await request(server)
+              .post('/fhircast/R4')
+              .set('Content-Type', ContentType.JSON)
+              .set('Authorization', 'Bearer ' + accessToken)
+              .send({
+                timestamp: new Date().toISOString(),
+                id: randomUUID(),
+                event: {
+                  'hub.topic': topic,
+                  'hub.event': 'DiagnosticReport-open',
+                  context: [
+                    { key: 'report', resource: report2 },
+                    { key: 'patient', resource: patient2 },
+                  ],
+                },
+              });
+            expect(res.status).toBe(202);
+          })
+          .expectJson((obj: FhircastMessagePayload<'DiagnosticReport-open'>) => {
+            expect(obj.event['hub.event']).toBe('DiagnosticReport-open');
+            lastVersionId = obj.event['context.versionId'];
+          })
+          .sendJson({ id: generateId(), status: '200' })
+          .exec(async () => {
+            // Reopen DiagnosticReport 1 — should restore content
+            const res = await request(server)
+              .post('/fhircast/R4')
+              .set('Content-Type', ContentType.JSON)
+              .set('Authorization', 'Bearer ' + accessToken)
+              .send({
+                timestamp: new Date().toISOString(),
+                id: randomUUID(),
+                event: {
+                  'hub.topic': topic,
+                  'hub.event': 'DiagnosticReport-open',
+                  context: [
+                    { key: 'report', resource: report1 },
+                    { key: 'patient', resource: patient1 },
+                  ],
+                },
+              });
+            expect(res.status).toBe(202);
+          })
+          .expectJson((obj: FhircastMessagePayload<'DiagnosticReport-open'>) => {
+            expect(obj.event['hub.event']).toBe('DiagnosticReport-open');
+            // Should restore the version ID from when we last updated report 1
+            expect(obj.event['context.versionId']).toBe(report1VersionId);
+          })
+          .sendJson({ id: generateId(), status: '200' })
+          .exec(async () => {
+            // Close DiagnosticReport 1
+            const res = await request(server)
+              .post('/fhircast/R4')
+              .set('Content-Type', ContentType.JSON)
+              .set('Authorization', 'Bearer ' + accessToken)
+              .send({
+                timestamp: new Date().toISOString(),
+                id: randomUUID(),
+                event: {
+                  'hub.topic': topic,
+                  'hub.event': 'DiagnosticReport-close',
+                  context: [
+                    { key: 'report', resource: report1 },
+                    { key: 'patient', resource: patient1 },
+                  ],
+                },
+              });
+            expect(res.status).toBe(202);
+          })
+          .expectJson((obj) => {
+            expect(obj.event['hub.event']).toBe('DiagnosticReport-close');
+          })
+          .sendJson({ id: generateId(), status: '200' })
+          .exec(async () => {
+            // Verify empty context
+            const res = await request(server)
+              .get(`/fhircast/R4/${topic}`)
+              .set('Authorization', 'Bearer ' + accessToken);
+            expect(res.status).toBe(200);
+            expect(res.body).toMatchObject({ 'context.type': '', context: [] });
+          })
+          .close()
+          .expectClosed();
+      }));
+
+    test('Unsubscribe returns 202', () =>
+      withTestContext(async () => {
+        const topic = randomUUID();
+
+        // Subscribe
+        const res1 = await request(server)
+          .post('/fhircast/R4')
+          .set('Content-Type', ContentType.JSON)
+          .set('Authorization', 'Bearer ' + accessToken)
+          .send({
+            'hub.channel.type': 'websocket',
+            'hub.mode': 'subscribe',
+            'hub.topic': topic,
+            'hub.events': 'Patient-open',
+          });
+
+        const endpoint = res1.body['hub.channel.endpoint'];
+
+        // Unsubscribe
+        const res2 = await request(server)
+          .post('/fhircast/R4')
+          .set('Content-Type', ContentType.JSON)
+          .set('Authorization', 'Bearer ' + accessToken)
+          .send({
+            'hub.channel.type': 'websocket',
+            'hub.mode': 'unsubscribe',
+            'hub.topic': topic,
+            'hub.channel.endpoint': endpoint,
+          });
+
+        expect(res2.status).toBe(202);
+        expect(res2.body['hub.channel.endpoint']).toBe(endpoint);
+      }));
+  });
+});

--- a/packages/server/src/ws/fhircast-r4.ts
+++ b/packages/server/src/ws/fhircast-r4.ts
@@ -1,0 +1,379 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { generateId } from '@medplum/core';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { IncomingMessage } from 'node:http';
+import os from 'node:os';
+import type { RawData, WebSocket } from 'ws';
+import { DEFAULT_HEARTBEAT_MS, heartbeat } from '../heartbeat';
+import { globalLogger } from '../logger';
+import { setGauge } from '../otel/otel';
+import { getPubSubRedisSubscriber } from '../redis';
+import { resolveEndpoint, getSubscriber } from '../fhircast-r4/subscriptions';
+import { getCurrentContext } from '../fhircast-r4/context-store';
+import { publishHeartbeat } from '../fhircast-r4/event-bus';
+import { handleSubscriberResponse, handleAbnormalClose, cleanupPendingAcks, registerCloseSocketCallback } from '../fhircast-r4/sync-error';
+import type { SubscriberResponse, SubscriptionConfirmation, SubscriptionDenial } from '../fhircast-r4/types';
+import { DEFAULT_CONFIG, isSubscriberResponse, RedisKeys, subscriberWantsEvent } from '../fhircast-r4/types';
+
+const hostname = os.hostname();
+const METRIC_OPTIONS = { attributes: { hostname } };
+
+/** Map of WebSocket -> subscriber info for active connections. */
+const activeConnections = new Map<WebSocket, ActiveConnection>();
+
+/** Map of endpoint -> WebSocket for looking up sockets by endpoint. */
+const endpointToSocket = new Map<string, WebSocket>();
+
+/** Set of active topic channels (projectId:topic) for heartbeat. */
+const activeTopicChannels = new Map<string, number>();
+
+let heartbeatHandler: (() => void) | undefined;
+let r4MessagesSent = 0;
+let r4MessagesReceived = 0;
+
+interface ActiveConnection {
+  endpoint: string;
+  projectId: string;
+  topic: string;
+  events: string;
+  subscriberName?: string;
+  redisSubscriber: ReturnType<typeof getPubSubRedisSubscriber>;
+  pingTimer?: ReturnType<typeof setInterval>;
+  missedPongs: number;
+}
+
+/**
+ * Initialize the FHIRcast R4 heartbeat.
+ * Publishes heartbeat events to all active topics at the configured interval.
+ */
+export function initFhircastR4Heartbeat(): void {
+  // Register the close-socket callback so sync-error.ts can disconnect non-responsive subscribers
+  // without needing a cross-layer import from routes -> ws
+  registerCloseSocketCallback(closeSocketForEndpoint);
+
+  if (!heartbeatHandler) {
+    heartbeatHandler = (): void => {
+      const periodSeconds = Math.ceil(DEFAULT_HEARTBEAT_MS / 1000);
+
+      for (const channelKey of activeTopicChannels.keys()) {
+        const parts = channelKey.split(':');
+        if (parts.length >= 2) {
+          const projectId = parts[0];
+          const topic = parts.slice(1).join(':');
+          publishHeartbeat(projectId, topic, periodSeconds).catch((err: Error) => {
+            globalLogger.error('[FHIRcast R4] Heartbeat publish error', { error: err.message });
+          });
+        }
+      }
+
+      // Report metrics
+      const heartbeatSeconds = DEFAULT_HEARTBEAT_MS / 1000;
+      setGauge('medplum.fhircast-r4.websocketCount', activeConnections.size, METRIC_OPTIONS);
+      setGauge('medplum.fhircast-r4.topicCount', activeTopicChannels.size, METRIC_OPTIONS);
+      setGauge('medplum.fhircast-r4.messagesSentPerSec', r4MessagesSent / heartbeatSeconds, METRIC_OPTIONS);
+      setGauge('medplum.fhircast-r4.messagesReceivedPerSec', r4MessagesReceived / heartbeatSeconds, METRIC_OPTIONS);
+      r4MessagesSent = 0;
+      r4MessagesReceived = 0;
+    };
+
+    heartbeat.addEventListener('heartbeat', heartbeatHandler);
+  }
+}
+
+/**
+ * Stop the FHIRcast R4 heartbeat.
+ */
+export function stopFhircastR4Heartbeat(): void {
+  if (heartbeatHandler) {
+    heartbeat.removeEventListener('heartbeat', heartbeatHandler);
+    heartbeatHandler = undefined;
+  }
+}
+
+/**
+ * Handle a new WebSocket connection to the FHIRcast R4 hub.
+ *
+ * Connection flow:
+ * 1. Extract endpoint from URL path: /ws/fhircast-r4/{endpoint}
+ * 2. Resolve endpoint to projectId:topic via Redis
+ * 3. If invalid, send denial and close
+ * 4. Create Redis subscriber for the topic channel
+ * 5. Send subscription confirmation per spec
+ * 6. Forward filtered events from Redis to WebSocket
+ * 7. Track subscriber responses for ack/SyncError
+ * 8. Ping/pong keepalive
+ */
+export async function handleFhircastR4Connection(socket: WebSocket, request: IncomingMessage): Promise<void> {
+  // Extract endpoint from URL: /ws/fhircast-r4/{endpoint}
+  const urlParts = (request.url as string).split('/').filter(Boolean);
+  const endpoint = urlParts[2]; // [0]='ws', [1]='fhircast-r4', [2]=endpoint
+
+  if (!endpoint) {
+    sendDenial(socket, '', '', 'missing endpoint in URL');
+    socket.close();
+    return;
+  }
+
+  // Resolve endpoint to project and topic
+  const mapping = await resolveEndpoint(endpoint);
+  if (!mapping) {
+    globalLogger.error('[FHIRcast R4] No topic for endpoint', { endpoint });
+    sendDenial(socket, '', '', 'invalid endpoint');
+    socket.close();
+    return;
+  }
+
+  const { projectId, topic } = mapping;
+
+  // Get subscriber record to retrieve event filter
+  const subscriber = await getSubscriber(projectId, topic, endpoint);
+  const subscriberEvents = subscriber?.events || '';
+  const subscriberName = subscriber?.subscriberName;
+  const leaseSeconds = subscriber?.leaseSeconds ?? DEFAULT_CONFIG.defaultLeaseSeconds;
+
+  // Create Redis subscriber for this connection
+  const redisSubscriber = getPubSubRedisSubscriber();
+  const channel = RedisKeys.topicChannel(projectId, topic);
+  await redisSubscriber.subscribe(channel);
+
+  // Track this connection
+  const conn: ActiveConnection = {
+    endpoint,
+    projectId,
+    topic,
+    events: subscriberEvents,
+    subscriberName,
+    redisSubscriber,
+    missedPongs: 0,
+  };
+  activeConnections.set(socket, conn);
+  endpointToSocket.set(endpoint, socket);
+
+  // Track topic ref count for heartbeat
+  const topicKey = `${projectId}:${topic}`;
+  activeTopicChannels.set(topicKey, (activeTopicChannels.get(topicKey) ?? 0) + 1);
+
+  // Forward messages from Redis to WebSocket (with per-subscriber event filtering)
+  redisSubscriber.on('message', (_channel: string, message: string) => {
+    try {
+      const parsed = JSON.parse(message);
+      const eventName = parsed._meta?.eventName || parsed.event?.['hub.event'];
+
+      // Filter: only send events this subscriber wants
+      if (eventName && subscriberEvents && !subscriberWantsEvent(subscriberEvents, eventName)) {
+        return; // Skip - subscriber didn't subscribe to this event type
+      }
+
+      // Remove internal metadata before sending to client
+      const { _meta, ...cleanPayload } = parsed;
+
+      // Backpressure: check if socket buffer is full
+      if (socket.bufferedAmount > 64 * 1024) {
+        globalLogger.warn('[FHIRcast R4] Socket buffer full, dropping message', {
+          endpoint,
+          bufferedAmount: socket.bufferedAmount,
+          eventName,
+        });
+        return;
+      }
+
+      socket.send(JSON.stringify(cleanPayload), { binary: false });
+      r4MessagesSent++;
+    } catch (err) {
+      globalLogger.error('[FHIRcast R4] Error forwarding message', {
+        endpoint,
+        error: String(err),
+      });
+    }
+  });
+
+  // Handle messages from subscriber (ack responses)
+  socket.on(
+    'message',
+    AsyncLocalStorage.bind(async (data: RawData) => {
+      r4MessagesReceived++;
+      try {
+        const message = JSON.parse((data as Buffer).toString('utf8'));
+
+        if (isSubscriberResponse(message)) {
+          // Process ack response
+          handleSubscriberResponse(endpoint, message as SubscriberResponse);
+        } else {
+          globalLogger.debug('[FHIRcast R4] Received non-ack message', { endpoint, message });
+        }
+      } catch (err) {
+        globalLogger.error('[FHIRcast R4] Error parsing WebSocket message', {
+          endpoint,
+          error: String(err),
+        });
+      }
+    })
+  );
+
+  // Handle WebSocket close
+  socket.on('close', (code: number) => {
+    const conn = activeConnections.get(socket);
+    if (conn) {
+      // Clean up ping timer
+      if (conn.pingTimer) {
+        clearInterval(conn.pingTimer);
+      }
+
+      // Clean up ack tracking
+      cleanupPendingAcks(endpoint);
+
+      // Handle abnormal close
+      if (subscriber) {
+        handleAbnormalClose(subscriber, code).catch((err) => {
+          globalLogger.error('[FHIRcast R4] Error handling abnormal close', { error: String(err) });
+        });
+      }
+
+      // Update topic ref count
+      const topicKey = `${conn.projectId}:${conn.topic}`;
+      const refCount = activeTopicChannels.get(topicKey);
+      if (refCount && refCount > 1) {
+        activeTopicChannels.set(topicKey, refCount - 1);
+      } else {
+        activeTopicChannels.delete(topicKey);
+      }
+
+      // Clean up maps
+      activeConnections.delete(socket);
+      endpointToSocket.delete(endpoint);
+
+      // Disconnect Redis subscriber
+      conn.redisSubscriber.disconnect();
+    }
+  });
+
+  // Start ping/pong keepalive
+  conn.pingTimer = setInterval(() => {
+    if (conn.missedPongs >= DEFAULT_CONFIG.maxMissedPongs) {
+      globalLogger.warn('[FHIRcast R4] Too many missed pongs, closing', { endpoint });
+      socket.close(1001, 'Ping timeout');
+      return;
+    }
+    conn.missedPongs++;
+    socket.ping();
+  }, DEFAULT_CONFIG.pingIntervalMs);
+
+  socket.on('pong', () => {
+    conn.missedPongs = 0;
+  });
+
+  // Send subscription confirmation per spec
+  // See: https://build.fhir.org/ig/HL7/fhircast-docs/2-4-Subscribing.html#subscription-confirmation
+  const confirmation: SubscriptionConfirmation = {
+    'hub.mode': 'subscribe',
+    'hub.topic': topic,
+    'hub.events': subscriberEvents,
+    'hub.lease_seconds': leaseSeconds,
+  };
+  socket.send(JSON.stringify(confirmation), { binary: false });
+  r4MessagesSent++;
+
+  // Send implicit open events for current context
+  // Per spec: Hub MAY send implied open events when new subscriber connects
+  await sendImplicitOpenEvents(socket, projectId, topic, subscriberEvents);
+
+  globalLogger.info('[FHIRcast R4] WebSocket connected', {
+    endpoint,
+    projectId,
+    topic,
+    events: subscriberEvents,
+    subscriberName,
+  });
+}
+
+/**
+ * Send implicit open events to a newly connected subscriber.
+ * If there's a current context, send the appropriate *-open event
+ * so the subscriber knows the current state.
+ */
+async function sendImplicitOpenEvents(
+  socket: WebSocket,
+  projectId: string,
+  topic: string,
+  subscriberEvents: string
+): Promise<void> {
+  try {
+    const currentContext = await getCurrentContext(projectId, topic);
+    if (!currentContext) {
+      return; // No current context to send
+    }
+
+    const contextType = currentContext['context.type'];
+    if (!contextType) {
+      return;
+    }
+
+    const openEventName = `${contextType}-open`;
+
+    // Only send if subscriber is subscribed to this open event
+    if (subscriberEvents && !subscriberWantsEvent(subscriberEvents, openEventName)) {
+      return;
+    }
+
+    // Filter out 'content' key from context for the open event
+    // (content is only returned via GetCurrentContext)
+    const contextWithoutContent = currentContext.context.filter((ctx) => ctx.key !== 'content');
+
+    const openEvent = {
+      timestamp: new Date().toISOString(),
+      id: generateId(),
+      event: {
+        'hub.topic': topic,
+        'hub.event': openEventName,
+        'context.versionId': currentContext['context.versionId'],
+        context: contextWithoutContent,
+      },
+    };
+
+    socket.send(JSON.stringify(openEvent), { binary: false });
+    r4MessagesSent++;
+
+    globalLogger.debug('[FHIRcast R4] Sent implicit open event', {
+      projectId,
+      topic,
+      eventName: openEventName,
+    });
+  } catch (err) {
+    globalLogger.error('[FHIRcast R4] Error sending implicit open events', { error: String(err) });
+  }
+}
+
+/**
+ * Send a subscription denial message over WebSocket.
+ */
+function sendDenial(socket: WebSocket, topic: string, events: string, reason: string): void {
+  const denial: SubscriptionDenial = {
+    'hub.mode': 'denied',
+    'hub.topic': topic,
+    'hub.events': events,
+    'hub.reason': reason,
+  };
+  socket.send(JSON.stringify(denial), { binary: false });
+  r4MessagesSent++;
+}
+
+/**
+ * Close the WebSocket for a specific endpoint.
+ * Used by sync-error.ts to disconnect non-responsive subscribers.
+ */
+export function closeSocketForEndpoint(endpoint: string): void {
+  const socket = endpointToSocket.get(endpoint);
+  if (socket) {
+    sendDenial(socket, '', '', 'Subscription terminated due to non-responsiveness');
+    socket.close(1000, 'Unsubscribed');
+  }
+}
+
+/**
+ * Get the active connection count (for testing/debugging).
+ */
+export function getActiveConnectionCount(): number {
+  return activeConnections.size;
+}

--- a/packages/server/src/ws/routes.ts
+++ b/packages/server/src/ws/routes.ts
@@ -13,6 +13,7 @@ import { handleAgentConnection } from './agent';
 import { handleAiRealtimeConnection } from './ai-realtime';
 import { handleEchoConnection, initEchoHeartbeat, stopEchoHeartbeat } from './echo';
 import { handleFhircastConnection, initFhircastHeartbeat, stopFhircastHeartbeat } from './fhircast';
+import { handleFhircastR4Connection, initFhircastR4Heartbeat, stopFhircastR4Heartbeat } from './fhircast-r4';
 import { handleR4SubscriptionConnection } from './subscriptions';
 
 const handlerMap = new Map<string, (socket: WebSocket, request: IncomingMessage) => Promise<void>>();
@@ -20,6 +21,7 @@ handlerMap.set('echo', handleEchoConnection);
 handlerMap.set('agent', handleAgentConnection);
 handlerMap.set('ai-realtime', handleAiRealtimeConnection);
 handlerMap.set('fhircast', handleFhircastConnection);
+handlerMap.set('fhircast-r4', handleFhircastR4Connection);
 handlerMap.set('subscriptions-r4', handleR4SubscriptionConnection);
 
 type WebSocketState = {
@@ -95,6 +97,7 @@ export function initWebSockets(server: http.Server): void {
   });
 
   initFhircastHeartbeat();
+  initFhircastR4Heartbeat();
   initEchoHeartbeat();
 }
 
@@ -104,6 +107,7 @@ function getWebSocketPath(path: string): string {
 
 export async function closeWebSockets(): Promise<void> {
   stopFhircastHeartbeat();
+  stopFhircastR4Heartbeat();
   stopEchoHeartbeat();
 
   if (wsServer) {


### PR DESCRIPTION
This pull request implements improvements to the FHIRCast subsystem, and makes the MedPlum implementation compliant with v3.0.0 of the [FHIRcast implementation guide](https://build.fhir.org/ig/HL7/fhircast-docs/), and integrates with the [OHIF DICOM Viewer FHIRcast implementation](https://github.com/OHIF/Viewers/pull/5988).


### Issues Addressed

This pull request also addresses the following issues:
 
  #5981 — [FHIRcast] Only propagate event notifications to a user for events they are subscribed to

 - How: Per-subscriber event filtering via subscriberWantsEvent() in types.ts and getSubscribersForEvent() in subscriptions.ts. Subscribers declare hub.events at subscription time; the WebSocket layer filters outbound events accordingly.
 - Commit: f9d8cbd6e (main implementation)

 #5979 — [FHIRcast] Generate SyncError when a subscriber times out

 - How: sync-error.ts tracks pending acknowledgments per subscriber with a 10-second timeout. On timeout: publishes SyncError to all subscribers, removes the non-responsive subscriber, closes their WebSocket. Also generates SyncError on 4xx/5xx refusal and abnormal WebSocket disconnect.
 - Commit: f9d8cbd6e

 #5978 — [FHIRcast] Support implicit *-open event notifications

 - How: ws/fhircast-r4.ts sends the current context as an implicit open event to newly connected subscribers after the subscription confirmation message.
 - Commit: f9d8cbd6e

 #5980 — [FHIRcast] Fix event notification response payload

 - How: The R4 hub uses the spec-compliant { id, status } response format. Event notification payloads follow the correct envelope structure (timestamp, id, event with hub.topic, hub.event, context).
 - Commit: f9d8cbd6e

 #6674 — FHIRCast: Cannot open multiple contexts with DiagnosticReport-open

 - How: context-store.ts implements multi-context support for DiagnosticReport with archived contexts via storeContext()/fetchStoredContext(). Opening a new DiagnosticReport context archives the previous one; re-opening restores it.
 - Commit: f9d8cbd6e

 #6788 — FHIRCast: Subscription Confirmation message is missing list of subscribed events

 - How: The R4 WebSocket handler sends a spec-compliant confirmation containing exactly hub.mode, hub.topic, hub.events (populated with the subscriber's granted events), and hub.lease_seconds. No extraneous fields.
 - Commit: f9d8cbd6e

 Issues Partially Addressed (1)

 #4854 — Implement FHIRcast event filtering based on provided FHIRcast scopes

 - What's done: Event filtering per the subscription request's hub.events field is fully implemented (subscribers only receive events they asked for).
 - What's not done: The hub does not validate that the subscriber's OAuth token scopes (fhircast/Patient-open.read, etc.) actually authorize the requested events.
 Scope-based enforcement is a separate concern from subscription-level filtering.

 
### Screenshots

1.  Screenshot of the OHIF DICOM Viewer being launched with a SMART Launch URL with the Medplum local server at http://localhost:8103, subscribing to a FHIRcast subscription, and receiving an event.  

<img width="1413" height="1069" alt="Screenshot 2026-05-29 at 2 24 43 PM" src="https://github.com/user-attachments/assets/fcc44c51-dcaf-4f07-9bb5-588c4dd976a5" />


2.  Screenshot of Postman utility sending a payload to the now spec-compliant /fhircast/hub route, which then relays to the subscribing OHIF DICOM Viewer.  
<img width="1582" height="1114" alt="Screenshot 2026-05-29 at 2 25 07 PM" src="https://github.com/user-attachments/assets/d1217d50-e8f7-44b0-b2b5-ff8bd42442da" />

# Medplum Integration

Step-by-step guide for setting up [Medplum](https://www.medplum.com/) as the FHIR R4
backend (and FHIRcast hub) for the OHIF FHIR Viewer.

Medplum is a good fit for this viewer's **CORS-direct** model: it ships with
`allowedOrigins: "*"` in development, so the browser calls the FHIR and FHIRcast
endpoints directly — no dev proxy required.

## 1. Install and Run the OHIF Viewer
Begin by installing the OHIF Viewer

```bash
# create a working directory
mkdir demo && cd demo

# install OHIF and the NOF FHIR extension
#git clone https://github.com/OHIF/Viewers

git clone https://github.com/awatson1978/Viewers
cd Viewers
git checkout -b fhircast-mvd
git pull origin fhircast-mvd

# install dependencies and run the app
brew install pnpm
pnpm install
pnpm dev
```


The extension is injected at startup through the `EXTRA_EXTENSIONS` environment
variable — no edits to `pluginConfig.json` are required. Its bundled `fhir-viewer`
mode is **auto-detected** and registered alongside it (no `EXTRA_MODES` needed).
The Medplum admin app runs on `:3000` (OHIF's default), so start OHIF on **`:3200`**
with `OHIF_PORT`:

```bash
# install the extension
cd extensions
git clone https://github.com/node-on-fhir/ohif-fhir-viewer
cd ..

# install dependencies and run the app
pnpm install
EXTRA_EXTENSIONS=@ohif/fhir-viewer pnpm dev
```

> **Mode auto-detection:** when an `EXTRA_EXTENSIONS` package contains a `mode/`
> subdirectory with a `package.json`, that mode is registered automatically. Use
> `EXTRA_MODES` only to override or add other modes explicitly.

The viewer is now available at `http://localhost:3200/fhir-viewer`.

## 2. Install and Run Medplum

Medplum needs Redis and PostgreSQL (provided via Docker), the API server, and the
admin app. See the [Medplum local dev docs](https://www.medplum.com/docs/contributing/run-the-stack)
for first-time clone/build steps.

| Service | URL | Notes |
|---|---|---|
| Medplum server | `http://localhost:8103` | FHIR R4 API + FHIRcast hub |
| Medplum app | `http://localhost:3000` | Admin UI for resource management |
| Redis | `localhost:6379` | Docker container `redis-1` |
| PostgreSQL | `localhost:5432` | Docker container `postgres-1` |

```bash
# Redis and Postgres
cd medplum
docker compose up -d

# Medplum API server (FHIR R4 + FHIRcast hub) on :8103
cd packages/server
npm run dev
```

The Medplum admin app runs on `http://localhost:3000` (start it per the Medplum
docs if it isn't already running).

> **CORS:** Medplum's dev config sets `allowedOrigins: "*"`, so OHIF (on `:3200`)
> can call the FHIR, OAuth, and FHIRcast endpoints on `:8103` directly. No
> `/fhir-proxy` and no `FHIR_SERVER` setting are involved — the browser talks to
> Medplum at its absolute origin.

## 3. Register the Viewer as a Client

OHIF authenticates against Medplum using SMART on FHIR (OAuth 2.0). Register a
`ClientApplication` so Medplum knows which app is requesting access.

1. In the Medplum app, navigate to `http://localhost:3000/ClientApplication/new`.
2. Set:
   - **Name**: `OHIF Viewer`
   - **Redirect URI**: `http://localhost:3200/fhir-viewer`
   - **Launch URI**: `http://localhost:3200/fhir-viewer`
3. Save.
4. **Copy the ClientApplication UUID** from the URL bar
   (`http://localhost:3000/ClientApplication/<uuid>`) — this is your SMART client ID.

Supply that UUID to OHIF at **runtime** — there is no `SMART_CLIENT_ID` build var
(OHIF is a static SPA). Use any of, most-specific wins:

1. **URL** — `?client_id=<uuid>` appended to the launch (per-launch).
2. **SMART Preferences panel** in OHIF — paste/register the client ID (per-user, saved to localStorage).
3. **`window.config`** — the `smartClientId` field in the data source `configuration` of the served `app-config.js` (per-deployment).

## 4. Order and Complete an Exam on a Patient

### A. Create test data in the Medplum app (`http://localhost:3000`)

1. **Patient** — sidebar → **Patient** → **New…**, fill name fields, save. Note the Patient ID.
2. **ServiceRequest** (the order) — **New…**, set `status: active`, `intent: order`,
   `subject: Patient/<id>`, a `code` (e.g. "CT Chest"), save.
3. **DiagnosticReport** (optional) — **New…**, set `status: preliminary`, `subject`,
   `basedOn: ServiceRequest/<id>`, a `code`, save.
4. **ImagingStudy** (optional) — **New…**, `status: available`, link to the Patient via `subject`.

### B. Trigger the SMART launch

1. Navigate to the Patient: `http://localhost:3000/Patient/<patient-id>`.
2. Click the **Apps** tab → click **OHIF Viewer**.
3. Medplum redirects the browser to
   `http://localhost:3200/fhir-viewer?iss=http://localhost:8103/fhir/R4&launch=<launch-id>`.
4. OHIF detects both `iss` and `launch` (Case B), discovers SMART config at
   `http://localhost:8103/fhir/R4/.well-known/smart-configuration`, and redirects to
   Medplum's authorize endpoint.
5. Authenticate at Medplum (or use the existing session) and grant consent. Medplum
   redirects back with `?code=…&state=…`; OHIF exchanges the code for a token at
   `/oauth2/token` and loads the patient's studies.

## 5. Verify FHIRcast

The fastest interop check skips the OAuth dance by injecting a token manually.

### A. Quick test with a manual token

1. **Get a token** — in the Medplum app console (`http://localhost:3000`):
   ```js
   JSON.parse(localStorage.getItem('@medplum:activeLogin')).accessToken
   ```
2. **Open OHIF with the ISS** (Case C — sets the FHIR server without an OAuth redirect):
   ```
   http://localhost:3200/fhir-viewer?iss=http://localhost:8103/fhir/R4
   ```
3. **Inject the token** in the OHIF tab's console, then **reload the same tab**
   (`sessionStorage` is per-tab):
   ```js
   sessionStorage.setItem('fhir_smart_token', JSON.stringify({
     access_token: '<PASTE-TOKEN>',
     expires_in: 3600,
     _savedAt: Date.now(),
   }));
   ```

### B. Subscribe and publish

1. Open the **FhirCast** panel. The hub URL is auto-discovered (SMART token `hub.url` →
   CapabilityStatement → probe) as `http://localhost:8103/fhircast/STU3`. The equivalent alias
   `http://localhost:8103/api/hub` also works. All called directly — no proxy.
2. Enter a topic (any string), select `Patient-open` / `ImagingStudy-open`, click **Subscribe**.
   Expect HTTP 202 and the WebSocket status to go **Open** (Medplum returns
   `ws://localhost:8103/ws/fhircast/<uuid>` in `hub.channel.endpoint`, used directly).
3. Publish a `Patient-open` event from a terminal. The canonical hub is `/fhircast/STU3`; the
   `/api/hub` alias accepts the same request:
   ```bash
   TOKEN="<access-token>"
   TOPIC="<topic-from-panel>"
   curl -s -X POST "http://localhost:8103/fhircast/STU3/$TOPIC" \
     -H "Authorization: Bearer $TOKEN" \
     -H 'Content-Type: application/json' \
     -d '{
       "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'",
       "id": "'$(uuidgen)'",
       "event": {
         "hub.topic": "'$TOPIC'",
         "hub.event": "Patient-open",
         "context": [{"key": "patient", "resource": {"resourceType": "Patient", "id": "test-patient-123"}}]
       }
     }'
   ```
4. The event should appear in the panel's **Received Events**. Wait 10+ seconds —
   **no `syncerror`** should appear (confirms OHIF's ACK reached Medplum). Click
   **Unsubscribe** for a clean disconnect.

### Success criteria

| Check | Expected |
|---|---|
| `.well-known/fhircast-configuration` | JSON with `eventsSupported` |
| Token injection | Persists after reload (same tab) |
| Hub URL auto-discovered | `http://localhost:8103/fhircast/STU3` (alias: `/api/hub`) |
| Subscription POST | HTTP 202 Accepted |
| WebSocket | Opens successfully |
| Event delivery | Appears in OHIF panel |
| Event ACK | No SyncError after 10s |
| Unsubscribe | Clean disconnect |

---

### Known Issues

The FHIRCast hub is confirmed to work in this demo, and external systems can push events to the hub, and it will relay to subscribers.  However, the MedPlum internal event bus hasn't been wired up to emit the necessary events to the hub, so updating DiagnosticReports, for example, won't emit DiagnosticReport events.  

