### PR TITLE
Fixes #9375 - Fix Debian package missing DuckDB native dependency

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -66,8 +66,8 @@ echo "Medplum data files" > "$VAR_DIR/README.txt"
 # Move into the working directory
 pushd "$LIB_DIR"
 
-# Install dependencies
-npm ci --omit=dev --omit=optional --omit=peer
+# Install production dependencies
+npm ci --omit=dev --omit=peer
 
 # Move back to the original directory
 popd
@@ -243,7 +243,7 @@ Package: $SERVICE_NAME
 Version: $VERSION
 Section: base
 Priority: optional
-Architecture: all
+Architecture: amd64
 Depends: debconf, nodejs
 Recommends: nginx, postgresql-16, redis-server
 Suggests: certbot
@@ -342,8 +342,7 @@ chmod 755 "$DEBIAN_DIR/prerm"
 
 # Build the package
 # Use the standard Debian package naming convention: <name>_<version>_<architecture>.deb
-# We can use architecture "all" because we are not building a binary package
-DEB_FILENAME="${SERVICE_NAME}_${VERSION}_all.deb"
+DEB_FILENAME="${SERVICE_NAME}_${VERSION}_amd64.deb"
 dpkg-deb --build --root-owner-group -Zgzip "$TMP_DIR" "$DEB_FILENAME"
 
 # Generate the checksum
@@ -358,4 +357,3 @@ rm -rf "$TMP_DIR"
 
 # Done
 echo "Done"
-


### PR DESCRIPTION
Fixes #9375

This PR fixes the Debian/APT package build for Medplum now that `@medplum/server` depends on DuckDB.

The Debian package build previously ran:

```bash
npm ci --omit=dev --omit=optional --omit=peer
```

DuckDB publishes its platform-specific native bindings, including `@duckdb/node-bindings-linux-x64`, as npm optional dependencies. Omitting optional dependencies caused the Debian package to exclude the required native `.node` binding, leading to runtime startup failures like:

```text
Error: Cannot find module '@duckdb/node-bindings-linux-x64/duckdb.node'
```

## Changes

- Include npm optional dependencies in the Debian package build by removing `--omit=optional`.
- Mark the Debian package as `Architecture: amd64`.
- Rename the generated package artifact from `medplum_${VERSION}_all.deb` to `medplum_${VERSION}_amd64.deb`.

## Notes

The package can no longer accurately use `Architecture: all` because it now contains native architecture-specific binaries via DuckDB. Arm64 support should be added separately with an arm64 build that produces `Architecture: arm64`.

## Testing

- Ran `bash -n scripts/build-deb.sh`.

Recommended follow-up validation before publishing:

```bash
./scripts/build-deb.sh
dpkg-deb -f medplum_${VERSION}_amd64.deb Architecture
dpkg-deb -c medplum_${VERSION}_amd64.deb | grep '@duckdb/node-bindings-linux-x64'
```