### PR TITLE
[React] Skip rendering "OK" in OperationOutcomeAlert

### DIFF
--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
@@ -253,9 +253,7 @@ export function AppointmentDetails(props: { appointment: WithId<Appointment> }):
           <Loader size="sm" />
         </Group>
       )}
-      {encounterOutcome && !isOk(encounterOutcome) && (
-        <OperationOutcomeAlert outcome={encounterOutcome} title="Loading Encounter failed" />
-      )}
+      <OperationOutcomeAlert outcome={encounterOutcome} title="Loading Encounter failed" />
       {hasPatient && !encounter && !encounterLoading && encounterOutcome && isOk(encounterOutcome) && (
         <CreateEncounterForm appointment={appointment} />
       )}

--- a/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceSchedulingPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Alert, Group, Input, Loader, Stack, Title } from '@mantine/core';
-import { EMPTY, getExtensionValue, isOk, normalizeErrorString } from '@medplum/core';
+import { EMPTY, getExtensionValue } from '@medplum/core';
 import type {
   Coding,
   Extension,
@@ -11,7 +11,7 @@ import type {
   Reference,
   ResourceType,
 } from '@medplum/fhirtypes';
-import { CodingInput, Form, ReferenceInput, SubmitButton } from '@medplum/react';
+import { CodingInput, Form, OperationOutcomeAlert, ReferenceInput, SubmitButton } from '@medplum/react';
 import { useMedplum, useResource } from '@medplum/react-hooks';
 import { IconAlertCircle } from '@tabler/icons-react';
 import type { JSX } from 'react';
@@ -136,21 +136,10 @@ export function ResourceSchedulingPage(): JSX.Element | null {
     return <Loader />;
   }
 
-  if (outcome && !isOk(outcome)) {
-    return (
-      <Alert color="red" icon={<IconAlertCircle />}>
-        {normalizeErrorString(outcome)}
-      </Alert>
-    );
-  }
-
-  if (!resource) {
-    return (
-      <Alert color="red" icon={<IconAlertCircle />}>
-        Error loading resource.
-      </Alert>
-    );
-  }
-
-  return <HealthcareServiceSchedulingForm service={resource as HealthcareService} />;
+  return (
+    <>
+      <OperationOutcomeAlert outcome={outcome} />
+      {resource && <HealthcareServiceSchedulingForm service={resource as HealthcareService} />}
+    </>
+  );
 }

--- a/examples/medplum-provider/src/pages/schedule/ScheduleSettingsPage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/ScheduleSettingsPage.tsx
@@ -4,7 +4,7 @@ import { Alert, Button, Group, Loader, Stack, Switch, Text, Title, Tooltip } fro
 import type { WithId } from '@medplum/core';
 import { deepClone, EMPTY, formatReferenceString, getExtensionValue, getReferenceString } from '@medplum/core';
 import type { HealthcareService, Reference, Schedule } from '@medplum/fhirtypes';
-import { Document, MedplumLink, useMedplum } from '@medplum/react';
+import { Document, MedplumLink, OperationOutcomeAlert, useMedplum } from '@medplum/react';
 import { useResource, useSearchResources } from '@medplum/react-hooks';
 import { IconAlertCircle } from '@tabler/icons-react';
 import type { JSX } from 'react';
@@ -23,7 +23,7 @@ const MAX_PAGE_SIZE = 1000;
 
 export function ScheduleSettings(props: { schedule: Schedule }): JSX.Element | null {
   const medplum = useMedplum();
-  const [services, servicesLoading] = useSearchResources('HealthcareService', {
+  const [services, servicesLoading, servicesOutcome] = useSearchResources('HealthcareService', {
     _sort: 'name',
     _count: MAX_PAGE_SIZE.toString(),
   });
@@ -33,20 +33,6 @@ export function ScheduleSettings(props: { schedule: Schedule }): JSX.Element | n
   // Store a copy of the Schedule that we can mutate while the viewer manipulates
   // the UI
   const [schedule, setSchedule] = useState(deepClone(props.schedule));
-
-  if (servicesLoading) {
-    return <Loader />;
-  }
-
-  if (!services?.length) {
-    return (
-      <Group>
-        <Alert color="red" variant="outline">
-          No HealthcareServices found.
-        </Alert>
-      </Group>
-    );
-  }
 
   function toggleServiceType(service: WithId<HealthcareService>, enabled: boolean): void {
     setDirty(true);
@@ -86,6 +72,10 @@ export function ScheduleSettings(props: { schedule: Schedule }): JSX.Element | n
     }
   }
 
+  if (servicesLoading) {
+    return <Loader />;
+  }
+
   return (
     <Stack gap="lg">
       <Stack gap="0">
@@ -95,13 +85,19 @@ export function ScheduleSettings(props: { schedule: Schedule }): JSX.Element | n
           <DocsLink path="scheduling">configuring Scheduling</DocsLink>.
         </Text>
       </Stack>
-      {services.length >= MAX_PAGE_SIZE && (
+      <OperationOutcomeAlert outcome={servicesOutcome} />
+      {!services?.length && (
+        <Alert color="red" variant="outline">
+          No HealthcareServices found.
+        </Alert>
+      )}
+      {(services?.length ?? 0) >= MAX_PAGE_SIZE && (
         <Alert color="yellow" variant="outline" icon={<IconAlertCircle />}>
           HealthcareService page size reached; some rows may not have been fetched.
         </Alert>
       )}
       <Stack gap="sm">
-        {services.map((service) => {
+        {services?.map((service) => {
           const schedulable = hasSchedulingParameters(service);
           return (
             <Group key={service.id}>

--- a/packages/react/src/OperationOutcomeAlert/OperationOutcomeAlert.test.tsx
+++ b/packages/react/src/OperationOutcomeAlert/OperationOutcomeAlert.test.tsx
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { allOk } from '@medplum/core';
+import type { OperationOutcome, OperationOutcomeIssue } from '@medplum/fhirtypes';
+import { render, screen } from '../test-utils/render';
+import { OperationOutcomeAlert } from './OperationOutcomeAlert';
+
+describe('OperationOutcomeAlert', () => {
+  test('renders nothing when no issue or outcome is provided', () => {
+    render(<OperationOutcomeAlert />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  test('renders nothing with an empty issues list', () => {
+    render(<OperationOutcomeAlert issues={[]} />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  test('renders each issue present in an OperationOutcome', () => {
+    const outcome = {
+      resourceType: 'OperationOutcome',
+      issue: [
+        { severity: 'fatal', code: 'invalid', details: { text: 'Major issue detected' } },
+        { severity: 'warning', code: 'invalid', details: { text: 'Minor issue detected' } },
+      ],
+    } satisfies OperationOutcome;
+    render(<OperationOutcomeAlert outcome={outcome} />);
+    expect(screen.queryByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Major issue detected')).toBeInTheDocument();
+    expect(screen.getByText('Minor issue detected')).toBeInTheDocument();
+  });
+
+  test('renders each issue present in an `issues` list', () => {
+    const issues = [
+      { severity: 'fatal', code: 'invalid', details: { text: 'Major issue detected' } },
+      { severity: 'warning', code: 'invalid', details: { text: 'Minor issue detected' } },
+    ] satisfies OperationOutcomeIssue[];
+    render(<OperationOutcomeAlert issues={issues} />);
+    expect(screen.queryByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Major issue detected')).toBeInTheDocument();
+    expect(screen.getByText('Minor issue detected')).toBeInTheDocument();
+  });
+
+  test('renders nothing for an "OK" outcome', () => {
+    render(<OperationOutcomeAlert outcome={allOk} />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  test('renders an "OK" outcome when `displayOkOutcomes` is set', () => {
+    render(<OperationOutcomeAlert outcome={allOk} displayOkOutcomes />);
+    expect(screen.queryByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('All OK')).toBeInTheDocument();
+  });
+
+  test('forwards additional props to the Alert component', () => {
+    const outcome = {
+      resourceType: 'OperationOutcome',
+      issue: [{ severity: 'fatal', code: 'invalid', details: { text: 'Major issue detected' } }],
+    } satisfies OperationOutcome;
+
+    render(<OperationOutcomeAlert outcome={outcome} title="Search Problem" />);
+    expect(screen.queryByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Search Problem')).toBeInTheDocument();
+    expect(screen.getByText('Major issue detected')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/OperationOutcomeAlert/OperationOutcomeAlert.tsx
+++ b/packages/react/src/OperationOutcomeAlert/OperationOutcomeAlert.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { AlertProps } from '@mantine/core';
 import { Alert } from '@mantine/core';
-import { operationOutcomeIssueToString } from '@medplum/core';
+import { isOk, operationOutcomeIssueToString } from '@medplum/core';
 import type { OperationOutcome, OperationOutcomeIssue } from '@medplum/fhirtypes';
 import { IconAlertCircle } from '@tabler/icons-react';
 import type { JSX } from 'react';
@@ -10,14 +10,21 @@ import type { JSX } from 'react';
 export interface OperationOutcomeAlertProps extends AlertProps {
   readonly outcome?: OperationOutcome;
   readonly issues?: OperationOutcomeIssue[];
+  readonly displayOkOutcomes?: boolean;
 }
 
 export function OperationOutcomeAlert(props: OperationOutcomeAlertProps): JSX.Element | null {
-  const { outcome, issues: issuesProp, ...spacingProps } = props;
+  const { outcome, issues: issuesProp, displayOkOutcomes, ...spacingProps } = props;
+
   const issues = outcome?.issue || issuesProp;
   if (!issues || issues.length === 0) {
     return null;
   }
+
+  if (outcome && isOk(outcome) && !displayOkOutcomes) {
+    return null;
+  }
+
   return (
     <Alert icon={<IconAlertCircle size={16} />} color="red" {...spacingProps}>
       {issues.map((issue) => (


### PR DESCRIPTION
The most common OperationOutcome results are informational, telling that an operation completed successfully. In general, we don't want to render "Alert" components for such a result. In cases where showing those results is desirable, you may add the new `displayOkOutcomes` prop.

One common example: The `useSearch*()` family of hooks in `@medplum/react-hooks` return an OperationOutcome that usually is a "success", but might have an issue indicating an access policy violation or an invalid search parameter. This provides an ergonomic way to consume that result in your application with less ceremony.

**Before**:
```
import { isOk } from '@medplum/core';
import { useSearch } from '@medplum/react-hooks';
import { OperationOutcomeAlert } from '@medplum/react';

function MyComponent() {
  const [patients, loading, outcome] = useSearch('Patient');
  if (loading) { return <Loader />; }
  if (outcome && !isOk(outcome)) {
    return <OperationOutcomeAlert outcome={outcome} />
  }
  return (
    <>
      {patients?.map((patient) => <ListItem patient={patient} />)}
    </>
  );
}
```

**After**:
```
import { useSearch } from '@medplum/react-hooks';
import { OperationOutcomeAlert } from '@medplum/react';

function MyComponent() {
  const [patients, loading, outcome] = useSearch('Patient');
  if (loading) { return <Loader />; }
  return (
    <>
      <OperationOutcomeAlert outcome={outcome} />
      {patients?.map((patient) => <ListItem patient={patient} />)}
    </>
  );
}
```