### PR TITLE
Allow `$export` with read-only scopes

### DIFF
--- a/packages/server/src/fhir/operations/groupexport.test.ts
+++ b/packages/server/src/fhir/operations/groupexport.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { ContentType } from '@medplum/core';
-import type { BulkDataExportOutput, Group, Patient } from '@medplum/fhirtypes';
+import { ContentType, getReferenceString } from '@medplum/core';
+import type { BulkDataExportOutput, Group, Organization, Patient } from '@medplum/fhirtypes';
 import express from 'express';
 import request from 'supertest';
 import { vi } from 'vitest';
@@ -398,5 +398,38 @@ describe('Group Export', () => {
 
       const bulkDataExport = await exporter.close(project);
       expect(bulkDataExport.status).toBe('completed');
+    }));
+
+  test('Export carries access-policy compartment as account', () =>
+    withTestContext(async () => {
+      // A caller whose access policy is compartment-scoped must still be able to read back
+      // the export's bookkeeping resources, so those resources carry the compartment as an
+      // account -- mirroring what the caller's own repo would have assigned on create.
+      const org = await systemRepo.createResource<Organization>({ resourceType: 'Organization', name: 'Acme' });
+      const compartment = { reference: getReferenceString(org) };
+      const { repo, project } = await createTestProject({
+        withRepo: true,
+        accessPolicy: {
+          compartment,
+          resource: [{ resourceType: '*', readonly: true }],
+        },
+      });
+
+      const exporter = new BulkExporter(repo);
+      const asyncJob = await exporter.start('http://example.com');
+      expect(asyncJob.meta?.accounts).toContainEqual(compartment);
+
+      // Writing output creates a Binary, which carries the same account.
+      const patient = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        meta: { project: project.id },
+        name: [{ given: ['Compartment'], family: 'Scoped' }],
+      });
+      await exporter.writeResource(patient);
+      expect(exporter.writers.Patient.binary.meta?.accounts).toContainEqual(compartment);
+
+      // The account survives close() so the completed job stays readable.
+      const completed = await exporter.close(project);
+      expect(completed.meta?.accounts).toContainEqual(compartment);
     }));
 });

--- a/packages/server/src/fhir/operations/groupexport.test.ts
+++ b/packages/server/src/fhir/operations/groupexport.test.ts
@@ -368,4 +368,35 @@ describe('Group Export', () => {
     const bulkDataExport = await exporter.close(project);
     expect(bulkDataExport.status).toBe('completed');
   });
+
+  test('Export with read-only access policy (no write scope)', () =>
+    withTestContext(async () => {
+      // Regression: $export is fundamentally a read operation. Its internal AsyncJob
+      // and Binary resources are server-side bookkeeping and must not require the caller
+      // to have write access -- e.g. a read-only `system/*.read` scope must still work.
+      // BulkExporter creates these via the system repo, scoped to the caller's project.
+      const { repo, project } = await createTestProject({
+        withRepo: true,
+        accessPolicy: { resource: [{ resourceType: '*', readonly: true }] },
+      });
+
+      const exporter = new BulkExporter(repo);
+
+      // Previously threw OperationOutcomeError(Forbidden): the AsyncJob was created via
+      // the caller's (read-only) repo.
+      const asyncJob = await exporter.start('http://example.com');
+      expect(asyncJob.id).toBeDefined();
+      expect(asyncJob.meta?.project).toBe(project.id);
+
+      // Writing output creates a Binary, which must also not require write access.
+      const patient = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        meta: { project: project.id },
+        name: [{ given: ['Read'], family: 'Only' }],
+      });
+      await exporter.writeResource(patient);
+
+      const bulkDataExport = await exporter.close(project);
+      expect(bulkDataExport.status).toBe('completed');
+    }));
 });

--- a/packages/server/src/fhir/operations/utils/bulkexporter.ts
+++ b/packages/server/src/fhir/operations/utils/bulkexporter.ts
@@ -50,11 +50,16 @@ export class BulkExporter {
   }
 
   async start(url: string): Promise<WithId<AsyncJob>> {
-    this.resource = await this.repo.createResource<AsyncJob>({
+    // The AsyncJob is internal bookkeeping for the export, not user-authored data.
+    // $export is a read operation, so creating it must not require the caller to have
+    // write access -- a read-only scope (e.g. system/*.read) is sufficient. Create it
+    // with the system repo, scoped to the caller's project so they can still poll it.
+    this.resource = await this.repo.getSystemRepo().createResource<AsyncJob>({
       resourceType: 'AsyncJob',
       status: 'active',
       request: url,
       requestTime: new Date().toISOString(),
+      meta: { project: this.repo.currentProject()?.id },
     });
     return this.resource;
   }
@@ -62,9 +67,13 @@ export class BulkExporter {
   async getWriter(resourceType: string): Promise<BulkFileWriter> {
     let writer = this.writers[resourceType];
     if (!writer) {
-      const binary = await this.repo.createResource<Binary>({
+      // Like the AsyncJob, the export output Binary is bookkeeping for a read operation,
+      // so create it with the system repo scoped to the caller's project. The exported
+      // data itself was already access-checked when read via the caller's repo.
+      const binary = await this.repo.getSystemRepo().createResource<Binary>({
         resourceType: 'Binary',
         contentType: NDJSON_CONTENT_TYPE,
+        meta: { project: this.repo.currentProject()?.id },
       });
       writer = new BulkFileWriter(binary);
       this.writers[resourceType] = writer;

--- a/packages/server/src/fhir/operations/utils/bulkexporter.ts
+++ b/packages/server/src/fhir/operations/utils/bulkexporter.ts
@@ -50,16 +50,22 @@ export class BulkExporter {
   }
 
   async start(url: string): Promise<WithId<AsyncJob>> {
-    // The AsyncJob is internal bookkeeping for the export, not user-authored data.
-    // $export is a read operation, so creating it must not require the caller to have
-    // write access -- a read-only scope (e.g. system/*.read) is sufficient. Create it
-    // with the system repo, scoped to the caller's project so they can still poll it.
+    // $export is a read operation, but it creates an AsyncJob to track itself. That write must
+    // not require the caller to have write access -- a read-only scope (e.g. system/*.read) is
+    // sufficient -- so create it with the system repo. Replicate the scoping the caller's own
+    // repo would have applied: their project (so they can read it back) and their access-policy
+    // compartment as the account (so a policy that filters AsyncJob by _compartment still
+    // matches it -- the poll in job.ts / bulkdata.ts reads through the caller's repo).
+    const accountCompartment = this.repo.effectiveAccessPolicy()?.compartment;
     this.resource = await this.repo.getSystemRepo().createResource<AsyncJob>({
       resourceType: 'AsyncJob',
       status: 'active',
       request: url,
       requestTime: new Date().toISOString(),
-      meta: { project: this.repo.currentProject()?.id },
+      meta: {
+        project: this.repo.currentProject()?.id,
+        accounts: accountCompartment ? [accountCompartment] : undefined,
+      },
     });
     return this.resource;
   }
@@ -67,13 +73,17 @@ export class BulkExporter {
   async getWriter(resourceType: string): Promise<BulkFileWriter> {
     let writer = this.writers[resourceType];
     if (!writer) {
-      // Like the AsyncJob, the export output Binary is bookkeeping for a read operation,
-      // so create it with the system repo scoped to the caller's project. The exported
-      // data itself was already access-checked when read via the caller's repo.
+      // Like the AsyncJob, the output Binary is bookkeeping for a read operation, so create it
+      // with the system repo (scoped to the caller's project + account compartment so they can
+      // presign/download it). The exported data was already access-checked when read.
+      const accountCompartment = this.repo.effectiveAccessPolicy()?.compartment;
       const binary = await this.repo.getSystemRepo().createResource<Binary>({
         resourceType: 'Binary',
         contentType: NDJSON_CONTENT_TYPE,
-        meta: { project: this.repo.currentProject()?.id },
+        meta: {
+          project: this.repo.currentProject()?.id,
+          accounts: accountCompartment ? [accountCompartment] : undefined,
+        },
       });
       writer = new BulkFileWriter(binary);
       this.writers[resourceType] = writer;
@@ -139,6 +149,9 @@ export class BulkExporter {
         ...this.resource,
         meta: {
           project: project.id,
+          // Preserve the account compartment assigned at start() so a caller whose access
+          // policy filters AsyncJob by _compartment can still read the completed job.
+          accounts: this.resource.meta?.accounts,
         },
         status: 'completed',
         transactionTime: new Date().toISOString(),


### PR DESCRIPTION
`$export` operations (`Group/{id}/$export`, `Patient/$export`, project-level `$export`) are
fundamentally **read** operations, but they create internal bookkeeping resources to track job
state and stage output:

- an `AsyncJob` to track the export, and
- one `Binary` per resource type to hold the NDJSON output.

Until now, `BulkExporter` created both of these using the **caller's** repository, so they were
subject to the caller's access policy. A caller with read-only access (for example a
`client_credentials` client granted `system/*.read`) would get an `HTTP 403 Forbidden` when
starting an export, because creating the `AsyncJob` is a write.

This PR makes `BulkExporter` create those bookkeeping resources with the **system repo**, scoped
to the caller's project. A read-only caller can now run `$export` end to end.

## Why this is safe

This does **not** widen access to exported data. The actual FHIR data is still read through the
caller's own repository (`getPatientEverything` / `exportResourceType`), so the caller's access
policy fully governs what ends up in the export.

Only the server-side artifacts of servicing the request move to the system repo:

- They are explicitly scoped to the caller's project (`meta.project`), so the caller can still
  poll the `AsyncJob` status and download the `Binary` files through their own (project-scoped)
  repo.
- They contain only server-controlled fields plus data that was already access-checked when it
  was read.

This also aligns the three creation/update points: `BulkExporter.close()` already updated the
`AsyncJob` via the system repo, so `start()` and `getWriter()` were the inconsistent outliers.

## Changes

- `packages/server/src/fhir/operations/utils/bulkexporter.ts`
  - `start()`: create the `AsyncJob` via `this.repo.getSystemRepo()`, scoped to the caller's
    project.
  - `getWriter()`: create the output `Binary` the same way.
- `packages/server/src/fhir/operations/groupexport.test.ts`
  - Regression test: an export run with a read-only access policy
    (`{ resourceType: '*', readonly: true }`) now succeeds — `start()` no longer throws
    `Forbidden`, the `AsyncJob` lands in the caller's project, and writing output (creating a
    `Binary`) also succeeds.

## Principle of least surprise

Requiring write capability to perform a read-only `$export` is a sharp edge: the `AsyncJob` is an
implementation detail of how Medplum tracks async jobs, not something the caller explicitly asked
to create. Creating an `AsyncJob` directly via `POST /AsyncJob` should still require write access;
doing it implicitly as the machinery of a read operation should not.

## Notes / follow-ups

- This removes a real latent fragility regardless of any specific incident: any read-leaning
  export client was one access-policy/scope tightening away from a 403 at `start()`.
- If we want to be fully explicit about the project rather than deriving it from
  `repo.currentProject()`, a follow-up could thread `project` through the `BulkExporter`
  constructor. The current approach keeps the change minimal and is a no-op for the existing
  system-repo unit tests.
