### PR TITLE
Update external JWT identity matching

### DIFF
--- a/packages/core/src/base-schema.json
+++ b/packages/core/src/base-schema.json
@@ -4231,8 +4231,36 @@
   },
   "IdentityProvider": {
     "elements": {
+      "issuer": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "audience": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "tokenVerificationMethod": {
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
+      },
+      "jwksUrl": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
       "authorizeUrl": {
-        "min": 1,
         "type": [
           {
             "code": "string"
@@ -4240,7 +4268,6 @@
         ]
       },
       "tokenUrl": {
-        "min": 1,
         "type": [
           {
             "code": "string"
@@ -4255,7 +4282,6 @@
         ]
       },
       "userInfoUrl": {
-        "min": 1,
         "type": [
           {
             "code": "string"
@@ -4277,7 +4303,6 @@
         ]
       },
       "clientId": {
-        "min": 1,
         "type": [
           {
             "code": "string"
@@ -4285,7 +4310,6 @@
         ]
       },
       "clientSecret": {
-        "min": 1,
         "type": [
           {
             "code": "string"

--- a/packages/definitions/src/fhir/r4/fhir.schema.json
+++ b/packages/definitions/src/fhir/r4/fhir.schema.json
@@ -62889,6 +62889,28 @@
     "IdentityProvider": {
       "description": "External Identity Provider (IdP) configuration details.",
       "properties": {
+        "issuer": {
+          "description": "Issuer URL for the external Identity Provider.",
+          "$ref": "#/definitions/string"
+        },
+        "audience": {
+          "description": "Audience URL for the external Identity Provider.",
+          "items": {
+            "$ref": "#/definitions/string"
+          },
+          "type": "array"
+        },
+        "tokenVerificationMethod": {
+          "description": "Token verification method for the external Identity Provider.",
+          "enum": [
+            "userinfo",
+            "jwks"
+          ]
+        },
+        "jwksUrl": {
+          "description": "Remote URL for the external Identity Provider JWKS endpoint.",
+          "$ref": "#/definitions/string"
+        },
         "authorizeUrl": {
           "description": "Remote URL for the external Identity Provider authorize endpoint.",
           "$ref": "#/definitions/string"
@@ -62953,14 +62975,7 @@
           ]
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "authorizeUrl",
-        "tokenUrl",
-        "userInfoUrl",
-        "clientId",
-        "clientSecret"
-      ]
+      "additionalProperties": false
     },
     "ProjectMembership_Access": {
       "description": "Extended access configuration using parameterized access policies.",

--- a/packages/definitions/src/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/src/fhir/r4/profiles-medplum.json
@@ -5751,17 +5751,81 @@
             }
           },
           {
+            "id" : "IdentityProvider.issuer",
+            "path" : "IdentityProvider.issuer",
+            "definition" : "Issuer URL for the external Identity Provider.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "string"
+            }],
+            "base" : {
+              "path" : "IdentityProvider.issuer",
+              "min" : 0,
+              "max" : "1"
+            }
+          },
+          {
+            "id" : "IdentityProvider.audience",
+            "path" : "IdentityProvider.audience",
+            "definition" : "Audience URL for the external Identity Provider.",
+            "min" : 0,
+            "max" : "*",
+            "type" : [{
+              "code" : "string"
+            }],
+            "base" : {
+              "path" : "IdentityProvider.audience",
+              "min" : 0,
+              "max" : "*"
+            }
+          },
+          {
+            "id" : "IdentityProvider.tokenVerificationMethod",
+            "path" : "IdentityProvider.tokenVerificationMethod",
+            "definition" : "Token verification method for the external Identity Provider.",
+            "min" : 0,
+            "max" : "1",
+            "base" : {
+              "path" : "IdentityProvider.tokenVerificationMethod",
+              "min" : 0,
+              "max" : "1"
+            },
+            "type" : [{
+              "code" : "code"
+            }],
+            "binding" : {
+              "strength" : "required",
+              "valueSet" : "https://medplum.com/fhir/ValueSet/identity-provider-token-verification-method|4.0.1"
+            }
+          },
+          {
+            "id" : "IdentityProvider.jwksUrl",
+            "path" : "IdentityProvider.jwksUrl",
+            "definition" : "Remote URL for the external Identity Provider JWKS endpoint.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "string"
+            }],
+            "base" : {
+              "path" : "IdentityProvider.jwksUrl",
+              "min" : 0,
+              "max" : "1"
+            }
+          },
+          {
             "id" : "IdentityProvider.authorizeUrl",
             "path" : "IdentityProvider.authorizeUrl",
             "definition" : "Remote URL for the external Identity Provider authorize endpoint.",
-            "min" : 1,
+            "min" : 0,
             "max" : "1",
             "type" : [{
               "code" : "string"
             }],
             "base" : {
               "path" : "IdentityProvider.authorizeUrl",
-              "min" : 1,
+              "min" : 0,
               "max" : "1"
             }
           },
@@ -5769,14 +5833,14 @@
             "id" : "IdentityProvider.tokenUrl",
             "path" : "IdentityProvider.tokenUrl",
             "definition" : "Remote URL for the external Identity Provider token endpoint.",
-            "min" : 1,
+            "min" : 0,
             "max" : "1",
             "type" : [{
               "code" : "string"
             }],
             "base" : {
               "path" : "IdentityProvider.tokenUrl",
-              "min" : 1,
+              "min" : 0,
               "max" : "1"
             }
           },
@@ -5803,14 +5867,14 @@
             "id" : "IdentityProvider.userInfoUrl",
             "path" : "IdentityProvider.userInfoUrl",
             "definition" : "Remote URL for the external Identity Provider userinfo endpoint.",
-            "min" : 1,
+            "min" : 0,
             "max" : "1",
             "type" : [{
               "code" : "string"
             }],
             "base" : {
               "path" : "IdentityProvider.userInfoUrl",
-              "min" : 1,
+              "min" : 0,
               "max" : "1"
             }
           },
@@ -5854,14 +5918,14 @@
             "id" : "IdentityProvider.clientId",
             "path" : "IdentityProvider.clientId",
             "definition" : "External Identity Provider client ID.",
-            "min" : 1,
+            "min" : 0,
             "max" : "1",
             "type" : [{
               "code" : "string"
             }],
             "base" : {
               "path" : "IdentityProvider.clientId",
-              "min" : 1,
+              "min" : 0,
               "max" : "1"
             }
           },
@@ -5869,14 +5933,14 @@
             "id" : "IdentityProvider.clientSecret",
             "path" : "IdentityProvider.clientSecret",
             "definition" : "External Identity Provider client secret.",
-            "min" : 1,
+            "min" : 0,
             "max" : "1",
             "type" : [{
               "code" : "string"
             }],
             "base" : {
               "path" : "IdentityProvider.clientSecret",
-              "min" : 1,
+              "min" : 0,
               "max" : "1"
             }
           },

--- a/packages/definitions/src/fhir/r4/valuesets-medplum.json
+++ b/packages/definitions/src/fhir/r4/valuesets-medplum.json
@@ -845,6 +845,51 @@
       }
     },
     {
+      "fullUrl": "https://medplum.com/fhir/CodeSystem/identity-provider-token-verification-method",
+      "resource": {
+        "resourceType": "CodeSystem",
+        "id": "identity-provider-token-verification-method",
+        "url": "https://medplum.com/fhir/CodeSystem/identity-provider-token-verification-method",
+        "name": "IdentityProviderTokenVerificationMethod",
+        "title": "Identity Provider Token Verification Method",
+        "status": "active",
+        "description": "Methods used by identity providers to verify the identity of the user via tokens.",
+        "valueSet": "https://medplum.com/fhir/ValueSet/identity-provider-token-verification-method",
+        "content": "complete",
+        "concept": [
+          {
+            "code": "userinfo",
+            "display": "userinfo",
+            "definition": "Clients that use the userinfo endpoint to verify the identity of the user."
+          },
+          {
+            "code": "jwks",
+            "display": "jwks",
+            "definition": "Clients that use a JSON Web Key Set (JWKS) to verify the identity of the user."
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "https://medplum.com/fhir/ValueSet/identity-provider-token-verification-method",
+      "resource": {
+        "resourceType": "ValueSet",
+        "id": "identity-provider-token-verification-method",
+        "url": "https://medplum.com/fhir/ValueSet/identity-provider-token-verification-method",
+        "name": "IdentityProviderTokenVerificationMethod",
+        "title": "Identity Provider Token Verification Method",
+        "status": "active",
+        "description": "Methods used by identity providers to verify the identity of the user via tokens.",
+        "compose": {
+          "include": [
+            {
+              "system": "https://medplum.com/fhir/CodeSystem/identity-provider-token-verification-method"
+            }
+          ]
+        }
+      }
+    },
+    {
       "fullUrl": "https://medplum.com/fhir/CodeSystem/token-endpoint-auth-methods-supported",
       "resource": {
         "resourceType": "CodeSystem",

--- a/packages/fhirtypes/dist/IdentityProvider.d.ts
+++ b/packages/fhirtypes/dist/IdentityProvider.d.ts
@@ -11,14 +11,34 @@
 export interface IdentityProvider {
 
   /**
+   * Issuer URL for the external Identity Provider.
+   */
+  issuer?: string;
+
+  /**
+   * Audience URL for the external Identity Provider.
+   */
+  audience?: string[];
+
+  /**
+   * Token verification method for the external Identity Provider.
+   */
+  tokenVerificationMethod?: 'userinfo' | 'jwks';
+
+  /**
+   * Remote URL for the external Identity Provider JWKS endpoint.
+   */
+  jwksUrl?: string;
+
+  /**
    * Remote URL for the external Identity Provider authorize endpoint.
    */
-  authorizeUrl: string;
+  authorizeUrl?: string;
 
   /**
    * Remote URL for the external Identity Provider token endpoint.
    */
-  tokenUrl: string;
+  tokenUrl?: string;
 
   /**
    * Client Authentication method used by Clients to authenticate to the
@@ -30,7 +50,7 @@ export interface IdentityProvider {
   /**
    * Remote URL for the external Identity Provider userinfo endpoint.
    */
-  userInfoUrl: string;
+  userInfoUrl?: string;
 
   /**
    * Optional userinfo mode. Defaults to standard OIDC userinfo semantics.
@@ -46,12 +66,12 @@ export interface IdentityProvider {
   /**
    * External Identity Provider client ID.
    */
-  clientId: string;
+  clientId?: string;
 
   /**
    * External Identity Provider client secret.
    */
-  clientSecret: string;
+  clientSecret?: string;
 
   /**
    * Optional flag to use PKCE in the token request.

--- a/packages/server/src/auth/external.test.ts
+++ b/packages/server/src/auth/external.test.ts
@@ -177,6 +177,22 @@ describe('External', () => {
     expect(res.body.issue[0].details.text).toBe('External token does not contain email address');
   });
 
+  test.each([
+    ['unverified', false],
+    ['missing email_verified', null],
+  ])('Rejects %s external email', async (_name, emailVerified) => {
+    const url = appendQueryParams('/auth/external', {
+      code: randomUUID(),
+      state: JSON.stringify({ domain }),
+    });
+
+    fetchMock.mockImplementation(() => mockFetchJson(buildTokens(email, undefined, emailVerified)));
+
+    const res = await request(app).get(url);
+    expect(res.status).toBe(400);
+    expect(res.body.issue[0].details.text).toBe('External token email is not verified');
+  });
+
   test('Email does not match domain', async () => {
     // Build the external callback URL with the known domain
     const url = appendQueryParams('/auth/external', {
@@ -800,11 +816,21 @@ describe('External', () => {
  * Returns fake tokens to mock the external identity provider.
  * @param email - The user email address to include in the ID token.
  * @param sub - The user subject to include as the sub claim.
+ * @param emailVerified - Whether to include a verified email claim; null omits the claim.
  * @returns Fake tokens to mock the external identity provider.
  */
-function buildTokens(email: string | undefined, sub?: string): Record<string, string> {
+function buildTokens(
+  email: string | undefined,
+  sub?: string,
+  emailVerified: boolean | null = true
+): Record<string, string> {
+  const claims: Record<string, unknown> = { email, sub };
+  if (emailVerified !== null) {
+    claims.email_verified = emailVerified;
+  }
+
   return {
-    id_token: 'header.' + Buffer.from(JSON.stringify({ email, sub }), 'ascii').toString('base64') + '.signature',
+    id_token: 'header.' + Buffer.from(JSON.stringify(claims), 'ascii').toString('base64') + '.signature',
   };
 }
 

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -221,6 +221,9 @@ async function resolveExternalLoginIdentity(
     if (!email) {
       throw new OperationOutcomeError(badRequest('External token does not contain email address'));
     }
+    if (userInfo.email_verified !== true) {
+      throw new OperationOutcomeError(badRequest('External token email is not verified'));
+    }
     return { email };
   }
 

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -260,6 +260,10 @@ async function verifyExternalCode(
   code: string,
   codeVerifier: string | undefined
 ): Promise<Record<string, unknown>> {
+  if (!idp.tokenUrl) {
+    throw new OperationOutcomeError(badRequest('Missing token URL for external identity provider'));
+  }
+
   const headers: HeadersInit = {
     Accept: ContentType.JSON,
     'Accept-Encoding': 'identity',
@@ -276,6 +280,10 @@ async function verifyExternalCode(
   }
 
   if (idp.tokenAuthMethod === OAuthTokenAuthMethod.ClientSecretPost) {
+    if (!idp.clientId || !idp.clientSecret) {
+      throw new OperationOutcomeError(badRequest('Missing client ID or client secret for external identity provider'));
+    }
+
     params.append('client_id', idp.clientId);
     params.append('client_secret', idp.clientSecret);
   } else {

--- a/packages/server/src/auth/method.ts
+++ b/packages/server/src/auth/method.ts
@@ -47,7 +47,7 @@ export async function isExternalAuth(email: string): Promise<{ domain: string; a
   }
 
   const idp = domainConfig.identityProvider;
-  if (!idp) {
+  if (!idp?.authorizeUrl || !idp.clientId) {
     return undefined;
   }
 

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -305,6 +305,7 @@ export interface MedplumBullmqConfig {
 }
 
 export interface MedplumExternalAuthConfig {
+  /** @deprecated Use identityProvider.issuer instead. */
   readonly issuer: string;
   /** Optional client ID used to select this external auth provider during token exchange. */
   readonly clientId?: string;

--- a/packages/server/src/oauth/external-token.ts
+++ b/packages/server/src/oauth/external-token.ts
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { JWTPayload } from '@medplum/core';
+import { badRequest, ContentType, isJwt, OperationOutcomeError, parseJWTPayload, tooManyRequests } from '@medplum/core';
+import type { IdentityProvider } from '@medplum/fhirtypes';
+import { createRemoteJWKSet, customFetch, jwtVerify } from 'jose';
+import { getLogger } from '../logger';
+import { safeFetch } from '../util/url';
+
+type TokenVerificationMethod = NonNullable<IdentityProvider['tokenVerificationMethod']>;
+
+/**
+ * Verifies a token issued by an external identity provider and returns verified claims.
+ * @param idp - External identity provider configuration.
+ * @param token - Token issued by the external identity provider.
+ * @returns Verified token claims.
+ */
+export async function verifyExternalToken(idp: IdentityProvider, token: string): Promise<JWTPayload> {
+  const method = getExternalTokenVerificationMethod(idp);
+  if (method === 'userinfo') {
+    return verifyExternalTokenWithUserInfo(idp, token);
+  }
+  return verifyExternalTokenWithJwks(idp, token);
+}
+
+function getExternalTokenVerificationMethod(idp: IdentityProvider): TokenVerificationMethod {
+  if (idp.tokenVerificationMethod) {
+    return idp.tokenVerificationMethod;
+  }
+  if (idp.userInfoUrl) {
+    return 'userinfo';
+  }
+  return 'jwks';
+}
+
+async function verifyExternalTokenWithUserInfo(idp: IdentityProvider, token: string): Promise<JWTPayload> {
+  if (!idp.userInfoUrl) {
+    throw new OperationOutcomeError(badRequest('Missing user info URL - check your identity provider configuration'));
+  }
+  const claims = await getExternalUserInfo(idp.userInfoUrl, token, idp);
+  assertExternalTokenAudience(idp, isJwt(token) ? parseJWTPayload(token) : claims);
+  return claims;
+}
+
+async function verifyExternalTokenWithJwks(idp: IdentityProvider, token: string): Promise<JWTPayload> {
+  const log = getLogger();
+  const jwksUrl = idp.jwksUrl;
+  if (!jwksUrl) {
+    throw new OperationOutcomeError(badRequest('Missing JWKS URL - check your identity provider configuration'));
+  }
+  if (!idp.issuer) {
+    throw new OperationOutcomeError(badRequest('Missing issuer - check your identity provider configuration'));
+  }
+
+  try {
+    const JWKS = createRemoteJWKSet(new URL(jwksUrl), { [customFetch]: safeFetch });
+    const { payload } = await jwtVerify(token, JWKS, {
+      issuer: idp.issuer,
+    });
+    assertExternalTokenAudience(idp, payload);
+    return payload;
+  } catch (err: unknown) {
+    log.warn('Failed to verify external token with JWKS', { err, jwksUrl, clientId: idp.clientId });
+    throw new OperationOutcomeError(badRequest('Failed to verify token - check your identity provider configuration'));
+  }
+}
+
+function assertExternalTokenAudience(idp: IdentityProvider, claims: JWTPayload): void {
+  const expectedAudience = idp.audience;
+  if (!expectedAudience) {
+    return;
+  }
+
+  if (!tokenAudienceMatches(claims.aud, expectedAudience)) {
+    throw new OperationOutcomeError(badRequest('Invalid token audience - check your identity provider configuration'));
+  }
+}
+
+function tokenAudienceMatches(
+  actualAudience: string | string[] | undefined,
+  expectedAudience: string | string[]
+): boolean {
+  const expectedAudiences = Array.isArray(expectedAudience) ? expectedAudience : [expectedAudience];
+  let actualAudiences: string[];
+  if (Array.isArray(actualAudience)) {
+    actualAudiences = actualAudience;
+  } else if (actualAudience) {
+    actualAudiences = [actualAudience];
+  } else {
+    actualAudiences = [];
+  }
+
+  return actualAudiences.some((audience) => expectedAudiences.includes(audience));
+}
+
+/**
+ * Returns the external identity provider user info for an access token.
+ * This can be used to verify the access token and get the user's email address.
+ * @param userInfoUrl - The user info URL from the identity provider configuration.
+ * @param externalAccessToken - The external identity provider access token.
+ * @param idp - Optional identity provider configuration.
+ * @returns The user info claims.
+ */
+export async function getExternalUserInfo(
+  userInfoUrl: string,
+  externalAccessToken: string,
+  idp?: IdentityProvider
+): Promise<JWTPayload> {
+  const log = getLogger();
+
+  const request = buildExternalUserInfoRequest(userInfoUrl, externalAccessToken, idp);
+
+  let response;
+  try {
+    response = await safeFetch(request.url, request.init);
+  } catch (err: any) {
+    log.warn('Error while verifying external auth code', err);
+    throw new OperationOutcomeError(badRequest('Failed to verify code - check your identity provider configuration'));
+  }
+
+  if (response.status === 429) {
+    log.warn('Auth rate limit exceeded', { url: request.url, clientId: idp?.clientId });
+    throw new OperationOutcomeError(tooManyRequests);
+  }
+
+  if (response.status !== 200) {
+    log.warn('Failed to verify external authorization code', { status: response.status });
+    throw new OperationOutcomeError(badRequest('Failed to verify code - check your identity provider configuration'));
+  }
+
+  const contentType = response.headers.get('content-type');
+  try {
+    if (contentType?.includes(ContentType.JSON)) {
+      return normalizeExternalUserInfo(await response.json(), idp);
+    } else if (contentType?.includes(ContentType.JWT)) {
+      return parseJWTPayload(await response.text());
+    }
+  } catch (err: any) {
+    if (err instanceof OperationOutcomeError) {
+      throw err;
+    }
+    log.warn('Failed to verify external authorization code', { err, userInfoUrl, contentType });
+    throw new OperationOutcomeError(badRequest('Failed to verify code - check your identity provider configuration'));
+  }
+
+  throw new OperationOutcomeError(badRequest(`Failed to verify code - unsupported content type: ${contentType}`));
+}
+
+function buildExternalUserInfoRequest(
+  userInfoUrl: string,
+  externalAccessToken: string,
+  idp: IdentityProvider | undefined
+): { url: string; init: RequestInit } {
+  if (idp?.userInfoMode === 'gcip') {
+    const apiKey = idp.userInfoApiKey;
+    if (!apiKey) {
+      throw new OperationOutcomeError(
+        badRequest('Missing user info API key - check your identity provider configuration')
+      );
+    }
+
+    const url = new URL(userInfoUrl);
+    url.searchParams.set('key', apiKey);
+
+    return {
+      url: url.toString(),
+      init: {
+        method: 'POST',
+        headers: {
+          Accept: ContentType.JSON,
+          'Accept-Encoding': 'identity',
+          'Content-Type': ContentType.JSON,
+        },
+        body: JSON.stringify({ idToken: externalAccessToken }),
+      },
+    };
+  }
+
+  return {
+    url: userInfoUrl,
+    init: {
+      method: 'GET',
+      headers: {
+        Accept: ContentType.JSON,
+        'Accept-Encoding': 'identity',
+        Authorization: `Bearer ${externalAccessToken}`,
+      },
+    },
+  };
+}
+
+function normalizeExternalUserInfo(body: Record<string, unknown>, idp?: IdentityProvider): Record<string, unknown> {
+  if (idp?.userInfoMode !== 'gcip') {
+    return body;
+  }
+
+  const users = body.users;
+  if (!Array.isArray(users) || users.length === 0 || !users[0] || typeof users[0] !== 'object') {
+    throw new OperationOutcomeError(badRequest('Failed to verify code - invalid user info response'));
+  }
+
+  const user = users[0] as Record<string, unknown>;
+  if (!user.localId) {
+    throw new OperationOutcomeError(badRequest('Failed to verify code - missing localId in user info response'));
+  }
+  return {
+    ...user,
+    sub: user.localId,
+  };
+}

--- a/packages/server/src/oauth/external.test.ts
+++ b/packages/server/src/oauth/external.test.ts
@@ -373,6 +373,32 @@ describe('External auth', () => {
     );
   });
 
+  test('Identity provider legacy useSubject maps verified subject', async () => {
+    await withExternalAuthProviders(
+      [
+        {
+          issuer: 'https://external-auth.example.com',
+          identityProvider: {
+            userInfoUrl: 'https://external-auth.example.com/oauth2/userinfo',
+            useSubject: true,
+          },
+        },
+      ],
+      async () => {
+        fetchMock.mockImplementationOnce(() => mockFetchJson({ sub: externalSub }));
+
+        const jwt = createFakeJwt({
+          iss: 'https://external-auth.example.com',
+          nonce: randomUUID(),
+        });
+        const res = await request(app)
+          .get(`/oauth2/userinfo`)
+          .set('Authorization', 'Bearer ' + jwt);
+        expect(res.status).toBe(200);
+      }
+    );
+  });
+
   test.each([
     {
       name: 'unverified email',

--- a/packages/server/src/oauth/external.test.ts
+++ b/packages/server/src/oauth/external.test.ts
@@ -484,6 +484,21 @@ describe('External auth', () => {
     expect(res2.status).toBe(200);
   });
 
+  test('Expired token is rejected before cache lookup', async () => {
+    fetchMock.mockClear();
+
+    const jwt = createFakeJwt({
+      iss: 'https://external-auth.example.com',
+      sub: externalSub,
+      exp: Math.floor(Date.now() / 1000) - 1,
+    });
+    const res = await request(app)
+      .get(`/oauth2/userinfo`)
+      .set('Authorization', 'Bearer ' + jwt);
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test('Sub claim with unknown externalId', async () => {
     fetchMock.mockImplementationOnce(() => mockFetchJson({ ok: true }));
 

--- a/packages/server/src/oauth/external.test.ts
+++ b/packages/server/src/oauth/external.test.ts
@@ -328,7 +328,7 @@ describe('External auth', () => {
       name: 'email to user membership',
       identitySource: 'email' as const,
       identityMappingMode: 'user-email' as const,
-      userInfo: () => ({ email }),
+      userInfo: () => ({ email, email_verified: true }),
     },
     {
       name: 'subject to membership externalId',
@@ -369,6 +369,42 @@ describe('External auth', () => {
           .get(`/oauth2/userinfo`)
           .set('Authorization', 'Bearer ' + jwt);
         expect(res.status).toBe(200);
+      }
+    );
+  });
+
+  test.each([
+    {
+      name: 'unverified email',
+      userInfo: { email, email_verified: false },
+    },
+    {
+      name: 'missing email_verified',
+      userInfo: { email },
+    },
+  ])('Identity provider email mapping rejects $name', async ({ userInfo }) => {
+    await withExternalAuthProviders(
+      [
+        {
+          issuer: 'https://external-auth.example.com',
+          identityProvider: {
+            userInfoUrl: 'https://external-auth.example.com/oauth2/userinfo',
+            identitySource: 'email',
+            identityMappingMode: 'user-email',
+          },
+        },
+      ],
+      async () => {
+        fetchMock.mockImplementationOnce(() => mockFetchJson(userInfo));
+
+        const jwt = createFakeJwt({
+          iss: 'https://external-auth.example.com',
+          nonce: randomUUID(),
+        });
+        const res = await request(app)
+          .get(`/oauth2/userinfo`)
+          .set('Authorization', 'Bearer ' + jwt);
+        expect(res.status).toBe(401);
       }
     );
   });

--- a/packages/server/src/oauth/external.test.ts
+++ b/packages/server/src/oauth/external.test.ts
@@ -5,11 +5,13 @@ import { encodeBase64Url, getReferenceString } from '@medplum/core';
 import type { Practitioner, Project, ProjectMembership } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
+import { exportJWK, generateKeyPair, SignJWT } from 'jose';
 import request from 'supertest';
 import { vi } from 'vitest';
 import { inviteUser } from '../admin/invite';
 import { initApp, shutdownApp } from '../app';
-import { loadTestConfig } from '../config/loader';
+import { getConfig, loadTestConfig } from '../config/loader';
+import type { MedplumExternalAuthConfig } from '../config/types';
 import type { SystemRepository } from '../fhir/repo';
 import { getProjectSystemRepo } from '../fhir/repo';
 import { createTestProject } from '../test.setup';
@@ -22,6 +24,7 @@ describe('External auth', () => {
   const app = express();
   const npi = randomUUID();
   const externalSub = randomUUID();
+  const email = `external-${randomUUID()}@example.com`;
   let testProject: WithId<Project>;
   let practitioner: WithId<ProfileResource>;
   let systemRepo: SystemRepository;
@@ -64,6 +67,15 @@ describe('External auth', () => {
       firstName: 'External',
       lastName: 'User',
       externalId: externalSub,
+    });
+
+    await inviteUser({
+      project,
+      resourceType: 'Practitioner',
+      firstName: 'Email',
+      lastName: 'User',
+      email,
+      sendEmail: false,
     });
   });
 
@@ -216,6 +228,181 @@ describe('External auth', () => {
     expect(res.status).toBe(200);
   });
 
+  test('Success by JWKS verification', async () => {
+    const keyPair = await generateKeyPair('ES256');
+    const publicJwk = await exportJWK(keyPair.publicKey);
+    const jwksUrl = 'https://external-auth.example.com/.well-known/jwks.json';
+
+    await withExternalAuthProviders(
+      [
+        {
+          issuer: 'https://external-auth.example.com',
+          identityProvider: {
+            issuer: 'https://external-auth.example.com',
+            audience: ['external-api'],
+            jwksUrl,
+            tokenVerificationMethod: 'jwks',
+          },
+        },
+      ],
+      async () => {
+        fetchMock.mockImplementationOnce(() => mockFetchJson({ keys: [publicJwk] }));
+
+        const jwt = await new SignJWT({
+          nonce: randomUUID(),
+        })
+          .setProtectedHeader({ alg: 'ES256' })
+          .setIssuer('https://external-auth.example.com')
+          .setSubject(externalSub)
+          .setAudience('external-api')
+          .setIssuedAt()
+          .setExpirationTime('2h')
+          .sign(keyPair.privateKey);
+
+        const res = await request(app)
+          .get(`/oauth2/userinfo`)
+          .set('Authorization', 'Bearer ' + jwt);
+        expect(res.status).toBe(200);
+        expect(fetchMock).toHaveBeenCalledWith(jwksUrl, expect.anything());
+      }
+    );
+  });
+
+  test.each([
+    {
+      name: 'string audience match succeeds',
+      expectedAudience: ['external-api'],
+      actualAudience: 'external-api',
+      status: 200,
+    },
+    {
+      name: 'array audience match succeeds',
+      expectedAudience: ['external-api', 'alternate-api'],
+      actualAudience: ['wrong-api', 'alternate-api'],
+      status: 200,
+    },
+    {
+      name: 'audience mismatch is rejected',
+      expectedAudience: ['external-api'],
+      actualAudience: 'wrong-api',
+      status: 401,
+    },
+    {
+      name: 'missing audience is rejected when expected audience is configured',
+      expectedAudience: ['external-api'],
+      actualAudience: undefined,
+      status: 401,
+    },
+  ])('$name', async ({ expectedAudience, actualAudience, status }) => {
+    await withExternalAuthProviders(
+      [
+        {
+          issuer: 'https://external-auth.example.com',
+          identityProvider: {
+            audience: expectedAudience,
+            userInfoUrl: 'https://external-auth.example.com/oauth2/userinfo',
+          },
+        },
+      ],
+      async () => {
+        if (status === 200) {
+          fetchMock.mockImplementationOnce(() => mockFetchJson({ ok: true }));
+        }
+
+        const jwt = createFakeJwt({
+          iss: 'https://external-auth.example.com',
+          aud: actualAudience,
+          sub: externalSub,
+          nonce: randomUUID(),
+        });
+        const res = await request(app)
+          .get(`/oauth2/userinfo`)
+          .set('Authorization', 'Bearer ' + jwt);
+        expect(res.status).toBe(status);
+      }
+    );
+  });
+
+  test.each([
+    {
+      name: 'email to user membership',
+      identitySource: 'email' as const,
+      identityMappingMode: 'user-email' as const,
+      userInfo: () => ({ email }),
+    },
+    {
+      name: 'subject to membership externalId',
+      identitySource: 'subject' as const,
+      identityMappingMode: 'project-membership-external-id' as const,
+      userInfo: () => ({ sub: externalSub }),
+    },
+    {
+      name: 'fhirUser to profile membership',
+      identitySource: 'fhir-user' as const,
+      identityMappingMode: 'project-membership-profile' as const,
+      userInfo: () => ({ fhirUser: getReferenceString(practitioner) }),
+    },
+  ])('Identity provider config maps $name', async ({ identitySource, identityMappingMode, userInfo }) => {
+    await withExternalAuthProviders(
+      [
+        {
+          issuer: 'https://external-auth.example.com',
+          identityProvider: {
+            authorizeUrl: 'https://external-auth.example.com/oauth2/authorize',
+            tokenUrl: 'https://external-auth.example.com/oauth2/token',
+            userInfoUrl: 'https://external-auth.example.com/oauth2/userinfo',
+            clientId: 'external-client',
+            clientSecret: 'external-secret',
+            identitySource,
+            identityMappingMode,
+          },
+        },
+      ],
+      async () => {
+        fetchMock.mockImplementationOnce(() => mockFetchJson(userInfo()));
+
+        const jwt = createFakeJwt({
+          iss: 'https://external-auth.example.com',
+          nonce: randomUUID(),
+        });
+        const res = await request(app)
+          .get(`/oauth2/userinfo`)
+          .set('Authorization', 'Bearer ' + jwt);
+        expect(res.status).toBe(200);
+      }
+    );
+  });
+
+  test('Identity provider without bearer mapping uses JWT claims', async () => {
+    await withExternalAuthProviders(
+      [
+        {
+          issuer: 'https://external-auth.example.com',
+          identityProvider: {
+            authorizeUrl: 'https://external-auth.example.com/oauth2/authorize',
+            tokenUrl: 'https://external-auth.example.com/oauth2/token',
+            userInfoUrl: 'https://external-auth.example.com/oauth2/userinfo',
+            clientId: 'external-client',
+            clientSecret: 'external-secret',
+          },
+        },
+      ],
+      async () => {
+        fetchMock.mockImplementationOnce(() => mockFetchJson({ email: `wrong-${email}` }));
+
+        const jwt = createFakeJwt({
+          iss: 'https://external-auth.example.com',
+          fhirUser: getReferenceString(practitioner),
+          nonce: randomUUID(),
+        });
+        const res = await request(app)
+          .get(`/oauth2/userinfo`)
+          .set('Authorization', 'Bearer ' + jwt);
+        expect(res.status).toBe(200);
+      }
+    );
+  });
+
   test('Sub claim with caching', async () => {
     fetchMock.mockImplementationOnce(() => mockFetchJson({ ok: true }));
 
@@ -341,4 +528,18 @@ describe('External auth', () => {
 
 function createFakeJwt(claims: Record<string, unknown>): string {
   return `header.${encodeBase64Url(JSON.stringify(claims))}.signature`;
+}
+
+async function withExternalAuthProviders(
+  externalAuthProviders: MedplumExternalAuthConfig[],
+  fn: () => Promise<void>
+): Promise<void> {
+  const savedExternalAuthProviders = getConfig().externalAuthProviders;
+  getConfig().externalAuthProviders = externalAuthProviders;
+
+  try {
+    await fn();
+  } finally {
+    getConfig().externalAuthProviders = savedExternalAuthProviders;
+  }
 }

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -37,6 +37,7 @@ import { getGlobalSystemRepo } from '../fhir/repo';
 import { getTopicForUser } from '../fhircast/utils';
 import { safeFetch } from '../util/url';
 import { validateClientCert } from './cert';
+import { verifyExternalToken } from './external-token';
 import type { MedplumRefreshTokenClaims } from './keys';
 import { generateSecret, verifyJwt } from './keys';
 import {
@@ -44,7 +45,6 @@ import {
   getAuthTokens,
   getClientApplication,
   getClientApplicationMembership,
-  getExternalUserInfo,
   hashCode,
   revokeLogin,
   timingSafeEqualStr,
@@ -542,7 +542,7 @@ async function tryGetExternalUserInfo(
   subjectToken: string
 ): Promise<JWTPayload | undefined> {
   try {
-    return await getExternalUserInfo(idp.userInfoUrl, subjectToken, idp);
+    return await verifyExternalToken(idp, subjectToken);
   } catch (err: any) {
     const outcome = normalizeOperationOutcome(err);
     sendTokenError(res, 'invalid_request', normalizeErrorString(err), getStatus(outcome));
@@ -566,13 +566,18 @@ function resolveExternalAuthProvider(clientId: string, client?: ClientApplicatio
     (provider) => (provider.clientId ?? provider.identityProvider?.clientId) === clientId
   );
   if (externalAuthConfig) {
+    const issuer = externalAuthConfig.identityProvider?.issuer ?? externalAuthConfig.issuer;
     if (externalAuthConfig.identityProvider) {
-      return externalAuthConfig.identityProvider;
+      return {
+        issuer,
+        userInfoUrl: externalAuthConfig.userInfoUrl,
+        ...externalAuthConfig.identityProvider,
+      };
     }
 
     const userInfoUrl = externalAuthConfig.userInfoUrl;
     if (userInfoUrl) {
-      return { userInfoUrl } as IdentityProvider;
+      return { issuer, userInfoUrl };
     }
   }
 

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -43,6 +43,7 @@ import { generateSecret, verifyJwt } from './keys';
 import {
   checkIpAccessRules,
   getAuthTokens,
+  getExternalAuthIdentityProvider,
   getClientApplication,
   getClientApplicationMembership,
   hashCode,
@@ -566,19 +567,7 @@ function resolveExternalAuthProvider(clientId: string, client?: ClientApplicatio
     (provider) => (provider.clientId ?? provider.identityProvider?.clientId) === clientId
   );
   if (externalAuthConfig) {
-    const issuer = externalAuthConfig.identityProvider?.issuer ?? externalAuthConfig.issuer;
-    if (externalAuthConfig.identityProvider) {
-      return {
-        issuer,
-        userInfoUrl: externalAuthConfig.userInfoUrl,
-        ...externalAuthConfig.identityProvider,
-      };
-    }
-
-    const userInfoUrl = externalAuthConfig.userInfoUrl;
-    if (userInfoUrl) {
-      return { issuer, userInfoUrl };
-    }
+    return getExternalAuthIdentityProvider(externalAuthConfig);
   }
 
   return client?.identityProvider;

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -43,9 +43,9 @@ import { generateSecret, verifyJwt } from './keys';
 import {
   checkIpAccessRules,
   getAuthTokens,
-  getExternalAuthIdentityProvider,
   getClientApplication,
   getClientApplicationMembership,
+  getExternalAuthIdentityProvider,
   hashCode,
   revokeLogin,
   timingSafeEqualStr,

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -1205,7 +1205,9 @@ async function tryExternalAuthLogin(
  * @param externalAuthConfig - The matching external auth provider config.
  * @returns Identity provider settings with a userinfo URL, or undefined if none is configured.
  */
-export function getExternalAuthIdentityProvider(externalAuthConfig: MedplumExternalAuthConfig): IdentityProvider | undefined {
+export function getExternalAuthIdentityProvider(
+  externalAuthConfig: MedplumExternalAuthConfig
+): IdentityProvider | undefined {
   const issuer = getExternalAuthProviderIssuer(externalAuthConfig);
   if (externalAuthConfig.identityProvider) {
     return {

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -1258,7 +1258,7 @@ async function getExternalBearerMembershipForIdentityProvider(
 
   if (identitySource === 'email' && identityMappingMode === 'user-email') {
     const email = isString(userInfo.email) ? userInfo.email.toLowerCase() : undefined;
-    if (!email) {
+    if (!email || userInfo.email_verified !== true) {
       return undefined;
     }
     const user = await getUserByEmail(email, undefined);

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -1111,7 +1111,7 @@ async function tryExternalAuthLogin(
   claims: JWTPayload,
   externalAuthConfig: MedplumExternalAuthConfig
 ): Promise<Pick<AuthState, 'login' | 'project' | 'membership'> | undefined> {
-  const idp = getExternalBearerIdentityProvider(externalAuthConfig);
+  const idp = getExternalAuthIdentityProvider(externalAuthConfig);
   if (!idp) {
     return undefined;
   }
@@ -1182,9 +1182,7 @@ async function tryExternalAuthLogin(
  * @param externalAuthConfig - The matching external auth provider config.
  * @returns Identity provider settings with a userinfo URL, or undefined if none is configured.
  */
-function getExternalBearerIdentityProvider(
-  externalAuthConfig: MedplumExternalAuthConfig
-): IdentityProvider | undefined {
+export function getExternalAuthIdentityProvider(externalAuthConfig: MedplumExternalAuthConfig): IdentityProvider | undefined {
   const issuer = getExternalAuthProviderIssuer(externalAuthConfig);
   if (externalAuthConfig.identityProvider) {
     return {
@@ -1201,7 +1199,7 @@ function getExternalBearerIdentityProvider(
   return undefined;
 }
 
-function getExternalAuthProviderIssuer(externalAuthConfig: MedplumExternalAuthConfig): string {
+export function getExternalAuthProviderIssuer(externalAuthConfig: MedplumExternalAuthConfig): string {
   return externalAuthConfig.identityProvider?.issuer ?? externalAuthConfig.issuer;
 }
 

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -1116,7 +1116,7 @@ async function tryExternalAuthLogin(
     return undefined;
   }
 
-  const useIdentityProviderMapping = !!(idp.identitySource || idp.identityMappingMode);
+  const useIdentityProviderMapping = !!(idp.identitySource || idp.identityMappingMode || idp.useSubject);
   const extensions = claims.ext as Record<string, unknown> | undefined;
   const profileString = claims.fhirUser ?? extensions?.fhirUser;
   if (!useIdentityProviderMapping && !isString(profileString) && !isString(claims.sub)) {
@@ -1236,8 +1236,8 @@ async function getExternalBearerMembershipFromClaims(
 /**
  * Resolves a direct external bearer token to a ProjectMembership using explicit IdentityProvider mapping settings.
  *
- * This path is used only when `identitySource` or `identityMappingMode` is configured on the
- * identity provider. Identity values come from the verified userinfo response, not from the
+ * This path is used only when `identitySource`, `identityMappingMode`, or legacy `useSubject`
+ * is configured on the identity provider. Identity values come from the verified userinfo response, not from the
  * original bearer-token claims.
  *
  * @param systemRepo - System repository used for cross-project membership lookup.

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -1076,6 +1076,11 @@ async function tryExternalAuth(
     return undefined;
   }
 
+  const cacheTtl = getExternalAuthCacheTtl(claims);
+  if (cacheTtl <= 0) {
+    return undefined;
+  }
+
   const redis = getCacheRedis();
   const redisKey = `medplum:ext-auth:${issuer}:${hashCode(accessToken)}:${hashCode(
     JSON.stringify(externalAuthConfig.identityProvider?.audience ?? null)
@@ -1097,11 +1102,29 @@ async function tryExternalAuth(
       return undefined;
     }
     ({ login, project, membership } = externalAuthState);
-    await redis.set(redisKey, JSON.stringify(login), 'EX', 3600);
+    await redis.set(redisKey, JSON.stringify(login), 'EX', cacheTtl);
   }
 
   const userConfig = await getUserConfiguration(systemRepo, project, membership);
   return { login, project, membership, userConfig };
+}
+
+/**
+ * Returns the Redis TTL for a cached external bearer login.
+ *
+ * The cache must not outlive the bearer token. Tokens without an `exp` claim keep
+ * the legacy one-hour TTL because userinfo validation may be the only expiry signal.
+ *
+ * @param claims - Parsed JWT claims from the presented bearer token.
+ * @returns Cache TTL in seconds, or 0 if the token is already expired.
+ */
+function getExternalAuthCacheTtl(claims: JWTPayload): number {
+  const maxTtl = 3600;
+  if (typeof claims.exp !== 'number') {
+    return maxTtl;
+  }
+
+  return Math.min(maxTtl, Math.max(0, Math.floor(claims.exp - Date.now() / 1000)));
 }
 
 async function tryExternalAuthLogin(

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -3,7 +3,6 @@
 import type { Filter, JWTPayload, ProfileResource, SearchRequest, WithId } from '@medplum/core';
 import {
   badRequest,
-  ContentType,
   createReference,
   forbidden,
   getDateProperty,
@@ -16,7 +15,6 @@ import {
   parseReference,
   parseSearchRequest,
   resolveId,
-  tooManyRequests,
 } from '@medplum/core';
 import type {
   AccessPolicy,
@@ -56,8 +54,8 @@ import {
   LoginEvent,
   UserAuthenticationEvent,
 } from '../util/auditevent';
-import { safeFetch } from '../util/url';
 import { getStandardClientById } from './clients';
+import { verifyExternalToken } from './external-token';
 import type { MedplumAccessTokenClaims } from './keys';
 import { generateAccessToken, generateIdToken, generateRefreshToken, generateSecret, verifyJwt } from './keys';
 import type { AuthenticationResult, AuthState } from './middleware';
@@ -845,122 +843,6 @@ function includeRefreshToken(request: LoginRequest, client: ClientApplication | 
   return !!(client?.grantType?.includes('refresh_token') || scopeArray?.includes('offline_access'));
 }
 
-/**
- * Returns the external identity provider user info for an access token.
- * This can be used to verify the access token and get the user's email address.
- * @param userInfoUrl - The user info URL from the identity provider configuration.
- * @param externalAccessToken - The external identity provider access token.
- * @param idp - Optional identity provider configuration.
- * @returns The user info claims.
- */
-export async function getExternalUserInfo(
-  userInfoUrl: string,
-  externalAccessToken: string,
-  idp?: IdentityProvider
-): Promise<JWTPayload> {
-  const log = getLogger();
-
-  const request = buildExternalUserInfoRequest(userInfoUrl, externalAccessToken, idp);
-
-  let response;
-  try {
-    response = await safeFetch(request.url, request.init);
-  } catch (err: any) {
-    log.warn('Error while verifying external auth code', err);
-    throw new OperationOutcomeError(badRequest('Failed to verify code - check your identity provider configuration'));
-  }
-
-  if (response.status === 429) {
-    log.warn('Auth rate limit exceeded', { url: request.url, clientId: idp?.clientId });
-    throw new OperationOutcomeError(tooManyRequests);
-  }
-
-  if (response.status !== 200) {
-    log.warn('Failed to verify external authorization code', { status: response.status });
-    throw new OperationOutcomeError(badRequest('Failed to verify code - check your identity provider configuration'));
-  }
-
-  const contentType = response.headers.get('content-type');
-  try {
-    if (contentType?.includes(ContentType.JSON)) {
-      return normalizeExternalUserInfo(await response.json(), idp);
-    } else if (contentType?.includes(ContentType.JWT)) {
-      return parseJWTPayload(await response.text());
-    }
-  } catch (err: any) {
-    if (err instanceof OperationOutcomeError) {
-      throw err;
-    }
-    log.warn('Failed to verify external authorization code', { err, userInfoUrl, contentType });
-    throw new OperationOutcomeError(badRequest('Failed to verify code - check your identity provider configuration'));
-  }
-
-  throw new OperationOutcomeError(badRequest(`Failed to verify code - unsupported content type: ${contentType}`));
-}
-
-function buildExternalUserInfoRequest(
-  userInfoUrl: string,
-  externalAccessToken: string,
-  idp: IdentityProvider | undefined
-): { url: string; init: RequestInit } {
-  if (idp?.userInfoMode === 'gcip') {
-    const apiKey = idp.userInfoApiKey;
-    if (!apiKey) {
-      throw new OperationOutcomeError(
-        badRequest('Missing user info API key - check your identity provider configuration')
-      );
-    }
-
-    const url = new URL(userInfoUrl);
-    url.searchParams.set('key', apiKey);
-
-    return {
-      url: url.toString(),
-      init: {
-        method: 'POST',
-        headers: {
-          Accept: ContentType.JSON,
-          'Accept-Encoding': 'identity',
-          'Content-Type': ContentType.JSON,
-        },
-        body: JSON.stringify({ idToken: externalAccessToken }),
-      },
-    };
-  }
-
-  return {
-    url: userInfoUrl,
-    init: {
-      method: 'GET',
-      headers: {
-        Accept: ContentType.JSON,
-        'Accept-Encoding': 'identity',
-        Authorization: `Bearer ${externalAccessToken}`,
-      },
-    },
-  };
-}
-
-function normalizeExternalUserInfo(body: Record<string, unknown>, idp?: IdentityProvider): Record<string, unknown> {
-  if (idp?.userInfoMode !== 'gcip') {
-    return body;
-  }
-
-  const users = body.users;
-  if (!Array.isArray(users) || users.length === 0 || !users[0] || typeof users[0] !== 'object') {
-    throw new OperationOutcomeError(badRequest('Failed to verify code - invalid user info response'));
-  }
-
-  const user = users[0] as Record<string, unknown>;
-  if (!user.localId) {
-    throw new OperationOutcomeError(badRequest('Failed to verify code - missing localId in user info response'));
-  }
-  return {
-    ...user,
-    sub: user.localId,
-  };
-}
-
 interface ValidationAssertion {
   clientId?: string;
   clientSecret?: string;
@@ -1186,14 +1068,18 @@ async function tryExternalAuth(
 
   const claims = parseJWTPayload(accessToken);
   const issuer = claims.iss as string;
-  const externalAuthConfig = externalAuthProviders.find((provider) => provider.issuer === issuer);
+  const externalAuthConfig = externalAuthProviders.find(
+    (provider) => getExternalAuthProviderIssuer(provider) === issuer
+  );
   if (!externalAuthConfig) {
     // Not a configured external auth provider
     return undefined;
   }
 
   const redis = getCacheRedis();
-  const redisKey = `medplum:ext-auth:${issuer}:${hashCode(accessToken)}`;
+  const redisKey = `medplum:ext-auth:${issuer}:${hashCode(accessToken)}:${hashCode(
+    JSON.stringify(externalAuthConfig.identityProvider?.audience ?? null)
+  )}`;
   const cachedValue = await redis.get(redisKey);
   let login: Login;
   let project: WithId<Project> | undefined;
@@ -1225,84 +1111,30 @@ async function tryExternalAuthLogin(
   claims: JWTPayload,
   externalAuthConfig: MedplumExternalAuthConfig
 ): Promise<Pick<AuthState, 'login' | 'project' | 'membership'> | undefined> {
-  // To ensure broad compatibility, we check for the FHIR user profile in two places:
-  // the standard `fhirUser` claim and `ext.fhirUser` for identity providers
-  // that automatically place custom claims in an `ext` block.
+  const idp = getExternalBearerIdentityProvider(externalAuthConfig);
+  if (!idp) {
+    return undefined;
+  }
+
+  const useIdentityProviderMapping = !!(idp.identitySource || idp.identityMappingMode);
   const extensions = claims.ext as Record<string, unknown> | undefined;
   const profileString = claims.fhirUser ?? extensions?.fhirUser;
-
-  // If neither fhirUser nor sub is present, we cannot identify the user
-  if (!isString(profileString) && !isString(claims.sub)) {
+  if (!useIdentityProviderMapping && !isString(profileString) && !isString(claims.sub)) {
     return undefined;
   }
 
-  // Validate the token against the external IDP's userinfo endpoint
+  // Verify the token against the external IDP.
+  let verifiedClaims: JWTPayload;
   try {
-    const userInfoUrl = externalAuthConfig.identityProvider?.userInfoUrl ?? externalAuthConfig.userInfoUrl;
-    if (!userInfoUrl) {
-      return undefined;
-    }
-    await getExternalUserInfo(userInfoUrl, accessToken, externalAuthConfig.identityProvider);
+    verifiedClaims = await verifyExternalToken(idp, accessToken);
   } catch (err: any) {
-    getLogger().warn('Failed to get external user info', err);
+    getLogger().warn('Failed to verify external token', err);
     return undefined;
   }
 
-  let membership: WithId<ProjectMembership> | undefined;
-
-  if (isString(profileString)) {
-    // Path A: fhirUser claim present - look up profile, then find membership
-    // Profile string can be either a reference or a search string
-    let searchRequest: SearchRequest<ProfileResource>;
-    const queryIndex = profileString.indexOf('?');
-    if (queryIndex > -1) {
-      // Search string can be either relative (e.g. `Patient?identifier=foo`),
-      // or absolute (e.g. `https://idp.example.com/fhir/Patient?identifier=bar`)
-      // Isolate the resource type and query string from any preceding URL parts
-      const startIndex = profileString.lastIndexOf('/', queryIndex);
-      searchRequest = parseSearchRequest(profileString.substring(startIndex + 1));
-    } else {
-      const [resourceType, id] = profileString.split('/');
-      searchRequest = {
-        resourceType: resourceType as ProfileResource['resourceType'],
-        filters: [{ code: '_id', operator: Operator.EQUALS, value: id }],
-      };
-    }
-
-    // Search for the profile
-    const profile = await systemRepo.searchOne<ProfileResource>(searchRequest);
-    if (!profile) {
-      return undefined;
-    }
-
-    // Search for a ProjectMembership for the profile
-    membership = await systemRepo.searchOne<ProjectMembership>({
-      resourceType: 'ProjectMembership',
-      filters: [{ code: 'profile', operator: Operator.EQUALS, value: getReferenceString(profile) }],
-    });
-  } else {
-    // Path B: sub claim fallback - look up ProjectMembership by externalId
-    // Fetch at most 2 to detect duplicates efficiently; if 2+ exist, the externalId is ambiguous
-    const bundle = await systemRepo.search<ProjectMembership>({
-      resourceType: 'ProjectMembership',
-      filters: [
-        {
-          code: 'external-id',
-          operator: Operator.EXACT,
-          value: claims.sub as string,
-        },
-      ],
-      count: 2,
-    });
-
-    const entries = bundle.entry;
-    if (entries && entries.length > 1) {
-      getLogger().warn('Multiple ProjectMemberships found for external ID', { sub: claims.sub });
-      return undefined;
-    }
-
-    membership = entries?.[0]?.resource;
-  }
+  const membership = useIdentityProviderMapping
+    ? await getExternalBearerMembershipForIdentityProvider(systemRepo, verifiedClaims, idp)
+    : await getExternalBearerMembershipFromClaims(systemRepo, claims);
 
   if (!membership || membership.active === false) {
     return undefined;
@@ -1338,6 +1170,224 @@ async function tryExternalAuthLogin(
   );
 
   return { login, project, membership };
+}
+
+/**
+ * Returns the IdentityProvider settings used to validate direct external bearer tokens.
+ *
+ * Newer configs store userinfo settings in `identityProvider`; older configs store only
+ * a top-level `userInfoUrl`. This function normalizes those shapes for token validation
+ * without deciding how the token should map to a Medplum identity.
+ *
+ * @param externalAuthConfig - The matching external auth provider config.
+ * @returns Identity provider settings with a userinfo URL, or undefined if none is configured.
+ */
+function getExternalBearerIdentityProvider(
+  externalAuthConfig: MedplumExternalAuthConfig
+): IdentityProvider | undefined {
+  const issuer = getExternalAuthProviderIssuer(externalAuthConfig);
+  if (externalAuthConfig.identityProvider) {
+    return {
+      issuer,
+      userInfoUrl: externalAuthConfig.userInfoUrl,
+      ...externalAuthConfig.identityProvider,
+    };
+  }
+
+  if (externalAuthConfig.userInfoUrl) {
+    return { issuer, userInfoUrl: externalAuthConfig.userInfoUrl };
+  }
+
+  return undefined;
+}
+
+function getExternalAuthProviderIssuer(externalAuthConfig: MedplumExternalAuthConfig): string {
+  return externalAuthConfig.identityProvider?.issuer ?? externalAuthConfig.issuer;
+}
+
+/**
+ * Resolves a direct external bearer token to a ProjectMembership using JWT claims.
+ *
+ * This is the default direct-bearer mapping behavior: `fhirUser` (including
+ * `ext.fhirUser`) takes precedence, and `sub` falls back to matching
+ * `ProjectMembership.externalId`.
+ *
+ * @param systemRepo - System repository used for cross-project membership lookup.
+ * @param claims - Parsed JWT claims from the presented bearer token.
+ * @returns The resolved project membership, or undefined if no unambiguous membership matches.
+ */
+async function getExternalBearerMembershipFromClaims(
+  systemRepo: SystemRepository,
+  claims: JWTPayload
+): Promise<WithId<ProjectMembership> | undefined> {
+  const extensions = claims.ext as Record<string, unknown> | undefined;
+  const profileString = claims.fhirUser ?? extensions?.fhirUser;
+  if (isString(profileString)) {
+    // Path A: fhirUser claim present - look up profile, then find membership
+    // Profile string can be either a reference or a search string
+    return getProjectMembershipByProfileString(systemRepo, profileString);
+  }
+
+  if (isString(claims.sub)) {
+    return getProjectMembershipByExternalId(systemRepo, claims.sub);
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolves a direct external bearer token to a ProjectMembership using explicit IdentityProvider mapping settings.
+ *
+ * This path is used only when `identitySource` or `identityMappingMode` is configured on the
+ * identity provider. Identity values come from the verified userinfo response, not from the
+ * original bearer-token claims.
+ *
+ * @param systemRepo - System repository used for cross-project membership lookup.
+ * @param userInfo - Userinfo response returned by the external identity provider.
+ * @param idp - Identity provider configuration containing the mapping settings.
+ * @returns The resolved project membership, or undefined if the mapping is unsupported or no membership matches.
+ */
+async function getExternalBearerMembershipForIdentityProvider(
+  systemRepo: SystemRepository,
+  userInfo: JWTPayload,
+  idp: IdentityProvider
+): Promise<WithId<ProjectMembership> | undefined> {
+  const identitySource = idp.identitySource ?? (idp.useSubject ? 'subject' : 'email');
+  const identityMappingMode =
+    idp.identityMappingMode ?? (idp.useSubject ? 'project-membership-external-id' : 'user-email');
+
+  if (identitySource === 'email' && identityMappingMode === 'user-email') {
+    const email = isString(userInfo.email) ? userInfo.email.toLowerCase() : undefined;
+    if (!email) {
+      return undefined;
+    }
+    const user = await getUserByEmail(email, undefined);
+    return user ? getOnlyProjectMembershipForUser(systemRepo, user) : undefined;
+  }
+
+  if (identitySource === 'subject' && identityMappingMode === 'project-membership-external-id') {
+    return isString(userInfo.sub) ? getProjectMembershipByExternalId(systemRepo, userInfo.sub) : undefined;
+  }
+
+  if (identitySource === 'fhir-user' && identityMappingMode === 'project-membership-profile') {
+    const extensions = userInfo.ext as Record<string, unknown> | undefined;
+    const profileString = userInfo.fhirUser ?? extensions?.fhirUser;
+    return isString(profileString) ? getProjectMembershipByProfileString(systemRepo, profileString) : undefined;
+  }
+
+  getLogger().warn('Unsupported identity provider configuration for external bearer token', {
+    identitySource,
+    identityMappingMode,
+  });
+  return undefined;
+}
+
+/**
+ * Resolves a FHIR profile reference/search string to its ProjectMembership.
+ *
+ * Supports direct references such as `Practitioner/123`, relative search strings such as
+ * `Practitioner?identifier=abc`, and absolute URLs whose trailing path/query form a FHIR
+ * search string.
+ *
+ * @param systemRepo - System repository used to search profiles and memberships.
+ * @param profileString - FHIR profile reference or search string from `fhirUser`.
+ * @returns The membership for the resolved profile, or undefined if either resource is missing.
+ */
+async function getProjectMembershipByProfileString(
+  systemRepo: SystemRepository,
+  profileString: string
+): Promise<WithId<ProjectMembership> | undefined> {
+  let searchRequest: SearchRequest<ProfileResource>;
+  const queryIndex = profileString.indexOf('?');
+  if (queryIndex > -1) {
+    // Search string can be either relative (e.g. `Patient?identifier=foo`),
+    // or absolute (e.g. `https://idp.example.com/fhir/Patient?identifier=bar`)
+    // Isolate the resource type and query string from any preceding URL parts
+    const startIndex = profileString.lastIndexOf('/', queryIndex);
+    searchRequest = parseSearchRequest(profileString.substring(startIndex + 1));
+  } else {
+    const [resourceType, id] = profileString.split('/');
+    searchRequest = {
+      resourceType: resourceType as ProfileResource['resourceType'],
+      filters: [{ code: '_id', operator: Operator.EQUALS, value: id }],
+    };
+  }
+
+  const profile = await systemRepo.searchOne<ProfileResource>(searchRequest);
+  if (!profile) {
+    return undefined;
+  }
+
+  return systemRepo.searchOne<ProjectMembership>({
+    resourceType: 'ProjectMembership',
+    filters: [{ code: 'profile', operator: Operator.EQUALS, value: getReferenceString(profile) }],
+  });
+}
+
+/**
+ * Resolves a ProjectMembership by external ID.
+ *
+ * The lookup is intentionally cross-project because direct external bearer auth is configured
+ * at the server level. Duplicate matches are treated as ambiguous and fail closed.
+ *
+ * @param systemRepo - System repository used for cross-project membership lookup.
+ * @param externalId - External subject identifier to match against `ProjectMembership.externalId`.
+ * @returns The matching project membership, or undefined if none or multiple memberships match.
+ */
+async function getProjectMembershipByExternalId(
+  systemRepo: SystemRepository,
+  externalId: string
+): Promise<WithId<ProjectMembership> | undefined> {
+  // Fetch at most 2 to detect duplicates efficiently; if 2+ exist, the externalId is ambiguous.
+  const bundle = await systemRepo.search<ProjectMembership>({
+    resourceType: 'ProjectMembership',
+    filters: [
+      {
+        code: 'external-id',
+        operator: Operator.EXACT,
+        value: externalId,
+      },
+    ],
+    count: 2,
+  });
+
+  const entries = bundle.entry;
+  if (entries && entries.length > 1) {
+    getLogger().warn('Multiple ProjectMemberships found for external ID', { externalId });
+    return undefined;
+  }
+
+  return entries?.[0]?.resource;
+}
+
+/**
+ * Resolves a user's sole ProjectMembership.
+ *
+ * Email-based direct bearer mapping does not carry a project or membership selector. To avoid
+ * choosing a project implicitly, users with multiple memberships are treated as ambiguous and
+ * fail closed.
+ *
+ * @param systemRepo - System repository used for cross-project membership lookup.
+ * @param user - The resolved global user.
+ * @returns The user's only project membership, or undefined if the user has none or multiple.
+ */
+async function getOnlyProjectMembershipForUser(
+  systemRepo: SystemRepository,
+  user: WithId<User>
+): Promise<WithId<ProjectMembership> | undefined> {
+  const bundle = await systemRepo.search<ProjectMembership>({
+    resourceType: 'ProjectMembership',
+    filters: [{ code: 'user', operator: Operator.EQUALS, value: getReferenceString(user) }],
+    count: 2,
+  });
+
+  const entries = bundle.entry;
+  if (entries && entries.length > 1) {
+    getLogger().warn('Multiple ProjectMemberships found for external auth user', { user: getReferenceString(user) });
+    return undefined;
+  }
+
+  return entries?.[0]?.resource;
 }
 
 /**


### PR DESCRIPTION
This PR expands external auth support so Medplum can accept externally issued JWTs directly as bearer tokens for API calls, including tokens verified against a configured JWKS endpoint. It also consolidates external token verification into one helper path shared by direct bearer auth and token exchange, and moves `IdentityProvider` toward a capability-based model rather than assuming every provider is a full OAuth authorization-code provider.

## What Changed

### IdentityProvider model

- Adds `IdentityProvider.issuer`
- Adds `IdentityProvider.audience`
- Adds `IdentityProvider.tokenVerificationMethod` with `userinfo` and `jwks`
- Adds `IdentityProvider.jwksUrl`
- Makes OAuth-specific fields optional:
  - `authorizeUrl`
  - `tokenUrl`
  - `userInfoUrl`
  - `clientId`
  - `clientSecret`
- Adds the generated CodeSystem/ValueSet for `identity-provider-token-verification-method`
- Marks `MedplumExternalAuthConfig.issuer` as deprecated in favor of `identityProvider.issuer`, while preserving it for compatibility

### External token verification

- Adds `packages/server/src/oauth/external-token.ts`.
- Centralizes external token verification behind `verifyExternalToken(idp, token)`.
- Supports two verification methods:
  - `userinfo`: validates the presented bearer token by calling the configured userinfo endpoint.
  - `jwks`: validates the JWT signature and issuer using the configured JWKS URL.
- Uses `safeFetch` for remote userinfo and JWKS calls.
- Enforces configured `IdentityProvider.audience` when present.
- Preserves existing GCIP userinfo normalization.

### Direct external bearer auth

- Normalizes external auth provider config into a shared `IdentityProvider` shape.
- Supports JWKS-backed direct bearer auth.
- Preserves legacy direct bearer mapping when no explicit `IdentityProvider` mapping is configured:
  - `fhirUser` / `ext.fhirUser` maps to profile membership.
  - `sub` maps to `ProjectMembership.externalId`.
- Adds explicit direct bearer mapping through `IdentityProvider`:
  - `identitySource: "email"` + `identityMappingMode: "user-email"`
  - `identitySource: "subject"` + `identityMappingMode: "project-membership-external-id"`
  - `identitySource: "fhir-user"` + `identityMappingMode: "project-membership-profile"`
- Preserves legacy `useSubject: true` as shorthand for subject-to-membership mapping.
- Requires `email_verified === true` for email-based external identity mapping.
- Fails closed for ambiguous cross-project lookups:
  - Duplicate `ProjectMembership.externalId` matches are rejected.
  - Email mapping rejects users with multiple memberships.
- Adds configured audience to the Redis cache key.
- Bounds Redis cache TTL by the bearer token `exp` claim when present, and rejects already-expired tokens before cache lookup.

### Token exchange and external login

- Reuses `verifyExternalToken()` in token exchange instead of separately calling userinfo.
- Reuses shared external auth provider normalization in token exchange.
- Requires `email_verified === true` for external browser login email mapping.
- Adds runtime checks for now-optional OAuth fields before using them:
  - `tokenUrl`
  - `clientId`
  - `clientSecret`
- Updates external auth detection to require `authorizeUrl` and `clientId`, because `IdentityProvider` can now represent non-browser-login providers.

## Compatibility Notes

- Existing userinfo-based direct bearer auth remains supported.
- Existing legacy direct bearer mapping from JWT `fhirUser` or `sub` remains supported when no explicit mapping is configured.
- Existing `useSubject: true` configs remain supported.
- `MedplumExternalAuthConfig.issuer` remains present and usable, but new config should prefer `identityProvider.issuer`.
- Email-based user mapping is intentionally stricter: external userinfo/token claims must include `email_verified: true`.
- Tokens without an `exp` claim keep the previous one-hour cache behavior.

## Security Notes

- JWKS verification validates the JWT signature and issuer.
- Audience validation is enforced when `IdentityProvider.audience` is configured.
- Email-based mapping rejects unverified or missing `email_verified` claims to avoid mapping an attacker-controlled external email claim onto an existing Medplum user.
- Cached external bearer logins no longer outlive the bearer token `exp` claim.
- `safeFetch` is used for outbound userinfo and JWKS requests.
