### PR TITLE
Update 2026-05-08-plumcon-2026-lineup.mdx with Flávio

### DIFF
--- a/packages/docs/blog/2026-05-08-plumcon-2026-lineup.mdx
+++ b/packages/docs/blog/2026-05-08-plumcon-2026-lineup.mdx
@@ -94,6 +94,14 @@ This agenda is preliminary and subject to change.
     </tr>
     <tr>
       <td style={{ whiteSpace: 'nowrap' }}>TBD</td>
+      <td>**9 products on Medplum: modular foundations I wish I'd had on day one**</td>
+      <td align="center">
+        <img src="https://github.com/fjsj.png" alt="Flávio Juvenal" width="50" height="50" style={{borderRadius: '50%'}} />
+        [Flávio Juvenal](https://www.linkedin.com/in/flaviojuvenal), Vinta Software
+      </td>
+    </tr>    
+    <tr>
+      <td style={{ whiteSpace: 'nowrap' }}>TBD</td>
       <td>**Community Demos**</td>
       <td align="center">
         Medplum community


### PR DESCRIPTION
Kept the structure similar to codyhall. LMK if you need image on repo too at `/img/avatars/`.