### PR TITLE
Fix api-extractor warnings in react package

### DIFF
--- a/packages/react/src/Scheduler/Scheduler.tsx
+++ b/packages/react/src/Scheduler/Scheduler.tsx
@@ -13,13 +13,17 @@ import { ResourceAvatar } from '../ResourceAvatar/ResourceAvatar';
 import { ResourceName } from '../ResourceName/ResourceName';
 import classes from './Scheduler.module.css';
 
-type SchedulingOption<T> = [T, Date];
+export type SchedulingOption<T> = [T, Date];
 export type FetchOptionsFunction<T> = (period: Period) => Promise<SchedulingOption<T>[]>;
 
 export interface BaseSchedulerProps<T> {
+  /** A Reference or Resource to the actor being scheduled against (typically a Practitioner) */
   readonly actor?: Reference | Resource;
+  /** A function that fetches SchedulingOption pairs. If this is not a stable function it can cause duplicate queries. */
   readonly fetchOptions: FetchOptionsFunction<T>;
+  /** React nodes to render inside the scheduler container */
   readonly children?: React.ReactNode;
+  /** A callback invoked when a specific option is selected */
   readonly onSelectOption?: (el: T, date: Date) => void;
 }
 
@@ -28,10 +32,6 @@ export interface BaseSchedulerProps<T> {
  * calendar UI and lets the viewer drill down into options on a given day.
  *
  * @param props - The React props
- * @param props.actor - A Reference or Resource to the actor being scheduled against (typically a Practitioner)
- * @param props.fetchOptions - A function that fetches SchedulingOption pairs. If this is not a stable function it can cause duplicate queries.
- * @param props.onSelectOption - A callback invoked when a specific option is selected
- * @param props.children - React nodes to render inside the scheduler container
  * @returns the JSX Element
  */
 export function BaseScheduler<T>(props: BaseSchedulerProps<T>): JSX.Element | null {


### PR DESCRIPTION
Minor cleanup, fixing `api-extractor` warnings:

```
$ npm run build

> @medplum/react@5.1.15 build
> npm run clean && tsc && node esbuild.mjs && npm run api-extractor


> @medplum/react@5.1.15 clean
> rimraf dist storybook-static


> @medplum/react@5.1.15 api-extractor
> api-extractor run --local && shx cp dist/types.d.ts dist/cjs/index.d.ts && shx cp dist/types.d.ts dist/esm/index.d.ts


api-extractor 7.58.7  - https://api-extractor.com/

Using configuration from ./api-extractor.json
Analysis will use the bundled TypeScript version 6.0.3
Warning: src/Scheduler/Scheduler.tsx:17:1 - (ae-forgotten-export) The symbol "SchedulingOption" needs to be exported by the entry point index.d.ts
Warning: src/Scheduler/Scheduler.tsx:31:4 - (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
Warning: src/Scheduler/Scheduler.tsx:32:4 - (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
Warning: src/Scheduler/Scheduler.tsx:33:4 - (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
Warning: src/Scheduler/Scheduler.tsx:34:4 - (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters

API Extractor completed successfully
```