### PR TITLE
fix(react): display un-profiled extensions in resource views (#6999)

### DIFF
--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.test.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.test.tsx
@@ -101,4 +101,40 @@ describe('BackboneElementDisplay', () => {
     });
     expect(screen.getByText('Foo not implemented')).toBeInTheDocument();
   });
+
+  test('Displays un-sliced extensions as labeled rows', async () => {
+    await setup({
+      path: 'Patient',
+      value: {
+        type: 'Patient',
+        value: {
+          resourceType: 'Patient',
+          extension: [{ url: 'http://example.com/eye-color', valueString: 'blue' }],
+        },
+      },
+    });
+    expect(await screen.findByText('Eye Color')).toBeInTheDocument();
+    expect(screen.getByText('blue')).toBeInTheDocument();
+  });
+
+  test('Hides ignored extension URLs', async () => {
+    await setup({
+      path: 'Patient',
+      value: {
+        type: 'Patient',
+        value: {
+          resourceType: 'Patient',
+          extension: [
+            { url: 'http://example.com/eye-color', valueString: 'blue' },
+            {
+              url: 'http://synthetichealth.github.io/synthea/disability-adjusted-life-years',
+              valueDecimal: 1.23,
+            },
+          ],
+        },
+      },
+    });
+    expect(await screen.findByText('Eye Color')).toBeInTheDocument();
+    expect(screen.queryByText('1.23')).not.toBeInTheDocument();
+  });
 });

--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
@@ -78,10 +78,7 @@ export function BackboneElementDisplay(props: BackboneElementDisplayProps): JSX.
     newElementsContext,
     <DescriptionList compact={props.compact}>
       {Object.entries(elementsContext.elements).map(([key, property]) => {
-        if (EXTENSION_KEYS.includes(key) && isEmpty(property.slicing?.slices)) {
-          // an extension property without slices has no nested extensions
-          return null;
-        } else if (IGNORED_PROPERTIES.includes(key)) {
+        if (IGNORED_PROPERTIES.includes(key)) {
           return null;
         } else if (DEFAULT_IGNORED_NON_NESTED_PROPERTIES.includes(key) && property.path.split('.').length === 2) {
           return null;

--- a/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
+++ b/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
@@ -6,11 +6,13 @@ import { getPathDisplayName, isPopulated } from '@medplum/core';
 import { useMedplum } from '@medplum/react-hooks';
 import type { JSX } from 'react';
 import { useContext, useEffect, useMemo, useState } from 'react';
+import { DEFAULT_IGNORED_EXTENSION_URLS } from '../constants';
 import { DescriptionListEntry } from '../DescriptionList/DescriptionList';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { assignValuesIntoSlices, prepareSlices } from '../ResourceArrayInput/ResourceArrayInput.utils';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { SliceDisplay } from '../SliceDisplay/SliceDisplay';
+import { getExtensionDisplayName } from '../utils/extensions';
 
 const MAX_ARRAY_SIZE = 50;
 
@@ -59,9 +61,42 @@ export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Elem
   }
 
   let nonSliceContent: JSX.Element | undefined;
-  const showNonSliceValues = property.type[0]?.code !== 'Extension';
-  if (showNonSliceValues) {
-    const nonSliceValues = slicedValues[slices.length];
+  const nonSliceValues = slicedValues[slices.length];
+  if (property.type[0]?.code === 'Extension') {
+    // Un-sliced extensions can each have a different URL/meaning, so render one entry per
+    // extension labeled by a human-friendly name derived from its URL. Well-known noisy
+    // extensions (e.g. Synthea junk data) are suppressed via DEFAULT_IGNORED_EXTENSION_URLS.
+    const extensionEntries = nonSliceValues
+      .filter((ext) => ext?.url && !DEFAULT_IGNORED_EXTENSION_URLS.includes(ext.url))
+      .map((ext, valueIndex) => {
+        const display = (
+          <ResourcePropertyDisplay
+            path={props.path}
+            arrayElement={true}
+            property={property}
+            propertyType={propertyType}
+            value={ext}
+            ignoreMissingValues={props.ignoreMissingValues}
+            link={props.link}
+          />
+        );
+        const term = getExtensionDisplayName(ext.url);
+        if (props.includeDescriptionListEntry) {
+          return (
+            <DescriptionListEntry key={`${ext.url}-${valueIndex}`} term={term}>
+              {display}
+            </DescriptionListEntry>
+          );
+        }
+        return (
+          <Group key={`${ext.url}-${valueIndex}`} gap={4} wrap="nowrap">
+            <Text fw={500}>{term}:</Text>
+            {display}
+          </Group>
+        );
+      });
+    nonSliceContent = <>{extensionEntries}</>;
+  } else {
     const nonSliceElements = nonSliceValues.map((value, valueIndex) => (
       <div key={`${valueIndex}-${nonSliceValues.length}`}>
         <ResourcePropertyDisplay

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
@@ -285,4 +285,26 @@ describe('ResourceDiffTable', () => {
     expect(await screen.findByText('Replace contained[0].code.text')).toBeInTheDocument();
     expect(console.warn).toHaveBeenCalledWith('Failed to get element definition', expect.anything());
   });
+
+  test('Shows added extension value', async () => {
+    const original: Patient = {
+      resourceType: 'Patient',
+      id: '123',
+      meta: { versionId: '456' },
+      name: [{ family: 'Smith', given: ['John'] }],
+    };
+
+    const revised: Patient = {
+      ...original,
+      meta: { versionId: '457' },
+      extension: [{ url: 'http://example.com/eye-color', valueString: 'blue' }],
+    };
+
+    await act(async () => {
+      setup({ original, revised });
+    });
+
+    expect(await screen.findByText('Add extension')).toBeInTheDocument();
+    expect(screen.getByText('blue')).toBeInTheDocument();
+  });
 });

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
@@ -2,7 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Table } from '@mantine/core';
 import type { InternalSchemaElement, TypedValue } from '@medplum/core';
-import { arrayify, capitalize, evalFhirPathTyped, getSearchParameterDetails, toTypedValue } from '@medplum/core';
+import {
+  arrayify,
+  capitalize,
+  evalFhirPathTyped,
+  getSearchParameterDetails,
+  toTypedValue,
+  tryGetDataType,
+} from '@medplum/core';
 import type { Resource, SearchParameter } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import type { JSX } from 'react';
@@ -143,6 +150,19 @@ function jsonPathToFhirPath(path: string): string {
 }
 
 function tryGetElementDefinition(resourceType: string, fhirPath: string): InternalSchemaElement | undefined {
+  // Extensions are not searchable, so they cannot be resolved via SearchParameter details.
+  // Look them up directly from the resource schema so the diff keeps the full extension array
+  // (rather than dropping all but the first) and renders it as an Extension.
+  const lastPart = fhirPath
+    .replace(/\[\d+\]/g, '')
+    .split('.')
+    .pop();
+  if (lastPart === 'extension' || lastPart === 'modifierExtension') {
+    const element = tryGetDataType(resourceType)?.elements[lastPart];
+    if (element) {
+      return element;
+    }
+  }
   try {
     const details = getSearchParameterDetails(resourceType, {
       resourceType: 'SearchParameter',

--- a/packages/react/src/SearchControl/SearchUtils.render.test.tsx
+++ b/packages/react/src/SearchControl/SearchUtils.render.test.tsx
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { Observation } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react-hooks';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
+import { act, render, screen } from '../test-utils/render';
+import { getFieldDefinitions } from './SearchControlField';
+import { renderValue } from './SearchUtils';
+
+const medplum = new MockClient();
+
+describe('renderValue extension column', () => {
+  function setup(node: ReactNode): void {
+    render(
+      <MemoryRouter>
+        <MedplumProvider medplum={medplum}>{node}</MedplumProvider>
+      </MemoryRouter>
+    );
+  }
+
+  test('Renders an extension value in a table column', async () => {
+    const [field] = getFieldDefinitions({ resourceType: 'Observation', fields: ['extension'] });
+    const observation: Observation = {
+      resourceType: 'Observation',
+      id: '1',
+      status: 'final',
+      code: { text: 'Test' },
+      extension: [{ url: 'http://example.com/eye-color', valueString: 'blue' }],
+    };
+
+    await act(async () => {
+      setup(renderValue(observation, field));
+    });
+
+    expect(await screen.findByText('blue')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/constants.ts
+++ b/packages/react/src/constants.ts
@@ -5,3 +5,11 @@ export const DEFAULT_IGNORED_PROPERTIES = ['meta', 'implicitRules', 'contained',
 // Ignored only when they are top-level properties
 // e.g. Patient.language is ignored, but Patient.communication.language is not ignored
 export const DEFAULT_IGNORED_NON_NESTED_PROPERTIES = ['language', 'text'];
+
+// Extension URLs that are hidden from generic resource displays because they add noise without
+// clinical value. Seeded with Synthea synthetic-data extensions, which are a common source of
+// junk extensions. This list is intentionally conservative and can be extended.
+export const DEFAULT_IGNORED_EXTENSION_URLS = [
+  'http://synthetichealth.github.io/synthea/disability-adjusted-life-years',
+  'http://synthetichealth.github.io/synthea/quality-adjusted-life-years',
+];

--- a/packages/react/src/utils/extensions.test.ts
+++ b/packages/react/src/utils/extensions.test.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { getExtensionDisplayName } from './extensions';
+
+describe('getExtensionDisplayName', () => {
+  test('Empty URL falls back to "Extension"', () => {
+    expect(getExtensionDisplayName(undefined)).toBe('Extension');
+    expect(getExtensionDisplayName('')).toBe('Extension');
+  });
+
+  test('Humanizes the last path segment', () => {
+    expect(getExtensionDisplayName('http://hl7.org/fhir/StructureDefinition/patient-birthPlace')).toBe(
+      'Patient Birth Place'
+    );
+    expect(getExtensionDisplayName('http://example.com/my-ext')).toBe('My Ext');
+  });
+
+  test('Handles fragment URLs', () => {
+    expect(getExtensionDisplayName('http://example.com/StructureDefinition#race')).toBe('Race');
+  });
+});

--- a/packages/react/src/utils/extensions.ts
+++ b/packages/react/src/utils/extensions.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { getPathDisplayName } from '@medplum/core';
+
+/**
+ * Derives a human-friendly display name for an extension from its URL.
+ *
+ * Uses the last meaningful segment of the URL (after the final `/` or `#`) and humanizes it,
+ * e.g. `http://hl7.org/fhir/StructureDefinition/patient-birthPlace` becomes "Patient Birth Place".
+ * Falls back to the full URL when no usable segment is found, or "Extension" when the URL is empty.
+ *
+ * @param url - The extension URL.
+ * @returns A human-friendly display name for the extension.
+ */
+export function getExtensionDisplayName(url: string | undefined): string {
+  if (!url) {
+    return 'Extension';
+  }
+  const lastSegment = url.split(/[/#]/).filter(Boolean).pop();
+  if (!lastSegment) {
+    return url;
+  }
+  return getPathDisplayName(lastSegment) || url;
+}


### PR DESCRIPTION
## Summary

Fixes #6999. Extensions added to a resource were invisible in the **search/table column**, the **Timeline**, and the **resource detail view**. The generic display stack intentionally hid un-sliced extensions to avoid noise from Synthea junk data — but that also hid legitimate user extensions.

## Approach (addresses the feedback on the prior attempt, #9061)

PR #9061 was closed because simply un-hiding extensions doesn't handle resources with many/junk extensions. This PR addresses that directly, using patterns already in the codebase:

- **Render un-sliced extensions the same way profile-*sliced* extensions already render** — as inline labeled rows (`DescriptionListEntry`), with the label derived from the extension URL. No new UI concept.
- **Noise control via a `DEFAULT_IGNORED_EXTENSION_URLS` ignore-list**, mirroring the existing `DEFAULT_IGNORED_PROPERTIES` mechanism. Seeded conservatively with the common Synthea synthetic-data extensions (DALY/QALY); legitimate US-Core extensions are not suppressed. The list is easy to extend.

## Changes

- `BackboneElementDisplay`: stop hiding un-sliced extension arrays.
- `ResourceArrayDisplay`: render each un-sliced extension as a labeled row, filtered by the ignore-list. This single change fixes the **detail view** and the **table column** (both route through here).
- `ResourceDiffTable`: resolve the `extension` element definition directly from the schema so added extensions render fully in the **Timeline diff** (previously the lookup failed and dropped all but the first extension).
- New `getExtensionDisplayName(url)` helper and `DEFAULT_IGNORED_EXTENSION_URLS` constant.

## Testing

- New tests for all three surfaces (detail view, Timeline diff, table column), the ignore-list, and the URL→label helper.
- Full `@medplum/react` suite passes (1204 tests); `tsc`, lint, and api-extractor build are clean.

## Notes for reviewers

- The ignore-list is currently an internal constant (consistent with `DEFAULT_IGNORED_PROPERTIES`). Happy to make it configurable via prop/context if preferred.
- Per-URL/FHIRPath column targeting in the table is intentionally out of scope.
