### PR TITLE
Filter included ValueSet expansions by concepts

### DIFF
--- a/packages/server/src/fhir/operations/expand.test.ts
+++ b/packages/server/src/fhir/operations/expand.test.ts
@@ -1262,6 +1262,60 @@ describe('Expand', () => {
     );
   });
 
+  test('Include pre-expanded ValueSet with concept filter', async () => {
+    const preexpanded: ValueSet = {
+      resourceType: 'ValueSet',
+      status: 'draft',
+      url: 'http://example.com/ValueSet/pre-expanded-filtered-' + randomUUID(),
+      expansion: {
+        timestamp: new Date().toISOString(),
+        contains: [
+          { system: 'http://loinc.org', code: '8480-6', display: 'Systolic BP - Reported' },
+          { system: 'http://loinc.org', code: '8462-4', display: 'Diastolic BP - Reported' },
+          { system: 'http://loinc.org', code: '8310-5', display: 'Body temperature' },
+          { system: SNOMED, code: '75367002', display: 'Blood pressure' },
+        ],
+      },
+    };
+    const preexpandedRes = await request(app)
+      .post('/fhir/R4/ValueSet')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send(preexpanded);
+    expect(preexpandedRes.status).toStrictEqual(201);
+    const preexpandedValueSet = preexpandedRes.body as ValueSet;
+
+    const include: ValueSet = {
+      resourceType: 'ValueSet',
+      status: 'draft',
+      url: 'http://example.com/ValueSet/include-expanded-filtered-' + randomUUID(),
+      compose: {
+        include: [
+          {
+            valueSet: [preexpandedValueSet.url as string],
+            system: 'http://loinc.org',
+            concept: [{ code: '8462-4' }],
+          },
+        ],
+      },
+    };
+    const valueSetRes = await request(app)
+      .post('/fhir/R4/ValueSet')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send(include);
+    expect(valueSetRes.status).toStrictEqual(201);
+    const valueSet = valueSetRes.body as ValueSet;
+
+    const res = await request(app)
+      .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet.url as string)}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res.status).toStrictEqual(200);
+    const expansion = res.body.expansion as ValueSetExpansion;
+
+    expect(expansion.contains).toStrictEqual<ValueSetExpansionContains[]>([
+      { system: 'http://loinc.org', code: '8462-4', display: 'Diastolic BP - Reported' },
+    ]);
+  });
+
   test('Resolve synonyms', async () => {
     const codeSystem: CodeSystem = {
       resourceType: 'CodeSystem',

--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -190,11 +190,11 @@ async function computeExpansion(
           includedValueSet,
           {
             ...params,
-            count: maxCount - expansion.length,
+            count: include.system || include.concept ? MAX_EXPANSION_SIZE : maxCount - expansion.length,
           },
           terminologyResources
         );
-        expansion.push(...nestedExpansion);
+        expansion.push(...filterExpansionByInclude(nestedExpansion, include).slice(0, maxCount - expansion.length));
 
         if (expansion.length >= maxCount) {
           // Skip further expansion
@@ -234,6 +234,21 @@ async function computeExpansion(
   }
 
   return expansion;
+}
+
+export function filterExpansionByInclude(
+  expansion: ValueSetExpansionContains[],
+  include: ValueSetComposeInclude
+): ValueSetExpansionContains[] {
+  let result = expansion;
+  if (include.system) {
+    result = result.filter((concept) => concept.system === include.system);
+  }
+  if (include.concept) {
+    const allowedConcepts = new Set(include.concept.map((concept) => concept.code));
+    result = result.filter((concept) => allowedConcepts.has(concept.code));
+  }
+  return result;
 }
 
 async function includeInExpansion(

--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -161,7 +161,8 @@ async function computeExpansion(
   repo: Repository,
   valueSet: ValueSet,
   params: ValueSetExpandParameters,
-  terminologyResources: Record<string, WithId<CodeSystem> | WithId<ValueSet>> = Object.create(null)
+  terminologyResources: Record<string, WithId<CodeSystem> | WithId<ValueSet>> = Object.create(null),
+  constraint?: Pick<ValueSetComposeInclude, 'system' | 'concept'>
 ): Promise<ValueSetExpansionContains[]> {
   const preExpansion = valueSet.expansion;
   if (
@@ -170,7 +171,7 @@ async function computeExpansion(
     (!preExpansion.total || preExpansion.total === preExpansion.contains.length)
   ) {
     // Full expansion is already available, use that
-    return filterIncludedConcepts(preExpansion.contains, params);
+    return filterExpansionByConstraint(filterIncludedConcepts(preExpansion.contains, params), constraint);
   }
 
   if (!valueSet.compose?.include.length) {
@@ -180,8 +181,13 @@ async function computeExpansion(
   const maxCount = params.count ?? MAX_EXPANSION_SIZE;
   const expansion: ValueSetExpansionContains[] = [];
   for (const include of valueSet.compose.include) {
-    if (include.valueSet) {
-      for (const url of include.valueSet) {
+    const constrainedInclude = constrainInclude(include, constraint);
+    if (!constrainedInclude) {
+      continue;
+    }
+
+    if (constrainedInclude.valueSet) {
+      for (const url of constrainedInclude.valueSet) {
         const includedValueSet = await findTerminologyResource<ValueSet>(repo, 'ValueSet', url);
         terminologyResources[includedValueSet.url as string] = includedValueSet;
 
@@ -190,11 +196,12 @@ async function computeExpansion(
           includedValueSet,
           {
             ...params,
-            count: include.system || include.concept ? MAX_EXPANSION_SIZE : maxCount - expansion.length,
+            count: maxCount - expansion.length,
           },
-          terminologyResources
+          terminologyResources,
+          getIncludeConstraint(constrainedInclude)
         );
-        expansion.push(...filterExpansionByInclude(nestedExpansion, include).slice(0, maxCount - expansion.length));
+        expansion.push(...nestedExpansion.slice(0, maxCount - expansion.length));
 
         if (expansion.length >= maxCount) {
           // Skip further expansion
@@ -203,7 +210,7 @@ async function computeExpansion(
       }
       continue;
     }
-    if (!include.system) {
+    if (!constrainedInclude.system) {
       throw new OperationOutcomeError(
         badRequest('Missing system URL for ValueSet include', 'ValueSet.compose.include.system')
       );
@@ -215,12 +222,12 @@ async function computeExpansion(
     }
 
     const codeSystem =
-      (terminologyResources[include.system] as WithId<CodeSystem>) ??
-      (await findTerminologyResource(repo, 'CodeSystem', include.system));
-    terminologyResources[include.system] = codeSystem;
+      (terminologyResources[constrainedInclude.system] as WithId<CodeSystem>) ??
+      (await findTerminologyResource(repo, 'CodeSystem', constrainedInclude.system));
+    terminologyResources[constrainedInclude.system] = codeSystem;
 
-    if (include.concept) {
-      const filteredCodings = filterIncludedConcepts(include.concept, params, include.system);
+    if (constrainedInclude.concept) {
+      const filteredCodings = filterIncludedConcepts(constrainedInclude.concept, params, constrainedInclude.system);
       const validCodings = await validateCodings(codeSystem, filteredCodings, params);
       for (const c of validCodings) {
         if (c) {
@@ -229,26 +236,58 @@ async function computeExpansion(
         }
       }
     } else {
-      await includeInExpansion(include, expansion, codeSystem, params);
+      await includeInExpansion(constrainedInclude, expansion, codeSystem, params);
     }
   }
 
   return expansion;
 }
 
-export function filterExpansionByInclude(
+function getIncludeConstraint(include: ValueSetComposeInclude): Pick<ValueSetComposeInclude, 'system' | 'concept'> {
+  return { system: include.system, concept: include.concept };
+}
+
+function filterExpansionByConstraint(
   expansion: ValueSetExpansionContains[],
-  include: ValueSetComposeInclude
+  constraint?: Pick<ValueSetComposeInclude, 'system' | 'concept'>
 ): ValueSetExpansionContains[] {
   let result = expansion;
-  if (include.system) {
-    result = result.filter((concept) => concept.system === include.system);
+  if (constraint?.system) {
+    result = result.filter((concept) => concept.system === constraint.system);
   }
-  if (include.concept) {
-    const allowedConcepts = new Set(include.concept.map((concept) => concept.code));
+  if (constraint?.concept) {
+    const allowedConcepts = new Set(constraint.concept.map((concept) => concept.code));
     result = result.filter((concept) => allowedConcepts.has(concept.code));
   }
   return result;
+}
+
+export function constrainInclude(
+  include: ValueSetComposeInclude,
+  constraint?: Pick<ValueSetComposeInclude, 'system' | 'concept'>
+): ValueSetComposeInclude | undefined {
+  if (!constraint?.system && !constraint?.concept) {
+    return include;
+  }
+
+  if (include.system && constraint.system && include.system !== constraint.system) {
+    return undefined;
+  }
+
+  let concept = include.concept;
+  if (constraint.concept) {
+    if (concept) {
+      const allowedCodes = new Set(constraint.concept.map((c) => c.code));
+      concept = concept.filter((c) => allowedCodes.has(c.code));
+      if (concept.length === 0) {
+        return undefined;
+      }
+    } else {
+      concept = constraint.concept;
+    }
+  }
+
+  return { ...include, system: include.system ?? constraint.system, concept };
 }
 
 async function includeInExpansion(

--- a/packages/server/src/fhir/operations/expand.unit.test.ts
+++ b/packages/server/src/fhir/operations/expand.unit.test.ts
@@ -1,25 +1,43 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { ValueSetExpansionContains } from '@medplum/fhirtypes';
-import { filterExpansionByInclude } from './expand';
+import type { ValueSetComposeInclude } from '@medplum/fhirtypes';
+import { constrainInclude } from './expand';
 
-describe('filterExpansionByInclude', () => {
-  test('filters included ValueSet expansion by system and concepts', () => {
-    const expansion: ValueSetExpansionContains[] = [
-      { system: 'http://loinc.org', code: '8480-6', display: 'Systolic BP - Reported' },
-      { system: 'http://loinc.org', code: '8462-4', display: 'Diastolic BP - Reported' },
-      { system: 'http://loinc.org', code: '8310-5', display: 'Body temperature' },
-      { system: 'http://snomed.info/sct', code: '75367002', display: 'Blood pressure' },
-    ];
-
+describe('constrainInclude', () => {
+  test('adds inherited system and concept constraints to nested ValueSet includes', () => {
     expect(
-      filterExpansionByInclude(expansion, {
-        valueSet: ['http://example.com/ValueSet/vitals'],
-        system: 'http://loinc.org',
-        concept: [{ code: '8462-4' }],
-      })
-    ).toStrictEqual<ValueSetExpansionContains[]>([
-      { system: 'http://loinc.org', code: '8462-4', display: 'Diastolic BP - Reported' },
-    ]);
+      constrainInclude(
+        { valueSet: ['http://example.com/ValueSet/vitals'] },
+        { system: 'http://loinc.org', concept: [{ code: '8462-4' }] }
+      )
+    ).toStrictEqual<ValueSetComposeInclude>({
+      valueSet: ['http://example.com/ValueSet/vitals'],
+      system: 'http://loinc.org',
+      concept: [{ code: '8462-4' }],
+    });
+  });
+
+  test('intersects inherited concept constraints with include concepts', () => {
+    expect(
+      constrainInclude(
+        {
+          system: 'http://loinc.org',
+          concept: [
+            { code: '8480-6', display: 'Systolic BP - Reported' },
+            { code: '8462-4', display: 'Diastolic BP - Reported' },
+          ],
+        },
+        { system: 'http://loinc.org', concept: [{ code: '8462-4' }] }
+      )
+    ).toStrictEqual<ValueSetComposeInclude>({
+      system: 'http://loinc.org',
+      concept: [{ code: '8462-4', display: 'Diastolic BP - Reported' }],
+    });
+  });
+
+  test('skips includes from other systems', () => {
+    expect(
+      constrainInclude({ system: 'http://snomed.info/sct' }, { system: 'http://loinc.org' })
+    ).toBeUndefined();
   });
 });

--- a/packages/server/src/fhir/operations/expand.unit.test.ts
+++ b/packages/server/src/fhir/operations/expand.unit.test.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { ValueSetExpansionContains } from '@medplum/fhirtypes';
+import { filterExpansionByInclude } from './expand';
+
+describe('filterExpansionByInclude', () => {
+  test('filters included ValueSet expansion by system and concepts', () => {
+    const expansion: ValueSetExpansionContains[] = [
+      { system: 'http://loinc.org', code: '8480-6', display: 'Systolic BP - Reported' },
+      { system: 'http://loinc.org', code: '8462-4', display: 'Diastolic BP - Reported' },
+      { system: 'http://loinc.org', code: '8310-5', display: 'Body temperature' },
+      { system: 'http://snomed.info/sct', code: '75367002', display: 'Blood pressure' },
+    ];
+
+    expect(
+      filterExpansionByInclude(expansion, {
+        valueSet: ['http://example.com/ValueSet/vitals'],
+        system: 'http://loinc.org',
+        concept: [{ code: '8462-4' }],
+      })
+    ).toStrictEqual<ValueSetExpansionContains[]>([
+      { system: 'http://loinc.org', code: '8462-4', display: 'Diastolic BP - Reported' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `ValueSet/$expand` when a single `compose.include` imports another ValueSet and also specifies `system` / `concept` constraints.
- Intersect nested ValueSet expansions with the include's `system` and `concept` values before adding them to the parent expansion.
- Add an API regression test and a small unit test for the filtering helper.

Fixes #9057

## Testing

- `npm test --workspace=@medplum/server -- src/fhir/operations/expand.unit.test.ts`
- `npx eslint src/fhir/operations/expand.ts src/fhir/operations/expand.test.ts src/fhir/operations/expand.unit.test.ts`

Unable to run `npm test --workspace=@medplum/server -- src/fhir/operations/expand.test.ts` locally because Postgres/Redis are not running in this environment (`ECONNREFUSED` during `initAppServices`).