### PR TITLE
fix(server): reject Prefer: respond-async in $set-accounts without propagate

### DIFF
--- a/packages/server/src/fhir/operations/set-accounts.test.ts
+++ b/packages/server/src/fhir/operations/set-accounts.test.ts
@@ -452,6 +452,25 @@ describe('Patient Set Accounts Operation', () => {
     );
   });
 
+  test('Rejects async response without propagate', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/Patient/${patient.id}/$set-accounts`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .set('Prefer', 'respond-async')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'accounts',
+            valueReference: createReference(organization1),
+          },
+        ],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.issue?.[0]?.details?.text).toContain('propagate');
+  });
+
   test('Removes account without extended header', async () => {
     const setTwo = await request(app)
       .post(`/fhir/R4/Patient/${patient.id}/$set-accounts`)

--- a/packages/server/src/fhir/operations/set-accounts.ts
+++ b/packages/server/src/fhir/operations/set-accounts.ts
@@ -89,7 +89,14 @@ export async function setAccountsHandler(req: FhirRequest): Promise<FhirResponse
   const params = parseInputParameters<SetAccountsParameters>(operation, req);
 
   const { repo } = getAuthenticatedContext();
-  if (req.headers?.['prefer'] === 'respond-async' && params.propagate) {
+  const respondAsync = req.headers?.['prefer'] === 'respond-async';
+  if (respondAsync && !params.propagate) {
+    return [
+      badRequest('Prefer: respond-async is only supported for the $set-accounts operation when propagate is true'),
+    ];
+  }
+
+  if (respondAsync) {
     const { baseUrl } = getConfig();
     const exec = new AsyncJobExecutor(repo);
     const asyncJob = await exec.init(concatUrls(baseUrl, `${resourceType}/${id}/$set-accounts`));


### PR DESCRIPTION
## Summary

Fixes #8926.

When calling `$set-accounts` with `Prefer: respond-async` but without `propagate: true`, the server silently ran the operation synchronously instead of honoring the async preference. The caller had no indication their preference was ignored — the response looked like a normal synchronous 200.

This happened because the async branch was gated on `respond-async && params.propagate`; without `propagate`, execution short-circuited to the synchronous path.

The async worker only exists for the potentially long-running compartment propagation (the worker hardcodes `propagate: true`), so a non-propagate call has nothing to run in the background. Rather than silently falling back, this change returns a **400 Bad Request** so callers know the combination is unsupported (Option 1 from the issue).

## Changes

- `packages/server/src/fhir/operations/set-accounts.ts`: return `badRequest` when `respond-async` is requested without `propagate`.
- `packages/server/src/fhir/operations/set-accounts.test.ts`: add a test asserting the 400 response.

## Testing

- Typechecks cleanly.
- ⚠️ The vitest suite could not be run in my environment (server tests require Postgres + Redis, which weren't available). Please run `npm test -- src/fhir/operations/set-accounts.test.ts` in `packages/server` against a database to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)