### PR TITLE
docs(agent): add docs page for `Agent/$upgrade`

### DIFF
--- a/packages/docs/docs/agent/bulk-status.md
+++ b/packages/docs/docs/agent/bulk-status.md
@@ -177,6 +177,14 @@ Some useful search parameters are:
 - `status`
 - `_count` and `_offset`
 
+:::note[Default page size]
+
+When `_count` is omitted, the operation queries the status of at most the **default page of 20 agents** — it does _not_ automatically run against every matching agent. The maximum allowed `_count` is `100`. To cover more agents than fit on one page, use `_count` and `_offset` to page through the results (see the paging recipe below).
+
+:::
+
+> For more recipes and details on selecting operation targets, see [Using Agent search parameters in bulk operations](./using-search-parameters.md).
+
 ### Recipes
 
 Getting the status for one agent by name:
@@ -185,7 +193,7 @@ Getting the status for one agent by name:
 medplum get 'Agent/$bulk-status?name=Test+Agent+1'
 ```
 
-Getting the status of all active agents:
+Getting the status of active agents (using the `status=active` search parameter to select the operation targets; without a `_count`, this acts on at most the default page of 20 agents):
 
 ```bash
 medplum get 'Agent/$bulk-status?status=active'

--- a/packages/docs/docs/agent/fetch-logs.md
+++ b/packages/docs/docs/agent/fetch-logs.md
@@ -32,9 +32,13 @@ For example:
 medplum get 'Agent/$fetch-logs?_tag=Group+A'
 ```
 
+Here, `_tag=Group+A` is an `Agent` search parameter used to select which agents to fetch logs from. For example, to fetch logs from all active agents use `status=active`. See [Using Agent search parameters in bulk operations](./using-search-parameters.md) for more ways to select operation targets.
+
 ## Parameters
 
 - `limit` (optional; default: `20`): Maximum number of log entries to return per agent
+
+> The parameter above configures _how_ logs are fetched. To select _which_ agents to fetch logs from when using the multi-agent endpoint, use `Agent` search parameters — see [Using Agent search parameters in bulk operations](./using-search-parameters.md).
 
 ## Single Agent Response
 
@@ -193,6 +197,12 @@ Some useful search parameters are:
 - `status`
 - `_count` and `_offset`
 
+:::note[Default page size]
+
+When `_count` is omitted, the operation fetches logs from at most the **default page of 20 agents** — it does _not_ automatically run against every matching agent. The maximum allowed `_count` is `100`. To cover more agents than fit on one page, use `_count` and `_offset` to page through the results (see [Paging Through Agent Logs](#paging-through-agent-logs)).
+
+:::
+
 ## Recipes
 
 ### Single Agent by ID
@@ -221,7 +231,7 @@ medplum get 'Agent/$fetch-logs?identifier=agent-007'
 
 ### Multiple Agents by Name
 
-Fetch logs from all agents with a specific name prefix:
+Fetch logs from agents with a specific name prefix (without a `_count`, this acts on at most the default page of 20 agents):
 
 ```bash
 medplum get 'Agent/$fetch-logs?name=Production+Agent'
@@ -229,7 +239,7 @@ medplum get 'Agent/$fetch-logs?name=Production+Agent'
 
 ### Multiple Agents by Status
 
-Fetch logs from all active agents:
+Fetch logs from active agents (without a `_count`, this acts on at most the default page of 20 agents):
 
 ```bash
 medplum get 'Agent/$fetch-logs?status=active'
@@ -237,7 +247,7 @@ medplum get 'Agent/$fetch-logs?status=active'
 
 ### Multiple Agents with Limit
 
-Fetch logs from all agents, limited to 5 entries per agent:
+Fetch logs from the matched agents, limited to 5 entries per agent (without a `_count`, this acts on at most the default page of 20 agents):
 
 ```bash
 medplum get 'Agent/$fetch-logs?limit=5'

--- a/packages/docs/docs/agent/stats.md
+++ b/packages/docs/docs/agent/stats.md
@@ -32,6 +32,8 @@ For example:
 medplum get 'Agent/$stats?_tag=Group+A'
 ```
 
+Here, `_tag=Group+A` is an `Agent` search parameter used to select which agents to fetch stats from. For example, to fetch stats from all active agents use `status=active`. See [Using Agent search parameters in bulk operations](./using-search-parameters.md) for more ways to select operation targets.
+
 ## Single Agent Response
 
 When querying a single agent by ID, the response is a `Parameters` resource containing the stats payload.
@@ -179,6 +181,14 @@ Some useful search parameters are:
 - `status`
 - `_count` and `_offset`
 
+:::note[Default page size]
+
+When `_count` is omitted, the operation fetches stats from at most the **default page of 20 agents** — it does _not_ automatically run against every matching agent. The maximum allowed `_count` is `100`. To cover more agents than fit on one page, use `_count` and `_offset` to page through the results (see [Paging Through Agent Stats](#paging-through-agent-stats)).
+
+:::
+
+> For more recipes and details on selecting operation targets, see [Using Agent search parameters in bulk operations](./using-search-parameters.md).
+
 ## Recipes
 
 ### Single Agent by ID
@@ -199,7 +209,7 @@ medplum get 'Agent/$stats?identifier=agent-007'
 
 ### Multiple Agents by Name
 
-Fetch stats from all agents with a specific name prefix:
+Fetch stats from agents with a specific name prefix (without a `_count`, this acts on at most the default page of 20 agents):
 
 ```bash
 medplum get 'Agent/$stats?name=Production+Agent'
@@ -207,7 +217,7 @@ medplum get 'Agent/$stats?name=Production+Agent'
 
 ### Multiple Agents by Status
 
-Fetch stats from all active agents:
+Fetch stats from active agents (without a `_count`, this acts on at most the default page of 20 agents):
 
 ```bash
 medplum get 'Agent/$stats?status=active'

--- a/packages/docs/docs/agent/upgrade.md
+++ b/packages/docs/docs/agent/upgrade.md
@@ -38,11 +38,15 @@ For example:
 medplum get 'Agent/$upgrade?status=active'
 ```
 
+Here, `status=active` is an `Agent` search parameter used to select which agents to upgrade. See [Using Agent search parameters in bulk operations](./using-search-parameters.md) for more ways to select operation targets.
+
 ## Parameters
 
 - `version` (optional; default: latest published version): The version to upgrade the agent(s) to. When omitted, the agent upgrades to the latest available version.
 - `timeout` (optional; default: `45000`, max: `56000`): How long, in milliseconds, the server waits for the agent to acknowledge the upgrade request before returning an error. Values above the maximum are clamped to `56000`.
 - `force` (optional; default: `false`): When `true`, instructs the agent to upgrade even if it is already running the requested version.
+
+> The parameters above configure _how_ the upgrade runs. To select _which_ agents to upgrade when using the multi-agent endpoint, use `Agent` search parameters — see [Using Agent search parameters in bulk operations](./using-search-parameters.md).
 
 ## Single Agent Response
 
@@ -202,6 +206,12 @@ Some useful search parameters are:
 - `status`
 - `_count` and `_offset`
 
+:::note[Default page size]
+
+When `_count` is omitted, the operation upgrades at most the **default page of 20 agents** — it does _not_ automatically run against every matching agent. The maximum allowed `_count` is `100`. To upgrade more agents than fit on one page, use `_count` and `_offset` to page through the results (see [Paging Through Agents](#paging-through-agents)).
+
+:::
+
 ## Recipes
 
 ### Single Agent by ID
@@ -230,7 +240,7 @@ medplum get 'Agent/$upgrade?identifier=agent-007'
 
 ### Multiple Agents by Name
 
-Upgrade all agents with a specific name prefix:
+Upgrade agents with a specific name prefix (without a `_count`, this acts on at most the default page of 20 agents):
 
 ```bash
 medplum get 'Agent/$upgrade?name=Production+Agent'
@@ -238,7 +248,7 @@ medplum get 'Agent/$upgrade?name=Production+Agent'
 
 ### Multiple Agents by Status
 
-Upgrade all active agents:
+Upgrade active agents (without a `_count`, this acts on at most the default page of 20 agents):
 
 ```bash
 medplum get 'Agent/$upgrade?status=active'

--- a/packages/docs/docs/agent/upgrade.md
+++ b/packages/docs/docs/agent/upgrade.md
@@ -1,0 +1,276 @@
+---
+sidebar_position: 14
+---
+
+# Agent Upgrade
+
+Remotely upgrades the Medplum Agent software for a given agent or agents. Useful for rolling out new agent versions without needing physical or remote access to the host machine running the agent.
+
+:::info[Minimum versions]
+
+The `$upgrade` operation requires **Medplum Server > 3.1.9** and **Medplum Agent > 3.1.10**. See the [feature matrix](./features.md) for more details.
+
+:::
+
+## Invoke the `$upgrade` operation
+
+### Single Agent
+
+```
+[base]/Agent/[id]/$upgrade
+```
+
+For example:
+
+```bash
+medplum get 'Agent/[id]/$upgrade'
+```
+
+### Multiple Agents
+
+```
+[base]/Agent/$upgrade
+```
+
+For example:
+
+```bash
+medplum get 'Agent/$upgrade?status=active'
+```
+
+## Parameters
+
+- `version` (optional; default: latest published version): The version to upgrade the agent(s) to. When omitted, the agent upgrades to the latest available version.
+- `timeout` (optional; default: `45000`, max: `56000`): How long, in milliseconds, the server waits for the agent to acknowledge the upgrade request before returning an error. Values above the maximum are clamped to `56000`.
+- `force` (optional; default: `false`): When `true`, instructs the agent to upgrade even if it is already running the requested version.
+
+## Single Agent Response
+
+When invoking the operation on a single agent by ID, the response is the result of the upgrade request for that agent, either an `OperationOutcome` or `Parameters` resource.
+
+### Valid Response
+
+Example response when the agent accepts the upgrade request:
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "id": "ok",
+  "issue": [
+    {
+      "severity": "information",
+      "code": "informational",
+      "details": {
+        "text": "All OK"
+      }
+    }
+  ]
+}
+```
+
+## Multi-Agent Response
+
+When invoking the operation without an ID (querying multiple agents via search parameters), the response is a `Bundle` of `Parameters`. Each `Parameters` within the `Bundle` contains an `agent` and a `result`, which is the result of calling the `$upgrade` operation on that `Agent`, either a `Parameters` or `OperationOutcome` resource.
+
+### Valid Response
+
+Example response for multiple agents:
+
+```json
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Parameters",
+        "parameter": [
+          {
+            "name": "agent",
+            "resource": {
+              "resourceType": "Agent",
+              "name": "Test Agent 1",
+              "status": "active",
+              "id": "93f8b2fb-65a3-4977-a175-71b73b26fde7",
+              "meta": {
+                "versionId": "e182201a-6925-467f-a92b-496193fb4c39",
+                "lastUpdated": "2024-04-19T20:29:25.087Z"
+              }
+            }
+          },
+          {
+            "name": "result",
+            "resource": {
+              "resourceType": "OperationOutcome",
+              "id": "ok",
+              "issue": [
+                {
+                  "severity": "information",
+                  "code": "informational",
+                  "details": {
+                    "text": "All OK"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Parameters",
+        "parameter": [
+          {
+            "name": "agent",
+            "resource": {
+              "resourceType": "Agent",
+              "name": "Test Agent 2",
+              "status": "active",
+              "id": "a1b2c3d4-5e6f-7890-abcd-ef1234567890",
+              "meta": {
+                "versionId": "f293201a-6925-467f-a92b-496193fb4c39",
+                "lastUpdated": "2024-04-19T20:29:25.087Z"
+              }
+            }
+          },
+          {
+            "name": "result",
+            "resource": {
+              "resourceType": "OperationOutcome",
+              "issue": [
+                {
+                  "severity": "error",
+                  "code": "exception",
+                  "details": {
+                    "text": "Timeout"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+### Invalid Response
+
+Example outcome when no agents match the given query:
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [
+    {
+      "severity": "error",
+      "code": "invalid",
+      "details": {
+        "text": "No agent(s) for given query"
+      }
+    }
+  ]
+}
+```
+
+Example outcome when exceeding max `_count` limit:
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [
+    {
+      "severity": "error",
+      "code": "invalid",
+      "details": {
+        "text": "'_count' of 101 is greater than max of 100"
+      }
+    }
+  ]
+}
+```
+
+## Using search parameters
+
+All of the `Agent` search parameters can be used to select which agents to upgrade when using the multi-agent endpoint.
+
+Some useful search parameters are:
+
+- `name`
+- `status`
+- `_count` and `_offset`
+
+## Recipes
+
+### Single Agent by ID
+
+Upgrade a specific agent to the latest version:
+
+```bash
+medplum get 'Agent/93f8b2fb-65a3-4977-a175-71b73b26fde7/$upgrade'
+```
+
+### Single Agent to a Specific Version
+
+Upgrade a specific agent to a pinned version:
+
+```bash
+medplum get 'Agent/93f8b2fb-65a3-4977-a175-71b73b26fde7/$upgrade?version=3.1.10'
+```
+
+### Single Agent by Identifier
+
+Upgrade a specific agent by identifier:
+
+```bash
+medplum get 'Agent/$upgrade?identifier=agent-007'
+```
+
+### Multiple Agents by Name
+
+Upgrade all agents with a specific name prefix:
+
+```bash
+medplum get 'Agent/$upgrade?name=Production+Agent'
+```
+
+### Multiple Agents by Status
+
+Upgrade all active agents:
+
+```bash
+medplum get 'Agent/$upgrade?status=active'
+```
+
+### Force an Upgrade
+
+Upgrade an agent even if it is already running the requested version:
+
+```bash
+medplum get 'Agent/93f8b2fb-65a3-4977-a175-71b73b26fde7/$upgrade?version=3.1.10&force=true'
+```
+
+### Setting a Custom Timeout
+
+Wait up to 30 seconds for the agent to acknowledge the upgrade request:
+
+```bash
+medplum get 'Agent/93f8b2fb-65a3-4977-a175-71b73b26fde7/$upgrade?timeout=30000'
+```
+
+### Paging Through Agents
+
+Upgrade agents in batches, 50 agents at a time:
+
+```bash
+medplum get 'Agent/$upgrade?_count=50&_offset=0'
+medplum get 'Agent/$upgrade?_count=50&_offset=50'
+```
+
+:::tip[CLI]
+
+You can also invoke this operation using the Medplum CLI's [`agent upgrade` command](./agent-cli-commands.md#upgrade-command).
+
+:::

--- a/packages/docs/docs/agent/using-search-parameters.md
+++ b/packages/docs/docs/agent/using-search-parameters.md
@@ -1,0 +1,122 @@
+---
+sidebar_position: 9
+---
+
+# Using Agent Search Parameters in Bulk Operations
+
+Several of the Medplum Agent operations can act on more than one agent at a time. Instead of targeting a single agent by ID, you invoke the operation against the `Agent` _type_ endpoint and use `Agent` search parameters to select which agents the operation should run against.
+
+This page collects common "recipes" for selecting agents with search parameters, so you don't have to look up the same query patterns on each individual operation page.
+
+## Operations that support search parameters
+
+The following operations accept `Agent` search parameters to select their operation targets when invoked against the type-level endpoint (`[base]/Agent/$operation`):
+
+- [`$bulk-status`](./bulk-status.md)
+- [`$fetch-logs`](./fetch-logs.md)
+- [`$stats`](./stats.md)
+- [`$upgrade`](./upgrade.md)
+
+In each case, the operation is run against _every_ agent matched by the query, and the response is a `Bundle` of `Parameters`, one entry per matched agent.
+
+:::info[Single vs. multiple agents]
+
+The `$status` operation is single-agent only and does **not** accept search parameters. To query the status of multiple agents at once, use [`$bulk-status`](./bulk-status.md).
+
+:::
+
+## Available `Agent` search parameters
+
+The `Agent` resource defines the following resource-specific search parameters:
+
+- `name` — the agent's name (string search; matches by prefix)
+- `identifier` — an `Agent.identifier` (token search)
+- `status` — the agent's status, e.g. `active` or `off` (token search)
+
+In addition, the standard "global" search parameters apply, including:
+
+- `_id` — the agent's logical ID
+- `_tag` — a tag on `Agent.meta.tag`
+- `_lastUpdated` — when the agent resource was last updated
+- `_count` and `_offset` — for paging through large result sets
+
+:::note[Default and maximum page size]
+
+When `_count` is omitted, these operations act on at most the **default page size of 20 agents** — they do _not_ automatically run against every matching agent. The maximum allowed `_count` is `100`; requesting a larger `_count` returns an `OperationOutcome` error. To operate on more agents than fit on a single page, use `_count` and `_offset` to page through the results — see [Paging through agents](#paging-through-agents) below.
+
+:::
+
+## Recipes
+
+The recipes below use [`$bulk-status`](./bulk-status.md) as an example, but the same query patterns work for any operation that supports search parameters — just swap in the operation you want to run (`$fetch-logs`, `$stats`, `$upgrade`, etc.).
+
+### All active agents
+
+Select agents whose status is `active` — the most common multi-agent query. Note that without a `_count`, this acts on at most the default page of 20 agents (see [Paging through agents](#paging-through-agents) to cover more):
+
+```bash
+medplum get 'Agent/$bulk-status?status=active'
+```
+
+### Agents matching a name prefix
+
+Select all agents whose name starts with a given prefix:
+
+```bash
+medplum get 'Agent/$bulk-status?name=Production+Agent'
+```
+
+### Agents with a given tag
+
+Select all agents tagged with a particular value (useful for grouping agents by site, region, or deployment group):
+
+```bash
+medplum get 'Agent/$bulk-status?_tag=Group+A'
+```
+
+### Combining search parameters
+
+Search parameters can be combined to narrow the selection. For example, all `active` agents in `Group A`:
+
+```bash
+medplum get 'Agent/$bulk-status?status=active&_tag=Group+A'
+```
+
+### Paging through agents
+
+When operating on a large number of agents, page through them in batches using `_count` and `_offset`:
+
+```bash
+medplum get 'Agent/$bulk-status?_count=50&_offset=0'
+medplum get 'Agent/$bulk-status?_count=50&_offset=50'
+```
+
+## Targeting a single agent by name or identifier
+
+In addition to selecting an agent by its logical ID (`[base]/Agent/[id]/$operation`), you can target a single agent against the type-level endpoint by using a search parameter that you expect to be unique, most commonly `name` or `identifier`:
+
+```bash
+medplum get 'Agent/$bulk-status?name=Test+Agent+1'
+```
+
+```bash
+medplum get 'Agent/$fetch-logs?identifier=agent-007'
+```
+
+:::caution[These are conventions, not guarantees]
+
+Using `name` or `identifier` to target a "single" agent is only a convention. Neither `name` nor `identifier` is required to be unique across agents in a project — if the same name or identifier is shared by multiple agents, the operation will match and run against **all** of them, and the response will be a `Bundle` with an entry for each matched agent rather than a single result.
+
+If you need to operate on exactly one specific agent, target it by its logical ID instead:
+
+```bash
+medplum get 'Agent/93f8b2fb-65a3-4977-a175-71b73b26fde7/$bulk-status'
+```
+
+:::
+
+:::tip[CLI]
+
+Many of these operations can also be invoked using the Medplum CLI. See the [agent CLI commands](./agent-cli-commands.md) for details.
+
+:::


### PR DESCRIPTION
Adds docs for the `Agent/$upgrade` operation. Apparently we skipped this operation but had docs for using it via CLI