### PR TITLE
Enhance InvitePage with error handling and testing improvements

### DIFF
--- a/packages/app/src/admin/InvitePage.test.tsx
+++ b/packages/app/src/admin/InvitePage.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { conflict, multipleMatches, OperationOutcomeError } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router';
@@ -17,6 +18,24 @@ async function setup(url: string): Promise<void> {
         </MemoryRouter>
       </MedplumProvider>
     );
+  });
+}
+
+async function fillAndSubmitInviteForm(): Promise<void> {
+  await act(async () => {
+    fireEvent.change(screen.getByLabelText('First Name *'), {
+      target: { value: 'George' },
+    });
+    fireEvent.change(screen.getByLabelText('Last Name *'), {
+      target: { value: 'Washington' },
+    });
+    fireEvent.change(screen.getByLabelText('Email *'), {
+      target: { value: 'george@example.com' },
+    });
+  });
+
+  await act(async () => {
+    fireEvent.click(screen.getByText('Invite'));
   });
 }
 
@@ -39,6 +58,7 @@ describe('InvitePage', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await act(async () => {
       await vi.runOnlyPendingTimersAsync();
     });
@@ -258,5 +278,56 @@ describe('InvitePage', () => {
     });
     expect(screen.queryByText('success')).not.toBeInTheDocument();
     expect(screen.queryByText('Email sent')).not.toBeInTheDocument();
+  });
+
+  test('Show duplicate resource error', async () => {
+    vi.spyOn(medplum, 'invite').mockRejectedValueOnce(new OperationOutcomeError(multipleMatches));
+
+    await setup('/admin/invite');
+    expect(await screen.findByText('Invite')).toBeInTheDocument();
+    await fillAndSubmitInviteForm();
+
+    expect(screen.getByTestId('invite-error')).toHaveTextContent('Multiple resources found matching condition');
+    expect(screen.queryByText("User created, email couldn't be sent")).not.toBeInTheDocument();
+    expect(screen.getByText('Invite new member')).toBeInTheDocument();
+  });
+
+  test('Show conflict error', async () => {
+    vi.spyOn(medplum, 'invite').mockRejectedValueOnce(
+      new OperationOutcomeError(conflict('User is already a member of this project'))
+    );
+
+    await setup('/admin/invite');
+    expect(await screen.findByText('Invite')).toBeInTheDocument();
+    await fillAndSubmitInviteForm();
+
+    expect(screen.getByTestId('invite-error')).toHaveTextContent('User is already a member of this project');
+    expect(screen.queryByText("User created, email couldn't be sent")).not.toBeInTheDocument();
+    expect(screen.getByText('Invite new member')).toBeInTheDocument();
+  });
+
+  test('Show email failure when invite returns OperationOutcome', async () => {
+    vi.spyOn(medplum, 'invite').mockResolvedValueOnce({
+      resourceType: 'OperationOutcome',
+      id: 'ok',
+      issue: [
+        {
+          severity: 'error',
+          code: 'exception',
+          details: {
+            text: 'Could not send email. Make sure you have AWS SES set up.',
+          },
+        },
+      ],
+    });
+
+    await setup('/admin/invite');
+    expect(await screen.findByText('Invite')).toBeInTheDocument();
+    await fillAndSubmitInviteForm();
+
+    expect(screen.getByTestId('email-failure')).toBeInTheDocument();
+    expect(screen.getByText("User created, email couldn't be sent")).toBeInTheDocument();
+    expect(screen.getByText('Could not send email. Make sure you have AWS SES set up.')).toBeInTheDocument();
+    expect(screen.queryByTestId('invite-error')).not.toBeInTheDocument();
   });
 });

--- a/packages/app/src/admin/InvitePage.test.tsx
+++ b/packages/app/src/admin/InvitePage.test.tsx
@@ -29,12 +29,7 @@ async function setup(url: string): Promise<void> {
 }
 
 async function fillInviteForm(fields: InviteFormFields = {}): Promise<void> {
-  const {
-    resourceType,
-    firstName = 'George',
-    lastName = 'Washington',
-    email = 'george@example.com',
-  } = fields;
+  const { resourceType, firstName = 'George', lastName = 'Washington', email = 'george@example.com' } = fields;
 
   await act(async () => {
     if (resourceType) {

--- a/packages/app/src/admin/InvitePage.test.tsx
+++ b/packages/app/src/admin/InvitePage.test.tsx
@@ -9,6 +9,13 @@ import { act, fireEvent, render, screen } from '../test-utils/render';
 
 const medplum = new MockClient();
 
+interface InviteFormFields {
+  resourceType?: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+}
+
 async function setup(url: string): Promise<void> {
   await act(async () => {
     render(
@@ -21,22 +28,41 @@ async function setup(url: string): Promise<void> {
   });
 }
 
-async function fillAndSubmitInviteForm(): Promise<void> {
+async function fillInviteForm(fields: InviteFormFields = {}): Promise<void> {
+  const {
+    resourceType,
+    firstName = 'George',
+    lastName = 'Washington',
+    email = 'george@example.com',
+  } = fields;
+
   await act(async () => {
+    if (resourceType) {
+      fireEvent.change(screen.getByLabelText('Role'), {
+        target: { value: resourceType },
+      });
+    }
     fireEvent.change(screen.getByLabelText('First Name *'), {
-      target: { value: 'George' },
+      target: { value: firstName },
     });
     fireEvent.change(screen.getByLabelText('Last Name *'), {
-      target: { value: 'Washington' },
+      target: { value: lastName },
     });
     fireEvent.change(screen.getByLabelText('Email *'), {
-      target: { value: 'george@example.com' },
+      target: { value: email },
     });
   });
+}
 
+async function submitInviteForm(): Promise<void> {
   await act(async () => {
     fireEvent.click(screen.getByText('Invite'));
   });
+}
+
+async function fillAndSubmitInviteForm(fields?: InviteFormFields): Promise<void> {
+  await fillInviteForm(fields);
+  await submitInviteForm();
 }
 
 describe('InvitePage', () => {
@@ -73,22 +99,7 @@ describe('InvitePage', () => {
   test('Submit success', async () => {
     await setup('/admin/invite');
     expect(await screen.findByText('Invite')).toBeInTheDocument();
-
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText('First Name *'), {
-        target: { value: 'George' },
-      });
-      fireEvent.change(screen.getByLabelText('Last Name *'), {
-        target: { value: 'Washington' },
-      });
-      fireEvent.change(screen.getByLabelText('Email *'), {
-        target: { value: 'george@example.com' },
-      });
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Invite'));
-    });
+    await fillAndSubmitInviteForm();
 
     expect(screen.getByTestId('success')).toBeInTheDocument();
     expect(screen.getByText('Email sent')).toBeInTheDocument();
@@ -97,18 +108,7 @@ describe('InvitePage', () => {
   test('Submit with access policy', async () => {
     await setup('/admin/invite');
     expect(await screen.findByText('Invite')).toBeInTheDocument();
-
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText('First Name *'), {
-        target: { value: 'George' },
-      });
-      fireEvent.change(screen.getByLabelText('Last Name *'), {
-        target: { value: 'Washington' },
-      });
-      fireEvent.change(screen.getByLabelText('Email *'), {
-        target: { value: 'george@example.com' },
-      });
-    });
+    await fillInviteForm();
 
     const input = screen.getByPlaceholderText('Access Policy');
 
@@ -132,9 +132,7 @@ describe('InvitePage', () => {
       fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByText('Invite'));
-    });
+    await submitInviteForm();
 
     expect(screen.getByTestId('success')).toBeInTheDocument();
   });
@@ -142,24 +140,11 @@ describe('InvitePage', () => {
   test('Invite patient', async () => {
     await setup('/admin/invite');
     expect(await screen.findByText('Invite')).toBeInTheDocument();
-
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText('Role'), {
-        target: { value: 'Patient' },
-      });
-      fireEvent.change(screen.getByLabelText('First Name *'), {
-        target: { value: 'Peggy' },
-      });
-      fireEvent.change(screen.getByLabelText('Last Name *'), {
-        target: { value: 'Patient' },
-      });
-      fireEvent.change(screen.getByLabelText('Email *'), {
-        target: { value: 'peggypatient@example.com' },
-      });
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Invite'));
+    await fillAndSubmitInviteForm({
+      resourceType: 'Patient',
+      firstName: 'Peggy',
+      lastName: 'Patient',
+      email: 'peggypatient@example.com',
     });
 
     expect(screen.getByTestId('success')).toBeInTheDocument();
@@ -168,29 +153,18 @@ describe('InvitePage', () => {
   test('Invite admin', async () => {
     await setup('/admin/invite');
     expect(await screen.findByText('Invite')).toBeInTheDocument();
-
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText('Role'), {
-        target: { value: 'Practitioner' },
-      });
-      fireEvent.change(screen.getByLabelText('First Name *'), {
-        target: { value: 'Patty' },
-      });
-      fireEvent.change(screen.getByLabelText('Last Name *'), {
-        target: { value: 'Practitioner' },
-      });
-      fireEvent.change(screen.getByLabelText('Email *'), {
-        target: { value: 'pattypractitioner@example.com' },
-      });
+    await fillInviteForm({
+      resourceType: 'Practitioner',
+      firstName: 'Patty',
+      lastName: 'Practitioner',
+      email: 'pattypractitioner@example.com',
     });
 
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Admin'));
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByText('Invite'));
-    });
+    await submitInviteForm();
 
     expect(screen.getByTestId('success')).toBeInTheDocument();
   });
@@ -198,29 +172,18 @@ describe('InvitePage', () => {
   test('Invite project scoped user', async () => {
     await setup('/admin/invite');
     expect(await screen.findByText('Invite')).toBeInTheDocument();
-
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText('Role'), {
-        target: { value: 'Practitioner' },
-      });
-      fireEvent.change(screen.getByLabelText('First Name *'), {
-        target: { value: 'Patty' },
-      });
-      fireEvent.change(screen.getByLabelText('Last Name *'), {
-        target: { value: 'Practitioner' },
-      });
-      fireEvent.change(screen.getByLabelText('Email *'), {
-        target: { value: 'pattypractitioner@example.com' },
-      });
+    await fillInviteForm({
+      resourceType: 'Practitioner',
+      firstName: 'Patty',
+      lastName: 'Practitioner',
+      email: 'pattypractitioner@example.com',
     });
 
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Project scoped'));
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByText('Invite'));
-    });
+    await submitInviteForm();
 
     expect(screen.getByTestId('success')).toBeInTheDocument();
   });
@@ -228,26 +191,13 @@ describe('InvitePage', () => {
   test('Do not send email', async () => {
     await setup('/admin/invite');
     expect(await screen.findByText('Invite')).toBeInTheDocument();
-
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText('First Name *'), {
-        target: { value: 'George' },
-      });
-      fireEvent.change(screen.getByLabelText('Last Name *'), {
-        target: { value: 'Washington' },
-      });
-      fireEvent.change(screen.getByLabelText('Email *'), {
-        target: { value: 'george@example.com' },
-      });
-    });
+    await fillInviteForm();
 
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Send email'));
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByText('Invite'));
-    });
+    await submitInviteForm();
 
     expect(screen.getByTestId('success')).toBeInTheDocument();
     expect(screen.queryByText('Email sent')).not.toBeInTheDocument();
@@ -257,25 +207,14 @@ describe('InvitePage', () => {
     await setup('/admin/invite');
     expect(await screen.findByText('Invite')).toBeInTheDocument();
 
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText('First Name *'), {
-        target: { value: 'George' },
-      });
-      fireEvent.change(screen.getByLabelText('Last Name *'), {
-        target: { value: 'Washington' },
-      });
-      fireEvent.change(screen.getByLabelText('Email *'), {
-        target: { value: '' },
-      });
-    });
+    await fillInviteForm({ email: '' });
 
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Send email'));
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByText('Invite'));
-    });
+    await submitInviteForm();
+
     expect(screen.queryByText('success')).not.toBeInTheDocument();
     expect(screen.queryByText('Email sent')).not.toBeInTheDocument();
   });

--- a/packages/app/src/admin/InvitePage.tsx
+++ b/packages/app/src/admin/InvitePage.tsx
@@ -3,7 +3,12 @@
 import { Checkbox, Group, List, NativeSelect, Stack, Text, TextInput, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import type { InviteRequest } from '@medplum/core';
-import { isOperationOutcome, normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
+import {
+  isOperationOutcome,
+  normalizeErrorString,
+  normalizeOperationOutcome,
+  operationOutcomeToString,
+} from '@medplum/core';
 import type { AccessPolicy, OperationOutcome, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import {
   Form,
@@ -23,11 +28,14 @@ export function InvitePage(): JSX.Element {
   const [project, setProject] = useState(medplum.getProject());
   const [accessPolicy, setAccessPolicy] = useState<Reference<AccessPolicy>>();
   const [outcome, setOutcome] = useState<OperationOutcome>();
+  const [error, setError] = useState<OperationOutcome>();
   const [emailSent, setEmailSent] = useState(false);
   const [result, setResult] = useState<ProjectMembership | undefined>(undefined);
 
   const handleSubmit = useCallback(
     (formData: Record<string, string>): Promise<void> => {
+      setError(undefined);
+      setOutcome(undefined);
       const body = {
         resourceType: formData.resourceType as 'Practitioner' | 'Patient' | 'RelatedPerson',
         firstName: formData.firstName,
@@ -55,7 +63,7 @@ export function InvitePage(): JSX.Element {
         })
         .catch((err) => {
           showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false });
-          setOutcome(normalizeOperationOutcome(err));
+          setError(normalizeOperationOutcome(err));
         });
     },
     [medplum, project, accessPolicy]
@@ -66,8 +74,13 @@ export function InvitePage(): JSX.Element {
       {!result && !outcome && (
         <Stack>
           <Title>Invite new member</Title>
+          {error && (
+            <Text c="red" data-testid="invite-error">
+              {operationOutcomeToString(error)}
+            </Text>
+          )}
           {medplum.isSuperAdmin() && (
-            <FormSection title="Project" htmlFor="project" outcome={outcome}>
+            <FormSection title="Project" htmlFor="project" outcome={error}>
               <ResourceInput<Project>
                 resourceType="Project"
                 name="project"
@@ -81,24 +94,24 @@ export function InvitePage(): JSX.Element {
             label="Role"
             defaultValue="Practitioner"
             data={['Practitioner', 'Patient', 'RelatedPerson']}
-            error={getErrorsForInput(outcome, 'resourceType')}
+            error={getErrorsForInput(error, 'resourceType')}
           />
           <TextInput
             name="firstName"
             label="First Name"
             required={true}
             autoFocus={true}
-            error={getErrorsForInput(outcome, 'firstName')}
+            error={getErrorsForInput(error, 'firstName')}
           />
-          <TextInput name="lastName" label="Last Name" required={true} error={getErrorsForInput(outcome, 'lastName')} />
+          <TextInput name="lastName" label="Last Name" required={true} error={getErrorsForInput(error, 'lastName')} />
           <TextInput
             name="email"
             type="email"
             label="Email"
             required={true}
-            error={getErrorsForInput(outcome, 'email')}
+            error={getErrorsForInput(error, 'email')}
           />
-          <FormSection title="Access Policy" htmlFor="accessPolicy" outcome={outcome}>
+          <FormSection title="Access Policy" htmlFor="accessPolicy" outcome={error}>
             <AccessPolicyInput name="accessPolicy" onChange={setAccessPolicy} />
           </FormSection>
           <Checkbox name="sendEmail" label="Send email" defaultChecked={true} />
@@ -111,9 +124,9 @@ export function InvitePage(): JSX.Element {
         </Stack>
       )}
       {outcome && (
-        <div data-testid="success">
+        <div data-testid="email-failure">
           <p>User created, email couldn't be sent</p>
-          <p>Could not send email. Make sure you have AWS SES set up.</p>
+          <p>{operationOutcomeToString(outcome)}</p>
           <p>
             Click <MedplumLink to="/admin/project">here</MedplumLink> to return to the project admin page.
           </p>

--- a/packages/app/src/admin/InvitePage.tsx
+++ b/packages/app/src/admin/InvitePage.tsx
@@ -35,7 +35,6 @@ export function InvitePage(): JSX.Element {
   const handleSubmit = useCallback(
     (formData: Record<string, string>): Promise<void> => {
       setError(undefined);
-      setOutcome(undefined);
       const body = {
         resourceType: formData.resourceType as 'Practitioner' | 'Patient' | 'RelatedPerson',
         firstName: formData.firstName,
@@ -62,7 +61,7 @@ export function InvitePage(): JSX.Element {
           showNotification({ color: 'green', message: 'Invite success' });
         })
         .catch((err) => {
-          showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false });
+          showNotification({ color: 'red', message: normalizeErrorString(err) });
           setError(normalizeOperationOutcome(err));
         });
     },


### PR DESCRIPTION
TLDR, the admin invite flow threw an SES setup error for all failures associated, which is misleading. This PR displays the `OperationOutcome` error clearly to the admin user, and should allow them to self-debug issues more easily.

- Added error handling for duplicate resource and conflict scenarios in the InvitePage component.
- Implemented new tests to verify the display of error messages for multiple matches and existing members.
- Updated the InvitePage to utilize the operationOutcomeToString function for better error message presentation.
- Refactored the form submission logic to reset error states appropriately.

This update improves user feedback during the invite process and enhances test coverage for error scenarios.

Signed-off-by: Darren Eam <darreneam65@gmail.com>