### PR TITLE
fix(ccda): normalize address part text nodes in mapAddresses

### DIFF
--- a/packages/ccda/src/address.test.ts
+++ b/packages/ccda/src/address.test.ts
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { Patient } from '@medplum/fhirtypes';
+import { convertCcdaToFhir } from './ccda-to-fhir';
+import { convertXmlToCcda } from './xml';
+
+/**
+ * Address parts that carry an XML attribute (e.g. the HL7 `partType` on ADXP
+ * elements) are parsed by fast-xml-parser into `{ '#text': value, '@_partType': ... }`
+ * objects rather than bare strings. `mapAddresses` must normalize these via
+ * `nodeToString` (as the name mapper already does), otherwise the raw parser
+ * artifacts leak into the FHIR `Address` and downstream validation/persistence
+ * rejects the resource (a non-string `city` breaks `city.trim()`).
+ */
+describe('address text-node normalization', () => {
+  function patientFromXml(addrXml: string): Patient {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3">
+  <recordTarget>
+    <patientRole>
+      ${addrXml}
+      <patient>
+        <name use="L"><given>Jane</given><family>Doe</family></name>
+      </patient>
+    </patientRole>
+  </recordTarget>
+</ClinicalDocument>`;
+    const bundle = convertCcdaToFhir(convertXmlToCcda(xml));
+    return bundle.entry?.find((e) => e.resource?.resourceType === 'Patient')?.resource as Patient;
+  }
+
+  test('strips partType attribute artifacts from address parts', () => {
+    const patient = patientFromXml(`<addr use="HP">
+        <streetAddressLine partType="SAL">742 Evergreen Terrace</streetAddressLine>
+        <city partType="CTY">Springfield</city>
+        <state partType="STA">IL</state>
+        <postalCode partType="ZIP">62704</postalCode>
+        <country partType="CNT">US</country>
+      </addr>`);
+
+    const address = patient.address?.[0];
+    expect(address?.line).toEqual(['742 Evergreen Terrace']);
+    expect(address?.city).toBe('Springfield');
+    expect(address?.state).toBe('IL');
+    expect(address?.postalCode).toBe('62704');
+    expect(address?.country).toBe('US');
+
+    // None of the fields should leak the parser's object representation.
+    for (const value of [address?.city, address?.state, address?.postalCode, address?.country]) {
+      expect(typeof value).toBe('string');
+    }
+    const serialized = JSON.stringify(address);
+    expect(serialized).not.toContain('#text');
+    expect(serialized).not.toContain('@_partType');
+  });
+
+  test('plain string address parts are unchanged', () => {
+    const patient = patientFromXml(`<addr use="HP">
+        <streetAddressLine>742 Evergreen Terrace</streetAddressLine>
+        <city>Springfield</city>
+        <state>IL</state>
+        <postalCode>62704</postalCode>
+      </addr>`);
+
+    const address = patient.address?.[0];
+    expect(address?.line).toEqual(['742 Evergreen Terrace']);
+    expect(address?.city).toBe('Springfield');
+    expect(address?.state).toBe('IL');
+    expect(address?.postalCode).toBe('62704');
+  });
+});

--- a/packages/ccda/src/ccda-to-fhir.ts
+++ b/packages/ccda/src/ccda-to-fhir.ts
@@ -316,11 +316,11 @@ class CcdaToFhirConverter {
     }
     return addresses?.map((addr) => ({
       use: addr['@_use'] ? ADDRESS_USE_MAPPER.mapCcdaToFhir(addr['@_use']) : undefined,
-      line: addr.streetAddressLine,
-      city: addr.city,
-      state: addr.state,
-      postalCode: addr.postalCode,
-      country: addr.country,
+      line: addr.streetAddressLine?.map(nodeToString).filter(Boolean) as string[] | undefined,
+      city: nodeToString(addr.city),
+      state: nodeToString(addr.state),
+      postalCode: nodeToString(addr.postalCode),
+      country: nodeToString(addr.country),
     }));
   }
 

--- a/packages/ccda/src/types.ts
+++ b/packages/ccda/src/types.ts
@@ -37,11 +37,11 @@ export interface CcdaPatientRole {
 export interface CcdaAddr {
   '@_use'?: 'HP' | 'WP';
   '@_nullFlavor'?: 'UNK';
-  streetAddressLine?: string[];
-  city?: string;
-  state?: string;
-  postalCode?: string;
-  country?: string;
+  streetAddressLine?: (string | CcdaText)[];
+  city?: string | CcdaText;
+  state?: string | CcdaText;
+  postalCode?: string | CcdaText;
+  country?: string | CcdaText;
 }
 
 export interface CcdaPatient {


### PR DESCRIPTION
## Problem

In the C-CDA XML ITS, address parts (`ADXP`) and name parts (`ENXP`) may legally carry attributes — most commonly `partType` (e.g. `<city partType="CTY">Anytown</city>`). When an element has both text content **and** an attribute, `fast-xml-parser` represents it as an object rather than a string:

```json
{ "#text": "Anytown", "@_partType": "CTY" }
```

`mapCcdaNameToFhirHumanName` already normalizes every name part through `nodeToString`, so names are unaffected. But `mapAddresses` assigned the parsed values directly:

```ts
city: addr.city,   // -> { "#text": "Anytown", "@_partType": "CTY" } when an attribute is present
```

So FHIR `Address` fields can come out as objects instead of strings whenever the source emits the attributed form. Downstream this breaks FHIR validation (`$validate` reports `Invalid additional property "#text"` / `"@_partType"`) and any consumer that treats `Address.city` as a string (e.g. `city.trim()` throws `is not a function`).

This form is legal, just verbose — generators built on generic HL7 V3 datatype serializers commonly stamp `partType` on every part — so the converter should handle it on addresses the same way it already does on names.

## Fix

- Run every address part (`line`, `city`, `state`, `postalCode`, `country`) through `nodeToString`, mirroring `mapCcdaNameToFhirHumanName`.
- Widen the `CcdaAddr` string fields to `string | CcdaText` to reflect what the parser actually produces.

## Test

Adds `address.test.ts` covering both the `partType`-attributed form and the plain-string form, asserting the FHIR `Address` parts are clean strings with no `#text` / `@_partType` artifacts.

`npx vitest run` in `packages/ccda`: **266 passed, 1 skipped** (no regressions).
