### PR TITLE
Perf/cache compartment fhirpath

### DIFF
--- a/packages/core/src/fhirpath/parse.ts
+++ b/packages/core/src/fhirpath/parse.ts
@@ -241,9 +241,16 @@ export function parseFhirPath(input: string): FhirPathAtom {
  * Evaluates a FHIRPath expression against a resource or other object.
  * @param expression - The FHIRPath expression to evaluate.
  * @param input - The resource or object to evaluate the expression against.
+ * @param variables - A map of variables for eval input.
+ * @param cache - Cache for parsed ASTs.
  * @returns The result of the FHIRPath expression against the resource or object.
  */
-export function evalFhirPath(expression: string | FhirPathAtom, input: unknown): unknown[] {
+export function evalFhirPath(
+  expression: string | FhirPathAtom,
+  input: unknown,
+  variables: Record<string, TypedValue> = {},
+  cache: LRUCache<FhirPathAtom> | undefined = undefined
+): unknown[] {
   // eval requires a TypedValue array
   // As a convenience, we can accept array or non-array, and TypedValue or unknown value
   const array = Array.isArray(input) ? input : [input];
@@ -253,7 +260,7 @@ export function evalFhirPath(expression: string | FhirPathAtom, input: unknown):
       array[i] = toTypedValue(array[i]);
     }
   }
-  return evalFhirPathTyped(expression, array).map((e) => e.value);
+  return evalFhirPathTyped(expression, array, variables, cache).map((e) => e.value);
 }
 
 /**

--- a/packages/server/src/fhir/patient.ts
+++ b/packages/server/src/fhir/patient.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { WithId } from '@medplum/core';
-import { EMPTY, evalFhirPath, getReferenceString, getSearchParameter } from '@medplum/core';
+import type { FhirPathAtom, WithId } from '@medplum/core';
+import { EMPTY, evalFhirPath, getReferenceString, getSearchParameter, parseFhirPath } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import type {
   CompartmentDefinition,
@@ -44,6 +44,25 @@ export function getPatientCompartmentParams(resourceType: string): string[] | un
   return undefined;
 }
 
+const compartmentExpressionCache = new Map<string, FhirPathAtom>();
+
+/**
+ * Returns the parsed FHIRPath atom for a patient-compartment search parameter expression, caching
+ * the result. getPatients() runs on every resource write, so this avoids re-tokenizing and
+ * re-parsing the same fixed set of compartment expressions for every resource. The cache is bounded
+ * by the number of distinct compartment search parameters.
+ * @param expression - The search parameter's FHIRPath expression.
+ * @returns The parsed FHIRPath atom.
+ */
+function getParsedCompartmentExpression(expression: string): FhirPathAtom {
+  let parsed = compartmentExpressionCache.get(expression);
+  if (!parsed) {
+    parsed = parseFhirPath(expression);
+    compartmentExpressionCache.set(expression, parsed);
+  }
+  return parsed;
+}
+
 /**
  * Returns the patient compartment ID for a resource.
  * If the resource is in a patient compartment (i.e., an Observation about the patient),
@@ -62,7 +81,7 @@ export function getPatients(resource: Resource): (Reference<Patient> & { referen
   for (const code of params ?? EMPTY) {
     const searchParam = getSearchParameter(resource.resourceType, code);
     if (searchParam) {
-      const values = evalFhirPath(searchParam.expression as string, resource);
+      const values = evalFhirPath(getParsedCompartmentExpression(searchParam.expression as string), resource);
       for (const value of values) {
         const patient = getPatientFromUnknownValue(value);
         if (patient) {

--- a/packages/server/src/fhir/patient.ts
+++ b/packages/server/src/fhir/patient.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { FhirPathAtom, WithId } from '@medplum/core';
-import { EMPTY, evalFhirPath, getReferenceString, getSearchParameter, parseFhirPath } from '@medplum/core';
+import type { WithId } from '@medplum/core';
+import { EMPTY, evalFhirPath, getReferenceString, getSearchParameter, getSearchParameterDetails } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import type {
   CompartmentDefinition,
@@ -44,25 +44,6 @@ export function getPatientCompartmentParams(resourceType: string): string[] | un
   return undefined;
 }
 
-const compartmentExpressionCache = new Map<string, FhirPathAtom>();
-
-/**
- * Returns the parsed FHIRPath atom for a patient-compartment search parameter expression, caching
- * the result. getPatients() runs on every resource write, so this avoids re-tokenizing and
- * re-parsing the same fixed set of compartment expressions for every resource. The cache is bounded
- * by the number of distinct compartment search parameters.
- * @param expression - The search parameter's FHIRPath expression.
- * @returns The parsed FHIRPath atom.
- */
-function getParsedCompartmentExpression(expression: string): FhirPathAtom {
-  let parsed = compartmentExpressionCache.get(expression);
-  if (!parsed) {
-    parsed = parseFhirPath(expression);
-    compartmentExpressionCache.set(expression, parsed);
-  }
-  return parsed;
-}
-
 /**
  * Returns the patient compartment ID for a resource.
  * If the resource is in a patient compartment (i.e., an Observation about the patient),
@@ -81,7 +62,8 @@ export function getPatients(resource: Resource): (Reference<Patient> & { referen
   for (const code of params ?? EMPTY) {
     const searchParam = getSearchParameter(resource.resourceType, code);
     if (searchParam) {
-      const values = evalFhirPath(getParsedCompartmentExpression(searchParam.expression as string), resource);
+      const details = getSearchParameterDetails(resource.resourceType, searchParam);
+      const values = evalFhirPath(details.parsedExpression, resource);
       for (const value of values) {
         const patient = getPatientFromUnknownValue(value);
         if (patient) {


### PR DESCRIPTION
Continuing @jdjkelly's PR https://github.com/medplum/medplum/pull/9672/changes

`SearchParameter` is the definition resource from the FHIR spec

`SearchParameter.expression` is the FHIRpath expression string that defines what the search parameter is searching

`SearchParameterDetails` is Medplum's supplemental bag of details

`SearchParameterDetails.parsedExpression` is the pre-parsed version