### PR TITLE
fix: prevent logger serialization errors from crashing the server process

### DIFF
--- a/packages/core/src/logger.test.ts
+++ b/packages/core/src/logger.test.ts
@@ -115,6 +115,74 @@ describe('Logger', () => {
     );
   });
 
+  test('Error with circular reference in custom property', () => {
+    // Simulates an AbortError referencing an IncomingMessage -> TLSSocket -> ClientRequest cycle
+    const incomingMessage: Record<string, any> = { readable: true };
+    const clientRequest: Record<string, any> = { res: incomingMessage };
+    const tlsSocket: Record<string, any> = { _httpMessage: clientRequest };
+    incomingMessage.socket = tlsSocket;
+
+    const abortError = new Error('The operation was aborted') as any;
+    abortError.name = 'AbortError';
+    abortError.response = incomingMessage;
+
+    expect(() => testLogger.error('Unhandled promise rejection', abortError)).not.toThrow();
+    expect(testOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'ERROR',
+        msg: 'Unhandled promise rejection',
+        error: 'AbortError: The operation was aborted',
+        response: expect.objectContaining({
+          readable: true,
+          socket: expect.objectContaining({
+            _httpMessage: expect.objectContaining({ res: '[Circular]' }),
+          }),
+        }),
+      })
+    );
+  });
+
+  test('Circular reference in data', () => {
+    const data: Record<string, any> = { foo: 'bar' };
+    data.self = data;
+
+    expect(() => testLogger.info('Circular data', data)).not.toThrow();
+    // Logger.log shallow-copies data, so the original object reappears one level down
+    expect(testOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'INFO',
+        msg: 'Circular data',
+        foo: 'bar',
+        self: { foo: 'bar', self: '[Circular]' },
+      })
+    );
+  });
+
+  test('Repeated non-circular references are preserved', () => {
+    const shared = { id: '123' };
+
+    testLogger.info('Shared references', { first: shared, second: shared });
+    expect(testOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'INFO',
+        msg: 'Shared references',
+        first: { id: '123' },
+        second: { id: '123' },
+      })
+    );
+  });
+
+  test('Falls back to minimal log message when serialization throws', () => {
+    testLogger.info('Unserializable data', { value: BigInt(1) });
+    expect(testOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'INFO',
+        msg: 'Unserializable data',
+        loggerError: expect.stringContaining('BigInt'),
+      })
+    );
+  });
+
   test('parseLogLevel', () => {
     expect(parseLogLevel('DEbug')).toBe(LogLevel.DEBUG);
     expect(parseLogLevel('INFO')).toBe(LogLevel.INFO);

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { isError } from './outcomes';
+import { isError, normalizeErrorString } from './outcomes';
 
 /*
  * Once upon a time, we used Winston, and that was fine.
@@ -134,7 +134,7 @@ export class Logger implements ILogger {
     }
 
     this.write(
-      JSON.stringify({
+      stringifyLogMessage({
         level: LogLevelNames[level],
         timestamp: new Date().toISOString(),
         msg: this.prefix ? `${this.prefix}${msg}` : msg,
@@ -143,6 +143,51 @@ export class Logger implements ILogger {
       })
     );
   }
+}
+
+/**
+ * Stringifies a log message so that logging never throws.
+ *
+ * Log data can carry arbitrary object graphs, such as an error referencing a live HTTP request,
+ * which JSON.stringify rejects for circular references, BigInt values, or throwing getters.
+ * Circular references are replaced with "[Circular]"; any other serialization failure falls back
+ * to a minimal message.
+ * @param logMessage - The log message to stringify.
+ * @returns The JSON string representation of the log message.
+ */
+function stringifyLogMessage(logMessage: Record<string, any>): string {
+  try {
+    return JSON.stringify(logMessage);
+  } catch {
+    try {
+      return JSON.stringify(logMessage, createCircularReplacer());
+    } catch (err) {
+      const { level, timestamp, msg } = logMessage;
+      return JSON.stringify({ level, timestamp, msg, loggerError: normalizeErrorString(err) });
+    }
+  }
+}
+
+/**
+ * Creates a JSON.stringify replacer function that replaces circular references with "[Circular]".
+ * @returns A replacer function for use with JSON.stringify.
+ */
+function createCircularReplacer(): (this: unknown, key: string, value: unknown) => unknown {
+  const ancestors: unknown[] = [];
+  return function (this: unknown, _key: string, value: unknown): unknown {
+    if (typeof value !== 'object' || value === null) {
+      return value;
+    }
+    // `this` is the parent of `value`; pop until the stack is the chain from the root to `value`
+    while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) {
+      ancestors.pop();
+    }
+    if (ancestors.includes(value)) {
+      return '[Circular]';
+    }
+    ancestors.push(value);
+    return value;
+  };
 }
 
 export function parseLogLevel(level: string): LogLevel {

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -97,8 +97,9 @@ describe('Server', () => {
   });
 });
 
-describe('uncaughtException handler', () => {
+describe('process event handlers', () => {
   let handler: (err: Error, origin: NodeJS.UncaughtExceptionOrigin) => Promise<void>;
+  let rejectionHandler: NodeJS.UnhandledRejectionListener;
   let baselineUncaught: NodeJS.UncaughtExceptionListener[];
   let baselineRejection: NodeJS.UnhandledRejectionListener[];
 
@@ -109,6 +110,9 @@ describe('uncaughtException handler', () => {
     const installed = process.listeners('uncaughtException').filter((l) => !baselineUncaught.includes(l));
     expect(installed).toHaveLength(1);
     handler = installed[0] as (err: Error, origin: NodeJS.UncaughtExceptionOrigin) => Promise<void>;
+    const installedRejection = process.listeners('unhandledRejection').filter((l) => !baselineRejection.includes(l));
+    expect(installedRejection).toHaveLength(1);
+    rejectionHandler = installedRejection[0];
   });
 
   afterAll(async () => {
@@ -152,6 +156,32 @@ describe('uncaughtException handler', () => {
     expect(exitDrainSpy).not.toHaveBeenCalled();
 
     exitDrainSpy.mockRestore();
+  });
+
+  test('unhandledRejection handler does not throw on rejection reason with circular references', () => {
+    // A throw here would surface as an uncaughtException and take down the process
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    const incomingMessage: Record<string, any> = { readable: true };
+    const clientRequest: Record<string, any> = { res: incomingMessage };
+    const tlsSocket: Record<string, any> = { _httpMessage: clientRequest };
+    incomingMessage.socket = tlsSocket;
+
+    const abortError = new Error('The operation was aborted') as any;
+    abortError.name = 'AbortError';
+    abortError.response = incomingMessage;
+
+    expect(() => rejectionHandler(abortError, Promise.resolve())).not.toThrow();
+
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    const logLine = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+    expect(logLine).toMatchObject({
+      level: 'ERROR',
+      msg: 'Unhandled promise rejection',
+      error: 'AbortError: The operation was aborted',
+    });
+
+    stdoutSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
If an unhandled promise rejection carries an object with circular references — e.g. an AbortError from an aborted HTTPS request referencing a live IncomingMessage → TLSSocket → ClientRequest graph — the unhandledRejection handler logs it, JSON.stringify throws on the cycle, and the throw escapes the handler as an uncaughtException, which exits the process. A log line can kill the server.

## What

- `Logger.log` tries plain `JSON.stringify` first; on failure it retries with a replacer that emits `"[Circular]"` for cycles, then falls back to a minimal message if serialization still fails — so logging never throws.
- Tests: a circular AbortError through the core logger and through the server's installed `unhandledRejection` listener.