### PR TITLE
WIP: feat(migration): backfill delete history tombstones with meta.deleted

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -19,6 +19,7 @@ import {
 import { RepositoryMode } from '@medplum/fhir-router';
 import type {
   Binary,
+  Bundle,
   BundleEntry,
   Login,
   OperationOutcome,
@@ -29,6 +30,7 @@ import type {
   ProjectMembership,
   Questionnaire,
   ResearchDefinition,
+  Resource,
   ResourceType,
   ServiceRequest,
   User,
@@ -52,6 +54,30 @@ import { SelectQuery } from './sql';
 import * as tokenColumnModule from './token-column';
 
 vi.mock('hibp');
+
+function isHistoryEntryDeleted(entry: BundleEntry): boolean {
+  return (
+    entry.response?.status === '410' &&
+    entry.response?.outcome?.issue?.some((issue) => issue.code === 'deleted') === true
+  );
+}
+
+function isResourceCurrentlyDeleted<T extends Resource>(history: Bundle<T>): boolean {
+  return history.entry?.some(isHistoryEntryDeleted) ?? false;
+}
+
+function getLatestNonDeletedHistoryResource<T extends Resource>(history: Bundle<T>): WithId<T> | undefined {
+  const entry = history.entry?.find((e) => e.response?.status === '200' && e.resource);
+  return entry?.resource as WithId<T> | undefined;
+}
+
+function buildRestoredResource<T extends Resource>(latestVersion: WithId<T>): WithId<T> {
+  if (!latestVersion.meta?.deleted) {
+    return latestVersion;
+  }
+  const { deleted: _, ...meta } = latestVersion.meta;
+  return { ...latestVersion, meta } as WithId<T>;
+}
 
 describe('FHIR Repo', () => {
   const globalSystemRepo = getGlobalSystemRepo();
@@ -1077,28 +1103,15 @@ describe('FHIR Repo', () => {
       await systemRepo.deleteResource('Patient', patient.id);
 
       const history = await systemRepo.readHistory<Patient>('Patient', patient.id);
-      expect(
-        history.entry?.some(
-          (entry) =>
-            entry.response?.status === '410' &&
-            entry.response?.outcome?.issue?.some((issue) => issue.code === 'deleted') === true
-        ) ?? false
-      ).toBe(true);
+      expect(isResourceCurrentlyDeleted(history)).toBe(true);
 
-      const latestVersion = history.entry?.find((e) => e.response?.status === '200' && e.resource)?.resource as
-        | WithId<Patient>
-        | undefined;
+      const latestVersion = getLatestNonDeletedHistoryResource(history);
       expect(latestVersion).toBeDefined();
       if (!latestVersion) {
         throw new Error('Expected latest version');
       }
 
-      let resourceToRestore: WithId<Patient> = latestVersion;
-      if (latestVersion.meta?.deleted) {
-        const { deleted: _deleted, ...meta } = latestVersion.meta;
-        resourceToRestore = { ...latestVersion, meta };
-      }
-      const restored = await systemRepo.updateResource(resourceToRestore);
+      const restored = await systemRepo.updateResource(buildRestoredResource(latestVersion));
 
       expect(restored.name?.[0]?.family).toStrictEqual('Smith');
       expect(restored.meta?.deleted).toBeUndefined();

--- a/packages/server/src/migrations/data/backfill-delete-history-tombstones.int.test.ts
+++ b/packages/server/src/migrations/data/backfill-delete-history-tombstones.int.test.ts
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { randomUUID } from 'node:crypto';
+import type { Pool } from 'pg';
+import { escapeIdentifier } from 'pg';
+import { loadTestConfig } from '../../config/loader';
+import type { MedplumServerConfig } from '../../config/types';
+import { closeDatabase, DatabaseMode, getDatabasePool, initDatabase } from '../../database';
+import type { MigrationActionResult } from '../types';
+import { backfillDeleteHistoryTombstonesForResourceType } from './backfill-delete-history-tombstones';
+
+const resourceType = 'DeleteTombstoneBackfillTest';
+const historyTable = `${resourceType}_History`;
+
+describe('backfill delete history tombstones', () => {
+  let config: MedplumServerConfig;
+  let client: Pool;
+
+  beforeAll(async () => {
+    config = await loadTestConfig();
+    await initDatabase(config);
+    client = getDatabasePool(DatabaseMode.WRITER);
+  });
+
+  afterAll(async () => {
+    await client.query(`DROP TABLE IF EXISTS ${escapeIdentifier(historyTable)}`);
+    await client.query(`DROP TABLE IF EXISTS ${escapeIdentifier(resourceType)}`);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await client.query(`DROP TABLE IF EXISTS ${escapeIdentifier(historyTable)}`);
+    await client.query(`DROP TABLE IF EXISTS ${escapeIdentifier(resourceType)}`);
+    await client.query(`
+      CREATE TABLE ${escapeIdentifier(resourceType)} (
+        id UUID PRIMARY KEY,
+        "lastUpdated" TIMESTAMPTZ NOT NULL,
+        deleted BOOLEAN NOT NULL,
+        "projectId" UUID
+      )
+    `);
+    await client.query(`
+      CREATE TABLE ${escapeIdentifier(historyTable)} (
+        "versionId" UUID PRIMARY KEY,
+        id UUID NOT NULL,
+        content TEXT NOT NULL,
+        "lastUpdated" TIMESTAMPTZ NOT NULL
+      )
+    `);
+  });
+
+  async function runBackfill(): Promise<void> {
+    const results: MigrationActionResult[] = [];
+    await backfillDeleteHistoryTombstonesForResourceType(client, results, resourceType);
+  }
+
+  test('backfills empty delete history content with tombstone metadata', async () => {
+    const id = randomUUID();
+    const priorVersionId = randomUUID();
+    const deleteVersionId = randomUUID();
+    const projectId = randomUUID();
+    const priorLastUpdated = new Date('2025-01-01T00:00:00.000Z');
+    const deleteLastUpdated = new Date('2025-06-01T12:00:00.000Z');
+
+    await client.query(
+      `INSERT INTO ${escapeIdentifier(historyTable)} ("versionId", id, content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+      [
+        priorVersionId,
+        id,
+        JSON.stringify({
+          resourceType,
+          id,
+          meta: { versionId: priorVersionId, project: projectId },
+        }),
+        priorLastUpdated,
+      ]
+    );
+    await client.query(
+      `INSERT INTO ${escapeIdentifier(resourceType)} (id, "lastUpdated", deleted, "projectId") VALUES ($1, $2, $3, $4)`,
+      [id, deleteLastUpdated, true, projectId]
+    );
+    await client.query(
+      `INSERT INTO ${escapeIdentifier(historyTable)} ("versionId", id, content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+      [deleteVersionId, id, '', deleteLastUpdated]
+    );
+
+    await runBackfill();
+
+    const result = await client.query<{ content: string }>(
+      `SELECT content FROM ${escapeIdentifier(historyTable)} WHERE "versionId" = $1`,
+      [deleteVersionId]
+    );
+    expect(result.rows).toHaveLength(1);
+    const tombstone = JSON.parse(result.rows[0].content);
+    expect(tombstone).toMatchObject({
+      resourceType,
+      id,
+      meta: {
+        versionId: deleteVersionId,
+        lastUpdated: deleteLastUpdated.toISOString(),
+        deleted: true,
+        project: projectId,
+      },
+    });
+  });
+
+  test('backfills lastUpdated using ISO-8601 millisecond format', async () => {
+    const id = randomUUID();
+    const deleteVersionId = randomUUID();
+    const deleteLastUpdated = new Date('2025-06-01T12:34:56.789Z');
+
+    await client.query(
+      `INSERT INTO ${escapeIdentifier(resourceType)} (id, "lastUpdated", deleted, "projectId") VALUES ($1, $2, $3, $4)`,
+      [id, deleteLastUpdated, true, randomUUID()]
+    );
+    await client.query(
+      `INSERT INTO ${escapeIdentifier(historyTable)} ("versionId", id, content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+      [deleteVersionId, id, '', deleteLastUpdated]
+    );
+
+    await runBackfill();
+
+    const result = await client.query<{ content: string }>(
+      `SELECT content FROM ${escapeIdentifier(historyTable)} WHERE "versionId" = $1`,
+      [deleteVersionId]
+    );
+    const tombstone = JSON.parse(result.rows[0].content);
+    expect(tombstone.meta.lastUpdated).toBe(deleteLastUpdated.toISOString());
+  });
+
+  test('backfills empty history rows without a main resource row', async () => {
+    const id = randomUUID();
+    const versionId = randomUUID();
+    const lastUpdated = new Date('2025-06-01T12:00:00.000Z');
+
+    await client.query(
+      `INSERT INTO ${escapeIdentifier(historyTable)} ("versionId", id, content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+      [versionId, id, '', lastUpdated]
+    );
+
+    await runBackfill();
+
+    const result = await client.query<{ content: string }>(
+      `SELECT content FROM ${escapeIdentifier(historyTable)} WHERE "versionId" = $1`,
+      [versionId]
+    );
+    const tombstone = JSON.parse(result.rows[0].content);
+    expect(tombstone).toMatchObject({
+      resourceType,
+      id,
+      meta: {
+        versionId,
+        lastUpdated: lastUpdated.toISOString(),
+        deleted: true,
+      },
+    });
+  });
+
+  test('backfills empty history rows even when main resource is not deleted', async () => {
+    const id = randomUUID();
+    const versionId = randomUUID();
+    const lastUpdated = new Date('2025-06-01T12:00:00.000Z');
+
+    await client.query(
+      `INSERT INTO ${escapeIdentifier(resourceType)} (id, "lastUpdated", deleted, "projectId") VALUES ($1, $2, $3, $4)`,
+      [id, lastUpdated, false, randomUUID()]
+    );
+    await client.query(
+      `INSERT INTO ${escapeIdentifier(historyTable)} ("versionId", id, content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+      [versionId, id, '', lastUpdated]
+    );
+
+    await runBackfill();
+
+    const result = await client.query<{ content: string }>(
+      `SELECT content FROM ${escapeIdentifier(historyTable)} WHERE "versionId" = $1`,
+      [versionId]
+    );
+    const tombstone = JSON.parse(result.rows[0].content);
+    expect(tombstone).toMatchObject({
+      resourceType,
+      id,
+      meta: {
+        versionId,
+        lastUpdated: lastUpdated.toISOString(),
+        deleted: true,
+      },
+    });
+  });
+
+  test('is idempotent', async () => {
+    const id = randomUUID();
+    const deleteVersionId = randomUUID();
+    const deleteLastUpdated = new Date('2025-06-01T12:00:00.000Z');
+
+    await client.query(
+      `INSERT INTO ${escapeIdentifier(resourceType)} (id, "lastUpdated", deleted, "projectId") VALUES ($1, $2, $3, $4)`,
+      [id, deleteLastUpdated, true, randomUUID()]
+    );
+    await client.query(
+      `INSERT INTO ${escapeIdentifier(historyTable)} ("versionId", id, content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+      [deleteVersionId, id, '', deleteLastUpdated]
+    );
+
+    await runBackfill();
+    const afterFirst = await client.query<{ content: string }>(
+      `SELECT content FROM ${escapeIdentifier(historyTable)} WHERE "versionId" = $1`,
+      [deleteVersionId]
+    );
+
+    await runBackfill();
+    const afterSecond = await client.query<{ content: string }>(
+      `SELECT content FROM ${escapeIdentifier(historyTable)} WHERE "versionId" = $1`,
+      [deleteVersionId]
+    );
+
+    expect(afterSecond.rows[0].content).toBe(afterFirst.rows[0].content);
+  });
+
+  test('processes rows in batches until complete', async () => {
+    const deleteLastUpdated = new Date('2025-06-01T12:00:00.000Z');
+    const rows = [
+      { id: randomUUID(), versionId: randomUUID() },
+      { id: randomUUID(), versionId: randomUUID() },
+    ];
+
+    for (const row of rows) {
+      await client.query(
+        `INSERT INTO ${escapeIdentifier(resourceType)} (id, "lastUpdated", deleted, "projectId") VALUES ($1, $2, $3, $4)`,
+        [row.id, deleteLastUpdated, true, randomUUID()]
+      );
+      await client.query(
+        `INSERT INTO ${escapeIdentifier(historyTable)} ("versionId", id, content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+        [row.versionId, row.id, '', deleteLastUpdated]
+      );
+    }
+
+    const results: MigrationActionResult[] = [];
+    await backfillDeleteHistoryTombstonesForResourceType(client, results, resourceType, 1);
+
+    expect(results[0]?.iterations).toBe(2);
+
+    const result = await client.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM ${escapeIdentifier(historyTable)} WHERE content <> ''`
+    );
+    expect(Number(result.rows[0].count)).toBe(2);
+  });
+});

--- a/packages/server/src/migrations/data/backfill-delete-history-tombstones.ts
+++ b/packages/server/src/migrations/data/backfill-delete-history-tombstones.ts
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { globalLogger } from '../../logger';
+import type { DbClient, MigrationActionResult } from '../types';
+
+export const DELETE_HISTORY_TOMBSTONE_BACKFILL_BATCH_SIZE = 1000;
+
+/*
+ * Matches buildDeleteHistoryContent / Date.toISOString(): UTC, 3 ms digits, trailing Z in pure SQL
+ * This allows the backfill to use the same format as the Javascript
+ */
+const LAST_UPDATED_ISO_SQL = `to_char(date_trunc('milliseconds', h."lastUpdated") AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.FF3"Z"')`;
+
+/**
+ * Backfill legacy delete-history rows (content = '') with a minimal tombstone.
+ *
+ * Selects history rows with empty content and joins to the immediately prior
+ * history row (by lastUpdated) for the same id. Tombstone fields are taken from
+ * that prior content where available; delete-version metadata comes from the
+ * history row itself.
+ *
+ * meta.author is omitted for legacy rows because the delete actor was not stored.
+ * @param resourceType - The resource type to backfill.
+ * @param batchSize - The number of rows to process in each batch.
+ * @returns The SQL to backfill the delete history tombstones.
+ */
+export function buildBackfillDeleteHistoryTombstonesSql(
+  resourceType: string,
+  batchSize: number = DELETE_HISTORY_TOMBSTONE_BACKFILL_BATCH_SIZE
+): string {
+  const historyTable = `${resourceType}_History`;
+  return `WITH batch AS (
+  SELECT
+    h."versionId",
+    COALESCE(orig.content->>'resourceType', '${resourceType}') AS "resourceType",
+    COALESCE(orig.content->>'id', h.id::text) AS "resourceId",
+    ${LAST_UPDATED_ISO_SQL} AS "lastUpdatedIso",
+    orig.content->'meta'->>'project' AS project
+  FROM "${historyTable}" AS h
+  LEFT JOIN LATERAL (
+    SELECT content::jsonb AS content
+    FROM "${historyTable}" AS prev
+    WHERE prev.id = h.id
+      AND prev."lastUpdated" < h."lastUpdated"
+    ORDER BY prev."lastUpdated" DESC
+    LIMIT 1
+  ) AS orig ON true
+  WHERE h.content = ''
+  ORDER BY h."lastUpdated"
+  LIMIT ${batchSize}
+)
+  UPDATE "${historyTable}" AS h
+    SET content = (
+      jsonb_build_object(
+        'resourceType', batch."resourceType",
+        'id', batch."resourceId",
+        'meta',
+        jsonb_build_object(
+          'versionId', batch."versionId",
+          'lastUpdated', batch."lastUpdatedIso",
+          'deleted', true
+        ) || CASE
+          WHEN batch.project IS NOT NULL
+          THEN jsonb_build_object('project', batch.project)
+          ELSE '{}'::jsonb
+        END
+      )
+    )::text
+  FROM batch
+  WHERE h."versionId" = batch."versionId"
+  RETURNING h."lastUpdated"`;
+}
+
+interface BackfillDeleteHistoryTombstoneRow {
+  lastUpdated: Date;
+}
+
+export async function backfillDeleteHistoryTombstonesForResourceType(
+  client: DbClient,
+  results: MigrationActionResult[],
+  resourceType: string,
+  batchSize: number = DELETE_HISTORY_TOMBSTONE_BACKFILL_BATCH_SIZE
+): Promise<void> {
+  const sql = buildBackfillDeleteHistoryTombstonesSql(resourceType, batchSize);
+  const start = Date.now();
+  let iterations = 0;
+  let rowsProcessed = 0;
+  let throughLastUpdated: Date | undefined;
+
+  while (true) {
+    const result = await client.query<BackfillDeleteHistoryTombstoneRow>(sql);
+    if (result.rowCount === 0) {
+      break;
+    }
+    iterations++;
+
+    const batchThroughLastUpdated = result.rows.reduce(
+      (max: Date, row: BackfillDeleteHistoryTombstoneRow) => (row.lastUpdated > max ? row.lastUpdated : max),
+      result.rows[0].lastUpdated
+    );
+    rowsProcessed += result.rowCount ?? 0;
+    throughLastUpdated = batchThroughLastUpdated;
+
+    // log progress
+    globalLogger.info('Backfill delete history tombstones progress', {
+      resourceType,
+      batch: iterations,
+      rowsThisBatch: result.rowCount,
+      throughLastUpdated: batchThroughLastUpdated.toISOString(),
+      rowsProcessed,
+    });
+  }
+
+  results.push({
+    name: sql,
+    durationMs: Date.now() - start,
+    iterations,
+    rowsProcessed,
+    throughLastUpdated: throughLastUpdated?.toISOString(),
+  });
+}

--- a/packages/server/src/migrations/data/data-version-manifest.json
+++ b/packages/server/src/migrations/data/data-version-manifest.json
@@ -150,5 +150,8 @@
   },
   "v40": {
     "serverVersion": "5.1.24"
+  },
+  "v41": {
+    "serverVersion": "5.1.24"
   }
 }

--- a/packages/server/src/migrations/data/index.ts
+++ b/packages/server/src/migrations/data/index.ts
@@ -49,3 +49,4 @@ export * as v37 from './v37';
 export * as v38 from './v38';
 export * as v39 from './v39';
 export * as v40 from './v40';
+export * as v41 from './v41';

--- a/packages/server/src/migrations/data/v41.ts
+++ b/packages/server/src/migrations/data/v41.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { getResourceTypes } from '@medplum/core';
+import type { PoolClient } from 'pg';
+import { prepareCustomMigrationJobData, runCustomMigration } from '../../workers/post-deploy-migration';
+import type { MigrationActionResult } from '../types';
+import { backfillDeleteHistoryTombstonesForResourceType } from './backfill-delete-history-tombstones';
+import type { CustomPostDeployMigration } from './types';
+
+export const migration: CustomPostDeployMigration = {
+  type: 'custom',
+  prepareJobData: (asyncJob) => prepareCustomMigrationJobData(asyncJob),
+  run: async (repo, job, jobData) => runCustomMigration(repo, job, jobData, callback),
+};
+
+async function callback(client: PoolClient, results: MigrationActionResult[]): Promise<void> {
+  for (const resourceType of getResourceTypes()) {
+    await backfillDeleteHistoryTombstonesForResourceType(client, results, resourceType);
+  }
+}


### PR DESCRIPTION
Store minimal delete tombstones in _History using meta.deleted and add
post-deploy migration v39 to backfill legacy delete entries from prior
resource content.

Signed-off-by: Karl Pietrzak <karl@medplum.com>
