### PR TITLE
fix(server): render CMS-1500 Box 24E diagnosis pointers

### DIFF
--- a/packages/server/src/fhir/operations/utils/cms1500pdf.test.ts
+++ b/packages/server/src/fhir/operations/utils/cms1500pdf.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { HumanName } from '@medplum/fhirtypes';
-import { formatHumanName, getSimplePhone } from './cms1500pdf';
+import { formatDiagnosisPointers, formatHumanName, getSimplePhone } from './cms1500pdf';
 
 describe('CMS 1500 PDF Utils', () => {
   test('formats full name with middle name', () => {
@@ -85,5 +85,27 @@ describe('CMS 1500 PDF Utils', () => {
 
   test('removes standalone 1 prefix from the beginning of phone numbers', () => {
     expect(getSimplePhone('11234567890')).toBe('1234567890');
+  });
+
+  test('formats a single diagnosis pointer as a letter', () => {
+    expect(formatDiagnosisPointers([1])).toBe('A');
+  });
+
+  test('formats multiple diagnosis pointers with no separators (NUCC)', () => {
+    expect(formatDiagnosisPointers([1, 2])).toBe('AB');
+    expect(formatDiagnosisPointers([2, 4])).toBe('BD');
+  });
+
+  test('maps the 12th pointer to L (CMS-1500 Box 21 supports A-L)', () => {
+    expect(formatDiagnosisPointers([12])).toBe('L');
+  });
+
+  test('returns an empty string when there are no pointers', () => {
+    expect(formatDiagnosisPointers(undefined)).toBe('');
+    expect(formatDiagnosisPointers([])).toBe('');
+  });
+
+  test('ignores out-of-range pointers', () => {
+    expect(formatDiagnosisPointers([0, 1, 27])).toBe('A');
   });
 });

--- a/packages/server/src/fhir/operations/utils/cms1500pdf.ts
+++ b/packages/server/src/fhir/operations/utils/cms1500pdf.ts
@@ -254,7 +254,7 @@ export async function getClaimPDFDocDefinition(claim: Claim): Promise<TDocumentD
           createText(item.modifier?.[0]?.coding?.map((code) => code.code).join(', '), 246, y),
 
           // 24E. Diagnosis pointer
-          createText('', 335, y),
+          createText(formatDiagnosisPointers(item.diagnosisSequence), 335, y),
 
           // 24F. Charges
           createText(formatMoney(item.net), 373, y),
@@ -327,6 +327,24 @@ function createDate(date: string | undefined, x: number, y: number): (Content | 
     createText(date?.substring(8, 10), x + 21, y),
     createText(date?.substring(0, 4), x + 42, y),
   ];
+}
+
+/**
+ * Formats CMS-1500 Box 24E diagnosis pointers for a service line.
+ *
+ * `Claim.item.diagnosisSequence` holds 1-based references into the Box 21 diagnoses
+ * (`Claim.diagnosis.sequence`). Box 24E shows these as reference letters: 1 -> A, 2 -> B, ...
+ * Per the NUCC CMS-1500 instructions the letters are entered together with no separators
+ * (for example, a line justified by diagnoses A and B is shown as "AB").
+ *
+ * @param diagnosisSequence - The 1-based diagnosis pointers for a single service line.
+ * @returns The Box 24E reference letters (e.g. "AB"), or an empty string when there are none.
+ */
+export function formatDiagnosisPointers(diagnosisSequence: number[] | undefined): string {
+  return (diagnosisSequence ?? [])
+    .filter((seq) => seq >= 1 && seq <= 26)
+    .map((seq) => String.fromCharCode(64 + seq))
+    .join('');
 }
 
 export function getSimplePhone(phone: string | undefined): string | undefined {


### PR DESCRIPTION
## Problem

`getClaimPDFDocDefinition` hard-codes CMS-1500 Box 24E (diagnosis pointer) to an empty string:

```ts
// 24E. Diagnosis pointer
createText('', 335, y),
```

So every generated CMS-1500 PDF omits the per-line link between each service line and the Box 21 diagnoses that justify it — even when the Claim's `item.diagnosisSequence` is populated.

## Fix

Render the pointers from `item.diagnosisSequence` as reference letters (1 → A, 2 → B, …), entered with **no separators** per the NUCC CMS-1500 instructions (e.g. a line justified by diagnoses A and B shows as `AB`).

The mapping is extracted into a small pure `formatDiagnosisPointers()` helper, exported and unit-tested alongside the existing formatters (`formatHumanName`, `getSimplePhone`).

## Testing

Added unit tests for `formatDiagnosisPointers` covering single/multiple pointers, the A–L range, empty/undefined input, and out-of-range values. `getClaimPDFDocDefinition` itself requires an authenticated repo, so the full rendering path remains covered by the existing `claimexport` integration tests.
