### PR TITLE
Update staging ECS task definition

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -107,14 +107,54 @@ jobs:
         env:
           SERVER_DOCKERHUB_REPOSITORY: ${{ secrets.STAGING_DOCKERHUB_REPOSITORY }}
 
-      - name: Deploy Server
-        run: ./scripts/deploy-server.sh
+      - name: Get Server Task Definition
+        id: server-task-definition
+        run: |
+          task_definition="$(aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" --query 'services[0].taskDefinition' --output text)"
+          echo "task-definition=$task_definition" >> "$GITHUB_OUTPUT"
         env:
-          AWS_REGION: ${{ secrets.STAGING_AWS_REGION }}
           ECS_CLUSTER: ${{ secrets.STAGING_ECS_CLUSTER }}
           ECS_SERVICE: ${{ secrets.STAGING_ECS_SERVICE }}
-          WORKER_ECS_CLUSTER: ${{ secrets.STAGING_WORKER_ECS_CLUSTER }}
-          WORKER_ECS_SERVICE: ${{ secrets.STAGING_WORKER_ECS_SERVICE }}
+
+      - name: Render Server Task Definition
+        id: render-server-task-definition
+        uses: aws-actions/amazon-ecs-render-task-definition@138c24f321fdbdf7edee4a685519d253cae2cdea # v1.9.0
+        with:
+          task-definition-arn: ${{ steps.server-task-definition.outputs.task-definition }}
+          container-name: MedplumTaskDefinition
+          image: ${{ secrets.STAGING_DOCKERHUB_REPOSITORY }}:${{ github.sha }}
+
+      - name: Deploy Server Task Definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@c465972ecbd160473f22e683363b422a5412a3de # v2.6.3
+        with:
+          task-definition: ${{ steps.render-server-task-definition.outputs.task-definition }}
+          cluster: ${{ secrets.STAGING_ECS_CLUSTER }}
+          service: ${{ secrets.STAGING_ECS_SERVICE }}
+
+      - name: Get Worker Task Definition
+        id: worker-task-definition
+        run: |
+          task_definition="$(aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" --query 'services[0].taskDefinition' --output text)"
+          echo "task-definition=$task_definition" >> "$GITHUB_OUTPUT"
+        env:
+          ECS_CLUSTER: ${{ secrets.STAGING_WORKER_ECS_CLUSTER }}
+          ECS_SERVICE: ${{ secrets.STAGING_WORKER_ECS_SERVICE }}
+
+      - name: Render Worker Task Definition
+        id: render-worker-task-definition
+        uses: aws-actions/amazon-ecs-render-task-definition@138c24f321fdbdf7edee4a685519d253cae2cdea # v1.9.0
+        with:
+          task-definition-arn: ${{ steps.worker-task-definition.outputs.task-definition }}
+          container-name: BackgroundJobsWorkerContainer
+          image: ${{ secrets.STAGING_DOCKERHUB_REPOSITORY }}:${{ github.sha }}
+
+      - name: Deploy Worker Task Definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@c465972ecbd160473f22e683363b422a5412a3de # v2.6.3
+        with:
+          task-definition: ${{ steps.render-worker-task-definition.outputs.task-definition }}
+          cluster: ${{ secrets.STAGING_WORKER_ECS_CLUSTER }}
+          service: ${{ secrets.STAGING_WORKER_ECS_SERVICE }}
+
       - name: Deploy bot layer
         run: ./scripts/deploy-bot-layer.sh
         env:


### PR DESCRIPTION
Updates the staging deployment workflow to deploy server containers by registering new ECS task definition revisions with an immutable Docker image tag.

The staging server image build already publishes `${GITHUB_SHA}` in addition to `latest`. This change keeps the existing image build behavior, then updates ECS to use `${{ secrets.STAGING_DOCKERHUB_REPOSITORY }}:${{ github.sha }}` instead of forcing a new deployment of whatever image is currently behind `latest`.

## Changes

- Replaces the staging `scripts/deploy-server.sh` step with explicit ECS task definition render/deploy steps.
- Uses `aws-actions/amazon-ecs-render-task-definition` to copy the current service task definition and update only the Medplum server container image.
- Uses `aws-actions/amazon-ecs-deploy-task-definition` to register and deploy the rendered task definition.
- Applies the same image update to both staging ECS services:
  - `MedplumTaskDefinition`
  - `BackgroundJobsWorkerContainer`
- Pins the new AWS GitHub Actions to full commit SHAs.

## Notes

- The `Get Server Task Definition` and `Get Worker Task Definition` steps are required because staging does not keep ECS task definition JSON files checked into the repo. They fetch the task definition currently attached to each ECS service so the render action can update only the container image.
- The OTEL sidecar image still uses `latest` in staging config and will be handled separately because it changes infrequently.
- The staging AWS role may need these additional permissions:
  - `ecs:RegisterTaskDefinition`
  - `iam:PassRole`