### PR TITLE
logging(warehouse): better logging of startDate

### DIFF
--- a/packages/server/src/workers/data-warehouse-sync.ts
+++ b/packages/server/src/workers/data-warehouse-sync.ts
@@ -48,6 +48,7 @@ export function logDataWarehouseSyncStatus(config: MedplumServerConfig): void {
   globalLogger.info('Data warehouse sync is enabled', {
     destination: syncConfig.destination,
     cron: syncConfig.cron,
+    startDate: syncConfig.startDate,
   });
 }
 


### PR DESCRIPTION
One-liner to log the `startDate` parameter, if any.

Signed-off-by: Karl Pietrzak <karl@medplum.com>
