### PR TITLE
fix(core/ws): fix `ReconnectingWebSocket` types, fix error handler shape

### DIFF
--- a/packages/core/src/websockets/reconnecting-websocket.test.ts
+++ b/packages/core/src/websockets/reconnecting-websocket.test.ts
@@ -3,8 +3,8 @@
 import { vi } from 'vitest';
 import { WS } from 'vitest-websocket-mock';
 import { sleep } from '../utils';
-import { assert, normalizeErrorEvent, ReconnectingWebSocket } from './reconnecting-websocket';
 import type { ErrorEvent, WebSocketEventMap } from './reconnecting-websocket';
+import { assert, normalizeErrorEvent, ReconnectingWebSocket } from './reconnecting-websocket';
 
 describe('ReconnectingWebSocket', () => {
   let wsServer: WS;

--- a/packages/core/src/websockets/reconnecting-websocket.test.ts
+++ b/packages/core/src/websockets/reconnecting-websocket.test.ts
@@ -3,7 +3,8 @@
 import { vi } from 'vitest';
 import { WS } from 'vitest-websocket-mock';
 import { sleep } from '../utils';
-import { assert, ReconnectingWebSocket } from './reconnecting-websocket';
+import { assert, normalizeErrorEvent, ReconnectingWebSocket } from './reconnecting-websocket';
+import type { ErrorEvent, WebSocketEventMap } from './reconnecting-websocket';
 
 describe('ReconnectingWebSocket', () => {
   let wsServer: WS;
@@ -252,5 +253,150 @@ describe('ReconnectingWebSocket', () => {
 
     const errorEvent = await errorPromise;
     expect(errorEvent.type).toStrictEqual('error');
+    // The underlying mock dispatches a plain `Event` (the browser shape, with no `message`/`error`),
+    // so the normalized event should still carry a real `Error` and a non-empty `message`.
+    expect(errorEvent.error).toBeInstanceOf(Error);
+    expect(errorEvent.message).toStrictEqual('WebSocket error');
+  });
+
+  test('Dispatched close event preserves code/reason', async () => {
+    reconnectingWebSocket = new ReconnectingWebSocket('wss://example.com/ws');
+    await wsServer.connected;
+
+    // `reconnect()` goes through `_disconnect()`, which dispatches the polyfilled `CloseEvent`.
+    // `cloneEvent` must reconstruct it correctly rather than mangling `code` into the string 'close'.
+    const closePromise = new Promise<WebSocketEventMap['close']>((resolve) => {
+      reconnectingWebSocket.addEventListener('close', (event) => {
+        resolve(event);
+      });
+    });
+    reconnectingWebSocket.reconnect();
+
+    const closeEvent = await closePromise;
+    expect(closeEvent.type).toStrictEqual('close');
+    expect(closeEvent.code).toStrictEqual(1000);
+  });
+
+  describe('normalizeErrorEvent', () => {
+    beforeEach(() => {
+      // Constructing a ReconnectingWebSocket lazily initializes the internal Event polyfills that
+      // normalizeErrorEvent relies on; without this the helper has no `ErrorEvent` class to build.
+      reconnectingWebSocket = new ReconnectingWebSocket('wss://example.com/ws');
+    });
+
+    test('Browser shape (plain Event, no message/error)', () => {
+      const result = normalizeErrorEvent(new Event('error'), null);
+      expect(result.type).toStrictEqual('error');
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.message).toStrictEqual('WebSocket error');
+      expect(result.error.message).toStrictEqual('WebSocket error');
+    });
+
+    test('Bun shape (message string, no error)', () => {
+      const result = normalizeErrorEvent({ type: 'error', message: 'Failed to connect' } as ErrorEvent, null);
+      expect(result.type).toStrictEqual('error');
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.message).toStrictEqual('Failed to connect');
+      expect(result.error.message).toStrictEqual('Failed to connect');
+    });
+
+    test('ws/undici shape (real Error preserved)', () => {
+      const originalError = new Error('ECONNREFUSED');
+      const result = normalizeErrorEvent(
+        { type: 'error', message: 'ECONNREFUSED', error: originalError } as ErrorEvent,
+        null
+      );
+      expect(result.type).toStrictEqual('error');
+      // The original Error instance should be carried through unchanged.
+      expect(result.error).toBe(originalError);
+      expect(result.message).toStrictEqual('ECONNREFUSED');
+    });
+
+    test('Prefers a real error over a message string', () => {
+      const originalError = new Error('underlying cause');
+      const result = normalizeErrorEvent(
+        { type: 'error', message: 'some other message', error: originalError } as ErrorEvent,
+        null
+      );
+      expect(result.error).toBe(originalError);
+      expect(result.message).toStrictEqual('underlying cause');
+    });
+  });
+
+  describe('onX handler vs addEventListener receive distinct event identities', () => {
+    // For each event type, the `onX` handler receives the original (or normalized) event, while
+    // `addEventListener` listeners receive a clone — distinct object identities, equivalent content.
+    function expectDistinctIdentity(onEvent: Event | undefined, listenerEvent: Event, type: string): void {
+      expect(onEvent).toBeDefined();
+      expect(onEvent?.type).toStrictEqual(type);
+      expect(listenerEvent.type).toStrictEqual(type);
+      expect(listenerEvent).not.toBe(onEvent);
+    }
+
+    test('open', async () => {
+      reconnectingWebSocket = new ReconnectingWebSocket('wss://example.com/ws');
+      let onEvent: Event | undefined;
+      const listenerPromise = new Promise<WebSocketEventMap['open']>((resolve) => {
+        reconnectingWebSocket.onopen = (event) => {
+          onEvent = event;
+        };
+        reconnectingWebSocket.addEventListener('open', resolve);
+      });
+      await wsServer.connected;
+      const listenerEvent = await listenerPromise;
+      expectDistinctIdentity(onEvent, listenerEvent, 'open');
+    });
+
+    test('message', async () => {
+      reconnectingWebSocket = new ReconnectingWebSocket('wss://example.com/ws');
+      await wsServer.connected;
+      let onEvent: MessageEvent | undefined;
+      const listenerPromise = new Promise<WebSocketEventMap['message']>((resolve) => {
+        reconnectingWebSocket.onmessage = (event) => {
+          onEvent = event;
+        };
+        reconnectingWebSocket.addEventListener('message', resolve);
+      });
+      wsServer.send('Hello, world!');
+      const listenerEvent = await listenerPromise;
+      expectDistinctIdentity(onEvent, listenerEvent, 'message');
+      expect(listenerEvent.data).toStrictEqual('Hello, world!');
+      expect(listenerEvent.data).toStrictEqual(onEvent?.data);
+    });
+
+    test('close', async () => {
+      reconnectingWebSocket = new ReconnectingWebSocket('wss://example.com/ws');
+      await wsServer.connected;
+      let onEvent: WebSocketEventMap['close'] | undefined;
+      const listenerPromise = new Promise<WebSocketEventMap['close']>((resolve) => {
+        reconnectingWebSocket.onclose = (event) => {
+          onEvent = event;
+        };
+        reconnectingWebSocket.addEventListener('close', resolve);
+      });
+      reconnectingWebSocket.close();
+      const listenerEvent = await listenerPromise;
+      expectDistinctIdentity(onEvent, listenerEvent, 'close');
+      expect(listenerEvent.code).toStrictEqual(onEvent?.code);
+    });
+
+    test('error', async () => {
+      reconnectingWebSocket = new ReconnectingWebSocket('wss://example.com/ws');
+      await wsServer.connected;
+      let onEvent: WebSocketEventMap['error'] | undefined;
+      const listenerPromise = new Promise<WebSocketEventMap['error']>((resolve) => {
+        reconnectingWebSocket.onerror = (event) => {
+          onEvent = event;
+        };
+        reconnectingWebSocket.addEventListener('error', resolve);
+      });
+      wsServer.error();
+      const listenerEvent = await listenerPromise;
+      expectDistinctIdentity(onEvent, listenerEvent, 'error');
+      // The cloned event is a distinct ErrorEvent, but carries the same underlying Error instance.
+      expect(listenerEvent.error).toBeInstanceOf(Error);
+      expect(listenerEvent.error).toBe(onEvent?.error);
+      expect(listenerEvent.message).toStrictEqual(onEvent?.message);
+    });
   });
 });

--- a/packages/core/src/websockets/reconnecting-websocket.ts
+++ b/packages/core/src/websockets/reconnecting-websocket.ts
@@ -55,10 +55,23 @@ export type IWebSocketEventMap = {
 
 /**
  * Generic interface that an implementation of `WebSocket` must satisfy to be used with `ReconnectingWebSocket`.
- * This is a slightly modified fork of the `WebSocket` global type used in Node.
+ * This is a slightly modified fork of the `WebSocket` global type used in Node, narrowed to exactly the members
+ * `ReconnectingWebSocket` actually depends on.
  *
- * The main key difference is making all the `onclose`, `onerror`, etc. functions have `any[]` args, making `data` in `send()` of type `any`, and making `binaryType` of type string,
- * though the particular implementation should narrow each of these implementation-specific types.
+ * `addEventListener`/`removeEventListener` declare a typed overload against `IWebSocketEventMap` (the global event
+ * interfaces, used here rather than the local `WebSocketEventMap` since they are generic enough to describe the
+ * events `ReconnectingWebSocket` attaches to). They also declare the permissive string overload that the real
+ * `WebSocket` types carry, which is what lets conformant implementations whose event types do not structurally
+ * match the global ones (e.g. the `ws` library, whose events are a minimal subset and use `target: WebSocket`)
+ * still satisfy this interface.
+ *
+ * The `onopen`/`onclose`/`onmessage`/`onerror` handler properties are intentionally omitted: `ReconnectingWebSocket`
+ * never assigns to them (it uses `addEventListener`), and because they are function-valued properties their
+ * parameters are checked contravariantly, which no single precise event type can satisfy across implementations
+ * (e.g. `ws`'s events use `target: WebSocket` while the DOM's use `target: EventTarget | null`).
+ *
+ * `binaryType` is widened to `string` and `send()` accepts the full `Message` union; a particular implementation
+ * should narrow each of these implementation-specific types.
  */
 export interface IWebSocket {
   binaryType: string;
@@ -66,26 +79,21 @@ export interface IWebSocket {
   readonly bufferedAmount: number;
   readonly extensions: string;
 
-  onclose: ((...args: any[]) => any) | null;
-  onerror: ((...args: any[]) => any) | null;
-  onmessage: ((...args: any[]) => any) | null;
-  onopen: ((...args: any[]) => any) | null;
-
   readonly protocol: string;
   readonly readyState: number;
   readonly url: string;
 
   close(code?: number, reason?: string): void;
-  send(data: any): void;
+  send(data: Message): void;
 
   readonly CLOSED: number;
   readonly CLOSING: number;
   readonly CONNECTING: number;
   readonly OPEN: number;
 
-  addEventListener<K extends keyof WebSocketEventMap>(
+  addEventListener<K extends keyof IWebSocketEventMap>(
     type: K,
-    listener: (ev: WebSocketEventMap[K]) => any,
+    listener: (event: IWebSocketEventMap[K]) => void,
     options?: boolean | AddEventListenerOptions
   ): void;
   addEventListener(
@@ -93,9 +101,9 @@ export interface IWebSocket {
     listener: EventListenerOrEventListenerObject,
     options?: boolean | AddEventListenerOptions
   ): void;
-  removeEventListener<K extends keyof WebSocketEventMap>(
+  removeEventListener<K extends keyof IWebSocketEventMap>(
     type: K,
-    listener: (ev: WebSocketEventMap[K]) => any,
+    listener: (event: IWebSocketEventMap[K]) => void,
     options?: boolean | EventListenerOptions
   ): void;
   removeEventListener(
@@ -150,7 +158,41 @@ export function assert(condition: unknown, msg?: string): asserts condition {
 }
 
 function cloneEvent(e: Event): Event {
+  // The generic clone below relies on the DOM `(type, eventInitDict)` constructor convention, which
+  // native events follow. Our polyfilled `CloseEvent`/`ErrorEvent` use non-standard signatures
+  // (`(code, reason, target)` and `(error, target)`), so they must be reconstructed explicitly —
+  // otherwise e.g. a cloned close event ends up with `code: 'close'` and `reason: <event object>`.
+  if (e instanceof Events.CloseEvent) {
+    const closeEvent = e as CloseEvent;
+    return new Events.CloseEvent(closeEvent.code, closeEvent.reason, undefined);
+  }
+  if (e instanceof Events.ErrorEvent) {
+    const errorEvent = e as ErrorEvent;
+    return new Events.ErrorEvent(errorEvent.error ?? new Error(errorEvent.message), undefined);
+  }
   return new (e as any).constructor(e.type, e);
+}
+
+/**
+ * Normalizes the various `error` event shapes dispatched by different `WebSocket` implementations
+ * into a single `ErrorEvent` carrying a real `Error`, so downstream listeners always get `message`
+ * and `error` regardless of the underlying implementation:
+ *
+ * - Browsers dispatch a plain `Event` with no error details (per the WHATWG WebSocket spec).
+ * - Node's `ws` library and Node's built-in (undici) `WebSocket` dispatch an `ErrorEvent` with both
+ *   `message` and `error`.
+ * - Bun dispatches a plain `Event` with a `message` string but no `error`.
+ *
+ * @param event - The `error` event as dispatched by the underlying `WebSocket`.
+ * @param target - The `ReconnectingWebSocket` instance the normalized event is dispatched from.
+ * @returns An `ErrorEvent` with a populated `message` and `error`.
+ */
+export function normalizeErrorEvent(event: Event | ErrorEvent, target: unknown): ErrorEvent {
+  const candidate = event as Partial<ErrorEvent>;
+  if (candidate.error instanceof Error) {
+    return new Events.ErrorEvent(candidate.error, target);
+  }
+  return new Events.ErrorEvent(new Error(candidate.message || 'WebSocket error'), target);
 }
 
 export type Options<WS extends IWebSocket = WebSocket> = {
@@ -543,15 +585,19 @@ export class ReconnectingWebSocket<WS extends IWebSocket = WebSocket>
     this.dispatchEvent(cloneEvent(event));
   };
 
-  private readonly _handleError = (event: ErrorEvent): void => {
-    this._debug('error event', event.message);
-    this._disconnect(undefined, event.message === 'TIMEOUT' ? 'timeout' : undefined);
+  private readonly _handleError = (event: Event | ErrorEvent): void => {
+    // The `error` event shape differs across WebSocket implementations (plain `Event` in browsers,
+    // `ErrorEvent` in `ws`/undici, `Event` + `message` in Bun), so normalize it to an `ErrorEvent`
+    // carrying a real `Error` before doing anything with it.
+    const errorEvent = normalizeErrorEvent(event, this);
+    this._debug('error event', errorEvent.message);
+    this._disconnect(undefined, errorEvent.message === 'TIMEOUT' ? 'timeout' : undefined);
 
     if (this.onerror) {
-      this.onerror(event);
+      this.onerror(errorEvent);
     }
     this._debug('exec error listeners');
-    this.dispatchEvent(cloneEvent(event));
+    this.dispatchEvent(cloneEvent(errorEvent));
 
     this._connect();
   };


### PR DESCRIPTION
This cleans up some `any`s in the vendored `ReconnectingWebSocket` and also  fixes some real issues for the browser handling of errors emitted from the underlying `WebSocket` class