### PR TITLE
fix(mock): don't reuse ID 123 for two Patients

### DIFF
--- a/examples/medplum-provider/src/components/tasks/TaskProperties.test.tsx
+++ b/examples/medplum-provider/src/components/tasks/TaskProperties.test.tsx
@@ -181,7 +181,7 @@ describe('TaskProperties', () => {
   test('handles task with organization owner and displays organization', async () => {
     const organization: Organization = {
       resourceType: 'Organization',
-      id: 'org-123',
+      id: 'org-125',
       name: 'Test Organization',
     };
 
@@ -189,7 +189,7 @@ describe('TaskProperties', () => {
 
     const taskWithOrgOwner: Task = {
       ...mockTask,
-      owner: { reference: 'Organization/org-123', display: 'Test Organization' },
+      owner: { reference: 'Organization/org-125', display: 'Test Organization' },
     };
 
     setup(taskWithOrgOwner);

--- a/examples/medplum-provider/src/pages/resource/ResourcePage.test.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourcePage.test.tsx
@@ -32,7 +32,7 @@ describe('ResourcePage', () => {
   }
 
   test('Details tab renders', async () => {
-    await setup('/Practitioner/123');
+    await setup('/Practitioner/124');
     expect((await screen.findAllByText('Name'))[0]).toBeInTheDocument();
     expect(screen.getByText('Gender')).toBeInTheDocument();
   });
@@ -81,7 +81,7 @@ describe('ResourcePage', () => {
         id: 'project-1',
         features: ['scheduling'],
       });
-      await setup('/Practitioner/123', medplum);
+      await setup('/Practitioner/124', medplum);
       await screen.findByText('Details');
       expect(screen.queryByText('Scheduling')).not.toBeInTheDocument();
     });

--- a/packages/app/src/HomePage.test.tsx
+++ b/packages/app/src/HomePage.test.tsx
@@ -78,7 +78,7 @@ describe('HomePage', () => {
       accessToken: '123',
       refreshToken: '456',
       profile: {
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
       },
       project: {
         reference: 'Project/123',

--- a/packages/app/src/admin/CreateBotPage.test.tsx
+++ b/packages/app/src/admin/CreateBotPage.test.tsx
@@ -26,7 +26,7 @@ describe('CreateBotPage', () => {
       accessToken: '123',
       refreshToken: '456',
       profile: {
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
       },
       project: {
         reference: 'Project/123',

--- a/packages/app/src/admin/CreateClientPage.test.tsx
+++ b/packages/app/src/admin/CreateClientPage.test.tsx
@@ -26,7 +26,7 @@ describe('CreateClientPage', () => {
       accessToken: '123',
       refreshToken: '456',
       profile: {
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
       },
       project: {
         reference: 'Project/123',

--- a/packages/app/src/admin/InvitePage.test.tsx
+++ b/packages/app/src/admin/InvitePage.test.tsx
@@ -26,7 +26,7 @@ describe('InvitePage', () => {
       accessToken: '123',
       refreshToken: '456',
       profile: {
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
       },
       project: {
         reference: 'Project/123',

--- a/packages/app/src/admin/MemberDetailsPage.test.tsx
+++ b/packages/app/src/admin/MemberDetailsPage.test.tsx
@@ -11,7 +11,7 @@ describe('MemberDetailsPage', () => {
     medplum.setActiveLoginOverride({
       accessToken: '123',
       refreshToken: '456',
-      profile: { reference: 'Practitioner/123' },
+      profile: { reference: 'Practitioner/124' },
       project: { reference: 'Project/123' },
     });
     medplum.getProjectMembership = () => ({ admin }) as ProjectMembership;

--- a/packages/app/src/admin/MembersTable.test.tsx
+++ b/packages/app/src/admin/MembersTable.test.tsx
@@ -15,7 +15,7 @@ describe('MemberTable (Users page)', () => {
       accessToken: '123',
       refreshToken: '456',
       profile: {
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
       },
       project: {
         reference: 'Project/123',

--- a/packages/app/src/admin/ProjectPage.test.tsx
+++ b/packages/app/src/admin/ProjectPage.test.tsx
@@ -15,7 +15,7 @@ describe('ProjectPage', () => {
       accessToken: '123',
       refreshToken: '456',
       profile: {
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
       },
       project: {
         reference: 'Project/123',

--- a/packages/app/src/admin/RateLimitsPage.test.tsx
+++ b/packages/app/src/admin/RateLimitsPage.test.tsx
@@ -63,7 +63,7 @@ describe('RateLimitsPage', () => {
       accessToken: '123',
       refreshToken: '456',
       profile: {
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
       },
       project: {
         reference: 'Project/123',

--- a/packages/app/src/admin/SecretsPage.test.tsx
+++ b/packages/app/src/admin/SecretsPage.test.tsx
@@ -31,7 +31,7 @@ describe('SecretsPage', () => {
       accessToken: '123',
       refreshToken: '456',
       profile: {
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
       },
       project: {
         reference: 'Project/123',

--- a/packages/app/src/admin/SettingsPage.test.tsx
+++ b/packages/app/src/admin/SettingsPage.test.tsx
@@ -31,7 +31,7 @@ describe('SettingsPage', () => {
       accessToken: '123',
       refreshToken: '456',
       profile: {
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
       },
       project: {
         reference: 'Project/123',

--- a/packages/app/src/admin/SitesPage.test.tsx
+++ b/packages/app/src/admin/SitesPage.test.tsx
@@ -31,7 +31,7 @@ describe('SitesPage', () => {
       accessToken: '123',
       refreshToken: '456',
       profile: {
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
       },
       project: {
         reference: 'Project/123',

--- a/packages/app/src/components/ResourceHeader.test.tsx
+++ b/packages/app/src/components/ResourceHeader.test.tsx
@@ -81,11 +81,11 @@ describe('ResourceHeader', () => {
   test('Renders name', async () => {
     await setup({
       resourceType: 'Organization',
-      id: '123',
+      id: '125',
       name: 'Test Organization',
     });
 
-    expect(screen.queryByText('123')).not.toBeInTheDocument();
+    expect(screen.queryByText('125')).not.toBeInTheDocument();
     expect(screen.getByText('Test Organization')).toBeInTheDocument();
   });
 

--- a/packages/app/src/components/ResourceHeader.test.tsx
+++ b/packages/app/src/components/ResourceHeader.test.tsx
@@ -91,7 +91,7 @@ describe('ResourceHeader', () => {
 
   test('Handles reference', async () => {
     await setup({
-      reference: 'Organization/123',
+      reference: 'Organization/125',
     });
 
     expect(await screen.findByText('Test Organization')).toBeInTheDocument();

--- a/packages/app/src/index.test.tsx
+++ b/packages/app/src/index.test.tsx
@@ -19,7 +19,7 @@ describe('App Index', () => {
         accessToken: createFakeJwt({ client_id: '123', login_id: '123' }),
         refreshToken: '456',
         project: { reference: 'Project/123' },
-        profile: { reference: 'Practitioner/123' },
+        profile: { reference: 'Practitioner/124' },
       })
     );
 

--- a/packages/app/src/resource/AccountsPage.test.tsx
+++ b/packages/app/src/resource/AccountsPage.test.tsx
@@ -49,7 +49,7 @@ describe('AccountsPage', () => {
   });
 
   test('Unsupported resource type', async () => {
-    await setup('/Practitioner/123/accounts');
+    await setup('/Practitioner/124/accounts');
     expect(await screen.findByText('Unsupported resource type')).toBeInTheDocument();
   });
 });

--- a/packages/app/src/resource/EditPage.test.tsx
+++ b/packages/app/src/resource/EditPage.test.tsx
@@ -33,7 +33,7 @@ describe('EditPage', () => {
   }
 
   test('Edit tab renders', async () => {
-    await setup('/Practitioner/123/edit');
+    await setup('/Practitioner/124/edit');
     expect(await screen.findByText('Edit')).toBeInTheDocument();
   });
 
@@ -56,7 +56,7 @@ describe('EditPage', () => {
   });
 
   test('Delete button on edit page', async () => {
-    await setup('/Practitioner/123/edit');
+    await setup('/Practitioner/124/edit');
 
     const moreActions = screen.getByLabelText('More actions');
     expect(moreActions).toBeDefined();
@@ -74,7 +74,7 @@ describe('EditPage', () => {
   });
 
   test('Patch button on edit page', async () => {
-    await setup('/Practitioner/123/edit');
+    await setup('/Practitioner/124/edit');
 
     const moreActions = screen.getByLabelText('More actions');
     expect(moreActions).toBeDefined();

--- a/packages/app/src/resource/ExportPage.test.tsx
+++ b/packages/app/src/resource/ExportPage.test.tsx
@@ -39,7 +39,7 @@ describe('ExportPage', () => {
   });
 
   test('Unsupported', async () => {
-    await setup('/Practitioner/123/export');
+    await setup('/Practitioner/124/export');
     expect(await screen.findByText('Unsupported export type')).toBeInTheDocument();
   });
 });

--- a/packages/app/src/resource/JsonPage.test.tsx
+++ b/packages/app/src/resource/JsonPage.test.tsx
@@ -34,14 +34,14 @@ describe('JsonPage', () => {
   });
 
   test('JSON tab renders', async () => {
-    await setup('/Practitioner/123/json');
+    await setup('/Practitioner/124/json');
     expect(await screen.findByTestId('resource-json')).toBeInTheDocument();
 
     expect(screen.getByTestId('resource-json')).toBeInTheDocument();
   });
 
   test('JSON submit', async () => {
-    await setup('/Practitioner/123/json');
+    await setup('/Practitioner/124/json');
     expect(await screen.findByTestId('resource-json')).toBeInTheDocument();
 
     await act(async () => {
@@ -58,7 +58,7 @@ describe('JsonPage', () => {
   });
 
   test('JSON submit with meta', async () => {
-    await setup('/Practitioner/123/json');
+    await setup('/Practitioner/124/json');
     expect(await screen.findByTestId('resource-json')).toBeInTheDocument();
 
     await act(async () => {

--- a/packages/app/src/resource/ResourcePage.test.tsx
+++ b/packages/app/src/resource/ResourcePage.test.tsx
@@ -31,7 +31,7 @@ describe('ResourcePage', () => {
   });
 
   test('Details tab renders', async () => {
-    await setup('/Practitioner/123/details');
+    await setup('/Practitioner/124/details');
     expect((await screen.findAllByText('Name'))[0]).toBeInTheDocument();
     expect(screen.getByText('Gender')).toBeInTheDocument();
   });
@@ -60,12 +60,12 @@ describe('ResourcePage', () => {
   });
 
   test('History tab renders', async () => {
-    await setup('/Practitioner/123/history');
+    await setup('/Practitioner/124/history');
     expect(await screen.findByText('History')).toBeInTheDocument();
   });
 
   test('Blame tab renders', async () => {
-    await setup('/Practitioner/123/blame');
+    await setup('/Practitioner/124/blame');
     expect(await screen.findByText('Blame')).toBeInTheDocument();
   });
 
@@ -318,7 +318,7 @@ describe('ResourcePage', () => {
   test('Left click on tab', async () => {
     window.open = vi.fn();
 
-    await setup('/Practitioner/123/details');
+    await setup('/Practitioner/124/details');
 
     await act(async () => {
       fireEvent.click(screen.getByRole('tab', { name: 'History' }));

--- a/packages/app/src/resource/ResourceVersionPage.test.tsx
+++ b/packages/app/src/resource/ResourceVersionPage.test.tsx
@@ -38,7 +38,7 @@ describe('ResourceVersionPage', () => {
 
   test('Version not found', async () => {
     await act(async () => {
-      setup('/Practitioner/123/_history/3');
+      setup('/Practitioner/124/_history/3');
     });
 
     expect(await screen.findByText('Version not found')).toBeInTheDocument();
@@ -47,7 +47,7 @@ describe('ResourceVersionPage', () => {
 
   test('Diff tab renders', async () => {
     await act(async () => {
-      setup('/Practitioner/123/_history/1');
+      setup('/Practitioner/124/_history/1');
     });
 
     expect(await screen.findByText('Diff')).toBeInTheDocument();
@@ -56,7 +56,7 @@ describe('ResourceVersionPage', () => {
 
   test('Diff tab renders last version', async () => {
     await act(async () => {
-      setup('/Practitioner/123/_history/2');
+      setup('/Practitioner/124/_history/2');
     });
 
     expect(await screen.findByText('Diff')).toBeInTheDocument();
@@ -65,7 +65,7 @@ describe('ResourceVersionPage', () => {
 
   test('Raw tab renders', async () => {
     await act(async () => {
-      setup('/Practitioner/123/_history/1/raw');
+      setup('/Practitioner/124/_history/1/raw');
     });
 
     expect(await screen.findByText('Raw')).toBeInTheDocument();
@@ -74,7 +74,7 @@ describe('ResourceVersionPage', () => {
 
   test('Change tab', async () => {
     await act(async () => {
-      setup('/Practitioner/123/_history/1');
+      setup('/Practitioner/124/_history/1');
     });
 
     expect(await screen.findByText('Diff')).toBeInTheDocument();
@@ -88,7 +88,7 @@ describe('ResourceVersionPage', () => {
 
   test('Next button', async () => {
     await act(async () => {
-      setup('/Practitioner/123/_history/1');
+      setup('/Practitioner/124/_history/1');
     });
 
     expect(await screen.findByLabelText('Next page')).toBeInTheDocument();

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -153,7 +153,7 @@ describe('CLI auth', () => {
           accessToken: 'abc',
           refreshToken: 'xyz',
           profile: {
-            reference: 'Practitioner/123',
+            reference: 'Practitioner/124',
             display: 'Alice Smith',
           },
           project: {
@@ -168,7 +168,7 @@ describe('CLI auth', () => {
 
     expect((console.log as unknown as Mock).mock.calls).toStrictEqual([
       ['Server:  https://example.com/'],
-      ['Profile: Alice Smith (Practitioner/123)'],
+      ['Profile: Alice Smith (Practitioner/124)'],
       ['Project: My Project (Project/456)'],
     ]);
   });
@@ -183,7 +183,7 @@ describe('CLI auth', () => {
           accessToken: 'abc',
           refreshToken: 'xyz',
           profile: {
-            reference: 'Practitioner/123',
+            reference: 'Practitioner/124',
             display: 'Alice Smith',
           },
           project: {

--- a/packages/cli/src/project.test.ts
+++ b/packages/cli/src/project.test.ts
@@ -58,7 +58,7 @@ describe('CLI Project', () => {
             accessToken: 'abc',
             refreshToken: 'xyz',
             profile: {
-              reference: 'Practitioner/123',
+              reference: 'Practitioner/124',
               display: 'Alice Smith',
             },
             project: {
@@ -81,7 +81,7 @@ describe('CLI Project', () => {
           accessToken: 'abc',
           refreshToken: 'xyz',
           profile: {
-            reference: 'Practitioner/123',
+            reference: 'Practitioner/124',
             display: 'Alice Smith',
           },
           project: {
@@ -104,7 +104,7 @@ describe('CLI Project', () => {
             accessToken: 'abc',
             refreshToken: 'xyz',
             profile: {
-              reference: 'Practitioner/123',
+              reference: 'Practitioner/124',
               display: 'Alice Smith',
             },
             project: {
@@ -140,7 +140,7 @@ describe('CLI Project', () => {
             accessToken: 'abc',
             refreshToken: 'xyz',
             profile: {
-              reference: 'Practitioner/123',
+              reference: 'Practitioner/124',
               display: 'Alice Smith',
             },
             project: {
@@ -205,7 +205,7 @@ describe('CLI Project', () => {
           accessToken: 'abc',
           refreshToken: 'xyz',
           profile: {
-            reference: 'Practitioner/123',
+            reference: 'Practitioner/124',
             display: 'Alice Smith',
           },
           project: {
@@ -242,7 +242,7 @@ describe('CLI Project', () => {
           accessToken: 'abc',
           refreshToken: 'xyz',
           profile: {
-            reference: 'Practitioner/123',
+            reference: 'Practitioner/124',
             display: 'Alice Smith',
           },
           project: {

--- a/packages/core/src/pharmacy-utils.test.ts
+++ b/packages/core/src/pharmacy-utils.test.ts
@@ -55,7 +55,7 @@ describe('getPreferredPharmaciesFromPatient', () => {
         {
           url: PATIENT_PREFERRED_PHARMACY_URL,
           extension: [
-            { url: 'pharmacy', valueReference: { reference: 'Organization/123' } },
+            { url: 'pharmacy', valueReference: { reference: 'Organization/125' } },
             {
               url: 'type',
               valueCodeableConcept: {
@@ -68,7 +68,7 @@ describe('getPreferredPharmaciesFromPatient', () => {
     };
     const result = getPreferredPharmaciesFromPatient(patient);
     expect(result).toHaveLength(1);
-    expect(result[0]).toEqual({ organizationRef: { reference: 'Organization/123' }, isPrimary: true });
+    expect(result[0]).toEqual({ organizationRef: { reference: 'Organization/125' }, isPrimary: true });
   });
 
   test('Returns pharmacy with preferred (non-primary) type', () => {
@@ -101,7 +101,7 @@ describe('getPreferredPharmaciesFromPatient', () => {
         {
           url: PATIENT_PREFERRED_PHARMACY_URL,
           extension: [
-            { url: 'pharmacy', valueReference: { reference: 'Organization/123' } },
+            { url: 'pharmacy', valueReference: { reference: 'Organization/125' } },
             {
               url: 'type',
               valueCodeableConcept: {
@@ -156,7 +156,7 @@ describe('getPreferredPharmaciesFromPatient', () => {
       extension: [
         {
           url: PATIENT_PREFERRED_PHARMACY_URL,
-          extension: [{ url: 'pharmacy', valueReference: { reference: 'Organization/123' } }],
+          extension: [{ url: 'pharmacy', valueReference: { reference: 'Organization/125' } }],
         },
       ],
     };
@@ -172,7 +172,7 @@ describe('getPreferredPharmaciesFromPatient', () => {
         {
           url: PATIENT_PREFERRED_PHARMACY_URL,
           extension: [
-            { url: 'pharmacy', valueReference: { reference: 'Organization/123' } },
+            { url: 'pharmacy', valueReference: { reference: 'Organization/125' } },
             {
               url: 'type',
               valueCodeableConcept: { coding: [{ system: 'https://any-vendor.com', code: PHARMACY_TYPE_PRIMARY }] },
@@ -193,7 +193,7 @@ describe('getPreferredPharmaciesFromPatient', () => {
         {
           url: PATIENT_PREFERRED_PHARMACY_URL,
           extension: [
-            { url: 'pharmacy', valueReference: { reference: 'Organization/123' } },
+            { url: 'pharmacy', valueReference: { reference: 'Organization/125' } },
             {
               url: 'type',
               valueCodeableConcept: { coding: [{ system: 'https://wrong-system.com', code: PHARMACY_TYPE_PRIMARY }] },
@@ -218,7 +218,7 @@ describe('getPreferredPharmaciesFromPatient', () => {
 
 describe('createPreferredPharmacyExtension', () => {
   test('Creates primary pharmacy extension', () => {
-    const orgRef: Reference<Organization> = { reference: 'Organization/123' };
+    const orgRef: Reference<Organization> = { reference: 'Organization/125' };
     const extension = createPreferredPharmacyExtension(orgRef, true);
     expect(extension.url).toBe(PATIENT_PREFERRED_PHARMACY_URL);
     expect(extension.extension).toHaveLength(2);
@@ -238,7 +238,7 @@ describe('createPreferredPharmacyExtension', () => {
 describe('addPreferredPharmacyToPatient', () => {
   test('Adds pharmacy to patient with no extensions', () => {
     const patient: Patient = { resourceType: 'Patient' };
-    const orgRef: Reference<Organization> = { reference: 'Organization/123' };
+    const orgRef: Reference<Organization> = { reference: 'Organization/125' };
     const result = addPreferredPharmacyToPatient(patient, orgRef, false);
     expect(result.extension).toHaveLength(1);
     expect(result.extension?.[0].url).toBe(PATIENT_PREFERRED_PHARMACY_URL);
@@ -275,7 +275,7 @@ describe('addPreferredPharmacyToPatient', () => {
 describe('removePreferredPharmacyFromPatient', () => {
   test('Returns patient unchanged when no extensions', () => {
     const patient: Patient = { resourceType: 'Patient' };
-    const result = removePreferredPharmacyFromPatient(patient, { reference: 'Organization/123' });
+    const result = removePreferredPharmacyFromPatient(patient, { reference: 'Organization/125' });
     expect(result.extension).toBeUndefined();
   });
 
@@ -286,7 +286,7 @@ describe('removePreferredPharmacyFromPatient', () => {
         {
           url: PATIENT_PREFERRED_PHARMACY_URL,
           extension: [
-            { url: 'pharmacy', valueReference: { reference: 'Organization/123' } },
+            { url: 'pharmacy', valueReference: { reference: 'Organization/125' } },
             {
               url: 'type',
               valueCodeableConcept: {
@@ -297,7 +297,7 @@ describe('removePreferredPharmacyFromPatient', () => {
         },
       ],
     };
-    const result = removePreferredPharmacyFromPatient(patient, { reference: 'Organization/123' });
+    const result = removePreferredPharmacyFromPatient(patient, { reference: 'Organization/125' });
     expect(result.extension).toHaveLength(0);
   });
 });

--- a/packages/core/src/search/match.test.ts
+++ b/packages/core/src/search/match.test.ts
@@ -909,7 +909,7 @@ describe('Search matching', () => {
   test('Compartments', () => {
     const resource1: Patient = {
       resourceType: 'Patient',
-      meta: { compartment: [{ reference: 'Organization/123' }] },
+      meta: { compartment: [{ reference: 'Organization/125' }] },
     };
 
     const resource2: Patient = {
@@ -919,7 +919,7 @@ describe('Search matching', () => {
 
     const search1: SearchRequest = {
       resourceType: 'Patient',
-      filters: [{ code: '_compartment', operator: Operator.EQUALS, value: 'Organization/123' }],
+      filters: [{ code: '_compartment', operator: Operator.EQUALS, value: 'Organization/125' }],
     };
 
     const search2: SearchRequest = {
@@ -931,7 +931,7 @@ describe('Search matching', () => {
     // Support matching values without the resourceType prefix
     const search3: SearchRequest = {
       resourceType: 'Patient',
-      filters: [{ code: '_compartment', operator: Operator.EQUALS, value: '123' }],
+      filters: [{ code: '_compartment', operator: Operator.EQUALS, value: '125' }],
     };
 
     expect(matchesSearchRequest(resource1, search1)).toBe(true);

--- a/packages/core/src/subscriptions/index.test.ts
+++ b/packages/core/src/subscriptions/index.test.ts
@@ -1850,7 +1850,7 @@ describe('resourceMatchesSubscriptionCriteria', () => {
   );
 
   describe('Account matching logic', () => {
-    const ORGANIZATION_ONE = { reference: 'Organization/123' };
+    const ORGANIZATION_ONE = { reference: 'Organization/125' };
     const ORGANIZATION_TWO = { reference: 'Organization/456' };
     const ORGANIZATION_THREE = { reference: 'Organization/789' };
     const ORGANIZATION_FOUR = { reference: 'Organization/999' };

--- a/packages/dosespot-core/src/pharmacy-utils.test.ts
+++ b/packages/dosespot-core/src/pharmacy-utils.test.ts
@@ -93,7 +93,7 @@ describe('getPreferredPharmaciesFromPatient', () => {
             {
               url: 'pharmacy',
               valueReference: {
-                reference: 'Organization/123',
+                reference: 'Organization/125',
               },
             },
             {
@@ -116,7 +116,7 @@ describe('getPreferredPharmaciesFromPatient', () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
       organizationRef: {
-        reference: 'Organization/123',
+        reference: 'Organization/125',
       },
       isPrimary: true,
     });
@@ -171,7 +171,7 @@ describe('getPreferredPharmaciesFromPatient', () => {
             {
               url: 'pharmacy',
               valueReference: {
-                reference: 'Organization/123',
+                reference: 'Organization/125',
               },
             },
             {
@@ -255,7 +255,7 @@ describe('getPreferredPharmaciesFromPatient', () => {
             {
               url: 'pharmacy',
               valueReference: {
-                reference: 'Organization/123',
+                reference: 'Organization/125',
               },
             },
           ],
@@ -265,7 +265,7 @@ describe('getPreferredPharmaciesFromPatient', () => {
 
     const result = getPreferredPharmaciesFromPatient(patient);
     expect(result).toHaveLength(1);
-    expect(result[0].organizationRef.reference).toBe('Organization/123');
+    expect(result[0].organizationRef.reference).toBe('Organization/125');
     expect(result[0].isPrimary).toBe(false);
   });
 
@@ -279,7 +279,7 @@ describe('getPreferredPharmaciesFromPatient', () => {
             {
               url: 'pharmacy',
               valueReference: {
-                reference: 'Organization/123',
+                reference: 'Organization/125',
               },
             },
             {
@@ -314,7 +314,7 @@ describe('getPreferredPharmaciesFromPatient', () => {
             {
               url: 'pharmacy',
               valueReference: {
-                reference: 'Organization/123',
+                reference: 'Organization/125',
               },
             },
             {
@@ -357,14 +357,14 @@ describe('getPreferredPharmaciesFromPatient', () => {
 
 describe('createPreferredPharmacyExtension', () => {
   test('Creates primary pharmacy extension', () => {
-    const orgRef: Reference<Organization> = { reference: 'Organization/123' };
+    const orgRef: Reference<Organization> = { reference: 'Organization/125' };
     const extension = createPreferredPharmacyExtension(orgRef, true);
 
     expect(extension.url).toBe(PATIENT_PREFERRED_PHARMACY_URL);
     expect(extension.extension).toHaveLength(2);
 
     const pharmacyExt = extension.extension?.find((e) => e.url === 'pharmacy');
-    expect(pharmacyExt?.valueReference).toEqual({ reference: 'Organization/123' });
+    expect(pharmacyExt?.valueReference).toEqual({ reference: 'Organization/125' });
 
     const typeExt = extension.extension?.find((e) => e.url === 'type');
     expect(typeExt?.valueCodeableConcept?.coding?.[0]).toEqual({
@@ -392,7 +392,7 @@ describe('createPreferredPharmacyExtension', () => {
 describe('addPreferredPharmacyToPatient', () => {
   test('Adds pharmacy to patient with no extensions', () => {
     const patient: Patient = { resourceType: 'Patient' };
-    const orgRef: Reference<Organization> = { reference: 'Organization/123' };
+    const orgRef: Reference<Organization> = { reference: 'Organization/125' };
 
     const result = addPreferredPharmacyToPatient(patient, orgRef, false);
 
@@ -405,7 +405,7 @@ describe('addPreferredPharmacyToPatient', () => {
       resourceType: 'Patient',
       extension: [{ url: 'http://example.com/other', valueString: 'test' }],
     };
-    const orgRef: Reference<Organization> = { reference: 'Organization/123' };
+    const orgRef: Reference<Organization> = { reference: 'Organization/125' };
 
     const result = addPreferredPharmacyToPatient(patient, orgRef, false);
 
@@ -419,7 +419,7 @@ describe('addPreferredPharmacyToPatient', () => {
         {
           url: PATIENT_PREFERRED_PHARMACY_URL,
           extension: [
-            { url: 'pharmacy', valueReference: { reference: 'Organization/123' } },
+            { url: 'pharmacy', valueReference: { reference: 'Organization/125' } },
             {
               url: 'type',
               valueCodeableConcept: {
@@ -430,7 +430,7 @@ describe('addPreferredPharmacyToPatient', () => {
         },
       ],
     };
-    const orgRef: Reference<Organization> = { reference: 'Organization/123' };
+    const orgRef: Reference<Organization> = { reference: 'Organization/125' };
 
     const result = addPreferredPharmacyToPatient(patient, orgRef, true);
 
@@ -532,7 +532,7 @@ describe('addPreferredPharmacyToPatient', () => {
 describe('removePreferredPharmacyFromPatient', () => {
   test('Returns patient unchanged when no extensions', () => {
     const patient: Patient = { resourceType: 'Patient' };
-    const orgRef: Reference<Organization> = { reference: 'Organization/123' };
+    const orgRef: Reference<Organization> = { reference: 'Organization/125' };
 
     const result = removePreferredPharmacyFromPatient(patient, orgRef);
 
@@ -546,7 +546,7 @@ describe('removePreferredPharmacyFromPatient', () => {
         {
           url: PATIENT_PREFERRED_PHARMACY_URL,
           extension: [
-            { url: 'pharmacy', valueReference: { reference: 'Organization/123' } },
+            { url: 'pharmacy', valueReference: { reference: 'Organization/125' } },
             {
               url: 'type',
               valueCodeableConcept: {
@@ -557,7 +557,7 @@ describe('removePreferredPharmacyFromPatient', () => {
         },
       ],
     };
-    const orgRef: Reference<Organization> = { reference: 'Organization/123' };
+    const orgRef: Reference<Organization> = { reference: 'Organization/125' };
 
     const result = removePreferredPharmacyFromPatient(patient, orgRef);
 
@@ -571,7 +571,7 @@ describe('removePreferredPharmacyFromPatient', () => {
         {
           url: PATIENT_PREFERRED_PHARMACY_URL,
           extension: [
-            { url: 'pharmacy', valueReference: { reference: 'Organization/123' } },
+            { url: 'pharmacy', valueReference: { reference: 'Organization/125' } },
             {
               url: 'type',
               valueCodeableConcept: {
@@ -594,7 +594,7 @@ describe('removePreferredPharmacyFromPatient', () => {
         },
       ],
     };
-    const orgRef: Reference<Organization> = { reference: 'Organization/123' };
+    const orgRef: Reference<Organization> = { reference: 'Organization/125' };
 
     const result = removePreferredPharmacyFromPatient(patient, orgRef);
 
@@ -610,11 +610,11 @@ describe('removePreferredPharmacyFromPatient', () => {
         { url: 'http://example.com/other', valueString: 'test' },
         {
           url: PATIENT_PREFERRED_PHARMACY_URL,
-          extension: [{ url: 'pharmacy', valueReference: { reference: 'Organization/123' } }],
+          extension: [{ url: 'pharmacy', valueReference: { reference: 'Organization/125' } }],
         },
       ],
     };
-    const orgRef: Reference<Organization> = { reference: 'Organization/123' };
+    const orgRef: Reference<Organization> = { reference: 'Organization/125' };
 
     const result = removePreferredPharmacyFromPatient(patient, orgRef);
 
@@ -628,7 +628,7 @@ describe('removePreferredPharmacyFromPatient', () => {
       extension: [
         {
           url: PATIENT_PREFERRED_PHARMACY_URL,
-          extension: [{ url: 'pharmacy', valueReference: { reference: 'Organization/123' } }],
+          extension: [{ url: 'pharmacy', valueReference: { reference: 'Organization/125' } }],
         },
       ],
     };

--- a/packages/dosespot-react/src/utils.test.ts
+++ b/packages/dosespot-react/src/utils.test.ts
@@ -117,7 +117,7 @@ describe('utils', () => {
               {
                 url: 'pharmacy',
                 valueReference: {
-                  reference: 'Organization/123',
+                  reference: 'Organization/125',
                 },
               },
               {
@@ -138,7 +138,7 @@ describe('utils', () => {
 
       const result = getPreferredPharmaciesFromPatient(patient);
       expect(result).toHaveLength(1);
-      expect(result[0].organizationRef.reference).toBe('Organization/123');
+      expect(result[0].organizationRef.reference).toBe('Organization/125');
       expect(result[0].isPrimary).toBe(true);
     });
 
@@ -186,7 +186,7 @@ describe('utils', () => {
               {
                 url: 'pharmacy',
                 valueReference: {
-                  reference: 'Organization/123',
+                  reference: 'Organization/125',
                 },
               },
               {
@@ -295,7 +295,7 @@ describe('utils', () => {
 
   describe('createPreferredPharmacyExtension', () => {
     test('Creates primary pharmacy extension', () => {
-      const orgRef = { reference: 'Organization/123' };
+      const orgRef = { reference: 'Organization/125' };
       const ext = createPreferredPharmacyExtension(orgRef, true);
 
       expect(ext.url).toBe(PATIENT_PREFERRED_PHARMACY_URL);
@@ -327,7 +327,7 @@ describe('utils', () => {
       const patient: Patient = {
         resourceType: 'Patient',
       };
-      const orgRef = { reference: 'Organization/123' };
+      const orgRef = { reference: 'Organization/125' };
 
       const result = addPreferredPharmacyToPatient(patient, orgRef, false);
 
@@ -344,7 +344,7 @@ describe('utils', () => {
             extension: [
               {
                 url: 'pharmacy',
-                valueReference: { reference: 'Organization/123' },
+                valueReference: { reference: 'Organization/125' },
               },
               {
                 url: 'type',
@@ -369,7 +369,7 @@ describe('utils', () => {
       expect(result.extension).toHaveLength(2);
 
       // Check that the old primary pharmacy is now preferred
-      const oldPharmacy = findPharmacyExtension(result.extension, 'Organization/123');
+      const oldPharmacy = findPharmacyExtension(result.extension, 'Organization/125');
       expect(getPharmacyTypeCode(oldPharmacy)).toBe(PHARMACY_TYPE_PREFERRED);
 
       // Check that the new pharmacy is primary
@@ -386,7 +386,7 @@ describe('utils', () => {
             extension: [
               {
                 url: 'pharmacy',
-                valueReference: { reference: 'Organization/123' },
+                valueReference: { reference: 'Organization/125' },
               },
               {
                 url: 'type',
@@ -404,7 +404,7 @@ describe('utils', () => {
           },
         ],
       };
-      const orgRef = { reference: 'Organization/123' };
+      const orgRef = { reference: 'Organization/125' };
 
       const result = addPreferredPharmacyToPatient(patient, orgRef, true);
 
@@ -423,7 +423,7 @@ describe('utils', () => {
             extension: [
               {
                 url: 'pharmacy',
-                valueReference: { reference: 'Organization/123' },
+                valueReference: { reference: 'Organization/125' },
               },
               {
                 url: 'type',
@@ -441,7 +441,7 @@ describe('utils', () => {
           },
         ],
       };
-      const orgRef = { reference: 'Organization/123' };
+      const orgRef = { reference: 'Organization/125' };
 
       const result = addPreferredPharmacyToPatient(patient, orgRef, true);
 
@@ -460,7 +460,7 @@ describe('utils', () => {
           },
         ],
       };
-      const orgRef = { reference: 'Organization/123' };
+      const orgRef = { reference: 'Organization/125' };
 
       const result = addPreferredPharmacyToPatient(patient, orgRef, false);
 
@@ -479,7 +479,7 @@ describe('utils', () => {
             extension: [
               {
                 url: 'pharmacy',
-                valueReference: { reference: 'Organization/123' },
+                valueReference: { reference: 'Organization/125' },
               },
               {
                 url: 'type',
@@ -496,7 +496,7 @@ describe('utils', () => {
           },
         ],
       };
-      const orgRef = { reference: 'Organization/123' };
+      const orgRef = { reference: 'Organization/125' };
 
       const result = removePreferredPharmacyFromPatient(patient, orgRef);
 
@@ -512,7 +512,7 @@ describe('utils', () => {
             extension: [
               {
                 url: 'pharmacy',
-                valueReference: { reference: 'Organization/123' },
+                valueReference: { reference: 'Organization/125' },
               },
               {
                 url: 'type',
@@ -539,7 +539,7 @@ describe('utils', () => {
           },
         ],
       };
-      const orgRef = { reference: 'Organization/123' };
+      const orgRef = { reference: 'Organization/125' };
 
       const result = removePreferredPharmacyFromPatient(patient, orgRef);
 
@@ -552,7 +552,7 @@ describe('utils', () => {
       const patient: Patient = {
         resourceType: 'Patient',
       };
-      const orgRef = { reference: 'Organization/123' };
+      const orgRef = { reference: 'Organization/125' };
 
       const result = removePreferredPharmacyFromPatient(patient, orgRef);
 
@@ -572,7 +572,7 @@ describe('utils', () => {
             extension: [
               {
                 url: 'pharmacy',
-                valueReference: { reference: 'Organization/123' },
+                valueReference: { reference: 'Organization/125' },
               },
               {
                 url: 'type',
@@ -584,7 +584,7 @@ describe('utils', () => {
           },
         ],
       };
-      const orgRef = { reference: 'Organization/123' };
+      const orgRef = { reference: 'Organization/125' };
 
       const result = removePreferredPharmacyFromPatient(patient, orgRef);
 
@@ -613,7 +613,7 @@ describe('utils', () => {
           },
         ],
       };
-      const orgRef = { reference: 'Organization/123' };
+      const orgRef = { reference: 'Organization/125' };
 
       const result = removePreferredPharmacyFromPatient(patient, orgRef);
 
@@ -635,7 +635,7 @@ describe('utils', () => {
           },
         ],
       };
-      const orgRef = { reference: 'Organization/123' };
+      const orgRef = { reference: 'Organization/125' };
 
       const result = removePreferredPharmacyFromPatient(patient, orgRef);
 

--- a/packages/fhir-router/src/fhirrouter.test.ts
+++ b/packages/fhir-router/src/fhirrouter.test.ts
@@ -440,14 +440,14 @@ describe('FHIR Router', () => {
         body: patient,
         params: {},
         query: {
-          _account: 'Organization/123',
+          _account: 'Organization/125',
         },
       },
       repo
     );
     expect(res).toMatchObject(created);
     expect(resource).toMatchObject(patient);
-    expect(resource?.meta?.account?.reference).toStrictEqual('Organization/123');
+    expect(resource?.meta?.account?.reference).toStrictEqual('Organization/125');
   });
 
   test('Custom system-level operation returns not found', async () => {

--- a/packages/mock/README.md
+++ b/packages/mock/README.md
@@ -6,7 +6,7 @@ For example:
 
 - `GET fhir/R4/Patient/123` returns Homer Simpson
 - `GET fhir/R4/Practitioner/124` returns Dr. Alice Smith
-- `GET fhir/R4/Organization/123` returns Test Organization
+- `GET fhir/R4/Organization/125` returns Test Organization
 
 Well-known resource ids are exported as constants from `@medplum/mock` (for example `MOCK_HOMER_PATIENT_ID`, `MOCK_ALICE_PRACTITIONER_ID`).
 

--- a/packages/mock/README.md
+++ b/packages/mock/README.md
@@ -5,8 +5,10 @@ Provides the `MockClient` class and a large number of mocked endpoints and resou
 For example:
 
 - `GET fhir/R4/Patient/123` returns Homer Simpson
-- `GET fhir/R4/Practitioner/123` returns Dr. Alice Smith
+- `GET fhir/R4/Practitioner/124` returns Dr. Alice Smith
 - `GET fhir/R4/Organization/123` returns Test Organization
+
+Well-known resource ids are exported as constants from `@medplum/mock` (for example `MOCK_HOMER_PATIENT_ID`, `MOCK_ALICE_PRACTITIONER_ID`).
 
 ## Installation
 

--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -31,6 +31,7 @@ import type {
 import { randomUUID, webcrypto } from 'node:crypto';
 import { TextEncoder } from 'node:util';
 import { MockClient, MockFetchClient } from './client';
+import { MOCK_ALICE_PRACTITIONER_ID } from './constants';
 import { DrAliceSmith, DrAliceSmithSchedule, HomerSimpson } from './mocks';
 import { MockSubscriptionManager } from './subscription-manager';
 
@@ -334,7 +335,7 @@ describe('MockClient', () => {
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTE2MjM5MDIyLCJsb2dpbl9pZCI6InRlc3RpbmcxMjMifQ.lJGCbp2taTarRbamxaKFsTR_VRVgzvttKMmI5uFQSM0',
       refreshToken: '456',
       profile: {
-        reference: 'Practitioner/123',
+        reference: `Practitioner/${MOCK_ALICE_PRACTITIONER_ID}`,
       },
       project: {
         reference: 'Project/123',
@@ -809,7 +810,7 @@ describe('MockClient', () => {
       id: '456',
       user: { reference: 'User/123' },
       project: { reference: 'Project/123', display: 'Project 123' },
-      profile: { reference: 'Practitioner/123', display: 'Alice Smith' },
+      profile: { reference: `Practitioner/${MOCK_ALICE_PRACTITIONER_ID}`, display: 'Alice Smith' },
     });
 
     const createdBot = await medplum.post(

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -25,7 +25,6 @@ import {
 } from '@medplum/core';
 import type { FhirRequest, HttpMethod } from '@medplum/fhir-router';
 import { FhirRouter, MemoryRepository } from '@medplum/fhir-router';
-import { MOCK_ALICE_PRACTITIONER_ID } from './constants';
 import type {
   Agent,
   Binary,
@@ -38,6 +37,7 @@ import type {
   Subscription,
   UserConfiguration,
 } from '@medplum/fhirtypes';
+import { MOCK_ALICE_PRACTITIONER_ID } from './constants';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 /** @ts-ignore */
 import type { CustomTableLayout, TDocumentDefinitions, TFontDictionary } from 'pdfmake/interfaces';

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -25,6 +25,7 @@ import {
 } from '@medplum/core';
 import type { FhirRequest, HttpMethod } from '@medplum/fhir-router';
 import { FhirRouter, MemoryRepository } from '@medplum/fhir-router';
+import { MOCK_ALICE_PRACTITIONER_ID } from './constants';
 import type {
   Agent,
   Binary,
@@ -726,7 +727,7 @@ export class MockFetchClient {
           login_id: '123',
         }),
         refresh_token: createFakeJwt({ client_id: 123 }),
-        profile: { reference: 'Practitioner/123' },
+        profile: { reference: `Practitioner/${MOCK_ALICE_PRACTITIONER_ID}` },
       };
     }
 

--- a/packages/mock/src/constants.ts
+++ b/packages/mock/src/constants.ts
@@ -8,4 +8,4 @@ export const MOCK_HOMER_PATIENT_ID = '123';
 export const MOCK_ALICE_PRACTITIONER_ID = '124';
 
 /** Well-known MockClient Organization id for Test Organization. */
-export const MOCK_TEST_ORGANIZATION_ID = '123';
+export const MOCK_TEST_ORGANIZATION_ID = '125';

--- a/packages/mock/src/constants.ts
+++ b/packages/mock/src/constants.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/** Well-known MockClient Patient id for Homer Simpson. */
+export const MOCK_HOMER_PATIENT_ID = '123';
+
+/** Well-known MockClient Practitioner id for Dr. Alice Smith. */
+export const MOCK_ALICE_PRACTITIONER_ID = '124';
+
+/** Well-known MockClient Organization id for Test Organization. */
+export const MOCK_TEST_ORGANIZATION_ID = '123';

--- a/packages/mock/src/index.ts
+++ b/packages/mock/src/index.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+export * from './constants';
 export * from './client';
 export * from './mocks';
 export * from './subscription-manager';

--- a/packages/mock/src/index.ts
+++ b/packages/mock/src/index.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-export * from './constants';
 export * from './client';
+export * from './constants';
 export * from './mocks';
 export * from './subscription-manager';
 export * from './test-resources/fish-patient';

--- a/packages/mock/src/mocks/alice.ts
+++ b/packages/mock/src/mocks/alice.ts
@@ -3,10 +3,11 @@
 import type { WithId } from '@medplum/core';
 import { ContentType, createReference, lazy } from '@medplum/core';
 import type { Organization, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
+import { MOCK_ALICE_PRACTITIONER_ID, MOCK_TEST_ORGANIZATION_ID } from '../constants';
 
 export const TestOrganization: WithId<Organization> = {
   resourceType: 'Organization',
-  id: '123',
+  id: MOCK_TEST_ORGANIZATION_ID,
   meta: {
     versionId: '1',
   },
@@ -24,12 +25,12 @@ export const DifferentOrganization: WithId<Organization> = {
 
 export const DrAliceSmith: WithId<Practitioner> = {
   resourceType: 'Practitioner',
-  id: '123',
+  id: MOCK_ALICE_PRACTITIONER_ID,
   meta: {
     versionId: '2',
     lastUpdated: '2021-01-02T12:00:00Z',
     author: {
-      reference: 'Practitioner/123',
+      reference: `Practitioner/${MOCK_ALICE_PRACTITIONER_ID}`,
     },
   },
   name: [
@@ -48,12 +49,12 @@ export const DrAliceSmith: WithId<Practitioner> = {
 
 export const DrAliceSmithPreviousVersion: WithId<Practitioner> = {
   resourceType: 'Practitioner',
-  id: '123',
+  id: MOCK_ALICE_PRACTITIONER_ID,
   meta: {
     versionId: '1',
     lastUpdated: '2021-01-01T12:00:00Z',
     author: {
-      reference: 'Practitioner/123',
+      reference: `Practitioner/${MOCK_ALICE_PRACTITIONER_ID}`,
     },
   },
   name: [{ given: ['Medplum'], family: 'Admin' }],
@@ -64,7 +65,7 @@ export const DrAliceSmithSchedule: WithId<Schedule> = {
   id: 'alice-smith-schedule',
   actor: [
     {
-      reference: 'Practitioner/123',
+      reference: `Practitioner/${MOCK_ALICE_PRACTITIONER_ID}`,
       display: 'Dr. Alice Smith',
     },
   ],

--- a/packages/mock/src/mocks/questionnaire.ts
+++ b/packages/mock/src/mocks/questionnaire.ts
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { Questionnaire, QuestionnaireResponse } from '@medplum/fhirtypes';
+import { createReference } from '@medplum/core';
+import { DrAliceSmith } from './alice';
+import { MOCK_HOMER_PATIENT_ID } from '../constants';
 
 export const ExampleQuestionnaire: Questionnaire = {
   resourceType: 'Questionnaire',
@@ -25,9 +28,7 @@ export const ExampleQuestionnaireResponse: QuestionnaireResponse = {
   status: 'completed',
   questionnaire: 'https://example.com/example-questionnaire',
   subject: {
-    reference: 'Patient/123',
+    reference: `Patient/${MOCK_HOMER_PATIENT_ID}`,
   },
-  source: {
-    reference: 'Practitioner/123',
-  },
+  source: createReference(DrAliceSmith),
 };

--- a/packages/mock/src/mocks/questionnaire.ts
+++ b/packages/mock/src/mocks/questionnaire.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { Questionnaire, QuestionnaireResponse } from '@medplum/fhirtypes';
 import { createReference } from '@medplum/core';
-import { DrAliceSmith } from './alice';
+import type { Questionnaire, QuestionnaireResponse } from '@medplum/fhirtypes';
 import { MOCK_HOMER_PATIENT_ID } from '../constants';
+import { DrAliceSmith } from './alice';
 
 export const ExampleQuestionnaire: Questionnaire = {
   resourceType: 'Questionnaire',

--- a/packages/mock/src/mocks/simpsons.ts
+++ b/packages/mock/src/mocks/simpsons.ts
@@ -30,9 +30,7 @@ export const LisaSimpson: Patient = {
   meta: {
     versionId: '1',
     lastUpdated: '2020-01-01T12:00:00Z',
-    author: {
-      reference: 'Practitioner/123',
-    },
+    author: createReference(DrAliceSmith),
   },
   birthDate: '1981-05-09',
   name: [
@@ -114,9 +112,7 @@ export const BartSimpson: Patient = {
   meta: {
     versionId: '1',
     lastUpdated: '2020-01-01T12:00:00Z',
-    author: {
-      reference: 'Practitioner/123',
-    },
+    author: createReference(DrAliceSmith),
   },
   birthDate: '1979-12-17',
   name: [
@@ -202,9 +198,7 @@ export const HomerSimpson: Patient = {
   meta: {
     versionId: '2',
     lastUpdated: '2020-01-02T00:00:00.000Z',
-    author: {
-      reference: 'Practitioner/123',
-    },
+    author: createReference(DrAliceSmith),
   },
   identifier: [
     { system: 'abc', value: '123' },
@@ -285,9 +279,7 @@ export const HomerSimpsonPreviousVersion: Patient = {
   meta: {
     versionId: '1',
     lastUpdated: '2020-01-01T00:00:00.000Z',
-    author: {
-      reference: 'Practitioner/123',
-    },
+    author: createReference(DrAliceSmith),
   },
   name: [
     {
@@ -309,9 +301,7 @@ export const HomerEncounter: Encounter = {
   meta: {
     versionId: '456',
     lastUpdated: '2020-01-01T00:00:00.000Z',
-    author: {
-      reference: 'Practitioner/123',
-    },
+    author: createReference(DrAliceSmith),
   },
   status: 'finished',
   class: { code: 'AMB', display: 'ambulatory' },
@@ -322,9 +312,7 @@ export const HomerCommunication: Communication = {
   id: '123',
   meta: {
     lastUpdated: '2020-01-01T12:00:00Z',
-    author: {
-      reference: 'Practitioner/123',
-    },
+    author: createReference(DrAliceSmith),
   },
   status: 'completed',
   encounter: createReference(HomerEncounter),
@@ -340,9 +328,7 @@ export const HomerMedia: Media = {
   id: '123',
   meta: {
     lastUpdated: '2020-01-01T12:00:00Z',
-    author: {
-      reference: 'Practitioner/123',
-    },
+    author: createReference(DrAliceSmith),
   },
   status: 'completed',
   encounter: createReference(HomerEncounter),
@@ -588,9 +574,7 @@ export const HomerServiceRequest: ServiceRequest = {
   meta: {
     versionId: '1',
     lastUpdated: '2020-01-01T12:00:00Z',
-    author: {
-      reference: 'Practitioner/123',
-    },
+    author: createReference(DrAliceSmith),
   },
   identifier: [
     {
@@ -627,9 +611,7 @@ export const HomerDiagnosticReport: DiagnosticReport = {
   meta: {
     versionId: '1',
     lastUpdated: '2020-01-02T12:00:00Z',
-    author: {
-      reference: 'Practitioner/123',
-    },
+    author: createReference(DrAliceSmith),
   },
   status: 'final',
   code: { text: 'Test Report' },

--- a/packages/mock/src/mocks/subscription.ts
+++ b/packages/mock/src/mocks/subscription.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { AuditEvent, Subscription } from '@medplum/fhirtypes';
 import { createReference } from '@medplum/core';
+import type { AuditEvent, Subscription } from '@medplum/fhirtypes';
 import { DrAliceSmith } from './alice';
 
 export const ExampleSubscription: Subscription = {

--- a/packages/mock/src/mocks/subscription.ts
+++ b/packages/mock/src/mocks/subscription.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { AuditEvent, Subscription } from '@medplum/fhirtypes';
+import { createReference } from '@medplum/core';
+import { DrAliceSmith } from './alice';
 
 export const ExampleSubscription: Subscription = {
   resourceType: 'Subscription',
@@ -23,9 +25,7 @@ export const ExampleAuditEvent: AuditEvent = {
   meta: {
     lastUpdated: new Date().toISOString(),
     versionId: '456',
-    author: {
-      reference: 'Practitioner/123',
-    },
+    author: createReference(DrAliceSmith),
   },
   type: {
     system: 'http://terminology.hl7.org/CodeSystem/audit-event-type',
@@ -35,9 +35,7 @@ export const ExampleAuditEvent: AuditEvent = {
   agent: [
     {
       requestor: true,
-      who: {
-        reference: 'Practitioner/123',
-      },
+      who: createReference(DrAliceSmith),
     },
   ],
   source: {

--- a/packages/react-hooks/src/MedplumProvider/MedplumProvider.test.tsx
+++ b/packages/react-hooks/src/MedplumProvider/MedplumProvider.test.tsx
@@ -104,7 +104,7 @@ describe('MedplumProvider', () => {
             'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTE2MjM5MDIyLCJsb2dpbl9pZCI6InRlc3RpbmcxMjMifQ.lJGCbp2taTarRbamxaKFsTR_VRVgzvttKMmI5uFQSM0',
           refreshToken: '456',
           profile: {
-            reference: 'Practitioner/123',
+            reference: 'Practitioner/124',
           },
           project: {
             reference: 'Project/123',
@@ -196,7 +196,7 @@ describe('MedplumProvider', () => {
           'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTE2MjM5MDIyLCJsb2dpbl9pZCI6InRlc3RpbmcxMjMifQ.lJGCbp2taTarRbamxaKFsTR_VRVgzvttKMmI5uFQSM0',
         refreshToken: '456',
         profile: {
-          reference: 'Practitioner/123',
+          reference: 'Practitioner/124',
         },
         project: {
           reference: 'Project/123',
@@ -244,7 +244,7 @@ describe('MedplumProvider', () => {
           'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTE2MjM5MDIyLCJsb2dpbl9pZCI6InRlc3RpbmcxMjMifQ.lJGCbp2taTarRbamxaKFsTR_VRVgzvttKMmI5uFQSM0',
         refreshToken: '456',
         profile: {
-          reference: 'Practitioner/123',
+          reference: 'Practitioner/124',
         },
         project: {
           reference: 'Project/123',
@@ -303,7 +303,7 @@ describe('MedplumProvider', () => {
             'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTE2MjM5MDIyLCJsb2dpbl9pZCI6InRlc3RpbmcxMjMifQ.lJGCbp2taTarRbamxaKFsTR_VRVgzvttKMmI5uFQSM0',
           refreshToken: '456',
           profile: {
-            reference: 'Practitioner/123',
+            reference: 'Practitioner/124',
           },
           project: {
             reference: 'Project/123',
@@ -364,7 +364,7 @@ describe('MedplumProvider', () => {
         }),
         refreshToken: createFakeJwt({ client_id: '123' }),
         profile: {
-          reference: 'Practitioner/123',
+          reference: 'Practitioner/124',
         },
         project: {
           reference: 'Project/123',

--- a/packages/react/src/AnnotationInput/AnnotationInput.test.tsx
+++ b/packages/react/src/AnnotationInput/AnnotationInput.test.tsx
@@ -55,7 +55,7 @@ describe('AnnotationInput', () => {
       text: 'TEST',
       authorReference: {
         display: 'Alice Smith',
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
       },
       time: expect.anything(),
     });

--- a/packages/react/src/AppShell/Header.test.tsx
+++ b/packages/react/src/AppShell/Header.test.tsx
@@ -73,7 +73,7 @@ describe('Header', () => {
         accessToken: 'abc',
         refreshToken: 'xyz',
         profile: {
-          reference: 'Practitioner/123',
+          reference: 'Practitioner/124',
           display: 'Alice Smith',
         },
         project: {
@@ -89,7 +89,7 @@ describe('Header', () => {
           accessToken: 'abc',
           refreshToken: 'xyz',
           profile: {
-            reference: 'Practitioner/123',
+            reference: 'Practitioner/124',
             display: 'Alice Smith',
           },
           project: {
@@ -153,7 +153,7 @@ describe('Header', () => {
       fireEvent.click(screen.getByText('Account settings'));
     });
 
-    expect(navigateMock).toHaveBeenCalledWith('/Practitioner/123');
+    expect(navigateMock).toHaveBeenCalledWith('/Practitioner/124');
   });
 
   test('Sign out', async () => {

--- a/packages/react/src/PatientSummary/pharmacy-utils.test.ts
+++ b/packages/react/src/PatientSummary/pharmacy-utils.test.ts
@@ -38,7 +38,7 @@ describe('pharmacy-utils re-exports from @medplum/core', () => {
 
   test('PreferredPharmacy type is re-exported', () => {
     const pharmacy: PreferredPharmacy = {
-      organizationRef: { reference: 'Organization/123' },
+      organizationRef: { reference: 'Organization/125' },
       isPrimary: true,
     };
     expect(pharmacy.isPrimary).toBe(true);

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
@@ -1688,7 +1688,7 @@ export const KitchenSink = (): JSX.Element => (
               },
               {
                 valueReference: {
-                  reference: 'Organization/123',
+                  reference: 'Organization/125',
                   display: 'Test Organization',
                 },
               },
@@ -1867,7 +1867,7 @@ export const KitchenSinkWithInitialValues = (): JSX.Element => (
               },
               {
                 valueReference: {
-                  reference: 'Organization/123',
+                  reference: 'Organization/125',
                   display: 'Test Organization',
                 },
               },
@@ -1875,7 +1875,7 @@ export const KitchenSinkWithInitialValues = (): JSX.Element => (
             initial: [
               {
                 valueReference: {
-                  reference: 'Organization/123',
+                  reference: 'Organization/125',
                   display: 'Test Organization',
                 },
               },
@@ -1904,7 +1904,7 @@ export const KitchenSinkWithInitialValues = (): JSX.Element => (
             initial: [
               {
                 valueReference: {
-                  reference: 'Organization/123',
+                  reference: 'Organization/125',
                 },
               },
             ],
@@ -2041,7 +2041,7 @@ export const KitchenSinkWithQuestionnaireResponse = (): JSX.Element => (
               },
               {
                 valueReference: {
-                  reference: 'Organization/123',
+                  reference: 'Organization/125',
                   display: 'Test Organization',
                 },
               },

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -643,14 +643,14 @@ describe('QuestionnaireForm', () => {
               },
               {
                 valueReference: {
-                  reference: 'Organization/123',
+                  reference: 'Organization/125',
                 },
               },
             ],
             initial: [
               {
                 valueReference: {
-                  reference: 'Organization/123',
+                  reference: 'Organization/125',
                 },
               },
             ],
@@ -664,7 +664,7 @@ describe('QuestionnaireForm', () => {
     expect(radioButton1).toBeInTheDocument();
     expect((radioButton1 as HTMLInputElement).checked).toBe(false);
 
-    const radioButton2 = screen.getByLabelText('Organization/123');
+    const radioButton2 = screen.getByLabelText('Organization/125');
     expect(radioButton2).toBeInTheDocument();
     expect((radioButton2 as HTMLInputElement).checked).toBe(true);
   });
@@ -1084,7 +1084,7 @@ describe('QuestionnaireForm', () => {
               },
               {
                 valueReference: {
-                  reference: 'Organization/123',
+                  reference: 'Organization/125',
                   display: 'Test Organization',
                 },
               },
@@ -1092,7 +1092,7 @@ describe('QuestionnaireForm', () => {
             initial: [
               {
                 valueReference: {
-                  reference: 'Organization/123',
+                  reference: 'Organization/125',
                   display: 'Test Organization',
                 },
               },

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -770,7 +770,7 @@ describe('QuestionnaireForm', () => {
       questionnaire: 'Questionnaire/' + questionnaire.id,
       source: {
         display: 'Alice Smith',
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
       },
       item: [
         {

--- a/packages/react/src/QuestionnaireResponseDisplay/QuestionnaireResponseDisplay.stories.tsx
+++ b/packages/react/src/QuestionnaireResponseDisplay/QuestionnaireResponseDisplay.stories.tsx
@@ -376,7 +376,7 @@ export const KitchenSink = (): JSX.Element => (
             answer: [
               {
                 valueReference: {
-                  reference: 'Organization/123',
+                  reference: 'Organization/125',
                   display: 'Test Organization',
                 },
               },
@@ -429,7 +429,7 @@ export const KitchenSink = (): JSX.Element => (
             answer: [
               {
                 valueReference: {
-                  reference: 'Organization/123',
+                  reference: 'Organization/125',
                   display: 'Test Organization',
                 },
               },

--- a/packages/react/src/QuestionnaireResponseDisplay/QuestionnaireResponseDisplay.stories.tsx
+++ b/packages/react/src/QuestionnaireResponseDisplay/QuestionnaireResponseDisplay.stories.tsx
@@ -539,7 +539,7 @@ export const WithPages = (): JSX.Element => (
         ],
         status: 'completed',
         source: {
-          reference: 'Practitioner/123',
+          reference: 'Practitioner/124',
           display: 'Alice Smith',
         },
         authored: '2025-07-23T21:18:24.488Z',

--- a/packages/react/src/QuestionnaireResponseDisplay/QuestionnaireResponseDisplay.test.tsx
+++ b/packages/react/src/QuestionnaireResponseDisplay/QuestionnaireResponseDisplay.test.tsx
@@ -488,7 +488,7 @@ describe('QuestionnaireResponseDisplay', () => {
       ],
       status: 'completed',
       source: {
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
         display: 'Alice Smith',
       },
       authored: '2025-07-23T21:18:24.488Z',

--- a/packages/react/src/ReferenceDisplay/ReferenceDisplay.test.tsx
+++ b/packages/react/src/ReferenceDisplay/ReferenceDisplay.test.tsx
@@ -24,15 +24,15 @@ describe('ReferenceDisplay', () => {
   });
 
   test('Renders reference', () => {
-    setup(<ReferenceDisplay value={{ reference: 'Organization/123' }} />);
-    expect(screen.getByText('Organization/123')).toBeDefined();
-    expect(screen.getByText<HTMLAnchorElement>('Organization/123').href).toMatch('Organization/123');
+    setup(<ReferenceDisplay value={{ reference: 'Organization/125' }} />);
+    expect(screen.getByText('Organization/125')).toBeDefined();
+    expect(screen.getByText<HTMLAnchorElement>('Organization/125').href).toMatch('Organization/125');
   });
 
   test('Renders reference and display', () => {
-    setup(<ReferenceDisplay value={{ reference: 'Organization/123', display: 'Foo' }} />);
+    setup(<ReferenceDisplay value={{ reference: 'Organization/125', display: 'Foo' }} />);
     expect(screen.getByText('Foo')).toBeDefined();
-    expect(screen.getByText<HTMLAnchorElement>('Foo').href).toMatch('Organization/123');
+    expect(screen.getByText<HTMLAnchorElement>('Foo').href).toMatch('Organization/125');
   });
 
   test('Renders unknown properties', () => {
@@ -41,12 +41,12 @@ describe('ReferenceDisplay', () => {
   });
 
   test('Renders reference no link', () => {
-    setup(<ReferenceDisplay value={{ reference: 'Organization/123' }} link={false} />);
-    expect(screen.getByText('Organization/123')).toBeDefined();
+    setup(<ReferenceDisplay value={{ reference: 'Organization/125' }} link={false} />);
+    expect(screen.getByText('Organization/125')).toBeDefined();
   });
 
   test('Renders reference and display no link', () => {
-    setup(<ReferenceDisplay value={{ reference: 'Organization/123', display: 'Foo' }} link={false} />);
+    setup(<ReferenceDisplay value={{ reference: 'Organization/125', display: 'Foo' }} link={false} />);
     expect(screen.getByText('Foo')).toBeDefined();
   });
 });

--- a/packages/react/src/ResourceBlame/ResourceBlame.test.tsx
+++ b/packages/react/src/ResourceBlame/ResourceBlame.test.tsx
@@ -58,8 +58,8 @@ describe('ResourceBlame', () => {
             meta: {
               versionId: '1',
               lastUpdated: '2024-01-01T00:00:00Z',
-              author: { reference: 'Practitioner/123' },
-              onBehalfOf: { reference: 'Practitioner/123' },
+              author: { reference: 'Practitioner/124' },
+              onBehalfOf: { reference: 'Practitioner/124' },
             },
             name: [{ family: 'Doe' }],
           },

--- a/packages/react/src/ResourceForm/ResourceForm.test.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.test.tsx
@@ -80,7 +80,7 @@ describe('ResourceForm', () => {
 
     await setup({
       defaultValue: {
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
       },
       onSubmit,
     });

--- a/packages/react/src/ResourceHistoryTable/ResourceHistoryTable.test.tsx
+++ b/packages/react/src/ResourceHistoryTable/ResourceHistoryTable.test.tsx
@@ -61,8 +61,8 @@ describe('ResourceHistoryTable', () => {
             meta: {
               versionId: '1',
               lastUpdated: '2024-01-01T00:00:00Z',
-              author: { reference: 'Practitioner/123' },
-              onBehalfOf: { reference: 'Practitioner/123' },
+              author: { reference: 'Practitioner/124' },
+              onBehalfOf: { reference: 'Practitioner/124' },
             },
           },
         },

--- a/packages/react/src/ResourceTable/ResourceTable.test.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.test.tsx
@@ -38,7 +38,7 @@ describe('ResourceTable', () => {
   test('Renders Practitioner resource', async () => {
     await setup({
       value: {
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
       },
     });
 
@@ -51,7 +51,7 @@ describe('ResourceTable', () => {
   test('Ignore missing values', async () => {
     await setup({
       value: {
-        reference: 'Practitioner/123',
+        reference: 'Practitioner/124',
       },
       ignoreMissingValues: true,
     });

--- a/packages/react/src/SearchFilterEditor/SearchFilterEditor.test.tsx
+++ b/packages/react/src/SearchFilterEditor/SearchFilterEditor.test.tsx
@@ -100,7 +100,7 @@ describe('SearchFilterEditor', () => {
         {
           code: 'organization',
           operator: Operator.EQUALS,
-          value: 'Organization/123',
+          value: 'Organization/125',
         },
       ],
     };

--- a/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.test.tsx
+++ b/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.test.tsx
@@ -129,7 +129,7 @@ describe('SearchFilterValueInput', () => {
 
   test('Reference input', async () => {
     // Warm up the default value
-    await medplum.readResource('Organization', '123');
+    await medplum.readResource('Organization', '125');
 
     const onChange = vi.fn();
 
@@ -137,7 +137,7 @@ describe('SearchFilterValueInput', () => {
       <SearchFilterValueInput
         resourceType="Patient"
         searchParam={globalSchema.types['Patient'].searchParams?.['organization'] as SearchParameter}
-        defaultValue="Organization/123"
+        defaultValue="Organization/125"
         onChange={onChange}
       />
     );

--- a/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
+++ b/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
@@ -353,7 +353,7 @@ describe('SearchPopupMenu', () => {
         {
           code: 'organization',
           operator: Operator.EQUALS,
-          value: 'Organization/123',
+          value: 'Organization/125',
         },
       ],
     };

--- a/packages/react/src/Timeline/Timeline.test.tsx
+++ b/packages/react/src/Timeline/Timeline.test.tsx
@@ -34,8 +34,8 @@ describe('Timeline', () => {
     const resource: Communication = {
       resourceType: 'Communication',
       meta: {
-        author: { reference: 'Practitioner/123' },
-        onBehalfOf: { reference: 'Practitioner/123' },
+        author: { reference: 'Practitioner/124' },
+        onBehalfOf: { reference: 'Practitioner/124' },
       },
     } as Communication;
 
@@ -59,7 +59,7 @@ describe('Timeline', () => {
     const resource: Communication = {
       resourceType: 'Communication',
       meta: {
-        author: { reference: 'Practitioner/123' },
+        author: { reference: 'Practitioner/124' },
       },
     } as Communication;
 

--- a/packages/react/src/auth/RegisterForm.test.tsx
+++ b/packages/react/src/auth/RegisterForm.test.tsx
@@ -63,7 +63,7 @@ function mockFetch(url: string, options: any): Promise<any> {
       login: '1',
       code: '1',
     };
-  } else if (options.method === 'GET' && url.endsWith('Practitioner/123')) {
+  } else if (options.method === 'GET' && url.endsWith('Practitioner/124')) {
     status = 200;
     result = {
       resourceType: 'Practitioner',
@@ -80,7 +80,7 @@ function mockFetch(url: string, options: any): Promise<any> {
       token_type: 'Bearer',
       scope: 'openid',
       project: { reference: 'Project/123' },
-      profile: { reference: 'Practitioner/123' },
+      profile: { reference: 'Practitioner/124' },
     };
   } else if (options.method === 'GET' && url.endsWith('auth/me')) {
     status = 200;

--- a/packages/react/src/auth/SignInForm.test.tsx
+++ b/packages/react/src/auth/SignInForm.test.tsx
@@ -47,7 +47,7 @@ function mockFetch(url: string, options: any): Promise<any> {
           {
             id: '100',
             profile: {
-              reference: 'Practitioner/123',
+              reference: 'Practitioner/124',
               display: 'Alice Smith',
             },
             project: {
@@ -142,7 +142,7 @@ function mockFetch(url: string, options: any): Promise<any> {
       login: '1',
       code: '1',
     };
-  } else if (options.method === 'GET' && url.endsWith('Practitioner/123')) {
+  } else if (options.method === 'GET' && url.endsWith('Practitioner/124')) {
     status = 200;
     result = {
       resourceType: 'Practitioner',
@@ -159,7 +159,7 @@ function mockFetch(url: string, options: any): Promise<any> {
       token_type: 'Bearer',
       scope: 'openid',
       project: { reference: 'Project/123' },
-      profile: { reference: 'Practitioner/123' },
+      profile: { reference: 'Practitioner/124' },
     };
   } else if (options.method === 'GET' && url.endsWith('auth/me')) {
     status = 200;

--- a/packages/react/src/stories/referenceLab.ts
+++ b/packages/react/src/stories/referenceLab.ts
@@ -579,7 +579,7 @@ export const CreatinineObservation: Observation = {
   issued: '2013-04-04T14:34:00+01:00',
   performer: [
     {
-      reference: 'Practitioner/123',
+      reference: 'Practitioner/124',
       display: 'Dr. Alice Smith',
     },
   ],
@@ -621,7 +621,7 @@ export const CreatinineObservation: Observation = {
   note: [
     {
       text: 'Previously reported as 167 mg/dL on 2/3/2023, 8:40:14 PM',
-      authorReference: { reference: 'Practitioner/123', display: 'Dr. Alice Smith' },
+      authorReference: { reference: 'Practitioner/124', display: 'Dr. Alice Smith' },
     },
     {
       text: 'Previously reported as 10 mg/dL on 2/1/2023, 8:40:14 PM Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',

--- a/packages/react/src/stories/referenceLab.ts
+++ b/packages/react/src/stories/referenceLab.ts
@@ -652,7 +652,7 @@ export const ExampleReport: DiagnosticReport = {
   issued: '2013-03-11T10:28:00+01:00',
   performer: [
     {
-      reference: 'Organization/123',
+      reference: 'Organization/125',
       display: 'Test Organization',
     },
   ],

--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -317,7 +317,7 @@ describe('FHIR Routes', () => {
       .send({
         resourceType: 'Patient',
         managingOrganization: {
-          reference: 'Organization/123',
+          reference: 'Organization/125',
         },
       });
     expect(res.status).toBe(201);
@@ -328,7 +328,7 @@ describe('FHIR Routes', () => {
       .send({
         ...patient,
         managingOrganization: {
-          reference: 'Organization/123',
+          reference: 'Organization/125',
           display: '',
         },
       });


### PR DESCRIPTION
## Summary

- ID `123` was re-used, was a silent bug hiding inconsistency between the mock client and real client
- Assign Dr. Alice Smith `Practitioner/124` instead of reusing `123` (Homer Simpson remains `Patient/123`, Test Organization remains `Organization/123`).
- Create constants `MOCK_HOMER_PATIENT_ID`, `MOCK_ALICE_PRACTITIONER_ID`, `MOCK_TEST_ORGANIZATION_ID` for easier referencing

## Why?

Lookup tables such as `HumanName` index by `resourceId` only. The collision between `Patient/123` and `Practitioner/123` caused the practitioner's name row to overwrite the patient's during mock seeding, breaking SQL-backed name search.