### PR TITLE
Server: Scheduling Parameters can be inherited from HealthcareService

### DIFF
--- a/packages/docs/docs/scheduling/defining-availability.md
+++ b/packages/docs/docs/scheduling/defining-availability.md
@@ -915,7 +915,7 @@ This Schedule will use the default availability for the "Follow-Up" service (Mon
       "extension": [
         "url": "https://medplum.com/fhir/service-type-reference",
         "valueReference": {
-          "reference": "HealthcareService/new-patient-visit,
+          "reference": "HealthcareService/new-patient-visit",
           "display": "New Patient Visit"
         }
       ]
@@ -931,7 +931,7 @@ This Schedule will use the default availability for the "Follow-Up" service (Mon
       "extension": [
         "url": "https://medplum.com/fhir/service-type-reference",
         "valueReference": {
-          "reference": "HealthcareService/follow-up,
+          "reference": "HealthcareService/follow-up",
           "display": "Follow-up Visit"
         }
       ]

--- a/packages/docs/docs/scheduling/defining-availability.md
+++ b/packages/docs/docs/scheduling/defining-availability.md
@@ -5,7 +5,11 @@ sidebar_position: 10
 
 # Defining Availability (Alpha)
 
-This guide covers how to configure availability using the `SchedulingParameters` extension — at both the actor level (per Schedule) and the service type level (via HealthcareService). It covers scheduling constraints, override behavior, timezone handling, and multi-resource scheduling patterns.
+This guide covers how to configure availability using the `SchedulingParameters` extension — at both the actor level (per Schedule) and the service type level (via HealthcareService). It covers scheduling constraints, field-level inheritance, override behavior, timezone handling, and multi-resource scheduling patterns.
+
+Parameters may be defined on a HealthcareService and shared amongst all Schedules that book that type
+of appointment. Each Schedule may also override these parameters to define behaviors specific to that
+schedule as needed.
 
 The diagram below shows how availability can be defined at both
 - The [actor level](/docs/scheduling/defining-availability#actor-level-availability) (via Schedule)
@@ -15,8 +19,8 @@ The diagram below shows how availability can be defined at both
 %%{init: {'theme':'base', 'themeVariables': {'fontSize':'14px'}, 'flowchart': {'useMaxWidth': false, 'htmlLabels': true}}}%%
 graph TD
     C1[Practitioner<br/>*Dr. Smith*] --> B1
-    A[HealthcareService<br/>*Initial Visit Defaults*<br/><br/><b>Service-level<br/>defined availability</b><br/>ex. <i>1hr slot duration</i>] -.-> B1[Schedule<br/>*Dr. Smith's Schedule*<br/><br/><b>Actor-level<br/>defined availability</b><br/>ex. <i>Mon–Fri, 9am–5pm</i>]
-    A -.-> B2[Schedule<br/>*Dr. Johnson's Schedule*<br/><br/><b>Actor-level<br/>defined availability</b><br/>ex. <i>Mon–Fri, 9am–5pm</i>]
+    A[HealthcareService<br/>*Initial Visit Defaults*<br/><br/><b>Service-level defaults</b><br/>ex. <i>1hr slot duration, 10min buffer</i><br/><i>Mon–Fri 9am–5pm availability</i>] -.->|inherited by| B1[Schedule<br/>*Dr. Smith's Schedule*<br/><br/><b>Actor-level overrides</b><br/>ex. <i>availability: Mon–Wed only</i>]
+    A -.->|inherited by| B2[Schedule<br/>*Dr. Johnson's Schedule*<br/><br/><b>no overrides</b><br/><i>uses all service defaults</i>]
     C2[Practitioner<br/>*Dr. Johnson*] --> B2
 
     B1 --> D1[Slot<br/>*status: busy*]
@@ -42,24 +46,105 @@ graph TD
 
 ## The Scheduling Parameters Extension
 
-All scheduling constraints are managed through a single consolidated extension: `SchedulingParameters`. This extension can appear on both [HealthcareService](/docs/api/fhir/resources/healthcareservice) (for defaults) and [Schedule](/docs/api/fhir/resources/schedule).
+All scheduling constraints are managed through a single consolidated extension: `SchedulingParameters`. This extension can appear on both [HealthcareService](/docs/api/fhir/resources/healthcareservice) (for shared configuration) and [Schedule](/docs/api/fhir/resources/schedule).
 
-#### Extension Fields Reference
+To use scheduling APIs for a Schedule and HealthcareService, at least one of them must define the `duration` attribute (used to set how long the scheduled appointment will last). There must be a `timezone` attribute, which may also be defined on the Schedule's actor. (See [Timezone Resolution](#timezone-resolution))
 
-| Url                 | Type                                                        | Applies To                          | Required                                        | Behavior when defined                                                                                                                                                                | Behavior when not defined                                                              |
-| ------------------- | ----------------------------------------------------------- | ----------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| `service`           | Reference(HealthcareService)                                | Schedule only                       | Required                                        | Applies configuration only to the specified service type, overriding defaults for that service                                                                                       | N/A - must be specified                                                                |
-| `availability`      | [Nested extension](#availability-extension)                 | Schedule only                       | Optional                                        | Bookings must fully fit within the recurring windows (day-of-week + start time + end time).                                                                                          | Time is implicitly available by default (unless blocked by Slots or other constraints) |
-| `timezone`          | Code                                                        | Schedule only                       | Optional                                        | Specifies the timezone (IANA timezone identifier, e.g., `America/New_York`) for interpreting availability times. Falls back to the Schedule's actor timezone if not specified        | Uses the timezone defined on the Schedule's actor reference                            |
-| `duration`          | [Duration](/docs/api/fhir/datatypes/duration)               | Both Schedule and HealthcareService | Required                                        | Determines how long the time increments for a Slot are                                                                                                                               | N/A - must be specified                                                                |
-| `bufferBefore`      | [Duration](/docs/api/fhir/datatypes/duration)               | Both Schedule and HealthcareService | Optional                                        | Requires prep time before start to also be free                                                                                                                                      | No prep time required                                                                  |
-| `bufferAfter`       | [Duration](/docs/api/fhir/datatypes/duration)               | Both Schedule and HealthcareService | Optional                                        | Requires cleanup time after end to also be free                                                                                                                                      | No cleanup time required                                                               |
-| `alignmentInterval` | [Duration](/docs/api/fhir/datatypes/duration)               | Both Schedule and HealthcareService | Optional                                        | Start times must align to the interval (e.g., every 15 minutes)                                                                                                                      | Start times are not constrained by an interval grid                                    |
-| `alignmentOffset`   | [Duration](/docs/api/fhir/datatypes/duration)               | Both Schedule and HealthcareService | Optional, and alignmentInterval must be defined | Shifts allowed start times by the offset relative to the interval (e.g., with a 15-minute alignmentInterval and a 5-minute alignmentOffset, valid starts are :05, :20, :35, :50)     | Grid anchored to :00 (no shift)                                                        |
-| `bookingLimit`      | [Timing](/docs/api/fhir/datatypes/timing)                   | Both Schedule and HealthcareService | Optional                                        | Caps number of appointments per period (multiple entries can stack)                                                                                                                  | No capacity cap for that period                                                        |
+When using scheduling APIs to interact with multiple `Schedule` resources at once, they must be configured with matching `duration`, `alignmentInterval`, and `alignmentOffset` parameters. For this reason, Medplum recommends that these parameters only be set on `HealthcareService` resources.
+
+#### Extension Fields
+
+| Url                 | Type                                                        | Default Value                               | Description                                                                                                                                                             | `HealthcareService` usage notes                               | `Schedule` usage notes                                    |
+| ------------------- | ----------------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------- |
+| `duration`          | [Duration](/docs/api/fhir/datatypes/duration)               | *none*                                      | Determines how long the time increments for a Slot are                                                                                                                  |                                                               | Recommended to prefer setting this on `HealthcareService` |
+| `timezone`          | Code                                                        | *none*                                      | Specifies the timezone (IANA timezone identifier, e.g., `America/New_York`) for interpreting availability. When not set, falls back to the `Schedule.actor`'s timezone. |                                                               |                                                           |
+| `bufferBefore`      | [Duration](/docs/api/fhir/datatypes/duration)               | 0 minutes (no buffer needed)                | Sets prep-time needed before appointment start. It must be free at booking time, and will be reserved with a Slot.                                                      |                                                               |                                                           |
+| `bufferAfter`       | [Duration](/docs/api/fhir/datatypes/duration)               | 0 minutes (no buffer needed)                | Sets cleanup time needed after appointment end. It must be free at booking time, and will be reserved with a Slot.                                                      |                                                               |                                                           |
+| `alignmentInterval` | [Duration](/docs/api/fhir/datatypes/duration)               | 60 minutes (appointments start on-the-hour) | Start times must align to this interval (e.g., every 15 minutes)                                                                                                        |                                                               | Recommended to prefer setting this on `HealthcareService` |
+| `alignmentOffset`   | [Duration](/docs/api/fhir/datatypes/duration)               | 0 minutes                                   | Shifts allowed start times by this offset (e.g., with a 15-minute alignmentInterval and a 5-minute alignmentOffset, valid starts are :05, :20, :35, :50)                |                                                               | Recommended to prefer setting this on `HealthcareService` |
+| `service`           | `Reference(HealthcareService)`                              | *none*                                      | Pointer to the `HealthcareService` that these parameters  should override.                                                                                              | Not permitted                                                 |                                                           |
+| `availability`      | [Nested Extension](#availability-extension)                 | Always available                            | Weekly recurring availability windows. When set, appointments must fit inside these windows.                                                                            | Not permitted (use `HealthcareService.availableTime` instead) |                                                           |
+
 
 <details>
-<summary>Example of the `SchedulingParameters` extension</summary>
+<summary>Example of the `SchedulingParameters` extension on a `HealthcareService`</summary>
+
+```tsx
+{
+  "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
+  "extension": [
+    // Recommended: duration determines how long the time increments for a Slot are.
+    // If not set here, must be defined on all related Schedules. To book on multiple
+    // schedules at once, they must all match in this dimension.
+    {
+      "url": "duration",
+      "valueDuration": {
+        "value": 1,
+        "unit": "h"
+      }
+    },
+
+    // Recommended: Time alignment interval (appointment start time boundaries)
+    // To book on multiple schedules at once, they must all match in this dimension.
+    {
+      "url": "alignmentInterval",
+      "valueDuration": {
+        "value": 15,
+        "unit": "min",
+        "system": "http://unitsofmeasure.org",
+        "code": "min"
+      }
+    },
+
+    // Recommended: Time alignment offset (shift from interval boundaries)
+    // To book on multiple schedules at once, they must all match in this dimension.
+    {
+      "url": "alignmentOffset",
+      "valueDuration": {
+        "value": 0,
+        "unit": "min",
+        "system": "http://unitsofmeasure.org",
+        "code": "min"
+      }
+    }
+
+    // Optional: specify time zone for availability interpretation
+    // Falls back to Schedule's actor time zone if not specified
+    {
+      "url": "timezone",
+      "valueCode": "America/Los_Angeles"
+    },
+
+
+    // Optional: Buffer time required before appointment
+    {
+      "url": "bufferBefore",
+      "valueDuration": {
+        "value": 15,
+        "unit": "min",
+        "system": "http://unitsofmeasure.org",
+        "code": "min"
+      }
+    },
+
+    // Optional: Buffer time required after appointment
+    {
+      "url": "bufferAfter",
+      "valueDuration": {
+        "value": 10,
+        "unit": "min",
+        "system": "http://unitsofmeasure.org",
+        "code": "min"
+      }
+    }
+  ]
+}
+```
+</details>
+
+
+<details>
+<summary>Example of the `SchedulingParameters` extension on a `Schedule`</summary>
 
 ```tsx
 {
@@ -74,14 +159,15 @@ All scheduling constraints are managed through a single consolidated extension: 
       }
     },
 
-    // Optional: specify time zone for availability interpretation (Schedule only)
+    // Optional: specify time zone for availability interpretation
     // Falls back to Schedule's actor time zone if not specified
     {
       "url": "timezone",
       "valueCode": "America/Los_Angeles"
     },
 
-    // Required: duration determines how long the time increments for a Slot are
+    // Optional: duration determines how long the time increments for a Slot are.
+    // If not set here, must be defined on the related HealthcareService
     {
       "url": "duration",
       "valueDuration": {
@@ -148,18 +234,6 @@ All scheduling constraints are managed through a single consolidated extension: 
         "unit": "min",
         "system": "http://unitsofmeasure.org",
         "code": "min"
-      }
-    },
-
-    // Booking limits (can have multiple)
-    {
-      "url": "bookingLimit",
-      "valueTiming": {
-        "repeat": {
-          "frequency": 8,
-          "period": 1,
-          "periodUnit": "d"
-        }
       }
     }
   ]
@@ -321,9 +395,9 @@ The `availability` sub-extension mirrors the FHIR R5+ [`Availability`](https://h
 
 ### Service Types and HealthcareService
 
-An [HealthcareService](/docs/api/fhir/resources/healthcareservice) gives a mechanism to define the default scheduling parameters for a specific service type (appointment type), which can then be used by multiple [Practitioner](/docs/api/fhir/resources/practitioner)'s [Schedules](/docs/api/fhir/resources/schedule). This allows you to define standard appointment durations, buffer times, alignment intervals, and booking limits once and apply them across multiple providers.
+A [HealthcareService](/docs/api/fhir/resources/healthcareservice) gives a mechanism to define common scheduling parameters for an appointment type, which can then be used by multiple [Practitioner](/docs/api/fhir/resources/practitioner)'s [Schedules](/docs/api/fhir/resources/schedule). This allows you to define standard appointment durations, buffer times, alignment intervals, and booking limits once and apply them across multiple providers.
 
-To get the [Schedule](/docs/api/fhir/resources/schedule) to use the [HealthcareService](/docs/api/fhir/resources/healthcareservice)'s scheduling parameters, the `Schedule.serviceType` must include a reference to the HealthcareService in its extensions.
+For a `Schedule` to use the `HealthcareService`'s scheduling parameters, the `Schedule.serviceType` must include a reference to the HealthcareService in its extensions.
 
 ```tsx
 {
@@ -385,44 +459,29 @@ To get the [Schedule](/docs/api/fhir/resources/schedule) to use the [HealthcareS
 
 ### Override Behavior
 
-A [Practitioner](/docs/api/fhir/resources/practitioner)'s [Schedule](/docs/api/fhir/resources/schedule) can also override the default [HealthcareService](/docs/api/fhir/resources/healthcareservice)'s availability for a specific service type by defining a `serviceType` extension.
+A [Practitioner](/docs/api/fhir/resources/practitioner)'s [Schedule](/docs/api/fhir/resources/schedule) can override individual scheduling parameters for a specific service type by adding a `SchedulingParameters` extension that references that service. **Only the fields explicitly set on the Schedule override the HealthcareService defaults** — all other fields are inherited.
 
-Here is an example Schedule that overrides the availability for a specific service type.
+This means you only need to specify what differs. For example, to restrict availability to Tuesday and Thursday mornings while keeping all other parameters (duration, buffers, alignment) from the HealthcareService:
 
 ```tsx
 {
   "resourceType": "Schedule",
   "id": "dr-chen-schedule",
   "active": true,
+  "actor": [{"reference": "Practitioner/dr-chen"}],
   "serviceType": [
     {
-      "coding": [{"code": "new-patient-visit"}]
-      "extension":[
-        {
-          "url": "https://medplum.com/fhir/service-type-reference",
-          "valueReference": {
-            "reference": "HealthcareService/f44bbf25-bf57-4263-8f10-be060cc91672",
-            "display": "New Patient visit"
-          }
+      "coding": [{"code": "new-patient-visit"}],
+      "extension": [{
+        "url": "https://medplum.com/fhir/service-type-reference",
+        "valueReference": {
+          "reference": "HealthcareService/f44bbf25-bf57-4263-8f10-be060cc91672",
+          "display": "New Patient Visit"
         }
-      ]
-    },
-    {
-      "coding": [{"code": "follow-up"}]
-      "extension":[
-        {
-          "url": "https://medplum.com/fhir/service-type-reference",
-          "valueReference": {
-            "reference": "HealthcareService/5f93269f-b5de-4d76-9672-e35ecb37f201",
-            "display": "Follow-up visit"
-          }
-        }
-      ]
+      }]
     }
   ],
-  "actor": [{"reference": "Practitioner/dr-chen"}],
   "extension": [
-    // Service type level availability for this Practitioner - overrides any availability parameters specified elsewhere
     {
       "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
       "extension": [
@@ -430,16 +489,10 @@ Here is an example Schedule that overrides the availability for a specific servi
           "url": "service",
           "valueReference": {
             "reference": "HealthcareService/f44bbf25-bf57-4263-8f10-be060cc91672",
-            "display": "New Patient visit"
+            "display": "New Patient Visit"
           }
         },
-        {
-          "url": "duration",
-          "valueDuration": {
-            "value": 1,
-            "unit": "h"
-          }
-        },
+        // Only availability is overridden; duration, buffers, and alignment are inherited from HealthcareService
         {
           "url": "availability",
           "extension": [
@@ -460,12 +513,14 @@ Here is an example Schedule that overrides the availability for a specific servi
 }
 ```
 
-**All-or-nothing rule**: When a `SchedulingParameters` extension includes a `service`, it **completely replaces** the default configuration for that service. No attribute-level merging occurs.
+**Field-level inheritance**: When a Schedule has a `SchedulingParameters` extension for a service, each field is resolved independently using this priority order (highest to lowest):
 
-**Priority order** (highest to lowest):
+1. The field value from the Schedule's `SchedulingParameters` extension for that service
+2. The field value from the HealthcareService's `SchedulingParameters` extension
+3. The system default (0 for buffers and offset; 60 minutes for alignment interval; always-available for availability)
+4. Per-actor timezone information (via `Schedule.actor`; only for `timezone` attribute)
 
-1. Schedule where `https://medplum.com/fhir/StructureDefinition/SchedulingParameters.service` extension matches `service-type-reference` parameter on `$find` request.
-2. HealthcareService matching `service-type-reference` param on `$find` request. HealthcareService parameters are used.
+If a Schedule has **no** `SchedulingParameters` extension at all, all parameters are inherited from this chain.
 
 ### Blocking Time by Service Type
 
@@ -486,24 +541,13 @@ Here is an example of a [Slot](/docs/api/fhir/resources/slot) resource that bloc
 - **With serviceType**: Blocks only that specific service
 - **Without serviceType**: Blocks all services
 
+## Timezone Resolution
+
 ### Timezone per Scheduling Parameters Entry
 
 The `timezone` parameter allows you to specify different timezones for different service types within the same Schedule. This is useful when a provider needs to define availability in different timezones for different services (e.g., a doctor who provides cardiac surgery where they might travel to in one time zone and call center availability in another time zone).
 
 **Fallback Logic:** If no time zone is specified in the `scheduling-parameters` extension, then the availability will be interpreted in the time zone defined on the Schedule's actor reference (Practitioner, Location, or Device). It looks for the FHIR sanctioned time zone extension:
-
-```tsx
-{
-  "resourceType": "Practitioner",
-  "id": "dr-smith",
-  "extension": [
-    {
-      "url": "http://hl7.org/fhir/StructureDefinition/timezone",
-      "valueCode": "America/Los_Angeles"
-    }
-  ]
-}
-```
 
 :::tip[Adding a Timezone to an Actor]
 
@@ -532,7 +576,6 @@ There is no native timezone field on [`Practitioner`](/docs/api/fhir/resources/p
 
 **Important Notes:**
 
-- `timezone` is only available on Schedule resources, not HealthcareService
 - The time zone value should be an IANA time zone identifier (e.g., `America/New_York`, `America/Los_Angeles`, `America/Miami`)
 - When `timezone` is specified, all Time values in the `availability` extension are interpreted in that time zone
 
@@ -562,9 +605,10 @@ Here is an example of a Schedule with multiple service types, each with its own 
       "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
       "extension": [
         {
-          "url": "serviceType",
-          "valueCodeableConcept": {
-            "coding": [{"code": "cardiac-surgery"}]
+          "url": "service",
+          "valueReference": {
+            "reference": "HealthcareService/a8f88a98-2578-4644-b408-7ba73f104298",
+            "display": "Cardiac Surgery"
           }
         },
         {
@@ -603,9 +647,10 @@ Here is an example of a Schedule with multiple service types, each with its own 
           "valueCode": "America/New_York"
         },
         {
-          "url": "serviceType",
-          "valueCodeableConcept": {
-            "coding": [{"code": "call-center-availability"}]
+          "url": "service",
+          "valueReference": {
+            "reference": "HealthcareService/0dbe6bf1-40b8-4204-a406-f78b5a0e59d0"
+            "display": "Call Center Availability"
           }
         },
         {
@@ -789,13 +834,7 @@ This HealthcareService defines a 60-minute new patient visit with 15-minute buff
       },
       {"url": "bufferBefore", "valueDuration": {"value": 15, "unit": "min"}},
       {"url": "bufferAfter", "valueDuration": {"value": 15, "unit": "min"}},
-      {"url": "alignmentInterval", "valueDuration": {"value": 30, "unit": "min"}},
-      {
-        "url": "bookingLimit",
-        "valueTiming": {
-          "repeat": {"frequency": 3, "period": 1, "periodUnit": "d"}
-        }
-      }
+      {"url": "alignmentInterval", "valueDuration": {"value": 30, "unit": "min"}}
     ]
   }]
 }
@@ -852,7 +891,7 @@ It defines default availability of Monday-Friday, 9am-5pm.
 
 This schedule declares in its `serviceType` array that it can be booked for New Patient visits and Follow-Up visits.
 
-This Schedule will use the default availability for the "Follow-Up" service (Mon-Fri 9am-5pm), then override new patient visits to only be available on Tuesday and Thursday mornings (9am-1pm).
+This Schedule will use the default availability for the "Follow-Up" service (Mon-Fri 9am-5pm). It will override "New Patient Visit" appointment type to only be available on Tuesday and Thursday mornings (9am-1pm).
 
 ```tsx
 {
@@ -872,6 +911,13 @@ This Schedule will use the default availability for the "Follow-Up" service (Mon
           "system": "http://example.org/appointment-types",
           "code": "new-patient-visit"
         }
+      ],
+      "extension": [
+        "url": "https://medplum.com/fhir/service-type-reference",
+        "valueReference": {
+          "reference": "HealthcareService/new-patient-visit,
+          "display": "New Patient Visit"
+        }
       ]
     },
     {
@@ -880,6 +926,13 @@ This Schedule will use the default availability for the "Follow-Up" service (Mon
         {
           "system": "http://example.org/appointment-types",
           "code": "follow-up"
+        }
+      ],
+      "extension": [
+        "url": "https://medplum.com/fhir/service-type-reference",
+        "valueReference": {
+          "reference": "HealthcareService/follow-up,
+          "display": "Follow-up Visit"
         }
       ]
     }
@@ -890,19 +943,10 @@ This Schedule will use the default availability for the "Follow-Up" service (Mon
       "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
       "extension": [
         {
-          "url": "serviceType",
-          "valueCodeableConcept": {
-            "coding": [{
-              "system": "http://example.org/appointment-types",
-              "code": "new-patient-visit"
-            }]
-          }
-        },
-        {
-          "url": "duration",
-          "valueDuration": {
-            "value": 1,
-            "unit": "h"
+          "url": "service",
+          "valueReference": {
+            "reference": "HeathcareService/new-patient-visit",
+            dislpay: "New Patient Visit"
           }
         },
         {
@@ -929,8 +973,8 @@ This Schedule will use the default availability for the "Follow-Up" service (Mon
 
 **Result**:
 
-- **New patient visits (ie. `$find` called with `service-type=new-patient-visit`)**: Tue/Thu 9am-1pm only, 60 minutes, can start every 30 minutes, max 3 per day, 15-min buffers
-- **Follow-ups (ie. `$find` called with `service-type=follow-up`)**: Mon-Fri 9am-5pm, 20 minutes, can start every 10 minutes, 5-min buffers
+- **New patient visits (ie. `$find` with the "New patient visit" HealthcareService)**: Tue/Thu 9am-1pm only, 60 minutes, can start every 30 minutes, 15-min buffers
+- **Follow-ups (ie. `$find` called with the "Follow-up visit" HealthcareService)**: Mon-Fri 9am-5pm, 20 minutes, can start every 10 minutes, 5-min buffers
 
 ```mermaid
 %%{init: {'theme':'base', 'themeVariables': {'fontSize':'14px'}, 'flowchart': {'useMaxWidth': false, 'htmlLabels': true}}}%%
@@ -1262,9 +1306,9 @@ graph TD
 
 ### Best Practices
 
-#### 1. Use All-or-Nothing Overrides
+#### 1. Set Defaults on HealthcareService, Override Only What Differs on Schedule
 
-If adding a `service` configuration on Schedule, **specify ALL attributes** to avoid confusion about inheritance.
+Define `duration`, buffers, and alignment once on the HealthcareService. Only add a `SchedulingParameters` extension to a Schedule when that actor's availability or parameters differ from the service defaults. Omit any field that should be inherited.
 
 #### 2. Minimize Pre-Generated Slots
 

--- a/packages/server/src/fhir/operations/book.ts
+++ b/packages/server/src/fhir/operations/book.ts
@@ -191,13 +191,13 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
           const parameters = parameterGroup.get(schedule);
           assert(parameters);
 
-          if (parameters.duration !== durationMinutes) {
+          if (parameters.get('duration') !== durationMinutes) {
             throw new OperationOutcomeError(badRequest('No matching scheduling parameters found'));
           }
 
           const range = {
-            start: addMinutes(startDate, -1 * parameters.bufferBefore),
-            end: addMinutes(endDate, parameters.bufferAfter),
+            start: addMinutes(startDate, -1 * parameters.get('bufferBefore')),
+            end: addMinutes(endDate, parameters.get('bufferAfter')),
           };
           const searchStart = range.start.toISOString();
           const searchEnd = range.end.toISOString();
@@ -220,7 +220,7 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
           }
 
           const availability = applyExistingSlots({
-            availability: resolveAvailability(parameters, range, parameters.timezone),
+            availability: resolveAvailability(parameters, range, parameters.get('timezone')),
             slots: existingSlots,
             range,
             serviceType: healthcareService.type,
@@ -234,7 +234,7 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
             throw new OperationOutcomeError(badRequest('No availability found at this time'));
           }
 
-          if (parameters.bufferBefore) {
+          if (parameters.get('bufferBefore')) {
             bufferSlots.push({
               resourceType: 'Slot',
               status: 'busy-unavailable',
@@ -244,7 +244,7 @@ export async function appointmentBookHandler(req: FhirRequest): Promise<FhirResp
             });
           }
 
-          if (parameters.bufferAfter) {
+          if (parameters.get('bufferAfter')) {
             bufferSlots.push({
               resourceType: 'Slot',
               status: 'busy-unavailable',

--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -1733,10 +1733,18 @@ describe('Appointment/$find', () => {
     });
     expect(response.status).toBe(400);
     expect(response.body.issue[0].details.text).toBe("Scheduling parameters attribute 'duration' does not match");
+
+    /*
+     * TODO: Figure out an error format when SchedulingParameters may come from
+     * multiple sources; How do we represent an error like: "Schedule 1's
+     * duration, which was inherited from Service A, differs from Schedule 2's,
+     * which was explicitly set in one of its extensions"?
+     *
     expect(response.body.issue[0].expression).toEqual([
       "Parameters.schedule[0].extension[0].extension('duration')",
       "Parameters.schedule[1].extension[1].extension('duration')",
     ]);
+    */
   });
 
   test('each schedule applies its own bufferBefore/bufferAfter independently', async () => {

--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -1734,17 +1734,10 @@ describe('Appointment/$find', () => {
     expect(response.status).toBe(400);
     expect(response.body.issue[0].details.text).toBe("Scheduling parameters attribute 'duration' does not match");
 
-    /*
-     * TODO: Figure out an error format when SchedulingParameters may come from
-     * multiple sources; How do we represent an error like: "Schedule 1's
-     * duration, which was inherited from Service A, differs from Schedule 2's,
-     * which was explicitly set in one of its extensions"?
-     *
     expect(response.body.issue[0].expression).toEqual([
-      "Parameters.schedule[0].extension[0].extension('duration')",
-      "Parameters.schedule[1].extension[1].extension('duration')",
+      'Parameters.schedule[0].extension[0]',
+      'Parameters.schedule[1].extension[1]',
     ]);
-    */
   });
 
   test('each schedule applies its own bufferBefore/bufferAfter independently', async () => {

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -166,7 +166,7 @@ async function handler(params: {
     assert(schedulingParameters);
 
     const scheduleSlots = existingSlots.filter((slot) => resolveId(slot.schedule) === schedule.id);
-    let availability = resolveAvailability(schedulingParameters, effectiveRange, schedulingParameters.timezone);
+    let availability = resolveAvailability(schedulingParameters, effectiveRange, schedulingParameters.get('timezone'));
     availability = applyExistingSlots({
       availability,
       slots: scheduleSlots,
@@ -176,8 +176,8 @@ async function handler(params: {
 
     // Trim off bufferBefore/bufferAfter from availability
     availability = availability.map((interval) => ({
-      start: addMinutes(interval.start, schedulingParameters.bufferBefore),
-      end: addMinutes(interval.end, -1 * schedulingParameters.bufferAfter),
+      start: addMinutes(interval.start, schedulingParameters.get('bufferBefore')),
+      end: addMinutes(interval.end, -1 * schedulingParameters.get('bufferAfter')),
     }));
 
     // Optimization: restrict to windows long enough for the requested duration
@@ -186,7 +186,7 @@ async function handler(params: {
     // `start` after our previous buffer-trimming step.
     availability = availability.filter((interval) => {
       const durationMs = interval.end.getTime() - interval.start.getTime();
-      return durationMs >= schedulingParameters.duration * 60 * 1000;
+      return durationMs >= schedulingParameters.get('duration') * 60 * 1000;
     });
 
     return availability;
@@ -228,10 +228,10 @@ async function handler(params: {
         },
       ];
 
-      if (parameters.bufferBefore) {
+      if (parameters.get('bufferBefore')) {
         resultSlots.push({
           resourceType: 'Slot',
-          start: addMinutes(interval.start, -1 * parameters.bufferBefore).toISOString(),
+          start: addMinutes(interval.start, -1 * parameters.get('bufferBefore')).toISOString(),
           end: start,
           schedule: createReference(schedule),
           status: 'busy-unavailable',
@@ -240,11 +240,11 @@ async function handler(params: {
         });
       }
 
-      if (parameters.bufferAfter) {
+      if (parameters.get('bufferAfter')) {
         resultSlots.push({
           resourceType: 'Slot',
           start: end,
-          end: addMinutes(interval.end, parameters.bufferAfter).toISOString(),
+          end: addMinutes(interval.end, parameters.get('bufferAfter')).toISOString(),
           schedule: createReference(schedule),
           status: 'busy-unavailable',
           serviceType,

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.test.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.test.ts
@@ -21,12 +21,42 @@ describe('getHealthcareServiceSchedulingParameters', () => {
 
   test('with no extension returns default values', () => {
     const service = withPath(baseService, 'Path.HealthcareService');
-    expect(getHealthcareServiceSchedulingParameters(service)).toMatchObject({
+    expect(getHealthcareServiceSchedulingParameters(service).flatten()).toMatchObject({
       availability: [
         {
           dayOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
           availableStartTime: '00:00:00',
           availableEndTime: '00:00:00',
+        },
+      ],
+      bufferBefore: 0,
+      bufferAfter: 0,
+      alignmentInterval: 60,
+      alignmentOffset: 0,
+      service: { reference: 'HealthcareService/hs-12345' },
+    });
+  });
+
+  test('can set `availableTime` without an extension', () => {
+    const service = withPath(
+      {
+        ...baseService,
+        availableTime: [
+          {
+            daysOfWeek: ['sat', 'sun'],
+            availableStartTime: '10:00:00',
+            availableEndTime: '16:00:00',
+          },
+        ],
+      } satisfies HealthcareService,
+      'Path.HealthcareService'
+    );
+    expect(getHealthcareServiceSchedulingParameters(service).flatten()).toMatchObject({
+      availability: [
+        {
+          dayOfWeek: ['sat', 'sun'],
+          availableStartTime: '10:00:00',
+          availableEndTime: '16:00:00',
         },
       ],
       bufferBefore: 0,
@@ -51,7 +81,7 @@ describe('getHealthcareServiceSchedulingParameters', () => {
       'Path.HealthcareService'
     );
 
-    expect(getHealthcareServiceSchedulingParameters(service)).toMatchObject({
+    expect(getHealthcareServiceSchedulingParameters(service).flatten()).toMatchObject({
       availability: [
         {
           dayOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
@@ -65,7 +95,6 @@ describe('getHealthcareServiceSchedulingParameters', () => {
       alignmentOffset: 0,
       duration: 120,
       service: { reference: 'HealthcareService/hs-12345' },
-      timezone: undefined,
     });
   });
 
@@ -101,7 +130,7 @@ describe('getHealthcareServiceSchedulingParameters', () => {
       'Path.HealthcareService'
     );
 
-    expect(getHealthcareServiceSchedulingParameters(service)).toMatchObject({
+    expect(getHealthcareServiceSchedulingParameters(service).flatten()).toMatchObject({
       availability: [
         {
           dayOfWeek: ['mon', 'tue'],
@@ -194,7 +223,7 @@ describe('getHealthcareServiceSchedulingParameters', () => {
       } satisfies HealthcareService,
       'Path.HealthcareService'
     );
-    expect(getHealthcareServiceSchedulingParameters(serviceWithMissingEnd).availability).toMatchObject([
+    expect(getHealthcareServiceSchedulingParameters(serviceWithMissingEnd).flatten().availability).toMatchObject([
       { dayOfWeek: ['tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' },
     ]);
 
@@ -209,7 +238,7 @@ describe('getHealthcareServiceSchedulingParameters', () => {
       } satisfies HealthcareService,
       'Path.HealthcareService'
     );
-    expect(getHealthcareServiceSchedulingParameters(serviceWithMissingStart).availability).toMatchObject([
+    expect(getHealthcareServiceSchedulingParameters(serviceWithMissingStart).flatten().availability).toMatchObject([
       { dayOfWeek: ['tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' },
     ]);
 
@@ -221,7 +250,7 @@ describe('getHealthcareServiceSchedulingParameters', () => {
       } satisfies HealthcareService,
       'Path.HealthcareService'
     );
-    expect(getHealthcareServiceSchedulingParameters(serviceWithMissingDays).availability).toMatchObject([
+    expect(getHealthcareServiceSchedulingParameters(serviceWithMissingDays).flatten().availability).toMatchObject([
       { dayOfWeek: [], availableStartTime: '09:00:00', availableEndTime: '17:00:00' },
     ]);
   });
@@ -309,7 +338,7 @@ describe('getScheduleSchedulingParameters', () => {
     );
     const schedule = withPath(baseSchedule, 'Path.Schedule');
 
-    expect(getScheduleSchedulingParameters(schedule, service)).toMatchObject({
+    expect(getScheduleSchedulingParameters(schedule, service).flatten()).toMatchObject({
       availability: [
         {
           dayOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
@@ -323,7 +352,6 @@ describe('getScheduleSchedulingParameters', () => {
       alignmentOffset: 0,
       duration: 120,
       service: { reference: 'HealthcareService/hs-12345' },
-      timezone: undefined,
     });
   });
 
@@ -356,7 +384,7 @@ describe('getScheduleSchedulingParameters', () => {
     );
     const schedule = withPath(baseSchedule, 'Path.Schedule');
 
-    expect(getScheduleSchedulingParameters(schedule, service)).toMatchObject({
+    expect(getScheduleSchedulingParameters(schedule, service).flatten()).toMatchObject({
       availability: [
         {
           dayOfWeek: ['mon', 'tue'],
@@ -448,7 +476,7 @@ describe('getScheduleSchedulingParameters', () => {
       'Path.Schedule'
     );
 
-    expect(getScheduleSchedulingParameters(schedule, service)).toMatchObject({
+    expect(getScheduleSchedulingParameters(schedule, service).flatten()).toMatchObject({
       availability: [
         {
           dayOfWeek: ['wed'],

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.test.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.test.ts
@@ -1,18 +1,274 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { WithId } from '@medplum/core';
 import { createReference, generateId } from '@medplum/core';
 import type { HealthcareService, Practitioner, Project, Schedule } from '@medplum/fhirtypes';
 import { toCodeableReferenceLike } from '../../../util/servicetype';
 import { withPath } from '../../../util/withpath';
-import { chooseSchedulingParameters, parseSchedulingParametersExtensions } from './scheduling-parameters';
+import { getHealthcareServiceSchedulingParameters, getScheduleSchedulingParameters } from './scheduling-parameters';
 
-describe('parseSchedulingParametersExtensions', () => {
-  const project: Project = {
+describe('getHealthcareServiceSchedulingParameters', () => {
+  const project = {
     resourceType: 'Project',
     id: generateId(),
-  };
+  } satisfies Project;
+
+  const baseService = {
+    resourceType: 'HealthcareService',
+    id: 'hs-12345',
+    meta: { project: project.id },
+  } satisfies HealthcareService;
+
+  test('with no extension returns default values', () => {
+    const service = withPath(baseService, 'Path.HealthcareService');
+    expect(getHealthcareServiceSchedulingParameters(service)).toMatchObject({
+      availability: [
+        {
+          dayOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+          availableStartTime: '00:00:00',
+          availableEndTime: '00:00:00',
+        },
+      ],
+      bufferBefore: 0,
+      bufferAfter: 0,
+      alignmentInterval: 60,
+      alignmentOffset: 0,
+      service: { reference: 'HealthcareService/hs-12345' },
+    });
+  });
+
+  test('minimally specified extension sets default values', () => {
+    const service = withPath(
+      {
+        ...baseService,
+        extension: [
+          {
+            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+            extension: [{ url: 'duration', valueDuration: { unit: 'h', value: 2 } }],
+          },
+        ],
+      },
+      'Path.HealthcareService'
+    );
+
+    expect(getHealthcareServiceSchedulingParameters(service)).toMatchObject({
+      availability: [
+        {
+          dayOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+          availableStartTime: '00:00:00',
+          availableEndTime: '00:00:00',
+        },
+      ],
+      bufferBefore: 0,
+      bufferAfter: 0,
+      alignmentInterval: 60,
+      alignmentOffset: 0,
+      duration: 120,
+      service: { reference: 'HealthcareService/hs-12345' },
+      timezone: undefined,
+    });
+  });
+
+  test('maximally specified extension sets appropriate values', () => {
+    const service = withPath(
+      {
+        ...baseService,
+        availableTime: [
+          {
+            daysOfWeek: ['mon', 'tue'],
+            availableStartTime: '09:00:00',
+            availableEndTime: '17:00:00',
+          },
+          {
+            daysOfWeek: ['thu'],
+            allDay: true,
+          },
+        ],
+        extension: [
+          {
+            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+            extension: [
+              { url: 'duration', valueDuration: { unit: 'h', value: 2 } },
+              { url: 'bufferBefore', valueDuration: { unit: 'min', value: 10 } },
+              { url: 'bufferAfter', valueDuration: { unit: 'min', value: 20 } },
+              { url: 'alignmentInterval', valueDuration: { unit: 'min', value: 30 } },
+              { url: 'alignmentOffset', valueDuration: { unit: 'min', value: 15 } },
+              { url: 'timezone', valueCode: 'America/Phoenix' },
+            ],
+          },
+        ],
+      } satisfies HealthcareService,
+      'Path.HealthcareService'
+    );
+
+    expect(getHealthcareServiceSchedulingParameters(service)).toMatchObject({
+      availability: [
+        {
+          dayOfWeek: ['mon', 'tue'],
+          availableStartTime: '09:00:00',
+          availableEndTime: '17:00:00',
+        },
+        {
+          dayOfWeek: ['thu'],
+          availableStartTime: '00:00:00',
+          availableEndTime: '00:00:00',
+        },
+      ],
+      bufferBefore: 10,
+      bufferAfter: 20,
+      alignmentInterval: 30,
+      alignmentOffset: 15,
+      duration: 120,
+      service: { reference: 'HealthcareService/hs-12345' },
+      timezone: 'America/Phoenix',
+    });
+  });
+
+  test('"availability" subextension is not allowed', () => {
+    const service = withPath(
+      {
+        ...baseService,
+        extension: [
+          {
+            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+            extension: [
+              { url: 'duration', valueDuration: { unit: 'h', value: 2 } },
+              { url: 'availability', extension: [] },
+            ],
+          },
+        ],
+      } satisfies HealthcareService,
+      'Path.HealthcareService'
+    );
+    expect(() => getHealthcareServiceSchedulingParameters(service)).toThrow(
+      "Scheduling parameter attribute 'availability' is not allowed on HealthcareService"
+    );
+  });
+
+  test('"service" subextension is not allowed', () => {
+    const service = withPath(
+      {
+        ...baseService,
+        extension: [
+          {
+            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+            extension: [
+              { url: 'duration', valueDuration: { unit: 'h', value: 2 } },
+              { url: 'service', valueReference: createReference(baseService) },
+            ],
+          },
+        ],
+      } satisfies HealthcareService,
+      'Path.HealthcareService'
+    );
+    expect(() => getHealthcareServiceSchedulingParameters(service)).toThrow(
+      "Scheduling parameter attribute 'service' is not allowed on HealthcareService"
+    );
+  });
+
+  test('with an ambiguous duration unit throws', () => {
+    const service = withPath(
+      {
+        ...baseService,
+        extension: [
+          {
+            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+            extension: [{ url: 'duration', valueDuration: { unit: 'mo', value: 2 } }],
+          },
+        ],
+      } satisfies HealthcareService,
+      'Path.HealthcareService'
+    );
+    expect(() => getHealthcareServiceSchedulingParameters(service)).toThrow('Got unhandled duration unit "mo"');
+  });
+
+  test('ignores invalid availability entries', () => {
+    // check missing endTime: entry is dropped
+    const serviceWithMissingEnd = withPath(
+      {
+        ...baseService,
+        availableTime: [
+          { daysOfWeek: ['mon'], availableStartTime: '09:00:00' },
+          { daysOfWeek: ['tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' },
+        ],
+      } satisfies HealthcareService,
+      'Path.HealthcareService'
+    );
+    expect(getHealthcareServiceSchedulingParameters(serviceWithMissingEnd).availability).toMatchObject([
+      { dayOfWeek: ['tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' },
+    ]);
+
+    // check missing startTime: entry is dropped
+    const serviceWithMissingStart = withPath(
+      {
+        ...baseService,
+        availableTime: [
+          { daysOfWeek: ['mon'], availableEndTime: '17:00:00' },
+          { daysOfWeek: ['tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' },
+        ],
+      } satisfies HealthcareService,
+      'Path.HealthcareService'
+    );
+    expect(getHealthcareServiceSchedulingParameters(serviceWithMissingStart).availability).toMatchObject([
+      { dayOfWeek: ['tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' },
+    ]);
+
+    // check missing daysOfWeek: entry is included with empty dayOfWeek
+    const serviceWithMissingDays = withPath(
+      {
+        ...baseService,
+        availableTime: [{ availableStartTime: '09:00:00', availableEndTime: '17:00:00' }],
+      } satisfies HealthcareService,
+      'Path.HealthcareService'
+    );
+    expect(getHealthcareServiceSchedulingParameters(serviceWithMissingDays).availability).toMatchObject([
+      { dayOfWeek: [], availableStartTime: '09:00:00', availableEndTime: '17:00:00' },
+    ]);
+  });
+
+  test.each(['duration', 'bufferBefore', 'bufferAfter', 'alignmentInterval', 'alignmentOffset'])(
+    'Multiple subextensions of url "%s"',
+    (attribute) => {
+      const service = withPath(
+        {
+          ...baseService,
+          availableTime: [
+            {
+              daysOfWeek: ['mon', 'tue'],
+              availableStartTime: '09:00:00',
+              availableEndTime: '17:00:00',
+            },
+            {
+              daysOfWeek: ['thu'],
+              allDay: true,
+            },
+          ],
+          extension: [
+            {
+              url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+              extension: [
+                { url: 'duration', valueDuration: { unit: 'h', value: 2 } },
+                { url: attribute, valueDuration: { unit: 'min', value: 10 } },
+                { url: attribute, valueDuration: { unit: 'min', value: 20 } },
+              ],
+            },
+          ],
+        } satisfies HealthcareService,
+        'Path.HealthcareService'
+      );
+
+      expect(() => getHealthcareServiceSchedulingParameters(service)).toThrow(
+        `Scheduling parameter attribute '${attribute}' has too many values`
+      );
+    }
+  );
+});
+
+describe('getScheduleSchedulingParameters', () => {
+  const project = {
+    resourceType: 'Project',
+    id: generateId(),
+  } satisfies Project;
 
   const practitioner: Practitioner = {
     resourceType: 'Practitioner',
@@ -20,192 +276,164 @@ describe('parseSchedulingParametersExtensions', () => {
     meta: { project: project.id },
   };
 
-  const service: WithId<HealthcareService> = {
+  const baseService = {
     resourceType: 'HealthcareService',
     id: 'hs-12345',
-  };
+    meta: { project: project.id },
+  } satisfies HealthcareService;
 
-  test('minimally specified extension sets default values', () => {
-    const schedule: Schedule = {
-      resourceType: 'Schedule',
-      meta: { project: project.id },
-      actor: [createReference(practitioner)],
-      serviceType: toCodeableReferenceLike(service),
-      extension: [
-        {
-          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-          extension: [
-            // `duration` is required to have exactly one entry
-            { url: 'duration', valueDuration: { unit: 'h', value: 2 } },
-            // `service` is required to have exactly one entry
-            { url: 'service', valueReference: createReference(service) },
-          ],
-        },
-      ],
-    };
+  const baseSchedule = {
+    resourceType: 'Schedule',
+    actor: [createReference(practitioner)],
+    serviceType: toCodeableReferenceLike(baseService),
+  } satisfies Schedule;
 
-    expect(parseSchedulingParametersExtensions(withPath(schedule, 'Schedule'))).toMatchObject([
-      {
-        availability: [
-          {
-            dayOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
-            availableStartTime: '00:00:00',
-            availableEndTime: '00:00:00',
-          },
-        ],
-        bufferBefore: 0,
-        bufferAfter: 0,
-        alignmentInterval: 60,
-        alignmentOffset: 0,
-        duration: 120,
-        service: { reference: 'HealthcareService/hs-12345' },
-        timezone: undefined,
-      },
-    ]);
+  test('with no extension', () => {
+    const service = withPath(baseService, 'Path.HealthcareService');
+    const schedule = withPath(baseSchedule, 'Path.Schedule');
+    expect(() => getScheduleSchedulingParameters(schedule, service)).toThrow();
   });
 
-  test('with all the options', () => {
-    const schedule: Schedule = {
-      resourceType: 'Schedule',
-      meta: { project: project.id },
-      actor: [createReference(practitioner)],
-      serviceType: toCodeableReferenceLike(service),
-      extension: [
+  test('minimally specified extension sets default values', () => {
+    const service = withPath(
+      {
+        ...baseService,
+        extension: [
+          {
+            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+            extension: [{ url: 'duration', valueDuration: { unit: 'h', value: 2 } }],
+          },
+        ],
+      },
+      'Path.HealthcareService'
+    );
+    const schedule = withPath(baseSchedule, 'Path.Schedule');
+
+    expect(getScheduleSchedulingParameters(schedule, service)).toMatchObject({
+      availability: [
         {
-          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-          extension: [
-            { url: 'alignmentInterval', valueDuration: { unit: 'min', value: 30 } },
-            { url: 'alignmentOffset', valueDuration: { unit: 'min', value: 5 } },
-            { url: 'bufferAfter', valueDuration: { unit: 'min', value: 15 } },
-            { url: 'bufferBefore', valueDuration: { unit: 'min', value: 10 } },
-            { url: 'service', valueReference: createReference(service) },
-            { url: 'duration', valueDuration: { unit: 'h', value: 2 } },
-            { url: 'timezone', valueCode: 'America/Phoenix' },
-            {
-              url: 'availability',
-              extension: [
-                {
-                  url: 'availableTime',
-                  extension: [
-                    { url: 'daysOfWeek', valueCode: 'mon' },
-                    { url: 'availableStartTime', valueTime: '09:00:00' },
-                    { url: 'availableEndTime', valueTime: '17:00:00' },
-                  ],
-                },
-              ],
-            },
-            {
-              url: 'availability',
-              extension: [
-                {
-                  url: 'availableTime',
-                  extension: [
-                    { url: 'daysOfWeek', valueCode: 'tue' },
-                    { url: 'daysOfWeek', valueCode: 'thu' },
-                    { url: 'availableStartTime', valueTime: '12:00:00' },
-                    { url: 'availableEndTime', valueTime: '13:30:00' },
-                  ],
-                },
-              ],
-            },
-          ],
+          dayOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+          availableStartTime: '00:00:00',
+          availableEndTime: '00:00:00',
         },
       ],
-    };
+      bufferBefore: 0,
+      bufferAfter: 0,
+      alignmentInterval: 60,
+      alignmentOffset: 0,
+      duration: 120,
+      service: { reference: 'HealthcareService/hs-12345' },
+      timezone: undefined,
+    });
+  });
 
-    expect(parseSchedulingParametersExtensions(withPath(schedule, 'Schedule'))).toMatchObject([
+  test('maximally specified extension in service gets inherited', () => {
+    const service = withPath(
       {
-        availability: [
+        ...baseService,
+        availableTime: [
           {
-            dayOfWeek: ['mon'],
+            daysOfWeek: ['mon', 'tue'],
             availableStartTime: '09:00:00',
             availableEndTime: '17:00:00',
           },
-          {
-            dayOfWeek: ['tue', 'thu'],
-            availableStartTime: '12:00:00',
-            availableEndTime: '13:30:00',
-          },
         ],
-        bufferBefore: 10,
-        bufferAfter: 15,
-        alignmentInterval: 30,
-        alignmentOffset: 5,
-        duration: 120,
-        service: { reference: `HealthcareService/${service.id}` },
-        timezone: 'America/Phoenix',
-      },
-    ]);
-  });
-
-  describe('with availability extension', () => {
-    test('basic start/end time pair parses to correct availability', () => {
-      const schedule: Schedule = {
-        resourceType: 'Schedule',
-        meta: { project: project.id },
-        actor: [createReference(practitioner)],
-        serviceType: toCodeableReferenceLike(service),
         extension: [
           {
             url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
             extension: [
-              { url: 'duration', valueDuration: { unit: 'h', value: 1 } },
+              { url: 'duration', valueDuration: { unit: 'h', value: 2 } },
+              { url: 'bufferBefore', valueDuration: { unit: 'min', value: 10 } },
+              { url: 'bufferAfter', valueDuration: { unit: 'min', value: 20 } },
+              { url: 'alignmentInterval', valueDuration: { unit: 'min', value: 30 } },
+              { url: 'alignmentOffset', valueDuration: { unit: 'min', value: 15 } },
+              { url: 'timezone', valueCode: 'America/Phoenix' },
+            ],
+          },
+        ],
+      } satisfies HealthcareService,
+      'Path.HealthcareService'
+    );
+    const schedule = withPath(baseSchedule, 'Path.Schedule');
+
+    expect(getScheduleSchedulingParameters(schedule, service)).toMatchObject({
+      availability: [
+        {
+          dayOfWeek: ['mon', 'tue'],
+          availableStartTime: '09:00:00',
+          availableEndTime: '17:00:00',
+        },
+      ],
+      bufferBefore: 10,
+      bufferAfter: 20,
+      alignmentInterval: 30,
+      alignmentOffset: 15,
+      duration: 120,
+      service: { reference: 'HealthcareService/hs-12345' },
+      timezone: 'America/Phoenix',
+    });
+  });
+
+  test('maximally specified extension in schedule overrides service settings', () => {
+    const service = withPath(
+      {
+        ...baseService,
+        availableTime: [
+          {
+            daysOfWeek: ['mon', 'tue'],
+            availableStartTime: '09:00:00',
+            availableEndTime: '17:00:00',
+          },
+        ],
+        extension: [
+          {
+            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+            extension: [
+              { url: 'duration', valueDuration: { unit: 'h', value: 2 } },
+              { url: 'bufferBefore', valueDuration: { unit: 'min', value: 10 } },
+              { url: 'bufferAfter', valueDuration: { unit: 'min', value: 20 } },
+              { url: 'alignmentInterval', valueDuration: { unit: 'min', value: 30 } },
+              { url: 'alignmentOffset', valueDuration: { unit: 'min', value: 15 } },
+              { url: 'timezone', valueCode: 'America/Phoenix' },
+            ],
+          },
+        ],
+      } satisfies HealthcareService,
+      'Path.HealthcareService'
+    );
+    const schedule = withPath(
+      {
+        ...baseSchedule,
+        extension: [
+          {
+            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+            extension: [
               { url: 'service', valueReference: createReference(service) },
+              { url: 'duration', valueDuration: { unit: 'h', value: 3 } },
+              { url: 'bufferBefore', valueDuration: { unit: 'min', value: 12 } },
+              { url: 'bufferAfter', valueDuration: { unit: 'min', value: 24 } },
+              { url: 'alignmentInterval', valueDuration: { unit: 'min', value: 45 } },
+              { url: 'alignmentOffset', valueDuration: { unit: 'min', value: 5 } },
+              { url: 'timezone', valueCode: 'America/New_York' },
               {
                 url: 'availability',
                 extension: [
                   {
                     url: 'availableTime',
                     extension: [
-                      { url: 'daysOfWeek', valueCode: 'mon' },
                       { url: 'daysOfWeek', valueCode: 'wed' },
-                      { url: 'availableStartTime', valueTime: '09:00:00' },
-                      { url: 'availableEndTime', valueTime: '17:00:00' },
+                      { url: 'availableStartTime', valueTime: '08:00:00' },
+                      { url: 'availableEndTime', valueTime: '16:00:00' },
                     ],
                   },
                 ],
               },
-            ],
-          },
-        ],
-      };
-
-      expect(parseSchedulingParametersExtensions(withPath(schedule, 'Schedule'))).toMatchObject([
-        {
-          availability: [{ dayOfWeek: ['mon', 'wed'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' }],
-          duration: 60,
-          service: { reference: `HealthcareService/${service.id}` },
-        },
-      ]);
-    });
-
-    test('allDay: true produces full-day availability', () => {
-      const hs: WithId<HealthcareService> = {
-        resourceType: 'HealthcareService',
-        id: 'hs-12345',
-        type: [{ coding: [{ code: 'consult', system: 'http://example.com' }] }],
-      };
-
-      const schedule: Schedule = {
-        resourceType: 'Schedule',
-        meta: { project: project.id },
-        actor: [createReference(practitioner)],
-        serviceType: toCodeableReferenceLike(hs),
-        extension: [
-          {
-            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-            extension: [
-              { url: 'duration', valueDuration: { unit: 'min', value: 30 } },
-              { url: 'service', valueReference: createReference(hs) },
               {
                 url: 'availability',
                 extension: [
                   {
                     url: 'availableTime',
                     extension: [
-                      { url: 'daysOfWeek', valueCode: 'mon' },
-                      { url: 'daysOfWeek', valueCode: 'tue' },
-                      { url: 'daysOfWeek', valueCode: 'wed' },
                       { url: 'daysOfWeek', valueCode: 'thu' },
                       { url: 'daysOfWeek', valueCode: 'fri' },
                       { url: 'allDay', valueBoolean: true },
@@ -216,663 +444,30 @@ describe('parseSchedulingParametersExtensions', () => {
             ],
           },
         ],
-      };
-
-      expect(parseSchedulingParametersExtensions(withPath(schedule, 'Schedule'))).toMatchObject([
-        {
-          availability: [
-            {
-              dayOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri'],
-              availableStartTime: '00:00:00',
-              availableEndTime: '00:00:00',
-            },
-          ],
-        },
-      ]);
-    });
-
-    test('notAvailableTime is accepted without error and does not affect parsed availability', () => {
-      const hs: WithId<HealthcareService> = {
-        resourceType: 'HealthcareService',
-        id: 'hs-12345',
-        type: [{ coding: [{ code: 'consult', system: 'http://example.com' }] }],
-      };
-
-      const schedule: Schedule = {
-        resourceType: 'Schedule',
-        meta: { project: project.id },
-        actor: [createReference(practitioner)],
-        serviceType: toCodeableReferenceLike(hs),
-        extension: [
-          {
-            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-            extension: [
-              { url: 'duration', valueDuration: { unit: 'min', value: 30 } },
-              { url: 'service', valueReference: createReference(hs) },
-              {
-                url: 'availability',
-                extension: [
-                  {
-                    url: 'availableTime',
-                    extension: [
-                      { url: 'daysOfWeek', valueCode: 'mon' },
-                      { url: 'availableStartTime', valueTime: '09:00:00' },
-                      { url: 'availableEndTime', valueTime: '17:00:00' },
-                    ],
-                  },
-                  {
-                    url: 'notAvailableTime',
-                    extension: [
-                      { url: 'description', valueString: 'Holiday closure' },
-                      { url: 'during', valuePeriod: { start: '2025-12-25', end: '2025-12-26' } },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      };
-
-      expect(() => parseSchedulingParametersExtensions(withPath(schedule, 'Schedule'))).not.toThrow();
-      expect(parseSchedulingParametersExtensions(withPath(schedule, 'Schedule'))).toMatchObject([
-        { availability: [{ dayOfWeek: ['mon'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' }] },
-      ]);
-    });
-
-    test('availableTime missing both allDay and start/end is filtered out', () => {
-      const hs: WithId<HealthcareService> = {
-        resourceType: 'HealthcareService',
-        id: 'hs-12345',
-        type: [{ coding: [{ code: 'consult', system: 'http://example.com' }] }],
-      };
-
-      const schedule: Schedule = {
-        resourceType: 'Schedule',
-        meta: { project: project.id },
-        actor: [createReference(practitioner)],
-        serviceType: toCodeableReferenceLike(hs),
-        extension: [
-          {
-            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-            extension: [
-              { url: 'duration', valueDuration: { unit: 'min', value: 30 } },
-              { url: 'service', valueReference: createReference(hs) },
-              {
-                url: 'availability',
-                extension: [
-                  {
-                    url: 'availableTime',
-                    extension: [{ url: 'daysOfWeek', valueCode: 'mon' }],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      };
-
-      // Filtered out, so availability is empty — but does not throw
-      expect(() => parseSchedulingParametersExtensions(withPath(schedule, 'Schedule'))).not.toThrow();
-      expect(parseSchedulingParametersExtensions(withPath(schedule, 'Schedule'))).toMatchObject([{ availability: [] }]);
-    });
-
-    test('"availability" is not allowed in HealthcareService extension', () => {
-      const hs: HealthcareService = {
-        resourceType: 'HealthcareService',
-        extension: [
-          {
-            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-            extension: [
-              { url: 'duration', valueDuration: { unit: 'min', value: 30 } },
-              {
-                url: 'availability',
-                extension: [
-                  {
-                    url: 'availableTime',
-                    extension: [
-                      { url: 'daysOfWeek', valueCode: 'mon' },
-                      { url: 'availableStartTime', valueTime: '09:00:00' },
-                      { url: 'availableEndTime', valueTime: '17:00:00' },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      };
-
-      expect(() => parseSchedulingParametersExtensions(withPath(hs, 'HealthcareService'))).toThrow(
-        "Scheduling parameter attribute 'availability' is not allowed on HealthcareService"
-      );
-    });
-  });
-
-  test('missing required duration', () => {
-    const schedule: Schedule = {
-      resourceType: 'Schedule',
-      meta: { project: project.id },
-      actor: [createReference(practitioner)],
-      extension: [
-        {
-          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-          extension: [
-            {
-              url: 'availability',
-              extension: [
-                {
-                  url: 'availableTime',
-                  extension: [
-                    { url: 'daysOfWeek', valueCode: 'tue' },
-                    { url: 'daysOfWeek', valueCode: 'thu' },
-                    { url: 'availableStartTime', valueTime: '12:00:00' },
-                    { url: 'availableEndTime', valueTime: '13:30:00' },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    };
-
-    expect(() => parseSchedulingParametersExtensions(withPath(schedule, 'Schedule'))).toThrow(
-      "Required scheduling parameter attribute 'duration' is missing"
-    );
-  });
-
-  test.each(['duration', 'bufferBefore', 'bufferAfter', 'alignmentInterval', 'alignmentOffset'])(
-    'Multiple extension parameters of type "%s"',
-    (attribute) => {
-      const schedule: Schedule = {
-        resourceType: 'Schedule',
-        meta: { project: project.id },
-        actor: [createReference(practitioner)],
-        extension: [
-          {
-            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-            extension: [
-              { url: attribute, valueDuration: { unit: 'min', value: 10 } },
-              { url: attribute, valueDuration: { unit: 'min', value: 10 } },
-              { url: 'duration', valueDuration: { unit: 'h', value: 2 } },
-              {
-                url: 'availability',
-                extension: [
-                  {
-                    url: 'availableTime',
-                    extension: [
-                      { url: 'daysOfWeek', valueCode: 'tue' },
-                      { url: 'daysOfWeek', valueCode: 'thu' },
-                      { url: 'availableStartTime', valueTime: '12:00:00' },
-                      { url: 'availableEndTime', valueTime: '13:30:00' },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      };
-
-      expect(() => parseSchedulingParametersExtensions(withPath(schedule, 'Schedule'))).toThrow(
-        `Scheduling parameter attribute '${attribute}' has too many values`
-      );
-    }
-  );
-
-  test('with an ambiguous duration unit', () => {
-    const hs: WithId<HealthcareService> = {
-      resourceType: 'HealthcareService',
-      id: 'hs-12345',
-      type: [{ coding: [{ code: 'consult', system: 'http://example.com' }] }],
-    };
-
-    const unit = 'm'; // 'm' is "month" which is ambiguous (anywhere from 28 - 31 days)
-    const schedule: Schedule = {
-      resourceType: 'Schedule',
-      meta: { project: project.id },
-      actor: [createReference(practitioner)],
-      serviceType: toCodeableReferenceLike(hs),
-      extension: [
-        {
-          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-          extension: [
-            { url: 'duration', valueDuration: { unit, value: 1 } },
-            { url: 'service', valueReference: createReference(hs) },
-            {
-              url: 'availability',
-              extension: [
-                {
-                  url: 'availableTime',
-                  extension: [
-                    { url: 'daysOfWeek', valueCode: 'tue' },
-                    { url: 'daysOfWeek', valueCode: 'thu' },
-                    { url: 'availableStartTime', valueTime: '12:00:00' },
-                    { url: 'availableEndTime', valueTime: '13:30:00' },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    };
-
-    expect(() => parseSchedulingParametersExtensions(withPath(schedule, 'Schedule'))).toThrow(
-      `Got unhandled duration unit "m"`
-    );
-  });
-
-  describe('for a HealthcareService', () => {
-    const durationExt = { url: 'duration', valueDuration: { unit: 'min' as const, value: 30 } };
-
-    test('derives serviceType from HealthcareService.type and availability from availableTime', () => {
-      const hs: HealthcareService = {
-        resourceType: 'HealthcareService',
-        id: 'hs-12345',
-        type: [{ coding: [{ code: 'consult', system: 'http://example.com' }] }],
-        availableTime: [{ daysOfWeek: ['mon', 'tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' }],
-        extension: [
-          {
-            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-            extension: [durationExt],
-          },
-        ],
-      };
-
-      expect(parseSchedulingParametersExtensions(withPath(hs, 'HealthcareService'))).toMatchObject([
-        {
-          service: { reference: `HealthcareService/${hs.id}` },
-          availability: [{ dayOfWeek: ['mon', 'tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' }],
-          duration: 30,
-          bufferBefore: 0,
-          bufferAfter: 0,
-          alignmentInterval: 60,
-          alignmentOffset: 0,
-        },
-      ]);
-    });
-
-    test('allDay: true produces full-day availability', () => {
-      const hs: HealthcareService = {
-        resourceType: 'HealthcareService',
-        availableTime: [{ daysOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri'], allDay: true }],
-        extension: [
-          { url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters', extension: [durationExt] },
-        ],
-      };
-
-      expect(parseSchedulingParametersExtensions(withPath(hs, 'HealthcareService'))).toMatchObject([
-        {
-          availability: [
-            {
-              dayOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri'],
-              availableStartTime: '00:00:00',
-              availableEndTime: '00:00:00',
-            },
-          ],
-        },
-      ]);
-    });
-
-    test('allDay: true with no daysOfWeek defaults dayOfWeek to []', () => {
-      const hs: HealthcareService = {
-        resourceType: 'HealthcareService',
-        availableTime: [{ allDay: true }],
-        extension: [
-          { url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters', extension: [durationExt] },
-        ],
-      };
-
-      expect(parseSchedulingParametersExtensions(withPath(hs, 'HealthcareService'))).toMatchObject([
-        { availability: [{ dayOfWeek: [], availableStartTime: '00:00:00', availableEndTime: '00:00:00' }] },
-      ]);
-    });
-
-    test('availableTime with only startTime (no endTime) is filtered out', () => {
-      const hs: HealthcareService = {
-        resourceType: 'HealthcareService',
-        availableTime: [{ daysOfWeek: ['mon'], availableStartTime: '09:00:00' }],
-        extension: [
-          { url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters', extension: [durationExt] },
-        ],
-      };
-
-      expect(parseSchedulingParametersExtensions(withPath(hs, 'HealthcareService'))).toMatchObject([
-        { availability: [] },
-      ]);
-    });
-
-    test('availableTime with neither allDay nor start+end is filtered out', () => {
-      const hs: HealthcareService = {
-        resourceType: 'HealthcareService',
-        availableTime: [{ daysOfWeek: ['mon'] }],
-        extension: [
-          { url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters', extension: [durationExt] },
-        ],
-      };
-
-      expect(parseSchedulingParametersExtensions(withPath(hs, 'HealthcareService'))).toMatchObject([
-        { availability: [] },
-      ]);
-    });
-
-    test('availability is not required on HealthcareService', () => {
-      // No availableTime on resource, no availability in extension — should default to "always available"
-      const hs: HealthcareService = {
-        resourceType: 'HealthcareService',
-        id: 'hs-123',
-        extension: [
-          { url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters', extension: [durationExt] },
-        ],
-      };
-
-      expect(() => parseSchedulingParametersExtensions(withPath(hs, 'HealthcareService'))).not.toThrow();
-      expect(parseSchedulingParametersExtensions(withPath(hs, 'HealthcareService'))).toMatchObject([
-        {
-          availability: [
-            {
-              dayOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
-              availableStartTime: '00:00:00',
-              availableEndTime: '00:00:00',
-            },
-          ],
-          service: { reference: 'HealthcareService/hs-123' },
-          duration: 30,
-        },
-      ]);
-    });
-
-    test('multiple availableTime entries all contribute to availability', () => {
-      const hs: HealthcareService = {
-        resourceType: 'HealthcareService',
-        availableTime: [
-          { daysOfWeek: ['mon'], availableStartTime: '09:00:00', availableEndTime: '12:00:00' },
-          { daysOfWeek: ['wed'], availableStartTime: '13:00:00', availableEndTime: '17:00:00' },
-        ],
-        extension: [
-          { url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters', extension: [durationExt] },
-        ],
-      };
-
-      expect(parseSchedulingParametersExtensions(withPath(hs, 'HealthcareService'))).toMatchObject([
-        {
-          availability: [
-            { dayOfWeek: ['mon'], availableStartTime: '09:00:00', availableEndTime: '12:00:00' },
-            { dayOfWeek: ['wed'], availableStartTime: '13:00:00', availableEndTime: '17:00:00' },
-          ],
-        },
-      ]);
-    });
-
-    test('"availability" is not allowed in HealthcareService extension', () => {
-      const hs: HealthcareService = {
-        resourceType: 'HealthcareService',
-        extension: [
-          {
-            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-            extension: [
-              durationExt,
-              {
-                url: 'availability',
-                extension: [
-                  {
-                    url: 'availableTime',
-                    extension: [
-                      { url: 'daysOfWeek', valueCode: 'mon' },
-                      { url: 'availableStartTime', valueTime: '09:00:00' },
-                      { url: 'availableEndTime', valueTime: '17:00:00' },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      };
-
-      expect(() => parseSchedulingParametersExtensions(withPath(hs, 'HealthcareService'))).toThrow(
-        "Scheduling parameter attribute 'availability' is not allowed on HealthcareService"
-      );
-    });
-
-    test('"service" is not allowed in HealthcareService extension', () => {
-      const hs: HealthcareService = {
-        resourceType: 'HealthcareService',
-        extension: [
-          {
-            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-            extension: [durationExt, { url: 'service', valueReference: { reference: 'HealthcareService/123' } }],
-          },
-        ],
-      };
-
-      expect(() => parseSchedulingParametersExtensions(withPath(hs, 'HealthcareService'))).toThrow(
-        "Scheduling parameter attribute 'service' is not allowed on HealthcareService"
-      );
-    });
-  });
-});
-
-describe('chooseSchedulingParameters', () => {
-  const consultType = { coding: [{ system: 'http://example.com', code: 'consult' }] };
-  const yogaType = { coding: [{ code: 'yoga' }] };
-
-  // Reusable availability extension for Schedule resources (required on Schedule, not on HealthcareService)
-  const mondayAvailability = {
-    url: 'availability',
-    extension: [
-      {
-        url: 'availableTime',
-        extension: [
-          { url: 'daysOfWeek', valueCode: 'mon' },
-          { url: 'availableStartTime', valueTime: '09:00:00' },
-          { url: 'availableEndTime', valueTime: '17:00:00' },
-        ],
       },
-    ],
-  };
-
-  test('returns undefined when neither Schedule nor HealthcareService have the SchedulingParameters extension', () => {
-    const service: WithId<HealthcareService> = {
-      resourceType: 'HealthcareService',
-      type: [consultType],
-      id: 'hcs-100',
-      availableTime: [{ daysOfWeek: ['mon', 'tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' }],
-    };
-
-    const schedule: Schedule = {
-      resourceType: 'Schedule',
-      serviceType: toCodeableReferenceLike(service),
-      actor: [{ reference: 'Practitioner/test' }],
-    };
-
-    expect(chooseSchedulingParameters(withPath(schedule, 'Schedule'), withPath(service, 'HealthcareService'))).toEqual(
-      undefined
+      'Path.Schedule'
     );
-  });
 
-  test('returns undefined when the Schedule has no SchedulingParameters matching HealthcareService.type', () => {
-    const service1: WithId<HealthcareService> = {
-      resourceType: 'HealthcareService',
-      type: [consultType],
-      id: 'hcs-100',
-    };
-
-    const service2: WithId<HealthcareService> = {
-      resourceType: 'HealthcareService',
-      type: [yogaType],
-      id: 'hcs-123',
-    };
-
-    // Linked to service1 in serviceType, but only has scheduling parameters set for service2.
-    const schedule: Schedule = {
-      resourceType: 'Schedule',
-      serviceType: toCodeableReferenceLike(service1),
-      actor: [{ reference: 'Practitioner/test' }],
-      extension: [
+    expect(getScheduleSchedulingParameters(schedule, service)).toMatchObject({
+      availability: [
         {
-          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-          extension: [
-            { url: 'duration', valueDuration: { unit: 'min', value: 30 } },
-            { url: 'service', valueReference: createReference(service2) },
-            mondayAvailability,
-          ],
+          dayOfWeek: ['wed'],
+          availableStartTime: '08:00:00',
+          availableEndTime: '16:00:00',
+        },
+        {
+          dayOfWeek: ['thu', 'fri'],
+          availableStartTime: '00:00:00',
+          availableEndTime: '00:00:00',
         },
       ],
-    };
-
-    expect(chooseSchedulingParameters(withPath(schedule, 'Schedule'), withPath(service1, 'HealthcareService'))).toEqual(
-      undefined
-    );
-  });
-
-  test('falls back to HealthcareService when Schedule has no SchedulingParameters extension', () => {
-    const service: WithId<HealthcareService> = {
-      resourceType: 'HealthcareService',
-      type: [consultType],
-      id: 'hcs-100',
-      availableTime: [{ daysOfWeek: ['mon', 'tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' }],
-      extension: [
-        {
-          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-          extension: [{ url: 'duration', valueDuration: { unit: 'min', value: 30 } }],
-        },
-      ],
-    };
-
-    const schedule: Schedule = {
-      resourceType: 'Schedule',
-      serviceType: toCodeableReferenceLike(service),
-      actor: [{ reference: 'Practitioner/test' }],
-    };
-
-    const result = chooseSchedulingParameters(withPath(schedule, 'Schedule'), withPath(service, 'HealthcareService'));
-    expect(result?.duration).toBe(30);
-  });
-
-  test('falls back to HealthcareService when Schedule has no matching parameters', () => {
-    // Schedule has two extensions — each points at a different service.
-    // We query with a third service that has its own parameters. Neither Schedule
-    // extension matches, so chooseSchedulingParameters should fall through to
-    // the HealthcareService's own parameters.
-    const service1: WithId<HealthcareService> = { resourceType: 'HealthcareService', id: 'hcs-1' };
-    const service2: WithId<HealthcareService> = { resourceType: 'HealthcareService', id: 'hcs-2' };
-    const targetService: WithId<HealthcareService> = {
-      resourceType: 'HealthcareService',
-      id: 'hcs-target',
-      extension: [
-        {
-          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-          extension: [{ url: 'duration', valueDuration: { unit: 'min', value: 45 } }],
-        },
-      ],
-    };
-
-    const schedule: Schedule = {
-      resourceType: 'Schedule',
-      actor: [{ reference: 'Practitioner/test' }],
-      extension: [
-        {
-          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-          extension: [
-            { url: 'duration', valueDuration: { unit: 'min', value: 30 } },
-            { url: 'service', valueReference: createReference(service1) },
-            mondayAvailability,
-          ],
-        },
-        {
-          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-          extension: [
-            { url: 'duration', valueDuration: { unit: 'min', value: 60 } },
-            { url: 'service', valueReference: createReference(service2) },
-            mondayAvailability,
-          ],
-        },
-      ],
-    };
-
-    const result = chooseSchedulingParameters(
-      withPath(schedule, 'Schedule'),
-      withPath(targetService, 'HealthcareService')
-    );
-    expect(result?.duration).toBe(45);
-  });
-
-  test('Schedule-specific parameters take priority over HealthcareService', () => {
-    const service: WithId<HealthcareService> = {
-      resourceType: 'HealthcareService',
-      type: [consultType],
-      id: 'hcs-100',
-      availableTime: [{ daysOfWeek: ['mon', 'tue'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' }],
-      extension: [
-        {
-          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-          extension: [{ url: 'duration', valueDuration: { unit: 'min', value: 30 } }],
-        },
-      ],
-    };
-
-    const schedule: Schedule = {
-      resourceType: 'Schedule',
-      serviceType: toCodeableReferenceLike(service),
-      actor: [{ reference: 'Practitioner/test' }],
-      extension: [
-        {
-          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-          extension: [
-            { url: 'duration', valueDuration: { unit: 'min', value: 60 } },
-            mondayAvailability,
-            { url: 'service', valueReference: createReference(service) },
-          ],
-        },
-      ],
-    };
-
-    // HealthcareService says 30 min — Schedule's 60 min should win
-    const result = chooseSchedulingParameters(withPath(schedule, 'Schedule'), withPath(service, 'HealthcareService'));
-    expect(result?.duration).toBe(60);
-  });
-
-  test('only the matching Schedule entry is returned when multiple extensions exist', () => {
-    const service1: WithId<HealthcareService> = {
-      resourceType: 'HealthcareService',
-      type: [consultType],
-      id: 'hcs-100',
-    };
-
-    const service2: WithId<HealthcareService> = {
-      resourceType: 'HealthcareService',
-      type: [yogaType],
-      id: 'hcs-123',
-    };
-
-    const schedule: Schedule = {
-      resourceType: 'Schedule',
-      serviceType: [...toCodeableReferenceLike(service1), ...toCodeableReferenceLike(service2)],
-      actor: [{ reference: 'Practitioner/test' }],
-      extension: [
-        {
-          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-          extension: [
-            { url: 'duration', valueDuration: { unit: 'min', value: 60 } },
-            { url: 'service', valueReference: createReference(service1) },
-            mondayAvailability,
-          ],
-        },
-        {
-          url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
-          extension: [
-            { url: 'duration', valueDuration: { unit: 'min', value: 45 } },
-            { url: 'service', valueReference: createReference(service2) },
-            mondayAvailability,
-          ],
-        },
-      ],
-    };
-
-    const result = chooseSchedulingParameters(withPath(schedule, 'Schedule'), withPath(service1, 'HealthcareService'));
-    expect(result?.duration).toBe(60);
+      bufferBefore: 12,
+      bufferAfter: 24,
+      alignmentInterval: 45,
+      alignmentOffset: 5,
+      duration: 180,
+      service: { reference: 'HealthcareService/hs-12345' },
+      timezone: 'America/New_York',
+    });
   });
 });

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -11,16 +11,16 @@ import type {
   Resource,
   Schedule,
 } from '@medplum/fhirtypes';
+import { getLogger } from '../../../logger';
 import {
   assertExtensionBoolean,
   assertExtensionCode,
   assertExtensionDuration,
-  assertExtensionReference,
   assertExtensionTime,
   getExtensions,
 } from '../../../util/extension';
 import type { WithPath } from '../../../util/withpath';
-import { getPath, withPath } from '../../../util/withpath';
+import { getPath } from '../../../util/withpath';
 
 const SchedulingParametersURI = 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters';
 
@@ -87,15 +87,22 @@ type SchedulingParametersAvailability = {
   availableEndTime: WallClockTime;
 };
 
-export type SchedulingParameters = {
+type BaseSchedulingParameters = {
   availability: SchedulingParametersAvailability[];
   bufferBefore: number; // minutes
   bufferAfter: number; // minutes
   alignmentInterval: number; // minutes
   alignmentOffset: number; // minutes
-  duration: number; // minutes
   service: Reference<HealthcareService> & { reference: string };
   timezone?: string;
+};
+
+type ServiceSchedulingParameters = BaseSchedulingParameters & {
+  duration?: number; // minutes
+};
+
+export type SchedulingParameters = BaseSchedulingParameters & {
+  duration: number; // minutes
 };
 
 // FHIR Convention: when end <= start, the end time is interpreted as being in
@@ -107,8 +114,19 @@ const alwaysAvailable: SchedulingParametersAvailability = {
   availableEndTime: '00:00:00',
 };
 
-function isReferenceTo<T extends Resource>(reference: Reference<T>, resource: WithId<T>): boolean {
-  if (!reference.reference) {
+// Default values applied to HealthcareService SchedulingParameters (indirectly
+// applied to Schedule SchedulingParameters which inherit from HealthcareService
+// when not specified).
+const SERVICE_DEFAULTS = Object.freeze({
+  availability: [alwaysAvailable],
+  alignmentInterval: 60,
+  bufferBefore: 0,
+  bufferAfter: 0,
+  alignmentOffset: 0,
+});
+
+function isReferenceTo<T extends Resource>(reference: Reference<T> | undefined, resource: WithId<T>): boolean {
+  if (!reference?.reference) {
     return false;
   }
   const [refType, id] = reference.reference.split('/');
@@ -152,23 +170,6 @@ function atMostOne<T extends object>(arr: WithPath<T>[], attribute: string): Wit
   return arr[0];
 }
 
-function exactlyOne<T extends object>(arr: WithPath<T>[], attribute: string, options: { path?: string }): WithPath<T> {
-  if (arr.length < 1) {
-    throw new OperationOutcomeError(
-      badRequest(`Required scheduling parameter attribute '${attribute}' is missing`, options.path)
-    );
-  }
-  if (arr.length > 1) {
-    throw new OperationOutcomeError(
-      badRequest(
-        `Scheduling parameter attribute '${attribute}' has too many values`,
-        arr.map((obj) => getPath(obj))
-      )
-    );
-  }
-  return arr[0];
-}
-
 function exactlyZero(arr: WithPath<object>[], attribute: string, resourceType: string): void {
   if (arr.length > 0) {
     throw new OperationOutcomeError(
@@ -184,7 +185,7 @@ function exactlyZero(arr: WithPath<object>[], attribute: string, resourceType: s
 // work on complex types like `Availability`. We restrict this to a subset of
 // keys from SchedulingParameters that we know contain primitive types.
 function assertAllMatch(
-  values: WithPath<SchedulingParameters>[],
+  values: SchedulingParameters[],
   attribute: 'duration' | 'alignmentInterval' | 'alignmentOffset'
 ): void {
   if (values.length <= 1) {
@@ -192,49 +193,27 @@ function assertAllMatch(
   }
   const mismatched = values.find((value) => value[attribute] !== values[0][attribute]);
   if (mismatched) {
-    throw new OperationOutcomeError(
-      badRequest(`Scheduling parameters attribute '${attribute}' does not match`, [
-        // We special case these a little bit - SchedulingParameters
-        // attributes come from nested extensions, not direct attribute access
-        `${getPath(values[0])}.extension('${attribute}')`,
-        `${getPath(mismatched)}.extension('${attribute}')`,
-      ])
-    );
+    throw new OperationOutcomeError(badRequest(`Scheduling parameters attribute '${attribute}' does not match`));
   }
 }
 
 export function chooseSchedulingParameterGroup(
   schedules: WithPath<WithId<Schedule>>[],
   healthcareService: WithPath<WithId<HealthcareService>>
-): Map<WithPath<WithId<Schedule>>, WithPath<SchedulingParameters>> {
-  const serviceParams = parseSchedulingParametersExtensions(healthcareService).at(0);
-  const result = new Map<WithPath<WithId<Schedule>>, WithPath<SchedulingParameters>>();
+): Map<WithPath<WithId<Schedule>>, SchedulingParameters> {
+  const serviceParams = getHealthcareServiceSchedulingParameters(healthcareService);
+  const result = new Map<WithPath<WithId<Schedule>>, SchedulingParameters>();
 
   for (const schedule of schedules) {
-    const params = parseSchedulingParametersExtensions(schedule).find((parameters) =>
-      isReferenceTo(parameters.service, healthcareService)
-    );
-
-    // prefer schedule-specific overrides matching the requested service type,
-    // fall back to service-defined parameters otherwise.
-    const value = params ?? serviceParams;
-    if (!value) {
-      throw new OperationOutcomeError(
-        badRequest('No SchedulingParameters found on Schedule or HealthcareService', [
-          getPath(schedule),
-          getPath(healthcareService),
-        ])
-      );
-    }
-
-    result.set(schedule, value);
+    const params = getScheduleSchedulingParameters(schedule, healthcareService, serviceParams);
+    result.set(schedule, params);
   }
 
   return result;
 }
 
 export function extractCommonParameters(
-  schedulingParameters: WithPath<SchedulingParameters>[]
+  schedulingParameters: SchedulingParameters[]
 ): Pick<SchedulingParameters, 'duration' | 'alignmentInterval' | 'alignmentOffset'> {
   assertAllMatch(schedulingParameters, 'duration');
   assertAllMatch(schedulingParameters, 'alignmentInterval');
@@ -245,42 +224,6 @@ export function extractCommonParameters(
     alignmentInterval: schedulingParameters[0].alignmentInterval,
     alignmentOffset: schedulingParameters[0].alignmentOffset,
   };
-}
-
-/**
- * Given a Schedule and a HealthcareService, return the SchedulingParameters to
- * use.
- *
- * Priority order (highest to lowest):
- *  1. Entries from the Schedule matching the requested service-type
- *  2. Entries from HealthcareService
- *
- * @param schedule - Schedule resource
- * @param healthcareService - HealthcareService resource
- * @returns SchedulingParameters
- */
-export function chooseSchedulingParameters(
-  schedule: WithPath<Schedule>,
-  healthcareService: WithPath<WithId<HealthcareService>>
-): WithPath<SchedulingParameters> | undefined {
-  const scheduleSchedulingParameters = parseSchedulingParametersExtensions(schedule);
-
-  // Top priority: entries on the schedule pointing at this service
-  const specificMatch = scheduleSchedulingParameters.find((schedulingParameters) =>
-    isReferenceTo(schedulingParameters.service, healthcareService)
-  );
-
-  if (specificMatch) {
-    return specificMatch;
-  }
-
-  // Return the first scheduling extension on HealthcareService
-  const healthcareServiceSchedulingParameters = parseSchedulingParametersExtensions(healthcareService);
-  if (healthcareServiceSchedulingParameters.length) {
-    return healthcareServiceSchedulingParameters[0];
-  }
-
-  return undefined;
 }
 
 // Convert a single availability extension into SchedulingParametersAvailability entries.
@@ -381,90 +324,153 @@ function extractAvailability(
   return undefined;
 }
 
-/**
- * @param resource - A Schedule or HealthcareService to extract scheduling information from
- * @returns SchedulingParameters[] - An array of objects describing scheduling configuration
- */
-export function parseSchedulingParametersExtensions(
-  resource: WithPath<Schedule> | WithPath<HealthcareService>
-): WithPath<SchedulingParameters>[] {
-  const extensions = getExtensions(resource, SchedulingParametersURI);
+// Get SchedulingParameters from a HealthcareService or throw
+export function getHealthcareServiceSchedulingParameters(
+  healthcareService: WithPath<HealthcareService>
+): ServiceSchedulingParameters {
+  const extensions = getExtensions(healthcareService, SchedulingParametersURI);
+  if (extensions.length === 0) {
+    // Q: Should this be an error?
+    getLogger().warn('HealthcareService used for scheduling operation without SchedulingParameters extension');
+    return {
+      service: createReference(healthcareService),
+      ...SERVICE_DEFAULTS,
+    };
+  }
+  if (extensions.length > 1) {
+    throw new OperationOutcomeError(
+      badRequest('HealthcareService has too many scheduling parameters extensions', getPath(healthcareService))
+    );
+  }
+  const extension = extensions[0];
 
-  // Holds scheduling parameters extracted from attributes of the resource, to be merged into
-  // each extension on the resource
-  const resourceParameters: Partial<SchedulingParameters> = {};
-  if (resource.resourceType === 'HealthcareService') {
-    // Note: `resource.availableTime` could be explicitly set to `[]`, in which
-    // case we interpret this as "no availability" instead of falling back to
-    // the default "always available"
-    if (resource.availableTime) {
-      resourceParameters.availability = resource.availableTime.map(extractAvailability).filter(isDefined);
-    } else {
-      // if no availability constraint exists, default to "always available"
-      resourceParameters.availability = [alwaysAvailable];
-    }
+  // Default: 24/7 availability
+  let availability: SchedulingParametersAvailability[] = SERVICE_DEFAULTS.availability;
+  // HealthcareService stores availability in a native field, read it from there.
+  // Note: explicitly setting this field to an empty array makes this default to "never" available.
+  if (healthcareService.availableTime) {
+    availability = healthcareService.availableTime.map(extractAvailability).filter(isDefined);
   }
 
-  return extensions.map((extension) => {
-    const path = getPath(extension);
-    const duration = exactlyOne(getExtensions(extension, 'duration'), 'duration', { path });
+  // Q: Should `duration` be required on HealthcareService scheduling parameters?
+  const durationExt = atMostOne(getExtensions(extension, 'duration'), 'duration');
+  const bufferBeforeExt = atMostOne(getExtensions(extension, 'bufferBefore'), 'bufferBefore');
+  const bufferAfterExt = atMostOne(getExtensions(extension, 'bufferAfter'), 'bufferAfter');
+  const alignmentOffsetExt = atMostOne(getExtensions(extension, 'alignmentOffset'), 'alignmentOffset');
+  const alignmentIntervalExt = atMostOne(getExtensions(extension, 'alignmentInterval'), 'alignmentInterval');
+  const timezoneExt = atMostOne(getExtensions(extension, 'timezone'), 'timezone');
 
-    let availability: SchedulingParametersAvailability[];
-    const rawAvailability = getExtensions(extension, 'availability');
-    if (resource.resourceType === 'Schedule') {
-      if (rawAvailability.length) {
-        availability = rawAvailability.flatMap(extractAvailabilityR4);
-      } else {
-        // if no availability constraint exists, default to "always available"
-        availability = [alwaysAvailable];
-      }
-    } else {
-      exactlyZero(rawAvailability, 'availability', resource.resourceType);
-      availability = resourceParameters.availability ?? [];
-    }
+  // `service` sub-extension not allowed in HealthcareService; implied by resource
+  exactlyZero(getExtensions(extension, 'service'), 'service', healthcareService.resourceType);
 
-    const bufferBefore = atMostOne(getExtensions(extension, 'bufferBefore'), 'bufferBefore');
-    const bufferAfter = atMostOne(getExtensions(extension, 'bufferAfter'), 'bufferAfter');
-    const alignmentOffset = atMostOne(getExtensions(extension, 'alignmentOffset'), 'alignmentOffset');
-    const rawAlignmentInterval = atMostOne(getExtensions(extension, 'alignmentInterval'), 'alignmentInterval');
+  // `availablity` sub-extension not allowed in HealthcareService; use `HealthcareService.availableTime` instead
+  exactlyZero(getExtensions(extension, 'availability'), 'availability', healthcareService.resourceType);
 
-    const timezone = atMostOne(getExtensions(extension, 'timezone'), 'timezone');
-    if (timezone) {
-      assertExtensionCode(timezone);
-    }
+  // Convert "on the hour" alignment from the stored representation (0) to value usable as a modulus (60)
+  let alignmentInterval = alignmentIntervalExt
+    ? durationToMinutes(alignmentIntervalExt)
+    : SERVICE_DEFAULTS.alignmentInterval;
+  alignmentInterval = alignmentInterval === 0 ? 60 : alignmentInterval;
 
-    // `service` is expected in Schedule, not allowed in HealthcareService
-    let service: Reference<HealthcareService> & { reference: string };
-    const rawService = getExtensions(extension, 'service');
-    if (resource.resourceType === 'HealthcareService') {
-      exactlyZero(rawService, 'service', resource.resourceType);
-      service = createReference(resource);
-    } else {
-      const serviceExt = exactlyOne(rawService, 'service', { path });
-      assertExtensionReference<HealthcareService>(serviceExt, 'HealthcareService');
-      service = serviceExt.valueReference;
-    }
+  let timezone: string | undefined = undefined;
+  if (timezoneExt) {
+    assertExtensionCode(timezoneExt);
+    timezone = timezoneExt.valueCode;
+  }
 
-    // default alignmentInterval is "on the hour" (0)
-    let alignmentInterval = rawAlignmentInterval ? durationToMinutes(rawAlignmentInterval) : 0;
+  return {
+    service: createReference(healthcareService),
+    availability,
+    alignmentInterval,
+    duration: durationExt ? durationToMinutes(durationExt) : undefined,
+    bufferBefore: bufferBeforeExt ? durationToMinutes(bufferBeforeExt) : SERVICE_DEFAULTS.bufferBefore,
+    bufferAfter: bufferAfterExt ? durationToMinutes(bufferAfterExt) : SERVICE_DEFAULTS.bufferAfter,
+    alignmentOffset: alignmentOffsetExt ? durationToMinutes(alignmentOffsetExt) : SERVICE_DEFAULTS.alignmentOffset,
+    timezone,
+  };
+}
 
-    // Convert "on the hour" alignment from the structure (0) to one usable as a modulus (60)
-    alignmentInterval = alignmentInterval === 0 ? 60 : alignmentInterval;
+// Get SchedulingParameters for a Schedule/HealthcareService pairing.
+export function getScheduleSchedulingParameters(
+  schedule: WithPath<Schedule>,
+  healthcareService: WithPath<WithId<HealthcareService>>,
+  serviceParameters?: ServiceSchedulingParameters
+): SchedulingParameters {
+  // Parameters not set at the Schedule level get inherited from the Service level.
+  // We accept parsed serviceParameters as an optional input so that multi-scheduling
+  // endpoints can perform that parsing once and have the value be reused.
+  const defaultParameters = serviceParameters ?? getHealthcareServiceSchedulingParameters(healthcareService);
 
-    return withPath(
-      {
-        service, // Reference to a HealthcareService these parameters are used for
-        availability, // HealthcareService.availableTime or `availability` extension parameter
-
-        // These attributes always come from the extension
-        bufferBefore: bufferBefore ? durationToMinutes(bufferBefore) : 0,
-        bufferAfter: bufferAfter ? durationToMinutes(bufferAfter) : 0,
-        alignmentInterval,
-        alignmentOffset: alignmentOffset ? durationToMinutes(alignmentOffset) : 0,
-        duration: durationToMinutes(duration),
-        timezone: timezone?.valueCode,
-      },
-      getPath(extension)
-    );
+  const extensions = getExtensions(schedule, SchedulingParametersURI).filter((extension) => {
+    const serviceExt = getExtensions(extension, 'service');
+    return serviceExt.some((ext) => isReferenceTo(ext.valueReference, healthcareService));
   });
+
+  // If we didn't find an extension on the schedule for this service, use the
+  // service-derived values directly.
+  if (extensions.length === 0) {
+    // The only value we don't have a default for is `duration`, ensure that it
+    // was set in the service layer or fail.
+    if (defaultParameters.duration === undefined) {
+      throw new OperationOutcomeError(
+        badRequest("Scheduling parameter attribute 'duration' is missing", [getPath(schedule)])
+      );
+    }
+    return defaultParameters as SchedulingParameters;
+  }
+
+  // If there are multiple matches, the intention is unclear; abort.
+  if (extensions.length > 1) {
+    throw new OperationOutcomeError(
+      badRequest('Schedule has too many scheduling parameters extensions', getPath(schedule))
+    );
+  }
+  const extension = extensions[0];
+  const durationExt = atMostOne(getExtensions(extension, 'duration'), 'duration');
+  const bufferBeforeExt = atMostOne(getExtensions(extension, 'bufferBefore'), 'bufferBefore');
+  const bufferAfterExt = atMostOne(getExtensions(extension, 'bufferAfter'), 'bufferAfter');
+  const alignmentOffsetExt = atMostOne(getExtensions(extension, 'alignmentOffset'), 'alignmentOffset');
+  const alignmentIntervalExt = atMostOne(getExtensions(extension, 'alignmentInterval'), 'alignmentInterval');
+  const timezoneExt = atMostOne(getExtensions(extension, 'timezone'), 'timezone');
+
+  let timezone: string | undefined = undefined;
+  if (timezoneExt) {
+    assertExtensionCode(timezoneExt);
+    timezone = timezoneExt.valueCode;
+  }
+
+  // The "availability" sub-extension uses format that mirrors
+  // `HealthcareService.availableTime` attribute.  When Medplum moves to FHIR
+  // R5+, this can use the native `Availability` Metadata type instead.
+  const availabilityExt = getExtensions(extension, 'availability');
+  const availability = availabilityExt.length
+    ? availabilityExt.flatMap(extractAvailabilityR4)
+    : defaultParameters.availability;
+
+  // Convert "on the hour" alignment from the stored representation (0) to
+  // value usable as a modulus (60)
+  let alignmentInterval = alignmentIntervalExt
+    ? durationToMinutes(alignmentIntervalExt)
+    : defaultParameters.alignmentInterval;
+  alignmentInterval = alignmentInterval === 0 ? 60 : alignmentInterval;
+
+  // Use extension from schedule when present, fall back to service-defined
+  // value otherwise. Fail if no value set.
+  const duration = durationExt ? durationToMinutes(durationExt) : defaultParameters.duration;
+  if (duration === undefined) {
+    throw new OperationOutcomeError(
+      badRequest("Scheduling parameter attribute 'duration' is missing", [getPath(schedule)])
+    );
+  }
+
+  return {
+    service: defaultParameters.service,
+    availability,
+    alignmentInterval,
+    duration,
+    bufferBefore: bufferBeforeExt ? durationToMinutes(bufferBeforeExt) : defaultParameters.bufferBefore,
+    bufferAfter: bufferAfterExt ? durationToMinutes(bufferAfterExt) : defaultParameters.bufferAfter,
+    alignmentOffset: alignmentOffsetExt ? durationToMinutes(alignmentOffsetExt) : defaultParameters.alignmentOffset,
+    timezone: timezone ?? defaultParameters.timezone,
+  };
 }

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -337,7 +337,7 @@ export function getHealthcareServiceSchedulingParameters(
     getPath(healthcareService)
   );
 
-  let result: LayeredDict<ServiceSchedulingParameters> = LayeredDict.empty().addLayer(defaultsLayer);
+  let result: LayeredDict<ServiceSchedulingParameters> = LayeredDict.from(defaultsLayer);
 
   // HealthcareService stores availability in a native field, read it from there.
   // Note: explicitly setting this field to an empty array makes this default to "never" available.

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -19,8 +19,9 @@ import {
   assertExtensionTime,
   getExtensions,
 } from '../../../util/extension';
+import { LayeredDict } from '../../../util/layereddict';
 import type { WithPath } from '../../../util/withpath';
-import { getPath } from '../../../util/withpath';
+import { getPath, withPath } from '../../../util/withpath';
 
 const SchedulingParametersURI = 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters';
 
@@ -185,44 +186,34 @@ function exactlyZero(arr: WithPath<object>[], attribute: string, resourceType: s
 // work on complex types like `Availability`. We restrict this to a subset of
 // keys from SchedulingParameters that we know contain primitive types.
 function assertAllMatch(
-  values: SchedulingParameters[],
+  values: LayeredDict<SchedulingParameters>[],
   attribute: 'duration' | 'alignmentInterval' | 'alignmentOffset'
 ): void {
   if (values.length <= 1) {
     return;
   }
-  const mismatched = values.find((value) => value[attribute] !== values[0][attribute]);
+  const mismatched = values.find((value) => value.get(attribute) !== values[0].get(attribute));
   if (mismatched) {
-    throw new OperationOutcomeError(badRequest(`Scheduling parameters attribute '${attribute}' does not match`));
+    throw new OperationOutcomeError(
+      badRequest(`Scheduling parameters attribute '${attribute}' does not match`, [
+        values[0].getPath(attribute),
+        mismatched.getPath(attribute),
+      ])
+    );
   }
-}
-
-export function chooseSchedulingParameterGroup(
-  schedules: WithPath<WithId<Schedule>>[],
-  healthcareService: WithPath<WithId<HealthcareService>>
-): Map<WithPath<WithId<Schedule>>, SchedulingParameters> {
-  const serviceParams = getHealthcareServiceSchedulingParameters(healthcareService);
-  const result = new Map<WithPath<WithId<Schedule>>, SchedulingParameters>();
-
-  for (const schedule of schedules) {
-    const params = getScheduleSchedulingParameters(schedule, healthcareService, serviceParams);
-    result.set(schedule, params);
-  }
-
-  return result;
 }
 
 export function extractCommonParameters(
-  schedulingParameters: SchedulingParameters[]
+  schedulingParameters: LayeredDict<SchedulingParameters>[]
 ): Pick<SchedulingParameters, 'duration' | 'alignmentInterval' | 'alignmentOffset'> {
   assertAllMatch(schedulingParameters, 'duration');
   assertAllMatch(schedulingParameters, 'alignmentInterval');
   assertAllMatch(schedulingParameters, 'alignmentOffset');
 
   return {
-    duration: schedulingParameters[0].duration,
-    alignmentInterval: schedulingParameters[0].alignmentInterval,
-    alignmentOffset: schedulingParameters[0].alignmentOffset,
+    duration: schedulingParameters[0].get('duration'),
+    alignmentInterval: schedulingParameters[0].get('alignmentInterval'),
+    alignmentOffset: schedulingParameters[0].get('alignmentOffset'),
   };
 }
 
@@ -324,18 +315,51 @@ function extractAvailability(
   return undefined;
 }
 
+// In the SchedulingParameters extension, `alignmentInterval: 0` means "align
+// to the start of the hour". In our in-memory representation, we want to
+// convert this to a value that can be used as a modulus.
+function toHourlyModulus(value: number): number {
+  if (value === 0) {
+    return 60;
+  }
+  return value;
+}
+
 // Get SchedulingParameters from a HealthcareService or throw
 export function getHealthcareServiceSchedulingParameters(
   healthcareService: WithPath<HealthcareService>
-): ServiceSchedulingParameters {
-  const extensions = getExtensions(healthcareService, SchedulingParametersURI);
-  if (extensions.length === 0) {
-    // Q: Should this be an error?
-    getLogger().warn('HealthcareService used for scheduling operation without SchedulingParameters extension');
-    return {
+): LayeredDict<ServiceSchedulingParameters> {
+  const defaultsLayer = withPath(
+    {
       service: createReference(healthcareService),
       ...SERVICE_DEFAULTS,
-    };
+    },
+    getPath(healthcareService)
+  );
+
+  let result: LayeredDict<ServiceSchedulingParameters> = LayeredDict.empty().addLayer(defaultsLayer);
+
+  // HealthcareService stores availability in a native field, read it from there.
+  // Note: explicitly setting this field to an empty array makes this default to "never" available.
+  if (healthcareService.availableTime) {
+    result = result.addLayer(
+      withPath(
+        {
+          availability: healthcareService.availableTime.map(extractAvailability).filter(isDefined),
+        },
+        getPath(healthcareService)
+      )
+    );
+  }
+
+  const extensions = getExtensions(healthcareService, SchedulingParametersURI);
+  if (extensions.length === 0) {
+    // Proposal: make this an error before scheduling GA launch. Consider
+    // making `duration` a required field at the same time. This would simplify
+    // the type logic (`duration` could always be guaranteed, removing the
+    // difference between ServiceSchedulingParameters and SchedulingParameters.
+    getLogger().warn('HealthcareService used for scheduling operation without SchedulingParameters extension');
+    return result;
   }
   if (extensions.length > 1) {
     throw new OperationOutcomeError(
@@ -344,15 +368,6 @@ export function getHealthcareServiceSchedulingParameters(
   }
   const extension = extensions[0];
 
-  // Default: 24/7 availability
-  let availability: SchedulingParametersAvailability[] = SERVICE_DEFAULTS.availability;
-  // HealthcareService stores availability in a native field, read it from there.
-  // Note: explicitly setting this field to an empty array makes this default to "never" available.
-  if (healthcareService.availableTime) {
-    availability = healthcareService.availableTime.map(extractAvailability).filter(isDefined);
-  }
-
-  // Q: Should `duration` be required on HealthcareService scheduling parameters?
   const durationExt = atMostOne(getExtensions(extension, 'duration'), 'duration');
   const bufferBeforeExt = atMostOne(getExtensions(extension, 'bufferBefore'), 'bufferBefore');
   const bufferAfterExt = atMostOne(getExtensions(extension, 'bufferAfter'), 'bufferAfter');
@@ -363,39 +378,34 @@ export function getHealthcareServiceSchedulingParameters(
   // `service` sub-extension not allowed in HealthcareService; implied by resource
   exactlyZero(getExtensions(extension, 'service'), 'service', healthcareService.resourceType);
 
-  // `availablity` sub-extension not allowed in HealthcareService; use `HealthcareService.availableTime` instead
+  // `availability` sub-extension not allowed in HealthcareService; use `HealthcareService.availableTime` instead
   exactlyZero(getExtensions(extension, 'availability'), 'availability', healthcareService.resourceType);
 
-  // Convert "on the hour" alignment from the stored representation (0) to value usable as a modulus (60)
-  let alignmentInterval = alignmentIntervalExt
-    ? durationToMinutes(alignmentIntervalExt)
-    : SERVICE_DEFAULTS.alignmentInterval;
-  alignmentInterval = alignmentInterval === 0 ? 60 : alignmentInterval;
-
-  let timezone: string | undefined = undefined;
   if (timezoneExt) {
     assertExtensionCode(timezoneExt);
-    timezone = timezoneExt.valueCode;
   }
 
-  return {
-    service: createReference(healthcareService),
-    availability,
-    alignmentInterval,
-    duration: durationExt ? durationToMinutes(durationExt) : undefined,
-    bufferBefore: bufferBeforeExt ? durationToMinutes(bufferBeforeExt) : SERVICE_DEFAULTS.bufferBefore,
-    bufferAfter: bufferAfterExt ? durationToMinutes(bufferAfterExt) : SERVICE_DEFAULTS.bufferAfter,
-    alignmentOffset: alignmentOffsetExt ? durationToMinutes(alignmentOffsetExt) : SERVICE_DEFAULTS.alignmentOffset,
-    timezone,
-  };
+  return result.patchLayer(
+    withPath(
+      {
+        ...(durationExt && { duration: durationToMinutes(durationExt) }),
+        ...(bufferBeforeExt && { bufferBefore: durationToMinutes(bufferBeforeExt) }),
+        ...(bufferAfterExt && { bufferAfter: durationToMinutes(bufferAfterExt) }),
+        ...(alignmentOffsetExt && { alignmentOffset: durationToMinutes(alignmentOffsetExt) }),
+        ...(alignmentIntervalExt && { alignmentInterval: toHourlyModulus(durationToMinutes(alignmentIntervalExt)) }),
+        ...(timezoneExt && { timezone: timezoneExt.valueCode }),
+      },
+      getPath(extension)
+    )
+  );
 }
 
 // Get SchedulingParameters for a Schedule/HealthcareService pairing.
 export function getScheduleSchedulingParameters(
   schedule: WithPath<Schedule>,
   healthcareService: WithPath<WithId<HealthcareService>>,
-  serviceParameters?: ServiceSchedulingParameters
-): SchedulingParameters {
+  serviceParameters?: LayeredDict<ServiceSchedulingParameters>
+): LayeredDict<SchedulingParameters> {
   // Parameters not set at the Schedule level get inherited from the Service level.
   // We accept parsed serviceParameters as an optional input so that multi-scheduling
   // endpoints can perform that parsing once and have the value be reused.
@@ -409,17 +419,18 @@ export function getScheduleSchedulingParameters(
   // If we didn't find an extension on the schedule for this service, use the
   // service-derived values directly.
   if (extensions.length === 0) {
-    // The only value we don't have a default for is `duration`, ensure that it
-    // was set in the service layer or fail.
-    if (defaultParameters.duration === undefined) {
-      throw new OperationOutcomeError(
-        badRequest("Scheduling parameter attribute 'duration' is missing", [getPath(schedule)])
-      );
-    }
-    return defaultParameters as SchedulingParameters;
+    // The only value we don't have a default for is `duration`, ensure it was
+    // set in the service layer or fail.
+    return defaultParameters.refine((p): asserts p is SchedulingParameters => {
+      if (p.duration === undefined) {
+        throw new OperationOutcomeError(
+          badRequest("Scheduling parameter attribute 'duration' is missing", [getPath(schedule)])
+        );
+      }
+    });
   }
 
-  // If there are multiple matches, the intention is unclear; abort.
+  // If there are multiple matching extensions, the intention is unclear; abort.
   if (extensions.length > 1) {
     throw new OperationOutcomeError(
       badRequest('Schedule has too many scheduling parameters extensions', getPath(schedule))
@@ -433,44 +444,33 @@ export function getScheduleSchedulingParameters(
   const alignmentIntervalExt = atMostOne(getExtensions(extension, 'alignmentInterval'), 'alignmentInterval');
   const timezoneExt = atMostOne(getExtensions(extension, 'timezone'), 'timezone');
 
-  let timezone: string | undefined = undefined;
   if (timezoneExt) {
     assertExtensionCode(timezoneExt);
-    timezone = timezoneExt.valueCode;
   }
 
   // The "availability" sub-extension uses format that mirrors
-  // `HealthcareService.availableTime` attribute.  When Medplum moves to FHIR
+  // `HealthcareService.availableTime` attribute. When Medplum moves to FHIR
   // R5+, this can use the native `Availability` Metadata type instead.
   const availabilityExt = getExtensions(extension, 'availability');
-  const availability = availabilityExt.length
-    ? availabilityExt.flatMap(extractAvailabilityR4)
-    : defaultParameters.availability;
 
-  // Convert "on the hour" alignment from the stored representation (0) to
-  // value usable as a modulus (60)
-  let alignmentInterval = alignmentIntervalExt
-    ? durationToMinutes(alignmentIntervalExt)
-    : defaultParameters.alignmentInterval;
-  alignmentInterval = alignmentInterval === 0 ? 60 : alignmentInterval;
+  const layer = withPath(
+    {
+      ...(availabilityExt.length && { availability: availabilityExt.flatMap(extractAvailabilityR4) }),
+      ...(durationExt && { duration: durationToMinutes(durationExt) }),
+      ...(bufferBeforeExt && { bufferBefore: durationToMinutes(bufferBeforeExt) }),
+      ...(bufferAfterExt && { bufferAfter: durationToMinutes(bufferAfterExt) }),
+      ...(alignmentOffsetExt && { alignmentOffset: durationToMinutes(alignmentOffsetExt) }),
+      ...(alignmentIntervalExt && { alignmentInterval: toHourlyModulus(durationToMinutes(alignmentIntervalExt)) }),
+      ...(timezoneExt && { timezone: timezoneExt.valueCode }),
+    },
+    getPath(extension)
+  );
 
-  // Use extension from schedule when present, fall back to service-defined
-  // value otherwise. Fail if no value set.
-  const duration = durationExt ? durationToMinutes(durationExt) : defaultParameters.duration;
-  if (duration === undefined) {
-    throw new OperationOutcomeError(
-      badRequest("Scheduling parameter attribute 'duration' is missing", [getPath(schedule)])
-    );
-  }
-
-  return {
-    service: defaultParameters.service,
-    availability,
-    alignmentInterval,
-    duration,
-    bufferBefore: bufferBeforeExt ? durationToMinutes(bufferBeforeExt) : defaultParameters.bufferBefore,
-    bufferAfter: bufferAfterExt ? durationToMinutes(bufferAfterExt) : defaultParameters.bufferAfter,
-    alignmentOffset: alignmentOffsetExt ? durationToMinutes(alignmentOffsetExt) : defaultParameters.alignmentOffset,
-    timezone: timezone ?? defaultParameters.timezone,
-  };
+  return defaultParameters.patchLayer(layer).refine((p): asserts p is SchedulingParameters => {
+    if (p.duration === undefined) {
+      throw new OperationOutcomeError(
+        badRequest("Scheduling parameter attribute 'duration' is missing", [getPath(schedule)])
+      );
+    }
+  });
 }

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -424,7 +424,10 @@ export function getScheduleSchedulingParameters(
     return defaultParameters.refine((p): asserts p is SchedulingParameters => {
       if (p.duration === undefined) {
         throw new OperationOutcomeError(
-          badRequest("Scheduling parameter attribute 'duration' is missing", [getPath(schedule)])
+          badRequest("Scheduling parameter attribute 'duration' is missing", [
+            getPath(healthcareService),
+            getPath(schedule),
+          ])
         );
       }
     });

--- a/packages/server/src/fhir/operations/utils/scheduling.test.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.test.ts
@@ -4,6 +4,8 @@ import type { WithId } from '@medplum/core';
 import { createReference, DEFAULT_MAX_SEARCH_COUNT, generateId } from '@medplum/core';
 import type { HealthcareService, Practitioner, Project, Schedule, Slot } from '@medplum/fhirtypes';
 import type { Interval } from '../../../util/date';
+import { LayeredDict } from '../../../util/layereddict';
+import { withPath } from '../../../util/withpath';
 import type { Repository } from '../../repo';
 import {
   applyExistingSlots,
@@ -39,8 +41,11 @@ const service: WithId<HealthcareService> = {
 };
 
 describe('resolveAvailability', () => {
+  const layered = (sp: SchedulingParameters): LayeredDict<SchedulingParameters> =>
+    LayeredDict.empty().addLayer(withPath(sp, 'test'));
+
   test('having multiple days and times', async () => {
-    const schedulingParameters: SchedulingParameters = {
+    const schedulingParameters = layered({
       availability: [
         {
           dayOfWeek: ['mon', 'wed', 'thu'],
@@ -59,7 +64,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       service: createReference(service),
-    };
+    });
 
     const range = {
       start: new Date('2025-11-30T00:00:00.000-05:00'), // Start of Oct 30
@@ -78,7 +83,7 @@ describe('resolveAvailability', () => {
   });
 
   test('for an availability entry crossing midnight', () => {
-    const schedulingParameters: SchedulingParameters = {
+    const schedulingParameters = layered({
       availability: [
         {
           dayOfWeek: ['mon'],
@@ -92,7 +97,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       service: createReference(service),
-    };
+    });
 
     const range = {
       start: new Date('2025-11-30T00:00:00.000-05:00'), // Start of Oct 30
@@ -106,7 +111,7 @@ describe('resolveAvailability', () => {
   });
 
   test('all day availability', () => {
-    const schedulingParameters: SchedulingParameters = {
+    const schedulingParameters = layered({
       availability: [
         {
           dayOfWeek: ['mon', 'tue'],
@@ -120,7 +125,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       service: createReference(service),
-    };
+    });
 
     const range = {
       start: new Date('2025-11-30T00:00:00.000-05:00'), // Start of Oct 30
@@ -136,7 +141,7 @@ describe('resolveAvailability', () => {
   });
 
   test('availabilities crossing the start of the query range are clamped', () => {
-    const schedulingParameters: SchedulingParameters = {
+    const schedulingParameters = layered({
       availability: [
         {
           dayOfWeek: ['tue'],
@@ -150,7 +155,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       service: createReference(service),
-    };
+    });
 
     const range = {
       start: new Date('2025-12-02T12:00:00.000-05:00'), // Tue Oct 2, noon ET
@@ -164,7 +169,7 @@ describe('resolveAvailability', () => {
   });
 
   test('availabilities crossing the end of the query range are clamped', () => {
-    const schedulingParameters: SchedulingParameters = {
+    const schedulingParameters = layered({
       availability: [
         {
           dayOfWeek: ['tue'],
@@ -178,7 +183,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       service: createReference(service),
-    };
+    });
 
     const range = {
       start: new Date('2025-12-02T04:00:00.000-05:00'), // Tue Oct 2, 4am ET
@@ -193,7 +198,7 @@ describe('resolveAvailability', () => {
 
   // regression test for https://github.com/medplum/medplum/issues/8417
   test('when the request starts early in a UTC day', () => {
-    const schedulingParameters: SchedulingParameters = {
+    const schedulingParameters = layered({
       availability: [
         {
           dayOfWeek: ['tue', 'wed', 'thu'],
@@ -207,7 +212,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       service: createReference(service),
-    };
+    });
 
     const range = {
       start: new Date('2026-01-14T19:00:00.000-05:00'), // Wed Jan 14, 7pm ET (which is Jan 15, 12am UTC)
@@ -221,7 +226,7 @@ describe('resolveAvailability', () => {
   });
 
   test('on days with DST transitions', () => {
-    const schedulingParameters: SchedulingParameters = {
+    const schedulingParameters = layered({
       availability: [
         {
           dayOfWeek: ['sun'],
@@ -235,7 +240,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       service: createReference(service),
-    };
+    });
 
     // NY has a DST "spring forward" on March 8 2026
     const springRange = {
@@ -259,7 +264,7 @@ describe('resolveAvailability', () => {
   });
 
   test('availability spanning a DST change', () => {
-    const schedulingParameters: SchedulingParameters = {
+    const schedulingParameters = layered({
       availability: [
         {
           dayOfWeek: ['sun'],
@@ -273,7 +278,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       service: createReference(service),
-    };
+    });
 
     // NY has a DST "spring forward" on March 8 2026
     const range = {
@@ -301,7 +306,7 @@ describe('resolveAvailability', () => {
   });
 
   test('availability on an ambiguous DST fall back time chooses the earlier option', () => {
-    const schedulingParameters: SchedulingParameters = {
+    const schedulingParameters = layered({
       availability: [
         {
           dayOfWeek: ['sun'],
@@ -315,7 +320,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       service: createReference(service),
-    };
+    });
 
     // NY has a DST "fall back" on Nov 2 2025: 1:30am: happens twice
     const range = {
@@ -331,7 +336,7 @@ describe('resolveAvailability', () => {
   });
 
   test('availability on an ambiguous DST spring forward time starts late', () => {
-    const schedulingParameters: SchedulingParameters = {
+    const schedulingParameters = layered({
       availability: [
         {
           dayOfWeek: ['sun'],
@@ -345,7 +350,7 @@ describe('resolveAvailability', () => {
       alignmentInterval: 60,
       alignmentOffset: 0,
       service: createReference(service),
-    };
+    });
 
     // NY has a DST "spring forward" on March 8 2026; 2:30am never happens
     const range = {

--- a/packages/server/src/fhir/operations/utils/scheduling.test.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.test.ts
@@ -42,7 +42,7 @@ const service: WithId<HealthcareService> = {
 
 describe('resolveAvailability', () => {
   const layered = (sp: SchedulingParameters): LayeredDict<SchedulingParameters> =>
-    LayeredDict.empty().addLayer(withPath(sp, 'test'));
+    LayeredDict.from(withPath(sp, 'test'));
 
   test('having multiple days and times', async () => {
     const schedulingParameters = layered({

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -343,9 +343,10 @@ export async function getSchedulingParametersGroup(
 
       const timezone = getTimeZone(actor);
       if (timezone) {
-        // Tricky: `timezone` is defined to prefer shared scheduling parameter
-        // definition over per-actor configuration, so we put the actor-based
-        // layer at the bottom of the stack with `prepend`.
+        // Tricky: `timezone` is defined to prefer scheduling-parameter
+        // definitions coming from HealthcareService or Schedule extensions
+        // over per-actor configuration. We put the actor-based layer at the
+        // bottom of the stack with `prepend` to give it lowest priority.
         parameters = parameters.prependLayer(withPath({ timezone }, getPath(actor)));
       }
 

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -310,11 +310,14 @@ export function assertAllLoaded<T extends Resource>(
   }
 }
 
+// Gets SchedulingParameters information for a list of Schedule resources with
+// respect to a specific HealthcareService. Loads `Schedule.actor` references
+// to look for timezone information.
 export async function getSchedulingParametersGroup(
   repo: Repository,
   schedules: WithPath<WithId<Schedule>>[],
   healthcareService: WithPath<WithId<HealthcareService>>
-): Promise<Map<WithPath<WithId<Schedule>>, WithPath<SchedulingParameters & { timezone: string }>>> {
+): Promise<Map<WithPath<WithId<Schedule>>, SchedulingParameters & { timezone: string }>> {
   schedules.forEach((schedule) => {
     if (schedule.actor.length !== 1) {
       throw new OperationOutcomeError(
@@ -538,7 +541,7 @@ export async function validateProposedAppointment(
     Appointment,
     WithPath<Slot>[],
     HealthcareService,
-    Map<WithPath<WithId<Schedule>>, WithPath<SchedulingParameters & { timezone: string }>>,
+    Map<WithPath<WithId<Schedule>>, SchedulingParameters & { timezone: string }>,
   ]
 > {
   const { contained, ...appointment } = proposedAppointment;
@@ -603,7 +606,7 @@ export async function validateAllAvailability(
   repo: Repository,
   allSlots: WithPath<Slot>[],
   healthcareService: HealthcareService,
-  schedulingParameterGroup: Map<WithPath<WithId<Schedule>>, WithPath<SchedulingParameters & { timezone: string }>>
+  schedulingParameterGroup: Map<WithPath<WithId<Schedule>>, SchedulingParameters & { timezone: string }>
 ): Promise<void> {
   const groupedSlots = Object.groupBy(allSlots, (slot) => slot.schedule.reference ?? 'unknown');
   for (const [schedule, parameters] of schedulingParameterGroup.entries()) {

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -28,12 +28,13 @@ import assert from 'node:assert';
 import { Temporal } from 'temporal-polyfill';
 import type { Interval } from '../../../util/date';
 import { areIntervalsOverlapping, clamp, earliest, latest } from '../../../util/date';
+import type { LayeredDict } from '../../../util/layereddict';
 import { extractReferencesFromCodeableReferenceLike } from '../../../util/servicetype';
 import type { WithPath } from '../../../util/withpath';
 import { copyPaths, filterWithPaths, getPath, withPath } from '../../../util/withpath';
 import type { Repository } from '../../repo';
 import type { SchedulingParameters } from './scheduling-parameters';
-import { chooseSchedulingParameterGroup } from './scheduling-parameters';
+import { getHealthcareServiceSchedulingParameters, getScheduleSchedulingParameters } from './scheduling-parameters';
 import { uniqueOn } from './terminology';
 
 // Tricky: support zero-based and one-based indexing by including Sunday on both ends.
@@ -140,13 +141,14 @@ function mergeIntervals(left: Interval, right: Interval): Interval | undefined {
  * @returns An array of intervals of availability
  */
 export function resolveAvailability(
-  schedulingParameters: SchedulingParameters,
+  schedulingParameters: LayeredDict<SchedulingParameters>,
   interval: Interval,
   timeZone: string
 ): Interval[] {
   return eachDayOfInterval(interval, timeZone).flatMap((dayStart) => {
     const dayOfWeek = dayNames[dayStart.dayOfWeek];
-    return schedulingParameters.availability
+    return schedulingParameters
+      .get('availability')
       .filter((availability) => availability.dayOfWeek.includes(dayOfWeek))
       .map((availability) => {
         const [sH, sM, sS] = availability.availableStartTime.split(':').map(Number);
@@ -317,7 +319,7 @@ export async function getSchedulingParametersGroup(
   repo: Repository,
   schedules: WithPath<WithId<Schedule>>[],
   healthcareService: WithPath<WithId<HealthcareService>>
-): Promise<Map<WithPath<WithId<Schedule>>, SchedulingParameters & { timezone: string }>> {
+): Promise<Map<WithPath<WithId<Schedule>>, LayeredDict<SchedulingParameters & { timezone: string }>>> {
   schedules.forEach((schedule) => {
     if (schedule.actor.length !== 1) {
       throw new OperationOutcomeError(
@@ -331,17 +333,30 @@ export async function getSchedulingParametersGroup(
     .then((actors) => copyPaths(schedules, actors, { suffix: '.actor[0]' }));
   assertAllLoaded(actors, 'Loading schedule.actor failed');
 
-  const group = chooseSchedulingParameterGroup(schedules, healthcareService);
+  const serviceParams = getHealthcareServiceSchedulingParameters(healthcareService);
 
-  return new Map(
-    group.entries().map(([schedule, parameters], idx) => {
+  return new Map<WithPath<WithId<Schedule>>, LayeredDict<SchedulingParameters & { timezone: string }>>(
+    schedules.map((schedule, idx) => {
       const actor = actors[idx];
-      assert(actor);
-      const timezone = parameters.timezone ?? getTimeZone(actor);
-      if (!timezone) {
-        throw new OperationOutcomeError(badRequest('No timezone specified', getPath(actor)));
+
+      let parameters = getScheduleSchedulingParameters(schedule, healthcareService, serviceParams);
+
+      const timezone = getTimeZone(actor);
+      if (timezone) {
+        // Tricky: `timezone` is defined to prefer shared scheduling parameter
+        // definition over per-actor configuration, so we put the actor-based
+        // layer at the bottom of the stack with `prepend`.
+        parameters = parameters.prependLayer(withPath({ timezone }, getPath(actor)));
       }
-      return [schedule, { ...parameters, timezone }];
+
+      return [
+        schedule,
+        parameters.refine((p): asserts p is SchedulingParameters & { timezone: string } => {
+          if (p.timezone === undefined) {
+            throw new OperationOutcomeError(badRequest('No timezone specified', getPath(actor)));
+          }
+        }),
+      ];
     })
   );
 }
@@ -488,11 +503,11 @@ async function validateAvailability(
   repo: Repository,
   healthcareService: HealthcareService,
   schedule: WithId<Schedule>,
-  parameters: SchedulingParameters & { timezone: string },
+  parameters: LayeredDict<SchedulingParameters & { timezone: string }>,
   interval: Interval
 ): Promise<void> {
   const existingSlots = await slotsOverlappingInterval(repo, [schedule], interval);
-  let availability = resolveAvailability(parameters, interval, parameters.timezone);
+  let availability = resolveAvailability(parameters, interval, parameters.get('timezone'));
   availability = applyExistingSlots({
     availability,
     slots: existingSlots,
@@ -541,7 +556,7 @@ export async function validateProposedAppointment(
     Appointment,
     WithPath<Slot>[],
     HealthcareService,
-    Map<WithPath<WithId<Schedule>>, SchedulingParameters & { timezone: string }>,
+    Map<WithPath<WithId<Schedule>>, LayeredDict<SchedulingParameters & { timezone: string }>>,
   ]
 > {
   const { contained, ...appointment } = proposedAppointment;
@@ -596,7 +611,7 @@ export async function validateProposedAppointment(
     assert(parameters);
 
     const slotsForSchedule = proposedSlots.filter((slot) => resolveId(slot.schedule) === schedule.id);
-    validateSlots(slotsForSchedule, parameters);
+    validateSlots(slotsForSchedule, parameters.flatten());
   }
 
   return [appointment, proposedSlots, healthcareService, schedulingParameterGroup];
@@ -606,7 +621,7 @@ export async function validateAllAvailability(
   repo: Repository,
   allSlots: WithPath<Slot>[],
   healthcareService: HealthcareService,
-  schedulingParameterGroup: Map<WithPath<WithId<Schedule>>, SchedulingParameters & { timezone: string }>
+  schedulingParameterGroup: Map<WithPath<WithId<Schedule>>, LayeredDict<SchedulingParameters & { timezone: string }>>
 ): Promise<void> {
   const groupedSlots = Object.groupBy(allSlots, (slot) => slot.schedule.reference ?? 'unknown');
   for (const [schedule, parameters] of schedulingParameterGroup.entries()) {

--- a/packages/server/src/util/layereddict.test.ts
+++ b/packages/server/src/util/layereddict.test.ts
@@ -102,6 +102,16 @@ describe('types', () => {
     refined.get('duration') satisfies undefined;
   });
 
+  test('from() returns the value type from the layer, not unknown', () => {
+    const dict = LayeredDict.from(withPath({ duration: 30 }, 'HS/1'));
+    dict.get('duration') satisfies number;
+  });
+
+  test('from() requires a WithPath-annotated object', () => {
+    // @ts-expect-error plain objects must be wrapped with withPath() before passing to from()
+    LayeredDict.from({ duration: 30 });
+  });
+
   test('flatten() returns the merged type', () => {
     const dict = LayeredDict.empty()
       .addLayer(withPath({ duration: 30 }, 'HS/1'))
@@ -111,6 +121,34 @@ describe('types', () => {
 });
 
 describe('LayeredDict', () => {
+  describe('from()', () => {
+    test('get() returns the value from the layer', () => {
+      const dict = LayeredDict.from(withPath({ duration: 30 }, 'HealthcareService/1'));
+      expect(dict.get('duration')).toBe(30);
+    });
+
+    test('getPath() returns the path of the layer', () => {
+      const dict = LayeredDict.from(withPath({ duration: 30 }, 'HealthcareService/1'));
+      expect(dict.getPath('duration')).toBe('HealthcareService/1');
+    });
+
+    test('is equivalent to empty().addLayer()', () => {
+      const layer = withPath({ duration: 30 }, 'HealthcareService/1');
+      const via_from = LayeredDict.from(layer);
+      const via_empty = LayeredDict.empty().addLayer(layer);
+      expect(via_from.flatten()).toMatchObject(via_empty.flatten());
+      expect(via_from.getPath('duration')).toBe(via_empty.getPath('duration'));
+    });
+
+    test('can be further composed with addLayer()', () => {
+      const dict = LayeredDict.from(withPath({ duration: 30 }, 'HealthcareService/1')).addLayer(
+        withPath({ duration: 60 }, 'Schedule/2')
+      );
+      expect(dict.get('duration')).toBe(60);
+      expect(dict.getPath('duration')).toBe('Schedule/2');
+    });
+  });
+
   describe('addLayer()', () => {
     test('returns a new instance', () => {
       const base = LayeredDict.empty();

--- a/packages/server/src/util/layereddict.test.ts
+++ b/packages/server/src/util/layereddict.test.ts
@@ -1,0 +1,312 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { LayeredDict } from './layereddict';
+import { withPath } from './withpath';
+
+describe('types', () => {
+  test('get() returns the value type from the layer, not unknown', () => {
+    const dict = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HS/1'));
+    dict.get('duration') satisfies number;
+  });
+
+  test('get() preserves lower-layer types for keys absent from upper layers', () => {
+    const dict = LayeredDict.empty()
+      .addLayer(withPath({ alignmentInterval: 90 }, 'HS/1'))
+      .addLayer(withPath({ duration: 60 }, 'Sched/2'));
+    dict.get('alignmentInterval') satisfies number;
+    dict.get('duration') satisfies number;
+  });
+
+  test('upper layer type takes precedence over lower layer type for the same key', () => {
+    const dict = LayeredDict.empty()
+      .addLayer(withPath({ duration: 30 }, 'HS/1'))
+      .addLayer(withPath({ duration: 'sixty' }, 'Sched/2'));
+    dict.get('duration') satisfies string;
+    // @ts-expect-error duration is now string, not number
+    dict.get('duration') satisfies number;
+  });
+
+  test('getPath() returns string', () => {
+    const dict = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HS/1'));
+    dict.getPath('duration') satisfies string;
+  });
+
+  test('get() for a key absent from all layers is a compile error', () => {
+    const dict = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HS/1'));
+    // @ts-expect-error 'missing' is not a key in the dict
+    dict.get('missing');
+  });
+
+  test('getPath() for a key absent from all layers is a compile error', () => {
+    const dict = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HS/1'));
+    // @ts-expect-error 'missing' is not a key in the dict
+    expect(() => dict.getPath('missing')).toThrow();
+  });
+
+  test('addLayer() requires a WithPath-annotated object', () => {
+    const dict = LayeredDict.empty();
+    // @ts-expect-error plain objects must be wrapped with withPath() before passing to addLayer()
+    dict.addLayer({ duration: 30 });
+  });
+
+  test('prependLayer() new keys are accessible and existing keys retain their type', () => {
+    const dict = LayeredDict.empty()
+      .addLayer(withPath({ duration: 30 }, 'HS/1'))
+      .prependLayer(withPath({ timezone: 'America/New_York' }, 'Actor/1'));
+    dict.get('duration') satisfies number;
+    dict.get('timezone') satisfies string;
+  });
+
+  test('prependLayer() existing key type takes precedence over prepended key type', () => {
+    const dict = LayeredDict.empty()
+      .addLayer(withPath({ duration: 30 }, 'HS/1'))
+      .prependLayer(withPath({ duration: 'sixty' }, 'Actor/1'));
+    dict.get('duration') satisfies number;
+    // @ts-expect-error duration is number from the existing layer, not string from the prepended layer
+    dict.get('duration') satisfies string;
+  });
+
+  test('prependLayer() requires a WithPath-annotated object', () => {
+    const dict = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HS/1'));
+    // @ts-expect-error plain objects must be wrapped with withPath() before passing to prependLayer()
+    dict.prependLayer({ timezone: 'UTC' });
+  });
+
+  test('patchLayer() preserves the existing type', () => {
+    const dict = LayeredDict.empty()
+      .addLayer(withPath({ duration: 30, alignmentInterval: 60 }, 'HS/1'))
+      .patchLayer(withPath({ duration: 90 }, 'Sched/2'));
+    dict.get('duration') satisfies number;
+    dict.get('alignmentInterval') satisfies number;
+  });
+
+  test('patchLayer() does not widen the return type', () => {
+    // When merging in an optional property, we don't want the type system to
+    // lose track of the property actually being present in the lower layer.
+    const patch: { duration?: number | undefined } = {};
+
+    const dict = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HS/1'));
+    const patched = dict.patchLayer(withPath(patch, 'Sched/2'));
+    patched.get('duration') satisfies number;
+  });
+
+  test('refine() narrows the return type to the asserted type', () => {
+    const dict = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HS/1')) as LayeredDict<{ duration?: number }>;
+    const refined = dict.refine((p): asserts p is { duration: number } => {
+      if (p.duration === undefined) {
+        throw new Error('required');
+      }
+    });
+    refined.get('duration') satisfies number;
+    // @ts-expect-error duration is now required (number), not optional (number | undefined)
+    refined.get('duration') satisfies undefined;
+  });
+
+  test('flatten() returns the merged type', () => {
+    const dict = LayeredDict.empty()
+      .addLayer(withPath({ duration: 30 }, 'HS/1'))
+      .addLayer(withPath({ timezone: 'UTC' }, 'Sched/2'));
+    dict.flatten() satisfies { duration: number; timezone: string };
+  });
+});
+
+describe('LayeredDict', () => {
+  describe('addLayer()', () => {
+    test('returns a new instance', () => {
+      const base = LayeredDict.empty();
+      const dict = base.addLayer(withPath({ duration: 30 }, 'HealthcareService/1'));
+      expect(dict).not.toBe(base);
+    });
+
+    test('does not mutate the original dict', () => {
+      const base = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HealthcareService/1'));
+      base.addLayer(withPath({ duration: 60 }, 'Schedule/2'));
+      expect(base.get('duration')).toBe(30);
+      expect(base.getPath('duration')).toBe('HealthcareService/1');
+    });
+  });
+
+  describe('get()', () => {
+    test('returns the value from a single layer', () => {
+      const dict = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HealthcareService/1'));
+      expect(dict.get('duration')).toBe(30);
+    });
+
+    test('later layers override earlier layers for the same key', () => {
+      const dict = LayeredDict.empty()
+        .addLayer(withPath({ duration: 30 }, 'HealthcareService/1'))
+        .addLayer(withPath({ duration: 60 }, 'Schedule/2'));
+      expect(dict.get('duration')).toBe(60);
+    });
+
+    test('keys absent from later layers are still accessible from earlier layers', () => {
+      const dict = LayeredDict.empty()
+        .addLayer(withPath({ duration: 30, alignmentInterval: 90 }, 'HealthcareService/1'))
+        .addLayer(withPath({ duration: 60 }, 'Schedule/2'));
+      expect(dict.get('alignmentInterval')).toBe(90);
+    });
+  });
+
+  describe('getPath()', () => {
+    test('returns the path of the layer that defined the key', () => {
+      const dict = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HealthcareService/123'));
+      expect(dict.getPath('duration')).toBe('HealthcareService/123');
+    });
+
+    test('returns the path of the topmost layer when multiple layers define the same key', () => {
+      const dict = LayeredDict.empty()
+        .addLayer(withPath({ duration: 30 }, 'HealthcareService/1'))
+        .addLayer(withPath({ duration: 60 }, 'Schedule/2'));
+      expect(dict.getPath('duration')).toBe('Schedule/2');
+    });
+
+    test('traces a key back to the layer that defined it, even when higher layers exist', () => {
+      const dict = LayeredDict.empty()
+        .addLayer(withPath({ alignmentInterval: 90 }, 'HealthcareService/1'))
+        .addLayer(withPath({ duration: 60 }, 'Schedule/2'));
+      expect(dict.getPath('alignmentInterval')).toBe('HealthcareService/1');
+    });
+
+    test('throws when the key is not present in any layer', () => {
+      const dict = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HealthcareService/1'));
+      // Type cast required to bypass compile-time key constraint
+      expect(() => (dict as LayeredDict<any>).getPath('missing')).toThrow('Key "missing" not present');
+    });
+  });
+
+  describe('prependLayer()', () => {
+    test('returns a new instance', () => {
+      const base = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HealthcareService/1'));
+      const dict = base.prependLayer(withPath({ timezone: 'America/New_York' }, 'Actor/1'));
+      expect(dict).not.toBe(base);
+    });
+
+    test('does not mutate the original dict', () => {
+      const base = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HealthcareService/1'));
+      base.prependLayer(withPath({ duration: 60 }, 'Actor/1'));
+      expect(base.get('duration')).toBe(30);
+    });
+
+    test('prepended layer loses to existing layers for the same key', () => {
+      const dict = LayeredDict.empty()
+        .addLayer(withPath({ timezone: 'America/Chicago' }, 'HealthcareService/1'))
+        .prependLayer(withPath({ timezone: 'America/New_York' }, 'Actor/1'));
+      expect(dict.get('timezone')).toBe('America/Chicago');
+    });
+
+    test('prepended layer supplies keys absent from existing layers', () => {
+      const dict = LayeredDict.empty()
+        .addLayer(withPath({ duration: 30 }, 'HealthcareService/1'))
+        .prependLayer(withPath({ timezone: 'America/New_York' }, 'Actor/1'));
+      expect(dict.get('timezone')).toBe('America/New_York');
+      expect(dict.get('duration')).toBe(30);
+    });
+
+    test('getPath() returns the path of the existing layer when both define the same key', () => {
+      const dict = LayeredDict.empty()
+        .addLayer(withPath({ timezone: 'America/Chicago' }, 'HealthcareService/1'))
+        .prependLayer(withPath({ timezone: 'America/New_York' }, 'Actor/1'));
+      expect(dict.getPath('timezone')).toBe('HealthcareService/1');
+    });
+  });
+
+  describe('patchLayer()', () => {
+    test('returns a new instance', () => {
+      const base = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HealthcareService/1'));
+      const patched = base.patchLayer(withPath({ duration: 60 }, 'Schedule/2'));
+      expect(patched).not.toBe(base);
+    });
+
+    test('does not mutate the original dict', () => {
+      const base = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HealthcareService/1'));
+      base.patchLayer(withPath({ duration: 60 }, 'Schedule/2'));
+      expect(base.get('duration')).toBe(30);
+    });
+
+    test('overrides a key present in an earlier layer', () => {
+      const dict = LayeredDict.empty()
+        .addLayer(withPath({ duration: 30, alignmentInterval: 60 }, 'HealthcareService/1'))
+        .patchLayer(withPath({ duration: 90 }, 'Schedule/2'));
+      expect(dict.get('duration')).toBe(90);
+    });
+
+    test('leaves keys not mentioned in the patch unchanged', () => {
+      const dict = LayeredDict.empty()
+        .addLayer(withPath({ duration: 30, alignmentInterval: 60 }, 'HealthcareService/1'))
+        .patchLayer(withPath({ duration: 90 }, 'Schedule/2'));
+      expect(dict.get('alignmentInterval')).toBe(60);
+    });
+
+    test('getPath() points to the patch layer for overridden keys', () => {
+      const dict = LayeredDict.empty()
+        .addLayer(withPath({ duration: 30 }, 'HealthcareService/1'))
+        .patchLayer(withPath({ duration: 90 }, 'Schedule/2'));
+      expect(dict.getPath('duration')).toBe('Schedule/2');
+    });
+
+    test('getPath() still points to the original layer for unpatched keys', () => {
+      const dict = LayeredDict.empty()
+        .addLayer(withPath({ duration: 30, alignmentInterval: 60 }, 'HealthcareService/1'))
+        .patchLayer(withPath({ duration: 90 }, 'Schedule/2'));
+      expect(dict.getPath('alignmentInterval')).toBe('HealthcareService/1');
+    });
+  });
+
+  describe('refine()', () => {
+    test('returns the same dict retyped when the guard passes', () => {
+      // Cast to a plain type (without WithPath symbol) to match how LayeredDict
+      // is used in production code, where the type parameter is explicit.
+      const dict = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HealthcareService/1')) as LayeredDict<{
+        duration: number;
+      }>;
+      const refined = dict.refine((p): asserts p is { duration: number } => {
+        if (p.duration === undefined) {
+          throw new Error('duration required');
+        }
+      });
+      expect(refined.get('duration')).toBe(30);
+      expect(refined).toBe(dict);
+    });
+
+    test('throws the guard error when the assertion fails', () => {
+      const dict = LayeredDict.empty().addLayer(withPath({}, 'HealthcareService/1')) as LayeredDict<{
+        duration?: number;
+      }>;
+      expect(() =>
+        dict.refine((p): asserts p is { duration: number } => {
+          if (p.duration === undefined) {
+            throw new Error('duration required');
+          }
+        })
+      ).toThrow('duration required');
+    });
+
+    test('does not mutate the dict', () => {
+      const dict = LayeredDict.empty().addLayer(withPath({ duration: 30 }, 'HealthcareService/1')) as LayeredDict<{
+        duration: number;
+      }>;
+      dict.refine((_p): asserts _p is { duration: number } => {});
+      expect(dict.get('duration')).toBe(30);
+    });
+  });
+
+  describe('flatten()', () => {
+    test('returns all keys from a single layer', () => {
+      const dict = LayeredDict.empty().addLayer(
+        withPath({ duration: 30, alignmentInterval: 60 }, 'HealthcareService/1')
+      );
+      expect(dict.flatten()).toMatchObject({ duration: 30, alignmentInterval: 60 });
+    });
+
+    test('later layers override earlier layers in the flattened result', () => {
+      const dict = LayeredDict.empty()
+        .addLayer(withPath({ duration: 30, alignmentInterval: 60 }, 'HealthcareService/1'))
+        .addLayer(withPath({ duration: 90 }, 'Schedule/2'));
+      expect(dict.flatten()).toMatchObject({ duration: 90, alignmentInterval: 60 });
+    });
+
+    test('returns an empty object for an empty dict', () => {
+      expect(LayeredDict.empty().flatten()).toEqual({});
+    });
+  });
+});

--- a/packages/server/src/util/layereddict.ts
+++ b/packages/server/src/util/layereddict.ts
@@ -26,6 +26,16 @@ export class LayeredDict<const T extends Record<string, unknown> = {}> {
   }
 
   /**
+   * Create a LayeredDict with a single initial layer.
+   *
+   * @param layer - the initial layer
+   * @returns a new LayeredDict
+   */
+  static from<L extends Layer>(layer: L): LayeredDict<Merge<{}, L>> {
+    return new LayeredDict<Merge<{}, L>>([layer], { ...layer });
+  }
+
+  /**
    * Create a new LayeredDict with an Override layer applied on top of this
    *
    * @param layer - the overrides to add to the dictionary

--- a/packages/server/src/util/layereddict.ts
+++ b/packages/server/src/util/layereddict.ts
@@ -59,6 +59,12 @@ export class LayeredDict<const T extends Record<string, unknown> = {}> {
     return new LayeredDict<T>([...this.layers, layer], index);
   }
 
+  /**
+   * Gets the path annotation from the topmost layer defining the key
+   *
+   * @param key - the key to get path information for
+   * @returns string - the path annotation from the topmost layer defining the key
+   */
   getPath<K extends keyof T & string>(key: K): string {
     for (let i = this.layers.length - 1; i >= 0; i--) {
       const layer = this.layers[i];
@@ -69,6 +75,12 @@ export class LayeredDict<const T extends Record<string, unknown> = {}> {
     throw new Error(`Key "${key}" not present`);
   }
 
+  /**
+   * Get the value of the key from the topmost layer defining it
+   *
+   * @param key - the key to get the value of
+   * @returns The value associated with the input key in the topmost defining layer.
+   */
   get<K extends keyof T & string>(key: K): T[K] {
     return this.index[key];
   }
@@ -85,7 +97,12 @@ export class LayeredDict<const T extends Record<string, unknown> = {}> {
     return this as unknown as LayeredDict<U>;
   }
 
-  flatten(): T {
+  /**
+   * Return a read-only view of the dictionary, flattened into a JS object.
+   *
+   * @returns Object - The result of merging all the layers in this dictionary
+   */
+  flatten(): Readonly<T> {
     return this.index;
   }
 }

--- a/packages/server/src/util/layereddict.ts
+++ b/packages/server/src/util/layereddict.ts
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithPath } from './withpath';
+import { getPath as getLayerPath } from './withpath';
+
+type Prettify<T> = { [K in keyof T]: T[K] } & {};
+type Merge<Base, Top> = Prettify<Omit<Base, keyof Top> & Top>;
+type Layer = WithPath<{}>;
+
+export class LayeredDict<const T extends Record<string, unknown> = {}> {
+  private readonly layers: Layer[];
+  private readonly index: T;
+
+  private constructor(layers: Layer[], index: T) {
+    this.layers = layers;
+    this.index = Object.freeze(index);
+  }
+
+  /**
+   * Start an empty dict.
+   *
+   * @returns An empty LayeredDict
+   */
+  static empty(): LayeredDict {
+    return new LayeredDict<{}>([], {});
+  }
+
+  /**
+   * Create a new LayeredDict with an Override layer applied on top of this
+   *
+   * @param layer - the overrides to add to the dictionary
+   * @returns a new LayeredDict
+   */
+  addLayer<L extends Layer>(layer: L): LayeredDict<Merge<T, L>> {
+    const index = { ...this.index, ...layer };
+    return new LayeredDict<Merge<T, L>>([...this.layers, layer], index);
+  }
+
+  /**
+   * Create a new LayeredDict with an Override layer applied below all current layers
+   *
+   * @param layer - the values to add to the dictionary
+   * @returns a new LayeredDict
+   */
+  prependLayer<L extends Layer>(layer: L): LayeredDict<Merge<L, T>> {
+    const index = { ...layer, ...this.index };
+    return new LayeredDict<Merge<L, T>>([layer, ...this.layers], index);
+  }
+
+  /**
+   * Like addLayer, but for partial overrides that stay within the existing shape.
+   * The layer may override a subset of keys; the result type remains T.
+   *
+   * @param layer - partial overrides to apply
+   * @returns a new LayeredDict<T>
+   */
+  patchLayer(layer: WithPath<Partial<T>>): LayeredDict<T> {
+    const index = { ...this.index, ...layer };
+    return new LayeredDict<T>([...this.layers, layer], index);
+  }
+
+  getPath<K extends keyof T & string>(key: K): string {
+    for (let i = this.layers.length - 1; i >= 0; i--) {
+      const layer = this.layers[i];
+      if (Object.hasOwn(layer, key)) {
+        return getLayerPath(layer);
+      }
+    }
+    throw new Error(`Key "${key}" not present`);
+  }
+
+  get<K extends keyof T & string>(key: K): T[K] {
+    return this.index[key];
+  }
+
+  /**
+   * Asserts that the flattened value satisfies a narrower type, throwing if not.
+   * Use when a runtime check is needed to promote an optional field to required.
+   *
+   * @param guard - an assertion function that throws if the value does not satisfy U
+   * @returns this dict, re-typed as LayeredDict<U>
+   */
+  refine<U extends T>(guard: (flat: T) => asserts flat is U): LayeredDict<U> {
+    guard(this.index);
+    return this as unknown as LayeredDict<U>;
+  }
+
+  flatten(): T {
+    return this.index;
+  }
+}


### PR DESCRIPTION
When a Practitioner defines their availability, they may not intend to deviate from other practitioner's scheduling setup, particularly with` respect to fields like `duration` and `alignmentInterval` (as these must match across Schedule resources to be jointly used in $find/$book). The intent here is to make this common case easy.

To that end, when computing the SchedulingParameters to use, we now merge several "layers" of configuration:
- Entries from the `Schedule` scheduling-parameters extension matching the requested service type
- Entries from the `HealthcareService` scheduling-parameters extension
- The system default values
- The timezone information found on `Schedule.actor[0].extension("http://hl7.org/fhir/StructureDefinition/timezone").value`

In the future we may add additional layers (such as being able to specify a "wildcard" availability within your schedule to apply to multiple service-types).

We track these layers in a new data structure, the "Layered Dictionary". This allows fast lookups, but also provides a resolution mechanism for us to identify the source of a given configuration value. This lets us emit helpful error messages now, and may be used as a tool to help explain the mechanics of the system later. It has some nice mechanics for TypeScript to understand the fields inside the dictionary.

Resolves #8383 - This is slightly less precise than what was requested there. In this PR I bias towards flexibility, and still allow individual `Schedule` resources to override fields like `duration` and `alignmentInterval`, although I've documented that this is "not recommended". I chose this after experimenting a bit and feeling like the more complex nesting structure added significantly more pain to simple scenarios / getting started. I also felt like it was conceptually nice to say "all fields default to inheriting from HealthcareService". We may still want to adjust this before exiting the `beta` window for this feature.

## Potential Breaking Change

Common cases we have seen so far either specify SchedulingParameters only on one layer (HealthcareService or Practitioner), or fully specify SchedulingParameters on the Practitioner. These scenarios will not see any changes as a result of this PR.

In the scenario where someone has defined scheduling parameters on `HealthcareService`, and defined scheduling parameters on a `Practitioner`'s `Schedule`, and omitted a value on the schedule level, that would have been getting the default value and now would start inheriting the value from `HealthcareService`.

**Example**:
A HealthcareService defines `{ duration: 30, alignmentInterval: 30 }`:
```
{
  "resourceType": "HealthcareService",
  "id": "hs-1",
  "extension": [
    {
      "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
      "extension": [
        { "url": "duration", "valueDuration": { "value": 30, "unit": "min" } },
        { "url": "alignmentInterval", "valueDuration": { "value": 30, "unit": "min" } }
      ]
    }
  ]
}
```

A Practitioner's Schedule defines `{ duration: 30, bufferBefore: 10 }` for this service:
```
{
  "resourceType": "Schedule",
  "id": "s-2",
  "extension": [
    {
      "url": "https://medplum.com/fhir/StructureDefinition/SchedulingParameters",
      "extension": [
        { "url": "service", "valueReference": { "reference": "HealthcareService/hs-1" } },
        { "url": "duration", "valueDuration": { "value": 30, "unit": "min" } },
        { "url": "bufferBefore", "valueDuration": { "value": 10, "unit": "min" } }
      ]
    }
  ]
}
```

Before this change, the practitioner's schedule would have used the default alignment interval of `60` ("on-the-hour" scheduling). After this change, it will inherit the alignment interval of `30` from the HealthcareService.