### PR TITLE
Support prior auth in `Claim/$submit` operation

### DIFF
--- a/packages/server/src/fhir/operations/claimsubmit.test.ts
+++ b/packages/server/src/fhir/operations/claimsubmit.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
 import { ContentType, createReference } from '@medplum/core';
-import type { Bot, Claim, Project } from '@medplum/fhirtypes';
+import type { Bot, Bundle, Claim, Project } from '@medplum/fhirtypes';
 import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
@@ -12,6 +12,7 @@ import type { Repository } from '../repo';
 
 const app = express();
 const SUB_OPERATION_CODE = 'test-submit-claim';
+const PRIOR_AUTH_SUB_OPERATION_CODE = 'test-submit-prior-auth';
 
 const minimalClaim: Claim = {
   resourceType: 'Claim',
@@ -32,7 +33,8 @@ const minimalClaim: Claim = {
 };
 
 // Bot handler that echoes the submitted Claim back as a minimal ClaimResponse.
-const claimResponseBotCode = `
+function getClaimResponseBotCode(insurerDisplay: string): string {
+  return `
   exports.handler = async function (medplum, event) {
     const claim = event.input;
     return {
@@ -42,26 +44,36 @@ const claimResponseBotCode = `
       use: claim.use,
       patient: claim.patient,
       created: '2026-01-01T00:00:00.000Z',
-      insurer: { display: 'Test Payer' },
+      insurer: { display: '${insurerDisplay}' },
       outcome: 'complete',
     };
   };
 `;
+}
 
-// Sets the CLAIM_SUBMIT_OPERATION project setting to the given operation code.
-async function setClaimSubmitOperation(repo: Repository, project: WithId<Project>, code: string): Promise<void> {
+// Sets a claim submit project setting to the given operation code.
+async function setClaimSubmitOperation(
+  repo: Repository,
+  project: WithId<Project>,
+  code: string,
+  name = 'CLAIM_SUBMIT_OPERATION'
+): Promise<void> {
   const systemRepo = repo.getSystemRepo();
   await withTestContext(async () => {
-    const latest = await systemRepo.readResource('Project', project.id);
+    const latest = await systemRepo.readResource<Project>('Project', project.id);
     await systemRepo.updateResource({
       ...latest,
-      setting: [{ name: 'CLAIM_SUBMIT_OPERATION', valueString: code }],
+      setting: [...(latest.setting?.filter((s) => s.name !== name) ?? []), { name, valueString: code }],
     });
   });
 }
 
 // Creates a custom claim-submit OperationDefinition backed by a deployed Bot.
-async function deployClaimOperation(accessToken: string, code = SUB_OPERATION_CODE): Promise<void> {
+async function deployClaimOperation(
+  accessToken: string,
+  code = SUB_OPERATION_CODE,
+  insurerDisplay = 'Test Payer'
+): Promise<void> {
   const res1 = await request(app)
     .post('/fhir/R4/Bot')
     .set('Content-Type', ContentType.FHIR_JSON)
@@ -74,7 +86,7 @@ async function deployClaimOperation(accessToken: string, code = SUB_OPERATION_CO
     .post(`/fhir/R4/Bot/${bot.id}/$deploy`)
     .set('Content-Type', ContentType.FHIR_JSON)
     .set('Authorization', 'Bearer ' + accessToken)
-    .send({ code: claimResponseBotCode });
+    .send({ code: getClaimResponseBotCode(insurerDisplay) });
   expect(res2.status).toBe(200);
 
   const res3 = await request(app)
@@ -102,8 +114,8 @@ async function deployClaimOperation(accessToken: string, code = SUB_OPERATION_CO
   expect(res3.status).toBe(201);
 }
 
-function bodyWith(resource?: Claim): object {
-  const parameter: { name: string; resource?: Claim }[] = [];
+function bodyWith(resource?: Bundle | Claim): object {
+  const parameter: { name: string; resource?: Bundle | Claim }[] = [];
   if (resource !== undefined) {
     parameter.push({ name: 'resource', resource });
   }
@@ -130,6 +142,17 @@ describe('Claim $submit', () => {
       .send(bodyWith(minimalClaim));
     expect(res.status).toBe(400);
     expect(JSON.stringify(res.body)).toMatch(/not configured/i);
+  });
+
+  test('Returns 400 when PRIOR_AUTH_SUBMIT_OPERATION is not configured for preauthorization', async () => {
+    const accessToken = await initTestAuth();
+    const res = await request(app)
+      .post('/fhir/R4/Claim/$submit')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send(bodyWith({ ...minimalClaim, use: 'preauthorization' }));
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/PRIOR_AUTH_SUBMIT_OPERATION/);
   });
 
   test('Returns 400 when the configured operation has no matching OperationDefinition', async () => {
@@ -161,6 +184,85 @@ describe('Claim $submit', () => {
     expect(res.body.outcome).toBe('complete');
   });
 
+  test('Dispatches a raw Claim body to the operation named by the CLAIM_SUBMIT_OPERATION project setting', async () => {
+    const { project, accessToken, repo } = await createTestProject({ withAccessToken: true, withRepo: true });
+    await deployClaimOperation(accessToken);
+    await setClaimSubmitOperation(repo, project, SUB_OPERATION_CODE);
+
+    const res = await request(app)
+      .post('/fhir/R4/Claim/$submit')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send(minimalClaim);
+    expect(res.status).toBe(200);
+    expect(res.body.resourceType).toBe('ClaimResponse');
+    expect(res.body.outcome).toBe('complete');
+  });
+
+  test('Dispatches preauthorization claims to the PRIOR_AUTH_SUBMIT_OPERATION project setting', async () => {
+    const { project, accessToken, repo } = await createTestProject({ withAccessToken: true, withRepo: true });
+    await deployClaimOperation(accessToken, SUB_OPERATION_CODE, 'Claim Payer');
+    await deployClaimOperation(accessToken, PRIOR_AUTH_SUB_OPERATION_CODE, 'Prior Auth Payer');
+    await setClaimSubmitOperation(repo, project, SUB_OPERATION_CODE);
+    await setClaimSubmitOperation(repo, project, PRIOR_AUTH_SUB_OPERATION_CODE, 'PRIOR_AUTH_SUBMIT_OPERATION');
+
+    const res = await request(app)
+      .post('/fhir/R4/Claim/$submit')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send(bodyWith({ ...minimalClaim, use: 'preauthorization' }));
+    expect(res.status).toBe(200);
+    expect(res.body.resourceType).toBe('ClaimResponse');
+    expect(res.body.use).toBe('preauthorization');
+    expect(res.body.insurer?.display).toBe('Prior Auth Payer');
+  });
+
+  test('Dispatches Bundles containing preauthorization claims to the PRIOR_AUTH_SUBMIT_OPERATION project setting', async () => {
+    const { project, accessToken, repo } = await createTestProject({ withAccessToken: true, withRepo: true });
+    await deployClaimOperation(accessToken, SUB_OPERATION_CODE, 'Claim Payer');
+    await deployClaimOperation(accessToken, PRIOR_AUTH_SUB_OPERATION_CODE, 'Prior Auth Payer');
+    await setClaimSubmitOperation(repo, project, SUB_OPERATION_CODE);
+    await setClaimSubmitOperation(repo, project, PRIOR_AUTH_SUB_OPERATION_CODE, 'PRIOR_AUTH_SUBMIT_OPERATION');
+
+    const bundle: Bundle = {
+      resourceType: 'Bundle',
+      type: 'collection',
+      entry: [
+        { resource: { ...minimalClaim, use: 'preauthorization' } },
+        { resource: { resourceType: 'Patient', id: 'example' } },
+      ],
+    };
+
+    const res = await request(app)
+      .post('/fhir/R4/Claim/$submit')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send(bundle);
+    expect(res.status).toBe(200);
+    expect(res.body.resourceType).toBe('ClaimResponse');
+    expect(res.body.insurer?.display).toBe('Prior Auth Payer');
+  });
+
+  test('Returns 400 when a Bundle does not contain a Claim', async () => {
+    const { project, accessToken, repo } = await createTestProject({ withAccessToken: true, withRepo: true });
+    await deployClaimOperation(accessToken);
+    await setClaimSubmitOperation(repo, project, SUB_OPERATION_CODE);
+
+    const res = await request(app)
+      .post('/fhir/R4/Claim/$submit')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send(
+        bodyWith({
+          resourceType: 'Bundle',
+          type: 'collection',
+          entry: [{ resource: { resourceType: 'Patient', id: 'example' } }],
+        })
+      );
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/Claim submit must contain at least one Claim resource/i);
+  });
+
   test('Reads the Claim from the URL on the instance route', async () => {
     const { project, accessToken, repo } = await createTestProject({ withAccessToken: true, withRepo: true });
     await deployClaimOperation(accessToken);
@@ -175,7 +277,7 @@ describe('Claim $submit', () => {
     const claimId = createRes.body.id;
 
     const res = await request(app)
-      .get(`/fhir/R4/Claim/${claimId}/$submit`)
+      .post(`/fhir/R4/Claim/${claimId}/$submit`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Accept', 'application/fhir+json');
     expect(res.status).toBe(200);

--- a/packages/server/src/fhir/operations/claimsubmit.ts
+++ b/packages/server/src/fhir/operations/claimsubmit.ts
@@ -1,72 +1,63 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { badRequest } from '@medplum/core';
+import { badRequest, isResource } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Claim } from '@medplum/fhirtypes';
+import type { Bundle, Claim } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { tryCustomOperation } from './custom';
-import { makeOperationDefinition } from './definitions';
+import { getOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
 
 const CLAIM_SUBMIT_OPERATION_SETTING = 'CLAIM_SUBMIT_OPERATION';
+const PRIOR_AUTH_SUBMIT_OPERATION_SETTING = 'PRIOR_AUTH_SUBMIT_OPERATION';
 
-export const operation = makeOperationDefinition(
-  { scope: 'type-and-instance', resource: 'Claim' },
-  {
-    name: 'claim-submit',
-    code: 'submit',
-    parameter: [
-      {
-        use: 'in',
-        name: 'resource',
-        type: 'Claim',
-        min: 1,
-        max: '1',
-        documentation: 'The Claim to submit (for type-level POST).',
-      },
-      {
-        use: 'out',
-        name: 'return',
-        type: 'ClaimResponse',
-        min: 1,
-        max: '1',
-        documentation: 'The ClaimResponse returned by the underlying claim submission operation.',
-      },
-    ],
-  }
-);
+export const operation = getOperationDefinition('Claim', 'submit');
 
 interface ClaimSubmitParameters {
-  readonly resource: Claim;
+  readonly resource: Bundle | Claim;
 }
 
 /**
  * Common function to handle claim submit operations.
  *
- * Dispatches to the custom OperationDefinition named by the CLAIM_SUBMIT_OPERATION project
- * setting, passing the Claim resource as the request body. The core server stays
+ * Dispatches to the custom OperationDefinition named by the relevant project setting,
+ * passing the Claim or Bundle resource as the request body. The core server stays
  * vendor-neutral: any claim processor registers a custom OperationDefinition whose
  * implementation is a Bot, and $submit forwards to it via tryCustomOperation.
  *
  * @param req - The FHIR request.
- * @param claim - The FHIR Claim resource to submit.
+ * @param resource - The FHIR Claim or Bundle resource to submit.
  * @returns The FHIR response from the underlying custom operation.
  */
-async function handleClaimSubmit(req: FhirRequest, claim: Claim): Promise<FhirResponse> {
+async function handleClaimSubmit(req: FhirRequest, resource: Bundle | Claim): Promise<FhirResponse> {
   const { project, repo } = getAuthenticatedContext();
 
-  const customOperationCode = project.setting?.find((s) => s.name === CLAIM_SUBMIT_OPERATION_SETTING)?.valueString;
-  if (!customOperationCode) {
-    return [badRequest('Claim submit is not configured: set the CLAIM_SUBMIT_OPERATION project setting.')];
+  let claim: Claim | undefined = undefined;
+  if (isResource<Claim>(resource, 'Claim')) {
+    claim = resource;
+  } else if (isResource<Bundle>(resource, 'Bundle')) {
+    claim = resource.entry?.find((e) => isResource(e.resource, 'Claim'))?.resource as Claim | undefined;
   }
 
-  // Normalize to a type-level POST so tryCustomOperation forwards the Claim as the body,
+  if (!claim) {
+    return [badRequest('Claim submit must contain at least one Claim resource.')];
+  }
+
+  const operationSetting =
+    claim.use === 'preauthorization' ? PRIOR_AUTH_SUBMIT_OPERATION_SETTING : CLAIM_SUBMIT_OPERATION_SETTING;
+
+  const customOperationCode = project.setting?.find((s) => s.name === operationSetting)?.valueString;
+  if (!customOperationCode) {
+    return [badRequest(`Claim submit is not configured: set the ${operationSetting} project setting.`)];
+  }
+
+  // Normalize to a type-level POST so tryCustomOperation forwards the Claim or Bundle as the body,
   // regardless of whether the original request was the instance-level GET or type-level POST.
   const subRequest: FhirRequest = {
     ...req,
     method: 'POST',
     url: `/Claim/$${customOperationCode}`,
-    body: claim,
+    body: resource,
   };
   const result = await tryCustomOperation(subRequest, repo);
   if (!result) {
@@ -80,7 +71,7 @@ async function handleClaimSubmit(req: FhirRequest, claim: Claim): Promise<FhirRe
 }
 
 /**
- * Handles HTTP GET requests for the instance-level Claim $submit operation.
+ * Handles HTTP POST requests for the instance-level Claim $submit operation.
  *
  * Reads the claim from the database and dispatches it to the configured claim processor.
  *
@@ -90,7 +81,7 @@ async function handleClaimSubmit(req: FhirRequest, claim: Claim): Promise<FhirRe
  * @param req - The FHIR request.
  * @returns The FHIR response from the underlying custom operation.
  */
-export async function claimSubmitGetHandler(req: FhirRequest): Promise<FhirResponse> {
+export async function claimSubmitPostByIdHandler(req: FhirRequest): Promise<FhirResponse> {
   const { repo } = getAuthenticatedContext();
   const claimId = req.params.id;
 
@@ -116,10 +107,5 @@ export async function claimSubmitGetHandler(req: FhirRequest): Promise<FhirRespo
 export async function claimSubmitPostHandler(req: FhirRequest): Promise<FhirResponse> {
   const params = parseInputParameters<ClaimSubmitParameters>(operation, req);
   const claim = params.resource;
-
-  if (!claim) {
-    return [badRequest('The resource Claim is required')];
-  }
-
   return handleClaimSubmit(req, claim);
 }

--- a/packages/server/src/fhir/operations/claimsubmit.ts
+++ b/packages/server/src/fhir/operations/claimsubmit.ts
@@ -52,7 +52,7 @@ async function handleClaimSubmit(req: FhirRequest, resource: Bundle | Claim): Pr
   }
 
   // Normalize to a type-level POST so tryCustomOperation forwards the Claim or Bundle as the body,
-  // regardless of whether the original request was the instance-level GET or type-level POST.
+  // regardless of whether the original request was instance-level or type-level.
   const subRequest: FhirRequest = {
     ...req,
     method: 'POST',

--- a/packages/server/src/fhir/operations/utils/parameters.test.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.test.ts
@@ -131,6 +131,30 @@ const NestedOutputOperation: OperationDefinition = {
   ],
 };
 
+const SingleResourceInputOperation: OperationDefinition = {
+  resourceType: 'OperationDefinition',
+  name: 'single-resource-input',
+  status: 'active',
+  kind: 'operation',
+  code: 'single-resource-input',
+  system: true,
+  type: false,
+  instance: false,
+  parameter: [{ name: 'resource', use: 'in', min: 1, max: '1', type: 'Resource' }],
+};
+
+const SingleTypedResourceInputOperation: OperationDefinition = {
+  resourceType: 'OperationDefinition',
+  name: 'single-typed-resource-input',
+  status: 'active',
+  kind: 'operation',
+  code: 'single-typed-resource-input',
+  system: true,
+  type: false,
+  instance: false,
+  parameter: [{ name: 'patient', use: 'in', min: 1, max: '1', type: 'Patient' }],
+};
+
 describe('Operation Input/Output Parameters', () => {
   beforeAll(() => {
     indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json'));
@@ -258,6 +282,26 @@ describe('Operation Input/Output Parameters', () => {
         singleIn: 'Yo',
         complexIn: [{ reference: 'Observation/bp' }, { reference: 'Observation/bmi' }],
       });
+    });
+
+    test('Reads raw Resource body for single Resource input parameter', () => {
+      const patient: Patient = { resourceType: 'Patient', id: 'test-patient' };
+      const req: Request = { body: patient } as unknown as Request;
+      expect(parseInputParameters(SingleResourceInputOperation, req)).toEqual({ resource: patient });
+    });
+
+    test('Reads raw typed Resource body for single typed Resource input parameter', () => {
+      const patient: Patient = { resourceType: 'Patient', id: 'test-patient' };
+      const req: Request = { body: patient } as unknown as Request;
+      expect(parseInputParameters(SingleTypedResourceInputOperation, req)).toEqual({ patient });
+    });
+
+    test('Rejects raw Resource body that does not match the single typed Resource input parameter', () => {
+      const observation: Observation = { resourceType: 'Observation', status: 'final', code: { text: 'Test' } };
+      const req: Request = { body: observation } as unknown as Request;
+      expect(() => parseInputParameters(SingleTypedResourceInputOperation, req)).toThrow(
+        `Expected at least 1 value(s) for required input parameter 'patient'`
+      );
     });
 
     test.each<[Parameters | Record<string, any>, string]>([

--- a/packages/server/src/fhir/operations/utils/parameters.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.ts
@@ -48,7 +48,7 @@ export function parseInputParameters<T>(operation: OperationDefinition, req: Req
   // Otherwise, use the body
   const input = req.method === 'GET' ? parseQueryString(req.query, inputParameters) : req.body;
 
-  if (isResourceInputParam<T>(inputParameters, input)) {
+  if (isResourceInputParam(inputParameters, input)) {
     const param = inputParameters[0];
     return { [param.name]: validateInputParam(param, input) } as T;
   }
@@ -66,16 +66,13 @@ export function parseInputParameters<T>(operation: OperationDefinition, req: Req
   }
 }
 
-function isResourceInputParam<T>(inputParameters: OperationDefinitionParameter[], input: unknown): T | undefined {
-  if (
-    isResource(input) &&
-    input.resourceType !== 'Parameters' &&
-    inputParameters.length === 1 &&
-    (inputParameters[0].type === 'Resource' || isResource(input, inputParameters[0].type as ResourceType))
-  ) {
-    return input as T;
+function isResourceInputParam(inputParameters: OperationDefinitionParameter[], input: unknown): boolean {
+  if (!isResource(input) || input.resourceType === 'Parameters' || inputParameters.length !== 1) {
+    return false;
   }
-  return undefined;
+
+  const paramType = inputParameters[0].type;
+  return paramType === 'Resource' || (!!paramType && isResource(input, paramType as ResourceType));
 }
 
 function parseQueryString(

--- a/packages/server/src/fhir/operations/utils/parameters.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.ts
@@ -48,6 +48,11 @@ export function parseInputParameters<T>(operation: OperationDefinition, req: Req
   // Otherwise, use the body
   const input = req.method === 'GET' ? parseQueryString(req.query, inputParameters) : req.body;
 
+  if (isResourceInputParam<T>(inputParameters, input)) {
+    const param = inputParameters[0];
+    return { [param.name]: validateInputParam(param, input) } as T;
+  }
+
   if (input.resourceType === 'Parameters') {
     if (!input.parameter) {
       return {} as T;
@@ -59,6 +64,18 @@ export function parseInputParameters<T>(operation: OperationDefinition, req: Req
       inputParameters.map((param) => [param.name, validateInputParam(param, input[param.name])])
     ) as T;
   }
+}
+
+function isResourceInputParam<T>(inputParameters: OperationDefinitionParameter[], input: unknown): T | undefined {
+  if (
+    isResource(input) &&
+    input.resourceType !== 'Parameters' &&
+    inputParameters.length === 1 &&
+    (inputParameters[0].type === 'Resource' || isResource(input, inputParameters[0].type as ResourceType))
+  ) {
+    return input as T;
+  }
+  return undefined;
 }
 
 function parseQueryString(

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -30,7 +30,7 @@ import { appointmentCancelHandler } from './operations/cancel';
 import { ccdaExportHandler } from './operations/ccdaexport';
 import { chargeItemDefinitionApplyHandler } from './operations/chargeitemdefinitionapply';
 import { claimExportGetHandler, claimExportPostHandler } from './operations/claimexport';
-import { claimSubmitGetHandler, claimSubmitPostHandler } from './operations/claimsubmit';
+import { claimSubmitPostByIdHandler, claimSubmitPostHandler } from './operations/claimsubmit';
 import { clearAllWsSubsHandler } from './operations/clearallwssubs';
 import { codeSystemImportHandler } from './operations/codesystemimport';
 import { codeSystemLookupHandler } from './operations/codesystemlookup';
@@ -334,9 +334,8 @@ function initInternalFhirRouter(): FhirRouter {
   router.add('GET', '/Claim/:id/$export', claimExportGetHandler);
 
   // Claim $submit operation (dispatches to the custom operation configured via CLAIM_SUBMIT_OPERATION).
-  // POST passes the Claim via the 'resource' input parameter; GET reads the Claim from the URL.
   router.add('POST', '/Claim/$submit', claimSubmitPostHandler);
-  router.add('GET', '/Claim/:id/$submit', claimSubmitGetHandler);
+  router.add('POST', '/Claim/:id/$submit', claimSubmitPostByIdHandler);
 
   // Group $export operation
   router.add('GET', '/Group/:id/$export', groupExportHandler);

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -333,7 +333,7 @@ function initInternalFhirRouter(): FhirRouter {
   router.add('POST', '/Claim/$export', claimExportPostHandler);
   router.add('GET', '/Claim/:id/$export', claimExportGetHandler);
 
-  // Claim $submit operation (dispatches to the custom operation configured via CLAIM_SUBMIT_OPERATION).
+  // Claim $submit operation (dispatches to the configured claim or prior auth custom operation).
   router.add('POST', '/Claim/$submit', claimSubmitPostHandler);
   router.add('POST', '/Claim/:id/$submit', claimSubmitPostByIdHandler);
 


### PR DESCRIPTION
Adds basic Prior Authorization Support (PAS) routing to the `Claim/$submit` operation.

- Uses the canonical FHIR `Claim-submit` OperationDefinition so `$submit` accepts a `Resource` input, including `Claim` and `Bundle`
- Routes `Claim.use === 'preauthorization'` submissions through the `PRIOR_AUTH_SUBMIT_OPERATION` project setting
- Keeps existing claim submission behavior routed through `CLAIM_SUBMIT_OPERATION`
- Supports both type-level `POST /Claim/$submit` and instance-level `POST /Claim/:id/$submit`
- Allows Bundle inputs and uses the first contained `Claim` to choose the dispatch setting
- Returns a 400 response when a Bundle input does not contain any Claim resource
- Adds raw resource body support for single-resource operation inputs