### PR TITLE
Implement MCP search and fetch tools

### DIFF
--- a/packages/docs/docs/ai/mcp.md
+++ b/packages/docs/docs/ai/mcp.md
@@ -26,6 +26,46 @@ _Note: LLMs can sometimes cache sessions. If you experience issues, try disconne
 
 The Medplum MCP integration exposes several powerful tools for interacting with FHIR data. Here are the tools available in your MCP server:
 
+#### `search`
+
+- **Title:** FHIR Search
+- **Description:** Performs a read-only FHIR search through the authenticated repository. Pass a standard FHIR search string such as `Patient?name=Smith&_count=10`. Results contain only `id`, `title`, and `url`; `_count` defaults to 20 and is capped at 100. Use `_offset` for pagination and `_total=accurate` when the total number of matches is needed. `_include` and `_revinclude` are ignored; retrieve related resources explicitly with `fetch`.
+- **Annotations:** Read-only and idempotent.
+- **Schema:**
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "query": {
+      "type": "string",
+      "description": "FHIR search string, for example 'Patient?name=Smith&_count=10'."
+    }
+  },
+  "required": ["query"]
+}
+```
+
+#### `fetch`
+
+- **Title:** FHIR Read
+- **Description:** Reads one FHIR resource through the authenticated repository using a reference returned by `search`, such as `Patient/123`. The resource JSON is returned in `text`. Very large resources are truncated, and `Binary` resources are rejected to avoid adding base64 payloads to an LLM context.
+- **Annotations:** Read-only and idempotent.
+- **Schema:**
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "FHIR resource reference returned by search, for example 'Patient/123'."
+    }
+  },
+  "required": ["id"]
+}
+```
+
 #### `fhir-request`
 
 - **Title:** Perform a FHIR API Request
@@ -42,16 +82,16 @@ The Medplum MCP integration exposes several powerful tools for interacting with 
       "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
       "description": "The HTTP method for the request."
     },
-    "url": {
+    "path": {
       "type": "string",
-      "description": "The full FHIR API URL path (e.g., '/fhir/Patient')."
+      "description": "The path relative to the FHIR R4 base URL (e.g., 'Patient')."
     },
     "body": {
       "type": "object",
       "description": "The JSON body of the FHIR resource to be created or updated."
     }
   },
-  "required": ["method", "url"]
+  "required": ["method", "path"]
 }
 ```
 
@@ -61,14 +101,14 @@ Here are three examples demonstrating the core capabilities of the Medplum MCP i
 
 **Example 1: Finding High Blood Pressure Patients (Using search)**
 
-- **Prompt:** "What are the names of all patients who have a blood pressure observation with a systolic value greater than 140 in the last year?"
-- **Tool Call:** The AI will use the search tool with the resourceType set to "Patient" and searchParams filtering for patients linked to specific observations.
-- **Outcome:** The Medplum server responds with a list of patient names and IDs that match the criteria, which the AI can then summarize for the user.
+- **Prompt:** "Which blood pressure observations recorded a systolic value greater than 140 in the last year?"
+- **Tool Call:** The AI uses `search` with a FHIR search string for `Observation`, including the appropriate code, value, and date parameters.
+- **Outcome:** The Medplum server returns a bounded list of matching resource references and display titles. The AI can use `fetch` for the individual observations it needs to inspect.
 
 **Example 2: Scheduling a New Appointment (Using fhir-request)**
 
 - **Prompt:** "Create a new appointment for patient 'Jane Doe' with Dr. Smith for a routine check-up next Tuesday at 10 AM."
-- **Tool Call:** The AI will use the fhir-request tool with the method set to "POST", the url set to /fhir/Appointment, and a body containing the details of the new appointment.
+- **Tool Call:** The AI will use the fhir-request tool with the method set to "POST", the path set to `Appointment`, and a body containing the details of the new appointment.
 - **Outcome:** The Medplum server creates the appointment and returns a success message, which the AI can confirm with the user.
 
 **Example 3: Fetching Specific Lab Results (Using fetch)**

--- a/packages/server/src/mcp/routes.test.ts
+++ b/packages/server/src/mcp/routes.test.ts
@@ -20,7 +20,9 @@ import type { Server } from 'http';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
+import { Repository } from '../fhir/repo';
 import { initTestAuth } from '../test.setup';
+import { clampMcpSearchCount } from './server';
 
 type TransportType = 'stream' | 'sse';
 
@@ -30,6 +32,7 @@ interface McpSearchResponse {
     title: string;
     url: string;
   }[];
+  total?: number;
 }
 
 interface McpFetchResponse {
@@ -37,11 +40,6 @@ interface McpFetchResponse {
   title: string;
   text: string;
   url: string;
-  metadata: {
-    resourceType: string;
-    versionId?: string;
-    lastUpdated?: string;
-  };
 }
 
 async function connectMcpClient(port: number, transportType: TransportType, accessToken: string): Promise<Client> {
@@ -134,6 +132,15 @@ describe('MCP Routes', () => {
     expect(res).toHaveStatus(400);
   });
 
+  test('MCP search count is bounded', () => {
+    expect(clampMcpSearchCount(undefined)).toBe(20);
+    expect(clampMcpSearchCount(Number.NaN)).toBe(20);
+    expect(clampMcpSearchCount(-1)).toBe(20);
+    expect(clampMcpSearchCount(0)).toBe(0);
+    expect(clampMcpSearchCount(5)).toBe(5);
+    expect(clampMcpSearchCount(500)).toBe(100);
+  });
+
   test.each<TransportType>(['stream', 'sse'])('MCP with %s transport', async (transportType: TransportType) => {
     const client = await connectMcpClient(port, transportType, accessToken);
 
@@ -170,26 +177,53 @@ describe('MCP Routes', () => {
       }
 
       // 1. create
+      const family = `McpTest${transportType}${randomUUID().slice(0, 8)}`;
       const createResult = await fhirRequest<Patient>('POST', 'Patient', {
         resourceType: 'Patient',
-        name: [{ family: 'Doe', given: ['John'] }],
+        name: [{ family, given: ['John'] }],
       });
       expect(createResult.resourceType).toBe('Patient');
 
       // 2. MCP search
-      const searchToolResult = await client.callTool({
+      const searchSpy = vi.spyOn(Repository.prototype, 'search');
+      try {
+        const searchToolResult = await client.callTool({
+          name: 'search',
+          arguments: { query: `Patient?_id=${createResult.id}&_count=500&_total=accurate` },
+        });
+        expect(searchToolResult.isError).not.toBe(true);
+        const searchToolJson = getToolJson<McpSearchResponse>(searchToolResult);
+        expect(searchToolResult.structuredContent).toEqual(searchToolJson);
+        expect(searchToolJson.results).toEqual([
+          expect.objectContaining({
+            id: `Patient/${createResult.id}`,
+            title: `John ${family}`,
+            url: `http://localhost:${port}/fhir/R4/Patient/${createResult.id}`,
+          }),
+        ]);
+        expect(searchToolJson.total).toBe(1);
+        expect(searchSpy).toHaveBeenLastCalledWith(expect.objectContaining({ count: 100 }));
+
+        await client.callTool({
+          name: 'search',
+          arguments: {
+            query: `Patient?_id=${createResult.id}&_include=Patient:organization&_revinclude=Observation:subject`,
+          },
+        });
+        const lastSearchRequest = searchSpy.mock.calls[searchSpy.mock.calls.length - 1][0];
+        expect(lastSearchRequest.count).toBe(20);
+        expect(lastSearchRequest.include).toBeUndefined();
+        expect(lastSearchRequest.revInclude).toBeUndefined();
+      } finally {
+        searchSpy.mockRestore();
+      }
+
+      const invalidSearchResult = await client.callTool({
         name: 'search',
-        arguments: { query: `Patient?_id=${createResult.id}&_count=500` },
+        arguments: { query: `Patient/${createResult.id}/Observation` },
       });
-      expect(searchToolResult.isError).not.toBe(true);
-      const searchToolJson = getToolJson<McpSearchResponse>(searchToolResult);
-      expect(searchToolResult.structuredContent).toMatchObject(searchToolJson);
-      expect(searchToolJson.results).toEqual([
-        expect.objectContaining({
-          id: `Patient/${createResult.id}`,
-          url: `http://localhost:${port}/fhir/R4/Patient/${createResult.id}`,
-        }),
-      ]);
+      expect(invalidSearchResult.isError).toBe(true);
+      expect(getToolJson<OperationOutcome>(invalidSearchResult).resourceType).toBe('OperationOutcome');
 
       // 3. MCP fetch
       const fetchToolResult = await client.callTool({
@@ -202,9 +236,30 @@ describe('MCP Routes', () => {
       expect(fetchToolJson).toMatchObject({
         id: `Patient/${createResult.id}`,
         url: `http://localhost:${port}/fhir/R4/Patient/${createResult.id}`,
-        metadata: { resourceType: 'Patient' },
       });
       expect((JSON.parse(fetchToolJson.text) as Patient).id).toBe(createResult.id);
+
+      const bigPatient = await fhirRequest<Patient>('POST', 'Patient', {
+        resourceType: 'Patient',
+        name: [{ family: 'Y'.repeat(300) }],
+        extension: [{ url: 'https://example.com/large', valueString: 'x'.repeat(60_000) }],
+      });
+      const bigFetchResult = await client.callTool({
+        name: 'fetch',
+        arguments: { id: `Patient/${bigPatient.id}` },
+      });
+      const bigFetchJson = getToolJson<McpFetchResponse>(bigFetchResult);
+      expect(bigFetchResult.isError).not.toBe(true);
+      expect(bigFetchJson.text.length).toBeLessThan(51_000);
+      expect(bigFetchJson.text).toContain('[truncated');
+      expect(bigFetchJson.title.length).toBeLessThanOrEqual(200);
+      await fhirRequest('DELETE', `Patient/${bigPatient.id}`);
+
+      for (const id of ['example-id', `Patient/${createResult.id}/_history/1`, `Binary/${randomUUID()}`]) {
+        const invalidFetchResult = await client.callTool({ name: 'fetch', arguments: { id } });
+        expect(invalidFetchResult.isError).toBe(true);
+        expect(getToolJson<OperationOutcome>(invalidFetchResult).resourceType).toBe('OperationOutcome');
+      }
 
       // 4. MCP search and fetch respect access policies
       const limitedAccessToken = await initTestAuth({
@@ -225,12 +280,14 @@ describe('MCP Routes', () => {
           arguments: { query: `Patient?_id=${createResult.id}` },
         });
         expect(patientSearchResult.isError).toBe(true);
+        expect(getToolJson<OperationOutcome>(patientSearchResult).resourceType).toBe('OperationOutcome');
 
         const patientFetchResult = await limitedClient.callTool({
           name: 'fetch',
           arguments: { id: `Patient/${createResult.id}` },
         });
         expect(patientFetchResult.isError).toBe(true);
+        expect(getToolJson<OperationOutcome>(patientFetchResult).resourceType).toBe('OperationOutcome');
       } finally {
         await limitedClient.close();
       }

--- a/packages/server/src/mcp/routes.test.ts
+++ b/packages/server/src/mcp/routes.test.ts
@@ -22,6 +22,59 @@ import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import { initTestAuth } from '../test.setup';
 
+type TransportType = 'stream' | 'sse';
+
+interface McpSearchResponse {
+  results: {
+    id: string;
+    title: string;
+    url: string;
+  }[];
+}
+
+interface McpFetchResponse {
+  id: string;
+  title: string;
+  text: string;
+  url: string;
+  metadata: {
+    resourceType: string;
+    versionId?: string;
+    lastUpdated?: string;
+  };
+}
+
+async function connectMcpClient(port: number, transportType: TransportType, accessToken: string): Promise<Client> {
+  const baseUrl = `http://localhost:${port}/mcp/${transportType}`;
+  const transportOptions = {
+    requestInit: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  };
+  const transport =
+    transportType === 'stream'
+      ? new StreamableHTTPClientTransport(new URL(baseUrl), transportOptions)
+      : new SSEClientTransport(new URL(baseUrl), transportOptions);
+
+  const client = new Client({
+    name: 'example-client',
+    version: '1.0.0',
+  });
+
+  await client.connect(transport);
+  return client;
+}
+
+function getToolJson<T>(mcpResult: any): T {
+  const text = mcpResult.content?.[0]?.text;
+  if (typeof text !== 'string') {
+    throw new Error('MCP tool result did not include text content');
+  }
+  return JSON.parse(text) as T;
+}
+
 describe('MCP Routes', () => {
   const app = express();
   let accessToken: string;
@@ -81,37 +134,26 @@ describe('MCP Routes', () => {
     expect(res).toHaveStatus(400);
   });
 
-  test.each<string>(['stream', 'sse'])('MCP with %s transport', async (transportType: string) => {
-    const TransportClass = transportType === 'stream' ? StreamableHTTPClientTransport : SSEClientTransport;
-
-    const baseUrl = `http://localhost:${port}/mcp/${transportType}`;
-
-    const transport = new TransportClass(new URL(baseUrl), {
-      requestInit: {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      },
-    });
-
-    const client = new Client({
-      name: 'example-client',
-      version: '1.0.0',
-    });
-
-    await client.connect(transport);
+  test.each<TransportType>(['stream', 'sse'])('MCP with %s transport', async (transportType: TransportType) => {
+    const client = await connectMcpClient(port, transportType, accessToken);
 
     try {
       const tools = await client.listTools();
       expect(tools).toMatchObject({
         tools: [{ name: 'search' }, { name: 'fetch' }, { name: 'fhir-request' }],
       });
-
-      const searchToolResult = await client.callTool({ name: 'search', arguments: { query: 'example' } });
-      expect(searchToolResult).toBeDefined();
-
-      const fetchToolResult = await client.callTool({ name: 'fetch', arguments: { id: 'example-id' } });
-      expect(fetchToolResult).toBeDefined();
+      expect(tools.tools).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'search',
+            annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
+          }),
+          expect.objectContaining({
+            name: 'fetch',
+            annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
+          }),
+        ])
+      );
 
       // Convenience method to make FHIR requests
       async function fhirRequest<T>(method: string, path: string, body?: any): Promise<T> {
@@ -134,11 +176,70 @@ describe('MCP Routes', () => {
       });
       expect(createResult.resourceType).toBe('Patient');
 
-      // 2. read
+      // 2. MCP search
+      const searchToolResult = await client.callTool({
+        name: 'search',
+        arguments: { query: `Patient?_id=${createResult.id}&_count=500` },
+      });
+      expect(searchToolResult.isError).not.toBe(true);
+      const searchToolJson = getToolJson<McpSearchResponse>(searchToolResult);
+      expect(searchToolResult.structuredContent).toMatchObject(searchToolJson);
+      expect(searchToolJson.results).toEqual([
+        expect.objectContaining({
+          id: `Patient/${createResult.id}`,
+          url: `http://localhost:${port}/fhir/R4/Patient/${createResult.id}`,
+        }),
+      ]);
+
+      // 3. MCP fetch
+      const fetchToolResult = await client.callTool({
+        name: 'fetch',
+        arguments: { id: `Patient/${createResult.id}` },
+      });
+      expect(fetchToolResult.isError).not.toBe(true);
+      const fetchToolJson = getToolJson<McpFetchResponse>(fetchToolResult);
+      expect(fetchToolResult.structuredContent).toMatchObject(fetchToolJson);
+      expect(fetchToolJson).toMatchObject({
+        id: `Patient/${createResult.id}`,
+        url: `http://localhost:${port}/fhir/R4/Patient/${createResult.id}`,
+        metadata: { resourceType: 'Patient' },
+      });
+      expect((JSON.parse(fetchToolJson.text) as Patient).id).toBe(createResult.id);
+
+      // 4. MCP search and fetch respect access policies
+      const limitedAccessToken = await initTestAuth({
+        accessPolicy: {
+          resource: [{ resourceType: 'Observation', interaction: ['read', 'search'] }],
+        },
+      });
+      const limitedClient = await connectMcpClient(port, transportType, limitedAccessToken);
+      try {
+        const observationSearchResult = await limitedClient.callTool({
+          name: 'search',
+          arguments: { query: 'Observation?_count=1' },
+        });
+        expect(observationSearchResult.isError).not.toBe(true);
+
+        const patientSearchResult = await limitedClient.callTool({
+          name: 'search',
+          arguments: { query: `Patient?_id=${createResult.id}` },
+        });
+        expect(patientSearchResult.isError).toBe(true);
+
+        const patientFetchResult = await limitedClient.callTool({
+          name: 'fetch',
+          arguments: { id: `Patient/${createResult.id}` },
+        });
+        expect(patientFetchResult.isError).toBe(true);
+      } finally {
+        await limitedClient.close();
+      }
+
+      // 5. read
       const readResult = await fhirRequest<Patient>('GET', `Patient/${createResult.id}`);
       expect(readResult.id).toBe(createResult.id);
 
-      // 3. update
+      // 6. update
       const updateResult = await fhirRequest<Patient>('PUT', `Patient/${createResult.id}`, {
         ...createResult,
         address: [{ line: ['123 Main St'], city: 'Springfield', state: 'IL', postalCode: '62701' }],
@@ -146,7 +247,7 @@ describe('MCP Routes', () => {
       expect(updateResult.address).toBeDefined();
       expect(updateResult.address?.[0].line).toEqual(['123 Main St']);
 
-      // 4. patch
+      // 7. patch
       const patchedResult = await fhirRequest<Patient>('PATCH', `Patient/${updateResult.id}`, [
         { op: 'test', path: '/meta/versionId', value: updateResult.meta?.versionId },
         { op: 'add', path: '/telecom', value: [{ system: 'phone', value: '555-1234' }] },
@@ -154,16 +255,16 @@ describe('MCP Routes', () => {
       expect(patchedResult.telecom).toBeDefined();
       expect(patchedResult.telecom?.[0].value).toBe('555-1234');
 
-      // 5. search
+      // 8. search
       const searchResult = await fhirRequest<Bundle<Patient>>('GET', 'Patient');
       expect(searchResult.resourceType);
       expect(searchResult.entry?.some((e) => e.resource?.id === createResult.id)).toBeTruthy();
 
-      // 6. delete
+      // 9. delete
       const deleteResult = await fhirRequest<OperationOutcome>('DELETE', `Patient/${createResult.id}`);
       expect(deleteResult.id).toBe('ok');
 
-      // 7. unknown method
+      // 10. unknown method
       const unknownMethodResult = await fhirRequest<OperationOutcome>('UNKNOWN', `Patient/${createResult.id}`);
       expect(unknownMethodResult.issue?.[0].severity).toBe('error');
 

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -1,11 +1,99 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { concatUrls, isString, MEDPLUM_VERSION, MedplumClient } from '@medplum/core';
+import type { SearchRequest, WithId } from '@medplum/core';
+import {
+  concatUrls,
+  DEFAULT_SEARCH_COUNT,
+  getDisplayString,
+  getReferenceString,
+  isString,
+  MEDPLUM_VERSION,
+  MedplumClient,
+  parseReference,
+  parseSearchRequest,
+} from '@medplum/core';
+import type { Resource } from '@medplum/fhirtypes';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { getConfig } from '../config/loader';
 import { getAuthenticatedContext } from '../context';
+import { getFullUrl } from '../fhir/response';
 import { getLogger } from '../logger';
+
+const MCP_MAX_SEARCH_COUNT = 100;
+
+interface McpSearchResult {
+  id: string;
+  title: string;
+  url: string;
+}
+
+interface McpSearchResponse extends Record<string, unknown> {
+  results: McpSearchResult[];
+}
+
+interface McpFetchResponse extends Record<string, unknown> {
+  id: string;
+  title: string;
+  text: string;
+  url: string;
+  metadata: {
+    resourceType: string;
+    versionId?: string;
+    lastUpdated?: string;
+  };
+}
+
+function withJsonContent<T extends object>(
+  structuredContent: T
+): {
+  content: [{ type: 'text'; text: string }];
+  structuredContent: T;
+} {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(structuredContent) }],
+    structuredContent,
+  };
+}
+
+function applyMcpSearchCount(searchRequest: SearchRequest): void {
+  if (searchRequest.count === undefined) {
+    searchRequest.count = DEFAULT_SEARCH_COUNT;
+  } else {
+    searchRequest.count = Math.min(Math.max(searchRequest.count, 1), MCP_MAX_SEARCH_COUNT);
+  }
+}
+
+function toMcpSearchResult(resource: WithId<Resource>): McpSearchResult {
+  const id = getReferenceString(resource);
+  return {
+    id,
+    title: getDisplayString(resource) || id,
+    url: getFullUrl(resource.resourceType, resource.id),
+  };
+}
+
+function toMcpFetchResponse(resource: WithId<Resource>): McpFetchResponse {
+  const id = getReferenceString(resource);
+  const metadata: McpFetchResponse['metadata'] = {
+    resourceType: resource.resourceType,
+  };
+
+  if (resource.meta?.versionId) {
+    metadata.versionId = resource.meta.versionId;
+  }
+  if (resource.meta?.lastUpdated) {
+    metadata.lastUpdated = resource.meta.lastUpdated;
+  }
+
+  return {
+    id,
+    title: getDisplayString(resource) || id,
+    text: JSON.stringify(resource),
+    url: getFullUrl(resource.resourceType, resource.id),
+    metadata,
+  };
+}
 
 export function getMcpServer(): McpServer {
   const server = new McpServer({
@@ -13,33 +101,70 @@ export function getMcpServer(): McpServer {
     version: MEDPLUM_VERSION,
   });
 
-  /**
-   * Dummy document used for testing purposes.
-   *
-   * ChatGPT requires two standrad tools: "search" and "fetch".
-   * We implement stub versions of these tools that return a dummy document.
-   * If these tools are not implemented, ChatGPT will not connect to the Medplum server.
-   */
-  const dummyDocument = {
-    type: 'text',
-    id: 'dummy-doc',
-    text: 'This is a dummy document used for testing purposes.',
-    uri: 'https://example.com/dummy-doc',
-  } as const;
-
-  server.registerTool('search', { inputSchema: { query: z.string() } }, async ({ query }) => {
-    getLogger().debug(`Performing search for: "${query}"`);
-    return { content: [dummyDocument] };
-  });
+  server.registerTool(
+    'search',
+    {
+      description: 'Search FHIR resources with a FHIR search query such as "Patient?name=Smith&_count=10".',
+      inputSchema: {
+        query: z.string().describe('FHIR search query, for example "Patient?name=Smith&_count=10".'),
+      },
+      outputSchema: {
+        results: z.array(
+          z.object({
+            id: z.string(),
+            title: z.string(),
+            url: z.string(),
+          })
+        ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ query }) => {
+      getLogger().debug(`Performing search for: "${query}"`);
+      const ctx = getAuthenticatedContext();
+      const searchRequest = parseSearchRequest(query);
+      applyMcpSearchCount(searchRequest);
+      const results = (await ctx.repo.searchResources(searchRequest)).map(toMcpSearchResult);
+      return withJsonContent<McpSearchResponse>({ results });
+    }
+  );
 
   server.registerTool(
     'fetch',
     {
-      inputSchema: { id: z.string().describe('The ID of the resource to fetch, obtained from a search result.') },
+      description: 'Fetch a single FHIR resource by reference returned from search, such as "Patient/123".',
+      inputSchema: {
+        id: z.string().describe('FHIR resource reference returned by search, for example "Patient/123".'),
+      },
+      outputSchema: {
+        id: z.string(),
+        title: z.string(),
+        text: z.string(),
+        url: z.string(),
+        metadata: z.object({
+          resourceType: z.string(),
+          versionId: z.string().optional(),
+          lastUpdated: z.string().optional(),
+        }),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async ({ id }) => {
       getLogger().debug(`Performing fetch for ID: "${id}"`);
-      return { content: [dummyDocument] };
+      const ctx = getAuthenticatedContext();
+      const [resourceType, resourceId] = parseReference<Resource>({ reference: id });
+      const resource = await ctx.repo.readResource<Resource>(resourceType, resourceId);
+      return withJsonContent(toMcpFetchResponse(resource));
     }
   );
 

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { SearchRequest, WithId } from '@medplum/core';
+import type { WithId } from '@medplum/core';
 import {
+  badRequest,
   concatUrls,
   DEFAULT_SEARCH_COUNT,
   getDisplayString,
@@ -9,11 +10,14 @@ import {
   isString,
   MEDPLUM_VERSION,
   MedplumClient,
+  normalizeOperationOutcome,
+  OperationOutcomeError,
   parseReference,
   parseSearchRequest,
 } from '@medplum/core';
 import type { Resource } from '@medplum/fhirtypes';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { getConfig } from '../config/loader';
 import { getAuthenticatedContext } from '../context';
@@ -21,6 +25,8 @@ import { getFullUrl } from '../fhir/response';
 import { getLogger } from '../logger';
 
 const MCP_MAX_SEARCH_COUNT = 100;
+const MCP_MAX_TITLE_LENGTH = 200;
+const MCP_MAX_FETCH_LENGTH = 50_000;
 
 interface McpSearchResult {
   id: string;
@@ -30,6 +36,7 @@ interface McpSearchResult {
 
 interface McpSearchResponse extends Record<string, unknown> {
   results: McpSearchResult[];
+  total?: number;
 }
 
 interface McpFetchResponse extends Record<string, unknown> {
@@ -37,11 +44,6 @@ interface McpFetchResponse extends Record<string, unknown> {
   title: string;
   text: string;
   url: string;
-  metadata: {
-    resourceType: string;
-    versionId?: string;
-    lastUpdated?: string;
-  };
 }
 
 function withJsonContent<T extends object>(
@@ -56,42 +58,47 @@ function withJsonContent<T extends object>(
   };
 }
 
-function applyMcpSearchCount(searchRequest: SearchRequest): void {
-  if (searchRequest.count === undefined) {
-    searchRequest.count = DEFAULT_SEARCH_COUNT;
-  } else {
-    searchRequest.count = Math.min(Math.max(searchRequest.count, 1), MCP_MAX_SEARCH_COUNT);
+export function clampMcpSearchCount(count: number | undefined): number {
+  if (count === undefined || !Number.isFinite(count) || count < 0) {
+    return DEFAULT_SEARCH_COUNT;
   }
+  return Math.min(count, MCP_MAX_SEARCH_COUNT);
+}
+
+function getMcpTitle(resource: WithId<Resource>): string {
+  const reference = getReferenceString(resource);
+  const title = getDisplayString(resource) || reference;
+  return title.length > MCP_MAX_TITLE_LENGTH ? `${title.slice(0, MCP_MAX_TITLE_LENGTH - 3)}...` : title;
 }
 
 function toMcpSearchResult(resource: WithId<Resource>): McpSearchResult {
   const id = getReferenceString(resource);
   return {
     id,
-    title: getDisplayString(resource) || id,
+    title: getMcpTitle(resource),
     url: getFullUrl(resource.resourceType, resource.id),
   };
 }
 
 function toMcpFetchResponse(resource: WithId<Resource>): McpFetchResponse {
   const id = getReferenceString(resource);
-  const metadata: McpFetchResponse['metadata'] = {
-    resourceType: resource.resourceType,
-  };
-
-  if (resource.meta?.versionId) {
-    metadata.versionId = resource.meta.versionId;
-  }
-  if (resource.meta?.lastUpdated) {
-    metadata.lastUpdated = resource.meta.lastUpdated;
-  }
+  const json = JSON.stringify(resource);
 
   return {
     id,
-    title: getDisplayString(resource) || id,
-    text: JSON.stringify(resource),
+    title: getMcpTitle(resource),
+    text:
+      json.length > MCP_MAX_FETCH_LENGTH
+        ? `${json.slice(0, MCP_MAX_FETCH_LENGTH)}... [truncated ${json.length} character resource]`
+        : json,
     url: getFullUrl(resource.resourceType, resource.id),
-    metadata,
+  };
+}
+
+function withOperationOutcome(err: unknown): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(normalizeOperationOutcome(err)) }],
+    isError: true,
   };
 }
 
@@ -104,7 +111,11 @@ export function getMcpServer(): McpServer {
   server.registerTool(
     'search',
     {
-      description: 'Search FHIR resources with a FHIR search query such as "Patient?name=Smith&_count=10".',
+      title: 'FHIR Search',
+      description:
+        'Search FHIR resources using a FHIR search string such as "Patient?name=Smith&_count=10". ' +
+        `Returns at most ${MCP_MAX_SEARCH_COUNT} matches (default ${DEFAULT_SEARCH_COUNT}); use _offset to page. ` +
+        'Each result id is a FHIR reference that can be passed to fetch. _include and _revinclude are ignored.',
       inputSchema: {
         query: z.string().describe('FHIR search query, for example "Patient?name=Smith&_count=10".'),
       },
@@ -116,6 +127,7 @@ export function getMcpServer(): McpServer {
             url: z.string(),
           })
         ),
+        total: z.number().optional(),
       },
       annotations: {
         readOnlyHint: true,
@@ -124,20 +136,48 @@ export function getMcpServer(): McpServer {
         openWorldHint: false,
       },
     },
-    async ({ query }) => {
+    async ({ query }): Promise<CallToolResult> => {
       getLogger().debug(`Performing search for: "${query}"`);
-      const ctx = getAuthenticatedContext();
-      const searchRequest = parseSearchRequest(query);
-      applyMcpSearchCount(searchRequest);
-      const results = (await ctx.repo.searchResources(searchRequest)).map(toMcpSearchResult);
-      return withJsonContent<McpSearchResponse>({ results });
+      try {
+        const resourceType = query.split('?')[0];
+        if (!/^[A-Z][A-Za-z0-9]*$/.test(resourceType)) {
+          throw new OperationOutcomeError(
+            badRequest('Search query must start with a resource type, for example "Patient?name=Smith"')
+          );
+        }
+
+        const ctx = getAuthenticatedContext();
+        const searchRequest = parseSearchRequest(query);
+        delete searchRequest.include;
+        delete searchRequest.revInclude;
+        searchRequest.count = clampMcpSearchCount(searchRequest.count);
+
+        const bundle = await ctx.repo.search(searchRequest);
+        const results = (bundle.entry ?? []).flatMap((entry) => {
+          const resource = entry.resource;
+          if (entry.search?.mode !== 'match' || !resource?.id) {
+            return [];
+          }
+          return [toMcpSearchResult(resource)];
+        });
+        const response: McpSearchResponse = { results };
+        if (bundle.total !== undefined) {
+          response.total = bundle.total;
+        }
+        return withJsonContent(response);
+      } catch (err) {
+        return withOperationOutcome(err);
+      }
     }
   );
 
   server.registerTool(
     'fetch',
     {
-      description: 'Fetch a single FHIR resource by reference returned from search, such as "Patient/123".',
+      title: 'FHIR Read',
+      description:
+        'Fetch one FHIR resource using a reference returned by search, such as "Patient/123". ' +
+        'Very large resources are truncated, and Binary resources are not supported.',
       inputSchema: {
         id: z.string().describe('FHIR resource reference returned by search, for example "Patient/123".'),
       },
@@ -146,11 +186,6 @@ export function getMcpServer(): McpServer {
         title: z.string(),
         text: z.string(),
         url: z.string(),
-        metadata: z.object({
-          resourceType: z.string(),
-          versionId: z.string().optional(),
-          lastUpdated: z.string().optional(),
-        }),
       },
       annotations: {
         readOnlyHint: true,
@@ -159,12 +194,26 @@ export function getMcpServer(): McpServer {
         openWorldHint: false,
       },
     },
-    async ({ id }) => {
+    async ({ id }): Promise<CallToolResult> => {
       getLogger().debug(`Performing fetch for ID: "${id}"`);
-      const ctx = getAuthenticatedContext();
-      const [resourceType, resourceId] = parseReference<Resource>({ reference: id });
-      const resource = await ctx.repo.readResource<Resource>(resourceType, resourceId);
-      return withJsonContent(toMcpFetchResponse(resource));
+      try {
+        const parts = id.split('/');
+        if (parts.length !== 2 || !/^[A-Z][A-Za-z0-9]*$/.test(parts[0]) || !parts[1]) {
+          throw new OperationOutcomeError(
+            badRequest('The id must be a FHIR reference of the form "ResourceType/id", for example "Patient/123"')
+          );
+        }
+        if (parts[0] === 'Binary') {
+          throw new OperationOutcomeError(badRequest('Binary resources are not supported by the fetch tool'));
+        }
+
+        const ctx = getAuthenticatedContext();
+        const [resourceType, resourceId] = parseReference<Resource>({ reference: id });
+        const resource = await ctx.repo.readResource<Resource>(resourceType, resourceId);
+        return withJsonContent(toMcpFetchResponse(resource));
+      } catch (err) {
+        return withOperationOutcome(err);
+      }
     }
   );
 


### PR DESCRIPTION
## Summary

Fixes #9616.

This replaces the placeholder MCP `search` and `fetch` tools with read-only FHIR-backed implementations:

- `search` parses a FHIR search query, defaults `_count` to the core default, clamps requested counts to 100, and returns MCP search results with FHIR references, display titles, and resource URLs.
- `fetch` reads a single FHIR resource by reference and returns the resource JSON plus basic metadata.
- Both tools declare read-only/idempotent MCP annotations and run through the authenticated repository context, so existing access policy checks are applied.

## Tests

- `npm --workspace @medplum/server exec eslint -- src/mcp/server.ts src/mcp/routes.test.ts`
- `npm --workspace @medplum/server run build`
- `npm --workspace @medplum/server test -- src/mcp/routes.test.ts` *(blocked locally: app setup cannot connect to local Postgres/Redis, failing during seed before the MCP test body runs)*