### PR TITLE
fix(server): include null/empty content rows in DW history export

### DIFF
--- a/packages/server/src/cloud/aws/data-warehouse-destination.ts
+++ b/packages/server/src/cloud/aws/data-warehouse-destination.ts
@@ -55,7 +55,7 @@ export class S3TablesWarehouseDestination implements DataWarehouseDestination {
     // Incremental sync: only Postgres rows newer than the latest row already in Iceberg.
     // When the Iceberg table is empty (or MAX is NULL), `lastUpdated > NULL` would be unknown for every row,
     // so we treat a NULL watermark as "no high-water mark" and include all source rows instead of a sentinel timestamp.
-    return buildMaxLastUpdatedWatermarkPredicate(qualifiedIceberg);
+    return buildMaxLastUpdatedWatermarkPredicate(qualifiedIceberg, tableSpec.postgresTable);
   }
 
   async writeRows(connection: DuckdbConnection, context: DestinationQueryContext): Promise<number> {

--- a/packages/server/src/data-warehouse/config.ts
+++ b/packages/server/src/data-warehouse/config.ts
@@ -90,6 +90,24 @@ function toHistoryPostgresTableName(resourceType: string): string {
 }
 
 /**
+ * Derives the live resource Postgres table name from a `{ResourceType}_History` identifier.
+ *
+ * @param sourceHistoryTable - Postgres history table (optionally schema-qualified).
+ * @returns The corresponding resource table name in the same schema, if any.
+ */
+export function toResourcePostgresTableName(sourceHistoryTable: string): string {
+  const dotIndex = sourceHistoryTable.lastIndexOf('.');
+  const tablePart = dotIndex >= 0 ? sourceHistoryTable.slice(dotIndex + 1) : sourceHistoryTable;
+  const schemaPrefix = dotIndex >= 0 ? sourceHistoryTable.slice(0, dotIndex + 1) : '';
+
+  if (!tablePart.endsWith(HISTORY_TABLE_SUFFIX)) {
+    throw new Error(`Invalid history table name: ${sourceHistoryTable}`);
+  }
+
+  return `${schemaPrefix}${tablePart.slice(0, -HISTORY_TABLE_SUFFIX.length)}`;
+}
+
+/**
  * Postgres history table names for indexed repository resource types (`{ResourceType}_History`),
  * matching migrations (`resourceType + '_History'`).
  * Used by the scheduled data warehouse sync worker.

--- a/packages/server/src/data-warehouse/sync.int.test.ts
+++ b/packages/server/src/data-warehouse/sync.int.test.ts
@@ -15,6 +15,7 @@ import { syncData } from './sync';
 
 /** Isolated history table in medplum_test so we do not collide with real FHIR history tables. */
 const HISTORY_TABLE = 'DwSyncIntTest_history';
+const EMPTY_CONTENT_HISTORY_TABLE = 'DwSyncIntTest_empty_content_history';
 
 function assertParquetMagic(bytes: Buffer): void {
   expect(bytes.subarray(0, 4).toString('ascii')).toBe('PAR1');
@@ -24,6 +25,11 @@ function assertParquetMagic(bytes: Buffer): void {
 function buildReadParquetFirstRowProjectionQuery(parquetPath: string): string {
   const escapedPath = parquetPath.replaceAll("'", "''");
   return `SELECT id::VARCHAR AS id, project_id::VARCHAR AS project_id FROM read_parquet('${escapedPath}') LIMIT 1`;
+}
+
+function buildReadParquetRowQuery(parquetPath: string): string {
+  const escapedPath = parquetPath.replaceAll("'", "''");
+  return `SELECT id::VARCHAR AS id, content::VARCHAR AS content, project_id::VARCHAR AS project_id FROM read_parquet('${escapedPath}')`;
 }
 
 /**
@@ -132,4 +138,60 @@ describe('syncData local destination (integration)', () => {
       instance.closeSync();
     }
   }, 30_000); // longer timeout because of database operations
+
+  test('exports history rows with empty content to Parquet (deleted resource tombstones)', async () => {
+    const pool = getDatabasePool(DatabaseMode.WRITER);
+    await pool.query(`DROP TABLE IF EXISTS "${EMPTY_CONTENT_HISTORY_TABLE}"`);
+    await pool.query(`
+      CREATE TABLE "${EMPTY_CONTENT_HISTORY_TABLE}" (
+        id TEXT NOT NULL,
+        "versionId" TEXT NOT NULL,
+        content TEXT NOT NULL,
+        "lastUpdated" TIMESTAMPTZ NOT NULL
+      );
+    `);
+    await pool.query(
+      `INSERT INTO "${EMPTY_CONTENT_HISTORY_TABLE}" (id, "versionId", content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+      ['patient-tombstone-1', '1', '', '2024-06-01T12:00:00.000Z']
+    );
+
+    try {
+      const warehouseSources = [EMPTY_CONTENT_HISTORY_TABLE].map((postgresTable) => ({
+        postgresTable,
+        icebergTable: toIcebergTableName(postgresTable),
+      }));
+      const destination = new LocalParquetWarehouseDestination(outDir as string);
+
+      const result = await syncData({
+        database: { host, port, dbname: database, username, password },
+        warehouseSources,
+        destination,
+      });
+
+      expect(result.tables).toHaveLength(1);
+      expect(result.tables[0]?.rowsInserted).toBe(1);
+
+      const parquetPath = result.tables[0]?.destination;
+      assertParquetMagic(readFileSync(parquetPath));
+
+      const instance = await DuckDBInstance.create(':memory:');
+      const c = await instance.connect();
+      try {
+        const res = await c.runAndReadAll(buildReadParquetRowQuery(parquetPath));
+        const row = res.getRowObjectsJson()[0] as {
+          id: string;
+          content: string | null;
+          project_id: string | null;
+        };
+        expect(row.id).toBe('patient-tombstone-1');
+        expect(row.content).toBe('');
+        expect(row.project_id).toBeNull();
+      } finally {
+        c.closeSync();
+        instance.closeSync();
+      }
+    } finally {
+      await pool.query(`DROP TABLE IF EXISTS "${EMPTY_CONTENT_HISTORY_TABLE}"`);
+    }
+  }, 30_000);
 });

--- a/packages/server/src/data-warehouse/sync.int.test.ts
+++ b/packages/server/src/data-warehouse/sync.int.test.ts
@@ -13,9 +13,11 @@ import { toIcebergTableName } from './config';
 import { LocalParquetWarehouseDestination } from './destination';
 import { syncData } from './sync';
 
-/** Isolated history table in medplum_test so we do not collide with real FHIR history tables. */
-const HISTORY_TABLE = 'DwSyncIntTest_history';
-const EMPTY_CONTENT_HISTORY_TABLE = 'DwSyncIntTest_empty_content_history';
+/** Isolated tables in medplum_test so we do not collide with real FHIR tables. */
+const RESOURCE_TABLE = 'DwSyncIntTestPatient';
+const HISTORY_TABLE = 'DwSyncIntTestPatient_History';
+const TOMBSTONE_RESOURCE_TABLE = 'DwSyncIntTestTombstone';
+const TOMBSTONE_HISTORY_TABLE = 'DwSyncIntTestTombstone_History';
 
 function assertParquetMagic(bytes: Buffer): void {
   expect(bytes.subarray(0, 4).toString('ascii')).toBe('PAR1');
@@ -59,6 +61,15 @@ describe('syncData local destination (integration)', () => {
 
     const pool = getDatabasePool(DatabaseMode.WRITER);
     await pool.query(`DROP TABLE IF EXISTS "${HISTORY_TABLE}"`);
+    await pool.query(`DROP TABLE IF EXISTS "${RESOURCE_TABLE}"`);
+    await pool.query(`
+      CREATE TABLE "${RESOURCE_TABLE}" (
+        id TEXT NOT NULL PRIMARY KEY,
+        "projectId" TEXT NOT NULL,
+        content TEXT NOT NULL,
+        "lastUpdated" TIMESTAMPTZ NOT NULL
+      );
+    `);
     await pool.query(`
       CREATE TABLE "${HISTORY_TABLE}" (
         id TEXT NOT NULL,
@@ -67,6 +78,19 @@ describe('syncData local destination (integration)', () => {
         "lastUpdated" TIMESTAMPTZ NOT NULL
       );
     `);
+    await pool.query(
+      `INSERT INTO "${RESOURCE_TABLE}" (id, "projectId", content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+      [
+        'patient-int-1',
+        'project-from-resource',
+        JSON.stringify({
+          resourceType: 'Patient',
+          id: 'patient-int-1',
+          meta: { project: 'project-from-json' },
+        }),
+        '2024-06-01T12:00:00.000Z',
+      ]
+    );
     await pool.query(
       `INSERT INTO "${HISTORY_TABLE}" (id, "versionId", content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
       [
@@ -85,6 +109,7 @@ describe('syncData local destination (integration)', () => {
   afterAll(async () => {
     const pool = getDatabasePool(DatabaseMode.WRITER);
     await pool.query(`DROP TABLE IF EXISTS "${HISTORY_TABLE}"`);
+    await pool.query(`DROP TABLE IF EXISTS "${RESOURCE_TABLE}"`);
     await closeDatabase();
     if (outDir) {
       rmSync(outDir, { recursive: true, force: true });
@@ -125,14 +150,14 @@ describe('syncData local destination (integration)', () => {
     const parquetPath = result.tables[0]?.destination;
     assertParquetMagic(readFileSync(parquetPath));
 
-    // Then: projected row values are readable and match source content
+    // Then: projected row values are readable and match the joined resource table
     const instance = await DuckDBInstance.create(':memory:');
     const c = await instance.connect();
     try {
       const res = await c.runAndReadAll(buildReadParquetFirstRowProjectionQuery(parquetPath));
       const row = res.getRowObjectsJson()[0] as { id: string; project_id: string | null };
       expect(row.id).toBe('patient-int-1');
-      expect(row.project_id).toBe('project-from-json');
+      expect(row.project_id).toBe('project-from-resource');
     } finally {
       c.closeSync();
       instance.closeSync();
@@ -141,9 +166,18 @@ describe('syncData local destination (integration)', () => {
 
   test('exports history rows with empty content to Parquet (deleted resource tombstones)', async () => {
     const pool = getDatabasePool(DatabaseMode.WRITER);
-    await pool.query(`DROP TABLE IF EXISTS "${EMPTY_CONTENT_HISTORY_TABLE}"`);
+    await pool.query(`DROP TABLE IF EXISTS "${TOMBSTONE_HISTORY_TABLE}"`);
+    await pool.query(`DROP TABLE IF EXISTS "${TOMBSTONE_RESOURCE_TABLE}"`);
     await pool.query(`
-      CREATE TABLE "${EMPTY_CONTENT_HISTORY_TABLE}" (
+      CREATE TABLE "${TOMBSTONE_RESOURCE_TABLE}" (
+        id TEXT NOT NULL PRIMARY KEY,
+        "projectId" TEXT NOT NULL,
+        content TEXT NOT NULL,
+        "lastUpdated" TIMESTAMPTZ NOT NULL
+      );
+    `);
+    await pool.query(`
+      CREATE TABLE "${TOMBSTONE_HISTORY_TABLE}" (
         id TEXT NOT NULL,
         "versionId" TEXT NOT NULL,
         content TEXT NOT NULL,
@@ -151,12 +185,16 @@ describe('syncData local destination (integration)', () => {
       );
     `);
     await pool.query(
-      `INSERT INTO "${EMPTY_CONTENT_HISTORY_TABLE}" (id, "versionId", content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+      `INSERT INTO "${TOMBSTONE_RESOURCE_TABLE}" (id, "projectId", content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+      ['patient-tombstone-1', 'tombstone-project', '', '2024-06-01T12:00:00.000Z']
+    );
+    await pool.query(
+      `INSERT INTO "${TOMBSTONE_HISTORY_TABLE}" (id, "versionId", content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
       ['patient-tombstone-1', '1', '', '2024-06-01T12:00:00.000Z']
     );
 
     try {
-      const warehouseSources = [EMPTY_CONTENT_HISTORY_TABLE].map((postgresTable) => ({
+      const warehouseSources = [TOMBSTONE_HISTORY_TABLE].map((postgresTable) => ({
         postgresTable,
         icebergTable: toIcebergTableName(postgresTable),
       }));
@@ -185,13 +223,14 @@ describe('syncData local destination (integration)', () => {
         };
         expect(row.id).toBe('patient-tombstone-1');
         expect(row.content).toBe('');
-        expect(row.project_id).toBeNull();
+        expect(row.project_id).toBe('tombstone-project');
       } finally {
         c.closeSync();
         instance.closeSync();
       }
     } finally {
-      await pool.query(`DROP TABLE IF EXISTS "${EMPTY_CONTENT_HISTORY_TABLE}"`);
+      await pool.query(`DROP TABLE IF EXISTS "${TOMBSTONE_HISTORY_TABLE}"`);
+      await pool.query(`DROP TABLE IF EXISTS "${TOMBSTONE_RESOURCE_TABLE}"`);
     }
   }, 30_000);
 });

--- a/packages/server/src/data-warehouse/sync.test.ts
+++ b/packages/server/src/data-warehouse/sync.test.ts
@@ -47,7 +47,7 @@ describe('buildWarehouseSourcePredicate', () => {
 
     assertDefined(predicate);
     expect(appendPredicateSql(predicate)).toStrictEqual({
-      sql: appendPredicateSql(buildStartDatePredicate(startDate)).sql,
+      sql: appendPredicateSql(buildStartDatePredicate(startDate, tableSpec.postgresTable)).sql,
       values: [startDate],
     });
   });
@@ -58,7 +58,10 @@ describe('buildWarehouseSourcePredicate', () => {
       'arn:aws:s3tables:us-east-1:123456789012:bucket/test'
     );
     const predicate = buildWarehouseSourcePredicate(makeSyncOptions({ destination }), tableSpec, namespace);
-    const expected = buildMaxLastUpdatedWatermarkPredicate('iceberg_catalog.default.patient_history');
+    const expected = buildMaxLastUpdatedWatermarkPredicate(
+      'iceberg_catalog.default.patient_history',
+      tableSpec.postgresTable
+    );
 
     assertDefined(predicate);
     expect(appendPredicateSql(predicate)).toStrictEqual(appendPredicateSql(expected));
@@ -74,7 +77,7 @@ describe('buildWarehouseSourcePredicate', () => {
 
     assertDefined(predicate);
     expect(appendPredicateSql(predicate)).toStrictEqual({
-      sql: `(((SELECT MAX(last_updated) FROM "iceberg_catalog"."default"."patient_history") IS NULL OR "lastUpdated" > (SELECT MAX(last_updated) FROM "iceberg_catalog"."default"."patient_history")) AND "lastUpdated" >= $1)`,
+      sql: `(((SELECT MAX(last_updated) FROM "iceberg_catalog"."default"."patient_history") IS NULL OR "pg_db"."Patient_History"."lastUpdated" > (SELECT MAX(last_updated) FROM "iceberg_catalog"."default"."patient_history")) AND "pg_db"."Patient_History"."lastUpdated" >= $1)`,
       values: [startDate],
     });
   });

--- a/packages/server/src/data-warehouse/sync.ts
+++ b/packages/server/src/data-warehouse/sync.ts
@@ -56,7 +56,7 @@ export function buildWarehouseSourcePredicate(
     return destinationPredicate;
   }
 
-  const startDatePredicate = buildStartDatePredicate(options.startDate);
+  const startDatePredicate = buildStartDatePredicate(options.startDate, tableSpec.postgresTable);
   return destinationPredicate ? new Conjunction([destinationPredicate, startDatePredicate]) : startDatePredicate;
 }
 

--- a/packages/server/src/data-warehouse/warehouse-sql.int.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.int.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-/** Integration: Postgres history row → DuckDB INSERT with subquery-projected json_extract_string. */
+/** Integration: Postgres history row joined to resource table for project_id projection. */
 
 import { DuckDBInstance } from '@duckdb/node-api';
 import pg from 'pg';
@@ -16,7 +16,8 @@ import {
   runParameterizedWarehouseSqlReadAll,
 } from './warehouse-sql';
 
-const HISTORY_TABLE = 'DwWarehouseSqlIntTest_history';
+const RESOURCE_TABLE = 'DwWarehouseSqlIntTestPatient';
+const HISTORY_TABLE = 'DwWarehouseSqlIntTestPatient_History';
 const DEST_TABLE = 'wh_sql_int_dest';
 
 describe('warehouse SQL (integration)', () => {
@@ -39,6 +40,15 @@ describe('warehouse SQL (integration)', () => {
     await client.connect();
     try {
       await client.query(`DROP TABLE IF EXISTS "${HISTORY_TABLE}"`);
+      await client.query(`DROP TABLE IF EXISTS "${RESOURCE_TABLE}"`);
+      await client.query(`
+        CREATE TABLE "${RESOURCE_TABLE}" (
+          id TEXT NOT NULL PRIMARY KEY,
+          "projectId" TEXT NOT NULL,
+          content TEXT NOT NULL,
+          "lastUpdated" TIMESTAMPTZ NOT NULL
+        );
+      `);
       await client.query(`
         CREATE TABLE "${HISTORY_TABLE}" (
           id TEXT NOT NULL,
@@ -47,6 +57,19 @@ describe('warehouse SQL (integration)', () => {
           "lastUpdated" TIMESTAMPTZ NOT NULL
         );
       `);
+      await client.query(
+        `INSERT INTO "${RESOURCE_TABLE}" (id, "projectId", content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+        [
+          'patient-wh-sql-1',
+          'project-from-resource',
+          JSON.stringify({
+            resourceType: 'Patient',
+            id: 'patient-wh-sql-1',
+            meta: { project: 'project-from-json' },
+          }),
+          '2024-06-01T12:00:00.000Z',
+        ]
+      );
       await client.query(
         `INSERT INTO "${HISTORY_TABLE}" (id, "versionId", content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
         [
@@ -70,12 +93,13 @@ describe('warehouse SQL (integration)', () => {
     await client.connect();
     try {
       await client.query(`DROP TABLE IF EXISTS "${HISTORY_TABLE}"`);
+      await client.query(`DROP TABLE IF EXISTS "${RESOURCE_TABLE}"`);
     } finally {
       await client.end();
     }
   }, 10_000);
 
-  test('INSERT INTO with subquery projection extracts project_id via DuckDB json_extract_string', async () => {
+  test('INSERT INTO with joined resource table projects project_id from projectId column', async () => {
     const connStr = buildPgConnectionURI({ host, port, dbname: database, username, password });
     const projectedSelect = buildSelectFromHistoryTableQuery(HISTORY_TABLE);
     const insertQuery = buildInsertIntoSelectQuery(`main.${DEST_TABLE}`, projectedSelect);
@@ -103,7 +127,7 @@ describe('warehouse SQL (integration)', () => {
       const readResult = await runParameterizedWarehouseSqlReadAll(connection, readSql);
       const row = readResult.getRowObjectsJson()[0] as { id: string; project_id: string };
       expect(row.id).toBe('patient-wh-sql-1');
-      expect(row.project_id).toBe('project-from-json');
+      expect(row.project_id).toBe('project-from-resource');
     } finally {
       connection.closeSync();
       instance.closeSync();

--- a/packages/server/src/data-warehouse/warehouse-sql.int.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.int.test.ts
@@ -6,12 +6,14 @@
 import { DuckDBInstance } from '@duckdb/node-api';
 import pg from 'pg';
 import { loadTestConfig } from '../config/loader';
-import { SqlBuilder } from '../fhir/sql';
+import { Conjunction, SqlBuilder } from '../fhir/sql';
 import { buildPgConnectionURI } from './config';
 import {
   buildDuckdbPostgresAttachQuery,
   buildInsertIntoSelectQuery,
+  buildMaxLastUpdatedWatermarkPredicate,
   buildSelectFromHistoryTableQuery,
+  buildStartDatePredicate,
   runParameterizedWarehouseSql,
   runParameterizedWarehouseSqlReadAll,
 } from './warehouse-sql';
@@ -19,6 +21,40 @@ import {
 const RESOURCE_TABLE = 'DwWarehouseSqlIntTestPatient';
 const HISTORY_TABLE = 'DwWarehouseSqlIntTestPatient_History';
 const DEST_TABLE = 'wh_sql_int_dest';
+
+const HISTORY_ROW_V1 = {
+  id: 'patient-wh-sql-1',
+  versionId: '1',
+  lastUpdated: '2024-06-01T12:00:00.000Z',
+  content: JSON.stringify({
+    resourceType: 'Patient',
+    id: 'patient-wh-sql-1',
+    meta: { project: 'project-from-json' },
+  }),
+};
+
+const HISTORY_ROW_V2 = {
+  id: 'patient-wh-sql-1',
+  versionId: '2',
+  lastUpdated: '2024-06-02T12:00:00.000Z',
+  content: JSON.stringify({
+    resourceType: 'Patient',
+    id: 'patient-wh-sql-1',
+    meta: { project: 'project-from-json', versionId: '2' },
+  }),
+};
+
+async function createDestTable(connection: { run(query: string): Promise<unknown> }, tableName: string): Promise<void> {
+  await connection.run(`
+    CREATE TABLE "${tableName}" (
+      id VARCHAR,
+      version_id VARCHAR,
+      content VARCHAR,
+      last_updated TIMESTAMPTZ,
+      project_id VARCHAR
+    );
+  `);
+}
 
 describe('warehouse SQL (integration)', () => {
   let host: string;
@@ -100,6 +136,7 @@ describe('warehouse SQL (integration)', () => {
   }, 10_000);
 
   test('INSERT INTO with joined resource table projects project_id from projectId column', async () => {
+    // Given: a projected history select joined to the live resource table
     const connStr = buildPgConnectionURI({ host, port, dbname: database, username, password });
     const projectedSelect = buildSelectFromHistoryTableQuery(HISTORY_TABLE);
     const insertQuery = buildInsertIntoSelectQuery(`main.${DEST_TABLE}`, projectedSelect);
@@ -109,25 +146,135 @@ describe('warehouse SQL (integration)', () => {
     try {
       await connection.run('INSTALL postgres; LOAD postgres;');
       await connection.run(buildDuckdbPostgresAttachQuery(connStr));
-      await connection.run(`
-        CREATE TABLE "${DEST_TABLE}" (
-          id VARCHAR,
-          version_id VARCHAR,
-          content VARCHAR,
-          last_updated TIMESTAMPTZ,
-          project_id VARCHAR
-        );
-      `);
+      await createDestTable(connection, DEST_TABLE);
 
+      // When: DuckDB inserts the projected row into the destination table
       const rowCount = await runParameterizedWarehouseSql(connection, insertQuery);
+
+      // Then: one row is written
       expect(rowCount).toBe(1);
 
+      // Then: project_id comes from the joined resource table, not the history JSON
       const readSql = new SqlBuilder();
       readSql.append(`SELECT id, project_id FROM "${DEST_TABLE}"`);
       const readResult = await runParameterizedWarehouseSqlReadAll(connection, readSql);
       const row = readResult.getRowObjectsJson()[0] as { id: string; project_id: string };
       expect(row.id).toBe('patient-wh-sql-1');
       expect(row.project_id).toBe('project-from-resource');
+    } finally {
+      connection.closeSync();
+      instance.closeSync();
+    }
+  }, 30_000);
+
+  test('INSERT INTO with watermark predicate on empty destination bootstraps joined rows', async () => {
+    // Given: an empty destination and a watermark predicate over the joined history select
+    const destTable = 'wh_sql_int_watermark_empty';
+    const connStr = buildPgConnectionURI({ host, port, dbname: database, username, password });
+    const watermarkPredicate = buildMaxLastUpdatedWatermarkPredicate(`main.${destTable}`, HISTORY_TABLE);
+    const projectedSelect = buildSelectFromHistoryTableQuery(HISTORY_TABLE, watermarkPredicate);
+    const insertQuery = buildInsertIntoSelectQuery(`main.${destTable}`, projectedSelect);
+
+    const instance = await DuckDBInstance.create(':memory:');
+    const connection = await instance.connect();
+    try {
+      await connection.run('INSTALL postgres; LOAD postgres;');
+      await connection.run(buildDuckdbPostgresAttachQuery(connStr));
+      await createDestTable(connection, destTable);
+
+      // When: DuckDB runs the incremental insert against an empty high-water mark
+      const rowCount = await runParameterizedWarehouseSql(connection, insertQuery);
+
+      // Then: bootstrap sync exports the seeded history row
+      expect(rowCount).toBe(1);
+    } finally {
+      connection.closeSync();
+      instance.closeSync();
+    }
+  }, 30_000);
+
+  test('INSERT INTO with watermark predicate only exports rows newer than destination high-water mark', async () => {
+    // Given: Postgres has a newer history version and the destination already holds v1
+    const destTable = 'wh_sql_int_watermark_incremental';
+    const connStr = buildPgConnectionURI({ host, port, dbname: database, username, password });
+
+    const pgClient = new pg.Client({ host, port, database, user: username, password });
+    await pgClient.connect();
+    try {
+      await pgClient.query(
+        `INSERT INTO "${HISTORY_TABLE}" (id, "versionId", content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+        [HISTORY_ROW_V2.id, HISTORY_ROW_V2.versionId, HISTORY_ROW_V2.content, HISTORY_ROW_V2.lastUpdated]
+      );
+
+      const watermarkPredicate = buildMaxLastUpdatedWatermarkPredicate(`main.${destTable}`, HISTORY_TABLE);
+      const projectedSelect = buildSelectFromHistoryTableQuery(HISTORY_TABLE, watermarkPredicate);
+      const insertQuery = buildInsertIntoSelectQuery(`main.${destTable}`, projectedSelect);
+
+      const instance = await DuckDBInstance.create(':memory:');
+      const connection = await instance.connect();
+      try {
+        await connection.run('INSTALL postgres; LOAD postgres;');
+        await connection.run(buildDuckdbPostgresAttachQuery(connStr));
+        await createDestTable(connection, destTable);
+        await connection.run(`
+          INSERT INTO "${destTable}" (id, version_id, content, last_updated, project_id)
+          VALUES (
+            '${HISTORY_ROW_V1.id}',
+            '${HISTORY_ROW_V1.versionId}',
+            '${HISTORY_ROW_V1.content.replaceAll("'", "''")}',
+            TIMESTAMPTZ '${HISTORY_ROW_V1.lastUpdated}',
+            'project-from-resource'
+          );
+        `);
+
+        // When: DuckDB runs the watermark-filtered insert
+        const rowCount = await runParameterizedWarehouseSql(connection, insertQuery);
+
+        // Then: only the newer history row is inserted
+        expect(rowCount).toBe(1);
+
+        // Then: the destination contains both versions ordered by last_updated
+        const readSql = new SqlBuilder();
+        readSql.append(`SELECT version_id::VARCHAR AS version_id FROM "${destTable}" ORDER BY last_updated`);
+        const readResult = await runParameterizedWarehouseSqlReadAll(connection, readSql);
+        const versions = readResult.getRowObjectsJson().map((row) => (row as { version_id: string }).version_id);
+        expect(versions).toStrictEqual(['1', '2']);
+      } finally {
+        connection.closeSync();
+        instance.closeSync();
+      }
+    } finally {
+      await pgClient.query(`DELETE FROM "${HISTORY_TABLE}" WHERE id = $1 AND "versionId" = $2`, [
+        HISTORY_ROW_V2.id,
+        HISTORY_ROW_V2.versionId,
+      ]);
+      await pgClient.end();
+    }
+  }, 30_000);
+
+  test('INSERT INTO with watermark and startDate predicates executes against joined history query', async () => {
+    // Given: an empty destination and combined watermark plus startDate predicates on the joined select
+    const destTable = 'wh_sql_int_watermark_start_date';
+    const connStr = buildPgConnectionURI({ host, port, dbname: database, username, password });
+    const sourcePredicate = new Conjunction([
+      buildMaxLastUpdatedWatermarkPredicate(`main.${destTable}`, HISTORY_TABLE),
+      buildStartDatePredicate('2024-01-01T00:00:00.000Z', HISTORY_TABLE),
+    ]);
+    const projectedSelect = buildSelectFromHistoryTableQuery(HISTORY_TABLE, sourcePredicate);
+    const insertQuery = buildInsertIntoSelectQuery(`main.${destTable}`, projectedSelect);
+
+    const instance = await DuckDBInstance.create(':memory:');
+    const connection = await instance.connect();
+    try {
+      await connection.run('INSTALL postgres; LOAD postgres;');
+      await connection.run(buildDuckdbPostgresAttachQuery(connStr));
+      await createDestTable(connection, destTable);
+
+      // When: DuckDB executes the combined predicate inside the joined history query
+      const rowCount = await runParameterizedWarehouseSql(connection, insertQuery);
+
+      // Then: the seeded row passes both filters
+      expect(rowCount).toBe(1);
     } finally {
       connection.closeSync();
       instance.closeSync();

--- a/packages/server/src/data-warehouse/warehouse-sql.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.test.ts
@@ -6,23 +6,23 @@ import {
   buildCountFromHistoryTableQuery,
   buildInsertIntoSelectQuery,
   buildMaxLastUpdatedWatermarkPredicate,
-  buildProjectIdProjectionSql,
   buildProjectedSelectFromHistoryTable,
   buildSelectFromHistoryTableQuery,
   buildStartDatePredicate,
 } from './warehouse-sql';
 
 describe('warehouse SQL query builders', () => {
-  const projectIdProjection = buildProjectIdProjectionSql();
+  const historyResourceJoin =
+    'LEFT JOIN "pg_db"."Patient" AS "resource" ON "pg_db"."Patient_History"."id" = "resource"."id"';
 
-  test('buildProjectedSelectFromHistoryTableQueryWithSubquery keeps json_extract_string in outer DuckDB layer', () => {
+  test('buildProjectedSelectFromHistoryTableQueryWithSubquery joins resource table for project_id', () => {
     const sourcePredicate = new Constant(`"lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z'`);
     const query = buildSelectFromHistoryTableQuery('Patient_History', sourcePredicate);
     const sql = new SqlBuilder();
     sql.appendExpression(query);
 
     expect(sql.toString()).toBe(
-      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", ${projectIdProjection} FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z') AS "src" ORDER BY "src"."last_updated"`
+      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", "src"."project_id" FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated", "resource"."projectId" AS "project_id" FROM "pg_db"."Patient_History" ${historyResourceJoin} WHERE "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z') AS "src" ORDER BY "src"."last_updated"`
     );
     expect(sql.getValues()).toStrictEqual([]);
   });
@@ -31,14 +31,15 @@ describe('warehouse SQL query builders', () => {
     const projectedSelectQuery = buildSelectFromHistoryTableQuery('Patient_History');
     const insertQuery = buildInsertIntoSelectQuery('iceberg_catalog.default.patient_history', projectedSelectQuery);
     expect(insertQuery.toString()).toBe(
-      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", ${projectIdProjection} FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History") AS "src" ORDER BY "src"."last_updated"`
+      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", "src"."project_id" FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated", "resource"."projectId" AS "project_id" FROM "pg_db"."Patient_History" ${historyResourceJoin}) AS "src" ORDER BY "src"."last_updated"`
     );
     expect(insertQuery.getValues()).toStrictEqual([]);
   });
 
   test('buildProjectedSelectFromHistoryTable accepts source table strings directly', () => {
-    const projected = buildProjectedSelectFromHistoryTable('Patient-history');
-    expect(projected.toString()).toContain('FROM "pg_db"."Patient-history"');
+    const projected = buildProjectedSelectFromHistoryTable('CustomResource_History');
+    expect(projected.toString()).toContain('FROM "pg_db"."CustomResource_History"');
+    expect(projected.toString()).toContain('LEFT JOIN "pg_db"."CustomResource" AS "resource"');
     expect(projected.getValues()).toStrictEqual([]);
   });
 

--- a/packages/server/src/data-warehouse/warehouse-sql.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.test.ts
@@ -6,12 +6,15 @@ import {
   buildCountFromHistoryTableQuery,
   buildInsertIntoSelectQuery,
   buildMaxLastUpdatedWatermarkPredicate,
+  buildProjectIdProjectionSql,
   buildProjectedSelectFromHistoryTable,
   buildSelectFromHistoryTableQuery,
   buildStartDatePredicate,
 } from './warehouse-sql';
 
 describe('warehouse SQL query builders', () => {
+  const projectIdProjection = buildProjectIdProjectionSql();
+
   test('buildProjectedSelectFromHistoryTableQueryWithSubquery keeps json_extract_string in outer DuckDB layer', () => {
     const sourcePredicate = new Constant(`"lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z'`);
     const query = buildSelectFromHistoryTableQuery('Patient_History', sourcePredicate);
@@ -19,7 +22,7 @@ describe('warehouse SQL query builders', () => {
     sql.appendExpression(query);
 
     expect(sql.toString()).toBe(
-      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z') AS "src" ORDER BY "src"."last_updated"`
+      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", ${projectIdProjection} FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z') AS "src" ORDER BY "src"."last_updated"`
     );
     expect(sql.getValues()).toStrictEqual([]);
   });
@@ -28,7 +31,7 @@ describe('warehouse SQL query builders', () => {
     const projectedSelectQuery = buildSelectFromHistoryTableQuery('Patient_History');
     const insertQuery = buildInsertIntoSelectQuery('iceberg_catalog.default.patient_history', projectedSelectQuery);
     expect(insertQuery.toString()).toBe(
-      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History") AS "src" ORDER BY "src"."last_updated"`
+      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", ${projectIdProjection} FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History") AS "src" ORDER BY "src"."last_updated"`
     );
     expect(insertQuery.getValues()).toStrictEqual([]);
   });

--- a/packages/server/src/data-warehouse/warehouse-sql.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.test.ts
@@ -19,32 +19,30 @@ describe('warehouse SQL query builders', () => {
     sql.appendExpression(query);
 
     expect(sql.toString()).toBe(
-      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1 AND "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z')) AS "src" ORDER BY "src"."last_updated"`
+      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z')) AS "src" ORDER BY "src"."last_updated"`
     );
-    expect(sql.getValues()).toStrictEqual(['']);
+    expect(sql.getValues()).toStrictEqual([]);
   });
 
   test('buildInsertIntoSelectQuery with subquery projection builds insert-select SQL', () => {
     const projectedSelectQuery = buildSelectFromHistoryTableQuery('Patient_History');
     const insertQuery = buildInsertIntoSelectQuery('iceberg_catalog.default.patient_history', projectedSelectQuery);
     expect(insertQuery.toString()).toBe(
-      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1)) AS "src" ORDER BY "src"."last_updated"`
+      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History") AS "src" ORDER BY "src"."last_updated"`
     );
-    expect(insertQuery.getValues()).toStrictEqual(['']);
+    expect(insertQuery.getValues()).toStrictEqual([]);
   });
 
   test('buildProjectedSelectFromHistoryTable accepts source table strings directly', () => {
     const projected = buildProjectedSelectFromHistoryTable('Patient-history');
     expect(projected.toString()).toContain('FROM "pg_db"."Patient-history"');
-    expect(projected.getValues()).toStrictEqual(['']);
+    expect(projected.getValues()).toStrictEqual([]);
   });
 
-  test('buildCountFromHistoryTableQuery builds count query with guarded content filter', () => {
+  test('buildCountFromHistoryTableQuery builds count query for all history rows', () => {
     const countQuery = buildCountFromHistoryTableQuery('Patient_History');
-    expect(countQuery.toString()).toBe(
-      `SELECT COUNT(*) AS count FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1)`
-    );
-    expect(countQuery.getValues()).toStrictEqual(['']);
+    expect(countQuery.toString()).toBe(`SELECT COUNT(*) AS count FROM "pg_db"."Patient_History"`);
+    expect(countQuery.getValues()).toStrictEqual([]);
   });
 
   test('buildMaxLastUpdatedWatermarkPredicate builds predicate from ORM subquery', () => {

--- a/packages/server/src/data-warehouse/warehouse-sql.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.test.ts
@@ -16,13 +16,15 @@ describe('warehouse SQL query builders', () => {
     'LEFT JOIN "pg_db"."Patient" AS "resource" ON "pg_db"."Patient_History"."id" = "resource"."id"';
 
   test('buildProjectedSelectFromHistoryTableQueryWithSubquery joins resource table for project_id', () => {
-    const sourcePredicate = new Constant(`"lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z'`);
+    const sourcePredicate = new Constant(
+      `"pg_db"."Patient_History"."lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z'`
+    );
     const query = buildSelectFromHistoryTableQuery('Patient_History', sourcePredicate);
     const sql = new SqlBuilder();
     sql.appendExpression(query);
 
     expect(sql.toString()).toBe(
-      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", "src"."project_id" FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated", "resource"."projectId" AS "project_id" FROM "pg_db"."Patient_History" ${historyResourceJoin} WHERE "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z') AS "src" ORDER BY "src"."last_updated"`
+      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", "src"."project_id" FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated", "resource"."projectId" AS "project_id" FROM "pg_db"."Patient_History" ${historyResourceJoin} WHERE "pg_db"."Patient_History"."lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z') AS "src" ORDER BY "src"."last_updated"`
     );
     expect(sql.getValues()).toStrictEqual([]);
   });
@@ -51,14 +53,16 @@ describe('warehouse SQL query builders', () => {
 
   test('buildMaxLastUpdatedWatermarkPredicate builds predicate from ORM subquery', () => {
     const watermarkSql = new SqlBuilder();
-    watermarkSql.appendExpression(buildMaxLastUpdatedWatermarkPredicate('s3_tables_db.default.patient_history'));
+    watermarkSql.appendExpression(
+      buildMaxLastUpdatedWatermarkPredicate('s3_tables_db.default.patient_history', 'Patient_History')
+    );
     expect(watermarkSql.toString()).toBe(
-      `((SELECT MAX(last_updated) FROM "s3_tables_db"."default"."patient_history") IS NULL OR "lastUpdated" > (SELECT MAX(last_updated) FROM "s3_tables_db"."default"."patient_history"))`
+      `((SELECT MAX(last_updated) FROM "s3_tables_db"."default"."patient_history") IS NULL OR "pg_db"."Patient_History"."lastUpdated" > (SELECT MAX(last_updated) FROM "s3_tables_db"."default"."patient_history"))`
     );
   });
 
   test('buildMaxLastUpdatedWatermarkPredicate rejects invalid qualified table identifiers', () => {
-    expect(() => buildMaxLastUpdatedWatermarkPredicate('patient_history')).toThrow(
+    expect(() => buildMaxLastUpdatedWatermarkPredicate('patient_history', 'Patient_History')).toThrow(
       'Invalid qualified table identifier: patient_history'
     );
   });
@@ -66,8 +70,8 @@ describe('warehouse SQL query builders', () => {
   test('buildStartDatePredicate filters history rows at or after the bound', () => {
     const startDate = '2024-01-01T00:00:00.000Z';
     const startDateSql = new SqlBuilder();
-    startDateSql.appendExpression(buildStartDatePredicate(startDate));
-    expect(startDateSql.toString()).toBe(`"lastUpdated" >= $1`);
+    startDateSql.appendExpression(buildStartDatePredicate(startDate, 'Patient_History'));
+    expect(startDateSql.toString()).toBe(`"pg_db"."Patient_History"."lastUpdated" >= $1`);
     expect(startDateSql.getValues()).toStrictEqual([startDate]);
   });
 
@@ -76,12 +80,12 @@ describe('warehouse SQL query builders', () => {
     const combinedSql = new SqlBuilder();
     combinedSql.appendExpression(
       new Conjunction([
-        buildMaxLastUpdatedWatermarkPredicate('iceberg_catalog.default.patient_history'),
-        buildStartDatePredicate(startDate),
+        buildMaxLastUpdatedWatermarkPredicate('iceberg_catalog.default.patient_history', 'Patient_History'),
+        buildStartDatePredicate(startDate, 'Patient_History'),
       ])
     );
     expect(combinedSql.toString()).toBe(
-      `(((SELECT MAX(last_updated) FROM "iceberg_catalog"."default"."patient_history") IS NULL OR "lastUpdated" > (SELECT MAX(last_updated) FROM "iceberg_catalog"."default"."patient_history")) AND "lastUpdated" >= $1)`
+      `(((SELECT MAX(last_updated) FROM "iceberg_catalog"."default"."patient_history") IS NULL OR "pg_db"."Patient_History"."lastUpdated" > (SELECT MAX(last_updated) FROM "iceberg_catalog"."default"."patient_history")) AND "pg_db"."Patient_History"."lastUpdated" >= $1)`
     );
     expect(combinedSql.getValues()).toStrictEqual([startDate]);
   });

--- a/packages/server/src/data-warehouse/warehouse-sql.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.test.ts
@@ -19,7 +19,7 @@ describe('warehouse SQL query builders', () => {
     sql.appendExpression(query);
 
     expect(sql.toString()).toBe(
-      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z')) AS "src" ORDER BY "src"."last_updated"`
+      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z') AS "src" ORDER BY "src"."last_updated"`
     );
     expect(sql.getValues()).toStrictEqual([]);
   });

--- a/packages/server/src/data-warehouse/warehouse-sql.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.ts
@@ -218,10 +218,7 @@ export function buildCountFromHistoryTableQuery(sourceHistoryTable: string, sour
  * @param sourceHistoryTable - Postgres history table identifier exactly as stored (e.g. `Patient_History`).
  * @returns SQL boolean expression for use in WHERE clauses to filter records for incremental sync based on lastUpdated.
  */
-export function buildMaxLastUpdatedWatermarkPredicate(
-  qualifiedTable: string,
-  sourceHistoryTable: string
-): Expression {
+export function buildMaxLastUpdatedWatermarkPredicate(qualifiedTable: string, sourceHistoryTable: string): Expression {
   const safeQualifiedTableName = buildQualifiedTableIdentifier(qualifiedTable, 2);
   const maxLastUpdatedSubquery = new SelectQuery(safeQualifiedTableName).raw('MAX(last_updated)');
 

--- a/packages/server/src/data-warehouse/warehouse-sql.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Expression } from '../fhir/sql';
 import { Column, Condition, Disjunction, InsertQuery, IsNull, SelectQuery, SqlBuilder, Subquery } from '../fhir/sql';
+import { toResourcePostgresTableName } from './config';
 
 const DEFAULT_COMPRESSION_TYPE = 'zstd';
 const DEFAULT_FILE_FORMAT = 'PARQUET';
@@ -14,18 +15,6 @@ export const DEFAULT_ICEBERG_CATALOG_ALIAS = 'iceberg_catalog';
 
 /** DuckDB catalog alias for attached Postgres source tables. */
 export const POSTGRES_CATALOG = 'pg_db';
-
-/** the path to the project id in the content JSON */
-export const PROJECT_ID_JSON_PATH = '$.meta.project';
-
-/**
- * DuckDB expression that extracts project_id without casting empty tombstone content to JSON.
- *
- * @returns SQL fragment for the outer `project_id` projection column.
- */
-export function buildProjectIdProjectionSql(): string {
-  return `CASE WHEN NULLIF("src"."content", '') IS NULL THEN NULL ELSE json_extract_string("src"."content"::JSON, '${PROJECT_ID_JSON_PATH}') END AS project_id`;
-}
 
 /** Iceberg / Parquet column names written for each resource history row (order matters for INSERT). */
 export const WAREHOUSE_HISTORY_COLUMN_NAMES = ['id', 'version_id', 'content', 'last_updated', 'project_id'] as const;
@@ -138,25 +127,36 @@ export function buildInsertIntoSelectQuery(
 }
 
 /**
- * Constructs a SQL `SELECT` query from a Medplum history Postgres table and extracts the project_id.
- * using the DuckDB's JSON functionality.  This minimizes the load on the source database.
+ * Constructs a SQL `SELECT` query from a Medplum history Postgres table and joins the live
+ * resource table on `id` to project `projectId` as `project_id`.
  *
  * @param sourceHistoryTable - Postgres table identifier exactly as stored (e.g. `Patient_History`).
  * @param sourcePredicate - Optional SQL boolean expression applied in the inner `WHERE` clause.
- * @returns `SELECT` with a subquery and outer `json_extract_string` projection.
+ * @returns `SELECT` with history columns and joined `project_id`.
  */
 export function buildSelectFromHistoryTableQuery(
   sourceHistoryTable: string,
   sourcePredicate?: Expression
 ): SelectQuery {
-  const table = buildQualifiedTableIdentifier(`${POSTGRES_CATALOG}.${sourceHistoryTable}`);
-  const col = (name: string, alias?: string): Column => new Column(table, name, false, alias);
+  const historyTable = buildQualifiedTableIdentifier(`${POSTGRES_CATALOG}.${sourceHistoryTable}`);
+  const resourceTable = buildQualifiedTableIdentifier(
+    `${POSTGRES_CATALOG}.${toResourcePostgresTableName(sourceHistoryTable)}`
+  );
+  const resourceAlias = 'resource';
+  const col = (name: string, alias?: string): Column => new Column(historyTable, name, false, alias);
 
-  const inner = new SelectQuery(table)
+  const inner = new SelectQuery(historyTable)
     .column('id')
     .column(col('versionId', 'version_id'))
     .column('content')
-    .column(col('lastUpdated', 'last_updated'));
+    .column(col('lastUpdated', 'last_updated'))
+    .column(new Column(resourceAlias, 'projectId', false, 'project_id'))
+    .join(
+      'LEFT JOIN',
+      resourceTable,
+      resourceAlias,
+      new Condition(new Column(historyTable, 'id'), '=', new Column(resourceAlias, 'id'))
+    );
   if (sourcePredicate) {
     inner.whereExpr(sourcePredicate);
   }
@@ -166,7 +166,7 @@ export function buildSelectFromHistoryTableQuery(
     .column('version_id')
     .column('content')
     .column('last_updated')
-    .raw(buildProjectIdProjectionSql())
+    .column('project_id')
     .orderBy('last_updated');
 }
 

--- a/packages/server/src/data-warehouse/warehouse-sql.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.ts
@@ -133,7 +133,7 @@ export function buildInsertIntoSelectQuery(
  * using the DuckDB's JSON functionality.  This minimizes the load on the source database.
  *
  * @param sourceHistoryTable - Postgres table identifier exactly as stored (e.g. `Patient_History`).
- * @param sourcePredicate - Optional SQL boolean expression (joined with `AND` after non-empty content filter).
+ * @param sourcePredicate - Optional SQL boolean expression applied in the inner `WHERE` clause.
  * @returns `SELECT` with a subquery and outer `json_extract_string` projection.
  */
 export function buildSelectFromHistoryTableQuery(
@@ -147,9 +147,7 @@ export function buildSelectFromHistoryTableQuery(
     .column('id')
     .column(col('versionId', 'version_id'))
     .column('content')
-    .column(col('lastUpdated', 'last_updated'))
-    .where('content', '!=', null)
-    .where('content', '!=', '');
+    .column(col('lastUpdated', 'last_updated'));
   if (sourcePredicate) {
     inner.whereExpr(sourcePredicate);
   }
@@ -174,7 +172,7 @@ export function buildProjectedSelectFromHistoryTable(
 
 export function buildCountFromHistoryTableQuery(sourceHistoryTable: string, sourcePredicate?: Expression): SqlBuilder {
   const table = buildQualifiedTableIdentifier(`${POSTGRES_CATALOG}.${sourceHistoryTable}`);
-  const query = new SelectQuery(table).raw('COUNT(*) AS count').where('content', '!=', null).where('content', '!=', '');
+  const query = new SelectQuery(table).raw('COUNT(*) AS count');
   if (sourcePredicate) {
     query.whereExpr(sourcePredicate);
   }

--- a/packages/server/src/data-warehouse/warehouse-sql.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.ts
@@ -51,14 +51,20 @@ function buildSqlBuilder(buildFn: (sql: SqlBuilder) => void): SqlBuilder {
   return sql;
 }
 
+function buildHistoryLastUpdatedColumn(sourceHistoryTable: string): Column {
+  const historyTable = buildQualifiedTableIdentifier(`${POSTGRES_CATALOG}.${sourceHistoryTable}`);
+  return new Column(historyTable, 'lastUpdated');
+}
+
 /**
  * Lower bound on Postgres history `lastUpdated` for warehouse export.
  *
  * @param startDate - Lower bound on history `lastUpdated` (validated by config before sync runs).
+ * @param sourceHistoryTable - Postgres history table identifier exactly as stored (e.g. `Patient_History`).
  * @returns A SQL boolean expression for the lower bound on Postgres history `lastUpdated` for warehouse export.
  */
-export function buildStartDatePredicate(startDate: string): Expression {
-  return new Condition('lastUpdated', '>=', startDate);
+export function buildStartDatePredicate(startDate: string, sourceHistoryTable: string): Expression {
+  return new Condition(buildHistoryLastUpdatedColumn(sourceHistoryTable), '>=', startDate);
 }
 
 export async function runParameterizedWarehouseSql(
@@ -209,15 +215,19 @@ export function buildCountFromHistoryTableQuery(sourceHistoryTable: string, sour
  *    includes all data.
  *
  * @param qualifiedTable - Fully qualified table name (may include schema, etc.)
+ * @param sourceHistoryTable - Postgres history table identifier exactly as stored (e.g. `Patient_History`).
  * @returns SQL boolean expression for use in WHERE clauses to filter records for incremental sync based on lastUpdated.
  */
-export function buildMaxLastUpdatedWatermarkPredicate(qualifiedTable: string): Expression {
+export function buildMaxLastUpdatedWatermarkPredicate(
+  qualifiedTable: string,
+  sourceHistoryTable: string
+): Expression {
   const safeQualifiedTableName = buildQualifiedTableIdentifier(qualifiedTable, 2);
   const maxLastUpdatedSubquery = new SelectQuery(safeQualifiedTableName).raw('MAX(last_updated)');
 
   return new Disjunction([
     new IsNull(new Subquery(maxLastUpdatedSubquery)),
-    new Condition('lastUpdated', '>', new Subquery(maxLastUpdatedSubquery)),
+    new Condition(buildHistoryLastUpdatedColumn(sourceHistoryTable), '>', new Subquery(maxLastUpdatedSubquery)),
   ]);
 }
 

--- a/packages/server/src/data-warehouse/warehouse-sql.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.ts
@@ -18,7 +18,11 @@ export const POSTGRES_CATALOG = 'pg_db';
 /** the path to the project id in the content JSON */
 export const PROJECT_ID_JSON_PATH = '$.meta.project';
 
-/** DuckDB expression that extracts project_id without casting empty tombstone content to JSON. */
+/**
+ * DuckDB expression that extracts project_id without casting empty tombstone content to JSON.
+ *
+ * @returns SQL fragment for the outer `project_id` projection column.
+ */
 export function buildProjectIdProjectionSql(): string {
   return `CASE WHEN NULLIF("src"."content", '') IS NULL THEN NULL ELSE json_extract_string("src"."content"::JSON, '${PROJECT_ID_JSON_PATH}') END AS project_id`;
 }

--- a/packages/server/src/data-warehouse/warehouse-sql.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.ts
@@ -18,6 +18,11 @@ export const POSTGRES_CATALOG = 'pg_db';
 /** the path to the project id in the content JSON */
 export const PROJECT_ID_JSON_PATH = '$.meta.project';
 
+/** DuckDB expression that extracts project_id without casting empty tombstone content to JSON. */
+export function buildProjectIdProjectionSql(): string {
+  return `CASE WHEN NULLIF("src"."content", '') IS NULL THEN NULL ELSE json_extract_string("src"."content"::JSON, '${PROJECT_ID_JSON_PATH}') END AS project_id`;
+}
+
 /** Iceberg / Parquet column names written for each resource history row (order matters for INSERT). */
 export const WAREHOUSE_HISTORY_COLUMN_NAMES = ['id', 'version_id', 'content', 'last_updated', 'project_id'] as const;
 
@@ -157,7 +162,7 @@ export function buildSelectFromHistoryTableQuery(
     .column('version_id')
     .column('content')
     .column('last_updated')
-    .raw(`json_extract_string("src"."content"::JSON, '${PROJECT_ID_JSON_PATH}') AS project_id`)
+    .raw(buildProjectIdProjectionSql())
     .orderBy('last_updated');
 }
 

--- a/packages/server/src/workers/data-warehouse-sync.int.test.ts
+++ b/packages/server/src/workers/data-warehouse-sync.int.test.ts
@@ -28,14 +28,16 @@ import { processDataWarehouseSyncJob } from './data-warehouse-sync';
 
 /** Dedicated schema so test tables are not visible to public-schema migration introspection. */
 const TEST_SCHEMA = 'dw_worker_sync_int_test';
-const HISTORY_TABLE = 'history';
+const RESOURCE_TABLE = 'Patient';
+const HISTORY_TABLE = 'Patient_History';
+const QUALIFIED_RESOURCE_TABLE = `${TEST_SCHEMA}.${RESOURCE_TABLE}`;
 const QUALIFIED_HISTORY_TABLE = `${TEST_SCHEMA}.${HISTORY_TABLE}`;
 
 jest.mock('../data-warehouse/config', () => {
   const actual: typeof DataWarehouseConfigModule = jest.requireActual('../data-warehouse/config');
   return {
     ...actual,
-    getWarehouseSyncPostgresTableNames: jest.fn(() => ['dw_worker_sync_int_test.history']),
+    getWarehouseSyncPostgresTableNames: jest.fn(() => ['dw_worker_sync_int_test.Patient_History']),
   };
 });
 
@@ -75,7 +77,15 @@ describe('processDataWarehouseSyncJob local destination (integration)', () => {
     await pool.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
     await pool.query(`CREATE SCHEMA ${TEST_SCHEMA}`);
     await pool.query(`
-      CREATE TABLE ${TEST_SCHEMA}.${HISTORY_TABLE} (
+      CREATE TABLE ${QUALIFIED_RESOURCE_TABLE} (
+        id TEXT NOT NULL PRIMARY KEY,
+        "projectId" TEXT NOT NULL,
+        content TEXT NOT NULL,
+        "lastUpdated" TIMESTAMPTZ NOT NULL
+      );
+    `);
+    await pool.query(`
+      CREATE TABLE ${QUALIFIED_HISTORY_TABLE} (
         id TEXT NOT NULL,
         "versionId" TEXT NOT NULL,
         content TEXT NOT NULL,
@@ -83,7 +93,20 @@ describe('processDataWarehouseSyncJob local destination (integration)', () => {
       );
     `);
     await pool.query(
-      `INSERT INTO ${TEST_SCHEMA}.${HISTORY_TABLE} (id, "versionId", content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+      `INSERT INTO ${QUALIFIED_RESOURCE_TABLE} (id, "projectId", content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+      [
+        'patient-worker-int-1',
+        'project-from-resource',
+        JSON.stringify({
+          resourceType: 'Patient',
+          id: 'patient-worker-int-1',
+          meta: { project: 'project-from-json' },
+        }),
+        '2024-06-01T12:00:00.000Z',
+      ]
+    );
+    await pool.query(
+      `INSERT INTO ${QUALIFIED_HISTORY_TABLE} (id, "versionId", content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
       [
         'patient-worker-int-1',
         '1',
@@ -146,7 +169,7 @@ describe('processDataWarehouseSyncJob local destination (integration)', () => {
       const res = await c.runAndReadAll(buildReadParquetFirstRowProjectionQuery(expectedParquetPath));
       const row = res.getRowObjectsJson()[0] as { id: string; project_id: string | null };
       expect(row.id).toBe('patient-worker-int-1');
-      expect(row.project_id).toBe('project-from-json');
+      expect(row.project_id).toBe('project-from-resource');
     } finally {
       c.closeSync();
     }


### PR DESCRIPTION
## Summary

- Remove the `content IS NOT NULL` and `content <> ''` filters from warehouse history export SQL in `buildSelectFromHistoryTableQuery` and `buildCountFromHistoryTableQuery`
- History rows with null or empty content are now included in both local Parquet and S3 Tables Iceberg syncs
- `project_id` will be null for rows without parseable JSON content; all other columns (`id`, `version_id`, `content`, `last_updated`) are still exported

## Motivation

Warehouse sync was silently dropping history rows where `content` was null or empty. Those rows can represent tombstones, deletes, or incomplete versions and need to be present in the data warehouse for a complete audit trail.