### PR TITLE
fix(server): persist client-credentials auth Logins to Postgres

### DIFF
--- a/packages/server/src/auth/login-persistence.test.ts
+++ b/packages/server/src/auth/login-persistence.test.ts
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import { createReference } from '@medplum/core';
+import type { ClientApplication, Login } from '@medplum/fhirtypes';
+import { randomUUID } from 'node:crypto';
+import { initAppServices, shutdownApp } from '../app';
+import { loadTestConfig } from '../config/loader';
+import { DatabaseMode, getDatabasePool } from '../database';
+import { getGlobalSystemRepo } from '../fhir/repo';
+import { deleteResourceCacheEntry } from '../fhir/repository/resource-cache';
+import { withTestContext } from '../test.setup';
+
+const systemRepo = getGlobalSystemRepo();
+
+async function countLoginRows(id: string): Promise<number> {
+  const pool = getDatabasePool(DatabaseMode.WRITER);
+  const result = await pool.query('SELECT COUNT(*)::int AS count FROM "Login" WHERE "id" = $1', [id]);
+  return result.rows[0].count;
+}
+
+function buildLogin(authMethod: Login['authMethod']): Login {
+  const client: WithId<ClientApplication> = { resourceType: 'ClientApplication', id: randomUUID() };
+  return {
+    resourceType: 'Login',
+    authMethod,
+    user: createReference(client),
+    client: createReference(client),
+    authTime: new Date().toISOString(),
+    scope: 'openid',
+  };
+}
+
+describe('Auth Login persistence', () => {
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initAppServices(config);
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test('client Login is persisted to Postgres', async () => {
+    const login = await withTestContext(() => systemRepo.createResource<Login>(buildLogin('client')));
+    await expect(countLoginRows(login.id)).resolves.toBe(1);
+  });
+
+  test('execute Login remains cache-only (no Postgres row)', async () => {
+    const login = await withTestContext(() => systemRepo.createResource<Login>(buildLogin('execute')));
+    await expect(countLoginRows(login.id)).resolves.toBe(0);
+  });
+
+  test('Reads back a persisted client Login even after the cache entry is gone', async () => {
+    const login = await withTestContext(() => systemRepo.createResource<Login>(buildLogin('client')));
+    await deleteResourceCacheEntry('Login', login.id);
+    const reread = await withTestContext(() => systemRepo.readResource<Login>('Login', login.id));
+    expect(reread.id).toStrictEqual(login.id);
+    expect(reread.authMethod).toStrictEqual('client');
+  });
+});

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -2030,7 +2030,7 @@ export class Repository extends FhirRepository implements Disposable {
    * @returns True if the resource should be cached only and not written to the database.
    */
   private isCacheOnly(resource: Resource): boolean {
-    if (resource.resourceType === 'Login' && (resource.authMethod === 'client' || resource.authMethod === 'execute')) {
+    if (resource.resourceType === 'Login' && resource.authMethod === 'execute') {
       return true;
     }
     if (resource.resourceType === 'Subscription' && resource.channel?.type === 'websocket') {


### PR DESCRIPTION
## Why

medplum stores `client` (and `execute`) `Login` resources cache-only — Redis, never Postgres — via `isCacheOnly()` (upstream #1506). Since the cache Redis uses ElastiCache's default eviction (`volatile-lru`) and Login entries have a TTL, a still-valid Login can be evicted under memory pressure. The read path then returns `undefined`, so a valid, unexpired token gets a **401** that clients retry until expiry.

We saw exactly this happen under relatively extreme conditions with very high key eviction. Obviously reducing memory pressure is also sensible, but the number of keys being inserted is high enough to make the economics of expanding size unattractive.

## What

`client` Logins now persist to Postgres (like `password`/`google`), so an evicted cache entry is harmless — the read falls back to the DB row. Auth path unchanged. `execute` (highest-volume) Logins stay cache-only.

**Tradeoff:** reverses #1506 for `client`, so the `Login` table grows. But limited to only `client` auth method.

## Alternative

**`feat/auth-redis`** instead keeps Logins cache-only but isolates them onto a dedicated `noeviction` Redis: https://github.com/flexpa/medplum/pull/2/commits/a8283bf4ee40bf5c05cd75687f7fb512c53d9715

I can open the alternative as a PR if it's preferable

