### PR TITLE
fix: include _id search param in field selector display (Fixes #6043)

### DIFF
--- a/packages/react/src/SearchFieldEditor/SearchFieldEditor.tsx
+++ b/packages/react/src/SearchFieldEditor/SearchFieldEditor.tsx
@@ -132,23 +132,19 @@ function getFieldsList(
 ): string[] {
   const result = [] as string[];
   const keys = new Set<string>();
-  const names = new Set<string>();
 
   // Add properties first
   for (const key of Object.keys(typeSchema.elements)) {
     result.push(key);
     keys.add(key.toLowerCase());
-    names.add(buildFieldNameString(key));
   }
 
-  // Add search parameters if unique
+  // Add search parameters if unique by code
   if (searchParams) {
     for (const code of Object.keys(searchParams)) {
-      const name = buildFieldNameString(code);
-      if (!keys.has(code) && !names.has(name)) {
+      if (!keys.has(code)) {
         result.push(code);
         keys.add(code);
-        names.add(name);
       }
     }
   }


### PR DESCRIPTION
Fixes #6043

## Problem

The `_id` search parameter was not included in the field selector dropdown because the `getFieldsList` function in `SearchFieldEditor` deduplicated fields by display name. Since both the `id` property and `_id` search parameter resolve to the display name "ID", the `_id` search parameter was filtered out.

When `_id` appeared in the `fields` array (e.g., from URL parsing like `Patient?_fields=_id,name`), Mantine's `MultiSelect` couldn't find a matching entry in the data list and displayed the raw `_id` string instead of the user-friendly "ID" label.

## Solution

Removed the display-name-based deduplication from `getFieldsList`. The function now deduplicates by field code only (using the `keys` set), which correctly treats `id` and `_id` as distinct fields while still preventing true duplicates.

## Verification

All existing tests pass:

```
✓ src/SearchFieldEditor/SearchFieldEditor.test.tsx (3 tests) 241ms
✓ src/SearchControl/SearchControlField.test.ts (1 test) 2ms
✓ src/SearchControl/SearchUtils.test.tsx (21 tests) 5ms
```

ESLint passes with no new warnings (only a pre-existing `react-hooks/set-state-in-effect` warning unrelated to this change).

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
