### PR TITLE
Fixed flaky test in agent-main.test.ts

### DIFF
--- a/packages/agent/src/agent-main.test.ts
+++ b/packages/agent/src/agent-main.test.ts
@@ -20,6 +20,7 @@ vi.mock('./constants', async (importOriginal) => {
 describe('Main', () => {
   beforeEach(() => {
     console.log = vi.fn();
+    vi.mocked(existsSync).mockReturnValue(false);
 
     vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('process.exit');


### PR DESCRIPTION
- Isolates `agent-main.test.ts` from local `agent.properties` files by defaulting the mocked `existsSync` result to `false`.
- Preserves explicit properties-file test coverage by allowing those tests to opt in with their own `existsSync` mocks.

## Why

The `agentMain()` entrypoint falls back to `agent.properties` when command-line arguments are incomplete. If a developer has an ignored local `packages/agent/agent.properties` file, the `Missing arguments` test can unexpectedly read that file, start the app, and resolve instead of rejecting through the mocked `process.exit`.
