### PR TITLE
Fixed Patient-everything operation pagination links

### DIFF
--- a/packages/server/src/fhir/operations/patienteverything.test.ts
+++ b/packages/server/src/fhir/operations/patienteverything.test.ts
@@ -170,12 +170,36 @@ describe('Patient Everything Operation', () => {
     expect(bundle.link?.some((link) => link.relation === 'next')).toBeTruthy();
     expect(bundle.link?.some((link) => link.relation === 'first')).toBeTruthy();
     expect(bundle.link?.some((link) => link.relation === 'previous')).toBeTruthy();
+    for (const link of bundle.link ?? []) {
+      const url = new URL(link.url);
+      expect(url.pathname).toBe(`/fhir/R4/Patient/${patient.id}/$everything`);
+      expect(url.searchParams.has('_compartment')).toBe(false);
+      expect(url.searchParams.has('_sort')).toBe(false);
+      expect(url.searchParams.has('_type')).toBe(false);
+      expect(url.searchParams.get('_count')).toBe('1');
+    }
+    expect(new URL(bundle.link?.find((link) => link.relation === 'next')?.url as string).searchParams.get('_offset')).toBe(
+      '2'
+    );
 
-    // Execute the operation with "start" and "end" parameters
+    // Execute the operation with _type
     const res8 = await request(app)
-      .get(`/fhir/R4/Patient/${patient.id}/$everything?start=2020-01-01&end=2040-01-01`)
+      .get(`/fhir/R4/Patient/${patient.id}/$everything?_count=1&_type=Observation`)
       .set('Authorization', 'Bearer ' + accessToken);
     expect(res8.status).toBe(200);
+    const typeBundle = res8.body as Bundle;
+    for (const link of typeBundle.link ?? []) {
+      const url = new URL(link.url);
+      expect(url.pathname).toBe(`/fhir/R4/Patient/${patient.id}/$everything`);
+      expect(url.searchParams.get('_type')).toBe('Observation');
+      expect(url.searchParams.has('_compartment')).toBe(false);
+    }
+
+    // Execute the operation with "start" and "end" parameters
+    const res9 = await request(app)
+      .get(`/fhir/R4/Patient/${patient.id}/$everything?start=2020-01-01&end=2040-01-01`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res9.status).toBe(200);
   });
 
   test('Inline DocumentReference attachments', async () => {

--- a/packages/server/src/fhir/operations/patienteverything.test.ts
+++ b/packages/server/src/fhir/operations/patienteverything.test.ts
@@ -178,9 +178,9 @@ describe('Patient Everything Operation', () => {
       expect(url.searchParams.has('_type')).toBe(false);
       expect(url.searchParams.get('_count')).toBe('1');
     }
-    expect(new URL(bundle.link?.find((link) => link.relation === 'next')?.url as string).searchParams.get('_offset')).toBe(
-      '2'
-    );
+    expect(
+      new URL(bundle.link?.find((link) => link.relation === 'next')?.url as string).searchParams.get('_offset')
+    ).toBe('2');
 
     // Execute the operation with _type
     const res8 = await request(app)

--- a/packages/server/src/fhir/operations/patienteverything.test.ts
+++ b/packages/server/src/fhir/operations/patienteverything.test.ts
@@ -176,6 +176,7 @@ describe('Patient Everything Operation', () => {
       expect(url.searchParams.has('_compartment')).toBe(false);
       expect(url.searchParams.has('_sort')).toBe(false);
       expect(url.searchParams.has('_type')).toBe(false);
+      expect(url.searchParams.has('_inlineAttachments')).toBe(false);
       expect(url.searchParams.get('_count')).toBe('1');
     }
     expect(

--- a/packages/server/src/fhir/operations/patienteverything.ts
+++ b/packages/server/src/fhir/operations/patienteverything.ts
@@ -156,8 +156,8 @@ function rewritePatientEverythingLink(
     url.searchParams.set('_type', types.join(','));
   }
 
-  if (params?._inlineAttachments !== undefined) {
-    url.searchParams.set('_inlineAttachments', String(params._inlineAttachments));
+  if (params?._inlineAttachments) {
+    url.searchParams.set('_inlineAttachments', 'true');
   }
 
   return { ...link, url: url.toString() };

--- a/packages/server/src/fhir/operations/patienteverything.ts
+++ b/packages/server/src/fhir/operations/patienteverything.ts
@@ -4,6 +4,7 @@ import type { SearchRequest, WithId } from '@medplum/core';
 import {
   allOk,
   append,
+  concatUrls,
   flatMapFilter,
   getReferenceString,
   isReference,
@@ -17,6 +18,7 @@ import type {
   Binary,
   Bundle,
   BundleEntry,
+  BundleLink,
   CompartmentDefinitionResource,
   DocumentReference,
   DocumentReferenceContent,
@@ -47,7 +49,7 @@ export interface PatientEverythingParameters {
   _since?: string;
   _count?: number;
   _offset?: number;
-  _type?: ResourceType[];
+  _type?: ResourceType[] | string;
   _inlineAttachments?: boolean;
 }
 
@@ -90,9 +92,11 @@ export async function getPatientEverything(
   patient: WithId<Patient>,
   params?: PatientEverythingParameters
 ): Promise<Bundle<WithId<Resource>>> {
+  const types = normalizeTypes(params?._type);
+
   // First get all compartment resources
   const search: Partial<SearchRequest> = {
-    types: params?._type,
+    types: types.length > 0 ? types : undefined,
     count: params?._count,
     offset: params?._offset,
   };
@@ -104,6 +108,7 @@ export async function getPatientEverything(
     });
   }
   const bundle = await searchPatientCompartment(repo, patient, search);
+  rewritePatientEverythingLinks(bundle, patient, params);
 
   // Filter by requested date range
   filterByCareDate(bundle, params?.start, params?.end);
@@ -118,6 +123,58 @@ export async function getPatientEverything(
   }
 
   return bundle;
+}
+
+function rewritePatientEverythingLinks(
+  bundle: Bundle<WithId<Resource>>,
+  patient: WithId<Patient>,
+  params: PatientEverythingParameters | undefined
+): void {
+  if (!bundle.link?.length) {
+    return;
+  }
+
+  bundle.link = bundle.link.map((link) => rewritePatientEverythingLink(link, patient, params));
+}
+
+function rewritePatientEverythingLink(
+  link: BundleLink,
+  patient: WithId<Patient>,
+  params: PatientEverythingParameters | undefined
+): BundleLink {
+  const searchUrl = new URL(link.url);
+  const url = new URL(concatUrls(getConfig().baseUrl, `/fhir/R4/Patient/${patient.id}/$everything`));
+
+  setSearchParam(url, 'start', params?.start);
+  setSearchParam(url, 'end', params?.end);
+  setSearchParam(url, '_since', params?._since);
+  setSearchParam(url, '_count', searchUrl.searchParams.get('_count') ?? params?._count);
+  setSearchParam(url, '_offset', searchUrl.searchParams.get('_offset'));
+
+  const types = normalizeTypes(params?._type);
+  if (types.length > 0) {
+    url.searchParams.set('_type', types.join(','));
+  }
+
+  if (params?._inlineAttachments !== undefined) {
+    url.searchParams.set('_inlineAttachments', String(params._inlineAttachments));
+  }
+
+  return { ...link, url: url.toString() };
+}
+
+function setSearchParam(url: URL, name: string, value: string | number | undefined | null): void {
+  if (value !== undefined && value !== null && value !== '') {
+    url.searchParams.set(name, String(value));
+  }
+}
+
+function normalizeTypes(types: PatientEverythingParameters['_type']): ResourceType[] {
+  if (!types) {
+    return [];
+  }
+  const values = Array.isArray(types) ? types : [types];
+  return flatMapFilter(values, (type) => type.split(',').filter(Boolean) as ResourceType[]);
 }
 
 function isPatientEverythingInlineAttachmentsEnabled(req: FhirRequest, repo: Repository): boolean {


### PR DESCRIPTION
`Patient/$everything` response links incorrectly used FHIR search URLs rather than `Patient/$everything`.

For example:

```json
  "link": [
    {
      "relation": "self",
      "url": "http://localhost:8103/fhir/R4/Patient?_compartment=Patient%2F3c8ac1f4-a5c7-412d-93b2-fddcc3af352f&_count=1000&_sort=_id&_type=Account,ActivityDefinition,AdverseEvent,AllergyIntolerance,..."
    },
    {
      "relation": "first",
      "url": "http://localhost:8103/fhir/R4/Patient?_compartment=Patient%2F3c8ac1f4-a5c7-412d-93b2-fddcc3af352f&_count=1000&_sort=_id&_type=Account,ActivityDefinition,AdverseEvent,AllergyIntolerance,..."
    },
    {
      "relation": "next",
      "url": "http://localhost:8103/fhir/R4/Patient?_compartment=Patient%2F3c8ac1f4-a5c7-412d-93b2-fddcc3af352f&_count=1000&_offset=1000&_sort=_id&_type=Account,ActivityDefinition,AdverseEvent,AllergyIntolerance,..."
    }
  ]
```