### PR TITLE
feat(agent): add cursor pagination to `$fetch-logs`

### DIFF
--- a/packages/agent/src/app-fetch-logs.test.ts
+++ b/packages/agent/src/app-fetch-logs.test.ts
@@ -335,6 +335,123 @@ describe('Fetch Logs', () => {
     expect(state.logsResponse.logs).toBeDefined();
     expect(Array.isArray(state.logsResponse.logs)).toBe(true);
     expect(state.logsResponse.logs.length).toStrictEqual(10);
+    // 15 logs exist but only 10 were requested, so an older page remains.
+    expect(state.logsResponse.hasMore).toBe(true);
+    expect(typeof state.logsResponse.nextBefore).toBe('string');
+
+    await app.stop();
+    await new Promise<void>((resolve) => {
+      mockServer.stop(resolve);
+    });
+  });
+
+  test('should page backward through older logs using the before cursor', async () => {
+    const state = {
+      mySocket: undefined as Client | undefined,
+      responses: [] as AgentLogsResponse[],
+    };
+
+    function mockConnectionHandler(socket: Client): void {
+      state.mySocket = socket;
+      socket.on('message', (data) => {
+        const command = JSON.parse((data as Buffer).toString('utf8'));
+        switch (command.type) {
+          case 'agent:connect:request':
+            socket.send(Buffer.from(JSON.stringify({ type: 'agent:connect:response' })));
+            break;
+
+          case 'agent:heartbeat:request':
+            socket.send(Buffer.from(JSON.stringify({ type: 'agent:heartbeat:response' })));
+            break;
+
+          case 'agent:logs:response':
+            state.responses.push(command);
+            break;
+
+          default:
+            // Ignore other message types
+            break;
+        }
+      });
+    }
+
+    const mockServer = new Server('wss://example.com/ws/agent');
+    mockServer.on('connection', mockConnectionHandler);
+
+    const agent = await medplum.createResource<Agent>({
+      resourceType: 'Agent',
+      name: 'Test Agent',
+      status: 'active',
+    });
+
+    const [winstonLogger, cleanupLogFile] = createTestWinstonLogger();
+    cleanupFns.push(cleanupLogFile);
+    generateTestLogs(winstonLogger, 15);
+
+    const app = new App(medplum, agent.id, LogLevel.INFO, {
+      mainLogger: winstonLogger,
+    });
+    app.heartbeatPeriod = 100;
+    await app.start();
+
+    while (!state.mySocket) {
+      await sleep(100);
+    }
+
+    // Page 1: fetch the newest 10 of 15 logs.
+    state.mySocket.send(
+      Buffer.from(JSON.stringify({ type: 'agent:logs:request', limit: 10, callback: randomUUID() }))
+    );
+
+    let shouldThrow = false;
+    const timeout1 = setTimeout(() => {
+      shouldThrow = true;
+    }, 2500);
+    while (state.responses.length < 1) {
+      if (shouldThrow) {
+        throw new Error('Timeout waiting for first logs response');
+      }
+      await sleep(100);
+    }
+    clearTimeout(timeout1);
+
+    const page1 = state.responses[0];
+    expect(page1.statusCode).toBe(200);
+    expect(page1.logs.length).toStrictEqual(10);
+    expect(page1.hasMore).toBe(true);
+    expect(typeof page1.nextBefore).toBe('string');
+
+    // Page 2: use the cursor to fetch the remaining older logs.
+    state.mySocket.send(
+      Buffer.from(
+        JSON.stringify({
+          type: 'agent:logs:request',
+          limit: 10,
+          before: page1.nextBefore,
+          callback: randomUUID(),
+        })
+      )
+    );
+
+    shouldThrow = false;
+    const timeout2 = setTimeout(() => {
+      shouldThrow = true;
+    }, 2500);
+    while (state.responses.length < 2) {
+      if (shouldThrow) {
+        throw new Error('Timeout waiting for second logs response');
+      }
+      await sleep(100);
+    }
+    clearTimeout(timeout2);
+
+    const page2 = state.responses[1];
+    expect(page2.statusCode).toBe(200);
+    expect(Array.isArray(page2.logs)).toBe(true);
+    // At most 5 logs are older than the page-1 cursor, so no further page remains.
+    expect(page2.logs.length).toBeGreaterThan(0);
+    expect(page2.logs.length).toBeLessThanOrEqual(10);
+    expect(page2.hasMore).toBe(false);
 
     await app.stop();
     await new Promise<void>((resolve) => {

--- a/packages/agent/src/app-fetch-logs.test.ts
+++ b/packages/agent/src/app-fetch-logs.test.ts
@@ -399,9 +399,7 @@ describe('Fetch Logs', () => {
     }
 
     // Page 1: fetch the newest 10 of 15 logs.
-    state.mySocket.send(
-      Buffer.from(JSON.stringify({ type: 'agent:logs:request', limit: 10, callback: randomUUID() }))
-    );
+    state.mySocket.send(Buffer.from(JSON.stringify({ type: 'agent:logs:request', limit: 10, callback: randomUUID() })));
 
     let shouldThrow = false;
     const timeout1 = setTimeout(() => {

--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -1621,11 +1621,16 @@ export class App {
     }
 
     try {
-      const logs = await this.log.fetchLogs({ limit: command.limit });
+      const { logs, hasMore, nextBefore } = await this.log.fetchLogs({
+        limit: command.limit,
+        before: command.before,
+      });
       await this.sendToWebSocket({
         type: 'agent:logs:response',
         statusCode: 200,
         logs,
+        hasMore,
+        nextBefore,
         callback: command.callback,
       });
     } catch (err) {

--- a/packages/agent/src/logger.test.ts
+++ b/packages/agent/src/logger.test.ts
@@ -4,8 +4,8 @@ import type { MockInstance } from 'vitest';
 
 import type { LogLevelNames } from '@medplum/core';
 import { LogLevel, parseLogLevel, sleep } from '@medplum/core';
-import { writeFileSync } from 'node:fs';
 import { mkdtemp, rm } from 'fs/promises';
+import { writeFileSync } from 'node:fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {

--- a/packages/agent/src/logger.test.ts
+++ b/packages/agent/src/logger.test.ts
@@ -4,6 +4,7 @@ import type { MockInstance } from 'vitest';
 
 import type { LogLevelNames } from '@medplum/core';
 import { LogLevel, parseLogLevel, sleep } from '@medplum/core';
+import { writeFileSync } from 'node:fs';
 import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -852,6 +853,196 @@ describe('Agent Logger', () => {
       // Should contain warn and error messages
       expect(logContent).toContain('Warn message');
       expect(logContent).toContain('Error message');
+    });
+  });
+
+  describe('fetchLogs pagination across files', () => {
+    let tempDir: string;
+    let originalNodeEnv: string | undefined;
+
+    beforeAll(() => {
+      console.log = vi.fn();
+    });
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'medplum-fetchlogs-test-'));
+      // The DailyRotateFile transport (which backs fetchLogs' query) is only
+      // attached when NODE_ENV is not 'test'.
+      originalNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+    });
+
+    afterEach(async () => {
+      process.env.NODE_ENV = originalNodeEnv;
+      try {
+        await rm(tempDir, { recursive: true, force: true });
+      } catch (_error) {
+        // Ignore cleanup errors
+      }
+    });
+
+    function makeLogger(): WinstonWrapperLogger {
+      return new WinstonWrapperLogger(
+        { ...DEFAULT_LOGGER_CONFIG, logDir: tempDir, logLevel: LogLevel.DEBUG },
+        LoggerType.MAIN
+      );
+    }
+
+    // Writes raw log lines into a file named per the daily-rotate pattern so
+    // that winston's query picks it up as a rotated log file.
+    function writeLogFile(dateSuffix: string, entries: { level: string; msg: string; timestamp: string }[]): void {
+      writeRawLogFile(`medplum-agent-main-${dateSuffix}.log`, entries);
+    }
+
+    // Writes raw log lines into an arbitrarily-named file in the log dir.
+    function writeRawLogFile(name: string, entries: { level: string; msg: string; timestamp: string }[]): void {
+      writeFileSync(join(tempDir, name), entries.map((e) => JSON.stringify(e)).join('\n') + '\n');
+    }
+
+    test('reads entries across rotated files, including logs older than 24h', async () => {
+      // These timestamps are far older than the 24h window that
+      // winston-daily-rotate-file defaults to; before the fix they were
+      // silently dropped, so a limit could never reach across older files.
+      writeLogFile('2020-01-01', [
+        { level: 'INFO', msg: 'old file entry 1', timestamp: '2020-01-01T00:00:00.000Z' },
+        { level: 'INFO', msg: 'old file entry 2', timestamp: '2020-01-01T00:00:01.000Z' },
+      ]);
+      writeLogFile('2020-01-02', [
+        { level: 'INFO', msg: 'newer file entry 1', timestamp: '2020-01-02T00:00:00.000Z' },
+        { level: 'INFO', msg: 'newer file entry 2', timestamp: '2020-01-02T00:00:01.000Z' },
+      ]);
+
+      const logger = makeLogger();
+      const { logs, hasMore, nextBefore } = await logger.fetchLogs({ limit: 10 });
+
+      const messages = logs.map((l) => l.msg);
+      expect(messages).toContain('old file entry 1');
+      expect(messages).toContain('old file entry 2');
+      expect(messages).toContain('newer file entry 1');
+      expect(messages).toContain('newer file entry 2');
+      expect(hasMore).toBe(false);
+      expect(nextBefore).toBeUndefined();
+    });
+
+    test('reads entries across files rotated by size within the same day', async () => {
+      // winston-daily-rotate-file rotates by size within a single day by
+      // appending a counter: `<name>-<date>.log`, `<name>-<date>.log.1`, etc.
+      // (and `.gz` for archived rotations). All must be read.
+      writeRawLogFile('medplum-agent-main-2020-01-01.log', [
+        { level: 'INFO', msg: 'current same-day file', timestamp: '2020-01-01T00:00:03.000Z' },
+      ]);
+      writeRawLogFile('medplum-agent-main-2020-01-01.log.1', [
+        { level: 'INFO', msg: 'size-rotated same-day file', timestamp: '2020-01-01T00:00:02.000Z' },
+      ]);
+      writeRawLogFile('medplum-agent-main-2020-01-01.log.2', [
+        { level: 'INFO', msg: 'older size-rotated same-day file', timestamp: '2020-01-01T00:00:01.000Z' },
+      ]);
+
+      const logger = makeLogger();
+      const { logs, hasMore } = await logger.fetchLogs({ limit: 10 });
+
+      const messages = logs.map((l) => l.msg);
+      expect(messages).toContain('current same-day file');
+      expect(messages).toContain('size-rotated same-day file');
+      expect(messages).toContain('older size-rotated same-day file');
+      expect(hasMore).toBe(false);
+    });
+
+    test('paginates backward across files via the before cursor with no overlap', async () => {
+      writeLogFile('2020-01-01', [
+        { level: 'INFO', msg: 'entry 1', timestamp: '2020-01-01T00:00:01.000Z' },
+        { level: 'INFO', msg: 'entry 2', timestamp: '2020-01-01T00:00:02.000Z' },
+        { level: 'INFO', msg: 'entry 3', timestamp: '2020-01-01T00:00:03.000Z' },
+      ]);
+      writeLogFile('2020-01-02', [
+        { level: 'INFO', msg: 'entry 4', timestamp: '2020-01-02T00:00:04.000Z' },
+        { level: 'INFO', msg: 'entry 5', timestamp: '2020-01-02T00:00:05.000Z' },
+      ]);
+
+      const logger = makeLogger();
+
+      // nextBefore is an opaque cursor; we assert paging behavior rather than
+      // its exact encoding.
+      const page1 = await logger.fetchLogs({ limit: 2 });
+      expect(page1.logs.map((l) => l.msg)).toStrictEqual(['entry 5', 'entry 4']);
+      expect(page1.hasMore).toBe(true);
+      expect(page1.nextBefore).toContain('2020-01-02T00:00:04.000Z');
+
+      const page2 = await logger.fetchLogs({ limit: 2, before: page1.nextBefore });
+      expect(page2.logs.map((l) => l.msg)).toStrictEqual(['entry 3', 'entry 2']);
+      expect(page2.hasMore).toBe(true);
+      expect(page2.nextBefore).toContain('2020-01-01T00:00:02.000Z');
+
+      const page3 = await logger.fetchLogs({ limit: 2, before: page2.nextBefore });
+      expect(page3.logs.map((l) => l.msg)).toStrictEqual(['entry 1']);
+      expect(page3.hasMore).toBe(false);
+      expect(page3.nextBefore).toBeUndefined();
+    });
+
+    test('pages through entries that share a single timestamp without loss or overlap', async () => {
+      // A burst of five entries all written in the same millisecond. A naive
+      // timestamp cursor cannot page through these; the composite cursor can.
+      writeLogFile('2020-01-01', [
+        { level: 'INFO', msg: 'burst 1', timestamp: '2020-01-01T00:00:00.000Z' },
+        { level: 'INFO', msg: 'burst 2', timestamp: '2020-01-01T00:00:00.000Z' },
+        { level: 'INFO', msg: 'burst 3', timestamp: '2020-01-01T00:00:00.000Z' },
+        { level: 'INFO', msg: 'burst 4', timestamp: '2020-01-01T00:00:00.000Z' },
+        { level: 'INFO', msg: 'burst 5', timestamp: '2020-01-01T00:00:00.000Z' },
+      ]);
+
+      const logger = makeLogger();
+      const seen: string[] = [];
+      let before: string | undefined;
+      // Page through with a limit of 2 until exhausted.
+      for (let i = 0; i < 10; i++) {
+        const page = await logger.fetchLogs({ limit: 2, before });
+        seen.push(...page.logs.map((l) => l.msg));
+        if (!page.hasMore) {
+          break;
+        }
+        before = page.nextBefore;
+      }
+
+      // All five entries seen exactly once, no duplicates, no drops.
+      expect(seen).toHaveLength(5);
+      expect(new Set(seen).size).toBe(5);
+      for (let i = 1; i <= 5; i++) {
+        expect(seen).toContain(`burst ${i}`);
+      }
+    });
+
+    test('fills a single limit-only page across a file boundary', async () => {
+      // Regression: a `limit` with no `before` cursor must still reach into
+      // older rotated files to fill the page. The newest file holds fewer
+      // entries than the limit, so the page can only be filled by crossing the
+      // boundary into the older file. If the query stopped spanning files when
+      // `before` is absent (e.g. by dropping the `from: epoch 0` bound), this
+      // page would be truncated to just the newest file's entries.
+      writeLogFile('2020-01-01', [
+        { level: 'INFO', msg: 'old entry 1', timestamp: '2020-01-01T00:00:01.000Z' },
+        { level: 'INFO', msg: 'old entry 2', timestamp: '2020-01-01T00:00:02.000Z' },
+        { level: 'INFO', msg: 'old entry 3', timestamp: '2020-01-01T00:00:03.000Z' },
+      ]);
+      writeLogFile('2020-01-02', [
+        { level: 'INFO', msg: 'new entry 1', timestamp: '2020-01-02T00:00:04.000Z' },
+        { level: 'INFO', msg: 'new entry 2', timestamp: '2020-01-02T00:00:05.000Z' },
+      ]);
+
+      const logger = makeLogger();
+      // No `before` cursor; limit of 4 exceeds the 2 entries in the newest file.
+      const { logs, hasMore, nextBefore } = await logger.fetchLogs({ limit: 4 });
+
+      // The page spans both files: the two newest entries plus the two most
+      // recent entries from the older file.
+      expect(logs.map((l) => l.msg)).toStrictEqual(['new entry 2', 'new entry 1', 'old entry 3', 'old entry 2']);
+      // One older entry ('old entry 1') remains beyond this page.
+      expect(hasMore).toBe(true);
+      expect(nextBefore).toContain('2020-01-01T00:00:02.000Z');
+    });
+
+    test('throws on an invalid before cursor', async () => {
+      const logger = makeLogger();
+      await expect(logger.fetchLogs({ before: 'not-a-date' })).rejects.toThrow('Invalid before cursor');
     });
   });
 });

--- a/packages/agent/src/logger.ts
+++ b/packages/agent/src/logger.ts
@@ -423,7 +423,7 @@ export class WinstonWrapperLogger implements ILogger {
 
     let nextBefore: string | undefined;
     if (hasMore && logs.length > 0) {
-      const oldest = logs[logs.length - 1].timestamp;
+      const oldest = logs.at(-1).timestamp;
       // Number of returned entries sharing the oldest timestamp in this page.
       const sameTimestampInPage = logs.filter((l) => l.timestamp === oldest).length;
       // If this page continued within the same timestamp block as the incoming

--- a/packages/agent/src/logger.ts
+++ b/packages/agent/src/logger.ts
@@ -67,6 +67,25 @@ export interface WinstonWrapperLoggerInitOptions extends WinstonWrapperLoggerOpt
 
 export interface FetchLogsOptions {
   limit?: number;
+  /**
+   * Opaque pagination cursor. Pass the `nextBefore` value from a previous
+   * result to fetch the next (older) page. Treat it as an opaque token rather
+   * than parsing it; it encodes the boundary timestamp plus a same-timestamp
+   * offset so pagination is exact even when entries share a millisecond.
+   */
+  before?: string;
+}
+
+export interface FetchLogsResult {
+  /** The page of log entries, newest first. */
+  logs: LogMessage[];
+  /** Whether older log entries exist beyond this page. */
+  hasMore: boolean;
+  /**
+   * Opaque cursor to pass as `before` on the next request to fetch the next
+   * older page. Only set when `hasMore` is true.
+   */
+  nextBefore?: string;
 }
 
 export function cleanupLoggerConfig(config: Partial<AgentLoggerConfig>, configPathRoot: string = 'config'): string[] {
@@ -331,27 +350,89 @@ export class WinstonWrapperLogger implements ILogger {
     return this.winston;
   }
 
-  async fetchLogs(options?: FetchLogsOptions): Promise<LogMessage[]> {
+  async fetchLogs(options?: FetchLogsOptions): Promise<FetchLogsResult> {
     if (
       options?.limit !== undefined &&
-      (typeof options.limit !== 'number' || options.limit <= 0 || options.limit > MAX_LOG_LIMIT)
+      (typeof options.limit !== 'number' ||
+        !Number.isInteger(options.limit) ||
+        options.limit <= 0 ||
+        options.limit > MAX_LOG_LIMIT)
     ) {
       throw new Error(
         `Invalid limit: ${options.limit} - must be a valid positive integer less than or equal to ${MAX_LOG_LIMIT}`
       );
     }
     const limit = options?.limit ?? DEFAULT_LOG_LIMIT;
-    return new Promise((resolve, reject) => {
+
+    // Decode the pagination cursor. It is an opaque string of the form
+    // `<ISO timestamp>@<skip>`, where `skip` is the number of entries sharing
+    // that exact timestamp that have already been returned on prior pages.
+    // Log timestamps only have millisecond resolution, so a burst of entries
+    // (e.g. on startup) can share a single timestamp. A plain timestamp cursor
+    // would then either duplicate those entries (inclusive bound) or silently
+    // drop the ones that did not fit in the previous page (exclusive bound).
+    // The `skip` component lets us resume precisely within a same-timestamp
+    // block via winston's `start` offset, guaranteeing no duplicates, no
+    // dropped entries, and forward progress.
+    let until: Date | undefined;
+    let skip = 0;
+    if (options?.before !== undefined) {
+      const at = options.before.lastIndexOf('@');
+      const timestampPart = at === -1 ? options.before : options.before.slice(0, at);
+      const skipPart = at === -1 ? '0' : options.before.slice(at + 1);
+      const beforeMs = new Date(timestampPart).getTime();
+      const parsedSkip = Number(skipPart);
+      if (Number.isNaN(beforeMs) || !Number.isInteger(parsedSkip) || parsedSkip < 0) {
+        throw new Error(`Invalid before cursor: ${options.before}`);
+      }
+      // `winston-daily-rotate-file` treats `until` as inclusive (`time > until`
+      // is excluded), so entries at exactly this timestamp are included and the
+      // `skip` offset advances past the ones already returned.
+      until = new Date(beforeMs);
+      skip = parsedSkip;
+    }
+
+    // `winston-daily-rotate-file` defaults `from` to 24 hours before `until`,
+    // which silently drops any entries that have rotated into older files. We
+    // pass epoch 0 so the query considers every rotated log file, letting a
+    // single request page across file boundaries. We over-fetch by one entry
+    // beyond the skip window to determine whether an older page exists without
+    // a second query.
+    const queryLogs = await new Promise<LogMessage[]>((resolve, reject) => {
       this.winston.query(
-        { order: 'desc', limit, fields: ['level', 'msg', 'timestamp'] },
+        {
+          order: 'desc',
+          start: skip,
+          limit: limit + 1,
+          from: new Date(0),
+          ...(until ? { until } : {}),
+          fields: ['level', 'msg', 'timestamp'],
+        },
         (err, results: { dailyRotateFile: LogMessage[] }) => {
           if (err) {
             reject(err);
             return;
           }
-          resolve(results.dailyRotateFile);
+          resolve(results.dailyRotateFile ?? []);
         }
       );
     });
+
+    const hasMore = queryLogs.length > limit;
+    const logs = queryLogs.slice(0, limit);
+
+    let nextBefore: string | undefined;
+    if (hasMore && logs.length > 0) {
+      const oldest = logs[logs.length - 1].timestamp;
+      // Number of returned entries sharing the oldest timestamp in this page.
+      const sameTimestampInPage = logs.filter((l) => l.timestamp === oldest).length;
+      // If this page continued within the same timestamp block as the incoming
+      // cursor, carry the previously-skipped count forward so the next page
+      // resumes past everything already shown at that timestamp.
+      const carriedSkip = new Date(oldest).getTime() === until?.getTime() ? skip : 0;
+      nextBefore = `${oldest}@${carriedSkip + sameTimestampInPage}`;
+    }
+
+    return { logs, hasMore, nextBefore };
   }
 }

--- a/packages/agent/src/logger.ts
+++ b/packages/agent/src/logger.ts
@@ -423,7 +423,7 @@ export class WinstonWrapperLogger implements ILogger {
 
     let nextBefore: string | undefined;
     if (hasMore && logs.length > 0) {
-      const oldest = logs.at(-1).timestamp;
+      const oldest = (logs.at(-1) as LogMessage).timestamp;
       // Number of returned entries sharing the oldest timestamp in this page.
       const sameTimestampInPage = logs.filter((l) => l.timestamp === oldest).length;
       // If this page continued within the same timestamp block as the incoming

--- a/packages/app/src/resource/ToolsPage.test.tsx
+++ b/packages/app/src/resource/ToolsPage.test.tsx
@@ -652,7 +652,11 @@ describe('ToolsPage', () => {
             parameter: [
               {
                 name: 'logs',
-                valueString: JSON.stringify({ level: 'INFO', timestamp: '2020-01-02T00:00:00.000Z', msg: 'Newest log' }),
+                valueString: JSON.stringify({
+                  level: 'INFO',
+                  timestamp: '2020-01-02T00:00:00.000Z',
+                  msg: 'Newest log',
+                }),
               },
               { name: 'hasMore', valueBoolean: true },
               { name: 'nextBefore', valueString: '2020-01-02T00:00:00.000Z' },

--- a/packages/app/src/resource/ToolsPage.test.tsx
+++ b/packages/app/src/resource/ToolsPage.test.tsx
@@ -637,6 +637,75 @@ describe('ToolsPage', () => {
     expect((await screen.findAllByText(/there is an error/i))[0]).toBeInTheDocument();
   });
 
+  test('Fetch logs -- Load More paginates with before cursor', async () => {
+    medplum = new MockClient();
+    const seenBefore: (string | undefined)[] = [];
+    medplum.router.router.add('GET', 'Agent/:id/$fetch-logs', async (req) => {
+      const before = req.query.before as string | undefined;
+      seenBefore.push(before);
+      if (!before) {
+        // First page: newest logs, more remain.
+        return [
+          allOk,
+          {
+            resourceType: 'Parameters',
+            parameter: [
+              {
+                name: 'logs',
+                valueString: JSON.stringify({ level: 'INFO', timestamp: '2020-01-02T00:00:00.000Z', msg: 'Newest log' }),
+              },
+              { name: 'hasMore', valueBoolean: true },
+              { name: 'nextBefore', valueString: '2020-01-02T00:00:00.000Z' },
+            ],
+          },
+        ];
+      }
+      // Second page: older logs, nothing left.
+      return [
+        allOk,
+        {
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'logs',
+              valueString: JSON.stringify({ level: 'INFO', timestamp: '2020-01-01T00:00:00.000Z', msg: 'Older log' }),
+            },
+            { name: 'hasMore', valueBoolean: false },
+          ],
+        },
+      ];
+    });
+    agent = await medplum.createResource<Agent>({
+      resourceType: 'Agent',
+      name: 'Agente - Fetch logs load more',
+      status: 'active',
+    });
+
+    setup(`/${getReferenceString(agent)}/tools`);
+
+    expect((await screen.findAllByText(agent.name))[0]).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /fetch logs/i }));
+    });
+
+    expect((await screen.findAllByText(/newest log/i))[0]).toBeInTheDocument();
+
+    // A "Load More" button should appear because hasMore was true.
+    const loadMore = await screen.findByRole('button', { name: /load more logs/i });
+
+    act(() => {
+      fireEvent.click(loadMore);
+    });
+
+    // Older logs are appended beneath the first page.
+    expect((await screen.findAllByText(/older log/i))[0]).toBeInTheDocument();
+    expect((await screen.findAllByText(/newest log/i))[0]).toBeInTheDocument();
+
+    // The second request forwarded the cursor from the first response.
+    expect(seenBefore).toStrictEqual([undefined, '2020-01-02T00:00:00.000Z']);
+  });
+
   test('Get stats -- Success', async () => {
     medplum = new MockClient();
     const channelRtt = {

--- a/packages/app/src/resource/ToolsPage.tsx
+++ b/packages/app/src/resource/ToolsPage.tsx
@@ -202,6 +202,9 @@ export function ToolsPage(): JSX.Element | null {
   const [lastPing, setLastPing] = useState<string | undefined>();
   const [pinging, setPinging] = useState(false);
   const [logs, setLogs] = useState<string | undefined>();
+  const [logsHasMore, setLogsHasMore] = useState(false);
+  const [logsNextBefore, setLogsNextBefore] = useState<string | undefined>();
+  const [logLimit, setLogLimit] = useState(20);
   const [stats, setStats] = useState<AgentStats | undefined>();
   const [modalOpened, { open: openModal, close: closeModal }] = useDisclosure(false);
 
@@ -264,25 +267,49 @@ export function ToolsPage(): JSX.Element | null {
     [medplum, id]
   );
 
-  const handleFetchLogs = useCallback(
-    (formData: Record<string, string>) => {
+  const fetchLogsPage = useCallback(
+    (limit: number, before?: string): void => {
       setFetchingLogs(true);
-      const limit = formData.logLimit || 20;
+      const url = medplum.fhirUrl('Agent', id, '$fetch-logs');
+      url.searchParams.set('limit', String(limit));
+      if (before) {
+        url.searchParams.set('before', before);
+      }
       medplum
-        .get(medplum.fhirUrl('Agent', id, `$fetch-logs${limit !== undefined ? `?limit=${limit}` : ''}`), {
-          cache: 'reload',
-        })
+        .get(url, { cache: 'reload' })
         .then((result: Parameters) => {
-          const param = result?.parameter?.find((param) => param.name === 'logs');
-          if (param) {
-            setLogs(param?.valueString);
-          }
+          const pageLogs = result?.parameter?.find((param) => param.name === 'logs')?.valueString;
+          const hasMore = result?.parameter?.find((param) => param.name === 'hasMore')?.valueBoolean ?? false;
+          const nextBefore = result?.parameter?.find((param) => param.name === 'nextBefore')?.valueString;
+          // When paging with a cursor, append the older page beneath the existing
+          // logs; otherwise replace with the fresh first page.
+          setLogs((prev) => {
+            if (before && prev) {
+              return pageLogs ? `${prev}\n${pageLogs}` : prev;
+            }
+            return pageLogs;
+          });
+          setLogsHasMore(hasMore);
+          setLogsNextBefore(nextBefore);
         })
         .catch((err) => showError(normalizeErrorString(err)))
         .finally(() => setFetchingLogs(false));
     },
     [medplum, id]
   );
+
+  const handleFetchLogs = useCallback(
+    (formData: Record<string, string>) => {
+      const limit = Number(formData.logLimit) || 20;
+      setLogLimit(limit);
+      fetchLogsPage(limit);
+    },
+    [fetchLogsPage]
+  );
+
+  const handleLoadMoreLogs = useCallback(() => {
+    fetchLogsPage(logLimit, logsNextBefore);
+  }, [fetchLogsPage, logLimit, logsNextBefore]);
 
   const handleFetchStats = useCallback(() => {
     setFetchingStats(true);
@@ -405,6 +432,19 @@ export function ToolsPage(): JSX.Element | null {
           >
             Fetch Logs
           </Button>
+          {logsHasMore ? (
+            <Button
+              mt={22}
+              type="button"
+              variant="default"
+              onClick={handleLoadMoreLogs}
+              loading={fetchingLogs}
+              disabled={working && !fetchingLogs}
+              aria-label="Load more logs"
+            >
+              Load More
+            </Button>
+          ) : null}
         </Group>
       </Form>
       <Divider my="lg" />

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -83,12 +83,26 @@ export interface AgentUpgradeResponse extends BaseAgentMessage {
 export interface AgentLogsRequest extends BaseAgentRequestMessage {
   type: 'agent:logs:request';
   limit?: number;
+  /**
+   * Opaque pagination cursor. Pass the `nextBefore` value from a previous
+   * response to fetch the next (older) page; treat it as an opaque token rather
+   * than parsing it. Logs are read across all rotated log files, not just the
+   * most recent one.
+   */
+  before?: string;
 }
 
 export interface AgentLogsResponse extends BaseAgentMessage {
   type: 'agent:logs:response';
   statusCode: number;
   logs: LogMessage[];
+  /** Whether more (older) log entries exist beyond the ones returned in this page. */
+  hasMore: boolean;
+  /**
+   * Opaque cursor to pass as `before` in a subsequent request to fetch the next
+   * older page. Only present when `hasMore` is true.
+   */
+  nextBefore?: string;
 }
 
 export type AgentRttStats = {

--- a/packages/server/src/fhir/operations/agentfetchlogs.test.ts
+++ b/packages/server/src/fhir/operations/agentfetchlogs.test.ts
@@ -85,6 +85,7 @@ describe('Agent/$fetch-logs', () => {
           type: 'agent:logs:response',
           statusCode: 200,
           logs,
+          hasMore: false,
         }
       );
     }
@@ -122,7 +123,7 @@ describe('Agent/$fetch-logs', () => {
       agents[0],
       accessToken,
       'agent:logs:request',
-      { type: 'agent:logs:response', statusCode: 200, logs }
+      { type: 'agent:logs:response', statusCode: 200, logs, hasMore: false }
     );
 
     const res = await request(app)
@@ -141,6 +142,50 @@ describe('Agent/$fetch-logs', () => {
         }),
       ]),
     });
+
+    cleanup();
+  });
+
+  test('Fetch logs -- paginates with before cursor and returns hasMore/nextBefore', async () => {
+    const logs: LogMessage[] = [
+      { level: 'INFO', timestamp: '2020-01-02T00:00:01.000Z', msg: 'Older 1' },
+      { level: 'INFO', timestamp: '2020-01-02T00:00:00.000Z', msg: 'Older 2' },
+    ];
+
+    let receivedRequest: AgentLogsRequest | undefined;
+    const { cleanup } = await mockAgentResponse<AgentLogsRequest, AgentLogsResponse>(
+      agents[0],
+      accessToken,
+      'agent:logs:request',
+      { type: 'agent:logs:response', statusCode: 200, logs, hasMore: true, nextBefore: '2020-01-02T00:00:00.000Z' },
+      (req) => {
+        receivedRequest = req;
+      }
+    );
+
+    const res = await request(app)
+      .get(`/fhir/R4/Agent/${agents[0].id}/$fetch-logs`)
+      .query({ limit: 2, before: '2020-01-02T00:00:02.000Z' })
+      .set('Authorization', 'Bearer ' + accessToken);
+
+    expect(res.status).toBe(200);
+    const params = res.body as Parameters;
+
+    expect(params).toMatchObject<Parameters>({
+      resourceType: 'Parameters',
+      parameter: expect.arrayContaining<ParametersParameter>([
+        expect.objectContaining<ParametersParameter>({
+          name: 'logs',
+          valueString: logs.map((msg) => JSON.stringify(msg)).join('\n'),
+        }),
+        expect.objectContaining<ParametersParameter>({ name: 'hasMore', valueBoolean: true }),
+        expect.objectContaining<ParametersParameter>({ name: 'nextBefore', valueString: '2020-01-02T00:00:00.000Z' }),
+      ]),
+    });
+
+    // The `before` cursor and limit should be forwarded to the agent.
+    expect(receivedRequest?.before).toBe('2020-01-02T00:00:02.000Z');
+    expect(receivedRequest?.limit).toBe(2);
 
     cleanup();
   });

--- a/packages/server/src/fhir/operations/agentfetchlogs.ts
+++ b/packages/server/src/fhir/operations/agentfetchlogs.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { AgentLogsResponse, WithId } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Agent } from '@medplum/fhirtypes';
+import type { Agent, ParametersParameter } from '@medplum/fhirtypes';
 import { makeOperationDefinition } from './definitions';
 import { handleBulkAgentOperation, sendAndHandleAgentRequest } from './utils/agentutils';
 import { parseInputParameters } from './utils/parameters';
@@ -14,6 +14,7 @@ export const operation = makeOperationDefinition(
     code: 'fetch-logs',
     parameter: [
       { use: 'in', name: 'limit', type: 'integer', min: 0, max: '1' },
+      { use: 'in', name: 'before', type: 'string', min: 0, max: '1' },
       { use: 'out', name: 'return', type: 'Parameters', min: 1, max: '1' },
     ],
   }
@@ -30,7 +31,9 @@ export const operation = makeOperationDefinition(
  * @returns The FHIR response.
  */
 export async function agentFetchLogsHandler(req: FhirRequest): Promise<FhirResponse> {
-  const { limit: _limit, ...rest } = req.query;
+  // Strip pagination params from the query so they are not mistaken for Agent
+  // search filters by `handleBulkAgentOperation`. They are parsed separately.
+  const { limit: _limit, before: _before, ...rest } = req.query;
   const params = parseInputParameters<AgentFetchLogsOptions>(operation, req);
   req.query = rest;
 
@@ -39,23 +42,29 @@ export async function agentFetchLogsHandler(req: FhirRequest): Promise<FhirRespo
 
 export type AgentFetchLogsOptions = {
   limit?: number;
+  before?: string;
 };
 
 async function fetchLogs(agent: WithId<Agent>, options: AgentFetchLogsOptions): Promise<FhirResponse> {
   return sendAndHandleAgentRequest<AgentLogsResponse>(
     agent,
-    { type: 'agent:logs:request', limit: options?.limit },
+    { type: 'agent:logs:request', limit: options?.limit, before: options?.before },
     'agent:logs:response',
     {
       successHandler: (response) => {
+        const parameter: ParametersParameter[] = [
+          {
+            name: 'logs',
+            valueString: response.logs.map((msg) => JSON.stringify(msg)).join('\n'),
+          },
+          { name: 'hasMore', valueBoolean: response.hasMore ?? false },
+        ];
+        if (response.nextBefore !== undefined) {
+          parameter.push({ name: 'nextBefore', valueString: response.nextBefore });
+        }
         return {
           resourceType: 'Parameters',
-          parameter: [
-            {
-              name: 'logs',
-              valueString: response.logs.map((msg) => JSON.stringify(msg)).join('\n'),
-            },
-          ],
+          parameter,
         };
       },
     }

--- a/packages/server/src/fhir/operations/utils/agenttestutils.ts
+++ b/packages/server/src/fhir/operations/utils/agenttestutils.ts
@@ -50,7 +50,8 @@ export async function mockAgentResponse<
   agent: WithId<Agent>,
   accessToken: string,
   msgType: TRequest['type'],
-  res: TResponse
+  res: TResponse,
+  onRequest?: (req: TRequest) => void
 ): Promise<MockAgentResponseHandle> {
   if (!serverPort) {
     throw new Error('Must call `configMockAgents()` before calling `mockAgentResponse()`');
@@ -74,6 +75,7 @@ export async function mockAgentResponse<
     if (!msg.callback) {
       throw new Error('No callback in message to message received');
     }
+    onRequest?.(msg);
     ws.send(JSON.stringify({ ...res, callback: msg.callback }));
   };
   ws.addEventListener('message', handler);


### PR DESCRIPTION
Adds `before` parameter and cursor-based pagination to `$fetch-logs`, which expands the queryability of the agent logs.

Also fixes #8149 