### PR TITLE
perf(server): cache parsed patient-compartment FHIRPath expressions

### DIFF
--- a/packages/server/src/fhir/patient.ts
+++ b/packages/server/src/fhir/patient.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { WithId } from '@medplum/core';
-import { EMPTY, evalFhirPath, getReferenceString, getSearchParameter } from '@medplum/core';
+import type { FhirPathAtom, WithId } from '@medplum/core';
+import { EMPTY, evalFhirPath, getReferenceString, getSearchParameter, parseFhirPath } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import type {
   CompartmentDefinition,
@@ -44,6 +44,25 @@ export function getPatientCompartmentParams(resourceType: string): string[] | un
   return undefined;
 }
 
+const compartmentExpressionCache = new Map<string, FhirPathAtom>();
+
+/**
+ * Returns the parsed FHIRPath atom for a patient-compartment search parameter expression, caching
+ * the result. getPatients() runs on every resource write, so this avoids re-tokenizing and
+ * re-parsing the same fixed set of compartment expressions for every resource. The cache is bounded
+ * by the number of distinct compartment search parameters.
+ * @param expression - The search parameter's FHIRPath expression.
+ * @returns The parsed FHIRPath atom.
+ */
+function getParsedCompartmentExpression(expression: string): FhirPathAtom {
+  let parsed = compartmentExpressionCache.get(expression);
+  if (!parsed) {
+    parsed = parseFhirPath(expression);
+    compartmentExpressionCache.set(expression, parsed);
+  }
+  return parsed;
+}
+
 /**
  * Returns the patient compartment ID for a resource.
  * If the resource is in a patient compartment (i.e., an Observation about the patient),
@@ -62,7 +81,7 @@ export function getPatients(resource: Resource): (Reference<Patient> & { referen
   for (const code of params ?? EMPTY) {
     const searchParam = getSearchParameter(resource.resourceType, code);
     if (searchParam) {
-      const values = evalFhirPath(searchParam.expression as string, resource);
+      const values = evalFhirPath(getParsedCompartmentExpression(searchParam.expression as string), resource);
       for (const value of values) {
         const patient = getPatientFromUnknownValue(value);
         if (patient) {


### PR DESCRIPTION
## Summary

`getPatients()` runs on every resource write (to compute `meta.compartment`). For resources in the patient compartment it evaluates a FHIRPath expression for each compartment search parameter, and it parsed each expression from scratch on every call:

```ts
const values = evalFhirPath(searchParam.expression as string, resource); // re-tokenizes + re-parses every call
```

The set of compartment expressions is fixed, so the same handful were re-parsed for every such resource. This PR caches the parsed `FhirPathAtom` per expression string.

The benefit therefore scales with the share of patient-compartment writes. Nearly all of a clinical chart, but none of, say, a terminology / `StructureDefinition` import.

## Why

Profiling a bulk transaction insert (a 500-resource patient chart) showed FHIRPath `tokenize` + `parse` accounting for ~5% of active CPU, traced entirely to this call site.

## Impact

[We built a benchmark harness to performance profile batch inserts](https://github.com/flexpa/medplum/pull/7). It runs a 500 resource batch built from Synthea. 

This PR was benchmarked with three runs of 25 timed iterations each against `main` and against this branch (this commit cherry-picked onto the same harness), run back-to-back to control for machine state.

Averages:

| Metric | `main` | `main` + this PR | Δ |
|---|---|---|---|
| **CPU / transaction** | 474.3 ms | 417.3 ms | **−12.0%** |
| Wall / transaction | 1149.3 ms | 1067.1 ms | −7.2% |
| Throughput | 435 res/s | 469 res/s | +7.8% |

<details><summary>Per-run medians</summary>

| Run | main CPU (ms) | main wall (ms) | +PR CPU (ms) | +PR wall (ms) |
|----:|----:|----:|----:|----:|
| 1 | 465.4 | 1135.3 | 407.8 | 1039.8 |
| 2 | 480.7 | 1178.0 | 410.4 | 1054.5 |
| 3 | 476.7 | 1134.7 | 433.7 | 1107.1 |

</details>

## Correctness

- `parseFhirPath` is deterministic; the cached AST is identical to re-parsing
- The cache is keyed by expression string and bounded by the number of distinct compartment search parameters (a few dozen).
- `@medplum/core` unit tests, server typecheck, and lint all pass.

