### PR TITLE
WIP: Fix history bundle request method and URL to reflect original operations

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -420,6 +420,13 @@ describe('FHIR Repo', () => {
       }
     });
 
+    test('request method and url', async () => {
+      const history = await systemRepo.readHistory('Patient', versions.v1.id);
+      expect(history.entry).toHaveLength(2);
+      expect(history.entry?.[0]?.request).toMatchObject({ method: 'PUT', url: `Patient/${versions.v1.id}` });
+      expect(history.entry?.[1]?.request).toMatchObject({ method: 'POST', url: 'Patient' });
+    });
+
     test('with config.maxSearchOffset', async () => {
       const prevMax = getConfig().maxSearchOffset;
       getConfig().maxSearchOffset = 200;
@@ -965,12 +972,16 @@ describe('FHIR Repo', () => {
 
       const history1 = await systemRepo.readHistory('Patient', patient.id);
       expect(history1.entry?.length).toBe(1);
+      expect(history1.entry?.[0]?.request).toMatchObject({ method: 'POST', url: 'Patient' });
 
       // Delete the patient
       await systemRepo.deleteResource('Patient', patient.id);
 
       const history2 = await systemRepo.readHistory('Patient', patient.id);
       expect(history2.entry?.length).toBe(2);
+      expect(history2.entry?.[0]?.request?.method).toStrictEqual('DELETE');
+      expect(history2.entry?.[0]?.request?.url).toStrictEqual(`Patient/${patient.id}`);
+      expect(history2.entry?.[1]?.request).toMatchObject({ method: 'POST', url: 'Patient' });
 
       // Restore the patient
       await systemRepo.updateResource({ ...patient, meta: undefined });
@@ -979,11 +990,15 @@ describe('FHIR Repo', () => {
       expect(history3.entry?.length).toBe(3);
 
       const entries = history3.entry as BundleEntry[];
+      expect(entries[0].request).toMatchObject({ method: 'PUT', url: `Patient/${patient.id}` });
       expect(entries[0].response?.status).toStrictEqual('200');
       expect(entries[0].resource).toBeDefined();
+      expect(entries[1].request?.method).toStrictEqual('DELETE');
+      expect(entries[1].request?.url).toStrictEqual(`Patient/${patient.id}`);
       expect(entries[1].response?.status).toStrictEqual('410');
       expect((entries[1].response?.outcome as OperationOutcome).issue?.[0]?.details?.text).toMatch(/Deleted on /);
       expect(entries[1].resource).toBeUndefined();
+      expect(entries[2].request).toMatchObject({ method: 'POST', url: 'Patient' });
       expect(entries[2].response?.status).toStrictEqual('200');
       expect(entries[2].resource).toBeDefined();
     }));

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -119,7 +119,7 @@ import {
   getResourceCacheEntry,
   setResourceCacheEntry,
 } from './repository/resource-cache';
-import { buildDeletedResourceRow, buildResourceRow } from './repository/row-builder';
+import { buildDeletedResourceRow, buildResourceRow, calculateHistoryHttpMethod } from './repository/row-builder';
 import { validateRepositoryResource } from './repository/validation';
 import type { ResourceCap } from './resource-cap';
 import { getFullUrl } from './response';
@@ -704,6 +704,7 @@ export class Repository extends FhirRepository implements Disposable {
         }
       }
 
+      const offset = Math.max(0, options?.offset ?? 0);
       const rows = await new SelectQuery(resourceType + '_History')
         .column('versionId')
         .column('id')
@@ -712,7 +713,7 @@ export class Repository extends FhirRepository implements Disposable {
         .where('id', '=', id)
         .orderBy('lastUpdated', true)
         .limit(clamp(0, options?.limit ?? 100, DEFAULT_MAX_SEARCH_COUNT))
-        .offset(Math.max(0, options?.offset ?? 0))
+        .offset(offset)
         .execute(this.getDatabaseClient(DatabaseMode.READER));
 
       const countRows = await new SelectQuery(resourceType + '_History')
@@ -722,10 +723,11 @@ export class Repository extends FhirRepository implements Disposable {
 
       const totalCount = countRows[0].count as number;
 
-      const entries: BundleEntry<T>[] = [];
-
-      for (const row of rows) {
+      const entries: BundleEntry<T>[] = rows.map((row, i) => {
+        const isDeleted = !row.content;
+        const isCreate = offset + i === totalCount - 1;
         const resource = row.content ? this.removeHiddenFields(JSON.parse(row.content as string)) : undefined;
+        const method = calculateHistoryHttpMethod(isDeleted, isCreate);
         const outcome: OperationOutcome = row.content
           ? allOk
           : {
@@ -741,19 +743,19 @@ export class Repository extends FhirRepository implements Disposable {
                 },
               ],
             };
-        entries.push({
+        return {
           fullUrl: getFullUrl(resourceType, row.id),
           request: {
-            method: 'GET',
-            url: `${resourceType}/${row.id}/_history/${row.versionId}`,
+            method,
+            url: isCreate ? resourceType : `${resourceType}/${row.id}`,
           },
           response: {
             status: getStatus(outcome).toString(),
             outcome,
           },
           resource,
-        });
-      }
+        };
+      });
 
       const durationMs = Date.now() - startTime;
       this.logEvent(HistoryInteraction, AuditEventOutcome.Success, undefined, { resource, durationMs });

--- a/packages/server/src/fhir/repository/row-builder.test.ts
+++ b/packages/server/src/fhir/repository/row-builder.test.ts
@@ -11,7 +11,7 @@ import { DatabaseMode, getDatabasePool } from '../../database';
 import { createTestProject, withTestContext } from '../../test.setup';
 import { getProjectSystemRepo, Repository } from '../repo';
 import type { ColumnValue } from './row-builder';
-import { buildResourceRow, compareColumnValues } from './row-builder';
+import { buildResourceRow, calculateHistoryHttpMethod, compareColumnValues } from './row-builder';
 
 describe('Repository Row Builder', () => {
   let testProject: WithId<Project>;
@@ -392,5 +392,12 @@ describe('compareColumnValues', () => {
     ])('compareColumnValues(%p, %p) matches localeCompare', (a, b) => {
       expect(compareColumnValues(a, b)).toBe(String(a).localeCompare(String(b)));
     });
+  });
+
+  test('getHistoryBundleRequestMethod', () => {
+    expect(calculateHistoryHttpMethod(true, false)).toBe('DELETE');
+    expect(calculateHistoryHttpMethod(true, true)).toBe('DELETE');
+    expect(calculateHistoryHttpMethod(false, true)).toBe('POST');
+    expect(calculateHistoryHttpMethod(false, false)).toBe('PUT');
   });
 });

--- a/packages/server/src/fhir/repository/row-builder.ts
+++ b/packages/server/src/fhir/repository/row-builder.ts
@@ -34,6 +34,25 @@ import { buildTokenColumns } from '../token-column';
 
 export type ColumnValue = boolean | number | string | undefined | null;
 
+/**
+ * Returns the HTTP method for a history bundle entry's `request.method`.
+ * In a history bundle, this field indicates the action that originally occurred
+ * (POST for create, PUT for update, DELETE for delete), not the read used to fetch history.
+ * PATCH is not represented because patch vs full update is not persisted in history today.
+ * @param isDeleted - Whether this history version is a delete tombstone.
+ * @param isCreate - Whether this history version is the resource's initial create.
+ * @returns The HTTP method for the history bundle entry request.
+ */
+export function calculateHistoryHttpMethod(isDeleted: boolean, isCreate: boolean): 'DELETE' | 'POST' | 'PUT' {
+  if (isDeleted) {
+    return 'DELETE';
+  } else if (isCreate) {
+    return 'POST';
+  } else {
+    return 'PUT';
+  }
+}
+
 export function buildDeletedResourceRow(
   resourceType: ResourceType,
   id: string,


### PR DESCRIPTION
## Summary
- History bundle entries now use POST/PUT/DELETE in `request.method` to describe the write that produced each version, instead of GET.
- `request.url` uses the resource type alone for creates and `ResourceType/id` for updates and deletes, matching FHIR history bundle conventions.
- Adds `calculateHistoryHttpMethod` helper and test coverage for history request metadata.

## Test plan
- [x] `row-builder.test.ts` — `getHistoryBundleRequestMethod`
- [x] `repo.test.ts` — `request method and url`
- [x] `repo.test.ts` — `Read history after delete`