### PR TITLE
feat(app): add UI for submitting async batches

### DIFF
--- a/packages/app/src/AppRoutes.tsx
+++ b/packages/app/src/AppRoutes.tsx
@@ -80,6 +80,7 @@ export function AppRoutes(): JSX.Element {
         <Route path="/changepassword" element={<ChangePasswordPage />} />
         <Route path="/security" element={<SecurityPage />} />
         <Route path="/mfa" element={<MfaPage />} />
+        <Route path="/batch/:tab" element={<BatchPage />} />
         <Route path="/batch" element={<BatchPage />} />
         <Route path="/bulk/:resourceType" element={<BulkAppPage />} />
         <Route path="/smart" element={<SmartSearchPage />} />

--- a/packages/app/src/BatchPage.test.tsx
+++ b/packages/app/src/BatchPage.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { ContentType } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router';
@@ -251,6 +252,63 @@ describe('BatchPage', () => {
     await waitFor(() => {
       expect(postSpy).toHaveBeenCalled();
       expect(screen.getByTestId('batch-input')).toHaveValue('{"resourceType": "Bundle"}');
+    });
+  });
+
+  test('Submit Async Batch', async () => {
+    const postSpy = vi.spyOn(medplum, 'post');
+    const { user } = setup();
+
+    await user.click(screen.getByRole('tab', { name: 'JSON' }));
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('batch-input'), {
+        target: {
+          value: exampleBundle,
+        },
+      });
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Submit Async Batch' }));
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalled();
+    });
+
+    const [url, body, contentType, options] = postSpy.mock.calls[0];
+    expect(url.toString()).toStrictEqual(medplum.fhirUrl().toString());
+    expect(body).toMatchObject({ resourceType: 'Bundle' });
+    expect(contentType).toStrictEqual(ContentType.FHIR_JSON);
+    expect(options).toMatchObject({ headers: { Prefer: 'respond-async' } });
+  });
+
+  test('Shows batch jobs and downloads results', async () => {
+    const asyncJob = await medplum.createResource({
+      resourceType: 'AsyncJob',
+      status: 'completed',
+      requestTime: new Date().toISOString(),
+      request: medplum.fhirUrl().toString(),
+      output: {
+        resourceType: 'Parameters',
+        parameter: [{ name: 'results', valueReference: { reference: 'Binary/test-binary' } }],
+      },
+    });
+
+    window.URL.createObjectURL = vi.fn(() => 'blob:http://localhost/blob');
+    window.URL.revokeObjectURL = vi.fn();
+    const downloadSpy = vi
+      .spyOn(medplum, 'download')
+      .mockResolvedValue(new Blob(['{}'], { type: 'application/fhir+json' }));
+
+    const { user } = setup();
+
+    await user.click(screen.getByRole('tab', { name: 'Batch Jobs' }));
+
+    expect(await screen.findByText(asyncJob.id)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Download' }));
+
+    await waitFor(() => {
+      expect(downloadSpy).toHaveBeenCalledWith('Binary/test-binary');
     });
   });
 

--- a/packages/app/src/BatchPage.tsx
+++ b/packages/app/src/BatchPage.tsx
@@ -5,8 +5,10 @@ import {
   Button,
   Group,
   JsonInput,
+  LoadingOverlay,
   Modal,
   Stack,
+  Table,
   Tabs,
   Text,
   TextInput,
@@ -17,12 +19,24 @@ import type { FileWithPath } from '@mantine/dropzone';
 import { Dropzone } from '@mantine/dropzone';
 import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
-import { convertToTransactionBundle, normalizeErrorString, stringify } from '@medplum/core';
-import type { Bundle, Parameters, Resource } from '@medplum/fhirtypes';
-import { Document, Form, QrCodeScanner, useMedplum } from '@medplum/react';
-import { IconCheck, IconUpload, IconX } from '@tabler/icons-react';
+import type { SearchRequest, WithId } from '@medplum/core';
+import {
+  ContentType,
+  convertToTransactionBundle,
+  formatSearchQuery,
+  normalizeErrorString,
+  stringify,
+} from '@medplum/core';
+import type { AsyncJob, Bundle, OperationOutcome, Parameters, Resource } from '@medplum/fhirtypes';
+import { Document, Form, LinkTabs, MedplumLink, QrCodeScanner, useMedplum } from '@medplum/react';
+import { IconCheck, IconRefresh, IconUpload, IconX } from '@tabler/icons-react';
 import type { JSX } from 'react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+
+const PAGE_TABS = [
+  { label: 'Submit Batch', value: 'submit' },
+  { label: 'Batch Jobs', value: 'jobs' },
+];
 
 const DEFAULT_VALUE = `{"resourceType": "Bundle"}`;
 
@@ -103,6 +117,49 @@ export function BatchPage(): JSX.Element {
         showNotification({
           id,
           title: 'Batch Upload Failed',
+          color: 'red',
+          message: normalizeErrorString(err),
+          method: 'update',
+          icon: <IconX size="1rem" />,
+          withCloseButton: true,
+        });
+      }
+    },
+    [medplum]
+  );
+
+  const submitBatchAsync = useCallback(
+    async (str: string) => {
+      const id = 'batch-async-upload';
+      showNotification({
+        id,
+        title: 'Async Batch Submission in Progress',
+        message: 'Your batch job is being submitted...',
+        method: 'show',
+        loading: true,
+      });
+
+      try {
+        let bundle = JSON.parse(str) as Bundle;
+        if (bundle.type !== 'batch' && bundle.type !== 'transaction') {
+          bundle = convertToTransactionBundle(bundle);
+        }
+        await medplum.post<OperationOutcome>(medplum.fhirUrl(), bundle, ContentType.FHIR_JSON, {
+          headers: { Prefer: 'respond-async' },
+        });
+        showNotification({
+          id,
+          title: 'Async Batch Submitted',
+          message: 'Your batch job was submitted. See the "Batch Jobs" tab for status.',
+          color: 'green',
+          method: 'update',
+          icon: <IconCheck size="1rem" />,
+          withCloseButton: true,
+        });
+      } catch (err) {
+        showNotification({
+          id,
+          title: 'Async Batch Submission Failed',
           color: 'red',
           message: normalizeErrorString(err),
           method: 'update',
@@ -249,81 +306,91 @@ export function BatchPage(): JSX.Element {
         Use this page to create, read, or update multiple resources. For more details, see{' '}
         <Anchor href="https://www.hl7.org/fhir/http.html#transaction">FHIR Batch and Transaction</Anchor>.
       </Text>
-      {Object.keys(output).length === 0 && (
-        <Tabs defaultValue="upload" mt="xl">
-          <Tabs.List>
-            <Tabs.Tab value="upload">File Upload</Tabs.Tab>
-            <Tabs.Tab value="json">JSON</Tabs.Tab>
-          </Tabs.List>
+      <LinkTabs baseUrl="/batch" tabs={PAGE_TABS} mt="xl" keepMounted={false}>
+        <Tabs.Panel value="submit" pt="md">
+          {Object.keys(output).length === 0 && (
+            <Tabs defaultValue="upload">
+              <Tabs.List>
+                <Tabs.Tab value="upload">File Upload</Tabs.Tab>
+                <Tabs.Tab value="json">JSON</Tabs.Tab>
+              </Tabs.List>
 
-          <Tabs.Panel value="upload" pt="xs">
-            <Dropzone onDrop={handleFiles} accept={['application/json']}>
-              <Group justify="center" gap="xl" style={{ minHeight: 220, pointerEvents: 'none' }}>
-                <Dropzone.Accept>
-                  <IconUpload size={50} stroke={1.5} color={theme.colors[theme.primaryColor][5]} />
-                </Dropzone.Accept>
-                <Dropzone.Reject>
-                  <IconX size={50} stroke={1.5} color={theme.colors.red[5]} />
-                </Dropzone.Reject>
-                <Dropzone.Idle>
-                  <IconUpload size={50} stroke={1.5} />
-                </Dropzone.Idle>
+              <Tabs.Panel value="upload" pt="xs">
+                <Dropzone onDrop={handleFiles} accept={['application/json']}>
+                  <Group justify="center" gap="xl" style={{ minHeight: 220, pointerEvents: 'none' }}>
+                    <Dropzone.Accept>
+                      <IconUpload size={50} stroke={1.5} color={theme.colors[theme.primaryColor][5]} />
+                    </Dropzone.Accept>
+                    <Dropzone.Reject>
+                      <IconX size={50} stroke={1.5} color={theme.colors.red[5]} />
+                    </Dropzone.Reject>
+                    <Dropzone.Idle>
+                      <IconUpload size={50} stroke={1.5} />
+                    </Dropzone.Idle>
 
-                <div>
-                  <Text size="xl" inline>
-                    Drag files here or click to select files
-                  </Text>
-                  <Text size="sm" color="dimmed" inline mt={7}>
-                    Attach as many files as you like
-                  </Text>
-                </div>
-              </Group>
-            </Dropzone>
-          </Tabs.Panel>
-
-          <Tabs.Panel value="json" pt="xs">
-            <Form onSubmit={handleJson}>
-              <JsonInput
-                data-testid="batch-input"
-                name="input"
-                autosize
-                minRows={20}
-                value={value}
-                onChange={setValue}
-                deserialize={JSON.parse}
-              />
-              <Group justify="flex-end" mt="xl" wrap="nowrap">
-                <Button type="submit">Submit</Button>
-                <Button variant="default" onClick={() => smartScanDisclosure[1].open()}>
-                  SMART
-                </Button>
-              </Group>
-            </Form>
-          </Tabs.Panel>
-        </Tabs>
-      )}
-      {Object.keys(output).length > 0 && (
-        <>
-          <h3>Output</h3>
-          <Tabs defaultValue={Object.keys(output)[0]}>
-            <Tabs.List>
-              {Object.keys(output).map((name) => (
-                <Tabs.Tab key={name} value={name}>
-                  {name}
-                </Tabs.Tab>
-              ))}
-            </Tabs.List>
-            {Object.keys(output).map((name) => (
-              <Tabs.Panel key={name} value={name}>
-                <pre style={{ border: '1px solid #888' }}>{JSON.stringify(output[name], undefined, 2)}</pre>
+                    <div>
+                      <Text size="xl" inline>
+                        Drag files here or click to select files
+                      </Text>
+                      <Text size="sm" color="dimmed" inline mt={7}>
+                        Attach as many files as you like
+                      </Text>
+                    </div>
+                  </Group>
+                </Dropzone>
               </Tabs.Panel>
-            ))}
-          </Tabs>
-          <Group justify="flex-end" mt="xl" wrap="nowrap">
-            <Button onClick={() => setOutput({})}>Start over</Button>
-          </Group>
-        </>
-      )}
+
+              <Tabs.Panel value="json" pt="xs">
+                <Form onSubmit={handleJson}>
+                  <JsonInput
+                    data-testid="batch-input"
+                    name="input"
+                    autosize
+                    minRows={20}
+                    value={value}
+                    onChange={setValue}
+                    deserialize={JSON.parse}
+                  />
+                  <Group justify="flex-end" mt="xl" wrap="nowrap">
+                    <Button type="submit">Submit</Button>
+                    <Button variant="default" onClick={() => submitBatchAsync(value)}>
+                      Submit Async Batch
+                    </Button>
+                    <Button variant="default" onClick={() => smartScanDisclosure[1].open()}>
+                      SMART
+                    </Button>
+                  </Group>
+                </Form>
+              </Tabs.Panel>
+            </Tabs>
+          )}
+          {Object.keys(output).length > 0 && (
+            <>
+              <h3>Output</h3>
+              <Tabs defaultValue={Object.keys(output)[0]}>
+                <Tabs.List>
+                  {Object.keys(output).map((name) => (
+                    <Tabs.Tab key={name} value={name}>
+                      {name}
+                    </Tabs.Tab>
+                  ))}
+                </Tabs.List>
+                {Object.keys(output).map((name) => (
+                  <Tabs.Panel key={name} value={name}>
+                    <pre style={{ border: '1px solid #888' }}>{JSON.stringify(output[name], undefined, 2)}</pre>
+                  </Tabs.Panel>
+                ))}
+              </Tabs>
+              <Group justify="flex-end" mt="xl" wrap="nowrap">
+                <Button onClick={() => setOutput({})}>Start over</Button>
+              </Group>
+            </>
+          )}
+        </Tabs.Panel>
+        <Tabs.Panel value="jobs" pt="md">
+          <BatchJobsPanel />
+        </Tabs.Panel>
+      </LinkTabs>
       <Modal title="SMART" size="xl" opened={smartScanDisclosure[0]} onClose={smartScanDisclosure[1].close}>
         <Stack>
           <Group align="end">
@@ -353,5 +420,124 @@ export function BatchPage(): JSX.Element {
         </Stack>
       </Modal>
     </Document>
+  );
+}
+
+const BATCH_ASYNCJOB_SEARCH: SearchRequest = {
+  resourceType: 'AsyncJob',
+  fields: ['id', '_lastUpdated', 'request', 'status', 'requestTime'],
+  sortRules: [{ code: '_lastUpdated', descending: true }],
+  count: 100,
+};
+
+function isBatchAsyncJob(job: AsyncJob, fhirBaseUrl: URL): boolean {
+  if (!job.request) {
+    return false;
+  }
+  try {
+    return new URL(job.request).pathname === fhirBaseUrl.pathname;
+  } catch {
+    return false;
+  }
+}
+
+function BatchJobsPanel(): JSX.Element {
+  const medplum = useMedplum();
+  const [jobs, setJobs] = useState<WithId<AsyncJob>[]>();
+  const [loading, setLoading] = useState(false);
+  const [refreshCounter, setRefreshCounter] = useState(0);
+
+  useEffect(() => {
+    setLoading(true);
+    medplum
+      .searchResources('AsyncJob', formatSearchQuery(BATCH_ASYNCJOB_SEARCH), { cache: 'no-cache' })
+      .then((result) => {
+        setJobs(result.filter((job) => isBatchAsyncJob(job, medplum.fhirUrl())));
+      })
+      .catch((err) => {
+        notifications.show({ color: 'red', message: normalizeErrorString(err), autoClose: false });
+      })
+      .finally(() => setLoading(false));
+  }, [medplum, refreshCounter]);
+
+  const downloadResults = useCallback(
+    async (job: WithId<AsyncJob>) => {
+      const reference = job.output?.parameter?.find((p) => p.name === 'results')?.valueReference?.reference;
+      if (!reference) {
+        notifications.show({ color: 'red', message: 'No results are available for this job.', autoClose: false });
+        return;
+      }
+      try {
+        const blob = await medplum.download(reference);
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `batch-result-${job.id}.json`;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(url);
+      } catch (err) {
+        notifications.show({ color: 'red', message: normalizeErrorString(err), autoClose: false });
+      }
+    },
+    [medplum]
+  );
+
+  return (
+    <Stack>
+      <Group justify="flex-end">
+        <Button
+          size="xs"
+          variant="subtle"
+          leftSection={<IconRefresh size={14} />}
+          onClick={() => setRefreshCounter((prev) => prev + 1)}
+          loading={loading}
+        >
+          Refresh
+        </Button>
+      </Group>
+      <div style={{ position: 'relative' }}>
+        <LoadingOverlay visible={loading} />
+        <Table>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Job</Table.Th>
+              <Table.Th>Status</Table.Th>
+              <Table.Th>Request Time</Table.Th>
+              <Table.Th>Last Updated</Table.Th>
+              <Table.Th>Results</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {jobs?.length ? (
+              jobs.map((job) => (
+                <Table.Tr key={job.id}>
+                  <Table.Td>
+                    <MedplumLink to={`/AsyncJob/${job.id}`}>{job.id}</MedplumLink>
+                  </Table.Td>
+                  <Table.Td>{job.status}</Table.Td>
+                  <Table.Td>{job.requestTime}</Table.Td>
+                  <Table.Td>{job.meta?.lastUpdated}</Table.Td>
+                  <Table.Td>
+                    <Button
+                      size="xs"
+                      disabled={job.status !== 'completed'}
+                      onClick={() => downloadResults(job).catch(console.error)}
+                    >
+                      Download
+                    </Button>
+                  </Table.Td>
+                </Table.Tr>
+              ))
+            ) : (
+              <Table.Tr>
+                <Table.Td colSpan={5}>{loading ? '' : 'No batch jobs found'}</Table.Td>
+              </Table.Tr>
+            )}
+          </Table.Tbody>
+        </Table>
+      </div>
+    </Stack>
   );
 }


### PR DESCRIPTION
Adds a "Submit Async Batch" button that submits the bundle with `Prefer: respond-async`, and a "Batch Jobs" tab that lists the project's batch AsyncJobs with a button to download completed results from the underlying Binary