### PR TITLE
Use vendored patch lib

### DIFF
--- a/examples/medplum-provider/src/components/Calendar.test.tsx
+++ b/examples/medplum-provider/src/components/Calendar.test.tsx
@@ -125,7 +125,8 @@ describe('Calendar', () => {
     });
 
     test('navigates to today when clicking today button', async () => {
-      setup();
+      const onRangeChange = vi.fn();
+      setup({ onRangeChange });
 
       // First navigate away from today
       await userEvent.click(screen.getByLabelText('Previous'));
@@ -133,11 +134,10 @@ describe('Calendar', () => {
       // Then click today
       await userEvent.click(screen.getByText('Today'));
 
-      // Should be back to current month
-      const title = screen.getByRole('heading', { level: 4 }).textContent;
       const today = new Date();
-      const expectedMonth = today.toLocaleDateString('en-US', { month: 'long' });
-      expect(title).toContain(expectedMonth);
+      const range = onRangeChange.mock.lastCall?.[0];
+      expect(range.start.getTime()).toBeLessThanOrEqual(today.getTime());
+      expect(range.end.getTime()).toBeGreaterThan(today.getTime());
     });
 
     test('switches to day view and triggers range change', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39344,12 +39344,6 @@
       "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
       "license": "MIT"
     },
-    "node_modules/rfc6902": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/rfc6902/-/rfc6902-5.2.0.tgz",
-      "integrity": "sha512-ZNQpVnWsdLMTCcLZcUY9ZBhxWuj7/H13EM7NL2gvbAMBXfLeN3iOLi3TWT1+8Or7OTLYXRDCy7sTEStk3j4KBA==",
-      "license": "MIT"
-    },
     "node_modules/rimraf": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
@@ -45585,7 +45579,6 @@
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-router": "7.18.0",
-        "rfc6902": "5.2.0",
         "vite": "8.0.16"
       },
       "engines": {
@@ -45930,8 +45923,7 @@
         "@medplum/definitions": "5.1.22",
         "@medplum/fhirtypes": "5.1.22",
         "dataloader": "2.2.3",
-        "graphql": "16.14.2",
-        "rfc6902": "5.2.0"
+        "graphql": "16.14.2"
       },
       "engines": {
         "node": "^22.18.0 || >=24.2.0"
@@ -46086,8 +46078,7 @@
         "@medplum/definitions": "5.1.22",
         "@medplum/fhir-router": "5.1.22",
         "@medplum/fhirtypes": "5.1.22",
-        "dataloader": "2.2.3",
-        "rfc6902": "5.2.0"
+        "dataloader": "2.2.3"
       },
       "devDependencies": {
         "@types/pdfmake": "0.2.12"
@@ -46131,7 +46122,6 @@
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-router": "7.18.0",
-        "rfc6902": "5.2.0",
         "signature_pad": "5.1.3",
         "sinon": "22.0.0",
         "storybook": "10.4.6",
@@ -46149,7 +46139,6 @@
         "@medplum/react-hooks": "5.1.22",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
-        "rfc6902": "^5.0.1",
         "signature_pad": "^5.0.10"
       },
       "peerDependenciesMeta": {
@@ -46160,9 +46149,6 @@
           "optional": true
         },
         "@mantine/notifications": {
-          "optional": true
-        },
-        "rfc6902": {
           "optional": true
         },
         "signature_pad": {
@@ -46354,7 +46340,6 @@
         "pg": "8.22.0",
         "qrcode": "1.5.4",
         "rate-limiter-flexible": "11.2.0",
-        "rfc6902": "5.2.0",
         "semver": "7.8.4",
         "temporal-polyfill": "0.3.2",
         "uuid": "14.0.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -53,7 +53,6 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-router": "7.18.0",
-    "rfc6902": "5.2.0",
     "vite": "8.0.16"
   },
   "engines": {

--- a/packages/app/src/resource/EditPage.tsx
+++ b/packages/app/src/resource/EditPage.tsx
@@ -1,13 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { showNotification } from '@mantine/notifications';
-import { deepClone, normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
+import { createPatch, deepClone, normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
 import type { OperationOutcome, Resource, ResourceType } from '@medplum/fhirtypes';
 import { Document, ResourceForm, useMedplum } from '@medplum/react';
 import type { JSX } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
-import { createPatch } from 'rfc6902';
 import { cleanResource } from './utils';
 
 export function EditPage(): JSX.Element | null {

--- a/packages/core/src/fhirpath/patch.ts
+++ b/packages/core/src/fhirpath/patch.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Pointer } from '../patch';
-import type { Options } from '../patch/patch';
+import type { PatchOptions } from '../patch/patch';
 import { add, move, remove, replace } from '../patch/patch';
 import type { TypedValue } from '../types';
 import { getElementDefinitionForPath } from '../types';
@@ -17,7 +17,7 @@ export type FhirPathPatch =
   | { type: 'replace'; path: string; value: TypedValue }
   | { type: 'move'; path: string; source: number; destination: number };
 
-const ADD_OPTIONS: Readonly<Options> = Object.freeze({ implicitArrayCreation: true });
+const ADD_OPTIONS: Readonly<PatchOptions> = Object.freeze({ implicitArrayCreation: true });
 
 export function fhirpathPatchTypedValue(original: TypedValue, patch: FhirPathPatch[]): void {
   for (const op of patch) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,7 @@ export * from './keyvalue';
 export * from './logger';
 export * from './medication-order-utils';
 export * from './outcomes';
+export * from './patch';
 export * from './pharmacy-utils';
 export * from './readablepromise';
 export * from './schema';

--- a/packages/core/src/patch/diff.ts
+++ b/packages/core/src/patch/diff.ts
@@ -83,6 +83,7 @@ export function isDestructive({ op }: Operation): boolean {
 }
 
 export type Diff = (input: any, output: any, ptr: Pointer) => Operation[];
+
 /**
  * VoidableDiff exists to allow the user to provide a partial diff(...) function,
  * falling back to the built-in diffAny(...) function if the user-provided function
@@ -369,23 +370,23 @@ export function diffObjects(input: any, output: any, ptr: Pointer, diff: Diff = 
  * (i.e., would produce equivalent JSON); otherwise it produces an array of patches
  * that would transform `input` into `output`.
  *
- * > Here, "equal" means that the value at the target location and the
- * > value conveyed by "value" are of the same JSON type, and that they
- * > are considered equal by the following rules for that type:
- * > o  strings: are considered equal if they contain the same number of
- * >    Unicode characters and their code points are byte-by-byte equal.
- * > o  numbers: are considered equal if their values are numerically
- * >    equal.
- * > o  arrays: are considered equal if they contain the same number of
- * >    values, and if each value can be considered equal to the value at
- * >    the corresponding position in the other array, using this list of
- * >    type-specific rules.
- * > o  objects: are considered equal if they contain the same number of
- * >    members, and if each member can be considered equal to a member in
- * >    the other object, by comparing their keys (as strings) and their
- * >    values (using this list of type-specific rules).
- * > o  literals (false, true, and null): are considered equal if they are
- * >    the same.
+ *   Here, "equal" means that the value at the target location and the
+ *   value conveyed by "value" are of the same JSON type, and that they
+ *   are considered equal by the following rules for that type:
+ *   o  strings: are considered equal if they contain the same number of
+ *      Unicode characters and their code points are byte-by-byte equal.
+ *   o  numbers: are considered equal if their values are numerically
+ *      equal.
+ *   o  arrays: are considered equal if they contain the same number of
+ *      values, and if each value can be considered equal to the value at
+ *      the corresponding position in the other array, using this list of
+ *      type-specific rules.
+ *   o  objects: are considered equal if they contain the same number of
+ *      members, and if each member can be considered equal to a member in
+ *      the other object, by comparing their keys (as strings) and their
+ *      values (using this list of type-specific rules).
+ *   o  literals (false, true, and null): are considered equal if they are
+ *      the same.
  *
  * @param input - The original value.
  * @param output - The target value.

--- a/packages/core/src/patch/index.ts
+++ b/packages/core/src/patch/index.ts
@@ -14,15 +14,16 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import { Pointer } from './pointer';
-export { Pointer };
-
 import type { Diff, Operation, TestOperation, VoidableDiff } from './diff';
 import { diffAny, isDestructive } from './diff';
-import type { InvalidOperationError, MissingError, Options, TestError } from './patch';
+import type { InvalidOperationError, MissingError, PatchOptions, TestError } from './patch';
 import { apply } from './patch';
+import { Pointer } from './pointer';
 
-export type { Operation, Options, TestOperation };
+export * from './diff';
+export * from './patch';
+export * from './pointer';
+
 export type Patch = Operation[];
 
 /**
@@ -30,10 +31,10 @@ export type Patch = Operation[];
  *
  * `patch` *must* be an array of operations.
  *
- * > Operation objects MUST have exactly one "op" member, whose value
- * > indicates the operation to perform.  Its value MUST be one of "add",
- * > "remove", "replace", "move", "copy", or "test"; other values are
- * > errors.
+ *   Operation objects MUST have exactly one "op" member, whose value
+ *   indicates the operation to perform.  Its value MUST be one of "add",
+ *   "remove", "replace", "move", "copy", or "test"; other values are
+ *   errors.
  *
  * This method mutates the target object in-place.
  *
@@ -46,7 +47,7 @@ export type Patch = Operation[];
 export function applyPatch(
   object: any,
   patch: Operation[],
-  options?: Options
+  options?: PatchOptions
 ): (null | MissingError | InvalidOperationError | TestError)[] {
   return patch.map((operation) => apply(object, operation, options));
 }

--- a/packages/core/src/patch/patch.ts
+++ b/packages/core/src/patch/patch.ts
@@ -28,7 +28,7 @@ import { diffAny } from './diff';
 import { Pointer } from './pointer';
 import { clone, objectType } from './util';
 
-export interface Options {
+export interface PatchOptions {
   /**
    * When true, "add" operations with path ending in "/-" will implicitly
    * create an empty array where possible.
@@ -95,19 +95,19 @@ function _remove(object: any, key: string): void {
 }
 
 /**
- * >  o  If the target location specifies an array index, a new value is
- * >     inserted into the array at the specified index.
- * >  o  If the target location specifies an object member that does not
- * >     already exist, a new member is added to the object.
- * >  o  If the target location specifies an object member that does exist,
- * >     that member's value is replaced.
+ *  o  If the target location specifies an array index, a new value is
+ *     inserted into the array at the specified index.
+ *  o  If the target location specifies an object member that does not
+ *     already exist, a new member is added to the object.
+ *  o  If the target location specifies an object member that does exist,
+ *     that member's value is replaced.
  *
  * @param object - The object being patched.
  * @param operation - The operation to perform on the object.
  * @param options - Optional params.
  * @returns null on success, or error if one occurred.
  */
-export function add(object: any, operation: AddOperation, options?: Options): MissingError | null {
+export function add(object: any, operation: AddOperation, options?: PatchOptions): MissingError | null {
   const pointer = Pointer.fromJSON(operation.path);
   // Handle implicit array creation for terminal "/-" paths
   if (options?.implicitArrayCreation && pointer.tokens[pointer.tokens.length - 1] === '-') {
@@ -137,15 +137,15 @@ export function add(object: any, operation: AddOperation, options?: Options): Mi
 }
 
 /**
- * > The "remove" operation removes the value at the target location.
- * > The target location MUST exist for the operation to be successful.
+ * The "remove" operation removes the value at the target location.
+ * The target location MUST exist for the operation to be successful.
  *
  * @param object - The object being patched.
  * @param operation - The operation to perform on the object.
  * @param _options - Optional params.
  * @returns null on success, or error if one occurred.
  */
-export function remove(object: any, operation: RemoveOperation, _options?: Options): MissingError | null {
+export function remove(object: any, operation: RemoveOperation, _options?: PatchOptions): MissingError | null {
   // endpoint has parent, key, and value properties
   const endpoint = Pointer.fromJSON(operation.path).evaluate(object);
   if (endpoint.value === undefined) {
@@ -157,14 +157,14 @@ export function remove(object: any, operation: RemoveOperation, _options?: Optio
 }
 
 /**
- * > The "replace" operation replaces the value at the target location
- * > with a new value.  The operation object MUST contain a "value" member
- * > whose content specifies the replacement value.
- * > The target location MUST exist for the operation to be successful.
+ * The "replace" operation replaces the value at the target location
+ * with a new value.  The operation object MUST contain a "value" member
+ * whose content specifies the replacement value.
+ * The target location MUST exist for the operation to be successful.
  *
- * > This operation is functionally identical to a "remove" operation for
- * > a value, followed immediately by an "add" operation at the same
- * > location with the replacement value.
+ * This operation is functionally identical to a "remove" operation for
+ * a value, followed immediately by an "add" operation at the same
+ * location with the replacement value.
  *
  * Even more simply, it's like the add operation with an existence check.
  *
@@ -173,7 +173,7 @@ export function remove(object: any, operation: RemoveOperation, _options?: Optio
  * @param _options - Optional params.
  * @returns null on success, or error if one occurred.
  */
-export function replace(object: any, operation: ReplaceOperation, _options?: Options): MissingError | null {
+export function replace(object: any, operation: ReplaceOperation, _options?: PatchOptions): MissingError | null {
   const endpoint = Pointer.fromJSON(operation.path).evaluate(object);
   if (endpoint.parent === null) {
     return new MissingError(operation.path);
@@ -191,17 +191,17 @@ export function replace(object: any, operation: ReplaceOperation, _options?: Opt
 }
 
 /**
- * > The "move" operation removes the value at a specified location and
- * > adds it to the target location.
- * > The operation object MUST contain a "from" member, which is a string
- * > containing a JSON Pointer value that references the location in the
- * > target document to move the value from.
- * > This operation is functionally identical to a "remove" operation on
- * > the "from" location, followed immediately by an "add" operation at
- * > the target location with the value that was just removed.
+ * The "move" operation removes the value at a specified location and
+ * adds it to the target location.
+ * The operation object MUST contain a "from" member, which is a string
+ * containing a JSON Pointer value that references the location in the
+ * target document to move the value from.
+ * This operation is functionally identical to a "remove" operation on
+ * the "from" location, followed immediately by an "add" operation at
+ * the target location with the value that was just removed.
  *
- * > The "from" location MUST NOT be a proper prefix of the "path"
- * > location; i.e., a location cannot be moved into one of its children.
+ * The "from" location MUST NOT be a proper prefix of the "path"
+ * location; i.e., a location cannot be moved into one of its children.
  *
  * TODO: throw if the check described in the previous paragraph fails.
  *
@@ -210,7 +210,7 @@ export function replace(object: any, operation: ReplaceOperation, _options?: Opt
  * @param _options - Optional params.
  * @returns null on success, or error if one occurred.
  */
-export function move(object: any, operation: MoveOperation, _options?: Options): MissingError | null {
+export function move(object: any, operation: MoveOperation, _options?: PatchOptions): MissingError | null {
   const from_endpoint = Pointer.fromJSON(operation.from).evaluate(object);
   if (from_endpoint.value === undefined) {
     return new MissingError(operation.from);
@@ -225,15 +225,15 @@ export function move(object: any, operation: MoveOperation, _options?: Options):
 }
 
 /**
- * > The "copy" operation copies the value at a specified location to the
- * > target location.
- * > The operation object MUST contain a "from" member, which is a string
- * > containing a JSON Pointer value that references the location in the
- * > target document to copy the value from.
- * > The "from" location MUST exist for the operation to be successful.
+ * The "copy" operation copies the value at a specified location to the
+ * target location.
+ * The operation object MUST contain a "from" member, which is a string
+ * containing a JSON Pointer value that references the location in the
+ * target document to copy the value from.
+ * The "from" location MUST exist for the operation to be successful.
  *
- * > This operation is functionally identical to an "add" operation at the
- * > target location using the value specified in the "from" member.
+ * This operation is functionally identical to an "add" operation at the
+ * target location using the value specified in the "from" member.
  *
  * Alternatively, it's like 'move' without the 'remove'.
  *
@@ -242,7 +242,7 @@ export function move(object: any, operation: MoveOperation, _options?: Options):
  * @param _options - Optional params.
  * @returns null on success, or error if one occurred.
  */
-export function copy(object: any, operation: CopyOperation, _options?: Options): MissingError | null {
+export function copy(object: any, operation: CopyOperation, _options?: PatchOptions): MissingError | null {
   const from_endpoint = Pointer.fromJSON(operation.from).evaluate(object);
   if (from_endpoint.value === undefined) {
     return new MissingError(operation.from);
@@ -256,19 +256,19 @@ export function copy(object: any, operation: CopyOperation, _options?: Options):
 }
 
 /**
- * > The "test" operation tests that a value at the target location is
- * > equal to a specified value.
- * > The operation object MUST contain a "value" member that conveys the
- * > value to be compared to the target location's value.
- * > The target location MUST be equal to the "value" value for the
- * > operation to be considered successful.
+ * The "test" operation tests that a value at the target location is
+ * equal to a specified value.
+ * The operation object MUST contain a "value" member that conveys the
+ * value to be compared to the target location's value.
+ * The target location MUST be equal to the "value" value for the
+ * operation to be considered successful.
  *
  * @param object - The object being patched.
  * @param operation - The add operation to perform on the object.
  * @param _options - Optional params.
  * @returns null on success, or error if one occurred.
  */
-export function test(object: any, operation: TestOperation, _options?: Options): TestError | null {
+export function test(object: any, operation: TestOperation, _options?: PatchOptions): TestError | null {
   const endpoint = Pointer.fromJSON(operation.path).evaluate(object);
   // TODO: this diffAny(...).length usage could/should be lazy
   if (diffAny(endpoint.value, operation.value, new Pointer()).length) {
@@ -299,7 +299,7 @@ export class InvalidOperationError extends Error {
 export function apply(
   object: any,
   operation: Operation,
-  options?: Options
+  options?: PatchOptions
 ): MissingError | InvalidOperationError | TestError | null {
   switch (operation.op) {
     case 'add':

--- a/packages/core/src/patch/pointer.ts
+++ b/packages/core/src/patch/pointer.ts
@@ -20,14 +20,14 @@
  *
  * `token` should *not* contain any '/' characters.
  *
- * > Evaluation of each reference token begins by decoding any escaped
- * > character sequence.  This is performed by first transforming any
- * > occurrence of the sequence '~1' to '/', and then transforming any
- * > occurrence of the sequence '~0' to '~'.  By performing the
- * > substitutions in this order, an implementation avoids the error of
- * > turning '~01' first into '~1' and then into '/', which would be
- * > incorrect (the string '~01' correctly becomes '~1' after
- * > transformation).
+ * Evaluation of each reference token begins by decoding any escaped
+ * character sequence.  This is performed by first transforming any
+ * occurrence of the sequence '~1' to '/', and then transforming any
+ * occurrence of the sequence '~0' to '~'.  By performing the
+ * substitutions in this order, an implementation avoids the error of
+ * turning '~01' first into '~1' and then into '/', which would be
+ * incorrect (the string '~01' correctly becomes '~1' after
+ * transformation).
  *
  * Here's my take:
  *
@@ -45,9 +45,9 @@ export function unescapeToken(token: string): string {
 /**
  * Escape token part of a JSON Pointer string
  *
- * > '~' needs to be encoded as '~0' and '/'
- * > needs to be encoded as '~1' when these characters appear in a
- * > reference token.
+ * '~' needs to be encoded as '~0' and '/'
+ * needs to be encoded as '~1' when these characters appear in a
+ * reference token.
  *
  * This is the exact inverse of `unescapeToken()`, so the reverse replacements must take place in reverse order.
  *
@@ -92,7 +92,7 @@ export class Pointer {
   /**
    * Returns an object with 'parent', 'key', and 'value' properties.
    * In the special case that this Pointer's path == "",
-   * this object will be {parent: null, key: '', value: object}.
+   * this object will be `{parent: null, key: '', value: object}`.
    * Otherwise, parent and key will have the property such that parent[key] == value.
    *
    * @param object - The object against which to evaluate the pointer.

--- a/packages/fhir-router/esbuild.mjs
+++ b/packages/fhir-router/esbuild.mjs
@@ -17,7 +17,7 @@ const options = {
   tsconfig: 'tsconfig.json',
   minify: true,
   sourcemap: true,
-  external: ['@medplum/core', 'dataloader', 'rfc6902'],
+  external: ['@medplum/core', 'dataloader'],
 };
 
 esbuild

--- a/packages/fhir-router/package.json
+++ b/packages/fhir-router/package.json
@@ -60,8 +60,7 @@
     "@medplum/definitions": "5.1.22",
     "@medplum/fhirtypes": "5.1.22",
     "dataloader": "2.2.3",
-    "graphql": "16.14.2",
-    "rfc6902": "5.2.0"
+    "graphql": "16.14.2"
   },
   "engines": {
     "node": "^22.18.0 || >=24.2.0"

--- a/packages/fhir-router/src/fhirrouter.ts
+++ b/packages/fhir-router/src/fhirrouter.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { Operation } from '@medplum/core';
 import {
   EventTarget,
   OperationOutcomeError,
@@ -21,7 +22,6 @@ import type {
   ResourceType,
 } from '@medplum/fhirtypes';
 import type { IncomingHttpHeaders } from 'node:http';
-import type { Operation } from 'rfc6902';
 import type { LogEvent } from './batch';
 import { processBatch } from './batch';
 import { graphqlHandler } from './graphql';

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { SearchRequest, SortRule, WithId } from '@medplum/core';
+import type { Operation, SearchRequest, SortRule, WithId } from '@medplum/core';
 import {
   EMPTY,
   OperationOutcomeError,
   Operator,
   allOk,
+  applyPatch,
   badRequest,
   created,
   deepClone,
@@ -20,8 +21,6 @@ import {
   stringify,
 } from '@medplum/core';
 import type { Bundle, OperationOutcome, Parameters, Reference, Resource } from '@medplum/fhirtypes';
-import type { Operation } from 'rfc6902';
-import { applyPatch } from 'rfc6902';
 
 export type CreateResourceOptions = {
   assignedId?: boolean;

--- a/packages/mock/README.md
+++ b/packages/mock/README.md
@@ -22,8 +22,6 @@ Note the following peer dependencies:
 
 - [@medplum/core](https://www.npmjs.com/package/@medplum/core)
 - [@medplum/fhir-router](https://www.npmjs.com/package/@medplum/fhir-router)
-- If you want to use JSONPatch:
-  - [rfc6902](https://www.npmjs.com/package/rfc6902)
 - If you want to use GraphQL:
   - [graphql](https://www.npmjs.com/package/graphql)
   - [dataloader](https://www.npmjs.com/package/dataloader)

--- a/packages/mock/esbuild.mjs
+++ b/packages/mock/esbuild.mjs
@@ -17,7 +17,7 @@ const options = {
   tsconfig: 'tsconfig.json',
   minify: true,
   sourcemap: true,
-  external: ['@medplum/core', '@medplum/fhir-router', 'rfc6902'],
+  external: ['@medplum/core', '@medplum/fhir-router'],
 };
 
 esbuild

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -60,8 +60,7 @@
     "@medplum/definitions": "5.1.22",
     "@medplum/fhir-router": "5.1.22",
     "@medplum/fhirtypes": "5.1.22",
-    "dataloader": "2.2.3",
-    "rfc6902": "5.2.0"
+    "dataloader": "2.2.3"
   },
   "devDependencies": {
     "@types/pdfmake": "0.2.12"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -99,7 +99,6 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-router": "7.18.0",
-    "rfc6902": "5.2.0",
     "signature_pad": "5.1.3",
     "sinon": "22.0.0",
     "storybook": "10.4.6",
@@ -114,7 +113,6 @@
     "@medplum/react-hooks": "5.1.22",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "rfc6902": "^5.0.1",
     "signature_pad": "^5.0.10"
   },
   "peerDependenciesMeta": {
@@ -125,9 +123,6 @@
       "optional": true
     },
     "@mantine/notifications": {
-      "optional": true
-    },
-    "rfc6902": {
       "optional": true
     },
     "signature_pad": {

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
@@ -1,14 +1,19 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Table } from '@mantine/core';
-import type { InternalSchemaElement, TypedValue } from '@medplum/core';
-import { arrayify, capitalize, evalFhirPathTyped, getSearchParameterDetails, toTypedValue } from '@medplum/core';
+import type { InternalSchemaElement, Operation, TypedValue } from '@medplum/core';
+import {
+  arrayify,
+  capitalize,
+  createPatch,
+  evalFhirPathTyped,
+  getSearchParameterDetails,
+  toTypedValue,
+} from '@medplum/core';
 import type { Resource, SearchParameter } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import type { JSX } from 'react';
 import { useEffect, useMemo, useState } from 'react';
-import type { Operation } from 'rfc6902';
-import { createPatch } from 'rfc6902';
 import { ResourceDiffRow } from '../ResourceDiffRow/ResourceDiffRow';
 import classes from './ResourceDiffTable.module.css';
 

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -48,11 +48,5 @@ export default defineConfig({
        */
       shouldAdvanceTime: true,
     },
-    /*
-     * Run test files sequentially in isolated fork processes. React tests share global
-     * FHIR indexes and jsdom polyfills from test.setup.ts; parallel file runs cause flaky tests
-     */
-    pool: 'forks',
-    fileParallelism: false,
   },
 });

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -94,7 +94,6 @@
     "pg": "8.22.0",
     "qrcode": "1.5.4",
     "rate-limiter-flexible": "11.2.0",
-    "rfc6902": "5.2.0",
     "semver": "7.8.4",
     "temporal-polyfill": "0.3.2",
     "uuid": "14.0.0",

--- a/packages/server/src/fhir/operations/extract.ts
+++ b/packages/server/src/fhir/operations/extract.ts
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AsyncCrawlerVisitor, InternalTypeSchema, TypedValue, TypedValueWithPath } from '@medplum/core';
+import type { AsyncCrawlerVisitor, InternalTypeSchema, Operation, TypedValue, TypedValueWithPath } from '@medplum/core';
 import {
   allOk,
+  applyPatch,
   arrayify,
   badRequest,
   crawlTypedValueAsync,
@@ -31,8 +32,6 @@ import type {
   Resource,
 } from '@medplum/fhirtypes';
 import { randomUUID } from 'node:crypto';
-import type { Operation } from 'rfc6902';
-import { applyPatch } from 'rfc6902';
 import { getAuthenticatedContext } from '../../context';
 import type { Repository } from '../repo';
 import { parseInputParameters } from './utils/parameters';

--- a/packages/server/src/fhir/operations/refresh-reference-display.ts
+++ b/packages/server/src/fhir/operations/refresh-reference-display.ts
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { TypedValueWithPath } from '@medplum/core';
+import type { Operation, TypedValueWithPath } from '@medplum/core';
 import { allOk, badRequest, getDisplayString, isResourceType, pathToJSONPointer } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Operation } from 'rfc6902';
 import { getAuthenticatedContext } from '../../context';
 import { collectReferences } from '../references';
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { BackgroundJobInteraction, FhirPathPatch, Filter, SearchRequest, WithId } from '@medplum/core';
+import type { BackgroundJobInteraction, FhirPathPatch, Filter, Operation, SearchRequest, WithId } from '@medplum/core';
 import {
   AccessPolicyInteraction,
   accessPolicySupportsInteraction,
@@ -70,7 +70,6 @@ import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import { Readable } from 'node:stream';
 import type { PoolClient } from 'pg';
-import type { Operation } from 'rfc6902';
 import { getConfig } from '../config/loader';
 import { syntheticR4Project } from '../constants';
 import { AuthenticatedRequestContext, tryGetRequestContext } from '../context';

--- a/packages/server/src/scim/utils.ts
+++ b/packages/server/src/scim/utils.ts
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { SearchRequest, WithId } from '@medplum/core';
+import type { Operation, SearchRequest, WithId } from '@medplum/core';
 import { badRequest, forbidden, getReferenceString, OperationOutcomeError, Operator } from '@medplum/core';
 import type { Project, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
-import type { Operation } from 'rfc6902';
 import { inviteUser } from '../admin/invite';
 import { getConfig } from '../config/loader';
 import type { SystemRepository } from '../fhir/repo';

--- a/packages/server/src/util/patch.test.ts
+++ b/packages/server/src/util/patch.test.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { Operation } from 'rfc6902';
+import type { Operation } from '@medplum/core';
 import { patchObject } from './patch';
 
 describe('Patch utils', () => {

--- a/packages/server/src/util/patch.ts
+++ b/packages/server/src/util/patch.ts
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { badRequest, normalizeOperationOutcome, OperationOutcomeError } from '@medplum/core';
-import type { Operation } from 'rfc6902';
-import { applyPatch } from 'rfc6902';
+import type { Operation } from '@medplum/core';
+import { applyPatch, badRequest, normalizeOperationOutcome, OperationOutcomeError } from '@medplum/core';
 
 const patchOptions = { implicitArrayCreation: true };
 

--- a/packages/server/src/workers/download.ts
+++ b/packages/server/src/workers/download.ts
@@ -8,13 +8,13 @@ import {
   isGone,
   normalizeOperationOutcome,
   pathToJSONPointer,
+  Pointer,
   toTypedValue,
 } from '@medplum/core';
 import type { Binary, Project, Resource, ResourceType } from '@medplum/fhirtypes';
 import type { Job } from 'bullmq';
 import { Queue, Worker } from 'bullmq';
 import { Readable } from 'node:stream';
-import { Pointer } from 'rfc6902';
 import { getConfig } from '../config/loader';
 import { tryGetRequestContext, tryRunInRequestContext } from '../context';
 import { getShardSystemRepo } from '../fhir/repo';

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { BackgroundJobContext, BackgroundJobInteraction, WithId } from '@medplum/core';
+import type { BackgroundJobContext, BackgroundJobInteraction, Operation, WithId } from '@medplum/core';
 import {
   AccessPolicyInteraction,
   ContentType,
@@ -37,7 +37,6 @@ import type {
 import type { Job, MinimalJob } from 'bullmq';
 import { Queue, UnrecoverableError, Worker } from 'bullmq';
 import { createHmac } from 'node:crypto';
-import type { Operation } from 'rfc6902';
 import { executeBot } from '../bots/execute';
 import { getConfig } from '../config/loader';
 import type { SubscriptionAutoDisableTrigger } from '../config/types';


### PR DESCRIPTION
In https://github.com/medplum/medplum/pull/9335 we vendored the `rfc6902` library to enable custom [FHIRPatch](https://build.fhir.org/fhirpatch.html) semantics.

This PR replaces all references to `rfc6902` with `@medplum/core` and removes the dependency.

The patch methods were not previously exported and therefore not previously run through `api-documenter`, so this also required some cosmetic changes to JSDoc comments and renaming `Options` to `PatchOptions` to avoid naming collision.