### PR TITLE
feat(react): Add customization props to ChooseScopeForm

### DIFF
--- a/examples/medplum-smart-on-fhir-demo/src/pages/SetupPage.tsx
+++ b/examples/medplum-smart-on-fhir-demo/src/pages/SetupPage.tsx
@@ -1,11 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Anchor, Button, Stack, Text, Title } from '@mantine/core';
-import { Document, Loading, useMedplum } from '@medplum/react';
+import { Document, Loading, SignInForm, useMedplum } from '@medplum/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { JSX } from 'react';
 import { useNavigate } from 'react-router';
-import { MEDPLUM_CLIENT_ID } from '../config';
 import { DEMO_TAG, createDemoPatients } from '../data/demoData';
 
 type SetupStatus = 'init' | 'creating' | 'done' | 'error';
@@ -41,33 +40,36 @@ export function SetupPage(): JSX.Element {
   }, [medplum]);
 
   useEffect(() => {
-    if (hasRun.current) {
-      return;
+    if (medplum.isAuthenticated() && !hasRun.current) {
+      hasRun.current = true;
+      runSetup().catch(console.error);
     }
-    hasRun.current = true;
-
-    if (medplum.isAuthenticated()) {
-      queueMicrotask(() => {
-        runSetup().catch(console.error);
-      });
-      return;
-    }
-
-    // Redirect to Medplum for auth, or process the ?code= on return
-    medplum
-      .signInWithRedirect({ clientId: MEDPLUM_CLIENT_ID, redirectUri: window.location.origin + '/setup' })
-      .then((profile) => {
-        if (profile) {
-          // Returned from OAuth redirect with code processed — run setup
-          runSetup().catch(console.error);
-        }
-        // else: page is redirecting to Medplum auth
-      })
-      .catch((err) => {
-        setMessage(err instanceof Error ? err.message : 'Unknown error');
-        setStatus('error');
-      });
   }, [medplum, runSetup]);
+
+  if (!medplum.isAuthenticated() && status === 'init') {
+    return (
+      <Document width={400} px="xl" py="xl" bdrs="md">
+        <SignInForm
+          chooseScopes
+          onSuccess={() => runSetup().catch(console.error)}
+          chooseScopeFormProps={{
+            logo: <img src="/medplum-logo.svg" height={32} alt="" />,
+            title: 'Grant Demo Setup Access',
+            submitLabel: 'Connect',
+            children: (
+              <Text size="sm" c="dimmed" ta="center" mb="sm">
+                This app needs access to your Medplum project to generate demo patient data.
+              </Text>
+            ),
+          }}
+        >
+          <Text size="sm" c="dimmed" ta="center" mb="sm">
+            Sign in to your Medplum project to set up demo data.
+          </Text>
+        </SignInForm>
+      </Document>
+    );
+  }
 
   if (status === 'init' || status === 'creating') {
     return <Loading />;

--- a/packages/react/src/auth/ChooseScopeForm.stories.tsx
+++ b/packages/react/src/auth/ChooseScopeForm.stories.tsx
@@ -77,3 +77,30 @@ export function WithMultipleScopes(): JSX.Element {
     </div>
   );
 }
+
+export function CustomBranding(): JSX.Element {
+  return (
+    <div style={{ minHeight: '100vh' }}>
+      <Document width={500} px="xl" py="xl" bdrs="md">
+        <MedplumProvider medplum={medplum}>
+          <ChooseScopeForm
+            login="test@example.com"
+            scope="openid patient/Condition.* patient/Observation.*"
+            handleAuthResponse={console.log}
+            logo={
+              <div style={{ fontSize: 20, fontWeight: 800, color: 'var(--mantine-color-blue-6)', letterSpacing: '-0.5px' }}>
+                MyApp
+              </div>
+            }
+            title="Grant Access"
+            submitLabel="Allow"
+          >
+            <p style={{ fontSize: '0.875rem', color: 'var(--mantine-color-dimmed)', textAlign: 'center' }}>
+              This app would like to access the following data from your health record.
+            </p>
+          </ChooseScopeForm>
+        </MedplumProvider>
+      </Document>
+    </div>
+  );
+}

--- a/packages/react/src/auth/ChooseScopeForm.stories.tsx
+++ b/packages/react/src/auth/ChooseScopeForm.stories.tsx
@@ -88,7 +88,9 @@ export function CustomBranding(): JSX.Element {
             scope="openid patient/Condition.* patient/Observation.*"
             handleAuthResponse={console.log}
             logo={
-              <div style={{ fontSize: 20, fontWeight: 800, color: 'var(--mantine-color-blue-6)', letterSpacing: '-0.5px' }}>
+              <div
+                style={{ fontSize: 20, fontWeight: 800, color: 'var(--mantine-color-blue-6)', letterSpacing: '-0.5px' }}
+              >
                 MyApp
               </div>
             }

--- a/packages/react/src/auth/ChooseScopeForm.tsx
+++ b/packages/react/src/auth/ChooseScopeForm.tsx
@@ -3,7 +3,7 @@
 import { Checkbox, Flex, Group, Stack, Title } from '@mantine/core';
 import type { LoginAuthenticationResponse } from '@medplum/core';
 import { useMedplum } from '@medplum/react-hooks';
-import type { JSX } from 'react';
+import type { JSX, ReactNode } from 'react';
 import { Fragment } from 'react/jsx-runtime';
 import { Form } from '../Form/Form';
 import { SubmitButton } from '../Form/SubmitButton';
@@ -13,6 +13,10 @@ export interface ChooseScopeFormProps {
   readonly login: string;
   readonly scope: string | undefined;
   readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
+  readonly title?: string;
+  readonly submitLabel?: string;
+  readonly logo?: ReactNode;
+  readonly children?: ReactNode;
 }
 
 const openConditionScope = /^patient\/Condition\.(?:\*|c?r?u?d?s?)$/;
@@ -44,10 +48,11 @@ export function ChooseScopeForm(props: ChooseScopeFormProps): JSX.Element {
     >
       <Stack>
         <Flex direction="column" align="center" justify="center">
-          <Logo size={32} />
+          {props.logo ?? <Logo size={32} />}
           <Title order={3} py="lg">
-            Choose scope
+            {props.title ?? 'Choose scope'}
           </Title>
+          {props.children}
         </Flex>
         <Stack>
           {(props.scope ?? 'openid').split(' ').map((scopeName: string) => {
@@ -79,7 +84,7 @@ export function ChooseScopeForm(props: ChooseScopeFormProps): JSX.Element {
           })}
         </Stack>
         <Group justify="flex-end" mt="xl">
-          <SubmitButton fullWidth>Set Scope</SubmitButton>
+          <SubmitButton fullWidth>{props.submitLabel ?? 'Set Scope'}</SubmitButton>
         </Group>
       </Stack>
     </Form>

--- a/packages/react/src/auth/SignInForm.tsx
+++ b/packages/react/src/auth/SignInForm.tsx
@@ -10,8 +10,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Document } from '../Document/Document';
 import { AuthenticationForm } from './AuthenticationForm';
 import { ChooseProfileForm } from './ChooseProfileForm';
-import { ChooseScopeForm } from './ChooseScopeForm';
 import type { ChooseScopeFormProps } from './ChooseScopeForm';
+import { ChooseScopeForm } from './ChooseScopeForm';
 import { MfaForm } from './MfaForm';
 import { NewProjectForm } from './NewProjectForm';
 

--- a/packages/react/src/auth/SignInForm.tsx
+++ b/packages/react/src/auth/SignInForm.tsx
@@ -11,6 +11,7 @@ import { Document } from '../Document/Document';
 import { AuthenticationForm } from './AuthenticationForm';
 import { ChooseProfileForm } from './ChooseProfileForm';
 import { ChooseScopeForm } from './ChooseScopeForm';
+import type { ChooseScopeFormProps } from './ChooseScopeForm';
 import { MfaForm } from './MfaForm';
 import { NewProjectForm } from './NewProjectForm';
 
@@ -24,6 +25,7 @@ export interface SignInFormProps extends BaseLoginRequest {
   readonly onRegister?: () => void;
   readonly onCode?: (code: string) => void;
   readonly children?: ReactNode;
+  readonly chooseScopeFormProps?: Omit<ChooseScopeFormProps, 'login' | 'scope' | 'handleAuthResponse'>;
 }
 
 /**
@@ -42,6 +44,7 @@ export function SignInForm(props: SignInFormProps): JSX.Element {
   const {
     login: loginCode,
     chooseScopes,
+    chooseScopeFormProps,
     onSuccess,
     onForgotPassword,
     onRegister,
@@ -172,7 +175,14 @@ export function SignInForm(props: SignInFormProps): JSX.Element {
         } else if (memberships) {
           return <ChooseProfileForm login={login} memberships={memberships} handleAuthResponse={handleAuthResponse} />;
         } else if (props.chooseScopes) {
-          return <ChooseScopeForm login={login} scope={props.scope} handleAuthResponse={handleScopeResponse} />;
+          return (
+            <ChooseScopeForm
+              login={login}
+              scope={props.scope}
+              handleAuthResponse={handleScopeResponse}
+              {...chooseScopeFormProps}
+            />
+          );
         } else {
           return <div>Success</div>;
         }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -19,6 +19,7 @@ export * from './AttachmentButton/AttachmentButton';
 export * from './AttachmentDisplay/AttachmentDisplay';
 export * from './AttachmentInput/AttachmentInput';
 export * from './auth/ChangePasswordForm';
+export * from './auth/ChooseScopeForm';
 export * from './auth/MfaForm';
 export * from './auth/RegisterForm';
 export * from './auth/ResetPasswordForm';


### PR DESCRIPTION
## Summary

- Adds `title`, `submitLabel`, `logo`, and `children` props to `ChooseScopeFormProps` so callers can brand the scope consent step without a custom implementation
- Exports `ChooseScopeForm` from the package index
- Threads the new props through `SignInForm` via `chooseScopeFormProps?: Omit<ChooseScopeFormProps, 'login' | 'scope' | 'handleAuthResponse'>` so apps using the higher-level component don't need to drop down to the form directly
- Demonstrates the feature in `examples/medplum-smart-on-fhir-demo` by replacing the `signInWithRedirect` setup flow with an inline `SignInForm` that passes `chooseScopeFormProps` with a custom logo, title, and description

## Test plan

- [ ] Open Storybook → Medplum / Auth / ChooseScopeForm → **CustomBranding** story to verify logo, title, submitLabel, and children render correctly
- [ ] Verify existing stories (`Basic`, `WithOpenIdScope`, `WithConditionScope`, `WithObservationScope`, `WithMultipleScopes`) still render with defaults unchanged
- [ ] In `medplum-smart-on-fhir-demo`, navigate to `/setup` — confirm the sign-in form shows the custom description, and after sign-in the scope form shows the branded logo, "Grant Demo Setup Access" title, and description text
- [ ] Verify `SignInForm` without `chooseScopeFormProps` continues to work as before

Closes #9458