### PR TITLE
fix(core): bound the 401 retry in MedplumClient to prevent infinite loops

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -29,7 +29,7 @@ import type {
   NewUserRequest,
 } from './client';
 import { DEFAULT_ACCEPT, MedplumClient } from './client';
-import { createFakeJwt, mockFetch, mockFetchResponse } from './client-test-utils';
+import { createFakeJwt, mockFetch, mockFetchResponse, mockFetchWithStatus } from './client-test-utils';
 import { ContentType } from './contenttype';
 import * as environment from './environment';
 import {
@@ -1480,6 +1480,278 @@ describe('Client', () => {
     const result = client.get('expired');
     await expect(result).rejects.toThrow(new OperationOutcomeError(unauthorized));
     expect(onUnauthenticated).toHaveBeenCalled();
+  });
+
+  describe('Bounded 401 retry (terminal)', () => {
+    const clientId = 'test-client-id';
+    const clientSecret = 'test-client-secret';
+
+    /**
+     * Access token whose `exp` is far in the future, so `isAuthenticated()` returns true.
+     * Intentionally omits `login_id` so the token is not treated as a Medplum-server token
+     * (which would trigger an `auth/me` profile fetch unrelated to the 401 retry path).
+     * The `jti` discriminator keeps successive tokens byte-distinct so a test can tell a
+     * re-minted token apart from the rejected one.
+     * @param jti - Unique token id; defaults to a random UUID so each token is distinct.
+     * @returns A fake signed JWT string usable as a client access token.
+     */
+    function freshClientToken(jti = randomUUID()): string {
+      return createFakeJwt({ cid: clientId, jti, exp: Math.floor(Date.now() / 1000) + 3600 });
+    }
+
+    test('401 on a non-expired token forces exactly one re-mint then succeeds', async () => {
+      const firstToken = freshClientToken();
+      const secondToken = freshClientToken();
+      let mintCount = 0;
+      const seenFhirAuth: (string | undefined)[] = [];
+
+      const fetch = mockFetchWithStatus((url, options) => {
+        if (url.includes('oauth2/token')) {
+          mintCount++;
+          return [200, { access_token: mintCount === 1 ? firstToken : secondToken }];
+        }
+        if (url.includes('Patient/123')) {
+          const auth = (options?.headers as Record<string, string> | undefined)?.['Authorization'];
+          seenFhirAuth.push(auth);
+          if (auth === `Bearer ${firstToken}`) {
+            return [401, unauthorized];
+          }
+          return [200, { resourceType: 'Patient', id: '123' }];
+        }
+        return [200, {}];
+      });
+
+      const client = new MedplumClient({ fetch });
+      client.setBasicAuth(clientId, clientSecret);
+      await client.startClientLogin(clientId, clientSecret);
+      expect(client.getAccessToken()).toBe(firstToken);
+
+      const result = await client.readResource('Patient', '123');
+      expect(result).toMatchObject({ resourceType: 'Patient', id: '123' });
+
+      expect(mintCount).toBe(2);
+      expect(client.getAccessToken()).toBe(secondToken);
+      expect(seenFhirAuth).toStrictEqual([`Bearer ${firstToken}`, `Bearer ${secondToken}`]);
+    });
+
+    test('401 then 401 is terminal and bounded (fetch hit at most twice)', async () => {
+      let fhirCount = 0;
+      let mintCount = 0;
+      const onUnauthenticated = vi.fn();
+
+      const fetch = mockFetchWithStatus((url) => {
+        if (url.includes('oauth2/token')) {
+          mintCount++;
+          return [200, { access_token: freshClientToken() }];
+        }
+        if (url.includes('Patient/123')) {
+          fhirCount++;
+          return [401, unauthorized];
+        }
+        return [200, {}];
+      });
+
+      const client = new MedplumClient({ fetch, onUnauthenticated });
+      client.setBasicAuth(clientId, clientSecret);
+      await client.startClientLogin(clientId, clientSecret);
+
+      await expect(client.readResource('Patient', '123')).rejects.toThrow(new OperationOutcomeError(unauthorized));
+
+      expect(fhirCount).toBe(2);
+      expect(mintCount).toBe(2);
+      expect(onUnauthenticated).toHaveBeenCalled();
+    });
+
+    test('refresh-token client recovers from a 401 via the refresh grant', async () => {
+      const firstAccess = createFakeJwt({ login_id: '123', exp: Math.floor(Date.now() / 1000) + 3600 });
+      const secondAccess = createFakeJwt({ login_id: '456', exp: Math.floor(Date.now() / 1000) + 3600 });
+      let refreshGrantCount = 0;
+
+      const fetch = mockFetchWithStatus((url, options) => {
+        if (url.includes('oauth2/token')) {
+          const body = String(options?.body ?? '');
+          if (body.includes('grant_type=refresh_token')) {
+            refreshGrantCount++;
+          }
+          return [
+            200,
+            {
+              access_token: secondAccess,
+              refresh_token: createFakeJwt({ client_id: '123' }),
+              profile: { reference: 'Patient/123' },
+            },
+          ];
+        }
+        if (url.includes('auth/me')) {
+          return [200, { profile: { resourceType: 'Patient', id: '123' } }];
+        }
+        if (url.includes('Patient/123')) {
+          const auth = (options?.headers as Record<string, string> | undefined)?.['Authorization'];
+          return auth === `Bearer ${firstAccess}` ? [401, unauthorized] : [200, { resourceType: 'Patient', id: '123' }];
+        }
+        return [200, {}];
+      });
+
+      const client = new MedplumClient({ fetch });
+      client.setAccessToken(firstAccess, createFakeJwt({ client_id: '123' }));
+
+      const result = await client.readResource('Patient', '123');
+      expect(result).toMatchObject({ resourceType: 'Patient', id: '123' });
+      expect(refreshGrantCount).toBe(1);
+      expect(client.getAccessToken()).toBe(secondAccess);
+    });
+
+    test('transient 5xx retries do not consume the 401 budget', async () => {
+      const firstToken = freshClientToken();
+      const secondToken = freshClientToken();
+      let mintCount = 0;
+      let serverErrorServed = false;
+
+      const fetch = mockFetchWithStatus((url, options) => {
+        if (url.includes('oauth2/token')) {
+          mintCount++;
+          return [200, { access_token: mintCount === 1 ? firstToken : secondToken }];
+        }
+        if (url.includes('Patient/123')) {
+          const auth = (options?.headers as Record<string, string> | undefined)?.['Authorization'];
+          if (!serverErrorServed) {
+            serverErrorServed = true;
+            return [500, serverError(new Error('transient'))];
+          }
+          if (auth === `Bearer ${firstToken}`) {
+            return [401, unauthorized];
+          }
+          return [200, { resourceType: 'Patient', id: '123' }];
+        }
+        return [200, {}];
+      });
+
+      const client = new MedplumClient({ fetch });
+      client.setBasicAuth(clientId, clientSecret);
+      await client.startClientLogin(clientId, clientSecret);
+
+      vi.useFakeTimers();
+      try {
+        const promise = client.readResource('Patient', '123');
+        await vi.runAllTimersAsync();
+        const result = await promise;
+        expect(result).toMatchObject({ resourceType: 'Patient', id: '123' });
+      } finally {
+        vi.useRealTimers();
+      }
+      expect(mintCount).toBe(2);
+      expect(client.getAccessToken()).toBe(secondToken);
+    });
+
+    test('concurrent 401s collapse to a single re-mint (single-flight) with independent budgets', async () => {
+      const firstToken = freshClientToken();
+      const secondToken = freshClientToken();
+      let mintCount = 0;
+      let fhirCount = 0;
+
+      const fetch = mockFetchWithStatus((url, options) => {
+        if (url.includes('oauth2/token')) {
+          mintCount++;
+          return [200, { access_token: mintCount === 1 ? firstToken : secondToken }];
+        }
+        if (url.includes('Patient/')) {
+          fhirCount++;
+          const auth = (options?.headers as Record<string, string> | undefined)?.['Authorization'];
+          if (auth === `Bearer ${firstToken}`) {
+            return [401, unauthorized];
+          }
+          const id = url.split('Patient/')[1];
+          return [200, { resourceType: 'Patient', id }];
+        }
+        return [200, {}];
+      });
+
+      const client = new MedplumClient({ fetch });
+      client.setBasicAuth(clientId, clientSecret);
+      await client.startClientLogin(clientId, clientSecret);
+      expect(mintCount).toBe(1);
+
+      const results = await Promise.all([
+        client.readResource('Patient', 'a'),
+        client.readResource('Patient', 'b'),
+        client.readResource('Patient', 'c'),
+      ]);
+
+      expect(results.map((r) => r.id)).toStrictEqual(['a', 'b', 'c']);
+      expect(mintCount).toBe(2);
+      expect(fhirCount).toBe(6);
+      expect(client.getAccessToken()).toBe(secondToken);
+    });
+
+    test('happy path (200) issues no extra token mint', async () => {
+      const token = freshClientToken();
+      let mintCount = 0;
+      let fhirCount = 0;
+
+      const fetch = mockFetchWithStatus((url) => {
+        if (url.includes('oauth2/token')) {
+          mintCount++;
+          return [200, { access_token: token }];
+        }
+        if (url.includes('Patient/123')) {
+          fhirCount++;
+          return [200, { resourceType: 'Patient', id: '123' }];
+        }
+        return [200, {}];
+      });
+
+      const client = new MedplumClient({ fetch });
+      client.setBasicAuth(clientId, clientSecret);
+      await client.startClientLogin(clientId, clientSecret);
+
+      const result = await client.readResource('Patient', '123');
+      expect(result).toMatchObject({ resourceType: 'Patient', id: '123' });
+      expect(mintCount).toBe(1);
+      expect(fhirCount).toBe(1);
+    });
+
+    test('Medplum-server token: 401 recovery still re-mints and refreshes the profile', async () => {
+      const firstToken = createFakeJwt({ cid: clientId, login_id: 'L1', exp: Math.floor(Date.now() / 1000) + 3600 });
+      const secondToken = createFakeJwt({ cid: clientId, login_id: 'L2', exp: Math.floor(Date.now() / 1000) + 3600 });
+      let mintCount = 0;
+      let authMeCount = 0;
+      let fhirCount = 0;
+
+      const fetch = mockFetchWithStatus((url, options) => {
+        if (url.includes('oauth2/token')) {
+          mintCount++;
+          return [
+            200,
+            {
+              access_token: mintCount === 1 ? firstToken : secondToken,
+              refresh_token: createFakeJwt({ client_id: clientId }),
+              profile: { reference: 'Patient/1' },
+            },
+          ];
+        }
+        if (url.includes('auth/me')) {
+          authMeCount++;
+          return [200, { profile: { resourceType: 'Patient', id: '1' } }];
+        }
+        if (url.includes('Patient/1')) {
+          fhirCount++;
+          const auth = (options?.headers as Record<string, string> | undefined)?.['Authorization'];
+          return auth === `Bearer ${firstToken}` ? [401, unauthorized] : [200, { resourceType: 'Patient', id: '1' }];
+        }
+        return [200, {}];
+      });
+
+      const client = new MedplumClient({ fetch });
+      client.setBasicAuth(clientId, clientSecret);
+      await client.startClientLogin(clientId, clientSecret);
+
+      const result = await client.readResource('Patient', '1');
+      expect(result).toMatchObject({ resourceType: 'Patient', id: '1' });
+      expect(mintCount).toBe(2);
+      expect(fhirCount).toBe(2);
+      expect(authMeCount).toBe(2);
+      expect(client.getAccessToken()).toBe(secondToken);
+    });
   });
 
   test('fhirUrl', () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -799,7 +799,21 @@ interface AutoBatchEntry<T = any> {
 interface RequestState {
   statusUrl?: string;
   pollCount?: number;
+  /**
+   * Number of times this logical request has already been dispatched to the server.
+   * Starts at 0 for the initial attempt and is incremented before each 401 recovery
+   * retry. Used to bound the unauthenticated-retry path so a rejected token can never
+   * loop forever (see {@link MedplumClient.handleUnauthenticated}).
+   */
+  authAttempt?: number;
 }
+
+/**
+ * Maximum number of times a single logical request may be dispatched to the server
+ * across the 401/unauthenticated recovery path: 1 initial attempt + 1 recovery attempt.
+ * A 401 on the recovery attempt is terminal and is never retried again.
+ */
+const MAX_AUTH_ATTEMPTS = 2;
 
 /**
  * OAuth 2.0 Grant Type Identifiers
@@ -3601,7 +3615,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
 
     if (response.status === 401) {
       // Refresh and try again
-      return this.handleUnauthenticated(url, options);
+      return this.handleUnauthenticated<T>(url, options, state);
     }
 
     if (response.status === 204 || response.status === 304) {
@@ -3987,16 +4001,25 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   }
 
   /**
-   * Handles an unauthenticated response from the server.
-   * First, tries to refresh the access token and retry the request.
-   * Otherwise, calls unauthenticated callbacks and rejects.
+   * Handles an unauthenticated (HTTP 401) response from the server.
+   *
+   * Bounded and terminal: at most {@link MAX_AUTH_ATTEMPTS} attempts per request (1 initial
+   * + 1 recovery, tracked via {@link RequestState.authAttempt}). The recovery re-mints via a
+   * forced {@link MedplumClient.refresh} (bypassing the {@link MedplumClient.isAuthenticated}
+   * short-circuit on the rejected token), single-flight so concurrent 401s share one re-mint.
+   * A second 401 is terminal: clear auth, `onUnauthenticated`, reject — never recurse.
+   *
    * @param url - The URL of the original request.
    * @param options - Optional fetch request init options.
+   * @param state - The request state carrying the per-request attempt count.
    * @returns The result of the retry.
    */
-  private handleUnauthenticated(url: string, options: MedplumRequestOptions): Promise<any> {
-    if (this.refresh()) {
-      return this.request(url, options);
+  private async handleUnauthenticated<T>(url: string, options: MedplumRequestOptions, state: RequestState): Promise<T> {
+    const attempt = state.authAttempt ?? 0;
+    const refreshPromise = attempt + 1 < MAX_AUTH_ATTEMPTS ? this.refresh(undefined, true) : undefined;
+    if (refreshPromise) {
+      await refreshPromise;
+      return this.request<T>(url, options, { ...state, authAttempt: attempt + 1 });
     }
     this.clear();
     this.onUnauthenticated?.();
@@ -4100,10 +4123,11 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * has already refreshed.
    *
    * @param gracePeriod - Optional grace period in milliseconds threaded through to the post-lock authentication check.
+   * @param force - When true, re-mint even if the current token still looks locally valid — used by the 401 recovery path, where the server has rejected a token that has not locally expired. A newer token already in storage (e.g. from a peer tab) is still preferred over a fresh mint.
    * @returns The refresh promise if available; otherwise undefined.
    * @see https://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens
    */
-  private refresh(gracePeriod?: number): Promise<void> | undefined {
+  private refresh(gracePeriod?: number, force = false): Promise<void> | undefined {
     if (this.refreshPromise) {
       return this.refreshPromise;
     }
@@ -4112,7 +4136,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       return undefined;
     }
 
-    this.refreshPromise = this.runRefreshWithLock(gracePeriod);
+    this.refreshPromise = this.runRefreshWithLock(gracePeriod, force);
     return this.refreshPromise;
   }
 
@@ -4121,17 +4145,22 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * Tabs that wait on the lock check storage on acquisition and skip the network call
    * if a peer tab has already produced a fresh access token.
    * @param gracePeriod - Optional grace period in milliseconds used by the post-lock authentication check to decide whether the current token still has enough life left to skip the network refresh.
+   * @param force - When true, bypass the post-lock expiry short-circuit for the current token (still preferring a newer token a peer tab produced).
    * @returns Promise that resolves when the refresh (or short-circuit) is complete.
    */
-  private async runRefreshWithLock(gracePeriod?: number): Promise<ProfileResource | undefined> {
+  private async runRefreshWithLock(gracePeriod?: number, force = false): Promise<ProfileResource | undefined> {
     const run = (): Promise<ProfileResource | undefined> => {
       // Re-read latest tokens from storage before hitting the network.
       // A peer tab may have completed a refresh while we were queued on the lock.
+      const previousAccessToken = this.accessToken;
       const latest = this.getActiveLogin();
       if (latest?.accessToken && latest.accessToken !== this.accessToken) {
         this.setAccessToken(latest.accessToken, latest.refreshToken);
       }
-      if (this.isAuthenticated(gracePeriod)) {
+      // A forced refresh (401 recovery) skips the expiry short-circuit for the rejected
+      // token, but still reuses a different token a peer already produced if it is valid.
+      const adoptedNewerToken = this.accessToken !== previousAccessToken;
+      if (this.isAuthenticated(gracePeriod) && (!force || adoptedNewerToken)) {
         return Promise.resolve(this.getProfile());
       }
 


### PR DESCRIPTION
## Why

`MedplumClient` retries 401s with no attempt counter, so it can loop forever: it only re-mints when the token is *locally expired*, so when the server 401s a token whose `exp` is still in the future, it re-sends the same rejected token indefinitely.

When would this happen? High eviction rates in Redis. Logins are only stored in Redis, so it becomes a lottery under high eviction rate conditions: a still-valid Login gets evicted and the server 401s its token even though `exp` hasn't passed.

## What

Bound the 401 path and make it terminal:

- Max 2 attempts per request (1 initial + 1 recovery), via a per-request `authAttempt` so concurrent requests have independent budgets.
- Recovery forces a re-mint (a `force` flag on `refresh()` skips the `isAuthenticated()` short-circuit) so it can't re-send the rejected token; a newer token from a peer tab is still preferred.
- A 2nd 401 is terminal — clear auth, fire `onUnauthenticated`, throw; never recurse.
- Single-flight preserved; the 429/5xx retry budget is untouched.

Tests cover re-mint-then-success, bounded 401→401 throw, refresh-token recovery, 5xx independence, and concurrent single-flight. (A pre-existing loop where a Medplum-server token's internal `auth/me` persistently 401s is out of scope — documented inline.)

## Supersedes medplum/medplum#9588 (server-side Login writes)

This PR fixes it from the client and generalizes: a 401 on a not-locally-expired token forces a re-mint and retries once. That recovers the eviction case (the fresh token has a fresh Login) and bounds *any* persistent 401 — in one `@medplum/core` change, with none of medplum/medplum#9588's server-side tradeoffs (a growing `Login` table, or a dedicated `noeviction` Redis per the `feat/auth-redis` alternative).
