### PR TITLE
docs: update transaction bundle references to be up to date

### DIFF
--- a/packages/docs/docs/fhir-datastore/fhir-batch-requests.mdx
+++ b/packages/docs/docs/fhir-datastore/fhir-batch-requests.mdx
@@ -49,8 +49,19 @@ const transactionBundle = {
 :::caution[Transaction Support]
 Transaction support requires the `transaction-bundles` feature flag to be enabled on your project. Contact Medplum to enable this feature.
 
+If the feature flag is not enabled, a bundle with `type: "transaction"` is processed as a `batch`. Entries execute independently with no atomicity guarantee, and the server does not return an error or warning. Verify the flag is enabled on your project before relying on transaction semantics.
+
 The transaction feature is currently in beta. You may experience `409 conflict` errors when attempting transactions. If this occurs, implement retry logic in your client to handle these errors and retry the transaction until it succeeds.
 :::
+
+### Transaction Limits
+
+Transactions are subject to the following limits. Exceeding either limit causes the entire transaction to be rejected with a `400 Bad Request` error.
+
+- A transaction may contain at most **50 update operations**.
+- A transaction that contains conditional operations (a conditional create using `ifNoneExist`, a conditional update, or a conditional delete) runs under serializable database isolation and is limited to **8 entries**.
+
+To keep a larger transaction out of serializable mode, resolve conditional lookups before submitting it: search for the target resources first, then use plain creates and updates with known IDs inside the transaction.
 
 ## How to Perform a Batch Request
 

--- a/packages/docs/docs/integration/scriptsure/order-sets.md
+++ b/packages/docs/docs/integration/scriptsure/order-sets.md
@@ -66,6 +66,10 @@ const result = await medplum.executeBatch(convertToTransactionBundle(orderSetBun
 const pdId = result.entry?.find((e) => e.response?.location?.startsWith('PlanDefinition/'))?.response?.location?.split('/')[1];
 ```
 
+:::caution[Transaction behavior depends on the `transaction-bundles` project feature]
+If the `transaction-bundles` feature flag is not enabled on your project, the transaction bundle is silently processed as a batch. Entries execute independently with no atomicity, so a failed entry does not roll back the others and can leave a partial order set behind. See [FHIR Batch Requests](/docs/fhir-datastore/fhir-batch-requests) for details.
+:::
+
 <details>
 <summary>Example order set bundle (`PlanDefinition` + `ActivityDefinition`)</summary>
 

--- a/packages/docs/docs/migration/migration-pipelines.md
+++ b/packages/docs/docs/migration/migration-pipelines.md
@@ -70,7 +70,7 @@ This batch operation creates (or updates) two [`Patient`][patient] resources in 
 
 ## Using Transactions for Data Integrity
 
-[FHIR Transactions](/docs/fhir-datastore/fhir-batch-requests#internal-references) ensure that a set of resources are written together or fail together, maintaining data integrity. However, transactions are generally slower and are capped at 20 resources per transaction.
+[FHIR Transactions](/docs/fhir-datastore/fhir-batch-requests#internal-references) ensure that a set of resources are written together or fail together, maintaining data integrity. Transactions require the `transaction-bundles` feature flag on your project; without it, bundles with `type: "transaction"` are processed as batches and lose atomicity. Transactions are generally slower than batches, and two limits apply: a transaction may contain at most 50 update operations, and a transaction that includes conditional operations (conditional create, update, or delete) runs under serializable isolation and is limited to 8 entries. See [Transaction Limits](/docs/fhir-datastore/fhir-batch-requests#transaction-limits) for details.
 
 #### Example: Encounter with Clinical Impression
 

--- a/packages/docs/docs/self-hosting/project-settings.md
+++ b/packages/docs/docs/self-hosting/project-settings.md
@@ -36,7 +36,7 @@ are:
 | `graphql-introspection`   | Allows potentially-expensive [GraphQL schema introspection](/docs/graphql) queries                                               |
 | `terminology`             | Enable full standards-compliant implementation for the [`ValueSet/$expand` operation](/docs/api/fhir/operations/valueset-expand) |
 | `websocket-subscriptions` | Allows setting up a [Subscription](/docs/subscriptions) over Websockets                                                          |
-| `transaction-bundles`     | Use strong database transaction isolation for `transaction` Bundles                                                              |
+| `transaction-bundles`     | Process `transaction` Bundles atomically. Without this flag, `transaction` Bundles are processed as batches. See [FHIR Batch Requests](/docs/fhir-datastore/fhir-batch-requests#transaction-limits) |
 
 ## Project system settings
 


### PR DESCRIPTION
## Summary

- Replaced the stale "20-resource transaction cap" with the actual limits: 50 update operations, and 8 entries for transactions with conditional operations (serializable isolation)
- Documented fallback behavior when the `transaction-bundles` feature flag is disabled: `transaction` bundles silently process as batches with no atomicity
- Clarified the `transaction-bundles` feature flag description in project settings to reflect that it gates atomicity, not just isolation

## Test plan

- [x] Docs build passes
- [x] Verified accuracy against source (`packages/fhir-router/src/batch.ts`)