### PR TITLE
fix: stop polling cancelled AsyncJob by returning 200 from status endpoint (Fixes #5575)

### DIFF
--- a/packages/server/src/fhir/job.test.ts
+++ b/packages/server/src/fhir/job.test.ts
@@ -117,6 +117,17 @@ describe('Job status', () => {
         requestTime: job.requestTime,
         request: 'http://example.com',
       });
+
+      // Verify the status polling endpoint returns 200 (not 202) for cancelled jobs
+      // so that the client stops polling (fixes #5575)
+      const res4 = await request(app)
+        .get(`/fhir/R4/job/${job.id}/status`)
+        .set('Authorization', 'Bearer ' + accessToken);
+
+      expect(res4.status).toBe(200);
+      expect(res4.body).toStrictEqual(
+        expect.objectContaining({ id: job.id, request: job.request, status: 'cancelled' })
+      );
     }));
 
   test('Cancel -- error (job already completed)', () =>

--- a/packages/server/src/fhir/job.ts
+++ b/packages/server/src/fhir/job.ts
@@ -17,7 +17,7 @@ import { sendFhirResponse } from './response';
 
 export const jobRouter = Router();
 
-const finalJobStatusCodes = ['completed', 'error'];
+const finalJobStatusCodes = ['completed', 'error', 'cancelled'];
 
 jobRouter.get('/:id/status', async (req: Request, res: Response) => {
   const ctx = getAuthenticatedContext();


### PR DESCRIPTION
Fixes #5575

## Problem

When an `AsyncJob` is cancelled (e.g., a reindex job), the status polling endpoint (`GET /fhir/R4/job/:id/status`) returns HTTP 202 because `'cancelled'` is not included in `finalJobStatusCodes`. The Medplum client treats 202 as "still running" and continues polling indefinitely — the spinner never stops.

## Root Cause

In `packages/server/src/fhir/job.ts`, line 20:

```typescript
const finalJobStatusCodes = ['completed', 'error'];
```

`'cancelled'` is missing, so the server returns `accepted` (HTTP 202) for cancelled jobs instead of `allOk` (HTTP 200). The client's `pollStatus()` method sees 202 and keeps retrying.

## Fix

Add `'cancelled'` to `finalJobStatusCodes`:

```typescript
const finalJobStatusCodes = ['completed', 'error', 'cancelled'];
```

This is a one-line change. When the server returns HTTP 200 with the cancelled `AsyncJob` resource, the client receives it and stops polling. The UI in `SuperAdminStartAsyncJob.tsx` already handles `AsyncJob` resources by showing a "View AsyncJob" link, so the user can see the cancelled status.

## Verification

Added a test assertion to the existing `Cancel -- Happy path` test that verifies the status polling endpoint returns HTTP 200 (not 202) for cancelled jobs:

```typescript
// Verify the status polling endpoint returns 200 (not 202) for cancelled jobs
const res4 = await request(app)
  .get(`/fhir/R4/job/${job.id}/status`)
  .set('Authorization', 'Bearer ' + accessToken);

expect(res4.status).toBe(200);
expect(res4.body).toStrictEqual(
  expect.objectContaining({ id: job.id, request: job.request, status: 'cancelled' })
);
```

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.


## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-18 | Initial fix: add 'cancelled' to finalJobStatusCodes | rtmalikian |
| 2026-06-18 | Added DCO sign-off to commit | rtmalikian |
| 2026-06-18 | Updated PR documentation with changelog | rtmalikian |

### Files Changed
- `packages/server/src/fhir/job.ts` — Added `'cancelled'` to `finalJobStatusCodes` set so cancelled AsyncJobs return HTTP 200

### Verification
- ✅ Cancelled AsyncJob returns HTTP 200 (not 202) from status endpoint
- ✅ Medplum client stops polling after job cancellation
- ✅ DCO sign-off present on all commits
