### PR TITLE
[React] Teach `<MedplumLink>` types that we accept `<a>` props

### DIFF
--- a/packages/react/src/MedplumLink/MedplumLink.test.tsx
+++ b/packages/react/src/MedplumLink/MedplumLink.test.tsx
@@ -105,4 +105,15 @@ describe('MedplumLink', () => {
     expect(screen.getByText('test')).toBeDefined();
     fireEvent.click(screen.getByText('test'));
   });
+
+  test('Passes anchor DOM props through to the underlying element', () => {
+    setup(
+      <MedplumLink to="xyz" tabIndex={-1}>
+        test
+      </MedplumLink>
+    );
+    const node = screen.getByText('test');
+    expect(node).toBeDefined();
+    expect(node).toHaveAttribute('tabIndex', '-1');
+  });
 });

--- a/packages/react/src/MedplumLink/MedplumLink.tsx
+++ b/packages/react/src/MedplumLink/MedplumLink.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { AnchorProps } from '@mantine/core';
+import type { AnchorProps, ElementProps } from '@mantine/core';
 import { Anchor } from '@mantine/core';
 import { isReference, isResource } from '@medplum/core';
 import type { Reference, Resource } from '@medplum/fhirtypes';
@@ -8,7 +8,7 @@ import { useMedplumNavigate } from '@medplum/react-hooks';
 import type { JSX, MouseEvent, MouseEventHandler, ReactNode } from 'react';
 import { isAuxClick } from '../utils/dom';
 
-export interface MedplumLinkProps extends AnchorProps {
+export interface MedplumLinkProps extends AnchorProps, ElementProps<'a', keyof AnchorProps> {
   readonly to?: Resource | Reference | string;
   readonly suffix?: string;
   readonly label?: string;


### PR DESCRIPTION
Attributes like `tabIndex` that are defined on the `<a>` tag that will be rendered are ultimately spread down to the underlying DOM component. Because we wrap `<Anchor>`, a polymorphic Mantine component, we need to add a little extra ceremony to our type definition.

See https://mantine.dev/guides/typescript/#polymorphic-components-props-types