### PR TITLE
fix(server): add Provenance.activity search parameter

### DIFF
--- a/packages/definitions/src/fhir/r4/search-parameters-medplum.json
+++ b/packages/definitions/src/fhir/r4/search-parameters-medplum.json
@@ -869,6 +869,22 @@
       }
     },
     {
+      "fullUrl" : "http://hl7.org/fhir/SearchParameter/Provenance-activity",
+      "resource" : {
+        "resourceType" : "SearchParameter",
+        "id" : "Provenance-activity",
+        "url" : "http://hl7.org/fhir/SearchParameter/Provenance-activity",
+        "version" : "5.0.0",
+        "name" : "activity",
+        "status" : "draft",
+        "description" : "Activity that occurred",
+        "code" : "activity",
+        "base" : ["Provenance"],
+        "type" : "token",
+        "expression" : "Provenance.activity"
+      }
+    },
+    {
       "fullUrl" : "http://hl7.org/fhir/SearchParameter/ResearchStudy-classifier",
       "resource" : {
         "resourceType" : "SearchParameter",

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -302,8 +302,9 @@ export class Repository extends FhirRepository implements Disposable {
    *                Project.features (https://github.com/medplum/medplum/pull/9049)
    *                Login.preAuthorizedCodeHash (https://github.com/medplum/medplum/pull/9231)
    *                Project.link (https://github.com/medplum/medplum/pull/9159)
+   * 16. 06/20/26 - Added search parameter `Provenance-activity` (https://github.com/medplum/medplum/pull/9564)
    */
-  static readonly VERSION: number = 15;
+  static readonly VERSION: number = 16;
 
   /**
    * Constructs a new Repository instance.

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -3253,6 +3253,50 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       expect(bundleContains(bundle, c2)).not.toBeTruthy();
     }));
 
+  test('Provenance.activity search', () =>
+    withTestContext(async () => {
+      const code = randomUUID();
+      const otherCode = randomUUID();
+
+      const patient = await repo.createResource<Patient>({
+        resourceType: 'Patient',
+      });
+
+      const practitioner = await repo.createResource<Practitioner>({
+        resourceType: 'Practitioner',
+      });
+
+      const provenance = await repo.createResource<Provenance>({
+        resourceType: 'Provenance',
+        target: [createReference(patient)],
+        recorded: new Date().toISOString(),
+        activity: { coding: [{ system: SNOMED, code }] },
+        agent: [{ who: createReference(practitioner) }],
+      });
+
+      await repo.createResource<Provenance>({
+        resourceType: 'Provenance',
+        target: [createReference(patient)],
+        recorded: new Date().toISOString(),
+        activity: { coding: [{ system: SNOMED, code: otherCode }] },
+        agent: [{ who: createReference(practitioner) }],
+      });
+
+      const bundle = await repo.search({
+        resourceType: 'Provenance',
+        filters: [
+          {
+            code: 'activity',
+            operator: Operator.EQUALS,
+            value: `${SNOMED}|${code}`,
+          },
+        ],
+      });
+
+      expect(bundle.entry?.length).toStrictEqual(1);
+      expect(bundle.entry?.[0]?.resource?.id).toStrictEqual(provenance.id);
+    }));
+
   test('Condition.code :not next URL', () =>
     withTestContext(async () => {
       const p = await repo.createResource({

--- a/packages/server/src/fhir/searchparameter.test.ts
+++ b/packages/server/src/fhir/searchparameter.test.ts
@@ -235,6 +235,15 @@ describe('SearchParameterImplementation', () => {
     expectTokenColumnImplementation(impl);
   });
 
+  test('Provenance-activity', () => {
+    const searchParam = indexedSearchParams.find((e) => e.id === 'Provenance-activity') as SearchParameter;
+    const impl = getSearchParameterImplementation('Provenance', searchParam);
+    expectTokenColumnImplementation(impl);
+    expect(impl.tokenColumnName).toStrictEqual('__activity');
+    expect(impl.textSearchColumnName).toStrictEqual('__activityText');
+    expect(impl.sortColumnName).toStrictEqual('__activitySort');
+  });
+
   test.each([['Patient-identifier'], ['Patient-language']])(
     'token column for SearchParameter %s on Patient',
     (searchParamId) => {

--- a/packages/server/src/migrations/data/data-version-manifest.json
+++ b/packages/server/src/migrations/data/data-version-manifest.json
@@ -144,5 +144,8 @@
   },
   "v38": {
     "serverVersion": "5.1.13"
+  },
+  "v39": {
+    "serverVersion": "5.1.19"
   }
 }

--- a/packages/server/src/migrations/data/index.ts
+++ b/packages/server/src/migrations/data/index.ts
@@ -47,3 +47,4 @@ export * as v35 from './v35';
 export * as v36 from './v36';
 export * as v37 from './v37';
 export * as v38 from './v38';
+export * as v39 from './v39';

--- a/packages/server/src/migrations/data/v39.ts
+++ b/packages/server/src/migrations/data/v39.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
+
+import type { PoolClient } from 'pg';
+import { prepareCustomMigrationJobData, runCustomMigration } from '../../workers/post-deploy-migration';
+import * as fns from '../migrate-functions';
+import type { MigrationActionResult } from '../types';
+import type { CustomPostDeployMigration } from './types';
+
+export const migration: CustomPostDeployMigration = {
+  type: 'custom',
+  prepareJobData: (asyncJob) => prepareCustomMigrationJobData(asyncJob),
+  run: async (repo, job, jobData) => runCustomMigration(repo, job, jobData, callback),
+};
+
+// prettier-ignore
+async function callback(client: PoolClient, results: MigrationActionResult[]): Promise<void> {
+  await fns.idempotentCreateIndex(client, results, 'Provenance___activity_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "Provenance___activity_idx" ON "Provenance" USING gin ("__activity")`);
+  await fns.idempotentCreateIndex(client, results, 'Provenance___activityTextTrgm_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "Provenance___activityTextTrgm_idx" ON "Provenance" USING gin (token_array_to_text("__activityText") gin_trgm_ops)`);
+}

--- a/packages/server/src/migrations/schema/index.ts
+++ b/packages/server/src/migrations/schema/index.ts
@@ -117,3 +117,4 @@ export * as v105 from './v105';
 export * as v106 from './v106';
 export * as v107 from './v107';
 export * as v108 from './v108';
+export * as v109 from './v109';

--- a/packages/server/src/migrations/schema/v109.ts
+++ b/packages/server/src/migrations/schema/v109.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
+
+import type { PoolClient } from 'pg';
+import * as fns from '../migrate-functions';
+
+// prettier-ignore
+export async function run(client: PoolClient): Promise<void> {
+  const results: { name: string; durationMs: number }[] = []
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "Provenance" ADD COLUMN IF NOT EXISTS "__activity" UUID[]`);
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "Provenance" ADD COLUMN IF NOT EXISTS "__activityText" TEXT[]`);
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "Provenance" ADD COLUMN IF NOT EXISTS "__activitySort" TEXT`);
+}


### PR DESCRIPTION
## Summary

Adds the R5 `Provenance-activity` SearchParameter to Medplum's search parameter
bundle and wires it through the server's token-column search path, so
`Provenance` resources can be queried by `activity`
(e.g. `GET /Provenance?activity=<system>|<code>`).

Fixes #9472.

## Changes

- **SearchParameter** — add `http://hl7.org/fhir/SearchParameter/Provenance-activity`
  (token, expression `Provenance.activity`) to `search-parameters-medplum.json`.
- **Schema migration `v109`** — add the `__activity`, `__activityText`,
  `__activitySort` token columns to the `Provenance` table.
- **Data migration `v39`** — create the token (`gin`) and trigram-text
  (`gin_trgm_ops`) indexes.
- **`Repository.VERSION` 15 → 16** with a changelog entry.

New and updated `Provenance` resources are indexed on `activity` immediately;
existing rows pick up the column on reindex (`$reindex`), the same model used
for the recent `Project.link` search parameter (#9250). I left out a forced
reindex migration to avoid imposing a full `Provenance` reindex on every
deployment — happy to add one if you'd prefer immediate backfill.

The `v109` and `v39` migrations are generator output, not hand-written —
re-running `npm run migrate` against `main` emits them byte-for-byte.

## Testing

Run against Postgres 16 + Redis 7 using the standard test harness:

- `npx turbo run build --filter=@medplum/server`
- `npx turbo run lint --filter=@medplum/server`
- `npm run test:seed` — migrates a fresh `medplum_test` to head, applying `v109`
- `searchparameter.test.ts` — `Provenance-activity` token-column implementation
- `search.test.ts` — `Provenance.activity search` end-to-end (create + search by activity)
- `data-version-manifest.test.ts`, `migrate.test.ts`, `migrate-main.test.ts`
- Generator drift check — after applying the migrations, `npm run migrate --dryRun`
  reports no pending changes.
