### PR TITLE
feat(email): implement project-level SMTP configuration for sending emails

### DIFF
--- a/packages/docs/docs/self-hosting/project-settings.md
+++ b/packages/docs/docs/self-hosting/project-settings.md
@@ -58,22 +58,4 @@ The supported options that can be specified by a Super Admin in `Project.systemS
 
 ## Project SMTP
 
-Projects can send email through their own SMTP relay instead of the server-wide email provider. This applies to all project-scoped emails, both the [send email endpoint](/docs/sdk/core.medplumclient.sendemail) and system-generated emails (user invites, password resets, email verification, and MFA reset notifications) for users scoped to the project. The content of system-generated emails remains server-controlled; only the transport and sender address are project-configurable.
-
-Project SMTP is configured by a Project Admin with the following `Project.secret` entries:
-
-| Secret name           | Type    | Required | Description                                                                                     |
-| --------------------- | ------- | -------- | ----------------------------------------------------------------------------------------------- |
-| `smtpHost`            | string  | yes      | SMTP relay hostname. Setting this activates project SMTP for all project-scoped emails.        |
-| `smtpPort`            | integer | yes      | SMTP relay port                                                                                  |
-| `smtpUsername`        | string  | yes      | SMTP username                                                                                    |
-| `smtpPassword`        | string  | yes      | SMTP password                                                                                    |
-| `smtpSecure`          | boolean | no       | Use TLS when connecting. If not specified, inferred from `smtpPort === 465`.                    |
-| `smtpFromAddress`     | string  | no       | Default from address for emails sent through this relay                                          |
-| `smtpApprovedSenders` | string  | no       | Comma-separated list of email addresses allowed as the from address                              |
-
-When project SMTP is active, the from address is resolved as follows. If the caller specifies a from address, it must appear in `smtpApprovedSenders` to be used. Otherwise, the email is sent from `smtpFromAddress`, falling back to the server `supportEmail` if neither is set. The server-level `approvedSenderEmails` list is only consulted when sending through the server transport.
-
-If `smtpHost` is set but any required entry is missing or invalid, email sending for the project fails with an error rather than silently falling back to the server transport. This prevents system emails from being sent through an unintended transport with the wrong sender domain.
-
-Operators can disable project SMTP fleet-wide by setting `allowProjectSmtp` to `false` in the server config. When disabled, all emails use the server-wide email provider regardless of project secrets.
+Projects can send email through their own SMTP relay instead of the server-wide email provider, configured via `Project.secret` entries. See [Project SMTP](/docs/user-management/project-smtp) for the full configuration reference. Operators can disable this fleet-wide with the [`allowProjectSmtp`](/docs/self-hosting/server-config#allowprojectsmtp) server config setting.

--- a/packages/docs/docs/self-hosting/project-settings.md
+++ b/packages/docs/docs/self-hosting/project-settings.md
@@ -55,3 +55,25 @@ The supported options that can be specified by a Super Admin in `Project.systemS
 | `enableFhirQuota`              | boolean | If true, the totalFhirQuota limit will be enforced, returning `429 Too Many Requests` errors when the limit is exceeded over a minute. Please note that as of `v4.1.6`, FHIR quotas are enabled by default.                               | true    |
 | `searchOnReader`               | boolean | If true, FHIR search requests (except in batch requests) are served by the reader database pool if available                                                                                                                              | false   |
 | `redactAuditEvents`            | boolean | If true, remove human-readable detail strings from AuditEvent resources saved to the database and logs                                                                                                                                    | false   |
+
+## Project SMTP
+
+Projects can send email through their own SMTP relay instead of the server-wide email provider. This applies to all project-scoped emails, both the [send email endpoint](/docs/sdk/core.medplumclient.sendemail) and system-generated emails (user invites, password resets, email verification, and MFA reset notifications) for users scoped to the project. The content of system-generated emails remains server-controlled; only the transport and sender address are project-configurable.
+
+Project SMTP is configured by a Project Admin with the following `Project.secret` entries:
+
+| Secret name           | Type    | Required | Description                                                                                     |
+| --------------------- | ------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `smtpHost`            | string  | yes      | SMTP relay hostname. Setting this activates project SMTP for all project-scoped emails.        |
+| `smtpPort`            | integer | yes      | SMTP relay port                                                                                  |
+| `smtpUsername`        | string  | yes      | SMTP username                                                                                    |
+| `smtpPassword`        | string  | yes      | SMTP password                                                                                    |
+| `smtpSecure`          | boolean | no       | Use TLS when connecting. If not specified, inferred from `smtpPort === 465`.                    |
+| `smtpFromAddress`     | string  | no       | Default from address for emails sent through this relay                                          |
+| `smtpApprovedSenders` | string  | no       | Comma-separated list of email addresses allowed as the from address                              |
+
+When project SMTP is active, the from address is resolved as follows. If the caller specifies a from address, it must appear in `smtpApprovedSenders` to be used. Otherwise, the email is sent from `smtpFromAddress`, falling back to the server `supportEmail` if neither is set. The server-level `approvedSenderEmails` list is only consulted when sending through the server transport.
+
+If `smtpHost` is set but any required entry is missing or invalid, email sending for the project fails with an error rather than silently falling back to the server transport. This prevents system emails from being sent through an unintended transport with the wrong sender domain.
+
+Operators can disable project SMTP fleet-wide by setting `allowProjectSmtp` to `false` in the server config. When disabled, all emails use the server-wide email provider regardless of project secrets.

--- a/packages/docs/docs/self-hosting/server-config.md
+++ b/packages/docs/docs/self-hosting/server-config.md
@@ -324,7 +324,7 @@ Optional email provider setting. Can be one of: `'none'`, `'awsses'`, `'smtp'`.
 
 ### allowProjectSmtp
 
-Optional flag to allow projects to send email through their own SMTP relay, configured via `Project.secret` entries. See [Project SMTP](/docs/self-hosting/project-settings#project-smtp) for more details. Set to `false` to force all emails through the server-wide email provider.
+Optional flag to allow projects to send email through their own SMTP relay, configured via `Project.secret` entries. See [Project SMTP](/docs/user-management/project-smtp) for more details. Set to `false` to force all emails through the server-wide email provider.
 
 **Default:** `true`
 

--- a/packages/docs/docs/self-hosting/server-config.md
+++ b/packages/docs/docs/self-hosting/server-config.md
@@ -322,6 +322,12 @@ Optional email provider setting. Can be one of: `'none'`, `'awsses'`, `'smtp'`.
 
 **Default:** `'awsses'` if in AWS, otherwise `'none'`
 
+### allowProjectSmtp
+
+Optional flag to allow projects to send email through their own SMTP relay, configured via `Project.secret` entries. See [Project SMTP](/docs/self-hosting/project-settings#project-smtp) for more details. Set to `false` to force all emails through the server-wide email provider.
+
+**Default:** `true`
+
 ### bullmq
 
 Optional BullMQ configuration.

--- a/packages/docs/docs/self-hosting/server-config.md
+++ b/packages/docs/docs/self-hosting/server-config.md
@@ -316,6 +316,12 @@ Optional SMTP email settings to use SMTP for email. See [Sending SMTP Emails](/d
 
 **Default:** None
 
+#### smtp.secure
+
+Optional flag to use TLS when connecting to the SMTP relay (TLS-on-connect, as opposed to STARTTLS upgrade). Set to `true` for relays using implicit TLS, typically on port 465.
+
+**Default:** `false`
+
 ### emailProvider
 
 Optional email provider setting. Can be one of: `'none'`, `'awsses'`, `'smtp'`.

--- a/packages/docs/docs/user-management/custom-emails.mdx
+++ b/packages/docs/docs/user-management/custom-emails.mdx
@@ -17,7 +17,7 @@ The two main email messages are:
 
 Medplum fully supports creating a white-label experience where users do not see any Medplum branding. That includes overriding all email behavior.
 
-This document describes the steps to send custom email messages.
+This document describes the steps to send custom email messages. To send emails through your own SMTP relay and sender domain without customizing content, see [Project SMTP](/docs/user-management/project-smtp); the two features can be combined.
 
 :::info[]
 

--- a/packages/docs/docs/user-management/project-smtp.md
+++ b/packages/docs/docs/user-management/project-smtp.md
@@ -29,7 +29,13 @@ When project SMTP is active, the from address is resolved as follows. If the cal
 
 ## Failure behavior
 
-If `smtpHost` is set but any required entry is missing or invalid, email sending for the project fails with an error rather than silently falling back to the server transport. This prevents system emails from being sent through an unintended transport with the wrong sender domain. Make sure all four required entries are present and valid before relying on project SMTP.
+If `smtpHost` is set but any required entry is missing or invalid, email sending for the project fails with an error rather than silently falling back to the server transport. This prevents system emails from being sent through an unintended transport with the wrong sender domain.
+
+:::warning
+
+A misconfigured project SMTP setup blocks **all** project-scoped emails, including password reset and email verification, until the secrets are corrected. Users who request a password reset during that window will not receive an email. After adding or changing the secrets, verify the configuration with a test send via the [`sendEmail`](/docs/sdk/core.medplumclient.sendemail) API before relying on it.
+
+:::
 
 ## Self-hosting
 

--- a/packages/docs/docs/user-management/project-smtp.md
+++ b/packages/docs/docs/user-management/project-smtp.md
@@ -20,14 +20,12 @@ Project SMTP is configured by a Project Admin using [`Project.secret`](/docs/sel
 | `smtpUsername`        | string  | yes      | SMTP username                                                                             |
 | `smtpPassword`        | string  | yes      | SMTP password                                                                             |
 | `smtpSecure`          | boolean | no       | Use TLS when connecting. If not specified, inferred from `smtpPort === 465`.             |
-| `smtpFromAddress`     | string  | no       | Default from address for emails sent through this relay                                   |
+| `smtpFromAddress`     | string  | yes      | Default from address for emails sent through this relay                                   |
 | `smtpApprovedSenders` | string  | no       | Comma-separated list of email addresses allowed as the from address                       |
 
 ## From address resolution
 
-When project SMTP is active, the from address is resolved as follows. If the caller specifies a from address, it must appear in `smtpApprovedSenders` to be used. Otherwise, the email is sent from `smtpFromAddress`, falling back to the server support email if neither is set. The server-level approved sender list is only consulted when sending through the server transport.
-
-Setting `smtpFromAddress` is strongly recommended. If it is omitted, emails fall back to the server support address, which your relay's SPF/DKIM records likely do not cover, causing authentication failures or rejected mail.
+When project SMTP is active, emails are sent from `smtpFromAddress` by default. If the caller specifies a from address, it must appear in `smtpApprovedSenders` to be used; otherwise the project's default from address is used instead. The server-level approved sender list is only consulted when sending through the server transport.
 
 ## Failure behavior
 

--- a/packages/docs/docs/user-management/project-smtp.md
+++ b/packages/docs/docs/user-management/project-smtp.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 11
+tags: [auth]
+---
+
+# Project SMTP
+
+By default, all emails sent on behalf of your project use the Medplum server's email provider and sender address. Projects can instead send email through their own SMTP relay (such as SendGrid, Mailgun, or Amazon SES SMTP) so that emails arrive from your own domain.
+
+Project SMTP applies to all project-scoped emails. This includes emails sent via the [`sendEmail`](/docs/sdk/core.medplumclient.sendemail) API and system-generated emails for project-scoped users: user invites, password resets, email verification, and MFA reset notifications. The content of system-generated emails remains controlled by the Medplum server; project SMTP changes the transport and sender address. To customize email content, see [Custom Emails](/docs/user-management/custom-emails).
+
+## Configuration
+
+Project SMTP is configured by a Project Admin using [`Project.secret`](/docs/self-hosting/project-settings) entries. In the Medplum App, go to **Project Admin** → **Project** → **Secrets** and add the following entries:
+
+| Secret name           | Type    | Required | Description                                                                              |
+| --------------------- | ------- | -------- | ---------------------------------------------------------------------------------------- |
+| `smtpHost`            | string  | yes      | SMTP relay hostname. Setting this activates project SMTP for all project-scoped emails. |
+| `smtpPort`            | integer | yes      | SMTP relay port                                                                           |
+| `smtpUsername`        | string  | yes      | SMTP username                                                                             |
+| `smtpPassword`        | string  | yes      | SMTP password                                                                             |
+| `smtpSecure`          | boolean | no       | Use TLS when connecting. If not specified, inferred from `smtpPort === 465`.             |
+| `smtpFromAddress`     | string  | no       | Default from address for emails sent through this relay                                   |
+| `smtpApprovedSenders` | string  | no       | Comma-separated list of email addresses allowed as the from address                       |
+
+## From address resolution
+
+When project SMTP is active, the from address is resolved as follows. If the caller specifies a from address, it must appear in `smtpApprovedSenders` to be used. Otherwise, the email is sent from `smtpFromAddress`, falling back to the server support email if neither is set. The server-level approved sender list is only consulted when sending through the server transport.
+
+## Failure behavior
+
+If `smtpHost` is set but any required entry is missing or invalid, email sending for the project fails with an error rather than silently falling back to the server transport. This prevents system emails from being sent through an unintended transport with the wrong sender domain. Make sure all four required entries are present and valid before relying on project SMTP.
+
+## Self-hosting
+
+Self-hosted operators can disable project SMTP fleet-wide by setting [`allowProjectSmtp`](/docs/self-hosting/server-config#allowprojectsmtp) to `false` in the server config. When disabled, all emails use the server-wide email provider regardless of project secrets.

--- a/packages/docs/docs/user-management/project-smtp.md
+++ b/packages/docs/docs/user-management/project-smtp.md
@@ -27,6 +27,8 @@ Project SMTP is configured by a Project Admin using [`Project.secret`](/docs/sel
 
 When project SMTP is active, the from address is resolved as follows. If the caller specifies a from address, it must appear in `smtpApprovedSenders` to be used. Otherwise, the email is sent from `smtpFromAddress`, falling back to the server support email if neither is set. The server-level approved sender list is only consulted when sending through the server transport.
 
+Setting `smtpFromAddress` is strongly recommended. If it is omitted, emails fall back to the server support address, which your relay's SPF/DKIM records likely do not cover, causing authentication failures or rejected mail.
+
 ## Failure behavior
 
 If `smtpHost` is set but any required entry is missing or invalid, email sending for the project fails with an error rather than silently falling back to the server transport. This prevents system emails from being sent through an unintended transport with the wrong sender domain.

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -437,7 +437,7 @@ async function sendInviteEmail(
     ].join('\n');
   }
   try {
-    await sendEmail(systemRepo, options);
+    await sendEmail(systemRepo, options, request.project);
   } catch (err) {
     // A common error for new self-hosted Medplum servers is that SES is not configured.
     // A long time ago, we made the mistake of establishing a convention of HTTP 200 + OperationOutcome for this case.

--- a/packages/server/src/admin/project.ts
+++ b/packages/server/src/admin/project.ts
@@ -204,18 +204,22 @@ projectAdminRouter.post('/:projectId/members/:membershipId/mfa/reset', async (re
   });
 
   if (user.email) {
-    await sendEmail(systemRepo, {
-      to: user.email,
-      subject: 'Your multi-factor authentication has been reset',
-      text: [
-        `Hello ${user.firstName ?? user.email},`,
-        '',
-        'A project administrator has reset your multi-factor authentication (MFA) enrollment.',
-        'You will need to re-enroll the next time you sign in.',
-        '',
-        'If you did not expect this change, please contact your administrator immediately.',
-      ].join('\n'),
-    });
+    await sendEmail(
+      systemRepo,
+      {
+        to: user.email,
+        subject: 'Your multi-factor authentication has been reset',
+        text: [
+          `Hello ${user.firstName ?? user.email},`,
+          '',
+          'A project administrator has reset your multi-factor authentication (MFA) enrollment.',
+          'You will need to re-enroll the next time you sign in.',
+          '',
+          'If you did not expect this change, please contact your administrator immediately.',
+        ].join('\n'),
+      },
+      ctx.project
+    );
   }
 
   sendOutcome(res, allOk);

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { NewUserRequest, WithId } from '@medplum/core';
 import { badRequest, concatUrls, normalizeOperationOutcome } from '@medplum/core';
-import type { ClientApplication, Login, User } from '@medplum/fhirtypes';
+import type { ClientApplication, Login, Project, User } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import { body } from 'express-validator';
 import { pwnedPassword } from 'hibp';
@@ -133,21 +133,26 @@ async function sendVerificationEmail(user: WithId<User>, login: WithId<Login>): 
   const { id, secret } = await verifyEmail(user, redirectUri);
   const url = concatUrls(getConfig().appBaseUrl, `verifyemail/${id}/${secret}`);
   const systemRepo = getGlobalSystemRepo();
-  await sendEmail(systemRepo, {
-    to: user.email,
-    subject: 'Medplum Email Verification',
-    text: [
-      'We received a request to create a Medplum account using this email address.',
-      '',
-      'Please click the following link to verify your email address:',
-      '',
-      url,
-      '',
-      'If you received this in error, you can safely ignore it.',
-      '',
-      'Thank you,',
-      'Medplum',
-      '',
-    ].join('\n'),
-  });
+  const project = user.project ? await systemRepo.readReference<Project>(user.project) : undefined;
+  await sendEmail(
+    systemRepo,
+    {
+      to: user.email,
+      subject: 'Medplum Email Verification',
+      text: [
+        'We received a request to create a Medplum account using this email address.',
+        '',
+        'Please click the following link to verify your email address:',
+        '',
+        url,
+        '',
+        'If you received this in error, you can safely ignore it.',
+        '',
+        'Thank you,',
+        'Medplum',
+        '',
+      ].join('\n'),
+    },
+    project
+  );
 }

--- a/packages/server/src/auth/resetpassword.test.ts
+++ b/packages/server/src/auth/resetpassword.test.ts
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
 import { createReference, getReferenceString, Operator, resolveId } from '@medplum/core';
-import type { DomainConfiguration, UserSecurityRequest } from '@medplum/fhirtypes';
+import type { DomainConfiguration, Project, User, UserSecurityRequest } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import { pwnedPassword } from 'hibp';
 import { simpleParser } from 'mailparser';
 import fetch from 'node-fetch';
+import type { Transporter } from 'nodemailer';
+import nodemailer from 'nodemailer';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { getConfig, loadTestConfig } from '../config/loader';
@@ -166,6 +168,56 @@ describe('Reset Password', () => {
 
     const parsed = await simpleParser(args.Content.Raw.Data);
     expect(parsed.subject).toBe('Medplum Password Reset');
+  });
+
+  test('Project-scoped user uses project SMTP', async () => {
+    const email = `project-smtp-${randomUUID()}@example.com`;
+    const sendMail = jest.fn().mockResolvedValue({ messageId: '123' });
+    const createTransportSpy = jest.spyOn(nodemailer, 'createTransport');
+    createTransportSpy.mockReturnValue({ sendMail } as unknown as Transporter);
+
+    try {
+      const project = await withTestContext(async () => {
+        const project = await systemRepo.createResource<Project>({
+          resourceType: 'Project',
+          name: 'Project SMTP Reset Project',
+          secret: [
+            { name: 'smtpHost', valueString: 'smtp.project.example.com' },
+            { name: 'smtpPort', valueInteger: 587 },
+            { name: 'smtpUsername', valueString: 'projectuser' },
+            { name: 'smtpPassword', valueString: 'projectpass' },
+            { name: 'smtpFromAddress', valueString: 'support@project.example.com' },
+          ],
+        });
+        await systemRepo.createResource<User>({
+          resourceType: 'User',
+          meta: { project: project.id },
+          firstName: 'Reset',
+          lastName: 'Reset',
+          email,
+          passwordHash: 'abc',
+          project: createReference(project),
+        });
+        return project;
+      });
+
+      const res = await request(app).post('/auth/resetpassword').type('json').send({
+        email,
+        projectId: project.id,
+        recaptchaToken: 'xyz',
+      });
+      expect(res.status).toBe(200);
+
+      expect(createTransportSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ host: 'smtp.project.example.com', port: 587 })
+      );
+      expect(sendMail).toHaveBeenCalledTimes(1);
+      expect(sendMail.mock.calls[0][0].from).toBe('support@project.example.com');
+      expect(SESv2Client).not.toHaveBeenCalled();
+      expect(SendEmailCommand).not.toHaveBeenCalled();
+    } finally {
+      createTransportSpy.mockRestore();
+    }
   });
 
   test('External auth', async () => {

--- a/packages/server/src/auth/resetpassword.ts
+++ b/packages/server/src/auth/resetpassword.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Filter } from '@medplum/core';
 import { allOk, badRequest, concatUrls, createReference, Operator, resolveId } from '@medplum/core';
-import type { User, UserSecurityRequest } from '@medplum/fhirtypes';
+import type { Project, User, UserSecurityRequest } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import { body } from 'express-validator';
 import { getConfig } from '../config/loader';
@@ -71,23 +71,28 @@ export async function resetPasswordHandler(req: Request, res: Response): Promise
   const url = await resetPassword(systemRepo, user, 'reset', req.body.redirectUri);
 
   if (req.body.sendEmail !== false) {
-    await sendEmail(systemRepo, {
-      to: user.email,
-      subject: 'Medplum Password Reset',
-      text: [
-        'Someone requested to reset your Medplum password.',
-        '',
-        'Please click on the following link:',
-        '',
-        url,
-        '',
-        'If you received this in error, you can safely ignore it.',
-        '',
-        'Thank you,',
-        'Medplum',
-        '',
-      ].join('\n'),
-    });
+    const project = user.project ? await systemRepo.readReference<Project>(user.project) : undefined;
+    await sendEmail(
+      systemRepo,
+      {
+        to: user.email,
+        subject: 'Medplum Password Reset',
+        text: [
+          'Someone requested to reset your Medplum password.',
+          '',
+          'Please click on the following link:',
+          '',
+          url,
+          '',
+          'If you received this in error, you can safely ignore it.',
+          '',
+          'Thank you,',
+          'Medplum',
+          '',
+        ].join('\n'),
+      },
+      project
+    );
   }
 
   sendOutcome(res, allOk);

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -55,6 +55,8 @@ export interface MedplumServerConfig {
   backgroundJobsRedis?: MedplumRedisConfig;
   emailProvider?: 'none' | 'awsses' | 'smtp';
   smtp?: MedplumSmtpConfig;
+  /** Allow projects to configure their own SMTP transport via Project.secret entries. Default is `true`. */
+  allowProjectSmtp?: boolean;
   bullmq?: MedplumBullmqConfig;
   googleClientId?: string;
   googleClientSecret?: string;
@@ -276,6 +278,8 @@ export interface MedplumSmtpConfig {
   port: number;
   username: string;
   password: string;
+  /** Use TLS when connecting. If not specified, inferred from `port === 465`. */
+  secure?: boolean;
 }
 
 export interface MedplumBullmqConfig {

--- a/packages/server/src/email/email.test.ts
+++ b/packages/server/src/email/email.test.ts
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
+import type { WithId } from '@medplum/core';
 import { ContentType, getReferenceString } from '@medplum/core';
+import type { Project, ProjectSetting } from '@medplum/fhirtypes';
 import type { AwsClientStub } from 'aws-sdk-client-mock';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
@@ -330,5 +332,156 @@ describe('Email', () => {
     expect(mockSESv2Client.send.callCount).toBe(0);
 
     config.smtp = undefined;
+  });
+
+  describe('Project SMTP', () => {
+    let sendMail: jest.Mock;
+    let createTransportSpy: jest.SpyInstance;
+
+    function makeProject(secrets: ProjectSetting[]): WithId<Project> {
+      return { resourceType: 'Project', id: randomUUID(), secret: secrets };
+    }
+
+    const baseSecrets: ProjectSetting[] = [
+      { name: 'smtpHost', valueString: 'smtp.project.example.com' },
+      { name: 'smtpPort', valueInteger: 587 },
+      { name: 'smtpUsername', valueString: 'projectuser' },
+      { name: 'smtpPassword', valueString: 'projectpass' },
+    ];
+
+    beforeEach(() => {
+      sendMail = jest.fn().mockResolvedValue({ messageId: '123' });
+      createTransportSpy = jest.spyOn(nodemailer, 'createTransport');
+      createTransportSpy.mockClear();
+      createTransportSpy.mockReturnValue({ sendMail });
+    });
+
+    afterEach(() => {
+      createTransportSpy.mockRestore();
+      getConfig().allowProjectSmtp = undefined;
+      getConfig().smtp = undefined;
+    });
+
+    test('Uses project SMTP transport when configured', async () => {
+      const project = makeProject(baseSecrets);
+      await sendEmail(systemRepo, { to: 'alice@example.com', subject: 'Hello', text: 'Hello Alice' }, project);
+
+      expect(createTransportSpy).toHaveBeenCalledTimes(1);
+      expect(createTransportSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host: 'smtp.project.example.com',
+          port: 587,
+          secure: false,
+          auth: { user: 'projectuser', pass: 'projectpass' },
+        })
+      );
+      expect(sendMail).toHaveBeenCalledTimes(1);
+      expect(mockSESv2Client.send.callCount).toBe(0);
+    });
+
+    test('Infers secure for port 465', async () => {
+      const project = makeProject([
+        { name: 'smtpHost', valueString: 'smtp.project.example.com' },
+        { name: 'smtpPort', valueInteger: 465 },
+        { name: 'smtpUsername', valueString: 'projectuser' },
+        { name: 'smtpPassword', valueString: 'projectpass' },
+      ]);
+      await sendEmail(systemRepo, { to: 'alice@example.com', subject: 'Hello', text: 'Hello Alice' }, project);
+
+      expect(createTransportSpy).toHaveBeenCalledWith(expect.objectContaining({ port: 465, secure: true }));
+    });
+
+    test('Explicit smtpSecure overrides port inference', async () => {
+      const project = makeProject([
+        { name: 'smtpHost', valueString: 'smtp.project.example.com' },
+        { name: 'smtpPort', valueInteger: 465 },
+        { name: 'smtpUsername', valueString: 'projectuser' },
+        { name: 'smtpPassword', valueString: 'projectpass' },
+        { name: 'smtpSecure', valueBoolean: false },
+      ]);
+      await sendEmail(systemRepo, { to: 'alice@example.com', subject: 'Hello', text: 'Hello Alice' }, project);
+
+      expect(createTransportSpy).toHaveBeenCalledWith(expect.objectContaining({ port: 465, secure: false }));
+    });
+
+    test('From address approved by project sender list', async () => {
+      const project = makeProject([
+        ...baseSecrets,
+        { name: 'smtpFromAddress', valueString: 'default@project.example.com' },
+        { name: 'smtpApprovedSenders', valueString: 'sender@project.example.com' },
+      ]);
+      await sendEmail(
+        systemRepo,
+        { from: 'sender@project.example.com', to: 'alice@example.com', subject: 'Hello', text: 'Hello Alice' },
+        project
+      );
+
+      expect(sendMail).toHaveBeenCalledTimes(1);
+      expect(sendMail.mock.calls[0][0].from).toBe('sender@project.example.com');
+    });
+
+    test('Server-approved sender not accepted under project list', async () => {
+      const project = makeProject([
+        ...baseSecrets,
+        { name: 'smtpFromAddress', valueString: 'default@project.example.com' },
+        { name: 'smtpApprovedSenders', valueString: 'sender@project.example.com' },
+      ]);
+      // 'no-reply@example.com' is the server-approved sender, but not in the project list
+      await sendEmail(
+        systemRepo,
+        { from: 'no-reply@example.com', to: 'alice@example.com', subject: 'Hello', text: 'Hello Alice' },
+        project
+      );
+
+      expect(sendMail).toHaveBeenCalledTimes(1);
+      expect(sendMail.mock.calls[0][0].from).toBe('default@project.example.com');
+    });
+
+    test('Falls back to support email when project has no from address', async () => {
+      const project = makeProject(baseSecrets);
+      await sendEmail(systemRepo, { to: 'alice@example.com', subject: 'Hello', text: 'Hello Alice' }, project);
+
+      expect(sendMail).toHaveBeenCalledTimes(1);
+      expect(sendMail.mock.calls[0][0].from).toBe(getConfig().supportEmail);
+    });
+
+    test('Falls back to server transport when project SMTP not configured', async () => {
+      getConfig().smtp = {
+        host: 'smtp.server.example.com',
+        port: 587,
+        username: 'serveruser',
+        password: 'serverpass',
+      };
+      const project = makeProject([{ name: 'OPENAI_API_KEY', valueString: 'unrelated' }]);
+      await sendEmail(systemRepo, { to: 'alice@example.com', subject: 'Hello', text: 'Hello Alice' }, project);
+
+      expect(createTransportSpy).toHaveBeenCalledWith(expect.objectContaining({ host: 'smtp.server.example.com' }));
+      expect(mockSESv2Client.send.callCount).toBe(0);
+    });
+
+    test('Misconfigured project SMTP fails loudly', async () => {
+      const project = makeProject([
+        { name: 'smtpHost', valueString: 'smtp.project.example.com' },
+        { name: 'smtpPort', valueInteger: 587 },
+        { name: 'smtpUsername', valueString: 'projectuser' },
+        // Missing smtpPassword
+      ]);
+      await expect(
+        sendEmail(systemRepo, { to: 'alice@example.com', subject: 'Hello', text: 'Hello Alice' }, project)
+      ).rejects.toThrow('Project SMTP configuration is incomplete or invalid');
+
+      expect(sendMail).not.toHaveBeenCalled();
+      expect(mockSESv2Client.send.callCount).toBe(0);
+    });
+
+    test('Kill-switch disables project SMTP', async () => {
+      getConfig().allowProjectSmtp = false;
+      const project = makeProject(baseSecrets);
+      await sendEmail(systemRepo, { to: 'alice@example.com', subject: 'Hello', text: 'Hello Alice' }, project);
+
+      // Falls through to AWS SES (the configured emailProvider)
+      expect(sendMail).not.toHaveBeenCalled();
+      expect(mockSESv2Client.send.callCount).toBe(1);
+    });
   });
 });

--- a/packages/server/src/email/email.test.ts
+++ b/packages/server/src/email/email.test.ts
@@ -348,6 +348,7 @@ describe('Email', () => {
       { name: 'smtpPort', valueInteger: 587 },
       { name: 'smtpUsername', valueString: 'projectuser' },
       { name: 'smtpPassword', valueString: 'projectpass' },
+      { name: 'smtpFromAddress', valueString: 'noreply@project.example.com' },
     ];
 
     beforeEach(() => {
@@ -386,6 +387,7 @@ describe('Email', () => {
         { name: 'smtpPort', valueInteger: 465 },
         { name: 'smtpUsername', valueString: 'projectuser' },
         { name: 'smtpPassword', valueString: 'projectpass' },
+        { name: 'smtpFromAddress', valueString: 'noreply@project.example.com' },
       ]);
       await sendEmail(systemRepo, { to: 'alice@example.com', subject: 'Hello', text: 'Hello Alice' }, project);
 
@@ -398,6 +400,7 @@ describe('Email', () => {
         { name: 'smtpPort', valueInteger: 465 },
         { name: 'smtpUsername', valueString: 'projectuser' },
         { name: 'smtpPassword', valueString: 'projectpass' },
+        { name: 'smtpFromAddress', valueString: 'noreply@project.example.com' },
         { name: 'smtpSecure', valueBoolean: false },
       ]);
       await sendEmail(systemRepo, { to: 'alice@example.com', subject: 'Hello', text: 'Hello Alice' }, project);
@@ -407,7 +410,10 @@ describe('Email', () => {
 
     test('From address approved by project sender list', async () => {
       const project = makeProject([
-        ...baseSecrets,
+        { name: 'smtpHost', valueString: 'smtp.project.example.com' },
+        { name: 'smtpPort', valueInteger: 587 },
+        { name: 'smtpUsername', valueString: 'projectuser' },
+        { name: 'smtpPassword', valueString: 'projectpass' },
         { name: 'smtpFromAddress', valueString: 'default@project.example.com' },
         { name: 'smtpApprovedSenders', valueString: 'sender@project.example.com' },
       ]);
@@ -423,7 +429,10 @@ describe('Email', () => {
 
     test('Server-approved sender not accepted under project list', async () => {
       const project = makeProject([
-        ...baseSecrets,
+        { name: 'smtpHost', valueString: 'smtp.project.example.com' },
+        { name: 'smtpPort', valueInteger: 587 },
+        { name: 'smtpUsername', valueString: 'projectuser' },
+        { name: 'smtpPassword', valueString: 'projectpass' },
         { name: 'smtpFromAddress', valueString: 'default@project.example.com' },
         { name: 'smtpApprovedSenders', valueString: 'sender@project.example.com' },
       ]);
@@ -438,12 +447,19 @@ describe('Email', () => {
       expect(sendMail.mock.calls[0][0].from).toBe('default@project.example.com');
     });
 
-    test('Falls back to support email when project has no from address', async () => {
-      const project = makeProject(baseSecrets);
-      await sendEmail(systemRepo, { to: 'alice@example.com', subject: 'Hello', text: 'Hello Alice' }, project);
+    test('Missing smtpFromAddress fails loudly', async () => {
+      const project = makeProject([
+        { name: 'smtpHost', valueString: 'smtp.project.example.com' },
+        { name: 'smtpPort', valueInteger: 587 },
+        { name: 'smtpUsername', valueString: 'projectuser' },
+        { name: 'smtpPassword', valueString: 'projectpass' },
+      ]);
+      await expect(
+        sendEmail(systemRepo, { to: 'alice@example.com', subject: 'Hello', text: 'Hello Alice' }, project)
+      ).rejects.toThrow('Project SMTP configuration is incomplete or invalid');
 
-      expect(sendMail).toHaveBeenCalledTimes(1);
-      expect(sendMail.mock.calls[0][0].from).toBe(getConfig().supportEmail);
+      expect(sendMail).not.toHaveBeenCalled();
+      expect(mockSESv2Client.send.callCount).toBe(0);
     });
 
     test('Falls back to server transport when project SMTP not configured', async () => {
@@ -465,6 +481,7 @@ describe('Email', () => {
         { name: 'smtpHost', valueString: 'smtp.project.example.com' },
         { name: 'smtpPort', valueInteger: 587 },
         { name: 'smtpUsername', valueString: 'projectuser' },
+        { name: 'smtpFromAddress', valueString: 'noreply@project.example.com' },
         // Missing smtpPassword
       ]);
       await expect(

--- a/packages/server/src/email/email.test.ts
+++ b/packages/server/src/email/email.test.ts
@@ -16,6 +16,7 @@ import { Readable } from 'stream';
 import { initAppServices, shutdownApp } from '../app';
 import { getConfig, loadTestConfig } from '../config/loader';
 import { getGlobalSystemRepo } from '../fhir/repo';
+import { globalLogger } from '../logger';
 import { getBinaryStorage } from '../storage/loader';
 import { withTestContext } from '../test.setup';
 import { sendEmail } from './email';
@@ -472,6 +473,30 @@ describe('Email', () => {
 
       expect(sendMail).not.toHaveBeenCalled();
       expect(mockSESv2Client.send.callCount).toBe(0);
+    });
+
+    test('Logs and rethrows on project SMTP send failure', async () => {
+      const loggerErrorSpy = jest.spyOn(globalLogger, 'error').mockImplementation(() => undefined);
+      sendMail.mockRejectedValue(new Error('Connection refused'));
+      const project = makeProject(baseSecrets);
+
+      try {
+        await expect(
+          sendEmail(systemRepo, { to: 'alice@example.com', subject: 'Hello', text: 'Hello Alice' }, project)
+        ).rejects.toThrow('Connection refused');
+
+        expect(loggerErrorSpy).toHaveBeenCalledWith(
+          'Project SMTP send failed',
+          expect.objectContaining({
+            projectId: project.id,
+            host: 'smtp.project.example.com',
+            port: 587,
+            err: 'Connection refused',
+          })
+        );
+      } finally {
+        loggerErrorSpy.mockRestore();
+      }
     });
 
     test('Kill-switch disables project SMTP', async () => {

--- a/packages/server/src/email/email.ts
+++ b/packages/server/src/email/email.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { EMPTY } from '@medplum/core';
-import type { Binary } from '@medplum/fhirtypes';
+import type { WithId } from '@medplum/core';
+import { EMPTY, normalizeErrorString } from '@medplum/core';
+import type { Binary, Project } from '@medplum/fhirtypes';
 import { createTransport } from 'nodemailer';
 import type Mail from 'nodemailer/lib/mailer';
 import { sendEmailViaSes } from '../cloud/aws/email';
@@ -10,7 +11,7 @@ import type { MedplumSmtpConfig } from '../config/types';
 import type { Repository } from '../fhir/repo';
 import { globalLogger } from '../logger';
 import { getBinaryStorage } from '../storage/loader';
-import { getFromAddress } from './utils';
+import { getFromAddress, getProjectSmtpConfig } from './utils';
 
 /**
  * Sends an email using the AWS SES service.
@@ -18,10 +19,12 @@ import { getFromAddress } from './utils';
  * See options here: https://nodemailer.com/extras/mailcomposer/
  * @param repo - The user repository.
  * @param options - The MailComposer options.
+ * @param project - Optional project for project-level SMTP configuration.
  */
-export async function sendEmail(repo: Repository, options: Mail.Options): Promise<void> {
+export async function sendEmail(repo: Repository, options: Mail.Options, project?: WithId<Project>): Promise<void> {
   const config = getConfig();
-  const fromAddress = getFromAddress(options);
+  const projectSmtp = project ? getProjectSmtpConfig(project) : undefined;
+  const fromAddress = getFromAddress(options, projectSmtp);
 
   options.from = fromAddress;
   options.sender = fromAddress;
@@ -34,9 +37,11 @@ export async function sendEmail(repo: Repository, options: Mail.Options): Promis
   // "if set to true then fails with an error when a node tries to load content from a file"
   options.disableFileAccess = true;
 
-  globalLogger.info('Sending email', { to: options.to, subject: options.subject });
+  globalLogger.info('Sending email', { to: options.to, subject: options.subject, projectId: project?.id });
 
-  if (config.smtp) {
+  if (projectSmtp) {
+    await sendEmailViaSmtp(projectSmtp, options, project);
+  } else if (config.smtp) {
     await sendEmailViaSmtp(config.smtp, options);
   } else if (config.emailProvider === 'awsses') {
     await sendEmailViaSes(options);
@@ -88,15 +93,33 @@ async function processAttachment(repo: Repository, attachment: Mail.Attachment):
  * Sends an email via SMTP.
  * @param smtpConfig - The SMTP configuration.
  * @param options - The nodemailer options.
+ * @param project - Optional project when using project-level SMTP configuration.
  */
-async function sendEmailViaSmtp(smtpConfig: MedplumSmtpConfig, options: Mail.Options): Promise<void> {
+async function sendEmailViaSmtp(
+  smtpConfig: MedplumSmtpConfig,
+  options: Mail.Options,
+  project?: WithId<Project>
+): Promise<void> {
   const transport = createTransport({
     host: smtpConfig.host,
     port: smtpConfig.port,
+    secure: smtpConfig.secure ?? smtpConfig.port === 465,
     auth: {
       user: smtpConfig.username,
       pass: smtpConfig.password,
     },
   });
-  await transport.sendMail(options);
+  try {
+    await transport.sendMail(options);
+  } catch (err) {
+    if (project) {
+      globalLogger.error('Project SMTP send failed', {
+        projectId: project.id,
+        host: smtpConfig.host,
+        port: smtpConfig.port,
+        err: normalizeErrorString(err),
+      });
+    }
+    throw err;
+  }
 }

--- a/packages/server/src/email/email.ts
+++ b/packages/server/src/email/email.ts
@@ -95,7 +95,11 @@ async function processAttachment(repo: Repository, attachment: Mail.Attachment):
  * @param options - The nodemailer options.
  * @param projectId - Optional project ID when using project-level SMTP configuration.
  */
-async function sendEmailViaSmtp(smtpConfig: MedplumSmtpConfig, options: Mail.Options, projectId?: string): Promise<void> {
+async function sendEmailViaSmtp(
+  smtpConfig: MedplumSmtpConfig,
+  options: Mail.Options,
+  projectId?: string
+): Promise<void> {
   const transport = createTransport({
     host: smtpConfig.host,
     port: smtpConfig.port,

--- a/packages/server/src/email/email.ts
+++ b/packages/server/src/email/email.ts
@@ -40,7 +40,7 @@ export async function sendEmail(repo: Repository, options: Mail.Options, project
   globalLogger.info('Sending email', { to: options.to, subject: options.subject, projectId: project?.id });
 
   if (projectSmtp) {
-    await sendEmailViaSmtp(projectSmtp, options, project);
+    await sendEmailViaSmtp(projectSmtp, options, project?.id);
   } else if (config.smtp) {
     await sendEmailViaSmtp(config.smtp, options);
   } else if (config.emailProvider === 'awsses') {
@@ -93,17 +93,13 @@ async function processAttachment(repo: Repository, attachment: Mail.Attachment):
  * Sends an email via SMTP.
  * @param smtpConfig - The SMTP configuration.
  * @param options - The nodemailer options.
- * @param project - Optional project when using project-level SMTP configuration.
+ * @param projectId - Optional project ID when using project-level SMTP configuration.
  */
-async function sendEmailViaSmtp(
-  smtpConfig: MedplumSmtpConfig,
-  options: Mail.Options,
-  project?: WithId<Project>
-): Promise<void> {
+async function sendEmailViaSmtp(smtpConfig: MedplumSmtpConfig, options: Mail.Options, projectId?: string): Promise<void> {
   const transport = createTransport({
     host: smtpConfig.host,
     port: smtpConfig.port,
-    secure: smtpConfig.secure ?? smtpConfig.port === 465,
+    secure: smtpConfig.secure,
     auth: {
       user: smtpConfig.username,
       pass: smtpConfig.password,
@@ -112,9 +108,9 @@ async function sendEmailViaSmtp(
   try {
     await transport.sendMail(options);
   } catch (err) {
-    if (project) {
+    if (projectId) {
       globalLogger.error('Project SMTP send failed', {
-        projectId: project.id,
+        projectId,
         host: smtpConfig.host,
         port: smtpConfig.port,
         err: normalizeErrorString(err),

--- a/packages/server/src/email/routes.test.ts
+++ b/packages/server/src/email/routes.test.ts
@@ -4,6 +4,8 @@ import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
 import { ContentType } from '@medplum/core';
 import express from 'express';
 import { simpleParser } from 'mailparser';
+import type { Transporter } from 'nodemailer';
+import nodemailer from 'nodemailer';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
@@ -86,6 +88,46 @@ describe('Email API Routes', () => {
     const parsed = await simpleParser(args.Content.Raw.Data);
     expect(parsed.subject).toBe('Subject');
     expect(parsed.text).toBe('Body\n');
+  });
+
+  test('Send email via project SMTP', async () => {
+    const sendMail = jest.fn().mockResolvedValue({ messageId: '123' });
+    const createTransportSpy = jest.spyOn(nodemailer, 'createTransport');
+    createTransportSpy.mockReturnValue({ sendMail } as unknown as Transporter);
+
+    try {
+      const accessToken = await initTestAuth({
+        membership: { admin: true },
+        project: {
+          secret: [
+            { name: 'smtpHost', valueString: 'smtp.project.example.com' },
+            { name: 'smtpPort', valueInteger: 587 },
+            { name: 'smtpUsername', valueString: 'projectuser' },
+            { name: 'smtpPassword', valueString: 'projectpass' },
+            { name: 'smtpFromAddress', valueString: 'support@project.example.com' },
+          ],
+        },
+      });
+      const res = await request(app)
+        .post(`/email/v1/send`)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Content-Type', ContentType.JSON)
+        .send({
+          to: 'alice@example.com',
+          subject: 'Subject',
+          text: 'Body',
+        });
+      expect(res.status).toBe(200);
+
+      expect(createTransportSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ host: 'smtp.project.example.com', port: 587, secure: false })
+      );
+      expect(sendMail).toHaveBeenCalledTimes(1);
+      expect(sendMail.mock.calls[0][0].from).toBe('support@project.example.com');
+      expect(SESv2Client).toHaveBeenCalledTimes(0);
+    } finally {
+      createTransportSpy.mockRestore();
+    }
   });
 
   test('Handle SES error', async () => {

--- a/packages/server/src/email/routes.ts
+++ b/packages/server/src/email/routes.ts
@@ -29,6 +29,6 @@ emailRouter.post('/send', sendEmailValidator, async (req: Request, res: Response
   }
 
   // Use the user repository to enforce permission checks on email attachments
-  await sendEmail(ctx.repo, req.body);
+  await sendEmail(ctx.repo, req.body, ctx.project);
   sendOutcome(res, allOk);
 });

--- a/packages/server/src/email/utils.ts
+++ b/packages/server/src/email/utils.ts
@@ -1,34 +1,91 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import { OperationOutcomeError, badRequest } from '@medplum/core';
+import type { Project } from '@medplum/fhirtypes';
 import MailComposer from 'nodemailer/lib/mail-composer/index.js';
 import type Mail from 'nodemailer/lib/mailer';
 import type { Address } from 'nodemailer/lib/mailer';
 import { getConfig } from '../config/loader';
+import type { MedplumSmtpConfig } from '../config/types';
 import { getLogger } from '../logger';
+
+export interface ProjectSmtpConfig extends MedplumSmtpConfig {
+  fromAddress?: string;
+  approvedSenderEmails?: string;
+}
+
+/**
+ * Returns the project-level SMTP configuration, if configured.
+ * Project SMTP is configured via Project.secret entries: smtpHost, smtpPort, smtpUsername, smtpPassword,
+ * and optionally smtpSecure, smtpFromAddress, and smtpApprovedSenders.
+ * @param project - The project to read SMTP configuration from.
+ * @returns The project SMTP configuration, or undefined if not configured or disabled by server config.
+ */
+export function getProjectSmtpConfig(project: WithId<Project>): ProjectSmtpConfig | undefined {
+  if (getConfig().allowProjectSmtp === false) {
+    return undefined;
+  }
+
+  const secrets = project.secret;
+  const host = secrets?.find((s) => s.name === 'smtpHost')?.valueString;
+  if (!host) {
+    // Project SMTP not configured - caller falls back to server transport
+    return undefined;
+  }
+
+  const port = secrets?.find((s) => s.name === 'smtpPort')?.valueInteger;
+  const username = secrets?.find((s) => s.name === 'smtpUsername')?.valueString;
+  const password = secrets?.find((s) => s.name === 'smtpPassword')?.valueString;
+  if (!port || port <= 0 || !username || !password) {
+    getLogger().warn('Project SMTP is misconfigured', {
+      projectId: project.id,
+      missing: [!port || port <= 0 ? 'smtpPort' : '', !username ? 'smtpUsername' : '', !password ? 'smtpPassword' : '']
+        .filter(Boolean)
+        .join(','),
+    });
+    throw new OperationOutcomeError(badRequest('Project SMTP configuration is incomplete or invalid'));
+  }
+
+  return {
+    host,
+    port,
+    username,
+    password,
+    secure: secrets?.find((s) => s.name === 'smtpSecure')?.valueBoolean ?? port === 465,
+    fromAddress: secrets?.find((s) => s.name === 'smtpFromAddress')?.valueString,
+    approvedSenderEmails: secrets?.find((s) => s.name === 'smtpApprovedSenders')?.valueString,
+  };
+}
 
 /**
  * Returns the from address to use.
  * If the user specified a from address, it must be an approved sender.
- * Otherwise uses the support email address.
+ * When project SMTP is active, approval is validated only against the project's approved sender list,
+ * and the project's default from address is used as the fallback.
+ * Otherwise uses the server approved sender list and the support email address.
  * @param options - The user specified nodemailer options.
+ * @param projectSmtp - Optional project SMTP configuration.
  * @returns The from address to use.
  */
-export function getFromAddress(options: Mail.Options): string {
+export function getFromAddress(options: Mail.Options, projectSmtp?: ProjectSmtpConfig): string {
   const config = getConfig();
+  const approvedSenderEmails = projectSmtp ? projectSmtp.approvedSenderEmails : config.approvedSenderEmails;
+  const defaultFrom = projectSmtp?.fromAddress ?? config.supportEmail;
 
   if (options.from) {
     const fromAddress = addressToString(options.from);
     const fromEmail = extractEmailFromAddress(fromAddress);
-    if (fromAddress && fromEmail && config.approvedSenderEmails?.split(',')?.includes(fromEmail)) {
+    if (fromAddress && fromEmail && approvedSenderEmails?.split(',')?.includes(fromEmail)) {
       return fromAddress;
     }
     getLogger().warn('Email from address is not an approved sender', {
       from: fromAddress,
-      approvedSenders: config.approvedSenderEmails,
+      usingProjectSmtp: Boolean(projectSmtp),
     });
   }
 
-  return config.supportEmail;
+  return defaultFrom;
 }
 
 /**

--- a/packages/server/src/email/utils.ts
+++ b/packages/server/src/email/utils.ts
@@ -42,7 +42,7 @@ export function getProjectSmtpConfig(project: WithId<Project>): ProjectSmtpConfi
       projectId: project.id,
       missing: [!port || port <= 0 ? 'smtpPort' : '', !username ? 'smtpUsername' : '', !password ? 'smtpPassword' : '']
         .filter(Boolean)
-        .join(','),
+        .join(', '),
     });
     throw new OperationOutcomeError(badRequest('Project SMTP configuration is incomplete or invalid'));
   }

--- a/packages/server/src/email/utils.ts
+++ b/packages/server/src/email/utils.ts
@@ -81,6 +81,7 @@ export function getFromAddress(options: Mail.Options, projectSmtp?: ProjectSmtpC
     }
     getLogger().warn('Email from address is not an approved sender', {
       from: fromAddress,
+      approvedSenders: approvedSenderEmails,
       usingProjectSmtp: Boolean(projectSmtp),
     });
   }

--- a/packages/server/src/email/utils.ts
+++ b/packages/server/src/email/utils.ts
@@ -11,14 +11,14 @@ import type { MedplumSmtpConfig } from '../config/types';
 import { getLogger } from '../logger';
 
 export interface ProjectSmtpConfig extends MedplumSmtpConfig {
-  fromAddress?: string;
+  fromAddress: string;
   approvedSenderEmails?: string;
 }
 
 /**
  * Returns the project-level SMTP configuration, if configured.
  * Project SMTP is configured via Project.secret entries: smtpHost, smtpPort, smtpUsername, smtpPassword,
- * and optionally smtpSecure, smtpFromAddress, and smtpApprovedSenders.
+ * smtpFromAddress, and optionally smtpSecure and smtpApprovedSenders.
  * @param project - The project to read SMTP configuration from.
  * @returns The project SMTP configuration, or undefined if not configured or disabled by server config.
  */
@@ -30,17 +30,22 @@ export function getProjectSmtpConfig(project: WithId<Project>): ProjectSmtpConfi
   const secrets = project.secret;
   const host = secrets?.find((s) => s.name === 'smtpHost')?.valueString;
   if (!host) {
-    // Project SMTP not configured - caller falls back to server transport
     return undefined;
   }
 
   const port = secrets?.find((s) => s.name === 'smtpPort')?.valueInteger;
   const username = secrets?.find((s) => s.name === 'smtpUsername')?.valueString;
   const password = secrets?.find((s) => s.name === 'smtpPassword')?.valueString;
-  if (!port || port <= 0 || !username || !password) {
+  const fromAddress = secrets?.find((s) => s.name === 'smtpFromAddress')?.valueString;
+  if (!port || port <= 0 || !username || !password || !fromAddress) {
     getLogger().warn('Project SMTP is misconfigured', {
       projectId: project.id,
-      missing: [!port || port <= 0 ? 'smtpPort' : '', !username ? 'smtpUsername' : '', !password ? 'smtpPassword' : '']
+      missing: [
+        !port || port <= 0 ? 'smtpPort' : '',
+        !username ? 'smtpUsername' : '',
+        !password ? 'smtpPassword' : '',
+        !fromAddress ? 'smtpFromAddress' : '',
+      ]
         .filter(Boolean)
         .join(', '),
     });
@@ -53,7 +58,7 @@ export function getProjectSmtpConfig(project: WithId<Project>): ProjectSmtpConfi
     username,
     password,
     secure: secrets?.find((s) => s.name === 'smtpSecure')?.valueBoolean ?? port === 465,
-    fromAddress: secrets?.find((s) => s.name === 'smtpFromAddress')?.valueString,
+    fromAddress,
     approvedSenderEmails: secrets?.find((s) => s.name === 'smtpApprovedSenders')?.valueString,
   };
 }
@@ -62,7 +67,7 @@ export function getProjectSmtpConfig(project: WithId<Project>): ProjectSmtpConfi
  * Returns the from address to use.
  * If the user specified a from address, it must be an approved sender.
  * When project SMTP is active, approval is validated only against the project's approved sender list,
- * and the project's default from address is used as the fallback.
+ * and the project's `fromAddress` is used as the default (guaranteed to be set).
  * Otherwise uses the server approved sender list and the support email address.
  * @param options - The user specified nodemailer options.
  * @param projectSmtp - Optional project SMTP configuration.
@@ -71,7 +76,7 @@ export function getProjectSmtpConfig(project: WithId<Project>): ProjectSmtpConfi
 export function getFromAddress(options: Mail.Options, projectSmtp?: ProjectSmtpConfig): string {
   const config = getConfig();
   const approvedSenderEmails = projectSmtp ? projectSmtp.approvedSenderEmails : config.approvedSenderEmails;
-  const defaultFrom = projectSmtp?.fromAddress ?? config.supportEmail;
+  const defaultFrom = projectSmtp ? projectSmtp.fromAddress : config.supportEmail;
 
   if (options.from) {
     const fromAddress = addressToString(options.from);

--- a/packages/server/src/email/utils.ts
+++ b/packages/server/src/email/utils.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { OperationOutcomeError, badRequest } from '@medplum/core';
+import { OperationOutcomeError, serverError } from '@medplum/core';
 import type { Project } from '@medplum/fhirtypes';
 import MailComposer from 'nodemailer/lib/mail-composer/index.js';
 import type Mail from 'nodemailer/lib/mailer';
@@ -44,7 +44,7 @@ export function getProjectSmtpConfig(project: WithId<Project>): ProjectSmtpConfi
         .filter(Boolean)
         .join(', '),
     });
-    throw new OperationOutcomeError(badRequest('Project SMTP configuration is incomplete or invalid'));
+    throw new OperationOutcomeError(serverError(new Error('Project SMTP configuration is incomplete or invalid')));
   }
 
   return {

--- a/packages/server/src/fhir/operations/update-user-email.ts
+++ b/packages/server/src/fhir/operations/update-user-email.ts
@@ -104,23 +104,27 @@ async function updateUser(userId: string, params: InputParams, project: WithId<P
       const { id, secret } = await verifyEmail(user);
       const url = concatUrls(getConfig().appBaseUrl, `verifyemail/${id}/${secret}`);
 
-      await sendEmail(systemRepo, {
-        to: params.email,
-        subject: 'Medplum Email Address Updated',
-        text: [
-          'We received a request to update the email address associated with your Medplum account.',
-          '',
-          'Please click on the following link to verify your ability to receive emails:',
-          '',
-          url,
-          '',
-          'If you received this in error, you can safely ignore it.',
-          '',
-          'Thank you,',
-          'Medplum',
-          '',
-        ].join('\n'),
-      });
+      await sendEmail(
+        systemRepo,
+        {
+          to: params.email,
+          subject: 'Medplum Email Address Updated',
+          text: [
+            'We received a request to update the email address associated with your Medplum account.',
+            '',
+            'Please click on the following link to verify your ability to receive emails:',
+            '',
+            url,
+            '',
+            'If you received this in error, you can safely ignore it.',
+            '',
+            'Thank you,',
+            'Medplum',
+            '',
+          ].join('\n'),
+        },
+        project
+      );
     }
 
     if (params.updateProfileTelecom && user.project?.reference) {

--- a/packages/server/src/fhir/operations/update-user-email.ts
+++ b/packages/server/src/fhir/operations/update-user-email.ts
@@ -17,7 +17,7 @@ import { verifyEmail } from '../../auth/verifyemail';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import { sendEmail } from '../../email/email';
-import { getProjectSystemRepo } from '../repo';
+import { getGlobalSystemRepo, getProjectSystemRepo } from '../repo';
 import { makeOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
 
@@ -104,6 +104,16 @@ async function updateUser(userId: string, params: InputParams, project: WithId<P
       const { id, secret } = await verifyEmail(user);
       const url = concatUrls(getConfig().appBaseUrl, `verifyemail/${id}/${secret}`);
 
+      // Use the target user's own project for project-level SMTP configuration.
+      // A super admin may be operating across projects, so the caller's project is not authoritative.
+      let emailProject: WithId<Project> | undefined;
+      if (user.project) {
+        emailProject =
+          user.project.reference === getReferenceString(project)
+            ? project
+            : await getGlobalSystemRepo().readReference<Project>(user.project);
+      }
+
       await sendEmail(
         systemRepo,
         {
@@ -123,7 +133,7 @@ async function updateUser(userId: string, params: InputParams, project: WithId<P
             '',
           ].join('\n'),
         },
-        project
+        emailProject
       );
     }
 

--- a/packages/server/src/util/console.ts
+++ b/packages/server/src/util/console.ts
@@ -7,25 +7,6 @@ export class MockConsole {
     this.messages.push(params.join(' '));
   }
 
-  // Bots (and their dependencies) expect the standard console methods. Route all
-  // levels into the same buffer so a console.error/warn/info/debug call does not
-  // throw "console.X is not a function" inside the vmcontext sandbox.
-  error(...params: any[]): void {
-    this.log(...params);
-  }
-
-  warn(...params: any[]): void {
-    this.log(...params);
-  }
-
-  info(...params: any[]): void {
-    this.log(...params);
-  }
-
-  debug(...params: any[]): void {
-    this.log(...params);
-  }
-
   toString(): string {
     return this.messages.join('\n');
   }

--- a/packages/server/src/util/console.ts
+++ b/packages/server/src/util/console.ts
@@ -7,6 +7,25 @@ export class MockConsole {
     this.messages.push(params.join(' '));
   }
 
+  // Bots (and their dependencies) expect the standard console methods. Route all
+  // levels into the same buffer so a console.error/warn/info/debug call does not
+  // throw "console.X is not a function" inside the vmcontext sandbox.
+  error(...params: any[]): void {
+    this.log(...params);
+  }
+
+  warn(...params: any[]): void {
+    this.log(...params);
+  }
+
+  info(...params: any[]): void {
+    this.log(...params);
+  }
+
+  debug(...params: any[]): void {
+    this.log(...params);
+  }
+
   toString(): string {
     return this.messages.join('\n');
   }


### PR DESCRIPTION
## Summary

Adds project-level SMTP configuration so projects can send emails through their own SMTP relay (SendGrid, Mailgun, Amazon SES SMTP, etc.) instead of the server-wide email provider. This applies to all project-scoped emails, including the `sendEmail` API, user invites, password resets, email verification, and MFA reset notifications.

### Key design decisions

- **All SMTP config lives in `Project.secret`.** Keeps host, port, credentials, and from-address colocated in a single array for simple admin UX and auditability.
- **`smtpFromAddress` is required.** A project's SMTP relay won't have SPF/DKIM covering the server's support email, so falling back to it would cause delivery failures. Config is rejected at validation time if the from address is missing.
- **Fail loud on misconfiguration.** If `smtpHost` is set but any required field is missing, the send throws a 500 server error rather than silently falling back to the server transport. Send failures through a project relay are logged with `projectId`, `host`, and `port` for triage.
- **TLS inference is scoped to project SMTP.** `smtpSecure` defaults to true on port 465 for project relays. Server-level SMTP keeps its pre-existing behavior unless the new `smtp.secure` config field is explicitly set.
- **`allowProjectSmtp` kill-switch.** Self-hosted operators can disable the feature fleet-wide via server config.

### Changes

- `packages/server/src/email/utils.ts`: `getProjectSmtpConfig()` reads and validates project secrets; `getFromAddress()` uses the project-scoped approved sender list and from address
- `packages/server/src/email/email.ts`: `sendEmail()` accepts an optional `project` param, routes through project SMTP when configured, and logs project SMTP send failures
- `packages/server/src/email/routes.ts`: passes `ctx.project` to `sendEmail()`
- `packages/server/src/admin/invite.ts`, `newuser.ts`, `resetpassword.ts`, `project.ts`: thread the project through to `sendEmail()` for system-generated emails
- `packages/server/src/fhir/operations/update-user-email.ts`: resolves the target user's own project (not the caller's), so super admin cross-project email updates use the target project's SMTP config
- `packages/server/src/config/types.ts`: adds `allowProjectSmtp` and `smtp.secure` fields
- `packages/docs/`: new Project SMTP doc page, updated server config docs, cross-links from custom-emails and project-settings

## Test plan

- [ ] `npx jest packages/server/src/email/email.test.ts` covers the project SMTP transport, from-address resolution, secure inference and override, approved senders, misconfiguration errors (including missing `smtpFromAddress`), send-failure logging, and the kill-switch
- [ ] `npx jest packages/server/src/email/routes.test.ts` covers `POST /email/v1/send` with project SMTP secrets
- [ ] `npx jest packages/server/src/auth/resetpassword.test.ts` covers password reset for a project-scoped user via project SMTP
- [ ] Verify lint passes: `npm run lint` in `packages/server`
- [ ] Verify build passes: `npm run build` in `packages/server`
