### PR TITLE
Allow project admins to expunge with everything=true (#9330)

### DIFF
--- a/packages/server/src/fhir/operations/expunge.test.ts
+++ b/packages/server/src/fhir/operations/expunge.test.ts
@@ -159,6 +159,76 @@ describe('Expunge', () => {
     }
   });
 
+  test('Project admin can expunge patient everything within own project', async () => {
+    const { project, accessToken } = await createTestProject({
+      withAccessToken: true,
+      membership: { admin: true },
+    });
+
+    const patient = await systemRepo.createResource<Patient>({
+      resourceType: 'Patient',
+      meta: { project: project.id },
+      name: [{ given: ['Alice'], family: 'Smith' }],
+    });
+
+    const obs = await systemRepo.createResource<Observation>({
+      resourceType: 'Observation',
+      meta: { project: project.id },
+      status: 'final',
+      code: { coding: [{ system: LOINC, code: '12345-6' }] },
+      subject: { reference: 'Patient/' + patient.id },
+    });
+
+    expect(await existsInDatabase('Patient', patient.id)).toBe(true);
+    expect(await existsInDatabase('Observation', obs.id)).toBe(true);
+
+    const res = await request(app)
+      .post(`/fhir/R4/Patient/${patient.id}/$expunge?everything=true`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .set('X-Medplum', 'extended')
+      .send({});
+    expect(res.status).toBe(202);
+
+    const asyncJob = await waitForAsyncJob(res.headers['content-location'], app, accessToken);
+    // The job must complete cleanly: the Expunger iterates every resource type, and
+    // must skip the ones a project admin cannot search rather than erroring out.
+    expect(asyncJob.status).toBe('completed');
+
+    // Both the patient and its compartment resources should be expunged
+    expect(await existsInDatabase('Patient', patient.id)).toBe(false);
+    expect(await existsInDatabase('Observation', obs.id)).toBe(false);
+  });
+
+  test('Project admin cannot expunge patient everything in another project', async () => {
+    // Patient belongs to an unrelated project
+    const { project: otherProject } = await createTestProject({});
+    const otherPatient = await systemRepo.createResource<Patient>({
+      resourceType: 'Patient',
+      meta: { project: otherProject.id },
+      name: [{ given: ['Bob'], family: 'Jones' }],
+    });
+
+    const { accessToken } = await createTestProject({
+      withAccessToken: true,
+      membership: { admin: true },
+    });
+
+    const res = await request(app)
+      .post(`/fhir/R4/Patient/${otherPatient.id}/$expunge?everything=true`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .set('X-Medplum', 'extended')
+      .send({});
+    // The async job is accepted, but the project-scoped repo never finds the
+    // foreign patient, so it is left untouched.
+    expect(res.status).toBe(202);
+
+    await waitForAsyncJob(res.headers['content-location'], app, accessToken);
+
+    expect(await existsInDatabase('Patient', otherPatient.id)).toBe(true);
+  });
+
   test('Expunger.expunge() expunges all resource types', async () => {
     //setup
     const { project, client, membership } = await createTestProject({ withClient: true });

--- a/packages/server/src/fhir/operations/expunge.ts
+++ b/packages/server/src/fhir/operations/expunge.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { accepted, allOk, concatUrls, forbidden, getResourceTypes, Operator } from '@medplum/core';
+import { accepted, AccessPolicyInteraction, allOk, concatUrls, forbidden, getResourceTypes, Operator } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { ResourceType } from '@medplum/fhirtypes';
 import { getConfig } from '../../config/loader';
@@ -25,8 +25,10 @@ export async function expungeHandler(req: FhirRequest): Promise<FhirResponse> {
   const { resourceType, id } = req.params;
   const { everything } = req.query;
   if (resourceType === 'Project' || everything === 'true') {
-    // Only super admins can expunge a projects other than the current project
-    if (!ctx.project.superAdmin && id !== ctx.project.id) {
+    // Only super admins can expunge a project other than the current project.
+    // For non-Project resources, the project-scoped repo restricts the compartment
+    // search to the caller's own project, so project admins can safely expunge within it.
+    if (resourceType === 'Project' && !ctx.project.superAdmin && id !== ctx.project.id) {
       return [forbidden];
     }
     const { baseUrl } = getConfig();
@@ -63,6 +65,13 @@ export class Expunger {
 
   async expungeByResourceType(resourceType: ResourceType): Promise<void> {
     if (resourceType === 'Binary') {
+      return;
+    }
+
+    // Skip resource types the repository is not allowed to search (e.g. protected
+    // resource types such as Login/JsonWebKey/DomainConfiguration for non-super-admins).
+    // Otherwise the search below throws "forbidden" and aborts the entire expunge job.
+    if (!this.repo.supportsInteraction(AccessPolicyInteraction.SEARCH, resourceType)) {
       return;
     }
 

--- a/packages/server/src/fhir/operations/expunge.ts
+++ b/packages/server/src/fhir/operations/expunge.ts
@@ -1,6 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { accepted, AccessPolicyInteraction, allOk, concatUrls, forbidden, getResourceTypes, Operator } from '@medplum/core';
+import {
+  accepted,
+  AccessPolicyInteraction,
+  allOk,
+  concatUrls,
+  forbidden,
+  getResourceTypes,
+  Operator,
+} from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { ResourceType } from '@medplum/fhirtypes';
 import { getConfig } from '../../config/loader';


### PR DESCRIPTION
## Summary

Fixes #9330. Project admins could not call `Patient/<id>/$expunge?everything=true` for patients within their own project — they received a `403 Forbidden`.

There were two issues:

1. **Auth gate (the reported root cause).** The cross-project guard in `expungeHandler` (`expunge.ts`) applied to *all* `everything=true` requests, not just `Project` expunges:
   ```ts
   if (!ctx.project.superAdmin && id !== ctx.project.id) {
     return [forbidden];
   }
   ```
   For a `Patient`, `id` is the patient's id, which never equals the caller's project id, so every non-super-admin was rejected. The guard is now scoped to `resourceType === 'Project'`. Non-`Project` expunges are already constrained by the project-scoped repo's `_compartment` search, so a project admin can only reach resources in their own project.

2. **Expunger aborts mid-run.** `Expunger.expunge()` iterates over *every* resource type and calls `repo.search()` on each. For a non-super-admin, searching a protected resource type (`DomainConfiguration`, `JsonWebKey`, `Login`) throws `forbidden`, which aborted the entire async job (it ended in `error`, leaving resources unexpunged). The Expunger now skips resource types the repo cannot search via `repo.supportsInteraction(AccessPolicyInteraction.SEARCH, ...)` — the same gate used in `search.ts` and `resource-cap.ts`. Super-admin repos support all types, so their behavior is unchanged.

## Test plan

`expunge.test.ts` adds:
- Project admin expunges a patient + its `Observation` in their **own** project → `202`, async job status `completed`, both resources expunged. The `completed` assertion guards against the issue #2 regression.
- Project admin targeting a patient in **another** project → job is accepted but the foreign patient survives (the scoped repo never finds it).

Existing super-admin / cross-project / non-admin cases are unchanged.

```
npx jest src/fhir/operations/expunge.test.ts
# Test Suites: 1 passed, 1 total
# Tests:       11 passed, 11 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)