### PR TITLE
Tweak in RepositoryConnection.mode handling

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -15,6 +15,7 @@ import {
   parseSearchRequest,
   preconditionFailed,
 } from '@medplum/core';
+import { RepositoryMode } from '@medplum/fhir-router';
 import type {
   Binary,
   BundleEntry,
@@ -37,7 +38,7 @@ import { initAppServices, shutdownApp } from '../app';
 import { getConfig, loadTestConfig } from '../config/loader';
 import { r4ProjectId, systemResourceProjectId } from '../constants';
 import { runInAuthenticatedContext } from '../context';
-import { DatabaseMode } from '../database';
+import { DatabaseMode, getDatabasePool } from '../database';
 import { getLogger } from '../logger';
 import { bundleContains, createTestProject, spyOnQuery, withTestContext } from '../test.setup';
 import { AuditEventOutcome, createAuditEvent, ReadInteraction, RestfulOperationType } from '../util/auditevent';
@@ -68,6 +69,7 @@ describe('FHIR Repo', () => {
     testProjectRepo = new Repository({
       projects: [testProject],
       extendedMode: true,
+      strictMode: true,
       author: {
         reference: 'Practitioner/' + randomUUID(),
       },
@@ -91,6 +93,103 @@ describe('FHIR Repo', () => {
         userConfig: {} as UserConfiguration,
       })
     ).rejects.toThrow('Invalid reference');
+  });
+
+  describe('setMode routes reads to reader until writer promotion', () => {
+    type PoolQuerySpy = jest.SpiedFunction<ReturnType<typeof getDatabasePool>['query']>;
+    let readerPoolQuerySpy: PoolQuerySpy;
+    let writerPoolQuerySpy: PoolQuerySpy;
+
+    function resetSpies(): void {
+      readerPoolQuerySpy.mockClear();
+      writerPoolQuerySpy.mockClear();
+    }
+
+    beforeAll(() => {
+      readerPoolQuerySpy = jest.spyOn(getDatabasePool(DatabaseMode.READER), 'query');
+      writerPoolQuerySpy = jest.spyOn(getDatabasePool(DatabaseMode.WRITER), 'query');
+    });
+
+    beforeEach(() => {
+      resetSpies();
+    });
+
+    afterAll(() => {
+      readerPoolQuerySpy.mockRestore();
+      writerPoolQuerySpy.mockRestore();
+    });
+
+    test('on creates', () =>
+      withTestContext(async () => {
+        const repo = testProjectRepo.clone();
+
+        repo.setMode(RepositoryMode.READER);
+        await expect(repo.readResource('Patient', randomUUID())).rejects.toThrow('Not found');
+        expect(readerPoolQuerySpy).toHaveBeenCalledTimes(1);
+        expect(writerPoolQuerySpy).toHaveBeenCalledTimes(0);
+        expect(repo.mode).toBe(RepositoryMode.READER);
+        resetSpies();
+
+        await repo.createResource<Patient>({ resourceType: 'Patient' });
+        expect(readerPoolQuerySpy).toHaveBeenCalledTimes(0);
+        expect(writerPoolQuerySpy).toHaveBeenCalledTimes(0);
+        expect(repo.mode).toBe(RepositoryMode.WRITER);
+        resetSpies();
+
+        await expect(repo.readResource('Patient', randomUUID())).rejects.toThrow('Not found'); // randomUUID to ensure cache miss
+        expect(readerPoolQuerySpy).toHaveBeenCalledTimes(0);
+        expect(writerPoolQuerySpy).toHaveBeenCalledTimes(1);
+        expect(repo.mode).toBe(RepositoryMode.WRITER);
+        resetSpies();
+
+        repo.setMode(RepositoryMode.READER);
+        await expect(repo.readResource('Patient', randomUUID())).rejects.toThrow('Not found');
+        expect(readerPoolQuerySpy).toHaveBeenCalledTimes(1);
+        expect(writerPoolQuerySpy).toHaveBeenCalledTimes(0);
+        expect(repo.mode).toBe(RepositoryMode.READER);
+      }));
+
+    test('on updates', () =>
+      withTestContext(async () => {
+        // AuditEvent since it does not get cached on writes
+        const auditEvent = await testProjectRepo
+          .clone()
+          .createResource(
+            createAuditEvent(
+              RestfulOperationType,
+              ReadInteraction,
+              randomUUID(),
+              { reference: 'Practitioner/user-123' },
+              undefined,
+              AuditEventOutcome.Success
+            )
+          );
+
+        const repo = testProjectRepo.clone();
+
+        repo.setMode(RepositoryMode.READER);
+        await expect(repo.readResource('AuditEvent', randomUUID())).rejects.toThrow('Not found');
+        expect(readerPoolQuerySpy).toHaveBeenCalledTimes(1);
+        expect(writerPoolQuerySpy).toHaveBeenCalledTimes(0);
+        resetSpies();
+
+        await repo.updateResource({ ...auditEvent, outcomeDesc: 'updated' });
+        expect(readerPoolQuerySpy).toHaveBeenCalledTimes(1); // called to fetch existing resource; arguably incorrect and should be directed to writer
+        expect(writerPoolQuerySpy).toHaveBeenCalledTimes(0);
+        expect(repo.mode).toBe(RepositoryMode.WRITER);
+        resetSpies();
+
+        await expect(repo.readResource('AuditEvent', randomUUID())).rejects.toThrow('Not found');
+        expect(readerPoolQuerySpy).toHaveBeenCalledTimes(0);
+        expect(writerPoolQuerySpy).toHaveBeenCalledTimes(1);
+        expect(repo.mode).toBe(RepositoryMode.WRITER);
+        resetSpies();
+
+        await repo.updateResource({ ...auditEvent, outcomeDesc: 'something new' });
+        expect(readerPoolQuerySpy).toHaveBeenCalledTimes(0);
+        expect(writerPoolQuerySpy).toHaveBeenCalledTimes(1); // called to fetch existing resource
+        expect(repo.mode).toBe(RepositoryMode.WRITER);
+      }));
   });
 
   test('Read resource with undefined id', async () => {

--- a/packages/server/src/fhir/repository/repository-connection.ts
+++ b/packages/server/src/fhir/repository/repository-connection.ts
@@ -85,12 +85,17 @@ function validateScope(scope: unknown): Scope {
  */
 export class RepositoryConnection implements Disposable {
   private conn?: PoolClient;
+  /** Physical mode of the currently held PoolClient, if one is pinned. */
   private connMode?: DatabaseMode;
   private ownsClient = true;
   private transactionIsolationLevel?: TransactionIsolationLevel;
   private pinDepth = 0;
   private discardOnRelease = false;
   private closed = false;
+  /**
+   * Preferred mode for future pool-backed operations. Reader mode is opportunistic:
+   * once this connection performs writer work, future unpinned reads should use the writer pool.
+   */
   mode: RepositoryMode;
   private transactionIdleTracker?: TransactionIdleTracker;
 
@@ -228,10 +233,7 @@ export class RepositoryConnection implements Disposable {
       return this.conn;
     }
     this.assertCanAcquireConnection();
-    if (mode === DatabaseMode.WRITER) {
-      // If we ever use a writer, then all subsequent operations must use a writer.
-      this.mode = RepositoryMode.WRITER;
-    }
+    this.promoteRepositoryMode(mode);
     return getDatabasePool(this.mode === RepositoryMode.WRITER ? DatabaseMode.WRITER : mode);
   }
 
@@ -249,6 +251,7 @@ export class RepositoryConnection implements Disposable {
     }
 
     this.assertCanAcquireConnection();
+    this.promoteRepositoryMode(mode);
     this.conn = await getDatabasePool(mode).connect();
     this.connMode = mode;
     return this.conn;
@@ -746,6 +749,19 @@ export class RepositoryConnection implements Disposable {
     }
     if (this.connMode === DatabaseMode.READER && mode === DatabaseMode.WRITER) {
       throw new Error('Cannot use reader database connection for writer operation');
+    }
+  }
+
+  /**
+   * Promotes mode if applicable to adhere to the description
+   * from {@link FhirRepository.mode}: after using "writer" once it should
+   * use "writer" exclusively.
+   * @param mode - The database mode to promote.
+   */
+  private promoteRepositoryMode(mode: DatabaseMode): void {
+    if (mode === DatabaseMode.WRITER) {
+      // If we ever use a writer, then all subsequent operations must use a writer.
+      this.mode = RepositoryMode.WRITER;
     }
   }
 

--- a/packages/server/src/fhir/repository/transaction.test.ts
+++ b/packages/server/src/fhir/repository/transaction.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
 import { conflict, notFound, OperationOutcomeError, Operator, parseSearchRequest } from '@medplum/core';
+import { RepositoryMode } from '@medplum/fhir-router';
 import type { Patient } from '@medplum/fhirtypes';
 import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
@@ -914,6 +915,22 @@ describe('FHIR Repo Transactions', () => {
       errorSpy.mockRestore();
     }
   });
+
+  test('withTransaction promotes reader mode to writer mode', () =>
+    withTestContext(async () => {
+      const readerRepo = repo.clone();
+      readerRepo.setMode(RepositoryMode.READER);
+      expect(readerRepo.mode).toBe(RepositoryMode.READER);
+
+      await readerRepo.withTransaction(async (txRepo) => {
+        // eslint-disable-next-line medplum/no-transaction-callback-invoking-repo -- Verifies mode promotion on the shared connection.
+        expect(readerRepo.mode).toBe(RepositoryMode.WRITER);
+        expect(txRepo.mode).toBe(RepositoryMode.WRITER);
+        await txRepo.createResource<Patient>({ resourceType: 'Patient' });
+      });
+
+      expect(readerRepo.mode).toBe(RepositoryMode.WRITER);
+    }));
 
   test('borrowed repository connections do not reacquire clients after forced release', async () => {
     const rollbackError = new Error('rollback failed');


### PR DESCRIPTION
Note this exposes what I would arguably consider is a bug; the read before write when updating a resource can be directed to the reader depending on mode. It should probably always go to writer. I did NOT add that change since I wanted to get buy-in on the change. The cleanest way would be to call `this.setMode(RepositoryMode.WRITER);` at the top of `updateResourceImpl`.