### PR TITLE
More fine grained codeowners and PR review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,25 +5,30 @@
 # Order is important; the last matching pattern takes the most precedence.
 # GitHub CODEOWNERS computes required reviewers per-file. The required set for a PR is the union
 # of each changed file's owner (last matching pattern wins).
+#
+# @medplum/dev is the "backdrop" team: it is listed as a co-owner on every line so a dev member's
+# approval can satisfy the code-owner requirement for any file -- a break-glass path when the
+# primary owner is unavailable. Owners on a line are alternatives, so only ONE of them needs to
+# approve.
 
-# Dev is the default owner for everything in the repo.
-* @medplum/dev
+# Core is the default owner for everything in the repo.
+* @medplum/core @medplum/dev
 
 # FDE is the default owner for the "examples" directory.
-/examples/ @medplum/fde
+/examples/ @medplum/fde @medplum/dev
 
-# Both Dev and FDE own the packages/docs directory.
-/packages/docs/ @medplum/dev @medplum/fde
+# Both Core and FDE own the packages/docs directory.
+/packages/docs/ @medplum/core @medplum/fde @medplum/dev
 
 # Product owns the frontend packages. A PR that only touches these packages
-# needs review from Product alone; touching anything else pulls in that file's owner too.
-/packages/react/ @medplum/product
-/packages/react-hooks/ @medplum/product
-/packages/app/ @medplum/product
+# needs review from Product (or dev as backdrop); touching anything else pulls in that file's owner too.
+/packages/react/ @medplum/product @medplum/dev
+/packages/react-hooks/ @medplum/product @medplum/dev
+/packages/app/ @medplum/product @medplum/dev
 
-# A PR only touching these packages needs review from Integrations alone.
-/packages/dosespot-core/ @medplum/integrations
-/packages/dosespot-react/ @medplum/integrations
-/packages/health-gorilla-core/ @medplum/integrations
-/packages/health-gorilla-react/ @medplum/integrations
-/packages/scriptsure-react/ @medplum/integrations
+# A PR only touching these packages needs review from Integrations (or dev as backdrop).
+/packages/dosespot-core/ @medplum/integrations @medplum/dev
+/packages/dosespot-react/ @medplum/integrations @medplum/dev
+/packages/health-gorilla-core/ @medplum/integrations @medplum/dev
+/packages/health-gorilla-react/ @medplum/integrations @medplum/dev
+/packages/scriptsure-react/ @medplum/integrations @medplum/dev

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,13 +20,13 @@
 # Both Core and FDE own the packages/docs directory.
 /packages/docs/ @medplum/core @medplum/fde @medplum/dev
 
-# Product owns the frontend packages. A PR that only touches these packages
-# needs review from Product (or dev as backdrop); touching anything else pulls in that file's owner too.
-/packages/react/ @medplum/product @medplum/dev
-/packages/react-hooks/ @medplum/product @medplum/dev
-/packages/app/ @medplum/product @medplum/dev
+# Frontend owns the frontend packages. A PR that only touches these packages
+# needs review from Product; touching anything else pulls in that file's owner too.
+/packages/react/ @medplum/frontend @medplum/dev
+/packages/react-hooks/ @medplum/frontend @medplum/dev
+/packages/app/ @medplum/frontend @medplum/dev
 
-# A PR only touching these packages needs review from Integrations (or dev as backdrop).
+# A PR only touching these packages needs review from Integrations.
 /packages/dosespot-core/ @medplum/integrations @medplum/dev
 /packages/dosespot-react/ @medplum/integrations @medplum/dev
 /packages/health-gorilla-core/ @medplum/integrations @medplum/dev

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,29 @@
 # Medplum Code Owners
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
-# This is a comment.
 # Each line is a file pattern followed by one or more owners.
-
 # Order is important; the last matching pattern takes the most precedence.
+# GitHub CODEOWNERS computes required reviewers per-file. The required set for a PR is the union
+# of each changed file's owner (last matching pattern wins).
 
 # Dev is the default owner for everything in the repo.
 * @medplum/dev
 
 # FDE is the default owner for the "examples" directory.
-/examples/ @medplum/dev @medplum/fde
+/examples/ @medplum/fde
 
 # Both Dev and FDE own the packages/docs directory.
 /packages/docs/ @medplum/dev @medplum/fde
+
+# Product owns the frontend packages. A PR that only touches these packages
+# needs review from Product alone; touching anything else pulls in that file's owner too.
+/packages/react/ @medplum/product
+/packages/react-hooks/ @medplum/product
+/packages/app/ @medplum/product
+
+# A PR only touching these packages needs review from Integrations alone.
+/packages/dosespot-core/ @medplum/integrations
+/packages/dosespot-react/ @medplum/integrations
+/packages/health-gorilla-core/ @medplum/integrations
+/packages/health-gorilla-react/ @medplum/integrations
+/packages/scriptsure-react/ @medplum/integrations

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,15 +1,8 @@
-# Set to true to add reviewers to pull requests
-addReviewers: true
+# Reviewer assignment is handled by CODEOWNERS plus each team's
+# "Code review assignment" setting (Org -> Teams -> <team> -> Settings -> Code review),
+# which routes a team review request to a single member. This action only sets the
+# PR author as the assignee so the PR shows up in their "assigned" list.
+addReviewers: false
 
 # Set addAssignees to 'author' to set the PR creator as the assignee.
 addAssignees: author
-
-# A list of reviewers to be added to pull requests (GitHub user name)
-reviewers:
-  - mattlong
-  - mattwiller
-  - ThatOneBro
-
-# A number of reviewers added to the pull request
-# Set 0 to add all the reviewers (default: 0)
-numberOfReviewers: 1


### PR DESCRIPTION
With the previous config, all PRs were routed to three people which was a bottleneck. Attempting to spread it out to keep the PRs flowing. This means leaning more on `CODEOWNERS` and saying goodbye to `auto_assign.yml` which does not support disparate team assignment.

In addition to the changes in the PR, three new Github teams will be needed: **Core**, **Frontend**, **Integrations**. These teams will be configured to be auto-assigned to PRs.

The existing `@medplum/dev` is listed as a co-owner on every line, but will NOT be configured to auto-assign PR reviews. This is to allow anyone on that team to still be able to approve and allow a PR to be merged. This should effectively maintain backwards compatibility with our current branch protection rules on `main`.