### PR TITLE
Bulk import should recognize and retry on rate limits

### DIFF
--- a/packages/cli/src/bulk.test.ts
+++ b/packages/cli/src/bulk.test.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { ContentType, created, MedplumClient } from '@medplum/core';
+import { ContentType, created, MedplumClient, setRateLimitReset, tooManyRequests } from '@medplum/core';
 import type * as NodeStream from 'node:stream';
 import { ReadableStream } from 'node:stream/web';
 import type { Mock } from 'vitest';
@@ -357,6 +357,71 @@ describe('CLI Bulk Commands', () => {
       );
 
       expect(fetch).toHaveBeenCalled();
+    });
+
+    test('retries rate-limited entries without resending successful entries', async () => {
+      vi.useFakeTimers();
+      try {
+        const rateLimitOutcome = structuredClone(tooManyRequests);
+        setRateLimitReset(rateLimitOutcome, 1000);
+        fetch
+          .mockResolvedValueOnce({
+            status: 200,
+            headers: new Headers({ 'content-type': ContentType.FHIR_JSON }),
+            json: async () => ({
+              resourceType: 'Bundle',
+              type: 'transaction-response',
+              entry: [
+                { response: { outcome: created, status: '201' } },
+                ...testLineOutput.slice(1).map(() => ({ response: { outcome: rateLimitOutcome, status: '429' } })),
+              ],
+            }),
+          })
+          .mockResolvedValueOnce({
+            status: 200,
+            headers: new Headers({ 'content-type': ContentType.FHIR_JSON }),
+            json: async () => ({
+              resourceType: 'Bundle',
+              type: 'transaction-response',
+              entry: testLineOutput.slice(1).map(() => ({ response: { outcome: created, status: '201' } })),
+            }),
+          });
+
+        const importPromise = main(['node', 'index.js', 'bulk', 'import', 'Patient.json']);
+        await vi.advanceTimersByTimeAsync(1000);
+        await importPromise;
+
+        expect(fetch).toHaveBeenCalledTimes(2);
+        const retryBundle = JSON.parse(fetch.mock.calls[1][1].body);
+        expect(retryBundle.entry).toHaveLength(testLineOutput.length - 1);
+        expect(retryBundle.entry[0].resource.id).toBe('2222222');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    test('retries an outer 429 response', async () => {
+      vi.useFakeTimers();
+      try {
+        const rateLimitOutcome = structuredClone(tooManyRequests);
+        setRateLimitReset(rateLimitOutcome, 1000);
+        fetch.mockResolvedValueOnce({
+          status: 429,
+          headers: new Headers({
+            'content-type': ContentType.FHIR_JSON,
+            ratelimit: '"fhirInteractions";r=0;t=1',
+          }),
+          json: async () => rateLimitOutcome,
+        });
+
+        const importPromise = main(['node', 'index.js', 'bulk', 'import', 'Patient.json']);
+        await vi.advanceTimersByTimeAsync(1000);
+        await importPromise;
+
+        expect(fetch).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/packages/cli/src/bulk.ts
+++ b/packages/cli/src/bulk.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { MedplumClient } from '@medplum/core';
-import { EMPTY } from '@medplum/core';
+import { EMPTY, getRateLimitReset, getStatus, OperationOutcomeError, sleep } from '@medplum/core';
 import type { BundleEntry, ExplanationOfBenefit, ExplanationOfBenefitItem, Resource } from '@medplum/fhirtypes';
 import { createReadStream, createWriteStream } from 'node:fs';
 import { resolve } from 'node:path';
@@ -10,7 +10,7 @@ import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import type { ReadableStream } from 'node:stream/web';
 import { createMedplumClient } from './util/client';
-import { MedplumCommand, addSubcommand, getUnsupportedExtension, prettyPrint } from './utils';
+import { addSubcommand, getUnsupportedExtension, MedplumCommand, prettyPrint } from './utils';
 
 const bulkExportCommand = new MedplumCommand('export');
 const bulkImportCommand = new MedplumCommand('import');
@@ -110,15 +110,60 @@ async function importFile(
 }
 
 async function sendBatchEntries(entries: BundleEntry[], medplum: MedplumClient): Promise<void> {
-  const result = await medplum.executeBatch({
-    resourceType: 'Bundle',
-    type: 'transaction',
-    entry: entries,
-  });
+  let pendingEntries = entries;
+  while (pendingEntries.length > 0) {
+    let result;
+    try {
+      result = await medplum.executeBatch(
+        {
+          resourceType: 'Bundle',
+          type: 'transaction',
+          entry: pendingEntries,
+        },
+        { maxRetries: 0 }
+      );
+    } catch (err) {
+      if (!(err instanceof OperationOutcomeError) || getStatus(err.outcome) !== 429) {
+        throw err;
+      }
+      await sleep(getRateLimitRetryDelay(err.outcome, medplum));
+      continue;
+    }
 
-  for (const resultEntry of result.entry ?? EMPTY) {
-    prettyPrint(resultEntry.response);
+    const retryEntries: BundleEntry[] = [];
+    for (let i = 0; i < pendingEntries.length; i++) {
+      const resultEntry = result.entry?.[i];
+      if (resultEntry?.response?.outcome && getStatus(resultEntry.response.outcome) === 429) {
+        retryEntries.push(pendingEntries[i]);
+      } else {
+        prettyPrint(resultEntry?.response);
+      }
+    }
+    if (retryEntries.length > 0) {
+      const rateLimitOutcome = result.entry?.find(
+        (entry) => entry.response?.outcome && getStatus(entry.response.outcome) === 429
+      )?.response?.outcome;
+      await sleep(getRateLimitRetryDelay(rateLimitOutcome, medplum));
+    }
+    pendingEntries = retryEntries;
   }
+}
+
+function getRateLimitRetryDelay(
+  outcome: NonNullable<BundleEntry['response']>['outcome'] | undefined,
+  medplum: MedplumClient
+): number {
+  const outcomeDelay = outcome && getRateLimitReset(outcome);
+  if (outcomeDelay !== undefined) {
+    return outcomeDelay;
+  }
+  return Math.max(
+    500,
+    ...medplum
+      .rateLimitStatus()
+      .filter((limit) => limit.remainingUnits === 0)
+      .map((limit) => limit.secondsUntilReset * 1000)
+  );
 }
 
 function parseResource(jsonString: string, addExtensionsForMissingValues: boolean): Resource {

--- a/packages/core/src/outcomes.test.ts
+++ b/packages/core/src/outcomes.test.ts
@@ -12,6 +12,7 @@ import {
   created,
   forbidden,
   getOutcomeRedirectUrl,
+  getRateLimitReset,
   getStatus,
   gone,
   isAccepted,
@@ -32,6 +33,7 @@ import {
   redirectOk,
   serverError,
   serverTimeout,
+  setRateLimitReset,
   tooManyRequests,
   unauthorized,
   unsupportedMediaType,
@@ -88,6 +90,18 @@ describe('Outcomes', () => {
       coding: [{ code: 'errcode' }],
       text: 'bad',
     });
+  });
+
+  test('Rate limit reset', () => {
+    const outcome = structuredClone(tooManyRequests);
+    setRateLimitReset(outcome, 1500);
+    expect(getRateLimitReset(outcome)).toBe(2000);
+  });
+
+  test('Legacy rate limit reset from diagnostics', () => {
+    const outcome = structuredClone(tooManyRequests);
+    outcome.issue[0].diagnostics = JSON.stringify({ remainingPoints: 0, msBeforeNext: 1500 });
+    expect(getRateLimitReset(outcome)).toBe(1500);
   });
 
   test('Bad Request', () => {

--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -3,6 +3,7 @@
 import type { OperationOutcome, OperationOutcomeIssue } from '@medplum/fhirtypes';
 import { arrayify } from './array';
 import type { Constraint } from './typeschema/types';
+import { EMPTY } from './utils';
 
 const OK_ID = 'ok';
 const CREATED_ID = 'created';
@@ -225,8 +226,8 @@ export const tooManyRequests: OperationOutcome = {
  * @param msBeforeNext - Milliseconds until the rate limit resets.
  */
 export function setRateLimitReset(outcome: OperationOutcome, msBeforeNext: number): void {
-  outcome.issue[0].extension = [
-    ...(outcome.issue[0].extension ?? []).filter((e) => e.url !== RATE_LIMIT_RESET_EXTENSION_URL),
+  outcome.extension = [
+    ...(outcome.extension ?? EMPTY).filter((e) => e.url !== RATE_LIMIT_RESET_EXTENSION_URL),
     {
       url: RATE_LIMIT_RESET_EXTENSION_URL,
       valueUnsignedInt: Math.ceil(msBeforeNext / 1000),
@@ -240,9 +241,7 @@ export function setRateLimitReset(outcome: OperationOutcome, msBeforeNext: numbe
  * @returns Milliseconds until reset, or undefined if not present.
  */
 export function getRateLimitReset(outcome: OperationOutcome): number | undefined {
-  const seconds = outcome.issue
-    .flatMap((issue) => issue.extension ?? [])
-    .find((e) => e.url === RATE_LIMIT_RESET_EXTENSION_URL)?.valueUnsignedInt;
+  const seconds = outcome.extension?.find((e) => e.url === RATE_LIMIT_RESET_EXTENSION_URL)?.valueUnsignedInt;
   if (seconds !== undefined) {
     return seconds * 1000;
   }

--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -18,6 +18,7 @@ const CONTENT_TOO_LARGE_ID = 'content-too-large';
 const UNSUPPORTED_MEDIA_TYPE_ID = 'unsupported-media-type';
 const MULTIPLE_MATCHES_ID = 'multiple-matches';
 const TOO_MANY_REQUESTS_ID = 'too-many-requests';
+export const RATE_LIMIT_RESET_EXTENSION_URL = 'https://medplum.com/fhir/StructureDefinition/rate-limit-reset';
 const ACCEPTED_ID = 'accepted';
 const SERVER_TIMEOUT_ID = 'server-timeout';
 const BUSINESS_RULE = 'business-rule';
@@ -217,6 +218,47 @@ export const tooManyRequests: OperationOutcome = {
     },
   ],
 };
+
+/**
+ * Adds the rate limit reset delay to an OperationOutcome.
+ * @param outcome - The rate limit outcome.
+ * @param msBeforeNext - Milliseconds until the rate limit resets.
+ */
+export function setRateLimitReset(outcome: OperationOutcome, msBeforeNext: number): void {
+  outcome.issue[0].extension = [
+    ...(outcome.issue[0].extension ?? []).filter((e) => e.url !== RATE_LIMIT_RESET_EXTENSION_URL),
+    {
+      url: RATE_LIMIT_RESET_EXTENSION_URL,
+      valueUnsignedInt: Math.ceil(msBeforeNext / 1000),
+    },
+  ];
+}
+
+/**
+ * Returns the number of milliseconds until a rate limit resets.
+ * @param outcome - The rate limit outcome.
+ * @returns Milliseconds until reset, or undefined if not present.
+ */
+export function getRateLimitReset(outcome: OperationOutcome): number | undefined {
+  const seconds = outcome.issue
+    .flatMap((issue) => issue.extension ?? [])
+    .find((e) => e.url === RATE_LIMIT_RESET_EXTENSION_URL)?.valueUnsignedInt;
+  if (seconds !== undefined) {
+    return seconds * 1000;
+  }
+
+  for (const issue of outcome.issue) {
+    try {
+      const diagnostics = JSON.parse(issue.diagnostics ?? '') as { msBeforeNext?: unknown };
+      if (typeof diagnostics.msBeforeNext === 'number') {
+        return diagnostics.msBeforeNext;
+      }
+    } catch {
+      // Ignore diagnostics that are not JSON rate limit metadata.
+    }
+  }
+  return undefined;
+}
 
 export function accepted(location: string): OperationOutcome {
   return {

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -334,7 +334,7 @@ describe('App', () => {
     expect(res).toHaveStatus(200);
     const res2 = await request(app).get('/api/');
     expect(res2).toHaveStatus(429);
-    expect(res2.body.issue[0].extension).toContainEqual({
+    expect(res2.body.extension).toContainEqual({
       url: 'https://medplum.com/fhir/StructureDefinition/rate-limit-reset',
       valueUnsignedInt: 60,
     });

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -334,6 +334,10 @@ describe('App', () => {
     expect(res).toHaveStatus(200);
     const res2 = await request(app).get('/api/');
     expect(res2).toHaveStatus(429);
+    expect(res2.body.issue[0].extension).toContainEqual({
+      url: 'https://medplum.com/fhir/StructureDefinition/rate-limit-reset',
+      valueUnsignedInt: 60,
+    });
     await deleteRedisKeys(getRateLimitRedis(), rateLimitRedisConfig.keyPrefix);
     expect(await shutdownApp()).toBeUndefined();
   });

--- a/packages/server/src/fhir/fhirquota.test.ts
+++ b/packages/server/src/fhir/fhirquota.test.ts
@@ -53,6 +53,10 @@ describe('FHIR Rate Limits', () => {
     const res2 = await request(app).get('/fhir/R4/Patient?_count=20').auth(accessToken, { type: 'bearer' }).send();
     expect(res2).toHaveStatus(429);
     expect(res2.get('ratelimit')).toStrictEqual('"fhirInteractions";r=0;t=60');
+    expect(res2.body.issue[0].extension).toContainEqual({
+      url: 'https://medplum.com/fhir/StructureDefinition/rate-limit-reset',
+      valueUnsignedInt: 60,
+    });
 
     // Block subsequent request
     const res3 = await request(app).get('/fhir/R4/Patient?_count=20').auth(accessToken, { type: 'bearer' }).send();

--- a/packages/server/src/fhir/fhirquota.test.ts
+++ b/packages/server/src/fhir/fhirquota.test.ts
@@ -53,7 +53,7 @@ describe('FHIR Rate Limits', () => {
     const res2 = await request(app).get('/fhir/R4/Patient?_count=20').auth(accessToken, { type: 'bearer' }).send();
     expect(res2).toHaveStatus(429);
     expect(res2.get('ratelimit')).toStrictEqual('"fhirInteractions";r=0;t=60');
-    expect(res2.body.issue[0].extension).toContainEqual({
+    expect(res2.body.extension).toContainEqual({
       url: 'https://medplum.com/fhir/StructureDefinition/rate-limit-reset',
       valueUnsignedInt: 60,
     });

--- a/packages/server/src/fhir/fhirquota.ts
+++ b/packages/server/src/fhir/fhirquota.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { Logger } from '@medplum/core';
-import { deepClone, LRUCache, OperationOutcomeError, tooManyRequests } from '@medplum/core';
+import { deepClone, LRUCache, OperationOutcomeError, setRateLimitReset, tooManyRequests } from '@medplum/core';
 import type { Response } from 'express';
 import type Redis from 'ioredis';
 import { RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
@@ -246,6 +246,7 @@ export class FhirRateLimiter {
 
     const outcome = deepClone(tooManyRequests);
     outcome.issue[0].diagnostics = JSON.stringify({ ...liveResult, limit: this.limiter.points });
+    setRateLimitReset(outcome, liveResult.msBeforeNext);
     throw new OperationOutcomeError(outcome);
   }
 

--- a/packages/server/src/ratelimit.ts
+++ b/packages/server/src/ratelimit.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { deepClone, LRUCache, tooManyRequests } from '@medplum/core';
+import { deepClone, LRUCache, setRateLimitReset, tooManyRequests } from '@medplum/core';
 import type { OperationOutcome } from '@medplum/fhirtypes';
 import type { Handler, Request, Response } from 'express';
 import type { RateLimiterRes } from 'rate-limiter-flexible';
@@ -99,6 +99,7 @@ function blockRequest(res: Response, result: RateLimiterRes, limiter: RateLimite
   addRateLimitHeader(result, res);
   const outcome: OperationOutcome = deepClone(tooManyRequests);
   outcome.issue[0].diagnostics = JSON.stringify({ ...result, limit: limiter.points });
+  setRateLimitReset(outcome, result.msBeforeNext);
   res.status(429).json(outcome).end();
 }
 


### PR DESCRIPTION
Updated 2026-08-10:

--------

Fixes #9506.

Medplum CLI bulk imports send resources in FHIR transaction bundles. When a project has real transaction bundles enabled, exceeding a rate limit returns an HTTP 429 response. When transactions are not enabled, the server processes the transaction bundle using batch semantics and returns an HTTP 200 response with 429 errors embedded in individual bundle entries.

The SDK's standard retry handling only sees the outer HTTP response, so it cannot recognize the embedded 429 responses. Its normal retry limit is also unsuitable for a bulk import that may legitimately run for hours.

This change adds retry handling specifically to the CLI bulk import flow:

- Disable the SDK's bounded retries for each bulk import request and handle retries in an outer loop.
- Retry outer HTTP 429 responses until the request succeeds.
- For transaction bundles processed with batch semantics, retry only the entries that returned 429.
- Do not resend entries that already succeeded, which avoids creating duplicate resources.
- Preserve the existing behavior for all non-429 entry failures.

## Rate limit reset metadata

Rate-limited `OperationOutcome` resources now include the reset delay as an extension:

```json
{
  "url": "https://medplum.com/fhir/StructureDefinition/rate-limit-reset",
  "valueUnsignedInt": 60
}
```

The value is the number of seconds until the rate limit resets, matching the `t` value in the `RateLimit` response header. The extension is emitted by both the HTTP request limiter and the FHIR interaction quota limiter.

The existing JSON metadata in `OperationOutcome.issue.diagnostics` remains unchanged. The client-side helper also reads `diagnostics.msBeforeNext` as a fallback for compatibility with servers that do not yet emit the extension.

If neither form of reset metadata is available, bulk import uses the most recent `RateLimit` header known to `MedplumClient`, with a 500 ms minimum fallback.

--------

Original PR:

--------

See: https://hl7.org/fhir/R4/http.html#transaction-response

> For a failed transaction, the server returns a single [OperationOutcome](https://hl7.org/fhir/R4/operationoutcome.html) instead of a Bundle.

The main motivation here is to make it so that transactions that fail due to rate limits return HTTP 429 so that `MedplumClient` can detect, sleep, and retry.

The Medplum CLI bulk import uses transaction bundles, which quickly fail on rate limits.

This is not backwards compatible.  We should discuss with the team before rolling out to check if there are any customer concerns.  If there are concerns, one potential compromise is to use the failed `OperationOutcome` for HTTP status, but continue to return the `Bundle`.  I'm more inclined to rip off the band-aid and return the proper response though.