### PR TITLE
Constrain scheduling operations with `Schedule.planningHorizon`

### DIFF
--- a/examples/medplum-provider/src/pages/schedule/FindPane.tsx
+++ b/examples/medplum-provider/src/pages/schedule/FindPane.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Button, Group, Stack, Title } from '@mantine/core';
+import { Button, Group, Stack, Text, Title } from '@mantine/core';
 import type { WithId } from '@medplum/core';
 import { EMPTY, formatDateTime, getReferenceString, isDefined } from '@medplum/core';
 import type { Appointment, Bundle, HealthcareService, Schedule, Slot } from '@medplum/fhirtypes';
@@ -125,6 +125,7 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
         },
         (error) => {
           if (!signal.aborted) {
+            setAppointments([]);
             showErrorNotification(error);
           }
         }
@@ -198,6 +199,11 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
             {formatDateTime(appointment.start)}
           </Button>
         ))}
+        {appointments?.length === 0 && (
+          <Text size="sm" c="dimmed" mt="sm">
+            No available appointments found in this calendar range.
+          </Text>
+        )}
       </Stack>
     );
   }

--- a/packages/server/src/fhir/operations/book.test.ts
+++ b/packages/server/src/fhir/operations/book.test.ts
@@ -123,13 +123,18 @@ describe('Appointment/$book', () => {
     return extension;
   }
 
-  async function makeSchedule(opts: { actor: Practitioner; extension?: Extension[] }): Promise<WithId<Schedule>> {
+  async function makeSchedule(opts: {
+    actor: Practitioner;
+    extension?: Extension[];
+    planningHorizon?: Schedule['planningHorizon'];
+  }): Promise<WithId<Schedule>> {
     return systemRepo.createResource<Schedule>({
       resourceType: 'Schedule',
       meta: { project: project.project.id },
       actor: [createReference(opts.actor)],
       serviceType: toCodeableReferenceLike(officeVisitService),
       extension: opts.extension ?? [makeSchedulingExtension({ service: officeVisitService })],
+      planningHorizon: opts.planningHorizon,
     });
   }
 
@@ -1710,6 +1715,45 @@ describe('Appointment/$book', () => {
       });
     expect(response.body).not.toHaveProperty('issue');
     expect(response.status).toEqual(201);
+  });
+
+  test('errors when appointment is outside schedule planning horizon', async () => {
+    const schedule = await makeSchedule({
+      actor: practitioner1,
+      planningHorizon: { end: '2026-01-14T00:00:00Z' },
+    });
+    const start = '2026-01-15T14:00:00Z';
+    const end = '2026-01-15T15:00:00Z';
+    const response = await request
+      .post('/fhir/R4/Appointment/$book')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              status: 'proposed',
+              start,
+              end,
+              serviceType: toCodeableReferenceLike(officeVisitService),
+              participant: [{ actor: schedule.actor[0], status: 'tentative' }],
+              contained: [
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(schedule),
+                  start,
+                  end,
+                } satisfies Slot,
+              ],
+            } satisfies Appointment,
+          },
+        ],
+      });
+    expect(response.status).toBe(400);
+    expect(response.body.issue[0].details.text).toBe('Appointment falls outside schedule planning horizon');
   });
 });
 

--- a/packages/server/src/fhir/operations/book.test.ts
+++ b/packages/server/src/fhir/operations/book.test.ts
@@ -1717,13 +1717,52 @@ describe('Appointment/$book', () => {
     expect(response.status).toEqual(201);
   });
 
-  test('errors when appointment is outside schedule planning horizon', async () => {
+  test('errors when appointment is after Schedule.planningHorizon.end', async () => {
     const schedule = await makeSchedule({
       actor: practitioner1,
       planningHorizon: { end: '2026-01-14T00:00:00Z' },
     });
     const start = '2026-01-15T14:00:00Z';
     const end = '2026-01-15T15:00:00Z';
+    const response = await request
+      .post('/fhir/R4/Appointment/$book')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'appointment',
+            resource: {
+              resourceType: 'Appointment',
+              status: 'proposed',
+              start,
+              end,
+              serviceType: toCodeableReferenceLike(officeVisitService),
+              participant: [{ actor: schedule.actor[0], status: 'tentative' }],
+              contained: [
+                {
+                  resourceType: 'Slot',
+                  status: 'busy',
+                  schedule: createReference(schedule),
+                  start,
+                  end,
+                } satisfies Slot,
+              ],
+            } satisfies Appointment,
+          },
+        ],
+      });
+    expect(response.status).toBe(400);
+    expect(response.body.issue[0].details.text).toBe('Appointment falls outside schedule planning horizon');
+  });
+
+  test('errors when appointment is before Schedule.planningHorizon.start', async () => {
+    const schedule = await makeSchedule({
+      actor: practitioner1,
+      planningHorizon: { start: '2026-01-15T00:00:00Z' },
+    });
+    const start = '2026-01-14T14:00:00Z';
+    const end = '2026-01-14T15:00:00Z';
     const response = await request
       .post('/fhir/R4/Appointment/$book')
       .set('Authorization', `Bearer ${project.accessToken}`)

--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -231,7 +231,7 @@ describe('Schedule/:id/$find', () => {
 
   async function makeSchedule(
     availability: AvailabilityOptions[],
-    opts?: { actor?: Schedule['actor'] }
+    opts?: { actor?: Schedule['actor']; planningHorizon?: Schedule['planningHorizon'] }
   ): Promise<Schedule> {
     const serviceType = availability.flatMap((entry) => toCodeableReferenceLike(entry.service));
     return systemRepo.createResource<Schedule>({
@@ -240,6 +240,7 @@ describe('Schedule/:id/$find', () => {
       actor: opts?.actor ?? [createReference(practitioner)],
       extension: makeSchedulingExtension(availability),
       serviceType,
+      planningHorizon: opts?.planningHorizon,
     });
   }
 
@@ -1036,6 +1037,90 @@ describe('Schedule/:id/$find', () => {
     });
   });
 
+  describe('planningHorizon', () => {
+    test('errors when range starts after planning horizon end', async () => {
+      const schedule = await makeSchedule([{ service: genericVisit, availability: fourDayWorkWeek, duration: 20 }], {
+        planningHorizon: { end: '2025-11-28T00:00:00Z' },
+      });
+      const response = await request
+        .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .query({
+          start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
+          end: new Date('2025-12-01T14:00:00.000-05:00').toISOString(),
+          'service-type-reference': `HealthcareService/${genericVisit.id}`,
+        });
+      expect(response.status).toBe(400);
+      expect(response.body.issue[0].details.text).toBe('Schedule planning horizon does not extend to requested range');
+    });
+
+    test('errors when range ends before planning horizon start', async () => {
+      const schedule = await makeSchedule([{ service: genericVisit, availability: fourDayWorkWeek, duration: 20 }], {
+        planningHorizon: { start: '2025-12-03T00:00:00Z' },
+      });
+      const response = await request
+        .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .query({
+          start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
+          end: new Date('2025-12-01T23:00:00.000-05:00').toISOString(),
+          'service-type-reference': `HealthcareService/${genericVisit.id}`,
+        });
+      expect(response.status).toBe(400);
+      expect(response.body.issue[0].details.text).toBe('Schedule planning horizon does not extend to requested range');
+    });
+
+    test('clips results at planning horizon end, excluding slots beyond the horizon', async () => {
+      // fourDayWorkWeek on Mon Dec 1 2025 (EST) gives slots at 10:00, 11:00, 12:00.
+      // horizon end at 11:30 EST clips the available window to 09:30–11:30, so
+      // only the 10:00 and 11:00 slots fit; the 12:00 slot is excluded.
+      const schedule = await makeSchedule([{ service: genericVisit, availability: fourDayWorkWeek, duration: 20 }], {
+        planningHorizon: { end: '2025-12-01T11:30:00-05:00' },
+      });
+      const response = await request
+        .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .query({
+          start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
+          end: new Date('2025-12-01T14:00:00.000-05:00').toISOString(),
+          'service-type-reference': `HealthcareService/${genericVisit.id}`,
+        });
+      expect(response.status).toBe(200);
+      expect(response.body).not.toHaveProperty('issue');
+      const starts = (response.body as Bundle<Slot>).entry?.map((e) => e.resource?.start) ?? [];
+      expect(starts).toContain(new Date('2025-12-01T10:00:00.000-05:00').toISOString());
+      expect(starts).toContain(new Date('2025-12-01T11:00:00.000-05:00').toISOString());
+      expect(starts).not.toContain(new Date('2025-12-01T12:00:00.000-05:00').toISOString());
+    });
+
+    test('clips results at planning horizon start, excluding slots before the horizon', async () => {
+      // fourDayWorkWeek on Mon Dec 1 2025 (EST) gives slots at 10:00, 11:00, 12:00.
+      // horizon start at 11:00 EST advances range.start forward, so the 10:00
+      // slot is excluded and only the 11:00 and 12:00 slots are returned.
+      const schedule = await makeSchedule([{ service: genericVisit, availability: fourDayWorkWeek, duration: 20 }], {
+        planningHorizon: { start: '2025-12-01T11:00:00-05:00' },
+      });
+      const response = await request
+        .get(`/fhir/R4/Schedule/${schedule.id}/$find`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .query({
+          start: new Date('2025-12-01T00:00:00.000-05:00').toISOString(),
+          end: new Date('2025-12-01T14:00:00.000-05:00').toISOString(),
+          'service-type-reference': `HealthcareService/${genericVisit.id}`,
+        });
+      expect(response.status).toBe(200);
+      expect(response.body).not.toHaveProperty('issue');
+      const starts = (response.body as Bundle<Slot>).entry?.map((e) => e.resource?.start) ?? [];
+      expect(starts).not.toContain(new Date('2025-12-01T10:00:00.000-05:00').toISOString());
+      expect(starts).toContain(new Date('2025-12-01T11:00:00.000-05:00').toISOString());
+      expect(starts).toContain(new Date('2025-12-01T12:00:00.000-05:00').toISOString());
+    });
+  });
+
   test('when serviceType has no codes', async () => {
     // create a HealthcareService with no `type` attribute
     const emptyService = await systemRepo.createResource<HealthcareService>({
@@ -1200,7 +1285,7 @@ describe('Appointment/$find', () => {
 
   async function makeSchedule(
     availability: AvailabilityOptions[],
-    opts?: { actor?: Schedule['actor'] }
+    opts?: { actor?: Schedule['actor']; planningHorizon?: Schedule['planningHorizon'] }
   ): Promise<Schedule> {
     const serviceType = availability.flatMap((entry) => toCodeableReferenceLike(entry.service));
     return systemRepo.createResource<Schedule>({
@@ -1209,6 +1294,7 @@ describe('Appointment/$find', () => {
       actor: opts?.actor ?? [createReference(practitioner)],
       extension: makeSchedulingExtension(availability),
       serviceType,
+      planningHorizon: opts?.planningHorizon,
     });
   }
 
@@ -1730,6 +1816,32 @@ describe('Appointment/$find', () => {
     expect(starts).not.toContain(new Date('2026-03-16T14:00:00-04:00').toISOString());
     // 3pm EDT: OK on A; blocked on B directly by B's busy slot
     expect(starts).not.toContain(new Date('2026-03-16T15:00:00-04:00').toISOString());
+  });
+
+  test('errors when one schedule has a planning horizon that excludes the requested range', async () => {
+    const practitionerSchedule = await makeSchedule(
+      [{ service: genericVisit, duration: 30, availability: monTueAvailability }],
+      { actor: [createReference(practitioner)] }
+    );
+    // location schedule's horizon ends before the requested range starts
+    const locationSchedule = await makeSchedule(
+      [{ service: genericVisit, duration: 30, availability: tueWedAvailability }],
+      {
+        actor: [createReference(location)],
+        planningHorizon: { end: '2026-03-15T00:00:00Z' },
+      }
+    );
+
+    const response = await makeRequest({
+      start: new Date('2026-03-16T00:00:00-04:00').toISOString(),
+      end: new Date('2026-03-21T00:00:00-04:00').toISOString(),
+      'service-type-reference': `HealthcareService/${genericVisit.id}`,
+      schedule: [`Schedule/${practitionerSchedule.id}`, `Schedule/${locationSchedule.id}`],
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.issue[0].details.text).toBe('Schedule planning horizon does not extend to requested range');
+    expect(response.body.issue[0].expression).toEqual(['Parameters.schedule[1]']);
   });
 
   test('_count is respected for multi-schedule results', async () => {

--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -1052,7 +1052,7 @@ describe('Schedule/:id/$find', () => {
           'service-type-reference': `HealthcareService/${genericVisit.id}`,
         });
       expect(response.status).toBe(400);
-      expect(response.body.issue[0].details.text).toBe('Schedule planning horizon does not extend to requested range');
+      expect(response.body.issue[0].details.text).toBe('Search range starts after schedule planning horizon ends');
     });
 
     test('errors when range ends before planning horizon start', async () => {
@@ -1069,7 +1069,7 @@ describe('Schedule/:id/$find', () => {
           'service-type-reference': `HealthcareService/${genericVisit.id}`,
         });
       expect(response.status).toBe(400);
-      expect(response.body.issue[0].details.text).toBe('Schedule planning horizon does not extend to requested range');
+      expect(response.body.issue[0].details.text).toBe('Search range ends before schedule planning horizon starts');
     });
 
     test('clips results at planning horizon end, excluding slots beyond the horizon', async () => {
@@ -1840,8 +1840,44 @@ describe('Appointment/$find', () => {
     });
 
     expect(response.status).toBe(400);
-    expect(response.body.issue[0].details.text).toBe('Schedule planning horizon does not extend to requested range');
+    expect(response.body.issue[0].details.text).toBe('Search range starts after schedule planning horizon ends');
     expect(response.body.issue[0].expression).toEqual(['Parameters.schedule[1]']);
+  });
+
+  test('clips search range to intersection of planning horizons across schedules', async () => {
+    // Both schedules cover Mon–Thu (fourDayWorkWeek).
+    // scheduleA horizon starts Tue Mar 17 → Mon slots excluded by A's horizon.
+    // scheduleB horizon ends Wed Mar 18 midnight → Wed/Thu slots excluded by B's horizon.
+    // Effective range is Tue Mar 17 only; Mon and Wed slots must be absent.
+    const scheduleA = await makeSchedule([{ service: genericVisit, duration: 60, availability: fourDayWorkWeek }], {
+      actor: [createReference(practitioner)],
+      planningHorizon: { start: '2026-03-17T00:00:00-04:00' },
+    });
+    const scheduleB = await makeSchedule([{ service: genericVisit, duration: 60, availability: fourDayWorkWeek }], {
+      actor: [createReference(location)],
+      planningHorizon: { end: '2026-03-18T00:00:00-04:00' },
+    });
+
+    const response = await makeRequest({
+      start: new Date('2026-03-16T00:00:00-04:00').toISOString(),
+      end: new Date('2026-03-19T17:00:00-04:00').toISOString(),
+      'service-type-reference': `HealthcareService/${genericVisit.id}`,
+      schedule: [`Schedule/${scheduleA.id}`, `Schedule/${scheduleB.id}`],
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).not.toHaveProperty('issue');
+
+    const starts = (response.body as Bundle<Appointment>).entry?.map((e) => e.resource?.start) ?? [];
+
+    expect(starts.length).toBeGreaterThan(0);
+    // No Monday slots — excluded by scheduleA's planningHorizon.start
+    // (fourDayWorkWeek with 60-min alignment produces slots at :00 — first is 10am)
+    expect(starts).not.toContain(new Date('2026-03-16T10:00:00-04:00').toISOString());
+    // Tuesday slots present — within both planning horizons
+    expect(starts).toContain(new Date('2026-03-17T10:00:00-04:00').toISOString());
+    // No Wednesday slots — excluded by scheduleB's planningHorizon.end
+    expect(starts).not.toContain(new Date('2026-03-18T10:00:00-04:00').toISOString());
   });
 
   test('_count is respected for multi-schedule results', async () => {

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -18,7 +18,7 @@ import type { Appointment, Bundle, HealthcareService, Reference, Schedule, Slot 
 import assert from 'node:assert';
 import { getAuthenticatedContext } from '../../context';
 import { flatMapMax } from '../../util/array';
-import { addMinutes } from '../../util/date';
+import { addMinutes, earliest, latest } from '../../util/date';
 import { isCodeableReferenceLikeTo, toCodeableReferenceLike } from '../../util/servicetype';
 import type { WithPath } from '../../util/withpath';
 import { copyPaths, getPath, withPath, withPaths } from '../../util/withpath';
@@ -134,6 +134,27 @@ async function handler(params: {
       throw new OperationOutcomeError(
         badRequest('Schedule is not schedulable for requested service type', getPath(schedule))
       );
+    }
+
+    // If a schedule has a planning horizon, constrain search to values inside that horizon
+    if (schedule.planningHorizon?.start) {
+      const horizonStart = new Date(schedule.planningHorizon.start);
+      if (range.end < horizonStart) {
+        throw new OperationOutcomeError(
+          badRequest('Schedule planning horizon does not extend to requested range', getPath(schedule))
+        );
+      }
+      range.start = latest([range.start, horizonStart]);
+    }
+
+    if (schedule.planningHorizon?.end) {
+      const horizonEnd = new Date(schedule.planningHorizon.end);
+      if (range.start > horizonEnd) {
+        throw new OperationOutcomeError(
+          badRequest('Schedule planning horizon does not extend to requested range', getPath(schedule))
+        );
+      }
+      range.end = earliest([range.end, horizonEnd]);
     }
   });
 

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -98,13 +98,12 @@ async function handler(params: {
     throw new OperationOutcomeError(badRequest(`Invalid _count, maximum allowed is ${DEFAULT_MAX_SEARCH_COUNT}`));
   }
 
-  const range = { start: new Date(params.start), end: new Date(params.end) };
-
-  if (range.start >= range.end) {
+  const requestedRange = { start: new Date(params.start), end: new Date(params.end) };
+  if (requestedRange.start >= requestedRange.end) {
     throw new OperationOutcomeError(badRequest('Invalid search time range'));
   }
 
-  const diffMilliseconds = range.end.valueOf() - range.start.valueOf();
+  const diffMilliseconds = requestedRange.end.valueOf() - requestedRange.start.valueOf();
   const diffDays = diffMilliseconds / (24 * 60 * 60 * 1000);
   if (diffDays > 31) {
     throw new OperationOutcomeError(badRequest('Search range cannot exceed 31 days'));
@@ -112,7 +111,7 @@ async function handler(params: {
 
   const [schedules, existingSlots, healthcareService] = await Promise.all([
     ctx.repo.readReferences(params.schedules).then((schedules) => copyPaths(params.schedules, schedules)),
-    slotsOverlappingInterval(ctx.repo, params.schedules, range),
+    slotsOverlappingInterval(ctx.repo, params.schedules, requestedRange),
     ctx.repo.readReference<HealthcareService>(params.healthcareService).catch((err) => {
       if (err instanceof OperationOutcomeError && isNotFound(err.outcome)) {
         throw new OperationOutcomeError(badRequest('HealthcareService not found'));
@@ -129,6 +128,7 @@ async function handler(params: {
     withPath(healthcareService, 'Parameters.service-type-reference')
   );
 
+  const effectiveRange = { start: requestedRange.start, end: requestedRange.end };
   schedules.forEach((schedule) => {
     if (!isCodeableReferenceLikeTo(schedule.serviceType, healthcareService)) {
       throw new OperationOutcomeError(
@@ -139,22 +139,22 @@ async function handler(params: {
     // If a schedule has a planning horizon, constrain search to values inside that horizon
     if (schedule.planningHorizon?.start) {
       const horizonStart = new Date(schedule.planningHorizon.start);
-      if (range.end < horizonStart) {
+      if (effectiveRange.end < horizonStart) {
         throw new OperationOutcomeError(
-          badRequest('Schedule planning horizon does not extend to requested range', getPath(schedule))
+          badRequest('Search range ends before schedule planning horizon starts', getPath(schedule))
         );
       }
-      range.start = latest([range.start, horizonStart]);
+      effectiveRange.start = latest([effectiveRange.start, horizonStart]);
     }
 
     if (schedule.planningHorizon?.end) {
       const horizonEnd = new Date(schedule.planningHorizon.end);
-      if (range.start > horizonEnd) {
+      if (effectiveRange.start > horizonEnd) {
         throw new OperationOutcomeError(
-          badRequest('Schedule planning horizon does not extend to requested range', getPath(schedule))
+          badRequest('Search range starts after schedule planning horizon ends', getPath(schedule))
         );
       }
-      range.end = earliest([range.end, horizonEnd]);
+      effectiveRange.end = earliest([effectiveRange.end, horizonEnd]);
     }
   });
 
@@ -166,11 +166,11 @@ async function handler(params: {
     assert(schedulingParameters);
 
     const scheduleSlots = existingSlots.filter((slot) => resolveId(slot.schedule) === schedule.id);
-    let availability = resolveAvailability(schedulingParameters, range, schedulingParameters.timezone);
+    let availability = resolveAvailability(schedulingParameters, effectiveRange, schedulingParameters.timezone);
     availability = applyExistingSlots({
       availability,
       slots: scheduleSlots,
-      range,
+      range: effectiveRange,
       serviceType: healthcareService.type,
     });
 

--- a/packages/server/src/fhir/operations/hold.test.ts
+++ b/packages/server/src/fhir/operations/hold.test.ts
@@ -1198,14 +1198,26 @@ describe('Appointment/$hold', () => {
   test('errors when appointment is outside schedule planning horizon', async () => {
     const schedule = await makeSchedule({
       actor: practitioner1,
-      planningHorizon: { end: '2026-01-14T00:00:00Z' },
+      planningHorizon: { start: '2026-01-01T00:00:00Z', end: '2026-01-14T00:00:00Z' },
     });
-    const response = await request
+
+    // trying to book before planningHorizon.start fails
+    const beforeHorizonResponse = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send(holdParams({ schedule, start: '2025-12-28T14:00:00Z', end: '2025-12-28T15:00:00Z' }));
+    expect(beforeHorizonResponse.status).toBe(400);
+    expect(beforeHorizonResponse.body.issue[0].details.text).toBe(
+      'Appointment falls outside schedule planning horizon'
+    );
+
+    // trying to book after planningHorizon.end fails
+    const afterHorizonResponse = await request
       .post('/fhir/R4/Appointment/$hold')
       .set('Authorization', `Bearer ${project.accessToken}`)
       .send(holdParams({ schedule, start: '2026-01-15T14:00:00Z', end: '2026-01-15T15:00:00Z' }));
-    expect(response.status).toBe(400);
-    expect(response.body.issue[0].details.text).toBe('Appointment falls outside schedule planning horizon');
+    expect(afterHorizonResponse.status).toBe(400);
+    expect(afterHorizonResponse.body.issue[0].details.text).toBe('Appointment falls outside schedule planning horizon');
   });
 });
 

--- a/packages/server/src/fhir/operations/hold.test.ts
+++ b/packages/server/src/fhir/operations/hold.test.ts
@@ -130,6 +130,7 @@ describe('Appointment/$hold', () => {
   async function makeSchedule(opts: {
     actor: WithId<Practitioner | Device>;
     extension?: Extension[];
+    planningHorizon?: Schedule['planningHorizon'];
   }): Promise<WithId<Schedule>> {
     return systemRepo.createResource<Schedule>({
       resourceType: 'Schedule',
@@ -137,6 +138,7 @@ describe('Appointment/$hold', () => {
       actor: [createReference(opts.actor)],
       serviceType: toCodeableReferenceLike(officeVisitService),
       extension: opts.extension ?? [makeSchedulingExtension({ service: officeVisitService })],
+      planningHorizon: opts.planningHorizon,
     });
   }
 
@@ -1191,6 +1193,19 @@ describe('Appointment/$hold', () => {
       resourceType: 'OperationOutcome',
       issue: [{ details: { text: 'No timezone specified' } }],
     });
+  });
+
+  test('errors when appointment is outside schedule planning horizon', async () => {
+    const schedule = await makeSchedule({
+      actor: practitioner1,
+      planningHorizon: { end: '2026-01-14T00:00:00Z' },
+    });
+    const response = await request
+      .post('/fhir/R4/Appointment/$hold')
+      .set('Authorization', `Bearer ${project.accessToken}`)
+      .send(holdParams({ schedule, start: '2026-01-15T14:00:00Z', end: '2026-01-15T15:00:00Z' }));
+    expect(response.status).toBe(400);
+    expect(response.body.issue[0].details.text).toBe('Appointment falls outside schedule planning horizon');
   });
 });
 

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -588,6 +588,24 @@ export async function validateAllAvailability(
     const end = latest(slots.map((slot) => new Date(slot.end)));
     assert(start && end);
     const interval = { start, end };
+
+    if (schedule.planningHorizon?.start) {
+      const horizonStart = new Date(schedule.planningHorizon.start);
+      if (interval.start < horizonStart) {
+        throw new OperationOutcomeError(
+          badRequest('Appointment falls outside schedule planning horizon', getPath(schedule))
+        );
+      }
+    }
+    if (schedule.planningHorizon?.end) {
+      const horizonEnd = new Date(schedule.planningHorizon.end);
+      if (interval.end > horizonEnd) {
+        throw new OperationOutcomeError(
+          badRequest('Appointment falls outside schedule planning horizon', getPath(schedule))
+        );
+      }
+    }
+
     await validateAvailability(repo, healthcareService, schedule, parameters, interval);
   }
 

--- a/packages/server/src/util/date.ts
+++ b/packages/server/src/util/date.ts
@@ -6,6 +6,8 @@
  * Largely following `date-fns` API design
  */
 
+type NonEmptyArray<T> = [T, ...T[]];
+
 export type Interval = {
   start: Date;
   end: Date;
@@ -40,6 +42,8 @@ export function clamp(date: Date, interval: Interval): Date {
   return date;
 }
 
+export function earliest(dates: NonEmptyArray<Date>): Date;
+export function earliest(dates: Date[]): Date | undefined;
 export function earliest(dates: Date[]): Date | undefined {
   let min: Date | undefined;
   for (const date of dates) {
@@ -50,6 +54,8 @@ export function earliest(dates: Date[]): Date | undefined {
   return min;
 }
 
+export function latest(dates: NonEmptyArray<Date>): Date;
+export function latest(dates: Date[]): Date | undefined;
 export function latest(dates: Date[]): Date | undefined {
   let max: Date | undefined;
   for (const date of dates) {


### PR DESCRIPTION
- In `$find` we can use this to reduce our search space for available slots early on, potentially saving some effort. We avoid returning appointment results that are outside of the planning horizon for any requested calendar.
- In `$book` and `$hold`, we validate that the proposed appointment is not outside the planning horizon.
- We add some minor touchups to Provider UI to handle errors and empty results in $find.
- If the schedule doesn't define `planningHorizon.start` or `planningHorizon.end`, the relevant checks are skipped. (As though the planning horizon extends in that direction indefinitely).

Resolves #8432