### PR TITLE
test(server): waitFor() should use clearInterval() not clearTimeout()

### DIFF
--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -315,13 +315,20 @@ export function bundleContains(bundle: Bundle, resource: Resource): BundleEntry 
  * Waits for a function to evaluate successfully.
  * Use this to wait for async behaviors without a handle.
  * @param fn - Function to call.
+ * @param timeoutMs - Maximum time to wait before rejecting (default 10s).
  */
-export function waitFor(fn: () => Promise<void>): Promise<void> {
-  return new Promise((resolve) => {
+export function waitFor(fn: () => Promise<void>, timeoutMs = 10_000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
     const timer = setInterval(() => {
+      if (Date.now() > deadline) {
+        clearInterval(timer);
+        reject(new Error(`waitFor timed out after ${timeoutMs}ms`));
+        return;
+      }
       fn()
         .then(() => {
-          clearTimeout(timer);
+          clearInterval(timer);
           resolve();
         })
         .catch(() => {


### PR DESCRIPTION
In trying to reduce test flakiness under high concurrency, we found an incorrect timer API usage in the test code. A timer that is created with `setInterval` it must be cancelled with `clearInterval`.

## What was wrong before

The committed version looked like this:

```typescript
const timer = setInterval(() => {
  fn()
    .then(() => {
      clearTimeout(timer);  // ← mismatch
      resolve();
    })
    ...
}, 100);
```

That pairs `setInterval` with `clearTimeout`, which is the wrong API pairing.

## Why that matters

`setInterval` and `setTimeout` return timer handles, but each has its own clear function:

| Created with   | Should clear with   |
|----------------|---------------------|
| `setInterval`  | `clearInterval`     |
| `setTimeout`   | `clearTimeout`      |

In Node.js, `clearTimeout` and `clearInterval` often share the same timer pool, so `clearTimeout` on an interval ID may appear to work. That’s incidental, not guaranteed. In browsers and other runtimes, behavior can differ.

If the interval isn’t actually cleared:

1. The 100ms polling keeps running after `resolve()`.
2. `fn()` keeps getting called in the background.
3. Tests can leak timers, hang, or flake under load.

The fix ensures the poll loop actually stops on both success and timeout.