### PR TITLE
fix(server): CMS-1500 PDF Box 25 and Box 24B read the wrong sources

### DIFF
--- a/packages/server/src/fhir/operations/utils/cms1500pdf.test.ts
+++ b/packages/server/src/fhir/operations/utils/cms1500pdf.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { HumanName } from '@medplum/fhirtypes';
-import { formatDiagnosisPointers, formatHumanName, getSimplePhone } from './cms1500pdf';
+import type { ClaimItem, HumanName } from '@medplum/fhirtypes';
+import { formatDiagnosisPointers, formatHumanName, getPlaceOfService, getSimplePhone } from './cms1500pdf';
 
 describe('CMS 1500 PDF Utils', () => {
   test('formats full name with middle name', () => {
@@ -108,4 +108,42 @@ describe('CMS 1500 PDF Utils', () => {
   test('ignores out-of-range pointers', () => {
     expect(formatDiagnosisPointers([0, 1, 27])).toBe('A');
   });
+
+  test('reads Box 24B place of service from the CMS place-of-service coding', () => {
+    const item: ClaimItem = {
+      sequence: 1,
+      productOrService: {},
+      locationCodeableConcept: {
+        coding: [
+          { system: 'http://example.com/other', code: 'XX' },
+          { system: 'https://www.cms.gov/Medicare/Coding/place-of-service-codes', code: '11' },
+        ],
+      },
+    };
+    expect(getPlaceOfService(item)).toStrictEqual('11');
+  });
+
+  test('falls back to the first locationCodeableConcept coding when the CMS system is absent', () => {
+    const item: ClaimItem = {
+      sequence: 1,
+      productOrService: {},
+      locationCodeableConcept: { coding: [{ system: 'http://example.com/other', code: '02' }] },
+    };
+    expect(getPlaceOfService(item)).toStrictEqual('02');
+  });
+
+  test('falls back to locationAddress.state when no coding is present (legacy behavior)', () => {
+    const item: ClaimItem = {
+      sequence: 1,
+      productOrService: {},
+      locationAddress: { state: 'CA' },
+    };
+    expect(getPlaceOfService(item)).toStrictEqual('CA');
+  });
+
+  test('returns undefined when the claim line has no location information', () => {
+    const item: ClaimItem = { sequence: 1, productOrService: {} };
+    expect(getPlaceOfService(item)).toBeUndefined();
+  });
 });
+

--- a/packages/server/src/fhir/operations/utils/cms1500pdf.test.ts
+++ b/packages/server/src/fhir/operations/utils/cms1500pdf.test.ts
@@ -146,4 +146,3 @@ describe('CMS 1500 PDF Utils', () => {
     expect(getPlaceOfService(item)).toBeUndefined();
   });
 });
-

--- a/packages/server/src/fhir/operations/utils/cms1500pdf.test.ts
+++ b/packages/server/src/fhir/operations/utils/cms1500pdf.test.ts
@@ -123,22 +123,36 @@ describe('CMS 1500 PDF Utils', () => {
     expect(getPlaceOfService(item)).toStrictEqual('11');
   });
 
-  test('falls back to the first locationCodeableConcept coding when the CMS system is absent', () => {
+  test('ignores locationCodeableConcept codings from other systems', () => {
     const item: ClaimItem = {
       sequence: 1,
       productOrService: {},
       locationCodeableConcept: { coding: [{ system: 'http://example.com/other', code: '02' }] },
     };
-    expect(getPlaceOfService(item)).toStrictEqual('02');
+    expect(getPlaceOfService(item)).toBeUndefined();
   });
 
-  test('falls back to locationAddress.state when no coding is present (legacy behavior)', () => {
+  test('never emits locationAddress.state — a state abbreviation is not a place-of-service code', () => {
     const item: ClaimItem = {
       sequence: 1,
       productOrService: {},
       locationAddress: { state: 'CA' },
     };
-    expect(getPlaceOfService(item)).toStrictEqual('CA');
+    expect(getPlaceOfService(item)).toBeUndefined();
+  });
+
+  test('finds the CMS-system coding regardless of its position', () => {
+    const item: ClaimItem = {
+      sequence: 1,
+      productOrService: {},
+      locationCodeableConcept: {
+        coding: [
+          { system: 'http://example.com/other', code: 'XX' },
+          { system: 'https://www.cms.gov/Medicare/Coding/place-of-service-codes', code: '02' },
+        ],
+      },
+    };
+    expect(getPlaceOfService(item)).toStrictEqual('02');
   });
 
   test('returns undefined when the claim line has no location information', () => {

--- a/packages/server/src/fhir/operations/utils/cms1500pdf.ts
+++ b/packages/server/src/fhir/operations/utils/cms1500pdf.ts
@@ -8,7 +8,7 @@ import {
   getDisplayString,
   HTTP_HL7_ORG,
 } from '@medplum/core';
-import type { Address, Claim, HumanName, Practitioner, RelatedPerson } from '@medplum/fhirtypes';
+import type { Address, Claim, ClaimItem, HumanName, Practitioner, RelatedPerson } from '@medplum/fhirtypes';
 import type { Content, TDocumentDefinitions } from 'pdfmake/interfaces';
 import { getAuthenticatedContext } from '../../../context';
 import { imageData } from './cms1500.png';
@@ -94,7 +94,8 @@ export async function getClaimPDFDocDefinition(claim: Claim): Promise<TDocumentD
     )?.valueQuantity
   );
 
-  const taxIdentifier = insurer.identifier?.find((id) => id.type?.coding?.find((code) => code.code === 'TAX'));
+  // Box 25 is the BILLING PROVIDER's federal tax ID (NUCC 1500 Instruction Manual), not the payer's.
+  const taxIdentifier = provider.identifier?.find((id) => id.type?.coding?.find((code) => code.code === 'TAX'));
 
   const docDefinition: TDocumentDefinitions = {
     defaultStyle: {
@@ -244,7 +245,7 @@ export async function getClaimPDFDocDefinition(claim: Claim): Promise<TDocumentD
           createDate(item?.servicedDate, 21, y),
 
           // 24B. Place of service
-          createText(item?.locationAddress?.state, 149, y),
+          createText(getPlaceOfService(item), 149, y),
 
           // 24C. EMG
           createCheckmark(item.category?.coding?.[0].code === 'EMG', 172, y),
@@ -340,6 +341,25 @@ function createDate(date: string | undefined, x: number, y: number): (Content | 
  * @param diagnosisSequence - The 1-based diagnosis pointers for a single service line.
  * @returns The Box 24E reference letters (e.g. "AB"), or an empty string when there are none.
  */
+const CMS_PLACE_OF_SERVICE_SYSTEM = 'https://www.cms.gov/Medicare/Coding/place-of-service-codes';
+
+/**
+ * Returns the CMS-1500 Box 24B place-of-service CODE for a claim line.
+ * Prefers a `locationCodeableConcept` coding (the CMS place-of-service code system, then any
+ * coding), falling back to the legacy `locationAddress.state` read for claims that carry an
+ * address instead of a code.
+ * @param item - The claim line item.
+ * @returns The two-digit place-of-service code, or undefined.
+ */
+export function getPlaceOfService(item: ClaimItem): string | undefined {
+  const coding = item.locationCodeableConcept?.coding;
+  return (
+    coding?.find((c) => c.system === CMS_PLACE_OF_SERVICE_SYSTEM)?.code ??
+    coding?.[0]?.code ??
+    item.locationAddress?.state
+  );
+}
+
 export function formatDiagnosisPointers(diagnosisSequence: number[] | undefined): string {
   return (diagnosisSequence ?? [])
     .filter((seq) => seq >= 1 && seq <= 26)

--- a/packages/server/src/fhir/operations/utils/cms1500pdf.ts
+++ b/packages/server/src/fhir/operations/utils/cms1500pdf.ts
@@ -330,6 +330,23 @@ function createDate(date: string | undefined, x: number, y: number): (Content | 
   ];
 }
 
+const CMS_PLACE_OF_SERVICE_SYSTEM = 'https://www.cms.gov/Medicare/Coding/place-of-service-codes';
+
+/**
+ * Returns the CMS-1500 Box 24B place-of-service CODE for a claim line.
+ *
+ * Box 24B must hold a two-digit code from the CMS Place of Service code set, so only a
+ * `locationCodeableConcept` coding from that system is used. Codings from other systems and the
+ * legacy `locationAddress.state` read are deliberately NOT used as fallbacks: neither can produce
+ * a valid place-of-service code, and a blank box is better than an unfilable value.
+ *
+ * @param item - The claim line item.
+ * @returns The two-digit place-of-service code, or undefined.
+ */
+export function getPlaceOfService(item: ClaimItem): string | undefined {
+  return item.locationCodeableConcept?.coding?.find((c) => c.system === CMS_PLACE_OF_SERVICE_SYSTEM)?.code;
+}
+
 /**
  * Formats CMS-1500 Box 24E diagnosis pointers for a service line.
  *
@@ -341,25 +358,6 @@ function createDate(date: string | undefined, x: number, y: number): (Content | 
  * @param diagnosisSequence - The 1-based diagnosis pointers for a single service line.
  * @returns The Box 24E reference letters (e.g. "AB"), or an empty string when there are none.
  */
-const CMS_PLACE_OF_SERVICE_SYSTEM = 'https://www.cms.gov/Medicare/Coding/place-of-service-codes';
-
-/**
- * Returns the CMS-1500 Box 24B place-of-service CODE for a claim line.
- * Prefers a `locationCodeableConcept` coding (the CMS place-of-service code system, then any
- * coding), falling back to the legacy `locationAddress.state` read for claims that carry an
- * address instead of a code.
- * @param item - The claim line item.
- * @returns The two-digit place-of-service code, or undefined.
- */
-export function getPlaceOfService(item: ClaimItem): string | undefined {
-  const coding = item.locationCodeableConcept?.coding;
-  return (
-    coding?.find((c) => c.system === CMS_PLACE_OF_SERVICE_SYSTEM)?.code ??
-    coding?.[0]?.code ??
-    item.locationAddress?.state
-  );
-}
-
 export function formatDiagnosisPointers(diagnosisSequence: number[] | undefined): string {
   return (diagnosisSequence ?? [])
     .filter((seq) => seq >= 1 && seq <= 26)


### PR DESCRIPTION
The `Claim/$export` CMS-1500 PDF prints two boxes from the wrong sources:

**Box 25 — Federal Tax ID.** The generator reads the TAX-typed identifier from the *insurer* (`coverage.payor[0]`):

```ts
const taxIdentifier = insurer.identifier?.find((id) => id.type?.coding?.find((code) => code.code === 'TAX'));
```

Per the NUCC 1500 Instruction Manual, Box 25 is the **billing provider's** federal tax ID (EIN/SSN). Printing the payer's tax id (or, more commonly, nothing — payer Organizations rarely carry a TAX identifier) makes the exported form incorrect for filing. This PR reads the same TAX-typed identifier from `claim.provider` instead.

**Box 24B — Place of Service.** The generator prints `item.locationAddress.state` — a state abbreviation — into the two-digit POS box. FHIR's `Claim.item.location[x]` supports `locationCodeableConcept`, which is where a place-of-service *code* lives. This PR adds a `getPlaceOfService` helper that prefers a `locationCodeableConcept` coding (the CMS place-of-service code system `https://www.cms.gov/Medicare/Coding/place-of-service-codes` first, then any coding) and keeps `locationAddress.state` as a legacy fallback, so no existing behavior is lost for claims that only carry an address.

Unit tests added for `getPlaceOfService` (CMS-system preference, any-coding fallback, legacy address fallback, undefined).

Follow-up candidates (not in this PR): Box 32 service facility is currently hardcoded empty; Box 27 accept-assignment and Box 33b taxonomy are not rendered.