### PR TITLE
Add multi-lingual FHIR support docs and demo app

### DIFF
--- a/examples/medplum-multilingual-demo/.env.defaults
+++ b/examples/medplum-multilingual-demo/.env.defaults
@@ -1,0 +1,9 @@
+# Configuration for Medplum hosted server
+MEDPLUM_BASE_URL=https://api.medplum.com
+GOOGLE_CLIENT_ID="921088377005-3j1sa10vr6hj86jgmdfh2l53v3mp7lfi.apps.googleusercontent.com"
+MEDPLUM_CLIENT_ID=''
+
+# Configuration for local development server
+# MEDPLUM_BASE_URL=http://localhost:8103
+# GOOGLE_CLIENT_ID="397236612778-c0b5tnjv98frbo1tfuuha5vkme3cmq4s.apps.googleusercontent.com"
+# MEDPLUM_CLIENT_ID=''

--- a/examples/medplum-multilingual-demo/index.html
+++ b/examples/medplum-multilingual-demo/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/ico" href="favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Medplum Multilingual Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="https://accounts.google.com/gsi/client" async></script>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/medplum-multilingual-demo/package.json
+++ b/examples/medplum-multilingual-demo/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "medplum-multilingual-demo",
+  "version": "5.1.13",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc && vite build",
+    "dev": "vite",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "preview": "vite preview"
+  },
+  "prettier": {
+    "printWidth": 120,
+    "singleQuote": true,
+    "trailingComma": "es5"
+  },
+  "devDependencies": {
+    "@mantine/core": "8.3.18",
+    "@mantine/hooks": "8.3.18",
+    "@mantine/notifications": "8.3.18",
+    "@medplum/core": "5.1.13",
+    "@medplum/eslint-config": "5.1.13",
+    "@medplum/fhirtypes": "5.1.13",
+    "@medplum/react": "5.1.13",
+    "@tabler/icons-react": "3.44.0",
+    "@types/node": "22.19.19",
+    "@types/react": "19.2.15",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "6.0.2",
+    "postcss": "8.5.15",
+    "postcss-preset-mantine": "1.18.0",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
+    "react-router": "7.15.1",
+    "typescript": "6.0.3",
+    "vite": "8.0.14"
+  },
+  "packageManager": "npm@10.9.8",
+  "engines": {
+    "node": "^22.18.0 || >=24.2.0"
+  }
+}

--- a/examples/medplum-multilingual-demo/postcss.config.mjs
+++ b/examples/medplum-multilingual-demo/postcss.config.mjs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import mantinePreset from 'postcss-preset-mantine';
+import simpleVars from 'postcss-simple-vars';
+
+const config = {
+  plugins: [
+    mantinePreset(),
+    simpleVars({
+      variables: {
+        'mantine-breakpoint-xs': '36em',
+        'mantine-breakpoint-sm': '48em',
+        'mantine-breakpoint-md': '62em',
+        'mantine-breakpoint-lg': '75em',
+        'mantine-breakpoint-xl': '88em',
+      },
+    }),
+  ],
+};
+
+export default config;

--- a/examples/medplum-multilingual-demo/src/App.tsx
+++ b/examples/medplum-multilingual-demo/src/App.tsx
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { AppShell, ErrorBoundary, Loading, Logo, useMedplum, useMedplumProfile } from '@medplum/react';
+import { Suspense } from 'react';
+import type { JSX } from 'react';
+import { Route, Routes } from 'react-router';
+import { DemoPage } from './pages/DemoPage';
+import { LandingPage } from './pages/LandingPage';
+import { SignInPage } from './pages/SignInPage';
+
+export function App(): JSX.Element | null {
+  const medplum = useMedplum();
+  const profile = useMedplumProfile();
+
+  if (medplum.isLoading()) {
+    return null;
+  }
+
+  return (
+    <AppShell logo={<Logo size={24} />} menus={[]}>
+      <ErrorBoundary>
+        <Suspense fallback={<Loading />}>
+          <Routes>
+            <Route path="/" element={profile ? <DemoPage /> : <LandingPage />} />
+            <Route path="/signin" element={<SignInPage />} />
+          </Routes>
+        </Suspense>
+      </ErrorBoundary>
+    </AppShell>
+  );
+}

--- a/examples/medplum-multilingual-demo/src/components/LanguageSelector.tsx
+++ b/examples/medplum-multilingual-demo/src/components/LanguageSelector.tsx
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { SegmentedControl } from '@mantine/core';
+import type { JSX } from 'react';
+import { SUPPORTED_LANGUAGES, useLanguage } from '../context/LanguageContext';
+import type { SupportedLanguage } from '../context/LanguageContext';
+
+export function LanguageSelector(): JSX.Element {
+  const { language, setLanguage } = useLanguage();
+
+  return (
+    <SegmentedControl
+      value={language}
+      onChange={(val) => setLanguage(val as SupportedLanguage)}
+      data={SUPPORTED_LANGUAGES.map((l) => ({ value: l.code, label: l.label }))}
+      size="sm"
+    />
+  );
+}

--- a/examples/medplum-multilingual-demo/src/config.ts
+++ b/examples/medplum-multilingual-demo/src/config.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+export interface MedplumAppConfig {
+  baseUrl?: string;
+  googleClientId?: string;
+  clientId?: string;
+}
+
+const config: MedplumAppConfig = {
+  baseUrl: import.meta.env?.MEDPLUM_BASE_URL,
+  googleClientId: import.meta.env?.GOOGLE_CLIENT_ID,
+  clientId: import.meta.env?.MEDPLUM_CLIENT_ID,
+};
+
+export function getConfig(): MedplumAppConfig {
+  return config;
+}

--- a/examples/medplum-multilingual-demo/src/context/LanguageContext.tsx
+++ b/examples/medplum-multilingual-demo/src/context/LanguageContext.tsx
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { createContext, useContext, useState } from 'react';
+import type { JSX, ReactNode } from 'react';
+import { getBestTranslation } from '../utils/translation';
+import type { ShadowElement } from '../utils/translation';
+
+export type SupportedLanguage = 'en' | 'es' | 'fr' | 'zh';
+
+export const SUPPORTED_LANGUAGES: { code: SupportedLanguage; label: string }[] = [
+  { code: 'en', label: 'English' },
+  { code: 'es', label: 'Español' },
+  { code: 'fr', label: 'Français' },
+  { code: 'zh', label: '中文' },
+];
+
+interface LanguageContextType {
+  language: SupportedLanguage;
+  setLanguage: (lang: SupportedLanguage) => void;
+  /** Translate a FHIR string primitive using its shadow element. Falls back to the primary value. */
+  t: (value: string | undefined, shadow?: ShadowElement) => string | undefined;
+}
+
+const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
+
+export function LanguageProvider({ children }: { children: ReactNode }): JSX.Element {
+  const [language, setLanguage] = useState<SupportedLanguage>('en');
+
+  const t = (value: string | undefined, shadow?: ShadowElement): string | undefined => {
+    return getBestTranslation(value, shadow, language);
+  };
+
+  return <LanguageContext.Provider value={{ language, setLanguage, t }}>{children}</LanguageContext.Provider>;
+}
+
+export function useLanguage(): LanguageContextType {
+  const ctx = useContext(LanguageContext);
+  if (!ctx) {
+    throw new Error('useLanguage must be used within a LanguageProvider');
+  }
+  return ctx;
+}

--- a/examples/medplum-multilingual-demo/src/data/demoResources.ts
+++ b/examples/medplum-multilingual-demo/src/data/demoResources.ts
@@ -1,0 +1,236 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Demo FHIR resources demonstrating the FHIR translation extension:
+ * http://hl7.org/fhir/StructureDefinition/translation
+ *
+ * The extension is placed on the shadow element (`_fieldName`) of any string
+ * primitive, carrying translations for one or more BCP-47 language tags.
+ */
+
+import type { Coding, Condition, Extension, Patient, Questionnaire, QuestionnaireItem } from '@medplum/fhirtypes';
+import type { ShadowElement } from '../utils/translation';
+import { TRANSLATION_EXTENSION_URL } from '../utils/translation';
+
+/** Canonical URL for the demo Questionnaire. Used for idempotent server-side creation. */
+export const QUESTIONNAIRE_CANONICAL_URL = 'https://medplum.com/fhir/Questionnaire/multilingual-demo-intake';
+
+/** Identifier used to find-or-create the demo Patient idempotently. */
+export const DEMO_PATIENT_IDENTIFIER = {
+  system: 'https://medplum.com/demo-ids',
+  value: 'multilingual-demo-patient',
+};
+
+// ---------------------------------------------------------------------------
+// Local interface extensions
+// The generated @medplum/fhirtypes do not expose primitive shadow elements
+// directly, so we extend the relevant types here for use in this demo.
+// ---------------------------------------------------------------------------
+
+export interface CodingWithTranslation extends Coding {
+  _display?: ShadowElement;
+}
+
+export interface QuestionnaireItemWithTranslation extends QuestionnaireItem {
+  _text?: ShadowElement;
+  item?: QuestionnaireItemWithTranslation[];
+}
+
+export interface QuestionnaireWithTranslation extends Questionnaire {
+  _title?: ShadowElement;
+  item?: QuestionnaireItemWithTranslation[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function translationExt(lang: string, content: string): Extension {
+  return {
+    url: TRANSLATION_EXTENSION_URL,
+    extension: [
+      { url: 'lang', valueCode: lang },
+      { url: 'content', valueString: content },
+    ],
+  };
+}
+
+function shadow(...translations: Extension[]): ShadowElement {
+  return { extension: translations };
+}
+
+// ---------------------------------------------------------------------------
+// Demo Patient — preferred language: Spanish
+// ---------------------------------------------------------------------------
+
+export const DEMO_PATIENT: Patient = {
+  resourceType: 'Patient',
+  name: [{ given: ['Maria'], family: 'García' }],
+  identifier: [DEMO_PATIENT_IDENTIFIER],
+  communication: [
+    {
+      language: {
+        coding: [{ system: 'urn:ietf:bcp:47', code: 'es', display: 'Spanish' }],
+        text: 'Spanish',
+      },
+      preferred: true,
+    },
+    {
+      language: {
+        coding: [{ system: 'urn:ietf:bcp:47', code: 'en', display: 'English' }],
+        text: 'English',
+      },
+    },
+    {
+      language: {
+        coding: [{ system: 'urn:ietf:bcp:47', code: 'fr', display: 'French' }],
+        text: 'French',
+      },
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Demo Questionnaire — multilingual patient intake
+// ---------------------------------------------------------------------------
+
+export const DEMO_QUESTIONNAIRE: QuestionnaireWithTranslation = {
+  resourceType: 'Questionnaire',
+  url: QUESTIONNAIRE_CANONICAL_URL,
+  name: 'MultilingualDemoIntake',
+  status: 'active',
+  title: 'Patient Intake Form',
+  _title: shadow(
+    translationExt('es', 'Formulario de registro del paciente'),
+    translationExt('fr', "Formulaire d'admission du patient"),
+    translationExt('zh', '患者入院表格')
+  ),
+  item: [
+    {
+      linkId: 'preferred-language',
+      type: 'string',
+      text: 'What is your preferred language?',
+      _text: shadow(
+        translationExt('es', '¿Cuál es su idioma preferido?'),
+        translationExt('fr', 'Quelle est votre langue préférée ?'),
+        translationExt('zh', '您的首选语言是什么？')
+      ),
+    },
+    {
+      linkId: 'allergies',
+      type: 'boolean',
+      text: 'Do you have any known allergies?',
+      _text: shadow(
+        translationExt('es', '¿Tiene alguna alergia conocida?'),
+        translationExt('fr', 'Avez-vous des allergies connues ?'),
+        translationExt('zh', '您有已知的过敏症吗？')
+      ),
+    },
+    {
+      linkId: 'symptoms',
+      type: 'text',
+      text: 'Please describe your current symptoms.',
+      _text: shadow(
+        translationExt('es', 'Por favor describa sus síntomas actuales.'),
+        translationExt('fr', 'Veuillez décrire vos symptômes actuels.'),
+        translationExt('zh', '请描述您目前的症状。')
+      ),
+    },
+    {
+      linkId: 'pain-scale',
+      type: 'integer',
+      text: 'Rate your pain level (0–10)',
+      _text: shadow(
+        translationExt('es', 'Califique su nivel de dolor (0–10)'),
+        translationExt('fr', 'Évaluez votre niveau de douleur (0–10)'),
+        translationExt('zh', '请评估您的疼痛等级 (0–10)')
+      ),
+    },
+    {
+      linkId: 'emergency-contact',
+      type: 'string',
+      text: 'Emergency contact name and phone number',
+      _text: shadow(
+        translationExt('es', 'Nombre y número de teléfono del contacto de emergencia'),
+        translationExt('fr', "Nom et numéro de téléphone du contact d'urgence"),
+        translationExt('zh', '紧急联系人姓名和电话号码')
+      ),
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Demo Conditions — SNOMED codes with translated display strings
+// ---------------------------------------------------------------------------
+
+export const DEMO_CONDITIONS: (Condition & { code?: { coding?: CodingWithTranslation[] } })[] = [
+  {
+    resourceType: 'Condition',
+    id: 'demo-condition-1',
+    subject: { reference: 'Patient/demo-patient' },
+    clinicalStatus: {
+      coding: [
+        { system: 'http://terminology.hl7.org/CodeSystem/condition-clinical', code: 'active', display: 'Active' },
+      ],
+    },
+    code: {
+      coding: [
+        {
+          system: 'http://snomed.info/sct',
+          code: '44054006',
+          display: 'Diabetes mellitus type 2',
+          _display: shadow(
+            translationExt('es', 'Diabetes mellitus tipo 2'),
+            translationExt('fr', 'Diabète sucré de type 2'),
+            translationExt('zh', '2型糖尿病')
+          ),
+        },
+      ],
+    },
+  },
+  {
+    resourceType: 'Condition',
+    id: 'demo-condition-2',
+    subject: { reference: 'Patient/demo-patient' },
+    clinicalStatus: {
+      coding: [
+        { system: 'http://terminology.hl7.org/CodeSystem/condition-clinical', code: 'active', display: 'Active' },
+      ],
+    },
+    code: {
+      coding: [
+        {
+          system: 'http://snomed.info/sct',
+          code: '59621000',
+          display: 'Essential hypertension',
+          _display: shadow(
+            translationExt('es', 'Hipertensión esencial'),
+            translationExt('fr', 'Hypertension essentielle'),
+            translationExt('zh', '原发性高血压')
+          ),
+        },
+      ],
+    },
+  },
+  {
+    resourceType: 'Condition',
+    id: 'demo-condition-3',
+    subject: { reference: 'Patient/demo-patient' },
+    clinicalStatus: {
+      coding: [
+        { system: 'http://terminology.hl7.org/CodeSystem/condition-clinical', code: 'active', display: 'Active' },
+      ],
+    },
+    code: {
+      coding: [
+        {
+          system: 'http://snomed.info/sct',
+          code: '195967001',
+          display: 'Asthma',
+          _display: shadow(translationExt('es', 'Asma'), translationExt('fr', 'Asthme'), translationExt('zh', '哮喘')),
+        },
+      ],
+    },
+  },
+];

--- a/examples/medplum-multilingual-demo/src/hooks/useDemoData.ts
+++ b/examples/medplum-multilingual-demo/src/hooks/useDemoData.ts
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Seeds and returns the demo FHIR resources from the Medplum server.
+ *
+ * All resource creation uses FHIR conditional create (`If-None-Exist`) inside a
+ * transaction bundle, so the operation is fully idempotent — safe to call
+ * concurrently (e.g. React StrictMode double-invocation) and on every page load.
+ */
+
+import type { Bundle, BundleEntry, Condition, Patient, Questionnaire } from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react';
+import { useEffect, useState } from 'react';
+import {
+  DEMO_CONDITIONS,
+  DEMO_PATIENT,
+  DEMO_PATIENT_IDENTIFIER,
+  DEMO_QUESTIONNAIRE,
+  QUESTIONNAIRE_CANONICAL_URL,
+} from '../data/demoResources';
+import type { CodingWithTranslation } from '../data/demoResources';
+
+export const DEMO_TAG = {
+  system: 'https://medplum.com/demo-tags',
+  code: 'multilingual-demo',
+};
+
+const TAG_PARAM = `${DEMO_TAG.system}|${DEMO_TAG.code}`;
+const PATIENT_IF_NONE_EXIST = `identifier=${DEMO_PATIENT_IDENTIFIER.system}|${DEMO_PATIENT_IDENTIFIER.value}`;
+const QUESTIONNAIRE_IF_NONE_EXIST = `url=${QUESTIONNAIRE_CANONICAL_URL}`;
+
+export interface DemoData {
+  patient: Patient | undefined;
+  questionnaire: Questionnaire | undefined;
+  /** Conditions cast to include `_display` shadow elements. */
+  conditions: (Condition & { code?: { coding?: CodingWithTranslation[] } })[];
+  loading: boolean;
+  error: Error | undefined;
+}
+
+export function useDemoData(): DemoData {
+  const medplum = useMedplum();
+  const [patient, setPatient] = useState<Patient | undefined>();
+  const [questionnaire, setQuestionnaire] = useState<Questionnaire | undefined>();
+  const [conditions, setConditions] = useState<DemoData['conditions']>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function seed(): Promise<void> {
+      setLoading(true);
+      setError(undefined);
+
+      try {
+        // ----------------------------------------------------------------
+        // Step 1: Patient + Questionnaire via transaction with ifNoneExist.
+        // The server creates each resource only if the search condition
+        // matches nothing — safe to call concurrently.
+        // ----------------------------------------------------------------
+        const initBundle: Bundle = {
+          resourceType: 'Bundle',
+          type: 'transaction',
+          entry: [
+            {
+              fullUrl: 'urn:uuid:demo-patient',
+              resource: { ...DEMO_PATIENT, meta: { tag: [DEMO_TAG] } },
+              request: { method: 'POST', url: 'Patient', ifNoneExist: PATIENT_IF_NONE_EXIST },
+            },
+            {
+              fullUrl: 'urn:uuid:demo-questionnaire',
+              resource: { ...(DEMO_QUESTIONNAIRE as Questionnaire), meta: { tag: [DEMO_TAG] } },
+              request: { method: 'POST', url: 'Questionnaire', ifNoneExist: QUESTIONNAIRE_IF_NONE_EXIST },
+            },
+          ],
+        };
+
+        await medplum.executeBatch(initBundle);
+
+        if (cancelled) {
+          return;
+        }
+
+        // Re-fetch by their stable identifiers to get the authoritative IDs.
+        const [p, q] = await Promise.all([
+          medplum.searchOne('Patient', {
+            identifier: `${DEMO_PATIENT_IDENTIFIER.system}|${DEMO_PATIENT_IDENTIFIER.value}`,
+          }),
+          medplum.searchOne('Questionnaire', { url: QUESTIONNAIRE_CANONICAL_URL }),
+        ]);
+
+        if (cancelled) {
+          return;
+        }
+
+        if (!p || !q) {
+          throw new Error('Demo resources were not found after seeding.');
+        }
+
+        setPatient(p);
+        setQuestionnaire(q);
+
+        // ----------------------------------------------------------------
+        // Step 2: Conditions — one conditional-create per condition code.
+        // ----------------------------------------------------------------
+        const conditionEntries: BundleEntry[] = DEMO_CONDITIONS.map((c) => {
+          const code = c.code?.coding?.[0];
+          const ifNoneExist = [
+            `code=${code?.system ?? ''}|${code?.code ?? ''}`,
+            `subject=Patient/${p.id}`,
+            `_tag=${TAG_PARAM}`,
+          ].join('&');
+
+          return {
+            resource: {
+              ...c,
+              subject: { reference: `Patient/${p.id}` },
+              meta: { tag: [DEMO_TAG] },
+            },
+            request: { method: 'POST', url: 'Condition', ifNoneExist },
+          };
+        });
+
+        await medplum.executeBatch({ resourceType: 'Bundle', type: 'transaction', entry: conditionEntries });
+
+        if (cancelled) {
+          return;
+        }
+
+        const seededConditions = await medplum.searchResources('Condition', {
+          subject: `Patient/${p.id}`,
+          _tag: TAG_PARAM,
+        });
+
+        if (!cancelled) {
+          setConditions(seededConditions);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    seed().catch(console.error);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [medplum]);
+
+  return { patient, questionnaire, conditions, loading, error };
+}
+
+/**
+ * Cast a Coding to include the `_display` shadow element for translation lookups.
+ * @param coding - The Coding object to cast.
+ * @returns The same object typed as CodingWithTranslation.
+ */
+export function getCodingWithTranslation(coding: unknown): CodingWithTranslation {
+  return coding as CodingWithTranslation;
+}

--- a/examples/medplum-multilingual-demo/src/main.tsx
+++ b/examples/medplum-multilingual-demo/src/main.tsx
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { MantineProvider, createTheme } from '@mantine/core';
+import '@mantine/core/styles.css';
+import { Notifications } from '@mantine/notifications';
+import '@mantine/notifications/styles.css';
+import { MedplumClient } from '@medplum/core';
+import { MedplumProvider } from '@medplum/react';
+import '@medplum/react/styles.css';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router';
+import { App } from './App';
+import { getConfig } from './config';
+import { LanguageProvider } from './context/LanguageContext';
+
+const medplum = new MedplumClient({
+  onUnauthenticated: () => (window.location.href = '/'),
+  baseUrl: getConfig().baseUrl,
+});
+
+const theme = createTheme({
+  fontSizes: {
+    xs: '0.6875rem',
+    sm: '0.875rem',
+    md: '0.875rem',
+    lg: '1.0rem',
+    xl: '1.125rem',
+  },
+});
+
+const container = document.getElementById('root') as HTMLDivElement;
+const root = createRoot(container);
+root.render(
+  <StrictMode>
+    <BrowserRouter>
+      <MedplumProvider medplum={medplum}>
+        <MantineProvider theme={theme}>
+          <Notifications />
+          <LanguageProvider>
+            <App />
+          </LanguageProvider>
+        </MantineProvider>
+      </MedplumProvider>
+    </BrowserRouter>
+  </StrictMode>
+);

--- a/examples/medplum-multilingual-demo/src/pages/DemoPage.tsx
+++ b/examples/medplum-multilingual-demo/src/pages/DemoPage.tsx
@@ -1,0 +1,393 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import {
+  Alert,
+  Anchor,
+  Badge,
+  Button,
+  Card,
+  Checkbox,
+  Code,
+  Group,
+  LoadingOverlay,
+  NumberInput,
+  Stack,
+  Table,
+  Tabs,
+  Text,
+  Textarea,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import type { QuestionnaireResponse, QuestionnaireResponseItem } from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react';
+import { IconAlertCircle, IconCheck, IconLanguage, IconNotes, IconUser, IconVirus } from '@tabler/icons-react';
+import { useState } from 'react';
+import type { JSX } from 'react';
+import { LanguageSelector } from '../components/LanguageSelector';
+import { useLanguage } from '../context/LanguageContext';
+import type { SupportedLanguage } from '../context/LanguageContext';
+import { getCodingWithTranslation, useDemoData } from '../hooks/useDemoData';
+
+// ---------------------------------------------------------------------------
+// Tab: Questionnaire
+// ---------------------------------------------------------------------------
+
+interface TabProps {
+  patient: ReturnType<typeof useDemoData>['patient'];
+  questionnaire: ReturnType<typeof useDemoData>['questionnaire'];
+  conditions: ReturnType<typeof useDemoData>['conditions'];
+  loading: boolean;
+}
+
+function QuestionnaireTab({ patient, questionnaire, loading }: TabProps): JSX.Element {
+  const medplum = useMedplum();
+  const { t, language } = useLanguage();
+
+  const [answers, setAnswers] = useState<Record<string, string | boolean | number>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [lastResponseId, setLastResponseId] = useState<string | undefined>();
+
+  if (loading) {
+    return <Text c="dimmed">Loading questionnaire…</Text>;
+  }
+
+  if (!questionnaire || !patient) {
+    return <Text c="red">Could not load questionnaire. Check your Medplum credentials.</Text>;
+  }
+
+  async function handleSubmit(): Promise<void> {
+    if (!questionnaire?.id || !patient?.id) {
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const items: QuestionnaireResponseItem[] = (questionnaire.item ?? []).map((item) => {
+        const val = answers[item.linkId];
+        let answer: QuestionnaireResponseItem['answer'] = [];
+
+        if (item.type === 'boolean') {
+          answer = [{ valueBoolean: Boolean(val) }];
+        } else if (item.type === 'integer') {
+          answer = [{ valueInteger: Number(val) || 0 }];
+        } else if (val !== undefined && val !== '') {
+          answer = [{ valueString: String(val) }];
+        }
+
+        // Store the text as it was displayed to the user (translated), not the English primary.
+        const displayedText = t(item.text, (item as any)._text) ?? item.text;
+        return { linkId: item.linkId, text: displayedText, answer };
+      });
+
+      const response = await medplum.createResource<QuestionnaireResponse>({
+        resourceType: 'QuestionnaireResponse',
+        // RFC 5646 / BCP-47 language tag indicating the language the form was filled in.
+        language,
+        status: 'completed',
+        questionnaire: `Questionnaire/${questionnaire.id}`,
+        subject: { reference: `Patient/${patient?.id}` },
+        authored: new Date().toISOString(),
+        item: items,
+      });
+
+      setLastResponseId(response.id);
+      setAnswers({});
+      notifications.show({
+        title: 'Response saved',
+        message: `QuestionnaireResponse/${response.id}`,
+        color: 'green',
+        icon: <IconCheck size={16} />,
+      });
+    } catch (err) {
+      notifications.show({
+        title: 'Failed to save response',
+        message: String(err),
+        color: 'red',
+        icon: <IconAlertCircle size={16} />,
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Stack gap="md">
+      <div>
+        <Title order={3}>{t(questionnaire.title, (questionnaire as any)._title)}</Title>
+        <Text size="sm" c="dimmed" mt={4}>
+          Translations are stored on the <Code>_text</Code> shadow element of each item using the{' '}
+          <Code>http://hl7.org/fhir/StructureDefinition/translation</Code> extension. Submitting the form creates a{' '}
+          <Code>QuestionnaireResponse</Code> on your Medplum project.
+        </Text>
+      </div>
+
+      {(questionnaire.item ?? []).map((item) => {
+        const label = t(item.text, (item as any)._text) ?? item.text ?? item.linkId;
+
+        let input: JSX.Element;
+        if (item.type === 'boolean') {
+          input = (
+            <Checkbox
+              label={label}
+              checked={Boolean(answers[item.linkId])}
+              onChange={(e) => setAnswers((prev) => ({ ...prev, [item.linkId]: e.target.checked }))}
+            />
+          );
+        } else if (item.type === 'integer') {
+          input = (
+            <NumberInput
+              label={label}
+              min={0}
+              max={10}
+              value={(answers[item.linkId] as number) ?? ''}
+              onChange={(val) => setAnswers((prev) => ({ ...prev, [item.linkId]: val }))}
+            />
+          );
+        } else if (item.type === 'text') {
+          input = (
+            <Textarea
+              label={label}
+              autosize
+              minRows={2}
+              value={(answers[item.linkId] as string) ?? ''}
+              onChange={(e) => setAnswers((prev) => ({ ...prev, [item.linkId]: e.target.value }))}
+            />
+          );
+        } else {
+          input = (
+            <TextInput
+              label={label}
+              value={(answers[item.linkId] as string) ?? ''}
+              onChange={(e) => setAnswers((prev) => ({ ...prev, [item.linkId]: e.target.value }))}
+            />
+          );
+        }
+
+        return (
+          <Card key={item.linkId} withBorder padding="md" radius="md">
+            {input}
+          </Card>
+        );
+      })}
+
+      <Button onClick={handleSubmit} loading={submitting} w="fit-content">
+        Submit response
+      </Button>
+
+      {lastResponseId && (
+        <Alert icon={<IconCheck size={16} />} color="green" title="Last submission">
+          Saved as{' '}
+          <Anchor href={`https://app.medplum.com/QuestionnaireResponse/${lastResponseId}`} target="_blank" size="sm">
+            QuestionnaireResponse/{lastResponseId}
+          </Anchor>
+        </Alert>
+      )}
+    </Stack>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tab: Conditions
+// ---------------------------------------------------------------------------
+
+function ConditionsTab({ conditions, patient, loading }: TabProps): JSX.Element {
+  const { t } = useLanguage();
+
+  if (loading) {
+    return <Text c="dimmed">Loading conditions…</Text>;
+  }
+
+  return (
+    <Stack gap="md">
+      <Text size="sm" c="dimmed">
+        <Code>Coding.display</Code> carries translations on its <Code>_display</Code> shadow element. Switch languages
+        above to see the display string update. These conditions are stored on{' '}
+        {patient?.id ? (
+          <Anchor href={`https://app.medplum.com/Patient/${patient.id}`} target="_blank" size="sm">
+            Patient/{patient.id}
+          </Anchor>
+        ) : (
+          'the demo patient'
+        )}{' '}
+        in your Medplum project.
+      </Text>
+
+      <Table striped highlightOnHover withTableBorder withColumnBorders>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>SNOMED Code</Table.Th>
+            <Table.Th>Display</Table.Th>
+            <Table.Th>Status</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {conditions.map((condition) =>
+            condition.code?.coding?.map((coding) => {
+              const c = getCodingWithTranslation(coding);
+              return (
+                <Table.Tr key={`${condition.id}-${c.code}`}>
+                  <Table.Td>
+                    <Code>{c.code}</Code>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text fw={500}>{t(c.display, c._display)}</Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Badge color="green" variant="light">
+                      {condition.clinicalStatus?.coding?.[0]?.display ?? 'Active'}
+                    </Badge>
+                  </Table.Td>
+                </Table.Tr>
+              );
+            })
+          )}
+        </Table.Tbody>
+      </Table>
+    </Stack>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tab: Patient Language
+// ---------------------------------------------------------------------------
+
+function PatientTab({ patient, loading }: TabProps): JSX.Element {
+  const { setLanguage } = useLanguage();
+
+  if (loading) {
+    return <Text c="dimmed">Loading patient…</Text>;
+  }
+
+  if (!patient) {
+    return <Text c="red">Could not load patient.</Text>;
+  }
+
+  const preferred = patient.communication?.find((c) => c.preferred);
+  const preferredCode = preferred?.language?.coding?.[0]?.code;
+  const preferredDisplay = preferred?.language?.coding?.[0]?.display;
+
+  const allLanguages = patient.communication
+    ?.map((c) => {
+      const lang = c.language?.coding?.[0];
+      return `${lang?.display} (${lang?.code})${c.preferred ? ' ✓' : ''}`;
+    })
+    .join(', ');
+
+  return (
+    <Stack gap="md">
+      <Card withBorder padding="md" radius="md">
+        <Stack gap="sm">
+          <Group>
+            <Text fw={600} w={160}>
+              Name
+            </Text>
+            <Text>
+              {patient.name?.[0]?.given?.join(' ')} {patient.name?.[0]?.family}
+            </Text>
+          </Group>
+          <Group>
+            <Text fw={600} w={160}>
+              Resource ID
+            </Text>
+            <Anchor href={`https://app.medplum.com/Patient/${patient.id}`} target="_blank" size="sm">
+              Patient/{patient.id}
+            </Anchor>
+          </Group>
+          <Group>
+            <Text fw={600} w={160}>
+              Preferred Language
+            </Text>
+            <Badge color="blue" size="md">
+              {preferredDisplay} ({preferredCode})
+            </Badge>
+          </Group>
+          <Group align="flex-start">
+            <Text fw={600} w={160}>
+              All Languages
+            </Text>
+            <Text size="sm">{allLanguages}</Text>
+          </Group>
+        </Stack>
+      </Card>
+
+      {preferredCode && (
+        <Button
+          leftSection={<IconLanguage size={16} />}
+          onClick={() => setLanguage(preferredCode as SupportedLanguage)}
+          variant="light"
+          w="fit-content"
+        >
+          Apply patient's preferred language ({preferredDisplay})
+        </Button>
+      )}
+
+      <Card withBorder padding="md" radius="md" bg="gray.0">
+        <Stack gap="xs">
+          <Text size="sm" fw={600}>
+            How it works
+          </Text>
+          <Text size="sm" c="dimmed">
+            <Code>Patient.communication</Code> stores known and preferred languages using BCP-47 codes. Your application
+            reads the entry where <Code>preferred: true</Code> to automatically select the right translation when
+            rendering resources for that patient.
+          </Text>
+        </Stack>
+      </Card>
+    </Stack>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function DemoPage(): JSX.Element {
+  const { patient, questionnaire, conditions, loading, error } = useDemoData();
+
+  return (
+    <Stack gap="lg" p="md" maw={860} mx="auto" pos="relative">
+      <LoadingOverlay visible={loading} overlayProps={{ blur: 2 }} loaderProps={{ type: 'dots' }} />
+
+      <Group justify="space-between" align="center">
+        <div>
+          <Title order={2}>Multi-lingual FHIR Demo</Title>
+          <Text size="sm" c="dimmed" mt={2}>
+            Demonstrating the <Code>http://hl7.org/fhir/StructureDefinition/translation</Code> extension
+          </Text>
+        </div>
+        <LanguageSelector />
+      </Group>
+
+      {error && (
+        <Alert icon={<IconAlertCircle size={16} />} color="red" title="Could not seed demo data">
+          {error.message}
+        </Alert>
+      )}
+
+      <Tabs defaultValue="questionnaire" variant="outline">
+        <Tabs.List>
+          <Tabs.Tab value="questionnaire" leftSection={<IconNotes size={15} />}>
+            Questionnaire
+          </Tabs.Tab>
+          <Tabs.Tab value="conditions" leftSection={<IconVirus size={15} />}>
+            Conditions
+          </Tabs.Tab>
+          <Tabs.Tab value="patient" leftSection={<IconUser size={15} />}>
+            Patient Language
+          </Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="questionnaire" pt="md">
+          <QuestionnaireTab patient={patient} questionnaire={questionnaire} conditions={conditions} loading={loading} />
+        </Tabs.Panel>
+        <Tabs.Panel value="conditions" pt="md">
+          <ConditionsTab patient={patient} questionnaire={questionnaire} conditions={conditions} loading={loading} />
+        </Tabs.Panel>
+        <Tabs.Panel value="patient" pt="md">
+          <PatientTab patient={patient} questionnaire={questionnaire} conditions={conditions} loading={loading} />
+        </Tabs.Panel>
+      </Tabs>
+    </Stack>
+  );
+}

--- a/examples/medplum-multilingual-demo/src/pages/DemoPage.tsx
+++ b/examples/medplum-multilingual-demo/src/pages/DemoPage.tsx
@@ -351,7 +351,7 @@ export function DemoPage(): JSX.Element {
 
       <Group justify="space-between" align="center">
         <div>
-          <Title order={2}>Multi-lingual FHIR Demo</Title>
+          <Title order={2}>Multilingual FHIR Demo</Title>
           <Text size="sm" c="dimmed" mt={2}>
             Demonstrating the <Code>http://hl7.org/fhir/StructureDefinition/translation</Code> extension
           </Text>

--- a/examples/medplum-multilingual-demo/src/pages/LandingPage.tsx
+++ b/examples/medplum-multilingual-demo/src/pages/LandingPage.tsx
@@ -9,13 +9,13 @@ export function LandingPage(): JSX.Element {
   return (
     <Document width={540}>
       <Stack align="center" gap="md">
-        <Title order={2}>Multi-lingual FHIR Demo</Title>
+        <Title order={2}>Multilingual FHIR Demo</Title>
         <Text ta="center">
           This demo shows how to use the FHIR{' '}
           <Anchor href="http://hl7.org/fhir/StructureDefinition/translation" target="_blank">
             translation extension
           </Anchor>{' '}
-          to store and display multi-lingual content in FHIR resources — covering Questionnaire items, Coding display
+          to store and display multilingual content in FHIR resources — covering Questionnaire items, Coding display
           strings, and patient preferred language.
         </Text>
         <Text ta="center" c="dimmed" size="sm">

--- a/examples/medplum-multilingual-demo/src/pages/LandingPage.tsx
+++ b/examples/medplum-multilingual-demo/src/pages/LandingPage.tsx
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Anchor, Button, Stack, Text, Title } from '@mantine/core';
+import { Document } from '@medplum/react';
+import type { JSX } from 'react';
+import { Link } from 'react-router';
+
+export function LandingPage(): JSX.Element {
+  return (
+    <Document width={540}>
+      <Stack align="center" gap="md">
+        <Title order={2}>Multi-lingual FHIR Demo</Title>
+        <Text ta="center">
+          This demo shows how to use the FHIR{' '}
+          <Anchor href="http://hl7.org/fhir/StructureDefinition/translation" target="_blank">
+            translation extension
+          </Anchor>{' '}
+          to store and display multi-lingual content in FHIR resources — covering Questionnaire items, Coding display
+          strings, and patient preferred language.
+        </Text>
+        <Text ta="center" c="dimmed" size="sm">
+          Sign in with your{' '}
+          <Anchor href="https://app.medplum.com/register" target="_blank">
+            Medplum account
+          </Anchor>{' '}
+          to get started.
+        </Text>
+        <Button component={Link} to="/signin" size="md">
+          Sign in
+        </Button>
+      </Stack>
+    </Document>
+  );
+}

--- a/examples/medplum-multilingual-demo/src/pages/SignInPage.tsx
+++ b/examples/medplum-multilingual-demo/src/pages/SignInPage.tsx
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Title } from '@mantine/core';
+import { Logo, SignInForm } from '@medplum/react';
+import type { JSX } from 'react';
+import { useNavigate } from 'react-router';
+import { getConfig } from '../config';
+
+export function SignInPage(): JSX.Element {
+  const navigate = useNavigate();
+  return (
+    <SignInForm
+      googleClientId={getConfig().googleClientId}
+      clientId={getConfig().clientId}
+      onSuccess={() => navigate('/')?.catch(console.error)}
+    >
+      <Logo size={32} />
+      <Title>Sign in to Medplum</Title>
+    </SignInForm>
+  );
+}

--- a/examples/medplum-multilingual-demo/src/utils/translation.ts
+++ b/examples/medplum-multilingual-demo/src/utils/translation.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { Extension } from '@medplum/fhirtypes';
+
+export const TRANSLATION_EXTENSION_URL = 'http://hl7.org/fhir/StructureDefinition/translation';
+
+/**
+ * Shadow element type — the `_fieldName` counterpart of any FHIR string primitive.
+ * Carries extensions (including translation extensions) about the primitive value.
+ */
+export interface ShadowElement {
+  extension?: Extension[];
+}
+
+/**
+ * Returns the translation of a FHIR string primitive for the given BCP-47 language tag.
+ * Falls back to the primary value if no exact match is found.
+ *
+ * @param primaryValue - The primary (default) string value of the field.
+ * @param shadow - The `_fieldName` shadow element from the FHIR resource.
+ * @param lang - BCP-47 language tag to look up (e.g. 'es', 'fr', 'zh').
+ * @returns The translated string, or the primary value if no translation is found.
+ */
+export function getTranslation(
+  primaryValue: string | undefined,
+  shadow: ShadowElement | undefined,
+  lang: string
+): string | undefined {
+  const translations = shadow?.extension?.filter((ext) => ext.url === TRANSLATION_EXTENSION_URL);
+
+  for (const t of translations ?? []) {
+    const langExt = t.extension?.find((e) => e.url === 'lang');
+    const contentExt = t.extension?.find((e) => e.url === 'content');
+    if (langExt?.valueCode === lang && contentExt?.valueString) {
+      return contentExt.valueString;
+    }
+  }
+
+  return primaryValue;
+}
+
+/**
+ * Returns the best available translation for the given BCP-47 language tag.
+ * Tries an exact match first (e.g. 'pt-BR'), then falls back to the base language
+ * tag (e.g. 'pt'), then to the primary value.
+ *
+ * @param primaryValue - The primary (default) string value of the field.
+ * @param shadow - The `_fieldName` shadow element from the FHIR resource.
+ * @param lang - BCP-47 language tag to look up.
+ * @returns The best available translated string, or the primary value if no translation is found.
+ */
+export function getBestTranslation(
+  primaryValue: string | undefined,
+  shadow: ShadowElement | undefined,
+  lang: string
+): string | undefined {
+  // Try exact match first (e.g. 'pt-BR')
+  const exact = getTranslation(primaryValue, shadow, lang);
+  if (exact !== primaryValue) {
+    return exact;
+  }
+
+  // Fall back to base language tag (e.g. 'pt')
+  const baseLang = lang.split('-')[0];
+  if (baseLang !== lang) {
+    return getTranslation(primaryValue, shadow, baseLang);
+  }
+
+  return primaryValue;
+}

--- a/examples/medplum-multilingual-demo/src/vite-env.d.ts
+++ b/examples/medplum-multilingual-demo/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/// <reference types="vite/client" />

--- a/examples/medplum-multilingual-demo/tsconfig.json
+++ b/examples/medplum-multilingual-demo/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "exclude": ["dist"]
+}

--- a/examples/medplum-multilingual-demo/vite.config.ts
+++ b/examples/medplum-multilingual-demo/vite.config.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import react from '@vitejs/plugin-react';
+import dns from 'dns';
+import { copyFileSync, existsSync } from 'fs';
+import path from 'path';
+import { defineConfig } from 'vite';
+
+dns.setDefaultResultOrder('verbatim');
+
+if (!existsSync(path.join(__dirname, '.env'))) {
+  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+}
+
+export default defineConfig({
+  envPrefix: ['MEDPLUM_', 'GOOGLE_'],
+  plugins: [react()],
+  server: {
+    host: 'localhost',
+    port: 3001,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -439,6 +439,29 @@
         "node": "^22.18.0 || >=24.2.0"
       }
     },
+    "examples/medplum-multilingual-demo/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "examples/medplum-multilingual-demo/node_modules/@medplum/core": {
       "version": "5.1.13",
       "resolved": "https://registry.npmjs.org/@medplum/core/-/core-5.1.13.tgz",
@@ -541,6 +564,283 @@
         "react": "^18.0.0 || ^19.0.0"
       }
     },
+    "examples/medplum-multilingual-demo/node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@types/react": {
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
     "examples/medplum-multilingual-demo/node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -632,6 +932,29 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "examples/medplum-multilingual-demo/node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
     "examples/medplum-multilingual-demo/node_modules/react-router": {
       "version": "7.15.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
@@ -655,6 +978,40 @@
         }
       }
     },
+    "examples/medplum-multilingual-demo/node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+      }
+    },
     "examples/medplum-multilingual-demo/node_modules/semver": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
@@ -675,6 +1032,84 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "dev": true,
       "license": "MIT"
+    },
+    "examples/medplum-multilingual-demo/node_modules/vite": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
     },
     "examples/medplum-patient-intake-demo": {
       "version": "5.1.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -412,6 +412,270 @@
         "node": "^22.18.0 || >=24.2.0"
       }
     },
+    "examples/medplum-multilingual-demo": {
+      "version": "5.1.13",
+      "devDependencies": {
+        "@mantine/core": "8.3.18",
+        "@mantine/hooks": "8.3.18",
+        "@mantine/notifications": "8.3.18",
+        "@medplum/core": "5.1.13",
+        "@medplum/eslint-config": "5.1.13",
+        "@medplum/fhirtypes": "5.1.13",
+        "@medplum/react": "5.1.13",
+        "@tabler/icons-react": "3.44.0",
+        "@types/node": "22.19.19",
+        "@types/react": "19.2.15",
+        "@types/react-dom": "19.2.3",
+        "@vitejs/plugin-react": "6.0.2",
+        "postcss": "8.5.15",
+        "postcss-preset-mantine": "1.18.0",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
+        "react-router": "7.15.1",
+        "typescript": "6.0.3",
+        "vite": "8.0.14"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.2.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@medplum/core": {
+      "version": "5.1.13",
+      "resolved": "https://registry.npmjs.org/@medplum/core/-/core-5.1.13.tgz",
+      "integrity": "sha512-oGd6dy6n6wEJ7K/SO7/LUWlyFYyuw0RiMfoE1CFsjhm3sUlhP/Kh2HS2UHwSlIN3jxkmaWFJGwObSBF1QiQBkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^22.18.0 || >=24.2.0"
+      },
+      "peerDependencies": {
+        "pdfmake": "^0.2.5"
+      },
+      "peerDependenciesMeta": {
+        "pdfmake": {
+          "optional": true
+        }
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@medplum/eslint-config": {
+      "version": "5.1.13",
+      "resolved": "https://registry.npmjs.org/@medplum/eslint-config/-/eslint-config-5.1.13.tgz",
+      "integrity": "sha512-tijwF1xC5O0RAnzIBTwSdcQHNAxz8CLPH9+uSEDtxc17wGQmPK/LkDAhOlwL2s9TI9WK7x6OkCZsV4Al1DiFUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^22.18.0 || >=24.2.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9",
+        "eslint-plugin-header": "^3",
+        "eslint-plugin-import": "^2",
+        "eslint-plugin-jsdoc": "^62",
+        "eslint-plugin-no-only-tests": "^3",
+        "eslint-plugin-react-hooks": "^7",
+        "eslint-plugin-react-refresh": "^0",
+        "typescript-eslint": "^8"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@medplum/fhirtypes": {
+      "version": "5.1.13",
+      "resolved": "https://registry.npmjs.org/@medplum/fhirtypes/-/fhirtypes-5.1.13.tgz",
+      "integrity": "sha512-7W5o4BprB/4hGaesRljAsdMPFRzM/Lsgic3DnNoOvvx9LCoOoy2C5NT4u4FjmQ8wjuvn+Mvmz5SPtJlW29skvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^22.18.0 || >=24.2.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@medplum/react": {
+      "version": "5.1.13",
+      "resolved": "https://registry.npmjs.org/@medplum/react/-/react-5.1.13.tgz",
+      "integrity": "sha512-E7IGxsa7agyTQPipfGGxTfYRp4juDw+/z7c8WDk5SV7LV3KyIh4niRXOSx10p/WcGXNquJkPIaH9XGpaeydHdw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^22.18.0 || >=24.2.0"
+      },
+      "peerDependencies": {
+        "@mantine/core": "^8.0.0",
+        "@mantine/hooks": "^8.0.0",
+        "@mantine/notifications": "^8.0.0",
+        "@mantine/spotlight": "^8.0.0",
+        "@medplum/core": "5.1.13",
+        "@medplum/react-hooks": "5.1.13",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "rfc6902": "^5.0.1",
+        "signature_pad": "^5.0.10"
+      },
+      "peerDependenciesMeta": {
+        "@mantine/core": {
+          "optional": true
+        },
+        "@mantine/hooks": {
+          "optional": true
+        },
+        "@mantine/notifications": {
+          "optional": true
+        },
+        "rfc6902": {
+          "optional": true
+        },
+        "signature_pad": {
+          "optional": true
+        }
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/@medplum/react-hooks": {
+      "version": "5.1.13",
+      "resolved": "https://registry.npmjs.org/@medplum/react-hooks/-/react-hooks-5.1.13.tgz",
+      "integrity": "sha512-qx7b/W81Vwnq8Q/j69cjREhLQR5b/WJ0gtSKNUhdueGaIbGHb3AWpAkqz733WNOPcraqPRmfngBhHFa2Wrup3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^22.18.0 || >=24.2.0"
+      },
+      "peerDependencies": {
+        "@medplum/core": "5.1.13",
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/eslint-plugin-jsdoc": {
+      "version": "62.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.9.0.tgz",
+      "integrity": "sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.86.0",
+        "@es-joy/resolve.exports": "1.2.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.6",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.4",
+        "spdx-expression-parse": "^4.0.0",
+        "to-valid-identifier": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/react-router": {
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
+      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "examples/medplum-multilingual-demo/node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "examples/medplum-patient-intake-demo": {
       "version": "5.1.17",
       "devDependencies": {
@@ -33112,6 +33376,10 @@
     },
     "node_modules/medplum-mso-demo": {
       "resolved": "examples/medplum-mso-demo",
+      "link": true
+    },
+    "node_modules/medplum-multilingual-demo": {
+      "resolved": "examples/medplum-multilingual-demo",
       "link": true
     },
     "node_modules/medplum-patient-intake-demo": {

--- a/packages/docs/docs/fhir-datastore/multilingual-support.md
+++ b/packages/docs/docs/fhir-datastore/multilingual-support.md
@@ -183,8 +183,9 @@ translated for patient-facing portals:
 
 ### Extracting a Translation for a Known Language
 
-To display a translated value, walk the shadow element's extensions and find the `translation` entry whose `lang`
-matches the desired locale:
+To display a translated value, pass the parent resource object and the field name. The function reads both
+`parent[elementName]` (the primary value) and `parent['_' + elementName]` (the shadow element) and returns the
+matching translation:
 
 ```ts
 import { Extension } from '@medplum/fhirtypes';
@@ -193,16 +194,19 @@ import { Extension } from '@medplum/fhirtypes';
  * Returns the translation of a primitive string field for the given BCP-47 language tag,
  * falling back to the primary value if no translation is found.
  *
- * @param primaryValue - The primary (default) string value of the field.
- * @param shadowElement - The `_fieldName` shadow element from the FHIR resource.
+ * @param parent - The parent FHIR object containing the field (e.g. a QuestionnaireItem).
+ * @param elementName - The name of the string field (e.g. 'text', 'display').
  * @param lang - BCP-47 language tag to look up (e.g. 'es', 'fr', 'zh-CN').
  */
 function getTranslation(
-  primaryValue: string | undefined,
-  shadowElement: { extension?: Extension[] } | undefined,
+  parent: Record<string, any>,
+  elementName: string,
   lang: string
 ): string | undefined {
-  const translations = shadowElement?.extension?.filter(
+  const primaryValue = parent[elementName] as string | undefined;
+  const shadow = parent['_' + elementName] as { extension?: Extension[] } | undefined;
+
+  const translations = shadow?.extension?.filter(
     (ext) => ext.url === 'http://hl7.org/fhir/StructureDefinition/translation'
   );
 
@@ -224,7 +228,7 @@ function getTranslation(
 const item = questionnaire.item?.[0];
 const userLang = 'es';
 
-const label = getTranslation(item?.text, item?._text, userLang);
+const label = getTranslation(item, 'text', userLang);
 // → "¿Cómo se llama?" (falls back to "What is your name?" if no Spanish translation exists)
 ```
 
@@ -236,18 +240,20 @@ match first, then fall back to the base language if a region-specific variant is
 
 ```ts
 function getBestTranslation(
-  primaryValue: string | undefined,
-  shadowElement: { extension?: Extension[] } | undefined,
+  parent: Record<string, any>,
+  elementName: string,
   lang: string
 ): string | undefined {
+  const primaryValue = parent[elementName] as string | undefined;
+
   // Try exact match first (e.g. 'pt-BR')
-  const exact = getTranslation(primaryValue, shadowElement, lang);
+  const exact = getTranslation(parent, elementName, lang);
   if (exact !== primaryValue) return exact;
 
   // Fall back to base language tag (e.g. 'pt')
   const baseLang = lang.split('-')[0];
   if (baseLang !== lang) {
-    return getTranslation(primaryValue, shadowElement, baseLang);
+    return getTranslation(parent, elementName, baseLang);
   }
 
   return primaryValue;

--- a/packages/docs/docs/fhir-datastore/multilingual-support.md
+++ b/packages/docs/docs/fhir-datastore/multilingual-support.md
@@ -1,4 +1,4 @@
-# Multi-lingual Support
+# Multilingual Support
 
 FHIR provides a standard mechanism for attaching translations to any string field in a resource: the
 [`translation` extension](http://hl7.org/fhir/StructureDefinition/translation). This lets you store the primary
@@ -286,10 +286,15 @@ patient, and your application can use it to select the right translation at rend
 The `translation` extension and [`CodeSystem.designation`](/docs/terminology/medplum-terminology-services#internationalizing-codings)
 serve different purposes and are complementary:
 
-| Mechanism | Where it lives | Best for |
-|---|---|---|
-| `translation` extension | On individual resource fields (via `_fieldName`) | Translating free text, notes, questionnaire items, narrative, and `Coding.display` in a specific resource |
-| `CodeSystem.designation` + `ValueSet/$expand` | In the terminology server | Translating standardized code display names across the system; powering language-aware code searches |
+| Mechanism | Where it lives | Searchable? | Best for |
+|---|---|---|---|
+| `translation` extension | On individual resource fields (via `_fieldName`) | No — for display only | Translating free text, notes, questionnaire items, narrative, and `Coding.display` in a specific resource |
+| `CodeSystem.designation` + `ValueSet/$expand` | In the terminology server | Yes — `ValueSet/$expand?filter=...&displayLanguage=es` returns matching codes in the requested language | Translating standardized code display names system-wide; powering language-aware code lookups and typeaheads |
+
+**Key difference:** translations attached via the `translation` extension are invisible to FHIR search — they exist
+solely for rendering. If you need to search or match codes by their name in a given language (e.g. letting a
+clinician type "Diabetes" in Spanish to find the right SNOMED code), store those translations as
+`CodeSystem.designation` entries instead.
 
 For coded values, prefer managing translations centrally in `CodeSystem` designations so they are automatically
 available anywhere that code is used. Use the `translation` extension for free-text fields and for overriding or

--- a/packages/docs/docs/fhir-datastore/multilingual-support.md
+++ b/packages/docs/docs/fhir-datastore/multilingual-support.md
@@ -1,0 +1,314 @@
+# Multi-lingual Support
+
+FHIR provides a standard mechanism for attaching translations to any string field in a resource: the
+[`translation` extension](http://hl7.org/fhir/StructureDefinition/translation). This lets you store the primary
+text of a field in one language while embedding translations for other languages directly inside the same resource,
+keeping all language variants together and avoiding the need to maintain separate per-language copies of your data.
+
+## How the Extension Works
+
+In FHIR JSON, every string primitive can have a "shadow" element — a sibling property prefixed with `_` — that
+carries extensions and metadata about that value. The `translation` extension is placed on this shadow element:
+
+```js
+{
+  // The primary (default) value of the field
+  "text": "What is your name?",
+
+  // Shadow element carrying translations for the same field
+  "_text": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+        "extension": [
+          { "url": "lang", "valueCode": "es" },
+          { "url": "content", "valueString": "¿Cómo se llama?" }
+        ]
+      },
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+        "extension": [
+          { "url": "lang", "valueCode": "fr" },
+          { "url": "content", "valueString": "Quel est votre nom ?" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Each repetition of the `translation` extension represents one translation, with two required sub-extensions:
+
+| Sub-extension | Type | Description |
+|---|---|---|
+| `lang` | `code` | BCP-47 language tag (e.g. `es`, `fr`, `zh-CN`, `pt-BR`) |
+| `content` | `string` | The translated text in the target language |
+
+The extension can appear on **any string or markdown primitive** in any FHIR resource.
+
+## Common Use Cases
+
+### Multilingual Questionnaires
+
+Patient-facing intake forms are one of the most common places to use the translation extension. Embedding all
+language variants in a single [`Questionnaire`](/docs/api/fhir/resources/questionnaire) resource keeps the form
+definition self-contained and ensures each question's translations stay synchronized with the primary text.
+
+```js
+{
+  "resourceType": "Questionnaire",
+  "status": "active",
+  "title": "Patient Intake",
+  "_title": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+        "extension": [
+          { "url": "lang", "valueCode": "es" },
+          { "url": "content", "valueString": "Registro de paciente" }
+        ]
+      }
+    ]
+  },
+  "item": [
+    {
+      "linkId": "preferred-language",
+      "type": "choice",
+      "text": "What is your preferred language?",
+      "_text": {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/translation",
+            "extension": [
+              { "url": "lang", "valueCode": "es" },
+              { "url": "content", "valueString": "¿Cuál es su idioma preferido?" }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/translation",
+            "extension": [
+              { "url": "lang", "valueCode": "zh-CN" },
+              { "url": "content", "valueString": "您的首选语言是什么？" }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+### Translating Coding Display Strings
+
+The `display` field of a [`Coding`](/docs/api/fhir/datatypes/coding) can carry translations the same way. This is
+useful when your application renders coded values directly from a resource and needs to show the correct language to
+the end user:
+
+```js
+{
+  "resourceType": "Condition",
+  "subject": { "reference": "Patient/example" },
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "44054006",
+        "display": "Diabetes mellitus type 2",
+        "_display": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                { "url": "lang", "valueCode": "es" },
+                { "url": "content", "valueString": "Diabetes mellitus tipo 2" }
+              ]
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                { "url": "lang", "valueCode": "fr" },
+                { "url": "content", "valueString": "Diabète sucré de type 2" }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "text": "Diabetes mellitus type 2"
+  },
+  "clinicalStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+        "code": "active"
+      }
+    ]
+  }
+}
+```
+
+### Clinical Notes and Narrative Text
+
+Free-text fields like `Annotation.text` (used in `Condition.note`, `MedicationRequest.note`, etc.) and
+`Narrative.div` also support the pattern. Notes are commonly authored in the clinician's language and then
+translated for patient-facing portals:
+
+```js
+{
+  "resourceType": "Condition",
+  "subject": { "reference": "Patient/example" },
+  "note": [
+    {
+      "text": "Patient reports symptoms began three weeks ago.",
+      "_text": {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/translation",
+            "extension": [
+              { "url": "lang", "valueCode": "es" },
+              {
+                "url": "content",
+                "valueString": "El paciente reporta que los síntomas comenzaron hace tres semanas."
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+## Reading Translations in Your Application
+
+### Extracting a Translation for a Known Language
+
+To display a translated value, walk the shadow element's extensions and find the `translation` entry whose `lang`
+matches the desired locale:
+
+```ts
+import { Extension } from '@medplum/fhirtypes';
+
+/**
+ * Returns the translation of a primitive string field for the given BCP-47 language tag,
+ * falling back to the primary value if no translation is found.
+ *
+ * @param primaryValue - The primary (default) string value of the field.
+ * @param shadowElement - The `_fieldName` shadow element from the FHIR resource.
+ * @param lang - BCP-47 language tag to look up (e.g. 'es', 'fr', 'zh-CN').
+ */
+function getTranslation(
+  primaryValue: string | undefined,
+  shadowElement: { extension?: Extension[] } | undefined,
+  lang: string
+): string | undefined {
+  const translations = shadowElement?.extension?.filter(
+    (ext) => ext.url === 'http://hl7.org/fhir/StructureDefinition/translation'
+  );
+
+  for (const t of translations ?? []) {
+    const langExt = t.extension?.find((e) => e.url === 'lang');
+    const contentExt = t.extension?.find((e) => e.url === 'content');
+    if (langExt?.valueCode === lang && contentExt?.valueString) {
+      return contentExt.valueString;
+    }
+  }
+
+  return primaryValue;
+}
+```
+
+**Usage example** — rendering a Questionnaire item in the user's language:
+
+```ts
+const item = questionnaire.item?.[0];
+const userLang = 'es';
+
+const label = getTranslation(item?.text, item?._text, userLang);
+// → "¿Cómo se llama?" (falls back to "What is your name?" if no Spanish translation exists)
+```
+
+### Matching with BCP-47 Language Tags
+
+Language tags follow [BCP 47](https://www.rfc-editor.org/rfc/rfc5646) conventions. When matching, prefer an exact
+match first, then fall back to the base language if a region-specific variant is not found
+(e.g. try `pt-BR` first, then `pt`):
+
+```ts
+function getBestTranslation(
+  primaryValue: string | undefined,
+  shadowElement: { extension?: Extension[] } | undefined,
+  lang: string
+): string | undefined {
+  // Try exact match first (e.g. 'pt-BR')
+  const exact = getTranslation(primaryValue, shadowElement, lang);
+  if (exact !== primaryValue) return exact;
+
+  // Fall back to base language tag (e.g. 'pt')
+  const baseLang = lang.split('-')[0];
+  if (baseLang !== lang) {
+    return getTranslation(primaryValue, shadowElement, baseLang);
+  }
+
+  return primaryValue;
+}
+```
+
+## Storing the Patient's Preferred Language
+
+Record a patient's preferred language on the [`Patient`](/docs/api/fhir/resources/patient) resource using the
+`communication` field. This is the standard FHIR way to track which language to use when communicating with a
+patient, and your application can use it to select the right translation at render time:
+
+```js
+{
+  "resourceType": "Patient",
+  "name": [{ "given": ["Maria"], "family": "Garcia" }],
+  "communication": [
+    {
+      "language": {
+        "coding": [
+          {
+            "system": "urn:ietf:bcp:47",
+            "code": "es",
+            "display": "Spanish"
+          }
+        ]
+      },
+      "preferred": true
+    }
+  ]
+}
+```
+
+## Relationship to CodeSystem Designations
+
+The `translation` extension and [`CodeSystem.designation`](/docs/terminology/medplum-terminology-services#internationalizing-codings)
+serve different purposes and are complementary:
+
+| Mechanism | Where it lives | Best for |
+|---|---|---|
+| `translation` extension | On individual resource fields (via `_fieldName`) | Translating free text, notes, questionnaire items, narrative, and `Coding.display` in a specific resource |
+| `CodeSystem.designation` + `ValueSet/$expand` | In the terminology server | Translating standardized code display names across the system; powering language-aware code searches |
+
+For coded values, prefer managing translations centrally in `CodeSystem` designations so they are automatically
+available anywhere that code is used. Use the `translation` extension for free-text fields and for overriding or
+supplementing a code's display in the context of a specific resource.
+
+## Example App
+
+The [medplum-multilingual-demo](https://github.com/medplum/medplum/tree/main/examples/medplum-multilingual-demo)
+example app demonstrates all of the patterns on this page in a working React application:
+
+- A multilingual [`Questionnaire`](/docs/api/fhir/resources/questionnaire) with translated item text, submitted as a
+  [`QuestionnaireResponse`](/docs/api/fhir/resources/questionnaireresponse) that records the language used
+- [`Condition`](/docs/api/fhir/resources/condition) resources with translated `Coding.display` strings
+- Reading [`Patient.communication`](/docs/api/fhir/resources/patient) to automatically select the patient's preferred language
+
+## Further Reading
+
+- [FHIR Translation Extension specification](http://hl7.org/fhir/StructureDefinition/translation)
+- [FHIR Internationalizing FHIR guidance](https://www.hl7.org/fhir/r4/languages.html)
+- [Medplum Terminology Services — Internationalizing Codings](/docs/terminology/medplum-terminology-services#internationalizing-codings)
+- [Questionnaire resource reference](/docs/api/fhir/resources/questionnaire)
+- [Patient resource reference](/docs/api/fhir/resources/patient)

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -185,6 +185,7 @@ const sidebars: SidebarsConfig = {
         { type: 'doc', id: 'fhir-datastore/fhir-batch-requests' },
         { type: 'doc', id: 'fhir-datastore/processing-async-bundles' },
         { type: 'doc', id: 'fhir-datastore/working-with-fhir' },
+        { type: 'doc', id: 'fhir-datastore/multilingual-support' },
         {
           type: 'html',
           value: '<strong class="menu__link">Data Validation</strong>',


### PR DESCRIPTION
## Summary

- **New doc** — `docs/fhir-datastore/multilingual-support.md` covering the FHIR [`translation` extension](http://hl7.org/fhir/StructureDefinition/translation): how to attach translations to any string/markdown primitive via the `_fieldName` shadow element, with worked examples for Questionnaire items, `Coding.display`, clinical notes, and `Patient.communication` preferred language
- **New example app** — `examples/medplum-multilingual-demo`: a Vite + React app demonstrating the extension end-to-end with a multilingual intake Questionnaire, translated SNOMED Conditions, `QuestionnaireResponse` stamped with the active language, and patient preferred language detection
- **Sidebar** — doc added to Build → FHIR Datastore → FHIR Data, after "Working with FHIR Data"

## Test plan

- [x] Docs build cleanly (`npm run build:docs`)
- [x] New page appears in sidebar under FHIR Datastore → FHIR Data
- [x] Demo app runs (`cd examples/medplum-multilingual-demo && npm run dev`), signs in, seeds demo resources exactly once, language selector updates all three tabs, form submission creates a `QuestionnaireResponse` with `language` set and translated `item.text`