### PR TITLE
Scheduling: default availability to "always"

### DIFF
--- a/packages/docs/docs/scheduling/defining-availability.md
+++ b/packages/docs/docs/scheduling/defining-availability.md
@@ -248,8 +248,7 @@ Here is an example of a [Schedule](/docs/api/fhir/resources/schedule) resource t
 
 ### `availability` Extension
 
-The `availability` sub-extension mirrors the FHIR R5+ [`Availability`](https://hl7.org/fhir/R5/metadatatypes.html#Availability) datatype shape.  It is encoded using nested R4 extensions (because R4 does not have a native `Availability` data type).  This is close to the R4 definition of `HealthcareService.availabileTime`, which is another possible source of scheduling availability data.
-If this sub-extension is not present, availability is constrained only by the presence of existing `Slot` resources for the schedule.
+The `availability` sub-extension mirrors the FHIR R5+ [`Availability`](https://hl7.org/fhir/R5/metadatatypes.html#Availability) datatype shape.  It is encoded using nested R4 extensions (because R4 does not have a native `Availability` data type).  This is close to the R4 definition of `HealthcareService.availabileTime`, which is another possible source of scheduling availability data. If this sub-extension is not present, availability is constrained only by the presence of existing `Slot` resources for the schedule.
 
 | Sub-extension         | Type          | Description                                          | Repeatable |
 | --------------------- | ------------- | ---------------------------------------------------- | ---------- |

--- a/packages/docs/docs/scheduling/defining-availability.md
+++ b/packages/docs/docs/scheduling/defining-availability.md
@@ -249,6 +249,7 @@ Here is an example of a [Schedule](/docs/api/fhir/resources/schedule) resource t
 ### `availability` Extension
 
 The `availability` sub-extension mirrors the FHIR R5+ [`Availability`](https://hl7.org/fhir/R5/metadatatypes.html#Availability) datatype shape.  It is encoded using nested R4 extensions (because R4 does not have a native `Availability` data type).  This is close to the R4 definition of `HealthcareService.availabileTime`, which is another possible source of scheduling availability data.
+If this sub-extension is not present, availability is constrained only by the presence of existing `Slot` resources for the schedule.
 
 | Sub-extension         | Type          | Description                                          | Repeatable |
 | --------------------- | ------------- | ---------------------------------------------------- | ---------- |

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.test.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.test.ts
@@ -20,12 +20,12 @@ describe('parseSchedulingParametersExtensions', () => {
     meta: { project: project.id },
   };
 
-  test('minimally specified extension sets default values', () => {
-    const service: WithId<HealthcareService> = {
-      resourceType: 'HealthcareService',
-      id: 'hs-12345',
-    };
+  const service: WithId<HealthcareService> = {
+    resourceType: 'HealthcareService',
+    id: 'hs-12345',
+  };
 
+  test('minimally specified extension sets default values', () => {
     const schedule: Schedule = {
       resourceType: 'Schedule',
       meta: { project: project.id },
@@ -39,20 +39,6 @@ describe('parseSchedulingParametersExtensions', () => {
             { url: 'duration', valueDuration: { unit: 'h', value: 2 } },
             // `service` is required to have exactly one entry
             { url: 'service', valueReference: createReference(service) },
-            // `availability` is required to have at least one entry
-            {
-              url: 'availability',
-              extension: [
-                {
-                  url: 'availableTime',
-                  extension: [
-                    { url: 'daysOfWeek', valueCode: 'mon' },
-                    { url: 'availableStartTime', valueTime: '09:00:00' },
-                    { url: 'availableEndTime', valueTime: '17:00:00' },
-                  ],
-                },
-              ],
-            },
           ],
         },
       ],
@@ -62,9 +48,9 @@ describe('parseSchedulingParametersExtensions', () => {
       {
         availability: [
           {
-            dayOfWeek: ['mon'],
-            availableStartTime: '09:00:00',
-            availableEndTime: '17:00:00',
+            dayOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+            availableStartTime: '00:00:00',
+            availableEndTime: '00:00:00',
           },
         ],
         bufferBefore: 0,
@@ -79,11 +65,6 @@ describe('parseSchedulingParametersExtensions', () => {
   });
 
   test('with all the options', () => {
-    const service: WithId<HealthcareService> = {
-      resourceType: 'HealthcareService',
-      id: 'hs-12345',
-    };
-
     const schedule: Schedule = {
       resourceType: 'Schedule',
       meta: { project: project.id },
@@ -158,11 +139,6 @@ describe('parseSchedulingParametersExtensions', () => {
   });
 
   describe('with availability extension', () => {
-    const service: WithId<HealthcareService> = {
-      resourceType: 'HealthcareService',
-      id: 'hs-12345',
-    };
-
     test('basic start/end time pair parses to correct availability', () => {
       const schedule: Schedule = {
         resourceType: 'Schedule',
@@ -371,24 +347,6 @@ describe('parseSchedulingParametersExtensions', () => {
         "Scheduling parameter attribute 'availability' is not allowed on HealthcareService"
       );
     });
-  });
-
-  test('missing required availability', () => {
-    const schedule: Schedule = {
-      resourceType: 'Schedule',
-      meta: { project: project.id },
-      actor: [createReference(practitioner)],
-      extension: [
-        {
-          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-          extension: [{ url: 'duration', valueDuration: { unit: 'h', value: 2 } }],
-        },
-      ],
-    };
-
-    expect(() => parseSchedulingParametersExtensions(withPath(schedule, 'Schedule'))).toThrow(
-      "Required scheduling parameter attribute 'availability' is missing"
-    );
   });
 
   test('missing required duration', () => {
@@ -601,7 +559,7 @@ describe('parseSchedulingParametersExtensions', () => {
     });
 
     test('availability is not required on HealthcareService', () => {
-      // No availableTime on resource, no availability in extension — should not throw
+      // No availableTime on resource, no availability in extension — should default to "always available"
       const hs: HealthcareService = {
         resourceType: 'HealthcareService',
         id: 'hs-123',
@@ -613,7 +571,13 @@ describe('parseSchedulingParametersExtensions', () => {
       expect(() => parseSchedulingParametersExtensions(withPath(hs, 'HealthcareService'))).not.toThrow();
       expect(parseSchedulingParametersExtensions(withPath(hs, 'HealthcareService'))).toMatchObject([
         {
-          availability: [],
+          availability: [
+            {
+              dayOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+              availableStartTime: '00:00:00',
+              availableEndTime: '00:00:00',
+            },
+          ],
           service: { reference: 'HealthcareService/hs-123' },
           duration: 30,
         },

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { badRequest, createReference, EMPTY, isDefined, OperationOutcomeError } from '@medplum/core';
+import { badRequest, createReference, isDefined, OperationOutcomeError } from '@medplum/core';
 import type {
   Extension,
   HealthcareService,
@@ -98,6 +98,12 @@ export type SchedulingParameters = {
   timezone?: string;
 };
 
+const alwaysAvailable: SchedulingParametersAvailability = {
+  dayOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+  availableStartTime: '00:00:00',
+  availableEndTime: '00:00:00',
+};
+
 function isReferenceTo<T extends Resource>(reference: Reference<T>, resource: WithId<T>): boolean {
   if (!reference.reference) {
     return false;
@@ -141,15 +147,6 @@ function atMostOne<T extends object>(arr: WithPath<T>[], attribute: string): Wit
     );
   }
   return arr[0];
-}
-
-function atLeastOne<T>(arr: T[], attribute: string, options: { path?: string }): T[] {
-  if (arr.length < 1) {
-    throw new OperationOutcomeError(
-      badRequest(`Required scheduling parameter attribute '${attribute}' is missing`, options.path)
-    );
-  }
-  return arr;
 }
 
 function exactlyOne<T extends object>(arr: WithPath<T>[], attribute: string, options: { path?: string }): WithPath<T> {
@@ -394,23 +391,31 @@ export function parseSchedulingParametersExtensions(
   // each extension on the resource
   const resourceParameters: Partial<SchedulingParameters> = {};
   if (resource.resourceType === 'HealthcareService') {
-    resourceParameters.availability = (resource.availableTime ?? EMPTY).map(extractAvailability).filter(isDefined);
+    if (resource.availableTime) {
+      resourceParameters.availability = resource.availableTime.map(extractAvailability).filter(isDefined);
+    } else {
+      // if no availability constraint exists, default to "always available"
+      resourceParameters.availability = [alwaysAvailable];
+    }
   }
 
   return extensions.map((extension) => {
     const path = getPath(extension);
     const duration = exactlyOne(getExtensions(extension, 'duration'), 'duration', { path });
 
-    // `availability` is required in Schedule, and not allowed in
-    // HealthcareService (where we read from availableTime instead).
+    let availability: SchedulingParametersAvailability[];
     const rawAvailability = getExtensions(extension, 'availability');
     if (resource.resourceType === 'Schedule') {
-      atLeastOne(rawAvailability, 'availability', { path });
+      if (rawAvailability.length) {
+        availability = rawAvailability.flatMap(extractAvailabilityR4);
+      } else {
+        // if no availability constraint exists, default to "always available"
+        availability = [alwaysAvailable];
+      }
     } else {
       exactlyZero(rawAvailability, 'availability', resource.resourceType);
+      availability = resourceParameters.availability ?? [];
     }
-
-    const availability = resourceParameters.availability ?? rawAvailability.flatMap(extractAvailabilityR4);
 
     const bufferBefore = atMostOne(getExtensions(extension, 'bufferBefore'), 'bufferBefore');
     const bufferAfter = atMostOne(getExtensions(extension, 'bufferAfter'), 'bufferAfter');

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -98,6 +98,9 @@ export type SchedulingParameters = {
   timezone?: string;
 };
 
+// FHIR Convention: when end <= start, the end time is interpreted as being in
+// the following day.  So 00:00:00 -> 00:00:00 on all 7 days means 24/7
+// availability.
 const alwaysAvailable: SchedulingParametersAvailability = {
   dayOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
   availableStartTime: '00:00:00',
@@ -391,6 +394,9 @@ export function parseSchedulingParametersExtensions(
   // each extension on the resource
   const resourceParameters: Partial<SchedulingParameters> = {};
   if (resource.resourceType === 'HealthcareService') {
+    // Note: `resource.availableTime` could be explicitly set to `[]`, in which
+    // case we interpret this as "no availability" instead of falling back to
+    // the default "always available"
     if (resource.availableTime) {
       resourceParameters.availability = resource.availableTime.map(extractAvailability).filter(isDefined);
     } else {


### PR DESCRIPTION
In the original spec and our documentation, we listed the "availability" sub-extension as an optional constraint. When not present, we should treat it as though there is no additional availability constraint (aka 24/7 availability).

The first implementation treated this sub-extension as required. In this PR we loosen that constraint to match the spec and docs.