### PR TITLE
fix(server): honor target type in _include and _revinclude

### DIFF
--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -2771,6 +2771,86 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       ).toStrictEqual(expected);
     }));
 
+  test('_include with target type', () =>
+    withTestContext(async () => {
+      // gh-9765: AuditEvent.entity.what can reference many types, so
+      // _include=AuditEvent:entity:Task must include only the Task, not every
+      // referenced resource type.
+      const task = await repo.createResource<Task>({
+        resourceType: 'Task',
+        status: 'completed',
+        intent: 'order',
+      });
+      const referencedAuditEvent = await repo.createResource<AuditEvent>({
+        resourceType: 'AuditEvent',
+        recorded: '2026-01-01T00:00:00.000Z',
+        type: { system: 'http://terminology.hl7.org/CodeSystem/audit-event-type', code: 'rest' },
+        agent: [{ requestor: true }],
+        source: { observer: { display: 'test' } },
+      });
+      const auditEvent = await repo.createResource<AuditEvent>({
+        resourceType: 'AuditEvent',
+        recorded: '2026-01-01T00:00:00.000Z',
+        type: { system: 'http://terminology.hl7.org/CodeSystem/audit-event-type', code: 'rest' },
+        agent: [{ requestor: true }],
+        source: { observer: { display: 'test' } },
+        entity: [
+          { what: { reference: getReferenceString(task) } },
+          { what: { reference: getReferenceString(referencedAuditEvent) } },
+        ],
+      });
+
+      const bundle = await repo.search({
+        resourceType: 'AuditEvent',
+        filters: [{ code: 'entity', operator: Operator.EQUALS, value: getReferenceString(task) }],
+        include: [{ resourceType: 'AuditEvent', searchParam: 'entity', targetType: 'Task' }],
+      });
+
+      // The Task is included; the referenced AuditEvent is not, because its type
+      // does not match the include target type.
+      expect(
+        bundle.entry?.map((e) => `${e.search?.mode}:${e.resource?.resourceType}/${e.resource?.id}`).sort()
+      ).toStrictEqual([`include:Task/${task.id}`, `match:AuditEvent/${auditEvent.id}`].sort());
+    }));
+
+  test('_revinclude with target type', () =>
+    withTestContext(async () => {
+      // gh-9765: _revinclude target type restricts which base resources are followed.
+      const identifier = randomUUID();
+      const task = await repo.createResource<Task>({
+        resourceType: 'Task',
+        status: 'completed',
+        intent: 'order',
+        identifier: [{ value: identifier }],
+      });
+      const auditEvent = await repo.createResource<AuditEvent>({
+        resourceType: 'AuditEvent',
+        recorded: '2026-01-01T00:00:00.000Z',
+        type: { system: 'http://terminology.hl7.org/CodeSystem/audit-event-type', code: 'rest' },
+        agent: [{ requestor: true }],
+        source: { observer: { display: 'test' } },
+        entity: [{ what: { reference: getReferenceString(task) } }],
+      });
+
+      // Target type matches the Task base result: the AuditEvent is reverse included.
+      const matched = await repo.search({
+        resourceType: 'Task',
+        filters: [{ code: 'identifier', operator: Operator.EQUALS, value: identifier }],
+        revInclude: [{ resourceType: 'AuditEvent', searchParam: 'entity', targetType: 'Task' }],
+      });
+      expect(
+        matched.entry?.map((e) => `${e.search?.mode}:${e.resource?.resourceType}/${e.resource?.id}`).sort()
+      ).toStrictEqual([`include:AuditEvent/${auditEvent.id}`, `match:Task/${task.id}`].sort());
+
+      // Target type Patient does not match the Task base result: nothing is reverse included.
+      const notMatched = await repo.search({
+        resourceType: 'Task',
+        filters: [{ code: 'identifier', operator: Operator.EQUALS, value: identifier }],
+        revInclude: [{ resourceType: 'AuditEvent', searchParam: 'entity', targetType: 'Patient' }],
+      });
+      expect(notMatched.entry?.filter((e) => e.search?.mode === 'include')).toHaveLength(0);
+    }));
+
   test('_revinclude:iterate', () =>
     withTestContext(async () => {
       /*

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -540,7 +540,7 @@ async function getSearchIncludeEntries(
   include: IncludeTarget,
   resources: Resource[]
 ): Promise<BundleEntry[]> {
-  const { resourceType, searchParam: code } = include;
+  const { resourceType, searchParam: code, targetType } = include;
   const searchParam = getSearchParameter(resourceType, code);
   if (!searchParam) {
     throw new OperationOutcomeError(badRequest(`Invalid include parameter: ${resourceType}:${code}`));
@@ -557,9 +557,18 @@ async function getSearchIncludeEntries(
     }
   }
 
-  const includedResources = (await repo.readReferences(references)).filter((v) => isResource(v)) as WithId<Resource>[];
-  if (searchParam.target && canonicalReferences.length > 0) {
-    const canonicalSearches = searchParam.target.map((resourceType) => {
+  // `_include=ResourceType:code:targetType` restricts the include to references of
+  // `targetType`; without the suffix every referenced resource type is returned.
+  const targetReferences = targetType
+    ? references.filter((reference) => reference.reference?.startsWith(targetType + '/'))
+    : references;
+
+  const includedResources = (await repo.readReferences(targetReferences)).filter((v) =>
+    isResource(v)
+  ) as WithId<Resource>[];
+  const canonicalTargets = targetType ? searchParam.target?.filter((t) => t === targetType) : searchParam.target;
+  if (canonicalTargets?.length && canonicalReferences.length > 0) {
+    const canonicalSearches = canonicalTargets.map((resourceType) => {
       const searchRequest = {
         resourceType: resourceType,
         filters: [
@@ -605,16 +614,37 @@ async function getSearchRevIncludeEntries(
   revInclude: IncludeTarget,
   resources: Resource[]
 ): Promise<BundleEntry[]> {
-  const { resourceType, searchParam: code } = revInclude;
+  const { resourceType, searchParam: code, targetType } = revInclude;
   const searchParam = getSearchParameter(resourceType, code);
   if (!searchParam) {
     throw new OperationOutcomeError(badRequest(`Invalid include parameter: ${resourceType}:${code}`));
   }
 
-  const references =
-    getSearchParameterImplementation(resourceType, searchParam).type === SearchParameterType.CANONICAL
-      ? flatMapFilter(resources, (r) => getCanonicalUrl(r))
-      : resources.map(getReferenceString);
+  // `_revinclude=ResourceType:code:targetType` restricts the reverse include to
+  // base resources of `targetType`. Build the references in a single pass,
+  // filtering to the target type as we go.
+  const isCanonical =
+    getSearchParameterImplementation(resourceType, searchParam).type === SearchParameterType.CANONICAL;
+  const references: string[] = [];
+  for (const resource of resources) {
+    if (targetType && resource.resourceType !== targetType) {
+      continue;
+    }
+    if (isCanonical) {
+      const canonicalUrl = getCanonicalUrl(resource);
+      if (canonicalUrl) {
+        references.push(canonicalUrl);
+      }
+    } else {
+      const reference = getReferenceString(resource);
+      if (reference) {
+        references.push(reference);
+      }
+    }
+  }
+  if (references.length === 0) {
+    return [];
+  }
   const searchRequest = {
     resourceType: resourceType as ResourceType,
     filters: [{ code, operator: Operator.EQUALS, value: references.join(',') }],


### PR DESCRIPTION
Fixes #9765.

`_include` and `_revinclude` take an optional target type, like `_include=AuditEvent:entity:Task`, to limit the include to references of that type. The parser reads the target type already, but the server ignored it: `getSearchIncludeEntries` returned every resource referenced by `AuditEvent.entity.what`, so the `:Task` suffix still pulled in the referenced AuditEvents.

For `_include`, the references are now filtered to the target type before they're read, and the canonical branch only searches the matching target. For `_revinclude`, the base resources are filtered to the target type before they're followed, returning early when none match. Neither path changes when no target type is present.

I added a test for each: an AuditEvent whose `entity.what` references both a Task and another AuditEvent, checking that `_include=AuditEvent:entity:Task` returns only the Task, plus the equivalent revinclude case. Both fail on `main` and pass with the change, and the rest of the search suite stays green.
