### PR TITLE
Update some docs "admonitions"

### DIFF
--- a/packages/docs/docs/access/access-policies.md
+++ b/packages/docs/docs/access/access-policies.md
@@ -554,7 +554,7 @@ Binary resources cannot use compartment-based access controls. They require expl
 }
 ```
 
-:::caution Binary Security Context
+:::caution[Binary Security Context]
 
 `Binary` resources cannot use compartment-based access controls. Access is restricted by matching the `securityContext` field to the patient. When creating a `Binary` in a patient context, always set `securityContext` to the patient reference — otherwise the patient will not be able to access it:
 

--- a/packages/docs/docs/api/fhir/operations/conceptmap-import.md
+++ b/packages/docs/docs/api/fhir/operations/conceptmap-import.md
@@ -36,7 +36,7 @@ This operation requires **admin privileges**. You must be a project admin (`Proj
 | `url`     | `uri`     | The canonical URL of the ConceptMap to import into        | No<sup>*</sup>      |
 | `mapping` | `complex` | One or more mappings to import (see structure below)      | Yes      |
 
-::: note
+:::note
 <sup>*</sup> Either the instance ID in the URL or the `url` parameter must be provided.
 :::
 

--- a/packages/docs/docs/integration/health-gorilla/sending-orders.md
+++ b/packages/docs/docs/integration/health-gorilla/sending-orders.md
@@ -327,7 +327,7 @@ Orders progress through several states:
    - Cannot be reactivated
    - Set by the client application
 
-::: caution
+:::caution
 
 Important: Once an order becomes `active`, it cannot be modified in the lab's system, even if updated in Medplum.
 


### PR DESCRIPTION
Some things that prevented a couple admonitions from rendering nicely in our docs:

- In a couple places there was a rogue space between the `:::` sigil and the admonition type that prevented the admonition from rendering nicely.

- In one place we were still using the old style of Admonition title (`:::caution Title Text`) instead of the stricter format Docusaurus v3 requires (`:::caution[Title Text]`).