### PR TITLE
Support nondivisible alignment times in `$find`

### DIFF
--- a/packages/docs/docs/scheduling/defining-availability.md
+++ b/packages/docs/docs/scheduling/defining-availability.md
@@ -62,9 +62,9 @@ When using scheduling APIs to interact with multiple `Schedule` resources at onc
 | `bufferAfter`       | [Duration](/docs/api/fhir/datatypes/duration)               | 0 minutes (no buffer needed)                | Sets cleanup time needed after appointment end. It must be free at booking time, and will be reserved with a Slot.                                                      |                                                               |                                                           |
 | `alignmentInterval` | [Duration](/docs/api/fhir/datatypes/duration)               | 60 minutes (appointments start on-the-hour) | Start times must align to this interval (e.g., every 15 minutes)                                                                                                        |                                                               | Recommended to prefer setting this on `HealthcareService` |
 | `alignmentOffset`   | [Duration](/docs/api/fhir/datatypes/duration)               | 0 minutes                                   | Shifts allowed start times by this offset (e.g., with a 15-minute alignmentInterval and a 5-minute alignmentOffset, valid starts are :05, :20, :35, :50)                |                                                               | Recommended to prefer setting this on `HealthcareService` |
+| `alignmentTimezone` | Code                                                        | 'Etc/UTC'                                   | Anchors the alignment grid to local midnight of the given timezone, keeping start times stable across DST transitions.                                                  |                                                               | Recommended to prefer setting this on `HealthcareService` |
 | `service`           | `Reference(HealthcareService)`                              | *none*                                      | Pointer to the `HealthcareService` that these parameters  should override.                                                                                              | Not permitted                                                 |                                                           |
 | `availability`      | [Nested Extension](#availability-extension)                 | Always available                            | Weekly recurring availability windows. When set, appointments must fit inside these windows.                                                                            | Not permitted (use `HealthcareService.availableTime` instead) |                                                           |
-
 
 <details>
 <summary>Example of the `SchedulingParameters` extension on a `HealthcareService`</summary>
@@ -106,7 +106,14 @@ When using scheduling APIs to interact with multiple `Schedule` resources at onc
         "system": "http://unitsofmeasure.org",
         "code": "min"
       }
-    }
+    },
+
+    // Optional: Timezone for anchoring the alignment grid to local midnight
+    // Independent of `timezone`, which controls availability window interpretation
+    {
+      "url": "alignmentTimezone",
+      "valueCode": "America/New_York"
+    },
 
     // Optional: specify time zone for availability interpretation
     // Falls back to Schedule's actor time zone if not specified
@@ -235,12 +242,47 @@ When using scheduling APIs to interact with multiple `Schedule` resources at onc
         "system": "http://unitsofmeasure.org",
         "code": "min"
       }
+    },
+
+    // Timezone for anchoring the alignment grid to local midnight
+    // Independent of `timezone`, which controls availability window interpretation
+    {
+      "url": "alignmentTimezone",
+      "valueCode": "America/New_York"
     }
   ]
 }
 ```
 
 </details>
+
+### Alignment grid
+
+Medplum Scheduling APIs generate possible appointments by projecting a repeating daily grid. These parameters control that grid:
+
+| Parameter           | Description                            | Default    |
+| ------------------- | -------------------------------------- | ---------- |
+| `alignmentInterval` | How frequently slot start times occur  | 60 minutes |
+| `alignmentOffset`   | Shifts slot start times by this amount | 0 minutes  |
+| `alignmentTimezone` | What timezone the grid is anchored to  | `Etc/UTC`  |
+
+#### `alignmentInterval`
+
+Sets how frequently appointments may begin. For back-to-back scheduling without gaps, set this value to match the `duration` parameter.
+
+#### `alignmentOffset`
+
+Example: to align your appointments starting at 9:15, 10:15, ..., set `alignmentOffset` to 15 minutes (with a 60-minute `alignmentInterval`).
+
+#### `alignmentTimezone`
+
+When clocks change for DST, slots appear to shift by an hour in local time — for example, a 9:00am slot may appear at 8:00am or 10:00am. Setting `alignmentTimezone` anchors the grid to local midnight instead, keeping slot times consistent year-round.
+
+**Relationship to `timezone`:** The two fields serve distinct purposes and can be set independently:
+- `timezone` — which timezone to use when reading `availableStartTime`/`availableEndTime` values
+- `alignmentTimezone` — which timezone's midnight to use as the alignment grid anchor
+
+The rare case in which they differ: a provider whose availability hours and appointment grid are managed in different timezones.
 
 ## Actor Level Availability
 

--- a/packages/docs/docs/scheduling/defining-availability.md
+++ b/packages/docs/docs/scheduling/defining-availability.md
@@ -50,7 +50,7 @@ All scheduling constraints are managed through a single consolidated extension: 
 
 To use scheduling APIs for a Schedule and HealthcareService, at least one of them must define the `duration` attribute (used to set how long the scheduled appointment will last). There must be a `timezone` attribute, which may also be defined on the Schedule's actor. (See [Timezone Resolution](#timezone-resolution))
 
-When using scheduling APIs to interact with multiple `Schedule` resources at once, they must be configured with matching `duration`, `alignmentInterval`, and `alignmentOffset` parameters. For this reason, Medplum recommends that these parameters only be set on `HealthcareService` resources.
+When using scheduling APIs to interact with multiple `Schedule` resources at once, they must be configured with matching `duration`, `alignmentInterval`, `alignmentTimezone`, and `alignmentOffset` parameters. For this reason, Medplum recommends that these parameters only be set on `HealthcareService` resources.
 
 #### Extension Fields
 

--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -1230,6 +1230,10 @@ describe('Appointment/$find', () => {
               url: 'duration',
               valueDuration: { value: 20, unit: 'min' },
             },
+            {
+              url: 'alignmentTimezone',
+              valueCode: 'America/Chicago',
+            },
           ],
         },
       ],
@@ -1752,6 +1756,47 @@ describe('Appointment/$find', () => {
     expect(response.body.issue[0].expression).toEqual([
       'Parameters.schedule[0].extension[0]',
       'Parameters.schedule[1].extension[1]',
+    ]);
+  });
+
+  test('errors when `alignmentTimezone` scheduling parameter differs across schedules', async () => {
+    // ScheduleA inherits `alignmentTimezone` from the service and gets `America/Chicago`.
+    const scheduleA = await makeSchedule(
+      [
+        {
+          service: genericVisit,
+          availability: monTueAvailability,
+        },
+      ],
+      { actor: [createReference(practitioner)] }
+    );
+
+    // ScheduleB explicitly sets `alignmentTimezone` to `America/New_York`
+    const scheduleB = await makeSchedule(
+      [
+        {
+          service: genericVisit,
+          availability: monTueAvailability,
+          alignmentTimezone: 'America/New_York',
+        },
+      ],
+      { actor: [createReference(location)] }
+    );
+
+    const response = await makeRequest({
+      start: new Date('2026-03-16T00:00:00-04:00').toISOString(),
+      end: new Date('2026-03-21T00:00:00-04:00').toISOString(),
+      'service-type-reference': `HealthcareService/${genericVisit.id}`,
+      schedule: [`Schedule/${scheduleA.id}`, `Schedule/${scheduleB.id}`],
+    });
+    expect(response.status).toBe(400);
+    expect(response.body.issue[0].details.text).toBe(
+      "Scheduling parameters attribute 'alignmentTimezone' does not match"
+    );
+
+    expect(response.body.issue[0].expression).toEqual([
+      'Parameters.service-type-reference.extension[0]',
+      'Parameters.schedule[1].extension[0]',
     ]);
   });
 

--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -35,6 +35,7 @@ type AvailabilityOptions = {
   duration?: number;
   availability: SchedulingParametersExtensionExtension;
   timezone?: string;
+  alignmentTimezone?: string;
 };
 
 const fourDayWorkWeek = {
@@ -198,7 +199,7 @@ describe('Schedule/:id/$find', () => {
 
   function makeSchedulingExtension(availability: AvailabilityOptions[]): Extension[] {
     return availability.map((options) => {
-      const { availability, timezone, service, ...durations } = options;
+      const { availability, timezone, alignmentTimezone, service, ...durations } = options;
 
       const extension = {
         url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
@@ -213,6 +214,13 @@ describe('Schedule/:id/$find', () => {
         extension.extension.push({
           url: 'timezone',
           valueCode: timezone,
+        });
+      }
+
+      if (alignmentTimezone) {
+        extension.extension.push({
+          url: 'alignmentTimezone',
+          valueCode: alignmentTimezone,
         });
       }
 
@@ -1252,7 +1260,7 @@ describe('Appointment/$find', () => {
 
   function makeSchedulingExtension(availability: AvailabilityOptions[]): Extension[] {
     return availability.map((options) => {
-      const { availability, timezone, service, ...durations } = options;
+      const { availability, timezone, alignmentTimezone, service, ...durations } = options;
 
       const extension = {
         url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
@@ -1267,6 +1275,13 @@ describe('Appointment/$find', () => {
         extension.extension.push({
           url: 'timezone',
           valueCode: timezone,
+        });
+      }
+
+      if (alignmentTimezone) {
+        extension.extension.push({
+          url: 'alignmentTimezone',
+          valueCode: alignmentTimezone,
         });
       }
 
@@ -2022,5 +2037,44 @@ describe('Appointment/$find', () => {
         },
       ],
     });
+  });
+
+  test('alignmentTimezone anchors the slot grid to local midnight', async () => {
+    // America/Chicago in December is CST (UTC-6). The Chicago midnight grid with
+    // alignment=50 has grid starts at 10:00, 10:50, 11:40 CST within the 09:30-12:30
+    // availability window. UTC anchoring would give 09:50, 10:40, 11:30 CST instead.
+    const schedule = await makeSchedule(
+      [
+        {
+          service: genericVisit,
+          availability: fourDayWorkWeek,
+          duration: 40,
+          alignmentInterval: 50,
+          alignmentTimezone: 'America/Chicago',
+          timezone: 'America/Chicago',
+        },
+      ],
+      { actor: [createReference(practitioner)] }
+    );
+    // Search Monday December 1, 2025, 09:30-12:30 CST window.
+    const response = await makeRequest({
+      start: new Date('2025-12-01T09:30:00.000-06:00').toISOString(),
+      end: new Date('2025-12-01T12:30:00.000-06:00').toISOString(),
+      schedule: [`Schedule/${schedule.id}`],
+      'service-type-reference': `HealthcareService/${genericVisit.id}`,
+    });
+    expect(response.body).not.toHaveProperty('issue');
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      resourceType: 'Bundle',
+      type: 'searchset',
+    });
+
+    const startTimes = (response.body as Bundle<Appointment>).entry?.map((e) => e.resource?.start) ?? [];
+    expect(startTimes).toEqual([
+      new Date('2025-12-01T10:00:00.000-06:00').toISOString(),
+      new Date('2025-12-01T10:50:00.000-06:00').toISOString(),
+      new Date('2025-12-01T11:40:00.000-06:00').toISOString(),
+    ]);
   });
 });

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -204,6 +204,7 @@ async function handler(params: {
         offsetMinutes: commonParameters.alignmentOffset,
         durationMinutes: commonParameters.duration,
         alignment: commonParameters.alignmentInterval,
+        timezone: commonParameters.alignmentTimezone,
         maxCount,
       }),
     pageSize

--- a/packages/server/src/fhir/operations/utils/find.test.ts
+++ b/packages/server/src/fhir/operations/utils/find.test.ts
@@ -127,6 +127,31 @@ describe('findAlignedSlotTimes', () => {
     ]);
   });
 
+  test('slot alignment by values that do not evenly divide an hour', () => {
+    // Slots are aligned to a fifty-minute grid. The first slot is found at `00:00`.
+    const slots50Midnight = findAlignedSlotTimes(
+      { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T03:00:00Z') },
+      { alignment: 50, offsetMinutes: 0, durationMinutes: 10 }
+    );
+    expect(slots50Midnight).toEqual([
+      { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T00:10:00Z') },
+      { start: new Date('2025-12-01T00:50:00Z'), end: new Date('2025-12-01T01:00:00Z') },
+      { start: new Date('2025-12-01T01:40:00Z'), end: new Date('2025-12-01T01:50:00Z') },
+      { start: new Date('2025-12-01T02:30:00Z'), end: new Date('2025-12-01T02:40:00Z') },
+    ]);
+
+    // When searching does not start at midnight, we still find slots aligned
+    // to the same fifty-minute grid.
+    const slots50Later = findAlignedSlotTimes(
+      { start: new Date('2025-12-01T01:00:00Z'), end: new Date('2025-12-01T03:00:00Z') },
+      { alignment: 50, offsetMinutes: 0, durationMinutes: 10 }
+    );
+    expect(slots50Later).toEqual([
+      { start: new Date('2025-12-01T01:40:00Z'), end: new Date('2025-12-01T01:50:00Z') },
+      { start: new Date('2025-12-01T02:30:00Z'), end: new Date('2025-12-01T02:40:00Z') },
+    ]);
+  });
+
   test('errors when alignment is zero', () => {
     expect(() => {
       findAlignedSlotTimes(

--- a/packages/server/src/fhir/operations/utils/find.test.ts
+++ b/packages/server/src/fhir/operations/utils/find.test.ts
@@ -152,6 +152,126 @@ describe('findAlignedSlotTimes', () => {
     ]);
   });
 
+  test('re-anchors the UTC grid at each UTC midnight for multi-day intervals', () => {
+    // Without re-anchoring, a 50-min grid starting on Dec 1 would place Dec 2
+    // slots at 00:10 and 01:00 — 10 minutes off Dec 2's midnight-anchored grid.
+    // Re-anchoring from Dec 2 midnight gives 00:00, 00:50, 01:40 (all 0 mod 50).
+    const slots = findAlignedSlotTimes(
+      { start: new Date('2025-12-01T23:10:00Z'), end: new Date('2025-12-02T01:50:00Z') },
+      { alignment: 50, offsetMinutes: 0, durationMinutes: 10 }
+    );
+    expect(slots).toEqual([
+      { start: new Date('2025-12-01T23:20:00Z'), end: new Date('2025-12-01T23:30:00Z') },
+      { start: new Date('2025-12-02T00:00:00Z'), end: new Date('2025-12-02T00:10:00Z') },
+      { start: new Date('2025-12-02T00:50:00Z'), end: new Date('2025-12-02T01:00:00Z') },
+      { start: new Date('2025-12-02T01:40:00Z'), end: new Date('2025-12-02T01:50:00Z') },
+    ]);
+  });
+
+  test('re-anchors the local grid at each local midnight for multi-day timezone intervals', () => {
+    // America/New_York in December is EST (UTC-5); local midnight = 05:00 UTC.
+    // Interval: 23:10 EST Dec 1 to 02:00 EST Dec 2 (= 04:10 UTC to 07:00 UTC).
+    // Re-anchoring from local midnight gives 00:00, 00:50, 01:40 EST on Dec 2.
+    const slots = findAlignedSlotTimes(
+      { start: new Date('2025-12-02T04:10:00Z'), end: new Date('2025-12-02T07:00:00Z') },
+      { alignment: 50, offsetMinutes: 0, durationMinutes: 10, timezone: 'America/New_York' }
+    );
+    expect(slots).toEqual([
+      // 23:20 EST Dec 1 — on Dec 1's grid (1400 min, 1400 % 50 = 0)
+      { start: new Date('2025-12-02T04:20:00Z'), end: new Date('2025-12-02T04:30:00Z') },
+      // 00:00 EST Dec 2 — first slot of re-anchored Dec 2 grid (0 % 50 = 0)
+      { start: new Date('2025-12-02T05:00:00Z'), end: new Date('2025-12-02T05:10:00Z') },
+      // 00:50 EST Dec 2 (50 % 50 = 0)
+      { start: new Date('2025-12-02T05:50:00Z'), end: new Date('2025-12-02T06:00:00Z') },
+      // 01:40 EST Dec 2 (100 % 50 = 0)
+      { start: new Date('2025-12-02T06:40:00Z'), end: new Date('2025-12-02T06:50:00Z') },
+    ]);
+  });
+
+  test('timezone option anchors the grid to local midnight, not UTC midnight', () => {
+    // Asia/Kolkata is UTC+5:30. Its 330-minute offset is not divisible by 50,
+    // so UTC and local midnight anchoring diverge here.
+    // 2025-11-30T18:30:00Z = midnight in Kolkata; 2025-11-30T21:30:00Z = 3am Kolkata.
+    const slots = findAlignedSlotTimes(
+      { start: new Date('2025-11-30T18:30:00Z'), end: new Date('2025-11-30T21:30:00Z') },
+      { alignment: 50, offsetMinutes: 0, durationMinutes: 10, timezone: 'Asia/Kolkata' }
+    );
+    // Grid anchored to local midnight (18:30 UTC): 18:30, 19:20, 20:10, 21:00 UTC
+    // = 00:00, 00:50, 01:40, 02:30 Kolkata
+    expect(slots).toEqual([
+      { start: new Date('2025-11-30T18:30:00Z'), end: new Date('2025-11-30T18:40:00Z') },
+      { start: new Date('2025-11-30T19:20:00Z'), end: new Date('2025-11-30T19:30:00Z') },
+      { start: new Date('2025-11-30T20:10:00Z'), end: new Date('2025-11-30T20:20:00Z') },
+      { start: new Date('2025-11-30T21:00:00Z'), end: new Date('2025-11-30T21:10:00Z') },
+    ]);
+  });
+
+  test('uneven slots crossing alignment grid thresholds', () => {
+    // When slots are not evenly divisible by 1day, they introduce an inconsistency in the grid.
+    // In this example, we have `alignment=50`, which does not evenly slice a 1440 minute day.
+    //
+    // There are several options:
+    // 1. Don't allow booking the slot that crosses over the end of the grid.
+    //    This leaves some time at the end of each day permanently unbookable.
+    //
+    // 2. Allow booking that slot, which can result in blocking normally available
+    //    slots in the next day's grid.
+    //
+    // 3. Change the anchoring strategy so that the grid is weekly. This reduces
+    //    the frequency of unbookable times, but means that you lose daily
+    //    consistency in scheduling.
+    //
+    // Each of these choices is defensible. We choose option 2 as what we feel
+    // is the best compromise.
+    //
+    // As a side effect, this means we tend to handle DST transition days well
+    // - these days may be 23 or 25 hours long (and so are not evenly divisible
+    // by as many common factors as your average day). Under this strategy we
+    // fill up the day and allow slots to extend over the boundary into the
+    // following day, potentially overlapping the grid.
+    const slots = findAlignedSlotTimes(
+      { start: new Date('2025-12-01T23:00:00Z'), end: new Date('2025-12-02T01:00:00Z') },
+      { alignment: 50, offsetMinutes: 0, durationMinutes: 50 }
+    );
+    expect(slots).toEqual([
+      // This slot at the end of Dec 1 is found, even though it extends outside the Dec 1
+      // grid and booking it would collide with the following slot.
+      { start: new Date('2025-12-01T23:20:00Z'), end: new Date('2025-12-02T00:10:00Z') },
+
+      // This slot is aligned to the start of the Dec 2 grid, even though booking it
+      // would collide with the previous slot.
+      { start: new Date('2025-12-02T00:00:00Z'), end: new Date('2025-12-02T00:50:00Z') },
+    ]);
+  });
+
+  test('DST: slot times stay consistent in local time across a DST boundary', () => {
+    // America/Chicago is CST (UTC-6) in winter and CDT (UTC-5) in summer.
+    // alignment=50 with UTC anchoring gives different local start times in each
+    // season; timezone anchoring keeps them the same.
+    const opts = { alignment: 50, offsetMinutes: 0, durationMinutes: 10, timezone: 'America/Chicago' };
+
+    // Winter (CST, UTC-6): 08:00–10:00 UTC = 02:00–04:00 CST
+    const winterSlots = findAlignedSlotTimes(
+      { start: new Date('2025-12-01T08:00:00Z'), end: new Date('2025-12-01T10:00:00Z') },
+      opts
+    );
+    // Summer (CDT, UTC-5): 07:00–09:00 UTC = 02:00–04:00 CDT (same local window)
+    const summerSlots = findAlignedSlotTimes(
+      { start: new Date('2025-06-01T07:00:00Z'), end: new Date('2025-06-01T09:00:00Z') },
+      opts
+    );
+
+    // Both should find slots at 02:30 and 03:20 local time — just different UTC representations.
+    expect(winterSlots).toEqual([
+      { start: new Date('2025-12-01T08:30:00Z'), end: new Date('2025-12-01T08:40:00Z') },
+      { start: new Date('2025-12-01T09:20:00Z'), end: new Date('2025-12-01T09:30:00Z') },
+    ]);
+    expect(summerSlots).toEqual([
+      { start: new Date('2025-06-01T07:30:00Z'), end: new Date('2025-06-01T07:40:00Z') },
+      { start: new Date('2025-06-01T08:20:00Z'), end: new Date('2025-06-01T08:30:00Z') },
+    ]);
+  });
+
   test('errors when alignment is zero', () => {
     expect(() => {
       findAlignedSlotTimes(

--- a/packages/server/src/fhir/operations/utils/find.test.ts
+++ b/packages/server/src/fhir/operations/utils/find.test.ts
@@ -6,7 +6,7 @@ describe('findAlignedSlotTimes', () => {
   test('can find a slot that exactly coincides with the interval', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T01:00:00Z') },
-      { alignment: 60, offsetMinutes: 0, durationMinutes: 60 }
+      { alignment: 60, offsetMinutes: 0, durationMinutes: 60, timezone: 'Etc/UTC' }
     );
     expect(slots).toEqual([{ start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T01:00:00Z') }]);
   });
@@ -14,7 +14,7 @@ describe('findAlignedSlotTimes', () => {
   test('returns empty when the interval is less than the duration', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T01:00:00Z') },
-      { alignment: 60, offsetMinutes: 0, durationMinutes: 90 }
+      { alignment: 60, offsetMinutes: 0, durationMinutes: 90, timezone: 'Etc/UTC' }
     );
     expect(slots).toEqual([]);
   });
@@ -22,7 +22,7 @@ describe('findAlignedSlotTimes', () => {
   test('it finds slots aligned to hours', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 60, offsetMinutes: 0, durationMinutes: 10 }
+      { alignment: 60, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T00:10:00Z') },
@@ -33,7 +33,7 @@ describe('findAlignedSlotTimes', () => {
   test('it finds slots aligned to half hours', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 30, offsetMinutes: 0, durationMinutes: 10 }
+      { alignment: 30, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T00:10:00Z') },
@@ -46,7 +46,7 @@ describe('findAlignedSlotTimes', () => {
   test('it finds slots aligned to quarter hours', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 15, offsetMinutes: 0, durationMinutes: 10 }
+      { alignment: 15, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T00:10:00Z') },
@@ -63,7 +63,7 @@ describe('findAlignedSlotTimes', () => {
   test('it finds slots aligned to ten minute marks', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 10, offsetMinutes: 0, durationMinutes: 10 }
+      { alignment: 10, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T00:10:00Z') },
@@ -84,7 +84,7 @@ describe('findAlignedSlotTimes', () => {
   test('offsetting alignment by five minutes', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 15, offsetMinutes: 5, durationMinutes: 10 }
+      { alignment: 15, offsetMinutes: 5, durationMinutes: 10, timezone: 'Etc/UTC' }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:05:00Z'), end: new Date('2025-12-01T00:15:00Z') },
@@ -101,7 +101,7 @@ describe('findAlignedSlotTimes', () => {
   test('offsetting alignment by 20 minutes', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 30, offsetMinutes: 20, durationMinutes: 10 }
+      { alignment: 30, offsetMinutes: 20, durationMinutes: 10, timezone: 'Etc/UTC' }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:20:00Z'), end: new Date('2025-12-01T00:30:00Z') },
@@ -117,7 +117,7 @@ describe('findAlignedSlotTimes', () => {
     // some time before the resulting slot start time.
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 30, offsetMinutes: -20, durationMinutes: 10 }
+      { alignment: 30, offsetMinutes: -20, durationMinutes: 10, timezone: 'Etc/UTC' }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:10:00Z'), end: new Date('2025-12-01T00:20:00Z') },
@@ -131,7 +131,7 @@ describe('findAlignedSlotTimes', () => {
     // Slots are aligned to a fifty-minute grid. The first slot is found at `00:00`.
     const slots50Midnight = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T03:00:00Z') },
-      { alignment: 50, offsetMinutes: 0, durationMinutes: 10 }
+      { alignment: 50, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
     );
     expect(slots50Midnight).toEqual([
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T00:10:00Z') },
@@ -144,7 +144,7 @@ describe('findAlignedSlotTimes', () => {
     // to the same fifty-minute grid.
     const slots50Later = findAlignedSlotTimes(
       { start: new Date('2025-12-01T01:00:00Z'), end: new Date('2025-12-01T03:00:00Z') },
-      { alignment: 50, offsetMinutes: 0, durationMinutes: 10 }
+      { alignment: 50, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
     );
     expect(slots50Later).toEqual([
       { start: new Date('2025-12-01T01:40:00Z'), end: new Date('2025-12-01T01:50:00Z') },
@@ -158,7 +158,7 @@ describe('findAlignedSlotTimes', () => {
     // Re-anchoring from Dec 2 midnight gives 00:00, 00:50, 01:40 (all 0 mod 50).
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T23:10:00Z'), end: new Date('2025-12-02T01:50:00Z') },
-      { alignment: 50, offsetMinutes: 0, durationMinutes: 10 }
+      { alignment: 50, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T23:20:00Z'), end: new Date('2025-12-01T23:30:00Z') },
@@ -231,7 +231,7 @@ describe('findAlignedSlotTimes', () => {
     // following day, potentially overlapping the grid.
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T23:00:00Z'), end: new Date('2025-12-02T01:00:00Z') },
-      { alignment: 50, offsetMinutes: 0, durationMinutes: 50 }
+      { alignment: 50, offsetMinutes: 0, durationMinutes: 50, timezone: 'Etc/UTC' }
     );
     expect(slots).toEqual([
       // This slot at the end of Dec 1 is found, even though it extends outside the Dec 1
@@ -276,7 +276,7 @@ describe('findAlignedSlotTimes', () => {
     expect(() => {
       findAlignedSlotTimes(
         { start: new Date('2025-12-01'), end: new Date('2025-12-08') },
-        { alignment: 0, offsetMinutes: 0, durationMinutes: 10 }
+        { alignment: 0, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
       );
     }).toThrow('Invalid alignment');
   });
@@ -284,7 +284,7 @@ describe('findAlignedSlotTimes', () => {
   test('maxCount option is respected', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 15, offsetMinutes: 0, durationMinutes: 10, maxCount: 5 }
+      { alignment: 15, offsetMinutes: 0, durationMinutes: 10, maxCount: 5, timezone: 'Etc/UTC' }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T00:10:00Z') },

--- a/packages/server/src/fhir/operations/utils/find.ts
+++ b/packages/server/src/fhir/operations/utils/find.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { Temporal } from 'temporal-polyfill';
 import type { Interval } from '../../../util/date';
 import { addMinutes, clamp } from '../../../util/date';
-import { normalizeIntervals, pairWithOverlaps } from './scheduling';
+import { eachDayOfInterval, normalizeIntervals, pairWithOverlaps } from './scheduling';
 
 // Given a date that could have a seconds / milliseconds component, return
 // the input date if it does not have any, and the start of the next minute
@@ -24,6 +25,15 @@ function mod(n: number, d: number): number {
   return ((n % d) + d) % d;
 }
 
+// Returns the number of minutes since local (or UTC) midnight for a given date.
+function minutesSinceMidnight(date: Date, timezone?: string): number {
+  if (timezone && timezone !== 'UTC' && timezone !== 'Etc/UTC') {
+    const zdt = Temporal.Instant.fromEpochMilliseconds(date.valueOf()).toZonedDateTimeISO(timezone);
+    return zdt.hour * 60 + zdt.minute;
+  }
+  return date.getUTCHours() * 60 + date.getUTCMinutes();
+}
+
 /**
  * Given an interval and slot duration and alignment information, return
  * intervals for each matching slot timing within that interval
@@ -34,6 +44,9 @@ function mod(n: number, d: number): number {
  * @param options.offsetMinutes - A number of minutes to offset the alignment by
  * @param options.durationMinutes - How long each slot should last
  * @param options.maxCount - Maximum number of intervals to find
+ * @param options.timezone - IANA timezone name (e.g. "America/Los_Angeles"). When provided the
+ *   alignment grid is anchored to local midnight in that timezone, keeping slot times stable
+ *   across DST transitions. Defaults to UTC midnight.
  * @returns An array of aligned slot intervals
  */
 export function findAlignedSlotTimes(
@@ -43,35 +56,42 @@ export function findAlignedSlotTimes(
     offsetMinutes: number;
     durationMinutes: number;
     maxCount?: number;
+    timezone?: string;
   }
 ): Interval[] {
   if (options.alignment < 1) {
-    throw new Error(`Invalid alignment; must be in range [1,60], got ${options.alignment}`);
+    throw new Error(`Invalid alignment; must be positive, got ${options.alignment}`);
   }
 
-  const firstMinuteStart = advanceToMinuteMark(interval.start);
+  const results: Interval[] = [];
 
-  // Find how much we need to shift the interval start to hit an alignment.
-  // Use total minutes since midnight so that non-hour-divisible alignments (e.g. 50min)
-  // stay anchored to 00:00 regardless of where the search interval starts.
-  const minutesSinceMidnight = firstMinuteStart.getUTCHours() * 60 + firstMinuteStart.getUTCMinutes();
-  const remainder = mod(minutesSinceMidnight - options.offsetMinutes, options.alignment);
-  const toAlign = remainder === 0 ? 0 : options.alignment - remainder;
+  for (const dayStart of eachDayOfInterval(interval, options.timezone ?? 'UTC')) {
+    const nextDay = dayStart.add({ days: 1 });
+    const dayInterval: Interval = {
+      start: new Date(Math.max(interval.start.valueOf(), dayStart.epochMilliseconds)),
+      end: new Date(Math.min(interval.end.valueOf(), nextDay.epochMilliseconds)),
+    };
 
-  // set start/end to the first interval boundaries
-  let start = addMinutes(firstMinuteStart, toAlign);
-  let end = addMinutes(start, options.durationMinutes);
+    const firstMinuteStart = advanceToMinuteMark(dayInterval.start);
 
-  // Find all aligned slots within the interval
-  const results = [];
-  while (end <= interval.end) {
-    results.push({ start, end });
-    start = addMinutes(start, options.alignment);
-    end = addMinutes(start, options.durationMinutes);
-    if (options.maxCount && results.length >= options.maxCount) {
-      break;
+    // Find how much to shift to the first aligned slot of this calendar day.
+    const msm = minutesSinceMidnight(firstMinuteStart, options.timezone);
+    const remainder = mod(msm - options.offsetMinutes, options.alignment);
+    const toAlign = remainder === 0 ? 0 : options.alignment - remainder;
+
+    let start = addMinutes(firstMinuteStart, toAlign);
+    let end = addMinutes(start, options.durationMinutes);
+
+    while (start < dayInterval.end && end <= interval.end) {
+      results.push({ start, end });
+      if (options.maxCount && results.length >= options.maxCount) {
+        return results;
+      }
+      start = addMinutes(start, options.alignment);
+      end = addMinutes(start, options.durationMinutes);
     }
   }
+
   return results;
 }
 

--- a/packages/server/src/fhir/operations/utils/find.ts
+++ b/packages/server/src/fhir/operations/utils/find.ts
@@ -82,6 +82,11 @@ export function findAlignedSlotTimes(
     let start = addMinutes(firstMinuteStart, toAlign);
     let end = addMinutes(start, options.durationMinutes);
 
+    // `start` values after the end of the current day will be processed in
+    // the next day's interval and aligned to that day's grid.
+    //
+    // `end` values are allowed to match up to (and including) the end of the
+    // search interval, but may not go beyond.
     while (start < dayInterval.end && end <= interval.end) {
       results.push({ start, end });
       if (options.maxCount && results.length >= options.maxCount) {

--- a/packages/server/src/fhir/operations/utils/find.ts
+++ b/packages/server/src/fhir/operations/utils/find.ts
@@ -30,7 +30,7 @@ function mod(n: number, d: number): number {
  *
  * @param interval - The interval to find slots within
  * @param options - The alignment parameters
- * @param options.alignment - An hour divisor to align to; should be in range [1, 60]
+ * @param options.alignment - Minutes between slot starts; the grid is anchored to midnight (offset by offsetMinutes). Must be >= 1.
  * @param options.offsetMinutes - A number of minutes to offset the alignment by
  * @param options.durationMinutes - How long each slot should last
  * @param options.maxCount - Maximum number of intervals to find
@@ -51,8 +51,11 @@ export function findAlignedSlotTimes(
 
   const firstMinuteStart = advanceToMinuteMark(interval.start);
 
-  // Find how much we need to shift the interval start to hit an alignment
-  const remainder = mod(firstMinuteStart.getMinutes() - options.offsetMinutes, options.alignment);
+  // Find how much we need to shift the interval start to hit an alignment.
+  // Use total minutes since midnight so that non-hour-divisible alignments (e.g. 50min)
+  // stay anchored to 00:00 regardless of where the search interval starts.
+  const minutesSinceMidnight = firstMinuteStart.getUTCHours() * 60 + firstMinuteStart.getUTCMinutes();
+  const remainder = mod(minutesSinceMidnight - options.offsetMinutes, options.alignment);
   const toAlign = remainder === 0 ? 0 : options.alignment - remainder;
 
   // set start/end to the first interval boundaries

--- a/packages/server/src/fhir/operations/utils/find.ts
+++ b/packages/server/src/fhir/operations/utils/find.ts
@@ -44,9 +44,9 @@ function minutesSinceMidnight(date: Date, timezone?: string): number {
  * @param options.offsetMinutes - A number of minutes to offset the alignment by
  * @param options.durationMinutes - How long each slot should last
  * @param options.maxCount - Maximum number of intervals to find
- * @param options.timezone - IANA timezone name (e.g. "America/Los_Angeles"). When provided the
- *   alignment grid is anchored to local midnight in that timezone, keeping slot times stable
- *   across DST transitions. Defaults to UTC midnight.
+ * @param options.timezone - IANA timezone name (e.g. "America/Los_Angeles"). The alignment
+ *   grid is anchored to local midnight in this timezone, keeping slot times stable across
+ *   DST transitions.
  * @returns An array of aligned slot intervals
  */
 export function findAlignedSlotTimes(
@@ -55,8 +55,8 @@ export function findAlignedSlotTimes(
     alignment: number;
     offsetMinutes: number;
     durationMinutes: number;
+    timezone: string;
     maxCount?: number;
-    timezone?: string;
   }
 ): Interval[] {
   if (options.alignment < 1) {
@@ -65,7 +65,7 @@ export function findAlignedSlotTimes(
 
   const results: Interval[] = [];
 
-  for (const dayStart of eachDayOfInterval(interval, options.timezone ?? 'UTC')) {
+  for (const dayStart of eachDayOfInterval(interval, options.timezone)) {
     const nextDay = dayStart.add({ days: 1 });
     const dayInterval: Interval = {
       start: new Date(Math.max(interval.start.valueOf(), dayStart.epochMilliseconds)),

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.test.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.test.ts
@@ -33,6 +33,7 @@ describe('getHealthcareServiceSchedulingParameters', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
+      alignmentTimezone: 'Etc/UTC',
       service: { reference: 'HealthcareService/hs-12345' },
     });
   });
@@ -63,6 +64,7 @@ describe('getHealthcareServiceSchedulingParameters', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
+      alignmentTimezone: 'Etc/UTC',
       service: { reference: 'HealthcareService/hs-12345' },
     });
   });
@@ -93,6 +95,7 @@ describe('getHealthcareServiceSchedulingParameters', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
+      alignmentTimezone: 'Etc/UTC',
       duration: 120,
       service: { reference: 'HealthcareService/hs-12345' },
     });
@@ -122,6 +125,7 @@ describe('getHealthcareServiceSchedulingParameters', () => {
               { url: 'bufferAfter', valueDuration: { unit: 'min', value: 20 } },
               { url: 'alignmentInterval', valueDuration: { unit: 'min', value: 30 } },
               { url: 'alignmentOffset', valueDuration: { unit: 'min', value: 15 } },
+              { url: 'alignmentTimezone', valueCode: 'America/Los_Angeles' },
               { url: 'timezone', valueCode: 'America/Phoenix' },
             ],
           },
@@ -147,6 +151,7 @@ describe('getHealthcareServiceSchedulingParameters', () => {
       bufferAfter: 20,
       alignmentInterval: 30,
       alignmentOffset: 15,
+      alignmentTimezone: 'America/Los_Angeles',
       duration: 120,
       service: { reference: 'HealthcareService/hs-12345' },
       timezone: 'America/Phoenix',
@@ -350,6 +355,7 @@ describe('getScheduleSchedulingParameters', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
+      alignmentTimezone: 'Etc/UTC',
       duration: 120,
       service: { reference: 'HealthcareService/hs-12345' },
     });
@@ -366,6 +372,7 @@ describe('getScheduleSchedulingParameters', () => {
             availableEndTime: '17:00:00',
           },
         ],
+
         extension: [
           {
             url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
@@ -375,6 +382,7 @@ describe('getScheduleSchedulingParameters', () => {
               { url: 'bufferAfter', valueDuration: { unit: 'min', value: 20 } },
               { url: 'alignmentInterval', valueDuration: { unit: 'min', value: 30 } },
               { url: 'alignmentOffset', valueDuration: { unit: 'min', value: 15 } },
+              { url: 'alignmentTimezone', valueCode: 'America/Los_Angeles' },
               { url: 'timezone', valueCode: 'America/Phoenix' },
             ],
           },
@@ -396,6 +404,7 @@ describe('getScheduleSchedulingParameters', () => {
       bufferAfter: 20,
       alignmentInterval: 30,
       alignmentOffset: 15,
+      alignmentTimezone: 'America/Los_Angeles',
       duration: 120,
       service: { reference: 'HealthcareService/hs-12345' },
       timezone: 'America/Phoenix',
@@ -422,6 +431,7 @@ describe('getScheduleSchedulingParameters', () => {
               { url: 'bufferAfter', valueDuration: { unit: 'min', value: 20 } },
               { url: 'alignmentInterval', valueDuration: { unit: 'min', value: 30 } },
               { url: 'alignmentOffset', valueDuration: { unit: 'min', value: 15 } },
+              { url: 'alignmentTimezone', valueCode: 'America/Los_Angeles' },
               { url: 'timezone', valueCode: 'America/Phoenix' },
             ],
           },
@@ -442,6 +452,7 @@ describe('getScheduleSchedulingParameters', () => {
               { url: 'bufferAfter', valueDuration: { unit: 'min', value: 24 } },
               { url: 'alignmentInterval', valueDuration: { unit: 'min', value: 45 } },
               { url: 'alignmentOffset', valueDuration: { unit: 'min', value: 5 } },
+              { url: 'alignmentTimezone', valueCode: 'America/Chicago' },
               { url: 'timezone', valueCode: 'America/New_York' },
               {
                 url: 'availability',
@@ -493,6 +504,7 @@ describe('getScheduleSchedulingParameters', () => {
       bufferAfter: 24,
       alignmentInterval: 45,
       alignmentOffset: 5,
+      alignmentTimezone: 'America/Chicago',
       duration: 180,
       service: { reference: 'HealthcareService/hs-12345' },
       timezone: 'America/New_York',

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -130,6 +130,10 @@ const SERVICE_DEFAULTS = Object.freeze({
   alignmentTimezone: 'Etc/UTC',
 });
 
+// This is a `Temporal.Instant` singleton that we instantiate once for
+// performance.
+const epochInstant = Temporal.Instant.fromEpochMilliseconds(0);
+
 function isReferenceTo<T extends Resource>(reference: Reference<T> | undefined, resource: WithId<T>): boolean {
   if (!reference?.reference) {
     return false;
@@ -175,7 +179,7 @@ function assertValidTimezone(ext: WithPath<Extension>): void {
   // "US/Pacific" is an alias for "America/Los_Angeles"), and is
   // case-insensitive (we accept "america/los_angeles" as valid).
   try {
-    Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO(ext.valueCode);
+    epochInstant.toZonedDateTimeISO(ext.valueCode);
   } catch {
     throw new OperationOutcomeError(badRequest(`Invalid timezone '${ext.valueCode}'`, getPath(ext)));
   }

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -149,6 +149,11 @@ function durationToMinutes(extension: WithPath<Extension>): number {
   if (value === undefined) {
     throw new OperationOutcomeError(badRequest('Got duration without value', getPath(extension)));
   }
+
+  if (value < 0) {
+    throw new OperationOutcomeError(badRequest('Got duration with negative value', getPath(extension)));
+  }
+
   switch (unit) {
     case 'wk':
       return value * 60 * 24 * 7;

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -11,6 +11,7 @@ import type {
   Resource,
   Schedule,
 } from '@medplum/fhirtypes';
+import { Temporal } from 'temporal-polyfill';
 import { getLogger } from '../../../logger';
 import {
   assertExtensionBoolean,
@@ -70,6 +71,7 @@ export type SchedulingParametersExtensionExtension =
   | { url: 'duration'; valueDuration: HardDuration }
   | { url: 'service'; valueReference: Reference<HealthcareService> & { reference: string } }
   | { url: 'timezone'; valueCode: string }
+  | { url: 'alignmentTimezone'; valueCode: string }
   | {
       url: 'availability';
       extension: (AvailabilityR4AvailableTime | AvailabilityR4NotAvailableTime)[];
@@ -96,6 +98,7 @@ type BaseSchedulingParameters = {
   alignmentOffset: number; // minutes
   service: Reference<HealthcareService> & { reference: string };
   timezone?: string;
+  alignmentTimezone: string;
 };
 
 type ServiceSchedulingParameters = BaseSchedulingParameters & {
@@ -124,6 +127,7 @@ const SERVICE_DEFAULTS = Object.freeze({
   bufferBefore: 0,
   bufferAfter: 0,
   alignmentOffset: 0,
+  alignmentTimezone: 'Etc/UTC',
 });
 
 function isReferenceTo<T extends Resource>(reference: Reference<T> | undefined, resource: WithId<T>): boolean {
@@ -159,6 +163,19 @@ function durationToMinutes(extension: WithPath<Extension>): number {
   }
 }
 
+function assertValidTimezone(ext: WithPath<Extension>): void {
+  assertExtensionCode(ext);
+  // Check that we can build a Temporal.ZonedDateTime with the given timezone.
+  // Note that this accepts non-canonical timezone identifiers (example:
+  // "US/Pacific" is an alias for "America/Los_Angeles"), and is
+  // case-insensitive (we accept "america/los_angeles" as valid).
+  try {
+    Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO(ext.valueCode);
+  } catch {
+    throw new OperationOutcomeError(badRequest(`Invalid timezone '${ext.valueCode}'`, getPath(ext)));
+  }
+}
+
 function atMostOne<T extends object>(arr: WithPath<T>[], attribute: string): WithPath<T> | undefined {
   if (arr.length > 1) {
     throw new OperationOutcomeError(
@@ -187,7 +204,7 @@ function exactlyZero(arr: WithPath<object>[], attribute: string, resourceType: s
 // keys from SchedulingParameters that we know contain primitive types.
 function assertAllMatch(
   values: LayeredDict<SchedulingParameters>[],
-  attribute: 'duration' | 'alignmentInterval' | 'alignmentOffset'
+  attribute: 'duration' | 'alignmentInterval' | 'alignmentOffset' | 'alignmentTimezone'
 ): void {
   if (values.length <= 1) {
     return;
@@ -205,15 +222,17 @@ function assertAllMatch(
 
 export function extractCommonParameters(
   schedulingParameters: LayeredDict<SchedulingParameters>[]
-): Pick<SchedulingParameters, 'duration' | 'alignmentInterval' | 'alignmentOffset'> {
+): Pick<SchedulingParameters, 'duration' | 'alignmentInterval' | 'alignmentOffset' | 'alignmentTimezone'> {
   assertAllMatch(schedulingParameters, 'duration');
   assertAllMatch(schedulingParameters, 'alignmentInterval');
   assertAllMatch(schedulingParameters, 'alignmentOffset');
+  assertAllMatch(schedulingParameters, 'alignmentTimezone');
 
   return {
     duration: schedulingParameters[0].get('duration'),
     alignmentInterval: schedulingParameters[0].get('alignmentInterval'),
     alignmentOffset: schedulingParameters[0].get('alignmentOffset'),
+    alignmentTimezone: schedulingParameters[0].get('alignmentTimezone'),
   };
 }
 
@@ -315,12 +334,16 @@ function extractAvailability(
   return undefined;
 }
 
-// In the SchedulingParameters extension, `alignmentInterval: 0` means "align
-// to the start of the hour". In our in-memory representation, we want to
-// convert this to a value that can be used as a modulus.
-function toHourlyModulus(value: number): number {
+// Extracts alignmentInterval from an extension: converts the 0→60 sentinel
+// ("align to the hour") and rejects values > 1440 min (one day), since the
+// per-day grid anchoring in findAlignedSlotTimes makes longer intervals meaningless.
+function extractAlignmentInterval(ext: WithPath<Extension>): number {
+  const value = durationToMinutes(ext);
   if (value === 0) {
     return 60;
+  }
+  if (value > 1440) {
+    throw new OperationOutcomeError(badRequest('alignmentInterval cannot exceed 1440 minutes (1 day)', getPath(ext)));
   }
   return value;
 }
@@ -373,6 +396,7 @@ export function getHealthcareServiceSchedulingParameters(
   const bufferAfterExt = atMostOne(getExtensions(extension, 'bufferAfter'), 'bufferAfter');
   const alignmentOffsetExt = atMostOne(getExtensions(extension, 'alignmentOffset'), 'alignmentOffset');
   const alignmentIntervalExt = atMostOne(getExtensions(extension, 'alignmentInterval'), 'alignmentInterval');
+  const alignmentTimezoneExt = atMostOne(getExtensions(extension, 'alignmentTimezone'), 'alignmentTimezone');
   const timezoneExt = atMostOne(getExtensions(extension, 'timezone'), 'timezone');
 
   // `service` sub-extension not allowed in HealthcareService; implied by resource
@@ -382,7 +406,11 @@ export function getHealthcareServiceSchedulingParameters(
   exactlyZero(getExtensions(extension, 'availability'), 'availability', healthcareService.resourceType);
 
   if (timezoneExt) {
-    assertExtensionCode(timezoneExt);
+    assertValidTimezone(timezoneExt);
+  }
+
+  if (alignmentTimezoneExt) {
+    assertValidTimezone(alignmentTimezoneExt);
   }
 
   return result.patchLayer(
@@ -392,7 +420,8 @@ export function getHealthcareServiceSchedulingParameters(
         ...(bufferBeforeExt && { bufferBefore: durationToMinutes(bufferBeforeExt) }),
         ...(bufferAfterExt && { bufferAfter: durationToMinutes(bufferAfterExt) }),
         ...(alignmentOffsetExt && { alignmentOffset: durationToMinutes(alignmentOffsetExt) }),
-        ...(alignmentIntervalExt && { alignmentInterval: toHourlyModulus(durationToMinutes(alignmentIntervalExt)) }),
+        ...(alignmentIntervalExt && { alignmentInterval: extractAlignmentInterval(alignmentIntervalExt) }),
+        ...(alignmentTimezoneExt && { alignmentTimezone: alignmentTimezoneExt.valueCode }),
         ...(timezoneExt && { timezone: timezoneExt.valueCode }),
       },
       getPath(extension)
@@ -445,10 +474,15 @@ export function getScheduleSchedulingParameters(
   const bufferAfterExt = atMostOne(getExtensions(extension, 'bufferAfter'), 'bufferAfter');
   const alignmentOffsetExt = atMostOne(getExtensions(extension, 'alignmentOffset'), 'alignmentOffset');
   const alignmentIntervalExt = atMostOne(getExtensions(extension, 'alignmentInterval'), 'alignmentInterval');
+  const alignmentTimezoneExt = atMostOne(getExtensions(extension, 'alignmentTimezone'), 'alignmentTimezone');
   const timezoneExt = atMostOne(getExtensions(extension, 'timezone'), 'timezone');
 
   if (timezoneExt) {
-    assertExtensionCode(timezoneExt);
+    assertValidTimezone(timezoneExt);
+  }
+
+  if (alignmentTimezoneExt) {
+    assertValidTimezone(alignmentTimezoneExt);
   }
 
   // The "availability" sub-extension uses format that mirrors
@@ -463,7 +497,8 @@ export function getScheduleSchedulingParameters(
       ...(bufferBeforeExt && { bufferBefore: durationToMinutes(bufferBeforeExt) }),
       ...(bufferAfterExt && { bufferAfter: durationToMinutes(bufferAfterExt) }),
       ...(alignmentOffsetExt && { alignmentOffset: durationToMinutes(alignmentOffsetExt) }),
-      ...(alignmentIntervalExt && { alignmentInterval: toHourlyModulus(durationToMinutes(alignmentIntervalExt)) }),
+      ...(alignmentIntervalExt && { alignmentInterval: extractAlignmentInterval(alignmentIntervalExt) }),
+      ...(alignmentTimezoneExt && { alignmentTimezone: alignmentTimezoneExt.valueCode }),
       ...(timezoneExt && { timezone: timezoneExt.valueCode }),
     },
     getPath(extension)

--- a/packages/server/src/fhir/operations/utils/scheduling.test.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.test.ts
@@ -63,6 +63,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
+      alignmentTimezone: 'America/New_York',
       service: createReference(service),
     });
 
@@ -96,6 +97,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
+      alignmentTimezone: 'America/New_York',
       service: createReference(service),
     });
 
@@ -124,6 +126,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
+      alignmentTimezone: 'America/New_York',
       service: createReference(service),
     });
 
@@ -154,6 +157,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
+      alignmentTimezone: 'America/New_York',
       service: createReference(service),
     });
 
@@ -182,6 +186,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
+      alignmentTimezone: 'America/New_York',
       service: createReference(service),
     });
 
@@ -211,6 +216,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
+      alignmentTimezone: 'America/New_York',
       service: createReference(service),
     });
 
@@ -239,6 +245,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
+      alignmentTimezone: 'America/New_York',
       service: createReference(service),
     });
 
@@ -277,6 +284,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
+      alignmentTimezone: 'America/New_York',
       service: createReference(service),
     });
 
@@ -319,6 +327,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
+      alignmentTimezone: 'America/New_York',
       service: createReference(service),
     });
 
@@ -349,6 +358,7 @@ describe('resolveAvailability', () => {
       bufferAfter: 0,
       alignmentInterval: 60,
       alignmentOffset: 0,
+      alignmentTimezone: 'America/New_York',
       service: createReference(service),
     });
 

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -42,7 +42,7 @@ import { uniqueOn } from './terminology';
 type DayOfWeek = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
 const dayNames: DayOfWeek[] = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
 
-function eachDayOfInterval(interval: Interval, timeZone: string): Temporal.ZonedDateTime[] {
+export function eachDayOfInterval(interval: Interval, timeZone: string): Temporal.ZonedDateTime[] {
   let t = Temporal.Instant.fromEpochMilliseconds(interval.start.valueOf())
     .toZonedDateTimeISO(timeZone)
     .withPlainTime({ hour: 0, minute: 0, second: 0, millisecond: 0 });


### PR DESCRIPTION
When using `alignmentInterval` that doesn't evenly divide the hour, you can end up with surprising results. For example, when using an alignment like "90 minutes", the grid alignment depended on the availability window that was being searched. This meant that searching for appointments on a single day could return slots aligned to two distinct grids as your search `start` time changed.

To resolve this, we need to choose a standard grid to use for this alignment, and ensure that we are matching it when generating appointment times in $find. In this PR we choose to align a daily grid to midnight (potentially offset by `alignmentOffset` scheduling parameter).

One tricky aspect to this is that the alignment grid should shift with local timezone rules. For example, imagine you are using a 90 minute alignment interval and your slots start at 9am PDT (-7). After the DST transition, if the alignment grid does not also shift, your slots would start beginning at 10am PST (-8).

Most businesses don't change their hours on these transitions, and so when they configure their alignment, the intention is usually for it to be consistent: "My day starts at 9am PT, and my first slot should align with that." To that end, we introduce a new SchedulingParameter attribute, `alignmentTimezone`. This lets you choose the zone that your alignment grid is anchored with respect to.

## Backwards compatibility note:
In cases where your slots are divisible by one hour, this does not make a difference[^1] (10,20,15,30,60 minute slots all evenly fill the entire daily grid). This was the only officially supported scenario in our previous alpha implementation; folks using other alignment values may see their scheduling grid suddenly jump when this is released.

I'm setting the default alignmentTimezone value to `Etc/UTC` - this is an easy-to-explain default that works well for some places (Arizona, Hawaii, Japan, anywhere that doesn't observe DST). It is likely that most users will want to override this to match their local timezone (e.g., `America/New_York`, `America/Los_Angeles`, `Europe/Paris`).

## Future Related Changes:
- This is building towards a solution for #8734, in which we would change the `alignmentInterval` default value. The most requested default value is one that matches the scheduling duration, allowing tip-to-tail booking by default. In that world, we can almost guarantee that alignment grids will diverge from evenly divisible values ("90 minutes" being a common example). For that reason, some kind of change like this is a prerequisite.

- With this updated slot generation in place, we should revisit enforcing alignment in $book. The original implementation assumed that the input value was evenly divisible, which broke on some outputs from $find in these non-divisible alignment values. We removed that restriction in #8331, which means that currently $book can be used to create appointments that violate scheduling constraints. We should update $book/$hold to test alignment with these new rules.

[^1]: Okay, it makes a difference in some rare edge cases, such as when you are on Lord Howe Island on a day in which a Daylight Savings Time transition shifts the clock by thirty minutes. I suspect that scheduling discontinuities in such environments are unsurprising.