### PR TITLE
fix(server): emit subscription delivery AuditEvents for bot subscriptions

### DIFF
--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -983,12 +983,19 @@ describe('Subscription Worker', () => {
           },
         ],
       });
-      expect(bundle.entry?.length).toStrictEqual(1);
+      expect(bundle.entry?.length).toStrictEqual(2);
 
-      const auditEvent = bundle.entry?.[0]?.resource as AuditEvent;
-      expect(auditEvent.outcomeDesc).toStrictEqual('Bots not enabled');
-      expect(auditEvent.period).toBeDefined();
-      expect(auditEvent.entity).toHaveLength(3);
+      const botEvent = bundle.entry?.map((e) => e.resource as AuditEvent).find((ae) => ae.type?.code === 'execute');
+      expect(botEvent).toBeDefined();
+      expect(botEvent?.outcomeDesc).toStrictEqual('Bots not enabled');
+      expect(botEvent?.period).toBeDefined();
+      expect(botEvent?.entity).toHaveLength(3);
+
+      const subscriptionEvent = bundle.entry
+        ?.map((e) => e.resource as AuditEvent)
+        .find((ae) => ae.type?.code === 'transmit');
+      expect(subscriptionEvent).toBeDefined();
+      expect(subscriptionEvent?.outcome).toStrictEqual(AuditEventOutcome.MinorFailure);
     }));
 
   test('Execute bot subscriptions', () =>
@@ -1044,8 +1051,15 @@ describe('Subscription Worker', () => {
           },
         ],
       });
-      expect(bundle.entry?.length).toStrictEqual(1);
-      expect(bundle.entry?.[0]?.resource?.outcome).toStrictEqual('0');
+      expect(bundle.entry?.length).toStrictEqual(2);
+
+      const botEvent = bundle.entry?.map((e) => e.resource as AuditEvent).find((ae) => ae.type?.code === 'execute');
+      expect(botEvent?.outcome).toStrictEqual(AuditEventOutcome.Success);
+
+      const subscriptionEvent = bundle.entry
+        ?.map((e) => e.resource as AuditEvent)
+        .find((ae) => ae.type?.code === 'transmit');
+      expect(subscriptionEvent?.outcome).toStrictEqual(AuditEventOutcome.Success);
     }));
 
   test('Execute bot subscriptions run as user', () =>
@@ -1102,8 +1116,15 @@ describe('Subscription Worker', () => {
           },
         ],
       });
-      expect(bundle.entry?.length).toStrictEqual(1);
-      expect(bundle.entry?.[0]?.resource?.outcome).toStrictEqual('0');
+      expect(bundle.entry?.length).toStrictEqual(2);
+
+      const botEvent = bundle.entry?.map((e) => e.resource as AuditEvent).find((ae) => ae.type?.code === 'execute');
+      expect(botEvent?.outcome).toStrictEqual(AuditEventOutcome.Success);
+
+      const subscriptionEvent = bundle.entry
+        ?.map((e) => e.resource as AuditEvent)
+        .find((ae) => ae.type?.code === 'transmit');
+      expect(subscriptionEvent?.outcome).toStrictEqual(AuditEventOutcome.Success);
     }));
 
   test('Execute Bot from linked Project', () =>
@@ -1172,12 +1193,15 @@ describe('Subscription Worker', () => {
       expect(fetch).not.toHaveBeenCalled();
 
       // The Subscription should have been triggered
+      // Both the bot execution AuditEvent and the subscription delivery AuditEvent should exist
       const events = await repo.search(subscriptionEvents);
-      expect(events.entry).toHaveLength(1);
-      expect(events.entry?.[0].resource).toMatchObject<Partial<AuditEvent>>({
-        resourceType: 'AuditEvent',
-        outcome: '0',
-      });
+      expect(events.entry).toHaveLength(2);
+      for (const entry of events.entry ?? []) {
+        expect(entry.resource).toMatchObject<Partial<AuditEvent>>({
+          resourceType: 'AuditEvent',
+          outcome: '0',
+        });
+      }
     }));
 
   test('Stop retries if Subscription status not active', () =>
@@ -1605,6 +1629,83 @@ describe('Subscription Worker', () => {
         expect(bundle.entry?.length).toStrictEqual(1);
 
         // Should also log AuditEvent via globalLogger
+        expect(writeSpy).toHaveBeenCalled();
+        const loggedCall = writeSpy.mock.calls.find((call: unknown[]) => {
+          try {
+            const parsed = JSON.parse(call[0] as string);
+            return parsed.resourceType === 'AuditEvent' && parsed.type?.code === 'transmit';
+          } catch {
+            return false;
+          }
+        });
+        expect(loggedCall).toBeDefined();
+      }));
+
+    test('bot subscription log only', () =>
+      withTestContext(async () => {
+        const bot = await botRepo.createResource<Bot>({
+          resourceType: 'Bot',
+          name: 'Test Bot',
+          description: 'Test Bot',
+          runtimeVersion: 'awslambda',
+          code: `
+        export async function handler(medplum, event) {
+          return event.input;
+        }
+      `,
+        });
+
+        await systemRepo.createResource<ProjectMembership>({
+          resourceType: 'ProjectMembership',
+          project: { reference: 'Project/' + bot.meta?.project },
+          user: createReference(bot),
+          profile: createReference(bot),
+        });
+
+        const subscription = await botRepo.createResource<Subscription>({
+          resourceType: 'Subscription',
+          reason: 'test',
+          status: 'active',
+          criteria: 'Patient',
+          channel: {
+            type: 'rest-hook',
+            endpoint: getReferenceString(bot),
+          },
+          extension: [
+            {
+              url: 'https://medplum.com/fhir/StructureDefinition/subscription-audit-event-destination',
+              valueCode: 'log',
+            },
+          ],
+        });
+
+        const patient = await botRepo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Smith' }],
+        });
+
+        fetchMock.mockImplementation(() => mockFetchStatus(200));
+
+        await findAndExecSubscriptionJob(patient, 'create');
+        expect(fetch).not.toHaveBeenCalled();
+
+        const bundle = await botRepo.search<AuditEvent>({
+          resourceType: 'AuditEvent',
+          filters: [
+            {
+              code: 'entity',
+              operator: Operator.EQUALS,
+              value: getReferenceString(subscription),
+            },
+          ],
+        });
+
+        // Should NOT create the subscription delivery AuditEvent resource in DB
+        // Only the bot execution AuditEvent should exist
+        expect(bundle.entry?.length).toStrictEqual(1);
+        expect(bundle.entry?.[0]?.resource?.type?.code).toStrictEqual('execute');
+
+        // Should log the subscription delivery AuditEvent via globalLogger
         expect(writeSpy).toHaveBeenCalled();
         const loggedCall = writeSpy.mock.calls.find((call: unknown[]) => {
           try {

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -892,17 +892,39 @@ async function execBot(
   const body = interaction === 'delete' ? { deletedResource: resource } : resource;
   const headers = buildRestHookHeaders(job, subscription, resource, interaction, JSON.stringify(body));
 
-  await executeBot({
-    subscription,
-    bot,
-    runAs,
-    requester,
-    input: body,
-    contentType: ContentType.FHIR_JSON,
-    requestTime,
-    traceId: ctx.traceId,
-    headers,
-  });
+  try {
+    const result = await executeBot({
+      subscription,
+      bot,
+      runAs,
+      requester,
+      input: body,
+      contentType: ContentType.FHIR_JSON,
+      requestTime,
+      traceId: ctx.traceId,
+      headers,
+    });
+    await createSubscriptionAuditEvent(
+      systemRepo,
+      resource,
+      requestTime,
+      result.success ? AuditEventOutcome.Success : AuditEventOutcome.MinorFailure,
+      `Attempt ${job.attemptsMade} bot execution ${result.success ? 'succeeded' : 'failed'}`,
+      subscription,
+      bot
+    );
+  } catch (ex) {
+    await createSubscriptionAuditEvent(
+      systemRepo,
+      resource,
+      requestTime,
+      AuditEventOutcome.MinorFailure,
+      `Attempt ${job.attemptsMade} received error ${ex}`,
+      subscription,
+      bot
+    );
+    throw ex;
+  }
 }
 
 async function catchJobError(


### PR DESCRIPTION

Fixes #9385

When a `Subscription` uses a Bot as its channel endpoint (`channel.endpoint = "Bot/<id>"`), no subscription delivery `AuditEvent` (`type.code = "transmit"`) was ever created, and the `subscription-audit-event-destination` extension was silently ignored. The HTTP rest-hook path calls `createSubscriptionAuditEvent()` after both successful and failed deliveries, but `execBot` in `packages/server/src/workers/subscription.ts` called `executeBot(...)` without ever recording the delivery.

Note that the Bot *execution* AuditEvent (`type.code = "execute"`, created by `createBotAuditEvent` inside `executeBot`) was unaffected — the gap was specifically the subscription delivery AuditEvent.

- Wraps the `executeBot` call in `execBot` with try/catch, mirroring the rest-hook path
- Calls `createSubscriptionAuditEvent()` with `AuditEventOutcome.Success` / `AuditEventOutcome.MinorFailure` based on the `BotExecutionResult`, and with `MinorFailure` before re-throwing when `executeBot` throws
- Passes the `Bot` to `createSubscriptionAuditEvent` so it is included in `AuditEvent.entity` (the function already accepted an optional `bot` parameter for exactly this)
- Because the destination handling lives in `createSubscriptionAuditEvent`, the `subscription-audit-event-destination` extension (`resource` / `log`) is now honored for Bot subscriptions with no extra code

No retry/backoff behavior changes: an unsuccessful bot execution result still does not throw (unchanged from before), and exceptions are re-thrown so the existing retry path is preserved. Errors thrown before `executeBot` (e.g. missing project membership) intentionally do not produce a delivery AuditEvent, matching how the rest-hook path only audits the delivery attempt itself.

## Tests

- Updated `Execute bot subscriptions`, `Execute bot subscriptions run as user`, `Execute Bot from linked Project`, and `Ignore bots if feature not enabled` to expect both the bot execution (`execute`) and subscription delivery (`transmit`) AuditEvents, asserting the outcome of each
- Added `bot subscription log only` under the `Subscription AuditEvent destination with logging` describe block, reproducing the issue's exact scenario: a Bot subscription with the `subscription-audit-event-destination` extension set to `log` now logs a `transmit` AuditEvent via the global logger and does not persist it as a resource

Verified locally against Postgres 16 / Redis 7: `vitest run src/workers/subscription.test.ts` — 72 passed, 2 skipped (pre-existing skips). `tsc --noEmit`, eslint, and prettier all clean.

