### PR TITLE
Replace helm-s3 plugin with native Helm + AWS CLI

### DIFF
--- a/.github/workflows/build-helm-charts.yml
+++ b/.github/workflows/build-helm-charts.yml
@@ -1,8 +1,8 @@
 name: Build Helm Charts
 
 concurrency:
-  group: ci-build-helm-${{ github.sha }}
-  cancel-in-progress: true
+  group: ci-build-helm
+  cancel-in-progress: false
 
 on:
   push:
@@ -19,6 +19,8 @@ jobs:
     timeout-minutes: 45
     permissions:
       id-token: write
+      contents: read
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -37,9 +39,6 @@ jobs:
         with:
           version: 'v4.2.1'
 
-      - name: Setup Helm S3
-        run: helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.17.1
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
@@ -49,19 +48,27 @@ jobs:
       - name: Import GPG key
         run: echo "${{ secrets.MEDPLUM_GPG_KEY }}" | gpg --batch --no-tty --import
 
-      - name: Add Medplum S3 Helm repository
-        run: helm repo add medplum-s3 s3://charts.medplum.com --force-update
-
       - name: Get Chart Version and File Name
         id: get_chart_info
         run: |
           CHART_NAME="medplum"
           CHART_VERSION=$(node -p "require('./package.json').version")
           CHART_FILE="${CHART_NAME}-${CHART_VERSION}.tgz"
-          echo "CHART_FILE=$CHART_FILE" >> $GITHUB_OUTPUT
+          echo "CHART_VERSION=$CHART_VERSION" >> "$GITHUB_OUTPUT"
+          echo "CHART_FILE=$CHART_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Package the Helm charts
         run: helm package ./charts
 
       - name: Push the chart to S3
-        run: helm s3 push ${{ steps.get_chart_info.outputs.CHART_FILE }} medplum-s3 --relative
+        run: |
+          aws --version
+
+          aws s3 cp s3://charts.medplum.com/index.yaml ./index-existing.yaml || true
+
+          helm repo index . \
+            --url https://charts.medplum.com \
+            --merge ./index-existing.yaml
+
+          aws s3 cp "${{ steps.get_chart_info.outputs.CHART_FILE }}" s3://charts.medplum.com/
+          aws s3 cp index.yaml s3://charts.medplum.com/index.yaml

--- a/.github/workflows/build-helm-charts.yml
+++ b/.github/workflows/build-helm-charts.yml
@@ -46,7 +46,22 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Import GPG key
-        run: echo "${{ secrets.MEDPLUM_GPG_KEY }}" | gpg --batch --no-tty --import
+        id: import_gpg_key
+        run: |
+          printf '%s' "$GPG_KEY" | gpg --batch --no-tty --import
+          gpg --batch --yes --export > ~/.gnupg/pubring.gpg
+          printf '%s' "$GPG_PASSPHRASE" | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --export-secret-keys "$GPG_KEY_ID" > ~/.gnupg/secring.gpg
+
+          HELM_SIGNING_KEY=$(gpg --batch --with-colons --list-secret-keys "$GPG_KEY_ID" | awk -F: '$1 == "uid" { print $10; exit }')
+          if [ -z "$HELM_SIGNING_KEY" ]; then
+            echo "Unable to find Helm signing key UID for MEDPLUM_GPG_KEY_ID"
+            exit 1
+          fi
+          echo "HELM_SIGNING_KEY=$HELM_SIGNING_KEY" >> "$GITHUB_OUTPUT"
+        env:
+          GPG_KEY: ${{ secrets.MEDPLUM_GPG_KEY }}
+          GPG_KEY_ID: ${{ secrets.MEDPLUM_GPG_KEY_ID }}
+          GPG_PASSPHRASE: ${{ secrets.MEDPLUM_GPG_PASSPHRASE }}
 
       - name: Get Chart Version and File Name
         id: get_chart_info
@@ -54,11 +69,17 @@ jobs:
           CHART_NAME="medplum"
           CHART_VERSION=$(node -p "require('./package.json').version")
           CHART_FILE="${CHART_NAME}-${CHART_VERSION}.tgz"
-          echo "CHART_VERSION=$CHART_VERSION" >> "$GITHUB_OUTPUT"
           echo "CHART_FILE=$CHART_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Package the Helm charts
-        run: helm package ./charts
+        run: |
+          helm package ./charts \
+            --sign \
+            --key "${{ steps.import_gpg_key.outputs.HELM_SIGNING_KEY }}" \
+            --keyring ~/.gnupg/secring.gpg \
+            --passphrase-file <(printf '%s' "$GPG_PASSPHRASE")
+        env:
+          GPG_PASSPHRASE: ${{ secrets.MEDPLUM_GPG_PASSPHRASE }}
 
       - name: Push the chart to S3
         run: |
@@ -70,5 +91,9 @@ jobs:
             --url https://charts.medplum.com \
             --merge ./index-existing.yaml
 
-          aws s3 cp "${{ steps.get_chart_info.outputs.CHART_FILE }}" s3://charts.medplum.com/
-          aws s3 cp index.yaml s3://charts.medplum.com/index.yaml
+          aws s3 cp "${{ steps.get_chart_info.outputs.CHART_FILE }}" s3://charts.medplum.com/ \
+            --content-type application/gzip
+          aws s3 cp "${{ steps.get_chart_info.outputs.CHART_FILE }}.prov" s3://charts.medplum.com/ \
+            --content-type application/octet-stream
+          aws s3 cp index.yaml s3://charts.medplum.com/index.yaml \
+            --content-type application/yaml

--- a/.github/workflows/build-helm-charts.yml
+++ b/.github/workflows/build-helm-charts.yml
@@ -49,7 +49,6 @@ jobs:
         id: import_gpg_key
         run: |
           printf '%s' "$GPG_KEY" | gpg --batch --no-tty --import
-          gpg --batch --yes --export > ~/.gnupg/pubring.gpg
           printf '%s' "$GPG_PASSPHRASE" | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --export-secret-keys "$GPG_KEY_ID" > ~/.gnupg/secring.gpg
 
           HELM_SIGNING_KEY=$(gpg --batch --with-colons --list-secret-keys "$GPG_KEY_ID" | awk -F: '$1 == "uid" { print $10; exit }')
@@ -87,9 +86,14 @@ jobs:
 
           aws s3 cp s3://charts.medplum.com/index.yaml ./index-existing.yaml || true
 
+          MERGE_ARGS=()
+          if [ -f ./index-existing.yaml ]; then
+            MERGE_ARGS=(--merge ./index-existing.yaml)
+          fi
+
           helm repo index . \
             --url https://charts.medplum.com \
-            --merge ./index-existing.yaml
+            "${MERGE_ARGS[@]}"
 
           aws s3 cp "${{ steps.get_chart_info.outputs.CHART_FILE }}" s3://charts.medplum.com/ \
             --content-type application/gzip


### PR DESCRIPTION
Our Helm chart publishing workflow currently depends on the `helm-s3` plugin:

```bash
helm plugin install https://github.com/hypnoglow/helm-s3.git
helm s3 push ...
```

After upgrading to Helm 4, plugin installation now fails with:

```text
Error: plugin source does not support verification. Use --verify=false to skip verification
```

While we could disable verification, this introduces additional plugin-specific maintenance and keeps a third-party dependency in our release pipeline.

### Solution

Replace `helm-s3` with native Helm and AWS CLI commands.

The workflow now:

1. Packages the chart using `helm package`
2. Downloads the existing `index.yaml` from S3
3. Regenerates the repository index using `helm repo index --merge`
4. Uploads the chart archive to S3
5. Uploads the updated `index.yaml` to S3

Consumers are unaffected because they already use the public HTTPS repository:

```bash
helm repo add medplum https://charts.medplum.com
```

Only the publishing implementation changes.

### Benefits

* Removes dependency on the `helm-s3` plugin
* Avoids Helm 4 plugin verification issues
* Uses only native Helm functionality (`helm package`, `helm repo index`)
* Simplifies the release pipeline
* Reduces long-term maintenance burden and supply-chain surface area

### Notes

The repository format remains unchanged (`index.yaml` + chart archives stored in S3). Existing chart installation and upgrade workflows continue to work without modification.
