### PR TITLE
fix(core/fhirpath): `as` should return empty collection on wrong type

### DIFF
--- a/packages/core/src/fhirpath/atoms.test.ts
+++ b/packages/core/src/fhirpath/atoms.test.ts
@@ -142,7 +142,15 @@ describe('Atoms', () => {
     // Empty results
     expect(evalFhirPath('component.value as Quantity', obs1)).toStrictEqual([]);
 
+    // Qualified type identifiers (e.g. `FHIR.Quantity`) resolve the same way
+    // See: https://hl7.org/fhirpath/N1/#:~:text=in%20a%20model.-,Type%20specifiers%20can%20have%20qualifiers%2C%20e.g.%20FHIR.Patient%2C%20where%20the%20qualifier%20is%20the%20name%20of%20the%20model.,-Patient.contained.all
+    expect(evalFhirPath('value as FHIR.Quantity', obs1)).toStrictEqual([obs1.valueQuantity]);
+
+    // A right operand that does not resolve to a valid type identifier throws,
+    // per https://hl7.org/fhirpath/N1/#astype-specifier
+    expect(() => evalFhirPath('value as 5', obs1)).toThrow('Expected a valid type identifier');
+
     // Multiple results still throw, since `as` requires a singleton collection
-    expect(() => evalFhirPath('component.value as Quantity', obs2)).toThrow('Expected singleton of type');
+    expect(() => evalFhirPath('component.value as Quantity', obs2)).toThrow('Expected singleton');
   });
 });

--- a/packages/core/src/fhirpath/atoms.test.ts
+++ b/packages/core/src/fhirpath/atoms.test.ts
@@ -134,14 +134,15 @@ describe('Atoms', () => {
 
     // Filters exclusively on type
     expect(evalFhirPath('value as Quantity', obs1)).toStrictEqual([obs1.valueQuantity]);
-    expect(() => evalFhirPath('value as Quantity', obs2)).toThrow('Expected singleton of type Quantity');
-    expect(() => evalFhirPath('value as CodeableConcept', obs1)).toThrow('Expected singleton of type CodeableConcept');
+    // A single item of the wrong type returns empty (not an error) per the FHIRPath spec
+    expect(evalFhirPath('value as Quantity', obs2)).toStrictEqual([]);
+    expect(evalFhirPath('value as CodeableConcept', obs1)).toStrictEqual([]);
     expect(evalFhirPath('value as CodeableConcept', obs2)).toStrictEqual([obs2.valueCodeableConcept]);
 
     // Empty results
     expect(evalFhirPath('component.value as Quantity', obs1)).toStrictEqual([]);
 
-    // Multiple results
-    expect(() => evalFhirPath('component.value as Quantity', obs2)).toThrow('Expected singleton of type Quantity');
+    // Multiple results still throw, since `as` requires a singleton collection
+    expect(() => evalFhirPath('component.value as Quantity', obs2)).toThrow('Expected singleton of type');
   });
 });

--- a/packages/core/src/fhirpath/atoms.ts
+++ b/packages/core/src/fhirpath/atoms.ts
@@ -7,7 +7,7 @@ import type { TypedValue } from '../types';
 import { isResource, PropertyType } from '../types';
 import type { TypedValueWithPath } from '../typeschema/crawler';
 import { getTypedPropertyValueWithPath } from '../typeschema/crawler';
-import { functions } from './functions';
+import { functions, getTypeName } from './functions';
 import {
   booleanToTypedValue,
   fhirPathArrayEquals,
@@ -326,7 +326,10 @@ export class IsAtom extends InfixOperatorAtom {
     if (leftValue.length !== 1) {
       return [];
     }
-    const typeName = (this.right as SymbolAtom).name;
+    const typeName = getTypeName(this.right);
+    if (!typeName) {
+      return [];
+    }
     return booleanToTypedValue(fhirPathIs(leftValue[0], typeName));
   }
 }

--- a/packages/core/src/fhirpath/fhirpath.test.ts
+++ b/packages/core/src/fhirpath/fhirpath.test.ts
@@ -646,11 +646,14 @@ describe('FHIRPath Test Suite', () => {
     });
 
     test('testPolymorphismAsB', () => {
-      expect(() => evalFhirPath('(Observation.value as Period).unit', observation)).toThrow();
+      // The official suite flags this as a semantic error (Period has no `unit`).
+      // Medplum evaluates dynamically, so `value as Period` on a Quantity yields the
+      // empty collection (rather than throwing), and `.unit` on empty is empty.
+      expect(evalFhirPath('(Observation.value as Period).unit', observation)).toStrictEqual([]);
     });
 
     test('testPolymorphismAsBFunction', () => {
-      expect(() => evalFhirPath('Observation.value.as(Period).start', observation)).toThrow();
+      expect(evalFhirPath('Observation.value.as(Period).start', observation)).toStrictEqual([]);
     });
   });
 

--- a/packages/core/src/fhirpath/fhirpath.test.ts
+++ b/packages/core/src/fhirpath/fhirpath.test.ts
@@ -1620,6 +1620,24 @@ describe('FHIRPath Test Suite', () => {
     });
   });
 
+  describe('testOfType', () => {
+    test('unqualified type name', () => {
+      expect(evalFhirPath('Patient.ofType(Patient).type().name', patient)).toStrictEqual(['Patient']);
+    });
+
+    test('FHIR-qualified type name', () => {
+      expect(evalFhirPath('Patient.ofType(FHIR.Patient).type().name', patient)).toStrictEqual(['Patient']);
+    });
+
+    test('FHIR-qualified type name with backticks', () => {
+      expect(evalFhirPath('Patient.ofType(FHIR.`Patient`).type().name', patient)).toStrictEqual(['Patient']);
+    });
+
+    test('non-matching type yields empty', () => {
+      expect(evalFhirPath('Patient.ofType(FHIR.Observation)', patient)).toStrictEqual([]);
+    });
+  });
+
   describe.skip('testRepeat', () => {
     test('testRepeat1', () => {
       expect(evalFhirPath('ValueSet.expansion.repeat(contains).count() = 10', valueset)).toStrictEqual([true]);

--- a/packages/core/src/fhirpath/fhirpath.test.ts
+++ b/packages/core/src/fhirpath/fhirpath.test.ts
@@ -3583,7 +3583,7 @@ describe('FHIRPath Test Suite', () => {
     });
   });
 
-  describe.skip('testType', () => {
+  describe('testType', () => {
     test('testType1', () => {
       expect(evalFhirPath("1.type().namespace = 'System'", patient)).toStrictEqual([true]);
     });
@@ -3616,11 +3616,13 @@ describe('FHIRPath Test Suite', () => {
       expect(evalFhirPath('true is System.Boolean', patient)).toStrictEqual([true]);
     });
 
-    test('testType9', () => {
+    // TODO: requires System-vs-FHIR namespace semantics in type()/fhirPathIs, which are not yet implemented.
+    test.skip('testType9', () => {
       expect(evalFhirPath("Patient.active.type().namespace = 'FHIR'", patient)).toStrictEqual([true]);
     });
 
-    test('testType10', () => {
+    // TODO: requires System-vs-FHIR namespace semantics in type()/fhirPathIs, which are not yet implemented.
+    test.skip('testType10', () => {
       expect(evalFhirPath("Patient.active.type().name = 'boolean'", patient)).toStrictEqual([true]);
     });
 
@@ -3628,7 +3630,8 @@ describe('FHIRPath Test Suite', () => {
       expect(evalFhirPath('Patient.active.is(boolean)', patient)).toStrictEqual([true]);
     });
 
-    test('testType12', () => {
+    // TODO: requires System-vs-FHIR namespace semantics in type()/fhirPathIs, which are not yet implemented.
+    test.skip('testType12', () => {
       expect(evalFhirPath('Patient.active.is(Boolean).not()', patient)).toStrictEqual([true]);
     });
 
@@ -3636,7 +3639,8 @@ describe('FHIRPath Test Suite', () => {
       expect(evalFhirPath('Patient.active.is(FHIR.boolean)', patient)).toStrictEqual([true]);
     });
 
-    test('testType14', () => {
+    // TODO: requires System-vs-FHIR namespace semantics in type()/fhirPathIs, which are not yet implemented.
+    test.skip('testType14', () => {
       expect(evalFhirPath('Patient.active.is(System.Boolean).not()', patient)).toStrictEqual([true]);
     });
 
@@ -3668,7 +3672,8 @@ describe('FHIRPath Test Suite', () => {
       expect(evalFhirPath('Patient.ofType(FHIR.Patient).type().name', patient)).toStrictEqual(['Patient']);
     });
 
-    test('testType22', () => {
+    // TODO: requires System-vs-FHIR namespace semantics in type()/fhirPathIs, which are not yet implemented.
+    test.skip('testType22', () => {
       expect(evalFhirPath('Patient.is(System.Patient).not()', patient)).toStrictEqual([true]);
     });
 

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -1769,8 +1769,12 @@ export const functions: Record<string, FhirPathFunction> = {
    */
   as: (context: AtomContext, input: TypedValue[], specifier: Atom): TypedValue[] => {
     const dataType = (specifier as SymbolAtom).name;
-    const value = singleton(input, dataType);
-    return value ? [value] : [];
+    // Per the FHIRPath spec, `x as T` on a single-item collection returns the item
+    // only when it is of type T (or a subtype), otherwise it returns the empty collection.
+    // It must NOT throw on a type mismatch; `singleton` only guards against collections
+    // with more than one item (e.g. `Observation.value as Quantity` when value is a string).
+    const value = singleton(input);
+    return value && fhirPathIs(value, dataType) ? [value] : [];
   },
 
   /*

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -30,6 +30,25 @@ export type FhirPathFunction = (context: AtomContext, input: TypedValue[], ...ar
  */
 const stub: FhirPathFunction = (): [] => [];
 
+/**
+ * Resolves a FHIRPath type specifier atom (as used by `is`, `as`, and `ofType`)
+ * to its type name. The specifier is either a simple identifier (`Quantity`) or a
+ * qualified identifier (`FHIR.Quantity`, `System.String`). Any other atom (a
+ * literal, arithmetic expression, etc.) does not name a type, so this returns the
+ * empty string and callers should treat the operation as yielding an empty collection.
+ * @param typeAtom - The type specifier atom (the right operand of `is`/`as`).
+ * @returns The resolved type name, or the empty string if the atom is not a type identifier.
+ */
+function getTypeName(typeAtom: Atom): string {
+  if (typeAtom instanceof SymbolAtom) {
+    return typeAtom.name;
+  }
+  if (typeAtom instanceof DotAtom && typeAtom.left instanceof SymbolAtom && typeAtom.right instanceof SymbolAtom) {
+    return typeAtom.left.name + '.' + typeAtom.right.name;
+  }
+  return '';
+}
+
 export const functions: Record<string, FhirPathFunction> = {
   /*
    * 5.1 Existence
@@ -1689,12 +1708,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * @returns True if the input element is of the desired type.
    */
   is: (_context: AtomContext, input: TypedValue[], typeAtom: Atom): TypedValue[] => {
-    let typeName = '';
-    if (typeAtom instanceof SymbolAtom) {
-      typeName = typeAtom.name;
-    } else if (typeAtom instanceof DotAtom) {
-      typeName = (typeAtom.left as SymbolAtom).name + '.' + (typeAtom.right as SymbolAtom).name;
-    }
+    const typeName = getTypeName(typeAtom);
     if (!typeName) {
       return [];
     }
@@ -1768,11 +1782,17 @@ export const functions: Record<string, FhirPathFunction> = {
    * @returns The value as the specific type.
    */
   as: (context: AtomContext, input: TypedValue[], specifier: Atom): TypedValue[] => {
-    const dataType = (specifier as SymbolAtom).name;
-    // Per the FHIRPath spec, `x as T` on a single-item collection returns the item
-    // only when it is of type T (or a subtype), otherwise it returns the empty collection.
-    // It must NOT throw on a type mismatch; `singleton` only guards against collections
-    // with more than one item (e.g. `Observation.value as Quantity` when value is a string).
+    // Per the FHIRPath spec, for `x as T`:
+    //   - if the right operand cannot be resolved to a valid type identifier, throw;
+    //   - if the input contains more than one item, throw (handled by `singleton`);
+    //   - otherwise return the item when it is of type T (or a subtype), else empty.
+    // See: https://hl7.org/fhirpath/N1/#:~:text=in%20a%20model.-,Type%20specifiers%20can%20have%20qualifiers%2C%20e.g.%20FHIR.Patient%2C%20where%20the%20qualifier%20is%20the%20name%20of%20the%20model.,-Patient.contained.all
+    const dataType = getTypeName(specifier);
+    if (!dataType) {
+      throw new Error(
+        `Expected a valid type identifier as the right operand of 'as', but found ${specifier.toString()}`
+      );
+    }
     const value = singleton(input);
     return value && fhirPathIs(value, dataType) ? [value] : [];
   },

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -39,7 +39,7 @@ const stub: FhirPathFunction = (): [] => [];
  * @param typeAtom - The type specifier atom (the right operand of `is`/`as`).
  * @returns The resolved type name, or the empty string if the atom is not a type identifier.
  */
-function getTypeName(typeAtom: Atom): string {
+export function getTypeName(typeAtom: Atom): string {
   if (typeAtom instanceof SymbolAtom) {
     return typeAtom.name;
   }

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -366,7 +366,11 @@ export const functions: Record<string, FhirPathFunction> = {
    * @returns A collection containing only those elements in the input collection that are of the given type or a subclass thereof.
    */
   ofType: (_context: AtomContext, input: TypedValue[], criteria: Atom): TypedValue[] => {
-    return input.filter((e) => e.type === (criteria as SymbolAtom).name);
+    const typeName = getTypeName(criteria);
+    if (!typeName) {
+      return [];
+    }
+    return input.filter((e) => fhirPathIs(e, typeName));
   },
 
   /*

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -62,8 +62,8 @@ export function singleton(collection: TypedValue[], type?: string): TypedValue |
   } else if (collection.length === 1 && (!type || collection[0].type === type)) {
     return collection[0];
   } else {
-    const ofTypePhrase = type ? `of type ${type}` : '';
-    throw new Error(`Expected singleton ${ofTypePhrase}, but found ${JSON.stringify(collection)}`);
+    const ofTypePhrase = type ? ` of type ${type}` : '';
+    throw new Error(`Expected singleton${ofTypePhrase}, but found ${JSON.stringify(collection)}`);
   }
 }
 

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -62,7 +62,8 @@ export function singleton(collection: TypedValue[], type?: string): TypedValue |
   } else if (collection.length === 1 && (!type || collection[0].type === type)) {
     return collection[0];
   } else {
-    throw new Error(`Expected singleton of type ${type}, but found ${JSON.stringify(collection)}`);
+    const ofTypePhrase = type ? `of type ${type}` : '';
+    throw new Error(`Expected singleton ${ofTypePhrase}, but found ${JSON.stringify(collection)}`);
   }
 }
 


### PR DESCRIPTION
According to the FHIRPath spec there are 3 exception cases, two of which should throw errors and one of which should return the empty collection.

See: https://hl7.org/fhirpath/N1/#:~:text=If%20the%20identifier%20cannot%20be%20resolved%20to%20a%20valid%20type%20identifier%2C%20the%20evaluator%20will%20throw%20an%20error.%20If%20there%20is%20more%20than%20one%20item%20in%20the%20input%20collection%2C%20the%20evaluator%20will%20throw%20an%20error.%20Otherwise%2C%20this%20operator%20returns%20the%20empty%20collection.

See also: https://build.fhir.org/ig/HL7/FHIRPath/en/#unary-operators--and--:~:text=Observation.value%20as%20Quantity%20//%20returns%20value%20as%20a%20Quantity%20if%20it%20is%20of%20type%20Quantity%2C%20and%20an%20empty%20result%20otherwise

If the left operand is of the specified type or a subclass, return the value of the left operand, otherwise:

Case 1: Cannot resolve identifier to valid type identifier -- Throw
Case 2: More than one item in collection -- Throw
Finally: Return empty collection <-- This is the case we don't handle properly today

This PR fixes that