### PR TITLE
Track idle in transaction time

### DIFF
--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -114,6 +114,9 @@ export interface MedplumServerConfig {
   /** Number of milliseconds to use as a base for exponential backoff in transaction retries */
   transactionExpBackoffBaseDelayMs?: number;
 
+  /** Optional threshold in milliseconds for logging and recording high idle time within transactions */
+  idleInTransactionLogThresholdMs?: number;
+
   /** Flag to enable/disable the binary storage auto-downloader service (default 'true' for enabled) */
   autoDownloadEnabled?: boolean;
 

--- a/packages/server/src/config/utils.ts
+++ b/packages/server/src/config/utils.ts
@@ -124,6 +124,7 @@ const integerKeys = new Set([
   'shutdownTimeoutMilliseconds',
   'transactionAttempts',
   'transactionExpBackoffBaseDelayMs',
+  'idleInTransactionLogThresholdMs',
   'fhirSearchMinLimit',
 
   'database.maxConnections',

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -1653,14 +1653,19 @@ describe('FHIR Repo', () => {
         })
       ).rejects.toThrow('work failed');
 
-      expect(recordHistogramValueSpy).toHaveBeenCalledWith(TransactionIdleTracker.OTEL_METRIC_NAME, 10, {
+      expect(recordHistogramValueSpy).toHaveBeenCalledWith(TransactionIdleTracker.OTEL_TOTAL_METRIC_NAME, 10, {
+        attributes: { attempt: 0, serializable: false, status: 'rolled_back' },
+        options: { unit: 'ms' },
+      });
+      expect(recordHistogramValueSpy).toHaveBeenCalledWith(TransactionIdleTracker.OTEL_MAX_METRIC_NAME, 10, {
         attributes: { attempt: 0, serializable: false, status: 'rolled_back' },
         options: { unit: 'ms' },
       });
       expect(warnSpy).toHaveBeenCalledWith(
         TransactionIdleTracker.LOG_HIGH_IDLE_TIME_MSG,
         expect.objectContaining({
-          idleMs: 10,
+          totalIdleMs: 10,
+          maxIdleMs: 10,
           queryCount: 1,
           status: 'rolled_back',
           transactionDurationMs: 10,
@@ -1697,12 +1702,27 @@ describe('FHIR Repo', () => {
 
     try {
       await repo.withTransaction(async () => {
+        now += 30;
+        await repo.withTransaction(async (txClient) => {
+          now += 20;
+          await txClient.query('SELECT 1');
+        });
+        now += 10;
+      });
+
+      expect(recordHistogramValueSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalledWith(TransactionIdleTracker.LOG_HIGH_IDLE_TIME_MSG, expect.anything());
+
+      now = 0;
+      query.mockClear();
+
+      await repo.withTransaction(async () => {
         now += 20;
         await repo.withTransaction(async (txClient) => {
           now += 5;
           await txClient.query('SELECT 1');
         });
-        now += 40;
+        now += 50;
       });
 
       expect(query.mock.calls.map(([sql]) => sql)).toStrictEqual([
@@ -1712,8 +1732,12 @@ describe('FHIR Repo', () => {
         'RELEASE SAVEPOINT sp2',
         'COMMIT',
       ]);
-      expect(recordHistogramValueSpy).toHaveBeenCalledTimes(1);
-      expect(recordHistogramValueSpy).toHaveBeenCalledWith(TransactionIdleTracker.OTEL_METRIC_NAME, 65, {
+      expect(recordHistogramValueSpy).toHaveBeenCalledTimes(2);
+      expect(recordHistogramValueSpy).toHaveBeenCalledWith(TransactionIdleTracker.OTEL_TOTAL_METRIC_NAME, 75, {
+        attributes: { attempt: 0, serializable: false, status: 'committed' },
+        options: { unit: 'ms' },
+      });
+      expect(recordHistogramValueSpy).toHaveBeenCalledWith(TransactionIdleTracker.OTEL_MAX_METRIC_NAME, 50, {
         attributes: { attempt: 0, serializable: false, status: 'committed' },
         options: { unit: 'ms' },
       });
@@ -1721,14 +1745,15 @@ describe('FHIR Repo', () => {
         TransactionIdleTracker.LOG_HIGH_IDLE_TIME_MSG,
         expect.objectContaining({
           attempt: 0,
-          idleMs: 65,
+          totalIdleMs: 75,
+          maxIdleMs: 50,
           queryCount: 4,
           queryDurationMs: 25,
           serializable: false,
           status: 'committed',
           thresholdMs: 50,
           transactionAttempts: 2,
-          transactionDurationMs: 90,
+          transactionDurationMs: 100,
         })
       );
       expect(client.query).toBe(query);

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -46,6 +46,7 @@ import * as workersModule from '../workers';
 import { getRepoForLogin } from './accesspolicy';
 import { getGlobalSystemRepo, getProjectSystemRepo, getShardSystemRepo, Repository } from './repo';
 import { RepositoryConnection } from './repository/repository-connection';
+import { TransactionIdleTracker } from './repository/transaction-idle-tracker';
 import { PostgresError, SelectQuery } from './sql';
 import * as tokenColumnModule from './token-column';
 
@@ -1577,7 +1578,7 @@ describe('FHIR Repo', () => {
           'COMMIT',
         ]);
         expect(client.query).toBe(query);
-        expect(warnSpy).not.toHaveBeenCalledWith('High idle time in transaction', expect.anything());
+        expect(warnSpy).not.toHaveBeenCalledWith(TransactionIdleTracker.LOG_HIGH_IDLE_TIME_MSG, expect.anything());
         expect(recordHistogramValueSpy).not.toHaveBeenCalled();
       } finally {
         restoreThreshold();
@@ -1618,7 +1619,7 @@ describe('FHIR Repo', () => {
       });
 
       expect(client.query).toBe(query);
-      expect(warnSpy).not.toHaveBeenCalledWith('High idle time in transaction', expect.anything());
+      expect(warnSpy).not.toHaveBeenCalledWith(TransactionIdleTracker.LOG_HIGH_IDLE_TIME_MSG, expect.anything());
       expect(recordHistogramValueSpy).not.toHaveBeenCalled();
     } finally {
       restoreThreshold();
@@ -1652,12 +1653,12 @@ describe('FHIR Repo', () => {
         })
       ).rejects.toThrow('work failed');
 
-      expect(recordHistogramValueSpy).toHaveBeenCalledWith('medplum.db.transactionIdleMs', 10, {
+      expect(recordHistogramValueSpy).toHaveBeenCalledWith(TransactionIdleTracker.OTEL_METRIC_NAME, 10, {
         attributes: { attempt: 0, serializable: false, status: 'rolled_back' },
         options: { unit: 'ms' },
       });
       expect(warnSpy).toHaveBeenCalledWith(
-        'High idle time in transaction',
+        TransactionIdleTracker.LOG_HIGH_IDLE_TIME_MSG,
         expect.objectContaining({
           idleMs: 10,
           queryCount: 1,
@@ -1712,12 +1713,12 @@ describe('FHIR Repo', () => {
         'COMMIT',
       ]);
       expect(recordHistogramValueSpy).toHaveBeenCalledTimes(1);
-      expect(recordHistogramValueSpy).toHaveBeenCalledWith('medplum.db.transactionIdleMs', 65, {
+      expect(recordHistogramValueSpy).toHaveBeenCalledWith(TransactionIdleTracker.OTEL_METRIC_NAME, 65, {
         attributes: { attempt: 0, serializable: false, status: 'committed' },
         options: { unit: 'ms' },
       });
       expect(warnSpy).toHaveBeenCalledWith(
-        'High idle time in transaction',
+        TransactionIdleTracker.LOG_HIGH_IDLE_TIME_MSG,
         expect.objectContaining({
           attempt: 0,
           idleMs: 65,

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -39,6 +39,7 @@ import { getConfig, loadTestConfig } from '../config/loader';
 import { r4ProjectId, systemResourceProjectId } from '../constants';
 import { DatabaseMode } from '../database';
 import { getLogger } from '../logger';
+import * as otelModule from '../otel/otel';
 import { bundleContains, createTestProject, withTestContext } from '../test.setup';
 import { AuditEventOutcome, createAuditEvent, ReadInteraction, RestfulOperationType } from '../util/auditevent';
 import * as workersModule from '../workers';
@@ -78,6 +79,15 @@ describe('FHIR Repo', () => {
   afterAll(async () => {
     await shutdownApp();
   });
+
+  function setIdleInTransactionLogThresholdMs(thresholdMs: number | undefined): () => void {
+    const config = getConfig();
+    const previousThresholdMs = config.idleInTransactionLogThresholdMs;
+    config.idleInTransactionLogThresholdMs = thresholdMs;
+    return () => {
+      config.idleInTransactionLogThresholdMs = previousThresholdMs;
+    };
+  }
 
   test('getRepoForLogin', async () => {
     await expect(
@@ -1538,6 +1548,195 @@ describe('FHIR Repo', () => {
     releaseSpy.mockRestore();
     warnSpy.mockRestore();
     errorSpy.mockRestore();
+  });
+
+  test.each([undefined, -1] as (number | undefined)[])(
+    'withTransaction does not record transaction idle metrics when threshold is %s',
+    async (thresholdMs) => {
+      const restoreThreshold = setIdleInTransactionLogThresholdMs(thresholdMs);
+      const query = jest.fn(async (_sql: string) => ({ rows: [] }));
+      const client = {
+        query,
+        release: jest.fn(),
+      } as unknown as PoolClient;
+      const repo = getShardSystemRepo(
+        'test-shard',
+        RepositoryConnection.borrowClient(client, { mode: DatabaseMode.WRITER })
+      );
+      const warnSpy = jest.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+      const recordHistogramValueSpy = jest.spyOn(otelModule, 'recordHistogramValue').mockImplementation(() => true);
+
+      try {
+        await repo.withTransaction(async (txClient) => {
+          await txClient.query('SELECT 1');
+        });
+
+        expect(query.mock.calls.map(([sql]) => sql)).toStrictEqual([
+          'BEGIN ISOLATION LEVEL REPEATABLE READ',
+          'SELECT 1',
+          'COMMIT',
+        ]);
+        expect(client.query).toBe(query);
+        expect(warnSpy).not.toHaveBeenCalledWith('High idle time in transaction', expect.anything());
+        expect(recordHistogramValueSpy).not.toHaveBeenCalled();
+      } finally {
+        restoreThreshold();
+        warnSpy.mockRestore();
+        recordHistogramValueSpy.mockRestore();
+      }
+    }
+  );
+
+  test('withTransaction disables idle tracking for callback-style queries', async () => {
+    const restoreThreshold = setIdleInTransactionLogThresholdMs(5);
+    let now = 0;
+    const dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+    const query = jest.fn((sql: string, callback?: (err: Error | undefined, result: { rows: any[] }) => void) => {
+      if (sql === 'SELECT 1' && callback) {
+        now += 10;
+        callback(undefined, { rows: [] });
+        return undefined;
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    const client = {
+      query,
+      release: jest.fn(),
+    } as unknown as PoolClient;
+    const repo = getShardSystemRepo(
+      'test-shard',
+      RepositoryConnection.borrowClient(client, { mode: DatabaseMode.WRITER })
+    );
+    const warnSpy = jest.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+    const recordHistogramValueSpy = jest.spyOn(otelModule, 'recordHistogramValue').mockImplementation(() => true);
+
+    try {
+      await repo.withTransaction(async (txClient) => {
+        await new Promise<void>((resolve, reject) => {
+          txClient.query('SELECT 1', (err) => (err ? reject(err) : resolve()));
+        });
+      });
+
+      expect(client.query).toBe(query);
+      expect(warnSpy).not.toHaveBeenCalledWith('High idle time in transaction', expect.anything());
+      expect(recordHistogramValueSpy).not.toHaveBeenCalled();
+    } finally {
+      restoreThreshold();
+      dateNowSpy.mockRestore();
+      warnSpy.mockRestore();
+      recordHistogramValueSpy.mockRestore();
+    }
+  });
+
+  test('withTransaction logs and records high idle time in rolled back transaction', async () => {
+    const restoreThreshold = setIdleInTransactionLogThresholdMs(0);
+    let now = 0;
+    const dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+    const query = jest.fn(async (_sql: string) => ({ rows: [] }));
+    const client = {
+      query,
+      release: jest.fn(),
+    } as unknown as PoolClient;
+    const repo = getShardSystemRepo(
+      'test-shard',
+      RepositoryConnection.borrowClient(client, { mode: DatabaseMode.WRITER })
+    );
+    const warnSpy = jest.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+    const recordHistogramValueSpy = jest.spyOn(otelModule, 'recordHistogramValue').mockImplementation(() => true);
+
+    try {
+      await expect(
+        repo.withTransaction(async () => {
+          now += 10;
+          throw new Error('work failed');
+        })
+      ).rejects.toThrow('work failed');
+
+      expect(recordHistogramValueSpy).toHaveBeenCalledWith('medplum.db.transactionIdleMs', 10, {
+        attributes: { attempt: 0, serializable: false, status: 'rolled_back' },
+        options: { unit: 'ms' },
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        'High idle time in transaction',
+        expect.objectContaining({
+          idleMs: 10,
+          queryCount: 1,
+          status: 'rolled_back',
+          transactionDurationMs: 10,
+        })
+      );
+    } finally {
+      restoreThreshold();
+      dateNowSpy.mockRestore();
+      warnSpy.mockRestore();
+      recordHistogramValueSpy.mockRestore();
+    }
+  });
+
+  test('withTransaction records outer transaction idle time across nested transactions', async () => {
+    const restoreThreshold = setIdleInTransactionLogThresholdMs(50);
+    let now = 0;
+    const dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+    const query = jest.fn(async (sql: string) => {
+      if (sql === 'SELECT 1') {
+        now += 25;
+      }
+      return { rows: [] };
+    });
+    const client = {
+      query,
+      release: jest.fn(),
+    } as unknown as PoolClient;
+    const repo = getShardSystemRepo(
+      'test-shard',
+      RepositoryConnection.borrowClient(client, { mode: DatabaseMode.WRITER })
+    );
+    const warnSpy = jest.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+    const recordHistogramValueSpy = jest.spyOn(otelModule, 'recordHistogramValue').mockImplementation(() => true);
+
+    try {
+      await repo.withTransaction(async () => {
+        now += 20;
+        await repo.withTransaction(async (txClient) => {
+          now += 5;
+          await txClient.query('SELECT 1');
+        });
+        now += 40;
+      });
+
+      expect(query.mock.calls.map(([sql]) => sql)).toStrictEqual([
+        'BEGIN ISOLATION LEVEL REPEATABLE READ',
+        'SAVEPOINT sp2',
+        'SELECT 1',
+        'RELEASE SAVEPOINT sp2',
+        'COMMIT',
+      ]);
+      expect(recordHistogramValueSpy).toHaveBeenCalledTimes(1);
+      expect(recordHistogramValueSpy).toHaveBeenCalledWith('medplum.db.transactionIdleMs', 65, {
+        attributes: { attempt: 0, serializable: false, status: 'committed' },
+        options: { unit: 'ms' },
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        'High idle time in transaction',
+        expect.objectContaining({
+          attempt: 0,
+          idleMs: 65,
+          queryCount: 4,
+          queryDurationMs: 25,
+          serializable: false,
+          status: 'committed',
+          thresholdMs: 50,
+          transactionAttempts: 2,
+          transactionDurationMs: 90,
+        })
+      );
+      expect(client.query).toBe(query);
+    } finally {
+      restoreThreshold();
+      dateNowSpy.mockRestore();
+      warnSpy.mockRestore();
+      recordHistogramValueSpy.mockRestore();
+    }
   });
 
   test('withStatementTimeout pins connection and discards it after callback', async () => {

--- a/packages/server/src/fhir/repository/repository-connection.ts
+++ b/packages/server/src/fhir/repository/repository-connection.ts
@@ -9,6 +9,8 @@ import { DatabaseMode, getDatabasePool } from '../../database';
 import { getLogger } from '../../logger';
 import type { TransactionIsolationLevel } from '../sql';
 import { isRetryableTransactionError, normalizeDatabaseError } from '../sql';
+import type { TransactionIdleStatus, TransactionIdleTrackerOptions } from './transaction-idle-tracker';
+import { TransactionIdleTracker } from './transaction-idle-tracker';
 
 const defaultTransactionAttempts = 2;
 const defaultExpBackoffBaseDelayMs = 50;
@@ -44,6 +46,7 @@ export class RepositoryConnection implements Disposable {
   private discardOnRelease = false;
   private closed = false;
   mode: RepositoryMode;
+  private transactionIdleTracker?: TransactionIdleTracker;
 
   private preCommitCallbacks: (() => Promise<void>)[] = [];
   private postCommitCallbacks: (() => Promise<void>)[] = [];
@@ -143,6 +146,7 @@ export class RepositoryConnection implements Disposable {
     const releaseErr = err || this.discardOnRelease;
     if (this.ownsClient) {
       const conn = this.conn;
+      this.discardTransactionIdleTracking();
       this.conn = undefined;
       this.connMode = undefined;
       this.discardOnRelease = false;
@@ -156,6 +160,7 @@ export class RepositoryConnection implements Disposable {
     } else if (releaseErr) {
       // Shared connection is known to be dead. Drop our reference so we don't reuse it.
       // The owner of the connection is responsible for the actual release.
+      this.discardTransactionIdleTracking();
       this.conn = undefined;
       this.connMode = undefined;
       this.discardOnRelease = false;
@@ -203,6 +208,14 @@ export class RepositoryConnection implements Disposable {
       try {
         const client = await this.beginTransaction(isolationLevel);
         transactionStarted = true;
+        if (this.transactionDepth === 1) {
+          this.startTransactionIdleTracking(client, {
+            thresholdMs: config.idleInTransactionLogThresholdMs ?? -1,
+            attempt,
+            transactionAttempts,
+            serializable: options?.serializable ?? false,
+          });
+        }
         const result = await callback(client);
         await this.commitTransaction();
         if (attempt > 0) {
@@ -346,6 +359,7 @@ export class RepositoryConnection implements Disposable {
       const conn = await this.getConnection(DatabaseMode.WRITER);
       if (this.transactionDepth === 1) {
         await conn.query('COMMIT');
+        this.finishTransactionIdleTracking('committed');
         this.transactionDepth = 0;
         this.transactionIsolationLevel = undefined;
         this.releaseConnection();
@@ -384,6 +398,10 @@ export class RepositoryConnection implements Disposable {
           await conn.query('ROLLBACK TO SAVEPOINT sp' + this.transactionDepth);
         }
       } catch (rollbackErr) {
+        if (isOuter) {
+          this.finishTransactionIdleTracking('rolled_back');
+        }
+
         // ROLLBACK itself failed — connection is effectively dead (e.g. killed by idle_in_transaction_session_timeout).
         getLogger().warn('Error rolling back transaction', {
           err: normalizeErrorString(rollbackErr),
@@ -398,6 +416,9 @@ export class RepositoryConnection implements Disposable {
         this.releaseConnection(error);
         return;
       }
+      if (isOuter) {
+        this.finishTransactionIdleTracking('rolled_back');
+      }
       this.transactionDepth--; // safe to decrement since early return if transactionDepth === 0
       this.truncateCommitCallbacks();
       if (isOuter) {
@@ -411,6 +432,23 @@ export class RepositoryConnection implements Disposable {
     if (this.transactionDepth === 0) {
       this.releaseConnection();
     }
+  }
+
+  private startTransactionIdleTracking(client: PoolClient, options: TransactionIdleTrackerOptions): void {
+    if (options.thresholdMs < 0 || this.transactionIdleTracker) {
+      return;
+    }
+    this.transactionIdleTracker = new TransactionIdleTracker(client, options);
+  }
+
+  private finishTransactionIdleTracking(status: TransactionIdleStatus): void {
+    this.transactionIdleTracker?.finish(status);
+    this.transactionIdleTracker = undefined;
+  }
+
+  private discardTransactionIdleTracking(): void {
+    this.transactionIdleTracker?.discard();
+    this.transactionIdleTracker = undefined;
   }
 
   private assertInTransaction(): void {

--- a/packages/server/src/fhir/repository/transaction-idle-tracker.ts
+++ b/packages/server/src/fhir/repository/transaction-idle-tracker.ts
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { PoolClient } from 'pg';
+import { getLogger } from '../../logger';
+import { recordHistogramValue } from '../../otel/otel';
+
+export type TransactionIdleStatus = 'committed' | 'rolled_back';
+
+export type TransactionIdleTrackerOptions = {
+  thresholdMs: number;
+  attempt: number;
+  transactionAttempts: number;
+  serializable: boolean;
+};
+
+export class TransactionIdleTracker {
+  private readonly client: PoolClient;
+  private readonly options: TransactionIdleTrackerOptions;
+  private readonly startTimeMs: number;
+  private readonly originalQuery: PoolClient['query'];
+  private readonly originalQueryFn: (...args: any[]) => any;
+  private readonly wrappedQuery: PoolClient['query'];
+  private lastIdleStartTimeMs: number;
+  private idleMs = 0;
+  private queryDurationMs = 0;
+  private activeQueryCount = 0;
+  private queryCount = 0;
+  private finished = false;
+
+  constructor(client: PoolClient, options: TransactionIdleTrackerOptions) {
+    this.client = client;
+    this.options = options;
+    this.startTimeMs = Date.now();
+    // The transaction is idle as soon as BEGIN finishes and until the first query starts.
+    this.lastIdleStartTimeMs = this.startTimeMs;
+    this.originalQuery = client.query;
+    this.originalQueryFn = client.query.bind(client);
+    this.wrappedQuery = ((...args: any[]) => this.query(args)) as PoolClient['query'];
+    // Patch only the transaction's dedicated PoolClient, and restore it when tracking ends.
+    client.query = this.wrappedQuery;
+  }
+
+  finish(status: TransactionIdleStatus): void {
+    if (this.finished) {
+      return;
+    }
+    this.finished = true;
+    this.restore();
+
+    // Keep both logs and metrics thresholded so this stays useful during spikes.
+    if (this.idleMs < this.options.thresholdMs) {
+      return;
+    }
+
+    const transactionDurationMs = Date.now() - this.startTimeMs;
+    const attributes = {
+      attempt: this.options.attempt,
+      serializable: this.options.serializable,
+      status,
+    };
+
+    recordHistogramValue('medplum.db.idleInTransactionMs', this.idleMs, {
+      attributes,
+      options: { unit: 'ms' },
+    });
+    getLogger().warn('High idle in transaction time', {
+      ...attributes,
+      idleMs: this.idleMs,
+      transactionDurationMs,
+      queryDurationMs: this.queryDurationMs,
+      queryCount: this.queryCount,
+      transactionAttempts: this.options.transactionAttempts,
+      thresholdMs: this.options.thresholdMs,
+    });
+  }
+
+  discard(): void {
+    if (this.finished) {
+      return;
+    }
+    // Stop measuring when the query shape cannot be timed accurately.
+    this.finished = true;
+    this.restore();
+  }
+
+  private query(args: any[]): any {
+    const queryStartTimeMs = Date.now();
+    // The gap since the previous completed query is the approximation of "idle in transaction".
+    this.startQuery(queryStartTimeMs);
+
+    try {
+      const result = this.originalQueryFn(...args);
+      if (result && typeof result.finally === 'function') {
+        // Promise-returning pg queries are the normal repository path and can be timed exactly.
+        return result.finally(() => this.endQuery(queryStartTimeMs));
+      }
+
+      // Callback/EventEmitter query styles still run, but we cannot know when DB work
+      // finishes without a broader wrapper. Disable reporting rather than emit false idle.
+      this.discard();
+      return result;
+    } catch (err) {
+      this.endQuery(queryStartTimeMs);
+      throw err;
+    }
+  }
+
+  private startQuery(queryStartTimeMs: number): void {
+    if (this.finished) {
+      return;
+    }
+    if (this.activeQueryCount === 0) {
+      // Only the first concurrent query closes the idle period.
+      this.idleMs += queryStartTimeMs - this.lastIdleStartTimeMs;
+    }
+    this.activeQueryCount++;
+  }
+
+  private endQuery(queryStartTimeMs: number): void {
+    if (this.finished) {
+      return;
+    }
+    const queryEndTimeMs = Date.now();
+    this.queryDurationMs += queryEndTimeMs - queryStartTimeMs;
+    this.queryCount++;
+    this.activeQueryCount = Math.max(this.activeQueryCount - 1, 0);
+    if (this.activeQueryCount === 0) {
+      // When the last active query ends, the transaction becomes idle again.
+      this.lastIdleStartTimeMs = queryEndTimeMs;
+    }
+  }
+
+  private restore(): void {
+    // Avoid clobbering a later wrapper if something else replaced query first.
+    if (this.client.query === this.wrappedQuery) {
+      this.client.query = this.originalQuery;
+    }
+  }
+}

--- a/packages/server/src/fhir/repository/transaction-idle-tracker.ts
+++ b/packages/server/src/fhir/repository/transaction-idle-tracker.ts
@@ -14,7 +14,8 @@ export type TransactionIdleTrackerOptions = {
 };
 
 export class TransactionIdleTracker {
-  static readonly OTEL_METRIC_NAME = 'medplum.db.idleInTransactionMs';
+  static readonly OTEL_MAX_METRIC_NAME = 'medplum.db.idleInTransactionMaxMs';
+  static readonly OTEL_TOTAL_METRIC_NAME = 'medplum.db.idleInTransactionTotalMs';
   static readonly LOG_HIGH_IDLE_TIME_MSG = 'High idle in transaction time';
   private readonly client: PoolClient;
   private readonly options: TransactionIdleTrackerOptions;
@@ -23,7 +24,8 @@ export class TransactionIdleTracker {
   private readonly originalQueryFn: (...args: any[]) => any;
   private readonly wrappedQuery: PoolClient['query'];
   private lastIdleStartTimeMs: number;
-  private idleMs = 0;
+  private maxIdleMs = 0;
+  private totalIdleMs = 0;
   private queryDurationMs = 0;
   private activeQueryCount = 0;
   private queryCount = 0;
@@ -50,7 +52,7 @@ export class TransactionIdleTracker {
     this.restore();
 
     // Keep both logs and metrics thresholded so this stays useful during spikes.
-    if (this.idleMs < this.options.thresholdMs) {
+    if (this.maxIdleMs < this.options.thresholdMs) {
       return;
     }
 
@@ -61,13 +63,18 @@ export class TransactionIdleTracker {
       status,
     };
 
-    recordHistogramValue(TransactionIdleTracker.OTEL_METRIC_NAME, this.idleMs, {
+    recordHistogramValue(TransactionIdleTracker.OTEL_TOTAL_METRIC_NAME, this.totalIdleMs, {
+      attributes,
+      options: { unit: 'ms' },
+    });
+    recordHistogramValue(TransactionIdleTracker.OTEL_MAX_METRIC_NAME, this.maxIdleMs, {
       attributes,
       options: { unit: 'ms' },
     });
     getLogger().warn(TransactionIdleTracker.LOG_HIGH_IDLE_TIME_MSG, {
       ...attributes,
-      idleMs: this.idleMs,
+      totalIdleMs: this.totalIdleMs,
+      maxIdleMs: this.maxIdleMs,
       transactionDurationMs,
       queryDurationMs: this.queryDurationMs,
       queryCount: this.queryCount,
@@ -113,7 +120,9 @@ export class TransactionIdleTracker {
     }
     if (this.activeQueryCount === 0) {
       // Only the first concurrent query closes the idle period.
-      this.idleMs += queryStartTimeMs - this.lastIdleStartTimeMs;
+      const idleMs = queryStartTimeMs - this.lastIdleStartTimeMs;
+      this.totalIdleMs += idleMs;
+      this.maxIdleMs = Math.max(this.maxIdleMs, idleMs);
     }
     this.activeQueryCount++;
   }

--- a/packages/server/src/fhir/repository/transaction-idle-tracker.ts
+++ b/packages/server/src/fhir/repository/transaction-idle-tracker.ts
@@ -14,6 +14,8 @@ export type TransactionIdleTrackerOptions = {
 };
 
 export class TransactionIdleTracker {
+  static readonly OTEL_METRIC_NAME = 'medplum.db.idleInTransactionMs';
+  static readonly LOG_HIGH_IDLE_TIME_MSG = 'High idle in transaction time';
   private readonly client: PoolClient;
   private readonly options: TransactionIdleTrackerOptions;
   private readonly startTimeMs: number;
@@ -33,8 +35,8 @@ export class TransactionIdleTracker {
     this.startTimeMs = Date.now();
     // The transaction is idle as soon as BEGIN finishes and until the first query starts.
     this.lastIdleStartTimeMs = this.startTimeMs;
-    this.originalQuery = client.query;
-    this.originalQueryFn = client.query.bind(client);
+    this.originalQuery = client.query; // for restoring
+    this.originalQueryFn = client.query.bind(client); // for calling the original query function
     this.wrappedQuery = ((...args: any[]) => this.query(args)) as PoolClient['query'];
     // Patch only the transaction's dedicated PoolClient, and restore it when tracking ends.
     client.query = this.wrappedQuery;
@@ -59,11 +61,11 @@ export class TransactionIdleTracker {
       status,
     };
 
-    recordHistogramValue('medplum.db.idleInTransactionMs', this.idleMs, {
+    recordHistogramValue(TransactionIdleTracker.OTEL_METRIC_NAME, this.idleMs, {
       attributes,
       options: { unit: 'ms' },
     });
-    getLogger().warn('High idle in transaction time', {
+    getLogger().warn(TransactionIdleTracker.LOG_HIGH_IDLE_TIME_MSG, {
       ...attributes,
       idleMs: this.idleMs,
       transactionDurationMs,


### PR DESCRIPTION
Adds an approximation of postgres idle in transaction time as measured from the application.

We may want to change what triggers metrics/log generation: currently it is the max idle in transaction to match the semantics of `idle_in_transaction_session_timeout`. Thinking about it more, maybe we want to add or change the trigger to total transaction duration? Or maybe even have multiple triggers...