### PR TITLE
feat(app): skip sign-in email prompt with a domain query parameter

### DIFF
--- a/packages/app/src/SignInPage.tsx
+++ b/packages/app/src/SignInPage.tsx
@@ -34,6 +34,7 @@ export function SignInPage(): JSX.Element {
       googleClientId={config.googleClientId}
       login={searchParams.get('login') || undefined}
       projectId={searchParams.get('project') || undefined}
+      externalAuthDomain={searchParams.get('domain') || undefined}
     >
       <Logo size={32} />
       {searchParams.get('project') !== 'new' && (

--- a/packages/docs/docs/auth/domain-level-identity-providers.md
+++ b/packages/docs/docs/auth/domain-level-identity-providers.md
@@ -97,3 +97,16 @@ Create a [`DomainConfiguration`](/docs/api/fhir/medplum/domainconfiguration) res
 Configuring a DL-IDP on the Medplum Hosted service requires a Medplum team member, contact us at hello@medplum.com to enable. For those self-hosting, setup below requires super admin privileges.
 
 :::
+
+## Skipping the email prompt
+
+By default, users open the sign-in form and type their email before being redirected to the identity provider. The Medplum App also accepts a `domain` query parameter on its sign-in page that skips the email prompt and redirects to the configured identity provider directly:
+
+```
+{medplumAppBaseUrl}/signin?domain={domain}
+```
+
+- For the Medplum hosted app, `medplumAppBaseUrl` is `https://app.medplum.com`, so the link is `https://app.medplum.com/signin?domain=mydomain.com`.
+- When self-hosting, use your own app base URL, e.g. `https://medplum.example.com/signin?domain=mydomain.com`.
+
+Because it is just a URL, you can use it anywhere you can place a link — a bookmark, an internal portal, or a launcher on your identity provider's dashboard — to take users straight to their identity provider. If the domain has no `DomainConfiguration`, the sign-in page falls back to the normal email/password form.

--- a/packages/react/src/auth/AuthenticationForm.tsx
+++ b/packages/react/src/auth/AuthenticationForm.tsx
@@ -7,12 +7,12 @@ import type {
   GoogleLoginRequest,
   LoginAuthenticationResponse,
 } from '@medplum/core';
-import { locationUtils, normalizeOperationOutcome } from '@medplum/core';
+import { badRequest, locationUtils, normalizeOperationOutcome } from '@medplum/core';
 import type { OperationOutcome } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import { IconPencil } from '@tabler/icons-react';
 import type { JSX, ReactNode } from 'react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Form } from '../Form/Form';
 import { SubmitButton } from '../Form/SubmitButton';
 import { GoogleButton } from '../GoogleButton/GoogleButton';
@@ -24,6 +24,7 @@ import { getErrorsForInput, getIssuesForExpression } from '../utils/outcomes';
 export interface AuthenticationFormProps extends BaseLoginRequest {
   readonly disableEmailAuth?: boolean;
   readonly disableGoogleAuth?: boolean;
+  readonly externalAuthDomain?: string;
   readonly onForgotPassword?: () => void;
   readonly onRegister?: () => void;
   readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
@@ -43,6 +44,7 @@ export function AuthenticationForm(props: AuthenticationFormProps): JSX.Element 
 export interface EmailFormProps extends BaseLoginRequest {
   readonly disableEmailAuth?: boolean;
   readonly disableGoogleAuth?: boolean;
+  readonly externalAuthDomain?: string;
   readonly onRegister?: () => void;
   readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
   readonly setEmail: (email: string) => void;
@@ -50,7 +52,7 @@ export interface EmailFormProps extends BaseLoginRequest {
 }
 
 export function EmailForm(props: EmailFormProps): JSX.Element {
-  const { setEmail, onRegister, handleAuthResponse, children, disableEmailAuth, ...baseLoginRequest } = props;
+  const { setEmail, onRegister, handleAuthResponse, children, disableEmailAuth, externalAuthDomain, ...baseLoginRequest } = props;
   const medplum = useMedplum();
   const googleClientId = !props.disableGoogleAuth && getGoogleClientId(props.googleClientId);
   const [outcome, setOutcome] = useState<OperationOutcome>();
@@ -101,6 +103,24 @@ export function EmailForm(props: EmailFormProps): JSX.Element {
     },
     [medplum, baseLoginRequest, isExternalAuth, handleAuthResponse]
   );
+
+  // When an external auth domain is provided (e.g. a direct-launch link), initiate external auth
+  // immediately instead of waiting for the user to type their email.
+  const externalAuthInitiated = useRef(false);
+  useEffect(() => {
+    if (!externalAuthDomain || externalAuthInitiated.current) {
+      return;
+    }
+    externalAuthInitiated.current = true;
+    medplum
+      .post('auth/method', { domain: externalAuthDomain })
+      .then(async (authMethod) => {
+        if (!(await isExternalAuth(authMethod))) {
+          setOutcome(badRequest(`No identity provider configured for ${externalAuthDomain}`));
+        }
+      })
+      .catch((err: unknown) => setOutcome(normalizeOperationOutcome(err)));
+  }, [medplum, externalAuthDomain, isExternalAuth]);
 
   return (
     <Form onSubmit={handleSubmit}>

--- a/packages/react/src/auth/AuthenticationForm.tsx
+++ b/packages/react/src/auth/AuthenticationForm.tsx
@@ -52,7 +52,15 @@ export interface EmailFormProps extends BaseLoginRequest {
 }
 
 export function EmailForm(props: EmailFormProps): JSX.Element {
-  const { setEmail, onRegister, handleAuthResponse, children, disableEmailAuth, externalAuthDomain, ...baseLoginRequest } = props;
+  const {
+    setEmail,
+    onRegister,
+    handleAuthResponse,
+    children,
+    disableEmailAuth,
+    externalAuthDomain,
+    ...baseLoginRequest
+  } = props;
   const medplum = useMedplum();
   const googleClientId = !props.disableGoogleAuth && getGoogleClientId(props.googleClientId);
   const [outcome, setOutcome] = useState<OperationOutcome>();

--- a/packages/react/src/auth/SignInForm.test.tsx
+++ b/packages/react/src/auth/SignInForm.test.tsx
@@ -16,9 +16,9 @@ function mockFetch(url: string, options: any): Promise<any> {
   let result: any;
 
   if (options.method === 'POST' && url.endsWith('/auth/method')) {
-    const { email } = JSON.parse(options.body);
+    const { email, domain } = JSON.parse(options.body);
     status = 200;
-    if (email === 'alice@external.example.com') {
+    if (email === 'alice@external.example.com' || domain === 'external.example.com') {
       result = {
         authorizeUrl: 'https://external.example.com/authorize',
         domain: 'external.example.com',
@@ -789,6 +789,26 @@ describe('SignInForm', () => {
 
     await waitFor(() => expect(assignSpy).toHaveBeenCalled());
     expect(assignSpy).toHaveBeenCalled();
+  });
+
+  test('externalAuthDomain initiates external auth without typing an email', async () => {
+    const assignSpy = vi.spyOn(locationUtils, 'assign').mockImplementation(() => {});
+    assignSpy.mockClear();
+
+    await setup({ externalAuthDomain: 'external.example.com' });
+
+    await waitFor(() => expect(assignSpy).toHaveBeenCalled());
+    expect(assignSpy).toHaveBeenCalledWith(expect.stringContaining('https://external.example.com/authorize'));
+  });
+
+  test('externalAuthDomain without a configured provider shows an error', async () => {
+    const assignSpy = vi.spyOn(locationUtils, 'assign').mockImplementation(() => {});
+    assignSpy.mockClear();
+
+    await setup({ externalAuthDomain: 'no-config.example.com' });
+
+    await waitFor(() => expect(screen.getByText(/No identity provider configured/)).toBeInTheDocument());
+    expect(assignSpy).not.toHaveBeenCalled();
   });
 
   test('MFA -- Success', async () => {

--- a/packages/react/src/auth/SignInForm.tsx
+++ b/packages/react/src/auth/SignInForm.tsx
@@ -22,6 +22,7 @@ export interface SignInFormProps extends BaseLoginRequest {
   readonly chooseScopes?: boolean;
   readonly disableEmailAuth?: boolean;
   readonly disableGoogleAuth?: boolean;
+  readonly externalAuthDomain?: string;
   readonly onSuccess?: () => void;
   readonly onForgotPassword?: () => void;
   readonly onRegister?: () => void;
@@ -51,6 +52,7 @@ export function SignInForm(props: SignInFormProps): JSX.Element {
     onForgotPassword,
     onRegister,
     onCode,
+    externalAuthDomain,
     ...baseLoginRequest
   } = props;
   const medplum = useMedplum();
@@ -173,6 +175,7 @@ export function SignInForm(props: SignInFormProps): JSX.Element {
               handleAuthResponse={handleAuthResponse}
               disableGoogleAuth={props.disableGoogleAuth}
               disableEmailAuth={props.disableEmailAuth}
+              externalAuthDomain={externalAuthDomain}
               {...baseLoginRequest}
             >
               {props.children}

--- a/packages/server/src/auth/method.test.ts
+++ b/packages/server/src/auth/method.test.ts
@@ -122,4 +122,65 @@ describe('Method', () => {
       .send({ email: 'alice@' + randomUUID() + '.com' });
     expect(res2).toHaveStatus(200);
   });
+
+  test('Missing email and domain parameters', async () => {
+    const res = await request(app).post('/auth/method').type('json').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('Domain parameter', async () => {
+    const domain = randomUUID() + '.example.com';
+    await withTestContext(() =>
+      systemRepo.createResource<DomainConfiguration>({
+        resourceType: 'DomainConfiguration',
+        domain,
+        identityProvider: {
+          authorizeUrl: 'https://example.com/oauth2/authorize',
+          tokenUrl: 'https://example.com/oauth2/token',
+          userInfoUrl: 'https://example.com/oauth2/userinfo',
+          clientId: '123',
+          clientSecret: '456',
+        },
+      })
+    );
+
+    // Domain config found via domain parameter (no email required)
+    const res1 = await request(app).post('/auth/method').type('json').send({ domain });
+    expect(res1.status).toBe(200);
+    expect(res1.body.domain).toBe(domain);
+    expect(res1.body.authorizeUrl).toBeDefined();
+
+    // Domain config not found
+    const res2 = await request(app)
+      .post('/auth/method')
+      .type('json')
+      .send({ domain: randomUUID() + '.com' });
+    expect(res2.status).toBe(200);
+    expect(res2.body).toStrictEqual({});
+  });
+
+  test('Domain parameter case sensitivity', async () => {
+    const domain = randomUUID() + '.example.com';
+    await withTestContext(() =>
+      systemRepo.createResource<DomainConfiguration>({
+        resourceType: 'DomainConfiguration',
+        domain,
+        identityProvider: {
+          authorizeUrl: 'https://example.com/oauth2/authorize',
+          tokenUrl: 'https://example.com/oauth2/token',
+          userInfoUrl: 'https://example.com/oauth2/userinfo',
+          clientId: '123',
+          clientSecret: '456',
+        },
+      })
+    );
+
+    // Domain lookup is case-insensitive
+    const res = await request(app)
+      .post('/auth/method')
+      .type('json')
+      .send({ domain: domain.toUpperCase() });
+    expect(res.status).toBe(200);
+    expect(res.body.authorizeUrl).toBeDefined();
+  });
 });

--- a/packages/server/src/auth/method.test.ts
+++ b/packages/server/src/auth/method.test.ts
@@ -176,10 +176,7 @@ describe('Method', () => {
     );
 
     // Domain lookup is case-insensitive
-    const res = await request(app)
-      .post('/auth/method')
-      .type('json')
-      .send({ domain: domain.toUpperCase() });
+    const res = await request(app).post('/auth/method').type('json').send({ domain: domain.toUpperCase() });
     expect(res.status).toBe(200);
     expect(res.body.authorizeUrl).toBeDefined();
   });

--- a/packages/server/src/auth/method.ts
+++ b/packages/server/src/auth/method.ts
@@ -54,9 +54,7 @@ export async function isExternalAuth(email: string): Promise<{ domain: string; a
  * @param domain - The email domain, e.g. "example.com".
  * @returns External auth url if available. Otherwise undefined.
  */
-async function getExternalAuthForDomain(
-  domain: string
-): Promise<{ domain: string; authorizeUrl: string } | undefined> {
+async function getExternalAuthForDomain(domain: string): Promise<{ domain: string; authorizeUrl: string } | undefined> {
   const domainConfig = await getDomainConfiguration(domain);
   if (!domainConfig) {
     return undefined;

--- a/packages/server/src/auth/method.ts
+++ b/packages/server/src/auth/method.ts
@@ -17,11 +17,17 @@ import { makeValidationMiddleware } from '../util/validator';
  */
 
 export const methodValidator = makeValidationMiddleware([
-  body('email').isEmail().withMessage('Valid email address is required'),
+  body('domain').optional().isString().withMessage('Domain must be a string'),
+  body('email')
+    .if((_value, { req }) => !req.body.domain)
+    .isEmail()
+    .withMessage('Valid email address is required'),
 ]);
 
 export async function methodHandler(req: Request, res: Response): Promise<void> {
-  const externalAuth = await isExternalAuth(req.body.email);
+  const externalAuth = req.body.domain
+    ? await getExternalAuthForDomain(req.body.domain)
+    : await isExternalAuth(req.body.email);
   if (externalAuth) {
     // Return the authorization URL
     // This indicates the client should redirect to the authorization URL
@@ -40,7 +46,17 @@ export async function methodHandler(req: Request, res: Response): Promise<void> 
  * @returns External auth url if available. Otherwise undefined.
  */
 export async function isExternalAuth(email: string): Promise<{ domain: string; authorizeUrl: string } | undefined> {
-  const domain = email.split('@')[1];
+  return getExternalAuthForDomain(email.split('@')[1]);
+}
+
+/**
+ * Checks if the given email domain is configured for external authentication.
+ * @param domain - The email domain, e.g. "example.com".
+ * @returns External auth url if available. Otherwise undefined.
+ */
+async function getExternalAuthForDomain(
+  domain: string
+): Promise<{ domain: string; authorizeUrl: string } | undefined> {
   const domainConfig = await getDomainConfiguration(domain);
   if (!domainConfig) {
     return undefined;


### PR DESCRIPTION
## Summary

Adds a `domain` query parameter to the Medplum App sign-in page that skips the email prompt and sends the user straight to their domain's external identity provider.

Previously, domain-level (DL-IDP) external login was always user-initiated: the user had to open the sign-in form and type their email before being redirected to the IdP. This lets you link into Medplum — from a bookmark, an internal portal, or a launcher on your identity provider's dashboard — and land users directly at their IdP. Because the app remains the OAuth client, the resulting login is identical to the normal user-initiated flow.

## Changes

- **server** (`auth/method.ts`): `/auth/method` now accepts a `domain` parameter as an alternative to `email`, so the app can perform the domain lookup without synthesizing an email. The shared lookup is extracted into `getExternalAuthForDomain`.
- **react** (`SignInForm`, `AuthenticationForm`): new optional `externalAuthDomain` prop. When set, the sign-in form initiates external auth on mount instead of waiting for email input, and shows an inline `No identity provider configured for <domain>` error when the domain has no configuration.
- **app** (`SignInPage`): reads the `domain` query parameter and passes it to `SignInForm`.
- **docs**: documents the `{medplumAppBaseUrl}/signin?domain=<domain>` link, with hosted and self-hosted examples.
