### PR TITLE
[codex] Fail CLI bot deploy on error outcome

### DIFF
--- a/packages/cli/src/bot.test.ts
+++ b/packages/cli/src/bot.test.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { allOk } from '@medplum/core';
+import { allOk, notFound } from '@medplum/core';
 import type { Bot } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { randomUUID } from 'node:crypto';
@@ -192,6 +192,34 @@ describe('CLI Bots', () => {
     const check = await medplum.readResource('Bot', bot.id);
     expect(check.code).toBeUndefined();
     expect(check.sourceCode).toBeDefined();
+  });
+
+  test('Deploy bot fails when deploy operation returns an error outcome', async () => {
+    medplum.router.router.add('POST', 'Bot/:id/$deploy', async () => [notFound]);
+
+    const bot = await medplum.createResource<Bot>({ id: randomUUID(), resourceType: 'Bot' });
+
+    (fs.existsSync as unknown as Mock).mockReturnValue(true);
+    (fs.readFileSync as unknown as Mock).mockReturnValue(
+      JSON.stringify({
+        bots: [
+          {
+            name: 'hello-world',
+            id: bot.id,
+            source: 'src/hello-world.ts',
+            dist: 'dist/hello-world.js',
+          },
+        ],
+      })
+    );
+
+    await expect(main(['node', 'index.js', 'bot', 'deploy', 'hello-world'])).rejects.toThrow(
+      'Process exited with exit code 1'
+    );
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Number of bots deployed: 0/));
+    expect(processError).toHaveBeenCalledWith(
+      expect.stringContaining('Error: 1 bot(s) had failures. Bots with failures:')
+    );
   });
 
   test('Deploy bot for multiple bot with wildcards ', async () => {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { MedplumClient, WithId } from '@medplum/core';
-import { ContentType, encodeBase64, OAuthSigningAlgorithm } from '@medplum/core';
+import { ContentType, encodeBase64, isOk, normalizeErrorString, OAuthSigningAlgorithm } from '@medplum/core';
 import type { Bot, Extension, OperationOutcome } from '@medplum/fhirtypes';
 import { Command } from 'commander';
 import { SignJWT } from 'jose';
@@ -85,6 +85,9 @@ export async function deployBot(medplum: MedplumClient, botConfig: MedplumBotCon
     filename: basename(codePath),
   });
   console.log('Deploy result: ' + deployResult.issue?.[0]?.details?.text);
+  if (!isOk(deployResult)) {
+    throw new Error(`Bot deploy failed: ${normalizeErrorString(deployResult)}`);
+  }
 }
 
 export async function createBot(


### PR DESCRIPTION
## What changed

- Updated `deployBot()` to treat non-OK `OperationOutcome` responses from `Bot/$deploy` as deployment failures.
- Added a regression test that returns a `notFound` outcome from `$deploy` and verifies `medplum bot deploy` exits non-zero.

## Why

Fixes #3692. Previously the CLI printed the deploy result text but did not fail when the server returned an error `OperationOutcome`, which could let CI pass after a failed bot deployment.

## Validation

- `npm test --workspace=@medplum/cli -- bot.test.ts`