### PR TITLE
feat(data warehouse): restore ORDER BY

### DIFF
--- a/packages/server/src/data-warehouse/warehouse-sql.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.test.ts
@@ -19,7 +19,7 @@ describe('warehouse SQL query builders', () => {
     sql.appendExpression(query);
 
     expect(sql.toString()).toBe(
-      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1 AND "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z')) AS "src"`
+      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1 AND "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z')) AS "src" ORDER BY "src"."last_updated"`
     );
     expect(sql.getValues()).toStrictEqual(['']);
   });
@@ -28,7 +28,7 @@ describe('warehouse SQL query builders', () => {
     const projectedSelectQuery = buildSelectFromHistoryTableQuery('Patient_History');
     const insertQuery = buildInsertIntoSelectQuery('iceberg_catalog.default.patient_history', projectedSelectQuery);
     expect(insertQuery.toString()).toBe(
-      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1)) AS "src"`
+      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1)) AS "src" ORDER BY "src"."last_updated"`
     );
     expect(insertQuery.getValues()).toStrictEqual(['']);
   });

--- a/packages/server/src/data-warehouse/warehouse-sql.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.ts
@@ -153,12 +153,14 @@ export function buildSelectFromHistoryTableQuery(
   if (sourcePredicate) {
     inner.whereExpr(sourcePredicate);
   }
+
   return new SelectQuery('src', inner)
     .column('id')
     .column('version_id')
     .column('content')
     .column('last_updated')
-    .raw(`json_extract_string("src"."content"::JSON, '${PROJECT_ID_JSON_PATH}') AS project_id`);
+    .raw(`json_extract_string("src"."content"::JSON, '${PROJECT_ID_JSON_PATH}') AS project_id`)
+    .orderBy('last_updated');
 }
 
 export function buildProjectedSelectFromHistoryTable(


### PR DESCRIPTION
ORDER BY in the query makes sure the data is ordered in the Parquet files,
which means the metadata in the Parquet files will contain the proper metadata
for each row group, such as min/max.

This metadata is then used by Iceberg and query engines, and suboptimal metadata
will result can result in slow/inefficient query plans.

The risk of spilling to disk is slow, as the data is small and ECS Fargate ephemeral disk
tasks have a default of 20GB, which is more than enough for each resource type.

Signed-off-by: Karl Pietrzak <karl@medplum.com>
