### PR TITLE
Update deploy-server.sh to pin images

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -107,53 +107,14 @@ jobs:
         env:
           SERVER_DOCKERHUB_REPOSITORY: ${{ secrets.STAGING_DOCKERHUB_REPOSITORY }}
 
-      - name: Get Server Task Definition
-        id: server-task-definition
-        run: |
-          task_definition="$(aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" --query 'services[0].taskDefinition' --output text)"
-          echo "task-definition=$task_definition" >> "$GITHUB_OUTPUT"
+      - name: Deploy Server
+        run: ./scripts/deploy-server.sh
         env:
+          SERVER_DOCKERHUB_REPOSITORY: ${{ secrets.STAGING_DOCKERHUB_REPOSITORY }}
           ECS_CLUSTER: ${{ secrets.STAGING_ECS_CLUSTER }}
           ECS_SERVICE: ${{ secrets.STAGING_ECS_SERVICE }}
-
-      - name: Render Server Task Definition
-        id: render-server-task-definition
-        uses: aws-actions/amazon-ecs-render-task-definition@138c24f321fdbdf7edee4a685519d253cae2cdea # v1.9.0
-        with:
-          task-definition-arn: ${{ steps.server-task-definition.outputs.task-definition }}
-          container-name: MedplumTaskDefinition
-          image: ${{ secrets.STAGING_DOCKERHUB_REPOSITORY }}:${{ github.sha }}
-
-      - name: Deploy Server Task Definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@c465972ecbd160473f22e683363b422a5412a3de # v2.6.3
-        with:
-          task-definition: ${{ steps.render-server-task-definition.outputs.task-definition }}
-          cluster: ${{ secrets.STAGING_ECS_CLUSTER }}
-          service: ${{ secrets.STAGING_ECS_SERVICE }}
-
-      - name: Get Worker Task Definition
-        id: worker-task-definition
-        run: |
-          task_definition="$(aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" --query 'services[0].taskDefinition' --output text)"
-          echo "task-definition=$task_definition" >> "$GITHUB_OUTPUT"
-        env:
-          ECS_CLUSTER: ${{ secrets.STAGING_WORKER_ECS_CLUSTER }}
-          ECS_SERVICE: ${{ secrets.STAGING_WORKER_ECS_SERVICE }}
-
-      - name: Render Worker Task Definition
-        id: render-worker-task-definition
-        uses: aws-actions/amazon-ecs-render-task-definition@138c24f321fdbdf7edee4a685519d253cae2cdea # v1.9.0
-        with:
-          task-definition-arn: ${{ steps.worker-task-definition.outputs.task-definition }}
-          container-name: BackgroundJobsWorkerContainer
-          image: ${{ secrets.STAGING_DOCKERHUB_REPOSITORY }}:${{ github.sha }}
-
-      - name: Deploy Worker Task Definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@c465972ecbd160473f22e683363b422a5412a3de # v2.6.3
-        with:
-          task-definition: ${{ steps.render-worker-task-definition.outputs.task-definition }}
-          cluster: ${{ secrets.STAGING_WORKER_ECS_CLUSTER }}
-          service: ${{ secrets.STAGING_WORKER_ECS_SERVICE }}
+          WORKER_ECS_CLUSTER: ${{ secrets.STAGING_WORKER_ECS_CLUSTER }}
+          WORKER_ECS_SERVICE: ${{ secrets.STAGING_WORKER_ECS_SERVICE }}
 
       - name: Deploy bot layer
         run: ./scripts/deploy-bot-layer.sh

--- a/scripts/build-docker-server.sh
+++ b/scripts/build-docker-server.sh
@@ -8,7 +8,7 @@ if [[ -z "${SERVER_DOCKERHUB_REPOSITORY}" ]]; then
   exit 1
 fi
 
-GITHUB_SHA="${GITHUB_SHA:-$(git rev-parse --short HEAD)}"
+GITHUB_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
 if [[ -z "${GITHUB_SHA}" ]]; then
   echo "GITHUB_SHA is missing"
   exit 1

--- a/scripts/deploy-server.sh
+++ b/scripts/deploy-server.sh
@@ -10,23 +10,85 @@ if [[ -z "${ECS_SERVICE}" ]]; then
   exit 1
 fi
 
+if [[ -z "${SERVER_DOCKERHUB_REPOSITORY}" ]]; then
+  echo "SERVER_DOCKERHUB_REPOSITORY is missing"
+  exit 1
+fi
+
+GITHUB_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
+if [[ -z "${GITHUB_SHA}" ]]; then
+  echo "GITHUB_SHA is missing"
+  exit 1
+fi
+
 # Fail on error
 set -e
 
 # Echo commands
 set -x
 
+# The immutable image we want the service to run
+IMAGE="${SERVER_DOCKERHUB_REPOSITORY}:${GITHUB_SHA}"
+
+# Pin an ECS service to $IMAGE by registering a new task definition revision
+# based on the currently-deployed one. This replaces `--force-new-deployment`
+# against a mutable `:latest` tag with a deploy of a specific git SHA.
+deploy_service() {
+  local cluster="$1"
+  local service="$2"
+
+  # Task definition ARN the service is currently running
+  local current_arn
+  current_arn=$(aws ecs describe-services \
+    --cluster "$cluster" \
+    --services "$service" \
+    --query 'services[0].taskDefinition' \
+    --output text)
+
+  # Fetch that task definition, swap the image tag on any container using our
+  # repository, and strip the read-only fields that register-task-definition
+  # rejects. Matching by repository (not container name) covers both the
+  # server container and the background-jobs worker container, which run the
+  # same image under different names.
+  local new_task_def
+  new_task_def=$(aws ecs describe-task-definition \
+    --task-definition "$current_arn" \
+    --query 'taskDefinition' \
+    --output json \
+    | jq --arg repo "$SERVER_DOCKERHUB_REPOSITORY" --arg image "$IMAGE" '
+        .containerDefinitions |= map(
+          if (.image | startswith($repo + ":")) then .image = $image else . end
+        )
+        | del(
+            .taskDefinitionArn,
+            .revision,
+            .status,
+            .requiresAttributes,
+            .compatibilities,
+            .registeredAt,
+            .registeredBy
+          )
+      ')
+
+  # Register the new revision
+  local new_arn
+  new_arn=$(aws ecs register-task-definition \
+    --cli-input-json "$new_task_def" \
+    --query 'taskDefinition.taskDefinitionArn' \
+    --output text)
+
+  # Point the service at the new revision
+  aws ecs update-service \
+    --cluster "$cluster" \
+    --service "$service" \
+    --task-definition "$new_arn"
+}
+
 # Update the medplum fargate service
-aws ecs update-service \
-  --cluster "$ECS_CLUSTER" \
-  --service "$ECS_SERVICE" \
-  --force-new-deployment
+deploy_service "$ECS_CLUSTER" "$ECS_SERVICE"
 
 # Optionally update a worker service if both env vars are set
 if [[ -n "${WORKER_ECS_CLUSTER}" && -n "${WORKER_ECS_SERVICE}" ]]; then
-  echo "Forcing new deployment of worker service $WORKER_ECS_SERVICE in $WORKER_ECS_CLUSTER"
-  aws ecs update-service \
-    --cluster "$WORKER_ECS_CLUSTER" \
-    --service "$WORKER_ECS_SERVICE" \
-    --force-new-deployment
+  echo "Deploying worker service $WORKER_ECS_SERVICE in $WORKER_ECS_CLUSTER"
+  deploy_service "$WORKER_ECS_CLUSTER" "$WORKER_ECS_SERVICE"
 fi

--- a/scripts/deploy-server.sh
+++ b/scripts/deploy-server.sh
@@ -23,6 +23,7 @@ fi
 
 # Fail on error
 set -e
+set -o pipefail
 
 # Echo commands
 set -x


### PR DESCRIPTION
Security flagged our production deployments for relying on the mutable Docker `:latest` tag. This PR removes that dependency for the ECS server and worker services: instead of forcing a new deployment against whatever `:latest` currently points at, we now register a task definition revision pinned to the immutable `:$GITHUB_SHA` image and deploy that specific revision.

Staging was already fixed in a prior change. This PR converges **both** environments onto a single deploy path so staging is a true rehearsal of prod.

## What was wrong

Production deploys flow through `deploy.yml` → `cicd-deploy.sh` → `deploy-server.sh`.

The old `deploy-server.sh` did:

```bash
aws ecs update-service --cluster "$ECS_CLUSTER" --service "$ECS_SERVICE" --force-new-deployment
```

`--force-new-deployment` re-pulls whatever image the *current* task definition references. Since that task definition pointed at `:latest`, every deploy depended on a mutable tag. This is the security finding: `:latest` can be overwritten, isn't auditable to a specific commit, and makes rollbacks and "what is actually running right now" ambiguous.

Note the `:$GITHUB_SHA` tag was **already being pushed** by `build-docker-server.sh` — it just wasn't the thing we deployed.

## What this PR does

- Rewrites `scripts/deploy-server.sh` to, for each service (server + optional worker): read the running task definition, swap the image on any container using our repository to `$SERVER_DOCKERHUB_REPOSITORY:$GITHUB_SHA`, strip the read-only fields, register a new revision, and point the service at it.
- Updates `.github/workflows/staging.yml` to call the same `deploy-server.sh` instead of the inline AWS-action steps, so staging and production run identical deploy logic.

No changes to `deploy.yml` are required — `SERVER_DOCKERHUB_REPOSITORY` and `GITHUB_SHA` are already in scope for the Deploy step.

## Why bash, and not GitHub Actions YAML

This was the main design decision, and we expect some reviewers to assume the fix "should" live in GitHub Actions YAML (mirroring the AWS actions used in staging). Here is the full reasoning.

The production deploy decision — *which* services to deploy — is made inside `cicd-deploy.sh`, in bash, by diffing the files changed in the push. Once control is inside that script, **you cannot invoke a GitHub Action**: the AWS `amazon-ecs-render-task-definition` / `amazon-ecs-deploy-task-definition` actions are only callable from workflow YAML. So the choice was never "bash vs. actions" in isolation — it was about *where the deploy decision lives*. We considered three options:

### Option 1 — Do the deploy in bash (chosen)

Reproduce what the AWS actions do — `describe-task-definition` → edit the image field → `register-task-definition` → `update-service --task-definition` — in ~15 lines of `aws` CLI + `jq`, right where the deploy already happens.

- **Smallest, most surgical change.** It fixes the problem at the exact line that had it. No workflow restructuring, no new job wiring, no changes to how the deploy decision is made.
- **Keeps the decide-and-execute flow intact.** `cicd-deploy.sh` remains the single place that decides what to deploy and then does it. We don't split that logic across a bash/YAML boundary.
- **The AWS actions aren't doing anything special.** They are thin wrappers around the same four `aws ecs` calls. Reproducing them in bash is low-risk and easy to read top-to-bottom.
- **Lets staging and prod share one code path** (see below), which is the best possible test coverage for a deploy script.
- Trade-off: we maintain a small amount of ECS deploy logic ourselves rather than delegating to a published action. We judged ~15 lines of well-understood CLI calls a smaller ongoing cost than the alternatives below.

### Option 2 — Move everything to GitHub Actions YAML

Move the file-diff decision logic out of bash and into the workflow (job outputs / a paths-filter action), then make every deploy step conditional and use the AWS actions.

- Largest change by far: the entire decide-what-to-deploy logic (~70 lines of bash covering many `packages/*` → service mappings) would be re-expressed in YAML.
- Duplicates orchestration between `staging.yml` and `deploy.yml` unless we also extract a reusable/composite action — more moving parts, more surface area.
- High blast radius on the one workflow we least want to destabilize, for a security finding that is actually narrow (only the ECS image reference).

### Option 3 — Hybrid: split "decide" from "deploy"

`cicd-deploy.sh` becomes decide-only and writes `deploy_server=true` etc. to
`$GITHUB_OUTPUT`; the server deploy moves up into conditional workflow steps
that reuse the AWS actions.

- Prod and staging would share the AWS-action mechanism — the main upside.
- But it creates a split-brain: the server deploy lives in YAML while the app, docs, and graphiql deploys (all S3-based and **not** affected by the `:latest` issue) stay in bash. Two orchestration styles for one pipeline.
- More disruptive than Option 1 for the same security outcome.

### Conclusion

The flagged problem is narrow: only the ECS server/worker deploy referenced `:latest`. Option 1 removes that dependency exactly where it lives, with the smallest diff, no workflow surgery, and — importantly — lets staging exercise the identical code path before anything reaches production. Options 2 and 3 are larger rewrites that don't buy a better security outcome; they'd be justified by a broader "move all CI/CD into YAML" goal, which is out of scope here.

We continue to **push** the `:latest` tag (self-hosters and docs reference it); we simply no longer **deploy** by it.

## Convergence: staging now runs the same script

`staging.yml` previously used the AWS actions inline (six steps: get/render/deploy for both the server and worker task definitions). Those are replaced with a single `Deploy Server` step invoking `scripts/deploy-server.sh` with the
`STAGING_*` secrets mapped onto the variable names the script expects. Every staging deploy is now a live rehearsal of the production deploy path.

## Implementation notes

- **Container matching is by repository, not name.** The script swaps the image on any container whose image starts with `$SERVER_DOCKERHUB_REPOSITORY:`. This covers both the server container and the background-jobs worker container
  (same image, different container names) with no per-service config, and leaves
  sidecars (e.g. an observability agent) untouched. The prior staging code
  matched by hardcoded container name (`MedplumTaskDefinition`, `BackgroundJobsWorkerContainer`); repository matching is equivalent as long as those containers run our image, which they do.
- **Stripped fields.** Before re-registering, we `del` the seven read-only fields that `register-task-definition` rejects (`taskDefinitionArn`, `revision`, `status`, `requiresAttributes`, `compatibilities`, `registeredAt`, `registeredBy`) — the same set the `amazon-ecs-render-task-definition` action removes.
- **Full SHA.** We deploy `:$GITHUB_SHA` (full 40-char SHA in CI), matching the tag `build-docker-server.sh` pushes.
- **No `--force-new-deployment` and no stability wait.** `update-service` with a new task-definition revision triggers a rollout on its own; we preserved the existing fire-and-forget behavior (no `aws ecs wait services-stable`).
