### PR TITLE
ci(build): make build job fail when sonar fails to run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -341,7 +341,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: SonarCloud Scan
         if: ${{ matrix.node-version == 22 && matrix.pg-version == 14 && matrix.redis-version == 7 }}
-        continue-on-error: true
         uses: SonarSource/sonarqube-scan-action@9598b8a83feef37de07f549027fab50ecffe6a6e # master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When Sonar fails to run, we get a silent failure because `continue-on-error: true` is set for the step. This means the job in the matrix that actually runs Sonar passes whenever there is a transient error, and the Sonar required check gets stuck, requiring a total rerun of the entire Build workflow.

This PR will fail just the job that is running Sonar, which means we can granularly retry just that one job in the whole workflow