### PR TITLE
Add login link to registration screen

### DIFF
--- a/examples/foomedical/src/pages/RegisterPage.tsx
+++ b/examples/foomedical/src/pages/RegisterPage.tsx
@@ -17,6 +17,7 @@ export function RegisterPage(): JSX.Element {
           clientId={import.meta.env.MEDPLUM_CLIENT_ID}
           recaptchaSiteKey={import.meta.env.RECAPTCHA_SITE_KEY}
           onSuccess={() => navigate('/')?.catch(console.error)}
+          onSignIn={() => navigate('/signin')?.catch(console.error)}
         >
           <h2>Register with Foo Medical</h2>
         </RegisterForm>

--- a/examples/medplum-provider/src/pages/RegisterPage.tsx
+++ b/examples/medplum-provider/src/pages/RegisterPage.tsx
@@ -40,6 +40,7 @@ export function RegisterPage(): JSX.Element | null {
       googleClientId={import.meta.env.GOOGLE_CLIENT_ID}
       recaptchaSiteKey={import.meta.env.RECAPTCHA_SITE_KEY}
       login={searchParams.get('login') || undefined}
+      onSignIn={() => navigate('/signin')?.catch(console.error)}
     >
       <Logo size={32} />
       <Title order={3} py="lg">

--- a/packages/app/src/RegisterPage.test.tsx
+++ b/packages/app/src/RegisterPage.test.tsx
@@ -9,7 +9,7 @@ import { TextEncoder } from 'util';
 import { AppRoutes } from './AppRoutes';
 import { getConfig } from './config';
 import type { UserEvent } from './test-utils/render';
-import { act, render, screen, userEvent } from './test-utils/render';
+import { act, fireEvent, render, screen, userEvent } from './test-utils/render';
 
 async function setup(medplum: MedplumClient): Promise<UserEvent> {
   const user = userEvent.setup();
@@ -81,6 +81,18 @@ describe('RegisterPage', () => {
     await user.type(screen.getByLabelText('Project Name *'), 'Test Project');
 
     await user.click(screen.getByRole('button'));
+  });
+
+  test('Sign in link navigates to sign in page', async () => {
+    const medplum = new MockClient();
+    medplum.getProfile = vi.fn(() => undefined);
+    await setup(medplum);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Sign In'));
+    });
+
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
   });
 
   test('Register disabled', async () => {

--- a/packages/app/src/RegisterPage.test.tsx
+++ b/packages/app/src/RegisterPage.test.tsx
@@ -76,7 +76,7 @@ describe('RegisterPage', () => {
     await user.type(screen.getByLabelText('Email *'), 'george@example.com');
     await user.type(screen.getByLabelText('Password *'), 'password');
 
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button', { name: 'Register Account' }));
 
     await user.type(screen.getByLabelText('Project Name *'), 'Test Project');
 

--- a/packages/app/src/RegisterPage.tsx
+++ b/packages/app/src/RegisterPage.tsx
@@ -42,6 +42,7 @@ export function RegisterPage(): JSX.Element | null {
       googleClientId={config.googleClientId}
       recaptchaSiteKey={config.recaptchaSiteKey}
       login={searchParams.get('login') || undefined}
+      onSignIn={() => navigate('/signin')?.catch(console.error)}
     >
       <Logo size={32} />
       <Title order={3} py="lg">

--- a/packages/react/src/auth/NewUserForm.tsx
+++ b/packages/react/src/auth/NewUserForm.tsx
@@ -143,7 +143,7 @@ export function NewUserForm(props: NewUserFormProps): JSX.Element {
             size="sm"
             mt="lg"
             c="dimmed"
-            style={{ textAlign: 'center' }}
+            ta="center"
             data-dashlane-ignore="true"
             data-lp-ignore="true"
             data-no-autofill="true"

--- a/packages/react/src/auth/NewUserForm.tsx
+++ b/packages/react/src/auth/NewUserForm.tsx
@@ -145,7 +145,7 @@ export function NewUserForm(props: NewUserFormProps): JSX.Element {
             {' and '}
             <Anchor href="https://www.medplum.com/terms">Terms&nbsp;of&nbsp;Service</Anchor>.
           </Text>
-          <Text c="dimmed" size="xs" pt="xs" ta="center">
+          <Text c="dimmed" size="xs" pb="xs" ta="center">
             This site is protected by reCAPTCHA and the Google{' '}
             <Anchor href="https://policies.google.com/privacy">Privacy&nbsp;Policy</Anchor>
             {' and '}
@@ -155,7 +155,7 @@ export function NewUserForm(props: NewUserFormProps): JSX.Element {
       </Form>
       {props.onSignIn && (
         <>
-          <Divider mt="lg" mb="xs" />
+          <Divider mt="lg" pb="xs" />
           <Text size="sm" mt="lg" c="dimmed" ta="center">
             Already have an account? <Anchor onClick={props.onSignIn}>Sign In</Anchor>
           </Text>

--- a/packages/react/src/auth/NewUserForm.tsx
+++ b/packages/react/src/auth/NewUserForm.tsx
@@ -161,7 +161,7 @@ export function NewUserForm(props: NewUserFormProps): JSX.Element {
           {' and '}
           <Anchor href="https://www.medplum.com/terms">Terms&nbsp;of&nbsp;Service</Anchor>.
         </Text>
-        <Text c="dimmed" size="xs" pb="xs" ta="center">
+        <Text c="dimmed" size="xs" ta="center">
           This site is protected by reCAPTCHA and the Google{' '}
           <Anchor href="https://policies.google.com/privacy">Privacy&nbsp;Policy</Anchor>
           {' and '}

--- a/packages/react/src/auth/NewUserForm.tsx
+++ b/packages/react/src/auth/NewUserForm.tsx
@@ -21,6 +21,7 @@ export interface NewUserFormProps {
   readonly googleClientId?: string;
   readonly recaptchaSiteKey?: string;
   readonly children?: ReactNode;
+  readonly onSignIn?: () => void;
   readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
 }
 
@@ -137,6 +138,20 @@ export function NewUserForm(props: NewUserFormProps): JSX.Element {
           pb="xs"
         />
         <SubmitButton fullWidth>Register Account</SubmitButton>
+        {props.onSignIn && (
+          <Text
+            size="sm"
+            mt="lg"
+            c="dimmed"
+            style={{ textAlign: 'center' }}
+            data-dashlane-ignore="true"
+            data-lp-ignore="true"
+            data-no-autofill="true"
+            data-form-type="navigation"
+          >
+            Already have an account? <Anchor onClick={props.onSignIn}>Sign In</Anchor>
+          </Text>
+        )}
         <Text c="dimmed" size="xs" pt="lg" ta="center">
           By clicking "Register Account" you agree to the Medplum{' '}
           <Anchor href="https://www.medplum.com/privacy">Privacy&nbsp;Policy</Anchor>

--- a/packages/react/src/auth/NewUserForm.tsx
+++ b/packages/react/src/auth/NewUserForm.tsx
@@ -145,7 +145,7 @@ export function NewUserForm(props: NewUserFormProps): JSX.Element {
             {' and '}
             <Anchor href="https://www.medplum.com/terms">Terms&nbsp;of&nbsp;Service</Anchor>.
           </Text>
-          <Text c="dimmed" size="xs" ta="center">
+          <Text c="dimmed" size="xs" pt="xs" ta="center">
             This site is protected by reCAPTCHA and the Google{' '}
             <Anchor href="https://policies.google.com/privacy">Privacy&nbsp;Policy</Anchor>
             {' and '}
@@ -155,7 +155,7 @@ export function NewUserForm(props: NewUserFormProps): JSX.Element {
       </Form>
       {props.onSignIn && (
         <>
-          <Divider mt="lg" />
+          <Divider mt="lg" mb="xs"/>
           <Text size="sm" mt="lg" c="dimmed" ta="center">
             Already have an account? <Anchor onClick={props.onSignIn}>Sign In</Anchor>
           </Text>

--- a/packages/react/src/auth/NewUserForm.tsx
+++ b/packages/react/src/auth/NewUserForm.tsx
@@ -39,132 +39,128 @@ export function NewUserForm(props: NewUserFormProps): JSX.Element {
   }, [recaptchaSiteKey]);
 
   return (
-    <Form
-      onSubmit={async (formData: Record<string, string>) => {
-        setOutcome(undefined);
-        try {
-          let recaptchaToken = '';
-          if (recaptchaSiteKey) {
-            recaptchaToken = await getRecaptcha(recaptchaSiteKey);
+    <>
+      <Form
+        onSubmit={async (formData: Record<string, string>) => {
+          setOutcome(undefined);
+          try {
+            let recaptchaToken = '';
+            if (recaptchaSiteKey) {
+              recaptchaToken = await getRecaptcha(recaptchaSiteKey);
+            }
+            props.handleAuthResponse(
+              await medplum.startNewUser({
+                projectId: props.projectId,
+                clientId: props.clientId,
+                firstName: formData.firstName,
+                lastName: formData.lastName,
+                email: formData.email,
+                password: formData.password,
+                remember: formData.remember === 'true',
+                recaptchaSiteKey,
+                recaptchaToken,
+              })
+            );
+          } catch (err) {
+            setOutcome(normalizeOperationOutcome(err));
           }
-          props.handleAuthResponse(
-            await medplum.startNewUser({
-              projectId: props.projectId,
-              clientId: props.clientId,
-              firstName: formData.firstName,
-              lastName: formData.lastName,
-              email: formData.email,
-              password: formData.password,
-              remember: formData.remember === 'true',
-              recaptchaSiteKey,
-              recaptchaToken,
-            })
-          );
-        } catch (err) {
-          setOutcome(normalizeOperationOutcome(err));
-        }
-      }}
-    >
-      <Flex direction="column" align="center" justify="center">
-        {props.children}
-      </Flex>
-      <OperationOutcomeAlert issues={issues} mb="lg" />
-      {googleClientId && (
+        }}
+      >
+        <Flex direction="column" align="center" justify="center">
+          {props.children}
+        </Flex>
+        <OperationOutcomeAlert issues={issues} mb="lg" />
+        {googleClientId && (
+          <>
+            <Box style={{ minHeight: 40 }}>
+              <GoogleButton
+                googleClientId={googleClientId}
+                handleGoogleCredential={async (response: GoogleCredentialResponse) => {
+                  try {
+                    props.handleAuthResponse(
+                      await medplum.startGoogleLogin({
+                        googleClientId: response.clientId,
+                        googleCredential: response.credential,
+                        projectId: props.projectId,
+                        createUser: true,
+                      })
+                    );
+                  } catch (err) {
+                    setOutcome(normalizeOperationOutcome(err));
+                  }
+                }}
+              />
+            </Box>
+            <Divider label="or" labelPosition="center" my="lg" />
+          </>
+        )}
+        <Stack gap="sm">
+          <TextInput
+            name="firstName"
+            type="text"
+            label="First name"
+            placeholder="First name"
+            required={true}
+            autoFocus={true}
+            error={getErrorsForInput(outcome, 'firstName')}
+          />
+          <TextInput
+            name="lastName"
+            type="text"
+            label="Last name"
+            placeholder="Last name"
+            required={true}
+            error={getErrorsForInput(outcome, 'lastName')}
+          />
+          <TextInput
+            name="email"
+            type="email"
+            label="Email"
+            placeholder="name@domain.com"
+            required={true}
+            error={getErrorsForInput(outcome, 'email')}
+          />
+          <PasswordInput
+            name="password"
+            label="Password"
+            autoComplete="off"
+            required={true}
+            error={getErrorsForInput(outcome, 'password')}
+          />
+        </Stack>
+        <Stack gap="xs">
+          <Checkbox
+            id="remember"
+            name="remember"
+            label="Remember me"
+            size="xs"
+            style={{ lineHeight: 1 }}
+            pt="md"
+            pb="xs"
+          />
+          <SubmitButton fullWidth>Register Account</SubmitButton>
+          <Text c="dimmed" size="xs" pt="lg" ta="center">
+            By clicking "Register Account" you agree to the Medplum{' '}
+            <Anchor href="https://www.medplum.com/privacy">Privacy&nbsp;Policy</Anchor>
+            {' and '}
+            <Anchor href="https://www.medplum.com/terms">Terms&nbsp;of&nbsp;Service</Anchor>.
+          </Text>
+          <Text c="dimmed" size="xs" ta="center">
+            This site is protected by reCAPTCHA and the Google{' '}
+            <Anchor href="https://policies.google.com/privacy">Privacy&nbsp;Policy</Anchor>
+            {' and '}
+            <Anchor href="https://policies.google.com/terms">Terms&nbsp;of&nbsp;Service</Anchor> apply.
+          </Text>
+        </Stack>
+      </Form>
+      {props.onSignIn && (
         <>
-          <Box style={{ minHeight: 40 }}>
-            <GoogleButton
-              googleClientId={googleClientId}
-              handleGoogleCredential={async (response: GoogleCredentialResponse) => {
-                try {
-                  props.handleAuthResponse(
-                    await medplum.startGoogleLogin({
-                      googleClientId: response.clientId,
-                      googleCredential: response.credential,
-                      projectId: props.projectId,
-                      createUser: true,
-                    })
-                  );
-                } catch (err) {
-                  setOutcome(normalizeOperationOutcome(err));
-                }
-              }}
-            />
-          </Box>
-          <Divider label="or" labelPosition="center" my="lg" />
-        </>
-      )}
-      <Stack gap="sm">
-        <TextInput
-          name="firstName"
-          type="text"
-          label="First name"
-          placeholder="First name"
-          required={true}
-          autoFocus={true}
-          error={getErrorsForInput(outcome, 'firstName')}
-        />
-        <TextInput
-          name="lastName"
-          type="text"
-          label="Last name"
-          placeholder="Last name"
-          required={true}
-          error={getErrorsForInput(outcome, 'lastName')}
-        />
-        <TextInput
-          name="email"
-          type="email"
-          label="Email"
-          placeholder="name@domain.com"
-          required={true}
-          error={getErrorsForInput(outcome, 'email')}
-        />
-        <PasswordInput
-          name="password"
-          label="Password"
-          autoComplete="off"
-          required={true}
-          error={getErrorsForInput(outcome, 'password')}
-        />
-      </Stack>
-      <Stack gap="xs">
-        <Checkbox
-          id="remember"
-          name="remember"
-          label="Remember me"
-          size="xs"
-          style={{ lineHeight: 1 }}
-          pt="md"
-          pb="xs"
-        />
-        <SubmitButton fullWidth>Register Account</SubmitButton>
-        {props.onSignIn && (
-          <Text
-            size="sm"
-            mt="lg"
-            c="dimmed"
-            ta="center"
-            data-dashlane-ignore="true"
-            data-lp-ignore="true"
-            data-no-autofill="true"
-            data-form-type="navigation"
-          >
+          <Divider mt="lg" />
+          <Text size="sm" mt="lg" c="dimmed" ta="center">
             Already have an account? <Anchor onClick={props.onSignIn}>Sign In</Anchor>
           </Text>
-        )}
-        <Text c="dimmed" size="xs" pt="lg" ta="center">
-          By clicking "Register Account" you agree to the Medplum{' '}
-          <Anchor href="https://www.medplum.com/privacy">Privacy&nbsp;Policy</Anchor>
-          {' and '}
-          <Anchor href="https://www.medplum.com/terms">Terms&nbsp;of&nbsp;Service</Anchor>.
-        </Text>
-        <Text c="dimmed" size="xs" ta="center">
-          This site is protected by reCAPTCHA and the Google{' '}
-          <Anchor href="https://policies.google.com/privacy">Privacy&nbsp;Policy</Anchor>
-          {' and '}
-          <Anchor href="https://policies.google.com/terms">Terms&nbsp;of&nbsp;Service</Anchor> apply.
-        </Text>
-      </Stack>
-    </Form>
+        </>
+      )}
+    </>
   );
 }

--- a/packages/react/src/auth/NewUserForm.tsx
+++ b/packages/react/src/auth/NewUserForm.tsx
@@ -39,128 +39,135 @@ export function NewUserForm(props: NewUserFormProps): JSX.Element {
   }, [recaptchaSiteKey]);
 
   return (
-    <>
-      <Form
-        onSubmit={async (formData: Record<string, string>) => {
-          setOutcome(undefined);
-          try {
-            let recaptchaToken = '';
-            if (recaptchaSiteKey) {
-              recaptchaToken = await getRecaptcha(recaptchaSiteKey);
-            }
-            props.handleAuthResponse(
-              await medplum.startNewUser({
-                projectId: props.projectId,
-                clientId: props.clientId,
-                firstName: formData.firstName,
-                lastName: formData.lastName,
-                email: formData.email,
-                password: formData.password,
-                remember: formData.remember === 'true',
-                recaptchaSiteKey,
-                recaptchaToken,
-              })
-            );
-          } catch (err) {
-            setOutcome(normalizeOperationOutcome(err));
+    <Form
+      onSubmit={async (formData: Record<string, string>) => {
+        setOutcome(undefined);
+        try {
+          let recaptchaToken = '';
+          if (recaptchaSiteKey) {
+            recaptchaToken = await getRecaptcha(recaptchaSiteKey);
           }
-        }}
-      >
-        <Flex direction="column" align="center" justify="center">
-          {props.children}
-        </Flex>
-        <OperationOutcomeAlert issues={issues} mb="lg" />
-        {googleClientId && (
-          <>
-            <Box style={{ minHeight: 40 }}>
-              <GoogleButton
-                googleClientId={googleClientId}
-                handleGoogleCredential={async (response: GoogleCredentialResponse) => {
-                  try {
-                    props.handleAuthResponse(
-                      await medplum.startGoogleLogin({
-                        googleClientId: response.clientId,
-                        googleCredential: response.credential,
-                        projectId: props.projectId,
-                        createUser: true,
-                      })
-                    );
-                  } catch (err) {
-                    setOutcome(normalizeOperationOutcome(err));
-                  }
-                }}
-              />
-            </Box>
-            <Divider label="or" labelPosition="center" my="lg" />
-          </>
-        )}
-        <Stack gap="sm">
-          <TextInput
-            name="firstName"
-            type="text"
-            label="First name"
-            placeholder="First name"
-            required={true}
-            autoFocus={true}
-            error={getErrorsForInput(outcome, 'firstName')}
-          />
-          <TextInput
-            name="lastName"
-            type="text"
-            label="Last name"
-            placeholder="Last name"
-            required={true}
-            error={getErrorsForInput(outcome, 'lastName')}
-          />
-          <TextInput
-            name="email"
-            type="email"
-            label="Email"
-            placeholder="name@domain.com"
-            required={true}
-            error={getErrorsForInput(outcome, 'email')}
-          />
-          <PasswordInput
-            name="password"
-            label="Password"
-            autoComplete="off"
-            required={true}
-            error={getErrorsForInput(outcome, 'password')}
-          />
-        </Stack>
-        <Stack gap="xs">
-          <Checkbox
-            id="remember"
-            name="remember"
-            label="Remember me"
-            size="xs"
-            style={{ lineHeight: 1 }}
-            pt="md"
-            pb="xs"
-          />
-          <SubmitButton fullWidth>Register Account</SubmitButton>
-          <Text c="dimmed" size="xs" pt="lg" ta="center">
-            By clicking "Register Account" you agree to the Medplum{' '}
-            <Anchor href="https://www.medplum.com/privacy">Privacy&nbsp;Policy</Anchor>
-            {' and '}
-            <Anchor href="https://www.medplum.com/terms">Terms&nbsp;of&nbsp;Service</Anchor>.
-          </Text>
-          <Text c="dimmed" size="xs" pb="xs" ta="center">
-            This site is protected by reCAPTCHA and the Google{' '}
-            <Anchor href="https://policies.google.com/privacy">Privacy&nbsp;Policy</Anchor>
-            {' and '}
-            <Anchor href="https://policies.google.com/terms">Terms&nbsp;of&nbsp;Service</Anchor> apply.
-          </Text>
-        </Stack>
-      </Form>
-      {props.onSignIn && (
+          props.handleAuthResponse(
+            await medplum.startNewUser({
+              projectId: props.projectId,
+              clientId: props.clientId,
+              firstName: formData.firstName,
+              lastName: formData.lastName,
+              email: formData.email,
+              password: formData.password,
+              remember: formData.remember === 'true',
+              recaptchaSiteKey,
+              recaptchaToken,
+            })
+          );
+        } catch (err) {
+          setOutcome(normalizeOperationOutcome(err));
+        }
+      }}
+    >
+      <Flex direction="column" align="center" justify="center">
+        {props.children}
+      </Flex>
+      <OperationOutcomeAlert issues={issues} mb="lg" />
+      {googleClientId && (
         <>
-          <Divider mt="lg" pb="xs" />
-          <Text size="sm" mt="lg" c="dimmed" ta="center">
-            Already have an account? <Anchor onClick={props.onSignIn}>Sign In</Anchor>
-          </Text>
+          <Box style={{ minHeight: 40 }}>
+            <GoogleButton
+              googleClientId={googleClientId}
+              handleGoogleCredential={async (response: GoogleCredentialResponse) => {
+                try {
+                  props.handleAuthResponse(
+                    await medplum.startGoogleLogin({
+                      googleClientId: response.clientId,
+                      googleCredential: response.credential,
+                      projectId: props.projectId,
+                      createUser: true,
+                    })
+                  );
+                } catch (err) {
+                  setOutcome(normalizeOperationOutcome(err));
+                }
+              }}
+            />
+          </Box>
+          <Divider label="or" labelPosition="center" my="lg" />
         </>
       )}
-    </>
+      <Stack gap="sm">
+        <TextInput
+          name="firstName"
+          type="text"
+          label="First name"
+          placeholder="First name"
+          required={true}
+          autoFocus={true}
+          error={getErrorsForInput(outcome, 'firstName')}
+        />
+        <TextInput
+          name="lastName"
+          type="text"
+          label="Last name"
+          placeholder="Last name"
+          required={true}
+          error={getErrorsForInput(outcome, 'lastName')}
+        />
+        <TextInput
+          name="email"
+          type="email"
+          label="Email"
+          placeholder="name@domain.com"
+          required={true}
+          error={getErrorsForInput(outcome, 'email')}
+        />
+        <PasswordInput
+          name="password"
+          label="Password"
+          autoComplete="off"
+          required={true}
+          error={getErrorsForInput(outcome, 'password')}
+        />
+      </Stack>
+      <Stack gap="xs">
+        <Checkbox
+          id="remember"
+          name="remember"
+          label="Remember me"
+          size="xs"
+          style={{ lineHeight: 1 }}
+          pt="md"
+          pb="xs"
+        />
+        <SubmitButton fullWidth>Register Account</SubmitButton>
+        {props.onSignIn && (
+          <Text
+            size="sm"
+            mt="lg"
+            c="dimmed"
+            ta="center"
+            data-dashlane-ignore="true"
+            data-lp-ignore="true"
+            data-no-autofill="true"
+            data-form-type="navigation"
+          >
+            Already have an account?{' '}
+            <Anchor component="button" type="button" onClick={props.onSignIn}>
+              Sign In
+            </Anchor>
+          </Text>
+        )}
+        <Text c="dimmed" size="xs" pt="lg" ta="center">
+          By clicking "Register Account" you agree to the Medplum{' '}
+          <Anchor href="https://www.medplum.com/privacy">Privacy&nbsp;Policy</Anchor>
+          {' and '}
+          <Anchor href="https://www.medplum.com/terms">Terms&nbsp;of&nbsp;Service</Anchor>.
+        </Text>
+        <Text c="dimmed" size="xs" pb="xs" ta="center">
+          This site is protected by reCAPTCHA and the Google{' '}
+          <Anchor href="https://policies.google.com/privacy">Privacy&nbsp;Policy</Anchor>
+          {' and '}
+          <Anchor href="https://policies.google.com/terms">Terms&nbsp;of&nbsp;Service</Anchor> apply.
+        </Text>
+      </Stack>
+    </Form>
   );
 }

--- a/packages/react/src/auth/NewUserForm.tsx
+++ b/packages/react/src/auth/NewUserForm.tsx
@@ -155,7 +155,7 @@ export function NewUserForm(props: NewUserFormProps): JSX.Element {
       </Form>
       {props.onSignIn && (
         <>
-          <Divider mt="lg" mb="xs"/>
+          <Divider mt="lg" mb="xs" />
           <Text size="sm" mt="lg" c="dimmed" ta="center">
             Already have an account? <Anchor onClick={props.onSignIn}>Sign In</Anchor>
           </Text>

--- a/packages/react/src/auth/RegisterForm.stories.tsx
+++ b/packages/react/src/auth/RegisterForm.stories.tsx
@@ -16,7 +16,12 @@ const recaptchaSiteKey = 'abc';
 export function Basic(): JSX.Element {
   return (
     <div style={{ minHeight: '100vh' }}>
-      <RegisterForm type="project" recaptchaSiteKey={recaptchaSiteKey} onSuccess={() => alert('Registered!')}>
+      <RegisterForm
+        type="project"
+        recaptchaSiteKey={recaptchaSiteKey}
+        onSuccess={() => alert('Registered!')}
+        onSignIn={() => alert('Sign In')}
+      >
         <Logo size={32} />
         <Title order={3} py="lg">
           Register a new account
@@ -29,7 +34,12 @@ export function Basic(): JSX.Element {
 export function WithFooter(): JSX.Element {
   return (
     <div style={{ minHeight: '100vh' }}>
-      <RegisterForm type="project" recaptchaSiteKey={recaptchaSiteKey} onSuccess={() => alert('Registered!')}>
+      <RegisterForm
+        type="project"
+        recaptchaSiteKey={recaptchaSiteKey}
+        onSuccess={() => alert('Registered!')}
+        onSignIn={() => alert('Sign In')}
+      >
         <Logo size={32} />
         <Title order={3} py="lg">
           Register a new account

--- a/packages/react/src/auth/RegisterForm.stories.tsx
+++ b/packages/react/src/auth/RegisterForm.stories.tsx
@@ -16,12 +16,7 @@ const recaptchaSiteKey = 'abc';
 export function Basic(): JSX.Element {
   return (
     <div style={{ minHeight: '100vh' }}>
-      <RegisterForm
-        type="project"
-        recaptchaSiteKey={recaptchaSiteKey}
-        onSuccess={() => alert('Registered!')}
-        onSignIn={() => alert('Sign In')}
-      >
+      <RegisterForm type="project" recaptchaSiteKey={recaptchaSiteKey} onSuccess={() => alert('Registered!')}>
         <Logo size={32} />
         <Title order={3} py="lg">
           Register a new account

--- a/packages/react/src/auth/RegisterForm.test.tsx
+++ b/packages/react/src/auth/RegisterForm.test.tsx
@@ -231,9 +231,7 @@ describe('RegisterForm', () => {
       onSignIn,
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByText('Sign In'));
-    });
+    fireEvent.click(screen.getByText('Sign In'));
 
     expect(onSignIn).toHaveBeenCalled();
   });

--- a/packages/react/src/auth/RegisterForm.test.tsx
+++ b/packages/react/src/auth/RegisterForm.test.tsx
@@ -212,6 +212,32 @@ describe('RegisterForm', () => {
     expect(onSuccess).toHaveBeenCalled();
   });
 
+  test('Sign in link hidden by default', async () => {
+    await setup({
+      type: 'project',
+      recaptchaSiteKey,
+      onSuccess: vi.fn(),
+    });
+
+    expect(screen.queryByText('Sign In')).not.toBeInTheDocument();
+  });
+
+  test('Sign in link calls onSignIn', async () => {
+    const onSignIn = vi.fn();
+    await setup({
+      type: 'project',
+      recaptchaSiteKey,
+      onSuccess: vi.fn(),
+      onSignIn,
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Sign In'));
+    });
+
+    expect(onSignIn).toHaveBeenCalled();
+  });
+
   test('Register new project success with empty recaptchaSiteKey', async () => {
     const onSuccess = vi.fn();
 

--- a/packages/react/src/auth/RegisterForm.tsx
+++ b/packages/react/src/auth/RegisterForm.tsx
@@ -21,10 +21,11 @@ export interface RegisterFormProps {
   readonly recaptchaSiteKey?: string;
   readonly children?: ReactNode;
   readonly onSuccess: () => void;
+  readonly onSignIn?: () => void;
 }
 
 export function RegisterForm(props: RegisterFormProps): JSX.Element {
-  const { type, projectId, clientId, googleClientId, recaptchaSiteKey, onSuccess } = props;
+  const { type, projectId, clientId, googleClientId, recaptchaSiteKey, onSuccess, onSignIn } = props;
   const medplum = useMedplum();
   const [login, setLogin] = useState<string | undefined>(props.login);
   const [outcome, setOutcome] = useState<OperationOutcome>();
@@ -66,6 +67,7 @@ export function RegisterForm(props: RegisterFormProps): JSX.Element {
           clientId={clientId}
           googleClientId={googleClientId}
           recaptchaSiteKey={recaptchaSiteKey}
+          onSignIn={onSignIn}
           handleAuthResponse={handleAuthResponse}
         >
           {props.children}


### PR DESCRIPTION
Fixes #9788 

## Problem 
There was not a good way to get back to the login page from the registration page. The user would have to navigate backwards in the browser, or update the URL path to go back. 

## Changes for users
Now, there will be a link at the bottom of the registration page, that will let the user go back to the login screen. This matches the same pattern that exists in the login page _("Don't have an account? Register")_ and in the reset password form _("Back to Sign In")_. 

<img width="496" height="741" alt="2026-07-08_15-16-23" src="https://github.com/user-attachments/assets/b8f5597c-f392-4234-bf70-61b0601098a9" />

## Code changes
- Add a new optional prop for `onSignIn?: () => void` to the new user form and the registration form.
- Wire `onSignIn={() => navigate('/signin')}` to the register page
- Update relevant tests appropriately
- Tell password managers to ignore the link (following pattern done in #6706)