### PR TITLE
Enforce author AccessPolicy for rest-hook Subscriptions

### DIFF
--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -1307,16 +1307,17 @@ describe('Subscription Worker', () => {
 
   test('AuditEvent has Subscription account details', () =>
     withTestContext(async () => {
-      const project = (await createTestProject()).project.id;
+      // Create the Subscription as a project-admin test user (admin is required to set meta.account)
+      // rather than the system user, so the author has a ProjectMembership and AccessPolicy.
+      const { repo: testRepo } = await createTestProject({ withRepo: true, membership: { admin: true } });
       const account = {
         reference: 'Organization/' + randomUUID(),
       };
 
-      const subscription = await systemRepo.createResource<Subscription>({
+      const subscription = await testRepo.createResource<Subscription>({
         resourceType: 'Subscription',
         reason: 'test',
         meta: {
-          project,
           account,
         },
         status: 'active',
@@ -1328,10 +1329,9 @@ describe('Subscription Worker', () => {
       });
       expect(subscription).toBeDefined();
 
-      const patient = await systemRepo.createResource<Patient>({
+      const patient = await testRepo.createResource<Patient>({
         resourceType: 'Patient',
         meta: {
-          project,
           account,
         },
         name: [{ given: ['Alice'], family: 'Smith' }],
@@ -1363,16 +1363,17 @@ describe('Subscription Worker', () => {
 
   test('AuditEvent outcome from custom codes', () =>
     withTestContext(async () => {
-      const project = (await createTestProject()).project.id;
+      // Create the Subscription as a project-admin test user (admin is required to set meta.account)
+      // rather than the system user, so the author has a ProjectMembership and AccessPolicy.
+      const { repo: testRepo } = await createTestProject({ withRepo: true, membership: { admin: true } });
       const account = {
         reference: 'Organization/' + randomUUID(),
       };
 
-      const subscription = await systemRepo.createResource<Subscription>({
+      const subscription = await testRepo.createResource<Subscription>({
         resourceType: 'Subscription',
         reason: 'test',
         meta: {
-          project,
           account,
         },
         status: 'active',
@@ -1390,10 +1391,9 @@ describe('Subscription Worker', () => {
       });
       expect(subscription).toBeDefined();
 
-      const patient = await systemRepo.createResource<Patient>({
+      const patient = await testRepo.createResource<Patient>({
         resourceType: 'Patient',
         meta: {
-          project,
           account,
         },
         name: [{ given: ['Alice'], family: 'Smith' }],
@@ -1424,14 +1424,13 @@ describe('Subscription Worker', () => {
 
   test('Subscription AuditEvent destination - default behavior creates resource', () =>
     withTestContext(async () => {
-      const project = (await createTestProject()).project.id;
+      // Create the Subscription as a test user (not the system user) so the author has a
+      // ProjectMembership and AccessPolicy that grant read access to the triggering resource.
+      const { repo: testRepo } = await createTestProject({ withRepo: true });
 
-      const subscription = await systemRepo.createResource<Subscription>({
+      const subscription = await testRepo.createResource<Subscription>({
         resourceType: 'Subscription',
         reason: 'test',
-        meta: {
-          project,
-        },
         status: 'active',
         criteria: 'Patient',
         channel: {
@@ -1440,11 +1439,8 @@ describe('Subscription Worker', () => {
         },
       });
 
-      const patient = await systemRepo.createResource<Patient>({
+      const patient = await testRepo.createResource<Patient>({
         resourceType: 'Patient',
-        meta: {
-          project,
-        },
         name: [{ given: ['Alice'], family: 'Smith' }],
       });
 
@@ -1484,14 +1480,13 @@ describe('Subscription Worker', () => {
 
     test('log only', () =>
       withTestContext(async () => {
-        const project = (await createTestProject()).project.id;
+        // Create the Subscription as a test user (not the system user) so the author has a
+        // ProjectMembership and AccessPolicy that grant read access to the triggering resource.
+        const { repo: testRepo } = await createTestProject({ withRepo: true });
 
-        const subscription = await systemRepo.createResource<Subscription>({
+        const subscription = await testRepo.createResource<Subscription>({
           resourceType: 'Subscription',
           reason: 'test',
-          meta: {
-            project,
-          },
           status: 'active',
           criteria: 'Patient',
           channel: {
@@ -1506,11 +1501,8 @@ describe('Subscription Worker', () => {
           ],
         });
 
-        const patient = await systemRepo.createResource<Patient>({
+        const patient = await testRepo.createResource<Patient>({
           resourceType: 'Patient',
-          meta: {
-            project,
-          },
           name: [{ given: ['Alice'], family: 'Smith' }],
         });
 
@@ -1547,14 +1539,13 @@ describe('Subscription Worker', () => {
 
     test('resource and log', () =>
       withTestContext(async () => {
-        const project = (await createTestProject()).project.id;
+        // Create the Subscription as a test user (not the system user) so the author has a
+        // ProjectMembership and AccessPolicy that grant read access to the triggering resource.
+        const { repo: testRepo } = await createTestProject({ withRepo: true });
 
-        const subscription = await systemRepo.createResource<Subscription>({
+        const subscription = await testRepo.createResource<Subscription>({
           resourceType: 'Subscription',
           reason: 'test',
-          meta: {
-            project,
-          },
           status: 'active',
           criteria: 'Patient',
           channel: {
@@ -1573,11 +1564,8 @@ describe('Subscription Worker', () => {
           ],
         });
 
-        const patient = await systemRepo.createResource<Patient>({
+        const patient = await testRepo.createResource<Patient>({
           resourceType: 'Patient',
-          meta: {
-            project,
-          },
           name: [{ given: ['Alice'], family: 'Smith' }],
         });
 

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -56,7 +56,13 @@ import { createTestProject, withTestContext } from '../test.setup';
 import { AuditEventOutcome } from '../util/auditevent';
 import type { SubEventsOptions } from '../ws/subscriptions';
 import type { SubscriptionJobData } from './subscription';
-import { addSubscriptionJobs, execSubscriptionJob, getSubscriptionQueue, initSubscriptionWorker } from './subscription';
+import {
+  addSubscriptionJobs,
+  execSubscriptionJob,
+  getSubscriptionQueue,
+  initSubscriptionWorker,
+  skipRestHookAccessPolicySystemSettingName,
+} from './subscription';
 import {
   clearSubscriptionFailures,
   getSubscriptionAutoDisableTriggers,
@@ -1796,16 +1802,13 @@ describe('Subscription Worker', () => {
       // Update the patient
       const patient2 = await apTestRepo.updateResource({ ...patient, name: [{ given: ['Bob'], family: 'Smith' }] });
 
+      (fetch as unknown as jest.Mock).mockClear();
       (fetch as unknown as jest.Mock).mockImplementation(() => ({ status: 200 }));
 
-      await findAndExecSubscriptionJob(patient2, 'update', subscription);
-      expect(fetch).toHaveBeenCalledWith(
-        url,
-        expect.objectContaining({
-          method: 'POST',
-          body: stringify(patient2),
-        })
-      );
+      // An unexpected throw inside satisfiesAccessPolicy() must be caught (no crash) and treated as
+      // not satisfied (fail-closed): the rest-hook is not delivered and the error is logged.
+      await expect(findAndExecSubscriptionJob(patient2, 'update', subscription)).rejects.toThrow('Job not found');
+      expect(fetch).not.toHaveBeenCalled();
 
       expect(writeSpy).toHaveBeenCalledWith(
         expect.stringMatching(/"level":"WARN".*Error occurred while checking access policy/)
@@ -1815,16 +1818,15 @@ describe('Subscription Worker', () => {
       writeSpy.mockRestore();
     }));
 
-  // TODO: Remove this test when enforcing AccessPolicy will not break things
-  test('Subscription -- Rest Hook Sub does not meet AccessPolicy', () =>
+  test('Subscription -- Rest Hook Sub that does not meet AccessPolicy is not delivered', () =>
     withTestContext(async () => {
       globalLogger.level = LogLevel.WARN;
       const writeSpy = jest.spyOn(globalLogger, 'write' as any).mockImplementation(() => undefined);
 
       const url = 'https://example.com/subscription';
 
-      // Create an access policy in different project
-      // This should trigger an error when the subscription is executed
+      // Create an access policy that is deleted before the subscription fires.
+      // This triggers an error inside satisfiesAccessPolicy() -> not satisfied.
       const accessPolicy = await repo.createResource<AccessPolicy>({
         resourceType: 'AccessPolicy',
         resource: [{ resourceType: 'Patient' }, { resourceType: 'Subscription' }],
@@ -1834,7 +1836,7 @@ describe('Subscription Worker', () => {
         withClient: true,
         withRepo: true,
         project: {
-          name: 'AccessPolicy Not Met but Should Succeed Project',
+          name: 'AccessPolicy Not Met -- Enforced Project',
           features: [],
         },
         membership: {
@@ -1862,15 +1864,73 @@ describe('Subscription Worker', () => {
       });
       expect(patient).toBeDefined();
 
-      // Clear the queue
-
       await systemRepo.deleteResource('AccessPolicy', accessPolicy.id);
 
       // Update the patient
       const patient2 = await apTestRepo.updateResource({ ...patient, name: [{ given: ['Bob'], family: 'Smith' }] });
 
+      (fetch as unknown as jest.Mock).mockClear();
       (fetch as unknown as jest.Mock).mockImplementation(() => ({ status: 200 }));
 
+      // The rest-hook must NOT fire -- the author's AccessPolicy was not satisfied.
+      await expect(findAndExecSubscriptionJob(patient2, 'update', subscription)).rejects.toThrow('Job not found');
+      expect(fetch).not.toHaveBeenCalled();
+
+      expect(writeSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/"level":"WARN".*Error occurred while checking access policy/)
+      );
+
+      globalLogger.level = LogLevel.NONE;
+      writeSpy.mockRestore();
+    }));
+
+  test('Subscription -- skipRestHookAccessPolicyCheck systemSetting restores legacy delivery', () =>
+    withTestContext(async () => {
+      const url = 'https://example.com/subscription';
+
+      // Same denied-access scenario as above, but the project opts out of enforcement.
+      const accessPolicy = await repo.createResource<AccessPolicy>({
+        resourceType: 'AccessPolicy',
+        resource: [{ resourceType: 'Patient' }, { resourceType: 'Subscription' }],
+      });
+
+      const { repo: apTestRepo } = await createTestProject({
+        withClient: true,
+        withRepo: true,
+        project: {
+          name: 'AccessPolicy Not Met -- Opt-out Project',
+          features: [],
+          systemSetting: [{ name: skipRestHookAccessPolicySystemSettingName, valueBoolean: true }],
+        },
+        membership: {
+          accessPolicy: createReference(accessPolicy),
+        },
+      });
+
+      const subscription = await apTestRepo.createResource<Subscription>({
+        resourceType: 'Subscription',
+        reason: 'test',
+        status: 'active',
+        criteria: 'Patient',
+        channel: {
+          type: 'rest-hook',
+          endpoint: url,
+        },
+      });
+
+      const patient = await apTestRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['Alice'], family: 'Smith' }],
+      });
+
+      await systemRepo.deleteResource('AccessPolicy', accessPolicy.id);
+
+      const patient2 = await apTestRepo.updateResource({ ...patient, name: [{ given: ['Bob'], family: 'Smith' }] });
+
+      (fetch as unknown as jest.Mock).mockClear();
+      (fetch as unknown as jest.Mock).mockImplementation(() => ({ status: 200 }));
+
+      // With the opt-out enabled, the legacy behavior is restored and the rest-hook fires.
       await findAndExecSubscriptionJob(patient2, 'update', subscription);
       expect(fetch).toHaveBeenCalledWith(
         url,
@@ -1880,12 +1940,7 @@ describe('Subscription Worker', () => {
         })
       );
 
-      expect(writeSpy).toHaveBeenCalledWith(
-        expect.stringMatching(/"level":"WARN".*Error occurred while checking access policy/)
-      );
-
       globalLogger.level = LogLevel.NONE;
-      writeSpy.mockRestore();
     }));
 
   test('Subscription -- Access policy is evaluated once per author across multiple matching subscriptions', () =>
@@ -2357,10 +2412,11 @@ describe('Subscription Worker', () => {
 
     test('Access policy cache is keyed by channel type -- rest-hook result does not bleed into websocket eval', () =>
       withTestContext(async () => {
-        // satisfiesAccessPolicy() is hardcoded to return `true` for non-websocket channel types
-        // (rest-hook enforcement is not yet implemented).  If the per-author cache were shared
-        // across channel types, the cached `true` from the rest-hook subscription would incorrectly
-        // allow the websocket subscription to bypass the access-policy check.
+        // The rest-hook and websocket channels can produce different access-policy results for the
+        // same author: with the `skipRestHookAccessPolicyCheck` opt-out enabled, rest-hook resolves
+        // to `true` (legacy behavior) while websocket still enforces the policy (`false` here).  If
+        // the per-author cache were shared across channel types, the rest-hook's `true` would
+        // incorrectly bleed into the websocket eval and allow it to bypass the access-policy check.
         const url = 'https://example.com/subscription';
 
         // An access policy that restricts Patient to a specific ID that will never match our patient.
@@ -2374,7 +2430,8 @@ describe('Subscription Worker', () => {
 
         // Create a project whose membership carries the denying access policy.
         // The project must have 'websocket-subscriptions' enabled so that the websocket
-        // subscription is fetched and evaluated.
+        // subscription is fetched and evaluated, and opts out of rest-hook enforcement so the
+        // two channel types diverge.
         const {
           repo: testRepo,
           project: testProject,
@@ -2387,6 +2444,7 @@ describe('Subscription Worker', () => {
           project: {
             name: 'Access Policy Cache Channel Type Isolation Project',
             features: ['websocket-subscriptions'],
+            systemSetting: [{ name: skipRestHookAccessPolicySystemSettingName, valueBoolean: true }],
           },
           membership: {
             accessPolicy: createReference(accessPolicy),
@@ -2427,8 +2485,8 @@ describe('Subscription Worker', () => {
         // and the rest-hook's cached `true` must not have been reused for the websocket check.
         await assertPromise;
 
-        // The rest-hook subscription MUST still be enqueued -- satisfiesAccessPolicy()
-        // unconditionally returns `true` for non-websocket channel types.
+        // The rest-hook subscription MUST still be enqueued -- the project opted out of rest-hook
+        // enforcement via `skipRestHookAccessPolicyCheck`.
         await findAndExecSubscriptionJob(patient, 'create', restHookSub);
       }));
 

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -224,12 +224,35 @@ export function getSubscriptionQueue(): Queue<SubscriptionJobData> | undefined {
 }
 
 /**
+ * The name of the `Project.systemSetting` boolean that, when `true`, restores the legacy
+ * behavior where rest-hook `Subscriptions` fire regardless of whether the `Subscription`
+ * author's `AccessPolicy` grants read access to the triggering resource.
+ *
+ * This is an intentionally insecure opt-out: enabling it lets a `Subscription` deliver
+ * resources the author could not otherwise read via the API.  It exists only to give operators
+ * a temporary escape hatch while migrating `Subscription` author memberships to have the
+ * appropriate `AccessPolicy` access after upgrading.  It is a `systemSetting` (super-admin only)
+ * so that a project administrator cannot disable the security control themselves, and it has no
+ * effect on WebSocket subscriptions, which have always enforced the `AccessPolicy`.
+ */
+export const skipRestHookAccessPolicySystemSettingName = 'skipRestHookAccessPolicyCheck';
+
+function skipsRestHookAccessPolicyCheck(project: Project): boolean {
+  return (
+    project.systemSetting?.find((s) => s.name === skipRestHookAccessPolicySystemSettingName)?.valueBoolean === true
+  );
+}
+
+/**
  * Checks if this resource should create a notification for this `Subscription` based on the access policy that should be applied for this `Subscription`.
  * The `AccessPolicy` of author's `ProjectMembership` for this resource's `Project` is used when evaluating whether the `AccessPolicy` is satisfied.
  *
- * Currently we log if the `AccessPolicy` is not satisfied only.
+ * A `Subscription` only fires for resources that the author's `AccessPolicy` grants read access to.
+ * This prevents a user from using a `Subscription` (in particular a rest-hook webhook) as a "wiretap"
+ * to receive resources they could not otherwise read directly via the API.
  *
- * TODO: Actually prevent notifications for `Subscriptions` where the `AccessPolicy` is not satisfied (for rest-hook subscriptions)
+ * For backwards compatibility, a project can restore the legacy behavior for rest-hook subscriptions
+ * via the super-admin-only {@link skipRestHookAccessPolicySystemSettingName} `systemSetting`.
  *
  * @param resource - The resource to evaluate against the `AccessPolicy`.
  * @param project - The project containing the resource.
@@ -289,8 +312,15 @@ async function satisfiesAccessPolicy(
     );
     satisfied = false;
   }
-  // Always return true if channelType !== websocket for now
-  return subscription.channel.type === 'websocket' ? satisfied : true;
+  // Enforce the author's AccessPolicy for all channel types so that a Subscription cannot deliver
+  // resources the author is not allowed to read.  The legacy (insecure) behavior, where rest-hook
+  // subscriptions fired regardless of the AccessPolicy, can be restored per-project via the
+  // super-admin-only `skipRestHookAccessPolicyCheck` systemSetting.  This opt-out never applies to
+  // WebSocket subscriptions, which have always enforced the AccessPolicy.
+  if (!satisfied && subscription.channel.type !== 'websocket' && skipsRestHookAccessPolicyCheck(project)) {
+    return true;
+  }
+  return satisfied;
 }
 
 /**
@@ -373,10 +403,11 @@ export async function addSubscriptionJobs(
     }
     if (matches) {
       const authorRef = getReferenceString(subscription.meta?.author as Reference);
-      // Channel type is part of the key because satisfiesAccessPolicy() is hardcoded to always
-      // return `true` for rest-hook subscriptions (see the TODO comment on that function).
-      // Without it, a cached `true` from a rest-hook sub could bypass the real policy check
-      // for a websocket sub sharing the same author.
+      // Channel type is part of the key because the two channel types resolve the author's
+      // membership differently: WebSocket subscriptions are evaluated against the specific
+      // membership they bound with (authorMembershipId), while rest-hook subscriptions resolve
+      // the membership by author. Keying by channel type keeps their cached results separate so a
+      // result computed for one channel type can never be reused for the other.
       const cacheKey =
         subscription.channel.type === 'websocket' && authorMembershipId
           ? authorMembershipId


### PR DESCRIPTION
Adds defense-in-depth to FHIR `Subscription` processing: rest-hook subscriptions now respect the **author's `AccessPolicy`** when deciding whether to deliver a notification, so a subscription only fires for resources its author is permitted to read. WebSocket subscriptions already enforced this; this change brings rest-hook channels in line.

This is a security enhancement, not a fix for a reachable issue — per existing guidance, the ability to create `Subscription` resources with `rest-hook` channels should be limited to project administrators via `AccessPolicy`. This adds an extra layer so that even where subscription creation is delegated more broadly, notification delivery stays within the author's access scope.

## Changes

- The subscription worker now evaluates the author's `AccessPolicy` for rest-hook channels and suppresses delivery when it is not satisfied.
- Added a super-admin-only `Project.systemSetting` (`skipRestHookAccessPolicyCheck`) to opt out per-project for backwards compatibility while configurations are reviewed.
- Updated tests to cover the enforced path, the opt-out, and fail-closed handling.

## Rollout notes

- Default behavior enforces the author's `AccessPolicy` for all channel types.
- Rest-hook subscriptions whose author membership has a narrow `AccessPolicy` may stop firing for out-of-scope resources after upgrade; the opt-out setting restores prior behavior if needed during migration.
- WebSocket subscriptions are unaffected.
