### PR TITLE
docs: fix small documentation typos and casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ to our documentation, you can help others who might have a similar use case!
 Our documentation is hosted on [medplum.com/docs](https://www.medplum.com/docs), but it is built from [Markdown](https://www.markdownguide.org/)
 files in our [`docs` package](https://github.com/medplum/medplum/tree/main/packages/docs/docs).
 
-For relatively small changes, you can edit files directly from your web browser on [Github.dev](https://github.dev/medplum/medplum/blob/main/packages/docs/docs/home.md)
+For relatively small changes, you can edit files directly from your web browser on [GitHub.dev](https://github.dev/medplum/medplum/blob/main/packages/docs/docs/home.md)
 without needing to clone the repository.
 
 #### Fixing a bug or implementing a new feature

--- a/examples/medplum-photon-integration/README.md
+++ b/examples/medplum-photon-integration/README.md
@@ -71,7 +71,7 @@ Once your Neutron project is created, you will need to set up credentials for th
 
 #### Photon Auth Token
 
-This app reads and writes from Neutron's API, which requires the auth token from your Nuetron project. Authentication is handled by bots, but the necessary secrets must be set up in your Medplum project.
+This app reads and writes from Neutron's API, which requires the auth token from your Neutron project. Authentication is handled by bots, but the necessary secrets must be set up in your Medplum project.
 
 These credentials can be accessed in your [Neutron project](https://app.neutron.health) by navigating to your project settings and clicking on the Developers Tab. Copy the Client ID and Client Secret from the Machine to Machine Application section. If this section does not appear in your settings, you will need to reach out to Photon Support at `support@photon.health` to ensure that it is properly set up.
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -4,7 +4,7 @@ On-prem agent for device connectivity.
 
 ## Building
 
-Published releases are built using Github Actions. See the [build-agent workflow](../../.github/workflows/build-agent.yml) for details.
+Published releases are built using GitHub Actions. See the [build-agent workflow](../../.github/workflows/build-agent.yml) for details.
 
 The following tools are used to build the agent:
 

--- a/packages/docs/docs/bots/bot-for-questionnaire-response/bot-for-questionnaire-response.md
+++ b/packages/docs/docs/bots/bot-for-questionnaire-response/bot-for-questionnaire-response.md
@@ -91,7 +91,7 @@ Let’s take a look at the resource that is created:
 
 ### 4. Write the Bot
 
-Next, we'll write a Bot that creates a [Patient](/docs/api/fhir/resources/patient) and [ServiceRequest](/docs/api/fhir/resources/servicerequest) based on the the user's response. To learn how to set up a new Bot, see the [Bot Basics tutorial](./bot-basics)
+Next, we'll write a Bot that creates a [Patient](/docs/api/fhir/resources/patient) and [ServiceRequest](/docs/api/fhir/resources/servicerequest) based on the user's response. To learn how to set up a new Bot, see the [Bot Basics tutorial](./bot-basics)
 
 To parse out the answers in the '[QuestionnaireResponse](/docs/api/fhir/resources/questionnaireresponse), we'll use the [`getQuestionnaireAnswers`](/docs/sdk/core.getquestionnaireanswers) utility function. This function returns a map from the question's `linkId` to the response.
 
@@ -101,7 +101,7 @@ To parse out the answers in the '[QuestionnaireResponse](/docs/api/fhir/resource
 const response = event.input as QuestionnaireResponse;
 const answers = getQuestionnaireAnswers(response);
 
-// Read out the the user's answers into separate variables
+// Read out the user's answers into separate variables
 // Here we provide default answers if the user's answer is 'undefined'
 const firstName = answers['firstName']?.valueString || '';
 const lastName = answers['lastName']?.valueString || '';
@@ -123,7 +123,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent): Promise<
   // a map of [linkId, answer] pairs.
   const answers = getQuestionnaireAnswers(response);
 
-  // Read out the the user's answers into separate variables
+  // Read out the user's answers into separate variables
   // Here we provide default answers if the user's answer is 'undefined'
   const firstName = answers['firstName']?.valueString || '';
   const lastName = answers['lastName']?.valueString || '';

--- a/packages/docs/docs/bots/unit-testing-bots.mdx
+++ b/packages/docs/docs/bots/unit-testing-bots.mdx
@@ -16,7 +16,7 @@ Medplum provides the [`MockClient`](https://github.com/medplum/medplum/blob/main
 
 ## Set up your test framework
 
-The first step is to set up your test framework in your Bots package. Medplum Bots will should work with any typescript/javascript test runner, and the Medplum team has tested our bots with [jest](https://jestjs.io/) and [vitest](https://vitest.dev/). Follow the instructions for your favorite framework to set up you package.
+The first step is to set up your test framework in your Bots package. Medplum Bots should work with any TypeScript/JavaScript test runner, and the Medplum team has tested our bots with [Jest](https://jestjs.io/) and [Vitest](https://vitest.dev/). Follow the instructions for your favorite framework to set up your package.
 
 Next you'll want to index the FHIR schema definitions. To keep the client small, the `MockClient` class only ships with a subset of the FHIR schema. Index the full schema as shown below, either in a [`beforeAll` function](https://vitest.dev/api/#beforeall) or [setup file](https://vitest.dev/config/#setupfiles), to make sure your [test queries](#query-the-results) work.
 

--- a/packages/docs/docs/integration/index.md
+++ b/packages/docs/docs/integration/index.md
@@ -48,10 +48,10 @@ Medplum supports the following first party integrations.
       <td><a href="/docs/auth/external-identity-providers">Entra Auth Setup</a></td>
     </tr>
     <tr>
-      <td><a href="https://www.google.com/recaptcha/about/">Recaptcha</a></td>
+      <td><a href="https://www.google.com/recaptcha/about/">reCAPTCHA</a></td>
       <td>Security</td>
-      <td>Enable recaptcha on patient registration</td>
-      <td><a href="/docs/user-management/custom-emails#setup-recaptcha">Setup recaptcha</a></td>
+      <td>Enable reCAPTCHA on patient registration</td>
+      <td><a href="/docs/user-management/custom-emails#setup-recaptcha">Set up reCAPTCHA</a></td>
     </tr>
     <tr style={{backgroundColor: '#f6f8fa'}}>
       <td colspan="4"><strong>Clinical Systems (EHR, HIE, Labs)</strong></td>
@@ -336,7 +336,7 @@ Complex integrations are built by composing [bots](/docs/bots/), [subscriptions]
 
 - [Running on localhost](/docs/contributing/run-the-stack) is useful for testing integrations
 - [CLI](/docs/cli/external-fhir-servers) is commonly used to test connectivity to external FHIR Servers
-- [Integration Features and Fixes](https://github.com/medplum/medplum/pulls?q=is%3Apr+label%3Aintegration) on Github show the code that powers many of the integrations.
+- [Integration Features and Fixes](https://github.com/medplum/medplum/pulls?q=is%3Apr+label%3Aintegration) on GitHub show the code that powers many of the integrations.
 - [Audit and Logging Features](https://github.com/medplum/medplum/pulls?q=is%3Apr+label%3Aaudit-logging) show several security and observability integrations.
 - [Bot Pull Requests](https://github.com/medplum/medplum/issues?q=label%3Abots) can be good reference material for how integrations work.
 - [Auth Pull Requests](https://github.com/medplum/medplum/pulls?q=is%3Apr+label%3Aauth) can also be good reference material for integration planning and learning.

--- a/packages/docs/docs/self-hosting/load-testing.md
+++ b/packages/docs/docs/self-hosting/load-testing.md
@@ -28,7 +28,7 @@ Artillery Scenarios define the steps you want the virtual users to go through du
 
 ### Healthcheck Testing
 
-One of the most basic Medplum server endpoints is the healtcheck at `/healthcheck`. This endpoint is unauthenticated. It connects to the Postgres database and Redis cache to verify connectivity. The healthcheck endpoint is used by load balancers to determine if the server instance is healthy.
+One of the most basic Medplum server endpoints is the healthcheck at `/healthcheck`. This endpoint is unauthenticated. It connects to the Postgres database and Redis cache to verify connectivity. The healthcheck endpoint is used by load balancers to determine if the server instance is healthy.
 
 Here is a sample Artillery configuration for testing the healthcheck endpoint:
 

--- a/packages/docs/docs/self-hosting/server-config.md
+++ b/packages/docs/docs/self-hosting/server-config.md
@@ -735,7 +735,7 @@ Optional flag to enable custom functions in Bots.
 
 ### AWS Secrets
 
-Postgres and Redis connection details have special cases due the way CDK exposes them.
+Postgres and Redis connection details have special cases due to the way CDK exposes them.
 
 When using a JSON config file, use JSON objects for `database` and `redis`. For example:
 

--- a/packages/docs/docs/terminology/common-terminologies.md
+++ b/packages/docs/docs/terminology/common-terminologies.md
@@ -1,6 +1,6 @@
 # Commonly Used Terminologies
 
-This guide provides a comprehensive reference for the most commonly used code systems and valuesets in healthcare applications. Each section includes the FHIR `system` URLs needed for proper coding in FHIR resources.
+This guide provides a comprehensive reference for the most commonly used code systems and ValueSets in healthcare applications. Each section includes the FHIR `system` URLs needed for proper coding in FHIR resources.
 
 ## Overview of Common Code Systems
 

--- a/packages/docs/docs/user-management/index.md
+++ b/packages/docs/docs/user-management/index.md
@@ -67,7 +67,7 @@ See our guide on [Project vs Server Scoped Users](/docs/user-management/project-
 
 ### Profiles
 
-_Within_ each project, a project member is represented by a specific FHIR resource, known as their **profile**. The `ProjectMembership.profile` element links the [` ProjectMembership`](/docs/api/fhir/medplum/projectmembership) to the profile resource.
+_Within_ each project, a project member is represented by a specific FHIR resource, known as their **profile**. The `ProjectMembership.profile` element links the [`ProjectMembership`](/docs/api/fhir/medplum/projectmembership) to the profile resource.
 
 A user's profile can be one of the three resource types in the table below. Incorporating the resources in the table below into ProjectMembership enable sophisticated access controls, as [Access Policies](/docs/access/access-policies) can access the profile of the current user ([read more](/docs/access/access-policies#patient-access))
 
@@ -182,7 +182,7 @@ This is the preferred method for removing user access for several reasons:
 
 To remove users from the existing project navigate to your [Project settings](https://app.medplum.com/admin/project) and to the Users and Patient tabs respectively. Click on a specific users or patients and click **Remove User**.
 
-We highly recommend leaving the associated FHIR resource (Patient, Practitioner, etc.) in place for audibility, record keeping and in case the membership needs to be reconstructed for some reason.
+We highly recommend leaving the associated FHIR resource (Patient, Practitioner, etc.) in place for auditability, record keeping and in case the membership needs to be reconstructed for some reason.
 
 ### Searching for Project Members
 
@@ -383,4 +383,4 @@ There are four major stages in the login flow: **Domain**, **Credentials**, **Pr
 - [Medplum resources](./api/fhir/medplum) related to authentication and authorization
 - [User registration](https://storybook.medplum.com/?path=/docs/medplum-registerform--basic) react component
 - [Sign in form](https://storybook.medplum.com/?path=/docs/medplum-signinform--basic) react component
-- [Auth Features and Fixes](https://github.com/medplum/medplum/pulls?q=is%3Apr+label%3Aauth) on Github
+- [Auth Features and Fixes](https://github.com/medplum/medplum/pulls?q=is%3Apr+label%3Aauth) on GitHub


### PR DESCRIPTION
## Summary
- Fix small typos and duplicated words across docs and examples.
- Normalize product/name casing for GitHub, reCAPTCHA, ValueSet, and Neutron.
- Clarify a few onboarding-oriented documentation sentences without changing behavior.

## Testing
- Searched the touched files for the corrected typo patterns with rg.
- Ran git diff --check upstream/main..HEAD.

## Notes
- Documentation-only changes; no runtime code changed.