### PR TITLE
test(agent,hl7): fix flaky `getFreePort` port collision

### DIFF
--- a/packages/agent/src/app.test.ts
+++ b/packages/agent/src/app.test.ts
@@ -22,7 +22,7 @@ import {
   sleep,
 } from '@medplum/core';
 import type { Agent, Bot, Endpoint, Resource } from '@medplum/fhirtypes';
-import { Hl7Client, Hl7Server } from '@medplum/hl7';
+import { getFreePort, Hl7Client, Hl7Server } from '@medplum/hl7';
 import { MockClient } from '@medplum/mock';
 import type { Client } from 'mock-socket';
 import { Server } from 'mock-socket';
@@ -42,7 +42,7 @@ import type { AgentHl7ChannelConnection } from './hl7';
 import { AgentHl7Channel } from './hl7';
 import type { Hl7ClientPool } from './hl7-client-pool';
 import * as pidModule from './pid';
-import { createEndpointWithRandomPort, getFreePort, waitFor } from './test-utils';
+import { createEndpointWithRandomPort, waitFor } from './test-utils';
 import { buildManifest, mockFetchForUpgrader } from './upgrader-test-utils';
 
 vi.mock('./constants', async (importOriginal) => {

--- a/packages/agent/src/app.test.ts
+++ b/packages/agent/src/app.test.ts
@@ -10,15 +10,15 @@ import type {
   AgentUpgradeResponse,
 } from '@medplum/core';
 import {
+  allOk,
+  clearReleaseCache,
   ContentType,
+  createReference,
+  getReferenceString,
   Hl7Message,
   LogLevel,
   MEDPLUM_VERSION,
   ReconnectingWebSocket,
-  allOk,
-  clearReleaseCache,
-  createReference,
-  getReferenceString,
   sleep,
 } from '@medplum/core';
 import type { Agent, Bot, Endpoint, Resource } from '@medplum/fhirtypes';

--- a/packages/agent/src/bytestream.test.ts
+++ b/packages/agent/src/bytestream.test.ts
@@ -3,11 +3,11 @@
 import type { AgentTransmitResponse } from '@medplum/core';
 import { allOk, ContentType, createReference, LogLevel, sleep } from '@medplum/core';
 import type { Agent, Bot, Endpoint, Resource } from '@medplum/fhirtypes';
+import { getFreePort } from '@medplum/hl7';
 import { MockClient } from '@medplum/mock';
 import { Server } from 'mock-socket';
 import net from 'node:net';
 import { App } from './app';
-import { getFreePort } from './test-utils';
 
 const medplum = new MockClient();
 let bot: Bot;

--- a/packages/agent/src/enhanced-hl7-client.test.ts
+++ b/packages/agent/src/enhanced-hl7-client.test.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { ILogger } from '@medplum/core';
 import { Hl7Message, TypedEventTarget } from '@medplum/core';
-import { Hl7Server, ReturnAckCategory } from '@medplum/hl7';
-import { createMockLogger, createTestEnhancedHl7Client, getFreePort } from './test-utils';
+import { getFreePort, Hl7Server, ReturnAckCategory } from '@medplum/hl7';
+import { createMockLogger, createTestEnhancedHl7Client } from './test-utils';
 import type { HeartbeatEmitter } from './types';
 
 describe('EnhancedHl7Client', () => {

--- a/packages/agent/src/hl7-client-pool.test.ts
+++ b/packages/agent/src/hl7-client-pool.test.ts
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Hl7Message, Logger, TypedEventTarget } from '@medplum/core';
 import type * as MedplumHl7 from '@medplum/hl7';
-import { Hl7Server } from '@medplum/hl7';
+import { getFreePort, Hl7Server } from '@medplum/hl7';
 import type { Mock } from 'vitest';
 import { CLIENT_RELEASE_COUNTDOWN_MS } from './constants';
 import type { EnhancedHl7Client } from './enhanced-hl7-client';
 import { Hl7ClientPool } from './hl7-client-pool';
 import { Hl7MessageTracker } from './hl7-message-tracker';
-import { getFreePort } from './test-utils';
 import type { HeartbeatEmitter } from './types';
 
 const hl7TestUtils = vi.hoisted(() => {

--- a/packages/agent/src/hl7-message-tracker.test.ts
+++ b/packages/agent/src/hl7-message-tracker.test.ts
@@ -3,11 +3,11 @@
 import type { ILogger } from '@medplum/core';
 import { Hl7Message, ReturnAckCategory, sleep, TypedEventTarget } from '@medplum/core';
 import type { Hl7Connection } from '@medplum/hl7';
-import { Hl7Server } from '@medplum/hl7';
+import { getFreePort, Hl7Server } from '@medplum/hl7';
 import { EnhancedHl7Client } from './enhanced-hl7-client';
 import { Hl7ClientPool } from './hl7-client-pool';
 import { Hl7MessageTracker } from './hl7-message-tracker';
-import { createMockLogger, getFreePort } from './test-utils';
+import { createMockLogger } from './test-utils';
 import type { HeartbeatEmitter } from './types';
 
 describe('Hl7MessageTracker', () => {

--- a/packages/agent/src/hl7.test.ts
+++ b/packages/agent/src/hl7.test.ts
@@ -20,7 +20,7 @@ import {
 } from '@medplum/core';
 import type { Agent, AgentChannel, Bot, Endpoint, Resource } from '@medplum/fhirtypes';
 import type { Hl7Connection } from '@medplum/hl7';
-import { Hl7Client, Hl7EnhancedAckSentEvent, Hl7Server, ReturnAckCategory } from '@medplum/hl7';
+import { getFreePort, Hl7Client, Hl7EnhancedAckSentEvent, Hl7Server, ReturnAckCategory } from '@medplum/hl7';
 import { MockClient } from '@medplum/mock';
 import type { Client } from 'mock-socket';
 import { Server } from 'mock-socket';
@@ -41,7 +41,7 @@ import {
   shouldSendAppLevelAck,
 } from './hl7';
 import { DEFAULT_NORMAL_MODE_MAX_ATTEMPTS, DEFAULT_RETRY_POLICY } from './queue/worker';
-import { createEndpointWithRandomPort, createMockLogger, getFreePort } from './test-utils';
+import { createEndpointWithRandomPort, createMockLogger } from './test-utils';
 
 vi.mock('./constants', async (importOriginal) => {
   const actual = await importOriginal<typeof AgentConstants>();

--- a/packages/agent/src/test-utils.ts
+++ b/packages/agent/src/test-utils.ts
@@ -110,24 +110,47 @@ export function createTestHl7ClientPool(
   return { pool, messageTracker, heartbeatEmitter };
 }
 
+// Every port ever handed out by `getFreePort`, so we never issue the same one twice
+// within a single test process — see the comment on `getFreePort` below.
+const issuedPorts = new Set<number>();
+
 // Used only for tests that need a free port number with *nothing* listening on it.
 // For tests that start an Hl7Server, prefer `server.start(0)` which returns the OS-assigned
 // port and never has a release-then-rebind window.
+//
+// Because we close the probing server before returning, the port is freed immediately and the
+// OS may hand the *same* ephemeral port to a subsequent call. Callers that allocate two ports
+// (e.g. one per channel) would then collide. To avoid this, remember every port we issue and
+// keep any probing server that lands on an already-issued port open until we find a fresh one,
+// so the OS can't reissue it in the same round.
 export async function getFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = createServer();
-    server.listen(0, () => {
-      const { port } = server.address() as { port: number };
-      server.close((err) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(port);
-        }
-      });
+  const heldServers: ReturnType<typeof createServer>[] = [];
+  const closeServer = async (server: ReturnType<typeof createServer>): Promise<void> =>
+    new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
     });
-    server.on('error', reject);
-  });
+  try {
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const server = createServer();
+      const port = await new Promise<number>((resolve, reject) => {
+        server.on('error', reject);
+        server.listen(0, () => {
+          resolve((server.address() as { port: number }).port);
+        });
+      });
+      if (issuedPorts.has(port)) {
+        // Keep this server listening so the OS won't hand the same port out again this round.
+        heldServers.push(server);
+        continue;
+      }
+      issuedPorts.add(port);
+      await closeServer(server);
+      return port;
+    }
+    throw new Error('Unable to find a free port after 20 attempts');
+  } finally {
+    await Promise.all(heldServers.map((server) => closeServer(server).catch(() => undefined)));
+  }
 }
 
 export async function createEndpointWithRandomPort(

--- a/packages/agent/src/test-utils.ts
+++ b/packages/agent/src/test-utils.ts
@@ -3,9 +3,9 @@
 import type { ILogger, MedplumClient, WithId } from '@medplum/core';
 import { LogLevel, TypedEventTarget, sleep } from '@medplum/core';
 import type { Endpoint } from '@medplum/fhirtypes';
+import { getFreePort } from '@medplum/hl7';
 import { randomUUID } from 'node:crypto';
 import { mkdirSync, rmSync } from 'node:fs';
-import { createServer } from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import type { Mock } from 'vitest';
@@ -108,49 +108,6 @@ export function createTestHl7ClientPool(
   const heartbeatEmitter = options.heartbeatEmitter ?? new TypedEventTarget();
   const pool = new Hl7ClientPool({ ...options, messageTracker, heartbeatEmitter });
   return { pool, messageTracker, heartbeatEmitter };
-}
-
-// Every port ever handed out by `getFreePort`, so we never issue the same one twice
-// within a single test process — see the comment on `getFreePort` below.
-const issuedPorts = new Set<number>();
-
-// Used only for tests that need a free port number with *nothing* listening on it.
-// For tests that start an Hl7Server, prefer `server.start(0)` which returns the OS-assigned
-// port and never has a release-then-rebind window.
-//
-// Because we close the probing server before returning, the port is freed immediately and the
-// OS may hand the *same* ephemeral port to a subsequent call. Callers that allocate two ports
-// (e.g. one per channel) would then collide. To avoid this, remember every port we issue and
-// keep any probing server that lands on an already-issued port open until we find a fresh one,
-// so the OS can't reissue it in the same round.
-export async function getFreePort(): Promise<number> {
-  const heldServers: ReturnType<typeof createServer>[] = [];
-  const closeServer = async (server: ReturnType<typeof createServer>): Promise<void> =>
-    new Promise((resolve, reject) => {
-      server.close((err) => (err ? reject(err) : resolve()));
-    });
-  try {
-    for (let attempt = 0; attempt < 20; attempt++) {
-      const server = createServer();
-      const port = await new Promise<number>((resolve, reject) => {
-        server.on('error', reject);
-        server.listen(0, () => {
-          resolve((server.address() as { port: number }).port);
-        });
-      });
-      if (issuedPorts.has(port)) {
-        // Keep this server listening so the OS won't hand the same port out again this round.
-        heldServers.push(server);
-        continue;
-      }
-      issuedPorts.add(port);
-      await closeServer(server);
-      return port;
-    }
-    throw new Error('Unable to find a free port after 20 attempts');
-  } finally {
-    await Promise.all(heldServers.map((server) => closeServer(server).catch(() => undefined)));
-  }
 }
 
 export async function createEndpointWithRandomPort(

--- a/packages/hl7/src/client.test.ts
+++ b/packages/hl7/src/client.test.ts
@@ -7,8 +7,9 @@ import net, { createServer } from 'node:net';
 import { Hl7Client } from './client';
 import type { Hl7Connection } from './connection';
 import type { Hl7ErrorEvent } from './events';
+import { getFreePort } from './free-port';
 import { Hl7Server } from './server';
-import { getFreePort, MockServer, MockSocket } from './test-utils';
+import { MockServer, MockSocket } from './test-utils';
 
 describe('Hl7Client', () => {
   describe('sendAndWait', () => {

--- a/packages/hl7/src/free-port.ts
+++ b/packages/hl7/src/free-port.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { AddressInfo } from 'node:net';
 import { createServer } from 'node:net';
 
 // Every port ever handed out by `getFreePort`, so we never issue the same one twice
@@ -34,7 +35,7 @@ export async function getFreePort(): Promise<number> {
       const port = await new Promise<number>((resolve, reject) => {
         server.on('error', reject);
         server.listen(0, () => {
-          resolve((server.address() as { port: number }).port);
+          resolve((server.address() as AddressInfo).port);
         });
       });
       if (issuedPorts.has(port)) {

--- a/packages/hl7/src/free-port.ts
+++ b/packages/hl7/src/free-port.ts
@@ -6,6 +6,9 @@ import { createServer } from 'node:net';
 // within a single test process — see the comment on `getFreePort` below.
 const issuedPorts = new Set<number>();
 
+// Cap on how many ephemeral ports we probe before giving up looking for a fresh one.
+const MAX_ATTEMPTS = 20;
+
 /**
  * Returns a TCP port number that is currently free, with *nothing* listening on it.
  *
@@ -26,7 +29,7 @@ export async function getFreePort(): Promise<number> {
       server.close((err) => (err ? reject(err) : resolve()));
     });
   try {
-    for (let attempt = 0; attempt < 20; attempt++) {
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
       const server = createServer();
       const port = await new Promise<number>((resolve, reject) => {
         server.on('error', reject);
@@ -43,7 +46,7 @@ export async function getFreePort(): Promise<number> {
       await closeServer(server);
       return port;
     }
-    throw new Error('Unable to find a free port after 20 attempts');
+    throw new Error(`Unable to find a free port after ${MAX_ATTEMPTS} attempts`);
   } finally {
     await Promise.all(heldServers.map((server) => closeServer(server).catch(() => undefined)));
   }

--- a/packages/hl7/src/free-port.ts
+++ b/packages/hl7/src/free-port.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { createServer } from 'node:net';
+
+// Every port ever handed out by `getFreePort`, so we never issue the same one twice
+// within a single test process — see the comment on `getFreePort` below.
+const issuedPorts = new Set<number>();
+
+/**
+ * Returns a TCP port number that is currently free, with *nothing* listening on it.
+ *
+ * Used only for tests that need a free port number. For tests that start an Hl7Server, prefer
+ * `server.start(0)`, which returns the OS-assigned port and never has a release-then-rebind window.
+ *
+ * Because we close the probing server before returning, the port is freed immediately and the OS
+ * may hand the *same* ephemeral port to a subsequent call. Callers that allocate two ports (e.g.
+ * one per channel) would then collide. To avoid this, we remember every port we issue and keep any
+ * probing server that lands on an already-issued port open until we find a fresh one, so the OS
+ * can't reissue it in the same round.
+ * @returns A promise that resolves with a free TCP port number.
+ */
+export async function getFreePort(): Promise<number> {
+  const heldServers: ReturnType<typeof createServer>[] = [];
+  const closeServer = async (server: ReturnType<typeof createServer>): Promise<void> =>
+    new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  try {
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const server = createServer();
+      const port = await new Promise<number>((resolve, reject) => {
+        server.on('error', reject);
+        server.listen(0, () => {
+          resolve((server.address() as { port: number }).port);
+        });
+      });
+      if (issuedPorts.has(port)) {
+        // Keep this server listening so the OS won't hand the same port out again this round.
+        heldServers.push(server);
+        continue;
+      }
+      issuedPorts.add(port);
+      await closeServer(server);
+      return port;
+    }
+    throw new Error('Unable to find a free port after 20 attempts');
+  } finally {
+    await Promise.all(heldServers.map((server) => closeServer(server).catch(() => undefined)));
+  }
+}

--- a/packages/hl7/src/index.ts
+++ b/packages/hl7/src/index.ts
@@ -5,4 +5,5 @@ export * from './client';
 export * from './connection';
 export * from './constants';
 export * from './events';
+export * from './free-port';
 export * from './server';

--- a/packages/hl7/src/test-utils.ts
+++ b/packages/hl7/src/test-utils.ts
@@ -80,22 +80,45 @@ export class MockServer extends EventEmitter {
   }
 }
 
+// Every port ever handed out by `getFreePort`, so we never issue the same one twice
+// within a single test process — see the comment on `getFreePort` below.
+const issuedPorts = new Set<number>();
+
 // Used only for tests that need a free port number with *nothing* listening on it.
 // For tests that start an Hl7Server, prefer `server.start(0)` which returns the OS-assigned
 // port and never has a release-then-rebind window.
+//
+// Because we close the probing server before returning, the port is freed immediately and the
+// OS may hand the *same* ephemeral port to a subsequent call. Callers that allocate two ports
+// (e.g. one per channel) would then collide. To avoid this, remember every port we issue and
+// keep any probing server that lands on an already-issued port open until we find a fresh one,
+// so the OS can't reissue it in the same round.
 export async function getFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = createServer();
-    server.listen(0, () => {
-      const { port } = server.address() as { port: number };
-      server.close((err) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(port);
-        }
-      });
+  const heldServers: ReturnType<typeof createServer>[] = [];
+  const closeServer = async (server: ReturnType<typeof createServer>): Promise<void> =>
+    new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
     });
-    server.on('error', reject);
-  });
+  try {
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const server = createServer();
+      const port = await new Promise<number>((resolve, reject) => {
+        server.on('error', reject);
+        server.listen(0, () => {
+          resolve((server.address() as { port: number }).port);
+        });
+      });
+      if (issuedPorts.has(port)) {
+        // Keep this server listening so the OS won't hand the same port out again this round.
+        heldServers.push(server);
+        continue;
+      }
+      issuedPorts.add(port);
+      await closeServer(server);
+      return port;
+    }
+    throw new Error('Unable to find a free port after 20 attempts');
+  } finally {
+    await Promise.all(heldServers.map((server) => closeServer(server).catch(() => undefined)));
+  }
 }

--- a/packages/hl7/src/test-utils.ts
+++ b/packages/hl7/src/test-utils.ts
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { EventEmitter } from 'node:events';
-import { createServer } from 'node:net';
 import { Duplex } from 'node:stream';
 
 export class MockSocket extends Duplex {
@@ -77,48 +76,5 @@ export class MockServer extends EventEmitter {
       this.connectionListener(serverSocket);
       this.sockets.add(serverSocket);
     }
-  }
-}
-
-// Every port ever handed out by `getFreePort`, so we never issue the same one twice
-// within a single test process — see the comment on `getFreePort` below.
-const issuedPorts = new Set<number>();
-
-// Used only for tests that need a free port number with *nothing* listening on it.
-// For tests that start an Hl7Server, prefer `server.start(0)` which returns the OS-assigned
-// port and never has a release-then-rebind window.
-//
-// Because we close the probing server before returning, the port is freed immediately and the
-// OS may hand the *same* ephemeral port to a subsequent call. Callers that allocate two ports
-// (e.g. one per channel) would then collide. To avoid this, remember every port we issue and
-// keep any probing server that lands on an already-issued port open until we find a fresh one,
-// so the OS can't reissue it in the same round.
-export async function getFreePort(): Promise<number> {
-  const heldServers: ReturnType<typeof createServer>[] = [];
-  const closeServer = async (server: ReturnType<typeof createServer>): Promise<void> =>
-    new Promise((resolve, reject) => {
-      server.close((err) => (err ? reject(err) : resolve()));
-    });
-  try {
-    for (let attempt = 0; attempt < 20; attempt++) {
-      const server = createServer();
-      const port = await new Promise<number>((resolve, reject) => {
-        server.on('error', reject);
-        server.listen(0, () => {
-          resolve((server.address() as { port: number }).port);
-        });
-      });
-      if (issuedPorts.has(port)) {
-        // Keep this server listening so the OS won't hand the same port out again this round.
-        heldServers.push(server);
-        continue;
-      }
-      issuedPorts.add(port);
-      await closeServer(server);
-      return port;
-    }
-    throw new Error('Unable to find a free port after 20 attempts');
-  } finally {
-    await Promise.all(heldServers.map((server) => closeServer(server).catch(() => undefined)));
   }
 }


### PR DESCRIPTION
`getFreePort` closed its probe server before returning, so two sequential calls could be handed the same ephemeral port by the OS. Tests that allocate multiple ports (e.g. the 'test' and 'prod' channels in "Setting a channel.endpoint.status to 'off'") then declared the same port and app.start() threw a config conflict.

Remember every issued port and hold a probe server open when it lands on an already-issued port, so the OS can't reissue it in the same round