### PR TITLE
 feat(server): add error, warn, info, debug, trace to MockConsole

### DIFF
--- a/packages/server/src/util/console.test.ts
+++ b/packages/server/src/util/console.test.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { MockConsole } from './console';
+
+describe('MockConsole', () => {
+  let console: MockConsole;
+
+  beforeEach(() => {
+    console = new MockConsole();
+  });
+
+  test('log() stores message', () => {
+    console.log('hello', 'world');
+    expect(console.messages).toEqual(['hello world']);
+  });
+
+  test('error() stores message', () => {
+    console.error('something went wrong');
+    expect(console.messages).toEqual(['something went wrong']);
+  });
+
+  test('warn() stores message', () => {
+    console.warn('be careful');
+    expect(console.messages).toEqual(['be careful']);
+  });
+
+  test('info() stores message', () => {
+    console.info('for your information');
+    expect(console.messages).toEqual(['for your information']);
+  });
+
+  test('debug() stores message', () => {
+    console.debug('debug value', 42);
+    expect(console.messages).toEqual(['debug value 42']);
+  });
+
+  test('trace() stores message', () => {
+    console.trace('trace point');
+    expect(console.messages).toEqual(['trace point']);
+  });
+
+  test('all methods contribute to the same messages array', () => {
+    console.log('log');
+    console.error('error');
+    console.warn('warn');
+    console.info('info');
+    console.debug('debug');
+    console.trace('trace');
+    expect(console.messages).toHaveLength(6);
+  });
+
+  test('toString() returns all messages joined by newline', () => {
+    console.log('first');
+    console.error('second');
+    console.warn('third');
+    expect(console.toString()).toBe('first\nsecond\nthird');
+  });
+});

--- a/packages/server/src/util/console.ts
+++ b/packages/server/src/util/console.ts
@@ -7,6 +7,26 @@ export class MockConsole {
     this.messages.push(params.join(' '));
   }
 
+  error(...params: any[]): void {
+    this.messages.push(params.join(' '));
+  }
+
+  warn(...params: any[]): void {
+    this.messages.push(params.join(' '));
+  }
+
+  info(...params: any[]): void {
+    this.messages.push(params.join(' '));
+  }
+
+  debug(...params: any[]): void {
+    this.messages.push(params.join(' '));
+  }
+
+  trace(...params: any[]): void {
+    this.messages.push(params.join(' '));
+  }
+
   toString(): string {
     return this.messages.join('\n');
   }


### PR DESCRIPTION
 Third-party packages imported by vmcontext bots may call console methods
  beyond `console.log`, causing runtime errors in the VM sandbox.

  Add `error`, `warn`, `info`, `debug`, and `trace` to `MockConsole` so
  bots that import libraries using those methods work correctly. All methods
  push to the shared `messages[]` array so `botConsole.toString()` captures
  full output regardless of log level.

  Also adds a `console.test.ts` unit test file covering all methods.

  Fixes #4928