### PR TITLE
Support `resource:number` in `convertToTransactionBundle`

### DIFF
--- a/packages/core/src/__fixtures__/example-00-a-fhirBundle.json
+++ b/packages/core/src/__fixtures__/example-00-a-fhirBundle.json
@@ -1,0 +1,103 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "resource:0",
+      "resource": {
+        "resourceType": "Patient",
+        "name": [
+          {
+            "family": "Anyperson",
+            "given": [
+              "John",
+              "B."
+            ]
+          }
+        ],
+        "birthDate": "1951-01-20"
+      }
+    },
+    {
+      "fullUrl": "resource:1",
+      "resource": {
+        "resourceType": "Immunization",
+        "status": "completed",
+        "vaccineCode": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/sid/cvx",
+              "code": "207"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "resource:0"
+        },
+        "occurrenceDateTime": "2021-01-01",
+        "performer": [
+          {
+            "actor": {
+              "display": "ABC General Hospital"
+            }
+          }
+        ],
+        "lotNumber": "0000001"
+      }
+    },
+    {
+      "fullUrl": "resource:2",
+      "resource": {
+        "resourceType": "Immunization",
+        "status": "completed",
+        "vaccineCode": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/sid/cvx",
+              "code": "207"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "resource:0"
+        },
+        "occurrenceDateTime": "2021-01-29",
+        "performer": [
+          {
+            "actor": {
+              "display": "ABC General Hospital"
+            }
+          }
+        ],
+        "lotNumber": "0000007"
+      }
+    },
+    {
+      "fullUrl": "resource:3",
+      "resource": {
+        "resourceType": "Immunization",
+        "status": "completed",
+        "vaccineCode": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/sid/cvx",
+              "code": "229"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "resource:0"
+        },
+        "occurrenceDateTime": "2022-09-05",
+        "performer": [
+          {
+            "actor": {
+              "display": "ABC General Hospital"
+            }
+          }
+        ],
+        "lotNumber": "0000001"
+      }
+    }
+  ]
+}

--- a/packages/core/src/__fixtures__/example-00-a-fhirBundle.json
+++ b/packages/core/src/__fixtures__/example-00-a-fhirBundle.json
@@ -9,10 +9,7 @@
         "name": [
           {
             "family": "Anyperson",
-            "given": [
-              "John",
-              "B."
-            ]
+            "given": ["John", "B."]
           }
         ],
         "birthDate": "1951-01-20"

--- a/packages/core/src/bundle.test.ts
+++ b/packages/core/src/bundle.test.ts
@@ -398,6 +398,30 @@ describe('Bundle tests', () => {
         expect(entry.request?.method).toBe('POST');
       }
     });
+
+    test('SMART Health Card style references', () => {
+      // Source: https://build.fhir.org/ig/HL7/smart-health-cards-and-links/example-00-a-fhirBundle.json
+      const smartHealthExamplePath = join(
+        dirname(fileURLToPath(import.meta.url)),
+        '__fixtures__',
+        'example-00-a-fhirBundle.json'
+      );
+      const bundle = JSON.parse(readFileSync(smartHealthExamplePath, 'utf8')) as Bundle;
+      const transactionBundle = convertToTransactionBundle(bundle);
+      expect(transactionBundle.resourceType).toBe('Bundle');
+      expect(transactionBundle.type).toBe('transaction');
+      expect(transactionBundle.entry?.length).toBeGreaterThan(0);
+
+      const patientEntry = transactionBundle.entry?.find((e) => e.resource?.resourceType === 'Patient');
+      const immunizations =
+        transactionBundle.entry
+          ?.filter((e) => e.resource?.resourceType === 'Immunization')
+          .map((e) => e.resource as any) ?? [];
+
+      for (const immunization of immunizations) {
+        expect(immunization.patient?.reference).toBe(patientEntry?.fullUrl);
+      }
+    });
   });
 
   describe('convertContainedResourcesToBundle', () => {

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -46,6 +46,10 @@ export function convertToTransactionBundle(bundle: Bundle): Bundle {
 
       entry.fullUrl = 'urn:uuid:' + idToUuid[id];
       delete entry.resource?.id;
+    } else if (entry.fullUrl?.startsWith('resource:')) {
+      const resourceId = entry.fullUrl.slice('resource:'.length);
+      idToUuid[resourceId] = generateId();
+      entry.fullUrl = 'urn:uuid:' + idToUuid[resourceId];
     }
   }
   const input = bundle.entry;
@@ -72,6 +76,8 @@ function referenceReplacer(key: string, value: string, idToUuid: Record<string, 
       id = value.split('/')[1];
     } else if (value.startsWith('urn:uuid:')) {
       id = value.slice(9);
+    } else if (value.startsWith('resource:')) {
+      id = value.slice('resource:'.length);
     } else if (value.startsWith('#')) {
       id = value.slice(1);
     }
@@ -206,7 +212,7 @@ function findReferences(resource: any, callback: (reference: string) => void): v
 
       if (isReference(value)) {
         const reference = value.reference;
-        if (reference.startsWith('urn:uuid:')) {
+        if (reference.startsWith('urn:uuid:') || reference.startsWith('resource:')) {
           callback(reference);
         }
       } else {


### PR DESCRIPTION
Adds support for SMART Health Card-style bundle-local references such as:

```json
{
  "fullUrl": "resource:0"
}
```

and

```json
{
  "patient": {
    "reference": "resource:0"
  }
}
```

when converting arbitrary FHIR bundles to transaction bundles using `convertToTransactionBundle()`.

### Background

FHIR allows references within a bundle to resolve against matching `Bundle.entry.fullUrl` values. While `urn:uuid:` is the most common representation, SMART Health Cards use compact `resource:N` URIs (for example `resource:0`, `resource:1`, etc.) to reduce QR code payload size.

Example:

```json
{
  "fullUrl": "resource:0",
  "resource": {
    "resourceType": "Patient"
  }
}
```

```json
{
  "patient": {
    "reference": "resource:0"
  }
}
```

These are valid bundle-local references and are commonly encountered when importing SMART Health Card payloads.

### Problem

`convertToTransactionBundle()` relies on reference analysis to:

* determine resource dependencies
* perform topological sorting
* rewrite references for transaction processing
* generate conditional create logic

Bundles containing `resource:N` references were not previously recognized as having valid intra-bundle relationships, resulting in incomplete dependency resolution.

### Solution

Extend bundle reference resolution logic to recognize `resource:N` URIs as bundle-local references whenever a matching `Bundle.entry.fullUrl` exists.

This allows SMART Health Card bundles and other bundles using compact `fullUrl` identifiers to participate in the same dependency analysis and transaction conversion workflow as bundles using `urn:uuid:` identifiers.

### Impact

* SMART Health Card bundles can now be passed directly to `convertToTransactionBundle()`
* Topological sorting correctly preserves resource dependencies
* Conditional create and reference rewriting continue to work as expected
* Improves compatibility with valid FHIR bundle-local reference patterns encountered in the wild
