### PR TITLE
[Provider] Always reveal appointment details drawer from calendar

### DIFF
--- a/examples/medplum-provider/src/components/Calendar.test.tsx
+++ b/examples/medplum-provider/src/components/Calendar.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Appointment, Slot } from '@medplum/fhirtypes';
 import { describe, expect, test, vi } from 'vitest';
-import { render, screen, userEvent } from '../test-utils/render';
+import { render, screen, userEvent, waitFor } from '../test-utils/render';
 import type { Range } from '../types/scheduling';
 import { Calendar } from './Calendar';
 
@@ -260,7 +260,7 @@ describe('Calendar', () => {
       expect(screen.getByText(/John Doe/)).toBeInTheDocument();
 
       await userEvent.click(screen.getByText(/John Doe/));
-      expect(onSelectAppointment).toHaveBeenCalledWith(appointment);
+      await waitFor(() => expect(onSelectAppointment).toHaveBeenCalledWith(appointment));
     });
 
     test('renders multiple appointments', async () => {
@@ -301,7 +301,7 @@ describe('Calendar', () => {
 
       expect(screen.getByText('Available')).toBeInTheDocument();
       await userEvent.click(screen.getByText('Available'));
-      expect(onSelectSlot).toHaveBeenCalledWith(slot);
+      await waitFor(() => expect(onSelectSlot).toHaveBeenCalledWith(slot));
       expect(onSelectAppointment).not.toHaveBeenCalled();
       expect(onSelectInterval).not.toHaveBeenCalled();
     });
@@ -332,7 +332,7 @@ describe('Calendar', () => {
       setup({ slots: [slot], onSelectSlot });
 
       await userEvent.click(screen.getByText('Available'));
-      expect(onSelectSlot).toHaveBeenCalledWith(slot);
+      await waitFor(() => expect(onSelectSlot).toHaveBeenCalledWith(slot));
     });
 
     test('filters out entered-in-error slots', async () => {

--- a/examples/medplum-provider/src/components/Calendar.test.tsx
+++ b/examples/medplum-provider/src/components/Calendar.test.tsx
@@ -60,7 +60,7 @@ describe('Calendar', () => {
     onSelectInterval?: () => void;
     onSelectSlot?: (slot: Slot) => void;
     onSelectAppointment?: (appointment: Appointment) => void;
-    onDoubleClickAppointment?: (appontment: Appointment) => void;
+    onDoubleClickAppointment?: (appointment: Appointment) => void;
     onRangeChange?: (range: Range) => void;
   } = {}): ReturnType<typeof render> => {
     return render(
@@ -338,7 +338,7 @@ describe('Calendar', () => {
       await expect(onSelectSlot).toHaveBeenCalledWith(slot);
     });
 
-    test('calls onDoubleClickAppointment when double-clicing an appointment', async () => {
+    test('calls onDoubleClickAppointment when double-clicking an appointment', async () => {
       const onDoubleClickAppointment = vi.fn();
       const appointment = createAppointment();
       setup({ appointments: [appointment], onDoubleClickAppointment });

--- a/examples/medplum-provider/src/components/Calendar.test.tsx
+++ b/examples/medplum-provider/src/components/Calendar.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Appointment, Slot } from '@medplum/fhirtypes';
 import { describe, expect, test, vi } from 'vitest';
-import { render, screen, userEvent, waitFor } from '../test-utils/render';
+import { render, screen, userEvent } from '../test-utils/render';
 import type { Range } from '../types/scheduling';
 import { Calendar } from './Calendar';
 
@@ -52,6 +52,7 @@ describe('Calendar', () => {
     onSelectInterval,
     onSelectSlot,
     onSelectAppointment,
+    onDoubleClickAppointment,
     onRangeChange,
   }: {
     slots?: Slot[];
@@ -59,6 +60,7 @@ describe('Calendar', () => {
     onSelectInterval?: () => void;
     onSelectSlot?: (slot: Slot) => void;
     onSelectAppointment?: (appointment: Appointment) => void;
+    onDoubleClickAppointment?: (appontment: Appointment) => void;
     onRangeChange?: (range: Range) => void;
   } = {}): ReturnType<typeof render> => {
     return render(
@@ -68,6 +70,7 @@ describe('Calendar', () => {
         onSelectInterval={onSelectInterval}
         onSelectSlot={onSelectSlot}
         onSelectAppointment={onSelectAppointment}
+        onDoubleClickAppointment={onDoubleClickAppointment}
         onRangeChange={onRangeChange}
       />
     );
@@ -260,7 +263,7 @@ describe('Calendar', () => {
       expect(screen.getByText(/John Doe/)).toBeInTheDocument();
 
       await userEvent.click(screen.getByText(/John Doe/));
-      await waitFor(() => expect(onSelectAppointment).toHaveBeenCalledWith(appointment));
+      await expect(onSelectAppointment).toHaveBeenCalledWith(appointment);
     });
 
     test('renders multiple appointments', async () => {
@@ -301,7 +304,7 @@ describe('Calendar', () => {
 
       expect(screen.getByText('Available')).toBeInTheDocument();
       await userEvent.click(screen.getByText('Available'));
-      await waitFor(() => expect(onSelectSlot).toHaveBeenCalledWith(slot));
+      await expect(onSelectSlot).toHaveBeenCalledWith(slot);
       expect(onSelectAppointment).not.toHaveBeenCalled();
       expect(onSelectInterval).not.toHaveBeenCalled();
     });
@@ -332,7 +335,16 @@ describe('Calendar', () => {
       setup({ slots: [slot], onSelectSlot });
 
       await userEvent.click(screen.getByText('Available'));
-      await waitFor(() => expect(onSelectSlot).toHaveBeenCalledWith(slot));
+      await expect(onSelectSlot).toHaveBeenCalledWith(slot);
+    });
+
+    test('calls onDoubleClickAppointment when double-clicing an appointment', async () => {
+      const onDoubleClickAppointment = vi.fn();
+      const appointment = createAppointment();
+      setup({ appointments: [appointment], onDoubleClickAppointment });
+
+      await userEvent.dblClick(screen.getByText(/John Doe/));
+      await expect(onDoubleClickAppointment).toHaveBeenCalledWith(appointment);
     });
 
     test('filters out entered-in-error slots', async () => {

--- a/examples/medplum-provider/src/components/Calendar.tsx
+++ b/examples/medplum-provider/src/components/Calendar.tsx
@@ -89,7 +89,9 @@ export function Calendar(props: {
   );
 
   // Add slight delay to click handler to permit double-clicks to register
-  const handleSelectEvent = useDebouncedCallback(handleSelectEventRaw, 100);
+  const handleSelectEventDebounced = useDebouncedCallback(handleSelectEventRaw, 100);
+
+  const handleSelectEvent = onDoubleClickAppointment ? handleSelectEventDebounced : handleSelectEventRaw;
 
   // FullCalendar creates new elements on each render rather than recycling them,
   // so dblclick listeners are cleaned up automatically when the old element is GC'd

--- a/examples/medplum-provider/src/components/Calendar.tsx
+++ b/examples/medplum-provider/src/components/Calendar.tsx
@@ -211,8 +211,10 @@ export function Calendar(props: {
           },
         }}
         eventDidMount={(info) => {
-          eventDataRef.current.set(info.el, info.event.extendedProps as ExtendedEvent);
-          info.el.addEventListener('dblclick', handleDblClick);
+          if (onDoubleClickAppointment) {
+            eventDataRef.current.set(info.el, info.event.extendedProps as ExtendedEvent);
+            info.el.addEventListener('dblclick', handleDblClick);
+          }
         }}
       />
     </div>

--- a/examples/medplum-provider/src/components/Calendar.tsx
+++ b/examples/medplum-provider/src/components/Calendar.tsx
@@ -10,12 +10,13 @@ import '@fullcalendar/react/themes/classic/palette.css';
 import '@fullcalendar/react/themes/classic/theme.css';
 import timeGridPlugin from '@fullcalendar/react/timegrid';
 import { Button, Group, SegmentedControl, Title, useComputedColorScheme } from '@mantine/core';
+import { useDebouncedCallback } from '@mantine/hooks';
 import { EMPTY, getReferenceString } from '@medplum/core';
 import type { Appointment, Slot } from '@medplum/fhirtypes';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import cx from 'clsx';
 import type { JSX } from 'react';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { Range } from '../types/scheduling';
 import { assertNever } from '../utils/assert';
 import classes from './Calendar.module.css';
@@ -65,14 +66,15 @@ export function Calendar(props: {
   onSelectInterval?: (slotInfo: Range) => void;
   onSelectSlot?: (slot: Slot) => void;
   onSelectAppointment?: (appointment: Appointment) => void;
+  onDoubleClickAppointment?: (appointment: Appointment) => void;
   onRangeChange?: (range: Range) => void;
   className?: string;
 }): JSX.Element {
   const colorScheme = useComputedColorScheme();
   const controller = useCalendarController();
-  const { onSelectAppointment, onSelectSlot } = props;
+  const { onSelectAppointment, onSelectSlot, onDoubleClickAppointment } = props;
 
-  const handleSelectEvent = useCallback(
+  const handleSelectEventRaw = useCallback(
     (event: EventApi) => {
       const ext = event.extendedProps as ExtendedEvent;
       if (ext.type === 'appointment') {
@@ -85,6 +87,27 @@ export function Calendar(props: {
     },
     [onSelectAppointment, onSelectSlot]
   );
+
+  // Add slight delay to click handler to permit double-clicks to register
+  const handleSelectEvent = useDebouncedCallback(handleSelectEventRaw, 100);
+
+  // FullCalendar creates new elements on each render rather than recycling them,
+  // so dblclick listeners are cleaned up automatically when the old element is GC'd
+  // — no eventWillUnmount teardown needed. The WeakMap and callback Ref let the
+  // single stable listener read the latest event data and prop without being
+  // re-registered on every render.
+  const eventDataRef = useRef(new WeakMap<Element, ExtendedEvent>());
+  const onDoubleClickRef = useRef(onDoubleClickAppointment);
+  useEffect(() => {
+    onDoubleClickRef.current = onDoubleClickAppointment;
+  }, [onDoubleClickAppointment]);
+
+  const handleDblClick = useCallback((e: Event) => {
+    const ext = eventDataRef.current.get(e.currentTarget as Element);
+    if (ext?.type === 'appointment') {
+      onDoubleClickRef.current?.(ext.appointment);
+    }
+  }, []);
 
   const events = useMemo(() => {
     const appointmentIndex = props.appointments.reduce<Record<string, Appointment>>((acc, appointment) => {
@@ -184,6 +207,10 @@ export function Calendar(props: {
           timeGridDay: {
             allDaySlot: false,
           },
+        }}
+        eventDidMount={(info) => {
+          eventDataRef.current.set(info.el, info.event.extendedProps as ExtendedEvent);
+          info.el.addEventListener('dblclick', handleDblClick);
         }}
       />
     </div>

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.module.css
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.module.css
@@ -1,0 +1,24 @@
+.AppointmentDetails {
+  /* If we have two adjacent `<Divider>` elements (such as when an interior
+   * component rendered `null`), hide the second divider */
+  > [role="separator"] + [role="separator"] {
+    display: none;
+  }
+}
+
+.metadata {
+  margin: 0;
+}
+
+.metadata dt {
+  font-size: var(--mantine-font-size-md);
+  font-weight: 800;
+}
+
+.metadata dd + dt {
+  margin-top: var(--mantine-spacing-xs);
+}
+
+.metadata dd {
+  margin-inline-start: var(--mantine-spacing-lg);
+}

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
@@ -7,11 +7,10 @@ import type { Appointment, Bundle, Patient, Slot } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import type { RenderResult } from '@testing-library/react';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { createEncounter } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
 import { AppointmentDetails } from './AppointmentDetails';
 
@@ -86,8 +85,8 @@ describe('AppointmentDetails', () => {
       const appointment = createAppointment();
       await setup({ appointment });
 
-      // formatPeriod should display the appointment time
-      expect(screen.getByText(/2024/)).toBeInTheDocument();
+      // "Appointment Start" and "Appointment End" are shown as timestamps
+      expect(screen.getAllByText(/2024/)).toHaveLength(2);
     });
 
     test('renders patient input when no patient participant exists', async () => {
@@ -363,102 +362,6 @@ describe('AppointmentDetails', () => {
 
       await waitFor(() => {
         expect(screen.queryByText('Set Up Encounter')).not.toBeInTheDocument();
-      });
-    });
-
-    test('Apply button is disabled when class and care template are not selected', async () => {
-      const appointment = createAppointmentWithPatient(patient.id);
-      await setup({ appointment });
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
-      });
-    });
-
-    test('shows warning notification when form submitted without required fields filled', async () => {
-      const appointment = createAppointmentWithPatient(patient.id);
-      await setup({ appointment });
-
-      await waitFor(() => {
-        expect(screen.getByText('Set Up Encounter')).toBeInTheDocument();
-      });
-
-      // Bypass the disabled button by submitting the form directly
-      const form = screen.getByText('Set Up Encounter').closest('div')?.querySelector('form');
-      expect(form).toBeTruthy();
-      await act(async () => {
-        fireEvent.submit(form as HTMLFormElement);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('Please fill out required fields.')).toBeInTheDocument();
-      });
-    });
-
-    test('does not call createEncounter when required fields are not filled', async () => {
-      const appointment = createAppointmentWithPatient(patient.id);
-      await setup({ appointment });
-
-      await waitFor(() => {
-        expect(screen.getByText('Set Up Encounter')).toBeInTheDocument();
-      });
-
-      // Submit the form without filling either field
-      const form = screen.getByText('Set Up Encounter').closest('div')?.querySelector('form');
-      expect(form).toBeTruthy();
-      await act(async () => {
-        fireEvent.submit(form as HTMLFormElement);
-      });
-
-      // createEncounter must not have been called
-      expect(createEncounter).not.toHaveBeenCalled();
-    });
-
-    test('createEncounter failure shows an error message', async () => {
-      const user = userEvent.setup();
-
-      // Create a PlanDefinition so ResourceInput can find it (searched by `name`)
-      await medplum.createResource({
-        resourceType: 'PlanDefinition',
-        name: 'Test Plan',
-        title: 'Test Plan',
-        status: 'active',
-      });
-
-      const encounterError = new Error('Failed to create encounter');
-      vi.mocked(createEncounter).mockRejectedValue(encounterError);
-
-      const appointment = createAppointmentWithPatient(patient.id);
-      await setup({ appointment });
-
-      await waitFor(() => {
-        expect(screen.getByText('Set Up Encounter')).toBeInTheDocument();
-      });
-
-      // Fill in Encounter Class — MockClient's ValueSet expansion returns 'Test Display'
-      const classInput = screen.getByLabelText(/Encounter Class/i);
-      await user.type(classInput, 'Test');
-      await waitFor(() => {
-        expect(screen.getByText('Test Display')).toBeInTheDocument();
-      });
-      await user.click(screen.getByText('Test Display'));
-
-      // Fill in Care template
-      const templateInput = screen.getByLabelText(/Care template/i);
-      await user.type(templateInput, 'Test Plan');
-      await waitFor(() => {
-        expect(screen.getByText('Test Plan')).toBeInTheDocument();
-      });
-      await user.click(screen.getByText('Test Plan'));
-
-      // Wait for the Apply button to become enabled, then submit
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: 'Apply' })).not.toBeDisabled();
-      });
-      await user.click(screen.getByRole('button', { name: 'Apply' }));
-
-      await waitFor(() => {
-        expect(showErrorNotification).toHaveBeenCalledWith(encounterError);
       });
     });
 

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
@@ -1,19 +1,51 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Button, Divider, Group, Stack, Text, Tooltip } from '@mantine/core';
-import { showNotification } from '@mantine/notifications';
+import { Button, Divider, Group, Loader, Stack, Tooltip } from '@mantine/core';
 import type { WithId } from '@medplum/core';
-import { createReference, EMPTY, formatHumanName, formatPeriod, isReference, isResource } from '@medplum/core';
-import type { Appointment, Bundle, Coding, Patient, PlanDefinition, Practitioner, Slot } from '@medplum/fhirtypes';
-import { CodingInput, Form, MedplumLink, ResourceAvatar, ResourceInput, useMedplum } from '@medplum/react';
-import { useResource } from '@medplum/react-hooks';
-import { IconAlertSquareRounded, IconFileCheck, IconTrash } from '@tabler/icons-react';
+import {
+  createReference,
+  EMPTY,
+  formatDateTime,
+  formatHumanName,
+  getExtension,
+  getReferenceString,
+  isOk,
+  isReference,
+  isResource,
+} from '@medplum/core';
+import type { Appointment, Bundle, CodeableConcept, Patient, Practitioner, Slot } from '@medplum/fhirtypes';
+import {
+  CodeableConceptDisplay,
+  Form,
+  MedplumLink,
+  OperationOutcomeAlert,
+  ResourceAvatar,
+  ResourceInput,
+  useMedplum,
+} from '@medplum/react';
+import { useResource, useSearchOne } from '@medplum/react-hooks';
+import { IconFileCheck, IconNotes, IconTrash } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useCallback, useState } from 'react';
-import { useNavigate } from 'react-router';
-import { createEncounter } from '../../utils/encounter';
+import { Link } from 'react-router';
+import { encounterUrl } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
-import { PlanDefinitionSummary } from '../plandefinition/PlanDefinitionSummary';
+import { ServiceTypeReferenceURI } from '../../utils/servicetype';
+import classes from './AppointmentDetails.module.css';
+import { CreateEncounterForm } from './CreateEncounterForm';
+
+// Medplum `serviceType` values may include an extension linking to a
+// HealthcareService; if present, use that as our display name first.
+// Fall back to normal CodeableConcept display otherwise.
+function ServiceTypeDisplay(props: { value: CodeableConcept }): JSX.Element {
+  const { value } = props;
+
+  const ext = getExtension(value, ServiceTypeReferenceURI);
+  if (ext?.valueReference?.display) {
+    return <>{ext.valueReference.display}</>;
+  }
+  return <CodeableConceptDisplay value={value} />;
+}
 
 type UpdateAppointmentFormProps = {
   appointment: WithId<Appointment>;
@@ -69,20 +101,17 @@ function UpdateAppointmentForm(props: UpdateAppointmentFormProps): JSX.Element {
   );
 }
 
-// This component is used when an appointment does not have a related Encounter
-// that we can direct the viewer to. It allows us to show some details for
-// appointments that are not fully configured and offer UI to complete set up.
-//
-// As one example, this can be used after a patient has scheduled an appointment
-// via $find/$hold to set up an Encounter and apply a plan definition to it.
 export function AppointmentDetails(props: {
   appointment: WithId<Appointment>;
   onAppointmentUpdate: (appointment: WithId<Appointment>) => void;
   onSlotUpdate: (slot: WithId<Slot>) => void;
 }): JSX.Element {
+  const { appointment, onAppointmentUpdate, onSlotUpdate } = props;
   const medplum = useMedplum();
-  const [planDefinition, setPlanDefinition] = useState<PlanDefinition | undefined>();
-  const [encounterClass, setEncounterClass] = useState<Coding | undefined>();
+
+  const [encounter, encounterLoading, encounterOutcome] = useSearchOne('Encounter', {
+    appointment: getReferenceString(appointment),
+  });
 
   // Extract references to a Patient and a Practitioner from `Appointment.participants`; we expect
   // one of each.
@@ -91,55 +120,6 @@ export function AppointmentDetails(props: {
   const practitionerRef = participants.find((r) => isReference<Practitioner>(r, 'Practitioner'));
 
   const patient = useResource(patientRef);
-  const navigate = useNavigate();
-  const { appointment, onAppointmentUpdate, onSlotUpdate } = props;
-
-  const handleSubmit = useCallback(async () => {
-    if (!patient) {
-      showNotification({
-        color: 'yellow',
-        icon: <IconAlertSquareRounded />,
-        title: 'Error',
-        message: 'Patient not loaded',
-      });
-      return;
-    }
-
-    if (!practitionerRef) {
-      showNotification({
-        color: 'yellow',
-        icon: <IconAlertSquareRounded />,
-        title: 'Error',
-        message: 'Appointment has no Practitioner participant',
-      });
-      return;
-    }
-
-    if (!encounterClass || !planDefinition) {
-      showNotification({
-        color: 'yellow',
-        icon: <IconAlertSquareRounded />,
-        title: 'Error',
-        message: 'Please fill out required fields.',
-      });
-      return;
-    }
-
-    try {
-      const encounter = await createEncounter(
-        medplum,
-        encounterClass,
-        patient,
-        planDefinition,
-        props.appointment,
-        practitionerRef
-      );
-
-      navigate(`/Patient/${patient.id}/Encounter/${encounter.id}`)?.catch(console.error);
-    } catch (err) {
-      showErrorNotification(err);
-    }
-  }, [medplum, patient, encounterClass, planDefinition, props.appointment, navigate, practitionerRef]);
 
   const cancellable =
     appointment.status === 'booked' || appointment.status === 'pending' || appointment.status === 'proposed';
@@ -193,61 +173,70 @@ export function AppointmentDetails(props: {
   }, [medplum, appointment, confirmable, onAppointmentUpdate, onSlotUpdate]);
 
   return (
-    <Stack gap="md">
-      <Text size="lg">{formatPeriod({ start: props.appointment.start, end: props.appointment.end })}</Text>
+    <Stack gap="md" className={classes.AppointmentDetails}>
+      <Divider />
+
       {!patientRef && <UpdateAppointmentForm appointment={props.appointment} onUpdate={props.onAppointmentUpdate} />}
 
       {!!patient && (
-        <>
-          <Group align="center" gap="sm">
-            <MedplumLink to={patient}>
-              <ResourceAvatar value={patient} size={48} radius={48} />
-            </MedplumLink>
-            <MedplumLink to={patient} fw={800} size="lg">
-              {formatHumanName(patient.name?.[0])}
-            </MedplumLink>
-          </Group>
-          <div>
-            <h3>Set Up Encounter</h3>
-            <Form onSubmit={handleSubmit}>
-              <Stack gap="md">
-                <ResourceInput<Practitioner>
-                  name="practitioner"
-                  resourceType="Practitioner"
-                  label="Practitioner"
-                  defaultValue={practitionerRef}
-                  disabled={true}
-                  required={true}
-                />
-
-                <CodingInput
-                  name="class"
-                  label="Encounter Class"
-                  binding="http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
-                  required={true}
-                  onChange={setEncounterClass}
-                  path="Encounter.class"
-                />
-
-                <ResourceInput<PlanDefinition>
-                  name="plandefinition"
-                  resourceType="PlanDefinition"
-                  label="Care template"
-                  onChange={setPlanDefinition}
-                  required={true}
-                />
-
-                <PlanDefinitionSummary planDefinition={planDefinition} />
-
-                <Button fullWidth type="submit" disabled={!planDefinition || !encounterClass}>
-                  Apply
-                </Button>
-              </Stack>
-            </Form>
-          </div>
-        </>
+        <Group align="center" gap="sm">
+          <MedplumLink to={patient}>
+            <ResourceAvatar value={patient} size={48} radius={48} />
+          </MedplumLink>
+          <MedplumLink to={patient} fw={800} size="lg">
+            {formatHumanName(patient.name?.[0])}
+          </MedplumLink>
+        </Group>
       )}
-      <Divider my="md" />
+
+      <Divider />
+
+      <dl className={classes.metadata}>
+        <dt>Appointment Start</dt>
+        <dd>{formatDateTime(props.appointment.start)}</dd>
+
+        <dt>Appointment End</dt>
+        <dd>{formatDateTime(props.appointment.end)}</dd>
+
+        {(props.appointment.serviceType ?? EMPTY).length > 0 && (
+          <>
+            <dt>Service Type</dt>
+            {(props.appointment.serviceType ?? EMPTY).map((serviceType, index) => (
+              <dd key={index}>
+                <ServiceTypeDisplay value={serviceType} />
+              </dd>
+            ))}
+          </>
+        )}
+      </dl>
+
+      <Divider />
+
+      {encounterLoading && (
+        <Group justify="center">
+          <Loader size="sm" />
+        </Group>
+      )}
+      {encounterOutcome && !isOk(encounterOutcome) && (
+        <OperationOutcomeAlert outcome={encounterOutcome} title="Loading Encounter failed" />
+      )}
+      {patientRef && !encounter && !encounterLoading && encounterOutcome && isOk(encounterOutcome) && (
+        <CreateEncounterForm appointment={appointment} patientRef={patientRef} practitionerRef={practitionerRef} />
+      )}
+
+      <Divider />
+
+      {encounter && (
+        <Button
+          component={Link}
+          to={encounterUrl(encounter)}
+          leftSection={<IconNotes size={16} />}
+          variant="outline"
+          color="dark"
+        >
+          View Encounter
+        </Button>
+      )}
       {confirmable && (
         <Button
           loading={confirmLoading}

--- a/examples/medplum-provider/src/components/schedule/CreateEncounterForm.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateEncounterForm.test.tsx
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { MantineProvider } from '@mantine/core';
+import { notifications, Notifications } from '@mantine/notifications';
+import type { WithId } from '@medplum/core';
+import type { Appointment, Patient, Practitioner, Reference } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { createEncounter } from '../../utils/encounter';
+import { showErrorNotification } from '../../utils/notifications';
+import { CreateEncounterForm } from './CreateEncounterForm';
+
+vi.mock('../../utils/notifications');
+vi.mock('../../utils/encounter', () => ({
+  createEncounter: vi.fn(),
+  encounterUrl: vi.fn().mockReturnValue('/Patient/patient-1/Encounter/enc-1'),
+}));
+
+describe('CreateEncounterForm', () => {
+  let medplum: MockClient;
+
+  const patientRef: Reference<Patient> = { reference: 'Patient/patient-1' };
+  const practitionerRef: Reference<Practitioner> = { reference: 'Practitioner/practitioner-1' };
+  const appointment: WithId<Appointment> = {
+    resourceType: 'Appointment',
+    id: 'appointment-1',
+    status: 'booked',
+    start: '2024-01-15T10:00:00Z',
+    end: '2024-01-15T10:30:00Z',
+    participant: [
+      { actor: patientRef, status: 'accepted' },
+      { actor: practitionerRef, status: 'accepted' },
+    ],
+  };
+
+  beforeEach(() => {
+    medplum = new MockClient();
+    vi.clearAllMocks();
+  });
+
+  beforeEach(async () => {
+    // Prevent notifications from leaking across test cases
+    notifications.clean();
+  });
+
+  type SetupOptions = {
+    patientRef: Reference<Patient>;
+    practitionerRef: Reference<Practitioner> | undefined;
+  };
+
+  const setup = (options: SetupOptions): ReturnType<typeof render> => {
+    return render(
+      <CreateEncounterForm
+        appointment={appointment}
+        patientRef={options.patientRef}
+        practitionerRef={options.practitionerRef}
+      />,
+      {
+        wrapper: ({ children }) => (
+          <MemoryRouter>
+            <MedplumProvider medplum={medplum}>
+              <MantineProvider>
+                <Notifications />
+                {children}
+              </MantineProvider>
+            </MedplumProvider>
+          </MemoryRouter>
+        ),
+      }
+    );
+  };
+
+  test('renders form with required fields', async () => {
+    setup({ patientRef, practitionerRef });
+
+    expect(screen.getByText('Set Up Encounter')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Encounter Class/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Care template/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
+  });
+
+  test('Apply button is disabled when class and care template are not selected', async () => {
+    setup({ patientRef, practitionerRef });
+
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+  });
+
+  test('shows warning when practitioner is not set', async () => {
+    setup({ patientRef, practitionerRef: undefined });
+
+    const form = screen.getByText('Set Up Encounter').closest('form');
+    expect(form).toBeTruthy();
+    await act(async () => {
+      fireEvent.submit(form as HTMLFormElement);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Appointment has no Practitioner participant')).toBeInTheDocument();
+    });
+    expect(createEncounter).not.toHaveBeenCalled();
+  });
+
+  test('shows warning when required fields are not filled', async () => {
+    setup({ patientRef, practitionerRef });
+
+    const form = screen.getByText('Set Up Encounter').closest('form');
+    expect(form).toBeTruthy();
+    await act(async () => {
+      fireEvent.submit(form as HTMLFormElement);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Please fill out required fields.')).toBeInTheDocument();
+    });
+  });
+
+  test('does not call createEncounter when required fields are not filled', async () => {
+    setup({ patientRef, practitionerRef });
+
+    const form = screen.getByText('Set Up Encounter').closest('form');
+    expect(form).toBeTruthy();
+    await act(async () => {
+      fireEvent.submit(form as HTMLFormElement);
+    });
+
+    expect(createEncounter).not.toHaveBeenCalled();
+  });
+
+  test('shows error notification on createEncounter failure', async () => {
+    const user = userEvent.setup();
+
+    await medplum.createResource({
+      resourceType: 'PlanDefinition',
+      name: 'Test Plan',
+      title: 'Test Plan',
+      status: 'active',
+    });
+
+    const encounterError = new Error('Failed to create encounter');
+    vi.mocked(createEncounter).mockRejectedValue(encounterError);
+
+    setup({ patientRef, practitionerRef });
+
+    // Fill in Encounter Class — MockClient's ValueSet expansion returns 'Test Display'
+    const classInput = screen.getByLabelText(/Encounter Class/i);
+    await user.type(classInput, 'Test');
+    await waitFor(() => {
+      expect(screen.getByText('Test Display')).toBeInTheDocument();
+    });
+    await user.click(screen.getByText('Test Display'));
+
+    // Fill in Care template
+    const templateInput = screen.getByLabelText(/Care template/i);
+    await user.type(templateInput, 'Test Plan');
+    await waitFor(() => {
+      expect(screen.getByText('Test Plan')).toBeInTheDocument();
+    });
+    await user.click(screen.getByText('Test Plan'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Apply' })).not.toBeDisabled();
+    });
+    await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+    await waitFor(() => {
+      expect(showErrorNotification).toHaveBeenCalledWith(encounterError);
+    });
+  });
+});

--- a/examples/medplum-provider/src/components/schedule/CreateEncounterForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateEncounterForm.tsx
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Button, Stack, Title } from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
+import type { WithId } from '@medplum/core';
+import type { Appointment, Coding, Patient, PlanDefinition, Practitioner, Reference } from '@medplum/fhirtypes';
+import { CodingInput, Form, ResourceInput, useMedplum } from '@medplum/react';
+import { IconAlertSquareRounded } from '@tabler/icons-react';
+import type { JSX } from 'react';
+import { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router';
+import { createEncounter, encounterUrl } from '../../utils/encounter';
+import { showErrorNotification } from '../../utils/notifications';
+import { PlanDefinitionSummary } from '../plandefinition/PlanDefinitionSummary';
+
+export interface CreateEncounterFormProps {
+  appointment: WithId<Appointment>;
+  patientRef: Reference<Patient>;
+  practitionerRef: Reference<Practitioner> | undefined;
+}
+
+export function CreateEncounterForm(props: CreateEncounterFormProps): JSX.Element {
+  const { patientRef, practitionerRef } = props;
+  const medplum = useMedplum();
+  const navigate = useNavigate();
+
+  const [planDefinition, setPlanDefinition] = useState<PlanDefinition | undefined>();
+  const [encounterClass, setEncounterClass] = useState<Coding | undefined>();
+
+  const handleSubmit = useCallback(async () => {
+    if (!practitionerRef) {
+      showNotification({
+        color: 'yellow',
+        icon: <IconAlertSquareRounded />,
+        title: 'Error',
+        message: 'Appointment has no Practitioner participant',
+      });
+      return;
+    }
+
+    if (!encounterClass || !planDefinition) {
+      showNotification({
+        color: 'yellow',
+        icon: <IconAlertSquareRounded />,
+        title: 'Error',
+        message: 'Please fill out required fields.',
+      });
+      return;
+    }
+
+    try {
+      const encounter = await createEncounter(
+        medplum,
+        encounterClass,
+        patientRef,
+        planDefinition,
+        props.appointment,
+        practitionerRef
+      );
+
+      navigate(encounterUrl(encounter))?.catch(console.error);
+    } catch (err) {
+      showErrorNotification(err);
+    }
+  }, [medplum, patientRef, encounterClass, planDefinition, props.appointment, navigate, practitionerRef]);
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Stack gap="md">
+        <Title order={4}>Set Up Encounter</Title>
+
+        <ResourceInput<Practitioner>
+          name="practitioner"
+          resourceType="Practitioner"
+          label="Practitioner"
+          defaultValue={practitionerRef}
+          disabled={true}
+          required={true}
+        />
+
+        <CodingInput
+          name="class"
+          label="Encounter Class"
+          binding="http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
+          required={true}
+          onChange={setEncounterClass}
+          path="Encounter.class"
+        />
+
+        <ResourceInput<PlanDefinition>
+          name="plandefinition"
+          resourceType="PlanDefinition"
+          label="Care template"
+          onChange={setPlanDefinition}
+          required={true}
+        />
+
+        <PlanDefinitionSummary planDefinition={planDefinition} />
+
+        <Button fullWidth type="submit" disabled={!planDefinition || !encounterClass}>
+          Apply
+        </Button>
+      </Stack>
+    </Form>
+  );
+}

--- a/examples/medplum-provider/src/pages/encounter/EncounterModal.test.tsx
+++ b/examples/medplum-provider/src/pages/encounter/EncounterModal.test.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
-import type { WithId } from '@medplum/core';
 import type { Encounter, Patient, PlanDefinition } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
@@ -112,13 +111,13 @@ describe('EncounterModal', () => {
 
   test('Form fields can be populated with values', async () => {
     const user = userEvent.setup();
-    const mockEncounter: WithId<Encounter> = {
+    const mockEncounter = {
       resourceType: 'Encounter',
       id: 'encounter-456',
       status: 'in-progress',
       class: { code: 'AMB', display: 'Ambulatory' },
       subject: { reference: 'Patient/patient-123' },
-    };
+    } satisfies Encounter;
 
     vi.mocked(encounterUtils.createEncounter).mockResolvedValue(mockEncounter);
 
@@ -240,13 +239,13 @@ describe('EncounterModal', () => {
   });
 
   test('Navigates to created encounter on success', async () => {
-    const mockEncounter: WithId<Encounter> = {
+    const mockEncounter = {
       resourceType: 'Encounter',
       id: 'new-encounter-789',
       status: 'in-progress',
       class: { code: 'AMB', display: 'Ambulatory' },
       subject: { reference: 'Patient/patient-123' },
-    };
+    } satisfies Encounter;
 
     vi.mocked(encounterUtils.createEncounter).mockResolvedValue(mockEncounter);
 

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
@@ -14,6 +14,7 @@ import { Calendar } from '../../components/Calendar';
 import { AppointmentDetails } from '../../components/schedule/AppointmentDetails';
 import { CreateVisit } from '../../components/schedule/CreateVisit';
 import type { Range } from '../../types/scheduling';
+import { encounterUrl } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
 import { mergeOverlappingSlots } from '../../utils/slots';
 import { FindPane } from './FindPane';
@@ -175,6 +176,24 @@ export function SchedulePage(): JSX.Element | null {
     [appointmentDetailsHandlers]
   );
 
+  const handleDoubleClickAppointment = useCallback(
+    async (appointment: Appointment) => {
+      if (!isResourceWithId(appointment)) {
+        showErrorNotification("Can't navigate to unsaved appointment");
+        return;
+      }
+      try {
+        const encounter = await medplum.searchOne('Encounter', { appointment: getReferenceString(appointment) });
+        if (encounter) {
+          await navigate(encounterUrl(encounter));
+        }
+      } catch (error) {
+        showErrorNotification(error);
+      }
+    },
+    [medplum, navigate]
+  );
+
   const handleAppointmentUpdate = useCallback(
     (updated: WithId<Appointment>) => {
       setAppointments((state) => (state ?? []).map((existing) => (existing.id === updated.id ? updated : existing)));
@@ -242,6 +261,7 @@ export function SchedulePage(): JSX.Element | null {
             appointments={appointments ?? []}
             onRangeChange={setRange}
             className={classes.calendar}
+            onDoubleClickAppointment={handleDoubleClickAppointment}
           />
 
           {schedule && range && (
@@ -253,6 +273,11 @@ export function SchedulePage(): JSX.Element | null {
               className={classes.findPane}
             />
           )}
+        </div>
+        <div>
+          <Text size="sm" color="dimmed" fs="italic">
+            Hint: Double-click on an appointment to jump to the encounter details.
+          </Text>
         </div>
       </Stack>
 

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
@@ -165,17 +165,21 @@ export function SchedulePage(): JSX.Element | null {
     [appointmentDetailsHandlers]
   );
 
-  // When an appointment is selected, navigate to the detail page
   const handleSelectAppointment = useCallback(
-    async (appointment: Appointment) => {
-      if (isResourceWithId(appointment)) {
-        setAppointmentDetails(appointment);
-        appointmentDetailsHandlers.open();
+    (appointment: Appointment) => {
+      if (!isResourceWithId(appointment)) {
+        showErrorNotification("Can't navigate to unsaved appointment");
+        return;
       }
+      setAppointmentDetails(appointment);
+      appointmentDetailsHandlers.open();
     },
     [appointmentDetailsHandlers]
   );
 
+  // On appointment double click, check if there is a related Encounter we can
+  // jump to. If not, we let the `handleSelectAppointment` handler show the
+  // appointment details drawer and don't need to take any action here.
   const handleDoubleClickAppointment = useCallback(
     async (appointment: Appointment) => {
       if (!isResourceWithId(appointment)) {

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
@@ -167,30 +167,12 @@ export function SchedulePage(): JSX.Element | null {
   // When an appointment is selected, navigate to the detail page
   const handleSelectAppointment = useCallback(
     async (appointment: Appointment) => {
-      if (!isResourceWithId(appointment)) {
-        showErrorNotification("Can't navigate to unsaved appointment");
-        return;
-      }
-      const reference = getReferenceString(appointment);
-
-      try {
-        const encounter = await medplum.searchOne('Encounter', [['appointment', reference]]);
-
-        if (!encounter) {
-          setAppointmentDetails(appointment);
-          appointmentDetailsHandlers.open();
-          return;
-        }
-
-        const patient = encounter.subject;
-        if (patient?.reference) {
-          await navigate(`/${patient.reference}/Encounter/${encounter.id}`);
-        }
-      } catch (error) {
-        showErrorNotification(error);
+      if (isResourceWithId(appointment)) {
+        setAppointmentDetails(appointment);
+        appointmentDetailsHandlers.open();
       }
     },
-    [medplum, navigate, appointmentDetailsHandlers]
+    [appointmentDetailsHandlers]
   );
 
   const handleAppointmentUpdate = useCallback(

--- a/examples/medplum-provider/src/utils/encounter.ts
+++ b/examples/medplum-provider/src/utils/encounter.ts
@@ -1,7 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { MedplumClient, WithId } from '@medplum/core';
-import { createReference, getExtension, getReferenceString, HTTP_HL7_ORG, isResource } from '@medplum/core';
+import {
+  createReference,
+  getExtension,
+  getReferenceString,
+  HTTP_HL7_ORG,
+  isReference,
+  isResource,
+} from '@medplum/core';
 import type {
   Appointment,
   ChargeItem,
@@ -22,11 +29,12 @@ export async function createAppointment(
   medplum: MedplumClient,
   start: Date,
   end: Date,
-  patient: Patient,
+  patient: Patient | Reference<Patient>,
   practitioner: Practitioner | Reference<Practitioner>,
   schedule?: Schedule
 ): Promise<Appointment> {
   const practitionerRef = isResource(practitioner) ? createReference(practitioner) : practitioner;
+  const patientRef = isResource(patient) ? createReference(patient) : patient;
 
   // If we have a schedule reference, add a busy slot to prevent future
   // scheduling operations (such as $find or $book) from thinking this
@@ -50,7 +58,7 @@ export async function createAppointment(
     slot: slot ? [createReference(slot)] : undefined,
     participant: [
       {
-        actor: createReference(patient),
+        actor: patientRef,
         status: 'accepted',
       },
       {
@@ -74,7 +82,7 @@ export async function createEncounter(
   const practitionerRef = isResource(practitioner) ? createReference(practitioner) : practitioner;
   const patientRef = isResource(patient) ? createReference(patient) : patient;
 
-  const encounter: WithId<Encounter> = await medplum.createResource({
+  const encounter = await medplum.createResource<Encounter>({
     resourceType: 'Encounter',
     status: 'planned',
     statusHistory: [],
@@ -279,4 +287,15 @@ export async function updateEncounterStatus(
   }
 
   return medplum.updateResource(updatedEncounter);
+}
+
+export function encounterUrl(encounter: WithId<Encounter>): string {
+  // If the encounter subject is a Patient, deep link to the encounter
+  // inside that patient's context
+  if (isReference(encounter.subject, 'Patient')) {
+    return `/${encounter.subject.reference}/Encounter/${encounter.id}`;
+  }
+
+  // Otherwise, link to the ResourcePage to show basic info
+  return `/Encounter/${encounter.id}`;
 }

--- a/examples/medplum-provider/src/utils/encounter.ts
+++ b/examples/medplum-provider/src/utils/encounter.ts
@@ -293,7 +293,7 @@ export function encounterUrl(encounter: WithId<Encounter>): string {
   // If the encounter subject is a Patient, deep link to the encounter
   // inside that patient's context
   if (isReference(encounter.subject, 'Patient')) {
-    return `/${encounter.subject.reference}/Encounter/${encounter.id}`;
+    return `/${encounter.subject.reference}/${getReferenceString(encounter)}`;
   }
 
   // Otherwise, link to the ResourcePage to show basic info


### PR DESCRIPTION
Previously, clicking on an appointment that had an encounter would navigate you directly to the encounter page. This meant that there was not a good way to interact with the appointment resource, such as if you want to cancel the appointment.

Now, selecting an appointment always starts by revealing the appointment in the AppointmentDetails drawer. That pane has a button linking to the encounter detail page when an Encounter resource already exists.

We also do some work on the styling of the AppointmentDetails drawer and the metadata revealed inside.

You may double-click on an appointment that has an associated encounter to jump directly to it.

<img width="1466" height="1069" alt="Screenshot 2026-06-24 at 11 04 47 AM" src="https://github.com/user-attachments/assets/3c4cf2a6-efff-41b8-a5be-58684afdf7aa" />
