### PR TITLE
Reentrant async batch

### DIFF
--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -90,7 +90,7 @@ export class Logger implements ILogger {
   clone(override?: LoggerConfigOverride): Logger {
     const config = this.getLoggerConfig();
     const mergedConfig = override
-      ? { ...config, override, options: { ...config.options, ...override.options } }
+      ? { ...config, ...override, options: { ...config.options, ...override.options } }
       : config;
     return new Logger(mergedConfig.write, mergedConfig.metadata, mergedConfig.level, mergedConfig.options);
   }

--- a/packages/fhir-router/src/batch.test.ts
+++ b/packages/fhir-router/src/batch.test.ts
@@ -1440,7 +1440,9 @@ describe('Batch', () => {
       while (processor.hasMoreEntries()) {
         await processor.processNextEntry();
         // Checkpoint: persist newly produced results and the advanced progress marker.
-        Object.assign(results, processor.takePendingResults());
+        const pending = processor.takePendingResults();
+        assert(pending);
+        Object.assign(results, pending);
         processed++;
 
         if (crashAfter !== undefined && !crashed && processed === crashAfter && processor.hasMoreEntries()) {
@@ -1520,7 +1522,10 @@ describe('Batch', () => {
       // Process the first entry, then take its results (checkpoint) and record the position.
       await processor.processNextEntry();
       const firstResults = processor.takePendingResults();
+      assert(firstResults);
       expect(Object.keys(firstResults)).toHaveLength(1);
+      const secondTake = processor.takePendingResults();
+      expect(secondTake).toBeUndefined();
       const resumePosition = processor.getPosition();
       expect(resumePosition).toStrictEqual(1);
 
@@ -1530,7 +1535,9 @@ describe('Batch', () => {
       const producedIndices = new Set<number>();
       while (resumed.hasMoreEntries()) {
         await resumed.processNextEntry();
-        for (const index of Object.keys(resumed.takePendingResults())) {
+        const pending = resumed.takePendingResults();
+        assert(pending);
+        for (const index of Object.keys(pending)) {
           producedIndices.add(Number(index));
         }
       }

--- a/packages/fhir-router/src/batch.test.ts
+++ b/packages/fhir-router/src/batch.test.ts
@@ -28,7 +28,8 @@ import type {
   Subscription,
 } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
-import { processBatch } from './batch';
+import type { BatchInitialState } from './batch';
+import { BatchProcessor, buildBatchResponseBundle, processBatch } from './batch';
 import type { FhirRequest } from './fhirrouter';
 import { FhirRouter } from './fhirrouter';
 import type { FhirRepository } from './repo';
@@ -1411,6 +1412,153 @@ describe('Batch', () => {
         outcome: badRequest('Cannot provide ID for create by update'),
       }),
       resource: undefined,
+    });
+  });
+
+  describe('Re-entrant processing', () => {
+    /**
+     * Drives a batch bundle through the re-entrant BatchProcessor API, one entry at a time, the
+     * way the async batch worker does. All durable state (initial state, progress marker, and
+     * per-entry results) is round-tripped through JSON to simulate persistence to durable storage.
+     * @param bundle - The batch bundle to process.
+     * @param crashAfter - If set, simulate a crash + resume after this many entries have been
+     *   processed, rehydrating a fresh processor via BatchProcessor.fromState.
+     * @returns The assembled response bundle.
+     */
+    async function runReentrant(bundle: Bundle, crashAfter?: number): Promise<Bundle> {
+      const results: Record<number, BundleEntry> = Object.create(null);
+      const entryCount = bundle.entry?.length ?? 0;
+
+      let processor = new BatchProcessor(router, repo, bundle, req);
+      const initialState = await processor.preprocess();
+      // Simulate persisting the initial state to durable storage and reloading it.
+      const durableState: BatchInitialState = JSON.parse(JSON.stringify(initialState));
+      Object.assign(results, durableState.preprocessResults);
+
+      let processed = 0;
+      let crashed = false;
+      while (processor.hasMoreEntries()) {
+        await processor.processNextEntry();
+        // Checkpoint: persist newly produced results and the advanced progress marker.
+        Object.assign(results, processor.takePendingResults());
+        processed++;
+
+        if (crashAfter !== undefined && !crashed && processed === crashAfter && processor.hasMoreEntries()) {
+          crashed = true;
+          // Simulate a crash and resume: rehydrate a fresh processor from the durable state at the
+          // last checkpointed position. Prior results live in `results` (durable storage).
+          const position = processor.getPosition();
+          processor = BatchProcessor.fromState(router, repo, req, JSON.parse(JSON.stringify(durableState)), position);
+        }
+      }
+
+      return buildBatchResponseBundle(durableState.bundle.type, entryCount, results);
+    }
+
+    function makeReferenceBundle(): Bundle {
+      const patientId = randomUUID();
+      const observationId = randomUUID();
+      return {
+        resourceType: 'Bundle',
+        type: 'batch',
+        entry: [
+          {
+            fullUrl: 'urn:uuid:' + patientId,
+            request: { method: 'POST', url: 'Patient' },
+            resource: { resourceType: 'Patient', id: patientId },
+          },
+          {
+            fullUrl: 'urn:uuid:' + observationId,
+            request: { method: 'POST', url: 'Observation' },
+            resource: {
+              resourceType: 'Observation',
+              status: 'final',
+              id: observationId,
+              subject: { reference: 'urn:uuid:' + patientId },
+              code: { text: 'test' },
+            },
+          },
+          { request: { method: 'GET', url: 'Patient?_count=1' } },
+        ],
+      };
+    }
+
+    test('Full run matches one-shot processBatch behavior', async () => {
+      const oneShot = await processBatch(req, repo, router, makeReferenceBundle());
+      const reentrant = await runReentrant(makeReferenceBundle());
+
+      expect(reentrant.type).toStrictEqual('batch-response');
+      expect(reentrant.entry).toHaveLength(3);
+      expect(reentrant.entry?.map((e) => e.response?.status)).toStrictEqual(
+        oneShot.entry?.map((e) => e.response?.status)
+      );
+      expect(reentrant.entry?.map((e) => e.response?.status)).toStrictEqual(['201', '201', '200']);
+    });
+
+    test('Placeholder references survive serialize -> fromState -> resume', async () => {
+      // Crash + resume BEFORE the Observation (entry 1) is processed, so the reference rewrite
+      // happens on the rehydrated processor using durably-persisted resolvedIdentities.
+      const bundle = await runReentrant(makeReferenceBundle(), 1);
+
+      const patientEntry = bundle.entry?.[0];
+      const observationEntry = bundle.entry?.[1];
+      expect(patientEntry?.response?.status).toStrictEqual('201');
+      expect(observationEntry?.response?.status).toStrictEqual('201');
+
+      const patientRef = patientEntry?.response?.location;
+      expect(patientRef).toMatch(/^Patient\//);
+      // The Observation's placeholder subject reference must resolve to the SAME patient that was
+      // created during preprocessing, not a newly-generated id.
+      expect((observationEntry?.resource as Observation)?.subject?.reference).toStrictEqual(patientRef);
+    });
+
+    test('Resume does not reprocess already-completed entries', async () => {
+      const bundle = makeReferenceBundle();
+      const processor = new BatchProcessor(router, repo, bundle, req);
+      const initialState = await processor.preprocess();
+
+      // Process the first entry, then take its results (checkpoint) and record the position.
+      await processor.processNextEntry();
+      const firstResults = processor.takePendingResults();
+      expect(Object.keys(firstResults)).toHaveLength(1);
+      const resumePosition = processor.getPosition();
+      expect(resumePosition).toStrictEqual(1);
+
+      // Rehydrate at the checkpointed position and finish. The resumed processor must only
+      // produce results for the remaining entries, never re-producing the first entry.
+      const resumed = BatchProcessor.fromState(router, repo, req, initialState, resumePosition);
+      const producedIndices = new Set<number>();
+      while (resumed.hasMoreEntries()) {
+        await resumed.processNextEntry();
+        for (const index of Object.keys(resumed.takePendingResults())) {
+          producedIndices.add(Number(index));
+        }
+      }
+      const firstIndex = Number(Object.keys(firstResults)[0]);
+      expect(producedIndices.has(firstIndex)).toBe(false);
+      // The remaining two entries (indices 1 and 2) should have been produced by the resumed run.
+      expect(resumed.getPosition()).toStrictEqual(3);
+      expect(producedIndices).toStrictEqual(new Set([1, 2]));
+    });
+
+    test('processNextEntry before preprocess throws', async () => {
+      const processor = new BatchProcessor(router, repo, makeReferenceBundle(), req);
+      await expect(processor.processNextEntry()).rejects.toThrow('processNextEntry called before preprocess()');
+    });
+
+    test('Malformed entries are captured as preprocess results', async () => {
+      const bundle = await runReentrant({
+        resourceType: 'Bundle',
+        type: 'batch',
+        entry: [
+          { request: { method: 'POST', url: 'Patient' }, resource: { resourceType: 'Patient' } },
+          // Missing request method -> error result produced during preprocessing
+          { resource: { resourceType: 'Patient' } },
+        ],
+      });
+      expect(bundle.entry).toHaveLength(2);
+      expect(bundle.entry?.[0]?.response?.status).toStrictEqual('201');
+      expect(bundle.entry?.[1]?.response?.status).toStrictEqual('400');
     });
   });
 });

--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Event, WithId } from '@medplum/core';
 import {
-  append,
   badRequest,
   getReferenceString,
   getStatus,
@@ -39,6 +38,45 @@ type BundlePreprocessInfo = {
 };
 
 /**
+ * A JSON-serializable form of `BundlePreprocessInfo`, where `resourceTypes` is an
+ * array rather than a `Set` so it can be persisted to durable storage.
+ */
+export type SerializableBundleInfo = {
+  ordering: number[];
+  requiresStrongTransaction: boolean;
+  updates: number;
+};
+
+/**
+ * The durable, JSON-serializable state produced by preprocessing a batch bundle. This is
+ * everything required to (re)hydrate a {@link BatchProcessor} and resume processing after a
+ * server restart or worker crash, EXCEPT the progress marker (the index into `bundleInfo.ordering`
+ * of the next entry to process) and the per-entry results produced so far, both of which the
+ * caller (e.g. the async batch worker) is responsible for persisting separately.
+ *
+ * @see BatchProcessor.preprocess
+ * @see BatchProcessor.fromState
+ */
+export interface BatchInitialState {
+  /**
+   * The preprocessed bundle. During preprocessing the bundle is mutated in place: `create`
+   * entries are assigned resource IDs and conditional `update`/`delete` URLs are rewritten to
+   * absolute references. This mutated form MUST be persisted and reloaded verbatim — re-running
+   * preprocessing on the original bundle would assign fresh random IDs and break references to
+   * resources that were already created.
+   */
+  bundle: Bundle;
+  bundleInfo: SerializableBundleInfo;
+  resolvedIdentities: Record<string, string>;
+  /**
+   * Result entries produced during preprocessing itself (i.e. error responses for malformed
+   * entries in a non-transaction bundle), keyed by their index in the original bundle. These
+   * entries are never re-processed, so they are captured here rather than in per-entry progress.
+   */
+  preprocessResults: Record<number, BundleEntry>;
+}
+
+/**
  * Processes a FHIR batch request.
  *
  * See: https://www.hl7.org/fhir/http.html#transaction
@@ -61,13 +99,33 @@ export async function processBatch(
 /**
  * The BatchProcessor class contains the state for processing a batch/transaction bundle.
  * In particular, it tracks rewritten IDs as necessary.
+ *
+ * The processor supports two modes of operation:
+ *
+ * 1. One-shot via {@link BatchProcessor.run}, used for synchronous batch/transaction requests.
+ *    This preprocesses and then processes every entry within a single call.
+ *
+ * 2. Re-entrant, used by the async batch worker. The caller drives processing one entry at a
+ *    time via {@link BatchProcessor.preprocess}, {@link BatchProcessor.hasMoreEntries}, and
+ *    {@link BatchProcessor.processNextEntry}, persisting durable state ({@link BatchInitialState},
+ *    progress marker, and per-entry results) as it goes. After a restart the processor is
+ *    rehydrated via {@link BatchProcessor.fromState} and processing resumes from the persisted
+ *    marker. Only `batch` bundles are re-entrant; `transaction` bundles must use {@link BatchProcessor.run}.
  */
-class BatchProcessor {
+export class BatchProcessor {
   private readonly router: FhirRouter;
   private repo: FhirRepository;
-  private readonly bundle: Bundle;
+  private bundle: Bundle;
   private readonly req: FhirRequest;
-  private readonly resolvedIdentities: Record<string, string>;
+  private resolvedIdentities: Record<string, string>;
+  private bundleInfo: BundlePreprocessInfo | undefined;
+  private resultEntries: (BundleEntry | OperationOutcome)[];
+  /** Index into `bundleInfo.ordering` of the next entry to process. */
+  private position: number;
+  /** Indices (into the original bundle) of results produced since the last {@link BatchProcessor.takePendingResults} call. */
+  private pendingIndices: number[];
+  /** Error messages accumulated across processed entries, for the post-batch telemetry event. */
+  private readonly errors: string[];
 
   /**
    * Creates a batch processor.
@@ -82,38 +140,177 @@ class BatchProcessor {
     this.bundle = bundle;
     this.req = req;
     this.resolvedIdentities = Object.create(null);
+    this.resultEntries = new Array(bundle.entry?.length ?? 0);
+    this.position = 0;
+    this.pendingIndices = [];
+    this.errors = [];
   }
 
   /**
-   * Processes a FHIR batch request.
+   * Rehydrates a batch processor from previously-persisted durable state so that processing can
+   * resume after a server restart or worker crash. Intended for the re-entrant (async batch)
+   * flow; the caller is responsible for loading the {@link BatchInitialState} and progress marker
+   * from durable storage, and for assembling the final response bundle from the durably-persisted
+   * result entries (this instance only tracks results produced in the current run).
+   * @param router - The FHIR router.
+   * @param repo - The FHIR repository.
+   * @param req - The request for the batch.
+   * @param initialState - The durable state produced by {@link BatchProcessor.preprocess}.
+   * @param position - The index into `bundleInfo.ordering` of the next entry to process.
+   * @returns A batch processor positioned to resume at `position`.
+   */
+  static fromState(
+    router: FhirRouter,
+    repo: FhirRepository,
+    req: FhirRequest,
+    initialState: BatchInitialState,
+    position: number
+  ): BatchProcessor {
+    const processor = new BatchProcessor(router, repo, initialState.bundle, req);
+    processor.resolvedIdentities = initialState.resolvedIdentities;
+    processor.bundleInfo = {
+      ...initialState.bundleInfo,
+    };
+    processor.position = position;
+    return processor;
+  }
+
+  /**
+   * Processes a FHIR batch request in a single call.
    * @returns The bundle response.
    */
   async run(): Promise<Bundle> {
+    await this.preprocess();
+    const bundleInfo = this.bundleInfo as BundlePreprocessInfo;
+
+    if (!this.isTransaction()) {
+      return this.processEntriesAndBuild();
+    }
+
+    return this.repo.withTransaction((txRepo) => this.withRepo(txRepo, () => this.processEntriesAndBuild()), {
+      serializable: bundleInfo.requiresStrongTransaction,
+    });
+  }
+
+  /**
+   * Validates and preprocesses the bundle, scanning entries to resolve identities, rewrite
+   * conditional references, and compute processing order.
+   *
+   * For the re-entrant flow, the returned {@link BatchInitialState} should be persisted to
+   * durable storage before processing entries so that the processor can be rehydrated via
+   * {@link BatchProcessor.fromState} after a restart.
+   * @returns The durable initial state for the batch.
+   */
+  async preprocess(): Promise<BatchInitialState> {
     const bundleType = this.bundle.type;
     if (bundleType !== 'batch' && bundleType !== 'transaction') {
       throw new OperationOutcomeError(badRequest('Unrecognized bundle type: ' + bundleType));
     }
 
-    const resultEntries: (BundleEntry | OperationOutcome)[] = new Array(this.bundle.entry?.length ?? 0);
-    const bundleInfo = await this.preprocessBundle(resultEntries);
+    this.bundleInfo = await this.preprocessBundle(this.resultEntries);
 
-    if (!this.isTransaction()) {
-      return this.processBatch(bundleInfo, resultEntries);
-    }
-
-    if (bundleInfo.updates > maxUpdates) {
-      throw new OperationOutcomeError(badRequest('Transaction contains more update operations than allowed'));
-    }
-    if (bundleInfo.requiresStrongTransaction && resultEntries.length > maxSerializableTransactionEntries) {
-      throw new OperationOutcomeError(badRequest('Transaction requires strict isolation but has too many entries'));
-    }
-
-    return this.repo.withTransaction(
-      (txRepo) => this.withRepo(txRepo, () => this.processBatch(bundleInfo, resultEntries)),
-      {
-        serializable: bundleInfo.requiresStrongTransaction,
+    if (this.isTransaction()) {
+      if (this.bundleInfo.updates > maxUpdates) {
+        throw new OperationOutcomeError(badRequest('Transaction contains more update operations than allowed'));
       }
-    );
+      if (this.bundleInfo.requiresStrongTransaction && this.resultEntries.length > maxSerializableTransactionEntries) {
+        throw new OperationOutcomeError(badRequest('Transaction requires strict isolation but has too many entries'));
+      }
+    }
+
+    // Capture any result entries produced during preprocessing itself (error responses for
+    // malformed entries). These are never re-processed, so they belong in the initial state.
+    const preprocessResults: Record<number, BundleEntry> = Object.create(null);
+    for (let i = 0; i < this.resultEntries.length; i++) {
+      if (this.resultEntries[i]) {
+        preprocessResults[i] = this.resultEntries[i];
+      }
+    }
+
+    return {
+      bundle: this.bundle,
+      bundleInfo: {
+        ordering: this.bundleInfo.ordering,
+        requiresStrongTransaction: this.bundleInfo.requiresStrongTransaction,
+        updates: this.bundleInfo.updates,
+      },
+      resolvedIdentities: this.resolvedIdentities,
+      preprocessResults,
+    };
+  }
+
+  /**
+   * @returns True if there are more entries to process, i.e. {@link BatchProcessor.processNextEntry} should be
+   * called again.
+   */
+  hasMoreEntries(): boolean {
+    return this.bundleInfo !== undefined && this.position < this.bundleInfo.ordering.length;
+  }
+
+  /**
+   * @returns The index into `bundleInfo.ordering` of the next entry to process. This is the
+   * progress marker that should be persisted (together with the result entries produced so far)
+   * to allow resuming via {@link BatchProcessor.fromState}.
+   */
+  getPosition(): number {
+    return this.position;
+  }
+
+  /**
+   * Returns the result entries produced since the last call (keyed by their index in the
+   * original bundle) and clears the pending buffer. The caller persists these to durable
+   * storage as a checkpoint before advancing the durable progress marker.
+   * @returns Newly-produced result entries, keyed by original bundle index.
+   */
+  takePendingResults(): Record<number, BundleEntry> {
+    const out: Record<number, BundleEntry> = Object.create(null);
+    for (const index of this.pendingIndices) {
+      out[index] = this.resultEntries[index];
+    }
+    this.pendingIndices = [];
+    return out;
+  }
+
+  private async processEntriesAndBuild(): Promise<Bundle> {
+    this.dispatchPreEvent();
+    while (this.hasMoreEntries()) {
+      await this.processNextEntry();
+    }
+    this.dispatchPostEvent();
+    return this.buildResultBundle();
+  }
+
+  private dispatchPreEvent(): void {
+    const preEvent: BatchEvent = {
+      type: 'batch',
+      bundleType: this.bundle.type,
+      count: this.bundle.entry?.length,
+      size: JSON.stringify(this.bundle).length,
+    };
+    this.router.dispatchEvent(preEvent);
+  }
+
+  private dispatchPostEvent(): void {
+    const postEvent: BatchEvent = {
+      type: 'batch',
+      bundleType: this.bundle.type,
+      errors: this.errors.length ? this.errors : undefined,
+    };
+    this.router.dispatchEvent(postEvent);
+  }
+
+  /**
+   * Assembles the response bundle from the result entries recorded on this instance. Used by the
+   * one-shot {@link BatchProcessor.run} flow. The re-entrant flow instead assembles the final bundle from durably
+   * persisted results via {@link buildBatchResponseBundle}.
+   * @returns The bundle response.
+   */
+  private buildResultBundle(): Bundle {
+    return {
+      resourceType: 'Bundle',
+      type: `${this.bundle.type}-response` as Bundle['type'],
+      entry: this.resultEntries,
+    };
   }
 
   /**
@@ -364,69 +561,60 @@ class BatchProcessor {
   }
 
   /**
-   * Processes a FHIR batch request.
-   * @param bundleInfo - The preprocessed Bundle information.
-   * @param resultEntries - The array of results.
-   * @returns The bundle response.
+   * Processes the next entry in the bundle ordering (the entry at the current progress marker),
+   * recording its result and advancing the marker.
+   *
+   * For `batch` bundles, per-entry errors are captured as error result entries and processing
+   * continues; a 429 (rate limit) terminates the batch, filling all remaining entries with the
+   * rate-limit outcome. For `transaction` bundles, any entry error is thrown so the enclosing
+   * transaction rolls back.
+   *
+   * Must be called only after {@link BatchProcessor.preprocess} or {@link BatchProcessor.fromState}. Callers should guard with
+   * {@link BatchProcessor.hasMoreEntries}.
    */
-  private async processBatch(
-    bundleInfo: BundlePreprocessInfo,
-    resultEntries: (BundleEntry | OperationOutcome)[]
-  ): Promise<Bundle> {
-    const bundleType = this.bundle.type;
-
+  async processNextEntry(): Promise<void> {
+    const bundleInfo = this.bundleInfo;
+    if (!bundleInfo) {
+      throw new Error('processNextEntry called before preprocess()/fromState()');
+    }
     const entries = this.bundle.entry;
     if (!entries) {
       throw new OperationOutcomeError(badRequest('Missing bundle entry'));
     }
-
-    const preEvent: BatchEvent = {
-      type: 'batch',
-      bundleType,
-      count: entries.length,
-      size: JSON.stringify(this.bundle).length,
-    };
-    this.router.dispatchEvent(preEvent);
-
-    let errors: string[] | undefined;
-    for (let n = 0; n < bundleInfo.ordering.length; n++) {
-      const entryIndex = bundleInfo.ordering[n];
-      const entry = entries[entryIndex];
-      const rewritten = this.rewriteIdsInObject(entry);
-      try {
-        resultEntries[entryIndex] = await this.processBatchEntry(rewritten);
-      } catch (err: any) {
-        if (this.isTransaction()) {
-          throw err;
-        }
-
-        errors = append(errors, err.message);
-        if (err instanceof OperationOutcomeError && getStatus(err.outcome) === 429) {
-          // Rate limit reached; terminate batch and finish to avoid further load on server
-          for (let i = n; i < bundleInfo.ordering.length; i++) {
-            const entryIndex = bundleInfo.ordering[i];
-            resultEntries[entryIndex] = buildBundleResponse(err.outcome);
-          }
-          break;
-        }
-
-        resultEntries[entryIndex] = buildBundleResponse(normalizeOperationOutcome(err));
-        continue;
-      }
+    if (this.position >= bundleInfo.ordering.length) {
+      return;
     }
 
-    const postEvent: BatchEvent = {
-      type: 'batch',
-      bundleType,
-      errors,
-    };
-    this.router.dispatchEvent(postEvent);
+    const n = this.position;
+    const entryIndex = bundleInfo.ordering[n];
+    const entry = entries[entryIndex];
+    const rewritten = this.rewriteIdsInObject(entry);
+    try {
+      this.setResult(entryIndex, await this.processBatchEntry(rewritten));
+      this.position = n + 1;
+    } catch (err: any) {
+      if (this.isTransaction()) {
+        throw err;
+      }
 
-    return {
-      resourceType: 'Bundle',
-      type: `${bundleType}-response` as Bundle['type'],
-      entry: resultEntries,
-    };
+      this.errors.push(err.message);
+      if (err instanceof OperationOutcomeError && getStatus(err.outcome) === 429) {
+        // Rate limit reached; terminate batch and finish to avoid further load on server
+        for (let i = n; i < bundleInfo.ordering.length; i++) {
+          this.setResult(bundleInfo.ordering[i], buildBundleResponse(err.outcome));
+        }
+        this.position = bundleInfo.ordering.length;
+        return;
+      }
+
+      this.setResult(entryIndex, buildBundleResponse(normalizeOperationOutcome(err)));
+      this.position = n + 1;
+    }
+  }
+
+  private setResult(index: number, entry: BundleEntry): void {
+    this.resultEntries[index] = entry;
+    this.pendingIndices.push(index);
   }
 
   /**
@@ -605,6 +793,31 @@ function buildBundleResponse(outcome: OperationOutcome, resource?: Resource): Bu
       location: isOk(outcome) && resource?.id ? getReferenceString(resource) : undefined,
     },
     resource,
+  };
+}
+
+/**
+ * Assembles a batch/transaction response bundle from result entries that were collected across
+ * multiple re-entrant processing runs and persisted to durable storage. Used by the async batch
+ * worker to build the final (or a partial) response bundle from checkpointed results.
+ * @param bundleType - The type of the request bundle (`batch` or `transaction`).
+ * @param entryCount - The number of entries in the original request bundle.
+ * @param results - The result entries, keyed by their index in the original request bundle.
+ * @returns The response bundle, with one entry per original request entry.
+ */
+export function buildBatchResponseBundle(
+  bundleType: Bundle['type'],
+  entryCount: number,
+  results: Record<number, BundleEntry>
+): Bundle {
+  const entry: BundleEntry[] = new Array(entryCount);
+  for (let i = 0; i < entryCount; i++) {
+    entry[i] = results[i];
+  }
+  return {
+    resourceType: 'Bundle',
+    type: `${bundleType}-response` as Bundle['type'],
+    entry,
   };
 }
 

--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -31,17 +31,7 @@ const localBundleReference = /urn(:|%3A)uuid(:|%3A)[0-9a-f]{8}-[0-9a-f]{4}-[0-9a
 
 type BundleEntryIdentity = { placeholder: string; reference: string };
 
-type BundlePreprocessInfo = {
-  ordering: number[];
-  requiresStrongTransaction: boolean;
-  updates: number;
-};
-
-/**
- * A JSON-serializable form of `BundlePreprocessInfo`, where `resourceTypes` is an
- * array rather than a `Set` so it can be persisted to durable storage.
- */
-export type SerializableBundleInfo = {
+export type BundlePreprocessInfo = {
   ordering: number[];
   requiresStrongTransaction: boolean;
   updates: number;
@@ -66,7 +56,7 @@ export interface BatchInitialState {
    * resources that were already created.
    */
   bundle: Bundle;
-  bundleInfo: SerializableBundleInfo;
+  bundleInfo: BundlePreprocessInfo;
   resolvedIdentities: Record<string, string>;
   /**
    * Result entries produced during preprocessing itself (i.e. error responses for malformed

--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -166,7 +166,7 @@ export class BatchProcessor {
   }
 
   /**
-   * Processes a FHIR batch request in a single call.
+   * Processes a FHIR batch or transaction request in a single call.
    * @returns The bundle response.
    */
   async run(): Promise<Bundle> {
@@ -264,7 +264,7 @@ export class BatchProcessor {
   private async processEntriesAndBuild(): Promise<Bundle> {
     this.dispatchPreEvent();
     while (this.hasMoreEntries()) {
-      await this.processNextEntry();
+      await this.processNextEntryImpl();
     }
     this.dispatchPostEvent();
     return this.buildResultBundle();
@@ -556,13 +556,29 @@ export class BatchProcessor {
    *
    * For `batch` bundles, per-entry errors are captured as error result entries and processing
    * continues; a 429 (rate limit) terminates the batch, filling all remaining entries with the
-   * rate-limit outcome. For `transaction` bundles, any entry error is thrown so the enclosing
-   * transaction rolls back.
+   * rate-limit outcome.
    *
-   * Must be called only after {@link BatchProcessor.preprocess} or {@link BatchProcessor.fromState}. Callers should guard with
-   * {@link BatchProcessor.hasMoreEntries}.
+   * Must be called only after {@link BatchProcessor.preprocess} or {@link BatchProcessor.fromState}.
+   * Callers should guard with {@link BatchProcessor.hasMoreEntries}. The re-entrant flow only supports
+   * `batch` semantics. For `transaction` bundles, use {@link BatchProcessor.run}.
    */
   async processNextEntry(): Promise<void> {
+    if (this.isTransaction()) {
+      throw new Error('Re-entrant batch processing does not support transaction semantics');
+    }
+    await this.processNextEntryImpl();
+  }
+
+  /**
+   * Processes the next entry in the bundle ordering (the entry at the current progress marker),
+   * recording its result and advancing the marker.
+   *
+   * For `batch` bundles, per-entry errors are captured as error result entries and processing
+   * continues; a 429 (rate limit) terminates the batch, filling all remaining entries with the
+   * rate-limit outcome. For `transaction` bundles, any entry error is thrown so the enclosing
+   * transaction rolls back.
+   */
+  private async processNextEntryImpl(): Promise<void> {
     const bundleInfo = this.bundleInfo;
     if (!bundleInfo) {
       throw new Error('processNextEntry called before preprocess()/fromState()');

--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -105,7 +105,7 @@ export async function processBatch(
 export class BatchProcessor {
   private readonly router: FhirRouter;
   private repo: FhirRepository;
-  private bundle: Bundle;
+  private readonly bundle: Bundle;
   private readonly req: FhirRequest;
   private resolvedIdentities: Record<string, string>;
   private bundleInfo: BundlePreprocessInfo | undefined;
@@ -250,9 +250,14 @@ export class BatchProcessor {
    * Returns the result entries produced since the last call (keyed by their index in the
    * original bundle) and clears the pending buffer. The caller persists these to durable
    * storage as a checkpoint before advancing the durable progress marker.
-   * @returns Newly-produced result entries, keyed by original bundle index.
+   * @returns Newly-produced result entries, keyed by original bundle index or `undefined`
+   * if no new entries were produced.
    */
-  takePendingResults(): Record<number, BundleEntry> {
+  takePendingResults(): Record<number, BundleEntry> | undefined {
+    if (this.pendingIndices.length === 0) {
+      return undefined;
+    }
+
     const out: Record<number, BundleEntry> = Object.create(null);
     for (const index of this.pendingIndices) {
       out[index] = this.resultEntries[index];

--- a/packages/fhir-router/src/index.ts
+++ b/packages/fhir-router/src/index.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 export { BatchProcessor, buildBatchResponseBundle, processBatch } from './batch';
-export type { BatchEvent, BatchInitialState, LogEvent, SerializableBundleInfo } from './batch';
+export type { BatchEvent, BatchInitialState, BundlePreprocessInfo, LogEvent } from './batch';
 export * from './fhirrouter';
 export * from './repo';
 export * from './urlrouter';

--- a/packages/fhir-router/src/index.ts
+++ b/packages/fhir-router/src/index.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-export { processBatch } from './batch';
-export type { BatchEvent, LogEvent } from './batch';
+export { BatchProcessor, buildBatchResponseBundle, processBatch } from './batch';
+export type { BatchEvent, BatchInitialState, LogEvent, SerializableBundleInfo } from './batch';
 export * from './fhirrouter';
 export * from './repo';
 export * from './urlrouter';

--- a/packages/server/src/async-batch.ts
+++ b/packages/server/src/async-batch.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { accepted, badRequest, OperationOutcomeError } from '@medplum/core';
-import type { Bundle } from '@medplum/fhirtypes';
+import type { Bundle, Project } from '@medplum/fhirtypes';
 import type { NextFunction, Request, Response } from 'express';
 import { json } from 'express';
 import { JSON_TYPE, runMiddleware } from './app';
@@ -10,7 +10,7 @@ import type { MedplumServerConfig } from './config/types';
 import { getAuthenticatedContext } from './context';
 import { AsyncJobExecutor } from './fhir/operations/utils/asyncjobexecutor';
 import { sendOutcome } from './fhir/outcomes';
-import { queueBatchProcessing } from './workers/batch';
+import { queueBatchProcessing, queueLegacyBatchProcessing } from './workers/batch';
 
 export function asyncBatchHandler(
   config: MedplumServerConfig
@@ -37,10 +37,18 @@ export function asyncBatchHandler(
     const exec = new AsyncJobExecutor(repo);
     await exec.init(`${req.protocol}://${req.get('host') + req.originalUrl}`);
     await exec.run(async (asyncJob) => {
-      await queueBatchProcessing(bundle, asyncJob);
+      if (useLegacyBatchProcessing(project)) {
+        await queueLegacyBatchProcessing(bundle, asyncJob);
+      } else {
+        await queueBatchProcessing(bundle, asyncJob);
+      }
     });
 
     const { baseUrl } = getConfig();
     sendOutcome(res, accepted(exec.getContentLocation(baseUrl)));
   };
+}
+
+function useLegacyBatchProcessing(project: Project): boolean {
+  return !project.systemSetting?.find((s) => s.name === 'reentrantAsyncBatch')?.valueBoolean;
 }

--- a/packages/server/src/cloud/aws/storage.ts
+++ b/packages/server/src/cloud/aws/storage.ts
@@ -1,6 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { CopyObjectCommand, GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import {
+  CopyObjectCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/cloudfront-signer';
 import { Upload } from '@aws-sdk/lib-storage';
 import { getSignedUrl as s3GetSignedUrl } from '@aws-sdk/s3-request-presigner';
@@ -95,6 +101,16 @@ export class S3Storage extends BaseBinaryStorage {
       })
     );
     return output.Body as Readable;
+  }
+
+  async deleteFile(key: string): Promise<void> {
+    // S3 DeleteObject is idempotent: deleting a missing key returns success.
+    await this.client.send(
+      new DeleteObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+      })
+    );
   }
 
   async copyFile(sourceKey: string, destinationKey: string): Promise<void> {

--- a/packages/server/src/cloud/azure/storage.ts
+++ b/packages/server/src/cloud/azure/storage.ts
@@ -59,6 +59,12 @@ export class AzureBlobStorage extends BaseBinaryStorage {
     return downloadBlockBlobResponse.readableStreamBody as Readable;
   }
 
+  async deleteFile(key: string): Promise<void> {
+    // deleteIfExists is idempotent: it resolves successfully if the blob does not exist.
+    const blobClient = this.containerClient.getBlobClient(key);
+    await blobClient.deleteIfExists();
+  }
+
   async copyFile(sourceKey: string, destinationKey: string): Promise<void> {
     const sourceBlobClient = this.containerClient.getBlobClient(sourceKey);
     const destinationBlobClient = this.containerClient.getBlobClient(destinationKey);

--- a/packages/server/src/cloud/gcp/storage.ts
+++ b/packages/server/src/cloud/gcp/storage.ts
@@ -57,6 +57,12 @@ export class GoogleCloudStorage extends BaseBinaryStorage {
     return file.createReadStream();
   }
 
+  async deleteFile(key: string): Promise<void> {
+    // ignoreNotFound makes delete idempotent: it resolves successfully if the file is absent.
+    const file = this.bucket.file(key);
+    await file.delete({ ignoreNotFound: true });
+  }
+
   async copyFile(sourceKey: string, destinationKey: string): Promise<void> {
     const sourceFile = this.bucket.file(sourceKey);
     const destinationFile = this.bucket.file(destinationKey);

--- a/packages/server/src/fhir/batch.test.ts
+++ b/packages/server/src/fhir/batch.test.ts
@@ -65,7 +65,16 @@ describe('Batch and Transaction processing', () => {
     // throttle timing, so zero the delay to avoid real sleeps that slow the suite down.
     config.asyncDelayScaling = 0;
     await initApp(app, config);
-    accessToken = await initTestAuth({ project: { features: ['transaction-bundles'] }, membership: { admin: true } });
+    accessToken = await initTestAuth({
+      project: {
+        features: ['transaction-bundles'],
+        // Opt in to re-entrant async batch processing (see workers/batch.ts). The async batch tests
+        // below exercise the re-entrant worker (checkpoints, resume, cancellation); without this
+        // flag the project defaults to the legacy single-shot path.
+        systemSetting: [{ name: 'reentrantAsyncBatch', valueBoolean: true }],
+      },
+      membership: { admin: true },
+    });
   });
 
   afterEach(() => {
@@ -1649,6 +1658,8 @@ describe('Batch and Transaction processing', () => {
         systemSetting: [
           { name: 'userFhirQuota', valueInteger: 200 },
           { name: 'enableFhirQuota', valueBoolean: true },
+          // Opt in to re-entrant async batch processing (see workers/batch.ts).
+          { name: 'reentrantAsyncBatch', valueBoolean: true },
         ],
       },
     });

--- a/packages/server/src/fhir/batch.test.ts
+++ b/packages/server/src/fhir/batch.test.ts
@@ -39,10 +39,7 @@ import { queueRegistry } from '../workers/utils';
  * @param overrides - Optional overrides applied on top of the defaults.
  * @returns A mock Job usable with execBatchJob.
  */
-function mockBatchJob(
-  data: ReentrantBatchJobData,
-  overrides?: Record<string, unknown>
-): Job<ReentrantBatchJobData> {
+function mockBatchJob(data: ReentrantBatchJobData, overrides?: Record<string, unknown>): Job<ReentrantBatchJobData> {
   const job: any = {
     id: '1',
     data,

--- a/packages/server/src/fhir/batch.test.ts
+++ b/packages/server/src/fhir/batch.test.ts
@@ -17,6 +17,7 @@ import type {
   UserConfiguration,
 } from '@medplum/fhirtypes';
 import type { Job } from 'bullmq';
+import { DelayedError } from 'bullmq';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import type { RateLimiterRes } from 'rate-limiter-flexible';
@@ -28,6 +29,30 @@ import { runInAuthenticatedContext } from '../context';
 import { createTestProject, initTestAuth, waitForAsyncJob } from '../test.setup';
 import type { BatchJobData } from '../workers/batch';
 import { execBatchJob, getBatchQueue } from '../workers/batch';
+import { queueRegistry } from '../workers/utils';
+
+/**
+ * Builds a minimal mock BullMQ Job for driving execBatchJob in tests. Provides an in-memory
+ * `updateData` so the re-entrant worker can persist its progress marker, and `queueName`/`token`
+ * so graceful-shutdown/delay code paths can be exercised.
+ * @param data - The batch job data.
+ * @param overrides - Optional overrides applied on top of the defaults.
+ * @returns A mock Job usable with execBatchJob.
+ */
+function mockBatchJob(data: BatchJobData, overrides?: Record<string, unknown>): Job<BatchJobData> {
+  const job: any = {
+    id: '1',
+    data,
+    queueName: 'BatchQueue',
+    token: 'test-token',
+    async updateData(newData: BatchJobData) {
+      job.data = newData;
+    },
+    async moveToDelayed() {},
+    ...overrides,
+  };
+  return job as Job<BatchJobData>;
+}
 
 describe('Batch and Transaction processing', () => {
   const app = express();
@@ -1174,15 +1199,15 @@ describe('Batch and Transaction processing', () => {
     const outcome = res.body as OperationOutcome;
     expect(outcome.issue[0].diagnostics).toMatch('http://');
 
-    // Manually push through BullMQ job
+    // Manually push through BullMQ job. The bundle travels via object storage, not the job data (#9124).
     expect(queue.add).toHaveBeenCalledWith(
       'BatchJobData',
-      expect.objectContaining<Partial<BatchJobData>>({
-        bundle,
-      })
+      expect.objectContaining<Partial<BatchJobData>>({ asyncJob: expect.anything() })
     );
+    const enqueued = queue.add.mock.calls[0][1] as BatchJobData & { bundle?: unknown };
+    expect(enqueued.bundle).toBeUndefined();
 
-    const job = { id: 1, data: queue.add.mock.calls[0][1] } as unknown as Job;
+    const job = mockBatchJob(enqueued);
     queue.add.mockClear();
 
     await expect(execBatchJob(job)).resolves.toBe(undefined);
@@ -1225,15 +1250,15 @@ describe('Batch and Transaction processing', () => {
     const outcome = res.body as OperationOutcome;
     expect(outcome.issue[0].diagnostics).toMatch('http://');
 
-    // Manually push through BullMQ job
+    // Manually push through BullMQ job. The bundle travels via object storage, not the job data (#9124).
     expect(queue.add).toHaveBeenCalledWith(
       'BatchJobData',
-      expect.objectContaining<Partial<BatchJobData>>({
-        bundle,
-      })
+      expect.objectContaining<Partial<BatchJobData>>({ asyncJob: expect.anything() })
     );
+    const enqueued = queue.add.mock.calls[0][1] as BatchJobData & { bundle?: unknown };
+    expect(enqueued.bundle).toBeUndefined();
 
-    const job = { id: 1, data: queue.add.mock.calls[0][1] } as unknown as Job;
+    const job = mockBatchJob(enqueued);
     queue.add.mockClear();
 
     await expect(execBatchJob(job)).resolves.toBe(undefined);
@@ -1259,6 +1284,143 @@ describe('Batch and Transaction processing', () => {
     });
 
     expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  test('Async batch resumes after graceful shutdown', async () => {
+    const queue = getBatchQueue() as any;
+    queue.add.mockClear();
+
+    const bundle: Bundle = {
+      resourceType: 'Bundle',
+      type: 'batch',
+      entry: [1, 2, 3, 4].map(() => ({
+        request: { method: 'POST', url: 'Patient' },
+        resource: { resourceType: 'Patient' },
+      })),
+    };
+
+    const res = await request(app)
+      .post(`/fhir/R4/`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .set('Prefer', 'respond-async')
+      .send(bundle);
+    expect(res.status).toStrictEqual(202);
+    const outcome = res.body as OperationOutcome;
+
+    const job = mockBatchJob(queue.add.mock.calls[0][1] as BatchJobData);
+    queue.add.mockClear();
+
+    // Simulate the queue closing after the first two entries are processed. isClosing is checked
+    // at the top of each loop iteration, so returning false twice lets two entries process before
+    // the job detects shutdown and delays itself.
+    let checks = 0;
+    const isClosingSpy = vi.spyOn(queueRegistry, 'isClosing').mockImplementation(() => checks++ >= 2);
+
+    // The delayed job re-throws DelayedError so BullMQ can re-queue it.
+    await expect(execBatchJob(job)).rejects.toBeInstanceOf(DelayedError);
+    isClosingSpy.mockRestore();
+
+    // Progress was checkpointed into the job data so a future worker can resume.
+    expect(job.data.position).toBeGreaterThan(0);
+    expect(job.data.position).toBeLessThan(4);
+
+    // The AsyncJob must still be in progress (not failed/completed) after being delayed.
+    // The status endpoint returns 202 while a job is not in a final state.
+    const jobUrl = outcome.issue[0].diagnostics as string;
+    const inProgress = await request(app)
+      .get(new URL(jobUrl).pathname)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('X-Medplum', 'extended')
+      .send();
+    expect(inProgress.status).toStrictEqual(202);
+
+    // Resume on a fresh worker: it rehydrates from durable state and finishes the batch.
+    const resumeJob = mockBatchJob(job.data);
+    await expect(execBatchJob(resumeJob)).resolves.toBe(undefined);
+
+    const asyncJob = await waitForAsyncJob(jobUrl, app, accessToken);
+    const resultsReference = asyncJob.output?.parameter?.find((p) => p.name === 'results')?.valueReference?.reference;
+    expect(resultsReference).toMatch(/^Binary\//);
+
+    const res2 = await request(app)
+      .get(`/fhir/R4/${resultsReference}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send();
+    expect(res2.status).toStrictEqual(200);
+    const results = res2.body as Bundle;
+    expect(results.type).toStrictEqual('batch-response');
+    // All four entries are present exactly once, across the pre- and post-resume runs.
+    expect(results.entry).toHaveLength(4);
+    expect(results.entry?.map((e) => e.response?.status)).toStrictEqual(['201', '201', '201', '201']);
+  });
+
+  test('Async batch makes partial results available when cancelled', async () => {
+    const queue = getBatchQueue() as any;
+    queue.add.mockClear();
+
+    const bundle: Bundle = {
+      resourceType: 'Bundle',
+      type: 'batch',
+      entry: [1, 2, 3, 4].map(() => ({
+        request: { method: 'POST', url: 'Patient' },
+        resource: { resourceType: 'Patient' },
+      })),
+    };
+
+    const res = await request(app)
+      .post(`/fhir/R4/`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .set('Prefer', 'respond-async')
+      .send(bundle);
+    expect(res.status).toStrictEqual(202);
+    const outcome = res.body as OperationOutcome;
+    const jobUrl = outcome.issue[0].diagnostics as string;
+    const asyncJobId = new URL(jobUrl).pathname.split('/').at(-2) as string;
+
+    const job = mockBatchJob(queue.add.mock.calls[0][1] as BatchJobData);
+    queue.add.mockClear();
+
+    // Process two entries, then delay (simulating a shutdown) to leave durable partial state.
+    let checks = 0;
+    const isClosingSpy = vi.spyOn(queueRegistry, 'isClosing').mockImplementation(() => checks++ >= 2);
+    await expect(execBatchJob(job)).rejects.toBeInstanceOf(DelayedError);
+    isClosingSpy.mockRestore();
+    const processedBeforeCancel = job.data.position as number;
+    expect(processedBeforeCancel).toBeGreaterThan(0);
+
+    // Cancel the AsyncJob out of band.
+    const cancelRes = await request(app)
+      .post(`/fhir/R4/AsyncJob/${asyncJobId}/$cancel`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send();
+    expect(cancelRes.status).toStrictEqual(200);
+
+    // Resuming a cancelled job must not process further entries; it publishes partial results.
+    const resumeJob = mockBatchJob(job.data);
+    await expect(execBatchJob(resumeJob)).resolves.toBe(undefined);
+
+    const cancelled = await request(app)
+      .get(new URL(jobUrl).pathname)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('X-Medplum', 'extended')
+      .send();
+    expect(cancelled.status).toStrictEqual(200);
+    expect(cancelled.body.status).toStrictEqual('cancelled');
+    const partialRef = cancelled.body.output?.parameter?.find((p: any) => p.name === 'partialResults')?.valueReference
+      ?.reference;
+    expect(partialRef).toMatch(/^Binary\//);
+
+    const res2 = await request(app)
+      .get(`/fhir/R4/${partialRef}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send();
+    expect(res2.status).toStrictEqual(200);
+    const partial = res2.body as Bundle;
+    expect(partial.type).toStrictEqual('batch-response');
+    // Only the entries processed before cancellation have results; the rest are absent.
+    expect(partial.entry?.filter(Boolean)).toHaveLength(processedBeforeCancel);
   });
 
   test('Transaction bundle account propagation', async () => {
@@ -1521,13 +1683,15 @@ describe('Batch and Transaction processing', () => {
     const outcome = res.body as OperationOutcome;
     expect(outcome.issue[0].diagnostics).toMatch('http://');
 
-    // Manually push through BullMQ job
+    // Manually push through BullMQ job. The bundle travels via object storage, not the job data (#9124).
     expect(queue.add).toHaveBeenCalledWith(
       'BatchJobData',
-      expect.objectContaining<Partial<BatchJobData>>({ bundle: batch })
+      expect.objectContaining<Partial<BatchJobData>>({ asyncJob: expect.anything() })
     );
+    const enqueued = queue.add.mock.calls[0][1] as BatchJobData & { bundle?: unknown };
+    expect(enqueued.bundle).toBeUndefined();
 
-    const job = { id: 1, data: queue.add.mock.calls[0][1] } as unknown as Job;
+    const job = mockBatchJob(enqueued);
     queue.add.mockClear();
 
     let count = 0;

--- a/packages/server/src/fhir/batch.test.ts
+++ b/packages/server/src/fhir/batch.test.ts
@@ -27,7 +27,7 @@ import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import { runInAuthenticatedContext } from '../context';
 import { createTestProject, initTestAuth, waitForAsyncJob } from '../test.setup';
-import type { BatchJobData } from '../workers/batch';
+import type { ReentrantBatchJobData } from '../workers/batch';
 import { execBatchJob, getBatchQueue } from '../workers/batch';
 import { queueRegistry } from '../workers/utils';
 
@@ -39,19 +39,22 @@ import { queueRegistry } from '../workers/utils';
  * @param overrides - Optional overrides applied on top of the defaults.
  * @returns A mock Job usable with execBatchJob.
  */
-function mockBatchJob(data: BatchJobData, overrides?: Record<string, unknown>): Job<BatchJobData> {
+function mockBatchJob(
+  data: ReentrantBatchJobData,
+  overrides?: Record<string, unknown>
+): Job<ReentrantBatchJobData> {
   const job: any = {
     id: '1',
     data,
     queueName: 'BatchQueue',
     token: 'test-token',
-    async updateData(newData: BatchJobData) {
+    async updateData(newData: ReentrantBatchJobData) {
       job.data = newData;
     },
     async moveToDelayed() {},
     ...overrides,
   };
-  return job as Job<BatchJobData>;
+  return job as Job<ReentrantBatchJobData>;
 }
 
 describe('Batch and Transaction processing', () => {
@@ -1202,9 +1205,9 @@ describe('Batch and Transaction processing', () => {
     // Manually push through BullMQ job. The bundle travels via object storage, not the job data (#9124).
     expect(queue.add).toHaveBeenCalledWith(
       'BatchJobData',
-      expect.objectContaining<Partial<BatchJobData>>({ asyncJob: expect.anything() })
+      expect.objectContaining<Partial<ReentrantBatchJobData>>({ asyncJobId: expect.anything() })
     );
-    const enqueued = queue.add.mock.calls[0][1] as BatchJobData & { bundle?: unknown };
+    const enqueued = queue.add.mock.calls[0][1] as ReentrantBatchJobData & { bundle?: unknown };
     expect(enqueued.bundle).toBeUndefined();
 
     const job = mockBatchJob(enqueued);
@@ -1253,9 +1256,9 @@ describe('Batch and Transaction processing', () => {
     // Manually push through BullMQ job. The bundle travels via object storage, not the job data (#9124).
     expect(queue.add).toHaveBeenCalledWith(
       'BatchJobData',
-      expect.objectContaining<Partial<BatchJobData>>({ asyncJob: expect.anything() })
+      expect.objectContaining<Partial<ReentrantBatchJobData>>({ asyncJobId: expect.anything() })
     );
-    const enqueued = queue.add.mock.calls[0][1] as BatchJobData & { bundle?: unknown };
+    const enqueued = queue.add.mock.calls[0][1] as ReentrantBatchJobData & { bundle?: unknown };
     expect(enqueued.bundle).toBeUndefined();
 
     const job = mockBatchJob(enqueued);
@@ -1308,7 +1311,7 @@ describe('Batch and Transaction processing', () => {
     expect(res.status).toStrictEqual(202);
     const outcome = res.body as OperationOutcome;
 
-    const job = mockBatchJob(queue.add.mock.calls[0][1] as BatchJobData);
+    const job = mockBatchJob(queue.add.mock.calls[0][1] as ReentrantBatchJobData);
     queue.add.mockClear();
 
     // Simulate the queue closing after the first two entries are processed. isClosing is checked
@@ -1379,7 +1382,7 @@ describe('Batch and Transaction processing', () => {
     const jobUrl = outcome.issue[0].diagnostics as string;
     const asyncJobId = new URL(jobUrl).pathname.split('/').at(-2) as string;
 
-    const job = mockBatchJob(queue.add.mock.calls[0][1] as BatchJobData);
+    const job = mockBatchJob(queue.add.mock.calls[0][1] as ReentrantBatchJobData);
     queue.add.mockClear();
 
     // Process two entries, then delay (simulating a shutdown) to leave durable partial state.
@@ -1686,9 +1689,9 @@ describe('Batch and Transaction processing', () => {
     // Manually push through BullMQ job. The bundle travels via object storage, not the job data (#9124).
     expect(queue.add).toHaveBeenCalledWith(
       'BatchJobData',
-      expect.objectContaining<Partial<BatchJobData>>({ asyncJob: expect.anything() })
+      expect.objectContaining<Partial<ReentrantBatchJobData>>({ asyncJobId: expect.anything() })
     );
-    const enqueued = queue.add.mock.calls[0][1] as BatchJobData & { bundle?: unknown };
+    const enqueued = queue.add.mock.calls[0][1] as ReentrantBatchJobData & { bundle?: unknown };
     expect(enqueued.bundle).toBeUndefined();
 
     const job = mockBatchJob(enqueued);

--- a/packages/server/src/fhir/batch.test.ts
+++ b/packages/server/src/fhir/batch.test.ts
@@ -60,6 +60,10 @@ describe('Batch and Transaction processing', () => {
 
   beforeAll(async () => {
     const config = await loadTestConfig();
+    // Async batches throttle by sleeping `points * asyncDelayScaling` ms per DB op in the async
+    // authenticated context (see Repository.recordFhirQuota). These tests exercise behavior, not
+    // throttle timing, so zero the delay to avoid real sleeps that slow the suite down.
+    config.asyncDelayScaling = 0;
     await initApp(app, config);
     accessToken = await initTestAuth({ project: { features: ['transaction-bundles'] }, membership: { admin: true } });
   });
@@ -1315,14 +1319,15 @@ describe('Batch and Transaction processing', () => {
     // at the top of each loop iteration, so returning false twice lets two entries process before
     // the job detects shutdown and delays itself.
     let checks = 0;
-    const isClosingSpy = vi.spyOn(queueRegistry, 'isClosing').mockImplementation(() => checks++ >= 2);
+    const closeAfterChecks = 2;
+    const isClosingSpy = vi.spyOn(queueRegistry, 'isClosing').mockImplementation(() => checks++ >= closeAfterChecks);
 
     // The delayed job re-throws DelayedError so BullMQ can re-queue it.
     await expect(execBatchJob(job)).rejects.toBeInstanceOf(DelayedError);
     isClosingSpy.mockRestore();
 
     // Progress was checkpointed into the job data so a future worker can resume.
-    expect(job.data.position).toStrictEqual(3);
+    expect(job.data.position).toStrictEqual(closeAfterChecks);
 
     // The AsyncJob must still be in progress (not failed/completed) after being delayed.
     // The status endpoint returns 202 while a job is not in a final state.
@@ -1708,7 +1713,7 @@ describe('Batch and Transaction processing', () => {
 
       return {
         remainingPoints: 200 - count * 100, // Allow every third call
-        msBeforeNext: 20, // Wait for one fake timers tick before next retry
+        msBeforeNext: 20,
         consumedPoints: 100,
         isFirstInDuration: false,
       } as RateLimiterRes;
@@ -1722,10 +1727,9 @@ describe('Batch and Transaction processing', () => {
       () => execBatchJob(job)
     );
 
-    // Must wait here, but `RateLimiterRedis` uses TTL time from Redis `PTTL` command
-
     await expect(jobResult).resolves.toBe(undefined);
-    // Rate limits should not actually be consumed
+    // In async context the rate limiter is bypassed entirely (the worker self-throttles via
+    // Repository.recordFhirQuota instead), so RateLimiterRedis.consume must never be called.
     expect(consumeMock).toHaveBeenCalledTimes(0);
 
     const jobUrl = outcome.issue[0].diagnostics as string;

--- a/packages/server/src/fhir/batch.test.ts
+++ b/packages/server/src/fhir/batch.test.ts
@@ -1322,8 +1322,7 @@ describe('Batch and Transaction processing', () => {
     isClosingSpy.mockRestore();
 
     // Progress was checkpointed into the job data so a future worker can resume.
-    expect(job.data.position).toBeGreaterThan(0);
-    expect(job.data.position).toBeLessThan(4);
+    expect(job.data.position).toStrictEqual(3);
 
     // The AsyncJob must still be in progress (not failed/completed) after being delayed.
     // The status endpoint returns 202 while a job is not in a final state.

--- a/packages/server/src/fhir/batch/checkpoint-store.test.ts
+++ b/packages/server/src/fhir/batch/checkpoint-store.test.ts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { BatchInitialState } from '@medplum/fhir-router';
+import type { Bundle, BundleEntry } from '@medplum/fhirtypes';
+import { loadTestConfig } from '../../config/loader';
+import { initBinaryStorage } from '../../storage/loader';
+import { BatchCheckpointStore } from './checkpoint-store';
+
+describe('BatchCheckpointStore', () => {
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    initBinaryStorage(config.binaryStorage);
+  });
+
+  function makeInitialState(): BatchInitialState {
+    return {
+      bundle: { resourceType: 'Bundle', type: 'batch', entry: [{ request: { method: 'GET', url: 'Patient' } }] },
+      bundleInfo: { ordering: [0], requiresStrongTransaction: false, updates: 0, resourceTypes: ['Patient'] },
+      resolvedIdentities: { 'urn:uuid:abc': 'Patient/123' },
+      preprocessResults: {},
+    };
+  }
+
+  test('Input bundle round-trips', async () => {
+    const store = new BatchCheckpointStore('input-test');
+    const bundle: Bundle = { resourceType: 'Bundle', type: 'batch', entry: [] };
+    await store.saveInputBundle(bundle);
+    expect(await store.loadInputBundle()).toStrictEqual(bundle);
+    await store.cleanup(0);
+  });
+
+  test('Initial state round-trips', async () => {
+    const store = new BatchCheckpointStore('state-test');
+    const state = makeInitialState();
+    await store.saveInitialState(state);
+    expect(await store.loadInitialState()).toStrictEqual(state);
+    await store.cleanup(0);
+  });
+
+  test('Result chunks accumulate and merge by index', async () => {
+    const store = new BatchCheckpointStore('chunks-test');
+    const chunk0: Record<number, BundleEntry> = {
+      0: { response: { status: '201' } },
+      2: { response: { status: '200' } },
+    };
+    const chunk1: Record<number, BundleEntry> = { 1: { response: { status: '404' } } };
+    await store.saveResultChunk(0, chunk0);
+    await store.saveResultChunk(1, chunk1);
+
+    const all = await store.loadAllResults(2);
+    // loadAllResults merges into a null-prototype object; compare structurally.
+    expect(all).toEqual({ ...chunk0, ...chunk1 });
+    await store.cleanup(2);
+  });
+
+  test('cleanup removes all objects and is safe to call again', async () => {
+    const store = new BatchCheckpointStore('cleanup-test');
+    await store.saveInputBundle({ resourceType: 'Bundle', type: 'batch' });
+    await store.saveInitialState(makeInitialState());
+    await store.saveResultChunk(0, { 0: { response: { status: '201' } } });
+
+    await store.cleanup(1);
+
+    // Objects are gone after cleanup.
+    await expect(store.loadInitialState()).rejects.toThrow();
+    // Cleanup is idempotent.
+    await expect(store.cleanup(1)).resolves.toBeUndefined();
+  });
+});

--- a/packages/server/src/fhir/batch/checkpoint-store.test.ts
+++ b/packages/server/src/fhir/batch/checkpoint-store.test.ts
@@ -15,7 +15,7 @@ describe('BatchCheckpointStore', () => {
   function makeInitialState(): BatchInitialState {
     return {
       bundle: { resourceType: 'Bundle', type: 'batch', entry: [{ request: { method: 'GET', url: 'Patient' } }] },
-      bundleInfo: { ordering: [0], requiresStrongTransaction: false, updates: 0, resourceTypes: ['Patient'] },
+      bundleInfo: { ordering: [0], requiresStrongTransaction: false, updates: 0 },
       resolvedIdentities: { 'urn:uuid:abc': 'Patient/123' },
       preprocessResults: {},
     };

--- a/packages/server/src/fhir/batch/checkpoint-store.test.ts
+++ b/packages/server/src/fhir/batch/checkpoint-store.test.ts
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { ILogger } from '@medplum/core';
 import type { BatchInitialState } from '@medplum/fhir-router';
 import type { Bundle, BundleEntry } from '@medplum/fhirtypes';
 import { loadTestConfig } from '../../config/loader';
+import { globalLogger } from '../../logger';
 import { initBinaryStorage } from '../../storage/loader';
 import { BatchCheckpointStore } from './checkpoint-store';
 
@@ -11,6 +13,8 @@ describe('BatchCheckpointStore', () => {
     const config = await loadTestConfig();
     initBinaryStorage(config.binaryStorage);
   });
+
+  const logger: ILogger = globalLogger;
 
   function makeInitialState(): BatchInitialState {
     return {
@@ -22,7 +26,7 @@ describe('BatchCheckpointStore', () => {
   }
 
   test('Input bundle round-trips', async () => {
-    const store = new BatchCheckpointStore('input-test');
+    const store = new BatchCheckpointStore('input-test', logger);
     const bundle: Bundle = { resourceType: 'Bundle', type: 'batch', entry: [] };
     await store.saveInputBundle(bundle);
     expect(await store.loadInputBundle()).toStrictEqual(bundle);
@@ -30,7 +34,7 @@ describe('BatchCheckpointStore', () => {
   });
 
   test('Initial state round-trips', async () => {
-    const store = new BatchCheckpointStore('state-test');
+    const store = new BatchCheckpointStore('state-test', logger);
     const state = makeInitialState();
     await store.saveInitialState(state);
     expect(await store.loadInitialState()).toStrictEqual(state);
@@ -38,7 +42,7 @@ describe('BatchCheckpointStore', () => {
   });
 
   test('Result chunks accumulate and merge by index', async () => {
-    const store = new BatchCheckpointStore('chunks-test');
+    const store = new BatchCheckpointStore('chunks-test', logger);
     const chunk0: Record<number, BundleEntry> = {
       0: { response: { status: '201' } },
       2: { response: { status: '200' } },
@@ -54,7 +58,7 @@ describe('BatchCheckpointStore', () => {
   });
 
   test('cleanup removes all objects and is safe to call again', async () => {
-    const store = new BatchCheckpointStore('cleanup-test');
+    const store = new BatchCheckpointStore('cleanup-test', logger);
     await store.saveInputBundle({ resourceType: 'Bundle', type: 'batch' });
     await store.saveInitialState(makeInitialState());
     await store.saveResultChunk(0, { 0: { response: { status: '201' } } });

--- a/packages/server/src/fhir/batch/checkpoint-store.ts
+++ b/packages/server/src/fhir/batch/checkpoint-store.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { ILogger } from '@medplum/core';
 import { ContentType, normalizeErrorString } from '@medplum/core';
 import type { BatchInitialState } from '@medplum/fhir-router';
 import type { Bundle, BundleEntry } from '@medplum/fhirtypes';
-import { globalLogger } from '../../logger';
 import { getBinaryStorage } from '../../storage/loader';
 import { readStreamToString } from '../../util/streams';
 
@@ -34,9 +34,11 @@ const STORE_CONCURRENCY = 4;
  */
 export class BatchCheckpointStore {
   private readonly keyPrefix: string;
+  private readonly logger: ILogger;
 
-  constructor(asyncJobId: string) {
+  constructor(asyncJobId: string, logger: ILogger) {
     this.keyPrefix = `system/async-batch/${asyncJobId}`;
+    this.logger = logger;
   }
 
   private inputKey(): string {
@@ -55,10 +57,8 @@ export class BatchCheckpointStore {
     const startTime = Date.now();
     await getBinaryStorage().writeFile(key, contentType, data);
     const duration = Date.now() - startTime;
-    globalLogger.info('BatchCheckpointStore write', {
-      keyPrefix: this.keyPrefix,
+    this.logger.info('BatchCheckpointStore write', {
       key,
-      contentType,
       size: data.length,
       durationMs: duration,
     });
@@ -69,8 +69,7 @@ export class BatchCheckpointStore {
     const stream = await getBinaryStorage().readFile(key);
     const data = await readStreamToString(stream);
     const duration = Date.now() - startTime;
-    globalLogger.info('BatchCheckpointStore read', {
-      keyPrefix: this.keyPrefix,
+    this.logger.info('BatchCheckpointStore read', {
       key,
       size: data.length,
       durationMs: duration,
@@ -123,9 +122,11 @@ export class BatchCheckpointStore {
   }
 
   /**
-   * Reads back all result chunks and merges them into a single map keyed by original bundle index.
-   * @param chunkCount - The number of chunks written so far (chunks `0` through `chunkCount - 1`).
-   * @returns All persisted result entries, keyed by original bundle index.
+   * Reads back the first `chunkCount` result chunks and merges them into a single map keyed by
+   * original bundle index. A caller that already holds recently-written chunks in memory may pass
+   * a smaller count to read back only the chunks it is missing.
+   * @param chunkCount - The number of leading chunks to read (chunks `0` through `chunkCount - 1`).
+   * @returns The persisted result entries from those chunks, keyed by original bundle index.
    */
   async loadAllResults(chunkCount: number): Promise<Record<number, BundleEntry>> {
     const all: Record<number, BundleEntry> = Object.create(null);
@@ -158,7 +159,7 @@ export class BatchCheckpointStore {
         try {
           await storage.deleteFile(key);
         } catch (err) {
-          globalLogger.warn('Failed to clean up async batch checkpoint object', {
+          this.logger.warn('BatchCheckpointStore failed to clean up object', {
             key,
             error: normalizeErrorString(err),
           });
@@ -175,21 +176,23 @@ export class BatchCheckpointStore {
     let nextIndex = 0;
     const concurrency = options.concurrency;
     const workerCount = Math.min(jobs.length, concurrency);
-
     const startTime = Date.now();
-    // invoke and wait for `workerCount` while loop workers to complete
-    // each worker processes items off the `items` queue one at a time until the queue is empty
-    await Promise.all(
-      Array.from({ length: workerCount }, async () => {
-        while (nextIndex < jobs.length) {
-          const job = jobs[nextIndex++];
-          await callback(job);
-        }
-      })
-    );
+
+    if (jobs.length) {
+      // invoke and wait for `workerCount` while loop workers to complete
+      // each worker processes items off the `items` queue one at a time until the queue is empty
+      await Promise.all(
+        Array.from({ length: workerCount }, async () => {
+          while (nextIndex < jobs.length) {
+            const job = jobs[nextIndex++];
+            await callback(job);
+          }
+        })
+      );
+    }
 
     if (options?.logMsg) {
-      globalLogger.info(options.logMsg, {
+      this.logger.info(options.logMsg, {
         keyPrefix: this.keyPrefix,
         jobCount: jobs.length,
         durationMs: Date.now() - startTime,

--- a/packages/server/src/fhir/batch/checkpoint-store.ts
+++ b/packages/server/src/fhir/batch/checkpoint-store.ts
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { ContentType, normalizeErrorString } from '@medplum/core';
+import type { BatchInitialState } from '@medplum/fhir-router';
+import type { Bundle, BundleEntry } from '@medplum/fhirtypes';
+import { globalLogger } from '../../logger';
+import { getBinaryStorage } from '../../storage/loader';
+import { readStreamToString } from '../../util/streams';
+
+/**
+ * Durable storage for the in-flight state of a re-entrant async batch, backed by object storage.
+ *
+ * Async batch processing can take minutes for large bundles, so it must survive server deploys
+ * and worker crashes. The large, immutable parts of the processor's state are persisted here so
+ * that a {@link import('@medplum/fhir-router').BatchProcessor} can be rehydrated and resume where
+ * it left off. Object storage (rather than Redis) is used because both the preprocessed bundle and
+ * the accumulated result entries can each be tens of megabytes, which would be costly to hold in
+ * Redis memory.
+ *
+ * State is split into two kinds of objects, both keyed by the AsyncJob id:
+ *
+ * - `state.json` — the {@link BatchInitialState} produced by preprocessing. Written once, before
+ *   any entry is processed, and never mutated.
+ * - `results/<seq>.json` — result entries produced since the previous checkpoint, keyed by their
+ *   index in the original bundle. Written once per checkpoint (append-only); never rewritten. This
+ *   avoids the O(n^2) write amplification of rewriting a single growing results object.
+ *
+ * The small, mutable progress marker (the ordering position and the number of result chunks
+ * written so far) is NOT stored here; it is persisted by the worker in the BullMQ job data. Given
+ * `state.json` and the chunk sequence, all objects can be read back or deleted by exact key
+ * without needing a list operation.
+ */
+export class BatchCheckpointStore {
+  private readonly keyPrefix: string;
+
+  constructor(asyncJobId: string) {
+    this.keyPrefix = `system/async-batch/${asyncJobId}`;
+  }
+
+  private inputKey(): string {
+    return `${this.keyPrefix}/input.json`;
+  }
+
+  private stateKey(): string {
+    return `${this.keyPrefix}/state.json`;
+  }
+
+  private chunkKey(seq: number): string {
+    return `${this.keyPrefix}/results/${seq}.json`;
+  }
+
+  /**
+   * Persists the raw input bundle to object storage. Called by the request handler before the job
+   * is enqueued so that the (potentially large) bundle travels out-of-band from the BullMQ job data
+   * (see {@link https://github.com/medplum/medplum/issues/9124}).
+   * @param bundle - The raw input bundle.
+   */
+  async saveInputBundle(bundle: Bundle): Promise<void> {
+    await getBinaryStorage().writeFile(this.inputKey(), ContentType.JSON, JSON.stringify(bundle));
+  }
+
+  /**
+   * Loads the raw input bundle so the worker can preprocess it on the first run.
+   * @returns The raw input bundle.
+   */
+  async loadInputBundle(): Promise<Bundle> {
+    const stream = await getBinaryStorage().readFile(this.inputKey());
+    return JSON.parse(await readStreamToString(stream)) as Bundle;
+  }
+
+  /**
+   * Persists the initial state produced by preprocessing. Written once, before processing entries.
+   * @param state - The durable initial state.
+   */
+  async saveInitialState(state: BatchInitialState): Promise<void> {
+    await getBinaryStorage().writeFile(this.stateKey(), ContentType.JSON, JSON.stringify(state));
+  }
+
+  /**
+   * Loads the previously-persisted initial state so processing can resume.
+   * @returns The durable initial state.
+   */
+  async loadInitialState(): Promise<BatchInitialState> {
+    const stream = await getBinaryStorage().readFile(this.stateKey());
+    return JSON.parse(await readStreamToString(stream)) as BatchInitialState;
+  }
+
+  /**
+   * Persists a checkpoint of result entries produced since the previous checkpoint. Each chunk is
+   * written to its own object and never rewritten.
+   * @param seq - The zero-based sequence number of this chunk.
+   * @param results - Result entries produced since the last checkpoint, keyed by original bundle index.
+   */
+  async saveResultChunk(seq: number, results: Record<number, BundleEntry>): Promise<void> {
+    await getBinaryStorage().writeFile(this.chunkKey(seq), ContentType.JSON, JSON.stringify(results));
+  }
+
+  /**
+   * Reads back all result chunks and merges them into a single map keyed by original bundle index.
+   * @param chunkCount - The number of chunks written so far (chunks `0` through `chunkCount - 1`).
+   * @returns All persisted result entries, keyed by original bundle index.
+   */
+  async loadAllResults(chunkCount: number): Promise<Record<number, BundleEntry>> {
+    const storage = getBinaryStorage();
+    const all: Record<number, BundleEntry> = Object.create(null);
+    for (let seq = 0; seq < chunkCount; seq++) {
+      const stream = await storage.readFile(this.chunkKey(seq));
+      Object.assign(all, JSON.parse(await readStreamToString(stream)) as Record<number, BundleEntry>);
+    }
+    return all;
+  }
+
+  /**
+   * Deletes all durable state for this batch. Best-effort: failures to delete individual objects
+   * are logged but do not throw, since cleanup runs after the job has already reached a terminal
+   * state and orphaned objects can be reclaimed by an object-storage lifecycle policy.
+   * @param chunkCount - The number of result chunks written so far.
+   */
+  async cleanup(chunkCount: number): Promise<void> {
+    const storage = getBinaryStorage();
+    const keys = [this.inputKey(), this.stateKey()];
+    for (let seq = 0; seq < chunkCount; seq++) {
+      keys.push(this.chunkKey(seq));
+    }
+    for (const key of keys) {
+      try {
+        await storage.deleteFile(key);
+      } catch (err) {
+        globalLogger.warn('Failed to clean up async batch checkpoint object', {
+          key,
+          error: normalizeErrorString(err),
+        });
+      }
+    }
+  }
+}

--- a/packages/server/src/fhir/batch/checkpoint-store.ts
+++ b/packages/server/src/fhir/batch/checkpoint-store.ts
@@ -38,7 +38,7 @@ export class BatchCheckpointStore {
   }
 
   private inputKey(): string {
-    return `${this.keyPrefix}/input.json`;
+    return `${this.keyPrefix}/inputBundle.json`;
   }
 
   private stateKey(): string {

--- a/packages/server/src/fhir/batch/checkpoint-store.ts
+++ b/packages/server/src/fhir/batch/checkpoint-store.ts
@@ -7,6 +7,8 @@ import { globalLogger } from '../../logger';
 import { getBinaryStorage } from '../../storage/loader';
 import { readStreamToString } from '../../util/streams';
 
+const STORE_CONCURRENCY = 4;
+
 /**
  * Durable storage for the in-flight state of a re-entrant async batch, backed by object storage.
  *
@@ -49,6 +51,33 @@ export class BatchCheckpointStore {
     return `${this.keyPrefix}/results/${seq}.json`;
   }
 
+  private async writeFile(key: string, contentType: string, data: string): Promise<void> {
+    const startTime = Date.now();
+    await getBinaryStorage().writeFile(key, contentType, data);
+    const duration = Date.now() - startTime;
+    globalLogger.info('BatchCheckpointStore write', {
+      keyPrefix: this.keyPrefix,
+      key,
+      contentType,
+      size: data.length,
+      durationMs: duration,
+    });
+  }
+
+  private async readFile(key: string): Promise<string> {
+    const startTime = Date.now();
+    const stream = await getBinaryStorage().readFile(key);
+    const data = await readStreamToString(stream);
+    const duration = Date.now() - startTime;
+    globalLogger.info('BatchCheckpointStore read', {
+      keyPrefix: this.keyPrefix,
+      key,
+      size: data.length,
+      durationMs: duration,
+    });
+    return data;
+  }
+
   /**
    * Persists the raw input bundle to object storage. Called by the request handler before the job
    * is enqueued so that the (potentially large) bundle travels out-of-band from the BullMQ job data
@@ -56,7 +85,7 @@ export class BatchCheckpointStore {
    * @param bundle - The raw input bundle.
    */
   async saveInputBundle(bundle: Bundle): Promise<void> {
-    await getBinaryStorage().writeFile(this.inputKey(), ContentType.JSON, JSON.stringify(bundle));
+    await this.writeFile(this.inputKey(), ContentType.JSON, JSON.stringify(bundle));
   }
 
   /**
@@ -64,8 +93,7 @@ export class BatchCheckpointStore {
    * @returns The raw input bundle.
    */
   async loadInputBundle(): Promise<Bundle> {
-    const stream = await getBinaryStorage().readFile(this.inputKey());
-    return JSON.parse(await readStreamToString(stream)) as Bundle;
+    return JSON.parse(await this.readFile(this.inputKey())) as Bundle;
   }
 
   /**
@@ -73,7 +101,7 @@ export class BatchCheckpointStore {
    * @param state - The durable initial state.
    */
   async saveInitialState(state: BatchInitialState): Promise<void> {
-    await getBinaryStorage().writeFile(this.stateKey(), ContentType.JSON, JSON.stringify(state));
+    await this.writeFile(this.stateKey(), ContentType.JSON, JSON.stringify(state));
   }
 
   /**
@@ -81,8 +109,7 @@ export class BatchCheckpointStore {
    * @returns The durable initial state.
    */
   async loadInitialState(): Promise<BatchInitialState> {
-    const stream = await getBinaryStorage().readFile(this.stateKey());
-    return JSON.parse(await readStreamToString(stream)) as BatchInitialState;
+    return JSON.parse(await this.readFile(this.stateKey())) as BatchInitialState;
   }
 
   /**
@@ -92,7 +119,7 @@ export class BatchCheckpointStore {
    * @param results - Result entries produced since the last checkpoint, keyed by original bundle index.
    */
   async saveResultChunk(seq: number, results: Record<number, BundleEntry>): Promise<void> {
-    await getBinaryStorage().writeFile(this.chunkKey(seq), ContentType.JSON, JSON.stringify(results));
+    await this.writeFile(this.chunkKey(seq), ContentType.JSON, JSON.stringify(results));
   }
 
   /**
@@ -101,12 +128,15 @@ export class BatchCheckpointStore {
    * @returns All persisted result entries, keyed by original bundle index.
    */
   async loadAllResults(chunkCount: number): Promise<Record<number, BundleEntry>> {
-    const storage = getBinaryStorage();
     const all: Record<number, BundleEntry> = Object.create(null);
-    for (let seq = 0; seq < chunkCount; seq++) {
-      const stream = await storage.readFile(this.chunkKey(seq));
-      Object.assign(all, JSON.parse(await readStreamToString(stream)) as Record<number, BundleEntry>);
-    }
+    const chunkSeqs = Array.from({ length: chunkCount }, (_, i) => i);
+    await this.runWithConcurrency(
+      chunkSeqs,
+      async (seq) => {
+        Object.assign(all, JSON.parse(await this.readFile(this.chunkKey(seq))) as Record<number, BundleEntry>);
+      },
+      { concurrency: STORE_CONCURRENCY, logMsg: 'BatchCheckpointStore loadAllResults' }
+    );
     return all;
   }
 
@@ -122,15 +152,55 @@ export class BatchCheckpointStore {
     for (let seq = 0; seq < chunkCount; seq++) {
       keys.push(this.chunkKey(seq));
     }
-    for (const key of keys) {
-      try {
-        await storage.deleteFile(key);
-      } catch (err) {
-        globalLogger.warn('Failed to clean up async batch checkpoint object', {
-          key,
-          error: normalizeErrorString(err),
-        });
-      }
+    await this.runWithConcurrency(
+      keys,
+      async (key) => {
+        try {
+          await storage.deleteFile(key);
+        } catch (err) {
+          globalLogger.warn('Failed to clean up async batch checkpoint object', {
+            key,
+            error: normalizeErrorString(err),
+          });
+        }
+      },
+      { concurrency: STORE_CONCURRENCY, logMsg: 'BatchCheckpointStore cleanup' }
+    );
+  }
+  private async runWithConcurrency<T>(
+    jobs: T[],
+    callback: (job: T) => Promise<void>,
+    options: RunWithConcurrencyOptions
+  ): Promise<void> {
+    let nextIndex = 0;
+    const concurrency = options.concurrency;
+    const workerCount = Math.min(jobs.length, concurrency);
+
+    const startTime = Date.now();
+    // invoke and wait for `workerCount` while loop workers to complete
+    // each worker processes items off the `items` queue one at a time until the queue is empty
+    await Promise.all(
+      Array.from({ length: workerCount }, async () => {
+        while (nextIndex < jobs.length) {
+          const job = jobs[nextIndex++];
+          await callback(job);
+        }
+      })
+    );
+
+    if (options?.logMsg) {
+      globalLogger.info(options.logMsg, {
+        keyPrefix: this.keyPrefix,
+        jobCount: jobs.length,
+        durationMs: Date.now() - startTime,
+      });
     }
   }
+}
+
+interface RunWithConcurrencyOptions {
+  /** Number of jobs to run in parallel. */
+  concurrency: number;
+  /** Optional message to log after jobs complete along with stats */
+  logMsg?: string;
 }

--- a/packages/server/src/storage/base.ts
+++ b/packages/server/src/storage/base.ts
@@ -18,6 +18,8 @@ export abstract class BaseBinaryStorage implements BinaryStorage {
 
   abstract copyFile(sourceKey: string, destinationKey: string): Promise<void>;
 
+  abstract deleteFile(key: string): Promise<void>;
+
   abstract getPresignedUrl(binary: Binary, opts?: PresignedUrlOptions): Promise<string>;
 
   readBinary(binary: Binary): Promise<Readable> {

--- a/packages/server/src/storage/filesystem.test.ts
+++ b/packages/server/src/storage/filesystem.test.ts
@@ -48,6 +48,25 @@ describe('FileSystemStorage', () => {
     expect(content).toStrictEqual('foo');
   });
 
+  test('deleteFile removes a file and is idempotent', async () => {
+    initBinaryStorage('file:binary');
+    const storage = getBinaryStorage();
+
+    const key = 'system/async-batch/delete-test/state.json';
+    await storage.writeFile(key, ContentType.JSON, '{"hello":"world"}');
+
+    // The file can be read back before deletion.
+    const stream = await storage.readFile(key);
+    expect(await streamToString(stream)).toStrictEqual('{"hello":"world"}');
+
+    // After deletion, reading throws.
+    await storage.deleteFile(key);
+    await expect(storage.readFile(key)).rejects.toThrow('File not found');
+
+    // Deleting a missing key is a no-op (idempotent).
+    await expect(storage.deleteFile(key)).resolves.toBeUndefined();
+  });
+
   test('Should throw an error when file is not found in readBinary()', async () => {
     initBinaryStorage('file:binary');
 

--- a/packages/server/src/storage/filesystem.ts
+++ b/packages/server/src/storage/filesystem.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Binary } from '@medplum/fhirtypes';
 import { createReadStream, createWriteStream, readFileSync } from 'node:fs';
-import { access, copyFile, mkdir } from 'node:fs/promises';
+import { access, copyFile, mkdir, rm } from 'node:fs/promises';
 import { resolve, sep } from 'node:path';
 import type { Readable } from 'node:stream';
 import { pipeline } from 'node:stream';
@@ -78,6 +78,11 @@ export class FileSystemStorage extends BaseBinaryStorage {
     const destinationPath = this.getPath(destinationKey);
     await this.ensureDirForFileExists(destinationPath);
     await copyFile(sourcePath, destinationPath);
+  }
+
+  async deleteFile(key: string): Promise<void> {
+    // force: true makes delete idempotent: it does not throw if the file is absent.
+    await rm(this.getPath(key), { force: true });
   }
 
   async getPresignedUrl(binary: Binary, opts?: PresignedUrlOptions): Promise<string> {

--- a/packages/server/src/storage/types.ts
+++ b/packages/server/src/storage/types.ts
@@ -36,9 +36,18 @@ export interface BinaryStorage {
 
   readBinary(binary: Binary): Promise<Readable>;
 
+  readFile(key: string): Promise<Readable>;
+
   copyBinary(sourceBinary: Binary, destinationBinary: Binary): Promise<void>;
 
   copyFile(sourceKey: string, destinationKey: string): Promise<void>;
+
+  /**
+   * Deletes a file by its storage key. Implementations must be idempotent: deleting a key that
+   * does not exist resolves successfully rather than throwing.
+   * @param key - The storage key to delete.
+   */
+  deleteFile(key: string): Promise<void>;
 
   getPresignedUrl(binary: Binary, opts?: PresignedUrlOptions): Promise<string>;
 }

--- a/packages/server/src/workers/batch.test.ts
+++ b/packages/server/src/workers/batch.test.ts
@@ -129,7 +129,7 @@ describe('Batch worker', () => {
     status: AsyncJob['status'] = 'accepted'
   ): Promise<{ asyncJob: WithId<AsyncJob>; job: Job<ReentrantBatchJobData> }> {
     const asyncJob = await createAsyncJob(status);
-    await new BatchCheckpointStore(asyncJob.id).saveInputBundle(bundle);
+    await new BatchCheckpointStore(asyncJob.id, globalLogger).saveInputBundle(bundle);
     const job = makeReentrantJob({ asyncJobId: asyncJob.id, authState, ...extra });
     return { asyncJob, job };
   }
@@ -243,7 +243,7 @@ describe('Batch worker', () => {
       withTestContext(async () => {
         const bundle = multiEntryBundle(3);
         const asyncJob = await createAsyncJob();
-        const store = new BatchCheckpointStore(asyncJob.id);
+        const store = new BatchCheckpointStore(asyncJob.id, globalLogger);
         await store.saveInputBundle(bundle);
 
         // Pre-populate durable state: preprocessed initial state plus one processed entry.
@@ -288,7 +288,7 @@ describe('Batch worker', () => {
 
         // Cancel the AsyncJob as a side effect of the first checkpoint write, so the subsequent
         // in-loop status re-read observes the cancellation and finalizes mid-flight.
-        const store = new BatchCheckpointStore(asyncJob.id);
+        const store = new BatchCheckpointStore(asyncJob.id, globalLogger);
         const realSaveResultChunk = store.saveResultChunk.bind(store);
         let saves = 0;
         vi.spyOn(BatchCheckpointStore.prototype, 'saveResultChunk').mockImplementation(async (seq, results) => {
@@ -424,7 +424,7 @@ describe('Batch worker', () => {
         expect(enqueued.bundle).toBeUndefined();
 
         // The bundle was persisted to durable storage.
-        const stored = await new BatchCheckpointStore(asyncJob.id).loadInputBundle();
+        const stored = await new BatchCheckpointStore(asyncJob.id, globalLogger).loadInputBundle();
         expect(stored).toStrictEqual(bundle);
       });
     });

--- a/packages/server/src/workers/batch.test.ts
+++ b/packages/server/src/workers/batch.test.ts
@@ -1,0 +1,563 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { getReferenceString } from '@medplum/core';
+import type { WithId } from '@medplum/core';
+import type { AsyncJob, Binary, Bundle } from '@medplum/fhirtypes';
+import { DelayedError, Worker } from 'bullmq';
+import type { Job } from 'bullmq';
+import type { Mock } from 'vitest';
+import { initAppServices, shutdownApp } from '../app';
+import { getUserConfiguration } from '../auth/me';
+import { loadTestConfig } from '../config/loader';
+import type { MedplumServerConfig } from '../config/types';
+import { runInAuthenticatedContext } from '../context';
+import { BatchCheckpointStore } from '../fhir/batch/checkpoint-store';
+import { AsyncJobExecutor } from '../fhir/operations/utils/asyncjobexecutor';
+import type { Repository, SystemRepository } from '../fhir/repo';
+import { getShardSystemRepo } from '../fhir/repo';
+import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
+import { globalLogger } from '../logger';
+import type { AuthState } from '../oauth/middleware';
+import { getBinaryStorage } from '../storage/loader';
+import { createTestProject, streamToString, withTestContext } from '../test.setup';
+import type { LegacyBatchJobData, ReentrantBatchJobData } from './batch';
+import {
+  execBatchJob,
+  execLegacyBatchJob,
+  getBatchQueue,
+  initBatchWorker,
+  queueBatchProcessing,
+} from './batch';
+import * as workerUtils from './utils';
+import { queueRegistry } from './utils';
+
+/**
+ * Builds a minimal mock BullMQ Job for a re-entrant batch, with a functional in-memory
+ * `updateData` so checkpoints persist the progress marker (enabling resume tests) and
+ * `moveToDelayed`/`token`/`queueName` so the graceful-shutdown path can be exercised.
+ * @param data - The re-entrant job data.
+ * @param overrides - Optional overrides applied on top of the defaults.
+ * @returns A mock Job usable with execBatchJob.
+ */
+function makeReentrantJob(
+  data: ReentrantBatchJobData,
+  overrides?: Record<string, unknown>
+): Job<ReentrantBatchJobData> {
+  const job: any = {
+    id: 'test-job',
+    name: 'BatchJobData',
+    data,
+    queueName: 'BatchQueue',
+    token: 'test-token',
+    async updateData(newData: ReentrantBatchJobData) {
+      job.data = newData;
+    },
+    moveToDelayed: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+  return job as Job<ReentrantBatchJobData>;
+}
+
+function makeLegacyJob(data: LegacyBatchJobData): Job<LegacyBatchJobData> {
+  return { id: 'legacy-job', name: 'BatchJobData', data, queueName: 'BatchQueue' } as unknown as Job<LegacyBatchJobData>;
+}
+
+const singleEntryBundle = (): Bundle => ({
+  resourceType: 'Bundle',
+  type: 'batch',
+  entry: [{ request: { method: 'POST', url: 'Patient' }, resource: { resourceType: 'Patient' } }],
+});
+
+const multiEntryBundle = (count: number): Bundle => ({
+  resourceType: 'Bundle',
+  type: 'batch',
+  entry: Array.from({ length: count }, () => ({
+    request: { method: 'POST', url: 'Patient' },
+    resource: { resourceType: 'Patient' },
+  })),
+});
+
+describe('Batch worker', () => {
+  let config: MedplumServerConfig;
+  let repo: Repository;
+  let systemRepo: SystemRepository;
+  let authState: AuthState;
+
+  beforeAll(async () => {
+    config = await loadTestConfig();
+    // Async batches throttle by sleeping `points * asyncDelayScaling` ms per DB op in the async
+    // authenticated context (see Repository.recordFhirQuota). These tests exercise behavior, not
+    // throttle timing, so zero the delay to keep the worker-processor tests fast.
+    config.asyncDelayScaling = 0;
+    await initAppServices(config);
+
+    const project = await createTestProject({ withClient: true, withAccessToken: true, withRepo: true });
+    repo = project.repo;
+    systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID);
+    const userConfig = await getUserConfiguration(systemRepo, project.project, project.membership);
+    authState = { login: project.login, project: project.project, membership: project.membership, userConfig };
+  });
+
+  beforeEach(() => {
+    // Silence noisy worker logs; individual tests re-spy on the logger as needed.
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    // restoreAllMocks (not clearAllMocks) so a spy that changed implementation is always reverted,
+    // even if the test failed before its inline mockRestore. Only affects vi.spyOn spies; the
+    // module-level bullmq vi.fn() mocks (Queue.add, etc.) are left intact.
+    vi.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  async function createAsyncJob(status: AsyncJob['status'] = 'accepted'): Promise<WithId<AsyncJob>> {
+    return repo.createResource<AsyncJob>({
+      resourceType: 'AsyncJob',
+      status,
+      request: 'https://example.com/fhir/R4',
+      requestTime: new Date().toISOString(),
+    });
+  }
+
+  // Sets up durable state for a re-entrant batch: creates the AsyncJob and stores the input bundle.
+  async function setupReentrantJob(
+    bundle: Bundle,
+    extra?: Partial<ReentrantBatchJobData>,
+    status: AsyncJob['status'] = 'accepted'
+  ): Promise<{ asyncJob: WithId<AsyncJob>; job: Job<ReentrantBatchJobData> }> {
+    const asyncJob = await createAsyncJob(status);
+    await new BatchCheckpointStore(asyncJob.id).saveInputBundle(bundle);
+    const job = makeReentrantJob({ asyncJobId: asyncJob.id, authState, ...extra });
+    return { asyncJob, job };
+  }
+
+  async function readAsyncJob(id: string): Promise<WithId<AsyncJob>> {
+    return systemRepo.readResource<AsyncJob>('AsyncJob', id);
+  }
+
+  // Reads the Bundle referenced by a `results`/`partialResults` output parameter.
+  async function readResultsBundle(asyncJob: AsyncJob): Promise<Bundle> {
+    const ref = asyncJob.output?.parameter?.find(
+      (p) => p.name === 'results' || p.name === 'partialResults'
+    )?.valueReference?.reference;
+    if (!ref) {
+      throw new Error('No results reference on AsyncJob output');
+    }
+    const binary = await systemRepo.readReference<Binary>({ reference: ref });
+    return JSON.parse(await streamToString(await getBinaryStorage().readBinary(binary))) as Bundle;
+  }
+
+  describe('execBatchJob (re-entrant)', () => {
+    test('Processes a batch to completion', () =>
+      withTestContext(async () => {
+        const { asyncJob, job } = await setupReentrantJob(multiEntryBundle(3));
+
+        await expect(execBatchJob(job)).resolves.toBeUndefined();
+
+        const finished = await readAsyncJob(asyncJob.id);
+        expect(finished.status).toStrictEqual('completed');
+        expect(finished.output?.parameter?.[0]).toMatchObject({
+          name: 'results',
+          valueReference: { reference: expect.stringMatching(/^Binary\//) },
+        });
+
+        const results = await readResultsBundle(finished);
+        expect(results.type).toStrictEqual('batch-response');
+        expect(results.entry).toHaveLength(3);
+        expect(results.entry?.map((e) => e.response?.status)).toStrictEqual(['201', '201', '201']);
+      }));
+
+    test('Fails on invalid bundle rejected during preprocessing, preserving the outcome', () =>
+      withTestContext(async () => {
+        const { asyncJob, job } = await setupReentrantJob({
+          resourceType: 'Bundle',
+          type: 'pergola' as Bundle['type'],
+        });
+
+        await expect(execBatchJob(job)).resolves.toBeUndefined();
+
+        const finished = await readAsyncJob(asyncJob.id);
+        expect(finished.status).toStrictEqual('error');
+        expect(finished.output?.parameter).toStrictEqual([
+          expect.objectContaining({
+            name: 'outcome',
+            resource: expect.objectContaining({
+              issue: [expect.objectContaining({ code: 'invalid', details: { text: expect.stringContaining('pergola') } })],
+            }),
+          }),
+        ]);
+      }));
+
+    test('Fails with partial results when a checkpoint write fails after preprocessing', () =>
+      withTestContext(async () => {
+        const { asyncJob, job } = await setupReentrantJob(multiEntryBundle(2), { checkpointEntries: 1 });
+
+        vi.spyOn(BatchCheckpointStore.prototype, 'saveResultChunk').mockRejectedValue(
+          new Error('object storage unavailable')
+        );
+        const cleanupSpy = vi.spyOn(BatchCheckpointStore.prototype, 'cleanup');
+
+        await expect(execBatchJob(job)).resolves.toBeUndefined();
+
+        const finished = await readAsyncJob(asyncJob.id);
+        expect(finished.status).toStrictEqual('error');
+        // Partial results and the error are attached to the output (plus the failJob outcome).
+        expect(finished.output?.parameter?.map((p) => p.name)).toEqual(
+          expect.arrayContaining(['results', 'error'])
+        );
+        expect(cleanupSpy).toHaveBeenCalled();
+      }));
+
+    test('Delays and re-queues when the queue is closing, then resumes to completion', () =>
+      withTestContext(async () => {
+        const { asyncJob, job } = await setupReentrantJob(multiEntryBundle(2));
+
+        // Allow the first entry to process, then report the queue as closing.
+        let checks = 0;
+        const isClosingSpy = vi.spyOn(queueRegistry, 'isClosing').mockImplementation(() => checks++ >= 1);
+
+        await expect(execBatchJob(job)).rejects.toBeInstanceOf(DelayedError);
+        expect((job as any).moveToDelayed).toHaveBeenCalledWith(expect.any(Number), 'test-token');
+        // Progress was checkpointed into the job data.
+        expect(job.data.position).toStrictEqual(1);
+        expect(job.data.chunkSeq).toStrictEqual(1);
+        // The AsyncJob is still in progress, not failed.
+        expect((await readAsyncJob(asyncJob.id)).status).toStrictEqual('accepted');
+
+        isClosingSpy.mockRestore();
+
+        // Resume on a fresh worker: rehydrate from durable state and finish.
+        const resumeJob = makeReentrantJob(job.data);
+        await expect(execBatchJob(resumeJob)).resolves.toBeUndefined();
+
+        const finished = await readAsyncJob(asyncJob.id);
+        expect(finished.status).toStrictEqual('completed');
+        const results = await readResultsBundle(finished);
+        expect(results.entry).toHaveLength(2);
+        expect(results.entry?.map((e) => e.response?.status)).toStrictEqual(['201', '201']);
+      }));
+
+    test('Publishes partial results when the AsyncJob was cancelled out of band', () =>
+      withTestContext(async () => {
+        const bundle = multiEntryBundle(3);
+        const asyncJob = await createAsyncJob();
+        const store = new BatchCheckpointStore(asyncJob.id);
+        await store.saveInputBundle(bundle);
+
+        // Pre-populate durable state: preprocessed initial state plus one processed entry.
+        const { BatchProcessor, FhirRouter } = await import('@medplum/fhir-router');
+        const processor = new BatchProcessor(new FhirRouter(), repo, bundle, {
+          method: 'POST',
+          url: '/',
+          pathname: '',
+          params: {},
+          query: {},
+          body: undefined,
+        });
+        const initialState = await processor.preprocess();
+        await store.saveInitialState(initialState);
+        await processor.processNextEntry();
+        await store.saveResultChunk(0, processor.takePendingResults());
+
+        // Cancel the job, then run: it should not process further, only publish partial results.
+        await repo.patchResource('AsyncJob', asyncJob.id, [{ op: 'add', path: '/status', value: 'cancelled' }]);
+        const job = makeReentrantJob({ asyncJobId: asyncJob.id, authState, position: 1, chunkSeq: 1 });
+        const cleanupSpy = vi.spyOn(BatchCheckpointStore.prototype, 'cleanup');
+
+        await expect(execBatchJob(job)).resolves.toBeUndefined();
+
+        const finished = await readAsyncJob(asyncJob.id);
+        expect(finished.status).toStrictEqual('cancelled');
+        expect(finished.output?.parameter).toStrictEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ name: 'partialResults' }),
+            expect.objectContaining({ name: 'processedEntries', valueInteger: 1 }),
+          ])
+        );
+        const results = await readResultsBundle(finished);
+        expect(results.entry?.filter(Boolean)).toHaveLength(1);
+        expect(cleanupSpy).toHaveBeenCalled();
+        cleanupSpy.mockRestore();
+      }));
+
+    test('Detects cancellation between checkpoints and publishes partial results', () =>
+      withTestContext(async () => {
+        const { asyncJob, job } = await setupReentrantJob(multiEntryBundle(2), { checkpointEntries: 1 });
+
+        // Cancel the AsyncJob as a side effect of the first checkpoint write, so the subsequent
+        // in-loop status re-read observes the cancellation and finalizes mid-flight.
+        const store = new BatchCheckpointStore(asyncJob.id);
+        const realSaveResultChunk = store.saveResultChunk.bind(store);
+        let saves = 0;
+        vi.spyOn(BatchCheckpointStore.prototype, 'saveResultChunk').mockImplementation(async (seq, results) => {
+          await realSaveResultChunk(seq, results);
+          if (++saves === 1) {
+            await repo.patchResource('AsyncJob', asyncJob.id, [{ op: 'add', path: '/status', value: 'cancelled' }]);
+          }
+        });
+
+        await expect(execBatchJob(job)).resolves.toBeUndefined();
+
+        const finished = await readAsyncJob(asyncJob.id);
+        expect(finished.status).toStrictEqual('cancelled');
+        expect(finished.output?.parameter).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ name: 'partialResults' }),
+            expect.objectContaining({ name: 'processedEntries', valueInteger: 1 }),
+          ])
+        );
+      }));
+
+    test('Swallows a failJob error thrown after preprocessing (partial-results branch)', () =>
+      withTestContext(async () => {
+        const { asyncJob, job } = await setupReentrantJob(multiEntryBundle(2), { checkpointEntries: 1 });
+        vi.spyOn(BatchCheckpointStore.prototype, 'saveResultChunk').mockRejectedValue(new Error('storage down'));
+        vi.spyOn(AsyncJobExecutor.prototype, 'failJob').mockRejectedValue(new Error('db down'));
+
+        // The failJob rejection is caught and logged; execBatchJob still resolves.
+        await expect(execBatchJob(job)).resolves.toBeUndefined();
+        expect(AsyncJobExecutor.prototype.failJob).toHaveBeenCalled();
+        expect((await readAsyncJob(asyncJob.id)).status).toStrictEqual('accepted');
+      }));
+
+    test('Swallows a failJob error when preprocessing fails (no partial results)', () =>
+      withTestContext(async () => {
+        const { job } = await setupReentrantJob({ resourceType: 'Bundle', type: 'pergola' as Bundle['type'] });
+        vi.spyOn(AsyncJobExecutor.prototype, 'failJob').mockRejectedValue(new Error('db down'));
+
+        await expect(execBatchJob(job)).resolves.toBeUndefined();
+        expect(AsyncJobExecutor.prototype.failJob).toHaveBeenCalled();
+      }));
+
+    test('Cancelled with no durable state cleans up without publishing results', () =>
+      withTestContext(async () => {
+        const { asyncJob, job } = await setupReentrantJob(singleEntryBundle(), undefined, 'cancelled');
+        const cleanupSpy = vi.spyOn(BatchCheckpointStore.prototype, 'cleanup');
+
+        await expect(execBatchJob(job)).resolves.toBeUndefined();
+
+        // finalizeInterrupted could not load initial state (none was persisted), so no results
+        // are published, but durable state is still cleaned up and the status is untouched.
+        const finished = await readAsyncJob(asyncJob.id);
+        expect(finished.status).toStrictEqual('cancelled');
+        expect(finished.output).toBeUndefined();
+        expect(cleanupSpy).toHaveBeenCalled();
+      }));
+  });
+
+  describe('execLegacyBatchJob (deprecated)', () => {
+    test('Processes a legacy batch to completion, counting per-entry errors', () =>
+      withTestContext(async () => {
+        const asyncJob = await createAsyncJob();
+        // One successful create and one failing read, so the worker's error tally is exercised.
+        const bundle: Bundle = {
+          resourceType: 'Bundle',
+          type: 'batch',
+          entry: [
+            { request: { method: 'POST', url: 'Patient' }, resource: { resourceType: 'Patient' } },
+            { request: { method: 'GET', url: 'Patient/00000000-0000-4000-8000-000000000000' } },
+          ],
+        };
+        const job = makeLegacyJob({ asyncJob, bundle, authState });
+
+        await expect(execLegacyBatchJob(job)).resolves.toBeUndefined();
+
+        const finished = await readAsyncJob(asyncJob.id);
+        expect(finished.status).toStrictEqual('completed');
+        const results = await readResultsBundle(finished);
+        expect(results.entry).toHaveLength(2);
+        expect(results.entry?.map((e) => e.response?.status)).toStrictEqual(['201', '404']);
+      }));
+
+    test('Fails the job when the batch request returns a non-ok outcome', () =>
+      withTestContext(async () => {
+        const asyncJob = await createAsyncJob();
+        const job = makeLegacyJob({
+          asyncJob,
+          bundle: { resourceType: 'Bundle', type: 'pergola' as Bundle['type'] },
+          authState,
+        });
+
+        await expect(execLegacyBatchJob(job)).resolves.toBeUndefined();
+
+        const finished = await readAsyncJob(asyncJob.id);
+        expect(finished.status).toStrictEqual('error');
+        expect(finished.output?.parameter?.[0]).toMatchObject({ name: 'outcome' });
+      }));
+
+    test('Fails the job when an unexpected error is thrown', () =>
+      withTestContext(async () => {
+        const asyncJob = await createAsyncJob();
+        const job = makeLegacyJob({ asyncJob, bundle: singleEntryBundle(), authState });
+
+        const writeSpy = vi
+          .spyOn(getBinaryStorage(), 'writeBinary')
+          .mockRejectedValue(new Error('storage exploded'));
+
+        await expect(execLegacyBatchJob(job)).resolves.toBeUndefined();
+
+        const finished = await readAsyncJob(asyncJob.id);
+        expect(finished.status).toStrictEqual('error');
+        writeSpy.mockRestore();
+      }));
+  });
+
+  describe('queueBatchProcessing', () => {
+    test('Stores the input bundle out-of-band and enqueues re-entrant job data', async () => {
+      const queue = getBatchQueue() as any;
+      queue.add.mockClear();
+      const bundle = singleEntryBundle();
+
+      await withTestContext(async () => {
+        const asyncJob = await createAsyncJob();
+
+        await runInAuthenticatedContext(authState, undefined, undefined, undefined, () =>
+          queueBatchProcessing(bundle, asyncJob)
+        );
+
+        // Enqueued data carries asyncJobId and authState, but NOT the bundle (#9124).
+        expect(queue.add).toHaveBeenCalledWith(
+          'BatchJobData',
+          expect.objectContaining<Partial<ReentrantBatchJobData>>({ asyncJobId: asyncJob.id, authState })
+        );
+        const enqueued = queue.add.mock.calls[0][1] as ReentrantBatchJobData & { bundle?: unknown };
+        expect(enqueued.bundle).toBeUndefined();
+
+        // The bundle was persisted to durable storage.
+        const stored = await new BatchCheckpointStore(asyncJob.id).loadInputBundle();
+        expect(stored).toStrictEqual(bundle);
+      });
+    });
+
+    test('Throws when the batch queue is not available', () =>
+      withTestContext(async () => {
+        const asyncJob = await createAsyncJob();
+        vi.spyOn(queueRegistry, 'get').mockReturnValue(undefined);
+
+        await expect(
+          runInAuthenticatedContext(authState, undefined, undefined, undefined, () =>
+            queueBatchProcessing(singleEntryBundle(), asyncJob)
+          )
+        ).rejects.toThrow('Job queue BatchQueue not available');
+      }));
+  });
+
+  describe('worker wiring', () => {
+    // Captures the processor function and the `failed` event handler registered by initBatchWorker.
+    function captureWorker(): {
+      processor: (job: Job) => Promise<void>;
+      failedHandler: (job: Job | undefined, err: Error) => Promise<void>;
+    } {
+      const { worker } = initBatchWorker(config);
+      const processor = vi.mocked(Worker).mock.calls.at(-1)?.[1] as (job: Job) => Promise<void>;
+      const onCalls = (worker?.on as unknown as Mock).mock.calls as [string, (...args: any[]) => any][];
+      const failedHandler = onCalls.find((c) => c[0] === 'failed')?.[1] as (
+        job: Job | undefined,
+        err: Error
+      ) => Promise<void>;
+      return { processor, failedHandler };
+    }
+
+    test('Dispatches re-entrant jobs to execBatchJob', () =>
+      withTestContext(async () => {
+        const { processor } = captureWorker();
+        const { asyncJob, job } = await setupReentrantJob(singleEntryBundle());
+
+        await expect(processor(job)).resolves.toBeUndefined();
+        expect((await readAsyncJob(asyncJob.id)).status).toStrictEqual('completed');
+      }));
+
+    test('Dispatches legacy jobs to execLegacyBatchJob', () =>
+      withTestContext(async () => {
+        const { processor } = captureWorker();
+        const asyncJob = await createAsyncJob();
+        const job = makeLegacyJob({ asyncJob, bundle: singleEntryBundle(), authState });
+
+        await expect(processor(job)).resolves.toBeUndefined();
+        expect((await readAsyncJob(asyncJob.id)).status).toStrictEqual('completed');
+      }));
+
+    test('Throws on unrecognized job data', () =>
+      withTestContext(async () => {
+        const { processor } = captureWorker();
+        await expect(processor({ data: { authState } } as unknown as Job)).rejects.toThrow(TypeError);
+      }));
+
+    test('Verbose logging fields resolve the async job reference for both job shapes', () =>
+      withTestContext(async () => {
+        const spy = vi.spyOn(workerUtils, 'addVerboseQueueLogging');
+        initBatchWorker(config);
+        const logFields = spy.mock.calls.at(-1)?.[2] as (job: Job) => Record<string, unknown>;
+        const asyncJob = await createAsyncJob();
+
+        expect(logFields(makeLegacyJob({ asyncJob, bundle: singleEntryBundle(), authState }))).toMatchObject({
+          asyncJob: getReferenceString(asyncJob),
+        });
+        expect(logFields(makeReentrantJob({ asyncJobId: asyncJob.id, authState }))).toHaveProperty('asyncJob');
+      }));
+
+    describe('failed handler', () => {
+      test('No-op when there is no job', async () => {
+        const { failedHandler } = captureWorker();
+        await expect(failedHandler(undefined, new Error('x'))).resolves.toBeUndefined();
+      });
+
+      test('No-op for a DelayedError (job was re-queued, not failed)', () =>
+        withTestContext(async () => {
+          const { failedHandler } = captureWorker();
+          const { asyncJob, job } = await setupReentrantJob(singleEntryBundle());
+          await failedHandler(job, new DelayedError());
+          expect((await readAsyncJob(asyncJob.id)).status).toStrictEqual('accepted');
+        }));
+
+      test('Fails the AsyncJob for a legacy job', () =>
+        withTestContext(async () => {
+          const { failedHandler } = captureWorker();
+          const asyncJob = await createAsyncJob();
+          await failedHandler(makeLegacyJob({ asyncJob, bundle: singleEntryBundle(), authState }), new Error('boom'));
+          expect((await readAsyncJob(asyncJob.id)).status).toStrictEqual('error');
+        }));
+
+      test('Fails the active AsyncJob and cleans up for a re-entrant job', () =>
+        withTestContext(async () => {
+          const { failedHandler } = captureWorker();
+          const { asyncJob, job } = await setupReentrantJob(singleEntryBundle(), { chunkSeq: 0 });
+          const cleanupSpy = vi.spyOn(BatchCheckpointStore.prototype, 'cleanup');
+
+          await failedHandler(job, new Error('boom'));
+
+          expect((await readAsyncJob(asyncJob.id)).status).toStrictEqual('error');
+          expect(cleanupSpy).toHaveBeenCalledWith(0);
+          cleanupSpy.mockRestore();
+        }));
+
+      test('Skips failing a re-entrant job that is no longer active but still cleans up', () =>
+        withTestContext(async () => {
+          const { failedHandler } = captureWorker();
+          const { asyncJob, job } = await setupReentrantJob(singleEntryBundle(), undefined, 'cancelled');
+          const cleanupSpy = vi.spyOn(BatchCheckpointStore.prototype, 'cleanup');
+
+          await failedHandler(job, new Error('boom'));
+
+          expect((await readAsyncJob(asyncJob.id)).status).toStrictEqual('cancelled');
+          expect(cleanupSpy).toHaveBeenCalled();
+          cleanupSpy.mockRestore();
+        }));
+
+      // Not wrapped in withTestContext so getLogger() falls back to the globalLogger we spy on.
+      test('Logs and returns for unrecognized job data', async () => {
+        const { failedHandler } = captureWorker();
+        const errorSpy = vi.spyOn(globalLogger, 'error').mockImplementation(() => {});
+        await failedHandler({ data: { authState } } as unknown as Job, new Error('boom'));
+        expect(errorSpy).toHaveBeenCalledWith(
+          'Unrecognized BatchJobData',
+          expect.objectContaining({ jobData: { authState } })
+        );
+      });
+    });
+  });
+});

--- a/packages/server/src/workers/batch.test.ts
+++ b/packages/server/src/workers/batch.test.ts
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { getReferenceString } from '@medplum/core';
 import type { WithId } from '@medplum/core';
+import { getReferenceString } from '@medplum/core';
 import type { AsyncJob, Binary, Bundle } from '@medplum/fhirtypes';
-import { DelayedError, Worker } from 'bullmq';
 import type { Job } from 'bullmq';
+import { DelayedError, Worker } from 'bullmq';
 import type { Mock } from 'vitest';
 import { initAppServices, shutdownApp } from '../app';
 import { getUserConfiguration } from '../auth/me';
@@ -21,13 +21,7 @@ import type { AuthState } from '../oauth/middleware';
 import { getBinaryStorage } from '../storage/loader';
 import { createTestProject, streamToString, withTestContext } from '../test.setup';
 import type { LegacyBatchJobData, ReentrantBatchJobData } from './batch';
-import {
-  execBatchJob,
-  execLegacyBatchJob,
-  getBatchQueue,
-  initBatchWorker,
-  queueBatchProcessing,
-} from './batch';
+import { execBatchJob, execLegacyBatchJob, getBatchQueue, initBatchWorker, queueBatchProcessing } from './batch';
 import * as workerUtils from './utils';
 import { queueRegistry } from './utils';
 
@@ -59,7 +53,12 @@ function makeReentrantJob(
 }
 
 function makeLegacyJob(data: LegacyBatchJobData): Job<LegacyBatchJobData> {
-  return { id: 'legacy-job', name: 'BatchJobData', data, queueName: 'BatchQueue' } as unknown as Job<LegacyBatchJobData>;
+  return {
+    id: 'legacy-job',
+    name: 'BatchJobData',
+    data,
+    queueName: 'BatchQueue',
+  } as unknown as Job<LegacyBatchJobData>;
 }
 
 const singleEntryBundle = (): Bundle => ({
@@ -141,9 +140,8 @@ describe('Batch worker', () => {
 
   // Reads the Bundle referenced by a `results`/`partialResults` output parameter.
   async function readResultsBundle(asyncJob: AsyncJob): Promise<Bundle> {
-    const ref = asyncJob.output?.parameter?.find(
-      (p) => p.name === 'results' || p.name === 'partialResults'
-    )?.valueReference?.reference;
+    const ref = asyncJob.output?.parameter?.find((p) => p.name === 'results' || p.name === 'partialResults')
+      ?.valueReference?.reference;
     if (!ref) {
       throw new Error('No results reference on AsyncJob output');
     }
@@ -186,7 +184,9 @@ describe('Batch worker', () => {
           expect.objectContaining({
             name: 'outcome',
             resource: expect.objectContaining({
-              issue: [expect.objectContaining({ code: 'invalid', details: { text: expect.stringContaining('pergola') } })],
+              issue: [
+                expect.objectContaining({ code: 'invalid', details: { text: expect.stringContaining('pergola') } }),
+              ],
             }),
           }),
         ]);
@@ -206,9 +206,7 @@ describe('Batch worker', () => {
         const finished = await readAsyncJob(asyncJob.id);
         expect(finished.status).toStrictEqual('error');
         // Partial results and the error are attached to the output (plus the failJob outcome).
-        expect(finished.output?.parameter?.map((p) => p.name)).toEqual(
-          expect.arrayContaining(['results', 'error'])
-        );
+        expect(finished.output?.parameter?.map((p) => p.name)).toEqual(expect.arrayContaining(['results', 'error']));
         expect(cleanupSpy).toHaveBeenCalled();
       }));
 
@@ -394,9 +392,7 @@ describe('Batch worker', () => {
         const asyncJob = await createAsyncJob();
         const job = makeLegacyJob({ asyncJob, bundle: singleEntryBundle(), authState });
 
-        const writeSpy = vi
-          .spyOn(getBinaryStorage(), 'writeBinary')
-          .mockRejectedValue(new Error('storage exploded'));
+        const writeSpy = vi.spyOn(getBinaryStorage(), 'writeBinary').mockRejectedValue(new Error('storage exploded'));
 
         await expect(execLegacyBatchJob(job)).resolves.toBeUndefined();
 

--- a/packages/server/src/workers/batch.test.ts
+++ b/packages/server/src/workers/batch.test.ts
@@ -259,7 +259,9 @@ describe('Batch worker', () => {
         const initialState = await processor.preprocess();
         await store.saveInitialState(initialState);
         await processor.processNextEntry();
-        await store.saveResultChunk(0, processor.takePendingResults());
+        const pending = processor.takePendingResults();
+        assert(pending);
+        await store.saveResultChunk(0, pending);
 
         // Cancel the job, then run: it should not process further, only publish partial results.
         await repo.patchResource('AsyncJob', asyncJob.id, [{ op: 'add', path: '/status', value: 'cancelled' }]);

--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -74,7 +74,7 @@ interface BaseBatchJobData {
   readonly traceId?: string;
 }
 
-interface LegacyBatchJobData extends BaseBatchJobData {
+export interface LegacyBatchJobData extends BaseBatchJobData {
   readonly asyncJob: WithId<AsyncJob>;
   readonly bundle: Bundle;
 }
@@ -489,7 +489,7 @@ function countBundleErrors(bundle: Bundle): number {
  * @deprecated Processes legacy jobs. Can be removed in v5.2+
  * @param job - The BullMQ job instance.
  */
-async function execLegacyBatchJob(job: Job<LegacyBatchJobData>): Promise<void> {
+export async function execLegacyBatchJob(job: Job<LegacyBatchJobData>): Promise<void> {
   const bundle = job.data.bundle;
   const { login, project, membership } = job.data.authState;
   const logger = getLogger();

--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -103,7 +103,7 @@ export type BatchJobData = LegacyBatchJobData | ReentrantBatchJobData;
 const queueName = 'BatchQueue';
 const jobName = 'BatchJobData';
 
-const defaultCheckpointEntries = 4;
+const defaultCheckpointEntries = 10;
 const defaultCheckpointIntervalMs = 5000;
 
 export const initBatchWorker: WorkerInitializer = (config, options?: WorkerInitializerOptions) => {
@@ -129,7 +129,7 @@ export const initBatchWorker: WorkerInitializer = (config, options?: WorkerIniti
           } else if ('asyncJobId' in job.data) {
             return execBatchJob(job as Job<ReentrantBatchJobData>);
           } else {
-            throw TypeError('Unrecognized BatchJobData', { cause: job.data });
+            throw new TypeError('Unrecognized BatchJobData', { cause: job.data });
           }
         });
       },
@@ -347,13 +347,18 @@ export async function execBatchJob(job: Job<ReentrantBatchJobData>): Promise<voi
     await checkpoint();
 
     // Assemble the complete response bundle and upload it as a Binary for async retrieval.
-    const { binary, bundle } = await assembleResultBundle(userRepo, store, initialState, chunkSeq);
-    const errors = countBundleErrors(bundle);
+    const { binary, bundle: resultBundle } = await assembleResultBundle(
+      userRepo.clone(),
+      store,
+      initialState,
+      chunkSeq
+    );
+    const errors = countBundleErrors(resultBundle);
     logger.info('Completed async batch request', {
       jobId: job.id,
       asyncJob: asyncJob.id,
       results: getReferenceString(binary),
-      entries: bundle.entry?.length,
+      entries: resultBundle.entry?.length,
       errors,
     });
     await exec.completeJob({

--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -103,7 +103,7 @@ export type BatchJobData = LegacyBatchJobData | ReentrantBatchJobData;
 const queueName = 'BatchQueue';
 const jobName = 'BatchJobData';
 
-const defaultCheckpointEntries = 50;
+const defaultCheckpointEntries = 4;
 const defaultCheckpointIntervalMs = 5000;
 
 export const initBatchWorker: WorkerInitializer = (config, options?: WorkerInitializerOptions) => {

--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { WithId } from '@medplum/core';
+import type { ILogger, WithId } from '@medplum/core';
 import {
   ContentType,
   createReference,
@@ -173,13 +173,15 @@ export const initBatchWorker: WorkerInitializer = (config, options?: WorkerIniti
           await new AsyncJobExecutor(systemRepo, asyncJob).failJob(failedErr ?? undefined);
         }
       } finally {
-        const store = new BatchCheckpointStore(job.data.asyncJobId);
+        const logger = getBatchLogger(job.data.asyncJobId, job.id);
+        const store = new BatchCheckpointStore(job.data.asyncJobId, logger);
         await store.cleanup(job.data.chunkSeq ?? 0);
       }
     });
     addVerboseQueueLogging<BatchJobData>(queue, worker, (job) => {
       const asyncJobRef = 'asyncJob' in job.data ? job.data.asyncJob : { id: job.data.asyncJobId };
       return {
+        subsystem: BATCH_LOGGER_SUBSYSTEM,
         asyncJob: getReferenceString(asyncJobRef),
         project: getReferenceString(job.data.authState.project),
         profile: job.data.authState.profile && getReferenceString(job.data.authState.profile),
@@ -221,7 +223,7 @@ export async function queueBatchProcessing(bundle: Bundle, asyncJob: WithId<Asyn
   // Persist the (potentially large) input bundle to durable object storage rather than carrying it
   // in the BullMQ job data (see https://github.com/medplum/medplum/issues/9124). The worker loads
   // it on the first run to preprocess.
-  await new BatchCheckpointStore(asyncJob.id).saveInputBundle(bundle);
+  await new BatchCheckpointStore(asyncJob.id, getBatchLogger(asyncJob.id)).saveInputBundle(bundle);
   return addBatchJobData({ asyncJobId: asyncJob.id, authState, requestId, traceId });
 }
 
@@ -251,9 +253,9 @@ async function getBatchUserRepo(authState: Readonly<AuthState>, userConfig: User
  */
 export async function execBatchJob(job: Job<ReentrantBatchJobData>): Promise<void> {
   const { authState } = job.data;
-  const logger = getLogger();
+  const logger = getBatchLogger(job.data.asyncJobId, job.id);
   const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be available in job.data.authState in the future
-  const store = new BatchCheckpointStore(job.data.asyncJobId);
+  const store = new BatchCheckpointStore(job.data.asyncJobId, logger);
   let asyncJob = await systemRepo.readResource<AsyncJob>('AsyncJob', job.data.asyncJobId);
   let chunkSeq = job.data.chunkSeq ?? 0;
 
@@ -297,6 +299,7 @@ export async function execBatchJob(job: Job<ReentrantBatchJobData>): Promise<voi
       initialState = await store.loadInitialState();
       position = job.data.position;
       processor = BatchProcessor.fromState(router, userRepo, req, initialState, position);
+      logger.info('resuming from checkpoint', { position, chunkSeq });
     }
 
     const checkpointEntries = job.data.checkpointEntries ?? defaultCheckpointEntries;
@@ -313,6 +316,7 @@ export async function execBatchJob(job: Job<ReentrantBatchJobData>): Promise<voi
         chunkSeq++;
       }
       await job.updateData({ ...job.data, position: processor.getPosition(), chunkSeq });
+      logger.info('checkpoint', { position: processor.getPosition(), chunkSeq });
       sinceCheckpoint = 0;
       lastCheckpointTime = Date.now();
     };
@@ -320,11 +324,7 @@ export async function execBatchJob(job: Job<ReentrantBatchJobData>): Promise<voi
     while (processor.hasMoreEntries()) {
       // Graceful shutdown: checkpoint and re-queue so a future worker resumes where we left off.
       if (queueRegistry.isClosing(job.queueName)) {
-        logger.info('Async batch job detected queue is closing; delaying', {
-          jobId: job.id,
-          asyncJob: asyncJob.id,
-          position: processor.getPosition(),
-        });
+        logger.info('delaying since queue is closing', { position: processor.getPosition() });
         await checkpoint();
         await moveToDelayedAndThrow(job, 'Async batch delayed since queue is closing');
       }
@@ -354,9 +354,7 @@ export async function execBatchJob(job: Job<ReentrantBatchJobData>): Promise<voi
       chunkSeq
     );
     const errors = countBundleErrors(resultBundle);
-    logger.info('Completed async batch request', {
-      jobId: job.id,
-      asyncJob: asyncJob.id,
+    logger.info('completed processing batch', {
       results: getReferenceString(binary),
       entries: resultBundle.entry?.length,
       errors,
@@ -373,7 +371,7 @@ export async function execBatchJob(job: Job<ReentrantBatchJobData>): Promise<voi
       throw err;
     }
 
-    logger.error('Async batch unhandled exception', err instanceof Error ? err : { err });
+    logger.error('unhandled exception', err instanceof Error ? err : { err });
     // Preserve a structured OperationOutcomeError (e.g. a bad bundle rejected during preprocessing)
     // rather than masking it as a generic server error.
     const failErr =
@@ -497,7 +495,7 @@ function countBundleErrors(bundle: Bundle): number {
 export async function execLegacyBatchJob(job: Job<LegacyBatchJobData>): Promise<void> {
   const bundle = job.data.bundle;
   const { login, project, membership } = job.data.authState;
-  const logger = getLogger();
+  const logger = getBatchLogger(job.data.asyncJob.id, job.id);
   const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be available in job.data.authState in the future
 
   // Prepare the original submitting user's repo
@@ -539,8 +537,6 @@ export async function execLegacyBatchJob(job: Job<LegacyBatchJobData>): Promise<
       }
 
       logger.info('Completed async batch request', {
-        jobId: job.id,
-        asyncJob: job.data.asyncJob.id,
         results: getReferenceString(binary),
         entries: bundle.entry.length,
         errors,
@@ -550,11 +546,7 @@ export async function execLegacyBatchJob(job: Job<LegacyBatchJobData>): Promise<
         parameter: [{ name: 'results', valueReference: createReference(binary) }],
       });
     } else {
-      logger.warn('Async batch request failed', {
-        jobId: job.id,
-        asyncJob: job.data.asyncJob.id,
-        outcome,
-      });
+      logger.warn('Async batch request failed', { outcome });
       await exec.failJob(new OperationOutcomeError(outcome));
     }
   } catch (err: any) {
@@ -562,4 +554,18 @@ export async function execLegacyBatchJob(job: Job<LegacyBatchJobData>): Promise<
     // Try to mark AsyncJob as failed, best effort
     await exec.failJob(new OperationOutcomeError(serverError(err))).catch(() => {});
   }
+}
+
+const BATCH_LOGGER_SUBSYSTEM = 'async-batch';
+
+function getBatchLogger(asyncJobId: string, jobId?: string): ILogger {
+  const baseLogger = getLogger();
+  const metadata: Record<string, string> = {
+    subsystem: BATCH_LOGGER_SUBSYSTEM,
+    asyncJob: 'AsyncJob/' + asyncJobId,
+  };
+  if (jobId) {
+    metadata.jobId = jobId;
+  }
+  return baseLogger.clone({ metadata });
 }

--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -311,7 +311,7 @@ export async function execBatchJob(job: Job<ReentrantBatchJobData>): Promise<voi
     // progress marker. This ordering guarantees the marker never moves past an unpersisted result.
     const checkpoint = async (): Promise<void> => {
       const pending = processor.takePendingResults();
-      if (Object.keys(pending).length > 0) {
+      if (pending) {
         await store.saveResultChunk(chunkSeq, pending);
         chunkSeq++;
       }

--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -269,7 +269,7 @@ export async function execBatchJob(job: Job<ReentrantBatchJobData>): Promise<voi
   let chunkSeq = job.data.chunkSeq ?? 0;
 
   if (!isJobActive(asyncJob)) {
-    await finalizeInterrupted(job, systemRepo, store, asyncJob, chunkSeq, authState);
+    await finalizeInterrupted(logger, systemRepo, store, asyncJob, chunkSeq, authState);
     return;
   }
 
@@ -346,7 +346,7 @@ export async function execBatchJob(job: Job<ReentrantBatchJobData>): Promise<voi
 
         asyncJob = await systemRepo.readResource<AsyncJob>('AsyncJob', asyncJob.id);
         if (!isJobActive(asyncJob)) {
-          await finalizeInterrupted(job, systemRepo, store, asyncJob, chunkSeq, authState);
+          await finalizeInterrupted(logger, systemRepo, store, asyncJob, chunkSeq, authState);
           return;
         }
       }
@@ -418,7 +418,7 @@ export async function execBatchJob(job: Job<ReentrantBatchJobData>): Promise<voi
  * results were persisted and records them on the AsyncJob's output without changing its status,
  * then cleans up durable state. Best-effort: an interrupted job's status was set by another party,
  * so a conflicting update is ignored.
- * @param job - The BullMQ job instance.
+ * @param logger - The logger instance.
  * @param systemRepo - The system repository.
  * @param store - The checkpoint store.
  * @param asyncJob - The (refreshed) AsyncJob, in a terminal/cancelled state.
@@ -426,7 +426,7 @@ export async function execBatchJob(job: Job<ReentrantBatchJobData>): Promise<voi
  * @param authState - The auth state captured when the batch was submitted.
  */
 async function finalizeInterrupted(
-  job: Job<ReentrantBatchJobData>,
+  logger: ILogger,
   systemRepo: SystemRepository,
   store: BatchCheckpointStore,
   asyncJob: WithId<AsyncJob>,
@@ -434,9 +434,7 @@ async function finalizeInterrupted(
   authState: Readonly<AuthState>
 ): Promise<void> {
   try {
-    getLogger().info('Async batch job cancelled mid-flight; making partial results available', {
-      jobId: job.id,
-      asyncJob: asyncJob.id,
+    logger.info('Async batch job cancelled mid-flight; making partial results available', {
       status: asyncJob.status,
     });
     const initialState = await store.loadInitialState();
@@ -453,8 +451,7 @@ async function finalizeInterrupted(
     // Best-effort: another party set this job's status, so a conflicting update is ignored.
     await updateAsyncJobOutput(systemRepo, asyncJob, output).catch(() => {});
   } catch (err) {
-    getLogger().warn('Could not assemble partial results for interrupted async batch', {
-      asyncJob: asyncJob.id,
+    logger.warn('Could not assemble partial results for interrupted async batch', {
       error: normalizeErrorString(err),
     });
   } finally {

--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -210,7 +210,7 @@ export function getBatchQueue(): Queue<BatchJobData> | undefined {
  * @param jobData - The batch job details.
  * @returns The enqueued job.
  */
-async function addBatchJobData(jobData: ReentrantBatchJobData): Promise<Job<BatchJobData>> {
+async function addBatchJobData(jobData: BatchJobData): Promise<Job<BatchJobData>> {
   const queue = queueRegistry.get<BatchJobData>(queueName);
   if (!queue) {
     throw new Error(`Job queue ${queueName} not available`);
@@ -225,6 +225,15 @@ export async function queueBatchProcessing(bundle: Bundle, asyncJob: WithId<Asyn
   // it on the first run to preprocess.
   await new BatchCheckpointStore(asyncJob.id, getBatchLogger(asyncJob.id)).saveInputBundle(bundle);
   return addBatchJobData({ asyncJobId: asyncJob.id, authState, requestId, traceId });
+}
+
+export async function queueLegacyBatchProcessing(
+  bundle: Bundle,
+  asyncJob: WithId<AsyncJob>
+): Promise<Job<BatchJobData>> {
+  const { authentication: authState, requestId, traceId } = getAuthenticatedContext();
+  const jobData: LegacyBatchJobData = { asyncJob, bundle, authState, requestId, traceId };
+  return addBatchJobData(jobData);
 }
 
 /**

--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -12,7 +12,7 @@ import {
 } from '@medplum/core';
 import type { BatchInitialState, FhirRequest } from '@medplum/fhir-router';
 import { BatchProcessor, buildBatchResponseBundle, FhirRouter } from '@medplum/fhir-router';
-import type { AsyncJob, Binary, Bundle, Parameters } from '@medplum/fhirtypes';
+import type { AsyncJob, Binary, Bundle, Parameters, UserConfiguration } from '@medplum/fhirtypes';
 import type { Job } from 'bullmq';
 import { DelayedError, Queue, Worker } from 'bullmq';
 import { getUserConfiguration } from '../auth/me';
@@ -68,11 +68,19 @@ import {
  * └──────────────────────────────────────────────────────────────────────────────────────────┘
  */
 
-export interface BatchJobData {
-  readonly asyncJob: WithId<AsyncJob>;
+interface BaseBatchJobData {
   readonly authState: Readonly<AuthState>;
   readonly requestId?: string;
   readonly traceId?: string;
+}
+
+interface LegacyBatchJobData extends BaseBatchJobData {
+  readonly asyncJob: WithId<AsyncJob>;
+  readonly bundle: Bundle;
+}
+
+export interface ReentrantBatchJobData extends BaseBatchJobData {
+  readonly asyncJobId: string;
   /**
    * Index into the preprocessed ordering of the next entry to process. `undefined` on the initial
    * enqueue (before the bundle has been preprocessed). Updated via `job.updateData` at each
@@ -89,6 +97,8 @@ export interface BatchJobData {
   /** Max milliseconds elapsed between checkpoints. Defaults to {@link defaultCheckpointIntervalMs}. */
   readonly checkpointIntervalMs?: number;
 }
+
+export type BatchJobData = LegacyBatchJobData | ReentrantBatchJobData;
 
 const queueName = 'BatchQueue';
 const jobName = 'BatchJobData';
@@ -113,7 +123,15 @@ export const initBatchWorker: WorkerInitializer = (config, options?: WorkerIniti
       queueName,
       (job) => {
         const { authState, requestId, traceId } = job.data;
-        return runInAuthenticatedContext(authState, requestId, traceId, { async: true }, () => execBatchJob(job));
+        return runInAuthenticatedContext(authState, requestId, traceId, { async: true }, () => {
+          if ('asyncJob' in job.data) {
+            return execLegacyBatchJob(job as Job<LegacyBatchJobData>);
+          } else if ('asyncJobId' in job.data) {
+            return execBatchJob(job as Job<ReentrantBatchJobData>);
+          } else {
+            throw TypeError('Unrecognized BatchJobData', { cause: job.data });
+          }
+        });
       },
       {
         ...defaultOptions,
@@ -122,45 +140,55 @@ export const initBatchWorker: WorkerInitializer = (config, options?: WorkerIniti
       }
     );
 
-    worker.on('failed', async (job, err) => {
+    worker.on('failed', async (job, failedErr) => {
       if (!job) {
         return;
       }
 
       // A delayed/re-queued job is not a failure; nothing to do.
-      if (err instanceof DelayedError) {
+      if (failedErr instanceof DelayedError) {
         return;
       }
 
       // This fires only when the job could not be recovered by re-entrant resume (e.g. it stalled
       // more than maxStalledCount times). Mark the AsyncJob failed if it is still in progress and
       // clean up any durable checkpoint state.
-      const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be available in job.data.authState in the future
-      const store = new BatchCheckpointStore(job.data.asyncJob.id);
-      try {
-        const asyncJob = await systemRepo.readResource<AsyncJob>('AsyncJob', job.data.asyncJob.id);
-        if (isJobActive(asyncJob)) {
-          await new AsyncJobExecutor(systemRepo, asyncJob).failJob(err ?? undefined);
-        }
-      } catch (readErr) {
-        // Fall back to failing with the stale snapshot if the job could not be re-read.
-        await new AsyncJobExecutor(systemRepo, job.data.asyncJob).failJob(err ?? undefined).catch(() => {});
-        getLogger().error('Async batch failed handler could not refresh AsyncJob', {
-          asyncJob: job.data.asyncJob.id,
-          error: normalizeErrorString(readErr),
-        });
+
+      if ('asyncJob' in job.data && job.data.asyncJob) {
+        job.data satisfies LegacyBatchJobData;
+        const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be available in job.data.authState in the future
+        const exec = new AsyncJobExecutor(systemRepo, job.data.asyncJob);
+        await exec.failJob();
+        return;
+      } else if (!('asyncJobId' in job.data) || !job.data.asyncJobId) {
+        getLogger().error('Unrecognized BatchJobData', { jobData: job.data });
+        return;
       }
-      await store.cleanup(job.data.chunkSeq ?? 0);
+
+      job.data satisfies ReentrantBatchJobData;
+      try {
+        const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be available in job.data.authState in the future
+        const asyncJob = await systemRepo.readResource<AsyncJob>('AsyncJob', job.data.asyncJobId);
+        if (isJobActive(asyncJob)) {
+          await new AsyncJobExecutor(systemRepo, asyncJob).failJob(failedErr ?? undefined);
+        }
+      } finally {
+        const store = new BatchCheckpointStore(job.data.asyncJobId);
+        await store.cleanup(job.data.chunkSeq ?? 0);
+      }
     });
-    addVerboseQueueLogging<BatchJobData>(queue, worker, (job) => ({
-      asyncJob: getReferenceString(job.data.asyncJob),
-      project: getReferenceString(job.data.authState.project),
-      profile: job.data.authState.profile && getReferenceString(job.data.authState.profile),
-      membership: getReferenceString(job.data.authState.membership),
-      onBehalfOf: job.data.authState.onBehalfOf && getReferenceString(job.data.authState.onBehalfOf),
-      onBehalfOfMembership:
-        job.data.authState.onBehalfOfMembership && getReferenceString(job.data.authState.onBehalfOfMembership),
-    }));
+    addVerboseQueueLogging<BatchJobData>(queue, worker, (job) => {
+      const asyncJobRef = 'asyncJob' in job.data ? job.data.asyncJob : { id: job.data.asyncJobId };
+      return {
+        asyncJob: getReferenceString(asyncJobRef),
+        project: getReferenceString(job.data.authState.project),
+        profile: job.data.authState.profile && getReferenceString(job.data.authState.profile),
+        membership: getReferenceString(job.data.authState.membership),
+        onBehalfOf: job.data.authState.onBehalfOf && getReferenceString(job.data.authState.onBehalfOf),
+        onBehalfOfMembership:
+          job.data.authState.onBehalfOfMembership && getReferenceString(job.data.authState.onBehalfOfMembership),
+      };
+    });
   }
 
   return { queue, worker, name: queueName };
@@ -177,15 +205,15 @@ export function getBatchQueue(): Queue<BatchJobData> | undefined {
 
 /**
  * Adds a batch job to the queue.
- * @param job - The batch job details.
+ * @param jobData - The batch job details.
  * @returns The enqueued job.
  */
-async function addBatchJobData(job: BatchJobData): Promise<Job<BatchJobData>> {
+async function addBatchJobData(jobData: ReentrantBatchJobData): Promise<Job<BatchJobData>> {
   const queue = queueRegistry.get<BatchJobData>(queueName);
   if (!queue) {
     throw new Error(`Job queue ${queueName} not available`);
   }
-  return queue.add(jobName, job);
+  return queue.add(jobName, jobData);
 }
 
 export async function queueBatchProcessing(bundle: Bundle, asyncJob: WithId<AsyncJob>): Promise<Job<BatchJobData>> {
@@ -194,65 +222,18 @@ export async function queueBatchProcessing(bundle: Bundle, asyncJob: WithId<Asyn
   // in the BullMQ job data (see https://github.com/medplum/medplum/issues/9124). The worker loads
   // it on the first run to preprocess.
   await new BatchCheckpointStore(asyncJob.id).saveInputBundle(bundle);
-  return addBatchJobData({ asyncJob, authState, requestId, traceId });
+  return addBatchJobData({ asyncJobId: asyncJob.id, authState, requestId, traceId });
 }
 
 /**
  * Builds the submitting user's repository for processing batch entries.
- * @param systemRepo - The system repository.
  * @param authState - The auth state captured when the batch was submitted.
+ * @param userConfig - The user's configuration.
  * @returns The user's repository.
  */
-async function getBatchUserRepo(systemRepo: SystemRepository, authState: Readonly<AuthState>): Promise<Repository> {
+async function getBatchUserRepo(authState: Readonly<AuthState>, userConfig: UserConfiguration): Promise<Repository> {
   const { login, project, membership } = authState;
-  const userConfig = await getUserConfiguration(systemRepo, project, membership);
   return getRepoForLogin({ login, project, membership, userConfig }, true);
-}
-
-function makeBatchRequest(): FhirRequest {
-  return {
-    method: 'POST',
-    url: '/',
-    pathname: '',
-    params: Object.create(null),
-    query: Object.create(null),
-    body: undefined,
-  };
-}
-
-/**
- * Assembles the response bundle from durably-persisted result entries and uploads it as a Binary
- * for async retrieval. Used for the final (complete) result as well as partial results when a job
- * is cancelled or fails; in the partial case, entries not yet processed are absent from the bundle.
- * @param repo - The user's repository (used to create the Binary).
- * @param store - The checkpoint store.
- * @param initialState - The preprocessed initial state.
- * @param chunkSeq - The number of result chunks written so far.
- * @returns The uploaded Binary and the assembled response bundle.
- */
-async function assembleResultBundle(
-  repo: Repository,
-  store: BatchCheckpointStore,
-  initialState: BatchInitialState,
-  chunkSeq: number
-): Promise<{ binary: Binary; bundle: Bundle }> {
-  const results = await store.loadAllResults(chunkSeq);
-  // Include error results produced during preprocessing (they are not part of any result chunk).
-  Object.assign(results, initialState.preprocessResults);
-  const entryCount = initialState.bundle.entry?.length ?? 0;
-  const bundle = buildBatchResponseBundle(initialState.bundle.type, entryCount, results);
-  const binary = await uploadBinaryData(repo, JSON.stringify(bundle), { contentType: ContentType.FHIR_JSON });
-  return { binary, bundle };
-}
-
-function countBundleErrors(bundle: Bundle): number {
-  let errors = 0;
-  for (const entry of bundle.entry ?? []) {
-    if (!entry?.response?.outcome || !isOk(entry.response.outcome)) {
-      errors++;
-    }
-  }
-  return errors;
 }
 
 /**
@@ -268,40 +249,44 @@ function countBundleErrors(bundle: Bundle): number {
  * state cleaned up) and swallowed so the job is not blindly re-executed from the beginning.
  * @param job - The batch job details.
  */
-export async function execBatchJob(job: Job<BatchJobData>): Promise<void> {
-  const { asyncJob, authState } = job.data;
+export async function execBatchJob(job: Job<ReentrantBatchJobData>): Promise<void> {
+  const { authState } = job.data;
   const logger = getLogger();
   const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be available in job.data.authState in the future
-  const store = new BatchCheckpointStore(asyncJob.id);
-  const exec = new AsyncJobExecutor(systemRepo, asyncJob);
-
+  const store = new BatchCheckpointStore(job.data.asyncJobId);
+  let asyncJob = await systemRepo.readResource<AsyncJob>('AsyncJob', job.data.asyncJobId);
   let chunkSeq = job.data.chunkSeq ?? 0;
+
+  if (!isJobActive(asyncJob)) {
+    await finalizeInterrupted(job, systemRepo, store, asyncJob, chunkSeq, authState);
+    return;
+  }
+
+  const exec = new AsyncJobExecutor(systemRepo, asyncJob);
+  let userConfig: UserConfiguration | undefined;
+  let userRepo: Repository | undefined;
   let initialState: BatchInitialState | undefined;
 
   try {
-    // Detect out-of-band cancellation (or an already-finished job) before doing any work.
-    let current = await systemRepo.readResource<AsyncJob>('AsyncJob', asyncJob.id);
-    if (!isJobActive(current)) {
-      logger.info('Async batch job is no longer active; making partial results available', {
-        jobId: job.id,
-        asyncJob: asyncJob.id,
-        status: current.status,
-      });
-      await finalizeInterrupted(systemRepo, store, current, chunkSeq, authState);
-      return;
-    }
+    userConfig = await getUserConfiguration(systemRepo, authState.project, authState.membership);
+    userRepo = await getBatchUserRepo(authState, userConfig);
 
-    const repo = await getBatchUserRepo(systemRepo, authState);
     const router = new FhirRouter();
-    const req = makeBatchRequest();
+    const req: FhirRequest = {
+      method: 'POST',
+      url: '/',
+      pathname: '',
+      params: Object.create(null),
+      query: Object.create(null),
+      body: undefined,
+    };
 
     let processor: BatchProcessor;
-    let position = job.data.position;
-
-    if (position === undefined) {
+    let position: number;
+    if (job.data.position === undefined) {
       // First run: load the raw bundle, preprocess it, and persist the initial state.
       const bundle = await store.loadInputBundle();
-      processor = new BatchProcessor(router, repo, bundle, req);
+      processor = new BatchProcessor(router, userRepo, bundle, req);
       initialState = await processor.preprocess();
       await store.saveInitialState(initialState);
       position = 0;
@@ -310,7 +295,8 @@ export async function execBatchJob(job: Job<BatchJobData>): Promise<void> {
     } else {
       // Resume: rehydrate the processor from durably-persisted state.
       initialState = await store.loadInitialState();
-      processor = BatchProcessor.fromState(router, repo, req, initialState, position);
+      position = job.data.position;
+      processor = BatchProcessor.fromState(router, userRepo, req, initialState, position);
     }
 
     const checkpointEntries = job.data.checkpointEntries ?? defaultCheckpointEntries;
@@ -349,15 +335,9 @@ export async function execBatchJob(job: Job<BatchJobData>): Promise<void> {
       if (sinceCheckpoint >= checkpointEntries || Date.now() - lastCheckpointTime >= checkpointIntervalMs) {
         await checkpoint();
 
-        // Detect out-of-band cancellation between checkpoints and make partial results available.
-        current = await systemRepo.readResource<AsyncJob>('AsyncJob', asyncJob.id);
-        if (!isJobActive(current)) {
-          logger.info('Async batch job cancelled mid-flight; making partial results available', {
-            jobId: job.id,
-            asyncJob: asyncJob.id,
-            status: current.status,
-          });
-          await finalizeInterrupted(systemRepo, store, current, chunkSeq, authState);
+        asyncJob = await systemRepo.readResource<AsyncJob>('AsyncJob', asyncJob.id);
+        if (!isJobActive(asyncJob)) {
+          await finalizeInterrupted(job, systemRepo, store, asyncJob, chunkSeq, authState);
           return;
         }
       }
@@ -367,7 +347,7 @@ export async function execBatchJob(job: Job<BatchJobData>): Promise<void> {
     await checkpoint();
 
     // Assemble the complete response bundle and upload it as a Binary for async retrieval.
-    const { binary, bundle } = await assembleResultBundle(repo, store, initialState, chunkSeq);
+    const { binary, bundle } = await assembleResultBundle(userRepo, store, initialState, chunkSeq);
     const errors = countBundleErrors(bundle);
     logger.info('Completed async batch request', {
       jobId: job.id,
@@ -381,22 +361,24 @@ export async function execBatchJob(job: Job<BatchJobData>): Promise<void> {
       parameter: [{ name: 'results', valueReference: createReference(binary) }],
     });
     await store.cleanup(chunkSeq);
-  } catch (err: any) {
-    // A DelayedError means the job was intentionally re-queued; propagate it for BullMQ to handle
-    // and leave durable state in place so the resumed job can continue.
+  } catch (err) {
+    // DelayedError means the job was intentionally re-queued; propagate for BullMQ to handle
+    // Assume job data and state have been updated before the throw, so no cleanup is needed.
     if (err instanceof DelayedError) {
       throw err;
     }
 
-    logger.error('Async batch unhandled exception', err);
+    logger.error('Async batch unhandled exception', err instanceof Error ? err : { err });
     // Preserve a structured OperationOutcomeError (e.g. a bad bundle rejected during preprocessing)
     // rather than masking it as a generic server error.
-    const failErr = err instanceof OperationOutcomeError ? err : new OperationOutcomeError(serverError(err));
-    // Best-effort: attach whatever partial results were persisted, then fail the job and clean up.
+    const failErr =
+      err instanceof OperationOutcomeError
+        ? err
+        : new OperationOutcomeError(serverError(new Error(normalizeErrorString(err))));
     try {
-      if (initialState) {
-        const repo = await getBatchUserRepo(systemRepo, authState);
-        const { binary } = await assembleResultBundle(repo, store, initialState, chunkSeq);
+      if (userRepo && initialState) {
+        // attach whatever partial results were persisted and fail the job
+        const { binary } = await assembleResultBundle(userRepo.clone(), store, initialState, chunkSeq);
         await exec
           .failJob(failErr, {
             resourceType: 'Parameters',
@@ -405,9 +387,13 @@ export async function execBatchJob(job: Job<BatchJobData>): Promise<void> {
               { name: 'error', valueString: normalizeErrorString(err) },
             ],
           })
-          .catch(() => {});
+          .catch((err) => {
+            logger.error('Could not fail async job with partial results', err);
+          });
       } else {
-        await exec.failJob(failErr).catch(() => {});
+        await exec.failJob(failErr).catch((err) => {
+          logger.error('Could not fail async job', err);
+        });
       }
     } finally {
       await store.cleanup(chunkSeq);
@@ -420,6 +406,7 @@ export async function execBatchJob(job: Job<BatchJobData>): Promise<void> {
  * results were persisted and records them on the AsyncJob's output without changing its status,
  * then cleans up durable state. Best-effort: an interrupted job's status was set by another party,
  * so a conflicting update is ignored.
+ * @param job - The BullMQ job instance.
  * @param systemRepo - The system repository.
  * @param store - The checkpoint store.
  * @param asyncJob - The (refreshed) AsyncJob, in a terminal/cancelled state.
@@ -427,6 +414,7 @@ export async function execBatchJob(job: Job<BatchJobData>): Promise<void> {
  * @param authState - The auth state captured when the batch was submitted.
  */
 async function finalizeInterrupted(
+  job: Job<ReentrantBatchJobData>,
   systemRepo: SystemRepository,
   store: BatchCheckpointStore,
   asyncJob: WithId<AsyncJob>,
@@ -434,8 +422,14 @@ async function finalizeInterrupted(
   authState: Readonly<AuthState>
 ): Promise<void> {
   try {
+    getLogger().info('Async batch job cancelled mid-flight; making partial results available', {
+      jobId: job.id,
+      asyncJob: asyncJob.id,
+      status: asyncJob.status,
+    });
     const initialState = await store.loadInitialState();
-    const repo = await getBatchUserRepo(systemRepo, authState);
+    const userConfig = await getUserConfiguration(systemRepo, authState.project, authState.membership);
+    const repo = await getBatchUserRepo(authState, userConfig);
     const { binary, bundle } = await assembleResultBundle(repo, store, initialState, chunkSeq);
     const output: Parameters = {
       resourceType: 'Parameters',
@@ -453,5 +447,114 @@ async function finalizeInterrupted(
     });
   } finally {
     await store.cleanup(chunkSeq);
+  }
+}
+
+/**
+ * Assembles the response bundle from durably-persisted result entries and uploads it as a Binary
+ * for async retrieval. Used for the final (complete) result as well as partial results when a job
+ * is cancelled or fails; in the partial case, entries not yet processed are absent from the bundle.
+ * @param repo - The user's repository (used to create the Binary).
+ * @param store - The checkpoint store.
+ * @param initialState - The preprocessed initial state.
+ * @param chunkSeq - The number of result chunks written so far.
+ * @returns The uploaded Binary and the assembled response bundle.
+ */
+async function assembleResultBundle(
+  repo: Repository,
+  store: BatchCheckpointStore,
+  initialState: BatchInitialState,
+  chunkSeq: number
+): Promise<{ binary: Binary; bundle: Bundle }> {
+  const results = await store.loadAllResults(chunkSeq);
+  // Include error results produced during preprocessing (they are not part of any result chunk).
+  Object.assign(results, initialState.preprocessResults);
+  const entryCount = initialState.bundle.entry?.length ?? 0;
+  const bundle = buildBatchResponseBundle(initialState.bundle.type, entryCount, results);
+  const binary = await uploadBinaryData(repo, JSON.stringify(bundle), { contentType: ContentType.FHIR_JSON });
+  return { binary, bundle };
+}
+
+function countBundleErrors(bundle: Bundle): number {
+  let errors = 0;
+  for (const entry of bundle.entry ?? []) {
+    if (!entry?.response?.outcome || !isOk(entry.response.outcome)) {
+      errors++;
+    }
+  }
+  return errors;
+}
+
+/**
+ * @deprecated Processes legacy jobs. Can be removed in v5.2+
+ * @param job - The BullMQ job instance.
+ */
+async function execLegacyBatchJob(job: Job<LegacyBatchJobData>): Promise<void> {
+  const bundle = job.data.bundle;
+  const { login, project, membership } = job.data.authState;
+  const logger = getLogger();
+  const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be available in job.data.authState in the future
+
+  // Prepare the original submitting user's repo
+  const userConfig = await getUserConfiguration(systemRepo, project, membership);
+  const repo = await getRepoForLogin({ login, project, membership, userConfig }, true);
+  const router = new FhirRouter();
+  const req: FhirRequest = {
+    method: 'POST',
+    url: '/',
+    pathname: '',
+    params: Object.create(null),
+    query: Object.create(null),
+    body: bundle,
+  };
+
+  const exec = new AsyncJobExecutor(systemRepo, job.data.asyncJob);
+
+  // Intentionally swallow all errors thrown during or after execution of the batch request, since we do NOT want to
+  // execute part or all of the batch more than once.
+  // If this function does not throw an error, the job will be considered "successful" and not requeued
+  try {
+    const [outcome, result] = await router.handleRequest(req, repo);
+
+    // Update the async job with system repo
+    if (isOk(outcome)) {
+      // Upload resulting Bundle JSON as Binary for async retrieval
+      const binary = await uploadBinaryData(repo, JSON.stringify(result), { contentType: ContentType.FHIR_JSON });
+
+      const bundle = result as Bundle;
+      if (!bundle.entry) {
+        return;
+      }
+
+      let errors = 0;
+      for (const entry of bundle.entry) {
+        if (!entry.response?.outcome || !isOk(entry.response.outcome)) {
+          errors++;
+        }
+      }
+
+      logger.info('Completed async batch request', {
+        jobId: job.id,
+        asyncJob: job.data.asyncJob.id,
+        results: getReferenceString(binary),
+        entries: bundle.entry.length,
+        errors,
+      });
+      await exec.completeJob({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'results', valueReference: createReference(binary) }],
+      });
+    } else {
+      logger.warn('Async batch request failed', {
+        jobId: job.id,
+        asyncJob: job.data.asyncJob.id,
+        outcome,
+      });
+      await exec.failJob(new OperationOutcomeError(outcome));
+    }
+  } catch (err: any) {
+    logger.error(`Async batch unhandled exception`, err);
+    // Try to mark AsyncJob as failed, best effort
+    await exec.failJob(new OperationOutcomeError(serverError(err))).catch(() => {});
   }
 }

--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -6,41 +6,95 @@ import {
   createReference,
   getReferenceString,
   isOk,
+  normalizeErrorString,
   OperationOutcomeError,
   serverError,
 } from '@medplum/core';
-import type { FhirRequest } from '@medplum/fhir-router';
-import { FhirRouter } from '@medplum/fhir-router';
-import type { AsyncJob, Bundle } from '@medplum/fhirtypes';
+import type { BatchInitialState, FhirRequest } from '@medplum/fhir-router';
+import { BatchProcessor, buildBatchResponseBundle, FhirRouter } from '@medplum/fhir-router';
+import type { AsyncJob, Binary, Bundle, Parameters } from '@medplum/fhirtypes';
 import type { Job } from 'bullmq';
-import { Queue, Worker } from 'bullmq';
+import { DelayedError, Queue, Worker } from 'bullmq';
 import { getUserConfiguration } from '../auth/me';
 import { getAuthenticatedContext, runInAuthenticatedContext } from '../context';
 import { getRepoForLogin } from '../fhir/accesspolicy';
+import { BatchCheckpointStore } from '../fhir/batch/checkpoint-store';
 import { uploadBinaryData } from '../fhir/binary';
 import { AsyncJobExecutor } from '../fhir/operations/utils/asyncjobexecutor';
+import type { Repository, SystemRepository } from '../fhir/repo';
 import { getShardSystemRepo } from '../fhir/repo';
 import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
 import { getLogger } from '../logger';
 import type { AuthState } from '../oauth/middleware';
 import type { WorkerInitializer, WorkerInitializerOptions } from './utils';
-import { addVerboseQueueLogging, defaultQueueOptions, getWorkerBullmqConfig, queueRegistry } from './utils';
+import {
+  addVerboseQueueLogging,
+  defaultQueueOptions,
+  getWorkerBullmqConfig,
+  isJobActive,
+  moveToDelayedAndThrow,
+  queueRegistry,
+  updateAsyncJobOutput,
+} from './utils';
 
 /*
- * The batch worker runs a batch asynchronously,
- * decoupled from an individual HTTP request.
+ * The batch worker runs a batch asynchronously, decoupled from an individual HTTP request.
+ *
+ * Processing is RE-ENTRANT so that a large batch survives server deploys and worker crashes
+ * (see https://github.com/medplum/medplum/issues/9681). Rather than processing the whole bundle in
+ * a single call, the worker drives the BatchProcessor one entry at a time and periodically
+ * checkpoints its in-flight state to durable object storage (see BatchCheckpointStore). On a
+ * graceful shutdown the job is delayed and re-queued; on resume the processor is rehydrated from
+ * durable state and continues from the last checkpoint.
+ *
+ * ┌──────────────────────────────────────────────────────────────────────────────────────────┐
+ * │ AT-LEAST-ONCE / REPLAY WINDOW — READ BEFORE CHANGING CHECKPOINT LOGIC                        │
+ * │                                                                                             │
+ * │ Each entry's database side-effects are committed BEFORE its result is checkpointed to       │
+ * │ durable storage. If a worker crashes (hard crash or the process is killed) after an entry's │
+ * │ side-effects commit but before the next checkpoint, that entry is re-processed when the job │
+ * │ resumes. Async batch processing is therefore AT-LEAST-ONCE per entry, NOT exactly-once.     │
+ * │                                                                                             │
+ * │ The replay window is bounded by the checkpoint cadence (BatchJobData.checkpointEntries      │
+ * │ entries OR .checkpointIntervalMs milliseconds, whichever comes first). Entries that are      │
+ * │ inherently NON-IDEMPOTENT — e.g. some PATCH operations (array insert/append) and plain POST │
+ * │ creates — may be applied more than once if a crash occurs within that window. A replayed    │
+ * │ POST create reuses the resource id assigned during preprocessing (persisted in the initial  │
+ * │ state), so depending on the create path it may upsert or conflict; the result recorded on   │
+ * │ replay reflects the replay attempt, not the original.                                       │
+ * │                                                                                             │
+ * │ This trade-off is intentional: we do NOT rewrite entries to force idempotency. Shrinking    │
+ * │ the checkpoint thresholds shrinks the window at the cost of more object-storage writes.     │
+ * └──────────────────────────────────────────────────────────────────────────────────────────┘
  */
 
 export interface BatchJobData {
   readonly asyncJob: WithId<AsyncJob>;
-  readonly bundle: Bundle;
   readonly authState: Readonly<AuthState>;
   readonly requestId?: string;
   readonly traceId?: string;
+  /**
+   * Index into the preprocessed ordering of the next entry to process. `undefined` on the initial
+   * enqueue (before the bundle has been preprocessed). Updated via `job.updateData` at each
+   * checkpoint so that a resumed/re-queued job continues from the last checkpoint.
+   */
+  readonly position?: number;
+  /** Number of result chunks written to durable storage so far. */
+  readonly chunkSeq?: number;
+
+  // Configurable checkpoint cadence. A checkpoint is taken whenever EITHER threshold is reached,
+  // whichever comes first (see the replay-window note above). Left unset, the defaults below apply.
+  /** Max number of entries processed between checkpoints. Defaults to {@link defaultCheckpointEntries}. */
+  readonly checkpointEntries?: number;
+  /** Max milliseconds elapsed between checkpoints. Defaults to {@link defaultCheckpointIntervalMs}. */
+  readonly checkpointIntervalMs?: number;
 }
 
 const queueName = 'BatchQueue';
 const jobName = 'BatchJobData';
+
+const defaultCheckpointEntries = 50;
+const defaultCheckpointIntervalMs = 5000;
 
 export const initBatchWorker: WorkerInitializer = (config, options?: WorkerInitializerOptions) => {
   const defaultOptions = defaultQueueOptions(config);
@@ -68,15 +122,35 @@ export const initBatchWorker: WorkerInitializer = (config, options?: WorkerIniti
       }
     );
 
-    worker.on('failed', async (job) => {
+    worker.on('failed', async (job, err) => {
       if (!job) {
         return;
       }
 
-      // Mark AsyncJob as failed
+      // A delayed/re-queued job is not a failure; nothing to do.
+      if (err instanceof DelayedError) {
+        return;
+      }
+
+      // This fires only when the job could not be recovered by re-entrant resume (e.g. it stalled
+      // more than maxStalledCount times). Mark the AsyncJob failed if it is still in progress and
+      // clean up any durable checkpoint state.
       const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be available in job.data.authState in the future
-      const exec = new AsyncJobExecutor(systemRepo, job.data.asyncJob);
-      await exec.failJob();
+      const store = new BatchCheckpointStore(job.data.asyncJob.id);
+      try {
+        const asyncJob = await systemRepo.readResource<AsyncJob>('AsyncJob', job.data.asyncJob.id);
+        if (isJobActive(asyncJob)) {
+          await new AsyncJobExecutor(systemRepo, asyncJob).failJob(err ?? undefined);
+        }
+      } catch (readErr) {
+        // Fall back to failing with the stale snapshot if the job could not be re-read.
+        await new AsyncJobExecutor(systemRepo, job.data.asyncJob).failJob(err ?? undefined).catch(() => {});
+        getLogger().error('Async batch failed handler could not refresh AsyncJob', {
+          asyncJob: job.data.asyncJob.id,
+          error: normalizeErrorString(readErr),
+        });
+      }
+      await store.cleanup(job.data.chunkSeq ?? 0);
     });
     addVerboseQueueLogging<BatchJobData>(queue, worker, (job) => ({
       asyncJob: getReferenceString(job.data.asyncJob),
@@ -116,79 +190,268 @@ async function addBatchJobData(job: BatchJobData): Promise<Job<BatchJobData>> {
 
 export async function queueBatchProcessing(bundle: Bundle, asyncJob: WithId<AsyncJob>): Promise<Job<BatchJobData>> {
   const { authentication: authState, requestId, traceId } = getAuthenticatedContext();
-  return addBatchJobData({ bundle, asyncJob, authState, requestId, traceId });
+  // Persist the (potentially large) input bundle to durable object storage rather than carrying it
+  // in the BullMQ job data (see https://github.com/medplum/medplum/issues/9124). The worker loads
+  // it on the first run to preprocess.
+  await new BatchCheckpointStore(asyncJob.id).saveInputBundle(bundle);
+  return addBatchJobData({ asyncJob, authState, requestId, traceId });
 }
 
 /**
- * Executes a batch job.
- * @param job - The batch job details.
+ * Builds the submitting user's repository for processing batch entries.
+ * @param systemRepo - The system repository.
+ * @param authState - The auth state captured when the batch was submitted.
+ * @returns The user's repository.
  */
-export async function execBatchJob(job: Job<BatchJobData>): Promise<void> {
-  const bundle = job.data.bundle;
-  const { login, project, membership } = job.data.authState;
-  const logger = getLogger();
-  const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be available in job.data.authState in the future
-
-  // Prepare the original submitting user's repo
+async function getBatchUserRepo(systemRepo: SystemRepository, authState: Readonly<AuthState>): Promise<Repository> {
+  const { login, project, membership } = authState;
   const userConfig = await getUserConfiguration(systemRepo, project, membership);
-  const repo = await getRepoForLogin({ login, project, membership, userConfig }, true);
-  const router = new FhirRouter();
-  const req: FhirRequest = {
+  return getRepoForLogin({ login, project, membership, userConfig }, true);
+}
+
+function makeBatchRequest(): FhirRequest {
+  return {
     method: 'POST',
     url: '/',
     pathname: '',
     params: Object.create(null),
     query: Object.create(null),
-    body: bundle,
+    body: undefined,
   };
+}
 
-  const exec = new AsyncJobExecutor(systemRepo, job.data.asyncJob);
+/**
+ * Assembles the response bundle from durably-persisted result entries and uploads it as a Binary
+ * for async retrieval. Used for the final (complete) result as well as partial results when a job
+ * is cancelled or fails; in the partial case, entries not yet processed are absent from the bundle.
+ * @param repo - The user's repository (used to create the Binary).
+ * @param store - The checkpoint store.
+ * @param initialState - The preprocessed initial state.
+ * @param chunkSeq - The number of result chunks written so far.
+ * @returns The uploaded Binary and the assembled response bundle.
+ */
+async function assembleResultBundle(
+  repo: Repository,
+  store: BatchCheckpointStore,
+  initialState: BatchInitialState,
+  chunkSeq: number
+): Promise<{ binary: Binary; bundle: Bundle }> {
+  const results = await store.loadAllResults(chunkSeq);
+  // Include error results produced during preprocessing (they are not part of any result chunk).
+  Object.assign(results, initialState.preprocessResults);
+  const entryCount = initialState.bundle.entry?.length ?? 0;
+  const bundle = buildBatchResponseBundle(initialState.bundle.type, entryCount, results);
+  const binary = await uploadBinaryData(repo, JSON.stringify(bundle), { contentType: ContentType.FHIR_JSON });
+  return { binary, bundle };
+}
 
-  // Intentionally swallow all errors thrown during or after execution of the batch request, since we do NOT want to
-  // execute part or all of the batch more than once.
-  // If this function does not throw an error, the job will be considered "successful" and not requeued
+function countBundleErrors(bundle: Bundle): number {
+  let errors = 0;
+  for (const entry of bundle.entry ?? []) {
+    if (!entry?.response?.outcome || !isOk(entry.response.outcome)) {
+      errors++;
+    }
+  }
+  return errors;
+}
+
+/**
+ * Executes a re-entrant batch job.
+ *
+ * On the first run the input bundle is loaded from durable storage, preprocessed, and its initial
+ * state is persisted. Entries are then processed one at a time, checkpointing progress and results
+ * to durable storage. If the queue is closing (graceful shutdown), the job is delayed and re-queued
+ * to resume later. On resume, the processor is rehydrated from durable state and continues from the
+ * last checkpoint.
+ *
+ * All errors other than {@link DelayedError} are handled here (the AsyncJob is failed and durable
+ * state cleaned up) and swallowed so the job is not blindly re-executed from the beginning.
+ * @param job - The batch job details.
+ */
+export async function execBatchJob(job: Job<BatchJobData>): Promise<void> {
+  const { asyncJob, authState } = job.data;
+  const logger = getLogger();
+  const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be available in job.data.authState in the future
+  const store = new BatchCheckpointStore(asyncJob.id);
+  const exec = new AsyncJobExecutor(systemRepo, asyncJob);
+
+  let chunkSeq = job.data.chunkSeq ?? 0;
+  let initialState: BatchInitialState | undefined;
+
   try {
-    const [outcome, result] = await router.handleRequest(req, repo);
+    // Detect out-of-band cancellation (or an already-finished job) before doing any work.
+    let current = await systemRepo.readResource<AsyncJob>('AsyncJob', asyncJob.id);
+    if (!isJobActive(current)) {
+      logger.info('Async batch job is no longer active; making partial results available', {
+        jobId: job.id,
+        asyncJob: asyncJob.id,
+        status: current.status,
+      });
+      await finalizeInterrupted(systemRepo, store, current, chunkSeq, authState);
+      return;
+    }
 
-    // Update the async job with system repo
-    if (isOk(outcome)) {
-      // Upload resulting Bundle JSON as Binary for async retrieval
-      const binary = await uploadBinaryData(repo, JSON.stringify(result), { contentType: ContentType.FHIR_JSON });
+    const repo = await getBatchUserRepo(systemRepo, authState);
+    const router = new FhirRouter();
+    const req = makeBatchRequest();
 
-      const bundle = result as Bundle;
-      if (!bundle.entry) {
-        return;
+    let processor: BatchProcessor;
+    let position = job.data.position;
+
+    if (position === undefined) {
+      // First run: load the raw bundle, preprocess it, and persist the initial state.
+      const bundle = await store.loadInputBundle();
+      processor = new BatchProcessor(router, repo, bundle, req);
+      initialState = await processor.preprocess();
+      await store.saveInitialState(initialState);
+      position = 0;
+      chunkSeq = 0;
+      await job.updateData({ ...job.data, position, chunkSeq });
+    } else {
+      // Resume: rehydrate the processor from durably-persisted state.
+      initialState = await store.loadInitialState();
+      processor = BatchProcessor.fromState(router, repo, req, initialState, position);
+    }
+
+    const checkpointEntries = job.data.checkpointEntries ?? defaultCheckpointEntries;
+    const checkpointIntervalMs = job.data.checkpointIntervalMs ?? defaultCheckpointIntervalMs;
+    let sinceCheckpoint = 0;
+    let lastCheckpointTime = Date.now();
+
+    // Flush results produced since the last checkpoint to durable storage, THEN advance the durable
+    // progress marker. This ordering guarantees the marker never moves past an unpersisted result.
+    const checkpoint = async (): Promise<void> => {
+      const pending = processor.takePendingResults();
+      if (Object.keys(pending).length > 0) {
+        await store.saveResultChunk(chunkSeq, pending);
+        chunkSeq++;
+      }
+      await job.updateData({ ...job.data, position: processor.getPosition(), chunkSeq });
+      sinceCheckpoint = 0;
+      lastCheckpointTime = Date.now();
+    };
+
+    while (processor.hasMoreEntries()) {
+      // Graceful shutdown: checkpoint and re-queue so a future worker resumes where we left off.
+      if (queueRegistry.isClosing(job.queueName)) {
+        logger.info('Async batch job detected queue is closing; delaying', {
+          jobId: job.id,
+          asyncJob: asyncJob.id,
+          position: processor.getPosition(),
+        });
+        await checkpoint();
+        await moveToDelayedAndThrow(job, 'Async batch delayed since queue is closing');
       }
 
-      let errors = 0;
-      for (const entry of bundle.entry) {
-        if (!entry.response?.outcome || !isOk(entry.response.outcome)) {
-          errors++;
+      await processor.processNextEntry();
+      sinceCheckpoint++;
+
+      if (sinceCheckpoint >= checkpointEntries || Date.now() - lastCheckpointTime >= checkpointIntervalMs) {
+        await checkpoint();
+
+        // Detect out-of-band cancellation between checkpoints and make partial results available.
+        current = await systemRepo.readResource<AsyncJob>('AsyncJob', asyncJob.id);
+        if (!isJobActive(current)) {
+          logger.info('Async batch job cancelled mid-flight; making partial results available', {
+            jobId: job.id,
+            asyncJob: asyncJob.id,
+            status: current.status,
+          });
+          await finalizeInterrupted(systemRepo, store, current, chunkSeq, authState);
+          return;
         }
       }
-
-      logger.info('Completed async batch request', {
-        jobId: job.id,
-        asyncJob: job.data.asyncJob.id,
-        results: getReferenceString(binary),
-        entries: bundle.entry.length,
-        errors,
-      });
-      await exec.completeJob({
-        resourceType: 'Parameters',
-        parameter: [{ name: 'results', valueReference: createReference(binary) }],
-      });
-    } else {
-      logger.warn('Async batch request failed', {
-        jobId: job.id,
-        asyncJob: job.data.asyncJob.id,
-        outcome,
-      });
-      await exec.failJob(new OperationOutcomeError(outcome));
     }
+
+    // Final checkpoint to flush any remaining results.
+    await checkpoint();
+
+    // Assemble the complete response bundle and upload it as a Binary for async retrieval.
+    const { binary, bundle } = await assembleResultBundle(repo, store, initialState, chunkSeq);
+    const errors = countBundleErrors(bundle);
+    logger.info('Completed async batch request', {
+      jobId: job.id,
+      asyncJob: asyncJob.id,
+      results: getReferenceString(binary),
+      entries: bundle.entry?.length,
+      errors,
+    });
+    await exec.completeJob({
+      resourceType: 'Parameters',
+      parameter: [{ name: 'results', valueReference: createReference(binary) }],
+    });
+    await store.cleanup(chunkSeq);
   } catch (err: any) {
-    logger.error(`Async batch unhandled exception`, err);
-    // Try to mark AsyncJob as failed, best effort
-    await exec.failJob(new OperationOutcomeError(serverError(err))).catch(() => {});
+    // A DelayedError means the job was intentionally re-queued; propagate it for BullMQ to handle
+    // and leave durable state in place so the resumed job can continue.
+    if (err instanceof DelayedError) {
+      throw err;
+    }
+
+    logger.error('Async batch unhandled exception', err);
+    // Preserve a structured OperationOutcomeError (e.g. a bad bundle rejected during preprocessing)
+    // rather than masking it as a generic server error.
+    const failErr = err instanceof OperationOutcomeError ? err : new OperationOutcomeError(serverError(err));
+    // Best-effort: attach whatever partial results were persisted, then fail the job and clean up.
+    try {
+      if (initialState) {
+        const repo = await getBatchUserRepo(systemRepo, authState);
+        const { binary } = await assembleResultBundle(repo, store, initialState, chunkSeq);
+        await exec
+          .failJob(failErr, {
+            resourceType: 'Parameters',
+            parameter: [
+              { name: 'results', valueReference: createReference(binary) },
+              { name: 'error', valueString: normalizeErrorString(err) },
+            ],
+          })
+          .catch(() => {});
+      } else {
+        await exec.failJob(failErr).catch(() => {});
+      }
+    } finally {
+      await store.cleanup(chunkSeq);
+    }
+  }
+}
+
+/**
+ * Handles a batch job that was interrupted out of band (e.g. cancelled). Assembles whatever partial
+ * results were persisted and records them on the AsyncJob's output without changing its status,
+ * then cleans up durable state. Best-effort: an interrupted job's status was set by another party,
+ * so a conflicting update is ignored.
+ * @param systemRepo - The system repository.
+ * @param store - The checkpoint store.
+ * @param asyncJob - The (refreshed) AsyncJob, in a terminal/cancelled state.
+ * @param chunkSeq - The number of result chunks written so far.
+ * @param authState - The auth state captured when the batch was submitted.
+ */
+async function finalizeInterrupted(
+  systemRepo: SystemRepository,
+  store: BatchCheckpointStore,
+  asyncJob: WithId<AsyncJob>,
+  chunkSeq: number,
+  authState: Readonly<AuthState>
+): Promise<void> {
+  try {
+    const initialState = await store.loadInitialState();
+    const repo = await getBatchUserRepo(systemRepo, authState);
+    const { binary, bundle } = await assembleResultBundle(repo, store, initialState, chunkSeq);
+    const output: Parameters = {
+      resourceType: 'Parameters',
+      parameter: [
+        { name: 'partialResults', valueReference: createReference(binary) },
+        { name: 'processedEntries', valueInteger: (bundle.entry ?? []).filter(Boolean).length },
+      ],
+    };
+    // Best-effort: another party set this job's status, so a conflicting update is ignored.
+    await updateAsyncJobOutput(systemRepo, asyncJob, output).catch(() => {});
+  } catch (err) {
+    getLogger().warn('Could not assemble partial results for interrupted async batch', {
+      asyncJob: asyncJob.id,
+      error: normalizeErrorString(err),
+    });
+  } finally {
+    await store.cleanup(chunkSeq);
   }
 }


### PR DESCRIPTION
Action items:

- [x] Add more verbose logging particularly for timing to `BatchCheckpointStore`
- [ ] Look in to having the duration persisting intermediate state detract from FHIR quota sleep duration between entries
- [x] Documentation pass

Fixes #9681 
Fixes #9124 