### PR TITLE
fix(ci): pin npm@11 in publish workflow to fix build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,8 +92,12 @@ jobs:
           GOOGLE_CLIENT_ID: '__GOOGLE_CLIENT_ID__'
           RECAPTCHA_SITE_KEY: '__RECAPTCHA_SITE_KEY__'
 
-      - name: Update npm # Ensure npm 11.5.1 or later is installed
-        run: npm install -g npm@latest
+      # npm 12.0.0 (npm@latest as of 2026-07-08) ships without the bundled `sigstore`
+      # dependency that `npm publish --provenance` requires, causing MODULE_NOT_FOUND
+      # on the first package publish. Pin npm 11.x until https://github.com/npm/cli/issues/9722 is fixed.
+      # Node 24's bundled npm may be older than 11.5.1, which trusted publishing needs.
+      - name: Pin npm 11 for provenance publish
+        run: npm install -g npm@11
 
       - name: Publish to NPM
         run: ./scripts/publish.sh


### PR DESCRIPTION
## Summary

The v5.1.25 release publish failed with:

```
npm error Cannot find module 'sigstore'
```

See https://github.com/medplum/medplum/actions/runs/29061326984/job/86263628051

As of npm 12.0.0 (released 2026-07-08), the published npm tarball omits the bundled `sigstore` dependency that `libnpmpublish` requires when `--provenance` is set. Our publish script uses `npm publish --provenance --access public`, so the job dies on the first package (`agent`) and nothing reaches npmjs.

## Fixes Deploy to Staging

This left git at 5.1.25 while npm still only has 5.1.24, which breaks staging deploys that install `@medplum/*` from the registry (e.g. `scripts/deploy-bot-layer.sh`).

This PR pins the global npm upgrade to `npm@11`, which bundles a working `sigstore` and still satisfies the `>= 11.5.1` requirement for trusted publishing.

- Upstream issue: https://github.com/npm/cli/issues/9722
- Failed publish run: https://github.com/medplum/medplum/actions/runs/29061326984
