### PR TITLE
Add more display fields to Import SMART Health Links UI

### DIFF
--- a/examples/medplum-provider/src/pages/smart/SmartHealthLinkImport.utils.test.ts
+++ b/examples/medplum-provider/src/pages/smart/SmartHealthLinkImport.utils.test.ts
@@ -140,6 +140,36 @@ describe('SmartHealthLinkImport utils', () => {
     );
   });
 
+  test('rewrites patient references by patient entry fullUrl', () => {
+    const patientFullUrl = 'urn:uuid:d8c63f84-d51c-469b-a4f8-abe3d04139fc';
+    const documentReferenceFullUrl = 'urn:uuid:85f5f237-cf9b-4d34-9c49-58d15d51ab80';
+    const result = buildSmartHealthLinkImportBundle(
+      {
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [
+          { fullUrl: patientFullUrl, resource: { ...sharedPatient, id: undefined } },
+          {
+            fullUrl: documentReferenceFullUrl,
+            resource: {
+              ...documentReference,
+              id: undefined,
+              subject: { reference: patientFullUrl },
+              author: [{ reference: patientFullUrl }],
+            },
+          },
+        ],
+      },
+      new Set([patientFullUrl, documentReferenceFullUrl]),
+      { ...sharedPatient, id: undefined },
+      { ...sharedPatient, id: 'local-patient' }
+    );
+
+    const importedDocumentReference = findResource(result, 'DocumentReference') as DocumentReference;
+    expect(importedDocumentReference.subject?.reference).toBe('Patient/local-patient');
+    expect(importedDocumentReference.author?.[0].reference).toBe('Patient/local-patient');
+  });
+
   test('selects id-less bundle entries by fullUrl', () => {
     const result = buildSmartHealthLinkImportBundle(
       {

--- a/examples/medplum-provider/src/pages/smart/SmartHealthLinkImport.utils.ts
+++ b/examples/medplum-provider/src/pages/smart/SmartHealthLinkImport.utils.ts
@@ -37,7 +37,14 @@ export function buildSmartHealthLinkImportBundle(
   sharedPatient: Patient,
   targetPatient: WithId<Patient>
 ): Bundle {
-  const sharedPatientRef = `Patient/${sharedPatient.id}`;
+  const sharedPatientRefs = new Set<string>();
+  if (sharedPatient.id) {
+    sharedPatientRefs.add(`Patient/${sharedPatient.id}`);
+  }
+  const sharedPatientFullUrl = bundle.entry?.find((entry) => isResource<Patient>(entry.resource, 'Patient'))?.fullUrl;
+  if (sharedPatientFullUrl) {
+    sharedPatientRefs.add(sharedPatientFullUrl);
+  }
   const targetPatientRef = `Patient/${targetPatient.id}`;
   const selectedBundle: Bundle = {
     resourceType: 'Bundle',
@@ -50,7 +57,7 @@ export function buildSmartHealthLinkImportBundle(
       })
       .map((entry) => ({
         fullUrl: entry.fullUrl,
-        resource: rewritePatientReference(entry.resource as Resource, sharedPatientRef, targetPatientRef),
+        resource: rewritePatientReference(entry.resource as Resource, sharedPatientRefs, targetPatientRef),
       })),
   };
   const transaction = convertToTransactionBundle(selectedBundle);
@@ -68,12 +75,12 @@ export function getMatchGrade(entry: BundleEntry<WithId<Patient>>): string | und
 
 function rewritePatientReference<T extends Resource>(
   resource: T,
-  sharedPatientRef: string,
+  sharedPatientRefs: Set<string>,
   targetPatientRef: string
 ): T {
   return JSON.parse(
     JSON.stringify(resource, (key, value) => {
-      if (key === 'reference' && value === sharedPatientRef) {
+      if (key === 'reference' && sharedPatientRefs.has(value)) {
         return targetPatientRef;
       }
       return value;

--- a/examples/medplum-provider/src/pages/smart/SmartHealthLinkImportPage.tsx
+++ b/examples/medplum-provider/src/pages/smart/SmartHealthLinkImportPage.tsx
@@ -49,6 +49,11 @@ export function SmartHealthLinkImportPage(): JSX.Element {
   const [selectedPatient, setSelectedPatient] = useState<WithId<Patient>>();
   const [createNewPatient, setCreateNewPatient] = useState(false);
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+  const [smartHealthLinkDetails, setSmartHealthLinkDetails] = useState<{
+    recipient?: string;
+    signingAuthority?: string;
+    expiresAt?: string;
+  }>();
 
   const items = bundle?.entry?.filter((entry) => entry.resource && getSmartHealthLinkBundleEntryKey(entry)) ?? [];
   const selectedItems = items.filter((entry) => {
@@ -70,6 +75,7 @@ export function SmartHealthLinkImportPage(): JSX.Element {
     setWarning([]);
     setBundle(undefined);
     setSharedPatient(undefined);
+    setSmartHealthLinkDetails(undefined);
     setMatches([]);
     setSelectedPatient(undefined);
     setCreateNewPatient(false);
@@ -90,6 +96,15 @@ export function SmartHealthLinkImportPage(): JSX.Element {
         .map((p) => p.valueString)
         .filter((value): value is string => !!value);
       setWarning(warnings ?? []);
+
+      const details = {
+        recipient: result.parameter?.find((p) => p.name === 'recipient')?.valueString,
+        signingAuthority: result.parameter?.find((p) => p.name === 'signingAuthority')?.valueString,
+        expiresAt: result.parameter?.find((p) => p.name === 'expiresAt')?.valueDateTime,
+      };
+      setSmartHealthLinkDetails(
+        details.recipient || details.signingAuthority || details.expiresAt ? details : undefined
+      );
 
       const resources = JSON.parse(
         result.parameter?.find((p) => p.name === 'fhirResources')?.valueString ?? '[]'
@@ -253,6 +268,40 @@ export function SmartHealthLinkImportPage(): JSX.Element {
             </Group>
           </Stack>
         </Paper>
+
+        {smartHealthLinkDetails && (
+          <Paper withBorder p="md">
+            <Stack gap="xs">
+              <Title order={3}>SMART Health Link Details</Title>
+              <Group gap="xl" align="start">
+                {smartHealthLinkDetails.recipient && (
+                  <div>
+                    <Text size="xs" c="dimmed" fw={700}>
+                      Recipient
+                    </Text>
+                    <Text size="sm">{smartHealthLinkDetails.recipient}</Text>
+                  </div>
+                )}
+                {smartHealthLinkDetails.signingAuthority && (
+                  <div>
+                    <Text size="xs" c="dimmed" fw={700}>
+                      Signing Authority
+                    </Text>
+                    <Text size="sm">{smartHealthLinkDetails.signingAuthority}</Text>
+                  </div>
+                )}
+                {smartHealthLinkDetails.expiresAt && (
+                  <div>
+                    <Text size="xs" c="dimmed" fw={700}>
+                      Expires
+                    </Text>
+                    <Text size="sm">{new Date(smartHealthLinkDetails.expiresAt).toLocaleString()}</Text>
+                  </div>
+                )}
+              </Group>
+            </Stack>
+          </Paper>
+        )}
 
         {sharedPatient && (
           <Card withBorder radius="sm" p="md">

--- a/examples/medplum-provider/src/pages/smart/SmartHealthLinkImportPage.tsx
+++ b/examples/medplum-provider/src/pages/smart/SmartHealthLinkImportPage.tsx
@@ -51,7 +51,7 @@ export function SmartHealthLinkImportPage(): JSX.Element {
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
   const [smartHealthLinkDetails, setSmartHealthLinkDetails] = useState<{
     recipient?: string;
-    signingAuthority?: string;
+    sourceOrigin?: string;
     expiresAt?: string;
   }>();
 
@@ -99,12 +99,10 @@ export function SmartHealthLinkImportPage(): JSX.Element {
 
       const details = {
         recipient: result.parameter?.find((p) => p.name === 'recipient')?.valueString,
-        signingAuthority: result.parameter?.find((p) => p.name === 'signingAuthority')?.valueString,
+        sourceOrigin: result.parameter?.find((p) => p.name === 'sourceOrigin')?.valueString,
         expiresAt: result.parameter?.find((p) => p.name === 'expiresAt')?.valueDateTime,
       };
-      setSmartHealthLinkDetails(
-        details.recipient || details.signingAuthority || details.expiresAt ? details : undefined
-      );
+      setSmartHealthLinkDetails(details.recipient || details.sourceOrigin || details.expiresAt ? details : undefined);
 
       const resources = JSON.parse(
         result.parameter?.find((p) => p.name === 'fhirResources')?.valueString ?? '[]'
@@ -282,12 +280,12 @@ export function SmartHealthLinkImportPage(): JSX.Element {
                     <Text size="sm">{smartHealthLinkDetails.recipient}</Text>
                   </div>
                 )}
-                {smartHealthLinkDetails.signingAuthority && (
+                {smartHealthLinkDetails.sourceOrigin && (
                   <div>
                     <Text size="xs" c="dimmed" fw={700}>
-                      Signing Authority
+                      Source Origin
                     </Text>
-                    <Text size="sm">{smartHealthLinkDetails.signingAuthority}</Text>
+                    <Text size="sm">{smartHealthLinkDetails.sourceOrigin}</Text>
                   </div>
                 )}
                 {smartHealthLinkDetails.expiresAt && (

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -362,6 +362,7 @@ describe('SMART Health operations', () => {
 
   test('Generate direct SMART Health Link and resolve payload', async () => {
     const patient = await createPatient();
+    const exp = Math.floor(Date.now() / 1000) + 300;
 
     const generateResponse = await request(app)
       .post(`/fhir/R4/Patient/${patient.id}/$generate-smart-health-link`)
@@ -369,7 +370,7 @@ describe('SMART Health operations', () => {
       .set('Content-Type', ContentType.JSON)
       .send({
         mode: 'direct',
-        exp: Math.floor(Date.now() / 1000) + 300,
+        exp,
         label: 'Test CMS Link',
         includeQrCode: true,
       });
@@ -419,6 +420,9 @@ describe('SMART Health operations', () => {
       .send({ shlink, recipient: 'Test Recipient' });
     expect(resolveResponse.status).toBe(200);
     expect(getBooleanParameter(resolveResponse.body, 'valid')).toBe(true);
+    expect(getStringParameter(resolveResponse.body, 'recipient')).toBe('Test Recipient');
+    expect(getStringParameter(resolveResponse.body, 'signingAuthority')).toBe(directUrl.origin);
+    expect(getDateTimeParameter(resolveResponse.body, 'expiresAt')).toBe(new Date(exp * 1000).toISOString());
 
     const fhirResources = JSON.parse(getStringParameter(resolveResponse.body, 'fhirResources')) as Bundle[];
     expect(fhirResources[0]?.resourceType).toBe('Bundle');
@@ -428,6 +432,7 @@ describe('SMART Health operations', () => {
 
   test('Resolves external direct SMART Health Link payloads', async () => {
     const key = base64url.encode(Buffer.alloc(32, 1));
+    const exp = Math.floor(Date.now() / 1000) + 300;
     const bundle: Bundle = {
       resourceType: 'Bundle',
       type: 'collection',
@@ -449,7 +454,7 @@ describe('SMART Health operations', () => {
           url: 'https://issuer.example.com/smart-link/payload?existing=true',
           key,
           flag: 'LU',
-          exp: Math.floor(Date.now() / 1000) + 300,
+          exp,
           v: 1,
         }),
         recipient: 'Test Recipient',
@@ -465,6 +470,9 @@ describe('SMART Health operations', () => {
       redirect: 'error',
       signal: expect.any(AbortSignal),
     });
+    expect(getStringParameter(resolveResponse.body, 'recipient')).toBe('Test Recipient');
+    expect(getStringParameter(resolveResponse.body, 'signingAuthority')).toBe('https://issuer.example.com');
+    expect(getDateTimeParameter(resolveResponse.body, 'expiresAt')).toBe(new Date(exp * 1000).toISOString());
 
     const fhirResources = JSON.parse(getStringParameter(resolveResponse.body, 'fhirResources')) as Bundle[];
     expect(fhirResources).toHaveLength(1);
@@ -790,6 +798,12 @@ function getBinaryId(smartHealthLink: SmartHealthLink): string {
 
 function getStringParameter(parameters: Parameters, name: string): string {
   const value = parameters.parameter?.find((p) => p.name === name)?.valueString;
+  expect(value).toBeDefined();
+  return value as string;
+}
+
+function getDateTimeParameter(parameters: Parameters, name: string): string {
+  const value = parameters.parameter?.find((p) => p.name === name)?.valueDateTime;
   expect(value).toBeDefined();
   return value as string;
 }

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -421,7 +421,7 @@ describe('SMART Health operations', () => {
     expect(resolveResponse.status).toBe(200);
     expect(getBooleanParameter(resolveResponse.body, 'valid')).toBe(true);
     expect(getStringParameter(resolveResponse.body, 'recipient')).toBe('Test Recipient');
-    expect(getStringParameter(resolveResponse.body, 'signingAuthority')).toBe(directUrl.origin);
+    expect(getStringParameter(resolveResponse.body, 'sourceOrigin')).toBe(directUrl.origin);
     expect(getDateTimeParameter(resolveResponse.body, 'expiresAt')).toBe(new Date(exp * 1000).toISOString());
 
     const fhirResources = JSON.parse(getStringParameter(resolveResponse.body, 'fhirResources')) as Bundle[];
@@ -471,7 +471,7 @@ describe('SMART Health operations', () => {
       signal: expect.any(AbortSignal),
     });
     expect(getStringParameter(resolveResponse.body, 'recipient')).toBe('Test Recipient');
-    expect(getStringParameter(resolveResponse.body, 'signingAuthority')).toBe('https://issuer.example.com');
+    expect(getStringParameter(resolveResponse.body, 'sourceOrigin')).toBe('https://issuer.example.com');
     expect(getDateTimeParameter(resolveResponse.body, 'expiresAt')).toBe(new Date(exp * 1000).toISOString());
 
     const fhirResources = JSON.parse(getStringParameter(resolveResponse.body, 'fhirResources')) as Bundle[];

--- a/packages/server/src/fhir/operations/smarthealthlinks.ts
+++ b/packages/server/src/fhir/operations/smarthealthlinks.ts
@@ -45,6 +45,15 @@ import { buildOutputParameters, parseInputParameters } from './utils/parameters'
 const EXTERNAL_SMART_HEALTH_LINK_FETCH_TIMEOUT_MS = 5000;
 const MAX_EXTERNAL_SMART_HEALTH_LINK_PAYLOAD_BYTES = 10 * 1024 * 1024;
 
+interface ResolvedSmartHealthLink {
+  manifest?: Record<string, unknown>;
+  fhirResources: Resource[];
+  recipient?: string;
+  signingAuthority?: string;
+  expiresAt?: string;
+  warnings?: string[];
+}
+
 export const smartHealthLinkRouter = Router();
 smartHealthLinkRouter.post('/:id/manifest', smartHealthLinkManifestHandler);
 smartHealthLinkRouter.get('/:id/payload', smartHealthLinkPayloadHandler);
@@ -84,6 +93,9 @@ export const resolveSmartHealthLinkOperation = makeOperationDefinition(
       { use: 'out', name: 'valid', type: 'boolean', min: 1, max: '1' },
       { use: 'out', name: 'manifest', type: 'string', min: 0, max: '1' },
       { use: 'out', name: 'fhirResources', type: 'string', min: 0, max: '1' },
+      { use: 'out', name: 'recipient', type: 'string', min: 0, max: '1' },
+      { use: 'out', name: 'signingAuthority', type: 'string', min: 0, max: '1' },
+      { use: 'out', name: 'expiresAt', type: 'dateTime', min: 0, max: '1' },
       { use: 'out', name: 'warning', type: 'string', min: 0, max: '*' },
       { use: 'out', name: 'error', type: 'string', min: 0, max: '1' },
     ],
@@ -204,6 +216,9 @@ export async function resolveSmartHealthLinkHandler(req: FhirRequest): Promise<F
         valid: true,
         manifest: JSON.stringify(result.manifest),
         fhirResources: JSON.stringify(result.fhirResources),
+        recipient: result.recipient,
+        signingAuthority: result.signingAuthority,
+        expiresAt: result.expiresAt,
         warning: result.warnings,
       }),
     ];
@@ -267,7 +282,7 @@ async function resolveGeneratedSmartHealthLink(
   shlink: string,
   recipient?: string,
   passcode?: string
-): Promise<{ manifest?: Record<string, unknown>; fhirResources: Resource[]; warnings?: string[] }> {
+): Promise<ResolvedSmartHealthLink> {
   const payload = parseSmartHealthLink(shlink);
   const id = getSmartHealthLinkId(payload.url);
   const smartHealthLink = id ? await readSmartHealthLink(id) : undefined;
@@ -291,7 +306,12 @@ async function resolveGeneratedSmartHealthLink(
     if (contentType === ContentType.FHIR_JSON) {
       fhirResources.push(JSON.parse(plaintext) as Resource);
     }
-    return { fhirResources };
+    return {
+      fhirResources,
+      recipient,
+      signingAuthority: new URL(smartHealthLink.url).origin,
+      expiresAt: smartHealthLink.expiresAt,
+    };
   }
   const manifest = await buildSmartHealthLinkManifest(smartHealthLink);
   for (const file of manifest.files) {
@@ -300,13 +320,18 @@ async function resolveGeneratedSmartHealthLink(
       fhirResources.push(JSON.parse(plaintext) as Resource);
     }
   }
-  return { manifest, fhirResources };
+  return {
+    manifest,
+    fhirResources,
+    signingAuthority: new URL(smartHealthLink.url).origin,
+    expiresAt: smartHealthLink.expiresAt,
+  };
 }
 
 async function resolveExternalSmartHealthLink(
   payload: SmartHealthLinkPayload,
   recipient?: string
-): Promise<{ fhirResources: Resource[]; warnings?: string[] }> {
+): Promise<ResolvedSmartHealthLink> {
   if (!payload.flag?.includes('U')) {
     throw new Error('Only direct SMART Health Links are supported');
   }
@@ -339,7 +364,13 @@ async function resolveExternalSmartHealthLink(
     throw new Error(`Unsupported SMART Health Link content type: ${contentType || 'unknown'}`);
   }
 
-  return { fhirResources: [JSON.parse(plaintext) as Resource], warnings };
+  return {
+    fhirResources: [JSON.parse(plaintext) as Resource],
+    recipient,
+    signingAuthority: url.origin,
+    expiresAt: payload.exp !== undefined ? new Date(payload.exp * 1000).toISOString() : undefined,
+    warnings,
+  };
 }
 
 async function encryptSmartHealthLinkFile(bundle: Bundle, key: string): Promise<string> {

--- a/packages/server/src/fhir/operations/smarthealthlinks.ts
+++ b/packages/server/src/fhir/operations/smarthealthlinks.ts
@@ -49,7 +49,7 @@ interface ResolvedSmartHealthLink {
   manifest?: Record<string, unknown>;
   fhirResources: Resource[];
   recipient?: string;
-  signingAuthority?: string;
+  sourceOrigin?: string;
   expiresAt?: string;
   warnings?: string[];
 }
@@ -94,7 +94,7 @@ export const resolveSmartHealthLinkOperation = makeOperationDefinition(
       { use: 'out', name: 'manifest', type: 'string', min: 0, max: '1' },
       { use: 'out', name: 'fhirResources', type: 'string', min: 0, max: '1' },
       { use: 'out', name: 'recipient', type: 'string', min: 0, max: '1' },
-      { use: 'out', name: 'signingAuthority', type: 'string', min: 0, max: '1' },
+      { use: 'out', name: 'sourceOrigin', type: 'string', min: 0, max: '1' },
       { use: 'out', name: 'expiresAt', type: 'dateTime', min: 0, max: '1' },
       { use: 'out', name: 'warning', type: 'string', min: 0, max: '*' },
       { use: 'out', name: 'error', type: 'string', min: 0, max: '1' },
@@ -217,7 +217,7 @@ export async function resolveSmartHealthLinkHandler(req: FhirRequest): Promise<F
         manifest: JSON.stringify(result.manifest),
         fhirResources: JSON.stringify(result.fhirResources),
         recipient: result.recipient,
-        signingAuthority: result.signingAuthority,
+        sourceOrigin: result.sourceOrigin,
         expiresAt: result.expiresAt,
         warning: result.warnings,
       }),
@@ -309,7 +309,7 @@ async function resolveGeneratedSmartHealthLink(
     return {
       fhirResources,
       recipient,
-      signingAuthority: new URL(smartHealthLink.url).origin,
+      sourceOrigin: new URL(smartHealthLink.url).origin,
       expiresAt: smartHealthLink.expiresAt,
     };
   }
@@ -323,7 +323,7 @@ async function resolveGeneratedSmartHealthLink(
   return {
     manifest,
     fhirResources,
-    signingAuthority: new URL(smartHealthLink.url).origin,
+    sourceOrigin: new URL(smartHealthLink.url).origin,
     expiresAt: smartHealthLink.expiresAt,
   };
 }
@@ -367,7 +367,7 @@ async function resolveExternalSmartHealthLink(
   return {
     fhirResources: [JSON.parse(plaintext) as Resource],
     recipient,
-    signingAuthority: url.origin,
+    sourceOrigin: url.origin,
     expiresAt: payload.exp !== undefined ? new Date(payload.exp * 1000).toISOString() : undefined,
     warnings,
   };


### PR DESCRIPTION

<img width="578" height="371" alt="image" src="https://github.com/user-attachments/assets/a975c02d-1c77-40f5-b11c-921413a0eff1" />


Adds a few optional metadata fields to the `$resolve-smart-health-link` response:

- `recipient`
- `sourceOrigin`
- `expiresAt`

The provider example app now displays those fields after resolving a SMART Health Link, giving users a clearer indication of who the link was resolved for, the origin of the shared payload URL, and when the link expires.

## Details

- Extends the `$resolve-smart-health-link` operation definition with the new optional output parameters.
- Returns the metadata from generated and external direct SMART Health Link resolution flows.
- Adds a small local `ResolvedSmartHealthLink` interface to keep resolver return values clear and consistent.
- Updates `examples/medplum-provider` to show a compact SMART Health Link details section.
- Extends existing SMART Health Link operation tests to assert the new response fields.