### PR TITLE
Fast fail batches with invalid `fullUrl` uuids

### DIFF
--- a/examples/medplum-demo-bots/src/billing-bots/superbill-test-data.ts
+++ b/examples/medplum-demo-bots/src/billing-bots/superbill-test-data.ts
@@ -48,7 +48,7 @@ export const testData: Bundle = {
       },
     },
     {
-      fullUrl: '29b59d2d-a47c-4b8f-a0d7-7d87bd7195d7',
+      fullUrl: 'urn:uuid:29b59d2d-a47c-4b8f-a0d7-7d87bd7195d7',
       request: { method: 'POST', url: 'Coverage' },
       resource: {
         resourceType: 'Coverage',

--- a/packages/fhir-router/src/batch.test.ts
+++ b/packages/fhir-router/src/batch.test.ts
@@ -10,6 +10,7 @@ import {
   indexStructureDefinitionBundle,
   isOk,
   LOINC,
+  parseSearchRequest,
 } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import type {
@@ -259,6 +260,98 @@ describe('Batch', () => {
     const results = bundle.entry as BundleEntry[];
     expect(results.length).toStrictEqual(1);
     expect(results[0].response?.status).toStrictEqual('201');
+  });
+
+  test('Process batch rejects invalid urn:uuid fullUrl and does not create dependent entry', async () => {
+    const markerIdentifier = randomUUID();
+    try {
+      await processBatch(req, repo, router, {
+        resourceType: 'Bundle',
+        type: 'batch',
+        entry: [
+          {
+            fullUrl: 'urn:uuid:not-a-valid-uuid',
+            request: { method: 'POST', url: 'Patient' },
+            resource: { resourceType: 'Patient' },
+          },
+          {
+            // References the bad fullUrl — would instantiate with a broken pointer if created
+            request: { method: 'POST', url: 'Observation' },
+            resource: {
+              resourceType: 'Observation',
+              status: 'final',
+              code: { text: 'test' },
+              subject: { reference: 'urn:uuid:not-a-valid-uuid' },
+              identifier: [{ system: 'urn:test', value: markerIdentifier }],
+            },
+          },
+          {
+            // Entirely unrelated — demonstrates the whole batch is aborted, not just affected entries
+            request: { method: 'POST', url: 'Practitioner' },
+            resource: {
+              resourceType: 'Practitioner',
+              identifier: [{ system: 'urn:test', value: markerIdentifier }],
+            },
+          },
+        ],
+      });
+      expect.fail('Expected error');
+    } catch (err) {
+      const outcome = (err as OperationOutcomeError).outcome;
+      expect(isOk(outcome)).toBe(false);
+      expect(outcome.issue?.[0]?.details?.text).toContain('Invalid fullUrl');
+    }
+
+    // Verify neither the dependent Observation nor the unrelated Practitioner was created
+    const observations = await repo.searchResources(
+      parseSearchRequest('Observation?identifier=urn:test|' + markerIdentifier)
+    );
+    expect(observations).toHaveLength(0);
+
+    const practitioners = await repo.searchResources(
+      parseSearchRequest('Practitioner?identifier=urn:test|' + markerIdentifier)
+    );
+    expect(practitioners).toHaveLength(0);
+  });
+
+  test('Process transaction rejects invalid urn:uuid fullUrl and does not create dependent entry', async () => {
+    const markerIdentifier = randomUUID();
+    try {
+      await processBatch(req, repo, router, {
+        resourceType: 'Bundle',
+        type: 'transaction',
+        entry: [
+          {
+            fullUrl: 'urn:uuid:not-a-valid-uuid',
+            request: { method: 'POST', url: 'Patient' },
+            resource: { resourceType: 'Patient' },
+          },
+          {
+            // References the bad fullUrl — would instantiate with a broken pointer if created
+            request: { method: 'POST', url: 'Observation' },
+            resource: {
+              resourceType: 'Observation',
+              status: 'final',
+              code: { text: 'test' },
+              subject: { reference: 'urn:uuid:not-a-valid-uuid' },
+              identifier: [{ system: 'urn:test', value: markerIdentifier }],
+            },
+          },
+        ],
+      });
+      expect.fail('Expected error');
+    } catch (err) {
+      const outcome = (err as OperationOutcomeError).outcome;
+      expect(isOk(outcome)).toBe(false);
+      expect(outcome.issue?.[0]?.details?.text).toContain('Invalid fullUrl');
+    }
+
+    // Transaction atomicity guarantees the Observation was never committed —
+    // verify it cannot be found even though it appeared after the invalid entry.
+    const created = await repo.searchResources(
+      parseSearchRequest('Observation?identifier=urn:test|' + markerIdentifier)
+    );
+    expect(created).toHaveLength(0);
   });
 
   test('Process batch create does not rewrite identifier', async () => {

--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -175,6 +175,16 @@ class BatchProcessor {
         );
         continue;
       }
+
+      // An invalid fullUrl is a structural error that makes the bundle's reference
+      // graph undefined — fail the entire bundle so we don't persist invalid pointers
+      const fullUrl = entry.fullUrl;
+      if (fullUrl && /^urn(?::|%3A)uuid/i.test(fullUrl) && !localBundleReference.test(fullUrl)) {
+        throw new OperationOutcomeError(
+          badRequest('Invalid fullUrl: must be a valid UUID URN', `Bundle.entry[${i}].fullUrl`)
+        );
+      }
+
       const outcome = await this.preprocessEntry(entry, i, seenIdentities);
       if (outcome) {
         if (!this.isTransaction()) {

--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -29,6 +29,7 @@ const maxUpdates = 50;
 const maxSerializableTransactionEntries = 8;
 
 const localBundleReference = /urn(:|%3A)uuid(:|%3A)[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+const exactLocalBundleReference = new RegExp(`^${localBundleReference.source}$`, localBundleReference.flags);
 
 type BundleEntryIdentity = { placeholder: string; reference: string };
 
@@ -179,7 +180,10 @@ class BatchProcessor {
       // An invalid fullUrl is a structural error that makes the bundle's reference
       // graph undefined — fail the entire bundle so we don't persist invalid pointers
       const fullUrl = entry.fullUrl;
-      if (fullUrl && /^urn(?::|%3A)uuid/i.test(fullUrl) && !localBundleReference.test(fullUrl)) {
+      if (fullUrl?.startsWith('http')) {
+        // We don't validate "http" and "https" URLs, as we assume that they are not used as
+        // reference replacements inside the batch/transaction.
+      } else if (fullUrl && !exactLocalBundleReference.test(fullUrl)) {
         throw new OperationOutcomeError(
           badRequest('Invalid fullUrl: must be a valid UUID URN', `Bundle.entry[${i}].fullUrl`)
         );


### PR DESCRIPTION
It's tempting to try to use named entries here, but if you use something other than a valid UUID and try to reference back to it from inside other documents, we can end up persisting invalid pointers.

Instead, let's spot these early and fail the entire batch or transaction bundle.

As one example, in commit https://github.com/medplum/medplum/pull/9540/changes/238e13ea2394fdf8233f2c747b9e7b3c07f6e2c6 I rewrite some docs to use real UUIDs, because when I tried to run the sample bundle it created bad data in my project.