### PR TITLE
Make MemoryRepository conditionalCreate more transactional 

### DIFF
--- a/packages/fhir-router/src/repo.test.ts
+++ b/packages/fhir-router/src/repo.test.ts
@@ -291,5 +291,33 @@ describe('MemoryRepository', () => {
       expect(resultAsc[getReferenceString(patients[0])].map((o) => o.valueString)).toStrictEqual(['0', '1', '2']);
       expect(resultAsc[getReferenceString(patients[1])].map((o) => o.valueString)).toStrictEqual(['0', '1']);
     });
+
+    test('concurrent conditionalCreate', async () => {
+      const patient: Patient = {
+        resourceType: 'Patient',
+        id: 'abcde',
+      };
+
+      const p1 = repo.conditionalCreate(patient, parseSearchRequest('Patient?_id=abcde'));
+      const p2 = repo.conditionalCreate(patient, parseSearchRequest('Patient?_id=abcde'));
+
+      await expect(p1).resolves.toMatchObject({
+        resource: patient,
+        outcome: {
+          resourceType: 'OperationOutcome',
+          id: 'created',
+        },
+      });
+      await expect(p2).resolves.toMatchObject({
+        resource: patient,
+        outcome: {
+          resourceType: 'OperationOutcome',
+          id: 'ok',
+        },
+      });
+
+      const results = await Promise.all([p1, p2]);
+      expect(results.map((r) => r.outcome.id)).toEqual(['created', 'ok']);
+    });
   });
 });

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -437,11 +437,11 @@ export class MemoryRepository extends FhirRepository {
     // MockRepository ignores reader/writer mode
   }
 
-  async createResource<T extends Resource>(
+  private createResourceSync<T extends Resource>(
     resource: T,
     options?: CreateResourceOptions,
     update: boolean = false
-  ): Promise<WithId<T>> {
+  ): WithId<T> {
     //simulate round-tripping through a JSON serialized format
     const parsed = JSON.parse(stringify(resource)) as T;
     const result = {
@@ -489,6 +489,14 @@ export class MemoryRepository extends FhirRepository {
     resourceHistory.push(result);
 
     return deepClone(result);
+  }
+
+  async createResource<T extends Resource>(
+    resource: T,
+    options?: CreateResourceOptions,
+    update: boolean = false
+  ): Promise<WithId<T>> {
+    return this.createResourceSync(resource, options, update);
   }
 
   generateId(): string {
@@ -592,7 +600,7 @@ export class MemoryRepository extends FhirRepository {
     return deepClone(version);
   }
 
-  async search<T extends Resource>(searchRequest: SearchRequest<T>): Promise<Bundle<WithId<T>>> {
+  private searchSync<T extends Resource>(searchRequest: SearchRequest<T>): Bundle<WithId<T>> {
     const { resourceType } = searchRequest;
     const resources = this.resources.get(resourceType) ?? new Map();
     const result = [];
@@ -617,6 +625,42 @@ export class MemoryRepository extends FhirRepository {
       entry: entry.length ? entry : undefined,
       total: result.length,
     };
+  }
+
+  async search<T extends Resource>(searchRequest: SearchRequest<T>): Promise<Bundle<WithId<T>>> {
+    return this.searchSync(searchRequest);
+  }
+
+  async conditionalCreate<T extends Resource>(
+    resource: T,
+    search: SearchRequest<T>,
+    options?: CreateResourceOptions
+  ): Promise<{ resource: WithId<T>; outcome: OperationOutcome }> {
+    if (search.resourceType !== resource.resourceType) {
+      throw new OperationOutcomeError(badRequest('Search type must match resource type for conditional update'));
+    }
+
+    search.count = 2;
+    search.sortRules = undefined;
+
+    // Not wrapped in transaction as we can use synchronous access to simulate
+    // transaction-like behavior
+    const bundle = this.searchSync(search);
+    const matches = bundle.entry?.map((e) => e.resource as WithId<T>) ?? [];
+    if (matches.length === 1) {
+      const existing = matches[0];
+      if (!options?.assignedId && resource.id && resource.id !== existing.id) {
+        throw new OperationOutcomeError(
+          badRequest('Resource ID did not match resolved ID', resource.resourceType + '.id')
+        );
+      }
+      return { resource: matches[0], outcome: allOk };
+    } else if (matches.length > 1) {
+      throw new OperationOutcomeError(multipleMatches);
+    }
+
+    const createdResource = this.createResourceSync(resource, options);
+    return { resource: createdResource, outcome: created };
   }
 
   async searchByReference<T extends Resource>(


### PR DESCRIPTION
We don't have a real DB here, but we can lean on the single-threaded nature of the JS runtime to get transaction-like behavior. We start by creating private "*Sync" versions of some methods that do not introduce async boundaries. We then add a `conditionalCreate` that wraps those synchronous methods to do the find + create without the opportunity for an async call to interleave between them.

I spotted this while investigating why some Storybook stories would error during re-rendering; in that context we are occasionally have code like `medplum.createResource({ resourceType: 'Patient', id: 'homer-simpson' })`, which throws when running a second time. There are a few avenues of remediation, but a natural one was to move towards ``medplum.createResourceIfNoneExist(homer, `_id=${homer.id}`)``. There are still some tricky aspects to work out in the stories (this doesn't work if the mock client doesn't have the search params for the requested type loaded), so in this PR I'm just introducing this small prerequisite step.