### PR TITLE
fix(provider): Create/update claim during export or submit

### DIFF
--- a/examples/medplum-provider/src/components/encounter/BillingTab.test.tsx
+++ b/examples/medplum-provider/src/components/encounter/BillingTab.test.tsx
@@ -24,7 +24,6 @@ import { SAVE_TIMEOUT_MS } from '../../config/constants';
 import * as useDebouncedUpdateResourceModule from '../../hooks/useDebouncedUpdateResource';
 import { ChartNoteStatus } from '../../types/encounter';
 import * as chargeItemsUtils from '../../utils/chargeitems';
-import * as claimsUtils from '../../utils/claims';
 import { BillingTab } from './BillingTab';
 
 vi.mock('@mantine/notifications', async () => {
@@ -120,6 +119,8 @@ describe('BillingTab', () => {
     vi.clearAllMocks();
     // Mock useDebouncedUpdateResource to return a function that resolves immediately
     vi.spyOn(useDebouncedUpdateResourceModule, 'useDebouncedUpdateResource').mockReturnValue(mockDebouncedUpdate());
+    // BillingTab fetches its own charge items; default to a single CPT charge item.
+    vi.spyOn(chargeItemsUtils, 'getChargeItemsForEncounter').mockResolvedValue([mockChargeItem]);
   });
 
   const setup = async (props: Partial<Parameters<typeof BillingTab>[0]> = {}): Promise<void> => {
@@ -135,10 +136,6 @@ describe('BillingTab', () => {
                 setEncounter={vi.fn()}
                 practitioner={mockPractitioner}
                 setPractitioner={vi.fn()}
-                chargeItems={[]}
-                setChargeItems={vi.fn()}
-                claim={undefined}
-                setClaim={vi.fn()}
                 chartNoteStatus={ChartNoteStatus.SignedAndLocked}
                 {...props}
               />
@@ -147,6 +144,24 @@ describe('BillingTab', () => {
         </MemoryRouter>
       );
     });
+  };
+
+  // Override the charge items BillingTab loads for the encounter.
+  const mockChargeItems = (items: WithId<ChargeItem>[]): void => {
+    vi.spyOn(chargeItemsUtils, 'getChargeItemsForEncounter').mockResolvedValue(items);
+  };
+
+  // BillingTab now fetches its own data. List fetches (Coverage, Practitioner, ChargeItemDefinition)
+  // go through searchResources; single-resource fetches (the existing Claim and its ClaimResponse)
+  // go through searchOne. Dispatch by resource type so tests can seed each independently.
+  const mockSearchResources = (resources: Record<string, unknown[]> = {}): void => {
+    vi.spyOn(medplum, 'searchResources').mockImplementation(((resourceType: string) =>
+      Promise.resolve(resources[resourceType] ?? [])) as any);
+  };
+
+  const mockSearchOne = (resources: { Claim?: WithId<Claim>; ClaimResponse?: WithId<ClaimResponse> } = {}): void => {
+    vi.spyOn(medplum, 'searchOne').mockImplementation(((resourceType: string) =>
+      Promise.resolve(resources[resourceType as 'Claim' | 'ClaimResponse'])) as any);
   };
 
   test('renders visit details panel', async () => {
@@ -200,27 +215,34 @@ describe('BillingTab', () => {
   });
 
   test('renders charge item list when charge items are provided', async () => {
-    await setup({ chargeItems: [mockChargeItem] });
+    mockChargeItems([mockChargeItem]);
+    await setup();
 
     expect(screen.getByText('Charge Items')).toBeInTheDocument();
     expect(screen.getByText('Add Charge Item')).toBeInTheDocument();
   });
 
-  test('does not render export claim button when no claim', async () => {
-    await setup({ claim: undefined });
+  test('does not render export claim button when there are no CPT charge items', async () => {
+    mockChargeItems([]);
+    await setup();
 
     expect(screen.queryByText('Export Claim')).not.toBeInTheDocument();
   });
 
-  test('renders export claim button when claim exists', async () => {
-    await setup({ claim: mockClaim });
+  test('renders export claim button when CPT charge items exist', async () => {
+    // The card is now gated on billable (CPT) charge items, not on a persisted claim.
+    await setup();
 
-    expect(screen.getByText('Export Claim')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Export Claim')).toBeInTheDocument();
+    });
   });
 
   test('shows export menu options when export button is clicked', async () => {
     const user = userEvent.setup();
-    await setup({ claim: mockClaim });
+    mockSearchResources({ Coverage: [mockCoverage] });
+    mockSearchOne({ Claim: mockClaim });
+    await setup();
 
     const exportButton = screen.getByText('Export Claim');
     await user.click(exportButton);
@@ -235,7 +257,8 @@ describe('BillingTab', () => {
   test('exports claim as CMS 1500 when option is selected', async () => {
     const user = userEvent.setup();
 
-    vi.spyOn(medplum, 'searchResources').mockResolvedValue([mockCoverage] as any);
+    mockSearchResources({ Coverage: [mockCoverage] });
+    mockSearchOne({ Claim: mockClaim });
     vi.spyOn(medplum, 'post').mockResolvedValue({
       resourceType: 'Media',
       content: { url: 'https://example.com/claim.pdf' },
@@ -243,7 +266,7 @@ describe('BillingTab', () => {
 
     const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
 
-    await setup({ claim: mockClaim });
+    await setup();
 
     const exportButton = screen.getByText('Export Claim');
     await user.click(exportButton);
@@ -265,7 +288,9 @@ describe('BillingTab', () => {
   test('shows missing diagnosis notification when submitting without conditions', async () => {
     const user = userEvent.setup();
 
-    await setup({ claim: mockClaim });
+    mockSearchResources({ Coverage: [mockCoverage] });
+    mockSearchOne({ Claim: mockClaim });
+    await setup();
 
     await waitFor(() => {
       expect(screen.getByText('Submit Claim')).toBeInTheDocument();
@@ -299,7 +324,8 @@ describe('BillingTab', () => {
     };
 
     vi.spyOn(medplum, 'readReference').mockResolvedValue(mockCondition as any);
-    vi.spyOn(medplum, 'searchResources').mockResolvedValue([mockCoverage] as any);
+    mockSearchResources({ Coverage: [mockCoverage] });
+    mockSearchOne({ Claim: mockClaim });
     const postSpy = vi.spyOn(medplum, 'post').mockImplementation(async (url: any) => {
       if (url?.toString().includes('$candid-submit-claim')) {
         return { resourceType: 'ClaimResponse', id: 'cr-1' };
@@ -310,7 +336,6 @@ describe('BillingTab', () => {
     const user = userEvent.setup();
 
     await setup({
-      claim: mockClaim,
       encounter: {
         ...mockEncounter,
         diagnosis: [{ condition: { reference: 'Condition/condition-1' } }],
@@ -344,7 +369,7 @@ describe('BillingTab', () => {
   });
 
   test('fetches coverage on mount', async () => {
-    vi.spyOn(medplum, 'searchResources').mockResolvedValue([mockCoverage] as any);
+    mockSearchResources({ Coverage: [mockCoverage] });
     await act(async () => {
       await setup();
     });
@@ -359,7 +384,9 @@ describe('BillingTab', () => {
 
   test('shows notification when EDI X12 menu item is clicked', async () => {
     const user = userEvent.setup();
-    await setup({ claim: mockClaim });
+    mockSearchResources({ Coverage: [mockCoverage] });
+    mockSearchOne({ Claim: mockClaim });
+    await setup();
 
     const exportButton = screen.getByText('Export Claim');
     await user.click(exportButton);
@@ -381,7 +408,9 @@ describe('BillingTab', () => {
 
   test('shows notification when NUCC Crosswalk CSV menu item is clicked', async () => {
     const user = userEvent.setup();
-    await setup({ claim: mockClaim });
+    mockSearchResources({ Coverage: [mockCoverage] });
+    mockSearchOne({ Claim: mockClaim });
+    await setup();
 
     const exportButton = screen.getByText('Export Claim');
     await user.click(exportButton);
@@ -401,13 +430,8 @@ describe('BillingTab', () => {
     });
   });
 
-  test('updates claim when charge item is added', async () => {
+  test('creates a charge item and updates the charge items list when added', async () => {
     const user = userEvent.setup();
-    const setChargeItems = vi.fn();
-    const setClaim = vi.fn();
-    const debouncedUpdateResource = mockDebouncedUpdate();
-
-    vi.spyOn(useDebouncedUpdateResourceModule, 'useDebouncedUpdateResource').mockReturnValue(debouncedUpdateResource);
 
     const mockCptCode: CodeableConcept = {
       coding: [
@@ -437,15 +461,6 @@ describe('BillingTab', () => {
       priceOverride: { value: 200, currency: 'USD' },
     };
 
-    const mockClaimItems = [
-      {
-        sequence: 1,
-        productOrService: {
-          coding: [{ system: 'http://www.ama-assn.org/go/cpt', code: '99214' }],
-        },
-      },
-    ];
-
     // Mock valueSetExpand for CPT code search
     medplum.valueSetExpand = vi.fn().mockResolvedValue({
       resourceType: 'ValueSet',
@@ -460,18 +475,13 @@ describe('BillingTab', () => {
       },
     });
 
-    // Mock searchResources for ChargeItemDefinition search
-    vi.spyOn(medplum, 'searchResources').mockResolvedValue([mockDefinition] as any);
+    // Mock searchResources for ChargeItemDefinition search (Claim/Coverage fetches return empty)
+    mockSearchResources({ ChargeItemDefinition: [mockDefinition], Coverage: [mockCoverage] });
+    mockChargeItems([]);
     vi.spyOn(medplum, 'createResource').mockResolvedValue(newChargeItem);
     vi.spyOn(chargeItemsUtils, 'applyChargeItemDefinition').mockResolvedValue(appliedChargeItem);
-    vi.spyOn(claimsUtils, 'getCptChargeItems').mockReturnValue(mockClaimItems);
-    vi.spyOn(chargeItemsUtils, 'calculateTotalPrice').mockReturnValue(200);
 
     await setup({
-      claim: mockClaim,
-      chargeItems: [],
-      setChargeItems,
-      setClaim,
       encounter: mockEncounter,
     });
 
@@ -573,7 +583,7 @@ describe('BillingTab', () => {
     if (submitButton) {
       await user.click(submitButton);
 
-      // Verify charge item was created and updateChargeItems was called
+      // Verify charge item was created and the list (now BillingTab-local state) was updated.
       await waitFor(() => {
         expect(medplum.createResource).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -584,42 +594,22 @@ describe('BillingTab', () => {
           })
         );
         expect(chargeItemsUtils.applyChargeItemDefinition).toHaveBeenCalled();
-        expect(setChargeItems).toHaveBeenCalledWith([appliedChargeItem]);
       });
 
-      // Verify claim was updated
-      await waitFor(
-        () => {
-          expect(claimsUtils.getCptChargeItems).toHaveBeenCalledWith([appliedChargeItem], {
-            reference: 'Encounter/encounter-123',
-          });
-          expect(chargeItemsUtils.calculateTotalPrice).toHaveBeenCalledWith([appliedChargeItem]);
-          expect(setClaim).toHaveBeenCalledWith(
-            expect.objectContaining({
-              resourceType: 'Claim',
-              item: mockClaimItems,
-              total: { value: 200 },
-            })
-          );
-          expect(debouncedUpdateResource).toHaveBeenCalledWith(
-            expect.objectContaining({
-              resourceType: 'Claim',
-              item: mockClaimItems,
-              total: { value: 200 },
-            })
-          );
-        },
-        { timeout: 5000 }
-      );
+      // The added charge item appears in the list, so the totals card renders (it only shows when
+      // there is at least one charge item).
+      await waitFor(() => {
+        expect(screen.getByText('Total Calculated Price to Bill')).toBeInTheDocument();
+      });
+
+      // The claim is no longer created or updated when a charge item is added; it is only
+      // persisted at export/submit time.
     }
   });
 
-  test('creates claim when practitioner is changed and charge items exist', async () => {
+  test('updates the encounter and resolves the practitioner when the practitioner is changed', async () => {
     const setEncounter = vi.fn();
-    const setClaim = vi.fn();
-    const debouncedUpdateResource = mockDebouncedUpdate();
-
-    vi.spyOn(useDebouncedUpdateResourceModule, 'useDebouncedUpdateResource').mockReturnValue(debouncedUpdateResource);
+    const setPractitioner = vi.fn();
 
     const mockPractitioner1: Practitioner = {
       resourceType: 'Practitioner',
@@ -650,19 +640,6 @@ describe('BillingTab', () => {
       priceOverride: { value: 200, currency: 'USD' },
     };
 
-    const newClaim: Claim & { id: string } = {
-      resourceType: 'Claim',
-      id: 'claim-new',
-      status: 'active',
-      type: { coding: [{ code: 'professional' }] },
-      use: 'claim',
-      created: new Date().toISOString(),
-      priority: { coding: [{ code: 'normal' }] },
-      insurance: [],
-      patient: { reference: 'Patient/patient-123' },
-      provider: { reference: 'Practitioner/practitioner-2' },
-    };
-
     const updatedEncounter: Encounter = {
       ...mockEncounter,
       participant: [
@@ -675,22 +652,17 @@ describe('BillingTab', () => {
     await medplum.createResource(mockPractitioner1);
     await medplum.createResource(mockPractitioner2);
 
-    // Mock searchResources to return different results based on resource type
-    // Use mockResolvedValue for Coverage (called on mount) and mockImplementation for Practitioner
-    vi.spyOn(medplum, 'searchResources')
-      .mockResolvedValueOnce([mockCoverage] as any) // Coverage search on mount
-      .mockResolvedValue([mockPractitioner1, mockPractitioner2] as any); // Practitioner searches
-    vi.spyOn(claimsUtils, 'createClaimFromEncounter').mockResolvedValue(newClaim);
+    // Mock searchResources to return different results based on resource type:
+    // Coverage on mount, Practitioner for the practitioner search, and no existing Claim.
+    mockSearchResources({ Coverage: [mockCoverage], Practitioner: [mockPractitioner1, mockPractitioner2] });
+    mockChargeItems([appliedChargeItem]); // Charge items already present
     vi.spyOn(medplum, 'updateResource').mockResolvedValue(updatedEncounter as any);
     vi.spyOn(medplum, 'readReference').mockResolvedValue(mockPractitioner2 as any);
 
     // Setup with charge items but no claim initially
     await setup({
-      claim: undefined, // No claim initially
-      chargeItems: [appliedChargeItem], // Charge items already present
-      setChargeItems: vi.fn(),
-      setClaim,
       setEncounter,
+      setPractitioner,
       encounter: {
         resourceType: 'Encounter',
         id: 'encounter-123',
@@ -739,214 +711,30 @@ describe('BillingTab', () => {
       { timeout: 1000 }
     );
 
+    // The encounter is saved and the new practitioner resolved; no claim is created or updated.
     await waitFor(
       () => {
-        expect(claimsUtils.createClaimFromEncounter).toHaveBeenCalledWith(
-          medplum,
-          mockPatient,
-          updatedEncounter,
-          mockPractitioner2,
-          [appliedChargeItem]
-        );
-        expect(setClaim).toHaveBeenCalledWith(newClaim);
+        expect(setPractitioner).toHaveBeenCalledWith(mockPractitioner2);
       },
       { timeout: 5000 }
     );
   }, 15000);
 
-  test('updates claim when practitioner is changed and claim already exists', async () => {
-    const setEncounter = vi.fn();
-    const setClaim = vi.fn();
-    const debouncedUpdateResource = mockDebouncedUpdate();
-
-    vi.spyOn(useDebouncedUpdateResourceModule, 'useDebouncedUpdateResource').mockReturnValue(debouncedUpdateResource);
-
-    const mockPractitioner1: WithId<Practitioner> = {
-      resourceType: 'Practitioner',
-      id: 'practitioner-1',
-      name: [{ given: ['Dr.'], family: 'Test' }],
-    };
-
-    const mockPractitioner2: WithId<Practitioner> = {
-      resourceType: 'Practitioner',
-      id: 'practitioner-2',
-      name: [{ given: ['Dr.'], family: 'Smith' }],
-    };
-
-    const appliedChargeItem: WithId<ChargeItem> = {
-      resourceType: 'ChargeItem',
-      id: 'charge-new',
-      status: 'planned',
-      subject: { reference: 'Patient/patient-123' },
-      code: {
-        coding: [
-          {
-            system: 'http://www.ama-assn.org/go/cpt',
-            code: '99214',
-            display: 'Office Visit Level 4',
-          },
-        ],
-      },
-      priceOverride: { value: 200, currency: 'USD' },
-    };
-
-    const existingClaim: Claim & { id: string } = {
-      resourceType: 'Claim',
-      id: 'claim-existing',
-      status: 'active',
-      type: { coding: [{ code: 'professional' }] },
-      use: 'claim',
-      created: new Date().toISOString(),
-      priority: { coding: [{ code: 'normal' }] },
-      insurance: [],
-      patient: { reference: 'Patient/patient-123' },
-      provider: { reference: 'Practitioner/practitioner-1' }, // Original practitioner
-    };
-
-    const updatedClaim: Claim & { id: string } = {
-      ...existingClaim,
-      provider: { reference: 'Practitioner/practitioner-2' }, // Updated practitioner
-    };
-
-    const updatedEncounter: Encounter = {
-      ...mockEncounter,
-      participant: [
-        {
-          individual: { reference: 'Practitioner/practitioner-2' },
-        },
-      ],
-    };
-
-    await medplum.createResource(mockPractitioner1);
-    await medplum.createResource(mockPractitioner2);
-
-    // Mock searchResources to return different results based on resource type
-    vi.spyOn(medplum, 'searchResources')
-      .mockResolvedValueOnce([mockCoverage] as any) // Coverage search on mount
-      .mockResolvedValue([mockPractitioner1, mockPractitioner2] as any); // Practitioner searches
-    vi.spyOn(medplum, 'updateResource').mockImplementation(async (resource: any) => {
-      // Return updated encounter when updating encounter, updated claim when updating claim
-      if (resource.resourceType === 'Encounter') {
-        return updatedEncounter as any;
-      }
-      if (resource.resourceType === 'Claim') {
-        return updatedClaim;
-      }
-      return resource;
-    });
-    vi.spyOn(medplum, 'readReference').mockResolvedValue(mockPractitioner2);
-
-    await setup({
-      claim: existingClaim,
-      chargeItems: [appliedChargeItem],
-      setChargeItems: vi.fn(),
-      setClaim,
-      setEncounter,
-      encounter: {
-        resourceType: 'Encounter',
-        id: 'encounter-123',
-        status: 'finished',
-        class: { code: 'AMB', system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode' },
-        subject: { reference: `Patient/${HomerSimpson.id}` },
-        participant: [
-          {
-            individual: { reference: 'Practitioner/practitioner-1' }, // Original practitioner
-          },
-        ],
-      },
-      practitioner: mockPractitioner1, // Start with practitioner-1
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText('Practitioner')).toBeInTheDocument();
-      expect(screen.getByText(/Dr\. Test/i)).toBeInTheDocument();
-    });
-
-    const practitionerText = screen.getByText(/Dr\. Test/i);
-    const practitionerContainer = practitionerText.closest('[data-testid]') || practitionerText.closest('div');
-    const clickableElement =
-      practitionerContainer?.querySelector('button') || practitionerText.closest('button') || practitionerText;
-
-    // Click to open the dropdown
-    await act(async () => {
-      fireEvent.click(clickableElement);
-    });
-
-    await waitFor(
-      () => {
-        const practitionerInput = screen.queryByPlaceholderText('Search for practitioner') as HTMLInputElement;
-        expect(practitionerInput).toBeInTheDocument();
-      },
-      { timeout: 3000 }
-    );
-
-    const practitionerInput = screen.getByPlaceholderText('Search for practitioner');
-
-    await act(async () => {
-      fireEvent.change(practitionerInput, { target: { value: 'Smith' } });
-    });
-
-    await waitFor(
-      () => {
-        const smithOption = screen.queryByText(/Smith/i);
-        expect(smithOption).toBeInTheDocument();
-      },
-      { timeout: 3000 }
-    );
-
-    await act(async () => {
-      const smithOption = screen.getByText(/Smith/i);
-      fireEvent.click(smithOption);
-    });
-
-    await waitFor(
-      () => {
-        const updateCalls = vi.mocked(medplum.updateResource).mock.calls;
-        const encounterUpdateCall = updateCalls.find((call) => (call[0] as any).resourceType === 'Encounter');
-        expect(encounterUpdateCall).toBeDefined();
-      },
-      { timeout: SAVE_TIMEOUT_MS + 2000 }
-    );
-
-    await waitFor(
-      () => {
-        expect(medplum.readReference).toHaveBeenCalledWith({ reference: 'Practitioner/practitioner-2' });
-      },
-      { timeout: 3000 }
-    );
-
-    await waitFor(
-      () => {
-        const updateCalls = vi.mocked(debouncedUpdateResource).mock.calls;
-        const claimUpdateCall = updateCalls.find((call) => {
-          const resource = call[0] as Claim;
-          return resource.resourceType === 'Claim' && resource.provider?.reference === 'Practitioner/practitioner-2';
-        });
-        expect(claimUpdateCall).toBeDefined();
-        expect(setClaim).toHaveBeenCalledWith(
-          expect.objectContaining({
-            resourceType: 'Claim',
-            provider: { reference: 'Practitioner/practitioner-2' },
-          })
-        );
-      },
-      { timeout: 5000 }
-    );
-  }, 15000);
-
-  test('handles export when claim id is missing', async () => {
+  test('creates the claim before exporting when none is persisted yet', async () => {
     const user = userEvent.setup();
 
-    vi.spyOn(medplum, 'searchResources').mockResolvedValue([mockCoverage] as any);
-    vi.spyOn(medplum, 'post').mockResolvedValue({
+    // No existing Claim for the encounter; coverage is present.
+    mockSearchResources({ Coverage: [mockCoverage] });
+    const createSpy = vi.spyOn(medplum, 'createResource').mockResolvedValue({ ...mockClaim, id: 'created-claim' });
+    const postSpy = vi.spyOn(medplum, 'post').mockResolvedValue({
       resourceType: 'Media',
       content: { url: 'https://example.com/claim.pdf' },
     });
+    const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
 
-    // Setup with a claim but with undefined id
-    await setup({ claim: { ...mockClaim, id: undefined as unknown as string } });
+    // No persisted claim yet; CPT charge items (default) drive the card.
+    await setup();
 
-    // Export button is visible but clicking it should be a no-op
     const exportButton = screen.getByText('Export Claim');
     await user.click(exportButton);
 
@@ -956,22 +744,66 @@ describe('BillingTab', () => {
 
     await user.click(screen.getByText('CMS 1500 Form'));
 
-    // Post should NOT be called due to early return
+    // The claim is created on demand, then exported.
     await waitFor(() => {
-      expect(medplum.post).not.toHaveBeenCalled();
+      expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ resourceType: 'Claim' }));
+      const exportCall = postSpy.mock.calls.find((c) => c[0]?.toString().includes('$export'));
+      expect(exportCall).toBeDefined();
+      expect(windowOpenSpy).toHaveBeenCalledWith('https://example.com/claim.pdf', '_blank');
     });
+
+    windowOpenSpy.mockRestore();
+  });
+
+  test('re-fetches the existing claim at persist time and updates it instead of creating a duplicate', async () => {
+    const user = userEvent.setup();
+
+    mockSearchResources({ Coverage: [mockCoverage] });
+
+    // No claim is in local state on mount (first lookup returns nothing), but one already exists by
+    // the time we export (second lookup), so generateClaim must update it rather than create another.
+    let claimLookups = 0;
+    vi.spyOn(medplum, 'searchOne').mockImplementation(((resourceType: string) => {
+      if (resourceType === 'Claim') {
+        claimLookups += 1;
+        return Promise.resolve(claimLookups === 1 ? undefined : mockClaim);
+      }
+      return Promise.resolve(undefined);
+    }) as any);
+
+    const updateSpy = vi.spyOn(medplum, 'updateResource');
+    const createSpy = vi.spyOn(medplum, 'createResource');
+    vi.spyOn(medplum, 'post').mockResolvedValue({
+      resourceType: 'Media',
+      content: { url: 'https://example.com/claim.pdf' },
+    });
+    const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    await setup();
+
+    await user.click(await screen.findByText('Export Claim'));
+    await user.click(await screen.findByText('CMS 1500 Form'));
+
+    await waitFor(() => {
+      // Pulled the existing claim and updated it (matched by its id), with no duplicate create.
+      expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ resourceType: 'Claim', id: 'claim-123' }));
+    });
+    expect(createSpy).not.toHaveBeenCalled();
+
+    windowOpenSpy.mockRestore();
   });
 
   test('shows error when export fails to return Media', async () => {
     const user = userEvent.setup();
 
-    vi.spyOn(medplum, 'searchResources').mockResolvedValue([mockCoverage] as any);
+    mockSearchResources({ Coverage: [mockCoverage] });
+    mockSearchOne({ Claim: mockClaim });
     vi.spyOn(medplum, 'post').mockResolvedValue({
       resourceType: 'OperationOutcome',
       issue: [{ severity: 'error', code: 'invalid' }],
     });
 
-    await setup({ claim: mockClaim });
+    await setup();
 
     const exportButton = screen.getByText('Export Claim');
     await user.click(exportButton);
@@ -999,7 +831,7 @@ describe('BillingTab', () => {
       payor: [{ reference: 'Patient/patient-123' }],
     };
 
-    vi.spyOn(medplum, 'searchResources').mockResolvedValue([] as any);
+    mockSearchResources();
     vi.spyOn(medplum, 'createResource').mockResolvedValue(selfPayCoverage as any);
     vi.spyOn(medplum, 'post').mockResolvedValue({
       resourceType: 'Media',
@@ -1008,7 +840,7 @@ describe('BillingTab', () => {
 
     const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
 
-    await setup({ claim: mockClaim });
+    await setup();
 
     const exportButton = screen.getByText('Export Claim');
     await user.click(exportButton);
@@ -1060,7 +892,8 @@ describe('BillingTab', () => {
         insurance: [{ sequence: 1, focal: true, coverage: { reference: 'Coverage/coverage-123' } }],
       };
 
-      vi.spyOn(medplum, 'searchResources').mockResolvedValue([mockCoverage] as any);
+      mockSearchResources({ Coverage: [mockCoverage] });
+      mockSearchOne({ Claim: mockClaim });
       vi.spyOn(medplum, 'readReference').mockResolvedValue(mockCondition as any);
       vi.spyOn(medplum, 'updateResource').mockResolvedValue(updatedClaim);
       const postSpy = vi.spyOn(medplum, 'post').mockImplementation(async (url: any) => {
@@ -1071,7 +904,6 @@ describe('BillingTab', () => {
       });
 
       await setup({
-        claim: mockClaim,
         encounter: { ...mockEncounter, diagnosis: [{ condition: { reference: 'Condition/condition-1' } }] },
       });
 
@@ -1111,7 +943,8 @@ describe('BillingTab', () => {
         code: { text: 'Headache' },
       };
 
-      vi.spyOn(medplum, 'searchResources').mockResolvedValue([mockCoverage] as any);
+      mockSearchResources({ Coverage: [mockCoverage] });
+      mockSearchOne({ Claim: mockClaim });
       vi.spyOn(medplum, 'readReference').mockResolvedValue(mockCondition as any);
       const createSpy = vi.spyOn(medplum, 'createResource').mockResolvedValue({
         resourceType: 'Coverage',
@@ -1122,7 +955,6 @@ describe('BillingTab', () => {
       } as any);
 
       await setup({
-        claim: mockClaim,
         encounter: { ...mockEncounter, diagnosis: [{ condition: { reference: 'Condition/condition-1' } }] },
       });
 
@@ -1159,17 +991,20 @@ describe('BillingTab', () => {
       total: [{ category: { coding: [{ code: 'submitted' }] }, amount: { value: 100 } }],
     };
 
+    // The Candid card requires BillingTab to find an existing Claim (searchOne) and then its
+    // ClaimResponse (searchOne). Seed both: mockClaim for the Claim lookup, claimResponse for the rest.
     const mockSearchOneWithClaimResponse = (claimResponse: WithId<ClaimResponse>): void => {
       vi.spyOn(medplum, 'searchOne').mockImplementation(((resourceType: string) =>
-        resourceType === 'ClaimResponse' ? Promise.resolve(claimResponse) : Promise.resolve(undefined)) as (
+        Promise.resolve(resourceType === 'Claim' ? mockClaim : claimResponse)) as (
         resourceType: string
-      ) => ReadablePromise<WithId<ClaimResponse> | undefined>);
+      ) => ReadablePromise<WithId<Claim> | WithId<ClaimResponse> | undefined>);
     };
 
     test('shows Candid claim card when a ClaimResponse exists', async () => {
+      mockSearchResources({ Coverage: [mockCoverage] });
       mockSearchOneWithClaimResponse(candidClaimResponse);
 
-      await setup({ claim: mockClaim });
+      await setup();
 
       await waitFor(() => {
         expect(screen.getByText('Claim Status:')).toBeInTheDocument();
@@ -1180,7 +1015,7 @@ describe('BillingTab', () => {
     test('displays status badge and submission date from ClaimResponse', async () => {
       mockSearchOneWithClaimResponse(candidClaimResponse);
 
-      await setup({ claim: mockClaim });
+      await setup();
 
       await waitFor(() => {
         expect(screen.getByText('Submitted')).toBeInTheDocument();
@@ -1191,7 +1026,7 @@ describe('BillingTab', () => {
     test('hides submission date when ClaimResponse has no created', async () => {
       mockSearchOneWithClaimResponse({ ...candidClaimResponse, created: '' });
 
-      await setup({ claim: mockClaim });
+      await setup();
 
       await waitFor(() => {
         expect(screen.getByText('Claim Status:')).toBeInTheDocument();
@@ -1205,7 +1040,7 @@ describe('BillingTab', () => {
 
       mockSearchOneWithClaimResponse(candidClaimResponse);
 
-      await setup({ claim: mockClaim });
+      await setup();
 
       await waitFor(() => {
         expect(screen.getByText('View Claim on Candid')).toBeInTheDocument();
@@ -1241,7 +1076,8 @@ describe('BillingTab', () => {
     };
 
     vi.spyOn(medplum, 'readReference').mockResolvedValue(mockCondition as any);
-    vi.spyOn(medplum, 'searchResources').mockResolvedValue([mockCoverage] as any);
+    mockSearchResources({ Coverage: [mockCoverage] });
+    mockSearchOne({ Claim: mockClaim });
     vi.spyOn(medplum, 'post').mockResolvedValue({
       resourceType: 'Media',
       content: { url: 'https://example.com/claim.pdf' },
@@ -1250,7 +1086,6 @@ describe('BillingTab', () => {
     const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
 
     await setup({
-      claim: mockClaim,
       encounter: {
         ...mockEncounter,
         diagnosis: [

--- a/examples/medplum-provider/src/components/encounter/BillingTab.tsx
+++ b/examples/medplum-provider/src/components/encounter/BillingTab.tsx
@@ -4,11 +4,10 @@ import { Button, Card, Flex, Group, Menu, Skeleton, Stack, Tooltip } from '@mant
 import { useDebouncedCallback } from '@mantine/hooks';
 import { notifications, showNotification } from '@mantine/notifications';
 import type { WithId } from '@medplum/core';
-import { getReferenceString, HTTP_HL7_ORG } from '@medplum/core';
+import { CPT, getReferenceString } from '@medplum/core';
 import type {
   ChargeItem,
   Claim,
-  ClaimDiagnosis,
   ClaimResponse,
   Condition,
   Coverage,
@@ -22,12 +21,12 @@ import type {
 import { useMedplum } from '@medplum/react';
 import { IconCircleOff, IconDownload, IconFileText, IconSend } from '@tabler/icons-react';
 import type { JSX } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { SAVE_TIMEOUT_MS } from '../../config/constants';
 import { useDebouncedUpdateResource } from '../../hooks/useDebouncedUpdateResource';
 import { ChartNoteStatus } from '../../types/encounter';
-import { calculateTotalPrice } from '../../utils/chargeitems';
-import { createClaimFromEncounter, getCptChargeItems } from '../../utils/claims';
+import { getChargeItemsForEncounter } from '../../utils/chargeitems';
+import { buildClaimFromEncounter } from '../../utils/claims';
 import { createSelfPayCoverage, isSelfPayCoverage } from '../../utils/coverage';
 import { showErrorNotification } from '../../utils/notifications';
 import { ChargeItemList } from '../ChargeItem/ChargeItemList';
@@ -42,27 +41,14 @@ export interface BillingTabProps {
   setEncounter: (encounter: WithId<Encounter>) => void;
   practitioner: WithId<Practitioner> | undefined;
   setPractitioner: (practitioner: WithId<Practitioner>) => void;
-  chargeItems: WithId<ChargeItem>[] | undefined;
-  setChargeItems: (chargeItems: WithId<ChargeItem>[]) => void;
-  claim: WithId<Claim> | undefined;
-  setClaim: (claim: WithId<Claim>) => void;
   chartNoteStatus: ChartNoteStatus;
 }
 
 export const BillingTab = (props: BillingTabProps): JSX.Element => {
-  const {
-    encounter,
-    setEncounter,
-    claim,
-    patient,
-    practitioner,
-    setPractitioner,
-    chargeItems,
-    setChargeItems,
-    setClaim,
-    chartNoteStatus,
-  } = props;
+  const { encounter, setEncounter, patient, practitioner, setPractitioner, chartNoteStatus } = props;
   const medplum = useMedplum();
+  const [claim, setClaim] = useState<WithId<Claim> | undefined>();
+  const [chargeItems, setChargeItems] = useState<WithId<ChargeItem>[]>([]);
   const [conditions, setConditions] = useState<Condition[]>([]);
   const [coverages, setCoverages] = useState<WithId<Coverage>[]>([]);
   const [coverage, setCoverage] = useState<WithId<Coverage> | undefined>();
@@ -71,12 +57,31 @@ export const BillingTab = (props: BillingTabProps): JSX.Element => {
   const [claimResponse, setClaimResponse] = useState<WithId<ClaimResponse> | null | undefined>(undefined);
   const [claimResponseLoading, setClaimResponseLoading] = useState(false);
 
-  const conditionsRef = useRef(conditions);
-  conditionsRef.current = conditions;
-  const claimRef = useRef(claim);
-  claimRef.current = claim;
   const debouncedUpdateResource = useDebouncedUpdateResource(medplum);
-  const debouncedUpdateClaim = useDebouncedUpdateResource(medplum);
+
+  useEffect(() => {
+    const fetchClaim = async (): Promise<void> => {
+      const response = await medplum.searchOne(
+        'Claim',
+        { encounter: getReferenceString(encounter), status: 'active,draft' },
+        { cache: 'no-cache' }
+      );
+      if (response) {
+        setClaim(response);
+      }
+    };
+
+    fetchClaim().catch((err) => showErrorNotification(err));
+  }, [encounter, medplum]);
+
+  useEffect(() => {
+    const loadChargeItems = async (): Promise<void> => {
+      const chargeItemsResult = await getChargeItemsForEncounter(medplum, encounter);
+      setChargeItems(chargeItemsResult);
+    };
+
+    loadChargeItems().catch((err) => showErrorNotification(err));
+  }, [encounter, medplum]);
 
   useEffect(() => {
     const fetchCoverage = async (): Promise<void> => {
@@ -119,7 +124,10 @@ export const BillingTab = (props: BillingTabProps): JSX.Element => {
     }
   }, [claim, medplum]);
 
+  // Refetch the ClaimResponse whenever the resolved claim changes (e.g. after the claim loads or is
+  // (re)persisted). The synchronous clear in fetchClaimResponse is intentional, so suppress the rule.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchClaimResponse().catch((err) => showErrorNotification(err));
   }, [fetchClaimResponse]);
 
@@ -132,108 +140,72 @@ export const BillingTab = (props: BillingTabProps): JSX.Element => {
     [encounter, setEncounter, debouncedUpdateResource]
   );
 
-  // Creates the claim if it doesn't exist yet, otherwise updates it with the given patch.
-  // Always folds in current diagnosis and insurance so every save is complete.
-  // Pass creationArgs to override encounter/practitioner/items used at creation time.
-  const syncClaim = useCallback(
-    async (
-      patch: Partial<Claim> = {},
-      creationArgs?: { enc?: WithId<Encounter>; prac?: WithId<Practitioner>; items?: WithId<ChargeItem>[] }
-    ): Promise<void> => {
-      const currentClaim = claimRef.current;
-      if (currentClaim) {
-        const updatedClaim = {
-          ...currentClaim,
-          diagnosis: createDiagnosisArray(conditionsRef.current),
-          ...(coverage && {
-            insurance: [{ sequence: 1, focal: true, coverage: { reference: getReferenceString(coverage) } }],
-          }),
-          ...patch,
-        };
-        setClaim(updatedClaim);
-        debouncedUpdateClaim(updatedClaim).catch((err) => showErrorNotification(err));
-        return;
+  const generateClaim = useCallback(
+    async (insuranceRefs?: Reference<Coverage>[]): Promise<WithId<Claim>> => {
+      if (!practitioner) {
+        throw new Error('A practitioner is required to create a claim');
       }
-      const enc = creationArgs?.enc ?? encounter;
-      const prac = creationArgs?.prac ?? practitioner;
-      const items = creationArgs?.items ?? chargeItems;
-      if (!patient?.id || !enc?.id || !prac?.id || !items?.length) {
-        return;
-      }
-      const newClaim = await createClaimFromEncounter(medplum, patient, enc, prac, items);
-      if (newClaim) {
-        setClaim(newClaim);
-      }
-    },
-    [chargeItems, coverage, debouncedUpdateClaim, encounter, medplum, patient, practitioner, setClaim]
-  );
+      const insurance = insuranceRefs ?? (coverage ? [{ reference: getReferenceString(coverage) }] : undefined);
+      const built = buildClaimFromEncounter({
+        patient,
+        encounter,
+        practitioner,
+        chargeItems,
+        conditions,
+        insurance,
+      });
 
-  // Re-sync claim whenever conditions, coverage, or claim id changes.
-  useEffect(() => {
-    if (!claimRef.current) {
-      return;
-    }
-    syncClaim().catch((err) => showErrorNotification(err));
-  }, [conditions, coverage, claim?.id, syncClaim]);
+      const existingClaim = await medplum.searchOne(
+        'Claim',
+        { encounter: getReferenceString(encounter), status: 'active,draft' },
+        { cache: 'no-cache' }
+      );
+
+      const saved = existingClaim?.id
+        ? await medplum.updateResource({
+            ...existingClaim,
+            ...built,
+            status: existingClaim.status ?? built.status,
+            created: existingClaim.created ?? built.created,
+          })
+        : await medplum.createResource(built);
+      setClaim(saved);
+      return saved;
+    },
+    [patient, encounter, practitioner, chargeItems, conditions, coverage, medplum, setClaim]
+  );
 
   const handleEncounterChange = useDebouncedCallback(async (updatedEncounter: Encounter): Promise<void> => {
     try {
       const savedEncounter = await medplum.updateResource(updatedEncounter);
       setEncounter(savedEncounter);
 
-      let currentPractitioner = practitioner;
       if (savedEncounter?.participant?.[0]?.individual) {
         const practitionerResult = await medplum.readReference(savedEncounter.participant[0].individual);
-        currentPractitioner = practitionerResult as WithId<Practitioner>;
-        setPractitioner(currentPractitioner);
+        setPractitioner(practitionerResult as WithId<Practitioner>);
       }
-
-      if (!patient?.id || !savedEncounter?.id || !currentPractitioner?.id || !chargeItems?.length) {
-        return;
-      }
-
-      await syncClaim(
-        { provider: { reference: getReferenceString(currentPractitioner) } },
-        { enc: savedEncounter, prac: currentPractitioner }
-      );
     } catch (err) {
       showErrorNotification(err);
     }
   }, SAVE_TIMEOUT_MS);
 
-  const updateChargeItems = useCallback(
-    async (updatedChargeItems: WithId<ChargeItem>[]): Promise<void> => {
-      setChargeItems(updatedChargeItems);
-      if (!patient?.id || !encounter?.id || !practitioner?.id || !updatedChargeItems.length) {
-        return;
+  const exportClaimAsCMS1500 = useCallback(async (): Promise<void> => {
+    try {
+      const saved = await generateClaim();
+      const response = await medplum.post<Media>(medplum.fhirUrl('Claim', '$export'), {
+        resourceType: 'Parameters',
+        parameter: [{ name: 'resource', resource: saved }],
+      });
+
+      if (response.resourceType === 'Media' && response.content?.url) {
+        window.open(response.content.url, '_blank');
+      } else {
+        showErrorNotification('Failed to download PDF');
       }
-      await syncClaim(
-        {
-          item: getCptChargeItems(updatedChargeItems, { reference: getReferenceString(encounter) }),
-          total: { value: calculateTotalPrice(updatedChargeItems) },
-        },
-        { items: updatedChargeItems }
-      );
-    },
-    [patient, encounter, practitioner, syncClaim, setChargeItems]
-  );
-
-  const exportClaimAsCMS1500 = async (): Promise<void> => {
-    if (!claim?.id) {
-      return;
+    } catch (err) {
+      showErrorNotification(err);
     }
-
-    const response = await medplum.post<Media>(medplum.fhirUrl('Claim', '$export'), {
-      resourceType: 'Parameters',
-      parameter: [{ name: 'resource', resource: claim }],
-    });
-
-    if (response.resourceType === 'Media' && response.content?.url) {
-      window.open(response.content.url, '_blank');
-    } else {
-      showErrorNotification('Failed to download PDF');
-    }
-  };
+  }, [generateClaim, medplum]);
 
   const runClaimSubmit = useCallback(
     async (
@@ -242,22 +214,10 @@ export const BillingTab = (props: BillingTabProps): JSX.Element => {
       successTitle: string,
       successMessage: string
     ): Promise<void> => {
-      if (!claim) {
-        return;
-      }
       setSubmitting(true);
-      debouncedUpdateClaim.cancel();
       try {
-        const updatedClaim = await medplum.updateResource({
-          ...claim,
-          insurance: coverageRefs.map((ref, index) => ({
-            sequence: index + 1,
-            focal: index === 0,
-            coverage: ref,
-          })),
-        });
-        setClaim(updatedClaim);
-        const result = await medplum.post(medplum.fhirUrl('Claim', updatedClaim.id, operation), {
+        const saved = await generateClaim(coverageRefs);
+        const result = await medplum.post(medplum.fhirUrl('Claim', saved.id, operation), {
           resourceType: 'Parameters',
           parameter: [],
         });
@@ -283,7 +243,7 @@ export const BillingTab = (props: BillingTabProps): JSX.Element => {
         setSubmitting(false);
       }
     },
-    [claim, debouncedUpdateClaim, fetchClaimResponse, medplum, setClaim]
+    [generateClaim, fetchClaimResponse, medplum]
   );
 
   const submitToCandid = useCallback(
@@ -392,7 +352,8 @@ export const BillingTab = (props: BillingTabProps): JSX.Element => {
   }, [conditions, coverages, medplum, patient]);
 
   const renderClaimCard = (): JSX.Element | null => {
-    if (!claim) {
+    const hasCptItems = chargeItems.some((item) => item.code?.coding?.some((c) => c.system === CPT));
+    if (!hasCptItems && !claim && !claimResponse) {
       return null;
     }
 
@@ -465,34 +426,12 @@ export const BillingTab = (props: BillingTabProps): JSX.Element => {
         />
       )}
 
-      {chargeItems && (
-        <ChargeItemList
-          patient={patient}
-          encounter={encounter}
-          chargeItems={chargeItems}
-          updateChargeItems={updateChargeItems}
-        />
-      )}
+      <ChargeItemList
+        patient={patient}
+        encounter={encounter}
+        chargeItems={chargeItems}
+        updateChargeItems={setChargeItems}
+      />
     </Stack>
   );
-};
-
-const createDiagnosisArray = (conditions: Condition[]): ClaimDiagnosis[] => {
-  return conditions.map((condition, index) => {
-    const icd10Coding = condition.code?.coding?.find((c) => c.system === `${HTTP_HL7_ORG}/fhir/sid/icd-10-cm`);
-    return {
-      diagnosisCodeableConcept: {
-        coding: icd10Coding
-          ? [
-              {
-                ...icd10Coding,
-                system: `${HTTP_HL7_ORG}/fhir/sid/icd-10`,
-              },
-            ]
-          : [],
-      },
-      sequence: index + 1,
-      type: [{ coding: [{ code: index === 0 ? 'principal' : 'secondary' }] }],
-    };
-  });
 };

--- a/examples/medplum-provider/src/components/encounter/EncounterChart.tsx
+++ b/examples/medplum-provider/src/components/encounter/EncounterChart.tsx
@@ -42,18 +42,14 @@ export const EncounterChart = (props: EncounterChartProps): JSX.Element => {
   const {
     encounter,
     patient: patientResource,
-    claim,
     practitioner,
     tasks,
     clinicalImpression,
-    chargeItems,
     appointment,
     setEncounter,
-    setClaim,
     setPractitioner,
     setTasks,
     setClinicalImpression,
-    setChargeItems,
   } = useEncounterChart(encounterProp);
 
   const [chartNote, setChartNote] = useState(clinicalImpression?.note?.[0]?.text);
@@ -264,13 +260,9 @@ export const EncounterChart = (props: EncounterChartProps): JSX.Element => {
             <BillingTab
               encounter={encounter}
               setEncounter={setEncounter}
-              claim={claim}
               patient={patientResource}
               practitioner={practitioner}
               setPractitioner={setPractitioner}
-              chargeItems={chargeItems}
-              setChargeItems={setChargeItems}
-              setClaim={setClaim}
               chartNoteStatus={chartNoteStatus}
             />
           )}

--- a/examples/medplum-provider/src/hooks/useEncounterChart.test.tsx
+++ b/examples/medplum-provider/src/hooks/useEncounterChart.test.tsx
@@ -1,7 +1,15 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import type { Appointment, ClinicalImpression, Encounter, Patient, Practitioner, Reference, Task } from '@medplum/fhirtypes';
+import type {
+  Appointment,
+  ClinicalImpression,
+  Encounter,
+  Patient,
+  Practitioner,
+  Reference,
+  Task,
+} from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, renderHook, waitFor } from '@testing-library/react';

--- a/examples/medplum-provider/src/hooks/useEncounterChart.test.tsx
+++ b/examples/medplum-provider/src/hooks/useEncounterChart.test.tsx
@@ -1,29 +1,15 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import type {
-  Appointment,
-  ChargeItem,
-  Claim,
-  ClinicalImpression,
-  Encounter,
-  Patient,
-  Practitioner,
-  Reference,
-  Task,
-} from '@medplum/fhirtypes';
+import type { Appointment, ClinicalImpression, Encounter, Patient, Practitioner, Reference, Task } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { JSX } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { getChargeItemsForEncounter } from '../utils/chargeitems';
-import { createClaimFromEncounter } from '../utils/claims';
 import { showErrorNotification } from '../utils/notifications';
 import { useEncounterChart } from './useEncounterChart';
 
-vi.mock('../utils/chargeitems');
-vi.mock('../utils/claims');
 vi.mock('../utils/notifications');
 
 const mockEncounter: WithId<Encounter> = {
@@ -76,37 +62,6 @@ const mockClinicalImpression: ClinicalImpression = {
   encounter: { reference: 'Encounter/encounter-123' },
 };
 
-const mockChargeItem: WithId<ChargeItem> = {
-  resourceType: 'ChargeItem',
-  id: 'charge-item-123',
-  status: 'billable',
-  subject: { reference: 'Patient/patient-123' },
-  code: { text: 'Test Charge' },
-};
-
-const mockClaim: WithId<Claim> = {
-  resourceType: 'Claim',
-  id: 'claim-123',
-  status: 'active',
-  type: { coding: [{ code: 'professional' }] },
-  use: 'claim',
-  created: new Date().toISOString(),
-  patient: { reference: 'Patient/patient-123' },
-  provider: { reference: 'Practitioner/practitioner-123' },
-  priority: { coding: [{ code: 'normal' }] },
-  insurance: [],
-  item: [
-    {
-      sequence: 1,
-      encounter: [{ reference: 'Encounter/encounter-123' }],
-      productOrService: {
-        coding: [{ code: 'CPT', system: 'http://terminology.hl7.org/CodeSystem/cpt' }],
-        text: 'CPT Code',
-      },
-    },
-  ],
-};
-
 describe('useEncounterChart', () => {
   let medplum: MockClient;
 
@@ -123,11 +78,9 @@ describe('useEncounterChart', () => {
     const { result } = renderHook(() => useEncounterChart(undefined), { wrapper });
 
     expect(result.current.encounter).toBeUndefined();
-    expect(result.current.claim).toBeUndefined();
     expect(result.current.practitioner).toBeUndefined();
     expect(result.current.tasks).toEqual([]);
     expect(result.current.clinicalImpression).toBeUndefined();
-    expect(result.current.chargeItems).toEqual([]);
     expect(result.current.appointment).toBeUndefined();
   });
 
@@ -136,8 +89,6 @@ describe('useEncounterChart', () => {
     const createdEncounter = await medplum.createResource(mockEncounter);
     await medplum.createResource(mockPractitioner);
 
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([mockChargeItem]);
-
     const encounterRef: Reference<Encounter> = { reference: `Encounter/${createdEncounter.id}` };
 
     const { result } = renderHook(() => useEncounterChart(encounterRef), { wrapper });
@@ -145,56 +96,12 @@ describe('useEncounterChart', () => {
     await waitFor(() => {
       expect(result.current.encounter?.id).toBe(createdEncounter.id);
     });
-
-    await waitFor(() => {
-      expect(result.current.chargeItems).toHaveLength(1);
-    });
-  });
-
-  test('loads charge items for encounter', async () => {
-    await medplum.createResource(mockEncounter);
-    await medplum.createResource(mockPractitioner);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([mockChargeItem]);
-
-    const { result } = renderHook(() => useEncounterChart(mockEncounter), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.chargeItems).toHaveLength(1);
-      expect(result.current.chargeItems[0].id).toBe('charge-item-123');
-    });
-  });
-
-  test('fetches existing claim for encounter', async () => {
-    const createdEncounter = await medplum.createResource(mockEncounter);
-    await medplum.createResource(mockPractitioner);
-    const claimWithEncounter: Claim = {
-      ...mockClaim,
-      item: [
-        {
-          sequence: 1,
-          encounter: [{ reference: `Encounter/${createdEncounter.id}` }],
-          productOrService: {
-            coding: [{ code: 'CPT', system: 'http://terminology.hl7.org/CodeSystem/cpt' }],
-            text: 'CPT Code',
-          },
-        },
-      ],
-    };
-    await medplum.createResource(claimWithEncounter);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([]);
-
-    const { result } = renderHook(() => useEncounterChart(createdEncounter), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.claim).toBeDefined();
-    });
   });
 
   test('fetches tasks for encounter', async () => {
     await medplum.createResource(mockEncounter);
     await medplum.createResource(mockPractitioner);
     await medplum.createResource(mockTask);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([]);
 
     const { result } = renderHook(() => useEncounterChart(mockEncounter), { wrapper });
 
@@ -220,7 +127,6 @@ describe('useEncounterChart', () => {
     await medplum.createResource(mockPractitioner);
     await medplum.createResource(newerTask);
     await medplum.createResource(olderTask);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([]);
 
     const { result } = renderHook(() => useEncounterChart(mockEncounter), { wrapper });
 
@@ -235,7 +141,6 @@ describe('useEncounterChart', () => {
     await medplum.createResource(mockEncounter);
     await medplum.createResource(mockPractitioner);
     await medplum.createResource(mockClinicalImpression);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([]);
 
     const { result } = renderHook(() => useEncounterChart(mockEncounter), { wrapper });
 
@@ -247,7 +152,6 @@ describe('useEncounterChart', () => {
   test('fetches practitioner from encounter participant', async () => {
     await medplum.createResource(mockEncounter);
     await medplum.createResource(mockPractitioner);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([]);
 
     const { result } = renderHook(() => useEncounterChart(mockEncounter), { wrapper });
 
@@ -260,7 +164,6 @@ describe('useEncounterChart', () => {
     await medplum.createResource(mockEncounter);
     await medplum.createResource(mockPractitioner);
     await medplum.createResource(mockAppointment);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([]);
 
     const { result } = renderHook(() => useEncounterChart(mockEncounter), { wrapper });
 
@@ -269,148 +172,12 @@ describe('useEncounterChart', () => {
     });
   });
 
-  test('creates claim when all conditions are met', async () => {
-    const newClaim: WithId<Claim> = {
-      resourceType: 'Claim',
-      id: 'new-claim-123',
-      status: 'active',
-      type: { coding: [{ code: 'professional' }] },
-      use: 'claim',
-      created: new Date().toISOString(),
-      patient: { reference: 'Patient/patient-123' },
-      provider: { reference: 'Practitioner/practitioner-123' },
-      priority: { coding: [{ code: 'normal' }] },
-      insurance: [],
-    };
-
-    await medplum.createResource(mockEncounter);
-    await medplum.createResource(mockPractitioner);
-    await medplum.createResource(mockPatient);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([mockChargeItem]);
-    vi.mocked(createClaimFromEncounter).mockResolvedValue(newClaim);
-
-    const { result } = renderHook(() => useEncounterChart(mockEncounter), { wrapper });
-
-    // Wait for all prerequisites to be met
-    await waitFor(() => {
-      expect(result.current.chargeItems).toHaveLength(1);
-      expect(result.current.practitioner).toBeDefined();
-    });
-
-    // Then wait for claim to be created
-    await waitFor(() => {
-      expect(result.current.claim?.id).toBe('new-claim-123');
-    });
-
-    expect(createClaimFromEncounter).toHaveBeenCalledWith(
-      medplum,
-      expect.objectContaining({ resourceType: 'Patient', id: 'patient-123' }),
-      expect.objectContaining({ resourceType: 'Encounter', id: 'encounter-123' }),
-      expect.objectContaining({ resourceType: 'Practitioner', id: 'practitioner-123' }),
-      [mockChargeItem]
-    );
-  });
-
-  test('does not create claim if one already exists', async () => {
-    await medplum.createResource(mockEncounter);
-    await medplum.createResource(mockPractitioner);
-    await medplum.createResource(mockPatient);
-    const createdClaim = await medplum.createResource(mockClaim);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([mockChargeItem]);
-
-    const { result } = renderHook(() => useEncounterChart(mockEncounter), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.claim).toBeDefined();
-    });
-
-    // Verify the existing claim is found (may have different ID due to MockClient)
-    expect(result.current.claim?.id).toBe(createdClaim.id);
-
-    // Verify no new claim is created
-    expect(createClaimFromEncounter).not.toHaveBeenCalled();
-  });
-
-  test('does not create claim if patient is missing', async () => {
-    await medplum.createResource(mockEncounter);
-    await medplum.createResource(mockPractitioner);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([mockChargeItem]);
-
-    const { result } = renderHook(() => useEncounterChart(mockEncounter), { wrapper });
-
-    // Wait for data to load
-    await waitFor(() => {
-      expect(result.current.chargeItems).toHaveLength(1);
-      expect(result.current.practitioner).toBeDefined();
-    });
-
-    // Verify claim was not created and remains undefined
-    expect(result.current.claim).toBeUndefined();
-    expect(createClaimFromEncounter).not.toHaveBeenCalled();
-  });
-
-  test('does not create claim if practitioner is missing', async () => {
-    const encounterWithoutPractitioner: WithId<Encounter> = {
-      ...mockEncounter,
-      participant: [],
-    };
-
-    await medplum.createResource(encounterWithoutPractitioner);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([mockChargeItem]);
-
-    const { result } = renderHook(() => useEncounterChart(encounterWithoutPractitioner), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.chargeItems).toHaveLength(1);
-    });
-
-    // Verify no practitioner and no claim
-    expect(result.current.practitioner).toBeUndefined();
-    expect(result.current.claim).toBeUndefined();
-    expect(createClaimFromEncounter).not.toHaveBeenCalled();
-  });
-
-  test('does not create claim if charge items are empty', async () => {
-    await medplum.createResource(mockEncounter);
-    await medplum.createResource(mockPractitioner);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([]);
-
-    const { result } = renderHook(() => useEncounterChart(mockEncounter), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.practitioner).toBeDefined();
-    });
-
-    // Verify no charge items and no claim
-    expect(result.current.chargeItems).toEqual([]);
-    expect(result.current.claim).toBeUndefined();
-    expect(createClaimFromEncounter).not.toHaveBeenCalled();
-  });
-
-  test('handles charge item fetch errors gracefully', async () => {
-    const error = new Error('Failed to fetch charge items');
-    await medplum.createResource(mockEncounter);
-    await medplum.createResource(mockPractitioner);
-    vi.mocked(getChargeItemsForEncounter).mockRejectedValue(error);
-
-    const { result } = renderHook(() => useEncounterChart(mockEncounter), { wrapper });
-
-    await waitFor(() => {
-      expect(showErrorNotification).toHaveBeenCalled();
-    });
-
-    // Hook should still function with empty charge items
-    expect(result.current.encounter).toBeDefined();
-    expect(result.current.chargeItems).toEqual([]);
-  });
-
   test('handles search errors gracefully', async () => {
     const error = new Error('Search failed');
     await medplum.createResource(mockEncounter);
 
     // Mock searchResources to fail
     medplum.searchResources = vi.fn().mockRejectedValue(error);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([]);
 
     const { result } = renderHook(() => useEncounterChart(mockEncounter), { wrapper });
 
@@ -428,7 +195,6 @@ describe('useEncounterChart', () => {
     await medplum.createResource(mockPatient);
     await medplum.createResource(mockEncounter);
     await medplum.createResource(mockPractitioner);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([]);
 
     const { result } = renderHook(() => useEncounterChart(mockEncounter), { wrapper });
 
@@ -440,7 +206,6 @@ describe('useEncounterChart', () => {
   test('allows manual state updates via setters', async () => {
     await medplum.createResource(mockEncounter);
     await medplum.createResource(mockPractitioner);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([]);
 
     const { result } = renderHook(() => useEncounterChart(undefined), { wrapper });
 
@@ -456,25 +221,5 @@ describe('useEncounterChart', () => {
     });
 
     expect(result.current.encounter?.status).toBe('finished');
-  });
-
-  test('updates claim via setter', async () => {
-    await medplum.createResource(mockEncounter);
-    await medplum.createResource(mockPractitioner);
-    vi.mocked(getChargeItemsForEncounter).mockResolvedValue([]);
-
-    const { result } = renderHook(() => useEncounterChart(mockEncounter), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.encounter).toBeDefined();
-    });
-
-    expect(result.current.claim).toBeUndefined();
-
-    act(() => {
-      result.current.setClaim(mockClaim);
-    });
-
-    expect(result.current.claim?.id).toBe('claim-123');
   });
 });

--- a/examples/medplum-provider/src/hooks/useEncounterChart.ts
+++ b/examples/medplum-provider/src/hooks/useEncounterChart.ts
@@ -4,8 +4,6 @@ import type { WithId } from '@medplum/core';
 import { getReferenceString } from '@medplum/core';
 import type {
   Appointment,
-  ChargeItem,
-  Claim,
   ClinicalImpression,
   Encounter,
   Patient,
@@ -16,27 +14,21 @@ import type {
 import { useMedplum, useResource } from '@medplum/react';
 import type { Dispatch, SetStateAction } from 'react';
 import { useEffect, useState } from 'react';
-import { getChargeItemsForEncounter } from '../utils/chargeitems';
-import { createClaimFromEncounter } from '../utils/claims';
 import { showErrorNotification } from '../utils/notifications';
 
 export interface EncounterChartHook {
   // State values
   encounter: WithId<Encounter> | undefined;
   patient: WithId<Patient> | undefined;
-  claim: WithId<Claim> | undefined;
   practitioner: WithId<Practitioner> | undefined;
   tasks: WithId<Task>[];
   clinicalImpression: WithId<ClinicalImpression> | undefined;
-  chargeItems: WithId<ChargeItem>[];
   appointment: WithId<Appointment> | undefined;
   // State setters
   setEncounter: Dispatch<SetStateAction<WithId<Encounter> | undefined>>;
-  setClaim: Dispatch<SetStateAction<WithId<Claim> | undefined>>;
   setPractitioner: Dispatch<SetStateAction<WithId<Practitioner> | undefined>>;
   setTasks: Dispatch<SetStateAction<WithId<Task>[]>>;
   setClinicalImpression: Dispatch<SetStateAction<WithId<ClinicalImpression> | undefined>>;
-  setChargeItems: Dispatch<SetStateAction<WithId<ChargeItem>[]>>;
   setAppointment: Dispatch<SetStateAction<WithId<Appointment> | undefined>>;
 }
 
@@ -46,40 +38,14 @@ export function useEncounterChart(encounter: WithId<Encounter> | Reference<Encou
   const patientReference = encounterResource?.subject as Reference<Patient> | undefined;
   const patientResource = useResource(patientReference);
   const [encounterState, setEncounter] = useState(encounterResource);
-  const [claim, setClaim] = useState<WithId<Claim> | undefined>();
   const [practitioner, setPractitioner] = useState<WithId<Practitioner> | undefined>();
   const [tasks, setTasks] = useState<WithId<Task>[]>([]);
   const [clinicalImpression, setClinicalImpression] = useState<WithId<ClinicalImpression> | undefined>();
-  const [chargeItems, setChargeItems] = useState<WithId<ChargeItem>[]>([]);
   const [appointment, setAppointment] = useState<WithId<Appointment> | undefined>();
 
   // Prefer encounterState (explicitly set via setEncounter) for immediate optimistic updates.
   // Falls back to encounterResource on initial load before any explicit set.
   const encounterToUse = encounterState ?? encounterResource;
-
-  useEffect(() => {
-    async function loadChargeItems(): Promise<void> {
-      if (encounterResource) {
-        const chargeItemsResult = await getChargeItemsForEncounter(medplum, encounterResource);
-        setChargeItems(chargeItemsResult);
-      }
-    }
-
-    async function fetchClaim(): Promise<void> {
-      if (!encounterResource?.id) {
-        return;
-      }
-      const response = await medplum.searchResources('Claim', `encounter=${getReferenceString(encounterResource)}`, {
-        cache: 'no-cache',
-      });
-      if (response.length !== 0) {
-        setClaim(response[0]);
-      }
-    }
-
-    loadChargeItems().catch(showErrorNotification);
-    fetchClaim().catch(showErrorNotification);
-  }, [encounterResource, medplum]);
 
   // Fetch tasks and clinical impressions on mount or when encounter ID changes
   useEffect(() => {
@@ -141,46 +107,17 @@ export function useEncounterChart(encounter: WithId<Encounter> | Reference<Encou
     }
   }, [encounterResource, medplum]);
 
-  useEffect(() => {
-    const createClaim = async (): Promise<void> => {
-      if (claim) {
-        // If a claim already exists, don't create a new one
-        return;
-      }
-
-      const patientId = patientResource?.id;
-      if (!patientId || !encounterResource?.id || !practitioner?.id || chargeItems.length === 0) {
-        return;
-      }
-      const newClaim = await createClaimFromEncounter(
-        medplum,
-        patientResource,
-        encounterResource,
-        practitioner,
-        chargeItems
-      );
-      if (newClaim) {
-        setClaim(newClaim);
-      }
-    };
-    createClaim().catch((err) => showErrorNotification(err));
-  }, [patientResource, encounterResource, medplum, claim, practitioner, chargeItems]);
-
   return {
     encounter: encounterToUse,
     patient: patientResource,
-    claim,
     practitioner,
     tasks,
     clinicalImpression,
-    chargeItems,
     appointment,
     setEncounter,
-    setClaim,
     setPractitioner,
     setTasks,
     setClinicalImpression,
-    setChargeItems,
     setAppointment,
   };
 }

--- a/examples/medplum-provider/src/utils/claims.test.ts
+++ b/examples/medplum-provider/src/utils/claims.test.ts
@@ -1,23 +1,38 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { CPT, createReference } from '@medplum/core';
-import type { ChargeItem, Claim, Coverage } from '@medplum/fhirtypes';
-import { MockClient } from '@medplum/mock';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { createClaimFromEncounter, getCptChargeItems } from './claims';
-import * as coverageModule from './coverage';
+import { CPT, HTTP_HL7_ORG, createReference } from '@medplum/core';
+import type { ChargeItem, Condition, Coverage, Encounter, Patient, Practitioner } from '@medplum/fhirtypes';
+import { describe, expect, test } from 'vitest';
+import { buildClaimFromEncounter, getCptChargeItems } from './claims';
 
 describe('claims utils', () => {
-  let medplum: MockClient;
-
-  beforeEach(() => {
-    medplum = new MockClient();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+  const patient: WithId<Patient> = { resourceType: 'Patient', id: 'patient-1' };
+  const encounter: WithId<Encounter> = {
+    resourceType: 'Encounter',
+    id: 'encounter-1',
+    status: 'finished',
+    class: { code: 'outpatient' },
+    subject: createReference(patient),
+  };
+  const practitioner: WithId<Practitioner> = { resourceType: 'Practitioner', id: 'practitioner-1' };
+  const coverage: WithId<Coverage> = {
+    resourceType: 'Coverage',
+    id: 'coverage-1',
+    status: 'active',
+    beneficiary: { reference: 'Patient/patient-1' },
+    payor: [{ reference: 'Organization/organization-1' }],
+  };
+  const chargeItems: WithId<ChargeItem>[] = [
+    {
+      resourceType: 'ChargeItem',
+      id: 'charge-1',
+      code: { coding: [{ system: CPT, code: '1111' }], text: 'Visit' },
+      priceOverride: { value: 25 },
+      status: 'billable',
+      subject: { reference: 'Patient/patient-1' },
+    },
+  ];
 
   describe('getCptChargeItems', () => {
     test('filters charge items to CPT codings and preserves modifiers', () => {
@@ -67,125 +82,76 @@ describe('claims utils', () => {
     });
   });
 
-  describe('createClaimFromEncounter', () => {
-    const chargeItems: WithId<ChargeItem>[] = [
-      {
-        resourceType: 'ChargeItem',
-        id: 'charge-1',
-        code: { coding: [{ system: CPT, code: '1111' }], text: 'Visit' },
-        priceOverride: { value: 25 },
-        status: 'billable',
-        subject: { reference: 'Patient/patient-1' },
-      },
-    ];
-
-    test('creates claim using existing coverage', async () => {
-      const patient = await medplum.updateResource({
-        resourceType: 'Patient',
-        id: 'patient-1',
+  describe('buildClaimFromEncounter', () => {
+    test('builds an in-memory draft claim from encounter state', () => {
+      const result = buildClaimFromEncounter({
+        patient,
+        encounter,
+        practitioner,
+        chargeItems,
+        insurance: [createReference(coverage)],
       });
 
-      const encounter = await medplum.updateResource({
-        resourceType: 'Encounter',
-        id: 'encounter-1',
-        subject: createReference(patient),
-        status: 'finished',
-        class: { code: 'outpatient' },
-      });
-
-      const practitioner = await medplum.updateResource({
-        resourceType: 'Practitioner',
-        id: 'practitioner-1',
-      });
-
-      const coverage: Coverage = {
-        resourceType: 'Coverage',
-        id: 'coverage-1',
-        status: 'active',
-        beneficiary: { reference: 'Patient/patient-1' },
-        payor: [{ reference: 'Organization/organization-1' }],
-      };
-
-      const claim: Claim = {
-        resourceType: 'Claim',
-        id: 'claim-1',
-        status: 'draft',
-        type: { coding: [{ code: 'professional' }] },
-        use: 'claim',
-        created: new Date().toISOString(),
-        patient: { reference: 'Patient/patient-1' },
-        provider: { reference: 'Practitioner/practitioner-1' },
-        priority: { coding: [{ code: 'normal' }] },
-        insurance: [{ sequence: 1, focal: true, coverage: { reference: 'Coverage/coverage-1' } }],
-        item: [
-          {
-            sequence: 1,
-            encounter: [{ reference: 'Encounter/encounter-1' }],
-            productOrService: { coding: [{ system: CPT, code: '1111' }], text: 'Visit' },
-            net: { value: 25 },
-          },
-        ],
-        total: { value: 25 },
-      };
-
-      vi.spyOn(medplum, 'searchResources').mockResolvedValue([coverage] as any);
-      const createSpy = vi.spyOn(medplum, 'createResource').mockResolvedValue(claim as any);
-
-      const result = await createClaimFromEncounter(medplum, patient, encounter, practitioner, chargeItems);
-
-      expect(createSpy).toHaveBeenCalledWith(
+      // No persistence: the returned claim has no id.
+      expect(result.id).toBeUndefined();
+      expect(result).toEqual(
         expect.objectContaining({
+          resourceType: 'Claim',
+          status: 'draft',
+          patient: expect.objectContaining({ reference: 'Patient/patient-1' }),
+          provider: expect.objectContaining({ reference: 'Practitioner/practitioner-1' }),
           insurance: [
             expect.objectContaining({
-              coverage: { reference: 'Coverage/coverage-1' },
+              sequence: 1,
+              focal: true,
+              coverage: expect.objectContaining({ reference: 'Coverage/coverage-1' }),
             }),
           ],
-          patient: { reference: 'Patient/patient-1' },
-          provider: expect.objectContaining({ reference: 'Practitioner/practitioner-1' }),
           total: { value: 25 },
         })
       );
-      expect(result).toBe(claim);
+      expect(result.item).toHaveLength(1);
     });
 
-    test('creates self-pay coverage when no coverage exists', async () => {
-      const patient = await medplum.updateResource({
-        resourceType: 'Patient',
-        id: 'patient-1',
-      });
+    test('defaults insurance to an empty array when none is provided', () => {
+      const result = buildClaimFromEncounter({ patient, encounter, practitioner, chargeItems });
+      expect(result.insurance).toEqual([]);
+    });
 
-      const encounter = await medplum.updateResource({
-        resourceType: 'Encounter',
-        id: 'enc-1',
-        subject: createReference(patient),
-        status: 'finished',
-        class: { code: 'outpatient' },
-      });
+    test('maps conditions to a diagnosis array, rewriting ICD-10-CM to ICD-10', () => {
+      const conditions: Condition[] = [
+        {
+          resourceType: 'Condition',
+          id: 'condition-1',
+          subject: { reference: 'Patient/patient-1' },
+          code: { coding: [{ system: `${HTTP_HL7_ORG}/fhir/sid/icd-10-cm`, code: 'R51' }] },
+        },
+        {
+          resourceType: 'Condition',
+          id: 'condition-2',
+          subject: { reference: 'Patient/patient-1' },
+          code: { coding: [{ system: `${HTTP_HL7_ORG}/fhir/sid/icd-10-cm`, code: 'J00' }] },
+        },
+      ];
 
-      const practitioner = await medplum.updateResource({
-        resourceType: 'Practitioner',
-        id: 'prac-1',
-      });
+      const result = buildClaimFromEncounter({ patient, encounter, practitioner, chargeItems, conditions });
 
-      vi.spyOn(medplum, 'searchResources').mockResolvedValue([] as any);
-
-      const createdCoverage: Coverage = {
-        resourceType: 'Coverage',
-        id: 'coverage-self',
-        status: 'active',
-        beneficiary: { reference: 'Patient/patient-1' },
-        payor: [{ reference: 'Organization/organization-1' }],
-      };
-
-      const coverageSpy = vi.spyOn(coverageModule, 'createSelfPayCoverage').mockResolvedValue(createdCoverage);
-      vi.spyOn(medplum, 'createResource').mockResolvedValue({ resourceType: 'Claim' } as any);
-
-      await createClaimFromEncounter(medplum, patient, encounter, practitioner, chargeItems);
-
-      expect(coverageSpy).toHaveBeenCalledWith(
-        medplum,
-        expect.objectContaining({ resourceType: 'Patient', id: 'patient-1' })
+      expect(result.diagnosis).toHaveLength(2);
+      expect(result.diagnosis?.[0]).toEqual(
+        expect.objectContaining({
+          sequence: 1,
+          type: [{ coding: [{ code: 'principal' }] }],
+          diagnosisCodeableConcept: {
+            coding: [expect.objectContaining({ system: `${HTTP_HL7_ORG}/fhir/sid/icd-10`, code: 'R51' })],
+          },
+        })
       );
+      expect(result.diagnosis?.[1]?.type).toEqual([{ coding: [{ code: 'secondary' }] }]);
+    });
+
+    test('omits diagnosis when there are no conditions', () => {
+      const result = buildClaimFromEncounter({ patient, encounter, practitioner, chargeItems });
+      expect(result.diagnosis).toBeUndefined();
     });
   });
 });

--- a/examples/medplum-provider/src/utils/claims.ts
+++ b/examples/medplum-provider/src/utils/claims.ts
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { MedplumClient, WithId } from '@medplum/core';
-import { CPT, createReference } from '@medplum/core';
+import type { WithId } from '@medplum/core';
+import { CPT, createReference, HTTP_HL7_ORG } from '@medplum/core';
 import type {
   ChargeItem,
   Claim,
+  ClaimDiagnosis,
   ClaimItem,
+  Condition,
   Coverage,
   Encounter,
   Patient,
@@ -13,22 +15,28 @@ import type {
   Reference,
 } from '@medplum/fhirtypes';
 import { calculateTotalPrice } from './chargeitems';
-import { createSelfPayCoverage } from './coverage';
 
-export async function createClaimFromEncounter(
-  medplum: MedplumClient,
-  patient: WithId<Patient>,
-  encounter: WithId<Encounter>,
-  practitioner: WithId<Practitioner>,
-  chargeItems: WithId<ChargeItem>[]
-): Promise<WithId<Claim> | undefined> {
-  const coverageResults = await medplum.searchResources('Coverage', `patient=Patient/${patient.id}&status=active`);
-  let coverage: Coverage = coverageResults[0];
-  if (!coverage) {
-    coverage = await createSelfPayCoverage(medplum, patient);
-  }
+export interface BuildClaimArgs {
+  patient: WithId<Patient>;
+  encounter: WithId<Encounter>;
+  practitioner: WithId<Practitioner>;
+  chargeItems: ChargeItem[];
+  conditions?: Condition[];
+  insurance?: Reference<Coverage>[];
+}
 
-  const claim: Claim = {
+/**
+ * Builds a draft Claim from the current encounter state. This is a pure, in-memory
+ * transformation: it performs no server reads or writes. Persisting the Claim
+ * (create or update) is the caller's responsibility, and only happens at export or
+ * submit time.
+ *
+ * @param args - Patient, encounter, practitioner, charge items, conditions, and insurance references.
+ * @returns An unpersisted Claim resource.
+ */
+export function buildClaimFromEncounter(args: BuildClaimArgs): Claim {
+  const { patient, encounter, practitioner, chargeItems, conditions, insurance } = args;
+  return {
     resourceType: 'Claim',
     status: 'draft',
     type: { coding: [{ code: 'professional' }] },
@@ -37,17 +45,11 @@ export async function createClaimFromEncounter(
     patient: createReference(patient),
     provider: createReference(practitioner),
     priority: { coding: [{ code: 'normal' }] },
-    insurance: [
-      {
-        sequence: 1,
-        focal: true,
-        coverage: createReference(coverage),
-      },
-    ],
+    insurance: (insurance ?? []).map((coverage, index) => ({ sequence: index + 1, focal: index === 0, coverage })),
+    ...(conditions?.length ? { diagnosis: createDiagnosisArray(conditions) } : {}),
     item: getCptChargeItems(chargeItems, createReference(encounter)),
     total: { value: calculateTotalPrice(chargeItems) },
   };
-  return medplum.createResource(claim);
 }
 
 export function getCptChargeItems(chargeItems: ChargeItem[], encounter: Reference<Encounter>): ClaimItem[] {
@@ -69,6 +71,26 @@ export function getCptChargeItems(chargeItems: ChargeItem[], encounter: Referenc
       },
       net: chargeItem.priceOverride,
       ...(modifiers && modifiers.length > 0 ? { modifier: modifiers } : {}),
+    };
+  });
+}
+
+export function createDiagnosisArray(conditions: Condition[]): ClaimDiagnosis[] {
+  return conditions.map((condition, index) => {
+    const icd10Coding = condition.code?.coding?.find((c) => c.system === `${HTTP_HL7_ORG}/fhir/sid/icd-10-cm`);
+    return {
+      diagnosisCodeableConcept: {
+        coding: icd10Coding
+          ? [
+              {
+                ...icd10Coding,
+                system: `${HTTP_HL7_ORG}/fhir/sid/icd-10`,
+              },
+            ]
+          : [],
+      },
+      sequence: index + 1,
+      type: [{ coding: [{ code: index === 0 ? 'principal' : 'secondary' }] }],
     };
   });
 }


### PR DESCRIPTION
Currently, In provider while updating an encounter. It would by try to update/create a claim with the same updates.
(charge items, conditions, practitioner, etc). This would create a lot of extra network calls and code to support it,

Simplify to create/update claim while exporting or submitting.