### PR TITLE
Remove browser history pollution from some internal redirects

### DIFF
--- a/examples/medplum-provider/src/pages/SearchPage.tsx
+++ b/examples/medplum-provider/src/pages/SearchPage.tsx
@@ -29,7 +29,9 @@ export function SearchPage(): JSX.Element {
       saveLastSearch(populatedSearch);
       setSearch(populatedSearch);
     } else {
-      navigate(`/${populatedSearch.resourceType}${formatSearchQuery(populatedSearch)}`)?.catch(console.error);
+      navigate(`/${populatedSearch.resourceType}${formatSearchQuery(populatedSearch)}`, { replace: true })?.catch(
+        console.error
+      );
     }
   }, [medplum, navigate, location]);
 

--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -33,7 +33,9 @@ export function HomePage(): JSX.Element {
       setSearch(populatedSearch);
     } else {
       // Otherwise, navigate to the desired URL
-      navigate(`/${populatedSearch.resourceType}${formatSearchQuery(populatedSearch)}`)?.catch(console.error);
+      navigate(`/${populatedSearch.resourceType}${formatSearchQuery(populatedSearch)}`, { replace: true })?.catch(
+        console.error
+      );
     }
   }, [medplum, navigate, location]);
 


### PR DESCRIPTION
When using some links in the sidebars of app.medplum.com or provider.medplum.com, these components would see that you landed on a page without default search parameters and push a new history entry for the same URL with the search parameters. This had some unfortunate consequences:

- The browser's "back" button stops working as intended: clicking "back" after one of these redirects happened would take you back to the unqualified page, which would immediately redirect you forward to the version with the default search parameters again. It takes either a slow browser or superhuman reflexes to click back fast enough to actually go back in your history.

- The browser's history list shows those intermediate pages in the history list, which makes it appear quite lengthy and confusing.

By using the "replace" option here when normalizing a URL to match the actual search parameters in use, the existing history entry is updated instead of having a new one created.