### PR TITLE
testing(server): Remove unnecessary pg inlining from Vitest config

### DIFF
--- a/packages/server/vite.config.ts
+++ b/packages/server/vite.config.ts
@@ -47,11 +47,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    server: {
-      deps: {
-        inline: ['pg'],
-      },
-    },
     setupFiles: ['./src/test.setup.ts'],
     // Jest used a single `testTimeout` for both tests and lifecycle hooks (beforeAll, afterAll, etc.).
     // Vitest splits these into `testTimeout` and `hookTimeout`, so both must be set explicitly.


### PR DESCRIPTION
## Summary
- Removes `server.deps.inline: ['pg']` from the server Vitest config
- Vitest v4 handles `pg` mocking and CJS interop without forcing the dependency through Vite's transform pipeline