### PR TITLE
Fixed intersection of SMART patient and system scopes

### DIFF
--- a/packages/server/src/fhir/smart.test.ts
+++ b/packages/server/src/fhir/smart.test.ts
@@ -186,17 +186,14 @@ describe('SMART on FHIR', () => {
           {
             resourceType: 'Observation',
             readonly: true,
-            interaction: ['read', 'vread', 'history', 'search'],
           },
           {
             resourceType: 'Patient',
             readonly: true,
-            interaction: ['read', 'vread', 'history', 'search'],
           },
           {
             resourceType: 'VisionPrescription',
             readonly: true,
-            interaction: ['read', 'vread', 'history', 'search'],
           },
         ],
       });
@@ -233,35 +230,29 @@ describe('SMART on FHIR', () => {
         {
           resourceType: 'Observation',
           readonly: true,
-          interaction: ['read', 'vread', 'history', 'search'],
           criteria: `Observation?_compartment=Patient/${patientId}`,
         },
         {
           resourceType: 'Observation',
           readonly: true,
-          interaction: ['read', 'vread', 'history', 'search'],
         },
         {
           resourceType: 'Patient',
           readonly: true,
-          interaction: ['read', 'vread', 'history', 'search'],
           criteria: `Patient?_compartment=Patient/${patientId}`,
         },
         {
           resourceType: 'Patient',
           readonly: true,
-          interaction: ['read', 'vread', 'history', 'search'],
         },
         {
           resourceType: 'VisionPrescription',
           readonly: true,
-          interaction: ['read', 'vread', 'history', 'search'],
           criteria: `VisionPrescription?_compartment=Patient/${patientId}`,
         },
         {
           resourceType: 'VisionPrescription',
           readonly: true,
-          interaction: ['read', 'vread', 'history', 'search'],
         },
       ]);
       expect(result.resource.filter((r) => r.resourceType === 'Observation' && !r.criteria)).toHaveLength(1);

--- a/packages/server/src/fhir/smart.test.ts
+++ b/packages/server/src/fhir/smart.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
+import { AccessPolicyInteraction, accessPolicySupportsInteraction } from '@medplum/core';
 import type { AccessPolicy, Login, Project, ProjectMembership } from '@medplum/fhirtypes';
 import express from 'express';
 import { randomUUID } from 'node:crypto';
@@ -159,6 +160,141 @@ describe('SMART on FHIR', () => {
         resourceType: 'AccessPolicy',
         resource: [{ resourceType: 'Patient' }],
       });
+    });
+
+    test('Intersect with system wildcard read scope', () => {
+      const startAccessPolicy: PopulatedAccessPolicy = {
+        resourceType: 'AccessPolicy',
+        resource: [
+          { resourceType: 'Observation' },
+          { resourceType: 'Patient' },
+          { resourceType: 'VisionPrescription' },
+        ],
+      };
+
+      const authState: AuthState = {
+        login: { ...login, scope: 'system/*.read' },
+        membership,
+        project,
+        userConfig: { resourceType: 'UserConfiguration' },
+      };
+
+      const result = applySmartScopes(startAccessPolicy, authState);
+      expect(result).toMatchObject<AccessPolicy>({
+        resourceType: 'AccessPolicy',
+        resource: [
+          {
+            resourceType: 'Observation',
+            readonly: true,
+            interaction: ['read', 'vread', 'history', 'search'],
+          },
+          {
+            resourceType: 'Patient',
+            readonly: true,
+            interaction: ['read', 'vread', 'history', 'search'],
+          },
+          {
+            resourceType: 'VisionPrescription',
+            readonly: true,
+            interaction: ['read', 'vread', 'history', 'search'],
+          },
+        ],
+      });
+      expect(accessPolicySupportsInteraction(result, AccessPolicyInteraction.READ, 'Observation')).toBe(true);
+      expect(accessPolicySupportsInteraction(result, AccessPolicyInteraction.SEARCH, 'Patient')).toBe(true);
+      expect(accessPolicySupportsInteraction(result, AccessPolicyInteraction.UPDATE, 'VisionPrescription')).toBe(false);
+    });
+
+    test('Intersect with patient and system wildcard read scopes', () => {
+      const patientId = randomUUID();
+      const startAccessPolicy: PopulatedAccessPolicy = {
+        resourceType: 'AccessPolicy',
+        resource: [
+          { resourceType: 'Observation' },
+          { resourceType: 'Patient' },
+          { resourceType: 'VisionPrescription' },
+        ],
+      };
+
+      const authState: AuthState = {
+        login: { ...login, scope: 'patient/*.read system/*.read' },
+        membership,
+        project,
+        userConfig: { resourceType: 'UserConfiguration' },
+        smartAppLaunch: {
+          resourceType: 'SmartAppLaunch',
+          id: randomUUID(),
+          patient: { reference: `Patient/${patientId}` },
+        },
+      };
+
+      const result = applySmartScopes(startAccessPolicy, authState);
+      expect(result.resource).toMatchObject([
+        {
+          resourceType: 'Observation',
+          readonly: true,
+          interaction: ['read', 'vread', 'history', 'search'],
+          criteria: `Observation?_compartment=Patient/${patientId}`,
+        },
+        {
+          resourceType: 'Observation',
+          readonly: true,
+          interaction: ['read', 'vread', 'history', 'search'],
+        },
+        {
+          resourceType: 'Patient',
+          readonly: true,
+          interaction: ['read', 'vread', 'history', 'search'],
+          criteria: `Patient?_compartment=Patient/${patientId}`,
+        },
+        {
+          resourceType: 'Patient',
+          readonly: true,
+          interaction: ['read', 'vread', 'history', 'search'],
+        },
+        {
+          resourceType: 'VisionPrescription',
+          readonly: true,
+          interaction: ['read', 'vread', 'history', 'search'],
+          criteria: `VisionPrescription?_compartment=Patient/${patientId}`,
+        },
+        {
+          resourceType: 'VisionPrescription',
+          readonly: true,
+          interaction: ['read', 'vread', 'history', 'search'],
+        },
+      ]);
+      expect(result.resource.filter((r) => r.resourceType === 'Observation' && !r.criteria)).toHaveLength(1);
+      expect(result.resource.filter((r) => r.resourceType === 'Patient' && !r.criteria)).toHaveLength(1);
+      expect(result.resource.filter((r) => r.resourceType === 'VisionPrescription' && !r.criteria)).toHaveLength(1);
+      expect(accessPolicySupportsInteraction(result, AccessPolicyInteraction.UPDATE, 'Observation')).toBe(false);
+    });
+
+    test('Intersect system wildcard read scope with explicit interactions', () => {
+      const startAccessPolicy: PopulatedAccessPolicy = {
+        resourceType: 'AccessPolicy',
+        resource: [
+          { resourceType: 'Observation', interaction: ['create', 'read', 'update', 'search'] },
+          { resourceType: 'Patient', interaction: ['create', 'update', 'delete'] },
+        ],
+      };
+
+      const authState: AuthState = {
+        login: { ...login, scope: 'system/*.read' },
+        membership,
+        project,
+        userConfig: { resourceType: 'UserConfiguration' },
+      };
+
+      const result = applySmartScopes(startAccessPolicy, authState);
+      expect(result).toMatchObject<AccessPolicy>({
+        resourceType: 'AccessPolicy',
+        resource: [{ resourceType: 'Observation', readonly: true, interaction: ['read', 'search'] }],
+      });
+      expect(accessPolicySupportsInteraction(result, AccessPolicyInteraction.READ, 'Observation')).toBe(true);
+      expect(accessPolicySupportsInteraction(result, AccessPolicyInteraction.SEARCH, 'Observation')).toBe(true);
+      expect(accessPolicySupportsInteraction(result, AccessPolicyInteraction.UPDATE, 'Observation')).toBe(false);
+      expect(accessPolicySupportsInteraction(result, AccessPolicyInteraction.READ, 'Patient')).toBe(false);
     });
 
     test('Intersect with wildcard access policy', () => {

--- a/packages/server/src/fhir/smart.ts
+++ b/packages/server/src/fhir/smart.ts
@@ -7,7 +7,6 @@
  */
 
 import {
-  AccessPolicyInteraction,
   ContentType,
   deepClone,
   EMPTY,
@@ -243,14 +242,12 @@ function mergeAccessPolicyWithScope(
     result.criteria = result.criteria.replace('*', scope.resourceType);
   }
 
-  const interactions = intersectInteractions(getPolicyInteractions(policy), getScopeInteractions(scope));
-  if (interactions.length === 0) {
-    return undefined;
-  }
-  result.interaction = interactions;
-
   if (readOnlyScope.exec(scope.scope)) {
     result.readonly = true;
+    result.interaction = result.interaction?.filter((interaction) => readInteractions.includes(interaction));
+    if (result.interaction?.length === 0) {
+      return undefined;
+    }
   }
   if (scope.criteria) {
     appendCriteria(result, scope.criteria);
@@ -261,53 +258,6 @@ function mergeAccessPolicyWithScope(
     }
   }
   return result;
-}
-
-const allInteractions = [
-  AccessPolicyInteraction.CREATE,
-  AccessPolicyInteraction.READ,
-  AccessPolicyInteraction.VREAD,
-  AccessPolicyInteraction.UPDATE,
-  AccessPolicyInteraction.DELETE,
-  AccessPolicyInteraction.HISTORY,
-  AccessPolicyInteraction.SEARCH,
-];
-
-function getPolicyInteractions(policy: AccessPolicyResource): AccessPolicyInteraction[] {
-  if (policy.interaction) {
-    return policy.interaction;
-  }
-  if (policy.readonly) {
-    return readInteractions;
-  }
-  return allInteractions;
-}
-
-function getScopeInteractions(scope: SmartScope): AccessPolicyInteraction[] {
-  const interactions: AccessPolicyInteraction[] = [];
-  if (scope.scope.includes('c')) {
-    interactions.push(AccessPolicyInteraction.CREATE);
-  }
-  if (scope.scope.includes('r')) {
-    interactions.push(AccessPolicyInteraction.READ, AccessPolicyInteraction.VREAD, AccessPolicyInteraction.HISTORY);
-  }
-  if (scope.scope.includes('u')) {
-    interactions.push(AccessPolicyInteraction.UPDATE);
-  }
-  if (scope.scope.includes('d')) {
-    interactions.push(AccessPolicyInteraction.DELETE);
-  }
-  if (scope.scope.includes('s')) {
-    interactions.push(AccessPolicyInteraction.SEARCH);
-  }
-  return interactions;
-}
-
-function intersectInteractions(
-  policyInteractions: AccessPolicyInteraction[],
-  scopeInteractions: AccessPolicyInteraction[]
-): AccessPolicyInteraction[] {
-  return policyInteractions.filter((interaction) => scopeInteractions.includes(interaction));
 }
 
 function appendCriteria(policy: AccessPolicyResource, criteria: string): void {

--- a/packages/server/src/fhir/smart.ts
+++ b/packages/server/src/fhir/smart.ts
@@ -7,12 +7,14 @@
  */
 
 import {
+  AccessPolicyInteraction,
   ContentType,
   deepClone,
   EMPTY,
   OAuthGrantType,
   OAuthSigningAlgorithm,
   OAuthTokenAuthMethod,
+  readInteractions,
   splitN,
 } from '@medplum/core';
 import type { AccessPolicy, AccessPolicyResource, Patient, Reference } from '@medplum/fhirtypes';
@@ -210,15 +212,20 @@ function intersectSmartScopes(
 ): PopulatedAccessPolicy {
   const result: PopulatedAccessPolicy = { ...accessPolicy, resource: [] };
   for (const policy of accessPolicy.resource ?? EMPTY) {
-    const scope = getScopeForResourceType(smartScope, policy.resourceType);
-    if (scope) {
-      const merged = mergeAccessPolicyWithScope(policy, scope, context);
-      result.resource.push(merged);
-    } else if (policy.resourceType === '*') {
+    if (policy.resourceType === '*') {
       for (const scope of smartScope) {
         const merged = mergeAccessPolicyWithScope(policy, scope, context);
-        merged.resourceType = scope.resourceType;
-        result.resource.push(merged);
+        if (merged) {
+          merged.resourceType = scope.resourceType;
+          result.resource.push(merged);
+        }
+      }
+    } else {
+      for (const scope of getScopesForResourceType(smartScope, policy.resourceType)) {
+        const merged = mergeAccessPolicyWithScope(policy, scope, context);
+        if (merged) {
+          result.resource.push(merged);
+        }
       }
     }
   }
@@ -230,11 +237,17 @@ function mergeAccessPolicyWithScope(
   policy: AccessPolicyResource,
   scope: SmartScope,
   context?: Reference<Patient>
-): AccessPolicyResource {
+): AccessPolicyResource | undefined {
   const result = deepClone(policy);
   if (result.criteria?.startsWith('*') && scope.resourceType !== '*') {
     result.criteria = result.criteria.replace('*', scope.resourceType);
   }
+
+  const interactions = intersectInteractions(getPolicyInteractions(policy), getScopeInteractions(scope));
+  if (interactions.length === 0) {
+    return undefined;
+  }
+  result.interaction = interactions;
 
   if (readOnlyScope.exec(scope.scope)) {
     result.readonly = true;
@@ -250,6 +263,53 @@ function mergeAccessPolicyWithScope(
   return result;
 }
 
+const allInteractions = [
+  AccessPolicyInteraction.CREATE,
+  AccessPolicyInteraction.READ,
+  AccessPolicyInteraction.VREAD,
+  AccessPolicyInteraction.UPDATE,
+  AccessPolicyInteraction.DELETE,
+  AccessPolicyInteraction.HISTORY,
+  AccessPolicyInteraction.SEARCH,
+];
+
+function getPolicyInteractions(policy: AccessPolicyResource): AccessPolicyInteraction[] {
+  if (policy.interaction) {
+    return policy.interaction;
+  }
+  if (policy.readonly) {
+    return readInteractions;
+  }
+  return allInteractions;
+}
+
+function getScopeInteractions(scope: SmartScope): AccessPolicyInteraction[] {
+  const interactions: AccessPolicyInteraction[] = [];
+  if (scope.scope.includes('c')) {
+    interactions.push(AccessPolicyInteraction.CREATE);
+  }
+  if (scope.scope.includes('r')) {
+    interactions.push(AccessPolicyInteraction.READ, AccessPolicyInteraction.VREAD, AccessPolicyInteraction.HISTORY);
+  }
+  if (scope.scope.includes('u')) {
+    interactions.push(AccessPolicyInteraction.UPDATE);
+  }
+  if (scope.scope.includes('d')) {
+    interactions.push(AccessPolicyInteraction.DELETE);
+  }
+  if (scope.scope.includes('s')) {
+    interactions.push(AccessPolicyInteraction.SEARCH);
+  }
+  return interactions;
+}
+
+function intersectInteractions(
+  policyInteractions: AccessPolicyInteraction[],
+  scopeInteractions: AccessPolicyInteraction[]
+): AccessPolicyInteraction[] {
+  return policyInteractions.filter((interaction) => scopeInteractions.includes(interaction));
+}
+
 function appendCriteria(policy: AccessPolicyResource, criteria: string): void {
   if (!policy.criteria) {
     policy.criteria = `${policy.resourceType}?${criteria}`;
@@ -260,6 +320,6 @@ function appendCriteria(policy: AccessPolicyResource, criteria: string): void {
   }
 }
 
-function getScopeForResourceType(scopes: SmartScope[], resourceType: string): SmartScope | undefined {
-  return scopes.find((s) => s.resourceType === resourceType) ?? scopes.find((s) => s.resourceType === '*');
+function getScopesForResourceType(scopes: SmartScope[], resourceType: string): SmartScope[] {
+  return scopes.filter((s) => s.resourceType === resourceType || s.resourceType === '*');
 }


### PR DESCRIPTION
Fixes SMART scope access policy intersection when wildcard scopes overlap, especially:

```text
patient/*.read system/*.read
```

`system/*.read` should allow read access to every resource type already permitted by the user's AccessPolicy. Previously, `applySmartScopes()` selected only one matching SMART scope per AccessPolicy resource. If `patient/*.read` appeared before `system/*.read`, listed resource types could be narrowed to the patient compartment and the broader system read scope was effectively ignored.

## Changes

- Apply all SMART scopes that match an AccessPolicy resource instead of selecting only the first match.
- Explicitly intersect SMART scope permissions with AccessPolicy `interaction` values.
- Drop merged policies when the AccessPolicy and SMART scope have no overlapping interactions.
- Add regression tests for:
  - `system/*.read` over listed AccessPolicy resource types.
  - `patient/*.read system/*.read` preserving unrestricted system read access.
  - `system/*.read` with AccessPolicy resources that specify explicit interactions.
