### PR TITLE
Display current project in navbar

### DIFF
--- a/packages/react/src/AppShell/Header.module.css
+++ b/packages/react/src/AppShell/Header.module.css
@@ -22,12 +22,21 @@
   }
 }
 
-.userName {
-  font-weight: 500;
-  line-height: 1px;
+.userInfo {
   margin-right: 3px;
+  min-width: 0;
+  max-width: 160px;
 
   @media (max-width: $mantine-breakpoint-xs) {
     display: none;
   }
+}
+
+.userName {
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.userProject {
+  line-height: 1.2;
 }

--- a/packages/react/src/AppShell/Header.test.tsx
+++ b/packages/react/src/AppShell/Header.test.tsx
@@ -46,6 +46,31 @@ describe('Header', () => {
     expect(screen.getByText('Alice Smith')).toBeInTheDocument();
   });
 
+  test('Renders active project name', async () => {
+    window.localStorage.setItem(
+      'activeLogin',
+      JSON.stringify({
+        accessToken: 'abc',
+        refreshToken: 'xyz',
+        profile: {
+          reference: 'Practitioner/124',
+          display: 'Alice Smith',
+        },
+        project: {
+          reference: 'Project/456',
+          display: 'My Project',
+        },
+      })
+    );
+
+    await setup();
+
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.getByText('My Project')).toBeInTheDocument();
+
+    window.localStorage.removeItem('activeLogin');
+  });
+
   test('Open and close the user menu', async () => {
     await setup();
 
@@ -119,7 +144,7 @@ describe('Header', () => {
       fireEvent.click(screen.getByText('Alice Smith'));
     });
 
-    expect(await screen.findByText('My Project')).toBeInTheDocument();
+    expect((await screen.findAllByText('My Project')).length).toBeGreaterThan(0);
     expect(await screen.findByText('My Other Project')).toBeInTheDocument();
 
     // Click on other project to switch

--- a/packages/react/src/AppShell/Header.tsx
+++ b/packages/react/src/AppShell/Header.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Group, AppShell as MantineAppShell, Menu, Text, UnstyledButton } from '@mantine/core';
+import { Box, Group, AppShell as MantineAppShell, Menu, Stack, Text, UnstyledButton } from '@mantine/core';
 import { formatHumanName } from '@medplum/core';
-import { useMedplumProfile } from '@medplum/react-hooks';
+import { useMedplum, useMedplumProfile } from '@medplum/react-hooks';
 import { IconChevronDown } from '@tabler/icons-react';
 import type { JSX, ReactNode } from 'react';
 import { useState } from 'react';
@@ -28,8 +28,10 @@ export interface HeaderProps {
 }
 
 export function Header(props: HeaderProps): JSX.Element {
+  const medplum = useMedplum();
   const profile = useMedplumProfile();
   const [userMenuOpened, setUserMenuOpened] = useState(false);
+  const projectDisplay = medplum.getProject()?.name ?? medplum.getActiveLogin()?.project.display;
 
   return (
     <MantineAppShell.Header p={0} style={{ zIndex: 101 }}>
@@ -68,9 +70,16 @@ export function Header(props: HeaderProps): JSX.Element {
                 >
                   <Group gap={7}>
                     <ResourceAvatar value={profile} radius="xl" size={24} />
-                    <Text size="sm" className={classes.userName}>
-                      {formatHumanName(profile?.name?.[0])}
-                    </Text>
+                    <Stack gap={0} className={classes.userInfo}>
+                      <Text size="sm" className={classes.userName} truncate>
+                        {formatHumanName(profile?.name?.[0])}
+                      </Text>
+                      {projectDisplay && (
+                        <Text size="xs" c="dimmed" className={classes.userProject} title={projectDisplay} truncate>
+                          {projectDisplay}
+                        </Text>
+                      )}
+                    </Stack>
                     <IconChevronDown size={12} stroke={1.5} />
                   </Group>
                 </UnstyledButton>

--- a/packages/react/src/AppShell/Navbar.module.css
+++ b/packages/react/src/AppShell/Navbar.module.css
@@ -118,6 +118,40 @@
   }
 }
 
+.userLink {
+  height: auto;
+  min-height: 36px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.userLinkLabel {
+  display: flex;
+  flex-direction: column;
+  margin-left: 8px;
+  min-width: 0;
+  opacity: 0;
+  transition: opacity 150ms ease;
+
+  &[data-opened] {
+    opacity: 1;
+  }
+}
+
+.userName {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.userProject {
+  font-size: var(--mantine-font-size-xs);
+  color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-dark-3));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .iconWrapper {
   position: relative;
   display: flex;

--- a/packages/react/src/AppShell/Navbar.module.css
+++ b/packages/react/src/AppShell/Navbar.module.css
@@ -138,20 +138,6 @@
   }
 }
 
-.userName {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.userProject {
-  font-size: var(--mantine-font-size-xs);
-  color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-dark-3));
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .iconWrapper {
   position: relative;
   display: flex;

--- a/packages/react/src/AppShell/Navbar.test.tsx
+++ b/packages/react/src/AppShell/Navbar.test.tsx
@@ -96,6 +96,47 @@ describe('Navbar', () => {
     expect(screen.getByText('Menu 1')).toBeInTheDocument();
   });
 
+  test('Renders user name and active project name', async () => {
+    window.localStorage.setItem(
+      'activeLogin',
+      JSON.stringify({
+        accessToken: 'abc',
+        refreshToken: 'xyz',
+        profile: {
+          reference: 'Practitioner/124',
+          display: 'Alice Smith',
+        },
+        project: {
+          reference: 'Project/456',
+          display: 'My Project',
+        },
+      })
+    );
+
+    const initialUrl = new URL('/', 'http://localhost');
+    await act(async () => {
+      render(
+        <MedplumProvider medplum={medplum} navigate={navigateMock}>
+          <MantineAppShell>
+            <Navbar
+              logo={<div>Logo</div>}
+              pathname={initialUrl.pathname}
+              searchParams={initialUrl.searchParams}
+              navbarToggle={toggleMock}
+              closeNavbar={closeMock}
+              userMenuEnabled={true}
+            />
+          </MantineAppShell>
+        </MedplumProvider>
+      );
+    });
+
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.getByText('My Project')).toBeInTheDocument();
+
+    window.localStorage.removeItem('activeLogin');
+  });
+
   test('Highlighted link', async () => {
     await setup('/link1');
 

--- a/packages/react/src/AppShell/Navbar.tsx
+++ b/packages/react/src/AppShell/Navbar.tsx
@@ -14,7 +14,7 @@ import {
 import { spotlight } from '@mantine/spotlight';
 import { formatHumanName } from '@medplum/core';
 import type { ResourceType } from '@medplum/fhirtypes';
-import { useMedplumNavigate, useMedplumProfile, useNotificationCount } from '@medplum/react-hooks';
+import { useMedplum, useMedplumNavigate, useMedplumProfile, useNotificationCount } from '@medplum/react-hooks';
 import { IconBookmark, IconCirclePlus, IconLayoutSidebar, IconSearch, IconX } from '@tabler/icons-react';
 import type { JSX, MouseEvent, MouseEventHandler, ReactNode, SyntheticEvent } from 'react';
 import { Fragment, useState } from 'react';
@@ -68,11 +68,13 @@ export interface NavbarProps {
 }
 
 export function Navbar(props: NavbarProps): JSX.Element {
+  const medplum = useMedplum();
   const navigate = useMedplumNavigate();
   const profile = useMedplumProfile();
   const activeLink = getActiveLink(props.pathname, props.searchParams, props.menus);
   const [userMenuOpened, setUserMenuOpened] = useState(false);
   const [bookmarkDialogVisible, setBookmarkDialogVisible] = useState(false);
+  const projectDisplay = medplum.getProject()?.name ?? medplum.getActiveLogin()?.project.display;
 
   function onLinkClick(e: SyntheticEvent, to: string): void {
     e.stopPropagation();
@@ -218,7 +220,7 @@ export function Navbar(props: NavbarProps): JSX.Element {
             >
               <Menu.Target>
                 <UnstyledButton
-                  className={classes.link}
+                  className={`${classes.link} ${classes.userLink}`}
                   pl="7"
                   aria-label="User menu"
                   data-active={userMenuOpened || undefined}
@@ -226,8 +228,13 @@ export function Navbar(props: NavbarProps): JSX.Element {
                   bd="1px 0 0 0 solid var(--mantine-color-gray-200)"
                 >
                   <ResourceAvatar value={profile} radius="xl" size={24} />
-                  <span className={classes.linkLabel} data-opened={opened || undefined}>
-                    {formatHumanName(profile?.name?.[0])}
+                  <span className={classes.userLinkLabel} data-opened={opened || undefined}>
+                    <span className={classes.userName}>{formatHumanName(profile?.name?.[0])}</span>
+                    {projectDisplay && (
+                      <span className={classes.userProject} title={projectDisplay}>
+                        {projectDisplay}
+                      </span>
+                    )}
                   </span>
                 </UnstyledButton>
               </Menu.Target>

--- a/packages/react/src/AppShell/Navbar.tsx
+++ b/packages/react/src/AppShell/Navbar.tsx
@@ -229,11 +229,13 @@ export function Navbar(props: NavbarProps): JSX.Element {
                 >
                   <ResourceAvatar value={profile} radius="xl" size={24} />
                   <span className={classes.userLinkLabel} data-opened={opened || undefined}>
-                    <span className={classes.userName}>{formatHumanName(profile?.name?.[0])}</span>
+                    <Text span inherit truncate>
+                      {formatHumanName(profile?.name?.[0])}
+                    </Text>
                     {projectDisplay && (
-                      <span className={classes.userProject} title={projectDisplay}>
+                      <Text span inherit fz="xs" c="dimmed" truncate title={projectDisplay}>
                         {projectDisplay}
-                      </span>
+                      </Text>
                     )}
                   </span>
                 </UnstyledButton>


### PR DESCRIPTION
Fixes #9623

## Problem

The user menu button (in both the header and the collapsible sidebar) only showed the signed-in user's name. There was no indication of which project you were currently working in, which is a real gap for users who belong to multiple projects and switch between them.

## Changes for users

The active project name now appears directly beneath your name in both the header user menu and the sidebar user menu. Long names are truncated with an ellipsis and show the full value on hover.

| | V1 | V2 |
|--------|--------|--------|
| Normal | <img width="231" height="113" alt="image" src="https://github.com/user-attachments/assets/a363f856-e6e5-4e0e-a67a-75f7da961d98" /> | <img width="260" height="123" alt="image" src="https://github.com/user-attachments/assets/944e6167-2fe0-47ed-8af2-901c7e7b0e64" /> |
| Truncated | <img width="269" height="92" alt="image" src="https://github.com/user-attachments/assets/c9a74447-edb5-49af-8422-3184297ace20" /> | <img width="266" height="115" alt="image" src="https://github.com/user-attachments/assets/63ab80e9-e377-43fb-a7dc-cfcf1b416360" /> | 

## Code changes

- Show the active project name under the user name in both `Header.tsx` and `Navbar.tsx`, styled as dimmed secondary text. The name is resolved as `medplum.getProject()?.name ?? medplum.getActiveLogin()?.project.display`, preferring the live project name and falling back to the cached login snapshot so a name shows immediately on load (we do this same pattern elsewhere in the code).
- Add `truncate` to the header user-name text so a long name ellipsizes on one line instead of wrapping, consistent with the project line.