### PR TITLE
fix(core): flaky base64 tests

### DIFF
--- a/packages/core/src/base64.test.ts
+++ b/packages/core/src/base64.test.ts
@@ -55,9 +55,9 @@ describe('Base64', () => {
   });
 
   test('Error', () => {
-    // Mock environment with neither browser nor Node.js
+    // Mock environment with neither browser nor Node.js (base64.ts uses getBuffer, not isNodeEnvironment)
     mockEnvironment.isBrowserEnvironment.mockReturnValue(false);
-    mockEnvironment.isNodeEnvironment.mockReturnValue(false);
+    mockEnvironment.getBuffer.mockReturnValue(undefined);
 
     expect(() => encodeBase64('Hello world')).toThrow('Unable to encode base64');
     expect(() => decodeBase64('SGVsbG8gd29ybGQ=')).toThrow('Unable to decode base64');


### PR DESCRIPTION
## Summary

- Mock `getBuffer` instead of `isNodeEnvironment` in the base64 Error test
- Aligns the test with what `encodeBase64` / `decodeBase64` actually check in `base64.ts`
- Prevents flaky failures when mock return values leak from the Node.js test case
- Flaky tests occurred in high concurrency scenarios
