### PR TITLE
Provider: Streamline scheduling encounter creation

### DIFF
--- a/examples/medplum-provider/src/App.tsx
+++ b/examples/medplum-provider/src/App.tsx
@@ -53,6 +53,7 @@ import { ResourceDetailPage } from './pages/resource/ResourceDetailPage';
 import { ResourceEditPage } from './pages/resource/ResourceEditPage';
 import { ResourceHistoryPage } from './pages/resource/ResourceHistoryPage';
 import { ResourcePage } from './pages/resource/ResourcePage';
+import { ResourceSchedulingPage } from './pages/resource/ResourceSchedulingPage';
 import { SchedulePage } from './pages/schedule/SchedulePage';
 import { ScheduleSettingsPage } from './pages/schedule/ScheduleSettingsPage';
 import { SearchPage } from './pages/SearchPage';
@@ -248,6 +249,7 @@ export function App(): JSX.Element | null {
                 <Route path="details" element={<ResourceDetailPage />} />
                 <Route path="edit" element={<ResourceEditPage />} />
                 <Route path="history" element={<ResourceHistoryPage />} />
+                <Route path="scheduling" element={<ResourceSchedulingPage />} />
               </Route>
               {hasDoseSpot && <Route path="/integrations/dosespot" element={<DoseSpotFavoritesPage />} />}
             </>

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
@@ -226,7 +226,7 @@ export function AppointmentDetails(props: {
                   binding="http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
                   required={true}
                   onChange={setEncounterClass}
-                  path="Encounter.type"
+                  path="Encounter.class"
                 />
 
                 <ResourceInput<PlanDefinition>

--- a/examples/medplum-provider/src/components/schedule/BookAppointmentForm.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/BookAppointmentForm.test.tsx
@@ -34,7 +34,7 @@ describe('BookAppointmentForm', () => {
   });
 
   type SetupOptions = {
-    onSuccess?: (result: { appointments: Appointment[]; slots: Slot[] }) => void;
+    onSuccess?: (result: { appointment: Appointment; slots: Slot[] }) => void;
   };
 
   const setup = async (options: SetupOptions = {}): Promise<void> => {
@@ -150,7 +150,7 @@ describe('BookAppointmentForm', () => {
     );
   });
 
-  test('calls onSuccess with appointments and slots from the response', async () => {
+  test('calls onSuccess with appointment and slots from the response', async () => {
     const user = userEvent.setup();
     const onSuccess = vi.fn();
 
@@ -203,7 +203,7 @@ describe('BookAppointmentForm', () => {
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledWith({
-        appointments: [bookedAppointment],
+        appointment: bookedAppointment,
         slots: [busySlot, bufferAfterSlot],
         patient: HomerSimpson,
       });

--- a/examples/medplum-provider/src/components/schedule/BookAppointmentForm.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/BookAppointmentForm.test.tsx
@@ -205,6 +205,7 @@ describe('BookAppointmentForm', () => {
       expect(onSuccess).toHaveBeenCalledWith({
         appointments: [bookedAppointment],
         slots: [busySlot, bufferAfterSlot],
+        patient: HomerSimpson,
       });
     });
   });

--- a/examples/medplum-provider/src/components/schedule/BookAppointmentForm.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/BookAppointmentForm.test.tsx
@@ -2,17 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
-import type { Appointment, Bundle, Slot } from '@medplum/fhirtypes';
+import type { WithId } from '@medplum/core';
+import type { Appointment, Bundle, Encounter, HealthcareService, PlanDefinition, Slot } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { createEncounter } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
+import { SchedulingEncounterCodingURI, SchedulingPlanDefinitionURI } from '../../utils/scheduling';
 import { BookAppointmentForm } from './BookAppointmentForm';
 
 vi.mock('../../utils/notifications');
+vi.mock('../../utils/encounter', () => ({
+  createEncounter: vi.fn(),
+}));
 
 describe('BookAppointmentForm', () => {
   let medplum: MockClient;
@@ -28,24 +34,39 @@ describe('BookAppointmentForm', () => {
     participant: [],
   };
 
+  const defaultHealthcareService: HealthcareService = {
+    resourceType: 'HealthcareService',
+    id: 'hcs-1',
+  };
+
   beforeEach(() => {
     medplum = new MockClient();
     vi.clearAllMocks();
   });
 
   type SetupOptions = {
-    onSuccess?: (result: { appointment: Appointment; slots: Slot[] }) => void;
+    onSuccess?: (result: {
+      appointment: Appointment;
+      slots: Slot[];
+      patient: typeof HomerSimpson;
+      encounter: Encounter | undefined;
+    }) => void;
+    healthcareService?: HealthcareService;
   };
 
   const setup = async (options: SetupOptions = {}): Promise<void> => {
-    const { onSuccess } = options;
+    const { onSuccess, healthcareService = defaultHealthcareService } = options;
     await act(async () => {
       render(
         <MemoryRouter>
           <MedplumProvider medplum={medplum}>
             <MantineProvider>
               <Notifications />
-              <BookAppointmentForm appointment={appointment} onSuccess={onSuccess} />
+              <BookAppointmentForm
+                appointment={appointment}
+                healthcareService={healthcareService}
+                onSuccess={onSuccess}
+              />
             </MantineProvider>
           </MedplumProvider>
         </MemoryRouter>
@@ -150,7 +171,7 @@ describe('BookAppointmentForm', () => {
     );
   });
 
-  test('calls onSuccess with appointment and slots from the response', async () => {
+  test('calls onSuccess with appointment, slots, patient, and encounter from the response', async () => {
     const user = userEvent.setup();
     const onSuccess = vi.fn();
 
@@ -206,6 +227,7 @@ describe('BookAppointmentForm', () => {
         appointment: bookedAppointment,
         slots: [busySlot, bufferAfterSlot],
         patient: HomerSimpson,
+        encounter: undefined,
       });
     });
   });
@@ -274,6 +296,204 @@ describe('BookAppointmentForm', () => {
     // After completion, the button should no longer be loading
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Create Appointment' })).not.toBeDisabled();
+    });
+  });
+
+  describe('encounter creation via bookEncounter', () => {
+    const planDefinition: WithId<PlanDefinition> = { resourceType: 'PlanDefinition', id: 'pd-1', status: 'active' };
+
+    const healthcareServiceWithEncounter: HealthcareService = {
+      resourceType: 'HealthcareService',
+      id: 'hcs-with-encounter',
+      extension: [
+        {
+          url: SchedulingPlanDefinitionURI,
+          valueReference: { reference: 'PlanDefinition/pd-1' },
+        },
+        {
+          url: SchedulingEncounterCodingURI,
+          valueCoding: { system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode', code: 'AMB' },
+        },
+      ],
+    };
+
+    // Appointment returned by $book with exactly one practitioner and one patient
+    const bookedAppointmentWithParticipants: Appointment = {
+      resourceType: 'Appointment',
+      id: 'appointment-1',
+      status: 'booked',
+      start,
+      end,
+      participant: [
+        { actor: { reference: 'Practitioner/prac-1' }, status: 'accepted' },
+        { actor: { reference: `Patient/${HomerSimpson.id}` }, status: 'accepted' },
+      ],
+    };
+
+    const makeBookResponse = (appt: Appointment): Bundle<Appointment | Slot> => ({
+      resourceType: 'Bundle',
+      type: 'collection',
+      entry: [{ resource: appt }],
+    });
+
+    test('creates encounter and passes it to onSuccess when healthcareService has required extensions', async () => {
+      const user = userEvent.setup();
+      const onSuccess = vi.fn();
+      const mockEncounter: Encounter = { resourceType: 'Encounter', id: 'enc-1', status: 'planned', class: {} };
+
+      medplum.post = vi.fn().mockResolvedValue(makeBookResponse(bookedAppointmentWithParticipants));
+      vi.spyOn(medplum, 'readReference').mockResolvedValue(planDefinition);
+      vi.mocked(createEncounter).mockResolvedValue(mockEncounter as Encounter & { id: string });
+
+      await setup({ onSuccess, healthcareService: healthcareServiceWithEncounter });
+
+      const patientInput = screen.getByRole('searchbox');
+      await user.type(patientInput, 'Homer');
+      await waitFor(() => expect(screen.getByText('Homer Simpson')).toBeInTheDocument());
+      await user.click(screen.getByText('Homer Simpson'));
+      await user.click(screen.getByRole('button', { name: 'Create Appointment' }));
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({ encounter: mockEncounter }));
+      });
+      expect(createEncounter).toHaveBeenCalledWith(
+        medplum,
+        { system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode', code: 'AMB' },
+        { reference: `Patient/${HomerSimpson.id}` },
+        planDefinition,
+        bookedAppointmentWithParticipants,
+        { reference: 'Practitioner/prac-1' }
+      );
+    });
+
+    test('skips encounter creation when healthcareService has no PlanDefinition extension', async () => {
+      const user = userEvent.setup();
+      const onSuccess = vi.fn();
+
+      medplum.post = vi.fn().mockResolvedValue(makeBookResponse(bookedAppointmentWithParticipants));
+
+      await setup({ onSuccess, healthcareService: defaultHealthcareService });
+
+      const patientInput = screen.getByRole('searchbox');
+      await user.type(patientInput, 'Homer');
+      await waitFor(() => expect(screen.getByText('Homer Simpson')).toBeInTheDocument());
+      await user.click(screen.getByText('Homer Simpson'));
+      await user.click(screen.getByRole('button', { name: 'Create Appointment' }));
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({ encounter: undefined }));
+      });
+      expect(createEncounter).not.toHaveBeenCalled();
+    });
+
+    test('skips encounter creation when healthcareService has no EncounterCoding extension', async () => {
+      const user = userEvent.setup();
+      const onSuccess = vi.fn();
+
+      const hcsWithoutCoding: HealthcareService = {
+        resourceType: 'HealthcareService',
+        id: 'hcs-no-coding',
+        extension: [{ url: SchedulingPlanDefinitionURI, valueReference: { reference: 'PlanDefinition/pd-1' } }],
+      };
+
+      medplum.post = vi.fn().mockResolvedValue(makeBookResponse(bookedAppointmentWithParticipants));
+
+      await setup({ onSuccess, healthcareService: hcsWithoutCoding });
+
+      const patientInput = screen.getByRole('searchbox');
+      await user.type(patientInput, 'Homer');
+      await waitFor(() => expect(screen.getByText('Homer Simpson')).toBeInTheDocument());
+      await user.click(screen.getByText('Homer Simpson'));
+      await user.click(screen.getByRole('button', { name: 'Create Appointment' }));
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({ encounter: undefined }));
+      });
+      expect(createEncounter).not.toHaveBeenCalled();
+    });
+
+    test('skips encounter creation when booked appointment has multiple practitioners', async () => {
+      const user = userEvent.setup();
+      const onSuccess = vi.fn();
+
+      const apptTwoPractitioners: Appointment = {
+        ...bookedAppointmentWithParticipants,
+        participant: [
+          { actor: { reference: 'Practitioner/prac-1' }, status: 'accepted' },
+          { actor: { reference: 'Practitioner/prac-2' }, status: 'accepted' },
+          { actor: { reference: `Patient/${HomerSimpson.id}` }, status: 'accepted' },
+        ],
+      };
+
+      medplum.post = vi.fn().mockResolvedValue(makeBookResponse(apptTwoPractitioners));
+      vi.spyOn(medplum, 'readReference').mockResolvedValue(planDefinition);
+
+      await setup({ onSuccess, healthcareService: healthcareServiceWithEncounter });
+
+      const patientInput = screen.getByRole('searchbox');
+      await user.type(patientInput, 'Homer');
+      await waitFor(() => expect(screen.getByText('Homer Simpson')).toBeInTheDocument());
+      await user.click(screen.getByText('Homer Simpson'));
+      await user.click(screen.getByRole('button', { name: 'Create Appointment' }));
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({ encounter: undefined }));
+      });
+      expect(createEncounter).not.toHaveBeenCalled();
+    });
+
+    test('skips encounter creation when booked appointment has multiple patients', async () => {
+      const user = userEvent.setup();
+      const onSuccess = vi.fn();
+
+      const apptTwoPatients: Appointment = {
+        ...bookedAppointmentWithParticipants,
+        participant: [
+          { actor: { reference: 'Practitioner/prac-1' }, status: 'accepted' },
+          { actor: { reference: `Patient/${HomerSimpson.id}` }, status: 'accepted' },
+          { actor: { reference: 'Patient/patient-2' }, status: 'accepted' },
+        ],
+      };
+
+      medplum.post = vi.fn().mockResolvedValue(makeBookResponse(apptTwoPatients));
+      vi.spyOn(medplum, 'readReference').mockResolvedValue(planDefinition);
+
+      await setup({ onSuccess, healthcareService: healthcareServiceWithEncounter });
+
+      const patientInput = screen.getByRole('searchbox');
+      await user.type(patientInput, 'Homer');
+      await waitFor(() => expect(screen.getByText('Homer Simpson')).toBeInTheDocument());
+      await user.click(screen.getByText('Homer Simpson'));
+      await user.click(screen.getByRole('button', { name: 'Create Appointment' }));
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({ encounter: undefined }));
+      });
+      expect(createEncounter).not.toHaveBeenCalled();
+    });
+
+    test('swallows encounter creation errors and still calls onSuccess with encounter undefined', async () => {
+      const user = userEvent.setup();
+      const onSuccess = vi.fn();
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      medplum.post = vi.fn().mockResolvedValue(makeBookResponse(bookedAppointmentWithParticipants));
+      vi.spyOn(medplum, 'readReference').mockResolvedValue(planDefinition);
+      vi.mocked(createEncounter).mockRejectedValue(new Error('PlanDefinition $apply failed'));
+
+      await setup({ onSuccess, healthcareService: healthcareServiceWithEncounter });
+
+      const patientInput = screen.getByRole('searchbox');
+      await user.type(patientInput, 'Homer');
+      await waitFor(() => expect(screen.getByText('Homer Simpson')).toBeInTheDocument());
+      await user.click(screen.getByText('Homer Simpson'));
+      await user.click(screen.getByRole('button', { name: 'Create Appointment' }));
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({ encounter: undefined }));
+      });
+      expect(consoleError).toHaveBeenCalled();
+      consoleError.mockRestore();
     });
   });
 });

--- a/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
@@ -3,7 +3,7 @@
 import { Button, Stack, Text } from '@mantine/core';
 import type { WithId } from '@medplum/core';
 import { createReference, EMPTY, formatPeriod, isDefined } from '@medplum/core';
-import type { Appointment, Bundle, Patient, Resource, Slot } from '@medplum/fhirtypes';
+import type { Appointment, Bundle, Patient, Slot } from '@medplum/fhirtypes';
 import { Form, ResourceInput, useMedplum } from '@medplum/react';
 import type { JSX } from 'react';
 import { useCallback, useState } from 'react';
@@ -13,21 +13,21 @@ import { SchedulingTransientIdentifier } from '../../utils/scheduling';
 type BookAppointmentFormProps = {
   appointment: Appointment;
   onSuccess?: (result: {
-    appointments: WithId<Appointment>[];
+    appointment: WithId<Appointment>;
     slots: WithId<Slot>[];
-    patient: Patient;
+    patient: WithId<Patient>;
   }) => void | Promise<void>;
 };
 
 export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Element {
   const medplum = useMedplum();
-  const [patient, setPatient] = useState<Patient | undefined>(undefined);
+  const [patient, setPatient] = useState<WithId<Patient> | undefined>(undefined);
   const [loading, setLoading] = useState(false);
 
   const { appointment, onSuccess } = props;
 
   const bookAppointment = useCallback(
-    async (patient: Patient) => {
+    async (patient: WithId<Patient>) => {
       setLoading(true);
 
       // merge patient into participants list
@@ -61,11 +61,13 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
         const slots = resources.filter(
           (obj: WithId<Slot> | WithId<Appointment>): obj is WithId<Slot> => obj.resourceType === 'Slot'
         );
-        const appointments = resources.filter(
+        const appointment = resources.find(
           (obj: WithId<Slot> | WithId<Appointment>): obj is WithId<Appointment> => obj.resourceType === 'Appointment'
         );
 
-        await onSuccess?.({ appointments, slots, patient });
+        if (appointment) {
+          await onSuccess?.({ appointment, slots, patient });
+        }
       } finally {
         setLoading(false);
       }
@@ -85,10 +87,7 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
     }
   }, [patient, bookAppointment]);
 
-  const choosePatient = useCallback((patient: Resource | undefined) => {
-    if (patient && patient.resourceType !== 'Patient') {
-      throw new Error(`Got unexpected resource type; expected 'Patient', got '${patient.resourceType}'`);
-    }
+  const choosePatient = useCallback((patient: WithId<Patient> | undefined) => {
     setPatient(patient);
   }, []);
 
@@ -96,7 +95,7 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
     <Form onSubmit={handleSubmit}>
       <Stack gap="md">
         <Text size="lg">{formatPeriod({ start: props.appointment.start, end: props.appointment.end })}</Text>
-        <ResourceInput
+        <ResourceInput<WithId<Patient>>
           label="Patient"
           resourceType="Patient"
           name="Patient-id"

--- a/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
@@ -85,7 +85,7 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
       // single patient in the `subject` parameter at this time. If there is
       // not exactly one patient in the appointment, skip encounter creation.
       const patient = patients[0];
-      if (!patients || patients.length > 1) {
+      if (!patient || patients.length > 1) {
         return undefined;
       }
 

--- a/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
@@ -2,20 +2,44 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Button, Stack, Text } from '@mantine/core';
 import type { WithId } from '@medplum/core';
-import { createReference, EMPTY, formatPeriod, isDefined } from '@medplum/core';
-import type { Appointment, Bundle, Patient, Slot } from '@medplum/fhirtypes';
+import {
+  createReference,
+  EMPTY,
+  formatPeriod,
+  getExtensionValue,
+  isCoding,
+  isDefined,
+  isReference,
+} from '@medplum/core';
+import type {
+  Appointment,
+  Bundle,
+  Encounter,
+  HealthcareService,
+  Patient,
+  PlanDefinition,
+  Practitioner,
+  Slot,
+} from '@medplum/fhirtypes';
 import { Form, ResourceInput, useMedplum } from '@medplum/react';
 import type { JSX } from 'react';
 import { useCallback, useState } from 'react';
+import { createEncounter } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
-import { SchedulingTransientIdentifier } from '../../utils/scheduling';
+import {
+  SchedulingEncounterCodingURI,
+  SchedulingPlanDefinitionURI,
+  SchedulingTransientIdentifier,
+} from '../../utils/scheduling';
 
 type BookAppointmentFormProps = {
   appointment: Appointment;
+  healthcareService: HealthcareService;
   onSuccess?: (result: {
     appointment: WithId<Appointment>;
     slots: WithId<Slot>[];
     patient: WithId<Patient>;
+    encounter: WithId<Encounter> | undefined;
   }) => void | Promise<void>;
 };
 
@@ -24,7 +48,53 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
   const [patient, setPatient] = useState<WithId<Patient> | undefined>(undefined);
   const [loading, setLoading] = useState(false);
 
-  const { appointment, onSuccess } = props;
+  const { appointment, healthcareService, onSuccess } = props;
+
+  const bookEncounter = useCallback(
+    async (appointment: WithId<Appointment>): Promise<WithId<Encounter> | undefined> => {
+      // If the HealthcareService we are booking with respect to has extensions holding the
+      // configuration needed to create an Encounter for this booking, we try to create the
+      // encounter now.
+      const planDefinitionRef = getExtensionValue(healthcareService, SchedulingPlanDefinitionURI);
+      const encounterClass = getExtensionValue(healthcareService, SchedulingEncounterCodingURI);
+      const practitioners = appointment.participant
+        .map((p) => p.actor)
+        .filter((actor) => isReference<Practitioner>(actor, 'Practitioner'));
+      const patients = appointment.participant
+        .map((p) => p.actor)
+        .filter((actor) => isReference<Patient>(actor, 'Patient'));
+
+      if (!isReference<PlanDefinition>(planDefinitionRef, 'PlanDefinition')) {
+        return undefined;
+      }
+
+      if (!isCoding(encounterClass)) {
+        return undefined;
+      }
+
+      // When creating an encounter, we want to call `PlanDefinition/:id/$apply`
+      // with exactly one practitioner. If we don't have an unambiguous choice
+      // here, instead of guessing we skip encounter creation. The viewer can
+      // set up the encounter themselves later.
+      const practitioner = practitioners[0];
+      if (!practitioner || practitioners.length > 1) {
+        return undefined;
+      }
+
+      // Medplum Server's `PlanDefinition/:id/$apply` operation only handles a
+      // single patient in the `subject` parameter at this time. If there is
+      // not exactly one patient in the appointment, skip encounter creation.
+      const patient = patients[0];
+      if (!patients || patients.length > 1) {
+        return undefined;
+      }
+
+      const planDefinition = await medplum.readReference(planDefinitionRef);
+
+      return createEncounter(medplum, encounterClass, patient, planDefinition, appointment, practitioner);
+    },
+    [medplum, healthcareService]
+  );
 
   const bookAppointment = useCallback(
     async (patient: WithId<Patient>) => {
@@ -66,13 +136,22 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
         );
 
         if (appointment) {
-          await onSuccess?.({ appointment, slots, patient });
+          let encounter: WithId<Encounter> | undefined;
+          try {
+            encounter = await bookEncounter(appointment);
+          } catch (err) {
+            // If we couldn't load the plan definition or create the encounter for
+            // some reason, we log the error but ignore it. The viewer can decide how
+            // to proceed and manually create the encounter.
+            console.error(err);
+          }
+          await onSuccess?.({ appointment, slots, patient, encounter });
         }
       } finally {
         setLoading(false);
       }
     },
-    [medplum, appointment, onSuccess]
+    [medplum, appointment, bookEncounter, onSuccess]
   );
 
   const handleSubmit = useCallback(async () => {

--- a/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
@@ -12,7 +12,11 @@ import { SchedulingTransientIdentifier } from '../../utils/scheduling';
 
 type BookAppointmentFormProps = {
   appointment: Appointment;
-  onSuccess?: (result: { appointments: WithId<Appointment>[]; slots: WithId<Slot>[] }) => void;
+  onSuccess?: (result: {
+    appointments: WithId<Appointment>[];
+    slots: WithId<Slot>[];
+    patient: Patient;
+  }) => void | Promise<void>;
 };
 
 export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Element {
@@ -61,7 +65,7 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
           (obj: WithId<Slot> | WithId<Appointment>): obj is WithId<Appointment> => obj.resourceType === 'Appointment'
         );
 
-        onSuccess?.({ appointments, slots });
+        await onSuccess?.({ appointments, slots, patient });
       } finally {
         setLoading(false);
       }

--- a/examples/medplum-provider/src/components/schedule/CreateVisit.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateVisit.tsx
@@ -138,7 +138,7 @@ export function CreateVisit(props: CreateVisitProps): JSX.Element {
             binding="http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
             required={true}
             onChange={setEncounterClass}
-            path="Encounter.type"
+            path="Encounter.class"
           />
 
           <ResourceInput

--- a/examples/medplum-provider/src/pages/encounter/EncounterModal.test.tsx
+++ b/examples/medplum-provider/src/pages/encounter/EncounterModal.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
+import type { WithId } from '@medplum/core';
 import type { Encounter, Patient, PlanDefinition } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
@@ -111,7 +112,7 @@ describe('EncounterModal', () => {
 
   test('Form fields can be populated with values', async () => {
     const user = userEvent.setup();
-    const mockEncounter: Encounter = {
+    const mockEncounter: WithId<Encounter> = {
       resourceType: 'Encounter',
       id: 'encounter-456',
       status: 'in-progress',
@@ -239,7 +240,7 @@ describe('EncounterModal', () => {
   });
 
   test('Navigates to created encounter on success', async () => {
-    const mockEncounter: Encounter = {
+    const mockEncounter: WithId<Encounter> = {
       resourceType: 'Encounter',
       id: 'new-encounter-789',
       status: 'in-progress',

--- a/examples/medplum-provider/src/pages/resource/ResourcePage.test.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourcePage.test.tsx
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
+import type { HealthcareService } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { ErrorBoundary, Loading, MedplumProvider } from '@medplum/react';
 import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { App } from '../../App';
 import { act, render, screen } from '../../test-utils/render';
 
@@ -33,5 +35,55 @@ describe('ResourcePage', () => {
     await setup('/Practitioner/123');
     expect((await screen.findAllByText('Name'))[0]).toBeInTheDocument();
     expect(screen.getByText('Gender')).toBeInTheDocument();
+  });
+
+  describe('Scheduling tab visibility', () => {
+    let medplum: MockClient;
+
+    beforeEach(() => {
+      medplum = new MockClient();
+      vi.clearAllMocks();
+    });
+
+    test('Scheduling tab appears for HealthcareService when scheduling feature is enabled', async () => {
+      medplum.getProject = vi.fn().mockReturnValue({
+        resourceType: 'Project',
+        id: 'project-1',
+        features: ['scheduling'],
+      });
+      const svc = await medplum.createResource<HealthcareService>({
+        resourceType: 'HealthcareService',
+        name: 'Test Service',
+      });
+      await setup(`/HealthcareService/${svc.id}`, medplum);
+      expect(await screen.findByText('Scheduling')).toBeInTheDocument();
+    });
+
+    test('Scheduling tab is absent when scheduling feature is not enabled', async () => {
+      medplum.getProject = vi.fn().mockReturnValue({
+        resourceType: 'Project',
+        id: 'project-1',
+        features: [],
+      });
+      const svc = await medplum.createResource<HealthcareService>({
+        resourceType: 'HealthcareService',
+        name: 'Test Service',
+      });
+      await setup(`/HealthcareService/${svc.id}`, medplum);
+      // Wait for the resource to load (Details tab is always present)
+      await screen.findByText('Details');
+      expect(screen.queryByText('Scheduling')).not.toBeInTheDocument();
+    });
+
+    test('Scheduling tab is absent for non-HealthcareService resource types even when feature is enabled', async () => {
+      medplum.getProject = vi.fn().mockReturnValue({
+        resourceType: 'Project',
+        id: 'project-1',
+        features: ['scheduling'],
+      });
+      await setup('/Practitioner/123', medplum);
+      await screen.findByText('Details');
+      expect(screen.queryByText('Scheduling')).not.toBeInTheDocument();
+    });
   });
 });

--- a/examples/medplum-provider/src/pages/resource/ResourcePage.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourcePage.tsx
@@ -10,11 +10,15 @@ import { Outlet, useNavigate, useParams } from 'react-router';
 import classes from './ResourcePage.module.css';
 import { useResourceType } from './useResourceType';
 
-const tabs = ['Details', 'Edit', 'History'];
+const baseTabs = ['Details', 'Edit', 'History'];
 
 export function ResourcePage(): JSX.Element | null {
   const navigate = useNavigate();
   const medplum = useMedplum();
+
+  const project = medplum.getProject();
+  const schedulingEnabled = project?.features?.includes('scheduling');
+
   const { resourceType, id } = useParams();
   const [resource, setResource] = useState<Resource | undefined>(undefined);
 
@@ -28,6 +32,11 @@ export function ResourcePage(): JSX.Element | null {
         .catch(console.error);
     }
   }, [medplum, resourceType, id, navigate]);
+
+  const tabs = [...baseTabs];
+  if (resourceType === 'HealthcareService' && schedulingEnabled) {
+    tabs.push('Scheduling');
+  }
 
   if (!resource) {
     return null;

--- a/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.test.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.test.tsx
@@ -12,6 +12,7 @@ import { ResourceSchedulingPage } from './ResourceSchedulingPage';
 
 vi.mock('../../utils/notifications', () => ({
   showErrorNotification: vi.fn(),
+  showSuccessNotification: vi.fn(),
 }));
 
 const AMB_CODING = {

--- a/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.test.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.test.tsx
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { HealthcareService } from '@medplum/fhirtypes';
+import type { HealthcareService, PlanDefinition } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { render, screen, userEvent, waitFor } from '../../test-utils/render';
-import { SchedulingEncounterCodingURI } from '../../utils/scheduling';
+import { SchedulingEncounterCodingURI, SchedulingPlanDefinitionURI } from '../../utils/scheduling';
 import { ResourceSchedulingPage } from './ResourceSchedulingPage';
 
 vi.mock('../../utils/notifications', () => ({
@@ -73,9 +73,8 @@ describe('ResourceSchedulingPage', () => {
 
     const updateSpy = vi.spyOn(medplum, 'updateResource');
 
-    // The existing coding shows as a pill (searchbox is hidden when a value is selected)
+    // The existing coding shows as a pill; the CodingInput's searchbox is hidden when a value is selected
     expect(screen.getByText('ambulatory')).toBeInTheDocument();
-    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
 
     // Saving without making changes preserves the existing extension
     await userEvent.click(screen.getByRole('button', { name: 'Save' }));
@@ -86,9 +85,14 @@ describe('ResourceSchedulingPage', () => {
     );
 
     // Clear "ambulatory" and select a new coding.
-    // MockClient always returns fixed test codes for any ValueSet/$expand call;
+    // MockClient always returns fixed test codes for any ValueSet/$expand call.
+    // After clearing, two searchboxes are visible (CodingInput + ReferenceInput); target by name.
     await userEvent.click(screen.getByTitle('Clear all'));
-    await userEvent.type(screen.getByRole('searchbox'), 'test');
+    const encounterInput = screen.getAllByRole('searchbox').find((el) => el.getAttribute('name') === 'encounterClass');
+    if (!encounterInput) {
+      throw new Error('Encounter input not found.');
+    }
+    await userEvent.type(encounterInput, 'test');
     await userEvent.click(await screen.findByText('Test Display 2'));
 
     // Submit and verify the new coding was saved
@@ -110,5 +114,38 @@ describe('ResourceSchedulingPage', () => {
     await waitFor(() => expect(updateSpy).toHaveBeenCalledTimes(4));
     const fourthSave = updateSpy.mock.calls[3][0] as HealthcareService;
     expect((fourthSave.extension ?? []).filter((e) => e.url === SchedulingEncounterCodingURI)).toHaveLength(0);
+  });
+
+  test('PlanDefinition reference is saved and preserved', async () => {
+    const planDef = await medplum.createResource<PlanDefinition>({
+      resourceType: 'PlanDefinition',
+      id: 'pd-1',
+      title: 'Annual Checkup Protocol',
+      status: 'active',
+    });
+    // Include display so ReferenceInput can render the pill without a separate fetch
+    const ref = { reference: `PlanDefinition/${planDef.id}`, display: 'Annual Checkup Protocol' };
+    await medplum.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      id: 'svc-pd',
+      name: 'Protocol Service',
+      extension: [{ url: SchedulingPlanDefinitionURI, valueReference: ref }],
+    });
+    setup('/HealthcareService/svc-pd/scheduling');
+    await screen.findByText('Protocol Service - Scheduling Configuration');
+    // The Plan Definition label confirms the input is rendered
+    expect(screen.getByText('Plan Definition')).toBeInTheDocument();
+
+    // Saving without interaction preserves the reference extension
+    const updateSpy = vi.spyOn(medplum, 'updateResource');
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(updateSpy).toHaveBeenCalledTimes(1));
+    const saved = updateSpy.mock.calls[0][0] as HealthcareService;
+    expect(saved.extension).toContainEqual(
+      expect.objectContaining({
+        url: SchedulingPlanDefinitionURI,
+        valueReference: expect.objectContaining({ reference: `PlanDefinition/${planDef.id}` }),
+      })
+    );
   });
 });

--- a/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.test.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.test.tsx
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { HealthcareService } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { render, screen, userEvent, waitFor } from '../../test-utils/render';
+import { SchedulingEncounterCodingURI } from '../../utils/scheduling';
+import { ResourceSchedulingPage } from './ResourceSchedulingPage';
+
+vi.mock('../../utils/notifications', () => ({
+  showErrorNotification: vi.fn(),
+}));
+
+const AMB_CODING = {
+  system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+  code: 'AMB',
+  display: 'ambulatory',
+};
+
+describe('ResourceSchedulingPage', () => {
+  let medplum: MockClient;
+
+  function setup(url: string): void {
+    render(
+      <MedplumProvider medplum={medplum}>
+        <MemoryRouter initialEntries={[url]}>
+          <Routes>
+            <Route path="/:resourceType/:id/scheduling" element={<ResourceSchedulingPage />} />
+          </Routes>
+        </MemoryRouter>
+      </MedplumProvider>
+    );
+  }
+
+  beforeEach(() => {
+    medplum = new MockClient();
+    vi.clearAllMocks();
+  });
+
+  test('shows unsupported resource type alert for non-HealthcareService', async () => {
+    await medplum.createResource({ resourceType: 'Patient', id: 'p-1' });
+    setup('/Patient/p-1/scheduling');
+    expect(await screen.findByText('Unsupported resource type')).toBeInTheDocument();
+  });
+
+  test('shows error alert when resource fails to load', async () => {
+    setup('/HealthcareService/does-not-exist/scheduling');
+    expect(await screen.findByRole('alert')).toHaveTextContent('Not found');
+  });
+
+  test('loading with no extensions', async () => {
+    await medplum.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      id: 'svc-1',
+      name: 'Primary Care',
+    });
+    setup('/HealthcareService/svc-1/scheduling');
+    expect(await screen.findByText('Primary Care - Scheduling Configuration')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  });
+
+  test('Updating SchedulingEncounterCoding extension', async () => {
+    await medplum.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      id: 'svc-ext',
+      name: 'Test Service',
+      extension: [{ url: SchedulingEncounterCodingURI, valueCoding: AMB_CODING }],
+    });
+    setup('/HealthcareService/svc-ext/scheduling');
+    await screen.findByText('Test Service - Scheduling Configuration');
+
+    const updateSpy = vi.spyOn(medplum, 'updateResource');
+
+    // The existing coding shows as a pill (searchbox is hidden when a value is selected)
+    expect(screen.getByText('ambulatory')).toBeInTheDocument();
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
+
+    // Saving without making changes preserves the existing extension
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(updateSpy).toHaveBeenCalledTimes(1));
+    const firstSave = updateSpy.mock.calls[0][0] as HealthcareService;
+    expect(firstSave.extension).toContainEqual(
+      expect.objectContaining({ url: SchedulingEncounterCodingURI, valueCoding: AMB_CODING })
+    );
+
+    // Clear "ambulatory" and select a new coding.
+    // MockClient always returns fixed test codes for any ValueSet/$expand call;
+    await userEvent.click(screen.getByTitle('Clear all'));
+    await userEvent.type(screen.getByRole('searchbox'), 'test');
+    await userEvent.click(await screen.findByText('Test Display 2'));
+
+    // Submit and verify the new coding was saved
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(updateSpy).toHaveBeenCalledTimes(2));
+    const secondSave = updateSpy.mock.calls[1][0] as HealthcareService;
+    const updatedExt = secondSave.extension?.find((e) => e.url === SchedulingEncounterCodingURI);
+    expect(updatedExt?.valueCoding?.code).toBe('test-code-2');
+
+    // Clear the field, submit — extension should be stripped
+    await userEvent.click(screen.getByTitle('Clear all'));
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(updateSpy).toHaveBeenCalledTimes(3));
+    const thirdSave = updateSpy.mock.calls[2][0] as HealthcareService;
+    expect((thirdSave.extension ?? []).filter((e) => e.url === SchedulingEncounterCodingURI)).toHaveLength(0);
+
+    // Submit again without touching the form — extension still absent
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(updateSpy).toHaveBeenCalledTimes(4));
+    const fourthSave = updateSpy.mock.calls[3][0] as HealthcareService;
+    expect((fourthSave.extension ?? []).filter((e) => e.url === SchedulingEncounterCodingURI)).toHaveLength(0);
+  });
+});

--- a/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.test.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.test.tsx
@@ -3,6 +3,7 @@
 import type { HealthcareService, PlanDefinition } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
+import { within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { render, screen, userEvent, waitFor } from '../../test-utils/render';
@@ -147,5 +148,58 @@ describe('ResourceSchedulingPage', () => {
         valueReference: expect.objectContaining({ reference: `PlanDefinition/${planDef.id}` }),
       })
     );
+  });
+
+  test('Unchanged extensions are not mutated', async () => {
+    const updateSpy = vi.spyOn(medplum, 'updateResource');
+
+    const planDef = await medplum.createResource<PlanDefinition>({
+      resourceType: 'PlanDefinition',
+      id: 'pd-2',
+      title: 'Routine Visit',
+      status: 'active',
+    });
+    const ref = { reference: `PlanDefinition/${planDef.id}`, display: planDef.title };
+
+    const originalExtensions = [
+      { url: SchedulingPlanDefinitionURI, valueReference: ref },
+      { url: SchedulingEncounterCodingURI, valueCoding: AMB_CODING },
+      { url: 'http://example.com/fhir/foo', valueString: 'Hello World' },
+    ];
+
+    await medplum.createResource<HealthcareService>({
+      resourceType: 'HealthcareService',
+      id: 'svc-2',
+      name: 'Office Visit',
+      extension: originalExtensions,
+    });
+    setup('/HealthcareService/svc-2/scheduling');
+    await screen.findByText('Office Visit - Scheduling Configuration');
+
+    // CodingInput hides the search input when at capacity (maxValues=1 with a value selected).
+    // Click "Clear all" first to remove the "ambulatory" pill, then the searchbox becomes visible.
+    // Scope to the PillsInput wrapper (parentElement of the testid node) to avoid ambiguity with
+    // the ReferenceInput's own "Clear all" button.
+    const encounterWrapper = screen.getByTestId('encounterClass').parentElement as HTMLElement;
+    await userEvent.click(within(encounterWrapper).getByTitle('Clear all'));
+
+    // Update the Encouner Class using one of the fixed test codes that MockClient returns
+    const encounterInput = screen.getByRole('searchbox');
+    await userEvent.type(encounterInput, 'test');
+    await userEvent.click(await screen.findByText('Test Display 2'));
+
+    // Submit update
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(updateSpy).toHaveBeenCalled();
+
+    const updated = updateSpy.mock.calls[0][0] as HealthcareService;
+    expect(updated.extension).toEqual([
+      originalExtensions[0],
+      {
+        url: SchedulingEncounterCodingURI,
+        valueCoding: { system: 'x', code: 'test-code-2', display: 'Test Display 2' },
+      },
+      originalExtensions[2],
+    ]);
   });
 });

--- a/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.tsx
@@ -81,7 +81,7 @@ function HealthcareServiceSchedulingForm({ service }: HealthcareServiceSchedulin
           name="encounterClass"
           label="Encounter Class"
           binding="http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
-          path="Encounter.type"
+          path="Encounter.class"
           description="The classification to apply to encounters created when scheduling this HealthcareService"
           defaultValue={encounterClass}
           onChange={setEncounterClass}

--- a/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.tsx
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Alert, Group, Loader, Stack, Title } from '@mantine/core';
+import { EMPTY, getExtensionValue, isOk, normalizeErrorString } from '@medplum/core';
+import type { Coding, HealthcareService, OperationOutcome, ResourceType } from '@medplum/fhirtypes';
+import { CodingInput, Form, SubmitButton } from '@medplum/react';
+import { useMedplum, useResource } from '@medplum/react-hooks';
+import { IconAlertCircle } from '@tabler/icons-react';
+import type { JSX } from 'react';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router';
+import { AlphaBanner } from '../../components/AlphaBanner';
+import { showErrorNotification, showSuccessNotification } from '../../utils/notifications';
+import { SchedulingEncounterCodingURI } from '../../utils/scheduling';
+
+interface HealthcareServiceSchedulingFormProps {
+  readonly service: HealthcareService;
+}
+
+function HealthcareServiceSchedulingForm({ service }: HealthcareServiceSchedulingFormProps): JSX.Element {
+  const medplum = useMedplum();
+  const [encounterClass, setEncounterClass] = useState<Coding | undefined>(
+    () => getExtensionValue(service, SchedulingEncounterCodingURI) as Coding | undefined
+  );
+
+  const handleSubmit = async (): Promise<void> => {
+    const updated = {
+      ...service,
+      extension: (service.extension ?? EMPTY).filter((ext) => ext.url !== SchedulingEncounterCodingURI),
+    };
+
+    if (encounterClass) {
+      updated.extension.push({
+        url: SchedulingEncounterCodingURI,
+        valueCoding: encounterClass,
+      });
+    }
+
+    try {
+      await medplum.updateResource(updated);
+      showSuccessNotification({ message: 'Scheduling configuration saved' });
+    } catch (err) {
+      showErrorNotification(err);
+    }
+  };
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Stack gap="md">
+        <Title order={2}>{service.name} - Scheduling Configuration</Title>
+        <AlphaBanner bdrs="md">Medplum Scheduling is in an Alpha period and is subject to change.</AlphaBanner>
+        <CodingInput
+          name="encounterClass"
+          label="Encounter Class"
+          binding="http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
+          path="Encounter.type"
+          description="The classification to apply to encounters created when scheduling this HealthcareService"
+          defaultValue={encounterClass}
+          onChange={setEncounterClass}
+        />
+        <Group justify="flex-end">
+          <SubmitButton>Save</SubmitButton>
+        </Group>
+      </Stack>
+    </Form>
+  );
+}
+
+export function ResourceSchedulingPage(): JSX.Element | null {
+  const { resourceType, id } = useParams() as { resourceType: ResourceType | undefined; id: string | undefined };
+  const [outcome, setOutcome] = useState<OperationOutcome | undefined>();
+  const resource = useResource({ reference: `${resourceType}/${id}` }, setOutcome);
+  const loading = !resource && !outcome;
+
+  useEffect(() => {
+    setOutcome(undefined);
+  }, [resourceType, id]);
+
+  if (resourceType !== 'HealthcareService') {
+    return (
+      <Alert color="yellow" icon={<IconAlertCircle />}>
+        Unsupported resource type
+      </Alert>
+    );
+  }
+
+  if (loading) {
+    return <Loader />;
+  }
+
+  if (outcome && !isOk(outcome)) {
+    return (
+      <Alert color="red" icon={<IconAlertCircle />}>
+        {normalizeErrorString(outcome)}
+      </Alert>
+    );
+  }
+
+  if (!resource) {
+    return (
+      <Alert color="red" icon={<IconAlertCircle />}>
+        Error loading resource.
+      </Alert>
+    );
+  }
+
+  return <HealthcareServiceSchedulingForm service={resource as HealthcareService} />;
+}

--- a/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.tsx
@@ -2,9 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Alert, Group, Input, Loader, Stack, Title } from '@mantine/core';
 import { EMPTY, getExtensionValue, isOk, normalizeErrorString } from '@medplum/core';
-import type { Coding, HealthcareService, OperationOutcome, PlanDefinition, Reference, ResourceType } from '@medplum/fhirtypes';
-import { useMedplum, useResource } from '@medplum/react-hooks';
+import type {
+  Coding,
+  Extension,
+  HealthcareService,
+  OperationOutcome,
+  PlanDefinition,
+  Reference,
+  ResourceType,
+} from '@medplum/fhirtypes';
 import { CodingInput, Form, ReferenceInput, SubmitButton } from '@medplum/react';
+import { useMedplum, useResource } from '@medplum/react-hooks';
 import { IconAlertCircle } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useEffect, useState } from 'react';
@@ -27,26 +35,34 @@ function HealthcareServiceSchedulingForm({ service }: HealthcareServiceSchedulin
   );
 
   const handleSubmit = async (): Promise<void> => {
-    const updated = {
-      ...service,
-      extension: (service.extension ?? EMPTY).filter(
-        (ext) => ext.url !== SchedulingEncounterCodingURI && ext.url !== SchedulingPlanDefinitionURI
-      ),
-    };
+    // This implementation is slightly tricky in order to try to update any existing extensions in
+    // place in the `extensions` array. This helps keep the history diff easy to read.
+    const nextExts: [string, Extension | undefined][] = [
+      [
+        SchedulingEncounterCodingURI,
+        encounterClass ? { url: SchedulingEncounterCodingURI, valueCoding: encounterClass } : undefined,
+      ],
+      [
+        SchedulingPlanDefinitionURI,
+        planDefinition ? { url: SchedulingPlanDefinitionURI, valueReference: planDefinition } : undefined,
+      ],
+    ];
 
-    if (encounterClass) {
-      updated.extension.push({
-        url: SchedulingEncounterCodingURI,
-        valueCoding: encounterClass,
-      });
+    const extensions = [...(service.extension ?? EMPTY)];
+    for (const [url, next] of nextExts) {
+      const idx = extensions.findIndex((e) => e.url === url);
+      if (next !== undefined) {
+        if (idx >= 0) {
+          extensions[idx] = next;
+        } else {
+          extensions.push(next);
+        }
+      } else if (idx >= 0) {
+        extensions.splice(idx, 1);
+      }
     }
 
-    if (planDefinition) {
-      updated.extension.push({
-        url: SchedulingPlanDefinitionURI,
-        valueReference: planDefinition,
-      });
-    }
+    const updated = { ...service, extension: extensions };
 
     try {
       await medplum.updateResource(updated);
@@ -69,6 +85,7 @@ function HealthcareServiceSchedulingForm({ service }: HealthcareServiceSchedulin
           description="The classification to apply to encounters created when scheduling this HealthcareService"
           defaultValue={encounterClass}
           onChange={setEncounterClass}
+          data-testid="encounterClass"
         />
         <Input.Wrapper
           label="Plan Definition"

--- a/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.tsx
@@ -1,17 +1,17 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Alert, Group, Loader, Stack, Title } from '@mantine/core';
+import { Alert, Group, Input, Loader, Stack, Title } from '@mantine/core';
 import { EMPTY, getExtensionValue, isOk, normalizeErrorString } from '@medplum/core';
-import type { Coding, HealthcareService, OperationOutcome, ResourceType } from '@medplum/fhirtypes';
-import { CodingInput, Form, SubmitButton } from '@medplum/react';
+import type { Coding, HealthcareService, OperationOutcome, PlanDefinition, Reference, ResourceType } from '@medplum/fhirtypes';
 import { useMedplum, useResource } from '@medplum/react-hooks';
+import { CodingInput, Form, ReferenceInput, SubmitButton } from '@medplum/react';
 import { IconAlertCircle } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import { AlphaBanner } from '../../components/AlphaBanner';
 import { showErrorNotification, showSuccessNotification } from '../../utils/notifications';
-import { SchedulingEncounterCodingURI } from '../../utils/scheduling';
+import { SchedulingEncounterCodingURI, SchedulingPlanDefinitionURI } from '../../utils/scheduling';
 
 interface HealthcareServiceSchedulingFormProps {
   readonly service: HealthcareService;
@@ -22,17 +22,29 @@ function HealthcareServiceSchedulingForm({ service }: HealthcareServiceSchedulin
   const [encounterClass, setEncounterClass] = useState<Coding | undefined>(
     () => getExtensionValue(service, SchedulingEncounterCodingURI) as Coding | undefined
   );
+  const [planDefinition, setPlanDefinition] = useState<Reference<PlanDefinition> | undefined>(
+    () => getExtensionValue(service, SchedulingPlanDefinitionURI) as Reference<PlanDefinition> | undefined
+  );
 
   const handleSubmit = async (): Promise<void> => {
     const updated = {
       ...service,
-      extension: (service.extension ?? EMPTY).filter((ext) => ext.url !== SchedulingEncounterCodingURI),
+      extension: (service.extension ?? EMPTY).filter(
+        (ext) => ext.url !== SchedulingEncounterCodingURI && ext.url !== SchedulingPlanDefinitionURI
+      ),
     };
 
     if (encounterClass) {
       updated.extension.push({
         url: SchedulingEncounterCodingURI,
         valueCoding: encounterClass,
+      });
+    }
+
+    if (planDefinition) {
+      updated.extension.push({
+        url: SchedulingPlanDefinitionURI,
+        valueReference: planDefinition,
       });
     }
 
@@ -58,6 +70,25 @@ function HealthcareServiceSchedulingForm({ service }: HealthcareServiceSchedulin
           defaultValue={encounterClass}
           onChange={setEncounterClass}
         />
+        <Input.Wrapper
+          label="Plan Definition"
+          description="The plan definition to apply to encounters created when scheduling this HealthcareService"
+        >
+          {/*
+            Tricky: The complex nesting of the `<input>` deeply inside
+            ReferenceInput prevents the margins here from applying
+            normally, so we add a custom spacing wrapper that matches what
+            Mantine would normally do.
+          */}
+          <div style={{ marginTop: 'calc(var(--mantine-spacing-xs) / 2)' }}>
+            <ReferenceInput
+              name="planDefinition"
+              targetTypes={['PlanDefinition']}
+              defaultValue={planDefinition}
+              onChange={setPlanDefinition}
+            />
+          </div>
+        </Input.Wrapper>
         <Group justify="flex-end">
           <SubmitButton>Save</SubmitButton>
         </Group>

--- a/examples/medplum-provider/src/pages/schedule/FindPane.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/FindPane.test.tsx
@@ -105,7 +105,7 @@ describe('FindPane', () => {
   type SetupOptions = {
     schedule?: WithId<Schedule>;
     range?: { start: Date; end: Date };
-    onSuccess?: (results: { appointments: Appointment[]; slots: Slot[] }) => void;
+    onSuccess?: (results: { appointment: Appointment; slots: Slot[] }) => void;
   };
 
   const setup = (options: SetupOptions = {}): ReturnType<typeof render> => {

--- a/examples/medplum-provider/src/pages/schedule/FindPane.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/FindPane.test.tsx
@@ -4,15 +4,27 @@ import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import type { WithId } from '@medplum/core';
 import { ReadablePromise } from '@medplum/core';
-import type { Appointment, CodeableConcept, HealthcareService, Schedule, Slot } from '@medplum/fhirtypes';
-import { MockClient } from '@medplum/mock';
+import type {
+  Appointment,
+  CodeableConcept,
+  Encounter,
+  HealthcareService,
+  PlanDefinition,
+  Schedule,
+  Slot,
+} from '@medplum/fhirtypes';
+import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { createEncounter } from '../../utils/encounter';
+import { SchedulingEncounterCodingURI, SchedulingPlanDefinitionURI } from '../../utils/scheduling';
 import { toCodeableReferenceLike } from '../../utils/servicetype';
 import { FindPane } from './FindPane';
+
+vi.mock('../../utils/encounter', () => ({ createEncounter: vi.fn() }));
 
 const SchedulingParametersURI = 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters';
 const ServiceTypeReferenceURI = 'https://medlpum.com/fhir/service-type-reference';
@@ -407,6 +419,117 @@ describe('FindPane', () => {
 
       // No scheduling params on the service or schedule, renders null
       await waitFor(() => expect(screen.getByTestId('FindPaneTestWrapper')).toBeEmptyDOMElement());
+    });
+  });
+
+  describe('Encounter navigation', () => {
+    const AMB = { system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode', code: 'AMB' };
+    const MOCK_ENCOUNTER: WithId<Encounter> = { resourceType: 'Encounter', id: 'enc-1', status: 'planned', class: AMB };
+
+    let serviceWithEncounterConfig: WithId<HealthcareService>;
+
+    beforeEach(async () => {
+      const planDef = await medplum.createResource<PlanDefinition>({
+        resourceType: 'PlanDefinition',
+        id: 'pd-1',
+        status: 'active',
+      });
+
+      serviceWithEncounterConfig = await medplum.createResource<HealthcareService>({
+        resourceType: 'HealthcareService',
+        name: 'Encounter Service',
+        extension: [
+          { url: SchedulingParametersURI, extension: [{ url: 'duration', valueDuration: { value: 30, unit: 'min' } }] },
+          { url: SchedulingEncounterCodingURI, valueCoding: AMB },
+          { url: SchedulingPlanDefinitionURI, valueReference: { reference: `PlanDefinition/${planDef.id}` } },
+        ],
+      });
+
+      // $book returns a booked appointment with exactly one practitioner and one patient so
+      // bookEncounter (inside BookAppointmentForm) will proceed to call createEncounter.
+      const bookedAppointment: Appointment = {
+        resourceType: 'Appointment',
+        id: 'booked-1',
+        status: 'booked',
+        start: '2024-01-16T10:00:00Z',
+        end: '2024-01-16T10:30:00Z',
+        participant: [
+          { actor: { reference: 'Practitioner/prac-1' }, status: 'accepted' },
+          { actor: { reference: `Patient/${HomerSimpson.id}` }, status: 'accepted' },
+        ],
+      };
+
+      medplum.post = vi.fn().mockResolvedValue({
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [{ resource: bookedAppointment }],
+      });
+
+      vi.mocked(createEncounter).mockResolvedValue(MOCK_ENCOUNTER);
+    });
+
+    // Renders FindPane inside a router that has a destination route for the encounter page
+    // so tests can assert that navigation actually happened.
+    const setupWithRoutes = (schedule: WithId<Schedule>, onSuccess = vi.fn()): void => {
+      render(
+        <MemoryRouter initialEntries={['/find']}>
+          <MedplumProvider medplum={medplum}>
+            <MantineProvider>
+              <Notifications />
+              <Routes>
+                <Route
+                  path="/find"
+                  element={<FindPane schedule={schedule} range={defaultRange} onSuccess={onSuccess} />}
+                />
+                <Route
+                  path="/Patient/:patientId/Encounter/:encounterId"
+                  element={<div data-testid="encounter-page" />}
+                />
+              </Routes>
+            </MantineProvider>
+          </MedplumProvider>
+        </MemoryRouter>
+      );
+    };
+
+    // Selects a patient and submits BookAppointmentForm.
+    const bookWithHomer = async (user: ReturnType<typeof userEvent.setup>): Promise<void> => {
+      const patientInput = await screen.findByRole('searchbox');
+      await user.type(patientInput, 'Homer');
+      await waitFor(() => expect(screen.getByText('Homer Simpson')).toBeInTheDocument());
+      await user.click(screen.getByText('Homer Simpson'));
+      await user.click(screen.getByRole('button', { name: 'Create Appointment' }));
+    };
+
+    test('navigates to the encounter page and does not call onSuccess when an encounter is returned', async () => {
+      const user = userEvent.setup();
+      const onSuccess = vi.fn();
+      // Single service → auto-selected; $find returns mock appointments from the outer beforeEach.
+      setupWithRoutes(createScheduleWithServices([serviceWithEncounterConfig]), onSuccess);
+
+      // Click the first appointment slot that appeared from $find (there are two)
+      const apptButtons = await screen.findAllByRole('button', { name: /2024/i });
+      await user.click(apptButtons[0]);
+      await bookWithHomer(user);
+
+      await waitFor(() => expect(screen.getByTestId('encounter-page')).toBeInTheDocument());
+      // handleBookSuccess returns early after navigate, so onSuccess is never called
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    test('calls onSuccess and does not navigate when no encounter is returned', async () => {
+      const user = userEvent.setup();
+      const onSuccess = vi.fn();
+      // healthcareService has no encounter extensions → bookEncounter returns undefined.
+      // Single service → auto-selected, so we go straight to waiting for the appointment buttons.
+      setupWithRoutes(createScheduleWithServices([healthcareService]), onSuccess);
+
+      const apptButtons = await screen.findAllByRole('button', { name: /2024/i });
+      await user.click(apptButtons[0]);
+      await bookWithHomer(user);
+
+      await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+      expect(screen.queryByTestId('encounter-page')).not.toBeInTheDocument();
     });
   });
 

--- a/examples/medplum-provider/src/pages/schedule/FindPane.tsx
+++ b/examples/medplum-provider/src/pages/schedule/FindPane.tsx
@@ -38,7 +38,7 @@ const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 type FindPaneProps = {
   schedule: WithId<Schedule>;
   range: Range;
-  onSuccess: (results: { appointments: WithId<Appointment>[]; slots: WithId<Slot>[] }) => void;
+  onSuccess: (results: { appointment: WithId<Appointment>; slots: WithId<Slot>[] }) => void;
   className?: string;
 };
 
@@ -165,7 +165,7 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
   }, []);
 
   const handleBookSuccess = useCallback(
-    async (results: { appointments: WithId<Appointment>[]; slots: WithId<Slot>[]; patient: Patient }) => {
+    async (results: { appointment: WithId<Appointment>; slots: WithId<Slot>[]; patient: WithId<Patient> }) => {
       try {
         const planDefinitionRef = getExtensionValue(selectedHealthcareService, SchedulingPlanDefinitionURI);
         const encounterClass = getExtensionValue(selectedHealthcareService, SchedulingEncounterCodingURI);
@@ -179,7 +179,7 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
             encounterClass as Coding,
             results.patient,
             planDefinition,
-            results.appointments[0],
+            results.appointment,
             practitioners[0]
           );
 

--- a/examples/medplum-provider/src/pages/schedule/FindPane.tsx
+++ b/examples/medplum-provider/src/pages/schedule/FindPane.tsx
@@ -2,19 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Button, Group, Stack, Text, Title } from '@mantine/core';
 import type { WithId } from '@medplum/core';
-import { EMPTY, formatDateTime, getExtensionValue, getReferenceString, isDefined, isReference } from '@medplum/core';
-import type {
-  Appointment,
-  Bundle,
-  Coding,
-  HealthcareService,
-  Patient,
-  PlanDefinition,
-  Practitioner,
-  Reference,
-  Schedule,
-  Slot,
-} from '@medplum/fhirtypes';
+import { EMPTY, formatDateTime, getReferenceString, isDefined } from '@medplum/core';
+import type { Appointment, Bundle, Encounter, HealthcareService, Patient, Schedule, Slot } from '@medplum/fhirtypes';
 import { CodeableConceptDisplay, useMedplum } from '@medplum/react';
 import { IconChevronRight, IconX } from '@tabler/icons-react';
 import type { JSX } from 'react';
@@ -23,14 +12,8 @@ import { useNavigate } from 'react-router';
 import { BookAppointmentForm } from '../../components/schedule/BookAppointmentForm';
 import { useSchedulingStartsAt } from '../../hooks/useSchedulingStartsAt';
 import type { Range } from '../../types/scheduling';
-import { createEncounter } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
-import {
-  hasSchedulingParameters,
-  SchedulingEncounterCodingURI,
-  SchedulingPlanDefinitionURI,
-  SchedulingTransientIdentifier,
-} from '../../utils/scheduling';
+import { hasSchedulingParameters, SchedulingTransientIdentifier } from '../../utils/scheduling';
 import { extractReferencesFromCodeableReferenceLike } from '../../utils/servicetype';
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
@@ -165,31 +148,16 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
   }, []);
 
   const handleBookSuccess = useCallback(
-    async (results: { appointment: WithId<Appointment>; slots: WithId<Slot>[]; patient: WithId<Patient> }) => {
-      try {
-        const planDefinitionRef = getExtensionValue(selectedHealthcareService, SchedulingPlanDefinitionURI);
-        const encounterClass = getExtensionValue(selectedHealthcareService, SchedulingEncounterCodingURI);
-        const practitioners = schedule.actor.filter((actor) => isReference<Practitioner>(actor, 'Practitioner'));
-
-        if (practitioners.length === 1 && planDefinitionRef && encounterClass) {
-          const planDefinition = await medplum.readReference(planDefinitionRef as Reference<PlanDefinition>);
-
-          const encounter = await createEncounter(
-            medplum,
-            encounterClass as Coding,
-            results.patient,
-            planDefinition,
-            results.appointment,
-            practitioners[0]
-          );
-
-          await navigate(`/Patient/${results.patient.id}/Encounter/${encounter.id}`);
-        }
-      } catch (err) {
-        // If we couldn't load the plan definition or create the encounter for
-        // some reason, we log the error but ignore it. The viewer can decide how
-        // to proceed and manually create the encounter.
-        console.error(err);
+    async (results: {
+      appointment: WithId<Appointment>;
+      slots: WithId<Slot>[];
+      patient: WithId<Patient>;
+      encounter?: WithId<Encounter>;
+    }) => {
+      const { patient, encounter } = results;
+      if (encounter) {
+        await navigate(`/Patient/${patient.id}/Encounter/${encounter.id}`);
+        return;
       }
 
       setSelectedHealthcareService(undefined);
@@ -197,7 +165,7 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
       setChosenAppointment(undefined);
       onSuccess(results);
     },
-    [medplum, onSuccess, schedule.actor, selectedHealthcareService, navigate]
+    [onSuccess, navigate]
   );
 
   if (!scheduleableServices?.length) {
@@ -215,7 +183,11 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
             </Button>
           </Group>
         </Title>
-        <BookAppointmentForm appointment={chosenAppointment} onSuccess={handleBookSuccess} />
+        <BookAppointmentForm
+          appointment={chosenAppointment}
+          healthcareService={selectedHealthcareService}
+          onSuccess={handleBookSuccess}
+        />
       </Stack>
     );
   }

--- a/examples/medplum-provider/src/pages/schedule/FindPane.tsx
+++ b/examples/medplum-provider/src/pages/schedule/FindPane.tsx
@@ -2,17 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Button, Group, Stack, Text, Title } from '@mantine/core';
 import type { WithId } from '@medplum/core';
-import { EMPTY, formatDateTime, getReferenceString, isDefined } from '@medplum/core';
-import type { Appointment, Bundle, HealthcareService, Schedule, Slot } from '@medplum/fhirtypes';
+import { EMPTY, formatDateTime, getExtensionValue, getReferenceString, isDefined, isReference } from '@medplum/core';
+import type {
+  Appointment,
+  Bundle,
+  Coding,
+  HealthcareService,
+  Patient,
+  PlanDefinition,
+  Practitioner,
+  Reference,
+  Schedule,
+  Slot,
+} from '@medplum/fhirtypes';
 import { CodeableConceptDisplay, useMedplum } from '@medplum/react';
 import { IconChevronRight, IconX } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
 import { BookAppointmentForm } from '../../components/schedule/BookAppointmentForm';
 import { useSchedulingStartsAt } from '../../hooks/useSchedulingStartsAt';
 import type { Range } from '../../types/scheduling';
+import { createEncounter } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
-import { hasSchedulingParameters, SchedulingTransientIdentifier } from '../../utils/scheduling';
+import {
+  hasSchedulingParameters,
+  SchedulingEncounterCodingURI,
+  SchedulingPlanDefinitionURI,
+  SchedulingTransientIdentifier,
+} from '../../utils/scheduling';
 import { extractReferencesFromCodeableReferenceLike } from '../../utils/servicetype';
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
@@ -45,6 +63,7 @@ function HealthcareServiceDisplay(props: { value: HealthcareService }): JSX.Elem
 // See https://www.medplum.com/docs/scheduling/defining-availability for details.
 export function FindPane(props: FindPaneProps): JSX.Element | null {
   const medplum = useMedplum();
+  const navigate = useNavigate();
   const [appointments, setAppointments] = useState<readonly Appointment[] | undefined>(undefined);
   const [chosenAppointment, setChosenAppointment] = useState<Appointment | undefined>(undefined);
   const [selectedHealthcareService, setSelectedHealthcareService] = useState<WithId<HealthcareService> | undefined>();
@@ -146,13 +165,39 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
   }, []);
 
   const handleBookSuccess = useCallback(
-    (results: { appointments: WithId<Appointment>[]; slots: WithId<Slot>[] }) => {
+    async (results: { appointments: WithId<Appointment>[]; slots: WithId<Slot>[]; patient: Patient }) => {
+      try {
+        const planDefinitionRef = getExtensionValue(selectedHealthcareService, SchedulingPlanDefinitionURI);
+        const encounterClass = getExtensionValue(selectedHealthcareService, SchedulingEncounterCodingURI);
+        const practitioners = schedule.actor.filter((actor) => isReference<Practitioner>(actor, 'Practitioner'));
+
+        if (practitioners.length === 1 && planDefinitionRef && encounterClass) {
+          const planDefinition = await medplum.readReference(planDefinitionRef as Reference<PlanDefinition>);
+
+          const encounter = await createEncounter(
+            medplum,
+            encounterClass as Coding,
+            results.patient,
+            planDefinition,
+            results.appointments[0],
+            practitioners[0]
+          );
+
+          await navigate(`/Patient/${results.patient.id}/Encounter/${encounter.id}`);
+        }
+      } catch (err) {
+        // If we couldn't load the plan definition or create the encounter for
+        // some reason, we log the error but ignore it. The viewer can decide how
+        // to proceed and manually create the encounter.
+        console.error(err);
+      }
+
       setSelectedHealthcareService(undefined);
       setAppointments([]);
       setChosenAppointment(undefined);
       onSuccess(results);
     },
-    [onSuccess]
+    [medplum, onSuccess, schedule.actor, selectedHealthcareService, navigate]
   );
 
   if (!scheduleableServices?.length) {

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
@@ -156,9 +156,9 @@ export function SchedulePage(): JSX.Element | null {
   );
 
   const handleBookSuccess = useCallback(
-    (results: { appointments: WithId<Appointment>[]; slots: Slot[] }) => {
-      setAppointments((state) => results.appointments.concat(state ?? EMPTY));
-      setAppointmentDetails(results.appointments[0]);
+    (results: { appointment: WithId<Appointment>; slots: Slot[] }) => {
+      setAppointments((state) => [...(state ?? EMPTY), results.appointment]);
+      setAppointmentDetails(results.appointment);
       appointmentDetailsHandlers.open();
       setSlots((state) => results.slots.concat(state ?? EMPTY));
     },

--- a/examples/medplum-provider/src/utils/encounter.ts
+++ b/examples/medplum-provider/src/utils/encounter.ts
@@ -66,20 +66,21 @@ export async function createAppointment(
 export async function createEncounter(
   medplum: MedplumClient,
   classification: Coding,
-  patient: Patient,
+  patient: Patient | Reference<Patient>,
   planDefinition: PlanDefinition,
   appointment: Appointment,
   practitioner: Practitioner | Reference<Practitioner>
-): Promise<Encounter> {
+): Promise<WithId<Encounter>> {
   const practitionerRef = isResource(practitioner) ? createReference(practitioner) : practitioner;
+  const patientRef = isResource(patient) ? createReference(patient) : patient;
 
-  const encounter: Encounter = await medplum.createResource({
+  const encounter: WithId<Encounter> = await medplum.createResource({
     resourceType: 'Encounter',
     status: 'planned',
     statusHistory: [],
     classHistory: [],
     class: classification,
-    subject: createReference(patient),
+    subject: patientRef,
     appointment: [createReference(appointment)],
     participant: [{ individual: practitionerRef }],
   });
@@ -88,7 +89,7 @@ export async function createEncounter(
     resourceType: 'ClinicalImpression',
     status: 'in-progress',
     description: 'Initial clinical impression',
-    subject: createReference(patient),
+    subject: patientRef,
     encounter: createReference(encounter),
     date: new Date().toISOString(),
   };
@@ -104,8 +105,8 @@ export async function createEncounter(
     ],
   });
 
-  await createChargeItemFromPlanDefinition(medplum, encounter, patient, planDefinition);
-  await handleChargeItemsFromTasks(medplum, encounter, patient);
+  await createChargeItemFromPlanDefinition(medplum, encounter, patientRef, planDefinition);
+  await handleChargeItemsFromTasks(medplum, encounter, patientRef);
 
   return encounter;
 }
@@ -113,7 +114,7 @@ export async function createEncounter(
 async function createChargeItemFromPlanDefinition(
   medplum: MedplumClient,
   encounter: Encounter,
-  patient: Patient,
+  patient: Reference<Patient>,
   planDefinition: PlanDefinition
 ): Promise<void> {
   const serviceBillingCodeExtension = getExtension(
@@ -142,7 +143,7 @@ async function createChargeItemFromPlanDefinition(
   const chargeItem: ChargeItem = {
     resourceType: 'ChargeItem',
     status: 'planned',
-    subject: createReference(patient),
+    subject: patient,
     context: createReference(encounter),
     occurrenceDateTime: new Date().toISOString(),
     code: serviceBillingCodeExtension.valueCodeableConcept,
@@ -159,7 +160,7 @@ async function createChargeItemFromPlanDefinition(
 async function handleChargeItemsFromTasks(
   medplum: MedplumClient,
   encounter: Encounter,
-  patient: Patient
+  patient: Reference<Patient>
 ): Promise<void> {
   const tasks = await medplum.search('Task', {
     encounter: getReferenceString(encounter),
@@ -192,7 +193,7 @@ async function handleChargeItemsFromTasks(
 
 async function createChargeItemFromServiceRequest(
   medplum: MedplumClient,
-  patient: Patient,
+  patient: Reference<Patient>,
   serviceRequest: ServiceRequest
 ): Promise<void> {
   const chargeDefinitionExtension = getExtension(
@@ -218,7 +219,7 @@ async function createChargeItemFromServiceRequest(
         reference: `ServiceRequest/${serviceRequest.id}`,
       },
     ],
-    subject: createReference(patient),
+    subject: patient,
     context: serviceRequest.encounter,
     occurrenceDateTime: serviceRequest.occurrenceDateTime || new Date().toISOString(),
     code: serviceRequest.code || { coding: [] },

--- a/examples/medplum-provider/src/utils/scheduling.ts
+++ b/examples/medplum-provider/src/utils/scheduling.ts
@@ -5,6 +5,7 @@ import type { HealthcareService, Identifier, Resource, Schedule } from '@medplum
 
 const SchedulingParametersURI = 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters';
 const MedplumSchedulingTransientIdentifierURI = 'https://medplum.com/fhir/scheduling-transient-id';
+export const SchedulingEncounterCodingURI = 'https://medplum.com/fhir/StructureDefinition/SchedulingEncounterCoding';
 
 export const SchedulingTransientIdentifier = {
   set(resource: Resource & { identifier?: Identifier[] }) {

--- a/examples/medplum-provider/src/utils/scheduling.ts
+++ b/examples/medplum-provider/src/utils/scheduling.ts
@@ -6,6 +6,7 @@ import type { HealthcareService, Identifier, Resource, Schedule } from '@medplum
 const SchedulingParametersURI = 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters';
 const MedplumSchedulingTransientIdentifierURI = 'https://medplum.com/fhir/scheduling-transient-id';
 export const SchedulingEncounterCodingURI = 'https://medplum.com/fhir/StructureDefinition/SchedulingEncounterCoding';
+export const SchedulingPlanDefinitionURI = 'https://medplum.com/fhir/StructureDefinition/SchedulingPlanDefinition';
 
 export const SchedulingTransientIdentifier = {
   set(resource: Resource & { identifier?: Identifier[] }) {


### PR DESCRIPTION
- Adds a new Provider page to configure HealthcareService scheduling, `/HealthcareService/:id/scheduling`. This tab only appears in projects that have the "scheduling" feature enabled.
- That tab allows setting two FHIR extensions specific provider-UI  into the HealthcareService resource. These hold a PlanDefiniton reference and an `ActEncounterCode` code. 
- When a HealthcareService is used to book an appointment, if that service is configured with both of these extensions, we automatically create an encounter with those values as configuration.

## New configuration page
<img width="1317" height="1082" alt="Screenshot 2026-06-01 at 5 05 20 PM" src="https://github.com/user-attachments/assets/90709e61-7299-49b0-bbff-27ad5686a8fa" />

## Encounter creation after configuration

https://github.com/user-attachments/assets/8515dce9-e50f-4d71-a874-46bfee06bf35
