### PR TITLE
Change deprecated default ElastiCache node type to cache.t4g.medium

### DIFF
--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -948,7 +948,7 @@ export class BackEnd extends Construct {
     const cluster = new elasticache.CfnReplicationGroup(this, `${id}Cluster`, {
       engine: options.engine ?? 'Redis',
       engineVersion: options.engineVersion ?? '6.x',
-      cacheNodeType: options.nodeType ?? 'cache.t2.medium',
+      cacheNodeType: options.nodeType ?? 'cache.t4g.medium',
       replicationGroupDescription: `${id}ReplicationGroup`,
       authToken: password.secretValueFromJson('password').toString(),
       transitEncryptionEnabled: true,

--- a/packages/cdk/src/index.test.ts
+++ b/packages/cdk/src/index.test.ts
@@ -609,11 +609,7 @@ describe('Infra', () => {
     const stack = new MedplumStack(app, config);
     const template = Template.fromStack(stack.primaryStack);
 
-    template.resourcePropertiesCountIs(
-      'AWS::ElastiCache::ReplicationGroup',
-      { CacheNodeType: 'cache.t4g.medium' },
-      1
-    );
+    template.resourcePropertiesCountIs('AWS::ElastiCache::ReplicationGroup', { CacheNodeType: 'cache.t4g.medium' }, 1);
   });
 
   // Regression test for https://github.com/medplum/medplum/issues/9287:

--- a/packages/cdk/src/index.test.ts
+++ b/packages/cdk/src/index.test.ts
@@ -595,6 +595,27 @@ describe('Infra', () => {
     await unlink(filename);
   });
 
+  // Regression test for https://github.com/medplum/medplum/issues/8985:
+  // The default ElastiCache node type was `cache.t2.medium`, but AWS no longer
+  // allows creating new ElastiCache clusters on T2 instances, so fresh deploys
+  // failed. The default must be a current-generation node type.
+  test('Default cacheNodeType is a supported instance type', async () => {
+    const sourceConfig = {
+      ...baseConfig,
+      stackName: 'MedplumDefaultCacheNodeTypeStack',
+    } as unknown as MedplumSourceInfraConfig;
+    const config = await normalizeInfraConfig(sourceConfig);
+    const app = new App();
+    const stack = new MedplumStack(app, config);
+    const template = Template.fromStack(stack.primaryStack);
+
+    template.resourcePropertiesCountIs(
+      'AWS::ElastiCache::ReplicationGroup',
+      { CacheNodeType: 'cache.t4g.medium' },
+      1
+    );
+  });
+
   // Regression test for https://github.com/medplum/medplum/issues/9287:
   // `loadBalancerLoggingPrefix` was being silently ignored because both
   // `BackEnd.createLoadBalancer` call sites passed `loadBalancerLoggingBucket`

--- a/packages/docs/docs/self-hosting/aws-cdk-settings.md
+++ b/packages/docs/docs/self-hosting/aws-cdk-settings.md
@@ -153,7 +153,7 @@ Number of database connections per API server instance
 
 ### cacheNodeType
 
-Optional [Elasticache Node Type](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html). Default value is `cache.t2.medium`.
+Optional [Elasticache Node Type](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html). Default value is `cache.t4g.medium`.
 
 ### cacheSecurityGroupId
 


### PR DESCRIPTION
Fixes #8985

## TL;DR
Update the default from `cache.t2.medium` to `cache.t4g.medium`. 

## Previously

Fresh self-hosted AWS deploys fail at the CDK deploy step. Our CDK defaults the ElastiCache Redis cluster to `cache.t2.medium`, but AWS [no longer allows creating new ElastiCache clusters on T2 instances](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/CacheNodes.SupportedTypes.html), so CloudFormation rejects the resource with `Invalid Cache Node Type: cache.t2.medium`. This leaves new users with a painful manual cleanup on their very first deploy.

## Fix implemented
Change the default to `cache.t4g.medium`, the current-generation equivalent of `t2.medium` per AWS's supported node types table, and per the recommendation from the above AWS doc. 

<img width="938" height="175" alt="image" src="https://github.com/user-attachments/assets/ba3ec990-a548-4b03-982c-958588b1a4bc" />

- We'll choose T4g over T3 because their specs are identical, and the former is supposedly cheaper ($0.054/hr vs. $0.068/hr), and since it's the newest generation. 

## Regression test 
The existing tests mostly just checked that synthesis didn't crash; nothing asserted the cache node type. A new test will do the following:
1. Build the whole Medplum stack with default config (no `cacheNodeType` entry)
2. Produces the CloudFormation template in memory (no AWS)
3. Asserts that the template contains exactly Redis cluster whose `CacheNodeType` is `cache.t4g-medium`. 

## Note on current user migration
Users who never set `cacheNodeType` (and were therefore on the old T2 default) will have their cluster upgraded to T4g on their next upgrade & redeploy. This shouldn't result in significant downtime (a couple of seconds): CloudFormation treats a node type change as a [no-interruption update](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-cachenodetype) (no destroy/recreate), and ElastiCache [scales the cluster online](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/Scaling.RedisReplGrps.html#Scaling.RedisReplGrps.ScaleUp) by setting up new machines alongside the old ones, copying the data over, and repointing DNS. AWS documents "less than 1 second downtime" on Redis 5.0.6+ (we default to 6.x).