### PR TITLE
Fixes #9646 - AuditEvent and transaction scoped repos

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -52,6 +52,7 @@ import { FhirRepository } from '@medplum/fhir-router';
 import type {
   AccessPolicy,
   AccessPolicyResource,
+  AuditEvent,
   Binary,
   Bundle,
   BundleEntry,
@@ -2179,9 +2180,17 @@ export class Repository extends FhirRepository implements Disposable {
     logAuditEvent(auditEvent);
 
     if (getConfig().saveAuditEvents && isResource(resource) && resource?.resourceType !== 'AuditEvent') {
-      auditEvent.id = this.generateId();
-      this.updateResourceImpl(auditEvent, true).catch((err) => getLogger().error('Failed to save AuditEvent', err));
+      this.saveAuditEvent(auditEvent);
     }
+  }
+
+  private saveAuditEvent(auditEvent: AuditEvent): void {
+    const auditRepo = getShardSystemRepo(this.shardId, undefined, { skipBackgroundJobs: true });
+    auditEvent.id = auditRepo.generateId();
+    auditRepo
+      .updateResourceImpl(auditEvent, true)
+      .catch((err) => getLogger().error('Failed to save AuditEvent', err))
+      .finally(() => auditRepo[Symbol.dispose]());
   }
 
   /**

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -2186,6 +2186,11 @@ export class Repository extends FhirRepository implements Disposable {
 
   private saveAuditEvent(auditEvent: AuditEvent): void {
     const auditRepo = getShardSystemRepo(this.shardId, undefined, { skipBackgroundJobs: true });
+    const accessPolicyAccount = this.context.accessPolicy?.compartment?.reference;
+    if (accessPolicyAccount) {
+      auditEvent.meta ??= {};
+      auditEvent.meta.account ??= { reference: accessPolicyAccount };
+    }
     auditEvent.id = auditRepo.generateId();
     auditRepo
       .updateResourceImpl(auditEvent, true)

--- a/packages/server/src/fhir/repository/method-guards.test.ts
+++ b/packages/server/src/fhir/repository/method-guards.test.ts
@@ -83,6 +83,7 @@ const knownPrivateMembers = new Set<PropertyKey>([
   'isCacheOnly',
   'restoreReadonlyFields',
   'logEvent',
+  'saveAuditEvent',
   'getCacheEntry',
   'getCacheEntries',
   'setCacheEntry',

--- a/packages/server/src/fhir/repository/transaction.test.ts
+++ b/packages/server/src/fhir/repository/transaction.test.ts
@@ -297,9 +297,9 @@ describe('FHIR Repo Transactions', () => {
             filters: [{ code: 'entity', operator: Operator.EQUALS, value: getReferenceString(patient) }],
           });
           expect(auditEvent).toBeDefined();
-          expect(auditEvent.meta?.account?.reference).toStrictEqual(accountReference);
-          expect(auditEvent.meta?.accounts).toContainEqual({ reference: accountReference });
-          expect(auditEvent.meta?.compartment).toContainEqual({ reference: accountReference });
+          expect(auditEvent?.meta?.account?.reference).toStrictEqual(accountReference);
+          expect(auditEvent?.meta?.accounts).toContainEqual({ reference: accountReference });
+          expect(auditEvent?.meta?.compartment).toContainEqual({ reference: accountReference });
         });
         expect(loggerErrorSpy).not.toHaveBeenCalledWith('Failed to save AuditEvent', expect.anything());
       } finally {

--- a/packages/server/src/fhir/repository/transaction.test.ts
+++ b/packages/server/src/fhir/repository/transaction.test.ts
@@ -265,11 +265,24 @@ describe('FHIR Repo Transactions', () => {
     withTestContext(async () => {
       const previousSaveAuditEvents = getConfig().saveAuditEvents;
       const loggerErrorSpy = vi.spyOn(getLogger(), 'error').mockImplementation(() => {});
+      const accountReference = 'Organization/' + randomUUID();
+      const { repo: compartmentRepo } = await createTestProject({
+        withRepo: true,
+        accessPolicy: {
+          resourceType: 'AccessPolicy',
+          compartment: { reference: accountReference },
+          resource: [
+            { resourceType: 'Patient' },
+            { resourceType: 'AuditEvent', criteria: `AuditEvent?_compartment=${accountReference}` },
+          ],
+        },
+      });
+      const compartmentSystemRepo = compartmentRepo.getSystemRepo();
       let patient: WithId<Patient> | undefined;
 
       getConfig().saveAuditEvents = true;
       try {
-        await repo.withTransaction(
+        await compartmentRepo.withTransaction(
           async (txRepo) => {
             patient = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
             await txRepo.createResource<Patient>({ resourceType: 'Patient' });
@@ -279,11 +292,14 @@ describe('FHIR Repo Transactions', () => {
 
         await waitFor(async () => {
           assert(patient);
-          const auditEvent = await systemRepo.searchOne<AuditEvent>({
+          const auditEvent = await compartmentSystemRepo.searchOne<AuditEvent>({
             resourceType: 'AuditEvent',
             filters: [{ code: 'entity', operator: Operator.EQUALS, value: getReferenceString(patient) }],
           });
           expect(auditEvent).toBeDefined();
+          expect(auditEvent.meta?.account?.reference).toStrictEqual(accountReference);
+          expect(auditEvent.meta?.accounts).toContainEqual({ reference: accountReference });
+          expect(auditEvent.meta?.compartment).toContainEqual({ reference: accountReference });
         });
         expect(loggerErrorSpy).not.toHaveBeenCalledWith('Failed to save AuditEvent', expect.anything());
       } finally {

--- a/packages/server/src/fhir/repository/transaction.test.ts
+++ b/packages/server/src/fhir/repository/transaction.test.ts
@@ -1,7 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { conflict, getReferenceString, notFound, OperationOutcomeError, Operator, parseSearchRequest } from '@medplum/core';
+import {
+  conflict,
+  getReferenceString,
+  notFound,
+  OperationOutcomeError,
+  Operator,
+  parseSearchRequest,
+} from '@medplum/core';
 import { RepositoryMode } from '@medplum/fhir-router';
 import type { AuditEvent, Patient } from '@medplum/fhirtypes';
 import assert from 'node:assert';
@@ -270,8 +277,8 @@ describe('FHIR Repo Transactions', () => {
           { serializable: true }
         );
 
-        assert(patient);
         await waitFor(async () => {
+          assert(patient);
           const auditEvent = await systemRepo.searchOne<AuditEvent>({
             resourceType: 'AuditEvent',
             filters: [{ code: 'entity', operator: Operator.EQUALS, value: getReferenceString(patient) }],

--- a/packages/server/src/fhir/repository/transaction.test.ts
+++ b/packages/server/src/fhir/repository/transaction.test.ts
@@ -1,19 +1,19 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { conflict, notFound, OperationOutcomeError, Operator, parseSearchRequest } from '@medplum/core';
+import { conflict, getReferenceString, notFound, OperationOutcomeError, Operator, parseSearchRequest } from '@medplum/core';
 import { RepositoryMode } from '@medplum/fhir-router';
-import type { Patient } from '@medplum/fhirtypes';
+import type { AuditEvent, Patient } from '@medplum/fhirtypes';
 import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import type { PoolClient } from 'pg';
 import type { MockInstance } from 'vitest';
 import { vi } from 'vitest';
 import { initAppServices, shutdownApp } from '../../app';
-import { loadTestConfig } from '../../config/loader';
+import { getConfig, loadTestConfig } from '../../config/loader';
 import { DatabaseMode } from '../../database';
 import { getLogger } from '../../logger';
-import { createTestProject, spyOnQuery, withTestContext } from '../../test.setup';
+import { createTestProject, spyOnQuery, waitFor, withTestContext } from '../../test.setup';
 import * as workersModule from '../../workers';
 import type { Repository, SystemRepository } from '../repo';
 import { getShardSystemRepo } from '../repo';
@@ -253,6 +253,37 @@ describe('FHIR Repo Transactions', () => {
       }
     })
   );
+
+  test('saved AuditEvents from transaction post-commit do not trip transaction scope guard', () =>
+    withTestContext(async () => {
+      const previousSaveAuditEvents = getConfig().saveAuditEvents;
+      const loggerErrorSpy = vi.spyOn(getLogger(), 'error').mockImplementation(() => {});
+      let patient: WithId<Patient> | undefined;
+
+      getConfig().saveAuditEvents = true;
+      try {
+        await repo.withTransaction(
+          async (txRepo) => {
+            patient = await txRepo.createResource<Patient>({ resourceType: 'Patient' });
+            await txRepo.createResource<Patient>({ resourceType: 'Patient' });
+          },
+          { serializable: true }
+        );
+
+        assert(patient);
+        await waitFor(async () => {
+          const auditEvent = await systemRepo.searchOne<AuditEvent>({
+            resourceType: 'AuditEvent',
+            filters: [{ code: 'entity', operator: Operator.EQUALS, value: getReferenceString(patient) }],
+          });
+          expect(auditEvent).toBeDefined();
+        });
+        expect(loggerErrorSpy).not.toHaveBeenCalledWith('Failed to save AuditEvent', expect.anything());
+      } finally {
+        getConfig().saveAuditEvents = previousSaveAuditEvents;
+        loggerErrorSpy.mockRestore();
+      }
+    }));
 
   test('Nested transaction post-commit', () =>
     withTestContext(async () => {


### PR DESCRIPTION
Fix saved `AuditEvent` persistence so it no longer reuses the request repository connection.

When `saveAuditEvents` is enabled, `Repository.logEvent()` was writing the generated `AuditEvent` with `this.updateResourceImpl(...)` in a fire-and-forget promise. For multi-write operations running inside `withTransaction`, that could reuse the same repository connection while it was still transaction-scoped, triggering:

```text
Repository is in an active transaction; use the transaction-scoped repository passed to the callback
```

## Changes

- Keep `Repository.logEvent()` synchronous.
- Move saved `AuditEvent` persistence into a private helper.
- Persist saved `AuditEvent` resources with a fresh `getShardSystemRepo(..., { skipBackgroundJobs: true })` instance, so detached audit writes use their own repository connection instead of the request or transaction-scoped repo.
- Add a regression test covering saved `AuditEvent` creation during a serializable multi-write transaction.
- Update repository method guard metadata for the new private helper.

## Why

Audit persistence is intentionally best-effort and detached from the original operation, but detached work must not keep using a repository whose connection/scope is controlled by the request flow. Using a separate system repository removes the shared-connection race while preserving the existing fire-and-forget behavior.
