### PR TITLE
Fixed SMART app launch launchUri permissions

### DIFF
--- a/packages/server/src/fhir/operations/launch.test.ts
+++ b/packages/server/src/fhir/operations/launch.test.ts
@@ -73,6 +73,19 @@ describe('ClientApplication/:id/$smart-launch', () => {
     expect(launch.id).toEqual(launchId);
   });
 
+  test('Does not launch ClientApplication from another project', async () => {
+    const otherProject = await createTestProject({
+      client: { launchUri: 'https://example.com/other-project-smart-launch' },
+      withClient: true,
+    });
+
+    const res = await request(app)
+      .get(`/fhir/R4/ClientApplication/${otherProject.client.id}/$smart-launch`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send();
+    expect(res.status).toBe(404);
+  });
+
   test('Preserves launch parameter', async () => {
     // Update ClientApplication with launchUri
     const launchUri = 'https://example.com/smart-launch';

--- a/packages/server/src/fhir/operations/launch.ts
+++ b/packages/server/src/fhir/operations/launch.ts
@@ -33,7 +33,7 @@ export async function appLaunchHandler(req: FhirRequest): Promise<FhirResponse> 
 
   const params = parseInputParameters<LaunchOperationParameters>(operation, req);
 
-  const clientApp = await ctx.systemRepo.readResource<ClientApplication>('ClientApplication', req.params.id);
+  const clientApp = await ctx.repo.readResource<ClientApplication>('ClientApplication', req.params.id);
 
   if (!clientApp.launchUri) {
     return [badRequest('ClientApplication not configured for launch')];


### PR DESCRIPTION
This PR tightens access control for the `ClientApplication/$smart-launch` operation by reading the target `ClientApplication` through the authenticated user's project-scoped repository before using its `launchUri`.

Previously, this operation loaded the target `ClientApplication` through the system repository. That meant an authenticated request with a known `ClientApplication` ID could reach launch handling before the usual project-scoped read checks were applied. The returned data was limited to redirect behavior based on the configured `launchUri`, but the operation should still follow the same access-control pattern as related operations.

## Changes

- Read the target `ClientApplication` via `ctx.repo.readResource(...)` in `$smart-launch`.
- Preserve existing launch behavior for clients the requester is allowed to read.
- Add a regression test confirming a requester from one project cannot launch a `ClientApplication` from another project.

