### PR TITLE
chore(vscode): enforce `organizeImports` in VSCode for repo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,8 +18,10 @@
   "[jsonc]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "never"
+    "source.fixAll.eslint": "never",
+    "source.organizeImports": "explicit"
   },
   "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",


### PR DESCRIPTION
I think this should fix the issue we see with `autofix.ci` always adding a commit, even when it's just to re-organize the imports.