### PR TITLE
MedplumClient emits resourceModified events

### DIFF
--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
@@ -31,15 +31,14 @@ describe('AppointmentDetails', () => {
 
   type SetupOptions = {
     appointment: WithId<Appointment>;
-    onAppointmentUpdate?: (appointment: Appointment) => void;
   };
 
   const setup = async (options: SetupOptions): Promise<RenderResult> => {
-    const { appointment, onAppointmentUpdate = vi.fn() } = options;
+    const { appointment } = options;
 
     let result!: RenderResult;
     await act(async () => {
-      result = render(<AppointmentDetails appointment={appointment} onAppointmentUpdate={onAppointmentUpdate} />, {
+      result = render(<AppointmentDetails appointment={appointment} />, {
         wrapper: ({ children }) => (
           <MemoryRouter>
             <MedplumProvider medplum={medplum}>
@@ -128,9 +127,8 @@ describe('AppointmentDetails', () => {
   });
 
   describe('Patient Selection', () => {
-    test('calls onAppointmentUpdate with updated appointment when patient is selected and form submitted', async () => {
+    test('calls updateResource with updated appointment when patient is selected and form submitted', async () => {
       const user = userEvent.setup();
-      const onAppointmentUpdate = vi.fn();
       const appointment = createAppointment();
 
       // Mock updateResource to return the updated appointment
@@ -146,7 +144,7 @@ describe('AppointmentDetails', () => {
       };
       medplum.updateResource = vi.fn().mockResolvedValue(updatedAppointment);
 
-      await setup({ appointment, onAppointmentUpdate });
+      await setup({ appointment });
 
       // Type in the patient search input (ResourceInput uses a searchbox role)
       const patientInput = screen.getByRole('searchbox');
@@ -174,26 +172,21 @@ describe('AppointmentDetails', () => {
           ]),
         })
       );
-
-      // Verify onAppointmentUpdate callback was called
-      expect(onAppointmentUpdate).toHaveBeenCalledWith(updatedAppointment);
     });
 
     test('does not call updateResource when no patient is selected', async () => {
       const user = userEvent.setup();
-      const onAppointmentUpdate = vi.fn();
       const appointment = createAppointment();
 
       medplum.updateResource = vi.fn();
 
-      await setup({ appointment, onAppointmentUpdate });
+      await setup({ appointment });
 
       // Submit without selecting a patient
       await user.click(screen.getByRole('button', { name: 'Update Appointment' }));
 
       // updateResource should not have been called
       expect(medplum.updateResource).not.toHaveBeenCalled();
-      expect(onAppointmentUpdate).not.toHaveBeenCalled();
     });
   });
 
@@ -212,7 +205,6 @@ describe('AppointmentDetails', () => {
 
     test('preserves existing participants when adding patient', async () => {
       const user = userEvent.setup();
-      const onAppointmentUpdate = vi.fn();
       const appointment = createAppointment({
         participant: [
           {
@@ -228,7 +220,7 @@ describe('AppointmentDetails', () => {
 
       medplum.updateResource = vi.fn().mockResolvedValue(appointment);
 
-      await setup({ appointment, onAppointmentUpdate });
+      await setup({ appointment });
 
       // Select a patient (ResourceInput uses a searchbox role)
       const patientInput = screen.getByRole('searchbox');
@@ -277,14 +269,13 @@ describe('AppointmentDetails', () => {
   describe('Error Handling', () => {
     test('handles updateResource failure', async () => {
       const user = userEvent.setup();
-      const onAppointmentUpdate = vi.fn();
       const appointment = createAppointment();
 
       const updateError = new Error('Network error');
 
       medplum.updateResource = vi.fn().mockRejectedValue(updateError);
 
-      await setup({ appointment, onAppointmentUpdate });
+      await setup({ appointment });
 
       // Select a patient (ResourceInput uses a searchbox role)
       const patientInput = screen.getByRole('searchbox');
@@ -298,10 +289,7 @@ describe('AppointmentDetails', () => {
       // Submit the form - this will cause an unhandled rejection
       await user.click(screen.getByRole('button', { name: 'Update Appointment' }));
 
-      // onAppointmentUpdate should not have been called since the request failed
       expect(medplum.updateResource).toHaveBeenCalled();
-      expect(onAppointmentUpdate).not.toHaveBeenCalled();
-
       expect(showErrorNotification).toHaveBeenCalledWith(updateError);
     });
   });
@@ -369,7 +357,6 @@ describe('AppointmentDetails', () => {
     const user = userEvent.setup();
     const appointment = createAppointment({ slot: [{ reference: 'Slot/slot-1' }] });
     const cancelledAppointment = { ...appointment, status: 'cancelled' as const };
-    const onAppointmentUpdate = vi.fn();
 
     const postPromise = Promise.withResolvers<Appointment>();
     const postMock = vi.fn().mockReturnValue(postPromise.promise);
@@ -377,7 +364,7 @@ describe('AppointmentDetails', () => {
     medplum.post = postMock;
 
     // click the button
-    const { rerender } = await setup({ appointment, onAppointmentUpdate });
+    const { rerender } = await setup({ appointment });
     const button = screen.getByRole('button', { name: /Cancel Visit/i });
     await user.click(button);
 
@@ -409,11 +396,8 @@ describe('AppointmentDetails', () => {
       id: 'slot-1',
     });
 
-    // it invoked onAppointmentUpdate callback
-    expect(onAppointmentUpdate).toHaveBeenCalledWith(cancelledAppointment);
-
     // re-render with cancelled appointment
-    await rerender(<AppointmentDetails appointment={cancelledAppointment} onAppointmentUpdate={onAppointmentUpdate} />);
+    await rerender(<AppointmentDetails appointment={cancelledAppointment} />);
 
     // cancel button is disabled
     await waitFor(() => expect(button).toHaveAttribute('data-disabled'));
@@ -458,18 +442,13 @@ describe('AppointmentDetails', () => {
     });
     const pendingAppointment = { ...bookedAppointment, status: 'pending' as const };
 
-    const onAppointmentUpdate = vi.fn();
-
     const postPromise = Promise.withResolvers<Bundle<Appointment | Slot>>();
     const postMock = vi.fn().mockReturnValue(postPromise.promise);
     const notifyResourceModifiedSpy = vi.spyOn(medplum, 'notifyResourceModified');
     medplum.post = postMock;
 
     // click the button
-    const { rerender } = await setup({
-      appointment: pendingAppointment,
-      onAppointmentUpdate,
-    });
+    const { rerender } = await setup({ appointment: pendingAppointment });
     const button = screen.getByRole('button', { name: /Confirm Appointment/i });
     await user.click(button);
 
@@ -490,9 +469,6 @@ describe('AppointmentDetails', () => {
 
     // button is no longer loading
     await waitFor(() => expect(button).not.toHaveAttribute('data-loading'));
-
-    // onAppointmentUpdate was called with the updated appointment
-    expect(onAppointmentUpdate).toHaveBeenCalledWith(bookedAppointment);
 
     // it announced the Appointment and Slot modifications on success
     expect(notifyResourceModifiedSpy).toHaveBeenCalledWith({
@@ -515,7 +491,7 @@ describe('AppointmentDetails', () => {
     });
 
     // re-render with booked appointment
-    await rerender(<AppointmentDetails appointment={bookedAppointment} onAppointmentUpdate={onAppointmentUpdate} />);
+    await rerender(<AppointmentDetails appointment={bookedAppointment} />);
 
     // button is not rendered when status is "booked"
     expect(screen.queryByRole('button', { name: 'Confirm Appointment' })).not.toBeInTheDocument();

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
@@ -367,7 +367,7 @@ describe('AppointmentDetails', () => {
 
   test('Cancel Visit button', async () => {
     const user = userEvent.setup();
-    const appointment = createAppointment();
+    const appointment = createAppointment({ slot: [{ reference: 'Slot/slot-1' }] });
     const cancelledAppointment = { ...appointment, status: 'cancelled' as const };
     const onAppointmentUpdate = vi.fn();
 
@@ -402,7 +402,12 @@ describe('AppointmentDetails', () => {
       id: appointment.id,
       resource: cancelledAppointment,
     });
-    expect(notifyResourceModifiedSpy).toHaveBeenCalledWith({ resourceType: 'Slot', operation: 'update' });
+
+    expect(notifyResourceModifiedSpy).toHaveBeenCalledWith({
+      resourceType: 'Slot',
+      operation: 'delete',
+      id: 'slot-1',
+    });
 
     // it invoked onAppointmentUpdate callback
     expect(onAppointmentUpdate).toHaveBeenCalledWith(cancelledAppointment);
@@ -430,10 +435,10 @@ describe('AppointmentDetails', () => {
 
   test('Confirm Visit button', async () => {
     const user = userEvent.setup();
-    const bookedAppointment = createAppointment();
-    const pendingAppointment = { ...bookedAppointment, status: 'pending' as const };
+
     const busySlot: Slot = {
       resourceType: 'Slot',
+      id: 'Slot-abc',
       start,
       end,
       status: 'busy',
@@ -441,11 +446,17 @@ describe('AppointmentDetails', () => {
     };
     const busyUnavailableSlot: Slot = {
       resourceType: 'Slot',
+      id: 'Slot-def',
       start,
       end,
       status: 'busy-unavailable',
       schedule: { reference: 'Schedule/abc123' },
     };
+
+    const bookedAppointment = createAppointment({
+      slot: [{ reference: 'Slot/Slot-abc' }, { reference: 'Slot/Slot-def' }],
+    });
+    const pendingAppointment = { ...bookedAppointment, status: 'pending' as const };
 
     const onAppointmentUpdate = vi.fn();
 
@@ -490,7 +501,18 @@ describe('AppointmentDetails', () => {
       id: bookedAppointment.id,
       resource: bookedAppointment,
     });
-    expect(notifyResourceModifiedSpy).toHaveBeenCalledWith({ resourceType: 'Slot', operation: 'update' });
+    expect(notifyResourceModifiedSpy).toHaveBeenCalledWith({
+      resourceType: 'Slot',
+      operation: 'update',
+      id: 'Slot-abc',
+      resource: busySlot,
+    });
+    expect(notifyResourceModifiedSpy).toHaveBeenCalledWith({
+      resourceType: 'Slot',
+      operation: 'update',
+      id: 'Slot-def',
+      resource: busyUnavailableSlot,
+    });
 
     // re-render with booked appointment
     await rerender(<AppointmentDetails appointment={bookedAppointment} onAppointmentUpdate={onAppointmentUpdate} />);

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
@@ -32,33 +32,25 @@ describe('AppointmentDetails', () => {
   type SetupOptions = {
     appointment: WithId<Appointment>;
     onAppointmentUpdate?: (appointment: Appointment) => void;
-    onSlotUpdate?: (slot: Slot) => void;
   };
 
   const setup = async (options: SetupOptions): Promise<RenderResult> => {
-    const { appointment, onAppointmentUpdate = vi.fn(), onSlotUpdate = vi.fn() } = options;
+    const { appointment, onAppointmentUpdate = vi.fn() } = options;
 
     let result!: RenderResult;
     await act(async () => {
-      result = render(
-        <AppointmentDetails
-          appointment={appointment}
-          onAppointmentUpdate={onAppointmentUpdate}
-          onSlotUpdate={onSlotUpdate}
-        />,
-        {
-          wrapper: ({ children }) => (
-            <MemoryRouter>
-              <MedplumProvider medplum={medplum}>
-                <MantineProvider>
-                  <Notifications />
-                  {children}
-                </MantineProvider>
-              </MedplumProvider>
-            </MemoryRouter>
-          ),
-        }
-      );
+      result = render(<AppointmentDetails appointment={appointment} onAppointmentUpdate={onAppointmentUpdate} />, {
+        wrapper: ({ children }) => (
+          <MemoryRouter>
+            <MedplumProvider medplum={medplum}>
+              <MantineProvider>
+                <Notifications />
+                {children}
+              </MantineProvider>
+            </MedplumProvider>
+          </MemoryRouter>
+        ),
+      });
     });
     return result;
   };
@@ -378,16 +370,14 @@ describe('AppointmentDetails', () => {
     const appointment = createAppointment();
     const cancelledAppointment = { ...appointment, status: 'cancelled' as const };
     const onAppointmentUpdate = vi.fn();
-    const onSlotUpdate = vi.fn();
 
     const postPromise = Promise.withResolvers<Appointment>();
     const postMock = vi.fn().mockReturnValue(postPromise.promise);
-    const invalidateSearchesMock = vi.fn();
+    const notifyResourceModifiedSpy = vi.spyOn(medplum, 'notifyResourceModified');
     medplum.post = postMock;
-    medplum.invalidateSearches = invalidateSearchesMock;
 
     // click the button
-    const { rerender } = await setup({ appointment, onAppointmentUpdate, onSlotUpdate });
+    const { rerender } = await setup({ appointment, onAppointmentUpdate });
     const button = screen.getByRole('button', { name: /Cancel Visit/i });
     await user.click(button);
 
@@ -405,21 +395,20 @@ describe('AppointmentDetails', () => {
     // button is no longer loading
     await waitFor(() => expect(button).not.toHaveAttribute('data-loading'));
 
-    // it invalidated Appointment and Slot searches on success
-    expect(invalidateSearchesMock).toHaveBeenCalledWith('Appointment');
-    expect(invalidateSearchesMock).toHaveBeenCalledWith('Slot');
+    // it announced the Appointment and Slot modifications on success
+    expect(notifyResourceModifiedSpy).toHaveBeenCalledWith({
+      resourceType: 'Appointment',
+      operation: 'update',
+      id: appointment.id,
+      resource: cancelledAppointment,
+    });
+    expect(notifyResourceModifiedSpy).toHaveBeenCalledWith({ resourceType: 'Slot', operation: 'update' });
 
     // it invoked onAppointmentUpdate callback
     expect(onAppointmentUpdate).toHaveBeenCalledWith(cancelledAppointment);
 
     // re-render with cancelled appointment
-    await rerender(
-      <AppointmentDetails
-        appointment={cancelledAppointment}
-        onAppointmentUpdate={onAppointmentUpdate}
-        onSlotUpdate={onSlotUpdate}
-      />
-    );
+    await rerender(<AppointmentDetails appointment={cancelledAppointment} onAppointmentUpdate={onAppointmentUpdate} />);
 
     // cancel button is disabled
     await waitFor(() => expect(button).toHaveAttribute('data-disabled'));
@@ -459,19 +448,16 @@ describe('AppointmentDetails', () => {
     };
 
     const onAppointmentUpdate = vi.fn();
-    const onSlotUpdate = vi.fn();
 
     const postPromise = Promise.withResolvers<Bundle<Appointment | Slot>>();
     const postMock = vi.fn().mockReturnValue(postPromise.promise);
-    const invalidateSearchesMock = vi.fn();
+    const notifyResourceModifiedSpy = vi.spyOn(medplum, 'notifyResourceModified');
     medplum.post = postMock;
-    medplum.invalidateSearches = invalidateSearchesMock;
 
     // click the button
     const { rerender } = await setup({
       appointment: pendingAppointment,
       onAppointmentUpdate,
-      onSlotUpdate,
     });
     const button = screen.getByRole('button', { name: /Confirm Appointment/i });
     await user.click(button);
@@ -497,22 +483,17 @@ describe('AppointmentDetails', () => {
     // onAppointmentUpdate was called with the updated appointment
     expect(onAppointmentUpdate).toHaveBeenCalledWith(bookedAppointment);
 
-    // onSlotUpdate was called with the updated slots
-    expect(onSlotUpdate).toHaveBeenCalledWith(busySlot);
-    expect(onSlotUpdate).toHaveBeenCalledWith(busyUnavailableSlot);
-
-    // it invalidated Appointment and Slot searches on success
-    expect(invalidateSearchesMock).toHaveBeenCalledWith('Appointment');
-    expect(invalidateSearchesMock).toHaveBeenCalledWith('Slot');
+    // it announced the Appointment and Slot modifications on success
+    expect(notifyResourceModifiedSpy).toHaveBeenCalledWith({
+      resourceType: 'Appointment',
+      operation: 'update',
+      id: bookedAppointment.id,
+      resource: bookedAppointment,
+    });
+    expect(notifyResourceModifiedSpy).toHaveBeenCalledWith({ resourceType: 'Slot', operation: 'update' });
 
     // re-render with booked appointment
-    await rerender(
-      <AppointmentDetails
-        appointment={bookedAppointment}
-        onAppointmentUpdate={onAppointmentUpdate}
-        onSlotUpdate={onSlotUpdate}
-      />
-    );
+    await rerender(<AppointmentDetails appointment={bookedAppointment} onAppointmentUpdate={onAppointmentUpdate} />);
 
     // button is not rendered when status is "booked"
     expect(screen.queryByRole('button', { name: 'Confirm Appointment' })).not.toBeInTheDocument();

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
@@ -52,14 +52,13 @@ function ServiceTypeDisplay(props: { value: CodeableConcept }): JSX.Element {
 
 type UpdateAppointmentFormProps = {
   appointment: WithId<Appointment>;
-  onUpdate: (appointment: WithId<Appointment>) => void;
 };
 
 function UpdateAppointmentForm(props: UpdateAppointmentFormProps): JSX.Element {
   const medplum = useMedplum();
   const [patient, setPatient] = useState<Patient | undefined>(undefined);
 
-  const { appointment, onUpdate } = props;
+  const { appointment } = props;
   const handleSubmit = useCallback(async () => {
     if (!patient) {
       return;
@@ -75,15 +74,12 @@ function UpdateAppointmentForm(props: UpdateAppointmentFormProps): JSX.Element {
       ],
     } satisfies Appointment;
 
-    let result: WithId<Appointment>;
     try {
-      result = await medplum.updateResource(updated);
+      await medplum.updateResource(updated);
     } catch (error) {
       showErrorNotification(error);
-      return;
     }
-    onUpdate?.(result);
-  }, [medplum, patient, appointment, onUpdate]);
+  }, [medplum, patient, appointment]);
 
   return (
     <Form onSubmit={handleSubmit}>
@@ -104,11 +100,8 @@ function UpdateAppointmentForm(props: UpdateAppointmentFormProps): JSX.Element {
   );
 }
 
-export function AppointmentDetails(props: {
-  appointment: WithId<Appointment>;
-  onAppointmentUpdate: (appointment: WithId<Appointment>) => void;
-}): JSX.Element {
-  const { appointment, onAppointmentUpdate } = props;
+export function AppointmentDetails(props: { appointment: WithId<Appointment> }): JSX.Element {
+  const { appointment } = props;
   const medplum = useMedplum();
 
   const [encounter, encounterLoading, encounterOutcome] = useSearchOne(
@@ -149,13 +142,12 @@ export function AppointmentDetails(props: {
       updated.slot?.forEach((slot) => {
         medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'delete', id: resolveId(slot) });
       });
-      onAppointmentUpdate(updated);
     } catch (err) {
       showErrorNotification(err);
     } finally {
       setCancelLoading(false);
     }
-  }, [medplum, appointment, onAppointmentUpdate]);
+  }, [medplum, appointment]);
 
   const confirmable = appointment.status === 'pending';
   const [confirmLoading, setConfirmLoading] = useState(false);
@@ -188,15 +180,12 @@ export function AppointmentDetails(props: {
           resource: slot,
         });
       });
-      if (updatedAppointment) {
-        onAppointmentUpdate(updatedAppointment);
-      }
     } catch (err) {
       showErrorNotification(err);
     } finally {
       setConfirmLoading(false);
     }
-  }, [medplum, appointment, confirmable, onAppointmentUpdate]);
+  }, [medplum, appointment, confirmable]);
 
   const sortedParticipants = appointment.participant
     .map((participant) => {
@@ -218,7 +207,7 @@ export function AppointmentDetails(props: {
     <Stack gap="md" className={classes.AppointmentDetails}>
       <Divider />
 
-      {!hasPatient && <UpdateAppointmentForm appointment={props.appointment} onUpdate={props.onAppointmentUpdate} />}
+      {!hasPatient && <UpdateAppointmentForm appointment={props.appointment} />}
 
       {sortedParticipants.map(({ actor, resourceType }, index) => {
         return (

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
@@ -106,9 +106,8 @@ function UpdateAppointmentForm(props: UpdateAppointmentFormProps): JSX.Element {
 export function AppointmentDetails(props: {
   appointment: WithId<Appointment>;
   onAppointmentUpdate: (appointment: WithId<Appointment>) => void;
-  onSlotUpdate: (slot: WithId<Slot>) => void;
 }): JSX.Element {
-  const { appointment, onAppointmentUpdate, onSlotUpdate } = props;
+  const { appointment, onAppointmentUpdate } = props;
   const medplum = useMedplum();
 
   const [encounter, encounterLoading, encounterOutcome] = useSearchOne(
@@ -134,8 +133,17 @@ export function AppointmentDetails(props: {
       const updated = await medplum.post<WithId<Appointment>>(
         medplum.fhirUrl('Appointment', appointment.id, '$cancel')
       );
-      medplum.invalidateSearches('Appointment');
-      medplum.invalidateSearches('Slot');
+      // $cancel is a custom operation, so the client cannot classify its modifications
+      // itself; announce them to invalidate caches and notify interested components.
+      // The operation also soft-deletes the appointment's slots, but does not return
+      // them, so the Slot announcement carries no id.
+      medplum.notifyResourceModified({
+        resourceType: 'Appointment',
+        operation: 'update',
+        id: updated.id,
+        resource: updated,
+      });
+      medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'update' });
       onAppointmentUpdate(updated);
     } catch (err) {
       showErrorNotification(err);
@@ -156,23 +164,26 @@ export function AppointmentDetails(props: {
       const updated = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(
         medplum.fhirUrl('Appointment', appointment.id, '$confirm')
       );
-      medplum.invalidateSearches('Appointment');
-      medplum.invalidateSearches('Slot');
       const updatedResources = updated.entry?.map((entry) => entry.resource) ?? EMPTY;
       const updatedAppointment = updatedResources.find((res) => isResource<Appointment>(res, 'Appointment'));
-      const updatedSlots = updatedResources.filter((res) => isResource<Slot>(res, 'Slot'));
+      // $confirm is a custom operation, so the client cannot classify its modifications
+      // itself; announce them to invalidate caches and notify interested components.
+      medplum.notifyResourceModified({
+        resourceType: 'Appointment',
+        operation: 'update',
+        id: updatedAppointment?.id,
+        resource: updatedAppointment,
+      });
+      medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'update' });
       if (updatedAppointment) {
         onAppointmentUpdate(updatedAppointment);
-      }
-      for (const updatedSlot of updatedSlots) {
-        onSlotUpdate(updatedSlot);
       }
     } catch (err) {
       showErrorNotification(err);
     } finally {
       setConfirmLoading(false);
     }
-  }, [medplum, appointment, confirmable, onAppointmentUpdate, onSlotUpdate]);
+  }, [medplum, appointment, confirmable, onAppointmentUpdate]);
 
   const sortedParticipants = appointment.participant
     .map((participant) => {

--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.tsx
@@ -13,6 +13,7 @@ import {
   isReference,
   isResource,
   parseReference,
+  resolveId,
 } from '@medplum/core';
 import type { Appointment, Bundle, CodeableConcept, Patient, Slot } from '@medplum/fhirtypes';
 import {
@@ -135,15 +136,19 @@ export function AppointmentDetails(props: {
       );
       // $cancel is a custom operation, so the client cannot classify its modifications
       // itself; announce them to invalidate caches and notify interested components.
-      // The operation also soft-deletes the appointment's slots, but does not return
-      // them, so the Slot announcement carries no id.
       medplum.notifyResourceModified({
         resourceType: 'Appointment',
         operation: 'update',
         id: updated.id,
         resource: updated,
       });
-      medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'update' });
+
+      // The $cancel operation soft-deletes the appointment's slots, but does
+      // not return any kind of tombstone for them, so we read the remaining
+      // pointers from the appointment resource and mark them as deleted.
+      updated.slot?.forEach((slot) => {
+        medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'delete', id: resolveId(slot) });
+      });
       onAppointmentUpdate(updated);
     } catch (err) {
       showErrorNotification(err);
@@ -166,6 +171,7 @@ export function AppointmentDetails(props: {
       );
       const updatedResources = updated.entry?.map((entry) => entry.resource) ?? EMPTY;
       const updatedAppointment = updatedResources.find((res) => isResource<Appointment>(res, 'Appointment'));
+      const updatedSlots = updatedResources.filter((res) => isResource<Slot>(res, 'Slot'));
       // $confirm is a custom operation, so the client cannot classify its modifications
       // itself; announce them to invalidate caches and notify interested components.
       medplum.notifyResourceModified({
@@ -174,7 +180,14 @@ export function AppointmentDetails(props: {
         id: updatedAppointment?.id,
         resource: updatedAppointment,
       });
-      medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'update' });
+      updatedSlots.forEach((slot) => {
+        medplum.notifyResourceModified({
+          resourceType: 'Slot',
+          operation: 'update',
+          id: slot.id,
+          resource: slot,
+        });
+      });
       if (updatedAppointment) {
         onAppointmentUpdate(updatedAppointment);
       }

--- a/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
@@ -124,9 +124,6 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
             parameter: [{ name: 'appointment', resource: booking }],
           }
         );
-        medplum.invalidateSearches('Appointment');
-        medplum.invalidateSearches('Slot');
-
         const resources = data.entry?.map((entry) => entry.resource).filter(isDefined) ?? EMPTY;
         const slots = resources.filter(
           (obj: WithId<Slot> | WithId<Appointment>): obj is WithId<Slot> => obj.resourceType === 'Slot'
@@ -134,6 +131,17 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
         const appointment = resources.find(
           (obj: WithId<Slot> | WithId<Appointment>): obj is WithId<Appointment> => obj.resourceType === 'Appointment'
         );
+
+        // $book is a custom operation, so the client cannot classify its modifications
+        // itself; announce them to invalidate caches and notify interested components
+        // (e.g. the schedule calendar).
+        medplum.notifyResourceModified({
+          resourceType: 'Appointment',
+          operation: 'create',
+          id: appointment?.id,
+          resource: appointment,
+        });
+        medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'update' });
 
         if (appointment) {
           let encounter: WithId<Encounter> | undefined;

--- a/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
@@ -141,7 +141,9 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
           id: appointment?.id,
           resource: appointment,
         });
-        medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'update' });
+        slots.forEach((slot) => {
+          medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'create', id: slot.id, resource: slot });
+        });
 
         if (appointment) {
           let encounter: WithId<Encounter> | undefined;

--- a/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/BookAppointmentForm.tsx
@@ -132,31 +132,36 @@ export function BookAppointmentForm(props: BookAppointmentFormProps): JSX.Elemen
           (obj: WithId<Slot> | WithId<Appointment>): obj is WithId<Appointment> => obj.resourceType === 'Appointment'
         );
 
+        if (!appointment) {
+          // This should never happen; if `$book` succeeded it should always
+          // have returned an Appointment resource. Fail loudly if we didn't
+          // get one back.
+          throw new Error('$book succeeded without returning an Appointment');
+        }
+
         // $book is a custom operation, so the client cannot classify its modifications
         // itself; announce them to invalidate caches and notify interested components
         // (e.g. the schedule calendar).
         medplum.notifyResourceModified({
           resourceType: 'Appointment',
           operation: 'create',
-          id: appointment?.id,
+          id: appointment.id,
           resource: appointment,
         });
         slots.forEach((slot) => {
           medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'create', id: slot.id, resource: slot });
         });
 
-        if (appointment) {
-          let encounter: WithId<Encounter> | undefined;
-          try {
-            encounter = await bookEncounter(appointment);
-          } catch (err) {
-            // If we couldn't load the plan definition or create the encounter for
-            // some reason, we log the error but ignore it. The viewer can decide how
-            // to proceed and manually create the encounter.
-            console.error(err);
-          }
-          await onSuccess?.({ appointment, slots, patient, encounter });
+        let encounter: WithId<Encounter> | undefined;
+        try {
+          encounter = await bookEncounter(appointment);
+        } catch (err) {
+          // If we couldn't load the plan definition or create the encounter for
+          // some reason, we log the error but ignore it. The viewer can decide how
+          // to proceed and manually create the encounter.
+          console.error(err);
         }
+        await onSuccess?.({ appointment, slots, patient, encounter });
       } finally {
         setLoading(false);
       }

--- a/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
@@ -3,9 +3,9 @@
 import { Drawer, Stack, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import type { WithId } from '@medplum/core';
-import { EMPTY, getReferenceString, isDefined, isReference, isResourceWithId, resolveId } from '@medplum/core';
+import { getReferenceString, isReference, isResourceWithId } from '@medplum/core';
 import type { Appointment, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
-import { useMedplum } from '@medplum/react';
+import { useMedplum, useResourceModified } from '@medplum/react';
 import type { JSX } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -36,6 +36,11 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
 
   const [appointmentSlot, setAppointmentSlot] = useState<Range>();
   const [appointmentDetails, setAppointmentDetails] = useState<WithId<Appointment> | undefined>(undefined);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  // Reload slots and appointments whenever this client modifies one, e.g. booking a
+  // visit from the FindPane or cancelling one from the appointment details drawer.
+  useResourceModified(['Slot', 'Appointment'], () => setRefreshKey((key) => key + 1));
 
   useEffect(() => {
     if (!range) {
@@ -57,7 +62,7 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
     return () => {
       active = false;
     };
-  }, [medplum, schedule, range]);
+  }, [medplum, schedule, range, refreshKey]);
 
   // Find appointments visible in the current range
   useEffect(() => {
@@ -80,7 +85,7 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
     return () => {
       active = false;
     };
-  }, [medplum, schedule, range]);
+  }, [medplum, schedule, range, refreshKey]);
 
   const practitioner = schedule.actor.find((actor) => isReference<Practitioner>(actor, 'Practitioner'));
 
@@ -115,12 +120,12 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
     [createAppointmentHandlers, practitioner]
   );
 
+  // The calendar data itself refreshes through the `useResourceModified` subscription
+  // above; this callback only handles the UI response to a successful booking.
   const handleBookSuccess = useCallback(
     (results: { appointment: WithId<Appointment>; slots: Slot[] }) => {
-      setAppointments((state) => [...(state ?? EMPTY), results.appointment]);
       setAppointmentDetails(results.appointment);
       appointmentDetailsHandlers.open();
-      setSlots((state) => results.slots.concat(state ?? EMPTY));
     },
     [appointmentDetailsHandlers]
   );
@@ -160,25 +165,13 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
 
   const handleAppointmentUpdate = useCallback(
     (updated: WithId<Appointment>) => {
-      setAppointments((state) => (state ?? []).map((existing) => (existing.id === updated.id ? updated : existing)));
       setAppointmentDetails((existing) => (existing?.id === updated.id ? updated : existing));
       if (updated.status === 'cancelled') {
         appointmentDetailsHandlers.close();
-
-        // If the appointment was cancelled with `$cancel`, it also
-        // soft-deleted the related slots. Remove them from our local state.
-        if (updated.slot) {
-          const ids = new Set(updated.slot.map((ref) => resolveId(ref)).filter(isDefined));
-          setSlots((state) => state?.filter((slot) => slot.id && !ids.has(slot.id)));
-        }
       }
     },
     [appointmentDetailsHandlers]
   );
-
-  const handleSlotUpdate = useCallback((updated: WithId<Slot>) => {
-    setSlots((state) => (state ?? []).map((existing) => (existing.id === updated.id ? updated : existing)));
-  }, []);
 
   const mergedSlots = useMemo(() => mergeOverlappingSlots(slots ?? []), [slots]);
 
@@ -235,11 +228,7 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
         h="100%"
       >
         {appointmentDetails && (
-          <AppointmentDetails
-            appointment={appointmentDetails}
-            onAppointmentUpdate={handleAppointmentUpdate}
-            onSlotUpdate={handleSlotUpdate}
-          />
+          <AppointmentDetails appointment={appointmentDetails} onAppointmentUpdate={handleAppointmentUpdate} />
         )}
       </Drawer>
     </>

--- a/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
@@ -36,11 +36,79 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
 
   const [appointmentSlot, setAppointmentSlot] = useState<Range>();
   const [appointmentDetails, setAppointmentDetails] = useState<WithId<Appointment> | undefined>(undefined);
-  const [refreshKey, setRefreshKey] = useState(0);
 
-  // Reload slots and appointments whenever this client modifies one, e.g. booking a
-  // visit from the FindPane or cancelling one from the appointment details drawer.
-  useResourceModified(['Slot', 'Appointment'], () => setRefreshKey((key) => key + 1));
+  // The predicates that scope this calendar's data. Both the searches below and the
+  // `useResourceModified` handlers use these so the optimistic updates stay consistent
+  // with what a refetch would return.
+  const scheduleRef = getReferenceString(schedule);
+  const actorRef = schedule.actor[0]?.reference;
+
+  // Keep the calendar's slots in sync with any Slot this client modifies, e.g. the
+  // slots created when booking a visit from the FindPane or soft-deleted when cancelling
+  // one from the appointment details drawer.
+  useResourceModified('Slot', (event) => {
+    if (event.operation === 'delete') {
+      // Deletes don't carry a resource, only the id of what went away.
+      if (event.id) {
+        setSlots((state) => state?.filter((slot) => slot.id !== event.id));
+      }
+      return;
+    }
+
+    const slot = event.resource;
+    if (!slot) {
+      return;
+    }
+    // Ignore slots that belong to a different schedule than the one shown here.
+    if (slot.schedule.reference !== scheduleRef) {
+      return;
+    }
+
+    setSlots((state) => {
+      // `create` prepends the new slot; `update`/`patch` replace it in place and leave
+      // an unloaded range untouched.
+      if (event.operation === 'create') {
+        const current = state ?? [];
+        return current.some((existing) => existing.id === slot.id) ? current : [slot, ...current];
+      }
+      return state?.map((existing) => (existing.id === slot.id ? slot : existing));
+    });
+  });
+
+  // Likewise keep the calendar's appointments in sync with any Appointment this client
+  // modifies, and mirror the change into the open appointment details drawer.
+  useResourceModified('Appointment', (event) => {
+    if (event.operation === 'delete') {
+      if (event.id) {
+        setAppointments((state) => state?.filter((appointment) => appointment.id !== event.id));
+        setAppointmentDetails((existing) => (existing?.id === event.id ? undefined : existing));
+      }
+      return;
+    }
+
+    const appointment = event.resource;
+    if (!appointment) {
+      return;
+    }
+    // Ignore appointments that don't involve this schedule's actor, mirroring the
+    // `actor` filter used by the search below.
+    if (!actorRef || !appointment.participant.some((p) => p.actor?.reference === actorRef)) {
+      return;
+    }
+
+    setAppointments((state) => {
+      if (event.operation === 'create') {
+        const current = state ?? [];
+        return current.some((existing) => existing.id === appointment.id) ? current : [...current, appointment];
+      }
+      return state?.map((existing) => (existing.id === appointment.id ? appointment : existing));
+    });
+    setAppointmentDetails((existing) => (existing?.id === appointment.id ? appointment : existing));
+    // A cancelled appointment can no longer be acted on, so close its details drawer.
+    if (appointment.status === 'cancelled') {
+      appointmentDetailsHandlers.close();
+    }
+  });
 
   useEffect(() => {
     if (!range) {
@@ -51,7 +119,7 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
     medplum
       .searchResources('Slot', [
         ['_count', '1000'],
-        ['schedule', getReferenceString(schedule)],
+        ['schedule', scheduleRef],
         ['start', `ge${range.start.toISOString()}`],
         ['start', `le${range.end.toISOString()}`],
         ['status:not', 'entered-in-error'],
@@ -62,11 +130,10 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
     return () => {
       active = false;
     };
-  }, [medplum, schedule, range, refreshKey]);
+  }, [medplum, scheduleRef, range]);
 
   // Find appointments visible in the current range
   useEffect(() => {
-    const actorRef = schedule.actor[0]?.reference;
     if (!actorRef || !range) {
       return () => {};
     }
@@ -85,7 +152,7 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
     return () => {
       active = false;
     };
-  }, [medplum, schedule, range, refreshKey]);
+  }, [medplum, actorRef, range]);
 
   const practitioner = schedule.actor.find((actor) => isReference<Practitioner>(actor, 'Practitioner'));
 
@@ -120,8 +187,8 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
     [createAppointmentHandlers, practitioner]
   );
 
-  // The calendar data itself refreshes through the `useResourceModified` subscription
-  // above; this callback only handles the UI response to a successful booking.
+  // The calendar's slots and appointments update through the `useResourceModified`
+  // subscriptions above; this callback only handles the UI response to a successful booking.
   const handleBookSuccess = useCallback(
     (results: { appointment: WithId<Appointment>; slots: Slot[] }) => {
       setAppointmentDetails(results.appointment);

--- a/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
@@ -230,16 +230,6 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
     [medplum, navigate]
   );
 
-  const handleAppointmentUpdate = useCallback(
-    (updated: WithId<Appointment>) => {
-      setAppointmentDetails((existing) => (existing?.id === updated.id ? updated : existing));
-      if (updated.status === 'cancelled') {
-        appointmentDetailsHandlers.close();
-      }
-    },
-    [appointmentDetailsHandlers]
-  );
-
   const mergedSlots = useMemo(() => mergeOverlappingSlots(slots ?? []), [slots]);
 
   return (
@@ -294,9 +284,7 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
         position="right"
         h="100%"
       >
-        {appointmentDetails && (
-          <AppointmentDetails appointment={appointmentDetails} onAppointmentUpdate={handleAppointmentUpdate} />
-        )}
+        {appointmentDetails && <AppointmentDetails appointment={appointmentDetails} />}
       </Drawer>
     </>
   );

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
@@ -539,7 +539,7 @@ describe('Cancel Visit integration', () => {
     });
   });
 
-  const setup = (initialPath = '/Calendar/Schedule/alice-smith-schedule'): ReturnType<typeof render> => {
+  const setup = (initialPath = `/Calendar/Schedule/${DrAliceSmithSchedule.id}`): ReturnType<typeof render> => {
     return render(
       <MemoryRouter initialEntries={[initialPath]}>
         <MedplumProvider medplum={medplum}>
@@ -563,7 +563,10 @@ describe('Cancel Visit integration', () => {
       status: 'booked',
       start: '2024-01-16T10:00:00Z',
       end: '2024-01-16T10:30:00Z',
-      participant: [{ actor: { reference: 'Patient/patient-1', display: 'Jane Doe' }, status: 'accepted' }],
+      participant: [
+        { actor: createReference(DrAliceSmith), status: 'accepted' },
+        { actor: { reference: 'Patient/patient-1', display: 'Jane Doe' }, status: 'accepted' },
+      ],
     } satisfies Appointment;
     const cancelledAppointment = { ...bookedAppointment, status: 'cancelled' } satisfies Appointment;
 

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
@@ -453,7 +453,7 @@ describe('$find/$book component integration tests', () => {
             end: slotEnd,
             slot: [{ reference: 'Slot/slot-123' }, { reference: 'Slot/slot-124' }],
             participant: [
-              { actor: { reference: 'Practitioner/practitioner-1' }, status: 'tentative' },
+              { actor: createReference(DrAliceSmith), status: 'tentative' },
               { actor: createReference(HomerSimpson), status: 'accepted' },
             ],
           },
@@ -466,7 +466,7 @@ describe('$find/$book component integration tests', () => {
             status: 'busy',
             start: slotStart,
             end: slotEnd,
-            schedule: { reference: 'Schedule/schedule-1' },
+            schedule: createReference(DrAliceSmithSchedule),
           },
         },
         {
@@ -477,12 +477,21 @@ describe('$find/$book component integration tests', () => {
             status: 'busy-unavailable',
             start: slotEnd,
             end: bufferEnd,
-            schedule: { reference: 'Schedule/schedule-1' },
+            schedule: createReference(DrAliceSmithSchedule),
           },
         },
       ],
     };
-    medplum.post = vi.fn().mockResolvedValue(mockBookResponse);
+    medplum.post = vi.fn().mockImplementation(async () => {
+      // Persist the booked resources like the real $book operation would, so that the
+      // calendar refresh triggered by the booking announcement can find them.
+      for (const entry of mockBookResponse.entry ?? []) {
+        if (entry.resource) {
+          await medplum.repo.createResource(entry.resource);
+        }
+      }
+      return mockBookResponse;
+    });
 
     await act(async () => {
       setup('/Calendar/Schedule/alice-smith-schedule');
@@ -507,12 +516,12 @@ describe('$find/$book component integration tests', () => {
     // Submit the form
     await user.click(screen.getByRole('button', { name: 'Create Appointment' }));
 
-    // Appointment should be in the big calendar
+    // Appointment should be in the big calendar once the calendar refreshes
     const calendar = screen.getByTestId('calendar');
-    expect(getByText(calendar, 'Homer Simpson')).toBeInTheDocument();
+    await waitFor(() => expect(getByText(calendar, 'Homer Simpson')).toBeInTheDocument());
 
     // Buffer-after unavailable slot should be in the big calendar
-    expect(screen.getByText('Blocked')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Blocked')).toBeInTheDocument());
   });
 });
 
@@ -558,9 +567,10 @@ describe('Cancel Visit integration', () => {
     } satisfies Appointment;
     const cancelledAppointment = { ...bookedAppointment, status: 'cancelled' } satisfies Appointment;
 
+    let appointmentSearchResults: Appointment[] = [bookedAppointment];
     medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
       if (resourceType === 'Appointment') {
-        return Promise.resolve([bookedAppointment]);
+        return Promise.resolve(appointmentSearchResults);
       }
       return Promise.resolve([]);
     });
@@ -572,7 +582,12 @@ describe('Cancel Visit integration', () => {
       return Promise.resolve(undefined); // no Encounter
     });
 
-    const postMock = vi.fn().mockResolvedValue(cancelledAppointment);
+    const postMock = vi.fn().mockImplementation(async () => {
+      // After $cancel, searches report the appointment as cancelled, so the calendar
+      // refresh triggered by the cancellation announcement no longer displays it.
+      appointmentSearchResults = [cancelledAppointment];
+      return cancelledAppointment;
+    });
     medplum.post = postMock;
 
     const user = userEvent.setup();

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -27,6 +27,7 @@ import type {
   NewPatientRequest,
   NewProjectRequest,
   NewUserRequest,
+  ResourceModifiedEvent,
 } from './client';
 import { DEFAULT_ACCEPT, MedplumClient } from './client';
 import { createFakeJwt, mockFetch, mockFetchResponse, mockFetchWithStatus } from './client-test-utils';
@@ -4761,6 +4762,150 @@ describe('Client', () => {
         duplex: 'half',
       })
     );
+  });
+
+  describe('Client events', () => {
+    test('Throwing event listener does not affect the caller', async () => {
+      const fetch = mockFetch(200, { resourceType: 'Patient', id: '123' });
+      const client = new MedplumClient({ fetch });
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      client.addEventListener('resourceModified', () => {
+        throw new Error('listener error');
+      });
+
+      const patient = await client.createResource<Patient>({ resourceType: 'Patient' });
+
+      expect(patient).toBeDefined();
+      expect(consoleError).toHaveBeenCalled();
+      consoleError.mockRestore();
+    });
+
+    test('resourceModified on create', async () => {
+      const fetch = mockFetch(200, { resourceType: 'Patient', id: '123' });
+      const client = new MedplumClient({ fetch });
+      const events: ResourceModifiedEvent[] = [];
+      client.addEventListener('resourceModified', (e) => events.push(e.payload));
+
+      const patient = await client.createResource<Patient>({ resourceType: 'Patient' });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ resourceType: 'Patient', operation: 'create', id: '123' });
+      expect(events[0].resource).toBe(patient);
+    });
+
+    test('resourceModified on createResourceIfNoneExist', async () => {
+      const fetch = mockFetch(200, { resourceType: 'Patient', id: '123' });
+      const client = new MedplumClient({ fetch });
+      const events: ResourceModifiedEvent[] = [];
+      client.addEventListener('resourceModified', (e) => events.push(e.payload));
+
+      await client.createResourceIfNoneExist<Patient>({ resourceType: 'Patient' }, 'identifier=123');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ resourceType: 'Patient', operation: 'create', id: '123' });
+    });
+
+    test('resourceModified on update', async () => {
+      const fetch = mockFetch(200, { resourceType: 'Patient', id: '123' });
+      const client = new MedplumClient({ fetch });
+      const events: ResourceModifiedEvent[] = [];
+      client.addEventListener('resourceModified', (e) => events.push(e.payload));
+
+      await client.updateResource<Patient>({ resourceType: 'Patient', id: '123' });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ resourceType: 'Patient', operation: 'update', id: '123' });
+    });
+
+    test('No resourceModified on update not modified', async () => {
+      const fetch = mockFetch(304, {});
+      const client = new MedplumClient({ fetch });
+      const events: ResourceModifiedEvent[] = [];
+      client.addEventListener('resourceModified', (e) => events.push(e.payload));
+
+      await client.updateResource<Patient>({ resourceType: 'Patient', id: '123' });
+
+      expect(events).toHaveLength(0);
+    });
+
+    test('resourceModified on upsert', async () => {
+      const fetch = mockFetch(200, { resourceType: 'Patient', id: '123' });
+      const client = new MedplumClient({ fetch });
+      const events: ResourceModifiedEvent[] = [];
+      client.addEventListener('resourceModified', (e) => events.push(e.payload));
+
+      await client.upsertResource<Patient>({ resourceType: 'Patient' }, 'identifier=123');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ resourceType: 'Patient', operation: 'update', id: '123' });
+    });
+
+    test('resourceModified on patch', async () => {
+      const fetch = mockFetch(200, { resourceType: 'Patient', id: '123' });
+      const client = new MedplumClient({ fetch });
+      const events: ResourceModifiedEvent[] = [];
+      client.addEventListener('resourceModified', (e) => events.push(e.payload));
+
+      await client.patchResource('Patient', '123', [{ op: 'replace', path: '/active', value: true }]);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ resourceType: 'Patient', operation: 'patch', id: '123' });
+    });
+
+    test('resourceModified on delete', async () => {
+      const fetch = mockFetch(200, {});
+      const client = new MedplumClient({ fetch });
+      const events: ResourceModifiedEvent[] = [];
+      client.addEventListener('resourceModified', (e) => events.push(e.payload));
+
+      await client.deleteResource('Patient', '123');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ resourceType: 'Patient', operation: 'delete', id: '123' });
+      expect(events[0].resource).toBeUndefined();
+    });
+
+    test('notifyResourceModified dispatches and invalidates search cache', async () => {
+      const fetch = mockFetch(200, { resourceType: 'Bundle', type: 'searchset', entry: [] });
+      const client = new MedplumClient({ fetch });
+      await client.search('Slot');
+      await client.search('Slot');
+      expect(fetch).toHaveBeenCalledTimes(1);
+
+      const events: ResourceModifiedEvent[] = [];
+      client.addEventListener('resourceModified', (e) => events.push(e.payload));
+      client.notifyResourceModified({ resourceType: 'Slot', operation: 'update' });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ resourceType: 'Slot', operation: 'update' });
+
+      await client.search('Slot');
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    test('notifyResourceModified caches the provided resource', async () => {
+      const fetch = mockFetch(200, {});
+      const client = new MedplumClient({ fetch });
+      const patient: WithId<Patient> = { resourceType: 'Patient', id: 'p1' };
+
+      client.notifyResourceModified({ resourceType: 'Patient', operation: 'update', id: 'p1', resource: patient });
+
+      const read = await client.readResource('Patient', 'p1');
+      expect(read).toBe(patient);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    test('notifyResourceModified on delete invalidates the cached read', async () => {
+      const fetch = mockFetch(200, { resourceType: 'Patient', id: 'p1' });
+      const client = new MedplumClient({ fetch });
+      await client.readResource('Patient', 'p1');
+      expect(fetch).toHaveBeenCalledTimes(1);
+
+      client.notifyResourceModified({ resourceType: 'Patient', operation: 'delete', id: 'p1' });
+
+      await client.readResource('Patient', 'p1');
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
   });
 });
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -925,6 +925,31 @@ export interface RequestProfileSchemaOptions extends MedplumRequestOptions {
 }
 
 /**
+ * Payload of the `resourceModified` event, emitted after this client instance successfully
+ * creates, updates, patches, or deletes a FHIR resource.
+ *
+ * Emitted by `createResource`, `createResourceIfNoneExist`, `updateResource`, `upsertResource`,
+ * `patchResource`, `deleteResource`, and by `notifyResourceModified`.
+ * Conditional methods (`createResourceIfNoneExist`, `upsertResource`) emit
+ * even when the server made no change, except on HTTP 304 "Not Modified".
+ *
+ * Custom operations (e.g. `Appointment/$book`), GraphQL mutations, FHIR
+ * Batches and Transactions (`executeBatch`), and writes made by other clients
+ * do not emit this event automatically — use `notifyResourceModified` to
+ * announce them.
+ */
+export interface ResourceModifiedEvent {
+  /** The type of the modified resource. */
+  resourceType: ResourceType;
+  /** How the resource was modified. */
+  operation: 'create' | 'update' | 'patch' | 'delete';
+  /** The resource id, when known. */
+  id?: string;
+  /** The server-returned resource, when available. Undefined for deletes. */
+  resource?: Resource;
+}
+
+/**
  * This map enumerates all the lifecycle events that `MedplumClient` emits and what the shape of the `Event` is.
  */
 export type MedplumClientEventMap = {
@@ -934,6 +959,7 @@ export type MedplumClientEventMap = {
   profileRefreshed: { type: 'profileRefreshed' };
   storageInitialized: { type: 'storageInitialized' };
   storageInitFailed: { type: 'storageInitFailed'; payload: { error: Error } };
+  resourceModified: { type: 'resourceModified'; payload: ResourceModifiedEvent };
 };
 
 /**
@@ -1281,6 +1307,37 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
         this.requestCache?.delete(key);
       }
     }
+  }
+
+  /**
+   * Notifies listeners that a resource was modified outside of the standard CRUD methods,
+   * and invalidates the relevant cached values.
+   *
+   * The client emits the `resourceModified` event automatically for `createResource`,
+   * `updateResource`, `patchResource`, `deleteResource`, and related methods. Use this method
+   * to announce modifications the client cannot classify itself, such as custom operations,
+   * GraphQL mutations, or out-of-band changes:
+   *
+   * ```typescript
+   * await medplum.post(medplum.fhirUrl('Appointment', '$book'), parameters);
+   * medplum.notifyResourceModified({ resourceType: 'Appointment', operation: 'create' });
+   * medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'update' });
+   * ```
+   *
+   * Cached searches for the resource type are invalidated. If `event.resource` is provided
+   * for a non-delete operation, it becomes the cached read value; otherwise, if `event.id`
+   * is provided, the cached read is invalidated.
+   * @category Caching
+   * @param event - The resource modification to announce.
+   */
+  notifyResourceModified(event: ResourceModifiedEvent): void {
+    if (event.operation !== 'delete' && event.resource) {
+      this.cacheResource(event.resource, undefined);
+    } else if (event.id) {
+      this.deleteCacheEntry(this.fhirUrl(event.resourceType, event.id).toString());
+    }
+    this.invalidateSearches(event.resourceType);
+    this.dispatchResourceModified(event);
   }
 
   /**
@@ -2270,12 +2327,19 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * @param options - Optional fetch options.
    * @returns The result of the create operation.
    */
-  createResource<T extends Resource>(resource: T, options?: MedplumRequestOptions): Promise<WithId<T>> {
+  async createResource<T extends Resource>(resource: T, options?: MedplumRequestOptions): Promise<WithId<T>> {
     if (!resource.resourceType) {
       throw new Error('Missing resourceType');
     }
     this.invalidateSearches(resource.resourceType);
-    return this.post(this.fhirUrl(resource.resourceType), resource, undefined, options);
+    const result = await this.post(this.fhirUrl(resource.resourceType), resource, undefined, options);
+    this.dispatchResourceModified({
+      resourceType: resource.resourceType,
+      operation: 'create',
+      id: result?.id,
+      resource: result,
+    });
+    return result;
   }
 
   /**
@@ -2331,6 +2395,12 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     this.cacheResource(result, options);
     this.invalidateUrl(this.fhirUrl(resource.resourceType, resource.id as string, '_history'));
     this.invalidateSearches(resource.resourceType);
+    this.dispatchResourceModified({
+      resourceType: resource.resourceType,
+      operation: 'create',
+      id: result?.id,
+      resource: result,
+    });
     return result;
   }
 
@@ -2351,6 +2421,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     const url = this.fhirSearchUrl(resource.resourceType, query);
 
     let result = await this.put(url, resource, undefined, options);
+    const notModified = !result;
     if (!result) {
       // On 304 not modified, result will be undefined
       // Return the user input instead
@@ -2359,6 +2430,14 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     this.cacheResource(result, options);
     this.invalidateUrl(this.fhirUrl(resource.resourceType, resource.id as string, '_history'));
     this.invalidateSearches(resource.resourceType);
+    if (!notModified) {
+      this.dispatchResourceModified({
+        resourceType: resource.resourceType,
+        operation: 'update',
+        id: result.id,
+        resource: result,
+      });
+    }
     return result;
   }
 
@@ -2728,6 +2807,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       throw new Error('Missing id');
     }
     let result = await this.put(this.fhirUrl(resource.resourceType, resource.id), resource, undefined, options);
+    const notModified = !result;
     if (!result) {
       // On 304 not modified, result will be undefined
       // Return the user input instead
@@ -2736,6 +2816,14 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     this.cacheResource(result, options);
     this.invalidateUrl(this.fhirUrl(resource.resourceType, resource.id, '_history'));
     this.invalidateSearches(resource.resourceType);
+    if (!notModified) {
+      this.dispatchResourceModified({
+        resourceType: resource.resourceType,
+        operation: 'update',
+        id: result.id,
+        resource: result,
+      });
+    }
     return result;
   }
 
@@ -2774,6 +2862,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     this.cacheResource(result, options);
     this.invalidateUrl(this.fhirUrl(resourceType, id, '_history'));
     this.invalidateSearches(resourceType);
+    this.dispatchResourceModified({ resourceType, operation: 'patch', id, resource: result });
     return result;
   }
 
@@ -2794,10 +2883,12 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * @param options - Optional fetch options.
    * @returns The result of the delete operation.
    */
-  deleteResource(resourceType: ResourceType, id: string, options?: MedplumRequestOptions): Promise<any> {
+  async deleteResource(resourceType: ResourceType, id: string, options?: MedplumRequestOptions): Promise<any> {
     this.deleteCacheEntry(this.fhirUrl(resourceType, id).toString());
     this.invalidateSearches(resourceType);
-    return this.delete(this.fhirUrl(resourceType, id), options);
+    const result = await this.delete(this.fhirUrl(resourceType, id), options);
+    this.dispatchResourceModified({ resourceType, operation: 'delete', id });
+    return result;
   }
 
   /**
@@ -3610,6 +3701,30 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   private deleteCacheEntry(key: string): void {
     if (this.requestCache) {
       this.requestCache.delete(key);
+    }
+  }
+
+  /**
+   * Dispatches an event, isolating listener exceptions from the caller.
+   * Used for events emitted during request processing, where a throwing
+   * listener must not corrupt the in-flight operation.
+   * @param event - The event to dispatch.
+   */
+  private safeDispatchEvent(event: MedplumClientEventMap[keyof MedplumClientEventMap]): void {
+    try {
+      this.dispatchEvent(event);
+    } catch (err) {
+      console.error('MedplumClient event listener error', err);
+    }
+  }
+
+  /**
+   * Dispatches a `resourceModified` event if there are any listeners.
+   * @param payload - The event payload.
+   */
+  private dispatchResourceModified(payload: ResourceModifiedEvent): void {
+    if (this.listenerCount('resourceModified') > 0) {
+      this.safeDispatchEvent({ type: 'resourceModified', payload });
     }
   }
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3705,26 +3705,16 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   }
 
   /**
-   * Dispatches an event, isolating listener exceptions from the caller.
-   * Used for events emitted during request processing, where a throwing
-   * listener must not corrupt the in-flight operation.
-   * @param event - The event to dispatch.
-   */
-  private safeDispatchEvent(event: MedplumClientEventMap[keyof MedplumClientEventMap]): void {
-    try {
-      this.dispatchEvent(event);
-    } catch (err) {
-      console.error('MedplumClient event listener error', err);
-    }
-  }
-
-  /**
    * Dispatches a `resourceModified` event if there are any listeners.
    * @param payload - The event payload.
    */
   private dispatchResourceModified(payload: ResourceModifiedEvent): void {
     if (this.listenerCount('resourceModified') > 0) {
-      this.safeDispatchEvent({ type: 'resourceModified', payload });
+      try {
+        this.dispatchEvent({ type: 'resourceModified', payload });
+      } catch (err) {
+        console.error("[MedplumClient] A 'resourceModified' event listener threw an error ", err);
+      }
     }
   }
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2419,7 +2419,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     const url = this.fhirSearchUrl(resource.resourceType, query);
 
     let result = await this.put(url, resource, undefined, options);
-    const notModified = !result;
+    const wasModified = result !== undefined;
     if (!result) {
       // On 304 not modified, result will be undefined
       // Return the user input instead
@@ -2428,7 +2428,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     this.cacheResource(result, options);
     this.invalidateUrl(this.fhirUrl(resource.resourceType, resource.id as string, '_history'));
     this.invalidateSearches(resource.resourceType);
-    if (!notModified) {
+    if (wasModified) {
       this.dispatchResourceModified({
         resourceType: resource.resourceType,
         operation: 'update',
@@ -2805,7 +2805,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       throw new Error('Missing id');
     }
     let result = await this.put(this.fhirUrl(resource.resourceType, resource.id), resource, undefined, options);
-    const notModified = !result;
+    const wasModified = result !== undefined;
     if (!result) {
       // On 304 not modified, result will be undefined
       // Return the user input instead
@@ -2814,7 +2814,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     this.cacheResource(result, options);
     this.invalidateUrl(this.fhirUrl(resource.resourceType, resource.id, '_history'));
     this.invalidateSearches(resource.resourceType);
-    if (!notModified) {
+    if (wasModified) {
       this.dispatchResourceModified({
         resourceType: resource.resourceType,
         operation: 'update',

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -933,20 +933,18 @@ export interface RequestProfileSchemaOptions extends MedplumRequestOptions {
  * Conditional methods (`createResourceIfNoneExist`, `upsertResource`) emit
  * even when the server made no change, except on HTTP 304 "Not Modified".
  *
- * Custom operations (e.g. `Appointment/$book`), GraphQL mutations, FHIR
- * Batches and Transactions (`executeBatch`), and writes made by other clients
- * do not emit this event automatically — use `notifyResourceModified` to
- * announce them.
+ * @template T - The type of the modified resource. Defaults to `Resource`; narrow it (e.g. via
+ * `useResourceModified('Slot', ...)`) to get a typed `resource` payload without extra guards.
  */
-export interface ResourceModifiedEvent {
+export interface ResourceModifiedEvent<T extends Resource = Resource> {
   /** The type of the modified resource. */
-  resourceType: ResourceType;
+  resourceType: T['resourceType'];
   /** How the resource was modified. */
   operation: 'create' | 'update' | 'patch' | 'delete';
   /** The resource id, when known. */
   id?: string;
   /** The server-returned resource, when available. Undefined for deletes. */
-  resource?: Resource;
+  resource?: WithId<T>;
 }
 
 /**

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -15,6 +15,7 @@ export * from './useQuestionnaireForm/useQuestionnaireForm';
 export * from './useQuestionnaireForm/utils';
 export * from './useResource/useResource';
 export * from './useResourceBoard/useResourceBoard';
+export * from './useResourceModified/useResourceModified';
 export * from './useSearch/useSearch';
 export * from './useSubscription/useSubscription';
 export * from './useSyncOrderSet/useSyncOrderSet';

--- a/packages/react-hooks/src/useResourceModified/useResourceModified.test.tsx
+++ b/packages/react-hooks/src/useResourceModified/useResourceModified.test.tsx
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { ResourceModifiedEvent } from '@medplum/core';
+import { MockClient } from '@medplum/mock';
+import { renderHook } from '@testing-library/react';
+import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
+import { useResourceModified } from './useResourceModified';
+
+describe('useResourceModified', () => {
+  function setup(
+    medplum: MockClient,
+    resourceType: Parameters<typeof useResourceModified>[0],
+    callback: (event: ResourceModifiedEvent) => void
+  ): { unmount: () => void } {
+    return renderHook(() => useResourceModified(resourceType, callback), {
+      wrapper: ({ children }) => <MedplumProvider medplum={medplum}>{children}</MedplumProvider>,
+    });
+  }
+
+  test('Invokes callback for matching modifications', async () => {
+    const medplum = new MockClient();
+    const events: ResourceModifiedEvent[] = [];
+    setup(medplum, 'Patient', (event) => events.push(event));
+
+    const patient = await medplum.createResource({ resourceType: 'Patient' });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ resourceType: 'Patient', operation: 'create', id: patient.id });
+
+    await medplum.deleteResource('Patient', patient.id);
+
+    expect(events).toHaveLength(2);
+    expect(events[1]).toMatchObject({ resourceType: 'Patient', operation: 'delete', id: patient.id });
+  });
+
+  test('Ignores modifications to other resource types', async () => {
+    const medplum = new MockClient();
+    const events: ResourceModifiedEvent[] = [];
+    setup(medplum, ['Slot', 'Appointment'], (event) => events.push(event));
+
+    await medplum.createResource({ resourceType: 'Practitioner' });
+    expect(events).toHaveLength(0);
+
+    medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'update' });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ resourceType: 'Slot', operation: 'update' });
+  });
+
+  test('Removes listener on unmount', async () => {
+    const medplum = new MockClient();
+    const callback = vi.fn();
+    const { unmount } = setup(medplum, 'Patient', callback);
+
+    expect(medplum.listenerCount('resourceModified')).toBe(1);
+    unmount();
+    expect(medplum.listenerCount('resourceModified')).toBe(0);
+
+    await medplum.createResource({ resourceType: 'Patient' });
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-hooks/src/useResourceModified/useResourceModified.ts
+++ b/packages/react-hooks/src/useResourceModified/useResourceModified.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { MedplumClientEventMap, ResourceModifiedEvent } from '@medplum/core';
-import type { ResourceType } from '@medplum/fhirtypes';
+import type { ExtractResource, ResourceType } from '@medplum/fhirtypes';
 import { useEffect, useRef } from 'react';
 import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
 
@@ -11,9 +11,13 @@ import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
  * The callback is invoked whenever this client instance creates, updates, patches, or deletes
  * a resource of one of the given types, including modifications announced with
  * `MedplumClient.notifyResourceModified`. Use it to keep local component state in sync with
- * mutations made elsewhere in the application:
+ * mutations made elsewhere in the application. Subscribing to a single resource type narrows
+ * the event so `event.resource` is typed to that resource, no type guard required:
  *
  * ```tsx
+ * useResourceModified('Slot', (event) => {
+ *   // event.resource is `WithId<Slot> | undefined`
+ * });
  * useResourceModified(['Slot', 'Appointment'], () => refreshSchedule());
  * ```
  *
@@ -23,9 +27,9 @@ import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
  * @param resourceType - The resource type or types to observe.
  * @param callback - Invoked with the event payload for each matching modification.
  */
-export function useResourceModified(
-  resourceType: ResourceType | ResourceType[],
-  callback: (event: ResourceModifiedEvent) => void
+export function useResourceModified<K extends ResourceType>(
+  resourceType: K | K[],
+  callback: (event: ResourceModifiedEvent<ExtractResource<K>>) => void
 ): void {
   const medplum = useMedplum();
   const callbackRef = useRef(callback);
@@ -39,7 +43,8 @@ export function useResourceModified(
     const types = new Set(typesKey.split(','));
     const listener = (event: MedplumClientEventMap['resourceModified']): void => {
       if (types.has(event.payload.resourceType)) {
-        callbackRef.current(event.payload);
+        // Guarded above: the payload's resourceType is one of `K`, so this narrowing holds.
+        callbackRef.current(event.payload as ResourceModifiedEvent<ExtractResource<K>>);
       }
     };
     medplum.addEventListener('resourceModified', listener);

--- a/packages/react-hooks/src/useResourceModified/useResourceModified.ts
+++ b/packages/react-hooks/src/useResourceModified/useResourceModified.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { MedplumClientEventMap, ResourceModifiedEvent } from '@medplum/core';
+import type { ResourceType } from '@medplum/fhirtypes';
+import { useEffect, useRef } from 'react';
+import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
+
+/**
+ * React hook for observing FHIR resource modifications made through the Medplum client.
+ *
+ * The callback is invoked whenever this client instance creates, updates, patches, or deletes
+ * a resource of one of the given types, including modifications announced with
+ * `MedplumClient.notifyResourceModified`. Use it to keep local component state in sync with
+ * mutations made elsewhere in the application:
+ *
+ * ```tsx
+ * useResourceModified(['Slot', 'Appointment'], () => refreshSchedule());
+ * ```
+ *
+ * Modifications made by other clients (or other users) are not observed;
+ * use `useSubscription` for server-side change notifications.
+ *
+ * @param resourceType - The resource type or types to observe.
+ * @param callback - Invoked with the event payload for each matching modification.
+ */
+export function useResourceModified(
+  resourceType: ResourceType | ResourceType[],
+  callback: (event: ResourceModifiedEvent) => void
+): void {
+  const medplum = useMedplum();
+  const callbackRef = useRef(callback);
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  const typesKey = Array.isArray(resourceType) ? resourceType.join(',') : resourceType;
+
+  useEffect(() => {
+    const types = new Set(typesKey.split(','));
+    const listener = (event: MedplumClientEventMap['resourceModified']): void => {
+      if (types.has(event.payload.resourceType)) {
+        callbackRef.current(event.payload);
+      }
+    };
+    medplum.addEventListener('resourceModified', listener);
+    return () => medplum.removeEventListener('resourceModified', listener);
+  }, [medplum, typesKey]);
+}


### PR DESCRIPTION
Concept: Instead of pushing state updates through patterns like React context managers or [prop-drilling various callbacks through large sub-trees](https://github.com/medplum/medplum/pull/9790), allow components to subscribe to mutations being routed through the same MedplumClient instance they are using.

This has the benefit of allowing a component to be reactive to updates that come from anything else under the same `<MedplumProvider>` root. As one example, if we have a calendar widget showing Appointments and Slots for a practitioner, and they edit one of those resources in a modal, the calendar can get notified of the mutation without explicit wiring. This PR shows the SchedulingDetails component taking advantage of the new hook.

Strategy Note: I considered an implementation of these hooks closer to the HTTP request level, which could be used to power other interfaces like a "FHIR XRay" UI showing what the application is doing behind the scenes. I've decided that the current goal is better achieved by staying more resource-focused, but we can layer in more event types in a similar pattern later. That idea is explored more in https://github.com/medplum/medplum/pull/9822. 

We don't handle some complex query types:
- Batch/Transaction queries: We don't have enough context in the client to know the intention of each component request; earlier versions of this PR tried to parse the HTTP request to infer it, but for now we omit that complexity and require users to emit the relevant notices themselves. (This matches current behavior where someone using `medplum.batchExecute(...)` would have to perform explicit medplum client cache invalidations. This suggests to me that in some future world we will want a more resource-focused batch API that can compose the batch operation from higher level operations we can interpret more readily.
- GraphQL mutations: For similar reasons, GraphQL mutations require manual event dispatch of related events.
- FHIR Operations (example from this PR: scheduling operations like `$book`, `$cancel`): The meaning of these are implementation dependent, and  out client doesn't know enough about what they mean to handle them effectively. They can also be overridden on a per-project basis with custom implementations, so even if the client offers some default behavior for a few common operations we may need to offer hooks to customize them as well.

Follow ups: I plan on extracting the scheduling queries into a reusable hook that can layer in these events for immediate local updates, and webhook subscriptions (when enabled) for getting real-time updates from other clients mutating the same resources. In the interest of keeping this PR more minimal, that is omitted for now. The Provider-app updates are here to demonstrate the usage of the events and hooks.