### PR TITLE
Add MedicationStatement resource to PatientSummary component

### DIFF
--- a/packages/react/src/PatientSummary/Medications.test.tsx
+++ b/packages/react/src/PatientSummary/Medications.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { createReference } from '@medplum/core';
-import type { MedicationRequest } from '@medplum/fhirtypes';
+import type { MedicationRequest, MedicationStatement } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactNode } from 'react';
@@ -56,6 +56,55 @@ describe('PatientSummary - Medications', () => {
     );
     expect(screen.getByText('Medications')).toBeInTheDocument();
     expect(screen.getByText('Tylenol')).toBeInTheDocument();
+  });
+
+  test('Renders medication statements', async () => {
+    await setup(
+      <Medications
+        patient={HomerSimpson}
+        medicationRequests={[]}
+        medicationStatements={[
+          {
+            resourceType: 'MedicationStatement',
+            id: 'statement-1',
+            status: 'active',
+            subject: createReference(HomerSimpson),
+            medicationCodeableConcept: { text: 'Atorvastatin' },
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Medications')).toBeInTheDocument();
+    expect(screen.getByText('Atorvastatin')).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  test('Medication statement click calls onClickResource', async () => {
+    const onClickResource = vi.fn();
+    const medicationStatement: MedicationStatement = {
+      resourceType: 'MedicationStatement',
+      id: 'statement-1',
+      status: 'active',
+      subject: createReference(HomerSimpson),
+      medicationCodeableConcept: { text: 'Atorvastatin' },
+    };
+
+    await setup(
+      <Medications
+        patient={HomerSimpson}
+        medicationRequests={[]}
+        medicationStatements={[medicationStatement]}
+        onClickResource={onClickResource}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Atorvastatin'));
+    });
+
+    expect(onClickResource).toHaveBeenCalledWith(medicationStatement);
+    expect(screen.queryByText('Edit Medication')).not.toBeInTheDocument();
   });
 
   test('Add medication', async () => {

--- a/packages/react/src/PatientSummary/Medications.tsx
+++ b/packages/react/src/PatientSummary/Medications.tsx
@@ -2,22 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Box, Flex, Group, Modal, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { getDisplayString } from '@medplum/core';
-import type { Encounter, MedicationRequest, Patient } from '@medplum/fhirtypes';
+import { formatCodeableConcept, getDisplayString } from '@medplum/core';
+import type { Encounter, MedicationRequest, MedicationStatement, Patient } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import type { JSX } from 'react';
 import { useCallback, useState } from 'react';
 import { StatusBadge } from '../StatusBadge/StatusBadge';
+import { compareByLastUpdatedDescending } from '../utils/date';
 import { CollapsibleSection } from './CollapsibleSection';
 import { MedicationDialog } from './MedicationDialog';
 import SummaryItem from './SummaryItem';
 import styles from './SummaryItem.module.css';
 
+export type MedicationSummaryResource = MedicationRequest | MedicationStatement;
+
 export interface MedicationsProps {
   readonly patient: Patient;
   readonly encounter?: Encounter;
   readonly medicationRequests: MedicationRequest[];
-  readonly onClickResource?: (resource: MedicationRequest) => void;
+  readonly medicationStatements?: MedicationStatement[];
+  readonly onClickResource?: (resource: MedicationSummaryResource) => void;
 }
 
 export function Medications(props: MedicationsProps): JSX.Element {
@@ -25,6 +29,7 @@ export function Medications(props: MedicationsProps): JSX.Element {
   const [medicationRequests, setMedicationRequests] = useState(props.medicationRequests);
   const [editMedication, setEditMedication] = useState<MedicationRequest>();
   const [opened, { open, close }] = useDisclosure(false);
+  const medications = [...medicationRequests, ...(props.medicationStatements ?? [])].sort(compareByLastUpdatedDescending);
 
   const handleSubmit = useCallback(
     async (medication: MedicationRequest) => {
@@ -51,19 +56,23 @@ export function Medications(props: MedicationsProps): JSX.Element {
           open();
         }}
       >
-        {medicationRequests.length > 0 ? (
+        {medications.length > 0 ? (
           <Flex direction="column" gap={8}>
-            {medicationRequests.map((medication) => (
+            {medications.map((medication) => (
               <SummaryItem
-                key={medication.id}
+                key={`${medication.resourceType}/${medication.id}`}
                 onClick={() => {
-                  setEditMedication(medication);
-                  open();
+                  if (medication.resourceType === 'MedicationRequest') {
+                    setEditMedication(medication);
+                    open();
+                  } else {
+                    props.onClickResource?.(medication);
+                  }
                 }}
               >
                 <Box>
                   <Text fw={500} className={styles.itemText}>
-                    {getDisplayString(medication)}
+                    {getMedicationDisplayString(medication)}
                   </Text>
                   <Group mt={2} gap={4}>
                     {medication.status && (
@@ -117,4 +126,12 @@ function getStatusColor(status?: string): string {
     default:
       return 'gray';
   }
+}
+
+function getMedicationDisplayString(medication: MedicationSummaryResource): string {
+  if (medication.medicationCodeableConcept) {
+    return formatCodeableConcept(medication.medicationCodeableConcept);
+  }
+
+  return getDisplayString(medication);
 }

--- a/packages/react/src/PatientSummary/Medications.tsx
+++ b/packages/react/src/PatientSummary/Medications.tsx
@@ -29,7 +29,9 @@ export function Medications(props: MedicationsProps): JSX.Element {
   const [medicationRequests, setMedicationRequests] = useState(props.medicationRequests);
   const [editMedication, setEditMedication] = useState<MedicationRequest>();
   const [opened, { open, close }] = useDisclosure(false);
-  const medications = [...medicationRequests, ...(props.medicationStatements ?? [])].sort(compareByLastUpdatedDescending);
+  const medications = [...medicationRequests, ...(props.medicationStatements ?? [])].sort(
+    compareByLastUpdatedDescending
+  );
 
   const handleSubmit = useCallback(
     async (medication: MedicationRequest) => {

--- a/packages/react/src/PatientSummary/PatientSummary.test.tsx
+++ b/packages/react/src/PatientSummary/PatientSummary.test.tsx
@@ -488,6 +488,10 @@ describe('PatientSummary', () => {
 
     expect(MedicationsSection.key).toBe('medications');
     expect(MedicationsSection.title).toBe('Medications');
+    expect(MedicationsSection.searches).toEqual([
+      { key: 'medicationRequests', resourceType: 'MedicationRequest', patientParam: 'subject' },
+      { key: 'medicationStatements', resourceType: 'MedicationStatement', patientParam: 'subject' },
+    ]);
 
     expect(LabsSection.key).toBe('labs');
     expect(LabsSection.searches).toHaveLength(2);

--- a/packages/react/src/PatientSummary/sectionConfigs.tsx
+++ b/packages/react/src/PatientSummary/sectionConfigs.tsx
@@ -9,6 +9,7 @@ import type {
   Coverage,
   DiagnosticReport,
   MedicationRequest,
+  MedicationStatement,
   Observation,
   ServiceRequest,
 } from '@medplum/fhirtypes';
@@ -141,15 +142,19 @@ export const ProblemListSection: PatientSummarySectionConfig = {
   ),
 };
 
-/** Medications section — searches for MedicationRequest resources. */
+/** Medications section — searches for MedicationRequest and MedicationStatement resources. */
 export const MedicationsSection: PatientSummarySectionConfig = {
   key: 'medications',
   title: 'Medications',
-  searches: [{ key: 'medications', resourceType: 'MedicationRequest', patientParam: 'subject' }],
+  searches: [
+    { key: 'medicationRequests', resourceType: 'MedicationRequest', patientParam: 'subject' },
+    { key: 'medicationStatements', resourceType: 'MedicationStatement', patientParam: 'subject' },
+  ],
   component: ({ results, patient, onClickResource }: SectionRenderContext) => (
     <Medications
       patient={patient}
-      medicationRequests={(results['medications'] as MedicationRequest[]) || []}
+      medicationRequests={(results['medicationRequests'] as MedicationRequest[]) || []}
+      medicationStatements={(results['medicationStatements'] as MedicationStatement[]) || []}
       onClickResource={onClickResource}
     />
   ),

--- a/packages/react/src/utils/date.test.ts
+++ b/packages/react/src/utils/date.test.ts
@@ -1,9 +1,22 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { Communication, Resource } from '@medplum/fhirtypes';
-import { sortByDateAndPriority } from './date';
+import { compareByLastUpdatedDescending, sortByDateAndPriority } from './date';
 
 describe('Date utils', () => {
+  test('Compare by lastUpdated descending', () => {
+    const input: Resource[] = [
+      { resourceType: 'Patient', id: 'old', meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
+      { resourceType: 'Patient', id: 'missing' },
+      { resourceType: 'Patient', id: 'new', meta: { lastUpdated: '2003-03-03T00:00:00.000Z' } },
+      { resourceType: 'Patient', id: 'middle', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
+    ];
+
+    input.sort(compareByLastUpdatedDescending);
+
+    expect(input.map((resource) => resource.id)).toEqual(['new', 'middle', 'old', 'missing']);
+  });
+
   test('Sort by date', () => {
     const input: Resource[] = [
       { resourceType: 'Patient', meta: { lastUpdated: '2003-03-03T00:00:00.000Z' } },

--- a/packages/react/src/utils/date.ts
+++ b/packages/react/src/utils/date.ts
@@ -3,6 +3,32 @@
 import type { Resource } from '@medplum/fhirtypes';
 
 /**
+ * Compares two resources by meta.lastUpdated descending.
+ * Resources without meta.lastUpdated sort after resources with meta.lastUpdated.
+ * @param a - First resource.
+ * @param b - Second resource.
+ * @returns Comparator result for Array.sort().
+ */
+export function compareByLastUpdatedDescending(a: Resource, b: Resource): number {
+  const aLastUpdated = a.meta?.lastUpdated;
+  const bLastUpdated = b.meta?.lastUpdated;
+
+  if (!aLastUpdated && !bLastUpdated) {
+    return 0;
+  }
+
+  if (!aLastUpdated) {
+    return 1;
+  }
+
+  if (!bLastUpdated) {
+    return -1;
+  }
+
+  return bLastUpdated.localeCompare(aLastUpdated);
+}
+
+/**
  * Sorts an array of resources in place by meta.lastUpdated ascending.
  * @param resources - Array of resources.
  * @param timelineResource - Optional primary resource of a timeline view. If specified, the primary resource will be sorted by meta.lastUpdated descending.


### PR DESCRIPTION
Adds display-layer support for `MedicationStatement` resources in the React `PatientSummary` medications section.

Historically, PatientSummary only displayed `MedicationRequest` resources. That aligned with US Core guidance, which recommends `MedicationRequest` and does not include `MedicationStatement`. We have generally discouraged use of `MedicationStatement` for operational medication workflows.

However, we have recently seen multiple customer examples where imported medication history arrives as `MedicationStatement`. This change lets PatientSummary surface those imported records alongside `MedicationRequest` resources so clinicians can see the data that is already present.

## Scope

- Fetches both `MedicationRequest` and `MedicationStatement` resources for the built-in medications section.
- Displays both resource types in the existing Medications list.
- Sorts the combined list by `meta.lastUpdated` descending using a shared date utility.
- Keeps add/edit behavior limited to `MedicationRequest`.
- Routes `MedicationStatement` row clicks through `onClickResource` instead of opening the `MedicationRequest` editor.

## Guidance

`MedicationRequest` remains the recommended resource for operational medication flows, including ePrescribe. `MedicationStatement` support here is intentionally limited to displaying imported data; it does not add authoring or workflow support for `MedicationStatement`.