### PR TITLE
[Provider] Reveal all appointment participants in detail pane

### DIFF
--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
@@ -38,8 +38,6 @@ describe('AppointmentDetails', () => {
   const setup = async (options: SetupOptions): Promise<RenderResult> => {
     const { appointment, onAppointmentUpdate = vi.fn(), onSlotUpdate = vi.fn() } = options;
 
-    // AppointmentDetails uses `useResource` to load patient information; wrap the setup
-    // in `act` so that async effect is visible in the rendered result.
     let result!: RenderResult;
     await act(async () => {
       result = render(

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
@@ -13,7 +13,7 @@ import {
   isReference,
   isResource,
 } from '@medplum/core';
-import type { Appointment, Bundle, CodeableConcept, Patient, Practitioner, Slot } from '@medplum/fhirtypes';
+import type { Appointment, Bundle, CodeableConcept, Patient, Slot } from '@medplum/fhirtypes';
 import {
   CodeableConceptDisplay,
   Form,
@@ -117,7 +117,6 @@ export function AppointmentDetails(props: {
   // one of each.
   const participants = props.appointment.participant.map((p) => p.actor);
   const patientRef = participants.find((r) => isReference<Patient>(r, 'Patient'));
-  const practitionerRef = participants.find((r) => isReference<Practitioner>(r, 'Practitioner'));
 
   const patient = useResource(patientRef);
 
@@ -221,7 +220,7 @@ export function AppointmentDetails(props: {
         <OperationOutcomeAlert outcome={encounterOutcome} title="Loading Encounter failed" />
       )}
       {patientRef && !encounter && !encounterLoading && encounterOutcome && isOk(encounterOutcome) && (
-        <CreateEncounterForm appointment={appointment} patientRef={patientRef} practitionerRef={practitionerRef} />
+        <CreateEncounterForm appointment={appointment} />
       )}
 
       <Divider />

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
@@ -21,6 +21,7 @@ import {
   OperationOutcomeAlert,
   ResourceAvatar,
   ResourceInput,
+  ResourceName,
   useMedplum,
 } from '@medplum/react';
 import { useSearchOne } from '@medplum/react-hooks';
@@ -194,9 +195,7 @@ export function AppointmentDetails(props: {
               <ResourceAvatar value={actor} size={48} radius={48} />
             </MedplumLink>
             <div>
-              <MedplumLink to={actor} size="lg" fw={800}>
-                {actor.display ?? actor.reference}
-              </MedplumLink>
+              <ResourceName value={actor} size="lg" fw={800} link />
               <Text size="xs" c="dimmed">
                 {resourceType}
               </Text>

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
@@ -1,17 +1,17 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Button, Divider, Group, Loader, Stack, Tooltip } from '@mantine/core';
+import { Button, Divider, Group, Loader, Stack, Text, Tooltip } from '@mantine/core';
 import type { WithId } from '@medplum/core';
 import {
   createReference,
   EMPTY,
   formatDateTime,
-  formatHumanName,
   getExtension,
   getReferenceString,
   isOk,
   isReference,
   isResource,
+  parseReference,
 } from '@medplum/core';
 import type { Appointment, Bundle, CodeableConcept, Patient, Slot } from '@medplum/fhirtypes';
 import {
@@ -23,7 +23,7 @@ import {
   ResourceInput,
   useMedplum,
 } from '@medplum/react';
-import { useResource, useSearchOne } from '@medplum/react-hooks';
+import { useSearchOne } from '@medplum/react-hooks';
 import { IconFileCheck, IconNotes, IconTrash } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useCallback, useState } from 'react';
@@ -109,16 +109,13 @@ export function AppointmentDetails(props: {
   const { appointment, onAppointmentUpdate, onSlotUpdate } = props;
   const medplum = useMedplum();
 
-  const [encounter, encounterLoading, encounterOutcome] = useSearchOne('Encounter', {
-    appointment: getReferenceString(appointment),
-  });
-
-  // Extract references to a Patient and a Practitioner from `Appointment.participants`; we expect
-  // one of each.
-  const participants = props.appointment.participant.map((p) => p.actor);
-  const patientRef = participants.find((r) => isReference<Patient>(r, 'Patient'));
-
-  const patient = useResource(patientRef);
+  const [encounter, encounterLoading, encounterOutcome] = useSearchOne(
+    'Encounter',
+    {
+      appointment: getReferenceString(appointment),
+    },
+    { debounceMs: 0 }
+  );
 
   const cancellable =
     appointment.status === 'booked' || appointment.status === 'pending' || appointment.status === 'proposed';
@@ -171,22 +168,42 @@ export function AppointmentDetails(props: {
     }
   }, [medplum, appointment, confirmable, onAppointmentUpdate, onSlotUpdate]);
 
+  const sortedParticipants = appointment.participant
+    .flatMap((participant) => {
+      const actor = participant.actor;
+      if (!isReference(actor)) {
+        return [];
+      }
+      const [resourceType] = parseReference(actor);
+      return [{ actor, resourceType }];
+    })
+    .sort((a, b) => (a.resourceType === 'Patient' ? 0 : 1) - (b.resourceType === 'Patient' ? 0 : 1));
+
+  const hasPatient = appointment.participant.some((p) => isReference(p.actor, 'Patient'));
+
   return (
     <Stack gap="md" className={classes.AppointmentDetails}>
       <Divider />
 
-      {!patientRef && <UpdateAppointmentForm appointment={props.appointment} onUpdate={props.onAppointmentUpdate} />}
+      {!hasPatient && <UpdateAppointmentForm appointment={props.appointment} onUpdate={props.onAppointmentUpdate} />}
 
-      {!!patient && (
-        <Group align="center" gap="sm">
-          <MedplumLink to={patient}>
-            <ResourceAvatar value={patient} size={48} radius={48} />
-          </MedplumLink>
-          <MedplumLink to={patient} fw={800} size="lg">
-            {formatHumanName(patient.name?.[0])}
-          </MedplumLink>
-        </Group>
-      )}
+      {sortedParticipants.map(({ actor, resourceType }, index) => {
+        return (
+          <Group align="center" gap="sm" key={`${actor.reference ?? ''}_${index}`}>
+            <MedplumLink to={actor} tabIndex={-1}>
+              <ResourceAvatar value={actor} size={48} radius={48} />
+            </MedplumLink>
+            <div>
+              <MedplumLink to={actor} size="lg" fw={800}>
+                {actor.display ?? actor.reference}
+              </MedplumLink>
+              <Text size="xs" c="dimmed">
+                {resourceType}
+              </Text>
+            </div>
+          </Group>
+        );
+      })}
 
       <Divider />
 
@@ -219,7 +236,7 @@ export function AppointmentDetails(props: {
       {encounterOutcome && !isOk(encounterOutcome) && (
         <OperationOutcomeAlert outcome={encounterOutcome} title="Loading Encounter failed" />
       )}
-      {patientRef && !encounter && !encounterLoading && encounterOutcome && isOk(encounterOutcome) && (
+      {hasPatient && !encounter && !encounterLoading && encounterOutcome && isOk(encounterOutcome) && (
         <CreateEncounterForm appointment={appointment} />
       )}
 

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
@@ -8,6 +8,7 @@ import {
   formatDateTime,
   getExtension,
   getReferenceString,
+  isDefined,
   isOk,
   isReference,
   isResource,
@@ -115,7 +116,11 @@ export function AppointmentDetails(props: {
     {
       appointment: getReferenceString(appointment),
     },
-    { debounceMs: 0 }
+    {
+      // Disable debouncer for faster encounter loading. This search is not driven by
+      // keyboard input and so won't benefit from debouncing.
+      debounceMs: 0,
+    }
   );
 
   const cancellable =
@@ -170,17 +175,20 @@ export function AppointmentDetails(props: {
   }, [medplum, appointment, confirmable, onAppointmentUpdate, onSlotUpdate]);
 
   const sortedParticipants = appointment.participant
-    .flatMap((participant) => {
+    .map((participant) => {
       const actor = participant.actor;
       if (!isReference(actor)) {
-        return [];
+        return undefined;
       }
       const [resourceType] = parseReference(actor);
-      return [{ actor, resourceType }];
+      return { actor, resourceType };
     })
+    .filter(isDefined)
     .sort((a, b) => (a.resourceType === 'Patient' ? 0 : 1) - (b.resourceType === 'Patient' ? 0 : 1));
 
-  const hasPatient = appointment.participant.some((p) => isReference(p.actor, 'Patient'));
+  // If there is a "Patient" participant, we sorted it to the front of the list, so we can
+  // check just the first entry.
+  const hasPatient = sortedParticipants[0]?.resourceType === 'Patient';
 
   return (
     <Stack gap="md" className={classes.AppointmentDetails}>

--- a/examples/medplum-provider/src/components/schedule/CreateEncounterForm.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateEncounterForm.test.tsx
@@ -106,6 +106,23 @@ describe('CreateEncounterForm', () => {
     expect(screen.queryByText('Set Up Encounter')).not.toBeInTheDocument();
   });
 
+  test('shows alert when multiple patients are in appointment.participants', async () => {
+    const patientful = {
+      ...appointment,
+      participant: [
+        ...appointment.participant,
+        {
+          actor: { reference: 'Patient/patient-2' },
+          status: 'accepted',
+        },
+      ],
+    } satisfies Appointment;
+    setup(patientful);
+
+    expect(screen.getByText('Too many Patients to create Encounter.')).toBeInTheDocument();
+    expect(screen.queryByText('Set Up Encounter')).not.toBeInTheDocument();
+  });
+
   test('when required fields are not filled', async () => {
     setup(appointment);
 

--- a/examples/medplum-provider/src/components/schedule/CreateEncounterForm.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateEncounterForm.test.tsx
@@ -3,6 +3,7 @@
 import { MantineProvider } from '@mantine/core';
 import { notifications, Notifications } from '@mantine/notifications';
 import type { WithId } from '@medplum/core';
+import { isReference } from '@medplum/core';
 import type { Appointment, Patient, Practitioner, Reference } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
@@ -47,35 +48,23 @@ describe('CreateEncounterForm', () => {
     notifications.clean();
   });
 
-  type SetupOptions = {
-    patientRef: Reference<Patient>;
-    practitionerRef: Reference<Practitioner> | undefined;
-  };
-
-  const setup = (options: SetupOptions): ReturnType<typeof render> => {
-    return render(
-      <CreateEncounterForm
-        appointment={appointment}
-        patientRef={options.patientRef}
-        practitionerRef={options.practitionerRef}
-      />,
-      {
-        wrapper: ({ children }) => (
-          <MemoryRouter>
-            <MedplumProvider medplum={medplum}>
-              <MantineProvider>
-                <Notifications />
-                {children}
-              </MantineProvider>
-            </MedplumProvider>
-          </MemoryRouter>
-        ),
-      }
-    );
+  const setup = (appointment: WithId<Appointment>): ReturnType<typeof render> => {
+    return render(<CreateEncounterForm appointment={appointment} />, {
+      wrapper: ({ children }) => (
+        <MemoryRouter>
+          <MedplumProvider medplum={medplum}>
+            <MantineProvider>
+              <Notifications />
+              {children}
+            </MantineProvider>
+          </MedplumProvider>
+        </MemoryRouter>
+      ),
+    });
   };
 
   test('renders form with required fields', async () => {
-    setup({ patientRef, practitionerRef });
+    setup(appointment);
 
     expect(screen.getByText('Set Up Encounter')).toBeInTheDocument();
     expect(screen.getByLabelText(/Encounter Class/i)).toBeInTheDocument();
@@ -84,28 +73,41 @@ describe('CreateEncounterForm', () => {
   });
 
   test('Apply button is disabled when class and care template are not selected', async () => {
-    setup({ patientRef, practitionerRef });
+    setup(appointment);
 
     expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
   });
 
-  test('shows warning when practitioner is not set', async () => {
-    setup({ patientRef, practitionerRef: undefined });
+  test('shows alert when no practitioner is in appointment.participants', async () => {
+    const practitionerless = {
+      ...appointment,
+      participant: appointment.participant.filter((p) => !isReference(p.actor, 'Practitioner')),
+    };
+    setup(practitionerless);
 
-    const form = screen.getByText('Set Up Encounter').closest('form');
-    expect(form).toBeTruthy();
-    await act(async () => {
-      fireEvent.submit(form as HTMLFormElement);
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText('Appointment has no Practitioner participant')).toBeInTheDocument();
-    });
-    expect(createEncounter).not.toHaveBeenCalled();
+    expect(screen.getByText('No Practitioner to create Encounter.')).toBeInTheDocument();
+    expect(screen.queryByText('Set Up Encounter')).not.toBeInTheDocument();
   });
 
-  test('shows warning when required fields are not filled', async () => {
-    setup({ patientRef, practitionerRef });
+  test('shows alert when multiple practitioners are in appointment.participants', async () => {
+    const practitionerful = {
+      ...appointment,
+      participant: [
+        ...appointment.participant,
+        {
+          actor: { reference: 'Practitioner/practitioner-2' },
+          status: 'accepted',
+        },
+      ],
+    } satisfies Appointment;
+    setup(practitionerful);
+
+    expect(screen.getByText('Too many Practitioners to create Encounter.')).toBeInTheDocument();
+    expect(screen.queryByText('Set Up Encounter')).not.toBeInTheDocument();
+  });
+
+  test('when required fields are not filled', async () => {
+    setup(appointment);
 
     const form = screen.getByText('Set Up Encounter').closest('form');
     expect(form).toBeTruthy();
@@ -113,20 +115,12 @@ describe('CreateEncounterForm', () => {
       fireEvent.submit(form as HTMLFormElement);
     });
 
+    // it shows a warning
     await waitFor(() => {
       expect(screen.getByText('Please fill out required fields.')).toBeInTheDocument();
     });
-  });
 
-  test('does not call createEncounter when required fields are not filled', async () => {
-    setup({ patientRef, practitionerRef });
-
-    const form = screen.getByText('Set Up Encounter').closest('form');
-    expect(form).toBeTruthy();
-    await act(async () => {
-      fireEvent.submit(form as HTMLFormElement);
-    });
-
+    // it did not invoke `createEncounter`
     expect(createEncounter).not.toHaveBeenCalled();
   });
 
@@ -143,7 +137,7 @@ describe('CreateEncounterForm', () => {
     const encounterError = new Error('Failed to create encounter');
     vi.mocked(createEncounter).mockRejectedValue(encounterError);
 
-    setup({ patientRef, practitionerRef });
+    setup(appointment);
 
     // Fill in Encounter Class — MockClient's ValueSet expansion returns 'Test Display'
     const classInput = screen.getByLabelText(/Encounter Class/i);

--- a/examples/medplum-provider/src/components/schedule/CreateEncounterForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateEncounterForm.tsx
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Button, Stack, Title } from '@mantine/core';
+import { Alert, Button, Stack, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import type { WithId } from '@medplum/core';
-import type { Appointment, Coding, Patient, PlanDefinition, Practitioner, Reference } from '@medplum/fhirtypes';
+import { isReference } from '@medplum/core';
+import type { Appointment, Coding, Patient, PlanDefinition, Practitioner } from '@medplum/fhirtypes';
 import { CodingInput, Form, ResourceInput, useMedplum } from '@medplum/react';
-import { IconAlertSquareRounded } from '@tabler/icons-react';
+import { IconAlertSquareRounded, IconInfoCircle } from '@tabler/icons-react';
 import type { JSX } from 'react';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { createEncounter, encounterUrl } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
@@ -15,29 +16,29 @@ import { PlanDefinitionSummary } from '../plandefinition/PlanDefinitionSummary';
 
 export interface CreateEncounterFormProps {
   appointment: WithId<Appointment>;
-  patientRef: Reference<Patient>;
-  practitionerRef: Reference<Practitioner> | undefined;
 }
 
 export function CreateEncounterForm(props: CreateEncounterFormProps): JSX.Element {
-  const { patientRef, practitionerRef } = props;
   const medplum = useMedplum();
   const navigate = useNavigate();
 
   const [planDefinition, setPlanDefinition] = useState<PlanDefinition | undefined>();
   const [encounterClass, setEncounterClass] = useState<Coding | undefined>();
 
-  const handleSubmit = useCallback(async () => {
-    if (!practitionerRef) {
-      showNotification({
-        color: 'yellow',
-        icon: <IconAlertSquareRounded />,
-        title: 'Error',
-        message: 'Appointment has no Practitioner participant',
-      });
-      return;
-    }
+  const patientRefs = useMemo(
+    () => props.appointment.participant.map((p) => p.actor).filter((actor) => isReference<Patient>(actor, 'Patient')),
+    [props.appointment.participant]
+  );
 
+  const practitionerRefs = useMemo(
+    () =>
+      props.appointment.participant
+        .map((p) => p.actor)
+        .filter((actor) => isReference<Practitioner>(actor, 'Practitioner')),
+    [props.appointment.participant]
+  );
+
+  const handleSubmit = useCallback(async () => {
     if (!encounterClass || !planDefinition) {
       showNotification({
         color: 'yellow',
@@ -52,17 +53,46 @@ export function CreateEncounterForm(props: CreateEncounterFormProps): JSX.Elemen
       const encounter = await createEncounter(
         medplum,
         encounterClass,
-        patientRef,
+        patientRefs[0],
         planDefinition,
         props.appointment,
-        practitionerRef
+        practitionerRefs[0]
       );
 
       navigate(encounterUrl(encounter))?.catch(console.error);
     } catch (err) {
       showErrorNotification(err);
     }
-  }, [medplum, patientRef, encounterClass, planDefinition, props.appointment, navigate, practitionerRef]);
+  }, [medplum, encounterClass, planDefinition, props.appointment, navigate, patientRefs, practitionerRefs]);
+
+  if (practitionerRefs.length > 1) {
+    return (
+      <Alert color="yellow" icon={<IconInfoCircle />}>
+        Too many Practitioners to create Encounter.
+      </Alert>
+    );
+  }
+  if (practitionerRefs.length === 0) {
+    return (
+      <Alert color="yellow" icon={<IconInfoCircle />}>
+        No Practitioner to create Encounter.
+      </Alert>
+    );
+  }
+  if (patientRefs.length > 1) {
+    return (
+      <Alert color="yellow" icon={<IconInfoCircle />}>
+        Too many Patients to create Encounter.
+      </Alert>
+    );
+  }
+  if (patientRefs.length === 0) {
+    return (
+      <Alert color="yellow" icon={<IconInfoCircle />}>
+        No Patient to create Encounter.
+      </Alert>
+    );
+  }
 
   return (
     <Form onSubmit={handleSubmit}>
@@ -73,7 +103,7 @@ export function CreateEncounterForm(props: CreateEncounterFormProps): JSX.Elemen
           name="practitioner"
           resourceType="Practitioner"
           label="Practitioner"
-          defaultValue={practitionerRef}
+          defaultValue={practitionerRefs[0]}
           disabled={true}
           required={true}
         />

--- a/examples/medplum-provider/src/components/schedule/CreateEncounterForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateEncounterForm.tsx
@@ -65,31 +65,26 @@ export function CreateEncounterForm(props: CreateEncounterFormProps): JSX.Elemen
     }
   }, [medplum, encounterClass, planDefinition, props.appointment, navigate, patientRefs, practitionerRefs]);
 
+  const warnings: string[] = [];
+
   if (practitionerRefs.length > 1) {
-    return (
-      <Alert color="yellow" icon={<IconInfoCircle />}>
-        Too many Practitioners to create Encounter.
-      </Alert>
-    );
+    warnings.push('Too many Practitioners to create Encounter.');
   }
   if (practitionerRefs.length === 0) {
-    return (
-      <Alert color="yellow" icon={<IconInfoCircle />}>
-        No Practitioner to create Encounter.
-      </Alert>
-    );
+    warnings.push('No Practitioner to create Encounter.');
   }
   if (patientRefs.length > 1) {
-    return (
-      <Alert color="yellow" icon={<IconInfoCircle />}>
-        Too many Patients to create Encounter.
-      </Alert>
-    );
+    warnings.push('Too many Patients to create Encounter.');
   }
   if (patientRefs.length === 0) {
+    warnings.push('No Patient to create Encounter.');
+  }
+  if (warnings.length) {
     return (
-      <Alert color="yellow" icon={<IconInfoCircle />}>
-        No Patient to create Encounter.
+      <Alert color="yellow" icon={<IconInfoCircle />} title="Can't create Encounter">
+        {warnings.map((warning) => (
+          <div key={warning}>{warning}</div>
+        ))}
       </Alert>
     );
   }


### PR DESCRIPTION
We were only showing the first Patient, with the understanding that the current schedule's Practitioner was implied. In the world with Appointments that have multiple associated participants, this breaks down a bit.

We now explicitly show all appointment participants, which may include multiple patients, practitioners, locations, devices, and more.

Relatedly, we adjust the `<CreateEncounterForm>` to block if there are multiple Patient or Practitioner resources associated with the appointment. Previously we were just taking the first one we found, which could lead to misconfigured Encounters; in the long run we should enhance this to let the viewer select the appropriate Patient/Practitioner record to work with. For now we will just warn when this ambiguity is hit.

<img width="1615" height="1148" alt="Screenshot 2026-06-30 at 5 39 21 PM" src="https://github.com/user-attachments/assets/8cacd50a-9260-4988-8f76-2103e2ca3c3f" />
