### PR TITLE
Reduce default db conn pool size

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -108,7 +108,7 @@ export function escapePgOptionsArg(value: string): string {
   return value.replaceAll('\\', '\\\\').replaceAll(' ', '\\ ');
 }
 
-const DEFAULT_MAX_CONNECTIONS = 100;
+const DEFAULT_MAX_CONNECTIONS = 50;
 const DEFAULT_STATEMENT_TIMEOUT = 60_000;
 const DEFAULT_TRANSACTION_ISOLATION = escapePgOptionsArg('repeatable read');
 const DEFAULT_IDLE_IN_TRANSACTION_SESSION_TIMEOUT = 30_000;


### PR DESCRIPTION
The current default PostgreSQL connection pool size is:

```ts
const DEFAULT_MAX_CONNECTIONS = 100;
```

This is probably too high for a default value and can easily exceed the available connections on a default PostgreSQL installation.

For example, a typical PostgreSQL configuration is:

```sql
max_connections = 100
superuser_reserved_connections = 3
```

Which means that only 97 connections are available to normal application users. A single connection pool configured for 100 connections can therefore exhaust the database's available connections by itself, resulting in errors such as:

```text
sorry, too many clients already
```

This can be especially confusing in local development environments where users are running a single Medplum instance against a default PostgreSQL installation and would not reasonably expect to hit connection limits immediately.

## Proposed Change

Reduce the default connection pool size from 100 to 50.

```diff
- const DEFAULT_MAX_CONNECTIONS = 100;
+ const DEFAULT_MAX_CONNECTIONS = 50;
```

The goal is not to establish 50 as the universally correct pool size, but rather to avoid a default configuration that can trivially exceed the connection limits of a common PostgreSQL deployment.

## Why 50?

The primary objective is to move away from a default that is effectively equal to PostgreSQL's default `max_connections` setting.

A value of 50:

* Provides substantial headroom for development and small deployments.
* Leaves room for administrative connections and other processes.
* Reduces the likelihood of connection exhaustion caused by a single Medplum process.
* Remains large enough that it is unlikely to become a bottleneck in typical environments.

## Alternatives Considered

### Smaller Defaults (10–20)

There is a strong argument that the default should be significantly lower, perhaps 10 or 20.

Many modern applications intentionally keep pool sizes small because:

* PostgreSQL generally performs better with fewer active connections.
* Multiple application processes often run simultaneously.
* Connection pools are frequently over-provisioned relative to actual concurrency.

A smaller default would be even safer and may ultimately be the better long-term choice.

### Keeping 100

Keeping the current default risks surprising users with connection exhaustion on otherwise standard PostgreSQL installations.

While large production deployments can and should explicitly tune pool sizes for their environment, a default value should be conservative enough to work well out-of-the-box.

## Discussion

The important part of this change is reducing the default from 100 to something more conservative.

I selected 50 as a middle ground that materially reduces the risk of exhausting PostgreSQL connections while remaining unlikely to impact existing deployments. However, I would be supportive of a lower default (e.g. 10 or 20) if the team feels that better reflects real-world usage patterns.
