### PR TITLE
feat(data warehouse): include and exclude filters for tables to sync

### DIFF
--- a/packages/server/src/config/loader.test.ts
+++ b/packages/server/src/config/loader.test.ts
@@ -437,11 +437,11 @@ describe('Config', () => {
 
   test('Env config dataWarehouse resourceTypes', async () => {
     setEnv('MEDPLUM_BASE_URL', 'http://localhost:3000');
-    setEnv('MEDPLUM_DATA_WAREHOUSE_RESOURCE_TYPES', '["Patient","Observation"]');
+    setEnv('MEDPLUM_DATA_WAREHOUSE_RESOURCE_TYPES', '{"included":["Patient","Observation"]}');
 
     const config = await loadConfig('env');
 
-    expect(config.dataWarehouse?.resourceTypes).toStrictEqual(['Patient', 'Observation']);
+    expect(config.dataWarehouse?.resourceTypes).toStrictEqual({ included: ['Patient', 'Observation'] });
   });
 
   test('Multi-source: file then env overlay', async () => {

--- a/packages/server/src/config/loader.test.ts
+++ b/packages/server/src/config/loader.test.ts
@@ -435,13 +435,22 @@ describe('Config', () => {
     expect(config.dataWarehouse?.localBasePath).toStrictEqual('/tmp/warehouse');
   });
 
-  test('Env config dataWarehouse resourceTypes', async () => {
+  test('Env config dataWarehouse resourceTypes included', async () => {
     setEnv('MEDPLUM_BASE_URL', 'http://localhost:3000');
-    setEnv('MEDPLUM_DATA_WAREHOUSE_RESOURCE_TYPES', '{"included":["Patient","Observation"]}');
+    setEnv('MEDPLUM_DATA_WAREHOUSE_RESOURCE_TYPES_INCLUDED', 'Patient,Observation');
 
     const config = await loadConfig('env');
 
-    expect(config.dataWarehouse?.resourceTypes).toStrictEqual({ included: ['Patient', 'Observation'] });
+    expect(config.dataWarehouse?.resourceTypes?.included).toStrictEqual(['Patient', 'Observation']);
+  });
+
+  test('Env config dataWarehouse resourceTypes excluded', async () => {
+    setEnv('MEDPLUM_BASE_URL', 'http://localhost:3000');
+    setEnv('MEDPLUM_DATA_WAREHOUSE_RESOURCE_TYPES_EXCLUDED', 'Binary');
+
+    const config = await loadConfig('env');
+
+    expect(config.dataWarehouse?.resourceTypes?.excluded).toStrictEqual(['Binary']);
   });
 
   test('Multi-source: file then env overlay', async () => {

--- a/packages/server/src/config/loader.test.ts
+++ b/packages/server/src/config/loader.test.ts
@@ -435,22 +435,22 @@ describe('Config', () => {
     expect(config.dataWarehouse?.localBasePath).toStrictEqual('/tmp/warehouse');
   });
 
-  test('Env config dataWarehouse resourceTypes included', async () => {
+  test('Env config dataWarehouse includeResourceTypes', async () => {
     setEnv('MEDPLUM_BASE_URL', 'http://localhost:3000');
-    setEnv('MEDPLUM_DATA_WAREHOUSE_RESOURCE_TYPES_INCLUDED', 'Patient,Observation');
+    setEnv('MEDPLUM_DATA_WAREHOUSE_INCLUDE_RESOURCE_TYPES', 'Patient,Observation');
 
     const config = await loadConfig('env');
 
-    expect(config.dataWarehouse?.resourceTypes?.included).toStrictEqual(['Patient', 'Observation']);
+    expect(config.dataWarehouse?.includeResourceTypes).toStrictEqual(['Patient', 'Observation']);
   });
 
-  test('Env config dataWarehouse resourceTypes excluded', async () => {
+  test('Env config dataWarehouse excludeResourceTypes', async () => {
     setEnv('MEDPLUM_BASE_URL', 'http://localhost:3000');
-    setEnv('MEDPLUM_DATA_WAREHOUSE_RESOURCE_TYPES_EXCLUDED', 'Binary');
+    setEnv('MEDPLUM_DATA_WAREHOUSE_EXCLUDE_RESOURCE_TYPES', 'Binary');
 
     const config = await loadConfig('env');
 
-    expect(config.dataWarehouse?.resourceTypes?.excluded).toStrictEqual(['Binary']);
+    expect(config.dataWarehouse?.excludeResourceTypes).toStrictEqual(['Binary']);
   });
 
   test('Multi-source: file then env overlay', async () => {

--- a/packages/server/src/config/loader.ts
+++ b/packages/server/src/config/loader.ts
@@ -240,11 +240,6 @@ function loadEnvConfig(): MedplumServerConfig {
       key = key.substring('DATA_WAREHOUSE_'.length);
       currConfig = config.dataWarehouse ??= {};
       section = 'dataWarehouse';
-      if (key.startsWith('RESOURCE_TYPES_')) {
-        key = key.substring('RESOURCE_TYPES_'.length);
-        currConfig = config.dataWarehouse.resourceTypes = config.dataWarehouse.resourceTypes ?? {};
-        section = 'dataWarehouse.resourceTypes';
-      }
     }
 
     // Convert key from CAPITAL_CASE to camelCase

--- a/packages/server/src/config/loader.ts
+++ b/packages/server/src/config/loader.ts
@@ -10,7 +10,7 @@ import { loadAzureConfig } from '../cloud/azure/config';
 import { loadGcpConfig } from '../cloud/gcp/config';
 import type { MedplumServerConfig } from './types';
 import type { ServerConfig } from './utils';
-import { addDefaults, isBooleanConfig, isFloatConfig, isIntegerConfig, isObjectConfig } from './utils';
+import { addDefaults, isArrayConfig, isBooleanConfig, isFloatConfig, isIntegerConfig, isObjectConfig } from './utils';
 import { warnInvalidDataWarehouseConfig } from './validate-config';
 
 let cachedConfig: ServerConfig | undefined = undefined;
@@ -240,6 +240,11 @@ function loadEnvConfig(): MedplumServerConfig {
       key = key.substring('DATA_WAREHOUSE_'.length);
       currConfig = config.dataWarehouse ??= {};
       section = 'dataWarehouse';
+      if (key.startsWith('RESOURCE_TYPES_')) {
+        key = key.substring('RESOURCE_TYPES_'.length);
+        currConfig = config.dataWarehouse.resourceTypes = config.dataWarehouse.resourceTypes ?? {};
+        section = 'dataWarehouse.resourceTypes';
+      }
     }
 
     // Convert key from CAPITAL_CASE to camelCase
@@ -257,6 +262,8 @@ function loadEnvConfig(): MedplumServerConfig {
       currConfig[key] = value === 'true';
     } else if (isObjectConfig(lookupKey) || isObjectConfig(key)) {
       currConfig[key] = JSON.parse(value ?? '');
+    } else if (isArrayConfig(lookupKey) || isArrayConfig(key)) {
+      currConfig[key] = value?.split(',').map((v) => v.trim());
     } else {
       currConfig[key] = value;
     }

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -326,13 +326,6 @@ export interface MedplumWorkersConfig {
 
 export type MedplumDataWarehouseDestinationType = 's3tables' | 'local';
 
-export interface MedplumDataWarehouseResourceTypesConfig {
-  /** FHIR resource types to include (e.g. `Patient`, `Observation`). When omitted, all types are candidates. */
-  included?: string[];
-  /** FHIR resource types to exclude from sync. Applied after `included`, if set. */
-  excluded?: string[];
-}
-
 export interface MedplumDataWarehouseConfig {
   /**
    * Enables/disables the scheduled sync worker. Defaults to false.
@@ -355,11 +348,10 @@ export interface MedplumDataWarehouseConfig {
    * History rows with `lastUpdated` before this value are excluded.
    */
   startDate?: string;
-  /**
-   * FHIR resource types to include and/or exclude from sync.
-   * When omitted, all resource history tables are synced.
-   */
-  resourceTypes?: MedplumDataWarehouseResourceTypesConfig;
+  /** FHIR resource types to include (e.g. `Patient`, `Observation`). When omitted, all types are candidates. */
+  includeResourceTypes?: string[];
+  /** FHIR resource types to exclude from sync. Cannot be set together with `includeResourceTypes`. */
+  excludeResourceTypes?: string[];
 }
 
 export interface MedplumFissionConfig {

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -326,6 +326,13 @@ export interface MedplumWorkersConfig {
 
 export type MedplumDataWarehouseDestinationType = 's3tables' | 'local';
 
+export interface MedplumDataWarehouseResourceTypesConfig {
+  /** FHIR resource types to include (e.g. `Patient`, `Observation`). When omitted, all types are candidates. */
+  included?: string[];
+  /** FHIR resource types to exclude from sync. Applied after `included`, if set. */
+  excluded?: string[];
+}
+
 export interface MedplumDataWarehouseConfig {
   /**
    * Enables/disables the scheduled sync worker. Defaults to false.
@@ -349,10 +356,10 @@ export interface MedplumDataWarehouseConfig {
    */
   startDate?: string;
   /**
-   * FHIR resource types to sync (e.g. `Patient`, `Observation`).
-   * When omitted, all indexed resource history tables are synced.
+   * FHIR resource types to include and/or exclude from sync.
+   * When omitted, all resource history tables are synced.
    */
-  resourceTypes?: string[];
+  resourceTypes?: MedplumDataWarehouseResourceTypesConfig;
 }
 
 export interface MedplumFissionConfig {

--- a/packages/server/src/config/utils.test.ts
+++ b/packages/server/src/config/utils.test.ts
@@ -74,12 +74,12 @@ describe('utils', () => {
     });
   });
 
-  test('setValue parses dataWarehouse.resourceTypes as JSON object', () => {
+  test('setValue stores dataWarehouse.includeResourceTypes as comma-separated list', () => {
     const config = {};
-    setValue(config, 'dataWarehouse.resourceTypes', '{"included":["Patient"],"excluded":["Binary"]}');
+    setValue(config, 'dataWarehouse.includeResourceTypes', 'Patient,Observation');
     expect(config).toEqual({
       dataWarehouse: {
-        resourceTypes: { included: ['Patient'], excluded: ['Binary'] },
+        includeResourceTypes: ['Patient', 'Observation'],
       },
     });
   });

--- a/packages/server/src/config/utils.test.ts
+++ b/packages/server/src/config/utils.test.ts
@@ -74,12 +74,12 @@ describe('utils', () => {
     });
   });
 
-  test('setValue parses dataWarehouse.resourceTypes as JSON array', () => {
+  test('setValue parses dataWarehouse.resourceTypes as JSON object', () => {
     const config = {};
-    setValue(config, 'dataWarehouse.resourceTypes', '["Patient","Observation"]');
+    setValue(config, 'dataWarehouse.resourceTypes', '{"included":["Patient"],"excluded":["Binary"]}');
     expect(config).toEqual({
       dataWarehouse: {
-        resourceTypes: ['Patient', 'Observation'],
+        resourceTypes: { included: ['Patient'], excluded: ['Binary'] },
       },
     });
   });

--- a/packages/server/src/config/utils.ts
+++ b/packages/server/src/config/utils.ts
@@ -199,14 +199,13 @@ const objectKeys = new Set([
   'workers.enabled',
   'workers.bullmq',
   'dataWarehouse',
-  'dataWarehouse.resourceTypes',
 ]);
 
 export function isObjectConfig(key: string): boolean {
   return objectKeys.has(key);
 }
 
-const arrayKeys = new Set(['dataWarehouse.resourceTypes.included', 'dataWarehouse.resourceTypes.excluded']);
+const arrayKeys = new Set(['dataWarehouse.includeResourceTypes', 'dataWarehouse.excludeResourceTypes']);
 
 export function isArrayConfig(key: string): boolean {
   return arrayKeys.has(key);
@@ -231,6 +230,8 @@ export function setValue(config: Record<string, unknown>, key: string, value: st
     parsedValue = value === 'true';
   } else if (isObjectConfig(key)) {
     parsedValue = JSON.parse(value);
+  } else if (isArrayConfig(key)) {
+    parsedValue = value.split(',').map((v) => v.trim());
   }
 
   obj[keySegments[0]] = parsedValue;

--- a/packages/server/src/config/utils.ts
+++ b/packages/server/src/config/utils.ts
@@ -206,10 +206,7 @@ export function isObjectConfig(key: string): boolean {
   return objectKeys.has(key);
 }
 
-const arrayKeys = new Set([
-  'dataWarehouse.resourceTypes.included',
-  'dataWarehouse.resourceTypes.excluded',
-]);
+const arrayKeys = new Set(['dataWarehouse.resourceTypes.included', 'dataWarehouse.resourceTypes.excluded']);
 
 export function isArrayConfig(key: string): boolean {
   return arrayKeys.has(key);

--- a/packages/server/src/config/utils.ts
+++ b/packages/server/src/config/utils.ts
@@ -206,6 +206,15 @@ export function isObjectConfig(key: string): boolean {
   return objectKeys.has(key);
 }
 
+const arrayKeys = new Set([
+  'dataWarehouse.resourceTypes.included',
+  'dataWarehouse.resourceTypes.excluded',
+]);
+
+export function isArrayConfig(key: string): boolean {
+  return arrayKeys.has(key);
+}
+
 export function setValue(config: Record<string, unknown>, key: string, value: string): void {
   const keySegments = key.split('.');
   let obj = config;

--- a/packages/server/src/config/validate-config.test.ts
+++ b/packages/server/src/config/validate-config.test.ts
@@ -84,9 +84,7 @@ describe('getDataWarehouseConfigErrors', () => {
             },
           })
         )
-      ).toContain(
-        'dataWarehouse.includeResourceTypes and dataWarehouse.excludeResourceTypes cannot both be set'
-      );
+      ).toContain('dataWarehouse.includeResourceTypes and dataWarehouse.excludeResourceTypes cannot both be set');
     });
 
     test('returns error when resource type filter contains unknown resource types', () => {

--- a/packages/server/src/config/validate-config.test.ts
+++ b/packages/server/src/config/validate-config.test.ts
@@ -69,8 +69,8 @@ describe('getDataWarehouseConfigErrors', () => {
     ).toStrictEqual([]);
   });
 
-  describe('resourceTypes', () => {
-    test('returns error when resourceTypes contains unknown resource types', () => {
+  describe('resource type filters', () => {
+    test('returns error when include and exclude are both set', () => {
       expect(
         getDataWarehouseConfigErrors(
           baseServerConfig({
@@ -79,14 +79,17 @@ describe('getDataWarehouseConfigErrors', () => {
               cron: '0 * * * *',
               destination: 'local',
               localBasePath: '/tmp/out',
-              resourceTypes: { included: ['Patient', 'NotARealResourceType'] },
+              includeResourceTypes: ['Patient'],
+              excludeResourceTypes: ['Binary'],
             },
           })
         )
-      ).toContain('dataWarehouse.resourceTypes contains unknown resource type(s): NotARealResourceType');
+      ).toContain(
+        'dataWarehouse.includeResourceTypes and dataWarehouse.excludeResourceTypes cannot both be set'
+      );
     });
 
-    test('returns no errors when resourceTypes lists known resource types', () => {
+    test('returns error when resource type filter contains unknown resource types', () => {
       expect(
         getDataWarehouseConfigErrors(
           baseServerConfig({
@@ -95,7 +98,40 @@ describe('getDataWarehouseConfigErrors', () => {
               cron: '0 * * * *',
               destination: 'local',
               localBasePath: '/tmp/out',
-              resourceTypes: { included: ['Patient', 'Observation'] },
+              includeResourceTypes: ['Patient', 'NotARealResourceType'],
+            },
+          })
+        )
+      ).toContain('dataWarehouse resource type filter contains unknown resource type(s): NotARealResourceType');
+    });
+
+    test('returns no errors when includeResourceTypes lists known resource types', () => {
+      expect(
+        getDataWarehouseConfigErrors(
+          baseServerConfig({
+            dataWarehouse: {
+              enabled: true,
+              cron: '0 * * * *',
+              destination: 'local',
+              localBasePath: '/tmp/out',
+              includeResourceTypes: ['Patient', 'Observation'],
+            },
+          })
+        )
+      ).toStrictEqual([]);
+    });
+
+    test('returns no errors when include is empty and exclude lists known resource types', () => {
+      expect(
+        getDataWarehouseConfigErrors(
+          baseServerConfig({
+            dataWarehouse: {
+              enabled: true,
+              cron: '0 * * * *',
+              destination: 'local',
+              localBasePath: '/tmp/out',
+              includeResourceTypes: [],
+              excludeResourceTypes: ['Account'],
             },
           })
         )

--- a/packages/server/src/config/validate-config.test.ts
+++ b/packages/server/src/config/validate-config.test.ts
@@ -79,7 +79,7 @@ describe('getDataWarehouseConfigErrors', () => {
               cron: '0 * * * *',
               destination: 'local',
               localBasePath: '/tmp/out',
-              resourceTypes: ['Patient', 'NotARealResourceType'],
+              resourceTypes: { included: ['Patient', 'NotARealResourceType'] },
             },
           })
         )
@@ -95,7 +95,7 @@ describe('getDataWarehouseConfigErrors', () => {
               cron: '0 * * * *',
               destination: 'local',
               localBasePath: '/tmp/out',
-              resourceTypes: ['Patient', 'Observation'],
+              resourceTypes: { included: ['Patient', 'Observation'] },
             },
           })
         )

--- a/packages/server/src/config/validate-config.ts
+++ b/packages/server/src/config/validate-config.ts
@@ -54,9 +54,7 @@ export function getDataWarehouseConfigErrors(config: MedplumServerConfig): strin
   }
 
   if (hasDataWarehouseIncludeAndExclude(dw)) {
-    errors.push(
-      'dataWarehouse.includeResourceTypes and dataWarehouse.excludeResourceTypes cannot both be set'
-    );
+    errors.push('dataWarehouse.includeResourceTypes and dataWarehouse.excludeResourceTypes cannot both be set');
   }
 
   const configuredResourceTypes = getConfiguredDataWarehouseResourceTypes(dw);

--- a/packages/server/src/config/validate-config.ts
+++ b/packages/server/src/config/validate-config.ts
@@ -7,9 +7,7 @@ import { getWarehouseSyncPostgresTableNames } from '../data-warehouse/config';
 import { globalLogger } from '../logger';
 import type { MedplumDataWarehouseResourceTypesConfig, MedplumServerConfig } from './types';
 
-function getConfiguredDataWarehouseResourceTypes(
-  resourceTypes?: MedplumDataWarehouseResourceTypesConfig
-): string[] {
+function getConfiguredDataWarehouseResourceTypes(resourceTypes?: MedplumDataWarehouseResourceTypesConfig): string[] {
   if (!resourceTypes) {
     return [];
   }

--- a/packages/server/src/config/validate-config.ts
+++ b/packages/server/src/config/validate-config.ts
@@ -5,7 +5,16 @@ import type { ILogger } from '@medplum/core';
 import isISO8601 from 'validator/lib/isISO8601.js';
 import { getWarehouseSyncPostgresTableNames } from '../data-warehouse/config';
 import { globalLogger } from '../logger';
-import type { MedplumServerConfig } from './types';
+import type { MedplumDataWarehouseResourceTypesConfig, MedplumServerConfig } from './types';
+
+function getConfiguredDataWarehouseResourceTypes(
+  resourceTypes?: MedplumDataWarehouseResourceTypesConfig
+): string[] {
+  if (!resourceTypes) {
+    return [];
+  }
+  return [...(resourceTypes.included ?? []), ...(resourceTypes.excluded ?? [])];
+}
 
 /**
  * Returns configuration errors for data warehouse sync when `dataWarehouse.enabled` is true.
@@ -45,10 +54,11 @@ export function getDataWarehouseConfigErrors(config: MedplumServerConfig): strin
     errors.push('dataWarehouse.startDate must be a valid ISO 8601 timestamp');
   }
 
-  if (dw.resourceTypes?.length) {
+  const configuredResourceTypes = getConfiguredDataWarehouseResourceTypes(dw.resourceTypes);
+  if (configuredResourceTypes.length > 0) {
     const knownTableNames = new Set(getWarehouseSyncPostgresTableNames());
     if (knownTableNames.size > 0) {
-      const unknownResourceTypes = dw.resourceTypes.filter(
+      const unknownResourceTypes = configuredResourceTypes.filter(
         (resourceType) => !knownTableNames.has(`${resourceType}_History`)
       );
       if (unknownResourceTypes.length > 0) {

--- a/packages/server/src/config/validate-config.ts
+++ b/packages/server/src/config/validate-config.ts
@@ -5,13 +5,14 @@ import type { ILogger } from '@medplum/core';
 import isISO8601 from 'validator/lib/isISO8601.js';
 import { getWarehouseSyncPostgresTableNames } from '../data-warehouse/config';
 import { globalLogger } from '../logger';
-import type { MedplumDataWarehouseResourceTypesConfig, MedplumServerConfig } from './types';
+import type { MedplumDataWarehouseConfig, MedplumServerConfig } from './types';
 
-function getConfiguredDataWarehouseResourceTypes(resourceTypes?: MedplumDataWarehouseResourceTypesConfig): string[] {
-  if (!resourceTypes) {
-    return [];
-  }
-  return [...(resourceTypes.included ?? []), ...(resourceTypes.excluded ?? [])];
+function getConfiguredDataWarehouseResourceTypes(dw: MedplumDataWarehouseConfig): string[] {
+  return [...(dw.includeResourceTypes ?? []), ...(dw.excludeResourceTypes ?? [])];
+}
+
+function hasDataWarehouseIncludeAndExclude(dw: MedplumDataWarehouseConfig): boolean {
+  return !!dw.includeResourceTypes?.length && !!dw.excludeResourceTypes?.length;
 }
 
 /**
@@ -52,7 +53,13 @@ export function getDataWarehouseConfigErrors(config: MedplumServerConfig): strin
     errors.push('dataWarehouse.startDate must be a valid ISO 8601 timestamp');
   }
 
-  const configuredResourceTypes = getConfiguredDataWarehouseResourceTypes(dw.resourceTypes);
+  if (hasDataWarehouseIncludeAndExclude(dw)) {
+    errors.push(
+      'dataWarehouse.includeResourceTypes and dataWarehouse.excludeResourceTypes cannot both be set'
+    );
+  }
+
+  const configuredResourceTypes = getConfiguredDataWarehouseResourceTypes(dw);
   if (configuredResourceTypes.length > 0) {
     const knownTableNames = new Set(getWarehouseSyncPostgresTableNames());
     if (knownTableNames.size > 0) {
@@ -61,7 +68,7 @@ export function getDataWarehouseConfigErrors(config: MedplumServerConfig): strin
       );
       if (unknownResourceTypes.length > 0) {
         errors.push(
-          `dataWarehouse.resourceTypes contains unknown resource type(s): ${unknownResourceTypes.join(', ')}`
+          `dataWarehouse resource type filter contains unknown resource type(s): ${unknownResourceTypes.join(', ')}`
         );
       }
     }

--- a/packages/server/src/data-warehouse/config.test.ts
+++ b/packages/server/src/data-warehouse/config.test.ts
@@ -114,12 +114,7 @@ describe('getWarehouseSyncPostgresTableNames', () => {
     const all = getWarehouseSyncPostgresTableNames();
     const filtered = getWarehouseSyncPostgresTableNames(['Patient', 'Observation']);
 
-    expect(all).toStrictEqual([
-      'Patient_History',
-      'Observation_History',
-      'Account_History',
-      'AuditEvent_History',
-    ]);
+    expect(all).toStrictEqual(['Patient_History', 'Observation_History', 'Account_History', 'AuditEvent_History']);
     expect(filtered).toStrictEqual(['Patient_History', 'Observation_History']);
   });
 

--- a/packages/server/src/data-warehouse/config.test.ts
+++ b/packages/server/src/data-warehouse/config.test.ts
@@ -112,14 +112,33 @@ describe('appendMedplumDatabaseSslSearchParams', () => {
 describe('getWarehouseSyncPostgresTableNames', () => {
   test('returns all history tables when resourceTypes is omitted', () => {
     const all = getWarehouseSyncPostgresTableNames();
-    const filtered = getWarehouseSyncPostgresTableNames(['Patient', 'Observation']);
+    const filtered = getWarehouseSyncPostgresTableNames({ included: ['Patient', 'Observation'] });
 
     expect(all).toStrictEqual(['Patient_History', 'Observation_History', 'Account_History']);
     expect(filtered).toStrictEqual(['Patient_History', 'Observation_History']);
   });
 
-  test('returns all history tables when resourceTypes is empty', () => {
-    expect(getWarehouseSyncPostgresTableNames([])).toStrictEqual(getWarehouseSyncPostgresTableNames());
+  test('returns all history tables when resourceTypes lists are empty', () => {
+    expect(getWarehouseSyncPostgresTableNames({})).toStrictEqual(getWarehouseSyncPostgresTableNames());
+    expect(getWarehouseSyncPostgresTableNames({ included: [], excluded: [] })).toStrictEqual(
+      getWarehouseSyncPostgresTableNames()
+    );
+  });
+
+  test('excludes resource types from sync', () => {
+    expect(getWarehouseSyncPostgresTableNames({ excluded: ['Account'] })).toStrictEqual([
+      'Patient_History',
+      'Observation_History',
+    ]);
+  });
+
+  test('applies excluded after included', () => {
+    expect(
+      getWarehouseSyncPostgresTableNames({
+        included: ['Patient', 'Observation', 'Account'],
+        excluded: ['Account'],
+      })
+    ).toStrictEqual(['Patient_History', 'Observation_History']);
   });
 });
 

--- a/packages/server/src/data-warehouse/config.test.ts
+++ b/packages/server/src/data-warehouse/config.test.ts
@@ -8,7 +8,7 @@ jest.mock('@medplum/core', () => {
   const actual = jest.requireActual('@medplum/core');
   return {
     ...actual,
-    getResourceTypes: jest.fn((): ResourceType[] => ['Patient', 'Observation', 'Account']),
+    getResourceTypes: jest.fn((): ResourceType[] => ['Patient', 'Observation', 'Account', 'AuditEvent']),
   };
 });
 
@@ -110,35 +110,38 @@ describe('appendMedplumDatabaseSslSearchParams', () => {
 });
 
 describe('getWarehouseSyncPostgresTableNames', () => {
-  test('returns all history tables when resourceTypes is omitted', () => {
+  test('returns all history tables when include and exclude are omitted', () => {
     const all = getWarehouseSyncPostgresTableNames();
-    const filtered = getWarehouseSyncPostgresTableNames({ included: ['Patient', 'Observation'] });
+    const filtered = getWarehouseSyncPostgresTableNames(['Patient', 'Observation']);
 
-    expect(all).toStrictEqual(['Patient_History', 'Observation_History', 'Account_History']);
+    expect(all).toStrictEqual([
+      'Patient_History',
+      'Observation_History',
+      'Account_History',
+      'AuditEvent_History',
+    ]);
     expect(filtered).toStrictEqual(['Patient_History', 'Observation_History']);
   });
 
-  test('returns all history tables when resourceTypes lists are empty', () => {
-    expect(getWarehouseSyncPostgresTableNames({})).toStrictEqual(getWarehouseSyncPostgresTableNames());
-    expect(getWarehouseSyncPostgresTableNames({ included: [], excluded: [] })).toStrictEqual(
-      getWarehouseSyncPostgresTableNames()
-    );
+  test('returns all history tables when include and exclude lists are empty', () => {
+    expect(getWarehouseSyncPostgresTableNames([], [])).toStrictEqual(getWarehouseSyncPostgresTableNames());
+    expect(getWarehouseSyncPostgresTableNames([], undefined)).toStrictEqual(getWarehouseSyncPostgresTableNames());
   });
 
   test('excludes resource types from sync', () => {
-    expect(getWarehouseSyncPostgresTableNames({ excluded: ['Account'] })).toStrictEqual([
+    expect(getWarehouseSyncPostgresTableNames(undefined, ['Account'])).toStrictEqual([
       'Patient_History',
       'Observation_History',
+      'AuditEvent_History',
     ]);
   });
 
-  test('applies excluded after included', () => {
-    expect(
-      getWarehouseSyncPostgresTableNames({
-        included: ['Patient', 'Observation', 'Account'],
-        excluded: ['Account'],
-      })
-    ).toStrictEqual(['Patient_History', 'Observation_History']);
+  test('includes all resource types except excluded when include is empty', () => {
+    expect(getWarehouseSyncPostgresTableNames([], ['AuditEvent'])).toStrictEqual([
+      'Patient_History',
+      'Observation_History',
+      'Account_History',
+    ]);
   });
 });
 

--- a/packages/server/src/data-warehouse/config.ts
+++ b/packages/server/src/data-warehouse/config.ts
@@ -2,11 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getResourceTypes } from '@medplum/core';
-import type {
-  MedplumDatabaseConfig,
-  MedplumDatabaseSslConfig,
-  MedplumDataWarehouseResourceTypesConfig,
-} from '../config/types';
+import type { MedplumDatabaseConfig, MedplumDatabaseSslConfig } from '../config/types';
 
 /** Default Postgres `statement_timeout` applied to DuckDB-attached connections (milliseconds). */
 export const DEFAULT_DW_DATABASE_STATEMENT_TIMEOUT = 60_000 * 5; // 5 minutes
@@ -98,14 +94,16 @@ function toHistoryPostgresTableName(resourceType: string): string {
  * matching migrations (`resourceType + '_History'`).
  * Used by the scheduled data warehouse sync worker.
  *
- * @param resourceTypes - Optional include/exclude lists. When both are omitted or empty, all types are included.
+ * @param includeResourceTypes - FHIR types to sync. When omitted or empty (and exclude is too), all types are included.
+ * @param excludeResourceTypes - FHIR types to omit from sync. Cannot be combined with a non-empty include list.
  * @returns The list of Postgres table names.
  */
-export function getWarehouseSyncPostgresTableNames(resourceTypes?: MedplumDataWarehouseResourceTypesConfig): string[] {
-  const included = resourceTypes?.included;
-  const excluded = resourceTypes?.excluded;
-  const hasIncluded = !!included?.length;
-  const hasExcluded = !!excluded?.length;
+export function getWarehouseSyncPostgresTableNames(
+  includeResourceTypes?: string[],
+  excludeResourceTypes?: string[]
+): string[] {
+  const hasIncluded = !!includeResourceTypes?.length;
+  const hasExcluded = !!excludeResourceTypes?.length;
 
   if (!hasIncluded && !hasExcluded) {
     return getResourceTypes().map(toHistoryPostgresTableName);
@@ -113,11 +111,10 @@ export function getWarehouseSyncPostgresTableNames(resourceTypes?: MedplumDataWa
 
   let types = getResourceTypes();
   if (hasIncluded) {
-    const includedSet = new Set(included);
+    const includedSet = new Set(includeResourceTypes);
     types = types.filter((resourceType) => includedSet.has(resourceType));
-  }
-  if (hasExcluded) {
-    const excludedSet = new Set(excluded);
+  } else if (hasExcluded) {
+    const excludedSet = new Set(excludeResourceTypes);
     types = types.filter((resourceType) => !excludedSet.has(resourceType));
   }
 

--- a/packages/server/src/data-warehouse/config.ts
+++ b/packages/server/src/data-warehouse/config.ts
@@ -101,9 +101,7 @@ function toHistoryPostgresTableName(resourceType: string): string {
  * @param resourceTypes - Optional include/exclude lists. When both are omitted or empty, all types are included.
  * @returns The list of Postgres table names.
  */
-export function getWarehouseSyncPostgresTableNames(
-  resourceTypes?: MedplumDataWarehouseResourceTypesConfig
-): string[] {
+export function getWarehouseSyncPostgresTableNames(resourceTypes?: MedplumDataWarehouseResourceTypesConfig): string[] {
   const included = resourceTypes?.included;
   const excluded = resourceTypes?.excluded;
   const hasIncluded = !!included?.length;

--- a/packages/server/src/data-warehouse/config.ts
+++ b/packages/server/src/data-warehouse/config.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getResourceTypes } from '@medplum/core';
-import type { MedplumDatabaseConfig, MedplumDatabaseSslConfig } from '../config/types';
+import type {
+  MedplumDatabaseConfig,
+  MedplumDatabaseSslConfig,
+  MedplumDataWarehouseResourceTypesConfig,
+} from '../config/types';
 
 /** Default Postgres `statement_timeout` applied to DuckDB-attached connections (milliseconds). */
 export const DEFAULT_DW_DATABASE_STATEMENT_TIMEOUT = 60_000 * 5; // 5 minutes
@@ -94,18 +98,32 @@ function toHistoryPostgresTableName(resourceType: string): string {
  * matching migrations (`resourceType + '_History'`).
  * Used by the scheduled data warehouse sync worker.
  *
- * @param resourceTypes - Optional FHIR resource types to include. When omitted or empty, all types are included.
+ * @param resourceTypes - Optional include/exclude lists. When both are omitted or empty, all types are included.
  * @returns The list of Postgres table names.
  */
-export function getWarehouseSyncPostgresTableNames(resourceTypes?: string[]): string[] {
-  if (!resourceTypes?.length) {
+export function getWarehouseSyncPostgresTableNames(
+  resourceTypes?: MedplumDataWarehouseResourceTypesConfig
+): string[] {
+  const included = resourceTypes?.included;
+  const excluded = resourceTypes?.excluded;
+  const hasIncluded = !!included?.length;
+  const hasExcluded = !!excluded?.length;
+
+  if (!hasIncluded && !hasExcluded) {
     return getResourceTypes().map(toHistoryPostgresTableName);
   }
 
-  const selectedTypes = new Set(resourceTypes);
-  return getResourceTypes()
-    .filter((resourceType) => selectedTypes.has(resourceType))
-    .map(toHistoryPostgresTableName);
+  let types = getResourceTypes();
+  if (hasIncluded) {
+    const includedSet = new Set(included);
+    types = types.filter((resourceType) => includedSet.has(resourceType));
+  }
+  if (hasExcluded) {
+    const excludedSet = new Set(excluded);
+    types = types.filter((resourceType) => !excludedSet.has(resourceType));
+  }
+
+  return types.map(toHistoryPostgresTableName);
 }
 
 /**

--- a/packages/server/src/data-warehouse/destination.test.ts
+++ b/packages/server/src/data-warehouse/destination.test.ts
@@ -12,7 +12,7 @@ describe('data warehouse destinations', () => {
     try {
       const destination = new LocalParquetWarehouseDestination(basePath);
       const table = destination.getDestinationName({
-        postgresTable: 'Patient_history',
+        postgresTable: 'Patient_History',
         icebergTable: 'patient_history',
       });
       expect(table).toContain('patient_history.parquet');

--- a/packages/server/src/data-warehouse/sync.int.test.ts
+++ b/packages/server/src/data-warehouse/sync.int.test.ts
@@ -111,12 +111,12 @@ describe('syncData local destination (integration)', () => {
     });
 
     // Then: sync reports an inserted parquet artifact for the expected table
-    expect(result.resources).toHaveLength(1);
-    expect(result.resources[0]?.count).toBe(1);
-    expect(result.resources[0]?.table).toContain(`${warehouseSources[0]?.icebergTable}.parquet`);
+    expect(result.tables).toHaveLength(1);
+    expect(result.tables[0]?.rowsInserted).toBe(1);
+    expect(result.tables[0]?.destination).toContain(`${warehouseSources[0]?.icebergTable}.parquet`);
 
     // Then: the written file is a valid parquet payload
-    const parquetPath = result.resources[0]?.table;
+    const parquetPath = result.tables[0]?.destination;
     assertParquetMagic(readFileSync(parquetPath));
 
     // Then: projected row values are readable and match source content

--- a/packages/server/src/data-warehouse/sync.test.ts
+++ b/packages/server/src/data-warehouse/sync.test.ts
@@ -9,7 +9,7 @@ import type { SyncOptions } from './sync';
 import { buildWarehouseSourcePredicate } from './sync';
 import { buildMaxLastUpdatedWatermarkPredicate, buildStartDatePredicate } from './warehouse-sql';
 
-const tableSpec = { postgresTable: 'Patient_history', icebergTable: 'patient_history' };
+const tableSpec = { postgresTable: 'Patient_History', icebergTable: 'patient_history' };
 const namespace = 'default';
 
 function appendPredicateSql(predicate: Expression): {

--- a/packages/server/src/data-warehouse/sync.ts
+++ b/packages/server/src/data-warehouse/sync.ts
@@ -5,7 +5,7 @@ import { DuckDBInstance } from '@duckdb/node-api';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { MedplumDatabaseConfig, MedplumDataWarehouseResourceTypesConfig } from '../config/types';
+import type { MedplumDatabaseConfig } from '../config/types';
 import type { Expression } from '../fhir/sql';
 import { Conjunction } from '../fhir/sql';
 import { globalLogger } from '../logger';
@@ -22,8 +22,10 @@ export interface SyncOptions {
   namespace?: string;
   /** Earliest history `lastUpdated` to export (ISO-8601 date or date-time string). */
   startDate?: string;
-  /** FHIR resource types to include/exclude; omitted means all types (see `warehouseSources`). */
-  resourceTypes?: MedplumDataWarehouseResourceTypesConfig;
+  /** FHIR resource types to include; omitted means all types (see `warehouseSources`). */
+  includeResourceTypes?: string[];
+  /** FHIR resource types to exclude from sync. */
+  excludeResourceTypes?: string[];
   onProgress?: (message: string, metadata?: Record<string, string | number>) => void | Promise<void>;
 }
 
@@ -72,7 +74,8 @@ async function runWarehouseTableSync(
   globalLogger.info('Starting warehouse sync', {
     tablesTotal,
     startDate: options.startDate,
-    resourceTypes: options.resourceTypes,
+    includeResourceTypes: options.includeResourceTypes,
+    excludeResourceTypes: options.excludeResourceTypes,
     warehouseSources: options.warehouseSources.map((spec) => ({
       icebergTable: spec.icebergTable,
     })),

--- a/packages/server/src/data-warehouse/sync.ts
+++ b/packages/server/src/data-warehouse/sync.ts
@@ -27,17 +27,16 @@ export interface SyncOptions {
   onProgress?: (message: string, metadata?: Record<string, string | number>) => void | Promise<void>;
 }
 
-export interface SyncResourceResult {
+export interface SyncTableResult {
   icebergTable: string;
-  table: string;
-  count: number;
+  postgresTable: string;
+  destination: string;
+  rowsInserted: number;
 }
 
 export interface SyncResult {
-  resources: SyncResourceResult[];
+  tables: SyncTableResult[];
 }
-
-export type SyncAction = 'skip-empty' | 'insert';
 
 function getSyncSourceConnectionString(options: SyncOptions): string {
   return buildPgConnectionURI(options.database);
@@ -65,13 +64,13 @@ async function runWarehouseTableSync(
   connection: WarehouseSyncDuckdbConnection,
   options: SyncOptions,
   namespace: string
-): Promise<SyncResourceResult[]> {
-  const results: SyncResourceResult[] = [];
+): Promise<SyncTableResult[]> {
+  const tables: SyncTableResult[] = [];
 
-  const total = options.warehouseSources.length;
+  const tablesTotal = options.warehouseSources.length;
 
   globalLogger.info('Starting warehouse sync', {
-    total,
+    tablesTotal,
     startDate: options.startDate,
     resourceTypes: options.resourceTypes,
     warehouseSources: options.warehouseSources.map((spec) => ({
@@ -82,36 +81,60 @@ async function runWarehouseTableSync(
 
   for (const [index, spec] of options.warehouseSources.entries()) {
     const { icebergTable, postgresTable } = spec;
-    const tableNumber = index + 1;
+    const tablesCompleted = index + 1;
     const sourcePredicate = buildWarehouseSourcePredicate(options, spec, namespace);
-    const resultTableName = options.destination.getDestinationName(spec);
+    const destination = options.destination.getDestinationName(spec);
     await options.destination.ensureTargetExists(spec, namespace);
 
-    const count = await options.destination.writeRows(connection, {
+    const rowsInserted = await options.destination.writeRows(connection, {
       tableSpec: spec,
       namespace,
       sourcePredicate,
     });
 
+    globalLogger.info('Warehouse table sync completed', {
+      tablesCompleted,
+      tablesTotal,
+      icebergTable,
+      postgresTable,
+      destination,
+      rowsInserted,
+      subsystem: 'data-warehouse-sync',
+    });
+
     if (options.onProgress) {
-      await options.onProgress(`Completed ${icebergTable}`, {
-        tableNumber,
-        total,
-        icebergTable,
-        postgresTable,
-        table: resultTableName,
-        count,
-      });
+      await options.onProgress(
+        `Completed ${icebergTable} (${rowsInserted} rows, table ${tablesCompleted}/${tablesTotal})`,
+        {
+          tablesCompleted,
+          tablesTotal,
+          icebergTable,
+          postgresTable,
+          destination,
+          rowsInserted,
+        }
+      );
     }
 
-    results.push({
+    tables.push({
       icebergTable,
-      table: resultTableName,
-      count,
+      postgresTable,
+      destination,
+      rowsInserted,
     });
   }
 
-  return results;
+  const rowsInserted = tables.reduce((n, t) => n + t.rowsInserted, 0);
+  globalLogger.info('Warehouse sync completed', {
+    tablesSynced: tables.length,
+    tablesWithRows: tables.filter((t) => t.rowsInserted > 0).length,
+    tablesEmpty: tables.filter((t) => t.rowsInserted === 0).length,
+    rowsInserted,
+    tables,
+    subsystem: 'data-warehouse-sync',
+  });
+
+  return tables;
 }
 
 export async function syncData(options: SyncOptions): Promise<SyncResult> {
@@ -134,8 +157,8 @@ export async function syncData(options: SyncOptions): Promise<SyncResult> {
       await connection.run(q);
     }
 
-    const resources = await runWarehouseTableSync(connection, options, namespace);
-    return { resources };
+    const tables = await runWarehouseTableSync(connection, options, namespace);
+    return { tables };
   } finally {
     // close the DuckDB connection
     connection?.closeSync();

--- a/packages/server/src/data-warehouse/sync.ts
+++ b/packages/server/src/data-warehouse/sync.ts
@@ -71,14 +71,11 @@ async function runWarehouseTableSync(
 
   const tablesTotal = options.warehouseSources.length;
 
-  globalLogger.info('Starting warehouse sync', {
+  globalLogger.info('Starting data warehouse sync', {
     tablesTotal,
     startDate: options.startDate,
     includeResourceTypes: options.includeResourceTypes,
     excludeResourceTypes: options.excludeResourceTypes,
-    warehouseSources: options.warehouseSources.map((spec) => ({
-      icebergTable: spec.icebergTable,
-    })),
     subsystem: 'data-warehouse-sync',
   });
 
@@ -95,11 +92,10 @@ async function runWarehouseTableSync(
       sourcePredicate,
     });
 
-    globalLogger.info('Warehouse table sync completed', {
+    globalLogger.debug(`Data warehouse table sync completed for table=${icebergTable}`, {
       tablesCompleted,
       tablesTotal,
       icebergTable,
-      postgresTable,
       destination,
       rowsInserted,
       subsystem: 'data-warehouse-sync',
@@ -112,7 +108,6 @@ async function runWarehouseTableSync(
           tablesCompleted,
           tablesTotal,
           icebergTable,
-          postgresTable,
           destination,
           rowsInserted,
         }
@@ -128,7 +123,7 @@ async function runWarehouseTableSync(
   }
 
   const rowsInserted = tables.reduce((n, t) => n + t.rowsInserted, 0);
-  globalLogger.info('Warehouse sync completed', {
+  globalLogger.info('Data warehouse sync completed', {
     tablesSynced: tables.length,
     tablesWithRows: tables.filter((t) => t.rowsInserted > 0).length,
     tablesEmpty: tables.filter((t) => t.rowsInserted === 0).length,

--- a/packages/server/src/data-warehouse/sync.ts
+++ b/packages/server/src/data-warehouse/sync.ts
@@ -22,7 +22,7 @@ export interface SyncOptions {
   namespace?: string;
   /** Earliest history `lastUpdated` to export (ISO-8601 date or date-time string). */
   startDate?: string;
-  /** FHIR resource types to include; omitted means all types (see `warehouseSources`). */
+  /** FHIR resource types to include; omitted means all types. */
   includeResourceTypes?: string[];
   /** FHIR resource types to exclude from sync. */
   excludeResourceTypes?: string[];

--- a/packages/server/src/data-warehouse/sync.ts
+++ b/packages/server/src/data-warehouse/sync.ts
@@ -5,7 +5,7 @@ import { DuckDBInstance } from '@duckdb/node-api';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { MedplumDatabaseConfig } from '../config/types';
+import type { MedplumDatabaseConfig, MedplumDataWarehouseResourceTypesConfig } from '../config/types';
 import type { Expression } from '../fhir/sql';
 import { Conjunction } from '../fhir/sql';
 import { globalLogger } from '../logger';
@@ -22,8 +22,8 @@ export interface SyncOptions {
   namespace?: string;
   /** Earliest history `lastUpdated` to export (ISO-8601 date or date-time string). */
   startDate?: string;
-  /** FHIR resource types to sync; omitted means all types (see `warehouseSources`). */
-  resourceTypes?: string[];
+  /** FHIR resource types to include/exclude; omitted means all types (see `warehouseSources`). */
+  resourceTypes?: MedplumDataWarehouseResourceTypesConfig;
   onProgress?: (message: string, metadata?: Record<string, string | number>) => void | Promise<void>;
 }
 

--- a/packages/server/src/data-warehouse/warehouse-sql.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.test.ts
@@ -14,21 +14,21 @@ import {
 describe('warehouse SQL query builders', () => {
   test('buildProjectedSelectFromHistoryTableQueryWithSubquery keeps json_extract_string in outer DuckDB layer', () => {
     const sourcePredicate = new Constant(`"lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z'`);
-    const query = buildSelectFromHistoryTableQuery('Patient_history', sourcePredicate);
+    const query = buildSelectFromHistoryTableQuery('Patient_History', sourcePredicate);
     const sql = new SqlBuilder();
     sql.appendExpression(query);
 
     expect(sql.toString()).toBe(
-      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_history"."id", "pg_db"."Patient_history"."versionId" AS "version_id", "pg_db"."Patient_history"."content", "pg_db"."Patient_history"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_history" WHERE ("pg_db"."Patient_history"."content" IS NOT NULL AND "pg_db"."Patient_history"."content" <> $1 AND "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z') ORDER BY "pg_db"."Patient_history"."lastUpdated") AS "src"`
+      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1 AND "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z') ORDER BY "pg_db"."Patient_History"."lastUpdated") AS "src"`
     );
     expect(sql.getValues()).toStrictEqual(['']);
   });
 
   test('buildInsertIntoSelectQuery with subquery projection builds insert-select SQL', () => {
-    const projectedSelectQuery = buildSelectFromHistoryTableQuery('Patient_history');
+    const projectedSelectQuery = buildSelectFromHistoryTableQuery('Patient_History');
     const insertQuery = buildInsertIntoSelectQuery('iceberg_catalog.default.patient_history', projectedSelectQuery);
     expect(insertQuery.toString()).toBe(
-      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_history"."id", "pg_db"."Patient_history"."versionId" AS "version_id", "pg_db"."Patient_history"."content", "pg_db"."Patient_history"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_history" WHERE ("pg_db"."Patient_history"."content" IS NOT NULL AND "pg_db"."Patient_history"."content" <> $1) ORDER BY "pg_db"."Patient_history"."lastUpdated") AS "src"`
+      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1) ORDER BY "pg_db"."Patient_History"."lastUpdated") AS "src"`
     );
     expect(insertQuery.getValues()).toStrictEqual(['']);
   });
@@ -40,9 +40,9 @@ describe('warehouse SQL query builders', () => {
   });
 
   test('buildCountFromHistoryTableQuery builds count query with guarded content filter', () => {
-    const countQuery = buildCountFromHistoryTableQuery('Patient_history');
+    const countQuery = buildCountFromHistoryTableQuery('Patient_History');
     expect(countQuery.toString()).toBe(
-      `SELECT COUNT(*) AS count FROM "pg_db"."Patient_history" WHERE ("pg_db"."Patient_history"."content" IS NOT NULL AND "pg_db"."Patient_history"."content" <> $1)`
+      `SELECT COUNT(*) AS count FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1)`
     );
     expect(countQuery.getValues()).toStrictEqual(['']);
   });

--- a/packages/server/src/data-warehouse/warehouse-sql.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.ts
@@ -132,7 +132,7 @@ export function buildInsertIntoSelectQuery(
  * Constructs a SQL `SELECT` query from a Medplum history Postgres table and extracts the project_id.
  * using the DuckDB's JSON functionality.  This minimizes the load on the source database.
  *
- * @param sourceHistoryTable - Postgres table identifier exactly as stored (e.g. `Patient_history` or `Patient_History`).
+ * @param sourceHistoryTable - Postgres table identifier exactly as stored (e.g. `Patient_History`).
  * @param sourcePredicate - Optional SQL boolean expression (joined with `AND` after non-empty content filter).
  * @returns `SELECT` with a subquery and outer `json_extract_string` projection.
  */

--- a/packages/server/src/workers/data-warehouse-sync.int.test.ts
+++ b/packages/server/src/workers/data-warehouse-sync.int.test.ts
@@ -130,7 +130,6 @@ describe('processDataWarehouseSyncJob local destination (integration)', () => {
         tablesCompleted: 1,
         tablesTotal: 1,
         icebergTable,
-        postgresTable: HISTORY_TABLE,
         destination: expectedParquetPath,
         rowsInserted: 1,
       })

--- a/packages/server/src/workers/data-warehouse-sync.int.test.ts
+++ b/packages/server/src/workers/data-warehouse-sync.int.test.ts
@@ -127,12 +127,12 @@ describe('processDataWarehouseSyncJob local destination (integration)', () => {
 
     expect(updateProgress).toHaveBeenCalledWith(
       expect.objectContaining({
-        tableNumber: 1,
-        total: 1,
+        tablesCompleted: 1,
+        tablesTotal: 1,
         icebergTable,
         postgresTable: HISTORY_TABLE,
-        table: expectedParquetPath,
-        count: 1,
+        destination: expectedParquetPath,
+        rowsInserted: 1,
       })
     );
 

--- a/packages/server/src/workers/data-warehouse-sync.test.ts
+++ b/packages/server/src/workers/data-warehouse-sync.test.ts
@@ -372,7 +372,7 @@ describe('data-warehouse sync worker', () => {
           tableNumber: 1,
           total: 1,
           icebergTable: 'patient_history',
-          postgresTable: 'Patient_history',
+          postgresTable: 'Patient_History',
           table: 'patient_history',
           count: 1,
         });
@@ -389,7 +389,7 @@ describe('data-warehouse sync worker', () => {
         tableNumber: 1,
         total: 1,
         icebergTable: 'patient_history',
-        postgresTable: 'Patient_history',
+        postgresTable: 'Patient_History',
         table: 'patient_history',
         count: 1,
       });

--- a/packages/server/src/workers/data-warehouse-sync.test.ts
+++ b/packages/server/src/workers/data-warehouse-sync.test.ts
@@ -38,8 +38,8 @@ import {
   refreshDataWarehouseSyncScheduler,
 } from './data-warehouse-sync';
 
-const TABLE_NAMES = ['Patient_history', 'Observation_history'];
-const FILTERABLE_TABLE_NAMES = ['Patient_History', 'Observation_History'];
+const TABLE_NAMES = ['Patient_History', 'Observation_History', 'Account_History', 'Encounter_History'];
+const FILTERED_HISTORY_TABLES = ['Patient_History', 'Observation_History'];
 
 jest.mock('../data-warehouse/config', () => {
   const actual: typeof DataWarehouseConfigModule = jest.requireActual('../data-warehouse/config');
@@ -50,7 +50,7 @@ jest.mock('../data-warehouse/config', () => {
         return TABLE_NAMES;
       }
       const selected = new Set(resourceTypes.included ?? []);
-      return FILTERABLE_TABLE_NAMES.filter((tableName) => selected.has(tableName.replace(/_History$/, '')));
+      return FILTERED_HISTORY_TABLES.filter((tableName) => selected.has(tableName.replace(/_History$/, '')));
     }),
   };
 });
@@ -140,7 +140,7 @@ describe('data-warehouse sync worker', () => {
     });
     expect(result.database).not.toBe(config);
     expect(result.destination.type).toStrictEqual('s3tables');
-    expect(result.warehouseSources).toHaveLength(2);
+    expect(result.warehouseSources).toHaveLength(TABLE_NAMES.length);
   });
 
   test('getDataWarehouseSyncOptions database is usable by buildPostgresConnectionUriFromMedplumDatabaseConfig', () => {

--- a/packages/server/src/workers/data-warehouse-sync.test.ts
+++ b/packages/server/src/workers/data-warehouse-sync.test.ts
@@ -45,11 +45,11 @@ jest.mock('../data-warehouse/config', () => {
   const actual: typeof DataWarehouseConfigModule = jest.requireActual('../data-warehouse/config');
   return {
     ...actual,
-    getWarehouseSyncPostgresTableNames: jest.fn((resourceTypes?: string[]) => {
-      if (!resourceTypes?.length) {
+    getWarehouseSyncPostgresTableNames: jest.fn((resourceTypes?: { included?: string[]; excluded?: string[] }) => {
+      if (!resourceTypes?.included?.length && !resourceTypes?.excluded?.length) {
         return TABLE_NAMES;
       }
-      const selected = new Set(resourceTypes);
+      const selected = new Set(resourceTypes.included ?? []);
       return FILTERABLE_TABLE_NAMES.filter((tableName) => selected.has(tableName.replace(/_History$/, '')));
     }),
   };
@@ -102,13 +102,13 @@ describe('data-warehouse sync worker', () => {
     await initConfig({
       dataWarehouse: {
         ...enabledDataWarehouse,
-        resourceTypes: ['Patient'],
+        resourceTypes: { included: ['Patient'] },
       },
     });
     const result = getDataWarehouseSyncOptions(config);
 
-    expect(result.resourceTypes).toStrictEqual(['Patient']);
-    expect(getWarehouseSyncPostgresTableNames).toHaveBeenCalledWith(['Patient']);
+    expect(result.resourceTypes).toStrictEqual({ included: ['Patient'] });
+    expect(getWarehouseSyncPostgresTableNames).toHaveBeenCalledWith({ included: ['Patient'] });
     expect(result.warehouseSources).toHaveLength(1);
     expect(result.warehouseSources[0]).toMatchObject({
       postgresTable: 'Patient_History',

--- a/packages/server/src/workers/data-warehouse-sync.test.ts
+++ b/packages/server/src/workers/data-warehouse-sync.test.ts
@@ -45,11 +45,11 @@ jest.mock('../data-warehouse/config', () => {
   const actual: typeof DataWarehouseConfigModule = jest.requireActual('../data-warehouse/config');
   return {
     ...actual,
-    getWarehouseSyncPostgresTableNames: jest.fn((resourceTypes?: { included?: string[]; excluded?: string[] }) => {
-      if (!resourceTypes?.included?.length && !resourceTypes?.excluded?.length) {
+    getWarehouseSyncPostgresTableNames: jest.fn((includeResourceTypes?: string[], _excludeResourceTypes?: string[]) => {
+      if (!includeResourceTypes?.length) {
         return TABLE_NAMES;
       }
-      const selected = new Set(resourceTypes.included ?? []);
+      const selected = new Set(includeResourceTypes);
       return FILTERED_HISTORY_TABLES.filter((tableName) => selected.has(tableName.replace(/_History$/, '')));
     }),
   };
@@ -106,19 +106,19 @@ describe('data-warehouse sync worker', () => {
     await initConfig();
   });
 
-  test('getDataWarehouseSyncOptions passes resourceTypes and filters warehouse sources', async () => {
+  test('getDataWarehouseSyncOptions passes includeResourceTypes and filters warehouse sources', async () => {
     jest.spyOn(validateConfig, 'getDataWarehouseConfigErrors').mockReturnValue([]);
 
     await initConfig({
       dataWarehouse: {
         ...enabledDataWarehouse,
-        resourceTypes: { included: ['Patient'] },
+        includeResourceTypes: ['Patient'],
       },
     });
     const result = getDataWarehouseSyncOptions(config);
 
-    expect(result.resourceTypes).toStrictEqual({ included: ['Patient'] });
-    expect(getWarehouseSyncPostgresTableNames).toHaveBeenCalledWith({ included: ['Patient'] });
+    expect(result.includeResourceTypes).toStrictEqual(['Patient']);
+    expect(getWarehouseSyncPostgresTableNames).toHaveBeenCalledWith(['Patient'], undefined);
     expect(result.warehouseSources).toHaveLength(1);
     expect(result.warehouseSources[0]).toMatchObject({
       postgresTable: 'Patient_History',

--- a/packages/server/src/workers/data-warehouse-sync.test.ts
+++ b/packages/server/src/workers/data-warehouse-sync.test.ts
@@ -56,9 +56,19 @@ jest.mock('../data-warehouse/config', () => {
 });
 jest.mock('../data-warehouse/sync', () => ({
   syncData: jest.fn(async () => ({
-    resources: [
-      { icebergTable: 'patient_history', table: 'patient_history.parquet', count: 1 },
-      { icebergTable: 'observation_history', table: 'observation_history.parquet', count: 0 },
+    tables: [
+      {
+        icebergTable: 'patient_history',
+        postgresTable: 'Patient_History',
+        destination: 'patient_history.parquet',
+        rowsInserted: 1,
+      },
+      {
+        icebergTable: 'observation_history',
+        postgresTable: 'Observation_History',
+        destination: 'observation_history.parquet',
+        rowsInserted: 0,
+      },
     ],
   })),
 }));
@@ -368,15 +378,15 @@ describe('data-warehouse sync worker', () => {
     test('forwards syncData onProgress to job.updateProgress', async () => {
       const updateProgress = jest.fn().mockResolvedValue(undefined);
       mockedSyncData.mockImplementationOnce(async (options) => {
-        await options?.onProgress?.('Completed patient_history', {
-          tableNumber: 1,
-          total: 1,
+        await options?.onProgress?.('Completed patient_history (1 rows, table 1/1)', {
+          tablesCompleted: 1,
+          tablesTotal: 1,
           icebergTable: 'patient_history',
           postgresTable: 'Patient_History',
-          table: 'patient_history',
-          count: 1,
+          destination: 'patient_history',
+          rowsInserted: 1,
         });
-        return { resources: [] };
+        return { tables: [] };
       });
 
       await processDataWarehouseSyncJob(config, {
@@ -386,12 +396,12 @@ describe('data-warehouse sync worker', () => {
       } as any);
 
       expect(updateProgress).toHaveBeenCalledWith({
-        tableNumber: 1,
-        total: 1,
+        tablesCompleted: 1,
+        tablesTotal: 1,
         icebergTable: 'patient_history',
         postgresTable: 'Patient_History',
-        table: 'patient_history',
-        count: 1,
+        destination: 'patient_history',
+        rowsInserted: 1,
       });
     });
   });

--- a/packages/server/src/workers/data-warehouse-sync.ts
+++ b/packages/server/src/workers/data-warehouse-sync.ts
@@ -49,7 +49,8 @@ export function logDataWarehouseSyncStatus(config: MedplumServerConfig): void {
     subsystem: 'data-warehouse-sync',
     destination: syncConfig.destination,
     cron: syncConfig.cron,
-    resourceTypes: syncConfig.resourceTypes,
+    includeResourceTypes: syncConfig.includeResourceTypes,
+    excludeResourceTypes: syncConfig.excludeResourceTypes,
     startDate: syncConfig.startDate,
   });
 }
@@ -230,7 +231,7 @@ export function getDataWarehouseSyncOptions(config: MedplumServerConfig): SyncOp
     throw new Error(errors.join('; '));
   }
 
-  const { namespace, startDate, resourceTypes } = syncConfig;
+  const { namespace, startDate, includeResourceTypes, excludeResourceTypes } = syncConfig;
 
   // Fallback to the writer database when readonly is not configured.
   // For RDS Proxy, set host and ssl.require on the database config directly.
@@ -241,7 +242,7 @@ export function getDataWarehouseSyncOptions(config: MedplumServerConfig): SyncOp
       ? new LocalParquetWarehouseDestination(syncConfig.localBasePath as string)
       : new S3TablesWarehouseDestination(config.awsRegion, syncConfig.awsS3TableArn as string);
 
-  const warehouseSources = getWarehouseSyncPostgresTableNames(resourceTypes)
+  const warehouseSources = getWarehouseSyncPostgresTableNames(includeResourceTypes, excludeResourceTypes)
     .map((postgresTable) => ({
       postgresTable,
       icebergTable: toIcebergTableName(postgresTable),
@@ -252,7 +253,8 @@ export function getDataWarehouseSyncOptions(config: MedplumServerConfig): SyncOp
     destination,
     namespace,
     startDate,
-    resourceTypes,
+    includeResourceTypes,
+    excludeResourceTypes,
     warehouseSources,
   };
 }

--- a/packages/server/src/workers/data-warehouse-sync.ts
+++ b/packages/server/src/workers/data-warehouse-sync.ts
@@ -183,15 +183,18 @@ export async function processDataWarehouseSyncJob(
         },
       });
 
-      const inserted = result.resources.filter((resource) => resource.count > 0).length;
-      const skipped = result.resources.length - inserted;
+      const tables = result.tables;
+      const tablesWithRows = tables.filter((t) => t.rowsInserted > 0).length;
+      const tablesEmpty = tables.length - tablesWithRows;
+      const rowsInserted = tables.reduce((n, t) => n + t.rowsInserted, 0);
       globalLogger.info('Data warehouse sync completed', {
         jobId: job.id,
         trigger: job.data.trigger,
-        inserted,
-        skipped,
-        total: result.resources.length,
-        resources: result.resources,
+        tablesSynced: tables.length,
+        tablesWithRows,
+        tablesEmpty,
+        rowsInserted,
+        tables,
         subsystem: 'data-warehouse-sync',
       });
     } catch (err) {


### PR DESCRIPTION
## Requirement

We want to be able to include/exclude tables  from the data warehouse sync process.

This change adds two new config values, `included` and `excluded`.


## Configuration

Along the way, added support for env var config for arrays, so one can set:

`MEDPLUM_DATA_WAREHOUSE_RESOURCE_TYPES_INCLUDED=Patient,Observation`

... instead of having to embed JSON, like:

`MEDPLUM_DATA_WAREHOUSE_RESOURCE_TYPES_INCLUDED='["Patient","Observation"]'`

This aligns with the long-term goal of transitioning to env vars for config as well.

Signed-off-by: Karl Pietrzak <karl@medplum.com>
