### PR TITLE
feature(warehouse): fast max(last_updated) iceberg calculation

### DIFF
--- a/packages/server/src/cloud/aws/data-warehouse-destination.test.ts
+++ b/packages/server/src/cloud/aws/data-warehouse-destination.test.ts
@@ -28,9 +28,9 @@ describe('data warehouse aws destination', () => {
 
   test('buildSourcePredicate queries Iceberg watermark before Postgres attach', async () => {
     vi.restoreAllMocks();
-    const readAll = vi.spyOn(warehouseSql, 'runParameterizedWarehouseSqlReadAll').mockResolvedValue({
-      getRowObjectsJson: () => [{ watermark: '2024-06-01T12:00:00.000Z' }],
-    });
+    const fetchWatermark = vi
+      .spyOn(warehouseSql, 'fetchIcebergWatermark')
+      .mockResolvedValue('2024-06-01T12:00:00.000Z');
 
     const destination = new S3TablesWarehouseDestination(
       'us-east-1',
@@ -38,7 +38,8 @@ describe('data warehouse aws destination', () => {
     );
     const predicate = await destination.buildSourcePredicate(connection, tableSpec, 'default');
 
-    expect(readAll).toHaveBeenCalledTimes(1);
+    expect(fetchWatermark).toHaveBeenCalledTimes(1);
+    expect(fetchWatermark).toHaveBeenCalledWith(connection, 'iceberg_catalog.default.patient_history');
     expect(predicate).toBeDefined();
     const sql = new SqlBuilder();
     sql.appendExpression(predicate as never);
@@ -48,9 +49,7 @@ describe('data warehouse aws destination', () => {
 
   test('buildSourcePredicate omits filter when Iceberg table is empty', async () => {
     vi.restoreAllMocks();
-    vi.spyOn(warehouseSql, 'runParameterizedWarehouseSqlReadAll').mockResolvedValue({
-      getRowObjectsJson: () => [{ watermark: null }],
-    });
+    vi.spyOn(warehouseSql, 'fetchIcebergWatermark').mockResolvedValue(undefined);
 
     const destination = new S3TablesWarehouseDestination(
       'us-east-1',

--- a/packages/server/src/cloud/aws/data-warehouse-destination.ts
+++ b/packages/server/src/cloud/aws/data-warehouse-destination.ts
@@ -15,11 +15,11 @@ import {
   buildManagedIcebergQualifiedTable,
   buildManagedIcebergSetupQueries,
   buildSelectFromHistoryTableQuery,
+  fetchIcebergWatermark,
   runParameterizedWarehouseSql,
-  runParameterizedWarehouseSqlReadAll,
 } from '../../data-warehouse/warehouse-sql';
 import type { Expression } from '../../fhir/sql';
-import { Condition, SelectQuery, SqlBuilder } from '../../fhir/sql';
+import { Condition } from '../../fhir/sql';
 import { createS3TablesClient, tableExists } from './data-warehouse-client';
 
 export class S3TablesWarehouseDestination implements DataWarehouseDestination {
@@ -61,13 +61,8 @@ export class S3TablesWarehouseDestination implements DataWarehouseDestination {
     namespace: string
   ): Promise<Expression | undefined> {
     const qualifiedIceberg = buildManagedIcebergQualifiedTable(namespace, tableSpec.icebergTable);
-    const safeQualifiedTableName = qualifiedIceberg.split('.').join('"."');
-    const watermarkQuery = new SqlBuilder();
-    watermarkQuery.appendExpression(new SelectQuery(safeQualifiedTableName).raw('MAX(last_updated) AS watermark'));
-    const result = await runParameterizedWarehouseSqlReadAll(connection, watermarkQuery);
-    const row = result.getRowObjectsJson()[0] as { watermark?: string | null } | undefined;
-    const watermark = row?.watermark ?? null;
-    if (watermark === null) {
+    const watermark = await fetchIcebergWatermark(connection, qualifiedIceberg);
+    if (!watermark) {
       return undefined;
     }
 

--- a/packages/server/src/data-warehouse/sync.ts
+++ b/packages/server/src/data-warehouse/sync.ts
@@ -33,6 +33,7 @@ export interface SyncTableResult {
   destination: string;
   rowsInserted: number;
   syncDurationMs: number;
+  watermarkDurationMs: number;
 }
 
 export interface SyncResult {
@@ -132,19 +133,13 @@ async function syncWarehouseTable(
   const tablesCompleted = index + 1;
   const destination = options.destination.getDestinationName(spec);
 
-  globalLogger.info(`Data warehouse table sync starting for table=${destination}`, {
-    tableIndex: tablesCompleted,
-    tablesTotal,
-    destination,
-    startDate: options.startDate,
-    subsystem: 'data-warehouse-sync',
-  });
-
   const syncStartTime = Date.now();
 
   await options.destination.ensureTargetExists(spec, namespace);
 
+  const watermarkStartTime = Date.now();
   const sourcePredicate = await buildWarehouseSourcePredicate(connection, options, spec, namespace);
+  const watermarkDurationMs = Date.now() - watermarkStartTime;
 
   for (const query of options.destination.getPostgresAttachQueries(sourceConnectionString)) {
     await connection.run(query);
@@ -159,13 +154,14 @@ async function syncWarehouseTable(
   const syncEndTime = Date.now();
   const syncDurationMs = syncEndTime - syncStartTime;
 
-  globalLogger.info(`Data warehouse table sync completed for table=${destination}`, {
+  globalLogger.info(`Data warehouse sync finished for table=${destination}`, {
     tableIndex: tablesCompleted,
     tablesCompleted,
     tablesTotal,
     destination,
     rowsInserted,
     syncDurationMs,
+    watermarkDurationMs,
     startDate: options.startDate,
     subsystem: 'data-warehouse-sync',
   });
@@ -186,6 +182,7 @@ async function syncWarehouseTable(
     destination,
     rowsInserted,
     syncDurationMs,
+    watermarkDurationMs,
   };
 }
 
@@ -197,14 +194,6 @@ async function runWarehouseTableSync(
   const tables: SyncTableResult[] = [];
 
   const tablesTotal = options.warehouseSources.length;
-
-  globalLogger.info('Starting data warehouse sync', {
-    tablesTotal,
-    startDate: options.startDate,
-    includeResourceTypes: options.includeResourceTypes,
-    excludeResourceTypes: options.excludeResourceTypes,
-    subsystem: 'data-warehouse-sync',
-  });
 
   for (const [index, spec] of options.warehouseSources.entries()) {
     // Close and re-open the DuckDB database between tables so each table sync

--- a/packages/server/src/data-warehouse/warehouse-sql.int.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.int.test.ts
@@ -8,13 +8,18 @@ import pg from 'pg';
 import { loadTestConfig } from '../config/loader';
 import { SqlBuilder } from '../fhir/sql';
 import { buildPgConnectionURI } from './config';
+import type { DuckdbConnection } from './warehouse-sql';
 import {
   buildDuckdbPostgresAttachQuery,
   buildInsertIntoSelectQuery,
   buildSelectFromHistoryTableQuery,
+  fetchIcebergWatermark,
   runParameterizedWarehouseSql,
   runParameterizedWarehouseSqlReadAll,
 } from './warehouse-sql';
+
+const PATIENT_HISTORY_TABLE = 'iceberg_catalog.default.patient_history';
+const DELETED_ONLY_TABLE = 'iceberg_catalog.default.deleted_only';
 
 const HISTORY_TABLE = 'DwWarehouseSqlIntTest_history';
 const DEST_TABLE = 'wh_sql_int_dest';
@@ -111,4 +116,83 @@ describe('warehouse SQL (integration)', () => {
       instance.closeSync();
     }
   }, 30_000);
+
+  test('fetchIcebergWatermark executes parameterized iceberg_column_stats against DuckDB', async () => {
+    // given
+    const instance = await DuckDBInstance.create(':memory:');
+    const connection = await instance.connect();
+    try {
+      await setupFakeIcebergColumnStats(connection);
+
+      // when
+      const watermark = await fetchIcebergWatermark(connection, PATIENT_HISTORY_TABLE);
+      // then
+      expect(watermark).toBeDefined();
+      expect(new Date(watermark as string).toISOString()).toBe('2024-07-15T08:30:00.000Z');
+    } finally {
+      connection.closeSync();
+      instance.closeSync();
+    }
+  });
+
+  test('fetchIcebergWatermark returns undefined when table has no manifest stats', async () => {
+    const instance = await DuckDBInstance.create(':memory:');
+    const connection = await instance.connect();
+    try {
+      await setupFakeIcebergColumnStats(connection);
+
+      const watermark = await fetchIcebergWatermark(connection, 'iceberg_catalog.default.empty_table');
+      expect(watermark).toBeUndefined();
+    } finally {
+      connection.closeSync();
+      instance.closeSync();
+    }
+  });
+
+  test('fetchIcebergWatermark ignores DELETED status and empty upper_bound rows', async () => {
+    const instance = await DuckDBInstance.create(':memory:');
+    const connection = await instance.connect();
+    try {
+      await setupFakeIcebergColumnStats(connection);
+
+      const watermark = await fetchIcebergWatermark(connection, DELETED_ONLY_TABLE);
+      expect(watermark).toBeUndefined();
+    } finally {
+      connection.closeSync();
+      instance.closeSync();
+    }
+  });
 });
+
+/**
+ * Stand-in for the Iceberg extension's `iceberg_column_stats` table function.
+ * @param connection - The DuckDB connection to use.
+ * @returns A promise that resolves when the fake iceberg_column_stats table function is set up.
+ */
+async function setupFakeIcebergColumnStats(connection: DuckdbConnection): Promise<void> {
+  await connection.run(`
+    CREATE TABLE iceberg_column_stats_fixture (
+      table_name VARCHAR,
+      column_name VARCHAR,
+      status VARCHAR,
+      upper_bound VARCHAR
+    );
+  `);
+  await connection.run(`
+    INSERT INTO iceberg_column_stats_fixture VALUES
+      ('${PATIENT_HISTORY_TABLE}', 'last_updated', 'ADDED', '2024-06-01T12:00:00.000Z'),
+      ('${PATIENT_HISTORY_TABLE}', 'last_updated', 'ADDED', '2024-07-15T08:30:00.000Z'),
+      ('${PATIENT_HISTORY_TABLE}', 'last_updated', 'DELETED', '2024-08-01T00:00:00.000Z'),
+      ('${PATIENT_HISTORY_TABLE}', 'last_updated', 'ADDED', ''),
+      ('${PATIENT_HISTORY_TABLE}', 'id', 'ADDED', '999'),
+      ('iceberg_catalog.default.other_table', 'last_updated', 'ADDED', '2024-12-01T00:00:00.000Z'),
+      ('${DELETED_ONLY_TABLE}', 'last_updated', 'DELETED', '2024-08-01T00:00:00.000Z'),
+      ('${DELETED_ONLY_TABLE}', 'last_updated', 'ADDED', '');
+  `);
+  await connection.run(`
+    CREATE OR REPLACE MACRO iceberg_column_stats(qualified_table) AS TABLE
+    SELECT column_name, status, upper_bound
+    FROM iceberg_column_stats_fixture f
+    WHERE f.table_name = qualified_table;
+  `);
+}

--- a/packages/server/src/data-warehouse/warehouse-sql.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.test.ts
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Condition, Conjunction, Constant, SqlBuilder } from '../fhir/sql';
+import type { DuckdbConnection } from './warehouse-sql';
 import {
-  buildCountFromHistoryTableQuery,
   buildInsertIntoSelectQuery,
   buildProjectedSelectFromHistoryTable,
   buildSelectFromHistoryTableQuery,
   buildStartDatePredicate,
+  fetchIcebergWatermark,
 } from './warehouse-sql';
 
 describe('warehouse SQL query builders', () => {
@@ -18,7 +19,7 @@ describe('warehouse SQL query builders', () => {
     sql.appendExpression(query);
 
     expect(sql.toString()).toBe(
-      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1 AND "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z')) AS "src" ORDER BY "src"."last_updated"`
+      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1 AND "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z')) AS "src"`
     );
     expect(sql.getValues()).toStrictEqual(['']);
   });
@@ -27,7 +28,7 @@ describe('warehouse SQL query builders', () => {
     const projectedSelectQuery = buildSelectFromHistoryTableQuery('Patient_History');
     const insertQuery = buildInsertIntoSelectQuery('iceberg_catalog.default.patient_history', projectedSelectQuery);
     expect(insertQuery.toString()).toBe(
-      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1)) AS "src" ORDER BY "src"."last_updated"`
+      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1)) AS "src"`
     );
     expect(insertQuery.getValues()).toStrictEqual(['']);
   });
@@ -44,20 +45,37 @@ describe('warehouse SQL query builders', () => {
     expect(projected.getValues()).toStrictEqual(['']);
   });
 
-  test('buildCountFromHistoryTableQuery builds count query with guarded content filter', () => {
-    const countQuery = buildCountFromHistoryTableQuery('Patient_History');
-    expect(countQuery.toString()).toBe(
-      `SELECT COUNT(*) AS count FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1)`
-    );
-    expect(countQuery.getValues()).toStrictEqual(['']);
-  });
-
   test('buildStartDatePredicate filters history rows at or after the bound', () => {
     const startDate = '2024-01-01T00:00:00.000Z';
     const startDateSql = new SqlBuilder();
     startDateSql.appendExpression(buildStartDatePredicate(startDate));
     expect(startDateSql.toString()).toBe(`"lastUpdated" >= $1`);
     expect(startDateSql.getValues()).toStrictEqual([startDate]);
+  });
+
+  test('fetchIcebergWatermark reads manifest upper_bounds without scanning Parquet', async () => {
+    let preparedSql = '';
+    const boundValues: unknown[] = [];
+    const connection = {
+      prepare: async (sql: string) => {
+        preparedSql = sql;
+        return {
+          bindValue(index: number, value: unknown) {
+            boundValues[index - 1] = value;
+          },
+          async runAndReadAll() {
+            return { getRowObjectsJson: () => [{ watermark: '2024-06-01T12:00:00.000Z' }] };
+          },
+        };
+      },
+    } as DuckdbConnection;
+
+    const watermark = await fetchIcebergWatermark(connection, 'iceberg_catalog.default.patient_history');
+    expect(watermark).toBe('2024-06-01T12:00:00.000Z');
+    expect(preparedSql).toBe(
+      `SELECT max(try_cast(upper_bound AS TIMESTAMPTZ)) AS watermark FROM iceberg_column_stats($1) WHERE ("column_name" = $2 AND "status" <> $3 AND "upper_bound" IS NOT NULL AND "upper_bound" <> $4)`
+    );
+    expect(boundValues).toStrictEqual(['iceberg_catalog.default.patient_history', 'last_updated', 'DELETED', '']);
   });
 
   test('Conjunction ANDs resolved watermark and startDate filters', () => {

--- a/packages/server/src/data-warehouse/warehouse-sql.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.ts
@@ -1,7 +1,16 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { Expression } from '../fhir/sql';
-import { Column, Condition, InsertQuery, SelectQuery, SqlBuilder } from '../fhir/sql';
+import {
+  Column,
+  Condition,
+  Conjunction,
+  InsertQuery,
+  Parameter,
+  SelectQuery,
+  SqlBuilder,
+  SqlFunction,
+} from '../fhir/sql';
 
 const DEFAULT_COMPRESSION_TYPE = 'zstd';
 const DEFAULT_FILE_FORMAT = 'PARQUET';
@@ -114,6 +123,46 @@ export function buildManagedIcebergQualifiedTable(namespace: string, icebergTabl
   return `${DEFAULT_ICEBERG_CATALOG_ALIAS}.${namespace}.${icebergTable}`;
 }
 
+/**
+ * Reads the incremental sync watermark from Iceberg manifest column stats (no Parquet scan).
+ *
+ * Uses per-file `upper_bound` values from `iceberg_column_stats`.
+ * Requires Iceberg V2+ tables with accurate `last_updated` bounds in manifest metadata.
+ *
+ * @param connection - DuckDB connection used to run the watermark query.
+ * @param qualifiedIcebergTable - Fully qualified table name (e.g. `iceberg_catalog.default.patient_history`).
+ * @returns The max `last_updated` upper bound, or `undefined` when the table is empty or has no stats.
+ */
+export async function fetchIcebergWatermark(
+  connection: Pick<DuckdbConnection, 'prepare'>,
+  qualifiedIcebergTable: string
+): Promise<string | undefined> {
+  // create the query
+  const statsTableFn = new SqlFunction('iceberg_column_stats', [new Parameter(qualifiedIcebergTable)]);
+  const watermarkColumn = new Column(undefined, 'max(try_cast(upper_bound AS TIMESTAMPTZ)) AS watermark', true);
+  const filters = new Conjunction([
+    new Condition('column_name', '=', 'last_updated'),
+    new Condition('status', '!=', 'DELETED'),
+    new Condition('upper_bound', '!=', null),
+    new Condition('upper_bound', '!=', ''),
+  ]);
+  // NOTE: SelectQuery only supports table identifiers or subqueries in FROM, not table-valued
+  //       functions like iceberg_column_stats(...), so we'll assemble this query with SqlBuilder directly.
+  const query = buildSqlBuilder((sql) => {
+    sql.append('SELECT ');
+    sql.appendColumn(watermarkColumn);
+    sql.append(' FROM ');
+    sql.appendExpression(statsTableFn);
+    sql.append(' WHERE ');
+    sql.appendExpression(filters);
+  });
+
+  // execute it
+  const result = await runParameterizedWarehouseSqlReadAll(connection, query);
+  const row = result.getRowObjectsJson()[0] as { watermark?: string | null } | undefined;
+  return row?.watermark ?? undefined;
+}
+
 export function buildInsertIntoSelectQuery(
   qualifiedTable: string,
   selectQuery: SelectQuery,
@@ -152,13 +201,14 @@ export function buildSelectFromHistoryTableQuery(
     inner.whereExpr(sourcePredicate);
   }
 
+  const projectIdExpression = `json_extract_string("src"."content"::JSON, '${PROJECT_ID_JSON_PATH}')`;
+
   return new SelectQuery('src', inner)
     .column('id')
     .column('version_id')
     .column('content')
     .column('last_updated')
-    .raw(`json_extract_string("src"."content"::JSON, '${PROJECT_ID_JSON_PATH}') AS project_id`)
-    .orderBy('last_updated');
+    .raw(`${projectIdExpression} AS project_id`);
 }
 
 export function buildProjectedSelectFromHistoryTable(
@@ -168,18 +218,6 @@ export function buildProjectedSelectFromHistoryTable(
   return buildSqlBuilder((sql) =>
     sql.appendExpression(buildSelectFromHistoryTableQuery(sourceHistoryTable, sourcePredicate))
   );
-}
-
-export function buildCountFromHistoryTableQuery(sourceHistoryTable: string, sourcePredicate?: Expression): SqlBuilder {
-  const table = buildQualifiedTableIdentifier(`${POSTGRES_CATALOG}.${sourceHistoryTable}`);
-  const query = new SelectQuery(table).raw('COUNT(*) AS count').where('content', '!=', null).where('content', '!=', '');
-  if (sourcePredicate) {
-    query.whereExpr(sourcePredicate);
-  }
-
-  return buildSqlBuilder((sql) => {
-    sql.appendExpression(query);
-  });
 }
 
 export function buildCopySelectToParquetQuery(selectQuery: SqlBuilder, parquetPath: string): SqlBuilder {
@@ -245,6 +283,17 @@ export function buildManagedIcebergSetupQueries(options: ManagedIcebergSetupOpti
   return [
     ...buildManagedIcebergExtensionQueries(),
     buildManagedS3CredentialSecretQuery(options.s3Region),
+    /*
+     * the default is 524288, which can take a LOT of memory since we're copying
+     * JSON content data
+     */
+    'SET partitioned_write_flush_threshold = 10000;',
+    /*
+     * Misleading option.  This is to allow duckdb to insert into a "sorted table", which is really a hint anyway.
+     * https://github.com/duckdb/duckdb-iceberg/issues/851
+     * https://github.com/duckdb/duckdb-iceberg/pull/992
+     */
+    'SET unsafe_iceberg_ignore_sort_order=true',
     /*
      * See https://duckdb.org/docs/current/core_extensions/postgres/connection_pool
      * the default connection pool settings are very aggressive; many connections, much parallelism

--- a/packages/server/src/workers/data-warehouse-sync.test.ts
+++ b/packages/server/src/workers/data-warehouse-sync.test.ts
@@ -61,11 +61,13 @@ function setupSyncDataMock(): MockInstance<typeof syncModule.syncData> {
         destination: 'patient_history.parquet',
         rowsInserted: 1,
         syncDurationMs: 0,
+        watermarkDurationMs: 0,
       },
       {
         destination: 'observation_history.parquet',
         rowsInserted: 0,
         syncDurationMs: 0,
+        watermarkDurationMs: 0,
       },
     ],
   });

--- a/packages/server/src/workers/data-warehouse-sync.ts
+++ b/packages/server/src/workers/data-warehouse-sync.ts
@@ -176,6 +176,16 @@ export async function processDataWarehouseSyncJob(
 
       const syncOptions = getDataWarehouseSyncOptions(config);
 
+      globalLogger.info('Data warehouse sync starting', {
+        jobId: job.id,
+        trigger: job.data.trigger,
+        tablesTotal: syncOptions.warehouseSources.length,
+        startDate: syncOptions.startDate,
+        includeResourceTypes: syncOptions.includeResourceTypes,
+        excludeResourceTypes: syncOptions.excludeResourceTypes,
+        subsystem: 'data-warehouse-sync',
+      });
+
       const result = await syncData({
         ...syncOptions,
         onProgress: async (_message, metadata) => {
@@ -184,8 +194,10 @@ export async function processDataWarehouseSyncJob(
       });
 
       let syncDurationSeconds = 0;
+      let watermarkDurationSeconds = 0;
       for (const table of result.tables) {
         syncDurationSeconds += table.syncDurationMs / 1000;
+        watermarkDurationSeconds += table.watermarkDurationMs / 1000;
       }
 
       const tables = result.tables;
@@ -194,6 +206,7 @@ export async function processDataWarehouseSyncJob(
       const rowsInserted = tables.reduce((n, t) => n + t.rowsInserted, 0);
       const jobEndTime = new Date();
       const durationSeconds = (jobEndTime.getTime() - jobStartTime.getTime()) / 1000;
+
       globalLogger.info('Data warehouse sync completed', {
         jobId: job.id,
         trigger: job.data.trigger,
@@ -203,7 +216,17 @@ export async function processDataWarehouseSyncJob(
         tablesEmpty,
         rowsInserted,
         tableCounts: Object.fromEntries(tables.map((t) => [t.destination, t.rowsInserted])),
+        tableTimings: Object.fromEntries(
+          tables.map((t) => [
+            t.destination,
+            {
+              syncDurationMs: t.syncDurationMs,
+              watermarkDurationMs: t.watermarkDurationMs,
+            },
+          ])
+        ),
         syncDurationSeconds,
+        watermarkDurationSeconds,
         jobStartTime: jobStartTime.toISOString(),
         jobEndTime: jobEndTime.toISOString(),
         durationSeconds,


### PR DESCRIPTION
## Summary 

Read incremental sync watermarks via Iceberg's `upper_bounds` from manifest instead of scanning Parquet files. It's non-obvious that  `SELECT MAX(last_updated)` scans Parquet files, but it's an artifact of DuckDB's query planner limitations when it comes to Iceberg manifests and Parquet files.  See   https://github.com/duckdb/duckdb/pull/23611 and https://github.com/The-Alchemist/duckdb-iceberg/pull/5

## Background
As the data warehouse in production has grown, the number of Parquet files has grown, as each "tick" creates a new file.  AWS compaction helps but is un-deterministic, and with DuckDB's limited query planner, we end up having to hundreds of Parquet files in S3 in order to figure out the latest sync high watermark.

This is unnecessary and slow.  The Iceberg manifest contains the `lower_bound` and `upper_bound` fields which we can use to calculate `MAX`, but technically these are bounds and not-exact values.  HOWEVER, we are both the creators and readers of the Parquet and Iceberg files, and we have verified experimentally that these are, in fact, exact values using this combination of DuckDB and DuckDB-Iceberg.

[Iceberg v4 introduced `tight_bounds` for  reasons like this](https://iceberg.apache.org/spec/#field-statistics), but it's still in draft phase and we'll have to wait until support for it appears in AWS Athena, DuckDB, etc.


## Risks

Technically speaking, we are relying on DuckDB behavior instead of strict Iceberg documented fields.  However, as experiments and code analysis have born out, this is OK.  This optimization might not be true for all Iceberg readers, but that is not relevant to this use case. As evidence, you can look at the following DuckDB / DuckDB-Iceberg code to verify that this solution does not skip rows:

* iceberg_column_stats exposes those manifest bounds directly:  https://github.com/duckdb/duckdb-iceberg/blob/main/src/function/metadata/iceberg_column_stats.cpp
* Timestamp bounds are exact (not truncated like strings)
    * Write: [duckdb-iceberg/src/core/expression/iceberg_value.cpp — TIMESTAMP_TZ serialize](https://github.com/duckdb/duckdb-iceberg/blob/main/src/core/expression/iceberg_value.cpp#L392-L403)
  * Read: [duckdb-iceberg/src/core/expression/iceberg_value.cpp — TIMESTAMP_TZ deserialize](https://github.com/duckdb/duckdb-iceberg/blob/main/src/core/expression/iceberg_value.cpp#L162-L171)
* Stats deserialization: [duckdb-iceberg/src/planning/iceberg_multi_file_list.cpp — DeserializeBounds](https://github.com/duckdb/duckdb-iceberg/blob/main/src/planning/iceberg_multi_file_list.cpp#L630-L664)

* duckdb-iceberg writes these bounds on insert: 
[duckdb-iceberg/src/execution/operator/iceberg_insert.cpp](https://github.com/duckdb/duckdb-iceberg/blob/main/src/execution/operator/iceberg_insert.cpp#L338-L347)
* Same bounds power filter pushdown today: https://github.com/duckdb/duckdb-iceberg/blob/main/src/planning/iceberg_multi_file_list.cpp#L667-L810

## Query Plan and Performance Comparison


### Old

```sql
explain analyze select max(last_updated) from encounter_history;
```

```mermaid
flowchart TD
    node_0_0["`**QUERY**`"]

    node_0_1["`**EXPLAIN_ANALYZE**
        Cardinality: 0
        Timing: 0.00s`"]

    node_0_2["`**UNGROUPED_AGGREGATE**
        Aggregates: max(#0)
        Cardinality: 1
        Timing: 0.01s`"]

    node_0_3["`**PROJECTION**
        Projections: last_updated
        Estimated Cardinality: 1254453
        Cardinality: 1254453
        Timing: 0.00s`"]

    node_0_4["`**TABLE_SCAN**
        Function: ICEBERG_SCAN
        Projections: last_updated
        Estimated Cardinality: 1254453
        Total Files Read: 598
        Filename(s): s3://18dmx-12mc-1b.parquet, ...
        Cardinality: 1254453
        Timing: 68.74s`"]

    node_0_0 --> node_0_1
    node_0_1 --> node_0_2
    node_0_2 --> node_0_3
    node_0_3 --> node_0_4
```

### New

```sql
explain analyze 
SELECT max(try_cast(upper_bound AS TIMESTAMPTZ))     
     FROM iceberg_column_stats('iceberg_catalog.default.encounter_history')
WHERE
     column_name = 'last_updated' AND status != 'DELETED' ;
```

```mermaid

flowchart TD
    node_0_0["`**QUERY**`"]

    node_0_1["`**EXPLAIN_ANALYZE**
        Cardinality: 0
        Timing: 0.00s`"]

    node_0_2["`**UNGROUPED_AGGREGATE**
        Aggregates: max(#0)
        Cardinality: 1
        Timing: 0.00s`"]

    node_0_3["`**PROJECTION**
        Projections: TRY_CAST(upper_bound AS TIMESTAMP WITH TIME ZONE)
        Estimated Cardinality: 1
        Cardinality: 598
        Timing: 0.00s`"]

    node_0_4["`**PROJECTION**
        Projections: #2
        Estimated Cardinality: 1
        Cardinality: 598
        Timing: 0.00s`"]

    node_0_5["`**FILTER**
        Expression: ((column_name = 'last_updated') AND (status != 'DELETED'))
        Estimated Cardinality: 1
        Cardinality: 598
        Timing: 0.00s`"]

    node_0_6["`**PROJECTION**
        Projections: #3
        #0
        #6
        Estimated Cardinality: 1
        Cardinality: 2990
        Timing: 0.00s`"]

    node_0_7["`**TABLE_SCAN**
        Function: ICEBERG_COLUMN_STATS
        Estimated Cardinality: 1
        Cardinality: 2990
        Timing: 0.01s`"]

    node_0_0 --> node_0_1
    node_0_1 --> node_0_2
    node_0_2 --> node_0_3
    node_0_3 --> node_0_4
    node_0_4 --> node_0_5
    node_0_5 --> node_0_6
    node_0_6 --> node_0_7
```
