### PR TITLE
First pass at normalizing Bot OperationOutcome response

### DIFF
--- a/packages/server/src/bots/execute.ts
+++ b/packages/server/src/bots/execute.ts
@@ -6,7 +6,13 @@ import { executeFissionBot } from '../cloud/fission/execute';
 import { recordHistogramValue } from '../otel/otel';
 import { AuditEventOutcome, createBotAuditEvent } from '../util/auditevent';
 import type { BotExecutionContext, BotExecutionRequest, BotExecutionResult } from './types';
-import { getBotAccessToken, getBotSecrets, isBotEnabled, writeBotInputToStorage } from './utils';
+import {
+  getBotAccessToken,
+  getBotSecrets,
+  isBotEnabled,
+  normalizeBotExecutionResult,
+  writeBotInputToStorage,
+} from './utils';
 import { runInVmContext } from './vmcontext';
 
 /**
@@ -50,6 +56,7 @@ export async function executeBot(request: BotExecutionRequest): Promise<BotExecu
   } else {
     result = { success: false, logResult: 'Bots not enabled' };
   }
+  result = normalizeBotExecutionResult(result);
   const executionTime = Number(process.hrtime.bigint() - execStart) / 1e9; // Report duration in seconds
 
   const attributes = { project: bot.meta?.project, bot: bot.id, outcome: result.success ? 'success' : 'failure' };

--- a/packages/server/src/bots/types.ts
+++ b/packages/server/src/bots/types.ts
@@ -42,6 +42,12 @@ export interface BotExecutionContext extends BotExecutionRequest {
 }
 
 export interface BotExecutionResult {
+  /**
+   * true if Medplum invoked the configured runtime, the handler completed without throwing,
+   * and the handler did not return a non-OK `OperationOutcome`
+   * false runtime failed, handler threw, execution was rejected or timed out, or handler
+   * returned a non-OK `OperationOutcome`
+   */
   readonly success: boolean;
   readonly logResult: string;
   readonly returnValue?: any;

--- a/packages/server/src/bots/utils.test.ts
+++ b/packages/server/src/bots/utils.test.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { allOk, badRequest } from '@medplum/core';
 import type { Bot } from '@medplum/fhirtypes';
-import { getJsFileExtension } from './utils';
+import { getJsFileExtension, normalizeBotExecutionResult } from './utils';
 
 describe('getJsFileExtension', () => {
   test('returns .cjs for CommonJS code with .cjs extension', () => {
@@ -45,5 +46,32 @@ describe('getJsFileExtension', () => {
     const bot = { id: '1' } as Bot;
     const code = 'const foo = 42;';
     expect(getJsFileExtension(bot, code)).toBe('.cjs');
+  });
+});
+
+describe('normalizeBotExecutionResult', () => {
+  test('keeps success true for OK OperationOutcome return values', () => {
+    expect(normalizeBotExecutionResult({ success: true, logResult: '', returnValue: allOk })).toMatchObject({
+      success: true,
+      returnValue: allOk,
+    });
+  });
+
+  test('sets success false for non-OK OperationOutcome return values', () => {
+    const outcome = badRequest('test');
+
+    expect(normalizeBotExecutionResult({ success: true, logResult: '', returnValue: outcome })).toMatchObject({
+      success: false,
+      returnValue: outcome,
+    });
+  });
+
+  test('does not reinterpret legacy runtime error objects', () => {
+    const returnValue = { errorType: 'OperationOutcomeError', errorMessage: 'test' };
+
+    expect(normalizeBotExecutionResult({ success: false, logResult: '', returnValue })).toMatchObject({
+      success: false,
+      returnValue,
+    });
   });
 });

--- a/packages/server/src/bots/utils.ts
+++ b/packages/server/src/bots/utils.ts
@@ -131,6 +131,20 @@ export function getOutParametersFromResult(result: OperationOutcome | BotExecuti
 }
 
 /**
+ * Normalizes the BotExecutionResult success flag based on structured FHIR outcomes.
+ * Runtime adapters should call this before returning so all bot execution surfaces
+ * agree on the meaning of a returned non-OK OperationOutcome.
+ * @param result - The bot execution result.
+ * @returns The normalized bot execution result.
+ */
+export function normalizeBotExecutionResult(result: BotExecutionResult): BotExecutionResult {
+  if (isOperationOutcome(result.returnValue) && !isOk(result.returnValue)) {
+    return { ...result, success: false };
+  }
+  return result;
+}
+
+/**
  * Returns true if the bot is enabled and bots are enabled for the project.
  * @param bot - The bot resource.
  * @returns True if the bot is enabled.

--- a/packages/server/src/cloud/aws/deploy.ts
+++ b/packages/server/src/cloud/aws/deploy.ts
@@ -28,14 +28,14 @@ export const LAMBDA_MEMORY = 1024;
 export const DEFAULT_LAMBDA_TIMEOUT = 10;
 export const MAX_LAMBDA_TIMEOUT = 900; // 60 * 15 (15 mins)
 
-const CJS_PREFIX = `const { ContentType, Hl7Message, MedplumClient, isOperationOutcome, normalizeOperationOutcome } = require("@medplum/core");
+const CJS_PREFIX = `const { ContentType, Hl7Message, MedplumClient, OperationOutcomeError, isOperationOutcome, normalizeOperationOutcome } = require("@medplum/core");
 const PdfPrinter = require("pdfmake");
 const userCode = require("./user.cjs");
 
 exports.handler = async (event, context) => {
 `;
 
-const ESM_PREFIX = `import { ContentType, Hl7Message, MedplumClient, isOperationOutcome, normalizeOperationOutcome } from '@medplum/core';
+const ESM_PREFIX = `import { ContentType, Hl7Message, MedplumClient, OperationOutcomeError, isOperationOutcome, normalizeOperationOutcome } from '@medplum/core';
 import PdfPrinter from 'pdfmake';
 import * as userCode from './user.mjs';
 
@@ -100,15 +100,16 @@ const WRAPPER_CODE =
     }
     return result;
   } catch (err) {
+    if (err instanceof OperationOutcomeError || isOperationOutcome(err)) {
+      return normalizeOperationOutcome(err);
+    }
+
     if (err instanceof Error) {
       console.log("Unhandled error: " + err.message + "\\n" + err.stack);
     } else if (typeof err === "object") {
       console.log("Unhandled error: " + JSON.stringify(err, undefined, 2));
     } else {
       console.log("Unhandled error: " + err);
-    }
-    if ((err && err.name === "OperationOutcomeError") || isOperationOutcome(err)) {
-      return normalizeOperationOutcome(err);
     }
     throw err;
   }

--- a/packages/server/src/cloud/aws/deploy.ts
+++ b/packages/server/src/cloud/aws/deploy.ts
@@ -28,14 +28,14 @@ export const LAMBDA_MEMORY = 1024;
 export const DEFAULT_LAMBDA_TIMEOUT = 10;
 export const MAX_LAMBDA_TIMEOUT = 900; // 60 * 15 (15 mins)
 
-const CJS_PREFIX = `const { ContentType, Hl7Message, MedplumClient } = require("@medplum/core");
+const CJS_PREFIX = `const { ContentType, Hl7Message, MedplumClient, isOperationOutcome, normalizeOperationOutcome } = require("@medplum/core");
 const PdfPrinter = require("pdfmake");
 const userCode = require("./user.cjs");
 
 exports.handler = async (event, context) => {
 `;
 
-const ESM_PREFIX = `import { ContentType, Hl7Message, MedplumClient } from '@medplum/core';
+const ESM_PREFIX = `import { ContentType, Hl7Message, MedplumClient, isOperationOutcome, normalizeOperationOutcome } from '@medplum/core';
 import PdfPrinter from 'pdfmake';
 import * as userCode from './user.mjs';
 
@@ -106,6 +106,9 @@ const WRAPPER_CODE =
       console.log("Unhandled error: " + JSON.stringify(err, undefined, 2));
     } else {
       console.log("Unhandled error: " + err);
+    }
+    if ((err && err.name === "OperationOutcomeError") || isOperationOutcome(err)) {
+      return normalizeOperationOutcome(err);
     }
     throw err;
   }

--- a/packages/server/src/cloud/aws/deploystreaming.ts
+++ b/packages/server/src/cloud/aws/deploystreaming.ts
@@ -3,14 +3,14 @@
 import type { Bot } from '@medplum/fhirtypes';
 import { CREATE_PDF_CODE, createBotZipFile, deployLambdaInternal } from './deploy';
 
-const CJS_PREFIX = `const { ContentType, Hl7Message, MedplumClient, getStatus, isOperationOutcome, normalizeOperationOutcome } = require("@medplum/core");
+const CJS_PREFIX = `const { ContentType, Hl7Message, MedplumClient, getStatus, OperationOutcomeError, isOperationOutcome, normalizeOperationOutcome } = require("@medplum/core");
 const PdfPrinter = require("pdfmake");
 const userCode = require("./user.cjs");
 
 exports.handler = awslambda.streamifyResponse(async (event, responseStream) => {
 `;
 
-const ESM_PREFIX = `import { ContentType, Hl7Message, MedplumClient, getStatus, isOperationOutcome, normalizeOperationOutcome } from '@medplum/core';
+const ESM_PREFIX = `import { ContentType, Hl7Message, MedplumClient, getStatus, OperationOutcomeError, isOperationOutcome, normalizeOperationOutcome } from '@medplum/core';
 import PdfPrinter from 'pdfmake';
 import * as userCode from './user.mjs';
 
@@ -50,6 +50,14 @@ const WRAPPER_CODE =
       writeResponse(responseStream, 200, result);
     }
   } catch (err) {
+    if (err instanceof OperationOutcomeError || isOperationOutcome(err)) {
+      const outcome = normalizeOperationOutcome(err);
+      if (!streaming || !botResponseStream?.streamStarted) {
+        writeResponse(responseStream, getStatus(outcome), outcome);
+      }
+      return;
+    }
+
     let errorResponse;
     if (err instanceof Error) {
       console.log("Unhandled error: " + err.message + "\\n" + err.stack);
@@ -72,13 +80,6 @@ const WRAPPER_CODE =
         errorMessage: String(err),
         stack: []
       };
-    }
-    if ((err && err.name === "OperationOutcomeError") || isOperationOutcome(err)) {
-      const outcome = normalizeOperationOutcome(err);
-      if (!streaming || !botResponseStream?.streamStarted) {
-        writeResponse(responseStream, getStatus(outcome), outcome);
-      }
-      return;
     }
     console.error("Invoke Error", JSON.stringify(errorResponse));
     if (!streaming || !botResponseStream?.streamStarted) {
@@ -135,6 +136,7 @@ class BotResponseStream {
   `
 function writeResponse(responseStream, statusCode, body) {
   responseStream.write(JSON.stringify({
+    nonStreamingResponse: true,
     statusCode,
     headers: { 'Content-Type': 'application/json' } }) + "\\n");
   if (body !== undefined) {

--- a/packages/server/src/cloud/aws/deploystreaming.ts
+++ b/packages/server/src/cloud/aws/deploystreaming.ts
@@ -3,14 +3,14 @@
 import type { Bot } from '@medplum/fhirtypes';
 import { CREATE_PDF_CODE, createBotZipFile, deployLambdaInternal } from './deploy';
 
-const CJS_PREFIX = `const { ContentType, Hl7Message, MedplumClient } = require("@medplum/core");
+const CJS_PREFIX = `const { ContentType, Hl7Message, MedplumClient, getStatus, isOperationOutcome, normalizeOperationOutcome } = require("@medplum/core");
 const PdfPrinter = require("pdfmake");
 const userCode = require("./user.cjs");
 
 exports.handler = awslambda.streamifyResponse(async (event, responseStream) => {
 `;
 
-const ESM_PREFIX = `import { ContentType, Hl7Message, MedplumClient } from '@medplum/core';
+const ESM_PREFIX = `import { ContentType, Hl7Message, MedplumClient, getStatus, isOperationOutcome, normalizeOperationOutcome } from '@medplum/core';
 import PdfPrinter from 'pdfmake';
 import * as userCode from './user.mjs';
 
@@ -72,6 +72,13 @@ const WRAPPER_CODE =
         errorMessage: String(err),
         stack: []
       };
+    }
+    if ((err && err.name === "OperationOutcomeError") || isOperationOutcome(err)) {
+      const outcome = normalizeOperationOutcome(err);
+      if (!streaming || !botResponseStream?.streamStarted) {
+        writeResponse(responseStream, getStatus(outcome), outcome);
+      }
+      return;
     }
     console.error("Invoke Error", JSON.stringify(errorResponse));
     if (!streaming || !botResponseStream?.streamStarted) {

--- a/packages/server/src/cloud/aws/execute.test.ts
+++ b/packages/server/src/cloud/aws/execute.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { InvokeCommand, LambdaClient, ListLayerVersionsCommand } from '@aws-sdk/client-lambda';
-import { ContentType } from '@medplum/core';
+import { badRequest, ContentType } from '@medplum/core';
 import type { Bot } from '@medplum/fhirtypes';
 import type { AwsClientStub } from 'aws-sdk-client-mock';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -230,5 +230,21 @@ describe('Execute', () => {
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toBe('text/plain; charset=utf-8');
     expect(res.text).toStrictEqual('input');
+  });
+
+  test('Returned non-OK OperationOutcome marks execution as failure', async () => {
+    const outcome = badRequest('Returned problem');
+    mockLambdaClient.on(InvokeCommand).callsFake(() => ({
+      LogResult: Buffer.from('END RequestId: 123').toString('base64'),
+      Payload: new TextEncoder().encode(JSON.stringify(outcome)),
+    }));
+
+    const res = await request(app)
+      .post(`/fhir/R4/Bot/${bot.id}/$execute`)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject(outcome);
   });
 });

--- a/packages/server/src/cloud/aws/executestreaming.test.ts
+++ b/packages/server/src/cloud/aws/executestreaming.test.ts
@@ -199,7 +199,6 @@ describe('Execute', () => {
       mockLambdaClient.on(InvokeWithResponseStreamCommand).callsFake(() => {
         const encoder = new TextEncoder();
         const headersJson = JSON.stringify({
-          statusCode: 200,
           headers: { 'Content-Type': 'text/event-stream' },
         });
 
@@ -313,20 +312,17 @@ describe('Execute', () => {
       expect(res.body).toMatchObject({ errorType: 'Error', errorMessage: 'Something failed' });
     });
 
-    test('Streaming execution with JSON content type still streams', async () => {
+    test('Streaming execution with JSON content still streams', async () => {
       mockLambdaClient.on(InvokeWithResponseStreamCommand).callsFake(() => {
         const encoder = new TextEncoder();
-        const headersJson = JSON.stringify({
-          statusCode: 200,
-          headers: { 'Content-Type': 'application/json' },
-        });
+        const headersJson = JSON.stringify({}); // statusCode and headers optional
 
         async function* createEventStream(): AsyncGenerator<{
           PayloadChunk?: { Payload: Uint8Array };
           InvokeComplete?: { LogResult?: string };
         }> {
-          yield { PayloadChunk: { Payload: encoder.encode(headersJson + '\n') } };
-          yield { PayloadChunk: { Payload: encoder.encode('{"chunks":[') } };
+          yield { PayloadChunk: { Payload: encoder.encode(headersJson + '\n{') } };
+          yield { PayloadChunk: { Payload: encoder.encode('"chunks":[') } };
           yield { PayloadChunk: { Payload: encoder.encode('{"chunk":1},') } };
           yield { PayloadChunk: { Payload: encoder.encode('{"chunk":2}]}') } };
           yield {
@@ -346,8 +342,8 @@ describe('Execute', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .send('input');
       expect(res.status).toBe(200);
-      expect(res.headers['content-type']).toBe('application/json');
-      expect(res.body).toStrictEqual({ chunks: [{ chunk: 1 }, { chunk: 2 }] });
+      expect(res.body).toStrictEqual({}); // since content-type is not application/json, supertest does not parse the body and leaves it as an empty object
+      expect(JSON.parse(res.text)).toStrictEqual({ chunks: [{ chunk: 1 }, { chunk: 2 }] });
     });
   });
 });

--- a/packages/server/src/cloud/aws/executestreaming.test.ts
+++ b/packages/server/src/cloud/aws/executestreaming.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { InvokeWithResponseStreamCommand, LambdaClient, ListLayerVersionsCommand } from '@aws-sdk/client-lambda';
-import { badRequest, ContentType } from '@medplum/core';
+import { badRequest, ContentType, getStatus } from '@medplum/core';
 import type { Bot } from '@medplum/fhirtypes';
 import type { AwsClientStub } from 'aws-sdk-client-mock';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -239,11 +239,12 @@ describe('Execute', () => {
       // This happens when bot returns early (e.g., OperationOutcome error)
       mockLambdaClient.on(InvokeWithResponseStreamCommand).callsFake(() => {
         const encoder = new TextEncoder();
+        const outcome = badRequest('Test error');
         const headersJson = JSON.stringify({
-          statusCode: 200,
+          nonStreamingResponse: true,
+          statusCode: getStatus(outcome),
           headers: { 'Content-Type': 'application/json' },
         });
-        const outcome = badRequest('Test error');
         const resultJson = JSON.stringify(outcome);
 
         async function* createEventStream(): AsyncGenerator<{
@@ -270,7 +271,7 @@ describe('Execute', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .send('input');
       expect(res.status).toBe(400);
-      expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
+      expect(res.headers['content-type']).toBe('application/json');
       expect(res.body.resourceType).toBe('OperationOutcome');
       expect(res.body.issue[0].details.text).toBe('Test error');
     });
@@ -279,6 +280,7 @@ describe('Execute', () => {
       mockLambdaClient.on(InvokeWithResponseStreamCommand).callsFake(() => {
         const encoder = new TextEncoder();
         const headersJson = JSON.stringify({
+          nonStreamingResponse: true,
           statusCode: 500,
           headers: { 'Content-Type': 'application/json' },
         });
@@ -309,6 +311,43 @@ describe('Execute', () => {
       expect(res.status).toBe(500);
       expect(res.headers['content-type']).toBe('application/json');
       expect(res.body).toMatchObject({ errorType: 'Error', errorMessage: 'Something failed' });
+    });
+
+    test('Streaming execution with JSON content type still streams', async () => {
+      mockLambdaClient.on(InvokeWithResponseStreamCommand).callsFake(() => {
+        const encoder = new TextEncoder();
+        const headersJson = JSON.stringify({
+          statusCode: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+
+        async function* createEventStream(): AsyncGenerator<{
+          PayloadChunk?: { Payload: Uint8Array };
+          InvokeComplete?: { LogResult?: string };
+        }> {
+          yield { PayloadChunk: { Payload: encoder.encode(headersJson + '\n') } };
+          yield { PayloadChunk: { Payload: encoder.encode('{"chunks":[') } };
+          yield { PayloadChunk: { Payload: encoder.encode('{"chunk":1},') } };
+          yield { PayloadChunk: { Payload: encoder.encode('{"chunk":2}]}') } };
+          yield {
+            InvokeComplete: {
+              LogResult: `U1RBUlQgUmVxdWVzdElkOiAxMjM0NQpFTkQgUmVxdWVzdElkOiAxMjM0NQ==`,
+            },
+          };
+        }
+
+        return { EventStream: createEventStream() };
+      });
+
+      const res = await request(app)
+        .post(`/fhir/R4/Bot/${streamingBot.id}/$execute`)
+        .set('Content-Type', ContentType.TEXT)
+        .set('Accept', 'text/event-stream')
+        .set('Authorization', 'Bearer ' + accessToken)
+        .send('input');
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toBe('application/json');
+      expect(res.body).toStrictEqual({ chunks: [{ chunk: 1 }, { chunk: 2 }] });
     });
   });
 });

--- a/packages/server/src/cloud/aws/executestreaming.test.ts
+++ b/packages/server/src/cloud/aws/executestreaming.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { InvokeWithResponseStreamCommand, LambdaClient, ListLayerVersionsCommand } from '@aws-sdk/client-lambda';
-import { ContentType } from '@medplum/core';
+import { badRequest, ContentType } from '@medplum/core';
 import type { Bot } from '@medplum/fhirtypes';
 import type { AwsClientStub } from 'aws-sdk-client-mock';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -243,10 +243,8 @@ describe('Execute', () => {
           statusCode: 200,
           headers: { 'Content-Type': 'application/json' },
         });
-        const resultJson = JSON.stringify({
-          resourceType: 'OperationOutcome',
-          issue: [{ severity: 'error', code: 'invalid', details: { text: 'Test error' } }],
-        });
+        const outcome = badRequest('Test error');
+        const resultJson = JSON.stringify(outcome);
 
         async function* createEventStream(): AsyncGenerator<{
           PayloadChunk?: { Payload: Uint8Array };
@@ -271,10 +269,46 @@ describe('Execute', () => {
         .set('Accept', 'text/event-stream')
         .set('Authorization', 'Bearer ' + accessToken)
         .send('input');
-      expect(res.status).toBe(200);
-      expect(res.headers['content-type']).toBe('application/json');
+      expect(res.status).toBe(400);
+      expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
       expect(res.body.resourceType).toBe('OperationOutcome');
       expect(res.body.issue[0].details.text).toBe('Test error');
+    });
+
+    test('Streaming wrapper generic JSON error preserves HTTP response', async () => {
+      mockLambdaClient.on(InvokeWithResponseStreamCommand).callsFake(() => {
+        const encoder = new TextEncoder();
+        const headersJson = JSON.stringify({
+          statusCode: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+        const errorJson = JSON.stringify({ errorType: 'Error', errorMessage: 'Something failed', stack: [] });
+
+        async function* createEventStream(): AsyncGenerator<{
+          PayloadChunk?: { Payload: Uint8Array };
+          InvokeComplete?: { LogResult?: string };
+        }> {
+          yield { PayloadChunk: { Payload: encoder.encode(headersJson + '\n') } };
+          yield { PayloadChunk: { Payload: encoder.encode(errorJson) } };
+          yield {
+            InvokeComplete: {
+              LogResult: `U1RBUlQgUmVxdWVzdElkOiAxMjM0NQpFTkQgUmVxdWVzdElkOiAxMjM0NQ==`,
+            },
+          };
+        }
+
+        return { EventStream: createEventStream() };
+      });
+
+      const res = await request(app)
+        .post(`/fhir/R4/Bot/${streamingBot.id}/$execute`)
+        .set('Content-Type', ContentType.TEXT)
+        .set('Accept', 'text/event-stream')
+        .set('Authorization', 'Bearer ' + accessToken)
+        .send('input');
+      expect(res.status).toBe(500);
+      expect(res.headers['content-type']).toBe('application/json');
+      expect(res.body).toMatchObject({ errorType: 'Error', errorMessage: 'Something failed' });
     });
   });
 });

--- a/packages/server/src/cloud/aws/executestreaming.ts
+++ b/packages/server/src/cloud/aws/executestreaming.ts
@@ -72,14 +72,13 @@ async function processEventStream(
         }
         if (result.preambleParsed) {
           preambleParsed = true;
-          const statusCode = result.preamble.statusCode || 200;
           if (result.preamble.nonStreamingResponse) {
             // nonStreamingResponse true means that streaming was not used in the user's handler
             // response body can also be parsed and included in the BotExecutionResult.returnValue
             responseChunks = [result.buffer];
           }
 
-          responseStream.startStreaming(statusCode, result.preamble.headers || {});
+          responseStream.startStreaming(result.preamble.statusCode || 200, result.preamble.headers || {});
           if (result.buffer) {
             responseStream.write(result.buffer);
           }
@@ -118,15 +117,16 @@ async function processEventStream(
 
   // make a best effort to parse the response body, but it's possible that streaming response was not JSON
   // or that the stream was not used correctly, so handle errors gracefully
-  let returnValue: BotExecutionResult['returnValue'];
   if (responseChunks && responseChunks.length > 0) {
     try {
-      returnValue = JSON.parse(responseChunks.join(''));
-    } catch {
-      getLogger().error('Failed to parse streaming response body');
+      const returnValue = JSON.parse(responseChunks.join(''));
+      return { success: true, logResult, returnValue };
+    } catch (err) {
+      getLogger().error('Failed to parse streaming response body', { err: normalizeErrorString(err) });
     }
   }
-  return { success: true, logResult, returnValue };
+
+  return { success: true, logResult };
 }
 
 const MAX_HEADER_SIZE = 65536; // 64KB

--- a/packages/server/src/cloud/aws/executestreaming.ts
+++ b/packages/server/src/cloud/aws/executestreaming.ts
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { InvokeWithResponseStreamCommand } from '@aws-sdk/client-lambda';
-import { isOperationOutcome, normalizeErrorString } from '@medplum/core';
+import { normalizeErrorString } from '@medplum/core';
 import { TextDecoder, TextEncoder } from 'node:util';
 import type { BotExecutionContext, BotExecutionResult } from '../../bots/types';
+import { getLogger } from '../../logger';
 import {
   buildLambdaPayload,
   getExecuteLambdaClient,
@@ -52,46 +53,48 @@ async function processEventStream(
   responseStream: NonNullable<BotExecutionContext['responseStream']>
 ): Promise<BotExecutionResult> {
   const decoder = new TextDecoder();
-  let headersParsed = false;
-  let bufferingWrapperResponse = false;
+  let preambleParsed = false;
   let buffer = '';
   let logResult = '';
-  let wrapperStatusCode = 200;
-  let wrapperHeaders: Record<string, string> | undefined = undefined;
-  let wrapperBody = '';
+  let responseChunks: string[] | undefined;
 
   for await (const event of eventStream) {
     if (event.PayloadChunk?.Payload) {
       const chunk = decoder.decode(event.PayloadChunk.Payload);
-      if (!headersParsed) {
-        const result = processStreamingHeaders(buffer + chunk);
+
+      // A JSON-encoded preamble containing the statusCode and headers and other metadata
+      // to be used in the responseStream must be the first line of the stream delimited by a newline
+      // buffer and attempt to process chunks until the preamble is fully received and parsed.
+      if (!preambleParsed) {
+        const result = processStreamingPreamble(buffer + chunk);
         if (result.error) {
           return { success: false, logResult: sanitizeLogResult(result.error) };
         }
-        headersParsed = result.headersParsed;
-        if (headersParsed && result.headers) {
-          wrapperStatusCode = result.headers.statusCode || 200;
-          if (isWrapperJsonResponse(result.headers.headers)) {
-            bufferingWrapperResponse = true;
-            wrapperHeaders = result.headers.headers;
-            wrapperBody += result.buffer;
-          } else {
-            responseStream.startStreaming(wrapperStatusCode, result.headers.headers || {});
-            if (result.buffer) {
-              responseStream.write(result.buffer);
-            }
+        if (result.preambleParsed) {
+          preambleParsed = true;
+          const statusCode = result.preamble.statusCode || 200;
+          if (result.preamble.nonStreamingResponse) {
+            // nonStreamingResponse true means that streaming was not used in the user's handler
+            // response body can also be parsed and included in the BotExecutionResult.returnValue
+            responseChunks = [result.buffer];
+          }
+
+          responseStream.startStreaming(statusCode, result.preamble.headers || {});
+          if (result.buffer) {
+            responseStream.write(result.buffer);
           }
           buffer = '';
         } else {
           buffer = result.buffer;
         }
-      } else if (bufferingWrapperResponse) {
-        wrapperBody += chunk;
       } else {
         responseStream.write(chunk);
         // Flush to ensure data is sent immediately to client
         if (typeof (responseStream as any).flush === 'function') {
           (responseStream as any).flush();
+        }
+        if (responseChunks) {
+          responseChunks.push(chunk);
         }
       }
     }
@@ -111,36 +114,38 @@ async function processEventStream(
     }
   }
 
-  if (bufferingWrapperResponse) {
-    const result = parseWrapperJsonResponse(wrapperStatusCode, wrapperBody, logResult);
-    if (result) {
-      return result;
-    }
-    responseStream.startStreaming(wrapperStatusCode, wrapperHeaders || {});
-    if (wrapperBody) {
-      responseStream.write(wrapperBody);
-    }
-    responseStream.end();
-    return { success: wrapperStatusCode >= 200 && wrapperStatusCode < 400, logResult };
-  }
-
   responseStream.end();
-  return { success: true, logResult };
+
+  // make a best effort to parse the response body, but it's possible that streaming response was not JSON
+  // or that the stream was not used correctly, so handle errors gracefully
+  let returnValue: BotExecutionResult['returnValue'];
+  if (responseChunks && responseChunks.length > 0) {
+    try {
+      returnValue = JSON.parse(responseChunks.join(''));
+    } catch {
+      getLogger().error('Failed to parse streaming response body');
+    }
+  }
+  return { success: true, logResult, returnValue };
 }
 
 const MAX_HEADER_SIZE = 65536; // 64KB
 
-function processStreamingHeaders(
-  buffer: string
-): {
-  headersParsed: boolean;
+type UnparsedResult = {
+  preambleParsed: false;
   buffer: string;
-  headers?: { statusCode?: number; headers?: Record<string, string> };
   error?: string;
-} {
+};
+type ParsedResult = {
+  preambleParsed: true;
+  buffer: string;
+  preamble: { statusCode?: number; headers?: Record<string, string>; nonStreamingResponse?: boolean };
+  error?: undefined;
+};
+function processStreamingPreamble(buffer: string): ParsedResult | UnparsedResult {
   if (buffer.length > MAX_HEADER_SIZE) {
     return {
-      headersParsed: false,
+      preambleParsed: false,
       buffer: '',
       error: `Streaming headers exceeded maximum size of ${MAX_HEADER_SIZE} bytes`,
     };
@@ -148,52 +153,20 @@ function processStreamingHeaders(
 
   const newlineIndex = buffer.indexOf('\n');
   if (newlineIndex === -1) {
-    return { headersParsed: false, buffer };
+    return { preambleParsed: false, buffer };
   }
 
   const headersLine = buffer.substring(0, newlineIndex);
-  const remainingData = buffer.substring(newlineIndex + 1);
+  const remainingBuffer = buffer.substring(newlineIndex + 1);
 
   try {
-    const headersJson = JSON.parse(headersLine);
-    return { headersParsed: true, buffer: remainingData, headers: headersJson };
+    const preamble = JSON.parse(headersLine);
+    return { preambleParsed: true, buffer: remainingBuffer, preamble };
   } catch (err) {
     return {
-      headersParsed: false,
+      preambleParsed: false,
       buffer: '',
       error: `Failed to parse streaming headers: ${headersLine} - ${String(err)}`,
     };
   }
-}
-
-function isWrapperJsonResponse(headers: Record<string, string> | undefined): boolean {
-  return getHeader(headers, 'content-type')?.toLowerCase().includes('application/json') === true;
-}
-
-function getHeader(headers: Record<string, string> | undefined, name: string): string | undefined {
-  if (!headers) {
-    return undefined;
-  }
-  const lowerName = name.toLowerCase();
-  const key = Object.keys(headers).find((k) => k.toLowerCase() === lowerName);
-  return key ? headers[key] : undefined;
-}
-
-function parseWrapperJsonResponse(statusCode: number, body: string, logResult: string): BotExecutionResult | undefined {
-  let returnValue: unknown;
-  try {
-    returnValue = body ? JSON.parse(body) : undefined;
-  } catch {
-    return undefined;
-  }
-
-  if (!isOperationOutcome(returnValue)) {
-    return undefined;
-  }
-
-  return {
-    success: statusCode >= 200 && statusCode < 300,
-    logResult,
-    returnValue,
-  };
 }

--- a/packages/server/src/cloud/aws/executestreaming.ts
+++ b/packages/server/src/cloud/aws/executestreaming.ts
@@ -140,7 +140,7 @@ type ParsedResult = {
   preambleParsed: true;
   buffer: string;
   preamble: { statusCode?: number; headers?: Record<string, string>; nonStreamingResponse?: boolean };
-  error?: undefined;
+  error?: never;
 };
 function processStreamingPreamble(buffer: string): ParsedResult | UnparsedResult {
   if (buffer.length > MAX_HEADER_SIZE) {

--- a/packages/server/src/cloud/aws/executestreaming.ts
+++ b/packages/server/src/cloud/aws/executestreaming.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { InvokeWithResponseStreamCommand } from '@aws-sdk/client-lambda';
-import { normalizeErrorString } from '@medplum/core';
+import { isOperationOutcome, normalizeErrorString } from '@medplum/core';
 import { TextDecoder, TextEncoder } from 'node:util';
 import type { BotExecutionContext, BotExecutionResult } from '../../bots/types';
 import {
@@ -53,19 +53,40 @@ async function processEventStream(
 ): Promise<BotExecutionResult> {
   const decoder = new TextDecoder();
   let headersParsed = false;
+  let bufferingWrapperResponse = false;
   let buffer = '';
   let logResult = '';
+  let wrapperStatusCode = 200;
+  let wrapperHeaders: Record<string, string> | undefined = undefined;
+  let wrapperBody = '';
 
   for await (const event of eventStream) {
     if (event.PayloadChunk?.Payload) {
       const chunk = decoder.decode(event.PayloadChunk.Payload);
       if (!headersParsed) {
-        const result = processStreamingHeaders(buffer + chunk, responseStream);
+        const result = processStreamingHeaders(buffer + chunk);
         if (result.error) {
           return { success: false, logResult: sanitizeLogResult(result.error) };
         }
         headersParsed = result.headersParsed;
-        buffer = result.buffer;
+        if (headersParsed && result.headers) {
+          wrapperStatusCode = result.headers.statusCode || 200;
+          if (isWrapperJsonResponse(result.headers.headers)) {
+            bufferingWrapperResponse = true;
+            wrapperHeaders = result.headers.headers;
+            wrapperBody += result.buffer;
+          } else {
+            responseStream.startStreaming(wrapperStatusCode, result.headers.headers || {});
+            if (result.buffer) {
+              responseStream.write(result.buffer);
+            }
+          }
+          buffer = '';
+        } else {
+          buffer = result.buffer;
+        }
+      } else if (bufferingWrapperResponse) {
+        wrapperBody += chunk;
       } else {
         responseStream.write(chunk);
         // Flush to ensure data is sent immediately to client
@@ -90,6 +111,19 @@ async function processEventStream(
     }
   }
 
+  if (bufferingWrapperResponse) {
+    const result = parseWrapperJsonResponse(wrapperStatusCode, wrapperBody, logResult);
+    if (result) {
+      return result;
+    }
+    responseStream.startStreaming(wrapperStatusCode, wrapperHeaders || {});
+    if (wrapperBody) {
+      responseStream.write(wrapperBody);
+    }
+    responseStream.end();
+    return { success: wrapperStatusCode >= 200 && wrapperStatusCode < 400, logResult };
+  }
+
   responseStream.end();
   return { success: true, logResult };
 }
@@ -97,9 +131,13 @@ async function processEventStream(
 const MAX_HEADER_SIZE = 65536; // 64KB
 
 function processStreamingHeaders(
-  buffer: string,
-  responseStream: NonNullable<BotExecutionContext['responseStream']>
-): { headersParsed: boolean; buffer: string; error?: string } {
+  buffer: string
+): {
+  headersParsed: boolean;
+  buffer: string;
+  headers?: { statusCode?: number; headers?: Record<string, string> };
+  error?: string;
+} {
   if (buffer.length > MAX_HEADER_SIZE) {
     return {
       headersParsed: false,
@@ -118,13 +156,7 @@ function processStreamingHeaders(
 
   try {
     const headersJson = JSON.parse(headersLine);
-    responseStream.startStreaming(headersJson.statusCode || 200, headersJson.headers || {});
-
-    if (remainingData) {
-      responseStream.write(remainingData);
-    }
-
-    return { headersParsed: true, buffer: '' };
+    return { headersParsed: true, buffer: remainingData, headers: headersJson };
   } catch (err) {
     return {
       headersParsed: false,
@@ -132,4 +164,36 @@ function processStreamingHeaders(
       error: `Failed to parse streaming headers: ${headersLine} - ${String(err)}`,
     };
   }
+}
+
+function isWrapperJsonResponse(headers: Record<string, string> | undefined): boolean {
+  return getHeader(headers, 'content-type')?.toLowerCase().includes('application/json') === true;
+}
+
+function getHeader(headers: Record<string, string> | undefined, name: string): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  const lowerName = name.toLowerCase();
+  const key = Object.keys(headers).find((k) => k.toLowerCase() === lowerName);
+  return key ? headers[key] : undefined;
+}
+
+function parseWrapperJsonResponse(statusCode: number, body: string, logResult: string): BotExecutionResult | undefined {
+  let returnValue: unknown;
+  try {
+    returnValue = body ? JSON.parse(body) : undefined;
+  } catch {
+    return undefined;
+  }
+
+  if (!isOperationOutcome(returnValue)) {
+    return undefined;
+  }
+
+  return {
+    success: statusCode >= 200 && statusCode < 300,
+    logResult,
+    returnValue,
+  };
 }

--- a/packages/server/src/cloud/fission/execute.test.ts
+++ b/packages/server/src/cloud/fission/execute.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { badRequest } from '@medplum/core';
 import type { WithId } from '@medplum/core';
+import { badRequest } from '@medplum/core';
 import type { Bot, ProjectMembership } from '@medplum/fhirtypes';
 import express from 'express';
 import fetch from 'node-fetch';

--- a/packages/server/src/cloud/fission/execute.test.ts
+++ b/packages/server/src/cloud/fission/execute.test.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { badRequest } from '@medplum/core';
 import type { WithId } from '@medplum/core';
 import type { Bot, ProjectMembership } from '@medplum/fhirtypes';
 import express from 'express';
@@ -110,11 +111,78 @@ describe('Execute Fission bots', () => {
       })
     ).resolves.toMatchObject({
       success: false,
+      logResult: 'unhandled error',
+      returnValue: { result: 'unhandled error' },
     });
 
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining(`bot-${bot.id}`),
       expect.objectContaining({ method: 'POST' })
     );
+  });
+
+  test('Legacy error response preserves OperationOutcome return value', async () => {
+    const bot: WithId<Bot> = {
+      resourceType: 'Bot',
+      id: randomUUID(),
+      name: 'Test Bot',
+      runtimeVersion: 'fission',
+    };
+    const outcome = badRequest('fission problem');
+
+    (fetch as unknown as jest.Mock).mockImplementationOnce(() => ({
+      status: 400,
+      ok: false,
+      text: jest.fn(async () => JSON.stringify({ logResult: 'unhandled error', returnValue: outcome })),
+    }));
+
+    await expect(
+      executeFissionBot({
+        bot,
+        runAs: {} as WithId<ProjectMembership>,
+        accessToken,
+        input: 'test input',
+        contentType: 'text/plain',
+        secrets: {},
+        traceId: randomUUID(),
+        headers: {},
+      })
+    ).resolves.toMatchObject({
+      success: false,
+      logResult: 'unhandled error',
+      returnValue: outcome,
+    });
+  });
+
+  test('Returned non-OK OperationOutcome is preserved', async () => {
+    const bot: WithId<Bot> = {
+      resourceType: 'Bot',
+      id: randomUUID(),
+      name: 'Test Bot',
+      runtimeVersion: 'fission',
+    };
+    const outcome = badRequest('returned problem');
+
+    (fetch as unknown as jest.Mock).mockImplementationOnce(() => ({
+      status: 200,
+      ok: true,
+      text: jest.fn(async () => JSON.stringify({ logResult: '', returnValue: outcome })),
+    }));
+
+    await expect(
+      executeFissionBot({
+        bot,
+        runAs: {} as WithId<ProjectMembership>,
+        accessToken,
+        input: 'test input',
+        contentType: 'text/plain',
+        secrets: {},
+        traceId: randomUUID(),
+        headers: {},
+      })
+    ).resolves.toMatchObject({
+      success: true,
+      returnValue: outcome,
+    });
   });
 });

--- a/packages/server/src/cloud/fission/execute.ts
+++ b/packages/server/src/cloud/fission/execute.ts
@@ -44,7 +44,9 @@ export async function executeFissionBot(request: BotExecutionContext): Promise<B
   }
 }
 
-function parseFissionResponseBody(body: string): { success?: boolean; logResult?: string; returnValue?: unknown } | undefined {
+function parseFissionResponseBody(
+  body: string
+): { success?: boolean; logResult?: string; returnValue?: unknown } | undefined {
   if (!body) {
     return undefined;
   }

--- a/packages/server/src/cloud/fission/execute.ts
+++ b/packages/server/src/cloud/fission/execute.ts
@@ -28,10 +28,12 @@ export async function executeFissionBot(request: BotExecutionContext): Promise<B
   try {
     const body = JSON.stringify(payload);
     const response = await executeFissionFunction(bot.id, body);
-    const responseBody = response ? JSON.parse(response) : undefined;
+    const responseBody = parseFissionResponseBody(response.body);
     return {
-      success: true,
-      logResult: responseBody?.logResult ?? '',
+      success: response.ok && responseBody?.success !== false,
+      logResult:
+        responseBody?.logResult ??
+        (response.ok ? '' : `HTTP error! Status: ${response.status}, Message: ${response.body}`),
       returnValue: responseBody?.returnValue,
     };
   } catch (err) {
@@ -39,5 +41,16 @@ export async function executeFissionBot(request: BotExecutionContext): Promise<B
       success: false,
       logResult: normalizeErrorString(err),
     };
+  }
+}
+
+function parseFissionResponseBody(body: string): { success?: boolean; logResult?: string; returnValue?: unknown } | undefined {
+  if (!body) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(body);
+  } catch {
+    return undefined;
   }
 }

--- a/packages/server/src/cloud/fission/execute.ts
+++ b/packages/server/src/cloud/fission/execute.ts
@@ -28,12 +28,10 @@ export async function executeFissionBot(request: BotExecutionContext): Promise<B
   try {
     const body = JSON.stringify(payload);
     const response = await executeFissionFunction(bot.id, body);
-    const responseBody = parseFissionResponseBody(response.body);
+    const responseBody = response.body ? JSON.parse(response.body) : undefined;
     return {
       success: response.ok && responseBody?.success !== false,
-      logResult:
-        responseBody?.logResult ??
-        (response.ok ? '' : `HTTP error! Status: ${response.status}, Message: ${response.body}`),
+      logResult: responseBody?.logResult ?? '',
       returnValue: responseBody?.returnValue,
     };
   } catch (err) {
@@ -41,18 +39,5 @@ export async function executeFissionBot(request: BotExecutionContext): Promise<B
       success: false,
       logResult: normalizeErrorString(err),
     };
-  }
-}
-
-function parseFissionResponseBody(
-  body: string
-): { success?: boolean; logResult?: string; returnValue?: unknown } | undefined {
-  if (!body) {
-    return undefined;
-  }
-  try {
-    return JSON.parse(body);
-  } catch {
-    return undefined;
   }
 }

--- a/packages/server/src/cloud/fission/utils.ts
+++ b/packages/server/src/cloud/fission/utils.ts
@@ -157,7 +157,13 @@ export async function deployFissionFunction(id: string, zipFile: Uint8Array): Pr
  * @param body - The request body to be sent to the function.
  * @returns A promise that resolves to the response body from the Fission function.
  */
-export async function executeFissionFunction(id: string, body: string): Promise<string> {
+export interface FissionFunctionResponse {
+  readonly ok: boolean;
+  readonly status: number;
+  readonly body: string;
+}
+
+export async function executeFissionFunction(id: string, body: string): Promise<FissionFunctionResponse> {
   const config = getFissionConfig();
 
   const relativeUrl = getRelativeUrl(id);
@@ -169,11 +175,9 @@ export async function executeFissionFunction(id: string, body: string): Promise<
     body,
   });
 
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`HTTP error! Status: ${response.status}, Message: ${errorText}`);
-  }
-
-  const data = await response.text();
-  return data;
+  return {
+    ok: response.ok,
+    status: response.status,
+    body: await response.text(),
+  };
 }

--- a/packages/server/src/cloud/fission/wrapper.ts
+++ b/packages/server/src/cloud/fission/wrapper.ts
@@ -61,6 +61,7 @@ module.exports = async function (context) {
     return {
       status: 200,
       body: JSON.stringify({
+        success: true,
         returnValue,
         logResult: logOutput.join('\\n'),
       }),
@@ -76,6 +77,7 @@ module.exports = async function (context) {
     return {
       status: 400,
       body: JSON.stringify({
+        success: false,
         returnValue: normalizeOperationOutcome(err),
         logResult: logOutput.join('\\n'),
       }),

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -46,6 +46,7 @@ export const executeHandler = async (req: Request, res: Response): Promise<void>
   } else {
     const result = await executeOperation(req, res);
 
+    // If a response has already started (e.g. SSE streaming), we do not control the response, clean up and return.
     if (res.headersSent) {
       if (!res.writableEnded) {
         res.end();


### PR DESCRIPTION
**Previous Behavior Matrix**

Note: For “awslambda with streaming”, assumes the handler returns/throws before manually starting `event.responseStream`.

| Runtime | Return `OperationOutcome` where `isOk() === true` | Return `OperationOutcome` where `isOk() === false` | Throw `OperationOutcomeError` |
|---|---|---|---|
| `awslambda` | `{ success: true, returnValue: outcome }` | `{ success: true, returnValue: outcome }` | `{ success: false, returnValue: { errorType: "OperationOutcomeError", errorMessage, trace/... } }`; `outcome` lost |
| `awslambda` streaming | `{ success: true, logResult }`; returned outcome written to HTTP stream body, not `returnValue` | `{ success: true, logResult }`; non-OK outcome streamed with HTTP status `200`, not reflected in `success` | `{ success: true, logResult }`; wrapper writes HTTP status `500` + serialized error object to stream, but server reports success unless Lambda `InvokeComplete.ErrorCode` is set |
| `vmcontext` | `{ success: true, returnValue: outcome }` | `{ success: true, returnValue: outcome }` | `{ success: false, returnValue: outcome }` |
| `fission` | `{ success: true, returnValue: outcome }` | `{ success: true, returnValue: outcome }` | `{ success: false, logResult: "HTTP error! Status: 400, Message: ...", returnValue: undefined }`; original `outcome` embedded as JSON text in `logResult`, not preserved structurally |

**`BotExecutionResult.success`**
Proposed more precise definition of `BotExecutionResult.success`:

- `true`: Medplum invoked the configured runtime, the handler completed without throwing, and the handler did not return a non-OK `OperationOutcome`.
- `false`: runtime failed, handler threw, execution was rejected or timed out, or handler returned a non-OK `OperationOutcome`.

**Implementation Decisions**
- Added a centralized final `BotExecutionResult` normalization
- Kept runtime-specific parsing only where needed to preserve behavior of Bots not reflecting changes in deploy code paths:
  - Fission now preserves legacy HTTP 400 wrapper bodies containing `{ returnValue, logResult }`.
  - Streaming Lambda now detects early wrapper JSON `OperationOutcome` responses and returns them as `BotExecutionResult`.
  - Generic streaming wrapper JSON errors still pass through as their original HTTP response.
  - Future Lambda wrappers preserve thrown `OperationOutcomeError` by returning/writing the normalized `OperationOutcome`.

**Impacted Consumers**
The normalization impacts:

- Audit and metrics in `executeBot`: returned non-OK outcomes now record as failure.
- Agent transmit responses: returned non-OK outcomes now produce status `400`/JSON failure behavior.
- Precommit bots: returned non-OK outcomes now block the write.
- Custom operations: returned non-OK outcomes now take the failure path.
- `$execute` HTTP responses for returned non-OK `OperationOutcome` were already mostly correct via `sendBotResponse`; normalization mainly makes audit/metrics and non-HTTP callers consistent.

Fixes #9247 