### PR TITLE
fix(ws): bind message listener before redis SUBSCRIBE

### DIFF
--- a/packages/server/src/ws/agent.ts
+++ b/packages/server/src/ws/agent.ts
@@ -155,13 +155,16 @@ export async function handleAgentConnection(socket: WebSocket, request: Incoming
     const agent = await repo.readResource<Agent>('Agent', agentId);
 
     // Connect to Redis
+    // Bind the message listener before awaiting the subscribe so that messages
+    // published immediately after subscription are not dropped.
     redisSubscriber = getPubSubRedisSubscriber();
-    await redisSubscriber.subscribe(getReferenceString(agent));
+    const subscribed = redisSubscriber.subscribe(getReferenceString(agent));
     redisSubscriber.on('message', (_channel: string, message: string) => {
       // When a message is received, send it to the agent
       socket.send(message, { binary: false });
       agentMessagesSent++;
     });
+    await subscribed;
 
     // Subscribe to heartbeat events
     heartbeat.addEventListener('heartbeat', heartbeatHandler);

--- a/packages/server/src/ws/echo.test.ts
+++ b/packages/server/src/ws/echo.test.ts
@@ -4,10 +4,14 @@ import type { Express } from 'express';
 import express from 'express';
 import type { Server } from 'node:http';
 import request from 'superwstest';
+import type { WebSocket } from 'ws';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
+import { globalLogger } from '../logger';
+import * as redis from '../redis';
 import { withTestContext } from '../test.setup';
+import { handleEchoConnection } from './echo';
 
 describe('Echo websocket', () => {
   let app: Express;
@@ -38,5 +42,28 @@ describe('Echo websocket', () => {
         .expectText('bar')
         .close()
         .expectClosed();
+    }));
+
+  test('Logs when subscribe rejects', () =>
+    withTestContext(async () => {
+      const subscribeError = new Error('Connection is closed.');
+      const subscriberSpy = jest.spyOn(redis, 'getPubSubRedisSubscriber').mockReturnValue({
+        subscribe: jest.fn().mockRejectedValue(subscribeError),
+        on: jest.fn(),
+        disconnect: jest.fn(),
+      } as any);
+      const errorSpy = jest.spyOn(globalLogger, 'error').mockImplementation(() => undefined);
+
+      const socket = { on: jest.fn(), send: jest.fn() } as unknown as WebSocket;
+
+      try {
+        await expect(handleEchoConnection(socket)).resolves.toBeUndefined();
+        expect(errorSpy).toHaveBeenCalledWith('[WS] Failed to subscribe to echo channel', {
+          error: subscribeError,
+        });
+      } finally {
+        subscriberSpy.mockRestore();
+        errorSpy.mockRestore();
+      }
     }));
 });

--- a/packages/server/src/ws/echo.test.ts
+++ b/packages/server/src/ws/echo.test.ts
@@ -1,6 +1,5 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { sleep } from '@medplum/core';
 import type { Express } from 'express';
 import express from 'express';
 import type { Server } from 'node:http';
@@ -33,9 +32,6 @@ describe('Echo websocket', () => {
     withTestContext(async () => {
       await request(server)
         .ws('/ws/echo')
-        .exec(async () => {
-          await sleep(10);
-        })
         .sendText('foo')
         .expectText('foo')
         .sendText('bar')

--- a/packages/server/src/ws/echo.ts
+++ b/packages/server/src/ws/echo.ts
@@ -46,7 +46,9 @@ export async function handleEchoConnection(socket: WebSocket): Promise<void> {
   const redisSubscriber = getPubSubRedisSubscriber();
   const channel = randomUUID();
 
-  await redisSubscriber.subscribe(channel);
+  // Attach socket listeners before awaiting the Redis subscription,
+  // otherwise messages sent by the client immediately after connecting are silently dropped
+  const subscribed = redisSubscriber.subscribe(channel);
 
   redisSubscriber.on('message', (channel: string, message: string) => {
     globalLogger.debug('[WS] redis message', { channel, message });
@@ -58,6 +60,7 @@ export async function handleEchoConnection(socket: WebSocket): Promise<void> {
     'message',
     AsyncLocalStorage.bind(async (data: RawData) => {
       echoMessagesReceived++;
+      await subscribed;
       await publish(channel, data as Buffer);
     })
   );
@@ -66,6 +69,15 @@ export async function handleEchoConnection(socket: WebSocket): Promise<void> {
     echoWebSockets.delete(socket);
     redisSubscriber.disconnect();
   });
+
+  // Listeners are already bound above, so no messages are missed while this resolves.
+  // Guard against rejection: a socket closing mid-subscribe triggers disconnect(), which
+  // rejects the in-flight subscribe with "Connection is closed."
+  try {
+    await subscribed;
+  } catch (err) {
+    globalLogger.error('[WS] Failed to subscribe to echo channel', { error: err });
+  }
 }
 
 export function stopEchoHeartbeat(): void {

--- a/packages/server/src/ws/fhircast.test.ts
+++ b/packages/server/src/ws/fhircast.test.ts
@@ -20,7 +20,11 @@ import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
 import { globalLogger } from '../logger';
+import * as redis from '../redis';
 import { initTestAuth, withTestContext } from '../test.setup';
+import { handleFhircastConnection } from './fhircast';
+import type { IncomingMessage } from 'node:http';
+import type { WebSocket } from 'ws';
 
 describe('FHIRcast WebSocket', () => {
   describe('Basic flow', () => {
@@ -915,6 +919,37 @@ describe('FHIRcast WebSocket', () => {
           .sendJson({ ok: true })
           .close()
           .expectClosed();
+      }));
+  });
+
+  describe('Subscribe failure', () => {
+    test('Closes socket and logs when subscribe rejects', () =>
+      withTestContext(async () => {
+        const subscribeError = new Error('Connection is closed.');
+        const cacheSpy = jest.spyOn(redis, 'getCacheRedis').mockReturnValue({
+          get: jest.fn().mockResolvedValue('project-id:my-topic'),
+        } as any);
+        const subscriberSpy = jest.spyOn(redis, 'getPubSubRedisSubscriber').mockReturnValue({
+          subscribe: jest.fn().mockRejectedValue(subscribeError),
+          on: jest.fn(),
+          disconnect: jest.fn(),
+        } as any);
+        const errorSpy = jest.spyOn(globalLogger, 'error').mockImplementation(() => undefined);
+
+        const socket = { on: jest.fn(), send: jest.fn(), close: jest.fn() } as unknown as WebSocket;
+        const req = { url: '/ws/fhircast/some-endpoint' } as IncomingMessage;
+
+        try {
+          await expect(handleFhircastConnection(socket, req)).resolves.toBeUndefined();
+          expect(errorSpy).toHaveBeenCalledWith('[FHIRcast]: Failed to subscribe to topic', {
+            err: subscribeError,
+          });
+          expect(socket.close).toHaveBeenCalled();
+        } finally {
+          cacheSpy.mockRestore();
+          subscriberSpy.mockRestore();
+          errorSpy.mockRestore();
+        }
       }));
   });
 });

--- a/packages/server/src/ws/fhircast.test.ts
+++ b/packages/server/src/ws/fhircast.test.ts
@@ -14,8 +14,9 @@ import type { Express } from 'express';
 import express from 'express';
 import { randomUUID } from 'node:crypto';
 import { once } from 'node:events';
-import type { Server } from 'node:http';
+import type { IncomingMessage, Server } from 'node:http';
 import request from 'superwstest';
+import type { WebSocket } from 'ws';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
@@ -23,8 +24,6 @@ import { globalLogger } from '../logger';
 import * as redis from '../redis';
 import { initTestAuth, withTestContext } from '../test.setup';
 import { handleFhircastConnection } from './fhircast';
-import type { IncomingMessage } from 'node:http';
-import type { WebSocket } from 'ws';
 
 describe('FHIRcast WebSocket', () => {
   describe('Basic flow', () => {

--- a/packages/server/src/ws/fhircast.ts
+++ b/packages/server/src/ws/fhircast.ts
@@ -95,8 +95,10 @@ export async function handleFhircastConnection(socket: WebSocket, request: Incom
   // except for additional SUBSCRIBE, PSUBSCRIBE, UNSUBSCRIBE and PUNSUBSCRIBE commands.
   const redisSubscriber = getPubSubRedisSubscriber();
 
-  // Subscribe to the topic
-  await redisSubscriber.subscribe(projectAndTopic);
+  // Bind all listeners (and topic bookkeeping) before awaiting the subscribe, so that
+  // messages published immediately after subscription are not dropped, and a socket that
+  // closes during the subscribe still cleans up its Redis subscriber.
+  const subscribed = redisSubscriber.subscribe(projectAndTopic);
 
   const topic = projectAndTopic?.split(':')[1] ?? 'invalid topic';
   // Increment ref count for the specified topic
@@ -133,6 +135,16 @@ export async function handleFhircastConnection(socket: WebSocket, request: Incom
     }
     redisSubscriber.disconnect();
   });
+
+  // Wait for the subscription to be established before sending the connection verification.
+  // Listeners are already bound above, so no messages are missed while this resolves.
+  try {
+    await subscribed;
+  } catch (err) {
+    globalLogger.error('[FHIRcast]: Failed to subscribe to topic', { err });
+    socket.close();
+    return;
+  }
 
   // Send initial connection verification
   // TODO: Fill in these properties

--- a/packages/server/src/ws/routes.test.ts
+++ b/packages/server/src/ws/routes.test.ts
@@ -1,6 +1,5 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { sleep } from '@medplum/core';
 import type { Express } from 'express';
 import express from 'express';
 import type { Server } from 'node:http';
@@ -35,9 +34,6 @@ describe('WebSockets', () => {
     withTestContext(async () => {
       await request(server)
         .ws('/ws/echo')
-        .exec(async () => {
-          await sleep(10);
-        })
         .sendText('foo')
         .expectText('foo')
         .sendText('bar')


### PR DESCRIPTION
This should fix the ocassional flakiness in the Echo WebSocket tests, as well as defensively guards against race conditions in other WebSockets handlers