### PR TITLE
fix(ws): tear down WebSocket subscription Redis listener on shutdown

### DIFF
--- a/packages/server/src/ws/routes.ts
+++ b/packages/server/src/ws/routes.ts
@@ -13,7 +13,7 @@ import { handleAgentConnection } from './agent';
 import { handleAiRealtimeConnection } from './ai-realtime';
 import { handleEchoConnection, initEchoHeartbeat, stopEchoHeartbeat } from './echo';
 import { handleFhircastConnection, initFhircastHeartbeat, stopFhircastHeartbeat } from './fhircast';
-import { handleR4SubscriptionConnection } from './subscriptions';
+import { closeWebSocketSubscriptionHandler, handleR4SubscriptionConnection } from './subscriptions';
 
 const handlerMap = new Map<string, (socket: WebSocket, request: IncomingMessage) => Promise<void>>();
 handlerMap.set('echo', handleEchoConnection);
@@ -105,6 +105,7 @@ function getWebSocketPath(path: string): string {
 export async function closeWebSockets(): Promise<void> {
   stopFhircastHeartbeat();
   stopEchoHeartbeat();
+  closeWebSocketSubscriptionHandler();
 
   if (wsServer) {
     wsServer.close();

--- a/packages/server/src/ws/subscriptions.test.ts
+++ b/packages/server/src/ws/subscriptions.test.ts
@@ -1963,6 +1963,8 @@ describe('Subscription Heartbeat', () => {
   });
 
   beforeEach(() => {
+    // subscriptions.ts keeps a module-level pub/sub subscriber that outlives individual
+    // WebSocket connections. Reset it between tests so each test starts from a clean state.
     closeWebSocketSubscriptionHandler();
   });
 
@@ -2041,6 +2043,7 @@ describe('Subscription Heartbeat', () => {
       const subscriberSpy = jest.spyOn(redisModule, 'getPubSubRedisSubscriber');
 
       try {
+        // First bind lazily creates the shared Redis subscriber for WebSocket fan-out.
         const subscription = await repo.createResource<Subscription>({
           resourceType: 'Subscription',
           reason: 'test',
@@ -2072,14 +2075,36 @@ describe('Subscription Heartbeat', () => {
         expect(subscriberSpy).toHaveBeenCalledTimes(1);
         const firstSubscriber = subscriberSpy.mock.results[0].value;
 
+        // Simulate the pub/sub connection dropping. The `end` listener in
+        // setupSubscriptionHandler should clear the module reference so the next bind
+        // can call getPubSubRedisSubscriber again.
         await new Promise<void>((resolve) => {
           firstSubscriber.once('end', resolve);
           firstSubscriber.disconnect();
         });
 
+        // Use a second subscription so the rebind has a fresh cache entry. Closing the
+        // first socket runs onDisconnect, which removes the binding token from Redis.
+        const secondSubscription = await repo.createResource<Subscription>({
+          resourceType: 'Subscription',
+          reason: 'test',
+          status: 'active',
+          criteria: 'Patient',
+          channel: {
+            type: 'websocket',
+          },
+        });
+
+        const secondRes = await request(server)
+          .get(`/fhir/R4/Subscription/${secondSubscription.id}/$get-ws-binding-token`)
+          .set('Authorization', 'Bearer ' + accessToken);
+
+        const secondToken = (secondRes.body as Parameters).parameter?.[0]?.valueString as string;
+
+        // A new WebSocket bind after the subscriber ended should recreate the connection.
         await request(server)
           .ws('/ws/subscriptions-r4')
-          .sendJson({ type: 'bind-with-token', payload: { token } })
+          .sendJson({ type: 'bind-with-token', payload: { token: secondToken } })
           .expectJson((actual) => {
             expect(actual).toMatchObject({
               resourceType: 'Bundle',

--- a/packages/server/src/ws/subscriptions.test.ts
+++ b/packages/server/src/ws/subscriptions.test.ts
@@ -42,6 +42,7 @@ import {
 } from '../pubsub';
 import * as redisModule from '../redis';
 import { createTestProject, withTestContext } from '../test.setup';
+import { closeWebSocketSubscriptionHandler } from './subscriptions';
 import { findAndExecDispatchJob } from '../workers/test-utils';
 
 jest.mock('hibp');
@@ -1959,6 +1960,10 @@ describe('Subscription Heartbeat', () => {
 
   afterAll(async () => {
     await shutdownApp();
+  });
+
+  beforeEach(() => {
+    closeWebSocketSubscriptionHandler();
   });
 
   test('Heartbeat received after binding to token', () =>

--- a/packages/server/src/ws/subscriptions.test.ts
+++ b/packages/server/src/ws/subscriptions.test.ts
@@ -42,8 +42,8 @@ import {
 } from '../pubsub';
 import * as redisModule from '../redis';
 import { createTestProject, withTestContext } from '../test.setup';
-import { closeWebSocketSubscriptionHandler } from './subscriptions';
 import { findAndExecDispatchJob } from '../workers/test-utils';
+import { closeWebSocketSubscriptionHandler } from './subscriptions';
 
 jest.mock('hibp');
 jest.mock('../constants', () => ({

--- a/packages/server/src/ws/subscriptions.test.ts
+++ b/packages/server/src/ws/subscriptions.test.ts
@@ -40,6 +40,7 @@ import {
   publish,
   setActiveSubscription,
 } from '../pubsub';
+import * as redisModule from '../redis';
 import { createTestProject, withTestContext } from '../test.setup';
 import { findAndExecDispatchJob } from '../workers/test-utils';
 
@@ -2028,6 +2029,66 @@ describe('Subscription Heartbeat', () => {
         })
         .close()
         .expectClosed();
+    }));
+
+  test('Recreates Redis subscriber when prior subscriber connection ends', () =>
+    withTestContext(async () => {
+      const subscriberSpy = jest.spyOn(redisModule, 'getPubSubRedisSubscriber');
+
+      try {
+        const subscription = await repo.createResource<Subscription>({
+          resourceType: 'Subscription',
+          reason: 'test',
+          status: 'active',
+          criteria: 'Patient',
+          channel: {
+            type: 'websocket',
+          },
+        });
+
+        const res = await request(server)
+          .get(`/fhir/R4/Subscription/${subscription.id}/$get-ws-binding-token`)
+          .set('Authorization', 'Bearer ' + accessToken);
+
+        const token = (res.body as Parameters).parameter?.[0]?.valueString as string;
+
+        await request(server)
+          .ws('/ws/subscriptions-r4')
+          .sendJson({ type: 'bind-with-token', payload: { token } })
+          .expectJson((actual) => {
+            expect(actual).toMatchObject({
+              resourceType: 'Bundle',
+              type: 'history',
+            });
+          })
+          .close()
+          .expectClosed();
+
+        expect(subscriberSpy).toHaveBeenCalledTimes(1);
+        const firstSubscriber = subscriberSpy.mock.results[0].value;
+
+        await new Promise<void>((resolve) => {
+          firstSubscriber.once('end', resolve);
+          firstSubscriber.disconnect();
+        });
+
+        await request(server)
+          .ws('/ws/subscriptions-r4')
+          .sendJson({ type: 'bind-with-token', payload: { token } })
+          .expectJson((actual) => {
+            expect(actual).toMatchObject({
+              resourceType: 'Bundle',
+              type: 'history',
+            });
+          })
+          .close()
+          .expectClosed();
+
+        expect(subscriberSpy).toHaveBeenCalledTimes(2);
+        expect(firstSubscriber).not.toBe(subscriberSpy.mock.results[1].value);
+      } finally {
+        subscriberSpy.mockRestore();
+      }
     }));
 
   test('Heartbeat not received before binding to token', () =>

--- a/packages/server/src/ws/subscriptions.ts
+++ b/packages/server/src/ws/subscriptions.ts
@@ -75,8 +75,14 @@ let subscriptionMessagesSent = 0;
 let subscriptionMessagesReceived = 0;
 
 async function setupSubscriptionHandler(): Promise<void> {
-  redisSubscriber = getPubSubRedisSubscriber();
-  redisSubscriber.on('message', async (channel: string, events: string) => {
+  const subscriber = getPubSubRedisSubscriber();
+  redisSubscriber = subscriber;
+  subscriber.on('end', () => {
+    if (redisSubscriber === subscriber) {
+      redisSubscriber = undefined;
+    }
+  });
+  subscriber.on('message', async (channel: string, events: string) => {
     globalLogger.debug('[WS] redis subscription events', { channel, events });
     const subEventPayload = JSON.parse(events) as V1SubEventPayload | V2SubEventPayload;
     let resource: WithId<Resource>;
@@ -172,7 +178,7 @@ async function setupSubscriptionHandler(): Promise<void> {
       }
     }
   });
-  await redisSubscriber.subscribe(WEBSOCKET_SUB_PUBLISH_CHANNEL);
+  await subscriber.subscribe(WEBSOCKET_SUB_PUBLISH_CHANNEL);
 }
 
 function isV1SubEventPayload(candidate: unknown): candidate is V1SubEventPayload {
@@ -655,6 +661,13 @@ export async function markInMemorySubscriptionsInactive(
         globalLogger.debug('Attempted to remove user subscription tracking when Redis is closed');
       }
     }
+  }
+}
+
+export function closeWebSocketSubscriptionHandler(): void {
+  if (redisSubscriber) {
+    redisSubscriber.disconnect();
+    redisSubscriber = undefined;
   }
 }
 

--- a/packages/server/src/ws/subscriptions.ts
+++ b/packages/server/src/ws/subscriptions.ts
@@ -97,88 +97,101 @@ async function setupSubscriptionHandler(): Promise<void> {
       subEventArgsArr = subEventPayload.events;
     }
 
-    const deadSubscriptionIds: string[] = [];
-    for (const [subscriptionId, options] of subEventArgsArr) {
-      const bundle = createSubEventNotification(resource, subscriptionId, options);
-      for (const socket of subToWsLookup.get(subscriptionId) ?? EMPTY) {
-        // Get the repo for this socket in the context of the subscription
-        const subMetadataMap = wsToSubLookup.get(socket);
-        if (!subMetadataMap) {
-          // We should really never hit this log, this is a true error
-          globalLogger.error('[WS] Unable to find sub metadata map for WebSocket');
-          continue;
-        }
-        const subMetadata = subMetadataMap.get(subscriptionId);
-        if (!subMetadata) {
-          // We should really never hit this log, this is a true error
-          globalLogger.error('[WS] Unable to find sub metadata entry for WebSocket', { subscriptionId });
-          continue;
-        }
-
-        let rewrittenBundle: Bundle;
-        try {
-          const repo = (await getLoginForAccessToken(undefined, subMetadata.rawToken))?.repo;
-          if (!repo) {
-            globalLogger.info('[WS] Unable to get login for the given access token', { subscriptionId });
-            deadSubscriptionIds.push(subscriptionId);
-            continue;
-          }
-          rewrittenBundle = await rewriteAttachments(RewriteMode.PRESIGNED_URL, repo, bundle);
-        } catch (err) {
-          globalLogger.error('[WS] Error occurred while rewriting attachments', { err });
-          continue;
-        }
-
-        socket.send(JSON.stringify(rewrittenBundle), { binary: false });
-        subscriptionMessagesSent++;
-      }
-      subscriptionEventsFired++;
-    }
-
-    if (deadSubscriptionIds.length > 0) {
-      for (const subscriptionId of deadSubscriptionIds) {
-        purgeSubscriptionFromLookups(subscriptionId);
-      }
-      try {
-        const redis = getCacheRedis();
-        const redisKeys = deadSubscriptionIds.map((id) => `Subscription/${id}`);
-        const cacheEntries = await redis.mget(...redisKeys);
-        const projectToSubsByResourceType = new Map<string, Map<ResourceType, string[]>>();
-        for (let i = 0; i < deadSubscriptionIds.length; i++) {
-          const cacheEntryStr = cacheEntries[i];
-          if (!cacheEntryStr) {
-            continue;
-          }
-          const cacheEntry = JSON.parse(cacheEntryStr) as CacheEntry<Subscription>;
-          const criteriaResourceType = cacheEntry.resource.criteria.split('?')[0] as ResourceType;
-          let subsByResourceType = projectToSubsByResourceType.get(cacheEntry.projectId);
-          if (!subsByResourceType) {
-            subsByResourceType = new Map<ResourceType, string[]>();
-            projectToSubsByResourceType.set(cacheEntry.projectId, subsByResourceType);
-          }
-          let subIds = subsByResourceType.get(criteriaResourceType);
-          if (!subIds) {
-            subIds = [];
-            subsByResourceType.set(criteriaResourceType, subIds);
-          }
-          subIds.push(deadSubscriptionIds[i]);
-        }
-        for (const [projectId, subIdsByResourceType] of projectToSubsByResourceType) {
-          for (const [resourceType, subIds] of subIdsByResourceType) {
-            globalLogger.info('[WS] Cleaning up dead subscriptions with invalid token', {
-              count: subIds.length,
-              projectId,
-              resourceType,
-            });
-          }
-          await markInMemorySubscriptionsInactive(projectId, subIdsByResourceType);
-        }
-      } catch (err) {
-        globalLogger.error('[WS] Error marking dead subscriptions inactive', { err });
-      }
-    }
+    const deadSubscriptionIds = await sendSubscriptionEventNotifications(resource, subEventArgsArr);
+    await handleDeadSubscriptions(deadSubscriptionIds);
   });
   await subscriber.subscribe(WEBSOCKET_SUB_PUBLISH_CHANNEL);
+}
+
+async function sendSubscriptionEventNotifications(
+  resource: WithId<Resource>,
+  subEventArgsArr: [string, SubEventsOptions][]
+): Promise<string[]> {
+  const deadSubscriptionIds: string[] = [];
+  for (const [subscriptionId, options] of subEventArgsArr) {
+    const bundle = createSubEventNotification(resource, subscriptionId, options);
+    for (const socket of subToWsLookup.get(subscriptionId) ?? EMPTY) {
+      // Get the repo for this socket in the context of the subscription
+      const subMetadataMap = wsToSubLookup.get(socket);
+      if (!subMetadataMap) {
+        // We should really never hit this log, this is a true error
+        globalLogger.error('[WS] Unable to find sub metadata map for WebSocket');
+        continue;
+      }
+      const subMetadata = subMetadataMap.get(subscriptionId);
+      if (!subMetadata) {
+        // We should really never hit this log, this is a true error
+        globalLogger.error('[WS] Unable to find sub metadata entry for WebSocket', { subscriptionId });
+        continue;
+      }
+
+      let rewrittenBundle: Bundle;
+      try {
+        const repo = (await getLoginForAccessToken(undefined, subMetadata.rawToken))?.repo;
+        if (!repo) {
+          globalLogger.info('[WS] Unable to get login for the given access token', { subscriptionId });
+          deadSubscriptionIds.push(subscriptionId);
+          continue;
+        }
+        rewrittenBundle = await rewriteAttachments(RewriteMode.PRESIGNED_URL, repo, bundle);
+      } catch (err) {
+        globalLogger.error('[WS] Error occurred while rewriting attachments', { err });
+        continue;
+      }
+
+      socket.send(JSON.stringify(rewrittenBundle), { binary: false });
+      subscriptionMessagesSent++;
+    }
+    subscriptionEventsFired++;
+  }
+  return deadSubscriptionIds;
+}
+
+async function handleDeadSubscriptions(deadSubscriptionIds: string[]): Promise<void> {
+  if (deadSubscriptionIds.length === 0) {
+    return;
+  }
+
+  for (const subscriptionId of deadSubscriptionIds) {
+    purgeSubscriptionFromLookups(subscriptionId);
+  }
+  try {
+    const redis = getCacheRedis();
+    const redisKeys = deadSubscriptionIds.map((id) => `Subscription/${id}`);
+    const cacheEntries = await redis.mget(...redisKeys);
+    const projectToSubsByResourceType = new Map<string, Map<ResourceType, string[]>>();
+    for (let i = 0; i < deadSubscriptionIds.length; i++) {
+      const cacheEntryStr = cacheEntries[i];
+      if (!cacheEntryStr) {
+        continue;
+      }
+      const cacheEntry = JSON.parse(cacheEntryStr) as CacheEntry<Subscription>;
+      const criteriaResourceType = cacheEntry.resource.criteria.split('?')[0] as ResourceType;
+      let subsByResourceType = projectToSubsByResourceType.get(cacheEntry.projectId);
+      if (!subsByResourceType) {
+        subsByResourceType = new Map<ResourceType, string[]>();
+        projectToSubsByResourceType.set(cacheEntry.projectId, subsByResourceType);
+      }
+      let subIds = subsByResourceType.get(criteriaResourceType);
+      if (!subIds) {
+        subIds = [];
+        subsByResourceType.set(criteriaResourceType, subIds);
+      }
+      subIds.push(deadSubscriptionIds[i]);
+    }
+    for (const [projectId, subIdsByResourceType] of projectToSubsByResourceType) {
+      for (const [resourceType, subIds] of subIdsByResourceType) {
+        globalLogger.info('[WS] Cleaning up dead subscriptions with invalid token', {
+          count: subIds.length,
+          projectId,
+          resourceType,
+        });
+      }
+      await markInMemorySubscriptionsInactive(projectId, subIdsByResourceType);
+    }
+  } catch (err) {
+    globalLogger.error('[WS] Error marking dead subscriptions inactive', { err });
+  }
 }
 
 function isV1SubEventPayload(candidate: unknown): candidate is V1SubEventPayload {


### PR DESCRIPTION
## Summary
- Add `closeWebSocketSubscriptionHandler()` to disconnect and clear the module-level Redis pub/sub subscriber used for WebSocket subscription fan-out.
- Call it from `closeWebSockets()` during graceful shutdown, alongside existing FHIRcast and echo heartbeat cleanup.
- Recreate the subscriber on bind when the prior connection has reached ioredis `'end'` status, not only when the reference is undefined.

## Motivation
After shutdown, `redisSubscriber` could remain truthy while pointing at a dead connection. That blocked `setupSubscriptionHandler()` from running on the next bind and left stale pub/sub state across server restarts.

## Test plan
- [ ] Bind a WebSocket subscription client, shut down the server, restart, and verify notifications still arrive on rebind
- [ ] `npm test -w @medplum/server -- src/ws/subscriptions.test.ts`