### PR TITLE
[Server] Enforce scheduling alignment in $book

### DIFF
--- a/packages/server/src/fhir/operations/book.test.ts
+++ b/packages/server/src/fhir/operations/book.test.ts
@@ -1358,6 +1358,51 @@ describe('Appointment/$book', () => {
         issue: [{ details: { text: 'Requested time slot is not available' } }],
       });
     });
+
+    test('rejects when the proposed slot start is not aligned to the scheduling grid', async () => {
+      const schedule = await makeSchedule({
+        actor: practitioner1,
+        extension: [
+          {
+            url: 'https://medplum.com/fhir/StructureDefinition/SchedulingParameters',
+            extension: [
+              threeDayAvailability,
+              { url: 'duration', valueDuration: { value: 60, unit: 'min' } },
+              { url: 'alignmentInterval', valueDuration: { value: 30, unit: 'min' } },
+              { url: 'alignmentOffset', valueDuration: { value: 0, unit: 'min' } },
+              { url: 'service', valueReference: createReference(officeVisitService) },
+            ],
+          },
+        ],
+      });
+
+      // 14:15Z is not on the 30-minute grid (valid starts are :00 and :30)
+      const misalignedStart = '2026-01-15T14:15:00Z';
+      const misalignedEnd = '2026-01-15T15:15:00Z';
+
+      const misalignedResponse = await request
+        .post('/fhir/R4/Appointment/$book')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send(appointmentParam({ schedule, start: misalignedStart, end: misalignedEnd }));
+
+      expect(misalignedResponse.status).toEqual(400);
+      expect(misalignedResponse.body).toMatchObject({
+        resourceType: 'OperationOutcome',
+        issue: [{ details: { text: 'Slot start time is not aligned to the scheduling grid' } }],
+      });
+
+      // 14:30Z is on the 30-minute grid
+      const alignedStart = '2026-01-15T14:30:00Z';
+      const alignedEnd = '2026-01-15T15:30:00Z';
+
+      const alignedResponse = await request
+        .post('/fhir/R4/Appointment/$book')
+        .set('Authorization', `Bearer ${project.accessToken}`)
+        .send(appointmentParam({ schedule, start: alignedStart, end: alignedEnd }));
+
+      expect(alignedResponse.body).not.toHaveProperty('issue');
+      expect(alignedResponse.status).toEqual(201);
+    });
   });
 
   describe('Loading schedulingParameters from HealthcareService', () => {

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -201,10 +201,12 @@ async function handler(params: {
     intersectingAvailability,
     (interval, _idx, maxCount) =>
       findAlignedSlotTimes(interval, {
-        offsetMinutes: commonParameters.alignmentOffset,
+        alignment: {
+          interval: commonParameters.alignmentInterval,
+          offset: commonParameters.alignmentOffset,
+          timezone: commonParameters.alignmentTimezone,
+        },
         durationMinutes: commonParameters.duration,
-        alignment: commonParameters.alignmentInterval,
-        timezone: commonParameters.alignmentTimezone,
         maxCount,
       }),
     pageSize

--- a/packages/server/src/fhir/operations/hold.test.ts
+++ b/packages/server/src/fhir/operations/hold.test.ts
@@ -903,9 +903,9 @@ describe('Appointment/$hold', () => {
         actor: practitioner1,
         extension: [makeSchedulingExtension({ service: officeVisitService, duration: 60, bufferBefore: 20 })],
       });
-      const bufferStart = '2026-01-15T09:00:00-05:00';
-      const busyStart = '2026-01-15T09:20:00-05:00';
-      const busyEnd = '2026-01-15T10:20:00-05:00';
+      const bufferStart = '2026-01-15T09:40:00-05:00';
+      const busyStart = '2026-01-15T10:00:00-05:00';
+      const busyEnd = '2026-01-15T11:00:00-05:00';
 
       const response = await request
         .post('/fhir/R4/Appointment/$hold')
@@ -928,6 +928,7 @@ describe('Appointment/$hold', () => {
           })
         );
 
+      expect(response.body).not.toHaveProperty('issue');
       expect(response.status).toEqual(201);
 
       const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
@@ -945,15 +946,15 @@ describe('Appointment/$hold', () => {
         actor: practitioner1,
         extension: [makeSchedulingExtension({ service: officeVisitService, duration: 60, bufferBefore: 20 })],
       });
-      const bufferStart = '2026-01-15T09:00:00-05:00';
-      const busyStart = '2026-01-15T09:20:00-05:00';
-      const busyEnd = '2026-01-15T10:20:00-05:00';
+      const bufferStart = '2026-01-15T09:40:00-05:00';
+      const busyStart = '2026-01-15T10:00:00-05:00';
+      const busyEnd = '2026-01-15T11:00:00-05:00';
 
       // Create an existing slot partially overlapping the requested buffer
       await systemRepo.createResource<Slot>({
         resourceType: 'Slot',
-        start: '2026-01-15T08:40:00-05:00',
-        end: '2026-01-15T09:10:00-05:00',
+        start: '2026-01-15T09:20:00-05:00',
+        end: '2026-01-15T09:50:00-05:00',
         status: 'busy',
         schedule: createReference(schedule),
         meta: { project: project.project.id },

--- a/packages/server/src/fhir/operations/utils/find.test.ts
+++ b/packages/server/src/fhir/operations/utils/find.test.ts
@@ -6,7 +6,7 @@ describe('findAlignedSlotTimes', () => {
   test('can find a slot that exactly coincides with the interval', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T01:00:00Z') },
-      { alignment: 60, offsetMinutes: 0, durationMinutes: 60, timezone: 'Etc/UTC' }
+      { alignment: { interval: 60, offset: 0, timezone: 'Etc/UTC' }, durationMinutes: 60 }
     );
     expect(slots).toEqual([{ start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T01:00:00Z') }]);
   });
@@ -14,7 +14,7 @@ describe('findAlignedSlotTimes', () => {
   test('returns empty when the interval is less than the duration', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T01:00:00Z') },
-      { alignment: 60, offsetMinutes: 0, durationMinutes: 90, timezone: 'Etc/UTC' }
+      { alignment: { interval: 60, offset: 0, timezone: 'Etc/UTC' }, durationMinutes: 90 }
     );
     expect(slots).toEqual([]);
   });
@@ -22,7 +22,7 @@ describe('findAlignedSlotTimes', () => {
   test('it finds slots aligned to hours', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 60, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
+      { alignment: { interval: 60, offset: 0, timezone: 'Etc/UTC' }, durationMinutes: 10 }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T00:10:00Z') },
@@ -33,7 +33,7 @@ describe('findAlignedSlotTimes', () => {
   test('it finds slots aligned to half hours', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 30, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
+      { alignment: { interval: 30, offset: 0, timezone: 'Etc/UTC' }, durationMinutes: 10 }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T00:10:00Z') },
@@ -46,7 +46,7 @@ describe('findAlignedSlotTimes', () => {
   test('it finds slots aligned to quarter hours', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 15, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
+      { alignment: { interval: 15, offset: 0, timezone: 'Etc/UTC' }, durationMinutes: 10 }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T00:10:00Z') },
@@ -63,7 +63,7 @@ describe('findAlignedSlotTimes', () => {
   test('it finds slots aligned to ten minute marks', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 10, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
+      { alignment: { interval: 10, offset: 0, timezone: 'Etc/UTC' }, durationMinutes: 10 }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T00:10:00Z') },
@@ -84,7 +84,7 @@ describe('findAlignedSlotTimes', () => {
   test('offsetting alignment by five minutes', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 15, offsetMinutes: 5, durationMinutes: 10, timezone: 'Etc/UTC' }
+      { alignment: { interval: 15, offset: 5, timezone: 'Etc/UTC' }, durationMinutes: 10 }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:05:00Z'), end: new Date('2025-12-01T00:15:00Z') },
@@ -101,7 +101,7 @@ describe('findAlignedSlotTimes', () => {
   test('offsetting alignment by 20 minutes', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 30, offsetMinutes: 20, durationMinutes: 10, timezone: 'Etc/UTC' }
+      { alignment: { interval: 30, offset: 20, timezone: 'Etc/UTC' }, durationMinutes: 10 }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:20:00Z'), end: new Date('2025-12-01T00:30:00Z') },
@@ -117,7 +117,7 @@ describe('findAlignedSlotTimes', () => {
     // some time before the resulting slot start time.
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 30, offsetMinutes: -20, durationMinutes: 10, timezone: 'Etc/UTC' }
+      { alignment: { interval: 30, offset: -20, timezone: 'Etc/UTC' }, durationMinutes: 10 }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:10:00Z'), end: new Date('2025-12-01T00:20:00Z') },
@@ -131,7 +131,7 @@ describe('findAlignedSlotTimes', () => {
     // Slots are aligned to a fifty-minute grid. The first slot is found at `00:00`.
     const slots50Midnight = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T03:00:00Z') },
-      { alignment: 50, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
+      { alignment: { interval: 50, offset: 0, timezone: 'Etc/UTC' }, durationMinutes: 10 }
     );
     expect(slots50Midnight).toEqual([
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T00:10:00Z') },
@@ -144,7 +144,7 @@ describe('findAlignedSlotTimes', () => {
     // to the same fifty-minute grid.
     const slots50Later = findAlignedSlotTimes(
       { start: new Date('2025-12-01T01:00:00Z'), end: new Date('2025-12-01T03:00:00Z') },
-      { alignment: 50, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
+      { alignment: { interval: 50, offset: 0, timezone: 'Etc/UTC' }, durationMinutes: 10 }
     );
     expect(slots50Later).toEqual([
       { start: new Date('2025-12-01T01:40:00Z'), end: new Date('2025-12-01T01:50:00Z') },
@@ -158,7 +158,7 @@ describe('findAlignedSlotTimes', () => {
     // Re-anchoring from Dec 2 midnight gives 00:00, 00:50, 01:40 (all 0 mod 50).
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T23:10:00Z'), end: new Date('2025-12-02T01:50:00Z') },
-      { alignment: 50, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
+      { alignment: { interval: 50, offset: 0, timezone: 'Etc/UTC' }, durationMinutes: 10 }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T23:20:00Z'), end: new Date('2025-12-01T23:30:00Z') },
@@ -174,7 +174,7 @@ describe('findAlignedSlotTimes', () => {
     // Re-anchoring from local midnight gives 00:00, 00:50, 01:40 EST on Dec 2.
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-02T04:10:00Z'), end: new Date('2025-12-02T07:00:00Z') },
-      { alignment: 50, offsetMinutes: 0, durationMinutes: 10, timezone: 'America/New_York' }
+      { alignment: { interval: 50, offset: 0, timezone: 'America/New_York' }, durationMinutes: 10 }
     );
     expect(slots).toEqual([
       // 23:20 EST Dec 1 — on Dec 1's grid (1400 min, 1400 % 50 = 0)
@@ -194,7 +194,7 @@ describe('findAlignedSlotTimes', () => {
     // 2025-11-30T18:30:00Z = midnight in Kolkata; 2025-11-30T21:30:00Z = 3am Kolkata.
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-11-30T18:30:00Z'), end: new Date('2025-11-30T21:30:00Z') },
-      { alignment: 50, offsetMinutes: 0, durationMinutes: 10, timezone: 'Asia/Kolkata' }
+      { alignment: { interval: 50, offset: 0, timezone: 'Asia/Kolkata' }, durationMinutes: 10 }
     );
     // Grid anchored to local midnight (18:30 UTC): 18:30, 19:20, 20:10, 21:00 UTC
     // = 00:00, 00:50, 01:40, 02:30 Kolkata
@@ -231,7 +231,7 @@ describe('findAlignedSlotTimes', () => {
     // following day, potentially overlapping the grid.
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T23:00:00Z'), end: new Date('2025-12-02T01:00:00Z') },
-      { alignment: 50, offsetMinutes: 0, durationMinutes: 50, timezone: 'Etc/UTC' }
+      { alignment: { interval: 50, offset: 0, timezone: 'Etc/UTC' }, durationMinutes: 50 }
     );
     expect(slots).toEqual([
       // This slot at the end of Dec 1 is found, even though it extends outside the Dec 1
@@ -248,7 +248,7 @@ describe('findAlignedSlotTimes', () => {
     // America/Chicago is CST (UTC-6) in winter and CDT (UTC-5) in summer.
     // alignment=50 with UTC anchoring gives different local start times in each
     // season; timezone anchoring keeps them the same.
-    const opts = { alignment: 50, offsetMinutes: 0, durationMinutes: 10, timezone: 'America/Chicago' };
+    const opts = { alignment: { interval: 50, offset: 0, timezone: 'America/Chicago' }, durationMinutes: 10 };
 
     // Winter (CST, UTC-6): 08:00–10:00 UTC = 02:00–04:00 CST
     const winterSlots = findAlignedSlotTimes(
@@ -276,7 +276,7 @@ describe('findAlignedSlotTimes', () => {
     expect(() => {
       findAlignedSlotTimes(
         { start: new Date('2025-12-01'), end: new Date('2025-12-08') },
-        { alignment: 0, offsetMinutes: 0, durationMinutes: 10, timezone: 'Etc/UTC' }
+        { alignment: { interval: 0, offset: 0, timezone: 'Etc/UTC' }, durationMinutes: 10 }
       );
     }).toThrow('Invalid alignment');
   });
@@ -284,7 +284,7 @@ describe('findAlignedSlotTimes', () => {
   test('maxCount option is respected', () => {
     const slots = findAlignedSlotTimes(
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T02:00:00Z') },
-      { alignment: 15, offsetMinutes: 0, durationMinutes: 10, maxCount: 5, timezone: 'Etc/UTC' }
+      { alignment: { interval: 15, offset: 0, timezone: 'Etc/UTC' }, durationMinutes: 10, maxCount: 5 }
     );
     expect(slots).toEqual([
       { start: new Date('2025-12-01T00:00:00Z'), end: new Date('2025-12-01T00:10:00Z') },

--- a/packages/server/src/fhir/operations/utils/find.ts
+++ b/packages/server/src/fhir/operations/utils/find.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Temporal } from 'temporal-polyfill';
 import type { Interval } from '../../../util/date';
 import { addMinutes, clamp } from '../../../util/date';
-import { eachDayOfInterval, normalizeIntervals, pairWithOverlaps } from './scheduling';
+import type { AlignmentOptions } from './scheduling';
+import { eachDayOfInterval, minutesSinceMidnight, mod, normalizeIntervals, pairWithOverlaps } from './scheduling';
 
 // Given a date that could have a seconds / milliseconds component, return
 // the input date if it does not have any, and the start of the next minute
@@ -17,55 +17,32 @@ function advanceToMinuteMark(date: Date): Date {
   return start;
 }
 
-// JS `%` operator is "remainder", not "modulo", and can return negative numbers.
-// Introducing our own mod function lets us guarantee that the result is in the
-// range [0, d).
-// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder
-function mod(n: number, d: number): number {
-  return ((n % d) + d) % d;
-}
-
-// Returns the number of minutes since local (or UTC) midnight for a given date.
-function minutesSinceMidnight(date: Date, timezone?: string): number {
-  if (timezone && timezone !== 'UTC' && timezone !== 'Etc/UTC') {
-    const zdt = Temporal.Instant.fromEpochMilliseconds(date.valueOf()).toZonedDateTimeISO(timezone);
-    return zdt.hour * 60 + zdt.minute;
-  }
-  return date.getUTCHours() * 60 + date.getUTCMinutes();
-}
-
 /**
  * Given an interval and slot duration and alignment information, return
  * intervals for each matching slot timing within that interval
  *
  * @param interval - The interval to find slots within
- * @param options - The alignment parameters
- * @param options.alignment - Minutes between slot starts; the grid is anchored to midnight (offset by offsetMinutes). Must be >= 1.
- * @param options.offsetMinutes - A number of minutes to offset the alignment by
+ * @param options - The alignment and slot parameters
+ * @param options.alignment - Parameters defining the alignment grid
  * @param options.durationMinutes - How long each slot should last
  * @param options.maxCount - Maximum number of intervals to find
- * @param options.timezone - IANA timezone name (e.g. "America/Los_Angeles"). The alignment
- *   grid is anchored to local midnight in this timezone, keeping slot times stable across
- *   DST transitions.
  * @returns An array of aligned slot intervals
  */
 export function findAlignedSlotTimes(
   interval: Interval,
   options: {
-    alignment: number;
-    offsetMinutes: number;
+    alignment: AlignmentOptions;
     durationMinutes: number;
-    timezone: string;
     maxCount?: number;
   }
 ): Interval[] {
-  if (options.alignment < 1) {
-    throw new Error(`Invalid alignment; must be positive, got ${options.alignment}`);
+  if (options.alignment.interval < 1) {
+    throw new Error(`Invalid alignment interval; must be positive, got ${options.alignment.interval}`);
   }
 
   const results: Interval[] = [];
 
-  for (const dayStart of eachDayOfInterval(interval, options.timezone)) {
+  for (const dayStart of eachDayOfInterval(interval, options.alignment.timezone)) {
     const nextDay = dayStart.add({ days: 1 });
     const dayInterval: Interval = {
       start: new Date(Math.max(interval.start.valueOf(), dayStart.epochMilliseconds)),
@@ -75,9 +52,9 @@ export function findAlignedSlotTimes(
     const firstMinuteStart = advanceToMinuteMark(dayInterval.start);
 
     // Find how much to shift to the first aligned slot of this calendar day.
-    const msm = minutesSinceMidnight(firstMinuteStart, options.timezone);
-    const remainder = mod(msm - options.offsetMinutes, options.alignment);
-    const toAlign = remainder === 0 ? 0 : options.alignment - remainder;
+    const msm = minutesSinceMidnight(firstMinuteStart, options.alignment.timezone);
+    const remainder = mod(msm - options.alignment.offset, options.alignment.interval);
+    const toAlign = remainder === 0 ? 0 : options.alignment.interval - remainder;
 
     let start = addMinutes(firstMinuteStart, toAlign);
     let end = addMinutes(start, options.durationMinutes);
@@ -92,7 +69,7 @@ export function findAlignedSlotTimes(
       if (options.maxCount && results.length >= options.maxCount) {
         return results;
       }
-      start = addMinutes(start, options.alignment);
+      start = addMinutes(start, options.alignment.interval);
       end = addMinutes(start, options.durationMinutes);
     }
   }

--- a/packages/server/src/fhir/operations/utils/scheduling.test.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.test.ts
@@ -9,6 +9,7 @@ import { withPath } from '../../../util/withpath';
 import type { Repository } from '../../repo';
 import {
   applyExistingSlots,
+  isAlignedToGrid,
   normalizeIntervals,
   removeAvailability,
   resolveAvailability,
@@ -712,5 +713,72 @@ describe('applyExistingSlots', () => {
     const serviceType = [{ coding: [{ system: 'http://example.com', code: 'office-visit' }] }];
 
     expect(applyExistingSlots({ availability: [], slots, range, serviceType })).toEqual(freeIntervals);
+  });
+});
+
+describe('isAlignedToGrid', () => {
+  const opts = { interval: 60, offset: 0, timezone: 'Etc/UTC' };
+
+  test('returns true for a date exactly on the hourly grid', () => {
+    expect(isAlignedToGrid(new Date('2025-12-01T09:00:00Z'), opts)).toBe(true);
+  });
+
+  test('returns false for a date not on the grid', () => {
+    expect(isAlignedToGrid(new Date('2025-12-01T09:37:00Z'), opts)).toBe(false);
+  });
+
+  test('returns false for a date with non-zero seconds', () => {
+    expect(isAlignedToGrid(new Date('2025-12-01T09:00:30Z'), opts)).toBe(false);
+  });
+
+  test('returns false for a date with non-zero milliseconds', () => {
+    expect(isAlignedToGrid(new Date('2025-12-01T09:00:00.500Z'), opts)).toBe(false);
+  });
+
+  test('respects alignmentOffset', () => {
+    const withOffset = { interval: 20, offset: 5, timezone: 'Etc/UTC' };
+    expect(isAlignedToGrid(new Date('2025-12-01T09:05:00Z'), withOffset)).toBe(true);
+    expect(isAlignedToGrid(new Date('2025-12-01T09:25:00Z'), withOffset)).toBe(true);
+    expect(isAlignedToGrid(new Date('2025-12-01T09:00:00Z'), withOffset)).toBe(false);
+    expect(isAlignedToGrid(new Date('2025-12-01T09:10:00Z'), withOffset)).toBe(false);
+  });
+
+  test('anchors to local midnight for non-UTC timezones', () => {
+    // America/Chicago in December is CST (UTC-6); local midnight = 06:00 UTC.
+    // With 50-min alignment, the Chicago and UTC grids differ (360 % 50 = 10).
+    // 09:20 UTC = 03:20 CST = 200 min since local midnight; 200 % 50 = 0 — on the Chicago grid
+    expect(
+      isAlignedToGrid(new Date('2025-12-01T09:20:00Z'), {
+        interval: 50,
+        offset: 0,
+        timezone: 'America/Chicago',
+      })
+    ).toBe(true);
+    // 09:10 UTC = 03:10 CST = 190 min since local midnight; 190 % 50 = 40 — not on the Chicago grid
+    expect(
+      isAlignedToGrid(new Date('2025-12-01T09:10:00Z'), {
+        interval: 50,
+        offset: 0,
+        timezone: 'America/Chicago',
+      })
+    ).toBe(false);
+  });
+
+  test('re-anchors the grid at local midnight for slots spanning midnight', () => {
+    // America/Chicago in December is CST (UTC-6); local midnight = 06:00 UTC.
+    // With 50-min alignment, the last grid point on Dec 1 is 23:20 CST = 05:20 UTC Dec 2
+    // (1400 min since Dec 1 midnight; 1400 % 50 = 0).
+    const lastSlotDec1 = new Date('2025-12-02T05:20:00Z');
+    expect(isAlignedToGrid(lastSlotDec1, { interval: 50, offset: 0, timezone: 'America/Chicago' })).toBe(true);
+
+    // Naïve continuation past Dec 1's grid would land at 00:10 CST Dec 2 = 06:10 UTC Dec 2
+    // (10 min since Dec 2 midnight; 10 % 50 = 10) — not on the re-anchored Dec 2 grid.
+    const naiveContinuation = new Date('2025-12-02T06:10:00Z');
+    expect(isAlignedToGrid(naiveContinuation, { interval: 50, offset: 0, timezone: 'America/Chicago' })).toBe(false);
+
+    // The actual first slot on Dec 2 is 00:00 CST = 06:00 UTC Dec 2
+    // (0 min since Dec 2 midnight; 0 % 50 = 0).
+    const firstSlotDec2 = new Date('2025-12-02T06:00:00Z');
+    expect(isAlignedToGrid(firstSlotDec2, { interval: 50, offset: 0, timezone: 'America/Chicago' })).toBe(true);
   });
 });

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -76,7 +76,7 @@ export function minutesSinceMidnight(date: Date, timezone?: string): number {
  * @returns boolean
  */
 export function isAlignedToGrid(date: Date, alignment: AlignmentOptions): boolean {
-  if (alignment.interval === 0) {
+  if (alignment.interval < 1) {
     throw new Error(`Invalid alignment interval; must be positive, got ${alignment.interval}`);
   }
   if (date.getUTCSeconds() !== 0 || date.getUTCMilliseconds() !== 0) {

--- a/packages/server/src/fhir/operations/utils/scheduling.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling.ts
@@ -37,10 +37,53 @@ import type { SchedulingParameters } from './scheduling-parameters';
 import { getHealthcareServiceSchedulingParameters, getScheduleSchedulingParameters } from './scheduling-parameters';
 import { uniqueOn } from './terminology';
 
+export type AlignmentOptions = {
+  interval: number;
+  offset: number;
+  timezone: string;
+};
+
 // Tricky: support zero-based and one-based indexing by including Sunday on both ends.
 // (Date#getDay() uses zero-based indexing and Temporal#dayOfWeek uses one-based indexing)
 type DayOfWeek = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
 const dayNames: DayOfWeek[] = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+
+// JS `%` operator is "remainder", not "modulo", and can return negative numbers.
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder
+export function mod(n: number, d: number): number {
+  return ((n % d) + d) % d;
+}
+
+// Returns the number of minutes since local (or UTC) midnight for a given date.
+export function minutesSinceMidnight(date: Date, timezone?: string): number {
+  if (timezone && timezone !== 'UTC' && timezone !== 'Etc/UTC') {
+    const zdt = Temporal.Instant.fromEpochMilliseconds(date.valueOf()).toZonedDateTimeISO(timezone);
+    return zdt.hour * 60 + zdt.minute;
+  }
+  return date.getUTCHours() * 60 + date.getUTCMinutes();
+}
+
+/**
+ * Returns true when `date` falls exactly on the alignment grid.
+ * The grid for a given day is anchored to local midnight in `timezone`:
+ * offset, offset+interval, offset+2*interval, ...
+ *
+ * @param date - a Date to test the alignment of
+ * @param alignment - parameters defining the alignment grid
+ * @param alignment.interval - minutes between grid entries
+ * @param alignment.offset - shift the grid by this amount
+ * @param alignment.timezone - anchors the grid to midnight in this timezone
+ * @returns boolean
+ */
+export function isAlignedToGrid(date: Date, alignment: AlignmentOptions): boolean {
+  if (alignment.interval === 0) {
+    throw new Error(`Invalid alignment interval; must be positive, got ${alignment.interval}`);
+  }
+  if (date.getUTCSeconds() !== 0 || date.getUTCMilliseconds() !== 0) {
+    return false;
+  }
+  return mod(minutesSinceMidnight(date, alignment.timezone) - alignment.offset, alignment.interval) === 0;
+}
 
 export function eachDayOfInterval(interval: Interval, timeZone: string): Temporal.ZonedDateTime[] {
   let t = Temporal.Instant.fromEpochMilliseconds(interval.start.valueOf())
@@ -422,9 +465,6 @@ export async function slotsOverlappingInterval(
 }
 
 // Ensures that the input slots match our scheduling parameter constraints
-//
-// Intentionally skipped for now: testing parameters.alignmentInterval and
-// parameters.alignmentOffset. See https://github.com/medplum/medplum/pull/8331.
 function validateSlots(slots: WithPath<Slot>[], parameters: SchedulingParameters): void {
   // Expect exactly one 'busy' slot with duration matching parameters.duration
   const busySlots = slots.filter((slot) => slot.status === 'busy');
@@ -441,6 +481,18 @@ function validateSlots(slots: WithPath<Slot>[], parameters: SchedulingParameters
   if (busyDurationMinutes !== parameters.duration) {
     throw new OperationOutcomeError(
       badRequest('Slot duration does not match scheduling parameters duration', getPath(busySlot))
+    );
+  }
+
+  if (
+    !isAlignedToGrid(new Date(busySlot.start), {
+      interval: parameters.alignmentInterval,
+      offset: parameters.alignmentOffset,
+      timezone: parameters.alignmentTimezone,
+    })
+  ) {
+    throw new OperationOutcomeError(
+      badRequest('Slot start time is not aligned to the scheduling grid', getPath(busySlot))
     );
   }
 


### PR DESCRIPTION
In #9488 (commit 6bd3b68ae) we established some rules for how scheduling slots should align to a grid when they are not evenly divisible by the hour. This should resolve the tension that we saw when we originally implemented the alignment testing: before that commit, `$find` could emit slots that would not pass validation, so we had disabled this enforcement (see #8331, commit f970721a9 for details).

With stronger understanding of the grid and more edge cases handled, it should now be the case that any results generated by `$find` (even with awkward alignment values) should be accepted by this validation.