### PR TITLE
Try to fix Renovate and Docker Hardened Images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,6 +19,16 @@
       "pinDigests": false
     },
     {
+      "description": "DHI Dockerfile",
+      "matchManagers": ["dockerfile"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["dhi.io/node"],
+      "versioning": "docker",
+      "groupName": "dependencies",
+      "groupSlug": "all",
+      "pinDigests": false
+    },
+    {
       "description": "GitHub Actions",
       "matchManagers": ["github-actions"],
       "groupName": "dependencies",


### PR DESCRIPTION
Attempt to improve Renovate support for Docker Hardened Images (DHI) by overriding the versioning strategy for `dhi.io/node`.

## Background

We recently changed our Dockerfiles from:

```dockerfile
FROM dhi.io/node:24
```

to:

```dockerfile
FROM dhi.io/node:24.16
FROM dhi.io/node:24.16-dev
```

This was motivated by a production incident caused by an unexpected upgrade from Node 24.16 to 24.17. By pinning to a specific minor version, we can make runtime upgrades explicit and review them through normal code review.

The next step is to have Renovate generate PRs when newer DHI images become available (e.g. `24.16` → `24.17`).

## Problem

Renovate successfully:

* Detects the Dockerfile dependencies
* Parses the current versions (`24.16` and `24.16-dev`)
* Authenticates to `dhi.io`
* Queries the DHI registry

However, it ultimately reports:

```
Found no results from datasource that look like a version
```

and produces no updates.

Debug logs show that Renovate is treating `dhi.io/node` with `versioning: "node"` and appears to be using Docker Hardened Image metadata rather than performing normal Docker tag enumeration.

Separately, manual testing confirms that the DHI registry exposes the expected tags, including:

```
24.17
24.17-dev
24.17.0-0
...
```

so the registry itself appears to be functioning correctly.

## Change

Add a package rule that explicitly forces Docker versioning for `dhi.io/node`:

```json
{
  "description": "DHI Docker images",
  "matchManagers": ["dockerfile"],
  "matchDatasources": ["docker"],
  "matchPackageNames": ["dhi.io/node"],
  "versioning": "docker"
}
```

## Expected Outcome

The hope is that Renovate will treat DHI images like a normal Docker repository and discover updates such as:

```
24.16     -> 24.17
24.16-dev -> 24.17-dev
```

and generate upgrade PRs accordingly.

## Caveats

This is somewhat exploratory.

The Renovate logs suggest the issue may be related to Renovate's built-in handling of Docker Hardened Images rather than our configuration. It's not yet clear whether forcing `versioning: "docker"` will fully resolve the problem.

At minimum, this gives us another data point and may help narrow the issue to either:

1. A configuration problem on our side, or
2. A Renovate bug / limitation in DHI support.
