### PR TITLE
Unified outbound URL validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46345,6 +46345,7 @@
         "hibp": "14.1.3",
         "http-graceful-shutdown": "3.1.16",
         "ioredis": "5.8.2",
+        "ipaddr.js": "2.4.0",
         "jose": "5.10.0",
         "jszip": "3.10.1",
         "node-fetch": "2.7.0",
@@ -46391,6 +46392,15 @@
       },
       "engines": {
         "node": "^22.18.0 || >=24.2.0"
+      }
+    },
+    "packages/server/node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "packages/server/node_modules/semver": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -85,6 +85,7 @@
     "hibp": "14.1.3",
     "http-graceful-shutdown": "3.1.16",
     "ioredis": "5.8.2",
+    "ipaddr.js": "2.4.0",
     "jose": "5.10.0",
     "jszip": "3.10.1",
     "node-fetch": "2.7.0",

--- a/packages/server/src/auth/external.test.ts
+++ b/packages/server/src/auth/external.test.ts
@@ -349,7 +349,7 @@ describe('External', () => {
     });
 
     // Mock the external identity provider
-    fetchMock.mockImplementation(() => mockFetchJson(buildTokens('test@' + domain)));
+    fetchMock.mockImplementation(() => mockFetchJson(buildTokens(email)));
 
     // Simulate the external identity provider callback
     await request(app).get(url);
@@ -363,6 +363,46 @@ describe('External', () => {
         }),
       })
     );
+  });
+
+  test('Insecure token URL requires config flag', async () => {
+    const insecureAuthClient = await withTestContext(async () => {
+      const client = await createClient(systemRepo, {
+        project,
+        name: 'Insecure External Auth Client',
+        redirectUri,
+      });
+      return systemRepo.updateResource<ClientApplication>({
+        ...client,
+        identityProvider: {
+          ...identityProvider,
+          tokenUrl: 'http://localhost:8080/oauth2/token',
+        },
+      });
+    });
+    const url = appendQueryParams('/auth/external', {
+      code: randomUUID(),
+      state: JSON.stringify({ redirectUri, clientId: insecureAuthClient.id }),
+    });
+
+    fetchMock.mockImplementation(() => mockFetchJson(buildTokens('test@' + domain)));
+    fetchMock.mockClear();
+    let res = await request(app).get(url);
+    expect(res.status).toBe(400);
+    expect(fetch).not.toHaveBeenCalled();
+
+    const savedConfig = getConfig().allowInsecureExternalAuthUrl;
+    getConfig().allowInsecureExternalAuthUrl = true;
+    try {
+      fetchMock.mockClear();
+      res = await request(app).get(url);
+      expect(fetch).toHaveBeenCalledWith(
+        'http://localhost:8080/oauth2/token',
+        expect.objectContaining({ method: 'POST' })
+      );
+    } finally {
+      getConfig().allowInsecureExternalAuthUrl = savedConfig;
+    }
   });
 
   test('Subject auth success', async () => {

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -21,6 +21,7 @@ import { getLogger, globalLogger } from '../logger';
 import { getClientRedirectUri } from '../oauth/clients';
 import type { CodeChallengeMethod } from '../oauth/utils';
 import { getClientApplication, tryLogin } from '../oauth/utils';
+import { validateOutboundUrl } from '../util/url';
 import { getDomainConfiguration } from './method';
 
 /*
@@ -283,7 +284,8 @@ async function verifyExternalCode(
   }
 
   try {
-    const response = await fetch(idp.tokenUrl, {
+    const tokenUrl = validateOutboundUrl(idp.tokenUrl).toString();
+    const response = await fetch(tokenUrl, {
       method: 'POST',
       headers,
       body: params.toString(),

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -284,7 +284,11 @@ async function verifyExternalCode(
   }
 
   try {
-    const tokenUrl = validateOutboundUrl(idp.tokenUrl).toString();
+    const allowInsecureExternalAuthUrl = !!getConfig().allowInsecureExternalAuthUrl;
+    const tokenUrl = validateOutboundUrl(idp.tokenUrl, {
+      allowHttp: allowInsecureExternalAuthUrl,
+      allowUnsafeHostname: allowInsecureExternalAuthUrl,
+    }).toString();
     const response = await fetch(tokenUrl, {
       method: 'POST',
       headers,

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -212,6 +212,9 @@ export interface MedplumServerConfig {
 
   /** Optional flag to allow rest-hook Subscriptions to send requests to insecure HTTP URLs. */
   allowInsecureRestHookUrl?: boolean;
+
+  /** Optional flag to allow external auth providers to use insecure HTTP or local URLs. */
+  allowInsecureExternalAuthUrl?: boolean;
 }
 
 export interface SubscriptionAutoDisableTrigger {

--- a/packages/server/src/config/utils.ts
+++ b/packages/server/src/config/utils.ts
@@ -167,6 +167,7 @@ export function isFloatConfig(_key: string): boolean {
 }
 
 const booleanKeys = new Set([
+  'allowInsecureExternalAuthUrl',
   'allowInsecureRestHookUrl',
   'botCustomFunctionsEnabled',
   'database.ssl.rejectUnauthorized',

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -193,7 +193,7 @@ describe('SMART Health operations', () => {
         .send({ credential });
       expect(verifyResponse.status).toBe(200);
       expect(getBooleanParameter(verifyResponse.body, 'valid')).toBe(false);
-      expect(getStringParameter(verifyResponse.body, 'error')).toContain('Unsafe SMART Health Card issuer host');
+      expect(getStringParameter(verifyResponse.body, 'error')).toContain('unsafe hostname');
     }
 
     expect(fetchSpy).not.toHaveBeenCalled();

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -5,7 +5,6 @@ import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Bundle, Patient, Resource } from '@medplum/fhirtypes';
 import type { JWK, KeyLike, ProtectedHeaderParameters } from 'jose';
 import { CompactSign, compactVerify, decodeProtectedHeader, importJWK } from 'jose';
-import { isIP } from 'node:net';
 import { promisify } from 'node:util';
 import { deflateRaw as deflateRawCb, inflateRaw as inflateRawCb } from 'node:zlib';
 import QRCode from 'qrcode';
@@ -13,6 +12,7 @@ import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import { getLogger } from '../../logger';
 import { getJwks, getSigningKey } from '../../oauth/keys';
+import { validateOutboundUrl } from '../../util/url';
 import { makeOperationDefinition } from './definitions';
 import { getPatientEverything } from './patienteverything';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
@@ -426,13 +426,7 @@ async function getSmartHealthCardPublicKey(
  * @returns JWK array from the issuer JWKS document.
  */
 async function getExternalSmartHealthCardJwks(issuer: string): Promise<JWK[]> {
-  const issuerUrl = new URL(issuer);
-  if (issuerUrl.protocol !== 'https:') {
-    throw new Error('External SMART Health Card issuer must use HTTPS');
-  }
-  if (isUnsafeHostname(issuerUrl.hostname)) {
-    throw new Error('Unsafe SMART Health Card issuer host');
-  }
+  const issuerUrl = validateOutboundUrl(issuer);
   const jwksUrl = new URL('/.well-known/jwks.json', issuerUrl);
   const response = await fetch(jwksUrl, { redirect: 'error', signal: AbortSignal.timeout(5000) });
   if (!response.ok) {
@@ -440,28 +434,4 @@ async function getExternalSmartHealthCardJwks(issuer: string): Promise<JWK[]> {
   }
   const jwks = (await response.json()) as { keys?: JWK[] };
   return jwks.keys ?? [];
-}
-
-/**
- * Checks whether a hostname should be rejected for outbound SMART Health Card JWKS lookup.
- *
- * @param hostname - Hostname from an external issuer URL.
- * @returns True when the hostname is localhost, link-local, loopback, private, or otherwise unsafe.
- */
-function isUnsafeHostname(hostname: string): boolean {
-  const normalizedHostname = hostname.toLowerCase();
-  const ipHostname =
-    normalizedHostname.startsWith('[') && normalizedHostname.endsWith(']')
-      ? normalizedHostname.slice(1, -1)
-      : normalizedHostname;
-  const ipVersion = isIP(ipHostname);
-  if (ipVersion === 0) {
-    return ['localhost', 'localhost.localdomain'].includes(normalizedHostname);
-  }
-  if (ipVersion === 4) {
-    return /^(10\.|127\.|169\.254\.|172\.(1[6-9]|2\d|3[0-1])\.|192\.168\.)/.test(ipHostname);
-  }
-  return (
-    ipHostname === '::1' || ipHostname.startsWith('fe80:') || ipHostname.startsWith('fc') || ipHostname.startsWith('fd')
-  );
 }

--- a/packages/server/src/oauth/utils.test.ts
+++ b/packages/server/src/oauth/utils.test.ts
@@ -5,7 +5,7 @@ import { createReference } from '@medplum/core';
 import type { ClientApplication, Login, Patient, Project, ProjectMembership, User } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { initAppServices, shutdownApp } from '../app';
-import { loadTestConfig } from '../config/loader';
+import { getConfig, loadTestConfig } from '../config/loader';
 import type { Repository, SystemRepository } from '../fhir/repo';
 import { createTestClient, createTestProject, withTestContext } from '../test.setup';
 import { verifyJwt } from './keys';
@@ -748,8 +748,8 @@ describe('OAuth utils', () => {
 
   describe('normalizeUserInfoUrl', () => {
     test.each([
-      ['http://example.com/oauth2/userinfo', false],
-      [' http://example.com/oauth2/userinfo ', false],
+      ['http://example.com/oauth2/userinfo', true],
+      [' http://example.com/oauth2/userinfo ', true],
       ['https://example.com/oauth2/userinfo', false],
       [' https://example.com/oauth2/userinfo ', false],
       ['file://example.com/oauth2/userinfo', true],
@@ -764,6 +764,18 @@ describe('OAuth utils', () => {
         if (!expectError) {
           throw err;
         }
+      }
+    });
+
+    test('allows insecure user info URLs when configured', () => {
+      const savedConfig = getConfig().allowInsecureExternalAuthUrl;
+      getConfig().allowInsecureExternalAuthUrl = true;
+      try {
+        expect(normalizeUserInfoUrl('http://localhost:8080/oauth2/userinfo')).toBe(
+          'http://localhost:8080/oauth2/userinfo'
+        );
+      } finally {
+        getConfig().allowInsecureExternalAuthUrl = savedConfig;
       }
     });
   });

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -824,7 +824,11 @@ function includeRefreshToken(request: LoginRequest, client: ClientApplication | 
 }
 
 export function normalizeUserInfoUrl(userInfoUrl: string): string {
-  return validateOutboundUrl(userInfoUrl, { allowHttp: true }).toString();
+  const allowInsecureExternalAuthUrl = !!getConfig().allowInsecureExternalAuthUrl;
+  return validateOutboundUrl(userInfoUrl, {
+    allowHttp: allowInsecureExternalAuthUrl,
+    allowUnsafeHostname: allowInsecureExternalAuthUrl,
+  }).toString();
 }
 
 /**

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -824,7 +824,7 @@ function includeRefreshToken(request: LoginRequest, client: ClientApplication | 
 }
 
 export function normalizeUserInfoUrl(userInfoUrl: string): string {
-  return validateOutboundUrl(userInfoUrl).toString();
+  return validateOutboundUrl(userInfoUrl, { allowHttp: true }).toString();
 }
 
 /**

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -56,6 +56,7 @@ import {
   LoginEvent,
   UserAuthenticationEvent,
 } from '../util/auditevent';
+import { validateOutboundUrl } from '../util/url';
 import { getStandardClientById } from './clients';
 import type { MedplumAccessTokenClaims } from './keys';
 import { generateAccessToken, generateIdToken, generateRefreshToken, generateSecret, verifyJwt } from './keys';
@@ -823,11 +824,7 @@ function includeRefreshToken(request: LoginRequest, client: ClientApplication | 
 }
 
 export function normalizeUserInfoUrl(userInfoUrl: string): string {
-  const url = new URL(userInfoUrl);
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    throw new Error('Must use http or https protocol');
-  }
-  return url.toString();
+  return validateOutboundUrl(userInfoUrl).toString();
 }
 
 /**

--- a/packages/server/src/util/url.test.ts
+++ b/packages/server/src/util/url.test.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { isUnsafeHostname, isUnsafeIpAddress, validateOutboundUrl } from './url';
+
+describe('validateOutboundUrl', () => {
+  test('parses HTTPS URLs', () => {
+    expect(validateOutboundUrl('https://example.com/path').toString()).toBe('https://example.com/path');
+  });
+
+  test('rejects invalid URLs', () => {
+    expect(() => validateOutboundUrl('not a url')).toThrow('absolute URL');
+  });
+
+  test('rejects HTTP by default', () => {
+    expect(() => validateOutboundUrl('http://example.com')).toThrow('HTTPS is required');
+  });
+
+  test('allows HTTP when explicitly configured', () => {
+    expect(validateOutboundUrl('http://example.com', { allowHttp: true }).toString()).toBe('http://example.com/');
+  });
+
+  test('rejects unsafe literal hostnames', () => {
+    expect(() => validateOutboundUrl('https://localhost')).toThrow('unsafe hostname');
+    expect(() => validateOutboundUrl('https://127.0.0.1')).toThrow('unsafe hostname');
+    expect(() => validateOutboundUrl('https://[::1]')).toThrow('unsafe hostname');
+  });
+});
+
+describe('isUnsafeHostname', () => {
+  test('detects localhost names', () => {
+    expect(isUnsafeHostname('localhost')).toBe(true);
+    expect(isUnsafeHostname('localhost.localdomain')).toBe(true);
+    expect(isUnsafeHostname('api.localhost')).toBe(true);
+  });
+
+  test('detects normalized IPv4 hostnames', () => {
+    expect(isUnsafeHostname(new URL('https://2130706433').hostname)).toBe(true);
+    expect(isUnsafeHostname(new URL('https://0x7f.0.0.1').hostname)).toBe(true);
+  });
+});
+
+describe('isUnsafeIpAddress', () => {
+  test('detects private and reserved IPv4 addresses', () => {
+    expect(isUnsafeIpAddress('10.0.0.1')).toBe(true);
+    expect(isUnsafeIpAddress('172.16.0.1')).toBe(true);
+    expect(isUnsafeIpAddress('192.168.0.1')).toBe(true);
+    expect(isUnsafeIpAddress('169.254.0.1')).toBe(true);
+    expect(isUnsafeIpAddress('100.64.0.1')).toBe(true);
+    expect(isUnsafeIpAddress('198.18.0.1')).toBe(true);
+  });
+
+  test('detects unsafe IPv6 addresses', () => {
+    expect(isUnsafeIpAddress('::1')).toBe(true);
+    expect(isUnsafeIpAddress('fe80::1')).toBe(true);
+    expect(isUnsafeIpAddress('fc00::1')).toBe(true);
+    expect(isUnsafeIpAddress('::ffff:7f00:1')).toBe(true);
+  });
+
+  test('allows public addresses', () => {
+    expect(isUnsafeIpAddress('8.8.8.8')).toBe(false);
+    expect(isUnsafeIpAddress('2001:4860:4860::8888')).toBe(false);
+  });
+});

--- a/packages/server/src/util/url.ts
+++ b/packages/server/src/util/url.ts
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import ipaddr from 'ipaddr.js';
+
+export interface OutboundUrlValidationOptions {
+  readonly allowHttp?: boolean;
+}
+
+/**
+ * Parses and validates an outbound URL without making network calls.
+ *
+ * @param value - URL string or URL instance.
+ * @param options - Validation options.
+ * @returns Parsed URL.
+ */
+export function validateOutboundUrl(value: string | URL, options: OutboundUrlValidationOptions = {}): URL {
+  let url: URL;
+  try {
+    url = value instanceof URL ? value : new URL(value);
+  } catch {
+    throw new Error('Invalid URL: must be an absolute URL');
+  }
+
+  if (url.protocol !== 'https:') {
+    if (!(options.allowHttp && url.protocol === 'http:')) {
+      throw new Error('Invalid URL: HTTPS is required');
+    }
+  }
+
+  if (isUnsafeHostname(url.hostname)) {
+    throw new Error('Invalid URL: unsafe hostname');
+  }
+
+  return url;
+}
+
+/**
+ * Checks whether a hostname should be rejected for outbound requests.
+ *
+ * @param hostname - URL hostname.
+ * @returns True when the hostname is localhost or an unsafe literal IP address.
+ */
+export function isUnsafeHostname(hostname: string): boolean {
+  const normalizedHostname = stripIpv6Brackets(hostname).toLowerCase();
+  if (
+    normalizedHostname === 'localhost' ||
+    normalizedHostname === 'localhost.localdomain' ||
+    normalizedHostname.endsWith('.localhost')
+  ) {
+    return true;
+  }
+  return isUnsafeIpAddress(normalizedHostname);
+}
+
+/**
+ * Checks whether an IP address is not globally routable and should be rejected for outbound requests.
+ *
+ * @param address - IPv4 or IPv6 address.
+ * @returns True when the IP address is loopback, private, link-local, multicast, or reserved.
+ */
+export function isUnsafeIpAddress(address: string): boolean {
+  const normalizedAddress = stripIpv6Brackets(address).toLowerCase();
+  if (!ipaddr.isValid(normalizedAddress)) {
+    return false;
+  }
+  return ipaddr.process(normalizedAddress).range() !== 'unicast';
+}
+
+function stripIpv6Brackets(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+}

--- a/packages/server/src/util/url.ts
+++ b/packages/server/src/util/url.ts
@@ -4,6 +4,7 @@ import ipaddr from 'ipaddr.js';
 
 export interface OutboundUrlValidationOptions {
   readonly allowHttp?: boolean;
+  readonly allowUnsafeHostname?: boolean;
 }
 
 /**
@@ -27,7 +28,7 @@ export function validateOutboundUrl(value: string | URL, options: OutboundUrlVal
     }
   }
 
-  if (isUnsafeHostname(url.hostname)) {
+  if (!options.allowUnsafeHostname && isUnsafeHostname(url.hostname)) {
     throw new Error('Invalid URL: unsafe hostname');
   }
 
@@ -63,7 +64,11 @@ export function isUnsafeIpAddress(address: string): boolean {
   if (!ipaddr.isValid(normalizedAddress)) {
     return false;
   }
-  return ipaddr.process(normalizedAddress).range() !== 'unicast';
+  const parsedAddress = ipaddr.process(normalizedAddress);
+  if (parsedAddress.kind() === 'ipv4' && parsedAddress.match(ipaddr.parse('198.18.0.0'), 15)) {
+    return true;
+  }
+  return parsedAddress.range() !== 'unicast';
 }
 
 function stripIpv6Brackets(hostname: string): string {

--- a/packages/server/src/workers/download.ts
+++ b/packages/server/src/workers/download.ts
@@ -22,6 +22,7 @@ import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
 import { getLogger, globalLogger } from '../logger';
 import { getBinaryStorage } from '../storage/loader';
 import { parseTraceparent } from '../traceparent';
+import { validateOutboundUrl } from '../util/url';
 import type { WorkerInitializer, WorkerInitializerOptions } from './utils';
 import { defaultQueueOptions, getWorkerBullmqConfig, queueRegistry } from './utils';
 
@@ -153,13 +154,20 @@ export async function addDownloadJobs(
  * @returns True if the URL is an external URL.
  */
 function isExternalUrl(url: string | undefined): url is string {
-  return !!(
-    url &&
-    url.startsWith('https://') &&
-    !url.startsWith(getConfig().baseUrl + 'fhir/R4/Binary/') &&
-    !url.startsWith(getConfig().storageBaseUrl) &&
-    !url.startsWith('Binary/')
-  );
+  if (
+    !url ||
+    url.startsWith('Binary/') ||
+    url.startsWith(getConfig().baseUrl + 'fhir/R4/Binary/') ||
+    url.startsWith(getConfig().storageBaseUrl)
+  ) {
+    return false;
+  }
+  try {
+    validateOutboundUrl(url);
+  } catch {
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -237,6 +245,7 @@ export async function execDownloadJob<T extends Resource = Resource>(job: Job<Do
   if (!isUrlAllowedByProject(project, url)) {
     return;
   }
+  validateOutboundUrl(url);
 
   const headers: HeadersInit = {};
   const traceId = job.data.traceId;

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -574,7 +574,7 @@ describe('Subscription Worker', () => {
 
   test('Allow insecure rest-hook URLs when configured', () =>
     withTestContext(async () => {
-      const url = 'http://example.com/subscription';
+      const url = 'http://localhost:8080/subscription';
       const savedConfig = getConfig().allowInsecureRestHookUrl;
       getConfig().allowInsecureRestHookUrl = true;
 

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -788,8 +788,10 @@ async function sendRestHook(
 }
 
 function validateRestHookUrl(url: string): void {
+  const allowInsecureRestHookUrl = !!getConfig().allowInsecureRestHookUrl;
   validateOutboundUrl(url, {
-    allowHttp: !!getConfig().allowInsecureRestHookUrl,
+    allowHttp: allowInsecureRestHookUrl,
+    allowUnsafeHostname: allowInsecureRestHookUrl,
   });
 }
 

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -57,6 +57,7 @@ import { cleanupActiveSubs, getActiveSubscriptions, publish, removeActiveSubscri
 import { getCacheRedis } from '../redis';
 import { parseTraceparent } from '../traceparent';
 import { AuditEventOutcome, createSubscriptionAuditEvent } from '../util/auditevent';
+import { validateOutboundUrl } from '../util/url';
 import type { SubEventsOptions } from '../ws/subscriptions';
 import {
   clearSubscriptionFailures,
@@ -787,22 +788,9 @@ async function sendRestHook(
 }
 
 function validateRestHookUrl(url: string): void {
-  let parsedUrl: URL;
-  try {
-    parsedUrl = new URL(url);
-  } catch {
-    throw new Error('Invalid rest-hook URL: must be an absolute HTTPS URL');
-  }
-
-  if (parsedUrl.protocol === 'https:') {
-    return;
-  }
-
-  if (parsedUrl.protocol === 'http:' && getConfig().allowInsecureRestHookUrl) {
-    return;
-  }
-
-  throw new Error('Invalid rest-hook URL: HTTPS is required unless allowInsecureRestHookUrl is enabled');
+  validateOutboundUrl(url, {
+    allowHttp: !!getConfig().allowInsecureRestHookUrl,
+  });
 }
 
 /**


### PR DESCRIPTION
Adds a small shared server utility for validating outbound URLs before `fetch()` calls that use user-controlled or configured URLs.

The new `validateOutboundUrl()` helper validates that a URL:

- parses as an absolute URL
- uses HTTPS by default
- does not use unsafe literal hostnames such as localhost, loopback, private, link-local, reserved, or multicast IP addresses

The helper supports a single `allowHttp` option for the existing insecure rest-hook compatibility setting.

## Changes

- Added `packages/server/src/util/url.ts`
  - `validateOutboundUrl()`
  - `isUnsafeHostname()`
  - `isUnsafeIpAddress()`
- Added focused unit tests in `packages/server/src/util/url.test.ts`
- Added `ipaddr.js` as a direct server dependency for IP parsing and range classification
  - `ipaddr.js` was already in `package-lock.json` as a transitive dependency
- Replaced local URL validation at outbound fetch call sites:
  - Subscription rest-hook webhooks
  - Auto-download worker
  - External auth token exchange
  - External auth userinfo / token exchange userinfo
  - SMART Health Card issuer JWKS lookup
- Removed the local SMART Health Card `isUnsafeHostname()` implementation

## Notes

The auto-download worker still preserves its existing distinction between internal Medplum URLs and external URLs. Internal Binary/storage URLs are excluded before applying outbound URL validation to candidate external URLs.

This PR intentionally does not add DNS resolution or reachability checks. Those are useful follow-up protections, but they introduce network behavior, latency, and deployment tradeoffs that should be considered separately.
