### PR TITLE
React: Extract useSchedulingResources hook

### DIFF
--- a/examples/medplum-provider/src/components/OutcomeAlert.tsx
+++ b/examples/medplum-provider/src/components/OutcomeAlert.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { AlertProps } from '@mantine/core';
+import type { AlertProps } from '@mantine/core';
 import { isOk } from '@medplum/core';
 import type { OperationOutcome, OperationOutcomeIssue } from '@medplum/fhirtypes';
 import { OperationOutcomeAlert } from '@medplum/react';

--- a/examples/medplum-provider/src/components/OutcomeAlert.tsx
+++ b/examples/medplum-provider/src/components/OutcomeAlert.tsx
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { AlertProps } from '@mantine/core';
+import { isOk } from '@medplum/core';
+import type { OperationOutcome, OperationOutcomeIssue } from '@medplum/fhirtypes';
+import { OperationOutcomeAlert } from '@medplum/react';
+import { IconAlertCircle, IconInfoCircle } from '@tabler/icons-react';
+import type { JSX } from 'react';
+
+export interface OutcomeAlertProps extends AlertProps {
+  outcome: OperationOutcome | undefined;
+}
+
+type Severity = OperationOutcomeIssue['severity'];
+
+const SEVERITY: Severity[] = ['information', 'warning', 'error', 'fatal'];
+
+const COLORS: Record<Severity, string> = {
+  information: 'blue',
+  warning: 'yellow',
+  error: 'orange',
+  fatal: 'red',
+};
+
+function maxSeverity(outcome: OperationOutcome): Severity {
+  return outcome.issue.reduce<OperationOutcomeIssue['severity']>(
+    (acc, issue) => (SEVERITY.indexOf(issue.severity) < SEVERITY.indexOf(acc) ? acc : issue.severity),
+    'information'
+  );
+}
+
+/**
+ * Shows an `<Alert>` component if the outcome exists and is something other
+ * than 'ok', otherwise returns `null`. Styles the alert based on the highest
+ * severity of issues
+ *
+ * @param props - The component props
+ * @param props.outcome - The OperationOutcome to maybe display an `<Alert>` for
+ * @returns - An `<Alert>` or null
+ */
+export function OutcomeAlert(props: OutcomeAlertProps): JSX.Element | null {
+  const { outcome, ...alertProps } = props;
+  if (!outcome || isOk(outcome)) {
+    return null;
+  }
+
+  const severity = maxSeverity(outcome);
+  const Icon = severity === 'information' ? IconInfoCircle : IconAlertCircle;
+
+  return <OperationOutcomeAlert outcome={outcome} color={COLORS[severity]} icon={<Icon size={20} />} {...alertProps} />;
+}

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
@@ -3,7 +3,7 @@
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import type { WithId } from '@medplum/core';
-import type { Appointment, Bundle, Patient, Slot } from '@medplum/fhirtypes';
+import type { Appointment, Patient, Slot } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import type { RenderResult } from '@testing-library/react';
@@ -11,6 +11,7 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { SchedulingAPI } from '../../hooks/useSchedulingResources';
 import { showErrorNotification } from '../../utils/notifications';
 import { AppointmentDetails } from './AppointmentDetails';
 
@@ -31,12 +32,22 @@ describe('AppointmentDetails', () => {
 
   type SetupOptions = {
     appointment: WithId<Appointment>;
-    onAppointmentUpdate?: (appointment: Appointment) => void;
-    onSlotUpdate?: (slot: Slot) => void;
+    onAppointmentUpdate?: (appointment: WithId<Appointment>) => void;
+    schedulingAPI?: Partial<SchedulingAPI>;
   };
 
-  const setup = async (options: SetupOptions): Promise<RenderResult> => {
-    const { appointment, onAppointmentUpdate = vi.fn(), onSlotUpdate = vi.fn() } = options;
+  type SetupResult = RenderResult & { schedulingAPI: SchedulingAPI };
+
+  const setup = async (options: SetupOptions): Promise<SetupResult> => {
+    const { appointment, onAppointmentUpdate = vi.fn() } = options;
+    const schedulingAPI: SchedulingAPI = {
+      book: vi.fn(),
+      cancel: vi.fn(),
+      confirm: vi.fn(),
+      find: vi.fn(),
+      updateAppointment: vi.fn(),
+      ...(options.schedulingAPI ?? {}),
+    };
 
     // AppointmentDetails uses `useResource` to load patient information; wrap the setup
     // in `act` so that async effect is visible in the rendered result.
@@ -45,8 +56,8 @@ describe('AppointmentDetails', () => {
       result = render(
         <AppointmentDetails
           appointment={appointment}
+          schedulingAPI={schedulingAPI}
           onAppointmentUpdate={onAppointmentUpdate}
-          onSlotUpdate={onSlotUpdate}
         />,
         {
           wrapper: ({ children }) => (
@@ -62,7 +73,7 @@ describe('AppointmentDetails', () => {
         }
       );
     });
-    return result;
+    return { ...result, schedulingAPI };
   };
 
   const createAppointment = (overrides?: Partial<Appointment>): WithId<Appointment> => ({
@@ -122,7 +133,6 @@ describe('AppointmentDetails', () => {
 
     test('renders Update Appointment button', async () => {
       const appointment = createAppointment();
-
       await setup({ appointment });
 
       expect(screen.getByRole('button', { name: 'Update Appointment' })).toBeInTheDocument();
@@ -130,7 +140,6 @@ describe('AppointmentDetails', () => {
 
     test('renders Cancel Visit button', async () => {
       const appointment = createAppointment();
-
       await setup({ appointment });
 
       expect(screen.getByRole('button', { name: 'Cancel Visit' })).toBeInTheDocument();
@@ -138,13 +147,12 @@ describe('AppointmentDetails', () => {
   });
 
   describe('Patient Selection', () => {
-    test('calls onAppointmentUpdate with updated appointment when patient is selected and form submitted', async () => {
+    test('calls schedulingAPI.updateAppointment when patient is selected and form submitted', async () => {
       const user = userEvent.setup();
       const onAppointmentUpdate = vi.fn();
       const appointment = createAppointment();
 
-      // Mock updateResource to return the updated appointment
-      const updatedAppointment: Appointment = {
+      const updatedAppointment: WithId<Appointment> = {
         ...appointment,
         participant: [
           ...appointment.participant,
@@ -154,9 +162,12 @@ describe('AppointmentDetails', () => {
           },
         ],
       };
-      medplum.updateResource = vi.fn().mockResolvedValue(updatedAppointment);
 
-      await setup({ appointment, onAppointmentUpdate });
+      const { schedulingAPI } = await setup({
+        appointment,
+        onAppointmentUpdate,
+        schedulingAPI: { updateAppointment: vi.fn().mockResolvedValue(updatedAppointment) },
+      });
 
       // Type in the patient search input (ResourceInput uses a searchbox role)
       const patientInput = screen.getByRole('searchbox');
@@ -171,8 +182,7 @@ describe('AppointmentDetails', () => {
       // Submit the form
       await user.click(screen.getByRole('button', { name: 'Update Appointment' }));
 
-      // Verify updateResource was called with the correct data
-      expect(medplum.updateResource).toHaveBeenCalledWith(
+      expect(schedulingAPI.updateAppointment).toHaveBeenCalledWith(
         expect.objectContaining({
           resourceType: 'Appointment',
           id: 'appointment-1',
@@ -189,20 +199,16 @@ describe('AppointmentDetails', () => {
       expect(onAppointmentUpdate).toHaveBeenCalledWith(updatedAppointment);
     });
 
-    test('does not call updateResource when no patient is selected', async () => {
+    test('does not call schedulingAPI.updateAppointment when no patient is selected', async () => {
       const user = userEvent.setup();
       const onAppointmentUpdate = vi.fn();
       const appointment = createAppointment();
 
-      medplum.updateResource = vi.fn();
+      const { schedulingAPI } = await setup({ appointment, onAppointmentUpdate });
 
-      await setup({ appointment, onAppointmentUpdate });
-
-      // Submit without selecting a patient
       await user.click(screen.getByRole('button', { name: 'Update Appointment' }));
 
-      // updateResource should not have been called
-      expect(medplum.updateResource).not.toHaveBeenCalled();
+      expect(schedulingAPI.updateAppointment).not.toHaveBeenCalled();
       expect(onAppointmentUpdate).not.toHaveBeenCalled();
     });
   });
@@ -236,9 +242,11 @@ describe('AppointmentDetails', () => {
         ],
       });
 
-      medplum.updateResource = vi.fn().mockResolvedValue(appointment);
-
-      await setup({ appointment, onAppointmentUpdate });
+      const { schedulingAPI } = await setup({
+        appointment,
+        onAppointmentUpdate,
+        schedulingAPI: { updateAppointment: vi.fn().mockResolvedValue(appointment) },
+      });
 
       // Select a patient (ResourceInput uses a searchbox role)
       const patientInput = screen.getByRole('searchbox');
@@ -249,11 +257,10 @@ describe('AppointmentDetails', () => {
       });
       await user.click(screen.getByText('Homer Simpson'));
 
-      // Submit the form
       await user.click(screen.getByRole('button', { name: 'Update Appointment' }));
 
       // Verify all original participants are preserved
-      expect(medplum.updateResource).toHaveBeenCalledWith(
+      expect(schedulingAPI.updateAppointment).toHaveBeenCalledWith(
         expect.objectContaining({
           participant: expect.arrayContaining([
             expect.objectContaining({
@@ -276,27 +283,26 @@ describe('AppointmentDetails', () => {
         end: undefined,
       });
 
-      // Should not throw
       await setup({ appointment });
 
-      // Component should still render
       expect(screen.getByRole('button', { name: 'Update Appointment' })).toBeInTheDocument();
     });
   });
 
   describe('Error Handling', () => {
-    test('handles updateResource failure', async () => {
+    test('shows error notification when schedulingAPI.updateAppointment fails', async () => {
       const user = userEvent.setup();
       const onAppointmentUpdate = vi.fn();
       const appointment = createAppointment();
 
       const updateError = new Error('Network error');
 
-      medplum.updateResource = vi.fn().mockRejectedValue(updateError);
+      const { schedulingAPI } = await setup({
+        appointment,
+        onAppointmentUpdate,
+        schedulingAPI: { updateAppointment: vi.fn().mockRejectedValue(updateError) },
+      });
 
-      await setup({ appointment, onAppointmentUpdate });
-
-      // Select a patient (ResourceInput uses a searchbox role)
       const patientInput = screen.getByRole('searchbox');
       await user.type(patientInput, 'Homer');
 
@@ -305,13 +311,10 @@ describe('AppointmentDetails', () => {
       });
       await user.click(screen.getByText('Homer Simpson'));
 
-      // Submit the form - this will cause an unhandled rejection
       await user.click(screen.getByRole('button', { name: 'Update Appointment' }));
 
-      // onAppointmentUpdate should not have been called since the request failed
-      expect(medplum.updateResource).toHaveBeenCalled();
+      expect(schedulingAPI.updateAppointment).toHaveBeenCalled();
       expect(onAppointmentUpdate).not.toHaveBeenCalled();
-
       expect(showErrorNotification).toHaveBeenCalledWith(updateError);
     });
   });
@@ -357,7 +360,7 @@ describe('AppointmentDetails', () => {
     });
 
     test('does not render Set Up Encounter section when there is no patient participant', async () => {
-      const appointment = createAppointment(); // no Patient participant
+      const appointment = createAppointment();
       await setup({ appointment });
 
       await waitFor(() => {
@@ -378,48 +381,39 @@ describe('AppointmentDetails', () => {
   test('Cancel Visit button', async () => {
     const user = userEvent.setup();
     const appointment = createAppointment();
-    const cancelledAppointment = { ...appointment, status: 'cancelled' as const };
+    const cancelledAppointment: WithId<Appointment> = { ...appointment, status: 'cancelled' };
     const onAppointmentUpdate = vi.fn();
-    const onSlotUpdate = vi.fn();
 
-    const postPromise = Promise.withResolvers<Appointment>();
-    const postMock = vi.fn().mockReturnValue(postPromise.promise);
-    const invalidateSearchesMock = vi.fn();
-    medplum.post = postMock;
-    medplum.invalidateSearches = invalidateSearchesMock;
+    const cancelResolvers = Promise.withResolvers<WithId<Appointment>>();
+    const { rerender, schedulingAPI } = await setup({
+      appointment,
+      onAppointmentUpdate,
+      schedulingAPI: { cancel: vi.fn().mockReturnValue(cancelResolvers.promise) },
+    });
 
-    // click the button
-    const { rerender } = await setup({ appointment, onAppointmentUpdate, onSlotUpdate });
     const button = screen.getByRole('button', { name: /Cancel Visit/i });
     await user.click(button);
 
-    // it invokes the $cancel endpoint
-    await waitFor(() => expect(medplum.post).toHaveBeenCalled());
-    const postUrl = postMock.mock.calls[0][0];
-    expect(postUrl.toString()).toContain(`Appointment/${appointment.id}/$cancel`);
+    await waitFor(() => expect(schedulingAPI.cancel).toHaveBeenCalledWith(appointment));
 
     // button goes into loading state
     await waitFor(() => expect(button).toHaveAttribute('data-loading'));
 
     // resolve the promise
-    postPromise.resolve(cancelledAppointment);
+    cancelResolvers.resolve(cancelledAppointment);
 
     // button is no longer loading
     await waitFor(() => expect(button).not.toHaveAttribute('data-loading'));
 
-    // it invalidated Appointment and Slot searches on success
-    expect(invalidateSearchesMock).toHaveBeenCalledWith('Appointment');
-    expect(invalidateSearchesMock).toHaveBeenCalledWith('Slot');
-
-    // it invoked onAppointmentUpdate callback
+    // invoked callback
     expect(onAppointmentUpdate).toHaveBeenCalledWith(cancelledAppointment);
 
     // re-render with cancelled appointment
     await rerender(
       <AppointmentDetails
         appointment={cancelledAppointment}
+        schedulingAPI={schedulingAPI}
         onAppointmentUpdate={onAppointmentUpdate}
-        onSlotUpdate={onSlotUpdate}
       />
     );
 
@@ -444,16 +438,18 @@ describe('AppointmentDetails', () => {
   test('Confirm Visit button', async () => {
     const user = userEvent.setup();
     const bookedAppointment = createAppointment();
-    const pendingAppointment = { ...bookedAppointment, status: 'pending' as const };
-    const busySlot: Slot = {
+    const pendingAppointment: WithId<Appointment> = { ...bookedAppointment, status: 'pending' };
+    const busySlot: WithId<Slot> = {
       resourceType: 'Slot',
+      id: 'slot-1',
       start,
       end,
       status: 'busy',
       schedule: { reference: 'Schedule/abc123' },
     };
-    const busyUnavailableSlot: Slot = {
+    const busyUnavailableSlot: WithId<Slot> = {
       resourceType: 'Slot',
+      id: 'slot-2',
       start,
       end,
       status: 'busy-unavailable',
@@ -461,37 +457,24 @@ describe('AppointmentDetails', () => {
     };
 
     const onAppointmentUpdate = vi.fn();
-    const onSlotUpdate = vi.fn();
+    const confirmResolvers = Promise.withResolvers<{ appointment: WithId<Appointment>; slots: WithId<Slot>[] }>();
 
-    const postPromise = Promise.withResolvers<Bundle<Appointment | Slot>>();
-    const postMock = vi.fn().mockReturnValue(postPromise.promise);
-    const invalidateSearchesMock = vi.fn();
-    medplum.post = postMock;
-    medplum.invalidateSearches = invalidateSearchesMock;
-
-    // click the button
-    const { rerender } = await setup({
+    const { rerender, schedulingAPI } = await setup({
       appointment: pendingAppointment,
       onAppointmentUpdate,
-      onSlotUpdate,
+      schedulingAPI: { confirm: vi.fn().mockReturnValue(confirmResolvers.promise) },
     });
+
     const button = screen.getByRole('button', { name: /Confirm Appointment/i });
     await user.click(button);
 
-    // it invokes the $confirm endpoint
-    await waitFor(() => expect(medplum.post).toHaveBeenCalled());
-    const postUrl = postMock.mock.calls[0][0];
-    expect(postUrl.toString()).toContain(`Appointment/${pendingAppointment.id}/$confirm`);
+    await waitFor(() => expect(schedulingAPI.confirm).toHaveBeenCalledWith(pendingAppointment));
 
     // button goes into loading state
     await waitFor(() => expect(button).toHaveAttribute('data-loading'));
 
     // resolve the promise
-    postPromise.resolve({
-      resourceType: 'Bundle',
-      type: 'transaction-response',
-      entry: [{ resource: bookedAppointment }, { resource: busySlot }, { resource: busyUnavailableSlot }],
-    });
+    confirmResolvers.resolve({ appointment: bookedAppointment, slots: [busySlot, busyUnavailableSlot] });
 
     // button is no longer loading
     await waitFor(() => expect(button).not.toHaveAttribute('data-loading'));
@@ -499,20 +482,12 @@ describe('AppointmentDetails', () => {
     // onAppointmentUpdate was called with the updated appointment
     expect(onAppointmentUpdate).toHaveBeenCalledWith(bookedAppointment);
 
-    // onSlotUpdate was called with the updated slots
-    expect(onSlotUpdate).toHaveBeenCalledWith(busySlot);
-    expect(onSlotUpdate).toHaveBeenCalledWith(busyUnavailableSlot);
-
-    // it invalidated Appointment and Slot searches on success
-    expect(invalidateSearchesMock).toHaveBeenCalledWith('Appointment');
-    expect(invalidateSearchesMock).toHaveBeenCalledWith('Slot');
-
     // re-render with booked appointment
     await rerender(
       <AppointmentDetails
         appointment={bookedAppointment}
+        schedulingAPI={schedulingAPI}
         onAppointmentUpdate={onAppointmentUpdate}
-        onSlotUpdate={onSlotUpdate}
       />
     );
 

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
@@ -11,26 +11,19 @@ import {
   getReferenceString,
   isOk,
   isReference,
-  isResource,
 } from '@medplum/core';
-import type { Appointment, Bundle, CodeableConcept, Patient, Practitioner, Slot } from '@medplum/fhirtypes';
-import {
-  CodeableConceptDisplay,
-  Form,
-  MedplumLink,
-  OperationOutcomeAlert,
-  ResourceAvatar,
-  ResourceInput,
-  useMedplum,
-} from '@medplum/react';
+import type { Appointment, CodeableConcept, Patient, Practitioner } from '@medplum/fhirtypes';
+import { CodeableConceptDisplay, Form, MedplumLink, ResourceAvatar, ResourceInput } from '@medplum/react';
 import { useResource, useSearchOne } from '@medplum/react-hooks';
 import { IconFileCheck, IconNotes, IconTrash } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useCallback, useState } from 'react';
 import { Link } from 'react-router';
+import type { SchedulingAPI } from '../../hooks/useSchedulingResources';
 import { encounterUrl } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
 import { ServiceTypeReferenceURI } from '../../utils/servicetype';
+import { OutcomeAlert } from '../OutcomeAlert';
 import classes from './AppointmentDetails.module.css';
 import { CreateEncounterForm } from './CreateEncounterForm';
 
@@ -49,14 +42,14 @@ function ServiceTypeDisplay(props: { value: CodeableConcept }): JSX.Element {
 
 type UpdateAppointmentFormProps = {
   appointment: WithId<Appointment>;
-  onUpdate: (appointment: WithId<Appointment>) => void;
+  updateAppointment: (appointment: WithId<Appointment>) => Promise<WithId<Appointment>>;
+  onAppointmentUpdate: (appointment: WithId<Appointment>) => void;
 };
 
 function UpdateAppointmentForm(props: UpdateAppointmentFormProps): JSX.Element {
-  const medplum = useMedplum();
   const [patient, setPatient] = useState<Patient | undefined>(undefined);
 
-  const { appointment, onUpdate } = props;
+  const { appointment, updateAppointment, onAppointmentUpdate } = props;
   const handleSubmit = useCallback(async () => {
     if (!patient) {
       return;
@@ -72,15 +65,12 @@ function UpdateAppointmentForm(props: UpdateAppointmentFormProps): JSX.Element {
       ],
     } satisfies Appointment;
 
-    let result: WithId<Appointment>;
     try {
-      result = await medplum.updateResource(updated);
+      onAppointmentUpdate(await updateAppointment(updated));
     } catch (error) {
       showErrorNotification(error);
-      return;
     }
-    onUpdate?.(result);
-  }, [medplum, patient, appointment, onUpdate]);
+  }, [patient, appointment, updateAppointment, onAppointmentUpdate]);
 
   return (
     <Form onSubmit={handleSubmit}>
@@ -101,13 +91,16 @@ function UpdateAppointmentForm(props: UpdateAppointmentFormProps): JSX.Element {
   );
 }
 
+function isConfirmable(appointment: Appointment): boolean {
+  return appointment.status === 'pending';
+}
+
 export function AppointmentDetails(props: {
   appointment: WithId<Appointment>;
+  schedulingAPI: SchedulingAPI;
   onAppointmentUpdate: (appointment: WithId<Appointment>) => void;
-  onSlotUpdate: (slot: WithId<Slot>) => void;
 }): JSX.Element {
-  const { appointment, onAppointmentUpdate, onSlotUpdate } = props;
-  const medplum = useMedplum();
+  const { appointment, schedulingAPI, onAppointmentUpdate } = props;
 
   const [encounter, encounterLoading, encounterOutcome] = useSearchOne('Encounter', {
     appointment: getReferenceString(appointment),
@@ -129,54 +122,43 @@ export function AppointmentDetails(props: {
   const handleCancel = useCallback(async () => {
     setCancelLoading(true);
     try {
-      const updated = await medplum.post<WithId<Appointment>>(
-        medplum.fhirUrl('Appointment', appointment.id, '$cancel')
-      );
-      medplum.invalidateSearches('Appointment');
-      medplum.invalidateSearches('Slot');
-      onAppointmentUpdate(updated);
+      const result = await schedulingAPI.cancel(appointment);
+      onAppointmentUpdate(result);
     } catch (err) {
       showErrorNotification(err);
     } finally {
       setCancelLoading(false);
     }
-  }, [medplum, appointment, onAppointmentUpdate]);
+  }, [schedulingAPI, onAppointmentUpdate, appointment]);
 
-  const confirmable = appointment.status === 'pending';
   const [confirmLoading, setConfirmLoading] = useState(false);
   const handleConfirm = useCallback(async () => {
-    if (!confirmable) {
+    if (!isConfirmable(appointment)) {
       console.error(new Error(`handleConfirm called from non confirmable status '${appointment.status}'`));
       return;
     }
     setConfirmLoading(true);
     try {
-      const updated = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(
-        medplum.fhirUrl('Appointment', appointment.id, '$confirm')
-      );
-      medplum.invalidateSearches('Appointment');
-      medplum.invalidateSearches('Slot');
-      const updatedResources = updated.entry?.map((entry) => entry.resource) ?? EMPTY;
-      const updatedAppointment = updatedResources.find((res) => isResource<Appointment>(res, 'Appointment'));
-      const updatedSlots = updatedResources.filter((res) => isResource<Slot>(res, 'Slot'));
-      if (updatedAppointment) {
-        onAppointmentUpdate(updatedAppointment);
-      }
-      for (const updatedSlot of updatedSlots) {
-        onSlotUpdate(updatedSlot);
-      }
+      const result = await schedulingAPI.confirm(appointment);
+      onAppointmentUpdate(result.appointment);
     } catch (err) {
       showErrorNotification(err);
     } finally {
       setConfirmLoading(false);
     }
-  }, [medplum, appointment, confirmable, onAppointmentUpdate, onSlotUpdate]);
+  }, [schedulingAPI, onAppointmentUpdate, appointment]);
 
   return (
     <Stack gap="md" className={classes.AppointmentDetails}>
       <Divider />
 
-      {!patientRef && <UpdateAppointmentForm appointment={props.appointment} onUpdate={props.onAppointmentUpdate} />}
+      {!patientRef && (
+        <UpdateAppointmentForm
+          appointment={props.appointment}
+          updateAppointment={schedulingAPI.updateAppointment}
+          onAppointmentUpdate={props.onAppointmentUpdate}
+        />
+      )}
 
       {!!patient && (
         <Group align="center" gap="sm">
@@ -217,9 +199,7 @@ export function AppointmentDetails(props: {
           <Loader size="sm" />
         </Group>
       )}
-      {encounterOutcome && !isOk(encounterOutcome) && (
-        <OperationOutcomeAlert outcome={encounterOutcome} title="Loading Encounter failed" />
-      )}
+      <OutcomeAlert outcome={encounterOutcome} title="Encounter Loading Issue" />
       {patientRef && !encounter && !encounterLoading && encounterOutcome && isOk(encounterOutcome) && (
         <CreateEncounterForm appointment={appointment} patientRef={patientRef} practitionerRef={practitionerRef} />
       )}
@@ -237,7 +217,7 @@ export function AppointmentDetails(props: {
           View Encounter
         </Button>
       )}
-      {confirmable && (
+      {isConfirmable(appointment) && (
         <Button
           loading={confirmLoading}
           onClick={handleConfirm}

--- a/examples/medplum-provider/src/components/schedule/BookAppointmentForm.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/BookAppointmentForm.test.tsx
@@ -3,13 +3,14 @@
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import type { WithId } from '@medplum/core';
-import type { Appointment, Bundle, Encounter, HealthcareService, PlanDefinition, Slot } from '@medplum/fhirtypes';
+import type { Appointment, Encounter, HealthcareService, PlanDefinition, Slot } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { SchedulingAPI } from '../../hooks/useSchedulingResources';
 import { createEncounter } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
 import { SchedulingEncounterCodingURI, SchedulingPlanDefinitionURI } from '../../utils/scheduling';
@@ -52,10 +53,19 @@ describe('BookAppointmentForm', () => {
       encounter: Encounter | undefined;
     }) => void;
     healthcareService?: HealthcareService;
+    schedulingAPI?: Partial<SchedulingAPI>;
   };
 
   const setup = async (options: SetupOptions = {}): Promise<void> => {
     const { onSuccess, healthcareService = defaultHealthcareService } = options;
+    const schedulingAPI: SchedulingAPI = {
+      book: vi.fn(),
+      cancel: vi.fn(),
+      confirm: vi.fn(),
+      find: vi.fn(),
+      updateAppointment: vi.fn(),
+      ...(options.schedulingAPI ?? {}),
+    };
     await act(async () => {
       render(
         <MemoryRouter>
@@ -66,6 +76,7 @@ describe('BookAppointmentForm', () => {
                 appointment={appointment}
                 healthcareService={healthcareService}
                 onSuccess={onSuccess}
+                schedulingAPI={schedulingAPI}
               />
             </MantineProvider>
           </MedplumProvider>
@@ -87,55 +98,38 @@ describe('BookAppointmentForm', () => {
     expect(screen.getByText(/2026/)).toBeInTheDocument();
   });
 
-  test('does not call $book when no patient is selected', async () => {
+  test('does not call book when no patient is selected', async () => {
     const user = userEvent.setup();
     const onSuccess = vi.fn();
-    medplum.post = vi.fn();
+    const bookMock = vi.fn();
 
-    await setup({ onSuccess });
+    await setup({ onSuccess, schedulingAPI: { book: bookMock } });
 
     await user.click(screen.getByRole('button', { name: 'Create Appointment' }));
 
-    expect(medplum.post).not.toHaveBeenCalled();
+    expect(bookMock).not.toHaveBeenCalled();
     expect(onSuccess).not.toHaveBeenCalled();
   });
 
-  test('calls $book with correct parameters when patient is selected', async () => {
+  test('calls schedulingAPI.book with booking that includes the selected patient', async () => {
     const user = userEvent.setup();
     const onSuccess = vi.fn();
 
-    const mockBookResponse: Bundle<Appointment | Slot> = {
-      resourceType: 'Bundle',
-      type: 'collection',
-      entry: [
-        {
-          resource: {
-            resourceType: 'Appointment',
-            id: 'appointment-1',
-            status: 'booked',
-            start,
-            end,
-            participant: [],
-          },
-        },
-        {
-          resource: {
-            resourceType: 'Slot',
-            id: 'slot-1',
-            status: 'busy',
-            start,
-            end,
-            schedule: { reference: 'Schedule/schedule-1' },
-          },
-        },
-      ],
+    const bookedAppointment: WithId<Appointment> = {
+      resourceType: 'Appointment',
+      id: 'appointment-1',
+      status: 'booked',
+      start,
+      end,
+      participant: [],
     };
+    const bookMock = vi.fn().mockResolvedValue({
+      appointment: bookedAppointment,
+      slots: [],
+    });
 
-    medplum.post = vi.fn().mockResolvedValue(mockBookResponse);
+    await setup({ onSuccess, schedulingAPI: { book: bookMock } });
 
-    await setup({ onSuccess });
-
-    // Select a patient via the ResourceInput autocomplete
     const patientInput = screen.getByRole('searchbox');
     await user.type(patientInput, 'Homer');
 
@@ -144,29 +138,20 @@ describe('BookAppointmentForm', () => {
     });
     await user.click(screen.getByText('Homer Simpson'));
 
-    // Submit the form
     await user.click(screen.getByRole('button', { name: 'Create Appointment' }));
 
-    // Verify the $book call
-    expect(medplum.post).toHaveBeenCalledWith(
-      new URL('https://example.com/fhir/R4/Appointment/$book'),
+    await waitFor(() => expect(bookMock).toHaveBeenCalled());
+
+    expect(bookMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        resourceType: 'Parameters',
-        parameter: [
-          {
-            name: 'appointment',
-            resource: expect.objectContaining({
-              resourceType: 'Appointment',
-              participant: expect.arrayContaining([
-                expect.objectContaining({
-                  actor: expect.objectContaining({ reference: `Patient/${HomerSimpson.id}` }),
-                  status: 'needs-action',
-                  required: 'required',
-                }),
-              ]),
-            }),
-          },
-        ],
+        resourceType: 'Appointment',
+        participant: expect.arrayContaining([
+          expect.objectContaining({
+            actor: expect.objectContaining({ reference: `Patient/${HomerSimpson.id}` }),
+            status: 'needs-action',
+            required: 'required',
+          }),
+        ]),
       })
     );
   });
@@ -175,7 +160,7 @@ describe('BookAppointmentForm', () => {
     const user = userEvent.setup();
     const onSuccess = vi.fn();
 
-    const bookedAppointment: Appointment = {
+    const bookedAppointment: WithId<Appointment> = {
       resourceType: 'Appointment',
       id: 'appointment-1',
       status: 'booked',
@@ -184,7 +169,7 @@ describe('BookAppointmentForm', () => {
       participant: [],
     };
 
-    const busySlot: Slot = {
+    const busySlot: WithId<Slot> = {
       resourceType: 'Slot',
       id: 'slot-1',
       status: 'busy',
@@ -193,7 +178,7 @@ describe('BookAppointmentForm', () => {
       schedule: { reference: 'Schedule/schedule-1' },
     };
 
-    const bufferAfterSlot: Slot = {
+    const bufferAfterSlot: WithId<Slot> = {
       resourceType: 'Slot',
       id: 'slot-2',
       status: 'busy-unavailable',
@@ -202,15 +187,12 @@ describe('BookAppointmentForm', () => {
       schedule: { reference: 'Schedule/schedule-1' },
     };
 
-    const mockBookResponse: Bundle<Appointment | Slot> = {
-      resourceType: 'Bundle',
-      type: 'collection',
-      entry: [{ resource: bookedAppointment }, { resource: busySlot }, { resource: bufferAfterSlot }],
-    };
+    const bookMock = vi.fn().mockResolvedValue({
+      appointment: bookedAppointment,
+      slots: [busySlot, bufferAfterSlot],
+    });
 
-    medplum.post = vi.fn().mockResolvedValue(mockBookResponse);
-
-    await setup({ onSuccess });
+    await setup({ onSuccess, schedulingAPI: { book: bookMock } });
 
     const patientInput = screen.getByRole('searchbox');
     await user.type(patientInput, 'Homer');
@@ -232,14 +214,13 @@ describe('BookAppointmentForm', () => {
     });
   });
 
-  test('shows error notification when $book fails', async () => {
+  test('shows error notification when book fails', async () => {
     const user = userEvent.setup();
     const onSuccess = vi.fn();
     const bookError = new Error('Network error');
+    const bookMock = vi.fn().mockRejectedValue(bookError);
 
-    medplum.post = vi.fn().mockRejectedValue(bookError);
-
-    await setup({ onSuccess });
+    await setup({ onSuccess, schedulingAPI: { book: bookMock } });
 
     const patientInput = screen.getByRole('searchbox');
     await user.type(patientInput, 'Homer');
@@ -260,16 +241,10 @@ describe('BookAppointmentForm', () => {
   test('shows loading state while booking is in-flight', async () => {
     const user = userEvent.setup();
 
-    // Use a promise we control to keep the booking in-flight
-    let resolveBook: (value: Bundle) => void;
-    medplum.post = vi.fn().mockImplementation(
-      () =>
-        new Promise<Bundle>((resolve) => {
-          resolveBook = resolve;
-        })
-    );
+    const bookResolvers = Promise.withResolvers<{ appointment: WithId<Appointment>; slots: WithId<Slot>[] }>();
+    const bookMock = vi.fn().mockReturnValue(bookResolvers.promise);
 
-    await setup();
+    await setup({ schedulingAPI: { book: bookMock } });
 
     const patientInput = screen.getByRole('searchbox');
     await user.type(patientInput, 'Homer');
@@ -281,19 +256,26 @@ describe('BookAppointmentForm', () => {
 
     await user.click(screen.getByRole('button', { name: 'Create Appointment' }));
 
-    // While the request is in-flight, the submit button should be disabled with a loading indicator
     const button = screen.getByRole('button', { name: 'Create Appointment' });
     await waitFor(() => {
       expect(button).toBeDisabled();
       expect(button).toHaveAttribute('data-loading', 'true');
     });
 
-    // Resolve the booking to clean up
     await act(async () => {
-      resolveBook({ resourceType: 'Bundle', type: 'collection', entry: [] });
+      bookResolvers.resolve({
+        appointment: {
+          resourceType: 'Appointment',
+          id: 'appointment-1',
+          status: 'booked',
+          start,
+          end,
+          participant: [],
+        },
+        slots: [],
+      });
     });
 
-    // After completion, the button should no longer be loading
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Create Appointment' })).not.toBeDisabled();
     });
@@ -317,8 +299,7 @@ describe('BookAppointmentForm', () => {
       ],
     };
 
-    // Appointment returned by $book with exactly one practitioner and one patient
-    const bookedAppointmentWithParticipants: Appointment = {
+    const bookedAppointmentWithParticipants: WithId<Appointment> = {
       resourceType: 'Appointment',
       id: 'appointment-1',
       status: 'booked',
@@ -330,22 +311,19 @@ describe('BookAppointmentForm', () => {
       ],
     };
 
-    const makeBookResponse = (appt: Appointment): Bundle<Appointment | Slot> => ({
-      resourceType: 'Bundle',
-      type: 'collection',
-      entry: [{ resource: appt }],
-    });
-
     test('creates encounter and passes it to onSuccess when healthcareService has required extensions', async () => {
       const user = userEvent.setup();
       const onSuccess = vi.fn();
       const mockEncounter: Encounter = { resourceType: 'Encounter', id: 'enc-1', status: 'planned', class: {} };
 
-      medplum.post = vi.fn().mockResolvedValue(makeBookResponse(bookedAppointmentWithParticipants));
+      const bookMock = vi.fn().mockResolvedValue({
+        appointment: bookedAppointmentWithParticipants,
+        slots: [],
+      });
       vi.spyOn(medplum, 'readReference').mockResolvedValue(planDefinition);
       vi.mocked(createEncounter).mockResolvedValue(mockEncounter as Encounter & { id: string });
 
-      await setup({ onSuccess, healthcareService: healthcareServiceWithEncounter });
+      await setup({ onSuccess, healthcareService: healthcareServiceWithEncounter, schedulingAPI: { book: bookMock } });
 
       const patientInput = screen.getByRole('searchbox');
       await user.type(patientInput, 'Homer');
@@ -370,9 +348,12 @@ describe('BookAppointmentForm', () => {
       const user = userEvent.setup();
       const onSuccess = vi.fn();
 
-      medplum.post = vi.fn().mockResolvedValue(makeBookResponse(bookedAppointmentWithParticipants));
+      const bookMock = vi.fn().mockResolvedValue({
+        appointment: bookedAppointmentWithParticipants,
+        slots: [],
+      });
 
-      await setup({ onSuccess, healthcareService: defaultHealthcareService });
+      await setup({ onSuccess, healthcareService: defaultHealthcareService, schedulingAPI: { book: bookMock } });
 
       const patientInput = screen.getByRole('searchbox');
       await user.type(patientInput, 'Homer');
@@ -396,9 +377,12 @@ describe('BookAppointmentForm', () => {
         extension: [{ url: SchedulingPlanDefinitionURI, valueReference: { reference: 'PlanDefinition/pd-1' } }],
       };
 
-      medplum.post = vi.fn().mockResolvedValue(makeBookResponse(bookedAppointmentWithParticipants));
+      const bookMock = vi.fn().mockResolvedValue({
+        appointment: bookedAppointmentWithParticipants,
+        slots: [],
+      });
 
-      await setup({ onSuccess, healthcareService: hcsWithoutCoding });
+      await setup({ onSuccess, healthcareService: hcsWithoutCoding, schedulingAPI: { book: bookMock } });
 
       const patientInput = screen.getByRole('searchbox');
       await user.type(patientInput, 'Homer');
@@ -416,7 +400,7 @@ describe('BookAppointmentForm', () => {
       const user = userEvent.setup();
       const onSuccess = vi.fn();
 
-      const apptTwoPractitioners: Appointment = {
+      const apptTwoPractitioners: WithId<Appointment> = {
         ...bookedAppointmentWithParticipants,
         participant: [
           { actor: { reference: 'Practitioner/prac-1' }, status: 'accepted' },
@@ -425,10 +409,10 @@ describe('BookAppointmentForm', () => {
         ],
       };
 
-      medplum.post = vi.fn().mockResolvedValue(makeBookResponse(apptTwoPractitioners));
+      const bookMock = vi.fn().mockResolvedValue({ appointment: apptTwoPractitioners, slots: [] });
       vi.spyOn(medplum, 'readReference').mockResolvedValue(planDefinition);
 
-      await setup({ onSuccess, healthcareService: healthcareServiceWithEncounter });
+      await setup({ onSuccess, healthcareService: healthcareServiceWithEncounter, schedulingAPI: { book: bookMock } });
 
       const patientInput = screen.getByRole('searchbox');
       await user.type(patientInput, 'Homer');
@@ -446,7 +430,7 @@ describe('BookAppointmentForm', () => {
       const user = userEvent.setup();
       const onSuccess = vi.fn();
 
-      const apptTwoPatients: Appointment = {
+      const apptTwoPatients: WithId<Appointment> = {
         ...bookedAppointmentWithParticipants,
         participant: [
           { actor: { reference: 'Practitioner/prac-1' }, status: 'accepted' },
@@ -455,10 +439,10 @@ describe('BookAppointmentForm', () => {
         ],
       };
 
-      medplum.post = vi.fn().mockResolvedValue(makeBookResponse(apptTwoPatients));
+      const bookMock = vi.fn().mockResolvedValue({ appointment: apptTwoPatients, slots: [] });
       vi.spyOn(medplum, 'readReference').mockResolvedValue(planDefinition);
 
-      await setup({ onSuccess, healthcareService: healthcareServiceWithEncounter });
+      await setup({ onSuccess, healthcareService: healthcareServiceWithEncounter, schedulingAPI: { book: bookMock } });
 
       const patientInput = screen.getByRole('searchbox');
       await user.type(patientInput, 'Homer');
@@ -477,11 +461,14 @@ describe('BookAppointmentForm', () => {
       const onSuccess = vi.fn();
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
-      medplum.post = vi.fn().mockResolvedValue(makeBookResponse(bookedAppointmentWithParticipants));
+      const bookMock = vi.fn().mockResolvedValue({
+        appointment: bookedAppointmentWithParticipants,
+        slots: [],
+      });
       vi.spyOn(medplum, 'readReference').mockResolvedValue(planDefinition);
       vi.mocked(createEncounter).mockRejectedValue(new Error('PlanDefinition $apply failed'));
 
-      await setup({ onSuccess, healthcareService: healthcareServiceWithEncounter });
+      await setup({ onSuccess, healthcareService: healthcareServiceWithEncounter, schedulingAPI: { book: bookMock } });
 
       const patientInput = screen.getByRole('searchbox');
       await user.type(patientInput, 'Homer');

--- a/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
@@ -2,18 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Button, Stack, Text } from '@mantine/core';
 import type { WithId } from '@medplum/core';
-import {
-  createReference,
-  EMPTY,
-  formatPeriod,
-  getExtensionValue,
-  isCoding,
-  isDefined,
-  isReference,
-} from '@medplum/core';
+import { createReference, formatPeriod, getExtensionValue, isCoding, isReference } from '@medplum/core';
 import type {
   Appointment,
-  Bundle,
   Encounter,
   HealthcareService,
   Patient,
@@ -24,15 +15,13 @@ import type {
 import { Form, ResourceInput, useMedplum } from '@medplum/react';
 import type { JSX } from 'react';
 import { useCallback, useState } from 'react';
+import type { SchedulingAPI } from '../../hooks/useSchedulingResources';
 import { createEncounter } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
-import {
-  SchedulingEncounterCodingURI,
-  SchedulingPlanDefinitionURI,
-  SchedulingTransientIdentifier,
-} from '../../utils/scheduling';
+import { SchedulingEncounterCodingURI, SchedulingPlanDefinitionURI } from '../../utils/scheduling';
 
 type BookAppointmentFormProps = {
+  schedulingAPI: SchedulingAPI;
   appointment: Appointment;
   healthcareService: HealthcareService;
   onSuccess?: (result: {
@@ -48,7 +37,7 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
   const [patient, setPatient] = useState<WithId<Patient> | undefined>(undefined);
   const [loading, setLoading] = useState(false);
 
-  const { appointment, healthcareService, onSuccess } = props;
+  const { appointment, healthcareService, onSuccess, schedulingAPI } = props;
 
   const bookEncounter = useCallback(
     async (appointment: WithId<Appointment>): Promise<WithId<Encounter> | undefined> => {
@@ -113,45 +102,25 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
         ],
       } satisfies Appointment;
 
-      // Remove any transient identifiers we added for use in the UI before submitting
-      SchedulingTransientIdentifier.remove(booking);
-
       try {
-        const data = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(
-          medplum.fhirUrl('Appointment', '$book'),
-          {
-            resourceType: 'Parameters',
-            parameter: [{ name: 'appointment', resource: booking }],
-          }
-        );
-        medplum.invalidateSearches('Appointment');
-        medplum.invalidateSearches('Slot');
-
-        const resources = data.entry?.map((entry) => entry.resource).filter(isDefined) ?? EMPTY;
-        const slots = resources.filter(
-          (obj: WithId<Slot> | WithId<Appointment>): obj is WithId<Slot> => obj.resourceType === 'Slot'
-        );
-        const appointment = resources.find(
-          (obj: WithId<Slot> | WithId<Appointment>): obj is WithId<Appointment> => obj.resourceType === 'Appointment'
-        );
-
-        if (appointment) {
-          let encounter: WithId<Encounter> | undefined;
-          try {
-            encounter = await bookEncounter(appointment);
-          } catch (err) {
-            // If we couldn't load the plan definition or create the encounter for
-            // some reason, we log the error but ignore it. The viewer can decide how
-            // to proceed and manually create the encounter.
-            console.error(err);
-          }
-          await onSuccess?.({ appointment, slots, patient, encounter });
+        const { appointment, slots } = await schedulingAPI.book(booking);
+        let encounter: WithId<Encounter> | undefined;
+        try {
+          encounter = await bookEncounter(appointment);
+        } catch (err) {
+          // If we couldn't load the plan definition or create the encounter for
+          // some reason, we log the error but ignore it. The viewer can decide how
+          // to proceed and manually create the encounter.
+          console.error(err);
         }
+        await onSuccess?.({ appointment, slots, patient, encounter });
+      } catch (err) {
+        showErrorNotification(err);
       } finally {
         setLoading(false);
       }
     },
-    [medplum, appointment, bookEncounter, onSuccess]
+    [appointment, bookEncounter, onSuccess, schedulingAPI]
   );
 
   const handleSubmit = useCallback(async () => {

--- a/examples/medplum-provider/src/components/schedule/FindPane.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/FindPane.test.tsx
@@ -3,7 +3,6 @@
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import type { WithId } from '@medplum/core';
-import { ReadablePromise } from '@medplum/core';
 import type {
   Appointment,
   CodeableConcept,
@@ -19,6 +18,7 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { SchedulingAPI } from '../../hooks/useSchedulingResources';
 import { createEncounter } from '../../utils/encounter';
 import {
   SchedulingEncounterCodingURI,
@@ -72,21 +72,6 @@ describe('FindPane', () => {
     medplum = new MockClient();
     vi.clearAllMocks();
 
-    // Mock the $find operation
-    const originalGet = medplum.get.bind(medplum);
-    medplum.get = vi.fn().mockImplementation((url, options) => {
-      if (url.toString().includes('$find')) {
-        return new ReadablePromise(
-          Promise.resolve({
-            resourceType: 'Bundle',
-            type: 'searchset',
-            entry: mockAppointments.map((appointment) => ({ resource: appointment })),
-          })
-        );
-      }
-      return originalGet(url, options);
-    });
-
     healthcareService = await medplum.createResource<HealthcareService>({
       resourceType: 'HealthcareService',
       name: 'Annual Checkup',
@@ -116,35 +101,46 @@ describe('FindPane', () => {
     });
   });
 
+  const buildSchedulingAPI = (overrides: Partial<SchedulingAPI> = {}): SchedulingAPI => ({
+    book: vi.fn(),
+    cancel: vi.fn(),
+    confirm: vi.fn(),
+    find: vi.fn().mockResolvedValue(mockAppointments),
+    updateAppointment: vi.fn(),
+    ...overrides,
+  });
+
   type SetupOptions = {
     schedule?: WithId<Schedule>;
     range?: { start: Date; end: Date };
     onSuccess?: (results: { appointment: Appointment; slots: Slot[] }) => void;
+    schedulingAPI?: Partial<SchedulingAPI>;
   };
 
-  const setup = (options: SetupOptions = {}): ReturnType<typeof render> => {
+  const setup = (options: SetupOptions = {}): ReturnType<typeof render> & { schedulingAPI: SchedulingAPI } => {
     const {
       schedule = createScheduleWithServices([healthcareService, healthcareService2]),
       range = defaultRange,
       onSuccess = vi.fn(),
     } = options;
+    const schedulingAPI = buildSchedulingAPI(options.schedulingAPI);
 
-    return render(
+    const result = render(
       <MemoryRouter>
         <MedplumProvider medplum={medplum}>
           <MantineProvider>
             <Notifications />
             <div data-testid="FindPaneTestWrapper">
-              <FindPane schedule={schedule} range={range} onSuccess={onSuccess} />
+              <FindPane schedule={schedule} range={range} onSuccess={onSuccess} schedulingAPI={schedulingAPI} />
             </div>
           </MantineProvider>
         </MedplumProvider>
       </MemoryRouter>
     );
+    return { ...result, schedulingAPI };
   };
 
   test('it renders null when there are no schedulable service types on the Schedule', async () => {
-    // schedule.serviceType is missing, no schedulable services
     const schedule = {
       resourceType: 'Schedule',
       id: 'schedule-123',
@@ -176,37 +172,42 @@ describe('FindPane', () => {
   });
 
   describe('HealthcareService Selection', () => {
-    test('fetches appointments when a service type is selected', async () => {
+    test('calls schedulingAPI.find when a service type is selected', async () => {
       const user = userEvent.setup();
-
+      let schedulingAPI!: SchedulingAPI;
       await act(async () => {
-        setup();
+        ({ schedulingAPI } = setup());
       });
 
       await user.click(screen.getByText('Annual Checkup'));
 
-      // check that Appointment/$find was called
-      expect(medplum.get).toHaveBeenCalledWith(
-        expect.objectContaining({ href: expect.stringContaining('Appointment/$find') }),
-        expect.any(Object)
+      await waitFor(() =>
+        expect(schedulingAPI.find).toHaveBeenCalledWith(
+          expect.objectContaining({
+            healthcareService: expect.objectContaining({ id: healthcareService.id }),
+          })
+        )
       );
+    });
 
-      // check that it was called with the service-type-reference parameter
-      expect(medplum.get).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: expect.stringContaining(
-            `service-type-reference=${encodeURIComponent(`HealthcareService/${healthcareService.id}`)}`
-          ),
-        }),
-        expect.any(Object)
-      );
+    test('passes the range to schedulingAPI.find', async () => {
+      const user = userEvent.setup();
+      let schedulingAPI!: SchedulingAPI;
+      await act(async () => {
+        ({ schedulingAPI } = setup());
+      });
 
-      // check that the schedule reference is included
-      expect(medplum.get).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: expect.stringContaining(`schedule=${encodeURIComponent('Schedule/schedule-1')}`),
-        }),
-        expect.any(Object)
+      await user.click(screen.getByText('Annual Checkup'));
+
+      await waitFor(() =>
+        expect(schedulingAPI.find).toHaveBeenCalledWith(
+          expect.objectContaining({
+            range: expect.objectContaining({
+              start: expect.any(Date),
+              end: expect.any(Date),
+            }),
+          })
+        )
       );
     });
 
@@ -280,9 +281,6 @@ describe('FindPane', () => {
       // Should immediately show the service type name, not the selection UI
       expect(screen.getByText('Annual Checkup')).toBeInTheDocument();
       expect(screen.queryByText('Schedule…')).not.toBeInTheDocument();
-
-      // Should fetch slots automatically
-      expect(medplum.get).toHaveBeenCalled();
     });
 
     test('does not show dismiss button when auto-selected with single option', async () => {
@@ -340,39 +338,42 @@ describe('FindPane', () => {
       const user = userEvent.setup();
 
       await act(async () => {
-        setup();
+        setup({ schedulingAPI: { find: vi.fn().mockRejectedValue(new Error('Network error')) } });
       });
 
-      medplum.get = vi.fn().mockRejectedValue(new Error('Network error'));
-
       await user.click(screen.getByText('Annual Checkup'));
-      expect(medplum.get).toHaveBeenCalled();
 
-      // Error notification should be shown
-      expect(screen.getByText(/Network error/i)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText(/Network error/i)).toBeInTheDocument();
+      });
     });
   });
 
   describe('Search Parameters', () => {
-    test('includes start and end dates in API call', async () => {
+    test('passes start and end dates to schedulingAPI.find', async () => {
       const user = userEvent.setup();
       const range = {
         start: new Date('2024-02-01T00:00:00Z'),
         end: new Date('2024-02-07T23:59:59Z'),
       };
 
+      let schedulingAPI!: SchedulingAPI;
       await act(async () => {
-        setup({ range });
+        ({ schedulingAPI } = setup({ range }));
       });
 
       await user.click(screen.getByText('Annual Checkup'));
 
-      const callUrl = (medplum.get as ReturnType<typeof vi.fn>).mock.calls
-        .map((call) => call[0])
-        .find((url) => url.toString().includes('$find'));
-
-      expect(callUrl?.href).toContain('start=');
-      expect(callUrl?.href).toContain('end=');
+      await waitFor(() =>
+        expect(schedulingAPI.find).toHaveBeenCalledWith(
+          expect.objectContaining({
+            range: expect.objectContaining({
+              start: expect.any(Date),
+              end: expect.any(Date),
+            }),
+          })
+        )
+      );
     });
   });
 
@@ -430,6 +431,18 @@ describe('FindPane', () => {
 
     let serviceWithEncounterConfig: WithId<HealthcareService>;
 
+    const bookedAppointment: Appointment = {
+      resourceType: 'Appointment',
+      id: 'booked-1',
+      status: 'booked',
+      start: '2024-01-16T10:00:00Z',
+      end: '2024-01-16T10:30:00Z',
+      participant: [
+        { actor: { reference: 'Practitioner/prac-1' }, status: 'accepted' },
+        { actor: { reference: `Patient/${HomerSimpson.id}` }, status: 'accepted' },
+      ],
+    };
+
     beforeEach(async () => {
       const planDef = await medplum.createResource<PlanDefinition>({
         resourceType: 'PlanDefinition',
@@ -447,32 +460,14 @@ describe('FindPane', () => {
         ],
       });
 
-      // $book returns a booked appointment with exactly one practitioner and one patient so
-      // bookEncounter (inside BookAppointmentForm) will proceed to call createEncounter.
-      const bookedAppointment: Appointment = {
-        resourceType: 'Appointment',
-        id: 'booked-1',
-        status: 'booked',
-        start: '2024-01-16T10:00:00Z',
-        end: '2024-01-16T10:30:00Z',
-        participant: [
-          { actor: { reference: 'Practitioner/prac-1' }, status: 'accepted' },
-          { actor: { reference: `Patient/${HomerSimpson.id}` }, status: 'accepted' },
-        ],
-      };
-
-      medplum.post = vi.fn().mockResolvedValue({
-        resourceType: 'Bundle',
-        type: 'collection',
-        entry: [{ resource: bookedAppointment }],
-      });
-
       vi.mocked(createEncounter).mockResolvedValue(MOCK_ENCOUNTER);
     });
 
-    // Renders FindPane inside a router that has a destination route for the encounter page
-    // so tests can assert that navigation actually happened.
-    const setupWithRoutes = (schedule: WithId<Schedule>, onSuccess = vi.fn()): void => {
+    const setupWithRoutes = (
+      schedule: WithId<Schedule>,
+      onSuccess = vi.fn(),
+      schedulingAPI = buildSchedulingAPI()
+    ): void => {
       render(
         <MemoryRouter initialEntries={['/find']}>
           <MedplumProvider medplum={medplum}>
@@ -481,7 +476,14 @@ describe('FindPane', () => {
               <Routes>
                 <Route
                   path="/find"
-                  element={<FindPane schedule={schedule} range={defaultRange} onSuccess={onSuccess} />}
+                  element={
+                    <FindPane
+                      schedule={schedule}
+                      range={defaultRange}
+                      onSuccess={onSuccess}
+                      schedulingAPI={schedulingAPI}
+                    />
+                  }
                 />
                 <Route
                   path="/Patient/:patientId/Encounter/:encounterId"
@@ -506,10 +508,12 @@ describe('FindPane', () => {
     test('navigates to the encounter page and does not call onSuccess when an encounter is returned', async () => {
       const user = userEvent.setup();
       const onSuccess = vi.fn();
-      // Single service → auto-selected; $find returns mock appointments from the outer beforeEach.
-      setupWithRoutes(createScheduleWithServices([serviceWithEncounterConfig]), onSuccess);
 
-      // Click the first appointment slot that appeared from $find (there are two)
+      const schedulingAPI = buildSchedulingAPI({
+        book: vi.fn().mockResolvedValue({ appointment: bookedAppointment, slots: [] }),
+      });
+      setupWithRoutes(createScheduleWithServices([serviceWithEncounterConfig]), onSuccess, schedulingAPI);
+
       const apptButtons = await screen.findAllByRole('button', { name: /2024/i });
       await user.click(apptButtons[0]);
       await bookWithHomer(user);
@@ -522,9 +526,11 @@ describe('FindPane', () => {
     test('calls onSuccess and does not navigate when no encounter is returned', async () => {
       const user = userEvent.setup();
       const onSuccess = vi.fn();
-      // healthcareService has no encounter extensions → bookEncounter returns undefined.
-      // Single service → auto-selected, so we go straight to waiting for the appointment buttons.
-      setupWithRoutes(createScheduleWithServices([healthcareService]), onSuccess);
+
+      const schedulingAPI = buildSchedulingAPI({
+        book: vi.fn().mockResolvedValue({ appointment: bookedAppointment, slots: [] }),
+      });
+      setupWithRoutes(createScheduleWithServices([healthcareService]), onSuccess, schedulingAPI);
 
       const apptButtons = await screen.findAllByRole('button', { name: /2024/i });
       await user.click(apptButtons[0]);
@@ -539,14 +545,11 @@ describe('FindPane', () => {
     test('passes abort signal to API call', async () => {
       const user = userEvent.setup();
 
-      await act(async () => {
-        setup();
-      });
+      const { schedulingAPI } = await act(async () => setup());
 
       await user.click(screen.getByText('Annual Checkup'));
-      expect(medplum.get).toHaveBeenCalledWith(
-        expect.objectContaining({ href: expect.stringContaining('$find') }),
-        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      expect(schedulingAPI.find).toHaveBeenCalledWith(
+        expect.objectContaining({ abortSignal: expect.any(AbortSignal) })
       );
     });
   });

--- a/examples/medplum-provider/src/components/schedule/FindPane.tsx
+++ b/examples/medplum-provider/src/components/schedule/FindPane.tsx
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Button, Group, Stack, Text, Title } from '@mantine/core';
 import type { WithId } from '@medplum/core';
-import { EMPTY, formatDateTime, getReferenceString, isDefined } from '@medplum/core';
-import type { Appointment, Bundle, Encounter, HealthcareService, Patient, Schedule, Slot } from '@medplum/fhirtypes';
+import { EMPTY, formatDateTime } from '@medplum/core';
+import type { Appointment, Encounter, HealthcareService, Patient, Schedule, Slot } from '@medplum/fhirtypes';
 import { CodeableConceptDisplay, useMedplum } from '@medplum/react';
 import { IconChevronRight, IconX } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { BookAppointmentForm } from '../../components/schedule/BookAppointmentForm';
+import type { SchedulingAPI } from '../../hooks/useSchedulingResources';
 import { useSchedulingStartsAt } from '../../hooks/useSchedulingStartsAt';
 import type { Range } from '../../types/scheduling';
 import { showErrorNotification } from '../../utils/notifications';
@@ -23,6 +24,7 @@ type FindPaneProps = {
   range: Range;
   onSuccess: (results: { appointment: WithId<Appointment>; slots: WithId<Slot>[] }) => void;
   className?: string;
+  schedulingAPI: SchedulingAPI;
 };
 
 function HealthcareServiceDisplay(props: { value: HealthcareService }): JSX.Element {
@@ -50,7 +52,7 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
   const [appointments, setAppointments] = useState<readonly Appointment[] | undefined>(undefined);
   const [chosenAppointment, setChosenAppointment] = useState<Appointment | undefined>(undefined);
   const [selectedHealthcareService, setSelectedHealthcareService] = useState<WithId<HealthcareService> | undefined>();
-  const { schedule, range, onSuccess } = props;
+  const { schedule, range, onSuccess, schedulingAPI } = props;
 
   const [healthcareServices, setHealthcareServices] = useState<WithId<HealthcareService>[] | undefined>();
 
@@ -91,56 +93,47 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
   const earliestSchedulable = useSchedulingStartsAt({ minimumNoticeMinutes: 30 });
 
   useEffect(() => {
-    if (!schedule || !selectedHealthcareService) {
+    if (!selectedHealthcareService) {
       return () => {};
     }
 
     // Compute search range
     const searchStart = range.start < earliestSchedulable ? earliestSchedulable : range.start;
     const searchEnd = searchStart < range.end ? range.end : new Date(searchStart.getTime() + ONE_WEEK_MS);
-    const start = searchStart.toISOString();
-    const end = searchEnd.toISOString();
 
     let completed = false;
     const controller = new AbortController();
     const signal = controller.signal;
 
-    const url = medplum.fhirUrl('Appointment', '$find');
-    url.searchParams.append('start', start);
-    url.searchParams.append('end', end);
-    url.searchParams.append('service-type-reference', getReferenceString(selectedHealthcareService));
-    url.searchParams.append('schedule', getReferenceString(schedule));
-
-    medplum
-      .get<Bundle<Appointment>>(url, { signal })
-      .then(
-        (bundle) => {
-          if (signal.aborted) {
-            return;
-          }
-          if (bundle.entry) {
-            bundle.entry.forEach((entry) => entry.resource && SchedulingTransientIdentifier.set(entry.resource));
-            setAppointments(bundle.entry.map((entry) => entry.resource).filter(isDefined));
-          } else {
-            setAppointments([]);
-          }
-        },
-        (error) => {
-          if (!signal.aborted) {
-            setAppointments([]);
-            showErrorNotification(error);
-          }
+    schedulingAPI
+      .find({
+        healthcareService: selectedHealthcareService,
+        range: { start: searchStart, end: searchEnd },
+        abortSignal: signal,
+      })
+      .then((appointments) => {
+        if (signal.aborted) {
+          return;
         }
-      )
+        setAppointments(appointments);
+      })
+      .catch((err) => {
+        if (signal.aborted) {
+          return;
+        }
+        setAppointments([]);
+        showErrorNotification(err);
+      })
       .finally(() => {
         completed = true;
       });
+
     return () => {
       if (!completed) {
         controller.abort();
       }
     };
-  }, [medplum, schedule, selectedHealthcareService, range, earliestSchedulable]);
+  }, [schedulingAPI, selectedHealthcareService, range, earliestSchedulable]);
 
   const handleDismiss = useCallback(() => {
     setSelectedHealthcareService(undefined);
@@ -187,6 +180,7 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
           appointment={chosenAppointment}
           healthcareService={selectedHealthcareService}
           onSuccess={handleBookSuccess}
+          schedulingAPI={props.schedulingAPI}
         />
       </Stack>
     );

--- a/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
@@ -3,15 +3,17 @@
 import { Drawer, Stack, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import type { WithId } from '@medplum/core';
-import { EMPTY, getReferenceString, isDefined, isReference, isResourceWithId, resolveId } from '@medplum/core';
+import { getReferenceString, isReference, isResourceWithId } from '@medplum/core';
 import type { Appointment, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react';
 import type { JSX } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { Calendar } from '../../components/Calendar';
+import { OutcomeAlert } from '../../components/OutcomeAlert';
 import { AppointmentDetails } from '../../components/schedule/AppointmentDetails';
 import { CreateVisit } from '../../components/schedule/CreateVisit';
+import { useSchedulingResources } from '../../hooks/useSchedulingResources';
 import type { Range } from '../../types/scheduling';
 import { encounterUrl } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
@@ -31,56 +33,12 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
   const [createAppointmentOpened, createAppointmentHandlers] = useDisclosure(false);
   const [appointmentDetailsOpened, appointmentDetailsHandlers] = useDisclosure(false);
   const [range, setRange] = useState<Range | undefined>(undefined);
-  const [slots, setSlots] = useState<Slot[] | undefined>(undefined);
-  const [appointments, setAppointments] = useState<WithId<Appointment>[] | undefined>(undefined);
 
   const [appointmentSlot, setAppointmentSlot] = useState<Range>();
   const [appointmentDetails, setAppointmentDetails] = useState<WithId<Appointment> | undefined>(undefined);
 
-  useEffect(() => {
-    if (!range) {
-      return () => {};
-    }
-    let active = true;
-
-    medplum
-      .searchResources('Slot', [
-        ['_count', '1000'],
-        ['schedule', getReferenceString(schedule)],
-        ['start', `ge${range.start.toISOString()}`],
-        ['start', `le${range.end.toISOString()}`],
-        ['status:not', 'entered-in-error'],
-      ])
-      .then((rawSlots) => active && setSlots(rawSlots))
-      .catch((error: unknown) => active && showErrorNotification(error));
-
-    return () => {
-      active = false;
-    };
-  }, [medplum, schedule, range]);
-
-  // Find appointments visible in the current range
-  useEffect(() => {
-    const actorRef = schedule.actor[0]?.reference;
-    if (!actorRef || !range) {
-      return () => {};
-    }
-    let active = true;
-
-    medplum
-      .searchResources('Appointment', [
-        ['_count', '1000'],
-        ['actor', actorRef],
-        ['date', `ge${range.start.toISOString()}`],
-        ['date', `le${range.end.toISOString()}`],
-      ])
-      .then((appointments) => active && setAppointments(appointments))
-      .catch((error: unknown) => active && showErrorNotification(error));
-
-    return () => {
-      active = false;
-    };
-  }, [medplum, schedule, range]);
+  const schedules = useMemo(() => [schedule], [schedule]);
+  const { slots, appointments, schedulingAPI, operationOutcome } = useSchedulingResources(schedules, range);
 
   const practitioner = schedule.actor.find((actor) => isReference<Practitioner>(actor, 'Practitioner'));
 
@@ -117,10 +75,8 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
 
   const handleBookSuccess = useCallback(
     (results: { appointment: WithId<Appointment>; slots: Slot[] }) => {
-      setAppointments((state) => [...(state ?? EMPTY), results.appointment]);
       setAppointmentDetails(results.appointment);
       appointmentDetailsHandlers.open();
-      setSlots((state) => results.slots.concat(state ?? EMPTY));
     },
     [appointmentDetailsHandlers]
   );
@@ -160,25 +116,13 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
 
   const handleAppointmentUpdate = useCallback(
     (updated: WithId<Appointment>) => {
-      setAppointments((state) => (state ?? []).map((existing) => (existing.id === updated.id ? updated : existing)));
       setAppointmentDetails((existing) => (existing?.id === updated.id ? updated : existing));
       if (updated.status === 'cancelled') {
         appointmentDetailsHandlers.close();
-
-        // If the appointment was cancelled with `$cancel`, it also
-        // soft-deleted the related slots. Remove them from our local state.
-        if (updated.slot) {
-          const ids = new Set(updated.slot.map((ref) => resolveId(ref)).filter(isDefined));
-          setSlots((state) => state?.filter((slot) => slot.id && !ids.has(slot.id)));
-        }
       }
     },
     [appointmentDetailsHandlers]
   );
-
-  const handleSlotUpdate = useCallback((updated: WithId<Slot>) => {
-    setSlots((state) => (state ?? []).map((existing) => (existing.id === updated.id ? updated : existing)));
-  }, []);
 
   const mergedSlots = useMemo(() => mergeOverlappingSlots(slots ?? []), [slots]);
 
@@ -186,6 +130,7 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
     <>
       <div className={classes.container}>
         <Stack className={classes.calendarPane}>
+          <OutcomeAlert outcome={operationOutcome} />
           <Calendar
             onSelectInterval={handleSelectInterval}
             onSelectAppointment={handleSelectAppointment}
@@ -207,6 +152,7 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
             range={range}
             onSuccess={handleBookSuccess}
             className={classes.findPane}
+            schedulingAPI={schedulingAPI}
           />
         )}
       </div>
@@ -238,7 +184,7 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
           <AppointmentDetails
             appointment={appointmentDetails}
             onAppointmentUpdate={handleAppointmentUpdate}
-            onSlotUpdate={handleSlotUpdate}
+            schedulingAPI={schedulingAPI}
           />
         )}
       </Drawer>

--- a/examples/medplum-provider/src/hooks/useSchedulingResources.test.tsx
+++ b/examples/medplum-provider/src/hooks/useSchedulingResources.test.tsx
@@ -1,0 +1,615 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import { ReadablePromise } from '@medplum/core';
+import type { Appointment, Bundle, HealthcareService, Schedule, Slot } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { JSX } from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { SchedulingTransientIdentifier } from '../utils/scheduling';
+import { useSchedulingResources } from './useSchedulingResources';
+
+describe('useSchedulingResources', () => {
+  let medplum: MockClient;
+
+  const schedule: WithId<Schedule> = {
+    resourceType: 'Schedule',
+    id: 'schedule-1',
+    actor: [{ reference: 'Practitioner/prac-1' }],
+    active: true,
+  };
+
+  // Stable array reference — passing [schedule] inline to renderHook creates a new array on every
+  // render, which causes the useEffect to re-run on each render (infinite loop).
+  const schedules = [schedule];
+
+  const range = {
+    start: new Date('2024-01-15T00:00:00Z'),
+    end: new Date('2024-01-21T23:59:59Z'),
+  };
+
+  beforeEach(() => {
+    medplum = new MockClient();
+    vi.clearAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }): JSX.Element => (
+    <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
+  );
+
+  describe('initial state', () => {
+    test('exposes schedulingAPI with all operations', () => {
+      const { result } = renderHook(() => useSchedulingResources(schedules, undefined), { wrapper });
+
+      expect(typeof result.current.schedulingAPI.book).toBe('function');
+      expect(typeof result.current.schedulingAPI.cancel).toBe('function');
+      expect(typeof result.current.schedulingAPI.confirm).toBe('function');
+      expect(typeof result.current.schedulingAPI.find).toBe('function');
+      expect(typeof result.current.schedulingAPI.updateAppointment).toBe('function');
+    });
+
+    test('slots and appointments are undefined when no range is provided', () => {
+      const { result } = renderHook(() => useSchedulingResources(schedules, undefined), { wrapper });
+
+      expect(result.current.slots).toBeUndefined();
+      expect(result.current.appointments).toBeUndefined();
+      expect(result.current.schedulingResources).toBeUndefined();
+    });
+  });
+
+  describe('data fetching', () => {
+    test('fetches slots and appointments when range is provided', async () => {
+      const mockSlot: WithId<Slot> = {
+        resourceType: 'Slot',
+        id: 'slot-1',
+        status: 'free',
+        start: '2024-01-16T10:00:00Z',
+        end: '2024-01-16T10:30:00Z',
+        schedule: { reference: 'Schedule/schedule-1' },
+      };
+      const mockAppointment: WithId<Appointment> = {
+        resourceType: 'Appointment',
+        id: 'appt-1',
+        status: 'booked',
+        participant: [],
+      };
+
+      medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
+        if (resourceType === 'Slot') return Promise.resolve([mockSlot]);
+        if (resourceType === 'Appointment') return Promise.resolve([mockAppointment]);
+        return Promise.resolve([]);
+      });
+
+      const { result } = renderHook(() => useSchedulingResources(schedules, range), { wrapper });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.slots).toEqual([mockSlot]);
+      expect(result.current.appointments).toEqual([mockAppointment]);
+    });
+
+    test('searches slots with correct schedule reference and date range', async () => {
+      medplum.searchResources = vi.fn().mockResolvedValue([]);
+
+      const { result } = renderHook(() => useSchedulingResources(schedules, range), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      const slotCall = (medplum.searchResources as ReturnType<typeof vi.fn>).mock.calls.find(
+        (args: unknown[]) => args[0] === 'Slot'
+      );
+      expect(slotCall).toBeDefined();
+      const [, slotParams] = slotCall!;
+      expect(slotParams).toContainEqual(['schedule', 'Schedule/schedule-1']);
+      expect(slotParams).toContainEqual(['start', `ge${range.start.toISOString()}`]);
+      expect(slotParams).toContainEqual(['status:not', 'entered-in-error']);
+    });
+
+    test('searches appointments with actor references and date range', async () => {
+      medplum.searchResources = vi.fn().mockResolvedValue([]);
+
+      const { result } = renderHook(() => useSchedulingResources(schedules, range), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      const apptCall = (medplum.searchResources as ReturnType<typeof vi.fn>).mock.calls.find(
+        (args: unknown[]) => args[0] === 'Appointment'
+      );
+      expect(apptCall).toBeDefined();
+      const [, apptParams] = apptCall!;
+      expect(apptParams).toContainEqual(['actor', 'Practitioner/prac-1']);
+      expect(apptParams).toContainEqual(['date', `ge${range.start.toISOString()}`]);
+    });
+
+    test('flattens slots and appointments across multiple schedules', async () => {
+      const schedule2: WithId<Schedule> = {
+        resourceType: 'Schedule',
+        id: 'schedule-2',
+        actor: [{ reference: 'Practitioner/prac-2' }],
+        active: true,
+      };
+
+      const slot1: WithId<Slot> = {
+        resourceType: 'Slot',
+        id: 's1',
+        status: 'free',
+        start: '2024-01-16T10:00:00Z',
+        end: '2024-01-16T10:30:00Z',
+        schedule: { reference: 'Schedule/schedule-1' },
+      };
+      const slot2: WithId<Slot> = {
+        resourceType: 'Slot',
+        id: 's2',
+        status: 'free',
+        start: '2024-01-16T11:00:00Z',
+        end: '2024-01-16T11:30:00Z',
+        schedule: { reference: 'Schedule/schedule-2' },
+      };
+
+      let slotCallCount = 0;
+      medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
+        if (resourceType === 'Slot') return Promise.resolve(slotCallCount++ === 0 ? [slot1] : [slot2]);
+        return Promise.resolve([]);
+      });
+
+      const schedules = [schedule, schedule2];
+      const { result } = renderHook(() => useSchedulingResources(schedules, range), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.slots).toHaveLength(2);
+      expect(result.current.slots).toContainEqual(slot1);
+      expect(result.current.slots).toContainEqual(slot2);
+    });
+
+    test('sets warning operationOutcome when results hit the page size limit', async () => {
+      const PAGE_SIZE = 1000;
+      const slots: WithId<Slot>[] = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+        resourceType: 'Slot' as const,
+        id: `slot-${i}`,
+        status: 'free' as const,
+        start: '2024-01-16T10:00:00Z',
+        end: '2024-01-16T10:30:00Z',
+        schedule: { reference: 'Schedule/schedule-1' },
+      }));
+
+      medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
+        if (resourceType === 'Slot') return Promise.resolve(slots);
+        return Promise.resolve([]);
+      });
+
+      const { result } = renderHook(() => useSchedulingResources(schedules, range), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.operationOutcome?.issue?.[0]?.code).toBe('incomplete');
+    });
+
+    test('sets error operationOutcome when fetch fails', async () => {
+      medplum.searchResources = vi.fn().mockRejectedValue(new Error('Network error'));
+
+      const { result } = renderHook(() => useSchedulingResources(schedules, range), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.operationOutcome).toBeDefined();
+      expect(result.current.operationOutcome?.issue?.[0]?.severity).toBe('error');
+    });
+  });
+
+  describe('book()', () => {
+    const existingSlot: WithId<Slot> = {
+      resourceType: 'Slot',
+      id: 'existing-slot',
+      status: 'free',
+      start: '2024-01-16T09:00:00Z',
+      end: '2024-01-16T09:30:00Z',
+      schedule: { reference: 'Schedule/schedule-1' },
+    };
+    const existingAppointment: WithId<Appointment> = {
+      resourceType: 'Appointment',
+      id: 'existing-appt',
+      status: 'booked',
+      participant: [],
+    };
+
+    const setupWithData = async () => {
+      medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
+        if (resourceType === 'Slot') return Promise.resolve([existingSlot]);
+        if (resourceType === 'Appointment') return Promise.resolve([existingAppointment]);
+        return Promise.resolve([]);
+      });
+
+      const hookResult = renderHook(() => useSchedulingResources(schedules, range), { wrapper });
+      await waitFor(() => expect(hookResult.result.current.loading).toBe(false));
+      return hookResult;
+    };
+
+    test('calls POST on Appointment/$book with a Parameters resource', async () => {
+      const { result } = await setupWithData();
+
+      const newAppointment: WithId<Appointment> = {
+        resourceType: 'Appointment',
+        id: 'new-appt',
+        status: 'booked',
+        participant: [],
+      };
+      const bundle: Bundle = {
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [{ resource: newAppointment }],
+      };
+      medplum.post = vi.fn().mockResolvedValue(bundle);
+      medplum.invalidateSearches = vi.fn();
+
+      await act(async () => {
+        await result.current.schedulingAPI.book({ resourceType: 'Appointment', status: 'proposed', participant: [] });
+      });
+
+      expect(medplum.post).toHaveBeenCalledWith(
+        expect.objectContaining({ href: expect.stringContaining('Appointment/$book') }),
+        expect.objectContaining({ resourceType: 'Parameters' })
+      );
+    });
+
+    test('removes SchedulingTransientIdentifier from appointment before posting', async () => {
+      const { result } = await setupWithData();
+
+      const newAppointment: WithId<Appointment> = {
+        resourceType: 'Appointment',
+        id: 'new-appt',
+        status: 'booked',
+        participant: [],
+      };
+      medplum.post = vi.fn().mockResolvedValue({
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [{ resource: newAppointment }],
+      });
+      medplum.invalidateSearches = vi.fn();
+
+      const appointmentWithId: Appointment = { resourceType: 'Appointment', status: 'proposed', participant: [] };
+      SchedulingTransientIdentifier.set(appointmentWithId);
+      expect(SchedulingTransientIdentifier.get(appointmentWithId)).toBeDefined();
+
+      await act(async () => {
+        await result.current.schedulingAPI.book(appointmentWithId);
+      });
+
+      const postCall = (medplum.post as ReturnType<typeof vi.fn>).mock.calls[0];
+      const parameters = postCall[1];
+      const postedAppointment = parameters.parameter[0].resource;
+      expect(SchedulingTransientIdentifier.get(postedAppointment)).toBeUndefined();
+    });
+
+    test('adds booked appointment and slot to local state', async () => {
+      const { result } = await setupWithData();
+
+      const newAppointment: WithId<Appointment> = {
+        resourceType: 'Appointment',
+        id: 'new-appt',
+        status: 'booked',
+        participant: [],
+      };
+      const newSlot: WithId<Slot> = {
+        resourceType: 'Slot',
+        id: 'new-slot',
+        status: 'busy',
+        start: '2024-01-16T10:00:00Z',
+        end: '2024-01-16T10:30:00Z',
+        schedule: { reference: 'Schedule/schedule-1' },
+      };
+      medplum.post = vi.fn().mockResolvedValue({
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [{ resource: newAppointment }, { resource: newSlot }],
+      });
+      medplum.invalidateSearches = vi.fn();
+
+      let bookResult!: { appointment: WithId<Appointment>; slots: WithId<Slot>[] };
+      await act(async () => {
+        bookResult = await result.current.schedulingAPI.book({
+          resourceType: 'Appointment',
+          status: 'proposed',
+          participant: [],
+        });
+      });
+
+      expect(bookResult.appointment).toEqual(newAppointment);
+      expect(bookResult.slots).toContainEqual(newSlot);
+      expect(result.current.appointments).toContainEqual(newAppointment);
+      expect(result.current.slots).toContainEqual(newSlot);
+      expect(result.current.appointments).toContainEqual(existingAppointment);
+      expect(result.current.slots).toContainEqual(existingSlot);
+    });
+
+    test('invalidates Appointment and Slot searches', async () => {
+      const { result } = await setupWithData();
+
+      const newAppointment: WithId<Appointment> = {
+        resourceType: 'Appointment',
+        id: 'new-appt',
+        status: 'booked',
+        participant: [],
+      };
+      medplum.post = vi.fn().mockResolvedValue({
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [{ resource: newAppointment }],
+      });
+      medplum.invalidateSearches = vi.fn();
+
+      await act(async () => {
+        await result.current.schedulingAPI.book({ resourceType: 'Appointment', status: 'proposed', participant: [] });
+      });
+
+      expect(medplum.invalidateSearches).toHaveBeenCalledWith('Appointment');
+      expect(medplum.invalidateSearches).toHaveBeenCalledWith('Slot');
+    });
+
+    test('throws when $book returns no Appointment in the bundle', async () => {
+      const { result } = await setupWithData();
+
+      medplum.post = vi.fn().mockResolvedValue({
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [],
+      });
+      medplum.invalidateSearches = vi.fn();
+
+      await expect(
+        act(async () => {
+          await result.current.schedulingAPI.book({ resourceType: 'Appointment', status: 'proposed', participant: [] });
+        })
+      ).rejects.toThrow('$book succeeded but did not return an Appointment');
+    });
+  });
+
+  describe('cancel()', () => {
+    test('calls POST on Appointment/:id/$cancel, updates the appointment, and removes its slots', async () => {
+      const slotToCancel: WithId<Slot> = {
+        resourceType: 'Slot',
+        id: 'slot-cancel',
+        status: 'busy',
+        start: '2024-01-16T10:00:00Z',
+        end: '2024-01-16T10:30:00Z',
+        schedule: { reference: 'Schedule/schedule-1' },
+      };
+      const otherSlot: WithId<Slot> = {
+        resourceType: 'Slot',
+        id: 'other-slot',
+        status: 'free',
+        start: '2024-01-16T11:00:00Z',
+        end: '2024-01-16T11:30:00Z',
+        schedule: { reference: 'Schedule/schedule-1' },
+      };
+      const appointmentToCancel: WithId<Appointment> = {
+        resourceType: 'Appointment',
+        id: 'appt-cancel',
+        status: 'booked',
+        participant: [],
+        slot: [{ reference: 'Slot/slot-cancel' }],
+      };
+
+      medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
+        if (resourceType === 'Slot') return Promise.resolve([slotToCancel, otherSlot]);
+        if (resourceType === 'Appointment') return Promise.resolve([appointmentToCancel]);
+        return Promise.resolve([]);
+      });
+
+      const { result } = renderHook(() => useSchedulingResources(schedules, range), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      const cancelledAppointment: WithId<Appointment> = {
+        ...appointmentToCancel,
+        status: 'cancelled',
+      };
+      medplum.post = vi.fn().mockResolvedValue(cancelledAppointment);
+      medplum.invalidateSearches = vi.fn();
+
+      await act(async () => {
+        await result.current.schedulingAPI.cancel(appointmentToCancel);
+      });
+
+      expect(medplum.post).toHaveBeenCalledWith(
+        expect.objectContaining({ href: expect.stringContaining(`Appointment/appt-cancel/$cancel`) })
+      );
+      expect(result.current.appointments).toContainEqual(cancelledAppointment);
+      expect(result.current.slots).not.toContainEqual(expect.objectContaining({ id: 'slot-cancel' }));
+      expect(result.current.slots).toContainEqual(otherSlot);
+    });
+  });
+
+  describe('confirm()', () => {
+    test('calls POST on Appointment/:id/$confirm and updates appointment and slots in state', async () => {
+      const pendingAppointment: WithId<Appointment> = {
+        resourceType: 'Appointment',
+        id: 'appt-pending',
+        status: 'pending',
+        participant: [],
+      };
+      const pendingSlot: WithId<Slot> = {
+        resourceType: 'Slot',
+        id: 'slot-pending',
+        status: 'busy',
+        start: '2024-01-16T10:00:00Z',
+        end: '2024-01-16T10:30:00Z',
+        schedule: { reference: 'Schedule/schedule-1' },
+      };
+
+      medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
+        if (resourceType === 'Slot') return Promise.resolve([pendingSlot]);
+        if (resourceType === 'Appointment') return Promise.resolve([pendingAppointment]);
+        return Promise.resolve([]);
+      });
+
+      const { result } = renderHook(() => useSchedulingResources(schedules, range), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      const bookedAppointment: WithId<Appointment> = { ...pendingAppointment, status: 'booked' };
+      const bookedSlot: WithId<Slot> = { ...pendingSlot, status: 'busy-unavailable' };
+
+      medplum.post = vi.fn().mockResolvedValue({
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [{ resource: bookedAppointment }, { resource: bookedSlot }],
+      });
+      medplum.invalidateSearches = vi.fn();
+
+      let confirmResult!: { appointment: WithId<Appointment>; slots: WithId<Slot>[] };
+      await act(async () => {
+        confirmResult = await result.current.schedulingAPI.confirm(pendingAppointment);
+      });
+
+      expect(medplum.post).toHaveBeenCalledWith(
+        expect.objectContaining({ href: expect.stringContaining('Appointment/appt-pending/$confirm') })
+      );
+      expect(confirmResult.appointment).toEqual(bookedAppointment);
+      expect(confirmResult.slots).toContainEqual(bookedSlot);
+      expect(result.current.appointments).toContainEqual(bookedAppointment);
+      expect(result.current.slots).toContainEqual(
+        expect.objectContaining({ id: 'slot-pending', status: 'busy-unavailable' })
+      );
+    });
+
+    test('throws when $confirm returns no Appointment', async () => {
+      medplum.searchResources = vi.fn().mockResolvedValue([]);
+
+      const { result } = renderHook(() => useSchedulingResources(schedules, range), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      medplum.post = vi.fn().mockResolvedValue({
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [],
+      });
+      medplum.invalidateSearches = vi.fn();
+
+      await expect(
+        act(async () => {
+          await result.current.schedulingAPI.confirm({
+            resourceType: 'Appointment',
+            id: 'appt-1',
+            status: 'pending',
+            participant: [],
+          });
+        })
+      ).rejects.toThrow('$confirm succeeded without returning updated Appointment');
+    });
+  });
+
+  describe('updateAppointment()', () => {
+    test('calls updateResource and reflects the change in local state', async () => {
+      const existing: WithId<Appointment> = {
+        resourceType: 'Appointment',
+        id: 'appt-update',
+        status: 'pending',
+        participant: [],
+      };
+
+      medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
+        if (resourceType === 'Appointment') return Promise.resolve([existing]);
+        return Promise.resolve([]);
+      });
+
+      const { result } = renderHook(() => useSchedulingResources(schedules, range), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      const updated: WithId<Appointment> = { ...existing, status: 'booked' };
+      medplum.updateResource = vi.fn().mockResolvedValue(updated);
+
+      await act(async () => {
+        await result.current.schedulingAPI.updateAppointment(existing);
+      });
+
+      expect(medplum.updateResource).toHaveBeenCalledWith(existing);
+      expect(result.current.appointments).toContainEqual(updated);
+      expect(result.current.appointments).not.toContainEqual(expect.objectContaining({ status: 'pending' }));
+    });
+  });
+
+  describe('find()', () => {
+    const setupWithEmptyData = async () => {
+      medplum.searchResources = vi.fn().mockResolvedValue([]);
+      const hookResult = renderHook(() => useSchedulingResources(schedules, range), { wrapper });
+      await waitFor(() => expect(hookResult.result.current.loading).toBe(false));
+      return hookResult;
+    };
+
+    test('builds URL with start, end, service-type-reference, and schedule params', async () => {
+      const { result } = await setupWithEmptyData();
+
+      const originalGet = medplum.get.bind(medplum);
+      medplum.get = vi.fn().mockImplementation((url: URL, options: unknown) => {
+        if (url.toString().includes('$find')) {
+          return new ReadablePromise(Promise.resolve({ resourceType: 'Bundle', type: 'searchset', entry: [] }));
+        }
+        return originalGet(url, options as RequestInit);
+      });
+
+      const healthcareService: WithId<HealthcareService> = { resourceType: 'HealthcareService', id: 'hcs-1' };
+      const findRange = { start: new Date('2024-01-16T00:00:00Z'), end: new Date('2024-01-16T23:59:59Z') };
+
+      await act(async () => {
+        await result.current.schedulingAPI.find({ healthcareService, range: findRange });
+      });
+
+      const callUrl = (medplum.get as ReturnType<typeof vi.fn>).mock.calls
+        .map((args: unknown[]) => args[0] as URL)
+        .find((url: URL) => url.toString().includes('$find'));
+
+      expect(callUrl).toBeDefined();
+      expect(callUrl!.href).toContain('start=');
+      expect(callUrl!.href).toContain('end=');
+      expect(callUrl!.href).toContain('service-type-reference=');
+      expect(callUrl!.href).toContain(encodeURIComponent('HealthcareService/hcs-1'));
+      expect(callUrl!.href).toContain(encodeURIComponent('Schedule/schedule-1'));
+    });
+
+    test('passes abort signal to the HTTP call', async () => {
+      const { result } = await setupWithEmptyData();
+
+      medplum.get = vi.fn().mockImplementation(() => {
+        return new ReadablePromise(Promise.resolve({ resourceType: 'Bundle', type: 'searchset', entry: [] }));
+      });
+
+      const controller = new AbortController();
+
+      await act(async () => {
+        await result.current.schedulingAPI.find({
+          healthcareService: { resourceType: 'HealthcareService', id: 'hcs-1' },
+          range: { start: new Date(), end: new Date() },
+          abortSignal: controller.signal,
+        });
+      });
+
+      expect(medplum.get).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ signal: controller.signal })
+      );
+    });
+
+    test('tags each returned appointment with SchedulingTransientIdentifier', async () => {
+      const { result } = await setupWithEmptyData();
+
+      const returnedAppointment: Appointment = { resourceType: 'Appointment', status: 'proposed', participant: [] };
+      medplum.get = vi.fn().mockImplementation(() => {
+        return new ReadablePromise(
+          Promise.resolve({
+            resourceType: 'Bundle',
+            type: 'searchset',
+            entry: [{ resource: returnedAppointment }],
+          })
+        );
+      });
+
+      let appointments!: Appointment[];
+      await act(async () => {
+        appointments = await result.current.schedulingAPI.find({
+          healthcareService: { resourceType: 'HealthcareService', id: 'hcs-1' },
+          range: { start: new Date(), end: new Date() },
+        });
+      });
+
+      expect(appointments).toHaveLength(1);
+      expect(SchedulingTransientIdentifier.get(appointments[0])).toBeDefined();
+    });
+  });
+});

--- a/examples/medplum-provider/src/hooks/useSchedulingResources.test.tsx
+++ b/examples/medplum-provider/src/hooks/useSchedulingResources.test.tsx
@@ -57,7 +57,6 @@ describe('useSchedulingResources', () => {
 
       expect(result.current.slots).toBeUndefined();
       expect(result.current.appointments).toBeUndefined();
-      expect(result.current.schedulingResources).toBeUndefined();
     });
   });
 
@@ -305,7 +304,12 @@ describe('useSchedulingResources', () => {
         resourceType: 'Appointment',
         id: 'new-appt',
         status: 'booked',
-        participant: [],
+        participant: [
+          {
+            status: 'tentative',
+            actor: { reference: 'Practitioner/prac-1' },
+          },
+        ],
       };
       const newSlot: WithId<Slot> = {
         resourceType: 'Slot',
@@ -322,14 +326,19 @@ describe('useSchedulingResources', () => {
       });
       medplum.invalidateSearches = vi.fn();
 
-      let bookResult!: { appointment: WithId<Appointment>; slots: WithId<Slot>[] };
-      await act(async () => {
-        bookResult = await result.current.schedulingAPI.book({
+      // let bookResult!: { appointment: WithId<Appointment>; slots: WithId<Slot>[] };
+      const bookResult = await act(() =>
+        result.current.schedulingAPI.book({
           resourceType: 'Appointment',
           status: 'proposed',
-          participant: [],
-        });
-      });
+          participant: [
+            {
+              status: 'tentative',
+              actor: { reference: 'Practitioner/prac-1' },
+            },
+          ],
+        })
+      );
 
       expect(bookResult.appointment).toEqual(newAppointment);
       expect(bookResult.slots).toContainEqual(newSlot);
@@ -346,7 +355,12 @@ describe('useSchedulingResources', () => {
         resourceType: 'Appointment',
         id: 'new-appt',
         status: 'booked',
-        participant: [],
+        participant: [
+          {
+            status: 'tentative',
+            actor: { reference: 'Practitioner/prac-1' },
+          },
+        ],
       };
       medplum.post = vi.fn().mockResolvedValue({
         resourceType: 'Bundle',
@@ -356,7 +370,16 @@ describe('useSchedulingResources', () => {
       medplum.invalidateSearches = vi.fn();
 
       await act(async () => {
-        await result.current.schedulingAPI.book({ resourceType: 'Appointment', status: 'proposed', participant: [] });
+        await result.current.schedulingAPI.book({
+          resourceType: 'Appointment',
+          status: 'proposed',
+          participant: [
+            {
+              status: 'tentative',
+              actor: { reference: 'Practitioner/prac-1' },
+            },
+          ],
+        });
       });
 
       expect(medplum.invalidateSearches).toHaveBeenCalledWith('Appointment');

--- a/examples/medplum-provider/src/hooks/useSchedulingResources.test.tsx
+++ b/examples/medplum-provider/src/hooks/useSchedulingResources.test.tsx
@@ -5,10 +5,12 @@ import { ReadablePromise } from '@medplum/core';
 import type { Appointment, Bundle, HealthcareService, Schedule, Slot } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
+import type { RenderHookResult } from '@testing-library/react';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { JSX } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { SchedulingTransientIdentifier } from '../utils/scheduling';
+import type { UseSchedulingResourcesResult } from './useSchedulingResources';
 import { useSchedulingResources } from './useSchedulingResources';
 
 describe('useSchedulingResources', () => {
@@ -77,8 +79,12 @@ describe('useSchedulingResources', () => {
       };
 
       medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
-        if (resourceType === 'Slot') return Promise.resolve([mockSlot]);
-        if (resourceType === 'Appointment') return Promise.resolve([mockAppointment]);
+        if (resourceType === 'Slot') {
+          return Promise.resolve([mockSlot]);
+        }
+        if (resourceType === 'Appointment') {
+          return Promise.resolve([mockAppointment]);
+        }
         return Promise.resolve([]);
       });
 
@@ -91,16 +97,18 @@ describe('useSchedulingResources', () => {
     });
 
     test('searches slots with correct schedule reference and date range', async () => {
-      medplum.searchResources = vi.fn().mockResolvedValue([]);
+      const searchMock = vi.fn().mockResolvedValue([]);
+      medplum.searchResources = searchMock;
 
       const { result } = renderHook(() => useSchedulingResources(schedules, range), { wrapper });
       await waitFor(() => expect(result.current.loading).toBe(false));
 
-      const slotCall = (medplum.searchResources as ReturnType<typeof vi.fn>).mock.calls.find(
-        (args: unknown[]) => args[0] === 'Slot'
-      );
+      const slotCall = searchMock.mock.calls.find((args: unknown[]) => args[0] === 'Slot');
       expect(slotCall).toBeDefined();
-      const [, slotParams] = slotCall!;
+      if (!slotCall) {
+        return;
+      }
+      const [, slotParams] = slotCall;
       expect(slotParams).toContainEqual(['schedule', 'Schedule/schedule-1']);
       expect(slotParams).toContainEqual(['start', `ge${range.start.toISOString()}`]);
       expect(slotParams).toContainEqual(['status:not', 'entered-in-error']);
@@ -116,7 +124,10 @@ describe('useSchedulingResources', () => {
         (args: unknown[]) => args[0] === 'Appointment'
       );
       expect(apptCall).toBeDefined();
-      const [, apptParams] = apptCall!;
+      if (!apptCall) {
+        return;
+      }
+      const [, apptParams] = apptCall;
       expect(apptParams).toContainEqual(['actor', 'Practitioner/prac-1']);
       expect(apptParams).toContainEqual(['date', `ge${range.start.toISOString()}`]);
     });
@@ -148,7 +159,9 @@ describe('useSchedulingResources', () => {
 
       let slotCallCount = 0;
       medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
-        if (resourceType === 'Slot') return Promise.resolve(slotCallCount++ === 0 ? [slot1] : [slot2]);
+        if (resourceType === 'Slot') {
+          return Promise.resolve(slotCallCount++ === 0 ? [slot1] : [slot2]);
+        }
         return Promise.resolve([]);
       });
 
@@ -173,7 +186,9 @@ describe('useSchedulingResources', () => {
       }));
 
       medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
-        if (resourceType === 'Slot') return Promise.resolve(slots);
+        if (resourceType === 'Slot') {
+          return Promise.resolve(slots);
+        }
         return Promise.resolve([]);
       });
 
@@ -210,10 +225,14 @@ describe('useSchedulingResources', () => {
       participant: [],
     };
 
-    const setupWithData = async () => {
+    const setupWithData = async (): Promise<RenderHookResult<UseSchedulingResourcesResult, void>> => {
       medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
-        if (resourceType === 'Slot') return Promise.resolve([existingSlot]);
-        if (resourceType === 'Appointment') return Promise.resolve([existingAppointment]);
+        if (resourceType === 'Slot') {
+          return Promise.resolve([existingSlot]);
+        }
+        if (resourceType === 'Appointment') {
+          return Promise.resolve([existingAppointment]);
+        }
         return Promise.resolve([]);
       });
 
@@ -389,8 +408,12 @@ describe('useSchedulingResources', () => {
       };
 
       medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
-        if (resourceType === 'Slot') return Promise.resolve([slotToCancel, otherSlot]);
-        if (resourceType === 'Appointment') return Promise.resolve([appointmentToCancel]);
+        if (resourceType === 'Slot') {
+          return Promise.resolve([slotToCancel, otherSlot]);
+        }
+        if (resourceType === 'Appointment') {
+          return Promise.resolve([appointmentToCancel]);
+        }
         return Promise.resolve([]);
       });
 
@@ -435,8 +458,12 @@ describe('useSchedulingResources', () => {
       };
 
       medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
-        if (resourceType === 'Slot') return Promise.resolve([pendingSlot]);
-        if (resourceType === 'Appointment') return Promise.resolve([pendingAppointment]);
+        if (resourceType === 'Slot') {
+          return Promise.resolve([pendingSlot]);
+        }
+        if (resourceType === 'Appointment') {
+          return Promise.resolve([pendingAppointment]);
+        }
         return Promise.resolve([]);
       });
 
@@ -505,7 +532,9 @@ describe('useSchedulingResources', () => {
       };
 
       medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
-        if (resourceType === 'Appointment') return Promise.resolve([existing]);
+        if (resourceType === 'Appointment') {
+          return Promise.resolve([existing]);
+        }
         return Promise.resolve([]);
       });
 
@@ -526,7 +555,7 @@ describe('useSchedulingResources', () => {
   });
 
   describe('find()', () => {
-    const setupWithEmptyData = async () => {
+    const setupWithEmptyData = async (): Promise<RenderHookResult<UseSchedulingResourcesResult, void>> => {
       medplum.searchResources = vi.fn().mockResolvedValue([]);
       const hookResult = renderHook(() => useSchedulingResources(schedules, range), { wrapper });
       await waitFor(() => expect(hookResult.result.current.loading).toBe(false));
@@ -556,11 +585,14 @@ describe('useSchedulingResources', () => {
         .find((url: URL) => url.toString().includes('$find'));
 
       expect(callUrl).toBeDefined();
-      expect(callUrl!.href).toContain('start=');
-      expect(callUrl!.href).toContain('end=');
-      expect(callUrl!.href).toContain('service-type-reference=');
-      expect(callUrl!.href).toContain(encodeURIComponent('HealthcareService/hcs-1'));
-      expect(callUrl!.href).toContain(encodeURIComponent('Schedule/schedule-1'));
+      if (!callUrl) {
+        return;
+      }
+      expect(callUrl.href).toContain('start=');
+      expect(callUrl.href).toContain('end=');
+      expect(callUrl.href).toContain('service-type-reference=');
+      expect(callUrl.href).toContain(encodeURIComponent('HealthcareService/hcs-1'));
+      expect(callUrl.href).toContain(encodeURIComponent('Schedule/schedule-1'));
     });
 
     test('passes abort signal to the HTTP call', async () => {

--- a/examples/medplum-provider/src/hooks/useSchedulingResources.ts
+++ b/examples/medplum-provider/src/hooks/useSchedulingResources.ts
@@ -11,10 +11,19 @@ import {
   normalizeOperationOutcome,
   resolveId,
 } from '@medplum/core';
-import type { Appointment, Bundle, HealthcareService, OperationOutcome, Schedule, Slot } from '@medplum/fhirtypes';
+import type {
+  Appointment,
+  Bundle,
+  HealthcareService,
+  OperationOutcome,
+  Resource,
+  Schedule,
+  Slot,
+} from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { Range } from '../types/scheduling';
+import { assertNever } from '../utils/assert';
 import { SchedulingTransientIdentifier } from '../utils/scheduling';
 
 const PAGE_SIZE = 1000;
@@ -29,46 +38,6 @@ export interface AppointmentFindOptions {
   healthcareService: WithId<HealthcareService>;
   range: Range;
   abortSignal?: AbortSignal;
-}
-
-async function fetchSchedulingResources(
-  medplum: MedplumClient,
-  schedule: WithId<Schedule>,
-  range: Range
-): Promise<SchedulingResources> {
-  const slotPromise = medplum.searchResources('Slot', [
-    ['_count', PAGE_SIZE.toString()],
-    ['schedule', getReferenceString(schedule)],
-    ['start', `ge${range.start.toISOString()}`],
-    ['start', `le${range.end.toISOString()}`],
-    ['status:not', 'entered-in-error'],
-  ]);
-
-  const actors = schedule.actor.map(getReferenceString).filter(isDefined);
-
-  // To make loading fast, we search for appointments related to the schedule participants
-  // because we can run this query in parallel to the Slot fetching query.
-  //
-  // Hypothetically, a slot could be referenced by an appointment that does not have a participant
-  // matching the schedule's actors. If we need to catch that we can emit a secondary query
-  // after `slotPromise` has resolved to find `Appointment?slot=Slot/1,Slot/2,...`.
-  //
-  // This seems to be uncommon in practice so we do not currently emit the extra query.
-  const appointmentPromise =
-    actors.length > 0
-      ? medplum.searchResources('Appointment', [
-          ['_count', PAGE_SIZE.toString()],
-          ['actor', actors.join(',')],
-          ['date', `ge${range.start.toISOString()}`],
-          ['date', `le${range.end.toISOString()}`],
-        ])
-      : [];
-
-  return {
-    schedule,
-    slots: await slotPromise,
-    appointments: await appointmentPromise,
-  };
 }
 
 export interface SchedulingAPI {
@@ -86,12 +55,115 @@ export interface SchedulingAPI {
 }
 
 export interface UseSchedulingResourcesResult {
+  schedulingResources: SchedulingResources[] | undefined;
   slots: Slot[] | undefined;
   appointments: Appointment[] | undefined;
-  schedulingResources: SchedulingResources[] | undefined;
   loading: boolean;
   operationOutcome: OperationOutcome | undefined;
   schedulingAPI: SchedulingAPI;
+}
+
+type OptimisticUpdateStore<T extends Resource> = Record<
+  string,
+  | { resource: T; action: 'created' | 'updated'; timestamp: number }
+  | { resource: undefined; action: 'deleted'; timestamp: number }
+>;
+
+function getTimestamp(resource: Resource): number | undefined {
+  if (resource.meta?.lastUpdated) {
+    return new Date(resource.meta.lastUpdated).getTime();
+  }
+  return undefined;
+}
+
+function isStaleOptimisticUpdate(timestamp: number, serverResource: Resource): boolean {
+  const lastUpdated = serverResource.meta?.lastUpdated;
+  return lastUpdated !== undefined && new Date(lastUpdated).getTime() > timestamp;
+}
+
+function isWithinRange(start: string | undefined, range: Range): boolean {
+  if (!start) {
+    return false;
+  }
+  const time = new Date(start).getTime();
+  return time >= range.start.getTime() && time <= range.end.getTime();
+}
+
+async function fetchSchedulingResources(
+  medplum: MedplumClient,
+  schedule: WithId<Schedule>,
+  range: Range
+): Promise<SchedulingResources> {
+  // To make loading fast, we search for appointments related to the schedule participants
+  // because we can run this query in parallel to the Slot fetching query.
+  //
+  // Hypothetically, a slot could be referenced by an appointment that does not
+  // have a participant matching the schedule's actors. If we need to catch
+  // that we can emit a secondary query after `slotPromise` has resolved to
+  // find Appointments with `Appointment.slot` matching one of our returned
+  // slots.
+  //
+  // This seems to be uncommon in practice, so we do not currently emit the extra query.
+  const actors = schedule.actor.map(getReferenceString).filter(isDefined);
+  const appointmentPromise =
+    actors.length > 0
+      ? medplum.searchResources('Appointment', [
+          ['_count', PAGE_SIZE.toString()],
+          ['actor', actors.join(',')],
+          ['date', `ge${range.start.toISOString()}`],
+          ['date', `le${range.end.toISOString()}`],
+          ['status:not', 'cancelled'],
+        ])
+      : [];
+
+  const slotPromise = medplum.searchResources('Slot', [
+    ['_count', PAGE_SIZE.toString()],
+    ['schedule', getReferenceString(schedule)],
+    ['start', `ge${range.start.toISOString()}`],
+    ['start', `le${range.end.toISOString()}`],
+    ['status:not', 'entered-in-error'],
+  ]);
+
+  return {
+    schedule,
+    slots: await slotPromise,
+    appointments: await appointmentPromise,
+  };
+}
+
+function applyOptimisticUpdates<T extends Resource>(
+  resources: WithId<T>[],
+  optimisticUpdates: OptimisticUpdateStore<WithId<T>>,
+  isVisible: (resource: T) => boolean
+): WithId<T>[] {
+  const seen = new Set<string>();
+  const values = resources
+    .map((resource) => {
+      seen.add(resource.id);
+      const update = optimisticUpdates[resource.id];
+      if (!update || isStaleOptimisticUpdate(update.timestamp, resource)) {
+        return resource;
+      }
+      if (update.action === 'deleted') {
+        return undefined;
+      } else if (update.action === 'updated' || update.action === 'created') {
+        return update.resource;
+      } else {
+        return assertNever(update.action);
+      }
+    })
+    .filter(isDefined);
+
+  const created = Object.values(optimisticUpdates)
+    .map((update) => {
+      if (update.action !== 'created' || seen.has(update.resource.id) || !isVisible(update.resource)) {
+        return undefined;
+      }
+      return update.resource;
+    })
+    .filter(isDefined);
+
+  return [...values, ...created];
 }
 
 export function useSchedulingResources(
@@ -101,8 +173,13 @@ export function useSchedulingResources(
   const medplum = useMedplum();
   const [schedulingResources, setSchedulingResources] = useState<SchedulingResources[] | undefined>();
   const [operationOutcome, setOperationOutcome] = useState<OperationOutcome>();
-  // Appointments booked while a fetch is in-flight; merged into results when the fetch lands.
-  const pendingBooksRef = useRef<{ appointment: WithId<Appointment>; slots: WithId<Slot>[] }[]>([]);
+  const [optimisticUpdates, setOptimisticUpdates] = useState<{
+    appointment: OptimisticUpdateStore<WithId<Appointment>>;
+    slot: OptimisticUpdateStore<WithId<Slot>>;
+  }>({
+    appointment: {},
+    slot: {},
+  });
 
   useEffect(() => {
     if (!range) {
@@ -110,40 +187,14 @@ export function useSchedulingResources(
     }
 
     let active = true;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSchedulingResources(undefined);
     setOperationOutcome(undefined);
 
     Promise.all(schedules.map((schedule) => fetchSchedulingResources(medplum, schedule, range)))
       .then((results) => {
         if (active) {
-          const pending = pendingBooksRef.current.splice(0);
-          const merged =
-            pending.length === 0
-              ? results
-              : results.map((resourceRow) => {
-                  let appts = resourceRow.appointments;
-                  let slots = resourceRow.slots;
-                  for (const { appointment, slots: pendingSlots } of pending) {
-                    const sm = new Map<string, WithId<Slot>[]>();
-                    for (const s of pendingSlots) {
-                      const id = resolveId(s.schedule);
-                      if (id) {
-                        const group = sm.get(id) ?? [];
-                        group.push(s);
-                        sm.set(id, group);
-                      }
-                    }
-                    const slotsForRow = sm.get(resourceRow.schedule.id);
-                    if (slotsForRow?.length) {
-                      appts = [...appts, appointment];
-                      slots = [...slots, ...slotsForRow];
-                    }
-                  }
-                  return appts === resourceRow.appointments
-                    ? resourceRow
-                    : { ...resourceRow, appointments: appts, slots };
-                });
-          setSchedulingResources(merged);
+          setSchedulingResources(results);
 
           const foundAllResources = results.every(
             (resourceRow) => resourceRow.slots.length < PAGE_SIZE && resourceRow.appointments.length < PAGE_SIZE
@@ -178,32 +229,37 @@ export function useSchedulingResources(
     };
   }, [medplum, schedules, range]);
 
-  const handleAppointmentUpdated = useCallback((updated: WithId<Appointment>) => {
-    setSchedulingResources((resources) => {
-      if (!resources) {
-        return undefined;
-      }
-      return resources.map((resourceRow) => {
-        return {
-          ...resourceRow,
-          appointments: resourceRow.appointments.map((a) => (a.id === updated.id ? updated : a)),
-        };
-      });
-    });
+  const optimisticAppointmentChange = useCallback((resource: WithId<Appointment>, action: 'created' | 'updated') => {
+    const timestamp = getTimestamp(resource) ?? Date.now();
+    setOptimisticUpdates((store) => ({
+      appointment: {
+        ...store.appointment,
+        [resource.id]: { resource, action, timestamp },
+      },
+      slot: store.slot,
+    }));
   }, []);
 
-  const updateSlot = useCallback((updated: WithId<Slot>) => {
-    setSchedulingResources((resources) => {
-      if (!resources) {
-        return undefined;
-      }
-      return resources.map((resourceRow) => {
-        return {
-          ...resourceRow,
-          slots: resourceRow.slots.map((s) => (s.id === updated.id ? updated : s)),
-        };
-      });
-    });
+  const optimisticSlotChange = useCallback((resource: WithId<Slot>, action: 'created' | 'updated') => {
+    const timestamp = getTimestamp(resource) ?? Date.now();
+    setOptimisticUpdates((store) => ({
+      appointment: store.appointment,
+      slot: {
+        ...store.slot,
+        [resource.id]: { resource, action, timestamp },
+      },
+    }));
+  }, []);
+
+  const optimisticSlotDelete = useCallback((id: string) => {
+    const timestamp = Date.now();
+    setOptimisticUpdates((store) => ({
+      appointment: store.appointment,
+      slot: {
+        ...store.slot,
+        [id]: { resource: undefined, action: 'deleted', timestamp },
+      },
+    }));
   }, []);
 
   const book = useCallback(
@@ -238,38 +294,12 @@ export function useSchedulingResources(
         throw new Error('$book succeeded but did not return an Appointment');
       }
 
-      const scheduleMap = new Map<string, WithId<Slot>[]>();
-      for (const slot of createdSlots) {
-        const id = resolveId(slot.schedule);
-        if (id) {
-          const group = scheduleMap.get(id) ?? [];
-          group.push(slot);
-          scheduleMap.set(id, group);
-        }
-      }
-
-      setSchedulingResources((resources) => {
-        if (!resources) {
-          // Fetch is in-flight; queue so the booking is merged when the fetch lands.
-          pendingBooksRef.current.push({ appointment: createdAppointment, slots: createdSlots });
-          return undefined;
-        }
-        return resources.map((resourceRow) => {
-          const slotsForRow = scheduleMap.get(resourceRow.schedule.id);
-          if (!slotsForRow?.length) {
-            return resourceRow;
-          }
-          return {
-            ...resourceRow,
-            appointments: [...resourceRow.appointments, createdAppointment],
-            slots: [...resourceRow.slots, ...slotsForRow],
-          };
-        });
-      });
+      optimisticAppointmentChange(createdAppointment, 'created');
+      createdSlots.forEach((createdSlot) => optimisticSlotChange(createdSlot, 'created'));
 
       return { appointment: createdAppointment, slots: createdSlots };
     },
-    [medplum]
+    [medplum, optimisticAppointmentChange, optimisticSlotChange]
   );
 
   const confirm = useCallback(
@@ -288,14 +318,14 @@ export function useSchedulingResources(
       const updatedAppointment = updatedResources.find((res) => isResource<Appointment>(res, 'Appointment'));
       const updatedSlots = updatedResources.filter((res) => isResource<Slot>(res, 'Slot'));
       if (updatedAppointment) {
-        handleAppointmentUpdated(updatedAppointment);
+        optimisticAppointmentChange(updatedAppointment, 'updated');
       } else {
         throw new Error('$confirm succeeded without returning updated Appointment');
       }
-      updatedSlots.map((updated) => updateSlot(updated));
+      updatedSlots.forEach((updated) => optimisticSlotChange(updated, 'updated'));
       return { appointment: updatedAppointment, slots: updatedSlots };
     },
-    [medplum, handleAppointmentUpdated, updateSlot]
+    [medplum, optimisticAppointmentChange, optimisticSlotChange]
   );
 
   const cancel = useCallback(
@@ -305,25 +335,20 @@ export function useSchedulingResources(
       );
       medplum.invalidateSearches('Appointment');
       medplum.invalidateSearches('Slot');
-      handleAppointmentUpdated(updated);
-      // $cancel soft-deletes referenced slots; remove them from our local state
+
+      optimisticAppointmentChange(updated, 'updated');
       if (updated.slot) {
-        const ids = new Set(updated.slot.map((ref) => resolveId(ref)).filter(isDefined));
-        setSchedulingResources((resources) => {
-          if (!resources) {
-            return undefined;
+        updated.slot.forEach((slot) => {
+          const id = resolveId(slot);
+          if (id) {
+            optimisticSlotDelete(id);
           }
-          return resources.map((resourceRow) => {
-            return {
-              ...resourceRow,
-              slots: resourceRow.slots.filter((s) => !ids.has(s.id)),
-            };
-          });
         });
       }
+
       return updated;
     },
-    [medplum, handleAppointmentUpdated]
+    [medplum, optimisticAppointmentChange, optimisticSlotDelete]
   );
 
   const find = useCallback(
@@ -353,10 +378,10 @@ export function useSchedulingResources(
   const updateAppointment = useCallback(
     async (appointment: WithId<Appointment>): Promise<WithId<Appointment>> => {
       const updated = await medplum.updateResource(appointment);
-      handleAppointmentUpdated(updated);
+      optimisticAppointmentChange(updated, 'updated');
       return updated;
     },
-    [medplum, handleAppointmentUpdated]
+    [medplum, optimisticAppointmentChange]
   );
 
   const schedulingAPI = useMemo(
@@ -370,22 +395,44 @@ export function useSchedulingResources(
     [book, cancel, confirm, find, updateAppointment]
   );
 
-  const slots = useMemo(() => {
-    if (!schedulingResources) {
+  const schedulingResourcesWithUpdates = useMemo(() => {
+    if (!schedulingResources || !range) {
       return undefined;
     }
-    return schedulingResources.map((resourceRow) => resourceRow.slots).flat();
-  }, [schedulingResources]);
+    return schedulingResources.map((resourceRow) => {
+      const scheduleRef = getReferenceString(resourceRow.schedule);
+      const actorRefs = new Set(resourceRow.schedule.actor.map((a) => getReferenceString(a)).filter(isDefined));
+      const isSlotVisible = (slot: Slot): boolean =>
+        getReferenceString(slot.schedule) === scheduleRef && isWithinRange(slot.start, range);
+      const isAppointmentVisible = (appt: Appointment): boolean =>
+        appt.participant.some(({ actor }) => {
+          const ref = actor && getReferenceString(actor);
+          return ref ? actorRefs.has(ref) : false;
+        }) && isWithinRange(appt.start, range);
+      return {
+        ...resourceRow,
+        slots: applyOptimisticUpdates(resourceRow.slots, optimisticUpdates.slot, isSlotVisible),
+        appointments: applyOptimisticUpdates(
+          resourceRow.appointments,
+          optimisticUpdates.appointment,
+          isAppointmentVisible
+        ),
+      };
+    });
+  }, [schedulingResources, optimisticUpdates.slot, optimisticUpdates.appointment, range]);
 
-  const appointments = useMemo(() => {
-    if (!schedulingResources) {
-      return undefined;
-    }
-    return schedulingResources.map((resourceRow) => resourceRow.appointments).flat();
-  }, [schedulingResources]);
+  const slots = useMemo(
+    () => schedulingResourcesWithUpdates?.flatMap((row) => row.slots),
+    [schedulingResourcesWithUpdates]
+  );
+
+  const appointments = useMemo(
+    () => schedulingResourcesWithUpdates?.flatMap((row) => row.appointments),
+    [schedulingResourcesWithUpdates]
+  );
 
   return {
-    schedulingResources,
+    schedulingResources: schedulingResourcesWithUpdates,
     loading: range !== undefined && operationOutcome === undefined,
     operationOutcome,
     schedulingAPI,

--- a/examples/medplum-provider/src/hooks/useSchedulingResources.ts
+++ b/examples/medplum-provider/src/hooks/useSchedulingResources.ts
@@ -89,6 +89,35 @@ function isWithinRange(start: string | undefined, range: Range): boolean {
   return time >= range.start.getTime() && time <= range.end.getTime();
 }
 
+function isSettledOptimisticUpdate(timestamp: number, freshResource: Resource): boolean {
+  const lastUpdated = freshResource.meta?.lastUpdated;
+  return lastUpdated !== undefined && new Date(lastUpdated).getTime() >= timestamp;
+}
+
+// Drops optimistic entries once a fresh fetch confirms they're no longer needed.
+// `created`/`updated` entries settle once the fetch returns the same id with an
+// equal-or-newer `lastUpdated`. `deleted` entries settle once the fetch stops
+// returning the id at all, since deletes (e.g. Appointment $cancel) remove the
+// resource outright rather than changing its status.
+function pruneSettledUpdates<T extends Resource>(
+  store: OptimisticUpdateStore<WithId<T>>,
+  freshResources: WithId<T>[]
+): OptimisticUpdateStore<WithId<T>> {
+  const freshById = new Map(freshResources.map((resource) => [resource.id, resource]));
+  const next: OptimisticUpdateStore<WithId<T>> = {};
+  for (const [id, update] of Object.entries(store)) {
+    const fresh = freshById.get(id);
+    const settled =
+      update.action === 'deleted'
+        ? fresh === undefined
+        : fresh !== undefined && isSettledOptimisticUpdate(update.timestamp, fresh);
+    if (!settled) {
+      next[id] = update;
+    }
+  }
+  return next;
+}
+
 async function fetchSchedulingResources(
   medplum: MedplumClient,
   schedule: WithId<Schedule>,
@@ -195,6 +224,16 @@ export function useSchedulingResources(
       .then((results) => {
         if (active) {
           setSchedulingResources(results);
+          setOptimisticUpdates((store) => ({
+            appointment: pruneSettledUpdates(
+              store.appointment,
+              results.flatMap((row) => row.appointments)
+            ),
+            slot: pruneSettledUpdates(
+              store.slot,
+              results.flatMap((row) => row.slots)
+            ),
+          }));
 
           const foundAllResources = results.every(
             (resourceRow) => resourceRow.slots.length < PAGE_SIZE && resourceRow.appointments.length < PAGE_SIZE

--- a/examples/medplum-provider/src/hooks/useSchedulingResources.ts
+++ b/examples/medplum-provider/src/hooks/useSchedulingResources.ts
@@ -13,7 +13,7 @@ import {
 } from '@medplum/core';
 import type { Appointment, Bundle, HealthcareService, OperationOutcome, Schedule, Slot } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Range } from '../types/scheduling';
 import { SchedulingTransientIdentifier } from '../utils/scheduling';
 
@@ -101,6 +101,8 @@ export function useSchedulingResources(
   const medplum = useMedplum();
   const [schedulingResources, setSchedulingResources] = useState<SchedulingResources[] | undefined>();
   const [operationOutcome, setOperationOutcome] = useState<OperationOutcome>();
+  // Appointments booked while a fetch is in-flight; merged into results when the fetch lands.
+  const pendingBooksRef = useRef<{ appointment: WithId<Appointment>; slots: WithId<Slot>[] }[]>([]);
 
   useEffect(() => {
     if (!range) {
@@ -114,7 +116,34 @@ export function useSchedulingResources(
     Promise.all(schedules.map((schedule) => fetchSchedulingResources(medplum, schedule, range)))
       .then((results) => {
         if (active) {
-          setSchedulingResources(results);
+          const pending = pendingBooksRef.current.splice(0);
+          const merged =
+            pending.length === 0
+              ? results
+              : results.map((resourceRow) => {
+                  let appts = resourceRow.appointments;
+                  let slots = resourceRow.slots;
+                  for (const { appointment, slots: pendingSlots } of pending) {
+                    const sm = new Map<string, WithId<Slot>[]>();
+                    for (const s of pendingSlots) {
+                      const id = resolveId(s.schedule);
+                      if (id) {
+                        const group = sm.get(id) ?? [];
+                        group.push(s);
+                        sm.set(id, group);
+                      }
+                    }
+                    const slotsForRow = sm.get(resourceRow.schedule.id);
+                    if (slotsForRow?.length) {
+                      appts = [...appts, appointment];
+                      slots = [...slots, ...slotsForRow];
+                    }
+                  }
+                  return appts === resourceRow.appointments
+                    ? resourceRow
+                    : { ...resourceRow, appointments: appts, slots };
+                });
+          setSchedulingResources(merged);
 
           const foundAllResources = results.every(
             (resourceRow) => resourceRow.slots.length < PAGE_SIZE && resourceRow.appointments.length < PAGE_SIZE
@@ -209,21 +238,31 @@ export function useSchedulingResources(
         throw new Error('$book succeeded but did not return an Appointment');
       }
 
-      const scheduleMap = new Map(createdSlots.map((slot) => [resolveId(slot.schedule), slot]));
+      const scheduleMap = new Map<string, WithId<Slot>[]>();
+      for (const slot of createdSlots) {
+        const id = resolveId(slot.schedule);
+        if (id) {
+          const group = scheduleMap.get(id) ?? [];
+          group.push(slot);
+          scheduleMap.set(id, group);
+        }
+      }
 
       setSchedulingResources((resources) => {
         if (!resources) {
+          // Fetch is in-flight; queue so the booking is merged when the fetch lands.
+          pendingBooksRef.current.push({ appointment: createdAppointment, slots: createdSlots });
           return undefined;
         }
         return resources.map((resourceRow) => {
-          const createdSlot = scheduleMap.get(resourceRow.schedule.id);
-          if (!createdSlot) {
+          const slotsForRow = scheduleMap.get(resourceRow.schedule.id);
+          if (!slotsForRow?.length) {
             return resourceRow;
           }
           return {
             ...resourceRow,
             appointments: [...resourceRow.appointments, createdAppointment],
-            slots: [...resourceRow.slots, createdSlot],
+            slots: [...resourceRow.slots, ...slotsForRow],
           };
         });
       });
@@ -347,7 +386,7 @@ export function useSchedulingResources(
 
   return {
     schedulingResources,
-    loading: operationOutcome === undefined,
+    loading: range !== undefined && operationOutcome === undefined,
     operationOutcome,
     schedulingAPI,
     slots,

--- a/examples/medplum-provider/src/hooks/useSchedulingResources.ts
+++ b/examples/medplum-provider/src/hooks/useSchedulingResources.ts
@@ -1,0 +1,356 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { MedplumClient, WithId } from '@medplum/core';
+import {
+  allOk,
+  deepClone,
+  EMPTY,
+  getReferenceString,
+  isDefined,
+  isResource,
+  normalizeOperationOutcome,
+  resolveId,
+} from '@medplum/core';
+import type { Appointment, Bundle, HealthcareService, OperationOutcome, Schedule, Slot } from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react-hooks';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { Range } from '../types/scheduling';
+import { SchedulingTransientIdentifier } from '../utils/scheduling';
+
+const PAGE_SIZE = 1000;
+
+export interface SchedulingResources {
+  schedule: WithId<Schedule>;
+  appointments: WithId<Appointment>[];
+  slots: WithId<Slot>[];
+}
+
+export interface AppointmentFindOptions {
+  healthcareService: WithId<HealthcareService>;
+  range: Range;
+  abortSignal?: AbortSignal;
+}
+
+async function fetchSchedulingResources(
+  medplum: MedplumClient,
+  schedule: WithId<Schedule>,
+  range: Range
+): Promise<SchedulingResources> {
+  const slotPromise = medplum.searchResources('Slot', [
+    ['_count', PAGE_SIZE.toString()],
+    ['schedule', getReferenceString(schedule)],
+    ['start', `ge${range.start.toISOString()}`],
+    ['start', `le${range.end.toISOString()}`],
+    ['status:not', 'entered-in-error'],
+  ]);
+
+  const actors = schedule.actor.map(getReferenceString).filter(isDefined);
+
+  // To make loading fast, we search for appointments related to the schedule participants
+  // because we can run this query in parallel to the Slot fetching query.
+  //
+  // Hypothetically, a slot could be referenced by an appointment that does not have a participant
+  // matching the schedule's actors. If we need to catch that we can emit a secondary query
+  // after `slotPromise` has resolved to find `Appointment?slot=Slot/1,Slot/2,...`.
+  //
+  // This seems to be uncommon in practice so we do not currently emit the extra query.
+  const appointmentPromise =
+    actors.length > 0
+      ? medplum.searchResources('Appointment', [
+          ['_count', PAGE_SIZE.toString()],
+          ['actor', actors.join(',')],
+          ['date', `ge${range.start.toISOString()}`],
+          ['date', `le${range.end.toISOString()}`],
+        ])
+      : [];
+
+  return {
+    schedule,
+    slots: await slotPromise,
+    appointments: await appointmentPromise,
+  };
+}
+
+export interface SchedulingAPI {
+  book: (appointment: Appointment) => Promise<{
+    appointment: WithId<Appointment>;
+    slots: WithId<Slot>[];
+  }>;
+  cancel: (appointment: WithId<Appointment>) => Promise<WithId<Appointment>>;
+  confirm: (appointment: WithId<Appointment>) => Promise<{
+    appointment: WithId<Appointment>;
+    slots: WithId<Slot>[];
+  }>;
+  find: (options: AppointmentFindOptions) => Promise<Appointment[]>;
+  updateAppointment: (appointment: WithId<Appointment>) => Promise<WithId<Appointment>>;
+}
+
+export interface UseSchedulingResourcesResult {
+  slots: Slot[] | undefined;
+  appointments: Appointment[] | undefined;
+  schedulingResources: SchedulingResources[] | undefined;
+  loading: boolean;
+  operationOutcome: OperationOutcome | undefined;
+  schedulingAPI: SchedulingAPI;
+}
+
+export function useSchedulingResources(
+  schedules: WithId<Schedule>[],
+  range: Range | undefined
+): UseSchedulingResourcesResult {
+  const medplum = useMedplum();
+  const [schedulingResources, setSchedulingResources] = useState<SchedulingResources[] | undefined>();
+  const [operationOutcome, setOperationOutcome] = useState<OperationOutcome>();
+
+  useEffect(() => {
+    if (!range) {
+      return () => {};
+    }
+
+    let active = true;
+    setSchedulingResources(undefined);
+    setOperationOutcome(undefined);
+
+    Promise.all(schedules.map((schedule) => fetchSchedulingResources(medplum, schedule, range)))
+      .then((results) => {
+        if (active) {
+          setSchedulingResources(results);
+
+          const foundAllResources = results.every(
+            (resourceRow) => resourceRow.slots.length < PAGE_SIZE && resourceRow.appointments.length < PAGE_SIZE
+          );
+
+          if (foundAllResources) {
+            setOperationOutcome(allOk);
+          } else {
+            setOperationOutcome({
+              resourceType: 'OperationOutcome',
+              issue: [
+                {
+                  severity: 'warning',
+                  code: 'incomplete',
+                  details: {
+                    text: 'Too many slots or appointments in range, some results may not be shown.',
+                  },
+                },
+              ],
+            });
+          }
+        }
+      })
+      .catch((err) => {
+        if (active) {
+          setOperationOutcome(normalizeOperationOutcome(err));
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [medplum, schedules, range]);
+
+  const handleAppointmentUpdated = useCallback((updated: WithId<Appointment>) => {
+    setSchedulingResources((resources) => {
+      if (!resources) {
+        return undefined;
+      }
+      return resources.map((resourceRow) => {
+        return {
+          ...resourceRow,
+          appointments: resourceRow.appointments.map((a) => (a.id === updated.id ? updated : a)),
+        };
+      });
+    });
+  }, []);
+
+  const updateSlot = useCallback((updated: WithId<Slot>) => {
+    setSchedulingResources((resources) => {
+      if (!resources) {
+        return undefined;
+      }
+      return resources.map((resourceRow) => {
+        return {
+          ...resourceRow,
+          slots: resourceRow.slots.map((s) => (s.id === updated.id ? updated : s)),
+        };
+      });
+    });
+  }, []);
+
+  const book = useCallback(
+    async (
+      appointment: Appointment
+    ): Promise<{
+      appointment: WithId<Appointment>;
+      slots: WithId<Slot>[];
+    }> => {
+      const booking = deepClone(appointment);
+      SchedulingTransientIdentifier.remove(booking);
+
+      const created = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(
+        medplum.fhirUrl('Appointment', '$book'),
+        {
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'appointment',
+              resource: booking,
+            },
+          ],
+        }
+      );
+      medplum.invalidateSearches('Appointment');
+      medplum.invalidateSearches('Slot');
+      const createdResources = created.entry?.map((entry) => entry.resource) ?? EMPTY;
+      const createdAppointment = createdResources.find((res) => isResource<Appointment>(res, 'Appointment'));
+      const createdSlots = createdResources.filter((res) => isResource<Slot>(res, 'Slot'));
+
+      if (!createdAppointment) {
+        throw new Error('$book succeeded but did not return an Appointment');
+      }
+
+      const scheduleMap = new Map(createdSlots.map((slot) => [resolveId(slot.schedule), slot]));
+
+      setSchedulingResources((resources) => {
+        if (!resources) {
+          return undefined;
+        }
+        return resources.map((resourceRow) => {
+          const createdSlot = scheduleMap.get(resourceRow.schedule.id);
+          if (!createdSlot) {
+            return resourceRow;
+          }
+          return {
+            ...resourceRow,
+            appointments: [...resourceRow.appointments, createdAppointment],
+            slots: [...resourceRow.slots, createdSlot],
+          };
+        });
+      });
+
+      return { appointment: createdAppointment, slots: createdSlots };
+    },
+    [medplum]
+  );
+
+  const confirm = useCallback(
+    async (
+      appointment: WithId<Appointment>
+    ): Promise<{
+      appointment: WithId<Appointment>;
+      slots: WithId<Slot>[];
+    }> => {
+      const updated = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(
+        medplum.fhirUrl('Appointment', appointment.id, '$confirm')
+      );
+      medplum.invalidateSearches('Appointment');
+      medplum.invalidateSearches('Slot');
+      const updatedResources = updated.entry?.map((entry) => entry.resource) ?? EMPTY;
+      const updatedAppointment = updatedResources.find((res) => isResource<Appointment>(res, 'Appointment'));
+      const updatedSlots = updatedResources.filter((res) => isResource<Slot>(res, 'Slot'));
+      if (updatedAppointment) {
+        handleAppointmentUpdated(updatedAppointment);
+      } else {
+        throw new Error('$confirm succeeded without returning updated Appointment');
+      }
+      updatedSlots.map((updated) => updateSlot(updated));
+      return { appointment: updatedAppointment, slots: updatedSlots };
+    },
+    [medplum, handleAppointmentUpdated, updateSlot]
+  );
+
+  const cancel = useCallback(
+    async (appointment: WithId<Appointment>): Promise<WithId<Appointment>> => {
+      const updated = await medplum.post<WithId<Appointment>>(
+        medplum.fhirUrl('Appointment', appointment.id, '$cancel')
+      );
+      medplum.invalidateSearches('Appointment');
+      medplum.invalidateSearches('Slot');
+      handleAppointmentUpdated(updated);
+      // $cancel soft-deletes referenced slots; remove them from our local state
+      if (updated.slot) {
+        const ids = new Set(updated.slot.map((ref) => resolveId(ref)).filter(isDefined));
+        setSchedulingResources((resources) => {
+          if (!resources) {
+            return undefined;
+          }
+          return resources.map((resourceRow) => {
+            return {
+              ...resourceRow,
+              slots: resourceRow.slots.filter((s) => !ids.has(s.id)),
+            };
+          });
+        });
+      }
+      return updated;
+    },
+    [medplum, handleAppointmentUpdated]
+  );
+
+  const find = useCallback(
+    async (options: AppointmentFindOptions): Promise<Appointment[]> => {
+      const start = options.range.start.toISOString();
+      const end = options.range.end.toISOString();
+      const url = medplum.fhirUrl('Appointment', '$find');
+      url.searchParams.append('start', start);
+      url.searchParams.append('end', end);
+      url.searchParams.append('service-type-reference', getReferenceString(options.healthcareService));
+      schedules.forEach((schedule) => {
+        url.searchParams.append('schedule', getReferenceString(schedule));
+      });
+
+      return medplum.get<Bundle<Appointment>>(url, { signal: options.abortSignal }).then((bundle) => {
+        if (bundle.entry) {
+          bundle.entry.forEach((entry) => entry.resource && SchedulingTransientIdentifier.set(entry.resource));
+          return bundle.entry.map((entry) => entry.resource).filter(isDefined);
+        } else {
+          return [];
+        }
+      });
+    },
+    [medplum, schedules]
+  );
+
+  const updateAppointment = useCallback(
+    async (appointment: WithId<Appointment>): Promise<WithId<Appointment>> => {
+      const updated = await medplum.updateResource(appointment);
+      handleAppointmentUpdated(updated);
+      return updated;
+    },
+    [medplum, handleAppointmentUpdated]
+  );
+
+  const schedulingAPI = useMemo(
+    () => ({
+      book,
+      cancel,
+      confirm,
+      find,
+      updateAppointment,
+    }),
+    [book, cancel, confirm, find, updateAppointment]
+  );
+
+  const slots = useMemo(() => {
+    if (!schedulingResources) {
+      return undefined;
+    }
+    return schedulingResources.map((resourceRow) => resourceRow.slots).flat();
+  }, [schedulingResources]);
+
+  const appointments = useMemo(() => {
+    if (!schedulingResources) {
+      return undefined;
+    }
+    return schedulingResources.map((resourceRow) => resourceRow.appointments).flat();
+  }, [schedulingResources]);
+
+  return {
+    schedulingResources,
+    loading: operationOutcome === undefined,
+    operationOutcome,
+    schedulingAPI,
+    slots,
+    appointments,
+  };
+}

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
@@ -466,7 +466,7 @@ describe('$find/$book component integration tests', () => {
             status: 'busy',
             start: slotStart,
             end: slotEnd,
-            schedule: { reference: 'Schedule/schedule-1' },
+            schedule: { reference: 'Schedule/alice-smith-schedule' },
           },
         },
         {
@@ -477,7 +477,7 @@ describe('$find/$book component integration tests', () => {
             status: 'busy-unavailable',
             start: slotEnd,
             end: bufferEnd,
-            schedule: { reference: 'Schedule/schedule-1' },
+            schedule: { reference: 'Schedule/alice-smith-schedule' },
           },
         },
       ],


### PR DESCRIPTION
In preparing for building UI that allows viewers to interact with multiple schedules at once, here we extract a hook that fetches the appropriate resources (related `Slot` and `Appointment` resources in the search range), and provides wrappers around the Scheduling APIs that can keep this state in sync with mutations.

This is intended to be pulled into `@medplum/react-hooks` once it feels it has stabilized here in the Provider app.

### Alternative Strategies Considered
- Make `MedplumClient` a more full featured event source - if we could receive events from the MedplumClient when mutations/operations happen to key resource types, we could avoid needing to expose our own API wrapper. This feels like a much larger lift and something to explore more broadly later.
- Using webhook subscriptions to receive changes - this might be something we layer in to this hook later (it would be nice if changes to your calendar from other sources would update in real time). This requires the "websocket-subscriptions" feature enabled on the project, so doesn't feel suitable as the basic building block (and could still result in some awkward windows between when a mutation completes and when the subscription event arrives).