### PR TITLE
Parse history content once for tombstone checks

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -124,7 +124,7 @@ import {
   buildDeletedResourceRow,
   buildDeleteHistoryContent,
   buildResourceRow,
-  isDeleteTombstone,
+  parseHistoryContent,
 } from './repository/row-builder';
 import { validateRepositoryResource } from './repository/validation';
 import type { ResourceCap } from './resource-cap';
@@ -731,8 +731,9 @@ export class Repository extends FhirRepository implements Disposable {
       const entries: BundleEntry<T>[] = [];
 
       for (const row of rows) {
-        const isDeleted = isDeleteTombstone(row.content as string);
-        const resource = !isDeleted ? this.removeHiddenFields(JSON.parse(row.content as string)) : undefined;
+        const parsed = parseHistoryContent(row.content as string);
+        const isDeleted = parsed.tombstone;
+        const resource = !isDeleted ? this.removeHiddenFields(parsed.resource) : undefined;
         const outcome: OperationOutcome = !isDeleted
           ? allOk
           : {
@@ -810,13 +811,12 @@ export class Repository extends FhirRepository implements Disposable {
         throw new OperationOutcomeError(notFound);
       }
 
-      if (isDeleteTombstone(rows[0].content as string)) {
+      const parsed = parseHistoryContent(rows[0].content as string);
+      if (parsed.tombstone) {
         throw new OperationOutcomeError(gone);
       }
 
-      const result = await this.authorizeBinarySecurityContext(
-        this.removeHiddenFields(JSON.parse(rows[0].content as string))
-      );
+      const result = await this.authorizeBinarySecurityContext(this.removeHiddenFields(parsed.resource));
       const durationMs = Date.now() - startTime;
       this.logEvent(VreadInteraction, AuditEventOutcome.Success, undefined, { resource: versionReference, durationMs });
       return result;

--- a/packages/server/src/fhir/repository/row-builder.test.ts
+++ b/packages/server/src/fhir/repository/row-builder.test.ts
@@ -17,6 +17,7 @@ import {
   buildResourceRow,
   compareColumnValues,
   isDeleteTombstone,
+  parseHistoryContent,
 } from './row-builder';
 
 describe('Repository Row Builder', () => {
@@ -444,6 +445,27 @@ describe('compareColumnValues', () => {
         deleted: true,
       },
     });
+  });
+
+  test('parseHistoryContent', () => {
+    expect(parseHistoryContent('')).toStrictEqual({ tombstone: true });
+    expect(parseHistoryContent(undefined)).toStrictEqual({ tombstone: true });
+
+    const tombstone = {
+      resourceType: 'Patient',
+      id: randomUUID(),
+      meta: { deleted: true },
+    };
+    expect(parseHistoryContent(JSON.stringify(tombstone))).toStrictEqual({ tombstone: true });
+
+    const patient = {
+      resourceType: 'Patient',
+      id: randomUUID(),
+      name: [{ family: 'Smith' }],
+    };
+    expect(parseHistoryContent(JSON.stringify(patient))).toStrictEqual({ tombstone: false, resource: patient });
+
+    expect(() => parseHistoryContent('{')).toThrow(SyntaxError);
   });
 
   test('isDeleteTombstone', () => {

--- a/packages/server/src/fhir/repository/row-builder.ts
+++ b/packages/server/src/fhir/repository/row-builder.ts
@@ -40,13 +40,25 @@ export interface DeleteHistoryContentOptions {
   author: Reference;
 }
 
+export type ParsedHistoryContent = { tombstone: true } | { tombstone: false; resource: Resource };
+
+export function parseHistoryContent(content: string | null | undefined): ParsedHistoryContent {
+  if (!content) {
+    return { tombstone: true };
+  }
+  const resource = JSON.parse(content) as Resource;
+  if (resource.meta?.deleted === true) {
+    return { tombstone: true };
+  }
+  return { tombstone: false, resource };
+}
+
 export function isDeleteTombstone(content: string | null | undefined): boolean {
   if (!content) {
     return true;
   }
   try {
-    const resource = JSON.parse(content) as Resource;
-    return resource.meta?.deleted === true;
+    return parseHistoryContent(content).tombstone;
   } catch {
     return false;
   }

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -51,7 +51,7 @@ import { DatabaseMode } from '../database';
 import { clamp } from './operations/utils/parameters';
 import { addRangeColumnsOrderBy, buildRangeColumnsSearchFilter } from './range-column';
 import type { Repository } from './repo';
-import { isDeleteTombstone } from './repository/row-builder';
+import { parseHistoryContent } from './repository/row-builder';
 import { getFullUrl } from './response';
 import type { ColumnSearchParameterImplementation } from './searchparameter';
 import { getSearchParameterImplementation, SearchStrategies } from './searchparameter';
@@ -349,8 +349,9 @@ async function getSearchEntries<T extends Resource>(
   const resources = [];
   for (let i = 0; i < rowCount; i++) {
     const row = rows[i];
-    if (row.content && !isDeleteTombstone(row.content as string)) {
-      resources.push(JSON.parse(row.content));
+    const parsed = parseHistoryContent(row.content as string);
+    if (!parsed.tombstone) {
+      resources.push(parsed.resource);
     } else {
       // Handle missing or tombstone content for soft-deleted resources.
       resources.push({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`isDeleteTombstone` was calling `JSON.parse()`, and callers immediately parsed the same content again to hydrate the resource. This adds a `parseHistoryContent` helper that parses once and returns either a tombstone marker or the parsed `Resource`.

## Changes

- Add `parseHistoryContent` in `row-builder.ts` and implement `isDeleteTombstone` on top of it
- Use the parsed value in `readHistory`, `readVersion`, and search result hydration
- Add unit tests for `parseHistoryContent`

## Testing

- `vitest run src/fhir/repository/row-builder.test.ts -t "parseHistoryContent|isDeleteTombstone"` (passes)
- Integration tests in `repo.test.ts` require a running database in this environment
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6428519-4dc5-49d2-b8f5-52cdbd62cb1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6428519-4dc5-49d2-b8f5-52cdbd62cb1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

