### PR TITLE
fix(server): paginate AWS Textract results via NextToken (#5879)

### DIFF
--- a/packages/server/src/cloud/aws/textract.test.ts
+++ b/packages/server/src/cloud/aws/textract.test.ts
@@ -91,6 +91,52 @@ describe('AWS Textract', () => {
     expect(res3.body.Blocks).toBeDefined();
   });
 
+  test('Paginated results', async () => {
+    // Override the shared single-page mock with a two-page (NextToken) sequence
+    mockTextractClient.reset();
+    mockTextractClient.on(StartDocumentTextDetectionCommand).resolves({ JobId: 'job-1' });
+    mockTextractClient
+      .on(GetDocumentTextDetectionCommand)
+      .resolvesOnce({ JobStatus: 'SUCCEEDED', NextToken: 'page-2', Blocks: [{ BlockType: 'LINE', Text: 'page one' }] })
+      .resolvesOnce({ JobStatus: 'SUCCEEDED', Blocks: [{ BlockType: 'LINE', Text: 'page two' }] });
+
+    const accessToken = await initTestAuth({ project: { features: ['aws-textract'] } });
+
+    // Step 1: Create a PDF Binary
+    const res1 = await request(app)
+      .post('/fhir/R4/Binary')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.TEXT)
+      .send('Hello world');
+    expect(res1.status).toBe(201);
+
+    // Step 2: Create a Media
+    const res2 = await request(app)
+      .post('/fhir/R4/Media')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Media',
+        status: 'completed',
+        content: { contentType: 'application/pdf', url: 'Binary/' + res1.body.id },
+      });
+    expect(res2.status).toBe(201);
+
+    // Step 3: Submit the Media to Textract
+    const res3 = await request(app)
+      .post(`/fhir/R4/Media/${res2.body.id}/$aws-textract`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res3.status).toBe(200);
+
+    // All pages of Blocks should be present (fails on buggy code: only "page one" returned)
+    const texts = res3.body.Blocks.map((b: { Text?: string }) => b.Text);
+    expect(texts).toContain('page one');
+    expect(texts).toContain('page two');
+
+    // The reported symptom: the merged result should no longer carry a NextToken
+    expect(res3.body.NextToken).toBeUndefined();
+  });
+
   test('Comprehend', async () => {
     const accessToken = await initTestAuth({ project: { features: ['aws-textract'] } });
 

--- a/packages/server/src/cloud/aws/textract.ts
+++ b/packages/server/src/cloud/aws/textract.ts
@@ -92,6 +92,22 @@ export async function awsTextractHandler(req: FhirRequest): Promise<FhirResponse
 
       // Otherwise, we're done
       textractResult = response;
+
+      // Text detection results may be paginated; follow NextToken to gather all blocks
+      let nextToken = response.NextToken;
+      while (nextToken) {
+        const nextResponse = await textractClient.send(
+          new GetDocumentTextDetectionCommand({
+            JobId: startResponse.JobId,
+            NextToken: nextToken,
+          })
+        );
+        if (nextResponse.Blocks) {
+          (textractResult.Blocks ??= []).push(...nextResponse.Blocks);
+        }
+        nextToken = nextResponse.NextToken;
+      }
+      textractResult.NextToken = undefined;
     }
   } catch (err: any) {
     getLogger().error('Error getting text detection:', err);


### PR DESCRIPTION
AWS Textract paginates GetDocumentTextDetection results for large documents: the first completed response carries a NextToken and the caller must follow it to retrieve the remaining Blocks. The handler stopped at the first response, so only the first page of text was returned and a stale NextToken leaked into the output.

Follow NextToken after the job completes, accumulating Blocks across all pages (matching the AWS pagination idiom in cloud/aws/config.ts) and clearing the trailing token on the merged result. Add a regression test covering the multi-page NextToken path.

Fixes #5879