### PR TITLE
fix(core): use statusOptions in pollStatus so status polls do not resend the request body

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -4126,6 +4126,47 @@ describe('Client', () => {
       expect(fetch).toHaveBeenCalledTimes(4);
       expect((response as any).resourceType).toStrictEqual('Patient');
     });
+
+    test('Status polls do not resend the request body', async () => {
+      const fetch = vi.fn();
+
+      // First time, return 202 Accepted with Content-Location
+      fetch.mockImplementationOnce(async () =>
+        mockFetchResponse(202, {}, { 'content-location': 'https://example.com/content-location/1' })
+      );
+
+      // Second time, return 202 Accepted with Content-Location
+      fetch.mockImplementationOnce(async () =>
+        mockFetchResponse(202, {}, { 'content-location': 'https://example.com/content-location/1' })
+      );
+
+      // Third time, return 200 with JSON
+      fetch.mockImplementationOnce(async () => mockFetchResponse(200, { resourceType: 'AsyncJob' }));
+
+      const client = new MedplumClient({ fetch });
+      await client.startAsyncRequest('/test', {
+        method: 'POST',
+        body: '{"resourceType":"Patient"}',
+        pollStatusOnAccepted: true,
+        pollStatusPeriod: 1,
+      });
+      expect(fetch).toHaveBeenCalledTimes(3);
+
+      // The initial request carries the body and the Prefer header
+      const initialOptions = fetch.mock.calls[0][1];
+      expect(initialOptions.method).toStrictEqual('POST');
+      expect(initialOptions.body).toStrictEqual('{"resourceType":"Patient"}');
+      expect(initialOptions.headers['Prefer']).toStrictEqual('respond-async');
+
+      // Status polls must be GETs without a body (fetch throws
+      // "Request with GET/HEAD method cannot have body" otherwise)
+      // and without the Prefer header
+      for (const [, pollOptions] of fetch.mock.calls.slice(1)) {
+        expect(pollOptions.method).toStrictEqual('GET');
+        expect(pollOptions.body).toBeUndefined();
+        expect(pollOptions.headers['Prefer']).toBeUndefined();
+      }
+    });
   });
 
   describe('Token refresh', () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3832,7 +3832,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       await sleep(retryDelay, { signal: options.signal });
       state.pollCount++;
     }
-    return this.request(statusUrl, { ...options, method: 'GET' }, state);
+    return this.request(statusUrl, statusOptions, state);
   }
 
   /**


### PR DESCRIPTION
Fixes #9731

## What

`MedplumClient.pollStatus()` builds a `statusOptions` object (`{ ...options, method: 'GET', body: undefined, redirect: 'follow' }`, plus `Prefer` header removal on the first poll) but then passes `{ ...options, method: 'GET' }` to `this.request()`, so `statusOptions` is dead code. The original request body is carried into the status polling GET, and fetch throws `TypeError: Request with GET/HEAD method cannot have body` (both undici and browsers reject it).

User-visible symptom: the Super Admin **Reindex Resources** form always reports failure (the reindex `AsyncJob` actually starts and completes server-side; only client polling breaks). Any body-carrying request with `pollStatusOnAccepted: true` is affected. See #9731 for a full repro on a stock `docker-compose.full-stack.yml` stack.

## Fix

One line: pass `statusOptions` to `this.request()`. This also revives the intended `Prefer` header removal and `redirect: 'follow'` behavior.

## Testing

Added a regression test in the `Prefer async` describe block asserting that the initial POST carries the body and `Prefer: respond-async`, and that every status poll is a GET with no body and no `Prefer` header.

- New test fails on `main` with `AssertionError: expected '{"resourceType":"Patient"}' to be undefined`, passes with the fix.
- `vitest run src/client.test.ts`: 199 passed (199).
- `tsc --noEmit` and `eslint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
