### PR TITLE
Update OTel auto-instrumentation for ESM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ ADD ./medplum-server-runtime.tar.gz ./
 
 EXPOSE 5000 8103
 
-ENTRYPOINT [ "node", "--require", "./packages/server/dist/otel/instrumentation.js", "packages/server/dist/index.js" ]
+ENTRYPOINT [ "node", "--experimental-loader=@opentelemetry/instrumentation/hook.mjs", "--import", "./packages/server/dist/otel/instrumentation.js", "packages/server/dist/index.js" ]

--- a/packages/docs/docs/self-hosting/install-on-digital-ocean.md
+++ b/packages/docs/docs/self-hosting/install-on-digital-ocean.md
@@ -45,7 +45,7 @@ npx turbo run build --filter=@medplum/server
 Use this run command:
 
 ```bash
-node --import ./packages/server/dist/otel/instrumentation.js packages/server/dist/index.js env
+node --experimental-loader=@opentelemetry/instrumentation/hook.mjs --import ./packages/server/dist/otel/instrumentation.js packages/server/dist/index.js env
 ```
 
 Set the App Platform HTTP port to the same value as `MEDPLUM_PORT`.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,11 +18,11 @@
     "build": "npm run clean && tsc && node build.mjs",
     "circular": "npx madge --circular dist/index.js",
     "clean": "rimraf dist",
-    "dev": "tsx watch --import ./src/otel/instrumentation.ts src/index.ts",
+    "dev": "tsx watch --experimental-loader=@opentelemetry/instrumentation/hook.mjs --import ./src/otel/instrumentation.ts src/index.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "migrate": "tsx src/migrations/migrate-main.ts",
-    "start": "node --import ./dist/otel/instrumentation.js dist/index.js",
+    "start": "node --experimental-loader=@opentelemetry/instrumentation/hook.mjs --import ./dist/otel/instrumentation.js dist/index.js",
     "test": "jest",
     "test:seed": "jest seed.test.ts --testTimeout=400000"
   },


### PR DESCRIPTION
Per [the OTel docs](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/esm-support.md), changes are necessary to support the monkey-patching necessary for auto-instrumentation with ESM.  This is expected to fix a few issues observed with emitted traces, including adding back missing attributes and adopting trace IDs from the host environment (e.g. AWS)