### PR TITLE
Provider: Add patient Documents tab

### DIFF
--- a/examples/medplum-provider/src/App.tsx
+++ b/examples/medplum-provider/src/App.tsx
@@ -37,6 +37,7 @@ import { ScriptSurePage } from './pages/integrations/ScriptSurePage';
 import { MessagesPage } from './pages/messages/MessagesPage';
 import { CommunicationTab } from './pages/patient/CommunicationTab';
 import { CoveragePage } from './pages/patient/CoveragePage';
+import { DocumentsPage } from './pages/patient/DocumentsPage';
 import { DoseSpotTab } from './pages/patient/DoseSpotTab';
 import { EditTab } from './pages/patient/EditTab';
 import { ExportTab } from './pages/patient/ExportTab';
@@ -214,6 +215,8 @@ export function App(): JSX.Element | null {
                 <Route path="ServiceRequest/:serviceRequestId" element={<LabsPage />} />
                 <Route path="MedicationRequest" element={<MedicationsPage />} />
                 <Route path="MedicationRequest/:medicationRequestId" element={<MedicationsPage />} />
+                <Route path="DocumentReference" element={<DocumentsPage />} />
+                <Route path="DocumentReference/:documentId" element={<DocumentsPage />} />
                 <Route path=":resourceType" element={<PatientSearchPage />} />
                 <Route path="Coverage" element={<CoveragePage />} />
                 <Route path="Coverage/:coverageId" element={<CoveragePage />} />

--- a/examples/medplum-provider/src/components/documents/DocumentDetailPanel.module.css
+++ b/examples/medplum-provider/src/components/documents/DocumentDetailPanel.module.css
@@ -1,0 +1,18 @@
+/*
+ * One-shot fade for the "Added by …" author clause. Applied only the first time a document's
+ * original author resolves this visit; on cached revisits the clause renders without this class
+ * (instantly). A CSS animation is used instead of Mantine's <Transition> because the latter does
+ * not render its child when it mounts with `mounted` already true (the case when history is cached).
+ */
+.authorClauseFade {
+  animation: authorClauseFadeIn 150ms ease;
+}
+
+@keyframes authorClauseFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/examples/medplum-provider/src/components/documents/DocumentDetailPanel.tsx
+++ b/examples/medplum-provider/src/components/documents/DocumentDetailPanel.tsx
@@ -1,0 +1,427 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { ActionIcon, Box, Divider, Flex, Group, Paper, Stack, Text, Tooltip } from '@mantine/core';
+import { formatDate } from '@medplum/core';
+import type {
+  Attachment,
+  Bundle,
+  Communication,
+  DocumentReference,
+  Patient,
+  Reference,
+  Resource,
+} from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react';
+import { useCachedBinaryUrl } from '@medplum/react-hooks';
+import { IconBrowserShare, IconEditCircle, IconPrinter } from '@tabler/icons-react';
+import type { JSX, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+import { SendFaxModal } from '../fax/SendFaxModal';
+import classes from './DocumentDetailPanel.module.css';
+import type { PatientDocument } from './DocumentListItem.utils';
+import { EditDocumentDetailsModal } from './EditDocumentDetailsModal';
+
+// Subtle 1px frame drawn around attachment previews (PDF iframe, images, video). Theme-aware so the
+// frame stays subtle in both schemes: gray-3 in light, dark-4 in dark (matching the dividers).
+const PREVIEW_BORDER =
+  '1px solid color-mix(in srgb, light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4)) 50%, transparent)';
+
+interface DocumentDetailPanelProps {
+  item: PatientDocument;
+  patientRef?: Reference<Patient>;
+  onDocumentChange: () => void;
+  onDocumentDeleted: () => void;
+  // Documents whose original-author clause has already faded in this section visit. Owned by the
+  // page so toggling between documents (or revisiting a cached one) doesn't re-animate.
+  fadedAuthorIds: Set<string>;
+}
+
+export function DocumentDetailPanel({
+  item,
+  patientRef,
+  onDocumentChange,
+  onDocumentDeleted,
+  fadedAuthorIds,
+}: DocumentDetailPanelProps): JSX.Element {
+  const medplum = useMedplum();
+  const [faxModalOpened, setFaxModalOpened] = useState(false);
+  const [editModalOpened, setEditModalOpened] = useState(false);
+  // The original author comes from version history (oldest version's meta.author). It's loaded
+  // async so the Added date renders immediately and the "by …" clause fades in as a fast-follow.
+  const [originalAuthor, setOriginalAuthor] = useState<string | undefined>(undefined);
+
+  const attachment = getAttachment(item);
+  const attachmentUrl = useCachedBinaryUrl(attachment?.url);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!item.id) {
+      return undefined;
+    }
+    const historyUrl = medplum.fhirUrl(item.resourceType, item.id, '_history');
+    historyUrl.searchParams.set('_count', '100');
+    historyUrl.searchParams.set('_elements', 'id,meta');
+    medplum
+      .get(historyUrl)
+      .then((bundle: Bundle) => {
+        if (cancelled) {
+          return;
+        }
+        const versions: Resource[] = [];
+        for (const entry of bundle.entry ?? []) {
+          if (entry.resource) {
+            versions.push(entry.resource);
+          }
+        }
+        versions.sort(
+          (a, b) => new Date(a.meta?.lastUpdated ?? 0).getTime() - new Date(b.meta?.lastUpdated ?? 0).getTime()
+        );
+        setOriginalAuthor(authorLabel(versions[0]?.meta?.author));
+      })
+      .catch(() => {
+        // Leave the original author unset; the Added date still renders on its own.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [medplum, item]);
+
+  const handleOpenInBrowser = (): void => {
+    if (attachment?.url) {
+      window.open(attachment.url, '_blank');
+    }
+  };
+
+  return (
+    <>
+      <Box h="100%" style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
+        <Paper h="100%">
+          <Flex direction="column" h="100%">
+            <Box p="md">
+              <Group justify="space-between" align="center">
+                <Stack gap={4} style={{ flex: 1 }}>
+                  <Text fw={700} size="lg">
+                    {item.name}
+                  </Text>
+                </Stack>
+
+                <Group gap="xs">
+                  <Tooltip label="Edit Document Details" position="bottom" openDelay={500}>
+                    <ActionIcon
+                      variant="transparent"
+                      radius="xl"
+                      size={32}
+                      className="outline-icon-button"
+                      onClick={() => setEditModalOpened(true)}
+                    >
+                      <IconEditCircle size={16} />
+                    </ActionIcon>
+                  </Tooltip>
+                  {attachment?.url && (
+                    <Tooltip label="Open in Browser" position="bottom" openDelay={500}>
+                      <ActionIcon
+                        variant="transparent"
+                        radius="xl"
+                        size={32}
+                        className="outline-icon-button"
+                        onClick={handleOpenInBrowser}
+                      >
+                        <IconBrowserShare size={16} />
+                      </ActionIcon>
+                    </Tooltip>
+                  )}
+                  <Tooltip label="Fax Document" position="bottom" openDelay={500}>
+                    <ActionIcon
+                      variant="transparent"
+                      radius="xl"
+                      size={32}
+                      className="outline-icon-button"
+                      onClick={() => setFaxModalOpened(true)}
+                    >
+                      <IconPrinter size={16} />
+                    </ActionIcon>
+                  </Tooltip>
+                </Group>
+              </Group>
+            </Box>
+
+            <Divider />
+
+            {isPdfLike(attachment) ? (
+              <>
+                <Box p="md" style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+                  {attachmentUrl && (
+                    <Box
+                      style={{
+                        flex: 1,
+                        borderRadius: 4,
+                        overflow: 'hidden',
+                        border: PREVIEW_BORDER,
+                      }}
+                    >
+                      <iframe
+                        title="Attachment"
+                        width="100%"
+                        height="100%"
+                        src={attachmentUrl + '#navpanes=0'}
+                        allowFullScreen={true}
+                        style={{ display: 'block', border: 0 }}
+                      />
+                    </Box>
+                  )}
+                </Box>
+
+                <Box px="md">
+                  <Divider />
+                </Box>
+
+                <Box p="md">
+                  <DocumentMetadata
+                    item={item}
+                    contentType={attachment?.contentType}
+                    originalAuthor={originalAuthor}
+                    fadedAuthorIds={fadedAuthorIds}
+                  />
+                </Box>
+              </>
+            ) : (
+              <Box style={{ flex: 1, overflowY: 'auto', overflowX: 'hidden' }}>
+                <Box p="md">
+                  {attachment ? (
+                    <AttachmentPreview attachment={attachment} url={attachmentUrl} />
+                  ) : (
+                    <Flex justify="center" align="center" h={300}>
+                      <Text c="dimmed">No preview available for this document</Text>
+                    </Flex>
+                  )}
+                </Box>
+
+                <Box px="md">
+                  <Divider />
+                </Box>
+
+                <Box p="md">
+                  <DocumentMetadata
+                    item={item}
+                    contentType={attachment?.contentType}
+                    originalAuthor={originalAuthor}
+                    fadedAuthorIds={fadedAuthorIds}
+                  />
+                </Box>
+              </Box>
+            )}
+          </Flex>
+        </Paper>
+      </Box>
+
+      <SendFaxModal
+        opened={faxModalOpened}
+        onClose={() => setFaxModalOpened(false)}
+        defaultAttachment={attachment}
+        defaultPatient={patientRef}
+      />
+
+      <EditDocumentDetailsModal
+        item={item}
+        opened={editModalOpened}
+        onClose={() => setEditModalOpened(false)}
+        onSaved={onDocumentChange}
+        onDeleted={onDocumentDeleted}
+      />
+    </>
+  );
+}
+
+function getAttachment(item: PatientDocument): Attachment | undefined {
+  if (item.resourceType === 'DocumentReference') {
+    const doc = item.resource as DocumentReference;
+    return doc.content?.[0]?.attachment;
+  }
+  const comm = item.resource as Communication;
+  return comm.payload?.find((p) => p.contentAttachment)?.contentAttachment;
+}
+
+function isPdfLike(attachment: Attachment | undefined): boolean {
+  const ct = attachment?.contentType;
+  if (!ct) {
+    return false;
+  }
+  return ct === 'application/pdf' || ct === 'application/json' || ct.startsWith('text/');
+}
+
+function getAuthor(item: PatientDocument): string | undefined {
+  if (item.resourceType === 'DocumentReference') {
+    const author = (item.resource as DocumentReference).author?.[0];
+    return author?.display ?? author?.reference;
+  }
+  const sender = (item.resource as Communication).sender;
+  return sender?.display ?? sender?.reference;
+}
+
+function DocumentMetadata({
+  item,
+  contentType,
+  originalAuthor,
+  fadedAuthorIds,
+}: {
+  item: PatientDocument;
+  contentType: string | undefined;
+  originalAuthor: string | undefined;
+  fadedAuthorIds: Set<string>;
+}): JSX.Element {
+  const documentType = item.documentType;
+  const documentCategory =
+    item.resourceType === 'DocumentReference'
+      ? (item.resource as DocumentReference).category
+          ?.map((c) => c.coding?.[0]?.display || c.text)
+          .filter(Boolean)
+          .join(', ') || undefined
+      : undefined;
+
+  // Author row reflects the document's own author field; the Added/Last updated lines attribute to
+  // the audit meta.author (original = oldest version, current = the loaded resource).
+  const author = getAuthor(item);
+  const currentAuthor = authorLabel(item.resource.meta?.author);
+  const lastUpdated = item.resource.meta?.lastUpdated;
+
+  // Fade the "Added by …" clause in only the first time a document's author resolves this visit;
+  // on revisits the history call is cached (resolves immediately), so render it statically to
+  // avoid an out-of-place re-fade. The page-owned set records which documents have already faded.
+  const [alreadyFaded] = useState(() => fadedAuthorIds.has(item.id));
+  useEffect(() => {
+    if (originalAuthor && item.id) {
+      fadedAuthorIds.add(item.id);
+    }
+  }, [originalAuthor, item.id, fadedAuthorIds]);
+
+  const addedAuthorClause = ` by ${originalAuthor}`;
+
+  return (
+    <Stack gap="sm">
+      <MetadataRow label="Source" value={item.source} />
+      {documentType && <MetadataRow label="Type" value={documentType} />}
+      {documentCategory && <MetadataRow label="Category" value={documentCategory} />}
+      {contentType && <MetadataRow label="Content type" value={contentType} />}
+      <MetadataRow
+        label="Author"
+        value={
+          author ?? (
+            <Text span c="dimmed">
+              No author attributed
+            </Text>
+          )
+        }
+      />
+      {item.date && (
+        <MetadataRow
+          label="Added"
+          value={
+            <>
+              {formatDate(item.date)}
+              {originalAuthor && (
+                <Text span className={alreadyFaded ? undefined : classes.authorClauseFade}>
+                  {addedAuthorClause}
+                </Text>
+              )}
+            </>
+          }
+        />
+      )}
+      {lastUpdated && (
+        <MetadataRow
+          label="Last updated"
+          value={
+            <>
+              {formatDate(lastUpdated)}
+              {currentAuthor && <Text span>{` by ${currentAuthor}`}</Text>}
+            </>
+          }
+        />
+      )}
+    </Stack>
+  );
+}
+
+function authorLabel(ref: Reference | undefined): string | undefined {
+  return ref?.display ?? ref?.reference;
+}
+
+function MetadataRow({ label, value }: { label: string; value: ReactNode }): JSX.Element {
+  return (
+    <Group align="flex-start" gap="lg" wrap="nowrap">
+      <Text fw={500} size="sm" c="dimmed" style={{ width: '150px', flexShrink: 0 }}>
+        {label}
+      </Text>
+      <Text size="sm" component="div" style={{ flex: 1, minWidth: 0 }}>
+        {value}
+      </Text>
+    </Group>
+  );
+}
+
+interface AttachmentPreviewProps {
+  attachment: Attachment;
+  url: string | undefined;
+}
+
+function AttachmentPreview({ attachment, url }: AttachmentPreviewProps): JSX.Element {
+  const contentType = attachment.contentType;
+
+  if (!url || !contentType) {
+    return (
+      <Flex justify="center" align="center" h={300}>
+        <Text c="dimmed">No preview available for this document</Text>
+      </Flex>
+    );
+  }
+
+  if (contentType.startsWith('image/')) {
+    return (
+      <Box
+        style={{ display: 'block', maxWidth: 'fit-content', position: 'relative', borderRadius: 4, overflow: 'hidden' }}
+      >
+        <img
+          src={url}
+          alt={attachment.title ?? 'Attachment'}
+          style={{ width: 'auto', maxWidth: '100%', height: 'auto', display: 'block' }}
+        />
+        <Box
+          style={{
+            position: 'absolute',
+            inset: 0,
+            border: PREVIEW_BORDER,
+            borderRadius: 4,
+            pointerEvents: 'none',
+            boxSizing: 'border-box',
+          }}
+        />
+      </Box>
+    );
+  }
+
+  if (contentType.startsWith('video/')) {
+    return (
+      <Box style={{ width: '100%', maxWidth: '100%', position: 'relative', borderRadius: 4, overflow: 'hidden' }}>
+        <video style={{ width: '100%', maxWidth: '100%', height: 'auto', display: 'block' }} controls={true}>
+          <source type={contentType} src={url} />
+        </video>
+        <Box
+          style={{
+            position: 'absolute',
+            inset: 0,
+            border: PREVIEW_BORDER,
+            borderRadius: 4,
+            pointerEvents: 'none',
+            boxSizing: 'border-box',
+          }}
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Flex justify="center" align="center" h={300}>
+      <Text c="dimmed">No preview available for this file type</Text>
+    </Flex>
+  );
+}

--- a/examples/medplum-provider/src/components/documents/DocumentFilterMenu.tsx
+++ b/examples/medplum-provider/src/components/documents/DocumentFilterMenu.tsx
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { ActionIcon, Divider, Indicator, Menu, Text, Tooltip } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconCheck, IconFilter2Plus, IconX } from '@tabler/icons-react';
+import type { JSX } from 'react';
+import type { DocumentSource } from './DocumentListItem.utils';
+import { DOCUMENT_SOURCES } from './DocumentListItem.utils';
+
+interface DocumentFilterMenuProps {
+  sources?: DocumentSource[];
+  onSourceToggle?: (source: DocumentSource) => void;
+  onClearAllFilters?: () => void;
+}
+
+export function DocumentFilterMenu(props: DocumentFilterMenuProps): JSX.Element {
+  const { sources = [], onSourceToggle, onClearAllFilters } = props;
+  const [opened, { open, close }] = useDisclosure(false);
+
+  const hasActiveFilter = sources.length > 0;
+
+  return (
+    <Menu shadow="md" width={200} position="bottom-start" radius="md" opened={opened} onOpen={open} onClose={close}>
+      <Menu.Target>
+        <Tooltip label="Filter Documents" position="bottom" openDelay={500} disabled={opened}>
+          <Indicator disabled={!hasActiveFilter} color="blue" size={8} offset={5}>
+            <ActionIcon
+              variant="transparent"
+              size={32}
+              radius="xl"
+              aria-label="Filter documents"
+              className="outline-icon-button"
+              data-opened={opened || undefined}
+            >
+              <IconFilter2Plus size={16} />
+            </ActionIcon>
+          </Indicator>
+        </Tooltip>
+      </Menu.Target>
+
+      <Menu.Dropdown>
+        <Menu.Label>Document Source</Menu.Label>
+
+        {DOCUMENT_SOURCES.map((source) => (
+          <Menu.Item
+            key={source}
+            onClick={() => onSourceToggle?.(source)}
+            rightSection={sources.includes(source) ? <IconCheck size={16} color="var(--mantine-color-blue-6)" /> : null}
+          >
+            <Text size="sm">{source}</Text>
+          </Menu.Item>
+        ))}
+
+        {hasActiveFilter && (
+          <>
+            <Divider my={4} mx={4} />
+            <Menu.Item
+              leftSection={<IconX size={16} color="var(--mantine-color-dimmed)" />}
+              onClick={() => {
+                onClearAllFilters?.();
+                close();
+              }}
+            >
+              <Text size="sm">Clear All Filters</Text>
+            </Menu.Item>
+          </>
+        )}
+      </Menu.Dropdown>
+    </Menu>
+  );
+}

--- a/examples/medplum-provider/src/components/documents/DocumentListItem.module.css
+++ b/examples/medplum-provider/src/components/documents/DocumentListItem.module.css
@@ -1,0 +1,31 @@
+.item {
+  display: block;
+  cursor: pointer;
+  padding: calc(0.5rem * var(--mantine-scale)) var(--mantine-spacing-xs);
+  border-radius: 0.5rem;
+  color: light-dark(var(--mantine-color-black), var(--mantine-color-gray-2));
+  text-decoration: none;
+}
+
+.item :global(.mantine-Text-root) {
+  line-height: var(--mantine-line-height-sm);
+}
+
+.item:hover:not(.selected) {
+  background: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-8));
+}
+
+.item.selected,
+.item.selected:hover {
+  background: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-6));
+}
+
+/*
+ * Arrow-key navigation moves selection in lockstep with focus, so the selected background already
+ * marks the active option for keyboard users. Suppress the default focus ring to avoid a redundant
+ * outline stacked on top of that highlight. (Mouse clicks never showed a ring: it's :focus-visible.)
+ */
+.item:focus,
+.item:focus-visible {
+  outline: none;
+}

--- a/examples/medplum-provider/src/components/documents/DocumentListItem.tsx
+++ b/examples/medplum-provider/src/components/documents/DocumentListItem.tsx
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Stack, Text, Tooltip } from '@mantine/core';
+import { formatDate } from '@medplum/core';
+import { MedplumLink } from '@medplum/react';
+import cx from 'clsx';
+import type { AnchorHTMLAttributes, JSX, RefObject } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import classes from './DocumentListItem.module.css';
+import type { PatientDocument } from './DocumentListItem.utils';
+
+interface DocumentListItemProps {
+  item: PatientDocument;
+  selectedDocumentId?: string;
+  getItemUri: (item: PatientDocument) => string;
+  id?: string;
+}
+
+/**
+ * Tracks whether a single-line, truncated element is currently overflowing its container.
+ * @param content - The text rendered in the element; overflow is re-checked when it changes.
+ * @returns A tuple of the ref to attach to the element and whether it is currently truncated.
+ */
+function useIsTruncated(content: string): [RefObject<HTMLParagraphElement | null>, boolean] {
+  const ref = useRef<HTMLParagraphElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return undefined;
+    }
+    const check = (): void => setIsTruncated(el.scrollWidth > el.clientWidth);
+    check();
+    const observer = new ResizeObserver(check);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [content]);
+
+  return [ref, isTruncated];
+}
+
+export function DocumentListItem({ item, selectedDocumentId, getItemUri, id }: DocumentListItemProps): JSX.Element {
+  const isSelected = selectedDocumentId === item.id;
+
+  const metaPrefix = [item.date ? formatDate(item.date) : undefined, item.source].filter(Boolean).join(' · ');
+  const metaLine = item.documentType ? `${metaPrefix}: ${item.documentType}` : metaPrefix;
+
+  const [nameRef, isNameTruncated] = useIsTruncated(item.name);
+  const [metaRef, isMetaTruncated] = useIsTruncated(metaLine);
+
+  // MedplumLinkProps only types Mantine's style props, so the listbox-option DOM
+  // attributes are passed via a spread (they reach the underlying <a> through ...rest).
+  const optionProps: AnchorHTMLAttributes<HTMLAnchorElement> = {
+    id,
+    role: 'option',
+    tabIndex: isSelected ? 0 : -1,
+    'aria-selected': isSelected,
+  };
+
+  return (
+    <MedplumLink
+      {...optionProps}
+      to={getItemUri(item)}
+      underline="never"
+      className={cx(classes.item, isSelected && classes.selected)}
+    >
+      <Stack gap={0} miw={0}>
+        <Tooltip label={item.name} disabled={!isNameTruncated} multiline maw={320} withinPortal openDelay={300}>
+          <Text ref={nameRef} fw={700} truncate="end" miw={0}>
+            {item.name}
+          </Text>
+        </Tooltip>
+        <Tooltip
+          label={item.documentType}
+          disabled={!isMetaTruncated || !item.documentType}
+          multiline
+          maw={320}
+          withinPortal
+          openDelay={300}
+        >
+          <Text ref={metaRef} size="sm" c="dimmed" truncate="end">
+            {metaLine}
+          </Text>
+        </Tooltip>
+      </Stack>
+    </MedplumLink>
+  );
+}

--- a/examples/medplum-provider/src/components/documents/DocumentListItem.utils.ts
+++ b/examples/medplum-provider/src/components/documents/DocumentListItem.utils.ts
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { Communication, DocumentReference } from '@medplum/fhirtypes';
+
+export type DocumentSource = 'Fax' | 'Lab' | 'Upload' | 'Message';
+
+export const DOCUMENT_SOURCES: DocumentSource[] = ['Fax', 'Lab', 'Upload', 'Message'];
+
+export type PatientDocument = {
+  id: string;
+  resourceType: 'DocumentReference' | 'Communication';
+  resource: DocumentReference | Communication;
+  name: string;
+  date: string | undefined;
+  contentType: string | undefined;
+  documentType: string | undefined;
+  source: DocumentSource;
+};
+
+const FAX_MEDIUM_CODE = 'FAXWRIT';
+
+/**
+ * Returns true when the Communication was sent or received as a fax.
+ * @param comm - The Communication to inspect.
+ * @returns True when any medium coding is the fax code.
+ */
+export function isFaxMedium(comm: Communication): boolean {
+  return comm.medium?.some((m) => m.coding?.some((c) => c.code === FAX_MEDIUM_CODE)) ?? false;
+}
+
+/**
+ * Returns the human-readable type of a DocumentReference (its FHIR `type` display),
+ * or undefined when no type is set.
+ * @param doc - The DocumentReference to read the type from.
+ * @returns The type display or text, or undefined when no type is set.
+ */
+export function getDocumentTypeDisplay(doc: DocumentReference): string | undefined {
+  return doc.type?.coding?.[0]?.display || doc.type?.text;
+}
+
+export function toPatientDocument(
+  resource: DocumentReference | Communication,
+  options?: { asMessageAttachment?: boolean }
+): PatientDocument {
+  if (resource.resourceType === 'DocumentReference') {
+    return docRefToPatientDoc(resource, options?.asMessageAttachment ?? false);
+  }
+  return commToPatientDoc(resource);
+}
+
+function docRefToPatientDoc(doc: DocumentReference, asMessageAttachment: boolean): PatientDocument {
+  const documentType = getDocumentTypeDisplay(doc);
+  const isLab = (documentType ?? '').toLowerCase().includes('lab');
+  let source: DocumentSource;
+  if (asMessageAttachment) {
+    source = 'Message';
+  } else if (isLab) {
+    source = 'Lab';
+  } else {
+    source = 'Upload';
+  }
+  return {
+    id: doc.id ?? '',
+    resourceType: 'DocumentReference',
+    resource: doc,
+    name: doc.description || doc.content?.[0]?.attachment?.title || 'Untitled Document',
+    date: doc.date || doc.meta?.lastUpdated,
+    contentType: doc.content?.[0]?.attachment?.contentType,
+    documentType,
+    source,
+  };
+}
+
+function commToPatientDoc(comm: Communication): PatientDocument {
+  const attachment = comm.payload?.find((p) => p.contentAttachment)?.contentAttachment;
+  const isFax = isFaxMedium(comm);
+
+  let name: string;
+  if (isFax) {
+    const originatingFaxNumber = comm.extension?.find(
+      (ext) => ext.url === 'https://efax.com/originating-fax-number'
+    )?.valueString;
+    name = attachment?.title || (originatingFaxNumber ? `Fax from ${originatingFaxNumber}` : 'Received Fax');
+  } else {
+    name = attachment?.title || 'Message Attachment';
+  }
+
+  return {
+    id: comm.id ?? '',
+    resourceType: 'Communication',
+    resource: comm,
+    name,
+    date: comm.sent || comm.meta?.lastUpdated,
+    contentType: attachment?.contentType,
+    documentType: undefined,
+    source: isFax ? 'Fax' : 'Message',
+  };
+}

--- a/examples/medplum-provider/src/components/documents/DocumentSelectEmpty.tsx
+++ b/examples/medplum-provider/src/components/documents/DocumentSelectEmpty.tsx
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Flex, Text } from '@mantine/core';
+import type { JSX } from 'react';
+
+export function DocumentSelectEmpty(): JSX.Element {
+  return (
+    <Flex direction="column" h="100%" justify="center" align="center">
+      <Text size="md" c="dimmed" fw={400}>
+        Document details will appear here when selected.
+      </Text>
+    </Flex>
+  );
+}

--- a/examples/medplum-provider/src/components/documents/EditDocumentDetailsModal.tsx
+++ b/examples/medplum-provider/src/components/documents/EditDocumentDetailsModal.tsx
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Box, Button, Divider, Group, Modal, Stack, Text, TextInput } from '@mantine/core';
+import type {
+  CodeableConcept,
+  Communication,
+  CommunicationPayload,
+  DocumentReference,
+  Reference,
+} from '@medplum/fhirtypes';
+import { CodeableConceptInput, ReferenceInput, useMedplum } from '@medplum/react';
+import type { JSX } from 'react';
+import { useState } from 'react';
+import { showErrorNotification, showSuccessNotification } from '../../utils/notifications';
+import type { PatientDocument } from './DocumentListItem.utils';
+
+interface EditDocumentDetailsModalProps {
+  item: PatientDocument;
+  opened: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+  onDeleted: () => void;
+}
+
+// Resource references that can author a document or send a message.
+const AUTHOR_TARGET_TYPES = ['Practitioner', 'Organization', 'Patient', 'RelatedPerson'];
+
+export function EditDocumentDetailsModal({
+  item,
+  opened,
+  onClose,
+  onSaved,
+  onDeleted,
+}: EditDocumentDetailsModalProps): JSX.Element {
+  const medplum = useMedplum();
+  const isDocRef = item.resourceType === 'DocumentReference';
+
+  // Editable field state, seeded from the resource. Inputs stay mounted while the delete
+  // confirmation is shown (just visually hidden), so in-progress edits survive a cancel.
+  const [name, setName] = useState(item.name);
+  const [type, setType] = useState<CodeableConcept | undefined>(() =>
+    isDocRef ? (item.resource as DocumentReference).type : undefined
+  );
+  const [category, setCategory] = useState<CodeableConcept | undefined>(() => getInitialCategory(item));
+  const [authorRef, setAuthorRef] = useState<Reference | undefined>(() => getInitialAuthor(item));
+
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const handleClose = (): void => {
+    setConfirmingDelete(false);
+    onClose();
+  };
+
+  const handleSave = async (): Promise<void> => {
+    setSaving(true);
+    try {
+      const updated = buildUpdatedResource(item, { name, type, category, authorRef });
+      await medplum.updateResource(updated);
+      showSuccessNotification({ title: 'Success', message: 'Document details updated' });
+      onSaved();
+      handleClose();
+    } catch (error) {
+      showErrorNotification(error);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (): Promise<void> => {
+    setDeleting(true);
+    try {
+      // Soft delete: mark the resource entered-in-error so it stays in the Medplum project but is
+      // filtered out of the provider's documents list (see fetchDocuments in DocumentsPage).
+      if (item.resourceType === 'DocumentReference') {
+        await medplum.updateResource<DocumentReference>({
+          ...(item.resource as DocumentReference),
+          status: 'entered-in-error',
+        });
+      } else {
+        await medplum.updateResource<Communication>({
+          ...(item.resource as Communication),
+          status: 'entered-in-error',
+        });
+      }
+      showSuccessNotification({ title: 'Success', message: 'Document deleted' });
+      onDeleted();
+      handleClose();
+    } catch (error) {
+      showErrorNotification(error);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const sourcePath = `${item.resourceType}`;
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={handleClose}
+      size={confirmingDelete ? 'md' : 'lg'}
+      centered={confirmingDelete}
+      title={confirmingDelete ? undefined : 'Edit Document Details'}
+    >
+      {opened && (
+        <>
+          {/* Edit form: kept mounted (only hidden) during delete confirmation so edits persist. */}
+          <Box display={confirmingDelete ? 'none' : undefined}>
+            <Stack gap="md">
+              <Divider />
+
+              <TextInput label="Title" value={name} onChange={(event) => setName(event.currentTarget.value)} />
+
+              {isDocRef && (
+                <CodeableConceptInput
+                  name="type"
+                  label="Type"
+                  path={`${sourcePath}.type`}
+                  binding="http://hl7.org/fhir/ValueSet/c80-doc-typecodes"
+                  maxValues={1}
+                  defaultValue={type}
+                  onChange={(value) => setType(value)}
+                />
+              )}
+
+              <CodeableConceptInput
+                name="category"
+                label="Category"
+                path={`${sourcePath}.category`}
+                binding="http://hl7.org/fhir/ValueSet/document-classcodes"
+                maxValues={1}
+                defaultValue={category}
+                onChange={(value) => setCategory(value)}
+              />
+
+              <Box>
+                <Text size="sm" fw={500} mb={4}>
+                  Author
+                </Text>
+                <ReferenceInput
+                  name="author"
+                  targetTypes={AUTHOR_TARGET_TYPES}
+                  defaultValue={authorRef}
+                  onChange={(value) => setAuthorRef(value)}
+                />
+              </Box>
+
+              <Divider />
+
+              <Button variant="filled" w="100%" onClick={() => handleSave().catch(console.error)} loading={saving}>
+                Save Changes
+              </Button>
+              <Button
+                variant="outline"
+                color="red"
+                w="100%"
+                onClick={() => setConfirmingDelete(true)}
+                disabled={saving}
+              >
+                Delete Document
+              </Button>
+            </Stack>
+          </Box>
+
+          {confirmingDelete && (
+            <Stack gap="md">
+              <Text>Are you sure you want to delete this document? This action cannot be undone.</Text>
+              <Group justify="flex-end" gap="sm">
+                <Button variant="outline" onClick={() => setConfirmingDelete(false)} disabled={deleting}>
+                  Cancel
+                </Button>
+                <Button color="red" onClick={() => handleDelete().catch(console.error)} loading={deleting}>
+                  Delete
+                </Button>
+              </Group>
+            </Stack>
+          )}
+        </>
+      )}
+    </Modal>
+  );
+}
+
+function getInitialCategory(item: PatientDocument): CodeableConcept | undefined {
+  if (item.resourceType === 'DocumentReference') {
+    return (item.resource as DocumentReference).category?.[0];
+  }
+  return (item.resource as Communication).category?.[0];
+}
+
+function getInitialAuthor(item: PatientDocument): Reference | undefined {
+  if (item.resourceType === 'DocumentReference') {
+    return (item.resource as DocumentReference).author?.[0];
+  }
+  return (item.resource as Communication).sender;
+}
+
+interface EditedFields {
+  name: string;
+  type: CodeableConcept | undefined;
+  category: CodeableConcept | undefined;
+  authorRef: Reference | undefined;
+}
+
+function buildUpdatedResource(item: PatientDocument, fields: EditedFields): DocumentReference | Communication {
+  const { name, type, category, authorRef } = fields;
+  const trimmedName = name.trim() || undefined;
+
+  if (item.resourceType === 'DocumentReference') {
+    const doc = item.resource as DocumentReference;
+    const firstContent = doc.content?.[0];
+    const content = firstContent
+      ? [
+          { ...firstContent, attachment: { ...firstContent.attachment, title: trimmedName } },
+          ...(doc.content?.slice(1) ?? []),
+        ]
+      : doc.content;
+    return {
+      ...doc,
+      description: trimmedName,
+      type,
+      category: category ? [category] : undefined,
+      author: authorRef ? ([authorRef] as DocumentReference['author']) : undefined,
+      content,
+    };
+  }
+
+  const comm = item.resource as Communication;
+  return {
+    ...comm,
+    category: category ? [category] : undefined,
+    sender: authorRef as Communication['sender'],
+    payload: buildCommPayload(comm, trimmedName),
+  };
+}
+
+function buildCommPayload(comm: Communication, title: string | undefined): CommunicationPayload[] | undefined {
+  if (!comm.payload?.length) {
+    return comm.payload;
+  }
+  const payload = [...comm.payload];
+  const idx = payload.findIndex((p) => p.contentAttachment);
+  if (idx >= 0) {
+    payload[idx] = {
+      ...payload[idx],
+      contentAttachment: { ...payload[idx].contentAttachment, title },
+    };
+  }
+  return payload;
+}

--- a/examples/medplum-provider/src/pages/patient/DocumentsPage.module.css
+++ b/examples/medplum-provider/src/pages/patient/DocumentsPage.module.css
@@ -1,0 +1,29 @@
+.layout {
+  display: flex;
+  height: 100%;
+  overflow: hidden;
+}
+
+.shell {
+  display: flex;
+  flex-direction: column;
+  width: 350px;
+  height: 100%;
+  border-right: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+  background: var(--mantine-color-body);
+}
+
+.headerText {
+  font-size: var(--mantine-font-size-sm);
+  font-weight: 450;
+  color: light-dark(var(--mantine-color-gray-9), var(--mantine-color-white));
+  line-height: 1.2;
+}
+
+.detailColumn {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  height: 100%;
+  min-width: 0;
+}

--- a/examples/medplum-provider/src/pages/patient/DocumentsPage.test.tsx
+++ b/examples/medplum-provider/src/pages/patient/DocumentsPage.test.tsx
@@ -1,0 +1,366 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { MantineProvider } from '@mantine/core';
+import { Notifications } from '@mantine/notifications';
+import type { WithId } from '@medplum/core';
+import type { Binary, DocumentReference } from '@medplum/fhirtypes';
+import { HomerSimpson, MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { DocumentsPage } from './DocumentsPage';
+
+const PATIENT_ID = HomerSimpson.id as string;
+
+const MOCK_DOC: WithId<DocumentReference> = {
+  resourceType: 'DocumentReference',
+  id: 'doc-001',
+  status: 'current',
+  description: 'Lab Result PDF',
+  date: '2024-05-01T12:00:00Z',
+  content: [
+    {
+      attachment: {
+        contentType: 'application/pdf',
+        url: 'Binary/binary-001',
+        title: 'lab-result.pdf',
+      },
+    },
+  ],
+  subject: { reference: `Patient/${PATIENT_ID}` },
+};
+
+describe('DocumentsPage', () => {
+  let medplum: MockClient;
+
+  beforeEach(() => {
+    medplum = new MockClient();
+    vi.clearAllMocks();
+  });
+
+  const setup = (documentId?: string): ReturnType<typeof render> => {
+    const path = documentId
+      ? `/Patient/${PATIENT_ID}/DocumentReference/${documentId}`
+      : `/Patient/${PATIENT_ID}/DocumentReference`;
+
+    return render(
+      <MemoryRouter initialEntries={[path]}>
+        <MedplumProvider medplum={medplum}>
+          <MantineProvider>
+            <Notifications />
+            <Routes>
+              <Route path="/Patient/:patientId/DocumentReference/:documentId" element={<DocumentsPage />} />
+              <Route path="/Patient/:patientId/DocumentReference" element={<DocumentsPage />} />
+            </Routes>
+          </MantineProvider>
+        </MedplumProvider>
+      </MemoryRouter>
+    );
+  };
+
+  test('shows empty state when no documents', async () => {
+    medplum.searchResources = vi.fn().mockResolvedValue([]);
+
+    setup();
+
+    await waitFor(() => {
+      expect(screen.getByText('No documents to display.')).toBeInTheDocument();
+    });
+  });
+
+  test('shows loading skeleton initially', async () => {
+    medplum.searchResources = vi.fn().mockImplementation(() => new Promise(() => {}));
+
+    setup();
+
+    await waitFor(() => {
+      const skeletons = document.querySelectorAll('.mantine-Skeleton-root');
+      expect(skeletons.length).toBeGreaterThan(0);
+    });
+  });
+
+  test('renders document list item when documents are returned', async () => {
+    medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
+      if (resourceType === 'DocumentReference') {
+        return Promise.resolve([MOCK_DOC]);
+      }
+      return Promise.resolve([]);
+    });
+
+    setup(MOCK_DOC.id);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Lab Result PDF').length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  test('renders upload document button', async () => {
+    medplum.searchResources = vi.fn().mockResolvedValue([]);
+
+    setup();
+
+    await waitFor(() => {
+      expect(screen.getByText('All Documents')).toBeInTheDocument();
+    });
+
+    const buttons = screen.getAllByRole('button');
+    const uploadButton = buttons.find((btn) => btn.querySelector('.tabler-icon-plus'));
+    expect(uploadButton).toBeInTheDocument();
+  });
+
+  test('renders filter documents button', async () => {
+    medplum.searchResources = vi.fn().mockResolvedValue([]);
+
+    setup();
+
+    await waitFor(() => {
+      expect(screen.getByText('All Documents')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: 'Filter documents' })).toBeInTheDocument();
+  });
+
+  test('redirects to the first document when the documentId in the URL is not found', async () => {
+    medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
+      if (resourceType === 'DocumentReference') {
+        return Promise.resolve([MOCK_DOC]);
+      }
+      return Promise.resolve([]);
+    });
+
+    setup('nonexistent-doc-id');
+
+    // The selection effect advances the URL to the first visible document, so its detail panel
+    // renders. The content-type row appears only in the detail panel, not in the list item, so it
+    // confirms the redirect resolved to a selected document rather than the empty placeholder.
+    await waitFor(() => {
+      expect(screen.getByText('application/pdf')).toBeInTheDocument();
+    });
+  });
+
+  test('navigates to the next document on ArrowDown', async () => {
+    const secondDoc: WithId<DocumentReference> = {
+      ...MOCK_DOC,
+      id: 'doc-002',
+      description: 'Second Lab Result',
+      date: '2024-05-02T12:00:00Z',
+    };
+
+    medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
+      if (resourceType === 'DocumentReference') {
+        return Promise.resolve([MOCK_DOC, secondDoc]);
+      }
+      return Promise.resolve([]);
+    });
+
+    setup(MOCK_DOC.id);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Lab Result PDF').length).toBeGreaterThanOrEqual(1);
+    });
+
+    await userEvent.keyboard('{ArrowDown}');
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Second Lab Result').length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  test('filters out Health Gorilla lab artifacts', async () => {
+    const hgLabDoc: WithId<DocumentReference> = {
+      resourceType: 'DocumentReference',
+      id: 'hg-lab-doc',
+      status: 'current',
+      description: 'HG Lab Result',
+      category: [
+        {
+          coding: [
+            {
+              system: 'https://www.medplum.com/integrations/health-gorilla/document-type',
+              code: 'lab',
+            },
+          ],
+        },
+      ],
+      content: [{ attachment: { contentType: 'application/pdf', url: 'Binary/hg-001' } }],
+    };
+
+    medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
+      if (resourceType === 'DocumentReference') {
+        return Promise.resolve([hgLabDoc, MOCK_DOC]);
+      }
+      return Promise.resolve([]);
+    });
+
+    setup(MOCK_DOC.id);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Lab Result PDF').length).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByText('HG Lab Result')).not.toBeInTheDocument();
+    });
+  });
+
+  test('filters out documents carrying a Health Gorilla identifier', async () => {
+    const hgIdentifiedDoc: WithId<DocumentReference> = {
+      resourceType: 'DocumentReference',
+      id: 'hg-identified-doc',
+      status: 'current',
+      description: 'HG Requisition',
+      identifier: [{ system: 'https://www.healthgorilla.com', value: 'req-123' }],
+      content: [{ attachment: { contentType: 'application/pdf', url: 'Binary/hg-002' } }],
+    };
+
+    medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
+      if (resourceType === 'DocumentReference') {
+        return Promise.resolve([hgIdentifiedDoc, MOCK_DOC]);
+      }
+      return Promise.resolve([]);
+    });
+
+    setup(MOCK_DOC.id);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Lab Result PDF').length).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByText('HG Requisition')).not.toBeInTheDocument();
+    });
+  });
+
+  test('filters out Stedi artifacts by identifier host but keeps lookalike hosts', async () => {
+    const stediDoc: WithId<DocumentReference> = {
+      resourceType: 'DocumentReference',
+      id: 'stedi-doc',
+      status: 'current',
+      description: 'Stedi Artifact',
+      identifier: [{ system: 'https://stedi.com/claims', value: 'c-1' }],
+      content: [{ attachment: { contentType: 'application/pdf', url: 'Binary/stedi-001' } }],
+    };
+    // A lookalike host must NOT be treated as Stedi (guards the host-boundary match).
+    const lookalikeDoc: WithId<DocumentReference> = {
+      resourceType: 'DocumentReference',
+      id: 'lookalike-doc',
+      status: 'current',
+      description: 'Lookalike Doc',
+      identifier: [{ system: 'https://stedi.com.evil.example/claims', value: 'c-2' }],
+      content: [{ attachment: { contentType: 'application/pdf', url: 'Binary/look-001' } }],
+    };
+
+    medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
+      if (resourceType === 'DocumentReference') {
+        return Promise.resolve([stediDoc, lookalikeDoc, MOCK_DOC]);
+      }
+      return Promise.resolve([]);
+    });
+
+    setup(MOCK_DOC.id);
+
+    const listbox = await screen.findByRole('listbox', { name: 'All documents' });
+    await waitFor(() => {
+      expect(within(listbox).getByText('Lab Result PDF')).toBeInTheDocument();
+      expect(within(listbox).getByText('Lookalike Doc')).toBeInTheDocument();
+      expect(within(listbox).queryByText('Stedi Artifact')).not.toBeInTheDocument();
+    });
+  });
+
+  test('uploads a selected file as a DocumentReference', async () => {
+    medplum.searchResources = vi.fn().mockResolvedValue([]);
+    const createBinary = vi
+      .spyOn(medplum, 'createBinary')
+      .mockResolvedValue({ resourceType: 'Binary', id: 'binary-xyz' } as WithId<Binary>);
+    const createResource = vi
+      .spyOn(medplum, 'createResource')
+      .mockResolvedValue({ resourceType: 'DocumentReference', id: 'new-doc' } as WithId<DocumentReference>);
+
+    setup();
+
+    await waitFor(() => {
+      expect(screen.getByText('All Documents')).toBeInTheDocument();
+    });
+
+    // The upload button only opens a native file picker, so drive the upload through the hidden
+    // file input directly (which is what the picker would populate).
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['hello'], 'report.pdf', { type: 'application/pdf' });
+    await userEvent.upload(fileInput, file);
+
+    await waitFor(() => {
+      expect(createBinary).toHaveBeenCalled();
+      expect(createResource).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resourceType: 'DocumentReference',
+          status: 'current',
+          description: 'report.pdf',
+        })
+      );
+    });
+  });
+
+  test('soft-deletes a document by marking it entered-in-error', async () => {
+    medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
+      if (resourceType === 'DocumentReference') {
+        return Promise.resolve([MOCK_DOC]);
+      }
+      return Promise.resolve([]);
+    });
+    const updateResource = vi
+      .spyOn(medplum, 'updateResource')
+      .mockResolvedValue({ ...MOCK_DOC, status: 'entered-in-error' });
+
+    setup(MOCK_DOC.id);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Lab Result PDF').length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Open the edit modal via its icon button, then confirm the two-step delete.
+    const editButton = screen.getAllByRole('button').find((btn) => btn.querySelector('.tabler-icon-edit-circle'));
+    await userEvent.click(editButton as HTMLElement);
+
+    await userEvent.click(await screen.findByText('Delete Document'));
+    await userEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(updateResource).toHaveBeenCalledWith(
+        expect.objectContaining({ resourceType: 'DocumentReference', id: MOCK_DOC.id, status: 'entered-in-error' })
+      );
+    });
+  });
+
+  test('filters the document list by source', async () => {
+    const labDoc: WithId<DocumentReference> = {
+      ...MOCK_DOC,
+      id: 'lab-doc',
+      description: 'Lab Report Doc',
+      date: '2024-05-03T12:00:00Z',
+      type: { coding: [{ display: 'Lab Report' }] },
+    };
+
+    medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
+      if (resourceType === 'DocumentReference') {
+        return Promise.resolve([MOCK_DOC, labDoc]);
+      }
+      return Promise.resolve([]);
+    });
+
+    setup(MOCK_DOC.id);
+
+    const listbox = await screen.findByRole('listbox', { name: 'All documents' });
+    await waitFor(() => {
+      expect(within(listbox).getByText('Lab Result PDF')).toBeInTheDocument();
+      expect(within(listbox).getByText('Lab Report Doc')).toBeInTheDocument();
+    });
+
+    // Open the filter menu and restrict to the "Lab" source.
+    await userEvent.click(screen.getByRole('button', { name: 'Filter documents' }));
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Lab' }));
+
+    await waitFor(() => {
+      const list = screen.getByRole('listbox', { name: 'All documents' });
+      expect(within(list).getByText('Lab Report Doc')).toBeInTheDocument();
+      // The Upload-source document is filtered out of the list (it remains selected in the detail
+      // panel, so we scope this assertion to the list itself).
+      expect(within(list).queryByText('Lab Result PDF')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/examples/medplum-provider/src/pages/patient/DocumentsPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/DocumentsPage.tsx
@@ -1,0 +1,451 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { ActionIcon, Divider, Flex, Group, ScrollArea, Skeleton, Stack, Text, Tooltip } from '@mantine/core';
+import { getReferenceString } from '@medplum/core';
+import type { Communication, DocumentReference } from '@medplum/fhirtypes';
+import { HEALTH_GORILLA_SYSTEM } from '@medplum/health-gorilla-core';
+import { useMedplum } from '@medplum/react';
+import { IconPlus } from '@tabler/icons-react';
+import type { JSX } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { DocumentDetailPanel } from '../../components/documents/DocumentDetailPanel';
+import { DocumentFilterMenu } from '../../components/documents/DocumentFilterMenu';
+import { DocumentListItem } from '../../components/documents/DocumentListItem';
+import type { DocumentSource, PatientDocument } from '../../components/documents/DocumentListItem.utils';
+import { isFaxMedium, toPatientDocument } from '../../components/documents/DocumentListItem.utils';
+import { DocumentSelectEmpty } from '../../components/documents/DocumentSelectEmpty';
+import { usePatient } from '../../hooks/usePatient';
+import { showErrorNotification } from '../../utils/notifications';
+import classes from './DocumentsPage.module.css';
+
+function getDocumentItemId(docId: string): string {
+  return `document-item-${docId}`;
+}
+
+function isDocumentListItem(element: Element | null | undefined): element is HTMLElement {
+  return element instanceof HTMLElement && element.id.startsWith('document-item-');
+}
+
+function getActiveDocumentIndex(filteredDocs: PatientDocument[], documentId: string | undefined): number {
+  if (isDocumentListItem(document.activeElement)) {
+    const focusedId = document.activeElement.id.slice('document-item-'.length);
+    const focusedIndex = filteredDocs.findIndex((doc) => doc.id === focusedId);
+    if (focusedIndex >= 0) {
+      return focusedIndex;
+    }
+  }
+
+  return filteredDocs.findIndex((doc) => doc.id === documentId);
+}
+
+// Stedi tags its artifacts with an identifier whose system is a stedi.com URL. Match on the parsed
+// hostname (exact host or a subdomain) rather than a substring, so lookalike hosts such as
+// "stedi.com.evil.example" or "notstedi.com" don't slip through.
+function isStediIdentifierSystem(system: string | undefined): boolean {
+  if (!system) {
+    return false;
+  }
+  try {
+    const host = new URL(system).hostname;
+    return host === 'stedi.com' || host.endsWith('.stedi.com');
+  } catch {
+    return false;
+  }
+}
+
+function isHGLabArtifact(doc: DocumentReference): boolean {
+  const hasHGCategory = doc.category?.some((cat) =>
+    cat.coding?.some((c) => c.system === 'https://www.medplum.com/integrations/health-gorilla/document-type')
+  );
+  if (hasHGCategory) {
+    return true;
+  }
+
+  const isDebugLog = doc.category?.some((cat) => cat.text?.startsWith('HG Debug Log'));
+  if (isDebugLog) {
+    return true;
+  }
+
+  // Health Gorilla artifacts carry an identifier under the Health Gorilla system, the same way
+  // Stedi artifacts are tagged below. This is portable across environments (unlike a fixed bot id).
+  const isHGIdentified = doc.identifier?.some((id) => id.system?.startsWith(HEALTH_GORILLA_SYSTEM));
+  if (isHGIdentified) {
+    return true;
+  }
+
+  const isAddendum = doc.type?.coding?.some((c) => c.display === 'Addendum Document');
+  if (isAddendum) {
+    return true;
+  }
+
+  const isStediArtifact = doc.identifier?.some((id) => isStediIdentifierSystem(id.system));
+  if (isStediArtifact) {
+    return true;
+  }
+
+  return false;
+}
+
+export function DocumentsPage(): JSX.Element {
+  // Remount per patient so list, loading, and selection state never leak across patients.
+  const { patientId } = useParams();
+  return <DocumentsPageContent key={patientId} />;
+}
+
+function DocumentsPageContent(): JSX.Element {
+  const { patientId, documentId } = useParams();
+  const navigate = useNavigate();
+  const medplum = useMedplum();
+  const patient = usePatient();
+  const patientReference = useMemo(() => (patient ? getReferenceString(patient) : undefined), [patient]);
+
+  const [documents, setDocuments] = useState<PatientDocument[]>([]);
+  // Starts true: the page mounts (per patient, via the key above) before the first fetch resolves.
+  const [loading, setLoading] = useState(true);
+  const [uploading, setUploading] = useState(false);
+  const [selectedSources, setSelectedSources] = useState<DocumentSource[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const shouldFocusSelectionRef = useRef(false);
+  const shouldScrollSelectionRef = useRef(false);
+  // Tracks which documents have already played the original-author fade this section visit, so
+  // revisiting one (history now cached → resolves immediately) renders the clause statically. One
+  // stable Set for the page's lifetime; it resets on remount, so re-entering the section animates again.
+  const [fadedAuthorIds] = useState(() => new Set<string>());
+
+  const fetchDocuments = useCallback(async (): Promise<void> => {
+    if (!patientReference) {
+      return;
+    }
+
+    try {
+      const [docRefs, attachmentComms] = await Promise.all([
+        medplum.searchResources(
+          'DocumentReference',
+          {
+            patient: patientReference,
+            _sort: '-_lastUpdated',
+            _count: '100',
+          },
+          { cache: 'no-cache' }
+        ),
+        medplum.searchResources(
+          'Communication',
+          {
+            subject: patientReference,
+            _sort: '-sent',
+            _count: '100',
+          },
+          { cache: 'no-cache' }
+        ),
+      ]);
+
+      // Message attachments are stored as separate DocumentReferences and linked from the
+      // message Communication via payload.contentReference. Collect those references so the
+      // backing DocumentReferences can be classified as "Message" rather than "Upload".
+      const messageDocRefRefs = new Set<string>();
+      for (const comm of attachmentComms) {
+        if (isFaxMedium(comm)) {
+          continue;
+        }
+        for (const p of comm.payload ?? []) {
+          if (p.contentReference?.reference) {
+            messageDocRefRefs.add(p.contentReference.reference);
+          }
+        }
+      }
+
+      const allDocs: PatientDocument[] = [
+        ...docRefs
+          // entered-in-error is a soft delete: kept in the project, hidden from the list.
+          .filter((d) => d.status !== 'entered-in-error' && !isHGLabArtifact(d))
+          .map((d: DocumentReference) =>
+            toPatientDocument(d, { asMessageAttachment: messageDocRefRefs.has(getReferenceString(d) ?? '') })
+          ),
+        ...attachmentComms
+          .filter((c: Communication) => c.status !== 'entered-in-error' && c.payload?.some((p) => p.contentAttachment))
+          .map((c: Communication) => toPatientDocument(c)),
+      ];
+
+      allDocs.sort((a, b) => {
+        const aTime = a.date ? new Date(a.date).getTime() : 0;
+        const bTime = b.date ? new Date(b.date).getTime() : 0;
+        return bTime - aTime;
+      });
+
+      setDocuments(allDocs);
+    } catch (error) {
+      showErrorNotification(error);
+    } finally {
+      setLoading(false);
+    }
+  }, [medplum, patientReference]);
+
+  useEffect(() => {
+    if (patientId) {
+      // Fetch on mount / patient change. fetchDocuments only updates state after its await
+      // resolves, so this is not the synchronous render loop the rule guards against.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      fetchDocuments().catch(showErrorNotification);
+    }
+  }, [patientId, fetchDocuments]);
+
+  const selectedDoc = useMemo(() => {
+    if (!documentId || documents.length === 0) {
+      return undefined;
+    }
+    return documents.find((doc) => doc.id === documentId);
+  }, [documentId, documents]);
+
+  useEffect(() => {
+    // Once documents are loaded, make sure the URL points at a visible one. This covers both no
+    // selection and a selection that no longer resolves (e.g. just soft-deleted, so filtered out).
+    if (loading || documents.length === 0) {
+      return;
+    }
+    const selectionResolves = documentId && documents.some((doc) => doc.id === documentId);
+    if (!selectionResolves) {
+      navigate(`/Patient/${patientId}/DocumentReference/${documents[0].id}`, { replace: true })?.catch(console.error);
+    }
+  }, [documentId, documents, loading, navigate, patientId]);
+
+  useEffect(() => {
+    if (!documentId || (!shouldFocusSelectionRef.current && !shouldScrollSelectionRef.current)) {
+      return;
+    }
+
+    const moveFocus = shouldFocusSelectionRef.current;
+    shouldFocusSelectionRef.current = false;
+    shouldScrollSelectionRef.current = false;
+
+    requestAnimationFrame(() => {
+      const item = document.getElementById(getDocumentItemId(documentId));
+      if (!item) {
+        return;
+      }
+
+      item.scrollIntoView({ block: 'nearest' });
+      if (moveFocus) {
+        item.focus({ preventScroll: true });
+      }
+    });
+  }, [documentId]);
+
+  const getItemUri = useCallback(
+    (item: PatientDocument): string => {
+      return `/Patient/${patientId}/DocumentReference/${item.id}`;
+    },
+    [patientId]
+  );
+
+  const handleDocumentChange = (): void => {
+    fetchDocuments().catch(showErrorNotification);
+  };
+
+  const handleDocumentDeleted = (): void => {
+    // Refetch; the deleted document drops out of the list and the selection effect advances the
+    // URL to the next visible document (or the empty state when none remain).
+    fetchDocuments().catch(showErrorNotification);
+  };
+
+  const handleFileUpload = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
+      const file = event.target.files?.[0];
+      if (!file || !patientReference) {
+        return;
+      }
+
+      setUploading(true);
+      try {
+        const binary = await medplum.createBinary(file, file.name, file.type);
+        await medplum.createResource<DocumentReference>({
+          resourceType: 'DocumentReference',
+          status: 'current',
+          subject: { reference: patientReference },
+          date: new Date().toISOString(),
+          description: file.name,
+          content: [
+            {
+              attachment: {
+                contentType: file.type,
+                url: `Binary/${binary.id}`,
+                title: file.name,
+              },
+            },
+          ],
+        });
+        await fetchDocuments();
+      } catch (error) {
+        showErrorNotification(error);
+      } finally {
+        setUploading(false);
+        if (fileInputRef.current) {
+          fileInputRef.current.value = '';
+        }
+      }
+    },
+    [medplum, patientReference, fetchDocuments]
+  );
+
+  const filteredDocs = useMemo(() => {
+    if (selectedSources.length === 0) {
+      return documents;
+    }
+    return documents.filter((doc) => selectedSources.includes(doc.source));
+  }, [documents, selectedSources]);
+
+  const navigateToDocument = useCallback(
+    (doc: PatientDocument, options?: { moveFocus?: boolean; scroll?: boolean }): void => {
+      if (options?.moveFocus) {
+        shouldFocusSelectionRef.current = true;
+      }
+      if (options?.scroll) {
+        shouldScrollSelectionRef.current = true;
+      }
+      navigate(getItemUri(doc))?.catch(console.error);
+    },
+    [navigate, getItemUri]
+  );
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent): void {
+      if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
+        return;
+      }
+
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+
+      if (target.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName)) {
+        return;
+      }
+
+      if (loading || filteredDocs.length === 0) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const currentIndex = getActiveDocumentIndex(filteredDocs, documentId);
+      let nextIndex: number;
+      if (event.key === 'ArrowDown') {
+        nextIndex = currentIndex < 0 ? 0 : Math.min(currentIndex + 1, filteredDocs.length - 1);
+      } else {
+        nextIndex = currentIndex < 0 ? filteredDocs.length - 1 : Math.max(currentIndex - 1, 0);
+      }
+
+      if (nextIndex === currentIndex) {
+        return;
+      }
+
+      navigateToDocument(filteredDocs[nextIndex], {
+        moveFocus: isDocumentListItem(document.activeElement),
+        scroll: true,
+      });
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [documentId, filteredDocs, loading, navigateToDocument]);
+
+  const handleSourceToggle = useCallback((source: DocumentSource): void => {
+    setSelectedSources((prev) => (prev.includes(source) ? prev.filter((s) => s !== source) : [...prev, source]));
+  }, []);
+
+  const patientRef = patient ? ({ reference: `Patient/${patient.id}` } as const) : undefined;
+
+  return (
+    <div className={classes.layout}>
+      <div className={classes.shell}>
+        <Flex h={64} align="center" justify="space-between" px="lg">
+          <span className={classes.headerText}>All Documents</span>
+          <Group gap="xs">
+            <input
+              type="file"
+              ref={fileInputRef}
+              onChange={handleFileUpload}
+              style={{ display: 'none' }}
+              accept=".pdf,.png,.jpg,.jpeg,.tiff,.doc,.docx"
+            />
+            <DocumentFilterMenu
+              sources={selectedSources}
+              onSourceToggle={handleSourceToggle}
+              onClearAllFilters={() => setSelectedSources([])}
+            />
+            <Tooltip label="Upload Document" position="bottom" openDelay={500}>
+              <ActionIcon
+                variant="filled"
+                color="blue"
+                size={32}
+                radius="xl"
+                loading={uploading}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <IconPlus size={16} />
+              </ActionIcon>
+            </Tooltip>
+          </Group>
+        </Flex>
+
+        <Divider />
+        <ScrollArea style={{ flex: 1 }} id="document-list-scrollarea">
+          {loading && <DocListSkeleton />}
+          {!loading && filteredDocs.length === 0 && <EmptyDocsState />}
+          {!loading && filteredDocs.length > 0 && (
+            <Stack gap={2} p="xs" role="listbox" aria-label="All documents">
+              {filteredDocs.map((item) => (
+                <DocumentListItem
+                  key={`${item.resourceType}-${item.id}`}
+                  id={getDocumentItemId(item.id)}
+                  item={item}
+                  selectedDocumentId={documentId}
+                  getItemUri={getItemUri}
+                />
+              ))}
+            </Stack>
+          )}
+        </ScrollArea>
+      </div>
+
+      {selectedDoc ? (
+        <DocumentDetailPanel
+          key={selectedDoc.id}
+          item={selectedDoc}
+          patientRef={patientRef}
+          onDocumentChange={handleDocumentChange}
+          onDocumentDeleted={handleDocumentDeleted}
+          fadedAuthorIds={fadedAuthorIds}
+        />
+      ) : (
+        <div className={classes.detailColumn}>
+          <DocumentSelectEmpty />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EmptyDocsState(): JSX.Element {
+  return (
+    <Flex direction="column" h="100%" justify="center" align="center" pt="xl">
+      <Text c="dimmed" fw={500}>
+        No documents to display.
+      </Text>
+    </Flex>
+  );
+}
+
+function DocListSkeleton(): JSX.Element {
+  return (
+    <Stack gap="md" p="md">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <Stack key={index} gap="xs">
+          <Skeleton height={16} width={`${85 - index * 5}%`} />
+          <Skeleton height={14} width={`${60 + index * 4}%`} />
+        </Stack>
+      ))}
+    </Stack>
+  );
+}

--- a/examples/medplum-provider/src/pages/patient/PatientPage.utils.ts
+++ b/examples/medplum-provider/src/pages/patient/PatientPage.utils.ts
@@ -94,7 +94,7 @@ export const PatientPageTabs: PatientPageTabInfo[] = [
   },
   {
     id: 'documentreference',
-    url: 'DocumentReference?subject=%patient.id',
+    url: 'DocumentReference?patient=%patient.id',
     label: 'Documents',
   },
   {


### PR DESCRIPTION
## Summary

Adds a dedicated patient **Documents** tab to the provider example app — a master/detail view over `DocumentReference` and message/fax `Communication` resources, replacing the generic search-table view for this tab.

### Features
- **List + detail layout** — scrollable document list with a preview panel (PDF/iframe, image, and video previews; metadata for everything else).
- **Upload** — upload a file directly as a `DocumentReference`.
- **Source filtering** — filter by Fax / Lab / Upload / Message.
- **Inline edit & soft-delete** — edit title/type/category/author; delete marks the resource `entered-in-error` (kept in the project, hidden from the list).
- **Keyboard navigation** — Arrow up/down moves selection in lockstep with focus.
- **Noise filtering** — Health Gorilla lab artifacts (by category, identifier, or addendum type) are hidden from the list.

### Changes
- New components under `examples/medplum-provider/src/components/documents/`.
- New `DocumentsPage` (`pages/patient/DocumentsPage.tsx`) + styles, wired into two routes in `App.tsx` (`DocumentReference`, `DocumentReference/:documentId`).
- Documents tab search param switched from `subject=` to `patient=` in `PatientPage.utils.ts` — `patient` resolves against the same `DocumentReference.subject` field but is constrained to Patient references, matching the page's own fetch and the other patient-scoped tabs.

## Test plan
- `npx tsc --noEmit` — clean
- `npx eslint` (page, components, tests) — clean
- `npx vitest run src/pages/patient/DocumentsPage.test.tsx` — **12 passing** (empty state, loading, list render, upload, soft-delete, source filter, keyboard nav, redirect-to-first, HG artifact filtering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
