### PR TITLE
feat(app): add interaction option to Resend Subscriptions modal

### DIFF
--- a/packages/app/src/resource/ResendSubscriptionsModal.test.tsx
+++ b/packages/app/src/resource/ResendSubscriptionsModal.test.tsx
@@ -64,6 +64,7 @@ describe('ResendSubscriptionsModal', () => {
 
     const request = resendCallback.mock.calls[0][0];
     expect(request.body.subscription).toBeUndefined();
+    expect(request.body.interaction).toBe('update');
     expect(request.body.verbose).toBe(false);
   });
 
@@ -116,6 +117,11 @@ describe('ResendSubscriptionsModal', () => {
       fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
     });
 
+    // Select the "Delete" interaction
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Interaction'), { target: { value: 'delete' } });
+    });
+
     // Check the "Verbose mode" checkbox
     await act(async () => {
       fireEvent.click(screen.getByText('Verbose mode', { exact: false }));
@@ -130,6 +136,7 @@ describe('ResendSubscriptionsModal', () => {
 
     const request = resendCallback.mock.calls[0][0];
     expect(request.body.subscription).toBe('Subscription/1234');
+    expect(request.body.interaction).toBe('delete');
     expect(request.body.verbose).toBe(true);
   });
 

--- a/packages/app/src/resource/ResendSubscriptionsModal.tsx
+++ b/packages/app/src/resource/ResendSubscriptionsModal.tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Button, Checkbox, Group, Modal, Stack } from '@mantine/core';
+import { Button, Checkbox, Group, Modal, NativeSelect, Stack } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
+import type { BackgroundJobInteraction } from '@medplum/core';
 import { getReferenceString, normalizeErrorString } from '@medplum/core';
 import type { Resource } from '@medplum/fhirtypes';
 import { Form, ResourceInput, useMedplum } from '@medplum/react';
@@ -19,6 +20,7 @@ export function ResendSubscriptionsModal(props: ResendSubscriptionsModalProps): 
   const { resource, opened, onClose } = props;
   const [choose, setChoose] = useState(false);
   const [subscription, setSubscription] = useState<Resource | undefined>();
+  const [interaction, setInteraction] = useState<BackgroundJobInteraction>('update');
   const [verbose, setVerbose] = useState(false);
 
   const handleSubmit = useCallback(async () => {
@@ -28,6 +30,7 @@ export function ResendSubscriptionsModal(props: ResendSubscriptionsModalProps): 
     try {
       await medplum.post(medplum.fhirUrl(resource.resourceType, resource.id, '$resend'), {
         subscription: choose && subscription ? getReferenceString(subscription) : undefined,
+        interaction,
         verbose,
       });
       showNotification({ color: 'green', message: 'Done' });
@@ -35,7 +38,7 @@ export function ResendSubscriptionsModal(props: ResendSubscriptionsModalProps): 
     } catch (err) {
       showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false });
     }
-  }, [medplum, resource, onClose, choose, subscription, verbose]);
+  }, [medplum, resource, onClose, choose, subscription, interaction, verbose]);
 
   return (
     <Modal opened={opened} onClose={onClose} title="Resend Subscriptions">
@@ -53,6 +56,17 @@ export function ResendSubscriptionsModal(props: ResendSubscriptionsModalProps): 
               onChange={setSubscription}
             />
           )}
+          <NativeSelect
+            label="Interaction"
+            description="The interaction type to resend (update by default)"
+            defaultValue="update"
+            data={[
+              { label: 'Update', value: 'update' },
+              { label: 'Create', value: 'create' },
+              { label: 'Delete', value: 'delete' },
+            ]}
+            onChange={(e) => setInteraction(e.currentTarget.value as BackgroundJobInteraction)}
+          />
           <Checkbox label="Verbose mode" onChange={(e) => setVerbose(e.currentTarget.checked)} />
           <Group justify="flex-end">
             <Button type="submit">Resend</Button>


### PR DESCRIPTION
## Summary

Adds an **Interaction** selector to the Resend Subscriptions modal (resource Timeline tab), letting users choose `update`, `create`, or `delete` when resending subscriptions.

Previously the modal only ever resent `update` interactions, even though the underlying [`$resend` operation](https://www.medplum.com/docs/api/fhir/operations/resend) supports selecting `create` and `delete` interactions.

## Changes

- `ResendSubscriptionsModal.tsx`: add a `NativeSelect` for the interaction type (defaults to `update`) and pass the selected `interaction` to the `$resend` request body.
- Updated tests to assert the `interaction` param is sent, including selecting `delete`.

## Test plan

- `packages/app/src/resource/ResendSubscriptionsModal.test.tsx` passes (4/4).

Fixes #7565

🤖 Generated with [Claude Code](https://claude.com/claude-code)