### PR TITLE
Fix DiagnosticReport conclusion field matching

### DIFF
--- a/packages/react/src/SearchControl/SearchControlField.test.ts
+++ b/packages/react/src/SearchControl/SearchControlField.test.ts
@@ -19,4 +19,23 @@ describe('getFieldDefinitions', () => {
     expect(identifierField?.searchParams?.length).toBe(1);
     expect(identifierField?.searchParams?.find((sp) => sp.code === 'identifier')).toBeDefined();
   });
+
+  test('DiagnosticReport conclusion does not match conclusionCode search parameter', () => {
+    const fieldDefs = getFieldDefinitions({
+      resourceType: 'DiagnosticReport',
+      fields: ['conclusion', 'conclusionCode'],
+    });
+
+    expect(fieldDefs.length).toBe(2);
+    const conclusionField = fieldDefs.find((field) => field.name === 'conclusion');
+    const conclusionCodeField = fieldDefs.find((field) => field.name === 'conclusionCode');
+
+    expect(conclusionField?.elementDefinition?.path).toBe('DiagnosticReport.conclusion');
+    expect(conclusionField?.searchParams).toBeUndefined();
+
+    expect(conclusionCodeField?.elementDefinition?.path).toBe('DiagnosticReport.conclusionCode');
+    expect(conclusionCodeField?.searchParams?.length).toBe(1);
+    expect(conclusionCodeField?.searchParams?.[0]?.code).toBe('conclusion');
+    expect(conclusionCodeField?.searchParams?.[0]?.expression).toBe('DiagnosticReport.conclusionCode');
+  });
 });

--- a/packages/react/src/SearchControl/SearchControlField.ts
+++ b/packages/react/src/SearchControl/SearchControlField.ts
@@ -103,7 +103,11 @@ function getFieldDefinition(resourceType: string, name: string): SearchControlFi
   // Best case: Exact match of element definition or search parameter.
   // Examples: ServiceRequest.subject, Patient.name, Patient.birthDate
   // In this case, we only show the one search parameter.
-  if (exactElementDefinition && exactSearchParam) {
+  if (
+    exactElementDefinition &&
+    exactSearchParam &&
+    isExactElementSearchParameter(resourceType, name, exactSearchParam)
+  ) {
     return { name, elementDefinition: exactElementDefinition, searchParams: [exactSearchParam] };
   }
 
@@ -115,12 +119,7 @@ function getFieldDefinition(resourceType: string, name: string): SearchControlFi
     const allSearchParams = getSearchParameters(resourceType);
     let searchParams: SearchParameter[] | undefined = undefined;
     if (allSearchParams) {
-      // To avoid matching names that happen to be prefixes of other names, e.g. id and identifier,
-      // match ${resourceType}.${name} followed by a non-name character OR the end of the string
-      // Name characters include letters, numbers, underscores, and hyphens
-      const pathRegex = new RegExp(`${resourceType}\\.${name.replaceAll('[x]', '')}([^\\w-]|$)`);
-
-      searchParams = Object.values(allSearchParams).filter((p) => !!p.expression && pathRegex.test(p?.expression));
+      searchParams = Object.values(allSearchParams).filter((p) => searchParameterMatchesElement(resourceType, name, p));
       if (searchParams.length === 0) {
         searchParams = undefined;
       }
@@ -143,4 +142,20 @@ function getFieldDefinition(resourceType: string, name: string): SearchControlFi
   // This is probably a malformed URL that includes an unknown field.
   // We will render the column header, but all cells will be empty.
   return { name };
+}
+
+function searchParameterMatchesElement(resourceType: string, name: string, searchParam: SearchParameter): boolean {
+  if (!searchParam.expression) {
+    return false;
+  }
+
+  // To avoid matching names that happen to be prefixes of other names, e.g. id and identifier,
+  // match ${resourceType}.${name} followed by a non-name character OR the end of the string.
+  // Name characters include letters, numbers, underscores, and hyphens.
+  const pathRegex = new RegExp(`${resourceType}\\.${name.replaceAll('[x]', '')}([^\\w-]|$)`);
+  return pathRegex.test(searchParam.expression);
+}
+
+function isExactElementSearchParameter(resourceType: string, name: string, searchParam: SearchParameter): boolean {
+  return searchParam.code !== name.toLowerCase() || searchParameterMatchesElement(resourceType, name, searchParam);
 }


### PR DESCRIPTION
Fixes #4761.

This fixes the SearchControl field matching for `DiagnosticReport.conclusion` and `DiagnosticReport.conclusionCode`.

FHIR R4 defines a `conclusion` SearchParameter whose expression points to `DiagnosticReport.conclusionCode`. Because `SearchControlField` previously treated an exact element name and exact SearchParameter code as a match without checking the expression, the free-text `DiagnosticReport.conclusion` element could be associated with the token SearchParameter for `DiagnosticReport.conclusionCode`.

This PR verifies that same-code exact SearchParameters actually match the element path before associating them with an exact element. It preserves existing alias behavior for SearchParameters whose code differs from the selected field name.

Validation:
- `npm --workspace packages/react test -- SearchControlField.test.ts`
- `npm --workspace packages/react test -- SearchControlField.test.ts SearchPopupMenu.test.tsx`
- `npx prettier --check packages/react/src/SearchControl/SearchControlField.ts packages/react/src/SearchControl/SearchControlField.test.ts`
- `git diff --check`

Note: the full local `npm --workspace packages/react test` suite was also run, but unrelated locale-sensitive assertions failed on this Windows environment (currency, date, and number formatting).