### PR TITLE
Data Warehouse DuckDB Lifecycle Cleanup

### DIFF
--- a/packages/server/src/data-warehouse/config.int.test.ts
+++ b/packages/server/src/data-warehouse/config.int.test.ts
@@ -79,6 +79,7 @@ describe('config (integration)', () => {
       expect(row.t).toBe('3s');
     } finally {
       connection.closeSync();
+      instance.closeSync();
     }
   }, 30_000);
 });

--- a/packages/server/src/data-warehouse/sync.int.test.ts
+++ b/packages/server/src/data-warehouse/sync.int.test.ts
@@ -129,6 +129,7 @@ describe('syncData local destination (integration)', () => {
       expect(row.project_id).toBe('project-from-json');
     } finally {
       c.closeSync();
+      instance.closeSync();
     }
   }, 30_000); // longer timeout because of database operations
 });

--- a/packages/server/src/data-warehouse/sync.ts
+++ b/packages/server/src/data-warehouse/sync.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { DuckDBInstance } from '@duckdb/node-api';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { MedplumDatabaseConfig } from '../config/types';
@@ -143,12 +144,13 @@ export async function syncData(options: SyncOptions): Promise<SyncResult> {
   const namespace = options.namespace ?? DEFAULT_NAMESPACE;
 
   let connection: WarehouseSyncDuckdbConnection | undefined;
+  let instance: DuckDBInstance | undefined;
   let duckdbTempDir: string | undefined;
   try {
     // create a temporary directory for the DuckDB database
     duckdbTempDir = mkdtempSync(join(tmpdir(), `medplum-dw-sync-`));
     const duckdbDatabasePath = join(duckdbTempDir, 'warehouse.duckdb');
-    const instance = await DuckDBInstance.create(duckdbDatabasePath);
+    instance = await DuckDBInstance.create(duckdbDatabasePath);
     connection = await instance.connect();
     for (const q of options.destination.getSetupQueries(sourceConnectionString)) {
       await connection.run(q);
@@ -157,14 +159,24 @@ export async function syncData(options: SyncOptions): Promise<SyncResult> {
     const tables = await runWarehouseTableSync(connection, options, namespace);
     return { tables };
   } finally {
-    // close the DuckDB connection
-    connection?.closeSync();
+    try {
+      connection?.closeSync();
+    } catch (err) {
+      globalLogger.warn('Failed closing data warehouse DuckDB connection', { err, subsystem: 'data-warehouse-sync' });
+    }
+
+    try {
+      instance?.closeSync();
+    } catch (err) {
+      globalLogger.warn('Failed closing data warehouse DuckDB instance', { err, subsystem: 'data-warehouse-sync' });
+    }
+
     /*
      * DuckDB often creates companion files next to the database, so
      * we're gonna delete the whole directory.
      */
     if (duckdbTempDir) {
-      rmSync(duckdbTempDir, { recursive: true, force: true });
+      await rm(duckdbTempDir, { recursive: true, force: true });
     }
   }
 }

--- a/packages/server/src/data-warehouse/sync.ts
+++ b/packages/server/src/data-warehouse/sync.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { DuckDBInstance } from '@duckdb/node-api';
-import { mkdtempSync } from 'node:fs';
-import { rm } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { MedplumDatabaseConfig } from '../config/types';
@@ -148,7 +147,7 @@ export async function syncData(options: SyncOptions): Promise<SyncResult> {
   let duckdbTempDir: string | undefined;
   try {
     // create a temporary directory for the DuckDB database
-    duckdbTempDir = mkdtempSync(join(tmpdir(), `medplum-dw-sync-`));
+    duckdbTempDir = await mkdtemp(join(tmpdir(), `medplum-dw-sync-`));
     const duckdbDatabasePath = join(duckdbTempDir, 'warehouse.duckdb');
     instance = await DuckDBInstance.create(duckdbDatabasePath);
     connection = await instance.connect();
@@ -176,7 +175,14 @@ export async function syncData(options: SyncOptions): Promise<SyncResult> {
      * we're gonna delete the whole directory.
      */
     if (duckdbTempDir) {
-      await rm(duckdbTempDir, { recursive: true, force: true });
+      try {
+        await rm(duckdbTempDir, { recursive: true, force: true });
+      } catch (err) {
+        globalLogger.warn('Failed deleting data warehouse DuckDB temp dir', {
+          err,
+          subsystem: 'data-warehouse-sync',
+        });
+      }
     }
   }
 }

--- a/packages/server/src/data-warehouse/warehouse-sql.int.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.int.test.ts
@@ -106,6 +106,7 @@ describe('warehouse SQL (integration)', () => {
       expect(row.project_id).toBe('project-from-json');
     } finally {
       connection.closeSync();
+      instance.closeSync();
     }
   }, 30_000);
 });

--- a/packages/server/src/data-warehouse/warehouse-sql.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.test.ts
@@ -19,7 +19,7 @@ describe('warehouse SQL query builders', () => {
     sql.appendExpression(query);
 
     expect(sql.toString()).toBe(
-      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1 AND "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z') ORDER BY "pg_db"."Patient_History"."lastUpdated") AS "src"`
+      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1 AND "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z')) AS "src"`
     );
     expect(sql.getValues()).toStrictEqual(['']);
   });
@@ -28,7 +28,7 @@ describe('warehouse SQL query builders', () => {
     const projectedSelectQuery = buildSelectFromHistoryTableQuery('Patient_History');
     const insertQuery = buildInsertIntoSelectQuery('iceberg_catalog.default.patient_history', projectedSelectQuery);
     expect(insertQuery.toString()).toBe(
-      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1) ORDER BY "pg_db"."Patient_History"."lastUpdated") AS "src"`
+      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1)) AS "src"`
     );
     expect(insertQuery.getValues()).toStrictEqual(['']);
   });

--- a/packages/server/src/data-warehouse/warehouse-sql.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.ts
@@ -153,8 +153,6 @@ export function buildSelectFromHistoryTableQuery(
   if (sourcePredicate) {
     inner.whereExpr(sourcePredicate);
   }
-  inner.orderBy('lastUpdated');
-
   return new SelectQuery('src', inner)
     .column('id')
     .column('version_id')


### PR DESCRIPTION
This PR makes a small, targeted cleanup change to the DuckDB lifecycle used by data warehouse sync jobs and removes an unnecessary source-table sort.

The motivation is production ECS telemetry showing increasing `Storage write (Bytes/Second)` over time on tasks running the S3 Tables data warehouse sync. The rate resets after deploys, which suggests process-lifetime DuckDB/native/temp-resource buildup rather than normal cumulative storage growth.

We do not know yet whether this fully explains the production behavior, but the missing `DuckDBInstance.closeSync()` is an obvious lifecycle gap and is worth fixing. Removing the unconditional sort also reduces a query shape that can cause DuckDB to spill intermediate data to local storage.

## Changes

- Close the `DuckDBInstance` after each sync, not just the DuckDB connection.
- Remove the unconditional `ORDER BY lastUpdated` from history-table export queries.
- Use async `fs.promises.rm()` for deleting the per-sync DuckDB temp directory.
- Close DuckDB instances in related integration tests.

## Why Remove `ORDER BY`

The previous query sorted every source history table by `lastUpdated` before writing to the destination. For Iceberg/S3 Tables, row order is not a correctness contract, and consumers should order explicitly when needed.

The sort can force DuckDB to materialize and spill intermediate state for large tables, which is a plausible contributor to elevated local write throughput. Removing it avoids a global sort during each table sync.

Tradeoff: local Parquet and Iceberg writes no longer have deterministic row order. That should not affect warehouse correctness.
