### PR TITLE
Provider: Spaces and Messages input experience updates

### DIFF
--- a/examples/medplum-provider/src/components/spaces/SpacesInbox.module.css
+++ b/examples/medplum-provider/src/components/spaces/SpacesInbox.module.css
@@ -135,6 +135,16 @@
   border-bottom-left-radius: 4px;
 }
 
+.contextBubble {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: var(--mantine-radius-xl);
+  background-color: light-dark(var(--mantine-color-blue-1), var(--mantine-color-blue-9));
+  color: light-dark(var(--mantine-color-blue-7), var(--mantine-color-blue-2));
+  max-width: 100%;
+}
+
 /* Scroll to bottom button */
 .scrollToBottomWrapper {
   position: absolute;
@@ -145,6 +155,7 @@
   justify-content: center;
   z-index: 20;
   pointer-events: none;
+  padding-bottom: var(--mantine-spacing-md);
   animation: fadeIn 0.2s ease-out;
 }
 
@@ -156,8 +167,7 @@
 /* Input Area */
 .inputArea {
   position: relative;
-  padding: var(--mantine-spacing-xl);
-  background: linear-gradient(to top, var(--mantine-color-body) 80%, rgba(255, 255, 255, 0));
+  padding: 0 var(--mantine-spacing-xl) calc(3 * var(--mantine-spacing-md));
   display: flex;
   justify-content: center;
 }
@@ -166,17 +176,19 @@
   width: 100%;
   max-width: 800px;
   position: relative;
-  background-color: var(--mantine-color-white);
-  border-radius: var(--mantine-radius-xl);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
-  border: 1px solid var(--mantine-color-gray-2);
-  padding: var(--mantine-spacing-xs);
-  transition: box-shadow 0.2s ease;
 }
 
-.inputWrapper:focus-within {
-  box-shadow: 0 4px 25px rgba(0, 0, 0, 0.1);
-  border-color: var(--mantine-color-blue-3);
+.inputDisclaimer {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: calc(3 * var(--mantine-spacing-md));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  pointer-events: none;
 }
 
 /* Resource Panel */
@@ -268,6 +280,7 @@
   background-color: var(--mantine-color-dark-9);
 }
 
+
 [data-mantine-color-scheme="dark"] .chatHeader {
   border-bottom: 1px solid var(--mantine-color-dark-6);
   background-color: rgba(26, 27, 30, 0.8);
@@ -276,15 +289,6 @@
 [data-mantine-color-scheme="dark"] .assistantMessage .messageContent {
   background-color: var(--mantine-color-dark-6);
   color: var(--mantine-color-gray-1);
-}
-
-[data-mantine-color-scheme="dark"] .inputArea {
-  background: linear-gradient(to top, var(--mantine-color-dark-9) 80%, rgba(0, 0, 0, 0));
-}
-
-[data-mantine-color-scheme="dark"] .inputWrapper {
-  background-color: var(--mantine-color-dark-7);
-  border: 1px solid var(--mantine-color-dark-4);
 }
 
 [data-mantine-color-scheme="dark"] .resourcePanel {

--- a/examples/medplum-provider/src/components/spaces/SpacesInbox.test.tsx
+++ b/examples/medplum-provider/src/components/spaces/SpacesInbox.test.tsx
@@ -131,10 +131,9 @@ describe('SpacesInbox', () => {
       });
 
       const input = screen.getByPlaceholderText('Ask, search, or make anything...');
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
 
       await user.type(input, 'Hello AI');
-      await user.click(sendButton);
+      await user.click(screen.getByRole('button', { name: 'Send message' }));
 
       await waitFor(() => {
         expect(medplum.createResource).toHaveBeenCalled();
@@ -150,14 +149,14 @@ describe('SpacesInbox', () => {
     });
 
     test('does not send empty messages', async () => {
-      const user = userEvent.setup();
-
       await act(async () => {
         setup();
       });
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
-      await user.click(sendButton);
 
+      // With an empty input there is no send button (voice mode is offered instead),
+      // so an empty message can never be submitted.
+      expect(screen.queryByRole('button', { name: 'Send message' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Start voice mode' })).toBeInTheDocument();
       expect(medplum.createResource).not.toHaveBeenCalled();
     });
 
@@ -196,10 +195,9 @@ describe('SpacesInbox', () => {
       });
 
       const input = screen.getByPlaceholderText('Ask, search, or make anything...');
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
 
       await user.type(input, 'Hello AI');
-      await user.click(sendButton);
+      await user.click(screen.getByRole('button', { name: 'Send message' }));
 
       await waitFor(() => {
         expect(screen.getByText('Hello AI')).toBeInTheDocument();
@@ -251,9 +249,8 @@ describe('SpacesInbox', () => {
       });
 
       const input = screen.getByPlaceholderText('Ask, search, or make anything...');
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
       await user.type(input, 'Get patient 123');
-      await user.click(sendButton);
+      await user.click(screen.getByRole('button', { name: 'Send message' }));
 
       await waitFor(
         () => {
@@ -305,10 +302,9 @@ describe('SpacesInbox', () => {
       });
 
       const input = screen.getByPlaceholderText('Ask, search, or make anything...');
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
 
       await user.type(input, 'Get nonexistent patient');
-      await user.click(sendButton);
+      await user.click(screen.getByRole('button', { name: 'Send message' }));
 
       await waitFor(() => {
         expect(medplum.get).toHaveBeenCalled();
@@ -362,10 +358,9 @@ describe('SpacesInbox', () => {
       });
 
       const input = screen.getByPlaceholderText('Ask, search, or make anything...');
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
 
       await user.type(input, 'Get patient');
-      await user.click(sendButton);
+      await user.click(screen.getByRole('button', { name: 'Send message' }));
 
       await waitFor(() => {
         expect(screen.getByTestId('resource-box')).toBeInTheDocument();
@@ -418,10 +413,9 @@ describe('SpacesInbox', () => {
       });
 
       const input = screen.getByPlaceholderText('Ask, search, or make anything...');
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
 
       await user.type(input, 'Get patient');
-      await user.click(sendButton);
+      await user.click(screen.getByRole('button', { name: 'Send message' }));
 
       await waitFor(() => {
         expect(screen.getByTestId('resource-box')).toBeInTheDocument();
@@ -477,10 +471,9 @@ describe('SpacesInbox', () => {
       });
 
       const input = screen.getByPlaceholderText('Ask, search, or make anything...');
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
 
       await user.type(input, 'Get patient');
-      await user.click(sendButton);
+      await user.click(screen.getByRole('button', { name: 'Send message' }));
 
       await waitFor(() => {
         expect(screen.getByTestId('resource-box')).toBeInTheDocument();
@@ -517,10 +510,9 @@ describe('SpacesInbox', () => {
       });
 
       const input = screen.getByPlaceholderText('Ask, search, or make anything...');
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
 
       await user.type(input, 'Hello AI');
-      await user.click(sendButton);
+      await user.click(screen.getByRole('button', { name: 'Send message' }));
 
       await waitFor(() => {
         expect(screen.getByText(/Error: Bot execution failed/)).toBeInTheDocument();
@@ -572,10 +564,9 @@ describe('SpacesInbox', () => {
       });
 
       const input = screen.getByPlaceholderText('Ask, search, or make anything...');
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
 
       await user.type(input, `${method} patient`);
-      await user.click(sendButton);
+      await user.click(screen.getByRole('button', { name: 'Send message' }));
 
       await waitFor(() => {
         expect((medplum as any)[clientMethod]).toHaveBeenCalled();
@@ -629,10 +620,9 @@ describe('SpacesInbox', () => {
       });
 
       const input = screen.getByPlaceholderText('Ask, search, or make anything...');
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
 
       await user.type(input, 'Search patients');
-      await user.click(sendButton);
+      await user.click(screen.getByRole('button', { name: 'Send message' }));
 
       await waitFor(() => {
         expect(medplum.get).toHaveBeenCalled();

--- a/examples/medplum-provider/src/components/spaces/SpacesInbox.tsx
+++ b/examples/medplum-provider/src/components/spaces/SpacesInbox.tsx
@@ -14,7 +14,8 @@ import {
   Text,
   ThemeIcon,
 } from '@mantine/core';
-import type { Communication, Reference } from '@medplum/fhirtypes';
+import { getDisplayString } from '@medplum/core';
+import type { Communication, DocumentReference, Patient, Reference } from '@medplum/fhirtypes';
 import { useMedplum, useResource } from '@medplum/react';
 import {
   IconArrowDown,
@@ -23,8 +24,10 @@ import {
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
   IconList,
+  IconPaperclip,
   IconPlus,
   IconRobot,
+  IconUser,
 } from '@tabler/icons-react';
 import cx from 'clsx';
 import type { JSX } from 'react';
@@ -66,6 +69,9 @@ export function SpacesInbox(props: SpaceInboxProps): JSX.Element {
   const [selectedResource, setSelectedResource] = useState<string | undefined>();
   const [selectedResources, setSelectedResources] = useState<string[] | undefined>();
   const [resourceFromComponent, setResourceFromComponent] = useState(false);
+  const [pendingFile, setPendingFile] = useState<File | undefined>(undefined);
+  const [pendingDocRef, setPendingDocRef] = useState<DocumentReference | undefined>(undefined);
+  const [selectedPatients, setSelectedPatients] = useState<Patient[]>([]);
   const [streamingContent, setStreamingContent] = useState<string | undefined>();
   const [streamingComponentCode, setStreamingComponentCode] = useState<string | undefined>();
   const [componentPanelOpen, setComponentPanelOpen] = useState(false);
@@ -202,7 +208,8 @@ export function SpacesInbox(props: SpaceInboxProps): JSX.Element {
       return;
     }
     const text = (overrideInput ?? input).trim();
-    if (!text) {
+    // A message can be sent with patient context alone, no text required
+    if (!text && selectedPatients.length === 0) {
       return;
     }
 
@@ -211,12 +218,23 @@ export function SpacesInbox(props: SpaceInboxProps): JSX.Element {
       setHasStarted(true);
     }
 
-    const userMessage: Message = { role: 'user', content: text };
+    let attachmentName: string | undefined;
+    if (pendingDocRef) {
+      attachmentName = pendingDocRef.description ?? pendingDocRef.content?.[0]?.attachment?.title ?? 'Document';
+    } else if (pendingFile) {
+      attachmentName = pendingFile.name;
+    }
+    const patientNames =
+      selectedPatients.length > 0 ? selectedPatients.map((p) => getDisplayString(p)) : undefined;
+
+    const userMessage: Message = { role: 'user', content: text, attachmentName, patientNames };
     const currentMessages = [...messages, userMessage];
     setMessages(currentMessages);
     isAtBottomRef.current = true;
     setShowScrollButton(false);
     setInput('');
+    setPendingFile(undefined);
+    setPendingDocRef(undefined);
     setCurrentFhirRequest(undefined);
     setStreamingContent(undefined);
     setComponentPreview(undefined);
@@ -237,6 +255,7 @@ export function SpacesInbox(props: SpaceInboxProps): JSX.Element {
         setRefreshKey,
         setCurrentFhirRequest,
         onNewTopic,
+        selectedPatients,
         onStreamChunk: (chunk) => {
           setStreamingContent((prev) => (prev ?? '') + chunk);
           setCurrentFhirRequest(undefined);
@@ -364,11 +383,10 @@ export function SpacesInbox(props: SpaceInboxProps): JSX.Element {
           ) : (
             <ScrollArea
               style={{ flex: 1 }}
-              offsetScrollbars
               viewportRef={scrollViewportRef}
               onScrollPositionChange={handleScrollPositionChange}
             >
-              <Stack gap="xl" p="xs">
+              <Stack gap="xl" py="xl" px={52} w="100%" maw={864} mx="auto">
                 {visibleMessages.map((message, index) => {
                   // FHIR tool calls — show each request paired with its response
                   if (message.role === 'assistant' && message.tool_calls && !message.content) {
@@ -458,6 +476,26 @@ export function SpacesInbox(props: SpaceInboxProps): JSX.Element {
                         message.role === 'user' ? classes.userMessage : classes.assistantMessage
                       )}
                     >
+                      {message.role === 'user' && message.patientNames && message.patientNames.length > 0 && (
+                        <Stack gap={4} mb={4} align="flex-end">
+                          {message.patientNames.map((name, i) => (
+                            <div key={i} className={classes.contextBubble}>
+                              <Group gap={4} wrap="nowrap">
+                                <IconUser size={12} />
+                                <Text fz="xs">{name}</Text>
+                              </Group>
+                            </div>
+                          ))}
+                        </Stack>
+                      )}
+                      {message.role === 'user' && message.attachmentName && (
+                        <div className={classes.contextBubble} style={{ marginBottom: 4 }}>
+                          <Group gap={4} wrap="nowrap">
+                            <IconPaperclip size={12} />
+                            <Text fz="xs">{message.attachmentName}</Text>
+                          </Group>
+                        </div>
+                      )}
                       {message.content && (
                         <div className={classes.messageContent}>
                           {message.role === 'assistant' ? (
@@ -605,9 +643,23 @@ export function SpacesInbox(props: SpaceInboxProps): JSX.Element {
               models={models}
               selectedModel={selectedModel}
               onModelChange={setSelectedModel}
-              backgroundColor="transparent"
+              selectedPatients={selectedPatients}
+              onAddPatient={(patient) => {
+                setSelectedPatients((prev) => {
+                  if (prev.some((p) => p.id === patient.id)) {
+                    return prev;
+                  }
+                  return [...prev, patient];
+                });
+              }}
+              onRemovePatient={(patientId) => {
+                setSelectedPatients((prev) => prev.filter((p) => p.id !== patientId));
+              }}
             />
           </div>
+          <Text size="xs" c="gray.6" className={classes.inputDisclaimer}>
+            AI models can make mistakes. Please double-check important information.
+          </Text>
         </div>
       </div>
 

--- a/examples/medplum-provider/src/components/spaces/SpacesInbox.tsx
+++ b/examples/medplum-provider/src/components/spaces/SpacesInbox.tsx
@@ -224,8 +224,7 @@ export function SpacesInbox(props: SpaceInboxProps): JSX.Element {
     } else if (pendingFile) {
       attachmentName = pendingFile.name;
     }
-    const patientNames =
-      selectedPatients.length > 0 ? selectedPatients.map((p) => getDisplayString(p)) : undefined;
+    const patientNames = selectedPatients.length > 0 ? selectedPatients.map((p) => getDisplayString(p)) : undefined;
 
     const userMessage: Message = { role: 'user', content: text, attachmentName, patientNames };
     const currentMessages = [...messages, userMessage];

--- a/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
+++ b/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
@@ -97,6 +97,7 @@ export function MessagesPage(): JSX.Element {
         inProgressUri={inProgressUri}
         completedUri={completedUri}
         uploadEnabled={true}
+        dictationEnabled={medplum.getProject()?.features?.includes('ai-realtime') ?? false}
       />
     </div>
   );

--- a/examples/medplum-provider/src/pages/patient/CommunicationTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/CommunicationTab.tsx
@@ -1,15 +1,16 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { SearchRequest } from '@medplum/core';
-import { formatSearchQuery, Operator } from '@medplum/core';
-import type { Communication } from '@medplum/fhirtypes';
-import { ThreadInbox } from '@medplum/react';
+import { formatSearchQuery, getReferenceString, Operator } from '@medplum/core';
+import type { Communication, DocumentReference, Reference } from '@medplum/fhirtypes';
+import { ThreadInbox, useMedplum } from '@medplum/react';
 import type { JSX } from 'react';
 import { useEffect, useMemo } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { normalizeCommunicationSearch } from '../../utils/communication-search';
 
 export function CommunicationTab(): JSX.Element {
+  const medplum = useMedplum();
   const { patientId, messageId } = useParams();
   const navigate = useNavigate();
   const location = useLocation();
@@ -64,6 +65,17 @@ export function CommunicationTab(): JSX.Element {
     navigate(getThreadUri(message))?.catch(console.error);
   };
 
+  const onViewInDocuments = (reference: Reference<DocumentReference>): void => {
+    medplum
+      .readReference(reference)
+      .then((docRef) => {
+        const subject = docRef.subject?.reference;
+        const path = subject ? `/${subject}/${getReferenceString(reference)}` : `/${getReferenceString(reference)}`;
+        navigate(path)?.catch(console.error);
+      })
+      .catch(console.error);
+  };
+
   return (
     <div style={{ height: '100%' }}>
       <ThreadInbox
@@ -76,6 +88,9 @@ export function CommunicationTab(): JSX.Element {
         onChange={onChange}
         inProgressUri={inProgressUri}
         completedUri={completedUri}
+        onViewInDocuments={onViewInDocuments}
+        uploadEnabled={true}
+        dictationEnabled={medplum.getProject()?.features?.includes('ai-realtime') ?? false}
       />
     </div>
   );

--- a/examples/medplum-provider/src/pages/spaces/ChatInput.module.css
+++ b/examples/medplum-provider/src/pages/spaces/ChatInput.module.css
@@ -1,0 +1,196 @@
+.chatInputBox {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid light-dark(var(--mantine-color-gray-4), var(--mantine-color-dark-4));
+  border-radius: var(--mantine-radius-lg);
+  background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-6));
+  padding-inline: 10px;
+  transition: border-color 100ms ease;
+
+  &:focus-within {
+    border-color: var(--mantine-color-blue-filled);
+  }
+}
+
+/* Voice mode keeps the focused blue border for the whole session — regardless of where the
+   user clicks — and only reverts when the Stop action ends voice mode. */
+.chatInputBox[data-voice-active] {
+  border-color: var(--mantine-color-blue-filled);
+}
+
+.chatPillsRow {
+  padding: 14px 4px 10px;
+}
+
+.chatInputBox[data-scrollable='true'] .chatPillsRow {
+  padding-bottom: 14px;
+}
+
+.chatAttachmentPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 1.75rem;
+  border: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+  border-radius: var(--mantine-radius-xl);
+  padding-inline: 4px 6px;
+  max-width: 100%;
+}
+
+.chatAttachmentPillDismiss {
+  color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-gray-5));
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
+  }
+}
+
+.chatTextareaRoot {
+  &:first-child .chatTextarea {
+    padding-top: 14px;
+  }
+}
+
+.chatTextarea {
+  border: none;
+  background: transparent;
+  padding: 0 8px calc(10px + 1lh);
+  min-height: unset;
+  font-size: var(--mantine-font-size-sm);
+  /* Hidden until real overflow: the autosize height is an integer while 1lh padding is
+     fractional, which can leave a 1-2px scrollable remainder at some zoom levels */
+  overflow-y: hidden;
+
+  &:focus {
+    border: none;
+    outline: none;
+    box-shadow: none;
+  }
+}
+
+.chatInputBox[data-scrollable='true'] .chatTextarea {
+  overflow-y: auto;
+}
+
+.chatActionBar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 0;
+}
+
+/* Listening indicator, matching the Patient Intake Questionnaire recording status */
+.listeningStatus {
+  display: flex;
+  align-items: center;
+  /* Match the patient pill: 4px group gap + 2px label margin = 6px between dot and label */
+  gap: 4px;
+  min-width: 0;
+  height: 32px;
+}
+
+.listeningDotWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  /* 16px dot with an 8px offset centers it on the Patients icon it temporarily replaces */
+  width: 16px;
+  height: 16px;
+  margin-left: 8px;
+  /* Static gray at the pulse's smallest size while connecting; turns red and pulses up once listening */
+  color: var(--mantine-color-gray-5);
+  transform: scale(0.8);
+
+  & svg {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.listeningStatus[data-state='recording'] .listeningDotWrapper {
+  color: var(--mantine-color-red-6);
+  animation: recordingPulse 2.5s ease-in-out infinite;
+}
+
+/* The brief moment a transcript auto-sends on a speech pause */
+.listeningStatus[data-state='sending'] .listeningDotWrapper {
+  color: var(--mantine-color-blue-6);
+  animation: recordingPulse 2.5s ease-in-out infinite;
+}
+
+.listeningLabel {
+  color: var(--mantine-color-gray-6);
+  white-space: nowrap;
+}
+
+@keyframes recordingPulse {
+  0%,
+  100% {
+    opacity: 0.5;
+    transform: scale(0.8);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Subtle action bar buttons: gray-0 on hover, gray-1 while their menu/popover is open.
+   No hover effect while selected. */
+.subtleActionButton {
+  /* Keep the dark-scheme icons close to white; the default "dark" subtle color is too dim on a dark-6 box.
+     !important is needed to beat Mantine's inline --ai-color; disabled state sets `color` directly so it's unaffected. */
+  --ai-color: light-dark(var(--mantine-color-dark-light-color), var(--mantine-color-dark-0)) !important;
+
+  &:hover:not(:disabled):not([data-disabled]):not([data-selected]) {
+    background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-5));
+  }
+
+  &[data-selected] {
+    background-color: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-4));
+  }
+}
+
+.modelPickerButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 32px;
+  padding-right: 12px;
+  border: none;
+  border-radius: var(--mantine-radius-xl);
+  background: transparent;
+  color: light-dark(var(--mantine-color-dark-light-color), var(--mantine-color-dark-0));
+  cursor: pointer;
+  transition: background-color 100ms ease;
+  white-space: nowrap;
+
+  &:hover:not([data-open]) {
+    background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-5));
+  }
+
+  &[data-open] {
+    background-color: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-4));
+  }
+}
+
+/* Filled send: Mantine's disabled filled styles are nearly invisible on the dark-6 input box */
+.sendActionButton:disabled,
+.sendActionButton[data-disabled] {
+  --ai-bg: light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4)) !important;
+  --ai-color: light-dark(var(--mantine-color-gray-5), var(--mantine-color-dark-1)) !important;
+  --ai-bd: light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4)) !important;
+  background-color: light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4)) !important;
+  color: light-dark(var(--mantine-color-gray-5), var(--mantine-color-dark-1)) !important;
+  opacity: 1 !important;
+}
+
+.modelMenuItem {
+  padding: calc(var(--mantine-spacing-xs) / 1.5) var(--mantine-spacing-xs);
+}

--- a/examples/medplum-provider/src/pages/spaces/ChatInput.tsx
+++ b/examples/medplum-provider/src/pages/spaces/ChatInput.tsx
@@ -171,22 +171,21 @@ export function ChatInput({
     startDictation,
     cancelDictation,
     acceptDictation,
-  } =
-    useDictation({
-      model: 'gpt-4o-transcribe',
-      getValue: () => inputRef.current,
-      setValue: (value) => {
-        inputRef.current = value;
-        onInputChange(value);
-      },
-      focusInput: () => textareaRef.current?.focus(),
-      onError: (err) => showErrorNotification(err),
-      onAppend: () => {
-        if (voiceActiveRef.current) {
-          autoSendRef.current?.();
-        }
-      },
-    });
+  } = useDictation({
+    model: 'gpt-4o-transcribe',
+    getValue: () => inputRef.current,
+    setValue: (value) => {
+      inputRef.current = value;
+      onInputChange(value);
+    },
+    focusInput: () => textareaRef.current?.focus(),
+    onError: (err) => showErrorNotification(err),
+    onAppend: () => {
+      if (voiceActiveRef.current) {
+        autoSendRef.current?.();
+      }
+    },
+  });
 
   let mode: InputMode = 'idle';
   if (voiceActive) {
@@ -563,11 +562,7 @@ export function ChatInput({
                   </ActionIcon>
                 </Tooltip>
               ) : (
-                <Tooltip
-                  label={isVoiceEnabled ? 'Voice Mode' : voiceDisabledTooltip}
-                  position="top"
-                  openDelay={100}
-                >
+                <Tooltip label={isVoiceEnabled ? 'Voice Mode' : voiceDisabledTooltip} position="top" openDelay={100}>
                   <ActionIcon
                     onClick={startVoiceMode}
                     size={32}

--- a/examples/medplum-provider/src/pages/spaces/ChatInput.tsx
+++ b/examples/medplum-provider/src/pages/spaces/ChatInput.tsx
@@ -1,15 +1,42 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { ActionIcon, Button, Group, Paper, Select, Stack, Textarea, Tooltip } from '@mantine/core';
-import { useDebouncedCallback } from '@mantine/hooks';
-import { useMedplum, useWhisper } from '@medplum/react';
-import { IconMicrophone, IconPlayerStopFilled, IconSend } from '@tabler/icons-react';
+import { ActionIcon, Group, Menu, Popover, Text, Textarea, Tooltip } from '@mantine/core';
+import { useDebouncedCallback, useDisclosure } from '@mantine/hooks';
+import { getDisplayString } from '@medplum/core';
+import type { Patient } from '@medplum/fhirtypes';
+import { ResourceAvatar, useDictation, useMedplum } from '@medplum/react';
+import {
+  IconArrowRight,
+  IconCheck,
+  IconCircleFilled,
+  IconMenu4,
+  IconMicrophone,
+  IconMicrophoneOff,
+  IconPlayerStop,
+  IconUsers,
+  IconX,
+} from '@tabler/icons-react';
 import type { JSX } from 'react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { showErrorNotification } from '../../utils/notifications';
 import type { SpaceModelOption } from '../../utils/spaceModels';
+import classes from './ChatInput.module.css';
+import { PatientPicker } from './PatientPicker';
 
 const SILENCE_AUTO_SEND_MS = 1000;
+
+function OpenAILogo({ size = 14 }: { size?: number }): JSX.Element {
+  return (
+    <svg width={size} height={size} viewBox="0 0 721 721" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M304.246 294.611V249.028C304.246 245.189 305.687 242.309 309.044 240.392L400.692 187.612C413.167 180.415 428.042 177.058 443.394 177.058C500.971 177.058 537.44 221.682 537.44 269.182C537.44 272.54 537.44 276.379 536.959 280.218L441.954 224.558C436.197 221.201 430.437 221.201 424.68 224.558L304.246 294.611ZM518.245 472.145V363.224C518.245 356.505 515.364 351.707 509.608 348.349L389.174 278.296L428.519 255.743C431.877 253.826 434.757 253.826 438.115 255.743L529.762 308.523C556.154 323.879 573.905 356.505 573.905 388.171C573.905 424.636 552.315 458.225 518.245 472.141V472.145ZM275.937 376.182L236.592 353.152C233.235 351.235 231.794 348.354 231.794 344.515V238.956C231.794 187.617 271.139 148.749 324.4 148.749C344.555 148.749 363.264 155.468 379.102 167.463L284.578 222.164C278.822 225.521 275.942 230.319 275.942 237.039V376.186L275.937 376.182ZM360.626 425.122L304.246 393.455V326.283L360.626 294.616L417.002 326.283V393.455L360.626 425.122ZM396.852 570.989C376.698 570.989 357.989 564.27 342.151 552.276L436.674 497.574C442.431 494.217 445.311 489.419 445.311 482.699V343.552L485.138 366.582C488.495 368.499 489.936 371.379 489.936 375.219V480.778C489.936 532.117 450.109 570.985 396.852 570.985V570.989ZM283.134 463.99L191.486 411.211C165.094 395.854 147.343 363.229 147.343 331.562C147.343 294.616 169.415 261.509 203.48 247.593V356.991C203.48 363.71 206.361 368.508 212.117 371.866L332.074 441.437L292.729 463.99C289.372 465.907 286.491 465.907 283.134 463.99ZM277.859 542.68C223.639 542.68 183.813 501.895 183.813 451.514C183.813 447.675 184.294 443.836 184.771 439.997L279.295 494.698C285.051 498.056 290.812 498.056 296.568 494.698L417.002 425.127V470.71C417.002 474.549 415.562 477.429 412.204 479.346L320.557 532.126C308.081 539.323 293.206 542.68 277.854 542.68H277.859ZM396.852 599.776C454.911 599.776 503.37 558.513 514.41 503.812C568.149 489.896 602.696 439.515 602.696 388.176C602.696 354.587 588.303 321.962 562.392 298.45C564.791 288.373 566.231 278.296 566.231 268.224C566.231 199.611 510.571 148.267 446.274 148.267C433.322 148.267 420.846 150.184 408.37 154.505C386.775 133.392 357.026 119.958 324.4 119.958C266.342 119.958 217.883 161.22 206.843 215.921C153.104 229.837 118.557 280.218 118.557 331.557C118.557 365.146 132.95 397.771 158.861 421.283C156.462 431.36 155.022 441.437 155.022 451.51C155.022 520.123 210.682 571.466 274.978 571.466C287.931 571.466 300.407 569.549 312.883 565.228C334.473 586.341 364.222 599.776 396.852 599.776Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+type InputMode = 'idle' | 'dictation' | 'voice';
 
 interface ChatInputProps {
   input: string;
@@ -20,7 +47,9 @@ interface ChatInputProps {
   models: SpaceModelOption[];
   selectedModel: string;
   onModelChange: (value: string) => void;
-  backgroundColor?: string;
+  selectedPatients: Patient[];
+  onAddPatient: (patient: Patient) => void;
+  onRemovePatient: (patientId: string) => void;
 }
 
 export function ChatInput({
@@ -32,10 +61,84 @@ export function ChatInput({
   models,
   selectedModel,
   onModelChange,
-  backgroundColor = '#fff',
+  selectedPatients,
+  onAddPatient,
+  onRemovePatient,
 }: ChatInputProps): JSX.Element {
   const medplum = useMedplum();
   const isVoiceEnabled = medplum.getProject()?.features?.includes('ai-realtime') ?? false;
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [modelPickerOpen, modelPickerHandlers] = useDisclosure(false);
+  const [patientPickerOpen, patientPickerHandlers] = useDisclosure(false);
+  const patientPickerDropdownRef = useRef<HTMLDivElement>(null);
+  const modelPickerDropdownRef = useRef<HTMLDivElement>(null);
+  const [scrollable, setScrollable] = useState(false);
+
+  // Track whether the textarea has grown past its max height and become scrollable
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) {
+      return undefined;
+    }
+    const raf = requestAnimationFrame(() => {
+      // 4px tolerance: sub-pixel rounding of the autosize height can leave a few stray
+      // pixels of scrollHeight; real overflow is at least a full line
+      setScrollable(el.scrollHeight > el.clientHeight + 4);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [input]);
+
+  useEffect(() => {
+    if (!patientPickerOpen) {
+      return undefined;
+    }
+    const handler = (e: MouseEvent): void => {
+      if (patientPickerDropdownRef.current && !patientPickerDropdownRef.current.contains(e.target as Node)) {
+        patientPickerHandlers.close();
+      }
+    };
+    const raf = requestAnimationFrame(() => {
+      document.addEventListener('mousedown', handler);
+    });
+    return () => {
+      cancelAnimationFrame(raf);
+      document.removeEventListener('mousedown', handler);
+    };
+  }, [patientPickerOpen, patientPickerHandlers]);
+
+  const prevPatientPickerOpen = useRef(false);
+  useEffect(() => {
+    if (prevPatientPickerOpen.current && !patientPickerOpen) {
+      textareaRef.current?.focus();
+    }
+    prevPatientPickerOpen.current = patientPickerOpen;
+  }, [patientPickerOpen]);
+
+  useEffect(() => {
+    if (!modelPickerOpen) {
+      return undefined;
+    }
+    const handler = (e: MouseEvent): void => {
+      if (modelPickerDropdownRef.current && !modelPickerDropdownRef.current.contains(e.target as Node)) {
+        modelPickerHandlers.close();
+      }
+    };
+    const raf = requestAnimationFrame(() => {
+      document.addEventListener('mousedown', handler);
+    });
+    return () => {
+      cancelAnimationFrame(raf);
+      document.removeEventListener('mousedown', handler);
+    };
+  }, [modelPickerOpen, modelPickerHandlers]);
+
+  const prevModelPickerOpen = useRef(false);
+  useEffect(() => {
+    if (prevModelPickerOpen.current && !modelPickerOpen) {
+      textareaRef.current?.focus();
+    }
+    prevModelPickerOpen.current = modelPickerOpen;
+  }, [modelPickerOpen]);
 
   const inputRef = useRef(input);
   useEffect(() => {
@@ -47,29 +150,55 @@ export function ChatInput({
     onSendRef.current = onSend;
   }, [onSend]);
 
-  // Stable handle to the debounced auto-send so onTranscript (defined before autoSend below) can
-  // arm it. Assigned in an effect once autoSend exists.
+  // Hands-free voice mode runs the same capture as dictation but auto-sends on a brief silence
+  const [voiceActive, setVoiceActive] = useState(false);
+  const voiceActiveRef = useRef(false);
+  useEffect(() => {
+    voiceActiveRef.current = voiceActive;
+  }, [voiceActive]);
+
   const autoSendRef = useRef<(() => void) | undefined>(undefined);
 
-  const { start, stop, status } = useWhisper({
-    model: 'gpt-4o-transcribe',
-    onTranscript: (text) => {
-      const trimmed = text.trim();
-      if (!trimmed) {
-        return;
-      }
-      const previous = inputRef.current.trim();
-      const next = previous ? `${previous} ${trimmed}` : trimmed;
-      inputRef.current = next;
-      onInputChange(next);
-      autoSendRef.current?.();
-    },
-  });
+  const {
+    start,
+    stop,
+    status,
+    muted,
+    setMuted,
+    isRecording,
+    interim,
+    dictating,
+    startDictation,
+    cancelDictation,
+    acceptDictation,
+  } =
+    useDictation({
+      model: 'gpt-4o-transcribe',
+      getValue: () => inputRef.current,
+      setValue: (value) => {
+        inputRef.current = value;
+        onInputChange(value);
+      },
+      focusInput: () => textareaRef.current?.focus(),
+      onError: (err) => showErrorNotification(err),
+      onAppend: () => {
+        if (voiceActiveRef.current) {
+          autoSendRef.current?.();
+        }
+      },
+    });
 
+  let mode: InputMode = 'idle';
+  if (voiceActive) {
+    mode = 'voice';
+  } else if (dictating) {
+    mode = 'dictation';
+  }
+
+  // Hands-free voice mode: send after a brief silence but keep listening
   const autoSend = useDebouncedCallback(() => {
     const pending = inputRef.current.trim();
-    stop();
-    if (pending) {
+    if (pending && voiceActiveRef.current) {
       onSendRef.current(pending);
     }
   }, SILENCE_AUTO_SEND_MS);
@@ -79,110 +208,386 @@ export function ChatInput({
   }, [autoSend]);
 
   useEffect(() => {
+    if (!voiceActiveRef.current) {
+      return;
+    }
     if (status === 'speech_stopped') {
       autoSend();
     } else if (status === 'speech_started' || status === 'listening') {
-      // User resumed talking: cancel the pending send; the next transcript or silence re-arms it.
       autoSend.cancel();
     }
   }, [status, autoSend]);
 
-  const isConnecting = status === 'requesting_microphone' || status === 'connecting' || status === 'connected';
-  const isRecording = status === 'listening' || status === 'speech_started' || status === 'speech_stopped';
-  const isActive = isConnecting || isRecording;
-
-  const handleVoiceToggle = (): void => {
-    if (isActive) {
-      autoSend.cancel();
-      const pending = inputRef.current.trim();
-      stop();
-      if (pending) {
-        onSend(pending);
-      }
-    } else {
-      start().catch(showErrorNotification);
-    }
+  const startVoiceMode = (): void => {
+    setMuted(false);
+    setVoiceActive(true);
+    start().catch((err) => {
+      setVoiceActive(false);
+      showErrorNotification(err);
+    });
   };
 
-  let voiceTooltip = 'Start voice input';
-  if (!isVoiceEnabled) {
-    voiceTooltip = 'Voice input is not enabled in this project. Add the "ai-realtime" feature to enable it.';
-  } else if (isActive) {
-    voiceTooltip = `Stop voice input (${status})`;
+  const stopVoiceMode = (): void => {
+    autoSend.cancel();
+    stop();
+    setVoiceActive(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent): void => {
+    // Voice mode owns sending via the silence auto-send; ignore Enter to avoid double-sends
+    if (voiceActive) {
+      e.preventDefault();
+      return;
+    }
+    // Enter during dictation accepts the dictated text before the parent sends it
+    if (dictating && e.key === 'Enter' && !e.shiftKey) {
+      acceptDictation();
+    }
+    onKeyDown(e);
+  };
+
+  const voiceDisabledTooltip = 'Voice input is not enabled. Add the "ai-realtime" feature to enable it.';
+  // In voice mode, a buffered transcript sitting in the input after a pause is about to auto-send.
+  // Tying this to the input value means "Sending…" clears the instant the send empties the textarea.
+  const sending = mode === 'voice' && status === 'speech_stopped' && input.trim().length > 0;
+  // Muting in voice mode pauses listening: show the gray "connecting" dot and a paused label
+  const paused = mode === 'voice' && muted;
+  let listeningState = 'connecting';
+  let listeningLabel = 'Connecting…';
+  if (paused) {
+    listeningLabel = 'Listening Paused…';
+  } else if (sending) {
+    listeningState = 'sending';
+    listeningLabel = 'Waiting to Send…';
+  } else if (isRecording) {
+    listeningState = 'recording';
+    listeningLabel = 'Listening…';
+  }
+
+  const selectedModelLabel = models.find((m) => m.value === selectedModel)?.label ?? selectedModel;
+
+  let inputPlaceholder = 'Ask, search, or make anything...';
+  if (mode === 'voice') {
+    inputPlaceholder = 'Start speaking—your transcribed words will appear here and then send when you pause.';
+  } else if (mode === 'dictation') {
+    inputPlaceholder = 'Start speaking—your transcribed words will appear here.';
+  }
+
+  // In voice mode, preview the live partial transcript appended after the committed text so the
+  // spoken words show up immediately, before the finalized chunk is committed and auto-sent.
+  let displayValue = input;
+  if (mode === 'voice' && interim) {
+    displayValue = input ? `${input} ${interim}` : interim;
   }
 
   return (
-    <Paper p="md" radius="lg" withBorder style={{ backgroundColor }}>
-      <Stack gap="sm">
-        <Group gap="md" wrap="nowrap" align="flex-end">
-          <Textarea
-            placeholder="Ask, search, or make anything..."
-            value={input}
-            onChange={(e) => onInputChange(e.currentTarget.value)}
-            onKeyDown={onKeyDown}
-            disabled={loading}
-            autosize
-            minRows={1}
-            maxRows={5}
-            style={{ flex: 1 }}
-            styles={{
-              input: {
-                border: 'none',
-                backgroundColor: 'transparent',
-                fontSize: '15px',
-                padding: 0,
-                resize: 'none',
-              },
-            }}
-          />
-          <Tooltip label={voiceTooltip}>
-            <ActionIcon
-              aria-label={isActive ? 'Stop voice input' : 'Start voice input'}
-              radius="xl"
-              size="lg"
-              variant="filled"
-              color={isRecording ? 'red' : undefined}
-              onClick={handleVoiceToggle}
-              disabled={loading || isConnecting || !isVoiceEnabled}
-              loading={isConnecting}
-              data-disabled={!isVoiceEnabled || undefined}
-              bg="#7c3aed"
-              style={!isVoiceEnabled ? { pointerEvents: 'auto' } : undefined}
-            >
-              {isRecording ? <IconPlayerStopFilled size={18} /> : <IconMicrophone size={18} />}
-            </ActionIcon>
-          </Tooltip>
-          <Button
-            aria-label="Send message"
-            radius="xl"
-            size="sm"
-            onClick={() => onSend()}
-            disabled={loading || !input.trim()}
-            w="36px"
-            h="36px"
-            bg="#7c3aed"
-            p={0}
-          >
-            <IconSend size={18} />
-          </Button>
+    <div
+      className={classes.chatInputBox}
+      data-scrollable={scrollable ? 'true' : undefined}
+      data-voice-active={mode === 'voice' ? 'true' : undefined}
+      onMouseDown={(e: React.MouseEvent) => {
+        const target = e.target as HTMLElement;
+        if (
+          !(target instanceof HTMLTextAreaElement) &&
+          !(target instanceof HTMLInputElement) &&
+          !target.closest('button')
+        ) {
+          e.preventDefault();
+          textareaRef.current?.focus();
+        }
+      }}
+    >
+      {selectedPatients.length > 0 && (
+        <Group gap={6} wrap="wrap" className={classes.chatPillsRow}>
+          {selectedPatients.map((patient) => {
+            const patientName = getDisplayString(patient);
+            return (
+              <div key={patient.id} className={classes.chatAttachmentPill}>
+                <ResourceAvatar value={patient} size={18} radius="xl" />
+                <Text fz="xs" ml={2}>
+                  {patientName}
+                </Text>
+                <span
+                  className={classes.chatAttachmentPillDismiss}
+                  role="button"
+                  tabIndex={0}
+                  onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                  onClick={() => {
+                    onRemovePatient(patient.id as string);
+                    textareaRef.current?.focus();
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      onRemovePatient(patient.id as string);
+                      textareaRef.current?.focus();
+                    }
+                  }}
+                  aria-label={`Remove ${patientName}`}
+                >
+                  <IconX size={12} />
+                </span>
+              </div>
+            );
+          })}
         </Group>
-        <Select
-          size="xs"
-          data={models}
-          value={selectedModel}
-          onChange={(value) => onModelChange(value ?? models[0]?.value)}
-          w="170px"
-          withCheckIcon={false}
-          fw={500}
-          pr="md"
-          styles={{
-            input: {
-              fontSize: '12px',
-              cursor: 'pointer',
-            },
-          }}
-        />
-      </Stack>
-    </Paper>
+      )}
+      <Textarea
+        ref={textareaRef}
+        placeholder={inputPlaceholder}
+        value={displayValue}
+        onChange={(e) => onInputChange(e.currentTarget.value)}
+        onKeyDown={handleKeyDown}
+        readOnly={mode === 'voice'}
+        autoFocus
+        autosize
+        minRows={1}
+        maxRows={5}
+        classNames={{ root: classes.chatTextareaRoot, input: classes.chatTextarea }}
+      />
+      <div className={classes.chatActionBar}>
+        <Group gap={8}>
+          {mode !== 'idle' ? (
+            <div className={classes.listeningStatus} data-state={listeningState}>
+              <span className={classes.listeningDotWrapper} aria-hidden>
+                <IconCircleFilled size={16} />
+              </span>
+              <Text fz="xs" fw={400} ml={2} className={classes.listeningLabel} aria-live="polite">
+                {listeningLabel}
+              </Text>
+            </div>
+          ) : (
+            /* Patient picker */
+            <Popover opened={patientPickerOpen} position="top-start" shadow="md" radius="md">
+              <Popover.Target>
+                <Tooltip label="Patients" position="top" openDelay={100} disabled={patientPickerOpen}>
+                  <ActionIcon
+                    onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                    onClick={() => {
+                      if (patientPickerOpen) {
+                        patientPickerHandlers.close();
+                      } else {
+                        patientPickerHandlers.open();
+                      }
+                    }}
+                    size={32}
+                    radius="xl"
+                    color="dark"
+                    variant="subtle"
+                    className={classes.subtleActionButton}
+                    data-selected={patientPickerOpen || undefined}
+                    aria-label="Patients"
+                    aria-haspopup="menu"
+                    aria-expanded={patientPickerOpen}
+                  >
+                    <IconUsers size={16} stroke={2} />
+                  </ActionIcon>
+                </Tooltip>
+              </Popover.Target>
+              <Popover.Dropdown
+                ref={patientPickerDropdownRef}
+                p={4}
+                miw={240}
+                onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+              >
+                <Menu>
+                  <PatientPicker
+                    excludeIds={selectedPatients.map((p) => p.id as string)}
+                    onSelect={(patient) => {
+                      onAddPatient(patient);
+                      patientPickerHandlers.close();
+                    }}
+                  />
+                </Menu>
+              </Popover.Dropdown>
+            </Popover>
+          )}
+        </Group>
+
+        <Group gap={8}>
+          {mode === 'voice' && (
+            <>
+              <Tooltip label={muted ? 'Unmute' : 'Mute'} position="top" openDelay={100}>
+                <ActionIcon
+                  onClick={() => setMuted(!muted)}
+                  size={32}
+                  radius="xl"
+                  color="dark"
+                  variant="subtle"
+                  className={classes.subtleActionButton}
+                  aria-label={muted ? 'Unmute' : 'Mute'}
+                >
+                  {muted ? (
+                    <IconMicrophoneOff size={16} stroke={2} color="var(--mantine-color-red-6)" />
+                  ) : (
+                    <IconMicrophone size={16} stroke={2} />
+                  )}
+                </ActionIcon>
+              </Tooltip>
+              <Tooltip label="Stop" position="top" openDelay={100}>
+                <ActionIcon
+                  onClick={stopVoiceMode}
+                  size={32}
+                  radius="xl"
+                  color="blue"
+                  variant="filled"
+                  aria-label="Stop voice mode"
+                >
+                  <IconPlayerStop size={16} stroke={2} />
+                </ActionIcon>
+              </Tooltip>
+            </>
+          )}
+          {mode === 'dictation' && (
+            <>
+              <Tooltip label="Cancel" position="top" openDelay={100}>
+                <ActionIcon
+                  onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                  onClick={cancelDictation}
+                  size={32}
+                  radius="xl"
+                  color="dark"
+                  variant="subtle"
+                  className={classes.subtleActionButton}
+                  aria-label="Cancel dictation"
+                >
+                  <IconX size={16} stroke={2} />
+                </ActionIcon>
+              </Tooltip>
+              <Tooltip label="Accept" position="top" openDelay={100}>
+                <ActionIcon
+                  onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                  onClick={acceptDictation}
+                  size={32}
+                  radius="xl"
+                  color="blue"
+                  variant="filled"
+                  aria-label="Accept dictated text"
+                >
+                  <IconCheck size={16} stroke={2} />
+                </ActionIcon>
+              </Tooltip>
+            </>
+          )}
+          {mode === 'idle' && (
+            <>
+              {/* Model selector */}
+              <Popover opened={modelPickerOpen} position="top-end" shadow="md" radius="md">
+                <Popover.Target>
+                  <Tooltip label="Model" position="top" openDelay={100} disabled={modelPickerOpen}>
+                    <button
+                      type="button"
+                      className={classes.modelPickerButton}
+                      data-open={modelPickerOpen || undefined}
+                      aria-haspopup="menu"
+                      aria-expanded={modelPickerOpen}
+                      onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                      onClick={() => {
+                        if (modelPickerOpen) {
+                          modelPickerHandlers.close();
+                        } else {
+                          modelPickerHandlers.open();
+                        }
+                      }}
+                    >
+                      <OpenAILogo size={24} />
+                      <Text fz="sm" fw={450} lh={1}>
+                        {selectedModelLabel}
+                      </Text>
+                    </button>
+                  </Tooltip>
+                </Popover.Target>
+                <Popover.Dropdown ref={modelPickerDropdownRef} p={4} miw={180}>
+                  <Menu>
+                    <Menu.Label style={{ padding: 'calc(var(--mantine-spacing-xs) / 2) var(--mantine-spacing-xs)' }}>
+                      Model
+                    </Menu.Label>
+                    {models.map((model) => (
+                      <Menu.Item
+                        key={model.value}
+                        className={classes.modelMenuItem}
+                        rightSection={
+                          model.value === selectedModel ? (
+                            <IconCheck size={16} color="var(--mantine-color-blue-6)" />
+                          ) : null
+                        }
+                        onClick={() => {
+                          onModelChange(model.value);
+                          modelPickerHandlers.close();
+                        }}
+                      >
+                        <Group gap={4} wrap="nowrap">
+                          <OpenAILogo size={24} />
+                          <Text size="sm">{model.label}</Text>
+                        </Group>
+                      </Menu.Item>
+                    ))}
+                  </Menu>
+                </Popover.Dropdown>
+              </Popover>
+
+              {/* Dictation */}
+              <Tooltip label={isVoiceEnabled ? 'Dictate' : voiceDisabledTooltip} position="top" openDelay={100}>
+                <ActionIcon
+                  onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                  onClick={startDictation}
+                  size={32}
+                  radius="xl"
+                  color="dark"
+                  variant="subtle"
+                  className={classes.subtleActionButton}
+                  aria-label="Dictate"
+                  disabled={loading || !isVoiceEnabled}
+                  data-disabled={!isVoiceEnabled || undefined}
+                  style={!isVoiceEnabled ? { pointerEvents: 'auto' } : undefined}
+                >
+                  <IconMicrophone size={16} stroke={2} />
+                </ActionIcon>
+              </Tooltip>
+
+              {/* Send / voice mode slot: voice mode when the input is empty, send once there is text.
+                      The send button is disabled while loading, but the textarea stays editable.
+                      A selected patient is sendable context on its own, so it also shows Send. */}
+              {input.trim() || selectedPatients.length > 0 ? (
+                <Tooltip label="Send" position="top" openDelay={100}>
+                  <ActionIcon
+                    onClick={() => onSend()}
+                    size={32}
+                    radius="xl"
+                    color="blue"
+                    variant="filled"
+                    className={classes.sendActionButton}
+                    aria-label="Send message"
+                    disabled={loading}
+                  >
+                    <IconArrowRight size={16} stroke={2} />
+                  </ActionIcon>
+                </Tooltip>
+              ) : (
+                <Tooltip
+                  label={isVoiceEnabled ? 'Voice Mode' : voiceDisabledTooltip}
+                  position="top"
+                  openDelay={100}
+                >
+                  <ActionIcon
+                    onClick={startVoiceMode}
+                    size={32}
+                    radius="xl"
+                    color="dark"
+                    variant="subtle"
+                    className={classes.subtleActionButton}
+                    aria-label="Start voice mode"
+                    disabled={loading || !isVoiceEnabled}
+                    data-disabled={!isVoiceEnabled || undefined}
+                    style={!isVoiceEnabled ? { pointerEvents: 'auto' } : undefined}
+                  >
+                    <IconMenu4 size={16} stroke={2} style={{ transform: 'rotate(90deg)' }} />
+                  </ActionIcon>
+                </Tooltip>
+              )}
+            </>
+          )}
+        </Group>
+      </div>
+    </div>
   );
 }

--- a/examples/medplum-provider/src/pages/spaces/PatientPicker.test.tsx
+++ b/examples/medplum-provider/src/pages/spaces/PatientPicker.test.tsx
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { MantineProvider, Menu } from '@mantine/core';
+import type { Patient } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { PatientPicker } from './PatientPicker';
+
+vi.mock('../../utils/notifications', () => ({
+  showErrorNotification: vi.fn(),
+}));
+
+const homer: Patient = { resourceType: 'Patient', id: 'p-homer', name: [{ given: ['Homer'], family: 'Simpson' }] };
+const marge: Patient = { resourceType: 'Patient', id: 'p-marge', name: [{ given: ['Marge'], family: 'Simpson' }] };
+
+describe('PatientPicker', () => {
+  let medplum: MockClient;
+  let searchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    medplum = new MockClient();
+    searchSpy = vi.fn().mockResolvedValue([homer, marge]);
+    medplum.searchResources = searchSpy as unknown as typeof medplum.searchResources;
+  });
+
+  function setup(props: Partial<Parameters<typeof PatientPicker>[0]> = {}): void {
+    render(
+      <MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <MantineProvider>
+            <Menu opened>
+              <PatientPicker onSelect={vi.fn()} {...props} />
+            </Menu>
+          </MantineProvider>
+        </MedplumProvider>
+      </MemoryRouter>
+    );
+  }
+
+  test('lists patients and calls onSelect when one is clicked', async () => {
+    const onSelect = vi.fn();
+    await act(async () => setup({ onSelect }));
+
+    expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
+    expect(screen.getByText('Marge Simpson')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Homer Simpson'));
+    expect(onSelect).toHaveBeenCalledWith(homer);
+  });
+
+  test('excludes patients listed in excludeIds', async () => {
+    await act(async () => setup({ excludeIds: ['p-homer'] }));
+
+    expect(await screen.findByText('Marge Simpson')).toBeInTheDocument();
+    expect(screen.queryByText('Homer Simpson')).not.toBeInTheDocument();
+  });
+
+  test('shows empty state when no patients are returned', async () => {
+    searchSpy.mockResolvedValue([]);
+    await act(async () => setup());
+
+    expect(await screen.findByText(/no patients found/i)).toBeInTheDocument();
+  });
+
+  test('searches by name as the user types', async () => {
+    await act(async () => setup());
+    await screen.findByText('Homer Simpson');
+
+    const input = screen.getByPlaceholderText('Search patients...');
+    fireEvent.change(input, { target: { value: 'Marge' } });
+
+    await waitFor(() => {
+      const searchedByName = searchSpy.mock.calls.some(
+        ([, params]) => params instanceof URLSearchParams && params.get('name') === 'Marge'
+      );
+      expect(searchedByName).toBe(true);
+    });
+  });
+
+  test('surfaces an error notification when the search fails', async () => {
+    const { showErrorNotification } = await import('../../utils/notifications');
+    const error = new Error('network down');
+    searchSpy.mockRejectedValueOnce(error);
+    await act(async () => setup());
+
+    await waitFor(() => {
+      expect(showErrorNotification).toHaveBeenCalledWith(error);
+    });
+    expect(await screen.findByText(/no patients found/i)).toBeInTheDocument();
+  });
+});

--- a/examples/medplum-provider/src/pages/spaces/PatientPicker.tsx
+++ b/examples/medplum-provider/src/pages/spaces/PatientPicker.tsx
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Box, Loader, Menu, Stack, Text, TextInput, Tooltip } from '@mantine/core';
+import { useDebouncedCallback } from '@mantine/hooks';
+import { getDisplayString } from '@medplum/core';
+import type { Patient } from '@medplum/fhirtypes';
+import { ResourceAvatar, useMedplum } from '@medplum/react';
+import type { JSX } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { showErrorNotification } from '../../utils/notifications';
+
+const MAX_RESULTS = 5;
+
+export interface PatientPickerProps {
+  readonly excludeIds?: string[];
+  readonly onSelect: (patient: Patient) => void;
+}
+
+export function PatientPicker({ excludeIds, onSelect }: PatientPickerProps): JSX.Element {
+  const medplum = useMedplum();
+  const [search, setSearch] = useState('');
+  const [patients, setPatients] = useState<Patient[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const excludeSet = useMemo(() => new Set(excludeIds ?? []), [excludeIds]);
+
+  const loadPatients = useCallback(
+    async (query: string) => {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams();
+        params.set('_sort', '-_lastUpdated');
+        params.set('_count', String(MAX_RESULTS + (excludeIds?.length ?? 0)));
+        const trimmed = query.trim();
+        if (trimmed) {
+          params.set('name', trimmed);
+        }
+        const results = await medplum.searchResources('Patient', params);
+        setPatients([...results]);
+      } catch (err) {
+        showErrorNotification(err);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [medplum, excludeIds?.length]
+  );
+
+  const debouncedLoadPatients = useDebouncedCallback((query: string) => {
+    // loadPatients handles its own errors internally; the catch only satisfies no-floating-promises
+    loadPatients(query).catch(() => undefined);
+  }, 300);
+
+  const mountedRef = useRef(false);
+  useEffect(() => {
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      loadPatients(search).catch(() => undefined);
+    } else {
+      debouncedLoadPatients(search);
+    }
+  }, [search, loadPatients, debouncedLoadPatients]);
+
+  const filteredPatients = useMemo(
+    () => patients.filter((p) => !excludeSet.has(p.id as string)).slice(0, MAX_RESULTS),
+    [patients, excludeSet]
+  );
+
+  const searchRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    requestAnimationFrame(() => searchRef.current?.focus());
+  }, []);
+
+  const stopEvents = {
+    onClick: (e: React.MouseEvent) => e.stopPropagation(),
+    onMouseDown: (e: React.MouseEvent) => e.stopPropagation(),
+  };
+
+  return (
+    <Stack gap={0}>
+      <Menu.Label style={{ padding: 'calc(var(--mantine-spacing-xs) / 2) var(--mantine-spacing-xs)' }}>Patients</Menu.Label>
+      {loading ? (
+        <Box py="sm" style={{ display: 'flex', justifyContent: 'center' }}>
+          <Loader size="xs" />
+        </Box>
+      ) : (
+        <Stack gap={0}>
+          {filteredPatients.map((patient) => {
+            const displayName = getDisplayString(patient);
+            return (
+              <Tooltip key={patient.id} label={displayName} disabled={displayName.length <= 28} openDelay={400} position="top">
+                <Menu.Item
+                  leftSection={<ResourceAvatar value={patient} size={24} radius="xl" />}
+                  onClick={() => onSelect(patient)}
+                  style={{ padding: 'calc(var(--mantine-spacing-xs) / 1.5) var(--mantine-spacing-xs)' }}
+                >
+                  <Text fz="sm" truncate>
+                    {displayName}
+                  </Text>
+                </Menu.Item>
+              </Tooltip>
+            );
+          })}
+          {filteredPatients.length === 0 && (
+            <Text fz="sm" c="dimmed" px="sm" py="xs">
+              No patients found
+            </Text>
+          )}
+        </Stack>
+      )}
+      <Box px="xs" pt={8} pb="xs" {...stopEvents}>
+        <TextInput
+          ref={searchRef}
+          placeholder="Search patients..."
+          size="sm"
+          value={search}
+          onChange={(e) => setSearch(e.currentTarget.value)}
+          onKeyDown={(e) => e.stopPropagation()}
+        />
+      </Box>
+    </Stack>
+  );
+}

--- a/examples/medplum-provider/src/pages/spaces/PatientPicker.tsx
+++ b/examples/medplum-provider/src/pages/spaces/PatientPicker.tsx
@@ -78,7 +78,9 @@ export function PatientPicker({ excludeIds, onSelect }: PatientPickerProps): JSX
 
   return (
     <Stack gap={0}>
-      <Menu.Label style={{ padding: 'calc(var(--mantine-spacing-xs) / 2) var(--mantine-spacing-xs)' }}>Patients</Menu.Label>
+      <Menu.Label style={{ padding: 'calc(var(--mantine-spacing-xs) / 2) var(--mantine-spacing-xs)' }}>
+        Patients
+      </Menu.Label>
       {loading ? (
         <Box py="sm" style={{ display: 'flex', justifyContent: 'center' }}>
           <Loader size="xs" />
@@ -88,7 +90,13 @@ export function PatientPicker({ excludeIds, onSelect }: PatientPickerProps): JSX
           {filteredPatients.map((patient) => {
             const displayName = getDisplayString(patient);
             return (
-              <Tooltip key={patient.id} label={displayName} disabled={displayName.length <= 28} openDelay={400} position="top">
+              <Tooltip
+                key={patient.id}
+                label={displayName}
+                disabled={displayName.length <= 28}
+                openDelay={400}
+                position="top"
+              >
                 <Menu.Item
                   leftSection={<ResourceAvatar value={patient} size={24} radius="xl" />}
                   onClick={() => onSelect(patient)}

--- a/examples/medplum-provider/src/types/spaces.ts
+++ b/examples/medplum-provider/src/types/spaces.ts
@@ -8,4 +8,6 @@ export interface Message {
   tool_call_id?: string;
   resources?: string[];
   componentCode?: string;
+  attachmentName?: string;
+  patientNames?: string[];
 }

--- a/examples/medplum-provider/src/utils/spaceMessaging.ts
+++ b/examples/medplum-provider/src/utils/spaceMessaging.ts
@@ -2,7 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { MedplumClient } from '@medplum/core';
 import { getReferenceString, isNotFound, OperationOutcomeError } from '@medplum/core';
-import type { Bundle, Communication, DocumentReference, Identifier, Patient, Resource, ResourceType } from '@medplum/fhirtypes';
+import type {
+  Bundle,
+  Communication,
+  DocumentReference,
+  Identifier,
+  Patient,
+  Resource,
+  ResourceType,
+} from '@medplum/fhirtypes';
 import type { useMedplum } from '@medplum/react';
 import type { Message } from '../types/spaces';
 import { createConversationTopic, saveMessage } from './spacePersistence';

--- a/examples/medplum-provider/src/utils/spaceMessaging.ts
+++ b/examples/medplum-provider/src/utils/spaceMessaging.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { MedplumClient } from '@medplum/core';
 import { getReferenceString, isNotFound, OperationOutcomeError } from '@medplum/core';
-import type { Bundle, Communication, Identifier, Resource, ResourceType } from '@medplum/fhirtypes';
+import type { Bundle, Communication, DocumentReference, Identifier, Patient, Resource, ResourceType } from '@medplum/fhirtypes';
 import type { useMedplum } from '@medplum/react';
 import type { Message } from '../types/spaces';
 import { createConversationTopic, saveMessage } from './spacePersistence';
@@ -358,6 +358,9 @@ export interface ProcessMessageParams {
   onStreamChunk?: (chunk: string) => void;
   onComponentStart?: () => void;
   onComponentStreamChunk?: (chunk: string) => void;
+  selectedPatients?: Patient[];
+  pendingDocRef?: DocumentReference;
+  pendingFile?: File;
 }
 
 export interface ProcessMessageResult {
@@ -382,6 +385,7 @@ export async function processMessage(params: ProcessMessageParams): Promise<Proc
     onStreamChunk,
     onComponentStart,
     onComponentStreamChunk,
+    selectedPatients,
   } = params;
 
   // Create topic on first message
@@ -397,6 +401,19 @@ export async function processMessage(params: ProcessMessageParams): Promise<Proc
   // Save user message
   if (activeTopicId) {
     await saveMessage(medplum, activeTopicId, userMessage, currentMessages.length - 1);
+  }
+
+  if (selectedPatients && selectedPatients.length > 0) {
+    const patientLines = selectedPatients.map((p) => {
+      const name = p.name?.[0];
+      const displayName = name ? `${name.given?.join(' ') ?? ''} ${name.family ?? ''}`.trim() : 'Unknown';
+      return `- ${displayName} (${getReferenceString(p)})`;
+    });
+    const patientContext: Message = {
+      role: 'system',
+      content: `The user has pre-selected the following patient(s) for this request. Use these patient references when the request involves a patient and do not ask which patient:\n${patientLines.join('\n')}`,
+    };
+    currentMessages.push(patientContext);
   }
 
   const MAX_AGENT_ITERATIONS = 10;

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -3,6 +3,7 @@
 export * from './MedplumProvider/MedplumProvider';
 export * from './MedplumProvider/MedplumProvider.context';
 export * from './useCachedBinaryUrl/useCachedBinaryUrl';
+export * from './useDictation/useDictation';
 export * from './useMedicationIFrame/useMedicationIFrame';
 export * from './useMedicationOrder/useMedicationOrder';
 export * from './useMedicationOrderSet/useMedicationOrderSet';

--- a/packages/react-hooks/src/useDictation/useDictation.test.tsx
+++ b/packages/react-hooks/src/useDictation/useDictation.test.tsx
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { act, renderHook } from '@testing-library/react';
+import type { UseWhisperOptions, UseWhisperResult, WhisperStatus } from '../useWhisper/useWhisper';
+import { useWhisper } from '../useWhisper/useWhisper';
+import { useDictation } from './useDictation';
+
+vi.mock('../useWhisper/useWhisper', () => ({
+  useWhisper: vi.fn(),
+}));
+
+const mockedUseWhisper = vi.mocked(useWhisper);
+
+/**
+ * Controls the mocked useWhisper so tests can drive transcripts and capture state.
+ */
+let lastOnTranscript: ((text: string) => void) | undefined;
+let lastOnInterimTranscript: ((text: string) => void) | undefined;
+let lastModel: string | undefined;
+let startMock: ReturnType<typeof vi.fn>;
+let stopMock: ReturnType<typeof vi.fn>;
+let setMutedMock: ReturnType<typeof vi.fn>;
+let whisperState: { status: WhisperStatus; muted: boolean; isListening: boolean };
+
+function applyWhisperMock(): void {
+  mockedUseWhisper.mockImplementation((options: UseWhisperOptions): UseWhisperResult => {
+    lastOnTranscript = options.onTranscript;
+    lastOnInterimTranscript = options.onInterimTranscript;
+    lastModel = options.model;
+    return {
+      status: whisperState.status,
+      error: undefined,
+      transcripts: [],
+      start: startMock as unknown as () => Promise<void>,
+      stop: stopMock as unknown as () => void,
+      isListening: whisperState.isListening,
+      muted: whisperState.muted,
+      setMuted: setMutedMock as unknown as (value: boolean) => void,
+    };
+  });
+}
+
+beforeEach(() => {
+  lastOnTranscript = undefined;
+  lastOnInterimTranscript = undefined;
+  lastModel = undefined;
+  startMock = vi.fn().mockResolvedValue(undefined);
+  stopMock = vi.fn();
+  setMutedMock = vi.fn();
+  whisperState = { status: 'idle', muted: false, isListening: false };
+  applyWhisperMock();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+/**
+ * Renders useDictation against a mutable string value, mimicking a controlled input.
+ *
+ * @param initial - The initial input value.
+ * @param extra - Extra useDictation options.
+ * @param extra.onError - Error callback invoked when start fails.
+ * @param extra.onAppend - Called after each transcript chunk is appended.
+ * @param extra.model - Whisper model passed through.
+ * @returns The hook result plus a `ref` exposing the current value and focus calls.
+ */
+function setup(
+  initial = '',
+  extra: { onError?: (err: unknown) => void; onAppend?: (value: string) => void; model?: string } = {}
+): {
+  result: { current: ReturnType<typeof useDictation> };
+  ref: { value: string; focusCount: number };
+  rerender: () => void;
+} {
+  const ref = { value: initial, focusCount: 0 };
+  const { result, rerender } = renderHook(() =>
+    useDictation({
+      getValue: () => ref.value,
+      setValue: (value) => {
+        ref.value = value;
+      },
+      focusInput: () => {
+        ref.focusCount += 1;
+      },
+      ...extra,
+    })
+  );
+  return { result, ref, rerender };
+}
+
+describe('useDictation', () => {
+  test('startDictation snapshots value, sets dictating, starts whisper', () => {
+    const { result } = setup('hello');
+    expect(result.current.dictating).toBe(false);
+    act(() => result.current.startDictation());
+    expect(result.current.dictating).toBe(true);
+    expect(startMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('passes default model to useWhisper', () => {
+    setup('');
+    expect(lastModel).toBe('gpt-4o-transcribe');
+  });
+
+  test('appends transcripts to the existing value with a space', () => {
+    const onAppend = vi.fn();
+    const { result, ref } = setup('hello', { onAppend });
+    act(() => result.current.startDictation());
+    act(() => lastOnTranscript?.('world'));
+    expect(ref.value).toBe('hello world');
+    expect(onAppend).toHaveBeenCalledWith('hello world');
+    act(() => lastOnTranscript?.('again'));
+    expect(ref.value).toBe('hello world again');
+  });
+
+  test('uses the transcript alone when the input was empty', () => {
+    const { result, ref } = setup('');
+    act(() => result.current.startDictation());
+    act(() => lastOnTranscript?.('  fresh start  '));
+    expect(ref.value).toBe('fresh start');
+  });
+
+  test('ignores empty/whitespace-only transcripts', () => {
+    const onAppend = vi.fn();
+    const { result, ref } = setup('keep', { onAppend });
+    act(() => result.current.startDictation());
+    act(() => lastOnTranscript?.('   '));
+    expect(ref.value).toBe('keep');
+    expect(onAppend).not.toHaveBeenCalled();
+  });
+
+  test('cancelDictation restores the pre-dictation value and stops', async () => {
+    const { result, ref } = setup('original');
+    act(() => result.current.startDictation());
+    act(() => lastOnTranscript?.('dictated text'));
+    expect(ref.value).toBe('original dictated text');
+    act(() => result.current.cancelDictation());
+    expect(ref.value).toBe('original');
+    expect(stopMock).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
+    expect(result.current.dictating).toBe(false);
+    expect(ref.focusCount).toBe(1);
+  });
+
+  test('acceptDictation keeps the dictated value and stops', async () => {
+    const { result, ref } = setup('original');
+    act(() => result.current.startDictation());
+    act(() => lastOnTranscript?.('dictated text'));
+    act(() => result.current.acceptDictation());
+    expect(ref.value).toBe('original dictated text');
+    expect(stopMock).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
+    expect(result.current.dictating).toBe(false);
+    expect(ref.focusCount).toBe(1);
+  });
+
+  test('resets dictating and reports error when start fails', async () => {
+    const onError = vi.fn();
+    const error = new Error('microphone denied');
+    startMock.mockRejectedValueOnce(error);
+    const { result } = setup('', { onError });
+    await act(async () => {
+      result.current.startDictation();
+      await Promise.resolve();
+    });
+    expect(result.current.dictating).toBe(false);
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+
+  test('exposes recording state and mute controls from useWhisper', () => {
+    whisperState = { status: 'listening', muted: true, isListening: true };
+    applyWhisperMock();
+    const { result } = setup('');
+    expect(result.current.isRecording).toBe(true);
+    expect(result.current.status).toBe('listening');
+    expect(result.current.muted).toBe(true);
+    act(() => result.current.setMuted(false));
+    expect(setMutedMock).toHaveBeenCalledWith(false);
+  });
+
+  test('exposes the streamed interim transcript and clears it when capture stops', () => {
+    whisperState = { status: 'listening', muted: false, isListening: true };
+    applyWhisperMock();
+    const { result, rerender } = setup('');
+    expect(result.current.interim).toBe('');
+
+    act(() => lastOnInterimTranscript?.('hello wor'));
+    expect(result.current.interim).toBe('hello wor');
+
+    // Capture stops -> the live preview is dropped
+    whisperState = { status: 'idle', muted: false, isListening: false };
+    applyWhisperMock();
+    rerender();
+    expect(result.current.interim).toBe('');
+  });
+
+  test('low-level start/stop are the whisper controls (no dictating toggle)', () => {
+    const { result } = setup('');
+    act(() => {
+      result.current.start().catch(() => undefined);
+    });
+    expect(startMock).toHaveBeenCalledTimes(1);
+    expect(result.current.dictating).toBe(false);
+    act(() => result.current.stop());
+    expect(stopMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-hooks/src/useDictation/useDictation.ts
+++ b/packages/react-hooks/src/useDictation/useDictation.ts
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { WhisperStatus } from '../useWhisper/useWhisper';
+import { useWhisper } from '../useWhisper/useWhisper';
+
+export interface UseDictationOptions {
+  /**
+   * Read the input's current text. Snapshotted when dictation starts (to restore on cancel)
+   * and used as the base each transcript chunk is appended to.
+   */
+  getValue: () => string;
+  /** Write text back to the input (the appended transcript, or the snapshot on cancel). */
+  setValue: (value: string) => void;
+  /** Refocus the input after dictation stops. */
+  focusInput?: () => void;
+  /** Transcription model passed to {@link useWhisper}. Defaults to `gpt-4o-transcribe`. */
+  model?: string;
+  /** Surface an error when starting capture fails. */
+  onError?: (err: unknown) => void;
+  /** Fired after each transcript chunk is appended, with the resulting full value. */
+  onAppend?: (value: string) => void;
+}
+
+export interface UseDictationResult {
+  /** True while a dictation session started via `startDictation` is active. */
+  dictating: boolean;
+  /** True once the mic is live and capturing (listening / speech started / speech stopped). */
+  isRecording: boolean;
+  /**
+   * Live partial transcript of the in-progress utterance, streamed in before it finalizes and is
+   * appended via `setValue`. Empty between utterances and once capture stops. Use it to render a
+   * preview of what the speaker is saying ahead of the committed text.
+   */
+  interim: string;
+  status: WhisperStatus;
+  muted: boolean;
+  setMuted: (value: boolean) => void;
+  /** Snapshot the current value and begin dictating. */
+  startDictation: () => void;
+  /** Stop and restore the value captured when dictation started. */
+  cancelDictation: () => void;
+  /** Stop and keep the dictated text. */
+  acceptDictation: () => void;
+  /**
+   * Low-level capture controls for building custom modes on top of dictation (e.g. a hands-free
+   * voice mode that auto-sends). These do not toggle `dictating` or snapshot the value.
+   */
+  start: () => Promise<void>;
+  stop: () => void;
+}
+
+/**
+ * Shared chat dictation behavior: wraps {@link useWhisper} to append transcribed speech into a
+ * text input, snapshotting the pre-dictation value so it can be restored on cancel. Works with
+ * both controlled inputs (via `getValue`/`setValue` over state) and uncontrolled ones (via the
+ * native value setter).
+ *
+ * @param options - The dictation options.
+ * @returns The dictation controls and state.
+ */
+export function useDictation(options: UseDictationOptions): UseDictationResult {
+  const { model = 'gpt-4o-transcribe' } = options;
+
+  // Keep the latest callbacks in a ref so the returned functions stay stable and the transcript
+  // handler always reads current values without re-subscribing useWhisper or forcing callers to memoize.
+  const optionsRef = useRef(options);
+  useEffect(() => {
+    optionsRef.current = options;
+  });
+
+  const [dictating, setDictating] = useState(false);
+  // Live partial transcript for the current utterance, before it finalizes into the value
+  const [interim, setInterim] = useState('');
+  // Value captured when dictation started, restored on cancel
+  const preDictationValueRef = useRef('');
+
+  const { start, stop, status, muted, setMuted, isListening } = useWhisper({
+    model,
+    onTranscript: (text) => {
+      const trimmed = text.trim();
+      if (!trimmed) {
+        return;
+      }
+      const previous = optionsRef.current.getValue().trim();
+      const next = previous ? `${previous} ${trimmed}` : trimmed;
+      optionsRef.current.setValue(next);
+      optionsRef.current.onAppend?.(next);
+    },
+    onInterimTranscript: setInterim,
+  });
+
+  // Drop any lingering preview once capture stops (stop/cancel/accept all settle here).
+  useEffect(() => {
+    if (!isListening) {
+      setInterim('');
+    }
+  }, [isListening]);
+
+  const startDictation = useCallback(() => {
+    preDictationValueRef.current = optionsRef.current.getValue();
+    setDictating(true);
+    start().catch((err) => {
+      setDictating(false);
+      optionsRef.current.onError?.(err);
+    });
+  }, [start]);
+
+  const exitDictationUi = useCallback(() => {
+    // Defer leaving dictation mode until after the current pointer/click event finishes.
+    // Otherwise Accept is replaced by Send (type="submit") mid-click and the release can submit the form.
+    setTimeout(() => {
+      setDictating(false);
+      optionsRef.current.focusInput?.();
+    }, 0);
+  }, []);
+
+  const cancelDictation = useCallback(() => {
+    stop();
+    optionsRef.current.setValue(preDictationValueRef.current);
+    exitDictationUi();
+  }, [stop, exitDictationUi]);
+
+  const acceptDictation = useCallback(() => {
+    stop();
+    exitDictationUi();
+  }, [stop, exitDictationUi]);
+
+  return {
+    dictating,
+    isRecording: isListening,
+    interim,
+    status,
+    muted,
+    setMuted,
+    startDictation,
+    cancelDictation,
+    acceptDictation,
+    start,
+    stop,
+  };
+}

--- a/packages/react-hooks/src/useWhisper/useWhisper.test.tsx
+++ b/packages/react-hooks/src/useWhisper/useWhisper.test.tsx
@@ -204,6 +204,79 @@ describe('useWhisper', () => {
     expect(result.current.isListening).toBe(true);
   });
 
+  test('streams interim transcripts and clears them on speech start and completion', async () => {
+    const wsServer = new WS('wss://example.com/ws/ai-realtime', { jsonProtocol: true });
+
+    const stream = { getTracks: () => [{ stop: vi.fn() }] } as unknown as MediaStream;
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+    });
+
+    mockAudioContext();
+
+    const interim: string[] = [];
+    const onTranscript = vi.fn();
+    const { result } = renderHook(() => useWhisper({ onTranscript, onInterimTranscript: (t) => interim.push(t) }), {
+      wrapper,
+    });
+
+    await startListening(result, wsServer);
+
+    // A new utterance clears any leftover interim text
+    await act(async () => {
+      wsServer.send({ type: 'input_audio_buffer.speech_started' });
+    });
+
+    // Deltas accumulate into a cumulative interim preview
+    await act(async () => {
+      wsServer.send({ type: 'conversation.item.input_audio_transcription.delta', delta: 'hel' });
+      wsServer.send({ type: 'conversation.item.input_audio_transcription.delta', delta: 'lo' });
+    });
+
+    // Completion clears the interim and emits the final transcript
+    await act(async () => {
+      wsServer.send({ type: 'conversation.item.input_audio_transcription.completed', transcript: 'hello' });
+    });
+
+    await waitFor(() => expect(onTranscript).toHaveBeenCalledWith('hello'));
+    expect(interim).toContain('hel');
+    expect(interim).toContain('hello');
+    expect(interim.at(-1)).toBe('');
+  });
+
+  test('mute toggles the audio track and resets on stop', async () => {
+    const wsServer = new WS('wss://example.com/ws/ai-realtime', { jsonProtocol: true });
+
+    const track = { stop: vi.fn(), enabled: true };
+    const stream = { getTracks: () => [track], getAudioTracks: () => [track] } as unknown as MediaStream;
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+    });
+
+    mockAudioContext();
+
+    const { result } = renderHook(() => useWhisper({}), { wrapper });
+
+    await startListening(result, wsServer);
+    expect(result.current.muted).toBe(false);
+
+    act(() => result.current.setMuted(true));
+    await waitFor(() => expect(result.current.muted).toBe(true));
+    expect(track.enabled).toBe(false);
+
+    act(() => result.current.setMuted(false));
+    await waitFor(() => expect(result.current.muted).toBe(false));
+    expect(track.enabled).toBe(true);
+
+    // Stopping capture resets the muted state for the next session
+    act(() => result.current.setMuted(true));
+    await waitFor(() => expect(result.current.muted).toBe(true));
+    act(() => result.current.stop());
+    await waitFor(() => expect(result.current.muted).toBe(false));
+  });
+
   test('handles ai-realtime:error message from server', async () => {
     const wsServer = new WS('wss://example.com/ws/ai-realtime', { jsonProtocol: true });
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/react-hooks/src/useWhisper/useWhisper.ts
+++ b/packages/react-hooks/src/useWhisper/useWhisper.ts
@@ -26,6 +26,13 @@ export type UseWhisperOptions = {
   model?: string;
   onTranscript?: (text: string) => void;
   /**
+   * Called with the partial transcript of the in-progress utterance as it streams in, before the
+   * final `onTranscript` fires. The argument is the full interim text so far (cumulative),
+   * or an empty string once the utterance finalizes. Use it to show a live preview of what the
+   * speaker is saying. Not all models emit deltas; when none arrive this simply never fires.
+   */
+  onInterimTranscript?: (text: string) => void;
+  /**
    * How long to keep the WebSocket warm after stop() before fully closing it, in milliseconds.
    * Defaults to 120000 (2 minutes). Set to 0 or a non-finite value to keep the socket warm
    * until unmount (the previous behavior).
@@ -44,12 +51,15 @@ export type UseWhisperResult = {
   start: () => Promise<void>;
   stop: () => void;
   isListening: boolean;
+  muted: boolean;
+  setMuted: (value: boolean) => void;
 };
 
 export function useWhisper({
   language = 'en',
   model = 'gpt-4o-transcribe',
   onTranscript,
+  onInterimTranscript,
   idleTimeoutMs = DEFAULT_IDLE_TIMEOUT_MS,
 }: UseWhisperOptions): UseWhisperResult {
   const medplum = useMedplum();
@@ -57,6 +67,12 @@ export function useWhisper({
   useEffect(() => {
     onTranscriptRef.current = onTranscript;
   }, [onTranscript]);
+  const onInterimTranscriptRef = useRef(onInterimTranscript);
+  useEffect(() => {
+    onInterimTranscriptRef.current = onInterimTranscript;
+  }, [onInterimTranscript]);
+  // Accumulates streamed delta text for the current utterance; cleared when it finalizes.
+  const interimRef = useRef('');
   const [status, setStatus] = useState<WhisperStatus>('idle');
   const [error, setError] = useState<unknown>(undefined);
   const [transcripts, setTranscripts] = useState<TranscriptItem[]>([]);
@@ -68,6 +84,18 @@ export function useWhisper({
   const startingCaptureRef = useRef(false);
   const sessionReadyRef = useRef(false);
   const capturingRef = useRef(false);
+  const [muted, setMutedState] = useState(false);
+  const mutedRef = useRef(false);
+
+  // Mute/unmute by toggling the captured mic track; keeps the warm session and worklet running
+  // (a disabled track emits silence, so the server VAD simply hears nothing).
+  const setMuted = useCallback((value: boolean) => {
+    mutedRef.current = value;
+    setMutedState(value);
+    audioStreamRef.current?.getAudioTracks().forEach((track) => {
+      track.enabled = !value;
+    });
+  }, []);
 
   // Stop capturing audio and release the microphone, but leave the WebSocket + OpenAI
   // session warm so the next start() can reuse them. This is the user-facing `stop`.
@@ -82,6 +110,10 @@ export function useWhisper({
 
     audioStreamRef.current?.getTracks().forEach((track) => track.stop());
     audioStreamRef.current = undefined;
+
+    // Each capture session starts unmuted
+    mutedRef.current = false;
+    setMutedState(false);
 
     setStatus(websocketRef.current ? 'idle' : 'disconnected');
   }, []);
@@ -226,6 +258,9 @@ export function useWhisper({
           break;
 
         case 'input_audio_buffer.speech_started':
+          // New utterance: drop any interim text left over from the previous one.
+          interimRef.current = '';
+          onInterimTranscriptRef.current?.('');
           setStatus('speech_started');
           break;
 
@@ -233,8 +268,19 @@ export function useWhisper({
           setStatus('speech_stopped');
           break;
 
+        case 'conversation.item.input_audio_transcription.delta':
+        case 'input_audio_transcription.delta':
+          if (message.delta) {
+            interimRef.current += message.delta;
+            onInterimTranscriptRef.current?.(interimRef.current);
+          }
+          break;
+
         case 'conversation.item.input_audio_transcription.completed':
         case 'input_audio_transcription.completed':
+          // The utterance finalized: clear the interim preview before emitting the final text.
+          interimRef.current = '';
+          onInterimTranscriptRef.current?.('');
           if (message.transcript) {
             const item = {
               text: message.transcript,
@@ -373,6 +419,8 @@ export function useWhisper({
     start,
     stop: stopCapture,
     isListening: status === 'listening' || status === 'speech_started' || status === 'speech_stopped',
+    muted,
+    setMuted,
   };
 }
 

--- a/packages/react/src/chat/BaseChat/BaseChat.dictation.test.tsx
+++ b/packages/react/src/chat/BaseChat/BaseChat.dictation.test.tsx
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Notifications } from '@mantine/notifications';
+import { createReference, getReferenceString } from '@medplum/core';
+import { DrAliceSmith, HomerSimpson, MockClient } from '@medplum/mock';
+import { MedplumProvider, useWhisper } from '@medplum/react-hooks';
+import type { JSX } from 'react';
+import { useState } from 'react';
+import { MemoryRouter } from 'react-router';
+import type { Mock } from 'vitest';
+import { act, fireEvent, render, screen } from '../../test-utils/render';
+import type { BaseChatProps } from './BaseChat';
+import { BaseChat } from './BaseChat';
+
+// Replace useWhisper with a controllable mock while keeping useDictation and the rest of react-hooks real.
+vi.mock(import('@medplum/react-hooks'), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useWhisper: vi.fn(),
+  };
+});
+
+const mockUseWhisper = useWhisper as unknown as Mock;
+
+type WhisperStatus =
+  | 'idle'
+  | 'requesting_microphone'
+  | 'connecting'
+  | 'connected'
+  | 'listening'
+  | 'speech_started'
+  | 'speech_stopped'
+  | 'disconnected'
+  | 'error';
+
+let whisper: {
+  setStatus: (status: WhisperStatus) => void;
+  emitTranscript: (text: string) => void;
+  start: Mock;
+  stop: Mock;
+};
+
+let startMock: Mock;
+let stopMock: Mock;
+
+function setupWhisperMock(): void {
+  let status: WhisperStatus = 'idle';
+  let onTranscript: ((text: string) => void) | undefined;
+  startMock = vi.fn().mockImplementation(async () => {
+    status = 'listening';
+    whisper.setStatus(status);
+  });
+  stopMock = vi.fn().mockImplementation(() => {
+    status = 'idle';
+    whisper.setStatus(status);
+  });
+  whisper = {
+    setStatus: (next: WhisperStatus) => {
+      status = next;
+      mockUseWhisper.mockImplementation((options) => {
+        if (options?.onTranscript) {
+          onTranscript = options.onTranscript;
+        }
+        return {
+          status,
+          error: undefined,
+          transcripts: [],
+          start: startMock,
+          stop: stopMock,
+          isListening: status === 'listening' || status === 'speech_started',
+          muted: false,
+          setMuted: vi.fn(),
+        };
+      });
+    },
+    emitTranscript: (text: string) => onTranscript?.(text),
+    start: startMock,
+    stop: stopMock,
+  };
+  mockUseWhisper.mockImplementation((options) => {
+    onTranscript = options.onTranscript;
+    return {
+      status,
+      error: undefined,
+      transcripts: [],
+      start: startMock,
+      stop: stopMock,
+      isListening: status === 'listening' || status === 'speech_started',
+      muted: false,
+      setMuted: vi.fn(),
+    };
+  });
+}
+
+const homerReference = createReference(HomerSimpson);
+const drAliceReference = createReference(DrAliceSmith);
+const QUERY = `sender=${getReferenceString(homerReference)},${getReferenceString(drAliceReference)}&recipient=${getReferenceString(homerReference)},${getReferenceString(drAliceReference)}`;
+
+function TestComponent(props: Omit<BaseChatProps, 'communications' | 'setCommunications'>): JSX.Element {
+  const [communications, setCommunications] = useState<BaseChatProps['communications']>([]);
+  return <BaseChat {...props} communications={communications} setCommunications={setCommunications} />;
+}
+
+async function setup(props: Omit<BaseChatProps, 'communications' | 'setCommunications'>): Promise<void> {
+  const medplum = new MockClient({ profile: DrAliceSmith });
+  await act(async () =>
+    render(<TestComponent {...props} />, ({ children }) => (
+      <MemoryRouter>
+        <Notifications />
+        <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
+      </MemoryRouter>
+    ))
+  );
+}
+
+async function startDictationWithText(text: string): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /dictate/i }));
+    await Promise.resolve();
+  });
+  act(() => {
+    whisper.emitTranscript(text);
+  });
+}
+
+describe('BaseChat dictation accept', () => {
+  beforeEach(() => {
+    setupWhisperMock();
+  });
+
+  test('Clicking Accept confirms the dictated text without sending', async () => {
+    const sendMessage = vi.fn();
+    await setup({ title: 'Test Chat', query: QUERY, sendMessage, dictationEnabled: true });
+    await startDictationWithText('dictated but not ready to send');
+
+    const acceptButton = screen.getByRole('button', { name: /accept dictated text/i });
+    expect(acceptButton).toHaveAttribute('type', 'button');
+
+    await act(async () => {
+      fireEvent.click(acceptButton);
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /send message/i })).toBeInTheDocument();
+  });
+
+  test('Accept does not send when the Send button replaces Accept mid-click', async () => {
+    const sendMessage = vi.fn();
+    await setup({ title: 'Test Chat', query: QUERY, sendMessage, dictationEnabled: true });
+    await startDictationWithText('dictated but not ready to send');
+
+    const acceptButton = screen.getByRole('button', { name: /accept dictated text/i });
+    fireEvent.mouseDown(acceptButton);
+    fireEvent.click(acceptButton);
+    fireEvent.mouseUp(acceptButton);
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('Enter during dictation accepts without sending', async () => {
+    const sendMessage = vi.fn();
+    await setup({ title: 'Test Chat', query: QUERY, sendMessage, dictationEnabled: true });
+    await startDictationWithText('dictated but not ready to send');
+
+    const chatInput = screen.getByPlaceholderText('Start speaking—your transcribed words will appear here.');
+    act(() => {
+      fireEvent.keyDown(chatInput, { key: 'Enter', code: 'Enter' });
+    });
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /send message/i })).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/chat/BaseChat/BaseChat.module.css
+++ b/packages/react/src/chat/BaseChat/BaseChat.module.css
@@ -22,24 +22,183 @@
 }
 
 .chatScrollArea {
-  padding: var(--mantine-spacing-xs);
+  padding: 0 var(--mantine-spacing-lg);
+}
+
+.chatScrollAreaViewport {
+  padding-top: var(--mantine-spacing-lg);
 }
 
 .chatInputContainer {
-  background-color: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
   flex-shrink: 0;
-  padding: 6px 8px;
-  position: relative;
+  padding-block: var(--mantine-spacing-lg);
+  margin-inline: var(--mantine-spacing-lg);
+  border-top: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
 }
 
-.chatPendingFile {
-  position: absolute;
-  bottom: 100%;
-  left: 0;
-  right: 0;
-  background-color: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
-  border-top: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-3));
-  padding: 4px 8px;
+.chatInputBox {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid light-dark(var(--mantine-color-gray-4), var(--mantine-color-dark-4));
+  border-radius: var(--mantine-radius-lg);
+  background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-6));
+  padding-inline: 10px;
+  transition: border-color 100ms ease;
+
+  &:focus-within {
+    border-color: var(--mantine-color-blue-filled);
+  }
+
+  &[data-disabled] {
+    background-color: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
+    border-color: light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+
+    &:focus-within {
+      border-color: light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+    }
+  }
+}
+
+.chatAttachmentPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 1.75rem;
+  border: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+  border-radius: var(--mantine-radius-xl);
+  padding-inline: 8px 6px;
+  max-width: 100%;
+  align-self: flex-start;
+  margin: 14px 4px 10px;
+}
+
+.chatInputBox[data-scrollable='true'] .chatAttachmentPill {
+  margin-bottom: 14px;
+}
+
+.chatAttachmentPillDismiss {
+  color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-gray-5));
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
+  }
+}
+
+.chatTextareaRoot {
+  /* When textarea is first child (no pill), add scrollable top padding */
+  &:first-child .chatTextarea {
+    padding-top: 14px;
+  }
+}
+
+.chatTextarea {
+  border: none;
+  background: transparent;
+  padding: 0 8px;
+  min-height: unset;
+
+  &:focus {
+    border: none;
+    outline: none;
+    box-shadow: none;
+  }
+
+  /* The disabled gray comes from the outer box; keep the textarea itself transparent */
+  &:disabled {
+    background: transparent;
+    opacity: 1;
+    color: var(--mantine-color-placeholder);
+  }
+}
+
+.chatActionBar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 0;
+}
+
+/* Subtle action bar buttons: gray-0 on hover, gray-1 while their menu/popover is open.
+   No hover effect while selected. */
+.subtleActionButton {
+  /* Keep the dark-scheme icons close to white; the default "dark" subtle color is too dim on a dark-6 box.
+     !important is needed to beat Mantine's inline --ai-color; disabled state sets `color` directly so it's unaffected. */
+  --ai-color: light-dark(var(--mantine-color-dark-light-color), var(--mantine-color-dark-0)) !important;
+
+  &:hover:not(:disabled):not([data-disabled]):not([data-selected]) {
+    background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-5));
+  }
+
+  &[data-selected] {
+    background-color: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-4));
+  }
+}
+
+/* Filled send: Mantine's disabled filled styles are nearly invisible on the dark-6 input box */
+.sendActionButton:disabled,
+.sendActionButton[data-disabled] {
+  --ai-bg: light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4)) !important;
+  --ai-color: light-dark(var(--mantine-color-gray-5), var(--mantine-color-dark-1)) !important;
+  --ai-bd: light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4)) !important;
+  background-color: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5)) !important;
+  color: light-dark(var(--mantine-color-gray-5), var(--mantine-color-dark-3)) !important;
+  opacity: 1 !important;
+}
+
+/* Listening indicator, matching the Patient Intake Questionnaire recording status */
+.listeningStatus {
+  display: flex;
+  align-items: center;
+  /* Match the patient pill: 4px group gap + 2px label margin = 6px between dot and label */
+  gap: 4px;
+  min-width: 0;
+  height: 32px;
+}
+
+.listeningDotWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  /* 16px dot with an 8px offset centers it on the paperclip icon it temporarily replaces */
+  width: 16px;
+  height: 16px;
+  margin-left: 8px;
+  /* Static gray at the pulse's smallest size while connecting; turns red and pulses up once listening */
+  color: var(--mantine-color-gray-5);
+  transform: scale(0.8);
+
+  & svg {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.listeningStatus[data-state='recording'] .listeningDotWrapper {
+  color: var(--mantine-color-red-6);
+  animation: recordingPulse 2.5s ease-in-out infinite;
+}
+
+.listeningLabel {
+  color: var(--mantine-color-gray-6);
+  white-space: nowrap;
+}
+
+@keyframes recordingPulse {
+  0%,
+  100% {
+    opacity: 0.5;
+    transform: scale(0.8);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .chatBubbleOuterWrap {
@@ -79,16 +238,6 @@
   text-align: right;
 }
 
-.chatPendingFile {
-  position: absolute;
-  bottom: 100%;
-  left: 0;
-  right: 0;
-  background-color: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
-  border-top: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-3));
-  padding: 4px 8px;
-}
-
 .chatBubbleAttachmentWithText {
   margin-top: 6px;
 }
@@ -99,6 +248,44 @@
   align-items: center;
 }
 
-.chatBubbleMenu {
-  align-self: center;
+.chatBubbleAttachmentRowLeft {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--mantine-spacing-xs);
+  margin-bottom: 4px;
+}
+
+.chatBubbleAttachmentRowRight {
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: center;
+  gap: var(--mantine-spacing-xs);
+  margin-bottom: 4px;
+}
+
+.chatBubbleMenuInline {
+  flex-shrink: 0;
+}
+
+.chatBubbleMenuItem {
+  padding-inline: var(--mantine-spacing-sm);
+  padding-inline-end: var(--mantine-spacing-lg);
+  padding-block: var(--mantine-spacing-xs);
+}
+
+/* Rounded hover highlight on the attach menu options */
+.attachMenuDropdown :global(.mantine-Menu-item) {
+  border-radius: 4px;
+}
+
+.truncatedMenuItem {
+  overflow: hidden;
+
+  & :global(.mantine-Menu-itemLabel) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
 }

--- a/packages/react/src/chat/BaseChat/BaseChat.module.css
+++ b/packages/react/src/chat/BaseChat/BaseChat.module.css
@@ -77,6 +77,9 @@
 }
 
 .chatAttachmentPillDismiss {
+  background: none;
+  border: none;
+  padding: 0;
   color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-gray-5));
   cursor: pointer;
   display: flex;

--- a/packages/react/src/chat/BaseChat/BaseChat.stories.tsx
+++ b/packages/react/src/chat/BaseChat/BaseChat.stories.tsx
@@ -59,15 +59,7 @@ export const Basic = (): JSX.Element => {
   );
 };
 
-export const DeliveredTimestamps = (): JSX.Element => {
-  const sent1 = new Date();
-  const received1 = new Date(sent1);
-  received1.setMilliseconds(sent1.getMilliseconds() + 100);
-  const sent2 = new Date(sent1);
-  sent2.setSeconds(sent1.getSeconds() + 1);
-  const received2 = new Date(sent2);
-  received2.setMilliseconds(sent2.getMilliseconds() + 100);
-
+export const WithAttachments = (): JSX.Element => {
   return (
     <Document>
       <div style={{ width: 360, height: 400, margin: '0 auto' }}>
@@ -81,25 +73,71 @@ export const DeliveredTimestamps = (): JSX.Element => {
               sender: createReference(DrAliceSmith),
               recipient: [createReference(HomerSimpson)],
               status: 'completed',
-              payload: [
-                { contentString: 'Hi, Homer. Can you come in to discuss treatment for your radiation poisoning?' },
-              ],
-              sent: sent1.toISOString(),
-              received: received1.toISOString(),
+              payload: [{ contentString: 'Click the paperclip to attach a document — or open one of these:' }],
+              sent: new Date().toISOString(),
             },
             {
+              // Inline file attachment: shows the attachment chip + an "Open in Browser" menu
               id: 'message-2',
               resourceType: 'Communication',
-              sender: createReference(HomerSimpson),
-              recipient: [createReference(DrAliceSmith)],
+              sender: createReference(DrAliceSmith),
+              recipient: [createReference(HomerSimpson)],
               status: 'completed',
-              payload: [{ contentString: 'Aww, not again... Doh!' }],
-              sent: sent2.toISOString(),
-              received: received2.toISOString(),
+              payload: [
+                {
+                  contentAttachment: {
+                    title: 'lab-results.pdf',
+                    url: 'https://example.com/lab-results.pdf',
+                    contentType: 'application/pdf',
+                  },
+                },
+              ],
+              sent: new Date().toISOString(),
+            },
+            {
+              // DocumentReference attachment: adds an "Open in Documents" menu item via onViewInDocuments
+              id: 'message-3',
+              resourceType: 'Communication',
+              sender: createReference(DrAliceSmith),
+              recipient: [createReference(HomerSimpson)],
+              status: 'completed',
+              payload: [{ contentReference: { reference: 'DocumentReference/care-plan', display: 'Care Plan' } }],
+              sent: new Date().toISOString(),
             },
           ]}
           setCommunications={() => undefined}
           sendMessage={() => undefined}
+          uploadEnabled
+          attachmentSubjectRef={createReference(HomerSimpson)}
+          onViewInDocuments={() => undefined}
+        />
+      </div>
+    </Document>
+  );
+};
+
+export const WithDictation = (): JSX.Element => {
+  return (
+    <Document>
+      <div style={{ width: 360, height: 400, margin: '0 auto' }}>
+        <BaseChat
+          title="Chat with Homer Simpson"
+          query={`sender=${getReferenceString(HomerSimpson)},${getReferenceString(DrAliceSmith)}&recipient=${getReferenceString(HomerSimpson)},${getReferenceString(DrAliceSmith)}`}
+          communications={[
+            {
+              id: 'message-1',
+              resourceType: 'Communication',
+              sender: createReference(DrAliceSmith),
+              recipient: [createReference(HomerSimpson)],
+              status: 'completed',
+              payload: [{ contentString: 'Tap the microphone to dictate a reply (requires the ai-realtime feature).' }],
+              sent: new Date().toISOString(),
+            },
+          ]}
+          setCommunications={() => undefined}
+          sendMessage={() => undefined}
+          uploadEnabled
+          dictationEnabled
         />
       </div>
     </Document>

--- a/packages/react/src/chat/BaseChat/BaseChat.test.tsx
+++ b/packages/react/src/chat/BaseChat/BaseChat.test.tsx
@@ -697,6 +697,46 @@ describe('BaseChat', () => {
     expect(screen.getByRole('button', { name: /attach file/i })).toBeInTheDocument();
   });
 
+  test('dictationEnabled defaults to false - no dictate button shown', async () => {
+    await setup({
+      title: 'Test Chat',
+      query: HOMER_DR_ALICE_CHAT_QUERY,
+      sendMessage: () => undefined,
+    });
+    expect(screen.queryByRole('button', { name: /dictate/i })).not.toBeInTheDocument();
+  });
+
+  test('dictationEnabled shows dictate button', async () => {
+    await setup({
+      title: 'Test Chat',
+      query: HOMER_DR_ALICE_CHAT_QUERY,
+      sendMessage: () => undefined,
+      dictationEnabled: true,
+    });
+    expect(screen.getByRole('button', { name: /dictate/i })).toBeInTheDocument();
+  });
+
+  test('Clicking the dictate button does not submit/send the form', async () => {
+    // The non-send buttons must be type="button"; otherwise they default to submit inside the
+    // form and send the current input. (Same root cause as the dictation Accept button sending.)
+    const sendMessage = vi.fn();
+    await setup({
+      title: 'Test Chat',
+      query: HOMER_DR_ALICE_CHAT_QUERY,
+      sendMessage,
+      dictationEnabled: true,
+    });
+
+    const chatInput = screen.getByPlaceholderText('Type a message...');
+    act(() => {
+      fireEvent.change(chatInput, { target: { value: 'draft text, not ready to send' } });
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /dictate/i }));
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   test('Messages with contentAttachment show filename and icon', async () => {
     const medplum = new MockClient({ profile: DrAliceSmith });
     medplum.setSubscriptionManager(defaultSubManager);
@@ -758,7 +798,7 @@ describe('BaseChat', () => {
 
     await setup({ title: 'Test Chat', query: HOMER_DR_ALICE_CHAT_QUERY, sendMessage: () => undefined }, medplum);
 
-    expect(await screen.findByRole('button', { name: /attachment options/i })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /open attachment/i })).toBeInTheDocument();
   });
 
   test('3-dots menu does not appear for text-only messages', async () => {
@@ -773,7 +813,7 @@ describe('BaseChat', () => {
     });
 
     expect(await screen.findByText('Hello, Medplum!')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /attachment options/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /open attachment/i })).not.toBeInTheDocument();
   });
 
   test('onViewInDocuments called when View in Documents clicked', async () => {
@@ -798,10 +838,10 @@ describe('BaseChat', () => {
       medplum
     );
 
-    const menuButton = await screen.findByRole('button', { name: /attachment options/i });
+    const menuButton = await screen.findByRole('button', { name: /open attachment/i });
     await act(() => fireEvent.click(menuButton));
 
-    const viewItem = await screen.findByRole('menuitem', { name: /view in documents/i });
+    const viewItem = await screen.findByRole('menuitem', { name: /open in documents/i });
     await act(() => fireEvent.click(viewItem));
 
     expect(onViewInDocuments).toHaveBeenCalledWith(createReference(docRef));
@@ -820,10 +860,10 @@ describe('BaseChat', () => {
 
     await setup({ title: 'Test Chat', query: HOMER_DR_ALICE_CHAT_QUERY, sendMessage: () => undefined }, medplum);
 
-    const menuButton = await screen.findByRole('button', { name: /attachment options/i });
+    const menuButton = await screen.findByRole('button', { name: /open attachment/i });
     await act(() => fireEvent.click(menuButton));
 
-    const downloadItem = await screen.findByRole('menuitem', { name: /download/i });
+    const downloadItem = await screen.findByRole('menuitem', { name: /open in browser/i });
     await act(() => fireEvent.click(downloadItem));
 
     expect(mockOpen).toHaveBeenCalledWith('https://example.com/file.pdf', '_blank', 'noopener,noreferrer');
@@ -843,10 +883,10 @@ describe('BaseChat', () => {
 
     await setup({ title: 'Test Chat', query: HOMER_DR_ALICE_CHAT_QUERY, sendMessage: () => undefined }, medplum);
 
-    const menuButton = await screen.findByRole('button', { name: /attachment options/i });
+    const menuButton = await screen.findByRole('button', { name: /open attachment/i });
     await act(() => fireEvent.click(menuButton));
 
-    const downloadItem = await screen.findByRole('menuitem', { name: /download/i });
+    const downloadItem = await screen.findByRole('menuitem', { name: /open in browser/i });
     await act(() => fireEvent.click(downloadItem));
 
     expect(mockOpen).not.toHaveBeenCalled();

--- a/packages/react/src/chat/BaseChat/BaseChat.test.tsx
+++ b/packages/react/src/chat/BaseChat/BaseChat.test.tsx
@@ -737,6 +737,77 @@ describe('BaseChat', () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  test('Selecting a recent document shows a removable attachment pill', async () => {
+    await defaultMedplum.createResource<DocumentReference>({
+      resourceType: 'DocumentReference',
+      status: 'current',
+      description: 'Lab summary',
+      content: [{ attachment: { title: 'lab.pdf', url: 'https://example.com/lab.pdf' } }],
+    });
+
+    await setup({
+      title: 'Test Chat',
+      query: HOMER_DR_ALICE_CHAT_QUERY,
+      sendMessage: () => undefined,
+      uploadEnabled: true,
+    });
+
+    // Open the attach menu and drill into the recent-documents view
+    await act(() => fireEvent.click(screen.getByRole('button', { name: /attach file/i })));
+    const recentItem = await screen.findByText('Recent Documents');
+    await act(() => fireEvent.click(recentItem));
+
+    // Pick the document; a pill with its name should appear in the input box
+    const docItem = await screen.findByText('Lab summary');
+    await act(() => fireEvent.click(docItem));
+    expect(await screen.findByText('Lab summary')).toBeInTheDocument();
+
+    // Remove the attachment via keyboard (Enter on the dismiss control); the pill should disappear
+    const removeButton = screen.getByRole('button', { name: /remove attachment/i });
+    await act(() => fireEvent.keyDown(removeButton, { key: 'Enter' }));
+    expect(screen.queryByText('Lab summary')).not.toBeInTheDocument();
+  });
+
+  test('Choosing a file shows a removable attachment pill with the file name', async () => {
+    await setup({
+      title: 'Test Chat',
+      query: HOMER_DR_ALICE_CHAT_QUERY,
+      sendMessage: () => undefined,
+      uploadEnabled: true,
+    });
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['data'], 'scan.png', { type: 'image/png' });
+    await act(() => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
+
+    expect(await screen.findByText('scan.png')).toBeInTheDocument();
+
+    // Removing via click clears the pill
+    await act(() => fireEvent.click(screen.getByRole('button', { name: /remove attachment/i })));
+    expect(screen.queryByText('scan.png')).not.toBeInTheDocument();
+  });
+
+  test('Upload menu item opens the file picker', async () => {
+    await setup({
+      title: 'Test Chat',
+      query: HOMER_DR_ALICE_CHAT_QUERY,
+      sendMessage: () => undefined,
+      uploadEnabled: true,
+    });
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const clickSpy = vi.spyOn(fileInput, 'click').mockImplementation(() => undefined);
+
+    await act(() => fireEvent.click(screen.getByRole('button', { name: /attach file/i })));
+    const uploadItem = await screen.findByText('Upload a file or image');
+    await act(() => fireEvent.click(uploadItem));
+
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
+
   test('Messages with contentAttachment show filename and icon', async () => {
     const medplum = new MockClient({ profile: DrAliceSmith });
     medplum.setSubscriptionManager(defaultSubManager);

--- a/packages/react/src/chat/BaseChat/BaseChat.test.tsx
+++ b/packages/react/src/chat/BaseChat/BaseChat.test.tsx
@@ -762,9 +762,9 @@ describe('BaseChat', () => {
     await act(() => fireEvent.click(docItem));
     expect(await screen.findByText('Lab summary')).toBeInTheDocument();
 
-    // Remove the attachment via keyboard (Enter on the dismiss control); the pill should disappear
+    // Remove the attachment; the pill should disappear
     const removeButton = screen.getByRole('button', { name: /remove attachment/i });
-    await act(() => fireEvent.keyDown(removeButton, { key: 'Enter' }));
+    await act(() => fireEvent.click(removeButton));
     expect(screen.queryByText('Lab summary')).not.toBeInTheDocument();
   });
 

--- a/packages/react/src/chat/BaseChat/BaseChat.tsx
+++ b/packages/react/src/chat/BaseChat/BaseChat.tsx
@@ -12,22 +12,28 @@ import {
   Skeleton,
   Stack,
   Text,
-  TextInput,
+  Textarea,
   Title,
+  Tooltip,
 } from '@mantine/core';
-import { useResizeObserver } from '@mantine/hooks';
+import { useDisclosure, useResizeObserver } from '@mantine/hooks';
 import { showNotification } from '@mantine/notifications';
 import type { ProfileResource, WithId } from '@medplum/core';
 import { getDisplayString, getReferenceString, normalizeErrorString } from '@medplum/core';
 import type { Attachment, Bundle, Communication, DocumentReference, Reference } from '@medplum/fhirtypes';
-import { useCachedBinaryUrl, useMedplum, useResource, useSubscription } from '@medplum/react-hooks';
+import { useCachedBinaryUrl, useDictation, useMedplum, useResource, useSubscription } from '@medplum/react-hooks';
 import {
   IconArrowRight,
-  IconDots,
-  IconDownload,
-  IconFileExport,
+  IconBrowserShare,
+  IconCheck,
+  IconCircleFilled,
+  IconEye,
+  IconFiles,
   IconFileText,
+  IconHistory,
+  IconMicrophone,
   IconPaperclip,
+  IconUpload,
   IconX,
 } from '@tabler/icons-react';
 import type { JSX } from 'react';
@@ -35,7 +41,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Form } from '../../Form/Form';
 import { ResourceAvatar } from '../../ResourceAvatar/ResourceAvatar';
 import classes from './BaseChat.module.css';
-import { DocumentPicker } from './DocumentPicker';
+import { DocumentPickerList, truncateMiddle } from './DocumentPicker';
 
 /**
  * Returns the URL only when its scheme is http or https, blocking javascript: / data: XSS vectors.
@@ -118,6 +124,7 @@ export interface BaseChatProps extends PaperProps {
   readonly excludeHeader?: boolean;
   readonly onError?: (err: Error) => void;
   readonly uploadEnabled?: boolean;
+  readonly dictationEnabled?: boolean;
   readonly attachmentSubjectRef?: Reference;
   readonly onViewInDocuments?: (reference: Reference<DocumentReference>) => void;
 }
@@ -143,13 +150,14 @@ export function BaseChat(props: BaseChatProps): JSX.Element | null {
     onError,
     excludeHeader = false,
     uploadEnabled = false,
+    dictationEnabled = false,
     attachmentSubjectRef,
     onViewInDocuments,
     ...paperProps
   } = props;
   const medplum = useMedplum();
 
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const firstScrollRef = useRef(true);
   const initialLoadRef = useRef(true);
@@ -159,8 +167,94 @@ export function BaseChat(props: BaseChatProps): JSX.Element | null {
   const [loading, setLoading] = useState(true);
   const [pendingFile, setPendingFile] = useState<File | undefined>(undefined);
   const [pendingDocRef, setPendingDocRef] = useState<DocumentReference | undefined>(undefined);
-  const [pickerOpen, setPickerOpen] = useState(false);
+  const [scrollable, setScrollable] = useState(false);
+  // The textarea is uncontrolled, so mirror whether it has text to drive the send button state
+  const [hasText, setHasText] = useState(false);
+
+  // Track whether the textarea has grown past its max height and become scrollable
+  const handleInput = useCallback(() => {
+    const el = inputRef.current;
+    if (el) {
+      setScrollable(el.scrollHeight > el.clientHeight + 1);
+      setHasText(el.value.trim().length > 0);
+    }
+  }, []);
+  const [pickerOpen, pickerHandlers] = useDisclosure(false);
+  // The attach popover swaps between its root menu and the recent-documents view in place
+  const [pickerView, setPickerView] = useState<'menu' | 'recent'>('menu');
+  const pickerDropdownRef = useRef<HTMLDivElement>(null);
+  const inputBoxRef = useRef<HTMLDivElement>(null);
+  // Attach menu target width: the base 220 widened by ~a third, but never wider than the input box less 10px
+  const [attachMenuWidth, setAttachMenuWidth] = useState(293);
+
+  useEffect(() => {
+    if (!pickerOpen) {
+      return undefined;
+    }
+    // The dropdown is anchored under the paperclip, ~10px in from the box's left edge (the box's
+    // padding-inline). Subtract that left inset plus another ~10px so the right edge sits inside the
+    // input box rather than aligning with (or overflowing) it. Otherwise use the wider default.
+    const boxWidth = inputBoxRef.current?.offsetWidth;
+    setAttachMenuWidth(boxWidth ? Math.min(293, boxWidth - 20) : 293);
+    const handler = (e: MouseEvent): void => {
+      // Skip the attach button itself; its own onClick toggles the menu. Closing here would let the
+      // button's click re-open it after this handler's re-render flips pickerOpen back to false.
+      if (
+        pickerDropdownRef.current &&
+        !pickerDropdownRef.current.contains(e.target as Node) &&
+        !(e.target as HTMLElement).closest('[aria-label="Attach file"]')
+      ) {
+        pickerHandlers.close();
+      }
+    };
+    // Delay registration so the opening click doesn't immediately close
+    const raf = requestAnimationFrame(() => {
+      document.addEventListener('mousedown', handler);
+    });
+    return () => {
+      cancelAnimationFrame(raf);
+      document.removeEventListener('mousedown', handler);
+    };
+  }, [pickerOpen, pickerHandlers]);
+
+  // Re-focus textarea when picker closes
+  const prevPickerOpen = useRef(false);
+  useEffect(() => {
+    if (prevPickerOpen.current && !pickerOpen) {
+      inputRef.current?.focus();
+      // View is reset to the root menu on open, not here, so the recent view stays visible
+      // through the close transition instead of flashing the root menu
+    }
+    prevPickerOpen.current = pickerOpen;
+  }, [pickerOpen]);
+
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // The textarea is uncontrolled, so write through the native setter and fire an
+  // input event so the autosize/scrollable handlers run
+  const setInputValue = useCallback((value: string): void => {
+    const el = inputRef.current;
+    if (!el) {
+      return;
+    }
+    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+    setter?.call(el, value);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  }, []);
+
+  // Dictation: speech streams into the textarea; the user accepts or cancels, nothing auto-sends
+  const {
+    dictating,
+    isRecording: isDictationRecording,
+    startDictation,
+    cancelDictation,
+    acceptDictation,
+  } = useDictation({
+    getValue: () => inputRef.current?.value ?? '',
+    setValue: setInputValue,
+    focusInput: () => inputRef.current?.focus(),
+    onError: (err) => showError(normalizeErrorString(err)),
+  });
 
   if (!loading) {
     initialLoadRef.current = false;
@@ -246,6 +340,8 @@ export function BaseChat(props: BaseChatProps): JSX.Element | null {
       if (inputRef.current) {
         inputRef.current.value = '';
       }
+      setScrollable(false);
+      setHasText(false);
       if (fileInputRef.current) {
         fileInputRef.current.value = '';
       }
@@ -297,21 +393,15 @@ export function BaseChat(props: BaseChatProps): JSX.Element | null {
     }
   });
 
-  const myLastDeliveredId = useMemo<string>(() => {
-    let i = communications.length;
-
-    while (i--) {
-      const comm = communications[i];
-      if (comm.sender?.reference === profileRefStr && comm.received) {
-        return comm.id as string;
-      }
-    }
-
-    return '';
-  }, [communications, profileRefStr]);
-
   if (!profile) {
     return null;
+  }
+
+  let inputPlaceholder = 'Replies are disabled';
+  if (dictating) {
+    inputPlaceholder = 'Start speaking—your transcribed words will appear here.';
+  } else if (!inputDisabled) {
+    inputPlaceholder = 'Type a message...';
   }
 
   return (
@@ -338,7 +428,12 @@ export function BaseChat(props: BaseChatProps): JSX.Element | null {
             </Group>
           </Stack>
         ) : (
-          <ScrollArea viewportRef={scrollAreaRef} className={classes.chatScrollArea} h={parentRect.height}>
+          <ScrollArea
+            viewportRef={scrollAreaRef}
+            className={classes.chatScrollArea}
+            classNames={{ viewport: classes.chatScrollAreaViewport }}
+            h={parentRect.height}
+          >
             {/* We don't wrap our scrollarea or scrollarea children with this overlay since it seems to break the rendering of the virtual scroll element */}
             {/* Instead we manually set the width and height to match the parent and use absolute positioning */}
             <LoadingOverlay
@@ -349,7 +444,6 @@ export function BaseChat(props: BaseChatProps): JSX.Element | null {
               const prevCommunication = i > 0 ? communications[i - 1] : undefined;
               const prevCommTime = prevCommunication ? parseSentTime(prevCommunication) : undefined;
               const currCommTime = parseSentTime(c);
-              const showDelivered = !!c.received && c.id === myLastDeliveredId;
               const payloads = c.payload ?? [];
               const contentRef = payloads.find((p) => p.contentReference)?.contentReference;
               const contentAttachment = payloads.find((p) => p.contentAttachment)?.contentAttachment;
@@ -371,20 +465,13 @@ export function BaseChat(props: BaseChatProps): JSX.Element | null {
                   )}
                   {isSender ? (
                     <Group justify="flex-end" align="flex-end" gap="xs" mb="sm">
-                      <div className={classes.chatBubbleMenu}>{menu}</div>
-                      <ChatBubble alignment="right" communication={c} showDelivered={showDelivered} />
-                      <ResourceAvatar
-                        radius="xl"
-                        color="orange"
-                        value={c.sender}
-                        mb={!showDelivered ? 'sm' : undefined}
-                      />
+                      <ChatBubble alignment="right" communication={c} menu={menu} />
+                      <ResourceAvatar radius="xl" color="orange" value={c.sender} mb="sm" />
                     </Group>
                   ) : (
                     <Group justify="flex-start" align="flex-end" gap="xs" mb="sm">
                       <ResourceAvatar radius="xl" value={c.sender} mb="sm" />
-                      <ChatBubble alignment="left" communication={c} />
-                      <div className={classes.chatBubbleMenu}>{menu}</div>
+                      <ChatBubble alignment="left" communication={c} menu={menu} />
                     </Group>
                   )}
                 </Stack>
@@ -394,31 +481,6 @@ export function BaseChat(props: BaseChatProps): JSX.Element | null {
         )}
       </div>
       <div className={classes.chatInputContainer}>
-        {(pendingFile || pendingDocRef) && (
-          <Group className={classes.chatPendingFile} gap={4} align="center" wrap="nowrap">
-            {pendingDocRef ? <IconFileText size="0.75rem" /> : <IconPaperclip size="0.75rem" />}
-            <Text fz="xs" c="dimmed" flex={1} truncate>
-              {pendingDocRef
-                ? (pendingDocRef.description ?? pendingDocRef.content?.[0]?.attachment?.title ?? 'Document')
-                : pendingFile?.name}
-            </Text>
-            <ActionIcon
-              size="xs"
-              variant="subtle"
-              color="red"
-              onClick={() => {
-                setPendingDocRef(undefined);
-                setPendingFile(undefined);
-                if (fileInputRef.current) {
-                  fileInputRef.current.value = '';
-                }
-              }}
-              aria-label="Remove attachment"
-            >
-              <IconX size="0.75rem" />
-            </ActionIcon>
-          </Group>
-        )}
         <input
           ref={fileInputRef}
           type="file"
@@ -433,68 +495,251 @@ export function BaseChat(props: BaseChatProps): JSX.Element | null {
           }}
         />
         <Form onSubmit={sendMessageInternal}>
-          <TextInput
-            ref={inputRef}
-            name="message"
-            placeholder={!inputDisabled ? 'Type a message...' : 'Replies are disabled'}
-            radius="xl"
-            leftSectionWidth={42}
-            rightSectionWidth={42}
-            disabled={inputDisabled}
-            leftSection={
-              !inputDisabled && uploadEnabled ? (
-                <Popover
-                  opened={pickerOpen}
-                  onChange={setPickerOpen}
-                  position="top-start"
-                  withArrow
-                  shadow="md"
-                  withinPortal
-                >
+          <div
+            ref={inputBoxRef}
+            className={classes.chatInputBox}
+            data-disabled={inputDisabled || undefined}
+            data-scrollable={scrollable ? 'true' : undefined}
+            onMouseDown={(e: React.MouseEvent) => {
+              // Keep textarea focused when clicking anywhere in the input box
+              if (!(e.target instanceof HTMLTextAreaElement) && !(e.target instanceof HTMLInputElement)) {
+                e.preventDefault();
+                inputRef.current?.focus();
+              }
+            }}
+          >
+            {(pendingFile || pendingDocRef) &&
+              (() => {
+                const fullName = pendingDocRef
+                  ? (pendingDocRef.description ?? pendingDocRef.content?.[0]?.attachment?.title ?? 'Document')
+                  : (pendingFile?.name ?? 'File');
+                const displayName = truncateMiddle(fullName, 24);
+                const isTruncated = displayName !== fullName;
+                return (
+                  <Tooltip label={fullName} openDelay={500} position="top" disabled={!isTruncated}>
+                    <div className={classes.chatAttachmentPill}>
+                      {pendingDocRef ? (
+                        <IconFileText size="0.875rem" color="var(--mantine-color-dimmed)" />
+                      ) : (
+                        <IconPaperclip size="0.875rem" color="var(--mantine-color-dimmed)" />
+                      )}
+                      <Text fz="xs">{displayName}</Text>
+                      <span
+                        className={classes.chatAttachmentPillDismiss}
+                        role="button"
+                        tabIndex={0}
+                        onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                        onClick={() => {
+                          setPendingDocRef(undefined);
+                          setPendingFile(undefined);
+                          if (fileInputRef.current) {
+                            fileInputRef.current.value = '';
+                          }
+                          inputRef.current?.focus();
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            setPendingDocRef(undefined);
+                            setPendingFile(undefined);
+                            if (fileInputRef.current) {
+                              fileInputRef.current.value = '';
+                            }
+                            inputRef.current?.focus();
+                          }
+                        }}
+                        aria-label="Remove attachment"
+                      >
+                        <IconX size="0.75rem" />
+                      </span>
+                    </div>
+                  </Tooltip>
+                );
+              })()}
+            <Textarea
+              ref={inputRef}
+              name="message"
+              placeholder={inputPlaceholder}
+              disabled={inputDisabled}
+              autoFocus={!inputDisabled}
+              autosize
+              minRows={1}
+              maxRows={6}
+              classNames={{ root: classes.chatTextareaRoot, input: classes.chatTextarea }}
+              onChange={handleInput}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  // Enter during dictation only confirms the transcript; Send submits explicitly
+                  if (dictating) {
+                    acceptDictation();
+                    return;
+                  }
+                  e.currentTarget.form?.requestSubmit();
+                }
+              }}
+            />
+            <div className={classes.chatActionBar}>
+              {dictating && (
+                <div className={classes.listeningStatus} data-state={isDictationRecording ? 'recording' : 'connecting'}>
+                  <span className={classes.listeningDotWrapper} aria-hidden>
+                    <IconCircleFilled size={16} />
+                  </span>
+                  <Text fz="xs" fw={400} ml={2} className={classes.listeningLabel} aria-live="polite">
+                    {isDictationRecording ? 'Listening…' : 'Connecting…'}
+                  </Text>
+                </div>
+              )}
+              {!dictating && !inputDisabled && uploadEnabled && (
+                <Popover opened={pickerOpen} position="top-start" shadow="md" radius="md">
                   <Popover.Target>
-                    <ActionIcon
-                      onClick={() => setPickerOpen((o) => !o)}
-                      size="1.5rem"
-                      radius="xl"
-                      color={pendingFile || pendingDocRef ? 'blue' : 'gray'}
-                      variant={pendingFile || pendingDocRef ? 'filled' : 'subtle'}
-                      aria-label="Attach file"
-                    >
-                      <IconPaperclip size="1rem" stroke={1.5} />
-                    </ActionIcon>
+                    <Tooltip label="Attach" position="top" openDelay={100} disabled={pickerOpen}>
+                      <ActionIcon
+                        type="button"
+                        onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                        onClick={() => {
+                          if (pickerOpen) {
+                            pickerHandlers.close();
+                          } else {
+                            // Reset to the root menu before opening so it's never visible during the
+                            // close transition (resetting on close flashes the root menu over the fade-out)
+                            setPickerView('menu');
+                            pickerHandlers.open();
+                            inputRef.current?.focus();
+                          }
+                        }}
+                        size={32}
+                        radius="xl"
+                        color="dark"
+                        variant="subtle"
+                        className={classes.subtleActionButton}
+                        data-selected={pickerOpen || undefined}
+                        aria-label="Attach file"
+                      >
+                        <IconPaperclip size={16} stroke={2} />
+                      </ActionIcon>
+                    </Tooltip>
                   </Popover.Target>
-                  <Popover.Dropdown p={0}>
-                    <DocumentPicker
-                      subjectRef={attachmentSubjectRef}
-                      onSelect={(doc) => {
-                        setPendingDocRef(doc);
-                        setPendingFile(undefined);
-                        setPickerOpen(false);
-                      }}
-                      onUpload={() => {
-                        setPickerOpen(false);
-                        fileInputRef.current?.click();
-                      }}
-                    />
+                  <Popover.Dropdown
+                    ref={pickerDropdownRef}
+                    className={classes.attachMenuDropdown}
+                    p={4}
+                    {...(pickerView === 'recent' ? { w: attachMenuWidth } : { miw: 220 })}
+                    onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                    onFocusCapture={(e: React.FocusEvent) => {
+                      // Allow focus on the search input, redirect everything else back to textarea
+                      if (!(e.target instanceof HTMLInputElement)) {
+                        e.preventDefault();
+                        inputRef.current?.focus();
+                      }
+                    }}
+                  >
+                    <Menu closeOnItemClick={false}>
+                      {pickerView === 'recent' ? (
+                        <DocumentPickerList
+                          subjectRef={attachmentSubjectRef}
+                          onSelect={(doc) => {
+                            setPendingDocRef(doc);
+                            setPendingFile(undefined);
+                            pickerHandlers.close();
+                          }}
+                        />
+                      ) : (
+                        <>
+                          <Menu.Item
+                            leftSection={<IconHistory size={16} color="var(--mantine-color-dimmed)" />}
+                            onClick={() => setPickerView('recent')}
+                          >
+                            <Text size="sm">Recent Documents</Text>
+                          </Menu.Item>
+                          <Menu.Item
+                            leftSection={<IconUpload size={16} color="var(--mantine-color-dimmed)" />}
+                            onClick={() => {
+                              pickerHandlers.close();
+                              fileInputRef.current?.click();
+                            }}
+                          >
+                            <Text size="sm">Upload a file or image</Text>
+                          </Menu.Item>
+                        </>
+                      )}
+                    </Menu>
                   </Popover.Dropdown>
                 </Popover>
-              ) : undefined
-            }
-            rightSection={
-              !inputDisabled ? (
-                <ActionIcon
-                  type="submit"
-                  size="1.5rem"
-                  radius="xl"
-                  color="blue"
-                  variant="filled"
-                  aria-label="Send message"
-                >
-                  <IconArrowRight size="1rem" stroke={1.5} />
-                </ActionIcon>
-              ) : undefined
-            }
-          />
+              )}
+              {!dictating && (inputDisabled || !uploadEnabled) && <div />}
+              {!inputDisabled && (
+                <Group gap={8}>
+                  {dictating ? (
+                    <>
+                      <Tooltip label="Cancel" position="top" openDelay={100}>
+                        <ActionIcon
+                          type="button"
+                          onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                          onClick={cancelDictation}
+                          size={32}
+                          radius="xl"
+                          color="dark"
+                          variant="subtle"
+                          className={classes.subtleActionButton}
+                          aria-label="Cancel dictation"
+                        >
+                          <IconX size={16} stroke={2} />
+                        </ActionIcon>
+                      </Tooltip>
+                      <Tooltip label="Accept" position="top" openDelay={100}>
+                        <ActionIcon
+                          type="button"
+                          onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                          onClick={acceptDictation}
+                          size={32}
+                          radius="xl"
+                          color="blue"
+                          variant="filled"
+                          aria-label="Accept dictated text"
+                        >
+                          <IconCheck size={16} stroke={2} />
+                        </ActionIcon>
+                      </Tooltip>
+                    </>
+                  ) : (
+                    <>
+                      {dictationEnabled && (
+                        <Tooltip label="Dictate" position="top" openDelay={100}>
+                          <ActionIcon
+                            type="button"
+                            onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                            onClick={startDictation}
+                            size={32}
+                            radius="xl"
+                            color="dark"
+                            variant="subtle"
+                            className={classes.subtleActionButton}
+                            aria-label="Dictate"
+                          >
+                            <IconMicrophone size={16} stroke={2} />
+                          </ActionIcon>
+                        </Tooltip>
+                      )}
+                      <Tooltip label="Send" position="top" openDelay={100}>
+                        <ActionIcon
+                          type="submit"
+                          size={32}
+                          radius="xl"
+                          color="blue"
+                          variant="filled"
+                          className={classes.sendActionButton}
+                          aria-label="Send message"
+                          disabled={!hasText && !pendingFile && !pendingDocRef}
+                        >
+                          <IconArrowRight size={16} stroke={2} />
+                        </ActionIcon>
+                      </Tooltip>
+                    </>
+                  )}
+                </Group>
+              )}
+            </div>
+          </div>
         </Form>
       </div>
     </Paper>
@@ -504,17 +749,17 @@ export function BaseChat(props: BaseChatProps): JSX.Element | null {
 interface ChatBubbleProps {
   readonly communication: Communication;
   readonly alignment: 'left' | 'right';
-  readonly showDelivered?: boolean;
+  readonly menu?: JSX.Element | null;
 }
 
 function ChatBubble(props: ChatBubbleProps): JSX.Element {
-  const { communication, alignment, showDelivered } = props;
+  const { communication, alignment, menu } = props;
   const payloads = communication.payload ?? [];
   const textContent = payloads.find((p) => p.contentString)?.contentString ?? '';
   const contentRef = payloads.find((p) => p.contentReference)?.contentReference;
   const attachment = payloads.find((p) => p.contentAttachment)?.contentAttachment;
+  const hasAttachment = !!(contentRef || attachment);
   const sentTime = new Date(communication.sent ?? -1);
-  const seenTime = new Date(communication.received ?? -1);
   const senderResource = useResource(communication.sender);
   return (
     <div className={classes.chatBubbleOuterWrap}>
@@ -533,21 +778,35 @@ function ChatBubble(props: ChatBubbleProps): JSX.Element {
             : sentTime.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
         </Text>
       </Text>
-      <div
-        className={
-          alignment === 'left' ? classes.chatBubbleLeftAlignedInnerWrap : classes.chatBubbleRightAlignedInnerWrap
-        }
-      >
-        <div className={classes.chatBubble}>
-          {textContent && <span>{textContent}</span>}
-          {contentRef && <ChatBubbleDocumentReference reference={contentRef} hasText={!!textContent} />}
-          {attachment && <ChatBubbleAttachment attachment={attachment} hasText={!!textContent} />}
+      {hasAttachment && (
+        <div
+          className={alignment === 'left' ? classes.chatBubbleAttachmentRowLeft : classes.chatBubbleAttachmentRowRight}
+        >
+          <div className={classes.chatBubble}>
+            {contentRef && <ChatBubbleDocumentReference reference={contentRef} hasText={false} />}
+            {attachment && <ChatBubbleAttachment attachment={attachment} hasText={false} />}
+          </div>
+          {menu && <div className={classes.chatBubbleMenuInline}>{menu}</div>}
         </div>
-      </div>
-      {showDelivered && (
-        <div style={{ textAlign: 'right' }}>
-          Delivered {seenTime.getHours()}:{seenTime.getMinutes().toString().length === 1 ? '0' : ''}
-          {seenTime.getMinutes()}
+      )}
+      {textContent && (
+        <div
+          className={
+            alignment === 'left' ? classes.chatBubbleLeftAlignedInnerWrap : classes.chatBubbleRightAlignedInnerWrap
+          }
+        >
+          <div className={classes.chatBubble}>
+            <span>{textContent}</span>
+          </div>
+        </div>
+      )}
+      {!hasAttachment && !textContent && (
+        <div
+          className={
+            alignment === 'left' ? classes.chatBubbleLeftAlignedInnerWrap : classes.chatBubbleRightAlignedInnerWrap
+          }
+        >
+          <div className={classes.chatBubble} />
         </div>
       )}
     </div>
@@ -579,11 +838,22 @@ interface ChatBubbleDocumentReferenceProps {
   readonly hasText: boolean;
 }
 
-function ChatBubbleDocumentReference({ reference, hasText }: ChatBubbleDocumentReferenceProps): JSX.Element | null {
+function ChatBubbleDocumentReference({ reference, hasText }: ChatBubbleDocumentReferenceProps): JSX.Element {
   const docRef = useResource<DocumentReference>(reference as Reference<DocumentReference>);
   const attachment = docRef?.content?.[0]?.attachment;
   if (!attachment) {
-    return null;
+    return (
+      <div className={hasText ? classes.chatBubbleAttachmentWithText : undefined}>
+        <Group gap={4} wrap="nowrap">
+          <span className={classes.chatBubbleAttachmentIcon}>
+            <IconPaperclip size="0.75rem" />
+          </span>
+          <Text fz="xs" truncate>
+            <Skeleton height="0.75rem" width={120} radius="sm" display="inline-block" />
+          </Text>
+        </Group>
+      </div>
+    );
   }
   return <ChatBubbleAttachment attachment={attachment} hasText={hasText} />;
 }
@@ -595,13 +865,12 @@ interface ChatBubbleMenuProps {
 }
 
 function ChatBubbleMenu({ contentRef, contentAttachment, onViewInDocuments }: ChatBubbleMenuProps): JSX.Element {
+  const [menuOpen, setMenuOpen] = useState(false);
   const docRef = useResource<DocumentReference>(contentRef as Reference<DocumentReference> | undefined);
   const attachment = contentRef ? docRef?.content?.[0]?.attachment : contentAttachment;
   const cachedUrl = useCachedBinaryUrl(attachment?.url);
 
-  const handleDownload = (): void => {
-    // Navigation requests don't include an Origin header so CORS never applies.
-    // fetch() / medplum.download() both send Origin which CloudFront rejects.
+  const handleOpenInBrowser = (): void => {
     const href = toSafeUrl(cachedUrl ?? attachment?.url);
     if (!href) {
       return;
@@ -610,23 +879,36 @@ function ChatBubbleMenu({ contentRef, contentAttachment, onViewInDocuments }: Ch
   };
 
   return (
-    <Menu withinPortal position="bottom-start" shadow="md">
+    <Menu withinPortal position="bottom-start" shadow="md" radius="md" onChange={setMenuOpen}>
       <Menu.Target>
-        <ActionIcon variant="outline" color="gray" radius="xl" size="sm" aria-label="Attachment options">
-          <IconDots size="0.75rem" />
-        </ActionIcon>
+        <Tooltip label="Open Attachment" position="top" openDelay={100} disabled={menuOpen}>
+          <ActionIcon
+            variant="transparent"
+            radius="xl"
+            size={32}
+            className="outline-icon-button"
+            aria-label="Open Attachment"
+          >
+            <IconEye size={16} />
+          </ActionIcon>
+        </Tooltip>
       </Menu.Target>
       <Menu.Dropdown>
         {contentRef && onViewInDocuments && (
           <Menu.Item
-            leftSection={<IconFileExport size="0.9rem" />}
+            className={classes.chatBubbleMenuItem}
+            leftSection={<IconFiles size={16} color="var(--mantine-color-dimmed)" />}
             onClick={() => onViewInDocuments(contentRef as Reference<DocumentReference>)}
           >
-            View in Documents
+            <Text size="sm">Open in Documents</Text>
           </Menu.Item>
         )}
-        <Menu.Item leftSection={<IconDownload size="0.9rem" />} onClick={handleDownload}>
-          Download
+        <Menu.Item
+          className={classes.chatBubbleMenuItem}
+          leftSection={<IconBrowserShare size={16} color="var(--mantine-color-dimmed)" />}
+          onClick={handleOpenInBrowser}
+        >
+          <Text size="sm">Open in Browser</Text>
         </Menu.Item>
       </Menu.Dropdown>
     </Menu>

--- a/packages/react/src/chat/BaseChat/BaseChat.tsx
+++ b/packages/react/src/chat/BaseChat/BaseChat.tsx
@@ -524,10 +524,9 @@ export function BaseChat(props: BaseChatProps): JSX.Element | null {
                         <IconPaperclip size="0.875rem" color="var(--mantine-color-dimmed)" />
                       )}
                       <Text fz="xs">{displayName}</Text>
-                      <span
+                      <button
+                        type="button"
                         className={classes.chatAttachmentPillDismiss}
-                        role="button"
-                        tabIndex={0}
                         onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
                         onClick={() => {
                           setPendingDocRef(undefined);
@@ -537,20 +536,10 @@ export function BaseChat(props: BaseChatProps): JSX.Element | null {
                           }
                           inputRef.current?.focus();
                         }}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            setPendingDocRef(undefined);
-                            setPendingFile(undefined);
-                            if (fileInputRef.current) {
-                              fileInputRef.current.value = '';
-                            }
-                            inputRef.current?.focus();
-                          }
-                        }}
                         aria-label="Remove attachment"
                       >
                         <IconX size="0.75rem" />
-                      </span>
+                      </button>
                     </div>
                   </Tooltip>
                 );

--- a/packages/react/src/chat/BaseChat/DocumentPicker.test.tsx
+++ b/packages/react/src/chat/BaseChat/DocumentPicker.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { Menu } from '@mantine/core';
 import { createReference, getReferenceString } from '@medplum/core';
 import type { DocumentReference } from '@medplum/fhirtypes';
 import { DrAliceSmith, HomerSimpson, MockClient } from '@medplum/mock';
@@ -7,10 +8,10 @@ import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen, waitFor } from '../../test-utils/render';
-import type { DocumentPickerProps } from './DocumentPicker';
-import { DocumentPicker } from './DocumentPicker';
+import type { DocumentPickerListProps } from './DocumentPicker';
+import { DocumentPickerList } from './DocumentPicker';
 
-describe('DocumentPicker', () => {
+describe('DocumentPickerList', () => {
   let medplum: MockClient;
 
   beforeEach(() => {
@@ -22,13 +23,18 @@ describe('DocumentPicker', () => {
     vi.useRealTimers();
   });
 
-  async function setup(props: DocumentPickerProps): Promise<void> {
+  async function setup(props: DocumentPickerListProps): Promise<void> {
     await act(async () =>
-      render(<DocumentPicker {...props} />, ({ children }: { children: ReactNode }) => (
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
-      ))
+      render(
+        <Menu opened>
+          <DocumentPickerList {...props} />
+        </Menu>,
+        ({ children }: { children: ReactNode }) => (
+          <MemoryRouter>
+            <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
+          </MemoryRouter>
+        )
+      )
     );
   }
 
@@ -38,15 +44,18 @@ describe('DocumentPicker', () => {
     });
   }
 
-  test('Shows header, search input, and upload option', async () => {
-    await setup({ onSelect: vi.fn(), onUpload: vi.fn() });
-    expect(screen.getByText('Attachments')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Search for a Document...')).toBeInTheDocument();
-    expect(screen.getByText('Upload an image, pdf, etc.')).toBeInTheDocument();
+  test('Shows Recent Documents label', async () => {
+    await setup({ onSelect: vi.fn() });
+    expect(screen.getByText('Recent Documents')).toBeInTheDocument();
+  });
+
+  test('Focuses the search input on mount', async () => {
+    await setup({ onSelect: vi.fn() });
+    expect(screen.getByPlaceholderText('Search documents...')).toHaveFocus();
   });
 
   test('Shows No documents found when no results', async () => {
-    await setup({ onSelect: vi.fn(), onUpload: vi.fn() });
+    await setup({ onSelect: vi.fn() });
     await flushDebounce();
     expect(await screen.findByText('No documents found')).toBeInTheDocument();
   });
@@ -59,7 +68,7 @@ describe('DocumentPicker', () => {
       content: [{ attachment: { title: 'blood-test.pdf' } }],
     });
 
-    await setup({ onSelect: vi.fn(), onUpload: vi.fn() });
+    await setup({ onSelect: vi.fn() });
     await flushDebounce();
 
     expect(await screen.findByText('Blood test results')).toBeInTheDocument();
@@ -72,7 +81,7 @@ describe('DocumentPicker', () => {
       content: [{ attachment: { title: 'xray.pdf' } }],
     });
 
-    await setup({ onSelect: vi.fn(), onUpload: vi.fn() });
+    await setup({ onSelect: vi.fn() });
     await flushDebounce();
 
     expect(await screen.findByText('xray.pdf')).toBeInTheDocument();
@@ -87,7 +96,7 @@ describe('DocumentPicker', () => {
       content: [{ attachment: { title: 'radiology.pdf' } }],
     });
 
-    await setup({ onSelect, onUpload: vi.fn() });
+    await setup({ onSelect });
     await flushDebounce();
 
     const docButton = await screen.findByText('Radiology report');
@@ -97,20 +106,11 @@ describe('DocumentPicker', () => {
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: doc.id }));
   });
 
-  test('Calls onUpload when upload option is clicked', async () => {
-    const onUpload = vi.fn();
-    await setup({ onSelect: vi.fn(), onUpload });
-
-    await act(async () => fireEvent.click(screen.getByText('Upload an image, pdf, etc.')));
-
-    expect(onUpload).toHaveBeenCalledTimes(1);
-  });
-
   test('Passes subject filter to search when subjectRef provided', async () => {
     const subjectRef = createReference(HomerSimpson);
     const searchSpy = vi.spyOn(medplum, 'searchResources').mockImplementation(() => Promise.resolve([]) as never);
 
-    await setup({ onSelect: vi.fn(), onUpload: vi.fn(), subjectRef });
+    await setup({ onSelect: vi.fn(), subjectRef });
     await flushDebounce();
 
     await waitFor(() => expect(searchSpy).toHaveBeenCalled());
@@ -125,34 +125,13 @@ describe('DocumentPicker', () => {
   test('Does not pass subject filter when subjectRef is not provided', async () => {
     const searchSpy = vi.spyOn(medplum, 'searchResources').mockImplementation(() => Promise.resolve([]) as never);
 
-    await setup({ onSelect: vi.fn(), onUpload: vi.fn() });
+    await setup({ onSelect: vi.fn() });
     await flushDebounce();
 
     await waitFor(() => expect(searchSpy).toHaveBeenCalled());
 
     const [, params] = searchSpy.mock.calls[0];
     expect((params as URLSearchParams).get('subject')).toBeNull();
-
-    searchSpy.mockRestore();
-  });
-
-  test('Passes description:contains filter when searching', async () => {
-    const searchSpy = vi.spyOn(medplum, 'searchResources').mockImplementation(() => Promise.resolve([]) as never);
-
-    await setup({ onSelect: vi.fn(), onUpload: vi.fn() });
-    await flushDebounce();
-    searchSpy.mockClear();
-
-    act(() => {
-      fireEvent.change(screen.getByPlaceholderText('Search for a Document...'), {
-        target: { value: 'blood' },
-      });
-    });
-    await flushDebounce();
-
-    await waitFor(() => expect(searchSpy).toHaveBeenCalled());
-    const [, params] = searchSpy.mock.calls[0];
-    expect((params as URLSearchParams).get('description:contains')).toBe('blood');
 
     searchSpy.mockRestore();
   });

--- a/packages/react/src/chat/BaseChat/DocumentPicker.test.tsx
+++ b/packages/react/src/chat/BaseChat/DocumentPicker.test.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Menu } from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
 import { createReference, getReferenceString } from '@medplum/core';
 import type { DocumentReference } from '@medplum/fhirtypes';
 import { DrAliceSmith, HomerSimpson, MockClient } from '@medplum/mock';
@@ -9,7 +10,12 @@ import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen, waitFor } from '../../test-utils/render';
 import type { DocumentPickerListProps } from './DocumentPicker';
-import { DocumentPickerList } from './DocumentPicker';
+import { DocumentPickerList, truncateMiddle } from './DocumentPicker';
+
+vi.mock(import('@mantine/notifications'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  showNotification: vi.fn(),
+}));
 
 describe('DocumentPickerList', () => {
   let medplum: MockClient;
@@ -134,5 +140,69 @@ describe('DocumentPickerList', () => {
     expect((params as URLSearchParams).get('subject')).toBeNull();
 
     searchSpy.mockRestore();
+  });
+
+  test('Filters results client-side when searching', async () => {
+    await medplum.createResource<DocumentReference>({
+      resourceType: 'DocumentReference',
+      status: 'current',
+      description: 'Blood test results',
+      content: [{ attachment: { title: 'results.pdf' } }],
+    });
+    await medplum.createResource<DocumentReference>({
+      resourceType: 'DocumentReference',
+      status: 'current',
+      content: [{ attachment: { title: 'xray.pdf' } }],
+    });
+    const searchSpy = vi.spyOn(medplum, 'searchResources');
+
+    await setup({ onSelect: vi.fn() });
+    await flushDebounce();
+    expect(await screen.findByText('Blood test results')).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.change(screen.getByPlaceholderText('Search documents...'), { target: { value: 'blood' } });
+    });
+    await flushDebounce();
+
+    // The matching title-only doc is filtered out; the description match remains
+    expect(screen.getByText('Blood test results')).toBeInTheDocument();
+    expect(screen.queryByText('xray.pdf')).not.toBeInTheDocument();
+
+    // A search request widens the page size so client-side filtering has results to work with
+    const searchCall = searchSpy.mock.calls.at(-1);
+    expect((searchCall?.[1] as URLSearchParams).get('_count')).toBe('50');
+
+    searchSpy.mockRestore();
+  });
+
+  test('Shows an error notification when the search fails', async () => {
+    vi.spyOn(medplum, 'searchResources').mockRejectedValue(new Error('boom'));
+
+    await setup({ onSelect: vi.fn() });
+    await flushDebounce();
+
+    await waitFor(() => expect(showNotification).toHaveBeenCalledWith(expect.objectContaining({ color: 'red' })));
+  });
+});
+
+describe('truncateMiddle', () => {
+  test('returns the name unchanged when within the limit', () => {
+    expect(truncateMiddle('short.pdf', 24)).toBe('short.pdf');
+  });
+
+  test('middle-truncates a long name while keeping the extension', () => {
+    const result = truncateMiddle('a-very-long-document-name.pdf', 20);
+    expect(result).toContain('….');
+    expect(result.endsWith('pdf')).toBe(true);
+    expect(result.length).toBeLessThanOrEqual(20);
+  });
+
+  test('truncates with a trailing ellipsis when there is no extension', () => {
+    expect(truncateMiddle('a-very-long-name-without-extension', 10)).toBe('a-very-lo…');
+  });
+
+  test('truncates with a trailing ellipsis when the extension leaves no room', () => {
+    expect(truncateMiddle('ab.superlongextension', 8)).toBe('ab.supe…');
   });
 });

--- a/packages/react/src/chat/BaseChat/DocumentPicker.tsx
+++ b/packages/react/src/chat/BaseChat/DocumentPicker.tsx
@@ -90,11 +90,11 @@ export function DocumentPickerList({ subjectRef, onSelect }: DocumentPickerListP
   // Fetch immediately on mount (when attach menu opens), debounce subsequent search changes
   const mountedRef = useRef(false);
   useEffect(() => {
-    if (!mountedRef.current) {
+    if (mountedRef.current) {
+      debouncedLoadDocs(search);
+    } else {
       mountedRef.current = true;
       loadDocs(search).catch(() => undefined);
-    } else {
-      debouncedLoadDocs(search);
     }
   }, [search, loadDocs, debouncedLoadDocs]);
 

--- a/packages/react/src/chat/BaseChat/DocumentPicker.tsx
+++ b/packages/react/src/chat/BaseChat/DocumentPicker.tsx
@@ -1,103 +1,155 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Divider, Loader, Stack, Text, TextInput, UnstyledButton } from '@mantine/core';
+import { Box, Loader, Menu, Stack, Text, TextInput, Tooltip } from '@mantine/core';
 import { useDebouncedCallback } from '@mantine/hooks';
-import { getReferenceString } from '@medplum/core';
+import { showNotification } from '@mantine/notifications';
+import { getReferenceString, normalizeErrorString } from '@medplum/core';
 import type { DocumentReference, Reference } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
-import { IconFileText, IconPaperclip } from '@tabler/icons-react';
+import { IconFileText } from '@tabler/icons-react';
 import type { JSX } from 'react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import classes from './BaseChat.module.css';
 
-export interface DocumentPickerProps {
+const MAX_RESULTS = 5;
+
+export interface DocumentPickerListProps {
   readonly subjectRef?: Reference;
   readonly onSelect: (doc: DocumentReference) => void;
-  readonly onUpload: () => void;
 }
 
-export function DocumentPicker({ subjectRef, onSelect, onUpload }: DocumentPickerProps): JSX.Element {
+export function truncateMiddle(name: string, maxLen: number): string {
+  if (name.length <= maxLen) {
+    return name;
+  }
+  const dotIndex = name.lastIndexOf('.');
+  if (dotIndex === -1) {
+    return name.slice(0, maxLen - 1) + '…';
+  }
+  const ext = name.slice(dotIndex + 1);
+  const available = maxLen - ext.length - 2;
+  if (available < 4) {
+    return name.slice(0, maxLen - 1) + '…';
+  }
+  return name.slice(0, available) + '….' + ext;
+}
+
+export function DocumentPickerList({ subjectRef, onSelect }: DocumentPickerListProps): JSX.Element {
   const medplum = useMedplum();
   const [search, setSearch] = useState('');
   const [docs, setDocs] = useState<DocumentReference[]>([]);
   const [loading, setLoading] = useState(true);
+  const searchRef = useRef<HTMLInputElement>(null);
   const subjectRefStr = subjectRef ? getReferenceString(subjectRef) : undefined;
 
-  const fetchDocs = useDebouncedCallback(async (query: string) => {
-    setLoading(true);
-    try {
-      const params = new URLSearchParams();
-      if (subjectRefStr) {
-        params.set('subject', subjectRefStr);
+  // Focus the search input as soon as the recent-documents view opens
+  useEffect(() => {
+    searchRef.current?.focus();
+  }, []);
+
+  const loadDocs = useCallback(
+    async (query: string) => {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams();
+        if (subjectRefStr) {
+          params.set('subject', subjectRefStr);
+        }
+        params.set('_sort', '-date');
+        const trimmed = query.trim().toLowerCase();
+        if (trimmed) {
+          params.set('_count', '50');
+          const results = await medplum.searchResources('DocumentReference', params);
+          const filtered = [...results]
+            .filter((doc) => {
+              const description = doc.description?.toLowerCase() ?? '';
+              const title = doc.content?.[0]?.attachment?.title?.toLowerCase() ?? '';
+              return description.includes(trimmed) || title.includes(trimmed);
+            })
+            .slice(0, MAX_RESULTS);
+          setDocs(filtered);
+        } else {
+          params.set('_count', String(MAX_RESULTS));
+          const results = await medplum.searchResources('DocumentReference', params);
+          setDocs([...results]);
+        }
+      } catch (err) {
+        showNotification({ color: 'red', message: normalizeErrorString(err) });
+      } finally {
+        setLoading(false);
       }
-      if (query.trim()) {
-        params.set('description:contains', query.trim());
-      }
-      params.set('_sort', '-date');
-      params.set('_count', '5');
-      const results = await medplum.searchResources('DocumentReference', params);
-      setDocs([...results]);
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
+    },
+    [medplum, subjectRefStr]
+  );
+
+  const debouncedLoadDocs = useDebouncedCallback((query: string) => {
+    // loadDocs handles its own errors internally; the catch only satisfies no-floating-promises
+    loadDocs(query).catch(() => undefined);
   }, 300);
 
+  // Fetch immediately on mount (when attach menu opens), debounce subsequent search changes
+  const mountedRef = useRef(false);
   useEffect(() => {
-    fetchDocs(search);
-  }, [fetchDocs, search]);
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      loadDocs(search).catch(() => undefined);
+    } else {
+      debouncedLoadDocs(search);
+    }
+  }, [search, loadDocs, debouncedLoadDocs]);
 
   const getDocName = (doc: DocumentReference): string =>
     doc.description ?? doc.content?.[0]?.attachment?.title ?? 'Untitled';
 
+  const stopEvents = {
+    onClick: (e: React.MouseEvent) => e.stopPropagation(),
+    onMouseDown: (e: React.MouseEvent) => e.stopPropagation(),
+  };
+
   return (
-    <Stack gap={0} w={280}>
-      <Text fw={500} fz="sm" px="sm" pt="sm" pb="xs">
-        Attachments
-      </Text>
-      <Box px="sm" pb="xs">
-        <TextInput
-          placeholder="Search for a Document..."
-          size="xs"
-          value={search}
-          onChange={(e) => setSearch(e.currentTarget.value)}
-        />
-      </Box>
-      <Divider />
+    <Stack gap={0}>
+      <Menu.Label>Recent Documents</Menu.Label>
       {loading ? (
         <Box py="sm" style={{ display: 'flex', justifyContent: 'center' }}>
           <Loader size="xs" />
         </Box>
       ) : (
         <Stack gap={0}>
-          {docs.map((doc) => (
-            <UnstyledButton
-              key={doc.id}
-              px="sm"
-              py="xs"
-              onClick={() => onSelect(doc)}
-              style={{ display: 'flex', alignItems: 'center', gap: 8 }}
-            >
-              <IconFileText size="1rem" style={{ flexShrink: 0, color: 'var(--mantine-color-blue-6)' }} />
-              <Text fz="sm" truncate>
-                {getDocName(doc)}
-              </Text>
-            </UnstyledButton>
-          ))}
+          {docs.map((doc) => {
+            const fullName = getDocName(doc);
+            const displayName = truncateMiddle(fullName, 24);
+            const isTruncated = displayName !== fullName;
+            return (
+              <Tooltip key={doc.id} label={fullName} disabled={!isTruncated} openDelay={400} position="top">
+                <Menu.Item
+                  className={classes.truncatedMenuItem}
+                  leftSection={<IconFileText size={16} color="var(--mantine-color-dimmed)" />}
+                  onClick={() => onSelect(doc)}
+                >
+                  <Text fz="sm" truncate>
+                    {displayName}
+                  </Text>
+                </Menu.Item>
+              </Tooltip>
+            );
+          })}
           {docs.length === 0 && (
-            <Text fz="xs" c="dimmed" px="sm" py="xs">
+            <Text fz="sm" c="dimmed" px="sm" py="xs">
               No documents found
             </Text>
           )}
         </Stack>
       )}
-      <Divider />
-      <UnstyledButton px="sm" py="xs" onClick={onUpload} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <IconPaperclip size="1rem" style={{ flexShrink: 0, color: 'var(--mantine-color-gray-6)' }} />
-        <Text fz="sm" c="dimmed">
-          Upload an image, pdf, etc.
-        </Text>
-      </UnstyledButton>
+      <Box px="xs" pt={8} pb="xs" {...stopEvents}>
+        <TextInput
+          ref={searchRef}
+          placeholder="Search documents..."
+          size="sm"
+          value={search}
+          onChange={(e) => setSearch(e.currentTarget.value)}
+          onKeyDown={(e) => e.stopPropagation()}
+        />
+      </Box>
     </Stack>
   );
 }

--- a/packages/react/src/chat/ThreadChat/ThreadChat.stories.tsx
+++ b/packages/react/src/chat/ThreadChat/ThreadChat.stories.tsx
@@ -52,3 +52,13 @@ export const WithAttachmentUpload = (): JSX.Element => {
     </Document>
   );
 };
+
+export const WithDictation = (): JSX.Element => {
+  return (
+    <Document>
+      <div style={{ width: 360, height: 400, margin: '0 auto' }}>
+        <ThreadChat thread={ExampleThreadHeader} uploadEnabled dictationEnabled />
+      </div>
+    </Document>
+  );
+};

--- a/packages/react/src/chat/ThreadChat/ThreadChat.test.tsx
+++ b/packages/react/src/chat/ThreadChat/ThreadChat.test.tsx
@@ -303,7 +303,7 @@ describe('ThreadChat', () => {
     expect(updatedMessage.status).toEqual('in-progress');
   });
 
-  test('Delivered timestamps show up when other participant has received chat', async () => {
+  test('Does not show a Delivered timestamp even when the other participant has received the chat', async () => {
     const thread = await createThreadHeader(defaultMedplum);
     const threadRef = createReference(thread);
 
@@ -331,7 +331,7 @@ describe('ThreadChat', () => {
     expect(
       screen.getByText("Sorry doc, I can't hear you over the Geiger counter at the plant. Can you call back later?")
     ).toBeInTheDocument();
-    expect(screen.getByText(/Delivered \d+:\d+/)).toBeInTheDocument();
+    expect(screen.queryByText(/Delivered \d+:\d+/)).not.toBeInTheDocument();
   });
 
   test('Clears messages if given a new thread', async () => {
@@ -492,8 +492,9 @@ describe('ThreadChat', () => {
 
     await setup({ thread, uploadEnabled: true });
 
-    // Open document picker
+    // Open the attach menu, then drill into the recent-documents view
     await act(() => fireEvent.click(screen.getByRole('button', { name: /attach file/i })));
+    await act(() => fireEvent.click(screen.getByText('Recent Documents')));
 
     // Wait for debounced fetch and document to appear
     await act(async () => {

--- a/packages/react/src/chat/ThreadChat/ThreadChat.test.tsx
+++ b/packages/react/src/chat/ThreadChat/ThreadChat.test.tsx
@@ -488,23 +488,17 @@ describe('ThreadChat', () => {
       content: [{ attachment: { title: 'report.pdf', url: 'https://example.com/report.pdf' } }],
     });
 
-    vi.useFakeTimers();
-
     await setup({ thread, uploadEnabled: true });
 
-    // Open the attach menu, then drill into the recent-documents view
+    // Open the attach menu, then drill into the recent-documents view. Use findByText so the
+    // Popover dropdown and (on-mount, non-debounced) document fetch have time to settle, rather
+    // than racing a synchronous query right after the opening click.
     await act(() => fireEvent.click(screen.getByRole('button', { name: /attach file/i })));
-    await act(() => fireEvent.click(screen.getByText('Recent Documents')));
-
-    // Wait for debounced fetch and document to appear
-    await act(async () => {
-      vi.advanceTimersByTime(300);
-    });
+    const recentItem = await screen.findByText('Recent Documents');
+    await act(() => fireEvent.click(recentItem));
 
     const docButton = await screen.findByText('Attached report');
     await act(() => fireEvent.click(docButton));
-
-    vi.useRealTimers();
 
     // Send message
     act(() => {

--- a/packages/react/src/chat/ThreadChat/ThreadChat.tsx
+++ b/packages/react/src/chat/ThreadChat/ThreadChat.tsx
@@ -14,13 +14,23 @@ export interface ThreadChatProps {
   readonly inputDisabled?: boolean;
   readonly excludeHeader?: boolean;
   readonly uploadEnabled?: boolean;
+  readonly dictationEnabled?: boolean;
   readonly onError?: (err: Error) => void;
   readonly onViewInDocuments?: (reference: Reference<DocumentReference>) => void;
 }
 
 export function ThreadChat(props: ThreadChatProps): JSX.Element | null {
-  const { thread, title, onMessageSent, inputDisabled, excludeHeader, uploadEnabled, onError, onViewInDocuments } =
-    props;
+  const {
+    thread,
+    title,
+    onMessageSent,
+    inputDisabled,
+    excludeHeader,
+    uploadEnabled,
+    dictationEnabled,
+    onError,
+    onViewInDocuments,
+  } = props;
   const medplum = useMedplum();
   const profile = useMedplumProfile();
   const prevThreadId = usePrevious(thread?.id);
@@ -119,6 +129,7 @@ export function ThreadChat(props: ThreadChatProps): JSX.Element | null {
       inputDisabled={inputDisabled}
       excludeHeader={excludeHeader}
       uploadEnabled={uploadEnabled}
+      dictationEnabled={dictationEnabled}
       onError={onError}
       attachmentSubjectRef={thread.subject}
       onViewInDocuments={onViewInDocuments}

--- a/packages/react/src/chat/ThreadInbox/ThreadInbox.stories.tsx
+++ b/packages/react/src/chat/ThreadInbox/ThreadInbox.stories.tsx
@@ -28,3 +28,23 @@ export const Basic = (): JSX.Element => {
     </Document>
   );
 };
+
+export const WithAttachmentsAndDictation = (): JSX.Element => {
+  return (
+    <Document>
+      <div style={{ height: 800 }}>
+        <ThreadInbox
+          query="_sort=-_lastUpdated"
+          threadId={undefined}
+          onNew={() => undefined}
+          getThreadUri={(topic: Communication) => `/Communication/${topic.id}`}
+          onChange={() => undefined}
+          inProgressUri="/Communication?status=in-progress"
+          completedUri="/Communication?status=completed"
+          uploadEnabled
+          dictationEnabled
+        />
+      </div>
+    </Document>
+  );
+};

--- a/packages/react/src/chat/ThreadInbox/ThreadInbox.tsx
+++ b/packages/react/src/chat/ThreadInbox/ThreadInbox.tsx
@@ -63,6 +63,7 @@ export interface ThreadInboxProps {
   readonly inProgressUri: string;
   readonly completedUri: string;
   readonly uploadEnabled?: boolean;
+  readonly dictationEnabled?: boolean;
   readonly onViewInDocuments?: (reference: Reference<DocumentReference>) => void;
   readonly allowPatientSelection?: boolean;
 }
@@ -77,6 +78,7 @@ export function ThreadInbox(props: ThreadInboxProps): JSX.Element {
     onNew,
     getThreadUri,
     uploadEnabled,
+    dictationEnabled,
     onViewInDocuments,
     onChange,
     inProgressUri,
@@ -263,9 +265,9 @@ export function ThreadInbox(props: ThreadInboxProps): JSX.Element {
           {selectedThread ? (
             <>
               {/* Main chat area */}
-              <Flex direction="column" style={{ flex: 1 }} h="100%" className={classes.rightBorder}>
-                <Paper h="100%">
-                  <Stack h="100%" gap={0}>
+              <Flex direction="column" style={{ flex: 1, minHeight: 0 }} className={classes.rightBorder}>
+                <Paper style={{ flex: 1, minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+                  <Stack style={{ flex: 1, minHeight: 0 }} gap={0}>
                     <Flex h={64} align="center" justify="space-between" p="md">
                       <Text fw={800} truncate fz="lg">
                         {selectedThread.topic?.text ?? 'Messages'}
@@ -299,13 +301,14 @@ export function ThreadInbox(props: ThreadInboxProps): JSX.Element {
                       </Menu>
                     </Flex>
                     <Divider />
-                    <Flex direction="column" style={{ flex: 1 }} h="100%">
+                    <Flex direction="column" style={{ flex: 1, minHeight: 0 }}>
                       <ThreadChat
                         key={`${getReferenceString(selectedThread)}`}
                         title={'Messages'}
                         thread={selectedThread}
                         excludeHeader={true}
                         uploadEnabled={uploadEnabled}
+                        dictationEnabled={dictationEnabled}
                         onViewInDocuments={onViewInDocuments}
                       />
                     </Flex>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,6 +30,7 @@ export * from './BackboneElementInput/BackboneElementInput';
 export * from './CalendarDateInput/CalendarDateInput';
 export * from './CalendarInput/CalendarInput';
 export * from './chat/BaseChat/BaseChat';
+export * from './chat/BaseChat/DocumentPicker';
 export * from './chat/ChatModal/ChatModal';
 export * from './chat/ThreadChat/ThreadChat';
 export * from './chat/ThreadInbox/ChatList';


### PR DESCRIPTION
This PR standardizes our inputs across the Spaces and Messages pages in Provider app. This also includes the addition of voice mode and patient selection for Spaces, attachment support for Messages and voice dictation for both. Key commits include:

- **`useWhisper` (react-hooks)** — stream interim/partial transcripts via `onInterimTranscript`, and add `muted`/`setMuted` that toggle the mic track while keeping the warm WebSocket + audio worklet alive
- **`useDictation` (react-hooks)** — new hook wrapping `useWhisper` with chat-input dictation semantics: snapshot the pre-dictation value, append finalized chunks, expose a live interim preview, and provide start/cancel/accept controls (cancel restores the snapshot) plus low-level start/stop passthrough
- **`DocumentPicker` (react)** — reshaped into a `Menu`-based `DocumentPickerList` showing the 5 most recent `DocumentReference`s with client-side search filtering; exported from the package, with an extension-aware `truncateMiddle` helper
- **`BaseChat` (react)** — new `dictationEnabled` prop surfacing a dictate button (Listening status + Cancel/Accept footer, Enter accepts rather than sends) and an attach popover that swaps between its root menu and the recent-documents list, rendering selected docs as a dismissible pill
- **`ThreadChat` / `ThreadInbox` (react)** — thread the `dictationEnabled` prop through to `BaseChat` and fix the inbox chat area to a flex/`minHeight:0` column so the new footer sizes correctly
- **Provider example app** — dictation + hands-free voice mode in the Spaces chat input, a `PatientPicker` for attaching patient context, document/file attachments, patient/attachment chips in `SpacesInbox`, and pre-selected patients injected as agent context in `processMessage`. Upload + feature-flagged (`ai-realtime`) dictation enabled on the thread inbox in `CommunicationTab` and `MessagesPage`
- Test coverage for `useDictation` (11), `BaseChat` dictation/attach (6), `DocumentPicker`, and `PatientPicker` (5).