### PR TITLE
Use renovate for dockerfile and github actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,20 @@
+{
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "dependencyDashboard": false,
+  "automerge": false,
+  "minimumReleaseAge": "3 days",
+  "packageRules": [
+    {
+      "description": "Docker base images: grouped weekly PR, pinned digests",
+      "matchManagers": ["dockerfile"],
+      "groupName": "docker base image updates",
+      "pinDigests": true
+    },
+    {
+      "description": "GitHub Actions: update SHA pins using upstream tags",
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions updates",
+      "pinDigests": true
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "enabledManagers": ["dockerfile", "github-actions"],
   "dependencyDashboard": false,
   "automerge": false,
   "minimumReleaseAge": "3 days",

--- a/.github/workflows/autofix-ci.yml
+++ b/.github/workflows/autofix-ci.yml
@@ -42,4 +42,4 @@ jobs:
       - run: npm run prettier
       - run: npm run lint:fix
 
-      - uses: autofix-ci/action@2891949f3779a1cafafae1523058501de3d4e944
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,22 @@
+name: Renovate
+
+on:
+  schedule:
+    # Every Monday at 9:00 AM UTC
+    # Every Monday at 1:00 AM PST (2:00 AM PDT)
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: renovatebot/github-action@8217b3fc286df088d7c27f3255fe8414463bc0fd # v46.1.15
+        with:
+          token: ${{ secrets.MEDPLUM_BOT_GITHUB_ACCESS_TOKEN }}


### PR DESCRIPTION
In response to yesterday's incident with Node.js 24.17, we are moving from floating Docker image tags to explicitly pinned versions in our `Dockerfile`s. Pinning versions gives us more predictable builds and reduces the risk of unexpected upstream changes affecting production.

The tradeoff is that pinned versions require an intentional upgrade process.

For NPM dependencies, we already have an established process using `npm-check-updates` and `upgrade.sh`. That workflow has served us well, but it only covers NPM packages.

This PR introduces Renovate, which can automatically detect and propose upgrades across multiple dependency types, including Docker base images and GitHub Actions.

## Scope

For now, Renovate is only responsible for:

* Docker base image versions in `Dockerfile`s
* GitHub Actions versions and pinned SHAs in workflow YAML files

NPM dependency management remains unchanged and continues to use `upgrade.sh`.

## Future Considerations

Over time, it may be worth evaluating whether Renovate can also take over some or all of our NPM upgrade workflow. However, `upgrade.sh` has accumulated a significant amount of institutional knowledge and operational nuance (cooldowns, exclusions, staged upgrades, etc.), so any migration would need to preserve those capabilities and provide a comparable developer experience.

This PR is intentionally limited in scope and does not change our existing NPM dependency upgrade process.
