### PR TITLE
feat(server): add measure-score search parameter for MeasureReport

### DIFF
--- a/packages/definitions/src/fhir/r4/search-parameters-medplum.json
+++ b/packages/definitions/src/fhir/r4/search-parameters-medplum.json
@@ -1958,6 +1958,23 @@
         "type": "reference",
         "expression": "HealthcareService.offeredIn"
       }
+    },
+    {
+      "fullUrl": "https://medplum.com/fhir/SearchParameter/MeasureReport-measure-score",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "MeasureReport-measure-score",
+        "url": "https://medplum.com/fhir/SearchParameter/MeasureReport-measure-score",
+        "version": "4.0.1",
+        "name": "measure-score",
+        "status": "draft",
+        "publisher": "Medplum",
+        "description": "The computed score for a group within a measure report",
+        "code": "measure-score",
+        "base": ["MeasureReport"],
+        "type": "quantity",
+        "expression": "MeasureReport.group.measureScore"
+      }
     }
   ]
 }

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -1476,6 +1476,61 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       expect(bundle3.entry?.[0]?.resource?.id).toStrictEqual(observation3.id);
     }));
 
+  test('Filter MeasureReport by measure-score', () =>
+    withTestContext(async () => {
+      if (!features) {
+        return; // measure-score is an array range column, only supported with the range-search feature
+      }
+      const measure = 'Measure/' + randomUUID();
+
+      const report1 = await repo.createResource<MeasureReport>({
+        resourceType: 'MeasureReport',
+        status: 'complete',
+        type: 'individual',
+        measure,
+        period: { start: '2024-01-01', end: '2024-12-31' },
+        group: [{ measureScore: { value: 0.25 } }],
+      });
+
+      const report2 = await repo.createResource<MeasureReport>({
+        resourceType: 'MeasureReport',
+        status: 'complete',
+        type: 'individual',
+        measure,
+        period: { start: '2024-01-01', end: '2024-12-31' },
+        group: [{ measureScore: { value: 0.9 } }],
+      });
+
+      const greaterThan = await repo.search<MeasureReport>({
+        resourceType: 'MeasureReport',
+        filters: [
+          { code: 'measure', operator: Operator.EQUALS, value: measure },
+          { code: 'measure-score', operator: Operator.GREATER_THAN, value: '0.5' },
+        ],
+      });
+      expect(greaterThan.entry?.length).toStrictEqual(1);
+      expect(greaterThan.entry?.[0]?.resource?.id).toStrictEqual(report2.id);
+
+      const lessThan = await repo.search<MeasureReport>({
+        resourceType: 'MeasureReport',
+        filters: [
+          { code: 'measure', operator: Operator.EQUALS, value: measure },
+          { code: 'measure-score', operator: Operator.LESS_THAN, value: '0.5' },
+        ],
+      });
+      expect(lessThan.entry?.length).toStrictEqual(1);
+      expect(lessThan.entry?.[0]?.resource?.id).toStrictEqual(report1.id);
+
+      const sorted = await repo.search<MeasureReport>({
+        resourceType: 'MeasureReport',
+        filters: [{ code: 'measure', operator: Operator.EQUALS, value: measure }],
+        sortRules: [{ code: 'measure-score', descending: true }],
+      });
+      expect(sorted.entry?.length).toStrictEqual(2);
+      expect(sorted.entry?.[0]?.resource?.id).toStrictEqual(report2.id);
+      expect(sorted.entry?.[1]?.resource?.id).toStrictEqual(report1.id);
+    }));
+
   test('ServiceRequest.orderDetail search', () =>
     withTestContext(async () => {
       const orderDetailText = randomUUID();

--- a/packages/server/src/migrations/data/data-version-manifest.json
+++ b/packages/server/src/migrations/data/data-version-manifest.json
@@ -144,5 +144,8 @@
   },
   "v38": {
     "serverVersion": "5.1.13"
+  },
+  "v39": {
+    "serverVersion": "5.1.16"
   }
 }

--- a/packages/server/src/migrations/data/index.ts
+++ b/packages/server/src/migrations/data/index.ts
@@ -47,3 +47,4 @@ export * as v35 from './v35';
 export * as v36 from './v36';
 export * as v37 from './v37';
 export * as v38 from './v38';
+export * as v39 from './v39';

--- a/packages/server/src/migrations/data/v39.ts
+++ b/packages/server/src/migrations/data/v39.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
+
+import type { PoolClient } from 'pg';
+import { prepareCustomMigrationJobData, runCustomMigration } from '../../workers/post-deploy-migration';
+import * as fns from '../migrate-functions';
+import type { MigrationActionResult } from '../types';
+import type { CustomPostDeployMigration } from './types';
+
+export const migration: CustomPostDeployMigration = {
+  type: 'custom',
+  prepareJobData: (asyncJob) => prepareCustomMigrationJobData(asyncJob),
+  run: async (repo, job, jobData) => runCustomMigration(repo, job, jobData, callback),
+};
+
+// prettier-ignore
+async function callback(client: PoolClient, results: MigrationActionResult[]): Promise<void> {
+  await fns.idempotentCreateIndex(client, results, 'MeasureReport_measureScore_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "MeasureReport_measureScore_idx" ON "MeasureReport" USING gin ("measureScore")`);
+  await fns.idempotentCreateIndex(client, results, 'MeasureReport___measureScore_sorted_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "MeasureReport___measureScore_sorted_idx" ON "MeasureReport" USING gist ("__measureScore", "__measureScoreSort")`);
+}

--- a/packages/server/src/migrations/schema/index.ts
+++ b/packages/server/src/migrations/schema/index.ts
@@ -117,3 +117,4 @@ export * as v105 from './v105';
 export * as v106 from './v106';
 export * as v107 from './v107';
 export * as v108 from './v108';
+export * as v109 from './v109';

--- a/packages/server/src/migrations/schema/v109.ts
+++ b/packages/server/src/migrations/schema/v109.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
+
+import type { PoolClient } from 'pg';
+import * as fns from '../migrate-functions';
+
+// prettier-ignore
+export async function run(client: PoolClient): Promise<void> {
+  const results: { name: string; durationMs: number }[] = []
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "MeasureReport" ADD COLUMN IF NOT EXISTS "__measureScore" NUMMULTIRANGE`);
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "MeasureReport" ADD COLUMN IF NOT EXISTS "__measureScoreSort" NUMERIC`);
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "MeasureReport" ADD COLUMN IF NOT EXISTS "measureScore" DOUBLE PRECISION[]`);
+}


### PR DESCRIPTION
## Summary

FHIR R4 defines no search parameter for `MeasureReport.group.measureScore`, so there is currently no way to query measure reports by their computed score. This adds a Medplum custom `measure-score` quantity search parameter, enabling comparator queries and sorting on the score:

```
GET /MeasureReport?measure=<measure>&measure-score=ge0.8
GET /MeasureReport?measure=<measure>&measure-score=gt0.5&_summary=count
GET /MeasureReport?measure=<measure>&_sort=-measure-score
```

This makes `MeasureReport` usable for the common "find/list/count subjects whose computed score crosses a threshold" pattern, without forcing that data onto `Observation`.

Closes #9401.

## Changes

- Add the `measure-score` SearchParameter (type `quantity`, expression `MeasureReport.group.measureScore`) to the medplum definitions bundle.
- Generated schema migration `v109` (range columns `__measureScore` / `__measureScoreSort` + legacy column) and post-deploy data migration `v39` (gin + gist indexes), via `npm run migrate`.
- Add `search.test.ts` coverage for comparator filtering (`gt`/`lt`) and sorting.

## Semantics note

A `MeasureReport` may contain multiple `group` entries, so `MeasureReport.group.measureScore` yields multiple values. With multi-range indexing, `measure-score=ge0.8` matches a report if **any** group's score qualifies. Happy to scope the expression to a single primary group instead if maintainers prefer — flagging the multi-group behavior explicitly.

## Heads-up: a generator bug I hit

When generating the data migration, the migration generator emitted the range-gist index's sort column **unquoted**:

```sql
... USING gist ("__measureScore", __measureScoreSort)   -- folds to lowercase, "column does not exist"
```

Existing committed migrations (e.g. `data/v35.ts`) quote it (`"__measureScoreSort"`), which is what actually works. I used the quoted form in `v39`. This bug is latent — it only surfaces when adding the first brand-new range-column search parameter since the v105/v35 bulk range migration (which this PR is). Might be worth fixing the generator's `buildIndexSql` rendering of the `sorted` expression column separately.

## Testing

- `seed.test.ts` passes — confirms `v109` + `v39` apply via the real migration runner (incl. post-deploy version finalization).
- `search.test.ts` (481), `searchparameter.test.ts`, `range-column.test.ts`, `migrate.test.ts` all pass.
- The new test guards the legacy (non-`range-search`) variant with `if (!features) return;`, matching existing array-range-column tests, since array quantity params aren't supported on the legacy column path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)