### PR TITLE
fix(server): annotate included search entries with their source match

### DIFF
--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -62,7 +62,13 @@ import { bundleContains, createTestProject, withTestContext } from '../test.setu
 import type { SystemRepository } from './repo';
 import { getGlobalSystemRepo, Repository } from './repo';
 import type { ChainedSearchLink } from './search';
-import { clampEstimateCount, Direction, getCount, parseChainedParameter } from './search';
+import {
+  clampEstimateCount,
+  Direction,
+  getCount,
+  parseChainedParameter,
+  SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+} from './search';
 import type { TokenColumnSearchParameterImplementation } from './searchparameter';
 import { getSearchParameterImplementation } from './searchparameter';
 import { SelectQuery } from './sql';
@@ -2418,7 +2424,61 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       });
       expect(bundle.total).toStrictEqual(1);
       expect(bundleContains(bundle, order)).toMatchObject<BundleEntry>({ search: { mode: 'match' } });
-      expect(bundleContains(bundle, patient)).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
+      expect(bundleContains(bundle, patient)).toMatchObject<BundleEntry>({
+        search: {
+          mode: 'include',
+          extension: [
+            {
+              url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+              valueReference: { reference: getReferenceString(order) },
+            },
+          ],
+        },
+      });
+    }));
+
+  test('Include references records all matching source resources', () =>
+    withTestContext(async () => {
+      const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+      const order1 = await repo.createResource<ServiceRequest>({
+        resourceType: 'ServiceRequest',
+        status: 'active',
+        intent: 'order',
+        subject: createReference(patient),
+      });
+      const order2 = await repo.createResource<ServiceRequest>({
+        resourceType: 'ServiceRequest',
+        status: 'active',
+        intent: 'order',
+        subject: createReference(patient),
+      });
+
+      const bundle = await repo.search({
+        resourceType: 'ServiceRequest',
+        include: [
+          {
+            resourceType: 'ServiceRequest',
+            searchParam: 'subject',
+          },
+        ],
+        filters: [{ code: 'subject', operator: Operator.EQUALS, value: getReferenceString(patient) }],
+      });
+
+      const patientEntry = bundleContains(bundle, patient);
+      expect(patientEntry).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
+      expect(patientEntry?.search?.extension).toEqual(
+        expect.arrayContaining([
+          {
+            url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+            valueReference: { reference: getReferenceString(order1) },
+          },
+          {
+            url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+            valueReference: { reference: getReferenceString(order2) },
+          },
+        ])
+      );
+      expect(patientEntry?.search?.extension).toHaveLength(2);
     }));
 
   test('Include canonical success', () =>
@@ -2447,7 +2507,17 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       });
       expect(bundle.total).toStrictEqual(1);
       expect(bundleContains(bundle, response)).toMatchObject<BundleEntry>({ search: { mode: 'match' } });
-      expect(bundleContains(bundle, questionnaire)).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
+      expect(bundleContains(bundle, questionnaire)).toMatchObject<BundleEntry>({
+        search: {
+          mode: 'include',
+          extension: [
+            {
+              url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+              valueReference: { reference: getReferenceString(response) },
+            },
+          ],
+        },
+      });
     }));
 
   test('Include PlanDefinition mixed types', () =>
@@ -2557,10 +2627,26 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
         search: { mode: 'match' },
       });
       expect(bundleContains(searchResult2, provenance1)).toMatchObject<BundleEntry>({
-        search: { mode: 'include' },
+        search: {
+          mode: 'include',
+          extension: [
+            {
+              url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+              valueReference: { reference: getReferenceString(practitioner1) },
+            },
+          ],
+        },
       });
       expect(bundleContains(searchResult2, provenance2)).toMatchObject<BundleEntry>({
-        search: { mode: 'include' },
+        search: {
+          mode: 'include',
+          extension: [
+            {
+              url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+              valueReference: { reference: getReferenceString(practitioner2) },
+            },
+          ],
+        },
       });
     }));
 
@@ -2590,7 +2676,17 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       });
       expect(bundle.total).toStrictEqual(1);
       expect(bundleContains(bundle, questionnaire)).toMatchObject<BundleEntry>({ search: { mode: 'match' } });
-      expect(bundleContains(bundle, response)).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
+      expect(bundleContains(bundle, response)).toMatchObject<BundleEntry>({
+        search: {
+          mode: 'include',
+          extension: [
+            {
+              url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+              valueReference: { reference: getReferenceString(questionnaire) },
+            },
+          ],
+        },
+      });
     }));
 
   test('Reverse include on denied type', () =>
@@ -3062,7 +3158,15 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
           }),
           expect.objectContaining<BundleEntry>({
             fullUrl: expect.stringContaining(getReferenceString(gp1)),
-            search: { mode: 'include' },
+            search: {
+              mode: 'include',
+              extension: [
+                {
+                  url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+                  valueReference: { reference: getReferenceString(patient1) },
+                },
+              ],
+            },
           }),
         ],
       });
@@ -3082,11 +3186,27 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
           }),
           expect.objectContaining<BundleEntry>({
             fullUrl: expect.stringContaining(getReferenceString(gp1)),
-            search: { mode: 'include' },
+            search: {
+              mode: 'include',
+              extension: [
+                {
+                  url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+                  valueReference: { reference: getReferenceString(patient1) },
+                },
+              ],
+            },
           }),
           expect.objectContaining<BundleEntry>({
             fullUrl: expect.stringContaining(getReferenceString(gp2)),
-            search: { mode: 'include' },
+            search: {
+              mode: 'include',
+              extension: [
+                {
+                  url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+                  valueReference: { reference: getReferenceString(patient2) },
+                },
+              ],
+            },
           }),
         ],
       });

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -2546,6 +2546,44 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       expect(bundleContains(bundle, patientB)?.search).toStrictEqual({ mode: 'match' });
     }));
 
+  test('Include source extension respects access-policy hidden fields', () =>
+    withTestContext(async () => {
+      // The policy can read ServiceRequest and Patient, but hides ServiceRequest.subject.
+      const { repo: restrictedRepo, project } = await createTestProject({
+        withRepo: true,
+        accessPolicy: {
+          resourceType: 'AccessPolicy',
+          resource: [{ resourceType: 'ServiceRequest', hiddenFields: ['subject'] }, { resourceType: 'Patient' }],
+        },
+      });
+      const patient = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        meta: { project: project.id },
+      });
+      const order = await systemRepo.createResource<ServiceRequest>({
+        resourceType: 'ServiceRequest',
+        meta: { project: project.id },
+        status: 'active',
+        intent: 'order',
+        subject: createReference(patient),
+      });
+
+      const bundle = await restrictedRepo.search({
+        resourceType: 'ServiceRequest',
+        filters: [{ code: '_id', operator: Operator.EQUALS, value: order.id }],
+        include: [{ resourceType: 'ServiceRequest', searchParam: 'subject' }],
+      });
+
+      // The include still resolves the patient, matching pre-existing behavior...
+      const orderEntry = bundleContains(bundle, order);
+      expect(orderEntry).toMatchObject<BundleEntry>({ search: { mode: 'match' } });
+      expect((orderEntry?.resource as ServiceRequest).subject).toBeUndefined();
+      const patientEntry = bundleContains(bundle, patient);
+      expect(patientEntry).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
+      // ...but the source extension does not re-expose the reference the policy hid.
+      expect(patientEntry?.search?.extension).toBeUndefined();
+    }));
+
   test('Include canonical success', () =>
     withTestContext(async () => {
       const canonicalURL = 'http://example.com/fhir/Questionnaire/PHQ-9/' + randomUUID();
@@ -2766,6 +2804,47 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
             url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
             valueReference: { reference: getReferenceString(practitioner2) },
           },
+        ])
+      );
+      expect(provenanceEntry?.search?.extension).toHaveLength(2);
+    }));
+
+  test('Reverse include records source for a versioned target reference', () =>
+    withTestContext(async () => {
+      const family = randomUUID();
+      const practitioner1 = await repo.createResource<Practitioner>({
+        resourceType: 'Practitioner',
+        name: [{ given: ['Homer'], family }],
+      });
+      const practitioner2 = await repo.createResource<Practitioner>({
+        resourceType: 'Practitioner',
+        name: [{ given: ['Marge'], family }],
+      });
+      // One target is unversioned, so the provenance is reverse-included; the other is a
+      // version-specific reference to a second matched practitioner. Source attribution must
+      // normalize that versioned reference back to the match, otherwise it is dropped.
+      const provenance = await repo.createResource<Provenance>({
+        resourceType: 'Provenance',
+        target: [
+          createReference(practitioner1),
+          { reference: `Practitioner/${practitioner2.id}/_history/${practitioner2.meta?.versionId}` },
+        ],
+        agent: [{ who: createReference(practitioner1) }],
+        recorded: new Date().toISOString(),
+      });
+
+      const bundle = await repo.search({
+        resourceType: 'Practitioner',
+        filters: [{ code: 'name', operator: Operator.EQUALS, value: family }],
+        revInclude: [{ resourceType: 'Provenance', searchParam: 'target' }],
+      });
+
+      const provenanceEntry = bundleContains(bundle, provenance);
+      expect(provenanceEntry).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
+      expect(provenanceEntry?.search?.extension).toEqual(
+        expect.arrayContaining([
+          { url: SEARCH_ENTRY_SOURCE_EXTENSION_URL, valueReference: { reference: getReferenceString(practitioner1) } },
+          { url: SEARCH_ENTRY_SOURCE_EXTENSION_URL, valueReference: { reference: getReferenceString(practitioner2) } },
         ])
       );
       expect(provenanceEntry?.search?.extension).toHaveLength(2);

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -2487,6 +2487,65 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       expect(patientEntry?.search?.extension).toHaveLength(2);
     }));
 
+  test('Include with versioned reference records source', () =>
+    withTestContext(async () => {
+      const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+      const order = await repo.createResource<ServiceRequest>({
+        resourceType: 'ServiceRequest',
+        status: 'active',
+        intent: 'order',
+        subject: { reference: `Patient/${patient.id}/_history/${patient.meta?.versionId}` },
+      });
+      const bundle = await repo.search({
+        resourceType: 'ServiceRequest',
+        include: [
+          {
+            resourceType: 'ServiceRequest',
+            searchParam: 'subject',
+          },
+        ],
+        filters: [{ code: '_id', operator: Operator.EQUALS, value: order.id }],
+      });
+      expect(bundleContains(bundle, patient)).toMatchObject<BundleEntry>({
+        search: {
+          mode: 'include',
+          extension: [
+            {
+              url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+              valueReference: { reference: getReferenceString(order) },
+            },
+          ],
+        },
+      });
+    }));
+
+  test('Match entries are never annotated with source extensions', () =>
+    withTestContext(async () => {
+      const identifier = randomUUID();
+      const patientB = await repo.createResource<Patient>({
+        resourceType: 'Patient',
+        identifier: [{ value: identifier }],
+      });
+      const patientA = await repo.createResource<Patient>({
+        resourceType: 'Patient',
+        identifier: [{ value: identifier }],
+        link: [{ other: createReference(patientB), type: 'replaces' }],
+      });
+      const bundle = await repo.search({
+        resourceType: 'Patient',
+        filters: [{ code: 'identifier', operator: Operator.EQUALS, value: identifier }],
+        include: [
+          {
+            resourceType: 'Patient',
+            searchParam: 'link',
+          },
+        ],
+      });
+      expect(bundle.entry).toHaveLength(2);
+      expect(bundleContains(bundle, patientA)?.search).toStrictEqual({ mode: 'match' });
+      expect(bundleContains(bundle, patientB)?.search).toStrictEqual({ mode: 'match' });
+    }));
+
   test('Include canonical success', () =>
     withTestContext(async () => {
       const canonicalURL = 'http://example.com/fhir/Questionnaire/PHQ-9/' + randomUUID();
@@ -2558,8 +2617,18 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       });
       expect(bundle.total).toStrictEqual(1);
       expect(bundleContains(bundle, plan)).toMatchObject<BundleEntry>({ search: { mode: 'match' } });
-      expect(bundleContains(bundle, activity1)).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
-      expect(bundleContains(bundle, activity2)).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
+      const planSourceExtension = [
+        {
+          url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+          valueReference: { reference: getReferenceString(plan) },
+        },
+      ];
+      expect(bundleContains(bundle, activity1)).toMatchObject<BundleEntry>({
+        search: { mode: 'include', extension: planSourceExtension },
+      });
+      expect(bundleContains(bundle, activity2)).toMatchObject<BundleEntry>({
+        search: { mode: 'include', extension: planSourceExtension },
+      });
     }));
 
   test('Include references invalid search param', async () =>
@@ -3079,6 +3148,23 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       expect(
         bundle.entry?.map((e) => `${e.search?.mode}:${e.resource?.resourceType}/${e.resource?.id}`).sort()
       ).toStrictEqual(expected);
+
+      // Revinclude sources on :iterate rounds point at the immediate parent, which may itself be an
+      // included resource rather than a match
+      const observation3Entry = bundle.entry?.find((e) => e.resource?.id === observation3.id);
+      expect(observation3Entry?.search?.extension).toStrictEqual([
+        {
+          url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+          valueReference: { reference: `Patient/${linked2.id}` },
+        },
+      ]);
+      const observation4Entry = bundle.entry?.find((e) => e.resource?.id === observation4.id);
+      expect(observation4Entry?.search?.extension).toStrictEqual([
+        {
+          url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+          valueReference: { reference: `Observation/${observation2.id}` },
+        },
+      ]);
     }));
 
   test('_include depth limit', () =>

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -2402,6 +2402,12 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       expect(result.entry?.[0]?.resource?.id).toStrictEqual(observation.id);
     }));
 
+  test('Search entry source extension URL is a stable public contract', () => {
+    expect(SEARCH_ENTRY_SOURCE_EXTENSION_URL).toStrictEqual(
+      'https://medplum.com/fhir/StructureDefinition/search-entry-source'
+    );
+  });
+
   test('Include references success', () =>
     withTestContext(async () => {
       const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
@@ -2650,6 +2656,52 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       });
     }));
 
+  test('Reverse include records all matching source resources', () =>
+    withTestContext(async () => {
+      const family = randomUUID();
+      const practitioner1 = await repo.createResource<Practitioner>({
+        resourceType: 'Practitioner',
+        name: [{ given: ['Homer'], family }],
+      });
+      const practitioner2 = await repo.createResource<Practitioner>({
+        resourceType: 'Practitioner',
+        name: [{ given: ['Marge'], family }],
+      });
+      const provenance = await repo.createResource<Provenance>({
+        resourceType: 'Provenance',
+        target: [createReference(practitioner1), createReference(practitioner2)],
+        agent: [{ who: createReference(practitioner1) }],
+        recorded: new Date().toISOString(),
+      });
+
+      const bundle = await repo.search({
+        resourceType: 'Practitioner',
+        filters: [{ code: 'name', operator: Operator.EQUALS, value: family }],
+        revInclude: [
+          {
+            resourceType: 'Provenance',
+            searchParam: 'target',
+          },
+        ],
+      });
+
+      const provenanceEntry = bundleContains(bundle, provenance);
+      expect(provenanceEntry).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
+      expect(provenanceEntry?.search?.extension).toEqual(
+        expect.arrayContaining([
+          {
+            url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+            valueReference: { reference: getReferenceString(practitioner1) },
+          },
+          {
+            url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+            valueReference: { reference: getReferenceString(practitioner2) },
+          },
+        ])
+      );
+      expect(provenanceEntry?.search?.extension).toHaveLength(2);
+    }));
+
   test('Reverse include canonical', () =>
     withTestContext(async () => {
       const canonicalURL = 'http://example.com/fhir/Questionnaire/PHQ-9/' + randomUUID();
@@ -2866,6 +2918,23 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       expect(
         bundle.entry?.map((e) => `${e.search?.mode}:${e.resource?.resourceType}/${e.resource?.id}`).sort()
       ).toStrictEqual(expected);
+
+      // practitioner2 is included by linked2 on one iteration and re-encountered via linked3 on the next;
+      // its deduplicated entry must accumulate both source references
+      const practitioner2Entry = bundle.entry?.find((e) => e.resource?.id === practitioner2.id);
+      expect(practitioner2Entry?.search?.extension).toEqual(
+        expect.arrayContaining([
+          {
+            url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+            valueReference: { reference: `Patient/${linked2.id}` },
+          },
+          {
+            url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+            valueReference: { reference: `Patient/${linked3.id}` },
+          },
+        ])
+      );
+      expect(practitioner2Entry?.search?.extension).toHaveLength(2);
     }));
 
   test('_revinclude:iterate', () =>

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -40,6 +40,7 @@ import type {
   Bundle,
   BundleEntry,
   BundleLink,
+  Extension,
   Reference,
   Resource,
   ResourceType,
@@ -85,6 +86,8 @@ const maxSearchResults = DEFAULT_MAX_SEARCH_COUNT;
 export const minCursorBasedSearchPageSize = 20;
 
 const canonicalReferenceTypes: string[] = [PropertyType.canonical, PropertyType.uri];
+
+export const SEARCH_ENTRY_SOURCE_EXTENSION_URL = 'https://medplum.com/fhir/StructureDefinition/search-entry-source';
 
 type SearchRequestWithCountAndOffset<T extends Resource = Resource> = SearchRequest<T> & {
   count: number;
@@ -516,6 +519,8 @@ async function getExtraEntries<T extends Resource>(
       const ref = `${resource.resourceType}/${resource.id}`;
       if (!seen.has(ref)) {
         entries.push(entry);
+      } else {
+        mergeSearchSourceExtensions(entries, entry);
       }
       seen.add(ref);
     }
@@ -545,14 +550,25 @@ async function getSearchIncludeEntries(
     throw new OperationOutcomeError(badRequest(`Invalid include parameter: ${resourceType}:${code}`));
   }
 
-  const fhirPathResult = evalFhirPathTyped(searchParam.expression as string, resources.map(toTypedValue));
   const references: Reference[] = [];
   const canonicalReferences: string[] = [];
-  for (const result of fhirPathResult) {
-    if (result.type === PropertyType.Reference) {
-      references.push(result.value);
-    } else if (canonicalReferenceTypes.includes(result.type)) {
-      canonicalReferences.push(result.value);
+  const referenceSources = new Map<string, Set<string>>();
+  const canonicalReferenceSources = new Map<string, Set<string>>();
+  for (const sourceResource of resources) {
+    const sourceReference = getReferenceString(sourceResource);
+    if (!sourceReference) {
+      continue;
+    }
+
+    const fhirPathResult = evalFhirPathTyped(searchParam.expression as string, [toTypedValue(sourceResource)]);
+    for (const result of fhirPathResult) {
+      if (result.type === PropertyType.Reference) {
+        references.push(result.value);
+        addSourceReference(referenceSources, result.value.reference, sourceReference);
+      } else if (canonicalReferenceTypes.includes(result.type)) {
+        canonicalReferences.push(result.value);
+        addSourceReference(canonicalReferenceSources, result.value, sourceReference);
+      }
     }
   }
 
@@ -583,11 +599,12 @@ async function getSearchIncludeEntries(
     }
   }
 
-  return includedResources.map((resource) => ({
-    fullUrl: getFullUrl(resource.resourceType, resource.id),
-    search: { mode: 'include' },
-    resource,
-  }));
+  return includedResources.map((resource) =>
+    buildIncludedEntry(resource, [
+      ...getSourceReferences(referenceSources, getReferenceString(resource)),
+      ...getSourceReferences(canonicalReferenceSources, getCanonicalUrl(resource)),
+    ])
+  );
 }
 
 /**
@@ -610,10 +627,12 @@ async function getSearchRevIncludeEntries(
     throw new OperationOutcomeError(badRequest(`Invalid include parameter: ${resourceType}:${code}`));
   }
 
-  const references =
-    getSearchParameterImplementation(resourceType, searchParam).type === SearchParameterType.CANONICAL
-      ? flatMapFilter(resources, (r) => getCanonicalUrl(r))
-      : resources.map(getReferenceString);
+  const isCanonical =
+    getSearchParameterImplementation(resourceType, searchParam).type === SearchParameterType.CANONICAL;
+  const sourceReferences = getRevIncludeSourceReferences(resources, isCanonical);
+  const references = isCanonical
+    ? flatMapFilter(resources, (r) => getCanonicalUrl(r))
+    : resources.map(getReferenceString);
   const searchRequest = {
     resourceType: resourceType as ResourceType,
     filters: [{ code, operator: Operator.EQUALS, value: references.join(',') }],
@@ -625,8 +644,120 @@ async function getSearchRevIncludeEntries(
   const entries = (await getSearchEntries(repo, searchRequest, query)).entry;
   for (const entry of entries) {
     entry.search = { mode: 'include' };
+    addSearchSourceExtensions(
+      entry,
+      getSearchParamSourceReferences(searchParam, entry.resource as Resource, sourceReferences)
+    );
   }
   return entries;
+}
+
+function getRevIncludeSourceReferences(resources: Resource[], isCanonical: boolean): Map<string, Set<string>> {
+  const result = new Map<string, Set<string>>();
+  for (const resource of resources) {
+    const sourceReference = getReferenceString(resource);
+    const targetReference = isCanonical ? getCanonicalUrl(resource) : sourceReference;
+    if (sourceReference && targetReference) {
+      addSourceReference(result, targetReference, sourceReference);
+    }
+  }
+  return result;
+}
+
+function getSearchParamSourceReferences(
+  searchParam: SearchParameter,
+  resource: Resource,
+  sourceReferences: Map<string, Set<string>>
+): string[] {
+  const result: string[] = [];
+  const fhirPathResult = evalFhirPathTyped(searchParam.expression as string, [toTypedValue(resource)]);
+  for (const value of fhirPathResult) {
+    let targetReference: string | undefined;
+    if (value.type === PropertyType.Reference) {
+      targetReference = value.value.reference;
+    } else if (canonicalReferenceTypes.includes(value.type)) {
+      targetReference = value.value;
+    }
+    if (targetReference) {
+      result.push(...getSourceReferences(sourceReferences, targetReference));
+    }
+  }
+  return [...new Set(result)];
+}
+
+function buildIncludedEntry(resource: WithId<Resource>, sourceReferences: string[]): BundleEntry {
+  const entry: BundleEntry = {
+    fullUrl: getFullUrl(resource.resourceType, resource.id),
+    search: { mode: 'include' },
+    resource,
+  };
+  addSearchSourceExtensions(entry, sourceReferences);
+  return entry;
+}
+
+function addSearchSourceExtensions(entry: BundleEntry, sourceReferences: string[]): void {
+  const uniqueReferences = [...new Set(sourceReferences)];
+  if (uniqueReferences.length === 0) {
+    return;
+  }
+
+  entry.search ??= { mode: 'include' };
+  entry.search.extension = [
+    ...(entry.search.extension ?? []),
+    ...uniqueReferences.map(
+      (reference): Extension => ({
+        url: SEARCH_ENTRY_SOURCE_EXTENSION_URL,
+        valueReference: { reference },
+      })
+    ),
+  ];
+}
+
+function mergeSearchSourceExtensions(entries: BundleEntry[], sourceEntry: BundleEntry): void {
+  const targetResource = sourceEntry.resource;
+  const sourceExtensions = sourceEntry.search?.extension?.filter((e) => e.url === SEARCH_ENTRY_SOURCE_EXTENSION_URL);
+  if (!targetResource || !sourceExtensions?.length) {
+    return;
+  }
+
+  const targetEntry = entries.find(
+    (entry) => entry.resource?.resourceType === targetResource.resourceType && entry.resource.id === targetResource.id
+  );
+  if (!targetEntry || targetEntry.search?.mode !== 'include') {
+    return;
+  }
+
+  const existingReferences = new Set(
+    targetEntry.search?.extension
+      ?.filter((e) => e.url === SEARCH_ENTRY_SOURCE_EXTENSION_URL)
+      .map((e) => e.valueReference?.reference)
+  );
+  addSearchSourceExtensions(
+    targetEntry,
+    sourceExtensions.flatMap((e) =>
+      e.valueReference?.reference && !existingReferences.has(e.valueReference.reference)
+        ? [e.valueReference.reference]
+        : []
+    )
+  );
+}
+
+function addSourceReference(
+  references: Map<string, Set<string>>,
+  targetReference: string | undefined,
+  source: string
+): void {
+  if (!targetReference) {
+    return;
+  }
+
+  const sourceReferences = references.get(targetReference) ?? new Set<string>();
+  sourceReferences.add(source);
+  references.set(targetReference, sourceReferences);
+}
+
+function getSourceReferences(references: Map<string, Set<string>>, targetReference: string | undefined): string[] {
+  return targetReference ? [...(references.get(targetReference) ?? EMPTY)] : [];
 }
 
 /**

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -1,6 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { FhirFilterExpression, Filter, IncludeTarget, SearchRequest, SortRule, WithId } from '@medplum/core';
+import type {
+  FhirFilterExpression,
+  FhirPathAtom,
+  Filter,
+  IncludeTarget,
+  SearchRequest,
+  SortRule,
+  WithId,
+} from '@medplum/core';
 import {
   AccessPolicyInteraction,
   badRequest,
@@ -494,7 +502,9 @@ async function getExtraEntries<T extends Resource>(
 ): Promise<void> {
   let base: Resource[] = resources;
   let iterateOnly = false;
-  const seen = new Set<string>(resources.map((r) => `${r.resourceType}/${r.id}`));
+  // Maps references of all resources in the bundle to their entry, or undefined for match entries,
+  // which never carry source extensions
+  const seen = new Map<string, BundleEntry | undefined>(resources.map((r) => [`${r.resourceType}/${r.id}`, undefined]));
   let depth = 0;
 
   while (base.length > 0) {
@@ -519,10 +529,10 @@ async function getExtraEntries<T extends Resource>(
       const ref = `${resource.resourceType}/${resource.id}`;
       if (!seen.has(ref)) {
         entries.push(entry);
+        seen.set(ref, entry);
       } else {
-        mergeSearchSourceExtensions(entries, entry);
+        mergeSearchSourceExtensions(seen.get(ref), entry);
       }
-      seen.add(ref);
     }
 
     iterateOnly = true; // Only consider :iterate params on iterations after the first
@@ -550,8 +560,9 @@ async function getSearchIncludeEntries(
     throw new OperationOutcomeError(badRequest(`Invalid include parameter: ${resourceType}:${code}`));
   }
 
-  const references: Reference[] = [];
-  const canonicalReferences: string[] = [];
+  const parsedExpression = parseFhirPath(searchParam.expression as string);
+  const references = new Map<string, Reference>();
+  const canonicalReferences = new Set<string>();
   const referenceSources = new Map<string, Set<string>>();
   const canonicalReferenceSources = new Map<string, Set<string>>();
   for (const sourceResource of resources) {
@@ -560,20 +571,22 @@ async function getSearchIncludeEntries(
       continue;
     }
 
-    const fhirPathResult = evalFhirPathTyped(searchParam.expression as string, [toTypedValue(sourceResource)]);
+    const fhirPathResult = evalFhirPathTyped(parsedExpression, [toTypedValue(sourceResource)]);
     for (const result of fhirPathResult) {
-      if (result.type === PropertyType.Reference) {
-        references.push(result.value);
+      if (result.type === PropertyType.Reference && result.value.reference) {
+        references.set(result.value.reference, result.value);
         addSourceReference(referenceSources, result.value.reference, sourceReference);
       } else if (canonicalReferenceTypes.includes(result.type)) {
-        canonicalReferences.push(result.value);
+        canonicalReferences.add(result.value);
         addSourceReference(canonicalReferenceSources, result.value, sourceReference);
       }
     }
   }
 
-  const includedResources = (await repo.readReferences(references)).filter((v) => isResource(v)) as WithId<Resource>[];
-  if (searchParam.target && canonicalReferences.length > 0) {
+  const includedResources = (await repo.readReferences(Array.from(references.values()))).filter((v) =>
+    isResource(v)
+  ) as WithId<Resource>[];
+  if (searchParam.target && canonicalReferences.size > 0) {
     const canonicalSearches = searchParam.target.map((resourceType) => {
       const searchRequest = {
         resourceType: resourceType,
@@ -581,7 +594,7 @@ async function getSearchIncludeEntries(
           {
             code: 'url',
             operator: Operator.EQUALS,
-            value: canonicalReferences.join(','),
+            value: Array.from(canonicalReferences).join(','),
           },
         ],
         count: DEFAULT_MAX_SEARCH_COUNT,
@@ -630,6 +643,7 @@ async function getSearchRevIncludeEntries(
   const isCanonical =
     getSearchParameterImplementation(resourceType, searchParam).type === SearchParameterType.CANONICAL;
   const sourceReferences = getRevIncludeSourceReferences(resources, isCanonical);
+  const parsedExpression = parseFhirPath(searchParam.expression as string);
   const references = isCanonical
     ? flatMapFilter(resources, (r) => getCanonicalUrl(r))
     : resources.map(getReferenceString);
@@ -646,7 +660,7 @@ async function getSearchRevIncludeEntries(
     entry.search = { mode: 'include' };
     addSearchSourceExtensions(
       entry,
-      getSearchParamSourceReferences(searchParam, entry.resource as Resource, sourceReferences)
+      getSearchParamSourceReferences(parsedExpression, entry.resource as Resource, sourceReferences)
     );
   }
   return entries;
@@ -665,12 +679,12 @@ function getRevIncludeSourceReferences(resources: Resource[], isCanonical: boole
 }
 
 function getSearchParamSourceReferences(
-  searchParam: SearchParameter,
+  parsedExpression: FhirPathAtom,
   resource: Resource,
   sourceReferences: Map<string, Set<string>>
 ): string[] {
   const result: string[] = [];
-  const fhirPathResult = evalFhirPathTyped(searchParam.expression as string, [toTypedValue(resource)]);
+  const fhirPathResult = evalFhirPathTyped(parsedExpression, [toTypedValue(resource)]);
   for (const value of fhirPathResult) {
     let targetReference: string | undefined;
     if (value.type === PropertyType.Reference) {
@@ -713,17 +727,9 @@ function addSearchSourceExtensions(entry: BundleEntry, sourceReferences: string[
   ];
 }
 
-function mergeSearchSourceExtensions(entries: BundleEntry[], sourceEntry: BundleEntry): void {
-  const targetResource = sourceEntry.resource;
+function mergeSearchSourceExtensions(targetEntry: BundleEntry | undefined, sourceEntry: BundleEntry): void {
   const sourceExtensions = sourceEntry.search?.extension?.filter((e) => e.url === SEARCH_ENTRY_SOURCE_EXTENSION_URL);
-  if (!targetResource || !sourceExtensions?.length) {
-    return;
-  }
-
-  const targetEntry = entries.find(
-    (entry) => entry.resource?.resourceType === targetResource.resourceType && entry.resource.id === targetResource.id
-  );
-  if (!targetEntry || targetEntry.search?.mode !== 'include') {
+  if (!targetEntry || !sourceExtensions?.length) {
     return;
   }
 

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -95,6 +95,12 @@ export const minCursorBasedSearchPageSize = 20;
 
 const canonicalReferenceTypes: string[] = [PropertyType.canonical, PropertyType.uri];
 
+/**
+ * Extension URL used on `Bundle.entry.search` of `_include`/`_revinclude` entries to record the
+ * resource(s) whose reference caused the entry to be included, one `valueReference` per source,
+ * deduplicated. On `:iterate` rounds the source is the immediate parent, which may itself be an
+ * included resource rather than a match. Match entries never carry this extension.
+ */
 export const SEARCH_ENTRY_SOURCE_EXTENSION_URL = 'https://medplum.com/fhir/StructureDefinition/search-entry-source';
 
 type SearchRequestWithCountAndOffset<T extends Resource = Resource> = SearchRequest<T> & {
@@ -574,11 +580,12 @@ async function getSearchIncludeEntries(
     const fhirPathResult = evalFhirPathTyped(parsedExpression, [toTypedValue(sourceResource)]);
     for (const result of fhirPathResult) {
       if (result.type === PropertyType.Reference && result.value.reference) {
-        references.set(result.value.reference, result.value);
-        addSourceReference(referenceSources, result.value.reference, sourceReference);
+        const targetReference = unversionedReference(result.value.reference);
+        references.set(targetReference, result.value);
+        addSourceReference(referenceSources, targetReference, sourceReference);
       } else if (canonicalReferenceTypes.includes(result.type)) {
         canonicalReferences.add(result.value);
-        addSourceReference(canonicalReferenceSources, result.value, sourceReference);
+        addSourceReference(canonicalReferenceSources, unversionedCanonical(result.value), sourceReference);
       }
     }
   }
@@ -688,9 +695,9 @@ function getSearchParamSourceReferences(
   for (const value of fhirPathResult) {
     let targetReference: string | undefined;
     if (value.type === PropertyType.Reference) {
-      targetReference = value.value.reference;
+      targetReference = value.value.reference ? unversionedReference(value.value.reference) : undefined;
     } else if (canonicalReferenceTypes.includes(value.type)) {
-      targetReference = value.value;
+      targetReference = unversionedCanonical(value.value);
     }
     if (targetReference) {
       result.push(...getSourceReferences(sourceReferences, targetReference));
@@ -746,6 +753,14 @@ function mergeSearchSourceExtensions(targetEntry: BundleEntry | undefined, sourc
         : []
     )
   );
+}
+
+function unversionedReference(reference: string): string {
+  return reference.split('/_history/')[0];
+}
+
+function unversionedCanonical(canonical: string): string {
+  return canonical.split('|')[0];
 }
 
 function addSourceReference(

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -12,6 +12,7 @@ import type {
 import {
   AccessPolicyInteraction,
   badRequest,
+  deepClone,
   DEFAULT_MAX_SEARCH_COUNT,
   DEFAULT_SEARCH_COUNT,
   deriveIdentifierSearchParameter,
@@ -577,14 +578,26 @@ async function getSearchIncludeEntries(
       continue;
     }
 
-    const fhirPathResult = evalFhirPathTyped(parsedExpression, [toTypedValue(sourceResource)]);
-    for (const result of fhirPathResult) {
+    // Resolve include targets from the resource as stored, preserving existing include behavior.
+    // Store the unversioned reference as the lookup key so duplicate targets read once, and so the
+    // read hits the resource cache (keyed unversioned) instead of missing on a versioned string.
+    for (const result of evalFhirPathTyped(parsedExpression, [toTypedValue(sourceResource)])) {
       if (result.type === PropertyType.Reference && result.value.reference) {
         const targetReference = unversionedReference(result.value.reference);
-        references.set(targetReference, result.value);
-        addSourceReference(referenceSources, targetReference, sourceReference);
+        references.set(targetReference, { reference: targetReference });
       } else if (canonicalReferenceTypes.includes(result.type)) {
         canonicalReferences.add(result.value);
+      }
+    }
+
+    // Attribute the include to its source using the caller-visible view of the resource, so a
+    // reference removed by the access policy does not surface in the source extension. This mirrors
+    // the reverse include path, which attributes from entries that are already field-filtered.
+    const visibleSource = repo.removeHiddenFields(deepClone(sourceResource));
+    for (const result of evalFhirPathTyped(parsedExpression, [toTypedValue(visibleSource)])) {
+      if (result.type === PropertyType.Reference && result.value.reference) {
+        addSourceReference(referenceSources, unversionedReference(result.value.reference), sourceReference);
+      } else if (canonicalReferenceTypes.includes(result.type)) {
         addSourceReference(canonicalReferenceSources, unversionedCanonical(result.value), sourceReference);
       }
     }


### PR DESCRIPTION
## Summary

Resolves #5235. Today there is no way to tell which match resource caused a
given `_include` / `_revinclude` resource to appear in a search bundle without
ad-hoc post-processing of the `Bundle`. This annotates each included entry with
a Medplum search-entry source extension pointing back at the originating match
resource(s), so clients can join included resources to their match (e.g.
auto-joining included rows in a `FhirPathTable`).

## Approach

Each `_include` / `_revinclude` entry gets `Bundle.entry.search.extension`
entries with url
`https://medplum.com/fhir/StructureDefinition/search-entry-source` and a
`valueReference` to every match resource that pulled the included resource in.
`Bundle.entry.search` is a FHIR `BackboneElement`, so extensions are valid
there, and the standard `search.mode = 'include'` behavior is unchanged.

#5235 left the exact mechanism open ("maybe via a `link`"); a namespaced search
extension keeps the join machine-readable without overloading
`Bundle.entry.link`. Happy to switch mechanisms if the team prefers.

## Changes

- Annotate `_include` and `_revinclude` entries with the source extension;
  handle both reference and canonical include paths.
- When several matches include the same resource, record every source reference
  (deduplicated).
- Tradeoff worth a look: building the source -> target map requires evaluating
  the include FHIRPath per match resource rather than once over the whole page
  (N evaluations for a page of N matches instead of 1). Flagging for review.

## Testing

Run against Postgres 16 + Redis 7:

- `npx turbo run build --filter=@medplum/server`
- `npx turbo run lint --filter=@medplum/server`
- `npm run test:seed`
- `search.test.ts` — full file, **485 / 485 passing**, including new coverage for
  reference/canonical `_include`, `_revinclude`, multi-source dedup, and the
  `_include on page boundary` interaction.
