### PR TITLE
Enhance patient invitation logic in admin module

### DIFF
--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -2,7 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
 import { allOk, ContentType, createReference, getReferenceString, normalizeErrorString } from '@medplum/core';
-import type { AccessPolicy, BundleEntry, Practitioner, ProjectMembership, User } from '@medplum/fhirtypes';
+import type {
+  AccessPolicy,
+  BundleEntry,
+  Patient,
+  Practitioner,
+  ProjectMembership,
+  RelatedPerson,
+  User,
+} from '@medplum/fhirtypes';
 import type { AwsClientStub } from 'aws-sdk-client-mock';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
@@ -1646,6 +1654,46 @@ describe('Admin Invite', () => {
         lastName: 'Jones',
         externalId: randomUUID(),
         sendEmail: false,
+      });
+
+      expect(membership.accessPolicy).toBeUndefined();
+    }));
+
+  test('Invite RelatedPerson does not apply defaultPatientAccessPolicy', () =>
+    withTestContext(async () => {
+      const { project } = await createTestProject();
+      const systemRepo = await getProjectSystemRepo(project);
+      const defaultAccessPolicy = await systemRepo.createResource<AccessPolicy>({
+        resourceType: 'AccessPolicy',
+        name: 'Default Patient Policy',
+        resource: [{ resourceType: 'Patient' }],
+      });
+      const patient = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        meta: { project: project.id },
+        name: [{ given: ['Alice'], family: 'Smith' }],
+      });
+      const relatedPerson = await systemRepo.createResource<RelatedPerson>({
+        resourceType: 'RelatedPerson',
+        meta: { project: project.id },
+        patient: createReference(patient),
+        name: [{ given: ['Bob'], family: 'Jones' }],
+      });
+      const projectWithDefault = await systemRepo.updateResource({
+        ...project,
+        defaultPatientAccessPolicy: createReference(defaultAccessPolicy),
+      });
+
+      const { membership } = await inviteUser({
+        project: projectWithDefault,
+        resourceType: 'RelatedPerson',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        externalId: randomUUID(),
+        sendEmail: false,
+        membership: {
+          profile: createReference(relatedPerson),
+        },
       });
 
       expect(membership.accessPolicy).toBeUndefined();

--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -20,7 +20,14 @@ import { loadTestConfig } from '../config/loader';
 import { DatabaseMode, getDatabasePool } from '../database';
 import { getProjectSystemRepo } from '../fhir/repo';
 import { SelectQuery } from '../fhir/sql';
-import { addTestUser, createTestProject, initTestAuth, setupPwnedPasswordMock, setupRecaptchaMock, withTestContext } from '../test.setup';
+import {
+  addTestUser,
+  createTestProject,
+  initTestAuth,
+  setupPwnedPasswordMock,
+  setupRecaptchaMock,
+  withTestContext,
+} from '../test.setup';
 import { inviteUser } from './invite';
 
 jest.mock('hibp');
@@ -1568,8 +1575,7 @@ describe('Admin Invite', () => {
       });
 
       expect(membership.accessPolicy?.reference).toBe(getReferenceString(defaultAccessPolicy));
-    })
-  );
+    }));
 
   test('Invite Patient uses explicit access policy over defaultPatientAccessPolicy', () =>
     withTestContext(async () => {
@@ -1601,8 +1607,7 @@ describe('Admin Invite', () => {
       });
 
       expect(membership.accessPolicy?.reference).toBe(getReferenceString(explicitAccessPolicy));
-    })
-  );
+    }));
 
   test('Invite Patient without explicit policy and no defaultPatientAccessPolicy', () =>
     withTestContext(async () => {
@@ -1618,8 +1623,7 @@ describe('Admin Invite', () => {
       });
 
       expect(membership.accessPolicy).toBeUndefined();
-    })
-  );
+    }));
 
   test('Invite Practitioner does not apply defaultPatientAccessPolicy', () =>
     withTestContext(async () => {
@@ -1645,6 +1649,5 @@ describe('Admin Invite', () => {
       });
 
       expect(membership.accessPolicy).toBeUndefined();
-    })
-  );
+    }));
 });

--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
 import { allOk, ContentType, createReference, getReferenceString, normalizeErrorString } from '@medplum/core';
-import type { BundleEntry, Practitioner, ProjectMembership, User } from '@medplum/fhirtypes';
+import type { AccessPolicy, BundleEntry, Practitioner, ProjectMembership, User } from '@medplum/fhirtypes';
 import type { AwsClientStub } from 'aws-sdk-client-mock';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
@@ -18,8 +18,10 @@ import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config/loader';
 import { DatabaseMode, getDatabasePool } from '../database';
+import { getProjectSystemRepo } from '../fhir/repo';
 import { SelectQuery } from '../fhir/sql';
-import { addTestUser, initTestAuth, setupPwnedPasswordMock, setupRecaptchaMock, withTestContext } from '../test.setup';
+import { addTestUser, createTestProject, initTestAuth, setupPwnedPasswordMock, setupRecaptchaMock, withTestContext } from '../test.setup';
+import { inviteUser } from './invite';
 
 jest.mock('hibp');
 jest.mock('node-fetch');
@@ -1541,4 +1543,108 @@ describe('Admin Invite', () => {
     expect(res2.status).toBe(409);
     expect(normalizeErrorString(res2.body)).toStrictEqual('User is already a member of this project');
   });
+
+  test('Invite Patient applies defaultPatientAccessPolicy when no explicit policy', () =>
+    withTestContext(async () => {
+      const { project } = await createTestProject();
+      const systemRepo = await getProjectSystemRepo(project);
+      const defaultAccessPolicy = await systemRepo.createResource<AccessPolicy>({
+        resourceType: 'AccessPolicy',
+        name: 'Default Patient Policy',
+        resource: [{ resourceType: 'Patient' }],
+      });
+      const projectWithDefault = await systemRepo.updateResource({
+        ...project,
+        defaultPatientAccessPolicy: createReference(defaultAccessPolicy),
+      });
+
+      const { membership } = await inviteUser({
+        project: projectWithDefault,
+        resourceType: 'Patient',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        externalId: randomUUID(),
+        sendEmail: false,
+      });
+
+      expect(membership.accessPolicy?.reference).toBe(getReferenceString(defaultAccessPolicy));
+    })
+  );
+
+  test('Invite Patient uses explicit access policy over defaultPatientAccessPolicy', () =>
+    withTestContext(async () => {
+      const { project } = await createTestProject();
+      const systemRepo = await getProjectSystemRepo(project);
+      const defaultAccessPolicy = await systemRepo.createResource<AccessPolicy>({
+        resourceType: 'AccessPolicy',
+        name: 'Default Patient Policy',
+        resource: [{ resourceType: 'Patient' }],
+      });
+      const explicitAccessPolicy = await systemRepo.createResource<AccessPolicy>({
+        resourceType: 'AccessPolicy',
+        name: 'Explicit Patient Policy',
+        resource: [{ resourceType: 'Patient' }],
+      });
+      const projectWithDefault = await systemRepo.updateResource({
+        ...project,
+        defaultPatientAccessPolicy: createReference(defaultAccessPolicy),
+      });
+
+      const { membership } = await inviteUser({
+        project: projectWithDefault,
+        resourceType: 'Patient',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        externalId: randomUUID(),
+        accessPolicy: createReference(explicitAccessPolicy),
+        sendEmail: false,
+      });
+
+      expect(membership.accessPolicy?.reference).toBe(getReferenceString(explicitAccessPolicy));
+    })
+  );
+
+  test('Invite Patient without explicit policy and no defaultPatientAccessPolicy', () =>
+    withTestContext(async () => {
+      const { project } = await createTestProject();
+
+      const { membership } = await inviteUser({
+        project,
+        resourceType: 'Patient',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        externalId: randomUUID(),
+        sendEmail: false,
+      });
+
+      expect(membership.accessPolicy).toBeUndefined();
+    })
+  );
+
+  test('Invite Practitioner does not apply defaultPatientAccessPolicy', () =>
+    withTestContext(async () => {
+      const { project } = await createTestProject();
+      const systemRepo = await getProjectSystemRepo(project);
+      const defaultAccessPolicy = await systemRepo.createResource<AccessPolicy>({
+        resourceType: 'AccessPolicy',
+        name: 'Default Patient Policy',
+        resource: [{ resourceType: 'Patient' }],
+      });
+      const projectWithDefault = await systemRepo.updateResource({
+        ...project,
+        defaultPatientAccessPolicy: createReference(defaultAccessPolicy),
+      });
+
+      const { membership } = await inviteUser({
+        project: projectWithDefault,
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        externalId: randomUUID(),
+        sendEmail: false,
+      });
+
+      expect(membership.accessPolicy).toBeUndefined();
+    })
+  );
 });

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -337,6 +337,8 @@ async function upsertProjectMembership(
     ...request.membership,
   };
 
+  // Patients only. RelatedPerson and Practitioner invites are unchanged.
+  // Also applies on upsert when no policy is provided in the request.
   if (
     request.resourceType === 'Patient' &&
     !partialMembership.accessPolicy &&

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -337,6 +337,15 @@ async function upsertProjectMembership(
     ...request.membership,
   };
 
+  if (
+    request.resourceType === 'Patient' &&
+    !partialMembership.accessPolicy &&
+    !partialMembership.access?.length &&
+    project.defaultPatientAccessPolicy
+  ) {
+    partialMembership.accessPolicy = project.defaultPatientAccessPolicy;
+  }
+
   if (request.forceNewMembership) {
     return createProjectMembership(systemRepo, user, project, profile, partialMembership);
   }

--- a/packages/server/src/scim/utils.ts
+++ b/packages/server/src/scim/utils.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { SearchRequest, WithId } from '@medplum/core';
 import { badRequest, forbidden, getReferenceString, OperationOutcomeError, Operator } from '@medplum/core';
-import type { AccessPolicy, Project, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
+import type { Project, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
 import type { Operation } from 'rfc6902';
 import { inviteUser } from '../admin/invite';
 import { getConfig } from '../config/loader';
@@ -83,12 +83,11 @@ export async function createScimUser(
 ): Promise<ScimUser> {
   const resourceType = getScimUserResourceType(scimUser);
 
-  let accessPolicy: Reference<AccessPolicy> | undefined = undefined;
-  if (resourceType === 'Patient') {
-    accessPolicy = project.defaultPatientAccessPolicy;
-    if (!accessPolicy) {
-      throw new OperationOutcomeError(badRequest('Missing defaultPatientAccessPolicy'));
-    }
+  // SCIM Patient provisioning requires a configured default policy. inviteUser applies
+  // defaultPatientAccessPolicy for Patients automatically, but admin invite allows
+  // creating Patients without one.
+  if (resourceType === 'Patient' && !project.defaultPatientAccessPolicy) {
+    throw new OperationOutcomeError(badRequest('Missing defaultPatientAccessPolicy'));
   }
 
   const { user, membership } = await inviteUser({
@@ -100,7 +99,6 @@ export async function createScimUser(
     externalId: scimUser.externalId,
     sendEmail: false,
     membership: {
-      accessPolicy,
       invitedBy,
       userName: scimUser.userName,
     },


### PR DESCRIPTION
- Updated invite functionality to apply default patient access policy when no explicit policy is provided.
- Added tests to verify behavior for inviting patients with and without explicit access policies.
- Ensured that inviting practitioners does not apply the default patient access policy.
- `upsertProjectMembership()` flow in `invite.ts` owns the default policy assignment. 
- Removed `defaultPatientAccessPolicy` assignment in SCIM user provisioning, letting `inviteUser() > upsertProjectMembership()` flow handle it. 

This improves the handling of access policies during user invitations, ensuring consistency and expected behavior in various scenarios.

Signed-off-by: Darren Eam <darreneam65@gmail.com>