### PR TITLE
WIP: fix(ws): send subscription bind handshake before heartbeat can fire

### DIFF
--- a/packages/server/src/ws/subscriptions.ts
+++ b/packages/server/src/ws/subscriptions.ts
@@ -418,6 +418,10 @@ export async function handleR4SubscriptionConnection(socket: WebSocket, request:
       membershipId: verifiedToken.membership_id,
     });
     subscribeWsToSubscription(socket, verifiedToken.subscription_id, rawToken, criteriaResourceType);
+    // Send handshake before ensureHeartbeatHandler or any await so a heartbeat tick
+    // cannot deliver a heartbeat message ahead of the bind handshake.
+    socket.send(JSON.stringify(createHandshakeBundle(verifiedToken.subscription_id)));
+    subscriptionMessagesSent++;
     ensureHeartbeatHandler();
     if (!userRef) {
       userRef = verifiedToken.profile;
@@ -433,9 +437,6 @@ export async function handleR4SubscriptionConnection(socket: WebSocket, request:
       projectId: socketProjectId,
       userSubscriptions: userSubCount,
     });
-    // Send a handshake to notify client that this subscription is active for this connection
-    socket.send(JSON.stringify(createHandshakeBundle(verifiedToken.subscription_id)));
-    subscriptionMessagesSent++;
 
     onDisconnect = async (): Promise<void> => {
       const subEntries = wsToSubLookup.get(socket);


### PR DESCRIPTION
## Summary

- Fix a race in WebSocket subscription bind where a periodic heartbeat could be delivered before the bind handshake
- After `subscribeWsToSubscription`, the server registered the heartbeat handler and awaited Redis before sending the handshake; with a short heartbeat interval (25ms in tests, or under load in prod), clients could receive `SubscriptionStatus.type: heartbeat` as the first message instead of `handshake`
- Send the handshake immediately after subscribing the socket, before `ensureHeartbeatHandler()` and any `await`

## Test plan

- [ ] `cd packages/server && npx vitest run src/ws/subscriptions.test.ts -t "Recovers when the subscription handler fails to initialize"` (stress loop if possible)
- [ ] `cd packages/server && npx vitest run src/ws/subscriptions.test.ts`
- [ ] Manual bind: confirm first JSON message after `bind-with-token` is always handshake