### PR TITLE
Update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,27 +12,35 @@
   },
   "packageRules": [
     {
-      "description": "Dockerfile",
-      "matchManagers": ["dockerfile"],
-      "groupName": "dependencies",
-      "groupSlug": "all",
-      "pinDigests": false
-    },
-    {
-      "description": "DHI Dockerfile",
+      "description": "DHI images",
       "matchManagers": ["dockerfile"],
       "matchDatasources": ["docker"],
       "matchPackageNames": ["dhi.io/node"],
       "versioning": "docker",
-      "groupName": "dependencies",
-      "groupSlug": "all",
+      "groupName": "DHI images",
+      "groupSlug": "dhi-images",
+      "pinDigests": false,
+      "minimumReleaseAge": "3 days",
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
+    },
+    {
+      "description": "Docker images",
+      "matchManagers": ["dockerfile"],
+      "excludePackageNames": ["dhi.io/node"],
+      "groupName": "Docker images",
+      "groupSlug": "docker-images",
       "pinDigests": false
+    },
+    {
+      "description": "Ignore setup-node runtime versions",
+      "matchPackageNames": ["actions/node-versions"],
+      "enabled": false
     },
     {
       "description": "GitHub Actions",
       "matchManagers": ["github-actions"],
-      "groupName": "dependencies",
-      "groupSlug": "all",
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions",
       "pinDigests": true
     }
   ]


### PR DESCRIPTION
This refines our Renovate configuration to make updates more reliable while preserving our existing workflow.

### Changes

* Split the single `renovate/all` branch into separate groups:

  * **DHI images**
  * **Other Docker images**
  * **GitHub Actions**
* Keep the existing 3-day release cooldown for DHI images, but use `minimumReleaseAgeBehaviour: "timestamp-optional"` so Renovate doesn't permanently defer updates when the registry doesn't provide a release timestamp.
* Ignore `actions/node-versions`, which is an internal implementation detail of `actions/setup-node` rather than a dependency we actually want Renovate to manage.

### Motivation

We've recently been using Renovate to migrate our Docker images from floating major versions (e.g. `24`) to fully-qualified versions (e.g. `24.18`) so that we don't automatically consume new Node.js releases. This was prompted by the Node.js 24.17 regression that affected production. The 3-day release cooldown remains an important part of that strategy and is intentionally preserved.

While testing, Renovate was consistently failing when trying to generate a single `renovate/all` branch containing every Docker and GitHub Actions update. The debug logs suggest this is related to Renovate's replacement/validation logic when processing a very large grouped change set.

Splitting updates into a few logical groups should make Renovate more reliable while still avoiding the flood of one-PR-per-dependency updates that we're trying to avoid.

The `actions/node-versions` rule also removes a source of noise where Renovate repeatedly attempts to resolve digest updates for values such as `24`, `22`, or `${{ matrix.node-version }}`, which are not actionable updates for us.
