### PR TITLE
[codex] Preserve agent logs on uninstall

### DIFF
--- a/packages/agent/installer.nsi
+++ b/packages/agent/installer.nsi
@@ -381,8 +381,17 @@ Section Uninstall
     # Uninstall the Start menu shortcuts
     RMDir /r /REBOOTOK "$SMPROGRAMS\${APP_NAME}"
 
-    # Delete the files
-    RMDir /r /REBOOTOK "$INSTDIR"
+    # Delete installer-managed files, but preserve runtime logs in $INSTDIR for retention.
+    Delete /REBOOTOK "$INSTDIR\agent.properties"
+    Delete /REBOOTOK "$INSTDIR\upgrade.json"
+    Delete /REBOOTOK "$INSTDIR\uninstall.exe"
+    Delete /REBOOTOK "$INSTDIR\README.md"
+    Delete /REBOOTOK "$INSTDIR\medplum-agent-*-win64.exe"
+    Delete /REBOOTOK "$INSTDIR\shawl-*-win64.exe"
+    Delete /REBOOTOK "$INSTDIR\shawl-*-legal.txt"
+
+    # Remove the install directory only if no logs or other runtime files remain.
+    RMDir /REBOOTOK "$INSTDIR"
 
     # Unregister the program
     DeleteRegKey HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${BASE_SERVICE_NAME}"


### PR DESCRIPTION
## What changed

- Replaced recursive deletion of the Windows Agent install directory during uninstall with deletion of installer-managed files only.
- Left `$INSTDIR` in place when runtime logs or other generated files remain.
- Still removes `$INSTDIR` when it becomes empty after deleting known installed files.

## Why

Fixes #3672. The previous uninstaller used `RMDir /r /REBOOTOK "$INSTDIR"`, which removed generated Agent log files that may be needed for retention or troubleshooting.

## Validation

- `git diff --check`

`makensis` is not installed in my local environment, so I could not compile the NSIS installer script locally.