### PR TITLE
feat(warehouse): async high water mark calculations

### DIFF
--- a/packages/server/src/cloud/aws/data-warehouse-destination.ts
+++ b/packages/server/src/cloud/aws/data-warehouse-destination.ts
@@ -42,6 +42,35 @@ export class S3TablesWarehouseDestination implements DataWarehouseDestination {
     });
   }
 
+  /*
+   * DuckDB session settings for managed Iceberg sync connections.
+   *
+   * These are connection-scoped (`SET` without `GLOBAL`) and must run on every
+   * DuckDB connection that reads or writes Iceberg / Postgres.
+   */
+  getConnectionSetupQueries(): string[] {
+    return [
+      /*
+       * the default is 524288, which can take a LOT of memory since we're copying
+       * JSON content data
+       */
+      'SET partitioned_write_flush_threshold = 10000;',
+      /*
+       * Misleading option.  This is to allow duckdb to insert into a "sorted table", which is really a hint anyway.
+       * https://github.com/duckdb/duckdb-iceberg/issues/851
+       * https://github.com/duckdb/duckdb-iceberg/pull/992
+       */
+      'SET unsafe_iceberg_ignore_sort_order=true',
+      /*
+       * See https://duckdb.org/docs/current/core_extensions/postgres/connection_pool
+       * the default connection pool settings are very aggressive; many connections, much parallelism
+       * That's not what we want for a sync process on a timer; we want to be gentle on our reader instances
+       */
+      'SET threads = 1',
+      'SET pg_use_ctid_scan = false',
+    ];
+  }
+
   getPostgresAttachQueries(connectionString: string): string[] {
     return [buildDuckdbPostgresAttachQuery(connectionString)];
   }

--- a/packages/server/src/data-warehouse/__test__/fake-iceberg-column-stats.ts
+++ b/packages/server/src/data-warehouse/__test__/fake-iceberg-column-stats.ts
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Mock DuckDB function for the Iceberg extension's `iceberg_column_stats` table function.
+ *
+ * Column shape matches what `fetchIcebergWatermark` reads from the live output.
+ *
+ * @param watermarkByQualifiedTable - Map of fully qualified Iceberg table name → last_updated upper_bound.
+ * @returns SQL statements to create the fixture table and macro (run before watermark reads).
+ */
+export function buildFakeIcebergColumnStatsSetupQueries(watermarkByQualifiedTable: Record<string, string>): string[] {
+  const values = Object.entries(watermarkByQualifiedTable)
+    .map(([table, upperBound]) => `('${table}', '${upperBound}')`)
+    .join(',\n      ');
+
+  return [
+    `CREATE OR REPLACE TABLE iceberg_column_stats_fixture (
+      table_name VARCHAR,
+      upper_bound VARCHAR
+    )`,
+    `INSERT INTO iceberg_column_stats_fixture VALUES
+      ${values}`,
+    `CREATE OR REPLACE MACRO iceberg_column_stats(qualified_table) AS TABLE
+      SELECT
+        'ADDED' AS status,
+        'last_updated' AS column_name,
+        upper_bound
+      FROM iceberg_column_stats_fixture f
+      WHERE f.table_name = qualified_table`,
+  ];
+}

--- a/packages/server/src/data-warehouse/destination.test.ts
+++ b/packages/server/src/data-warehouse/destination.test.ts
@@ -27,6 +27,7 @@ describe('data warehouse destinations', () => {
   test('local destination attaches postgres after setup', () => {
     const destination = new LocalParquetWarehouseDestination('/tmp/dw-local-destination');
     expect(destination.getSetupQueries()).toStrictEqual([]);
+    expect(destination.getConnectionSetupQueries()).toStrictEqual([]);
     expect(destination.getPostgresAttachQueries('postgresql://user:pass@localhost/db')).toStrictEqual([
       'INSTALL postgres',
       'LOAD postgres',

--- a/packages/server/src/data-warehouse/destination.ts
+++ b/packages/server/src/data-warehouse/destination.ts
@@ -23,10 +23,26 @@ export interface DestinationQueryContext {
 
 export interface DataWarehouseDestination {
   readonly type: DataWarehouseDestinationType;
-  /** DuckDB setup that does not require or open a Postgres connection. */
+  /**
+   * DuckDB instance setup (extensions, secrets, ATTACH) that does not require Postgres.
+   * Run once per DuckDB instance; shared by later connections from that instance.
+   */
   getSetupQueries(): string[];
-  /** Postgres attach SQL run after destination-side state (e.g. watermarks) is resolved. */
+  /**
+   * DuckDB session settings (`SET ...`) that are connection-scoped.
+   * Run on every connection opened from the instance.
+   */
+  getConnectionSetupQueries(): string[];
+  /**
+   * ATTACH Postgres is DuckDB's way of connecting to a database. run after all destination-side state (e.g. watermarks) has been resolved,
+   * It is intentionally not done at the beginning of sync because we want to avoid
+   * any potential idle-connection issues while watermarks from Icebergare are being read.
+   */
   getPostgresAttachQueries(connectionString: string): string[];
+  /**
+   * Verifies (or creates) the destination target for a source table.
+   * Called per table during watermark collection, before reading that table's watermark.
+   */
   ensureTargetExists(tableSpec: WarehouseSourceTable, namespace: string): Promise<void>;
   buildSourcePredicate(
     connection: DuckdbConnection,
@@ -50,6 +66,10 @@ export class LocalParquetWarehouseDestination implements DataWarehouseDestinatio
   }
 
   getSetupQueries(): string[] {
+    return [];
+  }
+
+  getConnectionSetupQueries(): string[] {
     return [];
   }
 

--- a/packages/server/src/data-warehouse/sync.int.test.ts
+++ b/packages/server/src/data-warehouse/sync.int.test.ts
@@ -1,46 +1,102 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-/** Integration tests for sync.ts: Postgres (medplum_test) → syncData → Parquet on disk. Worker wiring is tested in workers/data-warehouse-sync.test.ts. */
+/** Integration tests for sync.ts: Postgres (medplum_test) → syncData → fake S3 Iceberg. Worker wiring is tested in workers/data-warehouse-sync.test.ts; local Parquet e2e is in workers/data-warehouse-sync.int.test.ts. */
 
-import { DuckDBInstance } from '@duckdb/node-api';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { S3TablesWarehouseDestination } from '../cloud/aws/data-warehouse-destination';
 import { loadTestConfig } from '../config/loader';
 import { closeDatabase, DatabaseMode, getDatabasePool, initDatabase } from '../database';
+import { InsertQuery } from '../fhir/sql';
+import { buildFakeIcebergColumnStatsSetupQueries } from './__test__/fake-iceberg-column-stats';
+import type { WarehouseSourceTable } from './config';
 import { toIcebergTableName } from './config';
-import { LocalParquetWarehouseDestination } from './destination';
 import { syncData } from './sync';
+import { DEFAULT_ICEBERG_CATALOG_ALIAS, DEFAULT_NAMESPACE } from './warehouse-sql';
 
-/** Isolated history table in medplum_test so we do not collide with real FHIR history tables. */
-const HISTORY_TABLE = 'DwSyncIntTest_history';
-
-function assertParquetMagic(bytes: Buffer): void {
-  expect(bytes.subarray(0, 4).toString('ascii')).toBe('PAR1');
-  expect(bytes.subarray(bytes.length - 4).toString('ascii')).toBe('PAR1');
-}
-
-function buildReadParquetFirstRowProjectionQuery(parquetPath: string): string {
-  const escapedPath = parquetPath.replaceAll("'", "''");
-  return `SELECT id::VARCHAR AS id, project_id::VARCHAR AS project_id FROM read_parquet('${escapedPath}') LIMIT 1`;
-}
+/** Isolated history tables in medplum_test so we do not collide with real FHIR history tables. */
+const PATIENT_HISTORY_TABLE = 'DwSyncWmPatient_History';
+const OBSERVATION_HISTORY_TABLE = 'DwSyncWmObservation_History';
+const PATIENT_ICEBERG = toIcebergTableName(PATIENT_HISTORY_TABLE);
+const OBSERVATION_ICEBERG = toIcebergTableName(OBSERVATION_HISTORY_TABLE);
+const PATIENT_QUALIFIED = `${DEFAULT_ICEBERG_CATALOG_ALIAS}.${DEFAULT_NAMESPACE}.${PATIENT_ICEBERG}`;
+const OBSERVATION_QUALIFIED = `${DEFAULT_ICEBERG_CATALOG_ALIAS}.${DEFAULT_NAMESPACE}.${OBSERVATION_ICEBERG}`;
 
 /**
- * Exercises the local Parquet destination by writing a single row to a dedicated Postgres history table,
- * then syncing it to a local Parquet file.
+ * Fake AWS S3 Tables Iceberg destination, but half-real DuckDB: in-memory `iceberg_catalog` +
+ * `iceberg_column_stats` macro (no Iceberg extension).
  */
-describe('syncData local destination (integration)', () => {
+class FakeS3TablesWarehouseDestination extends S3TablesWarehouseDestination {
+  readonly icebergTables: string[];
+  readonly namespace: string;
+  watermarkByQualifiedTable: Record<string, string>;
+
+  constructor(options: {
+    icebergTables: string[];
+    namespace?: string;
+    watermarkByQualifiedTable: Record<string, string>;
+  }) {
+    super('us-east-1', 'arn:aws:s3tables:us-east-1:000000000000:bucket/fake');
+    this.icebergTables = options.icebergTables;
+    this.namespace = options.namespace ?? DEFAULT_NAMESPACE;
+    this.watermarkByQualifiedTable = options.watermarkByQualifiedTable;
+  }
+
+  override getSetupQueries(): string[] {
+    const createTables = this.icebergTables.map(
+      (icebergTable) => `
+        CREATE TABLE IF NOT EXISTS ${DEFAULT_ICEBERG_CATALOG_ALIAS}.${this.namespace}.${icebergTable} (
+          id UUID,
+          version_id UUID,
+          content VARCHAR,
+          last_updated TIMESTAMPTZ,
+          project_id UUID
+        );
+      `
+    );
+
+    return [
+      `ATTACH ':memory:' AS ${DEFAULT_ICEBERG_CATALOG_ALIAS}`,
+      `CREATE SCHEMA IF NOT EXISTS ${DEFAULT_ICEBERG_CATALOG_ALIAS}.${this.namespace}`,
+      ...createTables,
+      ...buildFakeIcebergColumnStatsSetupQueries(this.watermarkByQualifiedTable),
+      'INSTALL postgres',
+      'LOAD postgres',
+    ];
+  }
+
+  override getConnectionSetupQueries(): string[] {
+    return ['SET threads = 1', 'SET pg_use_ctid_scan = false'];
+  }
+
+  override async ensureTargetExists(): Promise<void> {}
+}
+
+describe('syncData (integration)', () => {
   let host: string;
   let port: number;
   let database: string;
   let username: string;
   let password: string;
-  let outDir: string | undefined;
 
-  /**
-   * Generates some fake test data
-   */
+  const initialWatermarks = {
+    [PATIENT_QUALIFIED]: '2024-06-01 12:00:00.000',
+    [OBSERVATION_QUALIFIED]: '2024-07-01 00:00:00.000',
+  };
+  const afterFirstSyncWatermarks = {
+    [PATIENT_QUALIFIED]: '2024-06-02 00:00:00.000',
+    [OBSERVATION_QUALIFIED]: '2024-07-02 00:00:00.000',
+  };
+
+  const patient1 = {
+    id: '3aa43dfe-c64d-465b-babc-700db9a0f780',
+    versionId: 'e40eedbb-9d71-445a-b619-88b1e0df97cd',
+    projectId: '6b3a4a25-15fa-4124-81d6-6903f5b1ee06',
+  };
+  const observation1 = {
+    id: '7190258c-4cc5-40df-ba81-111fb1d80d12',
+    projectId: patient1.projectId,
+  };
+
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initDatabase(config);
@@ -52,84 +108,146 @@ describe('syncData local destination (integration)', () => {
     password = db.password ?? '';
 
     const pool = getDatabasePool(DatabaseMode.WRITER);
-    await pool.query(`DROP TABLE IF EXISTS "${HISTORY_TABLE}"`);
-    await pool.query(`
-      CREATE TABLE "${HISTORY_TABLE}" (
-        id TEXT NOT NULL,
-        "versionId" TEXT NOT NULL,
-        content TEXT NOT NULL,
-        "lastUpdated" TIMESTAMPTZ NOT NULL
-      );
-    `);
-    await pool.query(
-      `INSERT INTO "${HISTORY_TABLE}" (id, "versionId", content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
-      [
-        'patient-int-1',
-        '1',
-        JSON.stringify({
-          resourceType: 'Patient',
-          id: 'patient-int-1',
-          meta: { project: 'project-from-json' },
-        }),
-        '2024-06-01T12:00:00.000Z',
-      ]
-    );
+    // One row at/before watermark (filtered out) and one after (exported on first sync).
+    await createHistoryTable(pool, PATIENT_HISTORY_TABLE, [
+      {
+        id: patient1.id,
+        versionId: patient1.versionId,
+        content: historyContent('Patient', patient1),
+        lastUpdated: '2024-05-01T00:00:00.000Z',
+      },
+      {
+        id: patient1.id,
+        versionId: '9e7bd58b-ec71-4fce-9cbf-8c0e1ce97199',
+        content: historyContent('Patient', patient1),
+        lastUpdated: '2024-06-02T00:00:00.000Z',
+      },
+    ]);
+    await createHistoryTable(pool, OBSERVATION_HISTORY_TABLE, [
+      {
+        id: observation1.id,
+        versionId: '34913591-3325-4aa2-97c2-644ab24489e0',
+        content: historyContent('Observation', observation1),
+        lastUpdated: '2024-06-15T00:00:00.000Z',
+      },
+      {
+        id: observation1.id,
+        versionId: '62c7cdbe-0f16-435f-83ea-445273b8e004',
+        content: historyContent('Observation', observation1),
+        lastUpdated: '2024-07-02T00:00:00.000Z',
+      },
+    ]);
   }, 10_000);
 
   afterAll(async () => {
     const pool = getDatabasePool(DatabaseMode.WRITER);
-    await pool.query(`DROP TABLE IF EXISTS "${HISTORY_TABLE}"`);
+    await pool.query(`DROP TABLE IF EXISTS "${PATIENT_HISTORY_TABLE}"`);
+    await pool.query(`DROP TABLE IF EXISTS "${OBSERVATION_HISTORY_TABLE}"`);
     await closeDatabase();
-    if (outDir) {
-      rmSync(outDir, { recursive: true, force: true });
-    }
-  }, 10_000); // DROP TABLE shouldn't take this long, but on CI it might
+  }, 10_000);
 
-  beforeEach(() => {
-    outDir = mkdtempSync(join(tmpdir(), 'medplum-dw-destination-'));
-  });
+  /**
+   * Real Postgres, fake AWS S3 Tables, real DuckDB and Parquet
+   */
+  test('e2e: incremental syncData Postgres to fake S3 Iceberg then empty second sync', async () => {
+    // given
+    const warehouseSources: WarehouseSourceTable[] = [
+      { postgresTable: PATIENT_HISTORY_TABLE, icebergTable: PATIENT_ICEBERG },
+      { postgresTable: OBSERVATION_HISTORY_TABLE, icebergTable: OBSERVATION_ICEBERG },
+    ];
+    const destination = new FakeS3TablesWarehouseDestination({
+      icebergTables: [PATIENT_ICEBERG, OBSERVATION_ICEBERG],
+      watermarkByQualifiedTable: initialWatermarks,
+    });
 
-  afterEach(() => {
-    if (outDir) {
-      rmSync(outDir, { recursive: true, force: true });
-    }
-  });
-
-  test('exports projected history rows to a Parquet file via local destination', async () => {
-    // Given: an isolated warehouse source and local parquet destination
-    const warehouseSources = [HISTORY_TABLE].map((postgresTable) => ({
-      postgresTable,
-      icebergTable: toIcebergTableName(postgresTable),
-    }));
-    const destination = new LocalParquetWarehouseDestination(outDir as string);
-
-    // When: we run data warehouse sync against the seeded history table
-    const result = await syncData({
+    // when — first sync inserts only post-watermark rows
+    const firstResult = await syncData({
       database: { host, port, dbname: database, username, password },
       warehouseSources,
       destination,
+      namespace: DEFAULT_NAMESPACE,
     });
 
-    // Then: sync reports an inserted parquet artifact for the expected table
-    expect(result.tables).toHaveLength(1);
-    expect(result.tables[0]?.rowsInserted).toBe(1);
-    expect(result.tables[0]?.destination).toContain(`${warehouseSources[0]?.icebergTable}.parquet`);
+    // then
+    expect(firstResult.tables).toHaveLength(2);
+    expect(firstResult.tables.map((t) => t.rowsInserted)).toStrictEqual([1, 1]);
+    expect(firstResult.tables.map((t) => t.destination)).toStrictEqual([OBSERVATION_ICEBERG, PATIENT_ICEBERG]);
 
-    // Then: the written file is a valid parquet payload
-    const parquetPath = result.tables[0]?.destination;
-    assertParquetMagic(readFileSync(parquetPath));
+    // when — simulate advancing watermarks as Iceberg column stats would after commit, then sync again
+    destination.watermarkByQualifiedTable = afterFirstSyncWatermarks;
+    const secondResult = await syncData({
+      database: { host, port, dbname: database, username, password },
+      warehouseSources,
+      destination,
+      namespace: DEFAULT_NAMESPACE,
+    });
 
-    // Then: projected row values are readable and match source content
-    const instance = await DuckDBInstance.create(':memory:');
-    const c = await instance.connect();
-    try {
-      const res = await c.runAndReadAll(buildReadParquetFirstRowProjectionQuery(parquetPath));
-      const row = res.getRowObjectsJson()[0] as { id: string; project_id: string | null };
-      expect(row.id).toBe('patient-int-1');
-      expect(row.project_id).toBe('project-from-json');
-    } finally {
-      c.closeSync();
-      instance.closeSync();
-    }
-  }, 30_000); // longer timeout because of database operations
+    // then — empty incremental delta
+    expect(secondResult.tables).toHaveLength(2);
+    expect(secondResult.tables.map((t) => t.rowsInserted)).toStrictEqual([0, 0]);
+
+    // when — insert new history rows after the advanced watermarks, then sync again
+    const pool = getDatabasePool(DatabaseMode.WRITER);
+    await new InsertQuery(PATIENT_HISTORY_TABLE, [
+      {
+        id: patient1.id,
+        versionId: 'a1b2c3d4-e5f6-4789-a012-3456789abcde',
+        content: historyContent('Patient', patient1),
+        lastUpdated: '2024-06-03T00:00:00.000Z',
+      },
+    ]).execute(pool);
+    await new InsertQuery(OBSERVATION_HISTORY_TABLE, [
+      {
+        id: observation1.id,
+        versionId: 'b2c3d4e5-f6a7-4890-b123-456789abcdef',
+        content: historyContent('Observation', observation1),
+        lastUpdated: '2024-07-03T00:00:00.000Z',
+      },
+    ]).execute(pool);
+
+    const thirdResult = await syncData({
+      database: { host, port, dbname: database, username, password },
+      warehouseSources,
+      destination,
+      namespace: DEFAULT_NAMESPACE,
+    });
+
+    // then — only the newly inserted rows are exported
+    expect(thirdResult.tables).toHaveLength(2);
+    expect(thirdResult.tables.map((t) => t.rowsInserted)).toStrictEqual([1, 1]);
+  }, 30_000);
 });
+
+function historyContent(resourceType: string, resource: { id: string; projectId: string }): string {
+  return JSON.stringify({
+    resourceType,
+    id: resource.id,
+    meta: { project: resource.projectId },
+  });
+}
+
+async function createHistoryTable(
+  pool: ReturnType<typeof getDatabasePool>,
+  tableName: string,
+  rows: { id: string; versionId: string; content: string; lastUpdated: string }[]
+): Promise<void> {
+  await pool.query(`DROP TABLE IF EXISTS "${tableName}"`);
+  await pool.query(`
+    CREATE TABLE "${tableName}" (
+      id UUID NOT NULL,
+      "versionId" UUID NOT NULL,
+      content TEXT NOT NULL,
+      "lastUpdated" TIMESTAMPTZ NOT NULL
+    );
+  `);
+  for (const row of rows) {
+    await new InsertQuery(tableName, [
+      {
+        id: row.id,
+        versionId: row.versionId,
+        content: row.content,
+        lastUpdated: row.lastUpdated,
+      },
+    ]).execute(pool);
+  }
+}

--- a/packages/server/src/data-warehouse/sync.test.ts
+++ b/packages/server/src/data-warehouse/sync.test.ts
@@ -4,10 +4,13 @@
 import { vi } from 'vitest';
 import type { Expression } from '../fhir/sql';
 import { Condition, SqlBuilder } from '../fhir/sql';
-import type { DataWarehouseDestination } from './destination';
+import type { WarehouseSourceTable } from './config';
+import * as dataWarehouseConfig from './config';
+import type { DataWarehouseDestination, DestinationQueryContext } from './destination';
 import { LocalParquetWarehouseDestination } from './destination';
 import type { SyncOptions } from './sync';
-import { buildWarehouseSourcePredicate } from './sync';
+import { buildWarehouseSourcePredicate, syncData } from './sync';
+import type { DuckdbConnection } from './warehouse-sql';
 import { buildStartDatePredicate } from './warehouse-sql';
 
 const tableSpec = { postgresTable: 'Patient_History', icebergTable: 'patient_history' };
@@ -102,3 +105,279 @@ describe('buildWarehouseSourcePredicate', () => {
     });
   });
 });
+
+describe('syncData', () => {
+  const patientSource: WarehouseSourceTable = {
+    postgresTable: 'Patient_History',
+    icebergTable: 'patient_history',
+  };
+  const observationSource: WarehouseSourceTable = {
+    postgresTable: 'Observation_History',
+    icebergTable: 'observation_history',
+  };
+
+  beforeEach(() => {
+    // Attach queries are empty in these tests; stub URI build so database config is not required.
+    vi.spyOn(dataWarehouseConfig, 'buildPgConnectionURI').mockReturnValue('postgresql://unused');
+  });
+
+  test('skips a table on Iceberg Conflict 409 and continues with remaining tables', async () => {
+    // given
+    const onProgress = vi.fn();
+    const destination = createFakeDestination({
+      writeRows: async (_connection: DuckdbConnection, context: DestinationQueryContext) => {
+        if (context.tableSpec.icebergTable === patientSource.icebergTable) {
+          throw new Error('HTTP 409 Conflict 409: commit conflict during compaction');
+        }
+        return 3;
+      },
+    });
+
+    // when
+    const result = await syncData({
+      database: {},
+      warehouseSources: [patientSource, observationSource],
+      destination,
+      onProgress,
+    });
+
+    // then
+    expect(result.tables).toHaveLength(2);
+    expect(result.tables).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          destination: patientSource.icebergTable,
+          status: 'skipped-conflict',
+          rowsInserted: 0,
+        }),
+        expect.objectContaining({
+          destination: observationSource.icebergTable,
+          rowsInserted: 3,
+        }),
+      ])
+    );
+    expect(result.tables.find((t) => t.destination === observationSource.icebergTable)?.status).toBeUndefined();
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.stringContaining(`Skipped ${patientSource.icebergTable}`),
+      expect.objectContaining({
+        destination: patientSource.icebergTable,
+        rowsInserted: 0,
+        tablesCompleted: 2,
+        tablesTotal: 2,
+      })
+    );
+  });
+
+  test('skips a table on CommitFailedException and continues with remaining tables', async () => {
+    // given
+    const destination = createFakeDestination({
+      writeRows: async (_connection: DuckdbConnection, context: DestinationQueryContext) => {
+        if (context.tableSpec.icebergTable === observationSource.icebergTable) {
+          throw new Error('CommitFailedException: concurrent commit');
+        }
+        return 2;
+      },
+    });
+
+    // when
+    const result = await syncData({
+      database: {},
+      warehouseSources: [patientSource, observationSource],
+      destination,
+    });
+
+    // then
+    expect(result.tables).toHaveLength(2);
+    expect(result.tables).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          destination: patientSource.icebergTable,
+          rowsInserted: 2,
+        }),
+        expect.objectContaining({
+          destination: observationSource.icebergTable,
+          status: 'skipped-conflict',
+          rowsInserted: 0,
+        }),
+      ])
+    );
+    expect(result.tables.find((t) => t.destination === patientSource.icebergTable)?.status).toBeUndefined();
+  });
+
+  test('skips a table on watermark read failure and continues with remaining tables', async () => {
+    // given
+    const onProgress = vi.fn();
+    const destination = createFakeDestination({
+      buildSourcePredicate: async (_connection, tableSpec) => {
+        if (tableSpec.icebergTable === patientSource.icebergTable) {
+          throw new Error('iceberg_column_stats failed');
+        }
+        return undefined;
+      },
+      writeRows: async () => 5,
+    });
+
+    // when
+    const result = await syncData({
+      database: {},
+      warehouseSources: [patientSource, observationSource],
+      destination,
+      onProgress,
+    });
+
+    // then
+    expect(result.tables).toHaveLength(2);
+    expect(result.tables).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          destination: patientSource.icebergTable,
+          status: 'skipped-watermark',
+          rowsInserted: 0,
+          syncDurationMs: 0,
+        }),
+        expect.objectContaining({
+          destination: observationSource.icebergTable,
+          rowsInserted: 5,
+        }),
+      ])
+    );
+    expect(result.tables.find((t) => t.destination === observationSource.icebergTable)?.status).toBeUndefined();
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.stringContaining(`Skipped ${patientSource.icebergTable}`),
+      expect.objectContaining({
+        destination: patientSource.icebergTable,
+        rowsInserted: 0,
+        tablesTotal: 2,
+      })
+    );
+    // Progress reaches total even when a watermark was skipped.
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.stringContaining(`table 2/2`),
+      expect.objectContaining({ tablesCompleted: 2, tablesTotal: 2 })
+    );
+  });
+
+  test('skips a table when destination target is missing and continues with remaining tables', async () => {
+    // given
+    const onProgress = vi.fn();
+    const destination = createFakeDestination({
+      ensureTargetExists: async (tableSpec) => {
+        if (tableSpec.icebergTable === patientSource.icebergTable) {
+          throw new Error('Managed Iceberg table does not exist: default.patient_history. Run migration before sync.');
+        }
+      },
+      writeRows: async () => 4,
+    });
+
+    // when
+    const result = await syncData({
+      database: {},
+      warehouseSources: [patientSource, observationSource],
+      destination,
+      onProgress,
+    });
+
+    // then
+    expect(result.tables).toHaveLength(2);
+    expect(result.tables).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          destination: patientSource.icebergTable,
+          status: 'skipped-missing-table',
+          rowsInserted: 0,
+          syncDurationMs: 0,
+        }),
+        expect.objectContaining({
+          destination: observationSource.icebergTable,
+          rowsInserted: 4,
+        }),
+      ])
+    );
+    expect(result.tables.find((t) => t.destination === observationSource.icebergTable)?.status).toBeUndefined();
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.stringContaining(`Skipped ${patientSource.icebergTable}`),
+      expect.objectContaining({
+        destination: patientSource.icebergTable,
+        rowsInserted: 0,
+        tablesTotal: 2,
+      })
+    );
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.stringContaining('destination table missing'),
+      expect.objectContaining({ destination: patientSource.icebergTable })
+    );
+  });
+
+  test('skips a table on unexpected watermark setup failure and continues the worker stripe', async () => {
+    // given — 9 sources so concurrency is 8 and worker 0 owns stripe [0, 8]
+    const warehouseSources: WarehouseSourceTable[] = Array.from({ length: 9 }, (_, i) => ({
+      postgresTable: `Resource${i}_History`,
+      icebergTable: `resource${i}_history`,
+    }));
+    const failingTable = warehouseSources[8].icebergTable;
+    let destinationNameCallsForFailing = 0;
+    const onProgress = vi.fn();
+    const destination = createFakeDestination({
+      getDestinationName: (spec) => {
+        if (spec.icebergTable === failingTable) {
+          destinationNameCallsForFailing += 1;
+          // Fail during watermark collection; later sync-loop calls must succeed for reporting.
+          if (destinationNameCallsForFailing === 1) {
+            throw new Error('watermark setup boom');
+          }
+        }
+        return spec.icebergTable;
+      },
+      writeRows: async () => 1,
+    });
+
+    // when
+    const result = await syncData({
+      database: {},
+      warehouseSources,
+      destination,
+      onProgress,
+    });
+
+    // then — failure on one stripe member does not drop the rest; all sources are reported
+    expect(result.tables).toHaveLength(9);
+    expect(result.tables.find((t) => t.destination === failingTable)).toEqual(
+      expect.objectContaining({
+        destination: failingTable,
+        status: 'skipped-watermark',
+        rowsInserted: 0,
+      })
+    );
+    expect(result.tables.filter((t) => !t.status)).toHaveLength(8);
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.stringContaining(`table 9/9`),
+      expect.objectContaining({ tablesCompleted: 9, tablesTotal: 9 })
+    );
+  });
+});
+
+/**
+ * Destination stub for syncData control-flow tests: empty setup/attach SQL so sync uses a real
+ * DuckDB instance without Iceberg or Postgres, while predicate/write behavior stays injectable.
+ * @param overrides - Optional overrides for ensureTargetExists, buildSourcePredicate, writeRows, and getDestinationName.
+ * @returns A DataWarehouseDestination suitable for syncData unit tests.
+ */
+function createFakeDestination(
+  overrides: Partial<{
+    ensureTargetExists: DataWarehouseDestination['ensureTargetExists'];
+    buildSourcePredicate: DataWarehouseDestination['buildSourcePredicate'];
+    writeRows: DataWarehouseDestination['writeRows'];
+    getDestinationName: DataWarehouseDestination['getDestinationName'];
+  }> = {}
+): DataWarehouseDestination {
+  return {
+    type: 'local',
+    getSetupQueries: () => [],
+    getConnectionSetupQueries: () => [],
+    getPostgresAttachQueries: () => [],
+    ensureTargetExists: overrides.ensureTargetExists ?? (async () => undefined),
+    buildSourcePredicate: overrides.buildSourcePredicate ?? (async () => undefined),
+    writeRows: overrides.writeRows ?? (async () => 1),
+    getDestinationName: overrides.getDestinationName ?? ((spec: WarehouseSourceTable) => spec.icebergTable),
+  };
+}

--- a/packages/server/src/data-warehouse/sync.ts
+++ b/packages/server/src/data-warehouse/sync.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { DuckDBInstance } from '@duckdb/node-api';
+import { normalizeErrorString } from '@medplum/core';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -14,6 +15,9 @@ import { buildPgConnectionURI } from './config';
 import type { DataWarehouseDestination } from './destination';
 import type { DuckdbConnection } from './warehouse-sql';
 import { buildStartDatePredicate, DEFAULT_NAMESPACE } from './warehouse-sql';
+
+/** Max concurrent DuckDB connections used to read Iceberg watermarks in parallel. */
+const WATERMARK_READ_CONCURRENCY = 8;
 
 export interface SyncOptions {
   database: MedplumDatabaseConfig;
@@ -29,8 +33,12 @@ export interface SyncOptions {
   onProgress?: (message: string, metadata?: Record<string, string | number>) => void | Promise<void>;
 }
 
+export type SyncTableSkipReason = 'skipped-conflict' | 'skipped-watermark' | 'skipped-missing-table';
+
 export interface SyncTableResult {
   destination: string;
+  /** Set when the table was skipped; omitted on successful sync. */
+  status?: SyncTableSkipReason;
   rowsInserted: number;
   syncDurationMs: number;
   watermarkDurationMs: number;
@@ -38,6 +46,17 @@ export interface SyncTableResult {
 
 export interface SyncResult {
   tables: SyncTableResult[];
+}
+
+interface WarehouseTableWatermark {
+  spec: WarehouseSourceTable;
+  sourcePredicate: Expression | undefined;
+  watermarkDurationMs: number;
+  /**
+   * Present when this table will not be written: Iceberg watermark read failed, or the
+   * destination target is missing.
+   */
+  status?: 'skipped-watermark' | 'skipped-missing-table';
 }
 
 function getSyncSourceConnectionString(options: SyncOptions): string {
@@ -63,21 +82,46 @@ type WarehouseSyncDuckdbConnection = DuckdbConnection & {
   closeSync(): void;
 };
 
+function closeWarehouseConnection(connection: WarehouseSyncDuckdbConnection | undefined, label: string): void {
+  if (!connection) {
+    return;
+  }
+  try {
+    connection.closeSync();
+  } catch (err) {
+    globalLogger.warn(`Failed closing data warehouse DuckDB ${label}`, { err, subsystem: 'data-warehouse-sync' });
+  }
+}
+
+async function connectWarehouse(
+  instance: DuckDBInstance,
+  options: SyncOptions,
+  label: string
+): Promise<WarehouseSyncDuckdbConnection> {
+  const connection = await instance.connect();
+  try {
+    for (const query of options.destination.getConnectionSetupQueries()) {
+      await connection.run(query);
+    }
+    return connection;
+  } catch (err) {
+    closeWarehouseConnection(connection, label);
+    throw err;
+  }
+}
+
 /**
- * Opens a fresh DuckDB instance/connection backed by a throwaway temp directory,
- * runs the destination setup queries, invokes `fn`, and tears everything down
- * afterwards. A new database is created and destroyed for each invocation.
+ * Opens a DuckDB instance (backed by a throwaway temp directory), runs destination
+ * setup on a short-lived connection, invokes `fn` with the instance, and tears
+ * everything down afterwards.
  * @param options - The sync options.
- * @param sourceConnectionString - The Postgres source connection string.
- * @param fn - Callback invoked with the ready-to-use DuckDB connection.
+ * @param fn - Callback invoked with the ready-to-use DuckDB instance.
  * @returns The value returned by `fn`.
  */
 async function withWarehouseConnection<T>(
   options: SyncOptions,
-  sourceConnectionString: string,
-  fn: (connection: WarehouseSyncDuckdbConnection) => Promise<T>
+  fn: (instance: DuckDBInstance) => Promise<T>
 ): Promise<T> {
-  let connection: WarehouseSyncDuckdbConnection | undefined;
   let instance: DuckDBInstance | undefined;
   let duckdbTempDir: string | undefined;
   try {
@@ -85,19 +129,20 @@ async function withWarehouseConnection<T>(
     duckdbTempDir = await mkdtemp(join(tmpdir(), `medplum-dw-sync-`));
     const duckdbDatabasePath = join(duckdbTempDir, 'warehouse.duckdb');
     instance = await DuckDBInstance.create(duckdbDatabasePath);
-    connection = await instance.connect();
-    for (const q of options.destination.getSetupQueries()) {
-      await connection.run(q);
-    }
 
-    return await fn(connection);
-  } finally {
+    // Instance-scoped setup (extensions, secrets, ATTACH) is shared by later connections.
+    // Session SETs are connection-scoped and applied in connectWarehouse().
+    const setupConnection = await instance.connect();
     try {
-      connection?.closeSync();
-    } catch (err) {
-      globalLogger.warn('Failed closing data warehouse DuckDB connection', { err, subsystem: 'data-warehouse-sync' });
+      for (const q of options.destination.getSetupQueries()) {
+        await setupConnection.run(q);
+      }
+    } finally {
+      closeWarehouseConnection(setupConnection, 'setup connection');
     }
 
+    return await fn(instance);
+  } finally {
     try {
       instance?.closeSync();
     } catch (err) {
@@ -121,38 +166,122 @@ async function withWarehouseConnection<T>(
   }
 }
 
-async function syncWarehouseTable(
+/*
+ * Reads one table's destination existence check and Iceberg watermark.
+ * Never throws: failures become skip entries so watermark workers can finish their stripe.
+ */
+async function readWarehouseTableWatermark(
   connection: WarehouseSyncDuckdbConnection,
   options: SyncOptions,
   spec: WarehouseSourceTable,
+  namespace: string
+): Promise<WarehouseTableWatermark> {
+  const watermarkStartTime = Date.now();
+  let destination = spec.icebergTable;
+  let phase: 'setup' | 'ensure' | 'watermark' = 'setup';
+  try {
+    destination = options.destination.getDestinationName(spec);
+    phase = 'ensure';
+    await options.destination.ensureTargetExists(spec, namespace);
+    phase = 'watermark';
+    const sourcePredicate = await buildWarehouseSourcePredicate(connection, options, spec, namespace);
+    return {
+      spec,
+      sourcePredicate,
+      watermarkDurationMs: Date.now() - watermarkStartTime,
+    };
+  } catch (err) {
+    const status = phase === 'ensure' ? 'skipped-missing-table' : 'skipped-watermark';
+    globalLogger.warn(
+      status === 'skipped-missing-table'
+        ? `Data warehouse destination table missing for table=${destination}`
+        : `Failed reading data warehouse watermark for table=${destination}`,
+      {
+        destination,
+        err,
+        subsystem: 'data-warehouse-sync',
+      }
+    );
+    return {
+      spec,
+      sourcePredicate: undefined,
+      watermarkDurationMs: Date.now() - watermarkStartTime,
+      status,
+    };
+  }
+}
+
+/**
+ * Resolves incremental source predicates for every warehouse table.
+ *
+ * Per-table existence checks and Iceberg watermark DuckDB reads fan out across
+ * watermark connections on the same instance (one query per connection). All watermark
+ * work finishes before this returns so the caller can attach Postgres afterwards.
+ * Per-table failures are logged and returned as skip entries (`skipped-missing-table` or
+ * `skipped-watermark`); successful tables still sync.
+ *
+ * @param instance - Shared DuckDB instance used to open watermark connections.
+ * @param options - Sync options including destination and warehouse source tables.
+ * @param namespace - Iceberg / warehouse namespace for target tables.
+ * @returns One entry per warehouse source table (including skip entries), sorted by Iceberg table name.
+ */
+async function collectWarehouseWatermarks(
+  instance: DuckDBInstance,
+  options: SyncOptions,
+  namespace: string
+): Promise<WarehouseTableWatermark[]> {
+  const sources = options.warehouseSources;
+  const concurrency = Math.min(WATERMARK_READ_CONCURRENCY, sources.length);
+  const watermarkConnections: WarehouseSyncDuckdbConnection[] = [];
+  try {
+    // Open one DuckDB connection per watermark worker.
+    for (let i = 0; i < concurrency; i++) {
+      watermarkConnections.push(await connectWarehouse(instance, options, 'watermark connection'));
+    }
+
+    // Fan out: worker i owns sources[i], sources[i + concurrency], …
+    // Use allSettled so we never close connections while sibling workers still have in-flight queries.
+    const settled = await Promise.allSettled(
+      watermarkConnections.map(async (connection, workerIndex) => {
+        const results: WarehouseTableWatermark[] = [];
+        for (let i = workerIndex; i < sources.length; i += concurrency) {
+          results.push(await readWarehouseTableWatermark(connection, options, sources[i], namespace));
+        }
+        return results;
+      })
+    );
+
+    // sort alphabetically because some jobs will finish faster than others
+    return settled
+      .flatMap((result) => (result.status === 'fulfilled' ? result.value : []))
+      .sort((a, b) => a.spec.icebergTable.localeCompare(b.spec.icebergTable));
+  } finally {
+    // Close watermark connections before Postgres is attached.
+    for (const connection of watermarkConnections) {
+      closeWarehouseConnection(connection, 'watermark connection');
+    }
+  }
+}
+
+async function writeWarehouseTable(
+  connection: WarehouseSyncDuckdbConnection,
+  options: SyncOptions,
+  watermark: WarehouseTableWatermark,
   namespace: string,
-  sourceConnectionString: string,
   index: number,
   tablesTotal: number
 ): Promise<SyncTableResult> {
   const tablesCompleted = index + 1;
+  const { spec, sourcePredicate, watermarkDurationMs } = watermark;
   const destination = options.destination.getDestinationName(spec);
 
   const syncStartTime = Date.now();
-
-  await options.destination.ensureTargetExists(spec, namespace);
-
-  const watermarkStartTime = Date.now();
-  const sourcePredicate = await buildWarehouseSourcePredicate(connection, options, spec, namespace);
-  const watermarkDurationMs = Date.now() - watermarkStartTime;
-
-  for (const query of options.destination.getPostgresAttachQueries(sourceConnectionString)) {
-    await connection.run(query);
-  }
-
   const rowsInserted = await options.destination.writeRows(connection, {
     tableSpec: spec,
     namespace,
     sourcePredicate,
   });
-
-  const syncEndTime = Date.now();
-  const syncDurationMs = syncEndTime - syncStartTime;
+  const syncDurationMs = Date.now() - syncStartTime;
 
   globalLogger.info(`Data warehouse sync finished for table=${destination}`, {
     tableIndex: tablesCompleted,
@@ -186,25 +315,116 @@ async function syncWarehouseTable(
   };
 }
 
+function buildSkippedTableResult(
+  destination: string,
+  status: SyncTableSkipReason,
+  watermarkDurationMs: number
+): SyncTableResult {
+  return {
+    destination,
+    status,
+    rowsInserted: 0,
+    syncDurationMs: 0,
+    watermarkDurationMs,
+  };
+}
+
+async function reportSkippedTableProgress(
+  options: SyncOptions,
+  destination: string,
+  reason: string,
+  tablesCompleted: number,
+  tablesTotal: number
+): Promise<void> {
+  if (!options.onProgress) {
+    return;
+  }
+  await options.onProgress(`Skipped ${destination} (${reason}, table ${tablesCompleted}/${tablesTotal})`, {
+    tablesCompleted,
+    tablesTotal,
+    destination,
+    rowsInserted: 0,
+  });
+}
+
 async function runWarehouseTableSync(
   options: SyncOptions,
   namespace: string,
   sourceConnectionString: string
 ): Promise<SyncTableResult[]> {
-  const tables: SyncTableResult[] = [];
+  return withWarehouseConnection(options, async (instance) => {
+    // in one session, grabs all high-watermarks for all tables (before Postgres attach)
+    const watermarks = await collectWarehouseWatermarks(instance, options, namespace);
+    const tablesTotal = options.warehouseSources.length;
 
-  const tablesTotal = options.warehouseSources.length;
+    // in another session, connect to postgres only after every Iceberg watermark has been fetched
+    const writeConnection = await connectWarehouse(instance, options, 'write connection');
+    try {
+      for (const query of options.destination.getPostgresAttachQueries(sourceConnectionString)) {
+        await writeConnection.run(query);
+      }
 
-  for (const [index, spec] of options.warehouseSources.entries()) {
-    // Close and re-open the DuckDB database between tables so each table sync
-    // runs against a fresh instance/connection and temp directory.
-    const result = await withWarehouseConnection(options, sourceConnectionString, (connection) =>
-      syncWarehouseTable(connection, options, spec, namespace, sourceConnectionString, index, tablesTotal)
-    );
-    tables.push(result);
-  }
+      const tables: SyncTableResult[] = [];
 
-  return tables;
+      // update each iceberg table (watermarks includes skip entries, so index tracks all sources)
+      for (const [index, watermark] of watermarks.entries()) {
+        const tablesCompleted = index + 1;
+        const destination = options.destination.getDestinationName(watermark.spec);
+
+        if (watermark.status === 'skipped-missing-table') {
+          tables.push(buildSkippedTableResult(destination, 'skipped-missing-table', watermark.watermarkDurationMs));
+          await reportSkippedTableProgress(
+            options,
+            destination,
+            'destination table missing',
+            tablesCompleted,
+            tablesTotal
+          );
+          continue;
+        }
+
+        if (watermark.status === 'skipped-watermark') {
+          tables.push(buildSkippedTableResult(destination, 'skipped-watermark', watermark.watermarkDurationMs));
+          await reportSkippedTableProgress(options, destination, 'watermark read failed', tablesCompleted, tablesTotal);
+          continue;
+        }
+
+        try {
+          const result = await writeWarehouseTable(writeConnection, options, watermark, namespace, index, tablesTotal);
+          tables.push(result);
+        } catch (err) {
+          const message = normalizeErrorString(err);
+          if (!message.includes('CommitFailedException') && !message.includes('409')) {
+            throw err;
+          }
+
+          globalLogger.info(
+            `Skipping data warehouse sync for table=${destination} due to Iceberg commit conflict (likely compaction)`,
+            {
+              destination,
+              tableIndex: tablesCompleted,
+              tablesTotal,
+              err,
+              subsystem: 'data-warehouse-sync',
+            }
+          );
+
+          tables.push(buildSkippedTableResult(destination, 'skipped-conflict', watermark.watermarkDurationMs));
+          await reportSkippedTableProgress(
+            options,
+            destination,
+            'Iceberg commit conflict',
+            tablesCompleted,
+            tablesTotal
+          );
+        }
+      }
+
+      return tables;
+    } finally {
+      closeWarehouseConnection(writeConnection, 'write connection');
+    }
+  });
 }
 
 export async function syncData(options: SyncOptions): Promise<SyncResult> {

--- a/packages/server/src/data-warehouse/warehouse-sql.int.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.int.test.ts
@@ -24,6 +24,10 @@ const DELETED_ONLY_TABLE = 'iceberg_catalog.default.deleted_only';
 const HISTORY_TABLE = 'DwWarehouseSqlIntTest_history';
 const DEST_TABLE = 'wh_sql_int_dest';
 
+const PATIENT_ID = '6e586f88-710f-42b2-9cc2-285496264c99';
+const VERSION_ID = 'c227e03f-b6d5-44f7-b191-8571ed508d7e';
+const PROJECT_ID = '71b6dae7-1e96-47ed-babb-c1a0e58a885f';
+
 describe('warehouse SQL (integration)', () => {
   let host: string;
   let port: number;
@@ -46,8 +50,8 @@ describe('warehouse SQL (integration)', () => {
       await client.query(`DROP TABLE IF EXISTS "${HISTORY_TABLE}"`);
       await client.query(`
         CREATE TABLE "${HISTORY_TABLE}" (
-          id TEXT NOT NULL,
-          "versionId" TEXT NOT NULL,
+          id UUID NOT NULL,
+          "versionId" UUID NOT NULL,
           content TEXT NOT NULL,
           "lastUpdated" TIMESTAMPTZ NOT NULL
         );
@@ -55,12 +59,12 @@ describe('warehouse SQL (integration)', () => {
       await client.query(
         `INSERT INTO "${HISTORY_TABLE}" (id, "versionId", content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
         [
-          'patient-wh-sql-1',
-          '1',
+          PATIENT_ID,
+          VERSION_ID,
           JSON.stringify({
             resourceType: 'Patient',
-            id: 'patient-wh-sql-1',
-            meta: { project: 'project-from-json' },
+            id: PATIENT_ID,
+            meta: { project: PROJECT_ID },
           }),
           '2024-06-01T12:00:00.000Z',
         ]
@@ -94,11 +98,11 @@ describe('warehouse SQL (integration)', () => {
       await connection.run(buildDuckdbPostgresAttachQuery(connStr));
       await connection.run(`
         CREATE TABLE "${DEST_TABLE}" (
-          id VARCHAR,
-          version_id VARCHAR,
+          id UUID,
+          version_id UUID,
           content VARCHAR,
           last_updated TIMESTAMPTZ,
-          project_id VARCHAR
+          project_id UUID
         );
       `);
 
@@ -109,8 +113,8 @@ describe('warehouse SQL (integration)', () => {
       readSql.append(`SELECT id, project_id FROM "${DEST_TABLE}"`);
       const readResult = await runParameterizedWarehouseSqlReadAll(connection, readSql);
       const row = readResult.getRowObjectsJson()[0] as { id: string; project_id: string };
-      expect(row.id).toBe('patient-wh-sql-1');
-      expect(row.project_id).toBe('project-from-json');
+      expect(row.id).toBe(PATIENT_ID);
+      expect(row.project_id).toBe(PROJECT_ID);
     } finally {
       connection.closeSync();
       instance.closeSync();

--- a/packages/server/src/data-warehouse/warehouse-sql.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.ts
@@ -273,34 +273,18 @@ export function buildManagedS3TablesIcebergAttachQuery(awsS3TableArn: string): s
 }
 
 /**
- * DuckDB setup for managed Iceberg (extensions, S3 secret, S3 Tables attach).
- * Postgres is attached separately after destination watermarks are resolved.
+ * DuckDB instance setup for managed Iceberg (extensions, S3 secret, S3 Tables attach).
+ *
+ * Run once per DuckDB instance. Session settings belong in
+ * `S3TablesWarehouseDestination.getConnectionSetupQueries` and must run on every connection.
  *
  * @param options - Attach options; requires `awsS3TableArn` and `s3Region`.
- * @returns SQL strings to run in order before per-table mutations.
+ * @returns SQL strings to run once on the DuckDB instance before opening work connections.
  */
 export function buildManagedIcebergSetupQueries(options: ManagedIcebergSetupOptions): string[] {
   return [
     ...buildManagedIcebergExtensionQueries(),
     buildManagedS3CredentialSecretQuery(options.s3Region),
-    /*
-     * the default is 524288, which can take a LOT of memory since we're copying
-     * JSON content data
-     */
-    'SET partitioned_write_flush_threshold = 10000;',
-    /*
-     * Misleading option.  This is to allow duckdb to insert into a "sorted table", which is really a hint anyway.
-     * https://github.com/duckdb/duckdb-iceberg/issues/851
-     * https://github.com/duckdb/duckdb-iceberg/pull/992
-     */
-    'SET unsafe_iceberg_ignore_sort_order=true',
-    /*
-     * See https://duckdb.org/docs/current/core_extensions/postgres/connection_pool
-     * the default connection pool settings are very aggressive; many connections, much parallelism
-     * That's not what we want for a sync process on a timer; we want to be gentle on our reader instances
-     */
-    'SET threads = 1',
-    'SET pg_use_ctid_scan = false',
     buildManagedS3TablesIcebergAttachQuery(options.awsS3TableArn),
   ];
 }

--- a/packages/server/src/workers/data-warehouse-sync.int.test.ts
+++ b/packages/server/src/workers/data-warehouse-sync.int.test.ts
@@ -10,7 +10,7 @@
  *
  * Contrast with:
  * - `data-warehouse-sync.test.ts` — unit tests for worker/scheduler wiring (mocked `syncData` / BullMQ).
- * - `data-warehouse/sync.int.test.ts` — same export pipeline via `syncData` directly (no worker layer).
+ * - `data-warehouse/sync.int.test.ts` — incremental `syncData` against fake S3 Iceberg (no worker layer).
  */
 
 import { DuckDBInstance } from '@duckdb/node-api';
@@ -47,8 +47,7 @@ function assertParquetMagic(bytes: Buffer): void {
 }
 
 function buildReadParquetFirstRowProjectionQuery(parquetPath: string): string {
-  const escapedPath = parquetPath.replaceAll("'", "''");
-  return `SELECT id::VARCHAR AS id, project_id::VARCHAR AS project_id FROM read_parquet('${escapedPath}') LIMIT 1`;
+  return `SELECT id AS id, project_id AS project_id FROM read_parquet('${parquetPath}') LIMIT 1`;
 }
 
 function buildTestConfig(outDir: string, base: MedplumServerConfig): MedplumServerConfig {

--- a/packages/server/src/workers/data-warehouse-sync.ts
+++ b/packages/server/src/workers/data-warehouse-sync.ts
@@ -182,6 +182,7 @@ export async function processDataWarehouseSyncJob(
         subsystem: 'data-warehouse-sync',
       });
 
+      // update job status
       const result = await syncData({
         ...syncOptions,
         onProgress: async (_message, metadata) => {
@@ -189,17 +190,18 @@ export async function processDataWarehouseSyncJob(
         },
       });
 
-      let syncDurationSeconds = 0;
-      let watermarkDurationSeconds = 0;
-      for (const table of result.tables) {
-        syncDurationSeconds += table.syncDurationMs / 1000;
-        watermarkDurationSeconds += table.watermarkDurationMs / 1000;
-      }
-
       const tables = result.tables;
-      const tablesWithRows = tables.filter((t) => t.rowsInserted > 0).length;
-      const tablesEmpty = tables.length - tablesWithRows;
-      const rowsInserted = tables.reduce((n, t) => n + t.rowsInserted, 0);
+      const syncedTables = tables.filter((t) => !t.status);
+      const skippedTables = tables.filter((t) => t.status);
+
+      // calculate timings
+      const syncDurationSeconds = syncedTables.map((t) => t.syncDurationMs / 1000).reduce((a, b) => a + b, 0);
+      const watermarkDurations = tables.map((t) => t.watermarkDurationMs / 1000);
+      const watermarkDurationSeconds = watermarkDurations.reduce((a, b) => a + b, 0);
+      const watermarkDurationSecondsMax = Math.max(0, ...watermarkDurations);
+      const tablesWithRows = syncedTables.filter((t) => t.rowsInserted > 0).length;
+      const tablesEmpty = syncedTables.length - tablesWithRows;
+      const rowsInserted = syncedTables.reduce((n, t) => n + t.rowsInserted, 0);
       const jobEndTime = new Date();
       const durationSeconds = (jobEndTime.getTime() - jobStartTime.getTime()) / 1000;
 
@@ -207,15 +209,18 @@ export async function processDataWarehouseSyncJob(
         jobId: job.id,
         trigger: job.data.trigger,
         startDate: syncOptions.startDate,
-        tablesSynced: tables.length,
+        tablesTotal: syncOptions.warehouseSources.length,
+        tablesSynced: syncedTables.length,
+        tablesSkipped: skippedTables.length,
         tablesWithRows,
         tablesEmpty,
         rowsInserted,
-        tableCounts: Object.fromEntries(tables.map((t) => [t.destination, t.rowsInserted])),
-        tableTimings: Object.fromEntries(
+        tableResults: Object.fromEntries(
           tables.map((t) => [
             t.destination,
             {
+              ...(t.status ? { status: t.status } : {}),
+              rowsInserted: t.rowsInserted,
               syncDurationMs: t.syncDurationMs,
               watermarkDurationMs: t.watermarkDurationMs,
             },
@@ -223,6 +228,7 @@ export async function processDataWarehouseSyncJob(
         ),
         syncDurationSeconds,
         watermarkDurationSeconds,
+        watermarkDurationSecondsMax,
         jobStartTime: jobStartTime.toISOString(),
         jobEndTime: jobEndTime.toISOString(),
         durationSeconds,


### PR DESCRIPTION

- Instead of creating and tearing down a DuckDB instance for **every** history table, open **one** instance for the whole job and destroy it at the end (so Iceberg catalog metadata does not carry stale watermarks across ticks).
- Resolve every table’s high watermark **before** attaching Postgres:
  - fan out Iceberg watermark reads across up to 8 DuckDB connections for _massive_ performance boost since some large tables like `patient_history` can take as much as 30 seconds for `MAX(last_updated)`
  - close watermark connections, then open one write connection, attach Postgres once, and run per-table inserts
- Deferring Postgres attach until after watermark work avoids idle-connection resets during Iceberg reads.
- On Iceberg commit conflicts (`CommitFailedException` / `Conflict_409`, typically from AWS compaction), skip that table and continue; the next tick will pick up the data rather than blocking the job on an unbounded compaction wait.