### PR TITLE
fix(agent): read DICOM using new Uint8Array(buffer) instead of buffer.buffer

### DIFF
--- a/packages/agent/src/dicom.ts
+++ b/packages/agent/src/dicom.ts
@@ -104,7 +104,7 @@ export class AgentDicomChannel extends BaseChannel {
             });
 
             // Parse the DICOM file into DICOM JSON
-            const dicomDict = dcmjs.data.DicomMessage.readFile(buffer.buffer);
+            const dicomDict = dcmjs.data.DicomMessage.readFile(new Uint8Array(buffer));
             dicomJson = {
               ...dicomDict.meta,
               ...dicomDict.dict,


### PR DESCRIPTION
## Bug
```
vitest src/dicom.test.ts


 ❯ src/dicom.test.ts (1 test | 1 failed) 63ms
   ❯ DICOM (1)
     × C-ECHO and C-STORE 38ms

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/dicom.test.ts > DICOM > C-ECHO and C-STORE
AssertionError: expected 272 to strictly equal +0

- Expected
+ Received

- 0
+ 272

 ❯ src/dicom.test.ts:106:55
    104|     expect(storeCommandDataset).toBeDefined();
    105|     expect(storeCommandDataset?.getTransferSyntaxUid()).toBe('1.2.840.1000…
    106|     expect(storeCommandDataset?.getElement('Status')).toStrictEqual(0);
       |                                                       ^
    107|
    108|     client.clearRequests();

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed (1)
      Tests  1 failed (1)
   Start at  11:06:34
   Duration  922ms (transform 566ms, setup 26ms, import 734ms, tests 63ms, environment 0ms)
```


## Summary
- Fix C-STORE handling when parsing DICOM files read from temp files on disk
- `readFileSync` can return a pooled `Buffer` with a non-zero `byteOffset`; passing `buffer.buffer` to `dcmjs.data.DicomMessage.readFile` reads the wrong slice and fails parsing
- Wrap the buffer in `Uint8Array` so dcmjs receives only the actual file bytes, restoring successful C-STORE responses
