### PR TITLE
Fixes for pagination and job recovery in $set-accounts

### DIFF
--- a/packages/server/src/fhir/operations/set-accounts.test.ts
+++ b/packages/server/src/fhir/operations/set-accounts.test.ts
@@ -452,6 +452,72 @@ describe('Patient Set Accounts Operation', () => {
     );
   });
 
+  test('Job aborts when AsyncJob.status is not continuable', async () => {
+    const queue = getSetAccountsQueue() as any;
+    queue.add.mockClear();
+
+    // Start the operation
+    const initRes = await request(app)
+      .post(`/fhir/R4/Patient/${patient.id}/$set-accounts`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .set('Prefer', 'respond-async')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'accounts',
+            valueReference: createReference(organization1),
+          },
+          {
+            name: 'propagate',
+            valueBoolean: true,
+          },
+        ],
+      });
+    expect(initRes.status).toBe(202);
+    expect(initRes.headers['content-location']).toBeDefined();
+    const jobUrlMatch = /job\/([^/]+)\/status/.exec(initRes.headers['content-location']);
+    const asyncJobId = jobUrlMatch?.[1];
+
+    // Cancel the job by updating AsyncJob.status
+    const cancelRes = await request(app)
+      .patch(`/fhir/R4/AsyncJob/${asyncJobId}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send([{ op: 'replace', path: '/status', value: 'cancelled' }]);
+    expect(cancelRes.status).toBe(200);
+
+    // Manually push through BullMQ job
+    expect(queue.add).toHaveBeenCalledWith(
+      'SetAccountsJobData',
+      expect.objectContaining<Partial<SetAccountsJobData>>({ resourceType: 'Patient', id: patient.id })
+    );
+
+    const job = { id: 1, data: queue.add.mock.calls[0][1] } as unknown as Job;
+    queue.add.mockClear();
+
+    await runInAuthenticatedContext(
+      { login, membership, project, userConfig: {} as unknown as UserConfiguration },
+      undefined,
+      undefined,
+      { async: true },
+      () => execSetAccountsJob(job)
+    );
+
+    // Check that the job status doesn't update and no output is provided
+    const contentLocation = new URL(initRes.headers['content-location']);
+    await waitForAsyncJob(initRes.headers['content-location'], app, accessToken);
+
+    const statusRes = await request(app)
+      .get(contentLocation.pathname)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(statusRes.status).toBe(200);
+    const resBody = statusRes.body as AsyncJob;
+    expect(resBody.status).toStrictEqual('cancelled');
+    expect(resBody.output?.parameter).toBeUndefined();
+  });
+
   test('Removes account without extended header', async () => {
     const setTwo = await request(app)
       .post(`/fhir/R4/Patient/${patient.id}/$set-accounts`)

--- a/packages/server/src/fhir/operations/set-accounts.ts
+++ b/packages/server/src/fhir/operations/set-accounts.ts
@@ -16,10 +16,11 @@ import {
   parseSearchRequest,
 } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Parameters, Reference, Resource, ResourceType } from '@medplum/fhirtypes';
+import type { AsyncJob, Parameters, Reference, Resource, ResourceType } from '@medplum/fhirtypes';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import { addSetAccountsJobData } from '../../workers/set-accounts';
+import { CancelledError } from '../../workers/utils';
 import type { Repository, SystemRepository } from '../repo';
 import { makeOperationDefinition } from './definitions';
 import { searchPatientCompartment } from './patienteverything';
@@ -110,20 +111,35 @@ export async function setAccountsHandler(req: FhirRequest): Promise<FhirResponse
   }
 }
 
+export async function setResourceAccounts(
+  repo: Repository,
+  resourceType: ResourceType,
+  id: string,
+  params: SetAccountsParameters
+): Promise<Parameters>;
+export async function setResourceAccounts(
+  repo: Repository,
+  resourceType: ResourceType,
+  id: string,
+  params: SetAccountsParameters,
+  asyncJobId: string
+): Promise<Parameters | undefined>;
 /**
  * Sets the `meta.accounts` array for the given resource, and optionally all resources in its compartment.
  * @param repo - The FHIR repository of the user.
  * @param resourceType - The type of the target resource.
  * @param id - The ID of the target resource.
  * @param params - Operation parameters.
- * @returns The number of resources updated.
+ * @param asyncJobId - (Optional) ID to use to track the status of the parent job.
+ * @returns The number of resources updated, or undefined if the operation could not finish.
  */
 export async function setResourceAccounts(
   repo: Repository,
   resourceType: ResourceType,
   id: string,
-  params: SetAccountsParameters
-): Promise<Parameters> {
+  params: SetAccountsParameters,
+  asyncJobId?: string
+): Promise<Parameters | undefined> {
   const isSuperAdmin = repo.isSuperAdmin();
   if (!repo.isProjectAdmin() && !isSuperAdmin) {
     throw new OperationOutcomeError(forbidden);
@@ -164,6 +180,13 @@ export async function setResourceAccounts(
     const search: Partial<SearchRequest> = { offset: 0, count: 1000 };
     const maxSearchOffset = getConfig().maxSearchOffset ?? Number.POSITIVE_INFINITY;
     while ((search.offset ?? 0) <= maxSearchOffset) {
+      if (asyncJobId) {
+        const shouldContinue = await shouldJobContinue(systemRepo, asyncJobId);
+        if (!shouldContinue) {
+          throw new CancelledError('Job cancelled');
+        }
+      }
+
       const bundle = await searchPatientCompartment(userRepo, target, search);
       for (const entry of bundle.entry ?? EMPTY) {
         const resource = entry.resource;
@@ -174,8 +197,10 @@ export async function setResourceAccounts(
       }
       const nextLink = bundle.link?.find((l) => l.relation === 'next');
       if (nextLink?.url) {
+        // Update search pagination to next page
         const nextSearch = parseSearchRequest(nextLink.url);
         search.offset = nextSearch.offset;
+        search.cursor = nextSearch.cursor;
       } else {
         break;
       }
@@ -212,4 +237,10 @@ async function updateCompartmentResource<T extends Resource>(
   // Use system repo to force update meta.accounts
   await getAuthenticatedContext().fhirRateLimiter?.recordWrite();
   return systemRepo.updateResource(resource);
+}
+
+const healthyJobStatuses: AsyncJob['status'][] = ['accepted', 'active'];
+async function shouldJobContinue(systemRepo: SystemRepository, asyncJobId: string): Promise<boolean> {
+  const asyncJob = await systemRepo.readResource<AsyncJob>('AsyncJob', asyncJobId);
+  return healthyJobStatuses.includes(asyncJob.status);
 }

--- a/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
+++ b/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
@@ -12,6 +12,7 @@ import { DatabaseMode, getDatabasePool } from '../../../database';
 import { getLogger } from '../../../logger';
 import { markPostDeployMigrationCompleted } from '../../../migration-sql';
 import { maybeAutoRunPendingPostDeployMigration } from '../../../migrations/migration-utils';
+import { CancelledError } from '../../../workers/utils';
 import { sendOutcome } from '../../outcomes';
 import type { Repository } from '../../repo';
 
@@ -137,6 +138,10 @@ export class AsyncJobExecutor {
     // to handle.
     if (err instanceof DelayedError) {
       throw err;
+    }
+    // Job has been cancelled: do not update the async job with additional data
+    if (err instanceof CancelledError) {
+      return this.resource;
     }
 
     const failedJob: WithId<AsyncJob> = {

--- a/packages/server/src/workers/set-accounts.ts
+++ b/packages/server/src/workers/set-accounts.ts
@@ -13,7 +13,7 @@ import { getShardSystemRepo } from '../fhir/repo';
 import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
 import type { AuthState } from '../oauth/middleware';
 import type { WorkerInitializer, WorkerInitializerOptions } from './utils';
-import { defaultQueueOptions, getWorkerBullmqConfig, queueRegistry } from './utils';
+import { addVerboseQueueLogging, defaultQueueOptions, getWorkerBullmqConfig, queueRegistry } from './utils';
 
 /*
  * The set-accounts worker asynchronously updates all account references
@@ -53,6 +53,9 @@ export const initSetAccountsWorker: WorkerInitializer = (config, options?: Worke
         ...workerBullmq,
       }
     );
+    addVerboseQueueLogging<SetAccountsJobData>(queue, worker, (job) => ({
+      asyncJob: 'AsyncJob/' + job.data.asyncJob.id,
+    }));
 
     worker.on('failed', async (job) => {
       if (!job) {
@@ -92,7 +95,7 @@ export async function addSetAccountsJobData(job: SetAccountsJobData): Promise<Jo
 }
 
 export async function execSetAccountsJob(job: Job<SetAccountsJobData>): Promise<void> {
-  const { resourceType, id, accounts } = job.data;
+  const { resourceType, id, accounts, asyncJob } = job.data;
   const { login, project, membership } = job.data.authState;
   const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // job.data will eventually include shardId
 
@@ -100,8 +103,8 @@ export async function execSetAccountsJob(job: Job<SetAccountsJobData>): Promise<
   const userConfig = await getUserConfiguration(systemRepo, project, membership);
   const repo = await getRepoForLogin({ login, project, membership, userConfig }, true);
 
-  const exec = new AsyncJobExecutor(repo, job.data.asyncJob);
+  const exec = new AsyncJobExecutor(repo, asyncJob);
   await exec.startAsync(async () => {
-    return setResourceAccounts(repo, resourceType, id, { accounts, propagate: true });
+    return setResourceAccounts(repo, resourceType, id, { accounts, propagate: true }, asyncJob.id);
   });
 }

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -308,3 +308,5 @@ export function defaultQueueOptions(config: MedplumServerConfig): QueueOptions {
     },
   };
 }
+
+export class CancelledError extends Error {}

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -309,4 +309,6 @@ export function defaultQueueOptions(config: MedplumServerConfig): QueueOptions {
   };
 }
 
-export class CancelledError extends Error {}
+export class CancelledError extends Error {
+  name = 'CancelledError';
+}


### PR DESCRIPTION
- Fixed search pagination to handle new `cursor` output from `Patient/$everything`
- Added verbose queue logging for async `$set-accounts`
- Check for `AsyncJob.status` on each `$set-accounts` loop iteration to fail fast on job cancel