### PR TITLE
[Provider] Hide slots related to cancelled appointments

### DIFF
--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
@@ -3,7 +3,15 @@
 import { ActionIcon, Box, Drawer, Group, Stack, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import type { WithId } from '@medplum/core';
-import { createReference, EMPTY, getReferenceString, isReference, isResourceWithId } from '@medplum/core';
+import {
+  createReference,
+  EMPTY,
+  getReferenceString,
+  isDefined,
+  isReference,
+  isResourceWithId,
+  resolveId,
+} from '@medplum/core';
 import type { Appointment, Practitioner, Reference, Schedule, Slot } from '@medplum/fhirtypes';
 import { ReferenceInput, useMedplum, useMedplumProfile } from '@medplum/react';
 import { IconSettings } from '@tabler/icons-react';
@@ -199,6 +207,12 @@ export function SchedulePage(): JSX.Element | null {
       setAppointmentDetails((existing) => (existing?.id === updated.id ? updated : existing));
       if (updated.status === 'cancelled') {
         appointmentDetailsHandlers.close();
+
+        // If the appointment has been cancelled, we also soft-delete the related slots
+        if (updated.slot) {
+          const ids = new Set(updated.slot.map((ref) => resolveId(ref)).filter(isDefined));
+          setSlots((state) => state?.filter((slot) => slot.id && !ids.has(slot.id)));
+        }
       }
     },
     [appointmentDetailsHandlers]

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
@@ -208,7 +208,8 @@ export function SchedulePage(): JSX.Element | null {
       if (updated.status === 'cancelled') {
         appointmentDetailsHandlers.close();
 
-        // If the appointment has been cancelled, we also soft-delete the related slots
+        // If the appointment was cancelled with `$cancel`, it also
+        // soft-deleted the related slots. Remove them from our local state.
         if (updated.slot) {
           const ids = new Set(updated.slot.map((ref) => resolveId(ref)).filter(isDefined));
           setSlots((state) => state?.filter((slot) => slot.id && !ids.has(slot.id)));

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
@@ -16,7 +16,7 @@ import type { Appointment, Practitioner, Reference, Schedule, Slot } from '@medp
 import { ReferenceInput, useMedplum, useMedplumProfile } from '@medplum/react';
 import { IconSettings } from '@tabler/icons-react';
 import type { JSX } from 'react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { Calendar } from '../../components/Calendar';
 import { AppointmentDetails } from '../../components/schedule/AppointmentDetails';
@@ -98,7 +98,7 @@ export function SchedulePage(): JSX.Element | null {
         ['start', `le${range.end.toISOString()}`],
         ['status:not', 'entered-in-error'],
       ])
-      .then((rawSlots) => active && setSlots(mergeOverlappingSlots(rawSlots)))
+      .then((rawSlots) => active && setSlots(rawSlots))
       .catch((error: unknown) => active && showErrorNotification(error));
 
     return () => {
@@ -241,6 +241,8 @@ export function SchedulePage(): JSX.Element | null {
 
   const schedulingEnabled = project?.features?.includes('scheduling');
 
+  const mergedSlots = useMemo(() => mergeOverlappingSlots(slots ?? []), [slots]);
+
   return (
     <>
       <Stack p="sm" className={classes.page}>
@@ -270,7 +272,7 @@ export function SchedulePage(): JSX.Element | null {
             onSelectInterval={handleSelectInterval}
             onSelectAppointment={handleSelectAppointment}
             onSelectSlot={handleSelectSlot}
-            slots={slots ?? []}
+            slots={mergedSlots}
             appointments={appointments ?? []}
             onRangeChange={setRange}
             className={classes.calendar}


### PR DESCRIPTION
If you have created an appointment with attributes like "bufferBefore", then when you use `$cancel` the Slot resource created to enforce that is also soft-deleted.

When you do this from the Provider UI, we want to clear such Slots from the calendar. We don't get the Slot resources back in the update response (as they have been deleted), so we inspect `Appointment.slot` to find references to the related Slot resources we can hide.