### PR TITLE
dep(coverallsapp/github-action): upgrade to v2.3.7 to remove warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -435,9 +435,10 @@ jobs:
       - name: Coveralls GitHub Action
         if: ${{ matrix.node-version == 22 && matrix.pg-version == 14 && matrix.redis-version == 7 }}
         continue-on-error: true
-        uses: coverallsapp/github-action@09b709cf6a16e30b0808ba050c7a6e8a5ef13f8d # master
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage/lcov.info
       - name: SonarCloud Scan
         # Skip on fork PRs (SONAR_TOKEN is unavailable to forks). Still runs on push to
         # main and merge_group; for pull_request events, only runs when the PR head is on


### PR DESCRIPTION
## Summary
- Upgrade `coverallsapp/github-action` from the stale `master` pin (`09b709cf`, v1 JavaScript action) to v2.3.7 (`5cbfd81b`)
- Explicitly pass `file: coverage/lcov.info` to match what `scripts/test.sh` generates (same path the v1 action defaulted to)

## Why?

Node v20 in Github actions is deprecated and we got a few warnings.  See https://github.com/medplum/medplum/actions/runs/28875770691, for example:

> Run tests (22, 14, 7)
> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: coverallsapp/github-action@09b709cf6a16e30b0808ba050c7a6e8a5ef13f8d. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This PR simply pins it to the latest and sets a parameter to match previous behavior.