### PR TITLE
Update async batch on failure

### DIFF
--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -67,6 +67,14 @@ export const initBatchWorker: WorkerInitializer = (config, options?: WorkerIniti
         ...workerBullmq,
       }
     );
+    worker.on('failed', async (job) => {
+      if (!job) {
+        return;
+      }
+      const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID);
+      const exec = new AsyncJobExecutor(systemRepo, job.data.asyncJob);
+      await exec.failJob().catch(() => {});
+    });
   }
 
   return { queue, worker, name: queueName };

--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -73,7 +73,7 @@ export const initBatchWorker: WorkerInitializer = (config, options?: WorkerIniti
       }
       const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID);
       const exec = new AsyncJobExecutor(systemRepo, job.data.asyncJob);
-      await exec.failJob().catch(() => {});
+      await exec.failJob();
     });
   }
 


### PR DESCRIPTION
Add failed event handler to BatchQueue worker to update AsyncJob status to error when a job is permanently failed by BullMQ