### PR TITLE
fix(spaces): default model order and dark-mode page background

### DIFF
--- a/examples/medplum-provider/src/pages/spaces/SpacesPage.module.css
+++ b/examples/medplum-provider/src/pages/spaces/SpacesPage.module.css
@@ -1,7 +1,7 @@
 .container {
   position: relative;
   height: calc(100vh - var(--app-shell-header-height, 0));
-  background-color: var(--mantine-color-gray-0);
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-9));
   display: flex;
   overflow: hidden;
 }

--- a/examples/medplum-provider/src/utils/spaceModels.ts
+++ b/examples/medplum-provider/src/utils/spaceModels.ts
@@ -17,9 +17,9 @@ export const AI_MODELS_SETTING = 'aiModels';
 
 /** Built-in fallback used when the project has not configured `aiModels`. */
 export const DEFAULT_MODELS: SpaceModelOption[] = [
-  { value: 'gpt-5-mini', label: 'GPT-5 Mini' },
-  { value: 'gpt-5.4', label: 'GPT-5.4' },
   { value: 'gpt-5.5', label: 'GPT-5.5' },
+  { value: 'gpt-5.4', label: 'GPT-5.4' },
+  { value: 'gpt-5-mini', label: 'GPT-5 Mini' },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Reorder `DEFAULT_MODELS` so `GPT-5.5` is the first entry, making it the preselected default in the Spaces model picker (`getDefaultModel` returns `models[0]`).
