### PR TITLE
DEMO: FHIR XRay

### DIFF
--- a/examples/medplum-provider/src/components/XRay.tsx
+++ b/examples/medplum-provider/src/components/XRay.tsx
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Badge, Modal, ScrollArea, Table, Text, Title } from '@mantine/core';
+import { useDisclosure, useHotkeys } from '@mantine/hooks';
+import type { MedplumClientEventMap } from '@medplum/core';
+import { useMedplum } from '@medplum/react';
+import type { JSX } from 'react';
+import { useEffect, useState } from 'react';
+
+/**
+ * A single HTTP round trip observed via the client's `requestStarted`/`requestFinished` events.
+ * Starts as pending and is updated in place once the matching `requestFinished` event arrives.
+ */
+interface XRayRequest {
+  requestId: number;
+  method: string;
+  url: string;
+  body?: string;
+  startTime: number;
+  finished: boolean;
+  durationMs?: number;
+  status?: number;
+  error?: Error;
+}
+
+export function XRay(): JSX.Element | null {
+  const medplum = useMedplum();
+  const [requests, setRequests] = useState<XRayRequest[]>([]);
+  const [opened, handlers] = useDisclosure(false);
+
+  useHotkeys([['mod+b', handlers.toggle]]);
+
+  useEffect(() => {
+    const requestStartedListener = (event: MedplumClientEventMap['requestStarted']): void => {
+      setRequests((prev) => [...prev, { ...event.payload, finished: false }]);
+    };
+    const requestFinishedListener = (event: MedplumClientEventMap['requestFinished']): void => {
+      setRequests((prev) =>
+        prev.map((request) =>
+          request.requestId === event.payload.requestId ? { ...request, ...event.payload, finished: true } : request
+        )
+      );
+    };
+    medplum.addEventListener('requestStarted', requestStartedListener);
+    medplum.addEventListener('requestFinished', requestFinishedListener);
+
+    return () => {
+      medplum.removeEventListener('requestStarted', requestStartedListener);
+      medplum.removeEventListener('requestFinished', requestFinishedListener);
+    };
+  }, [medplum]);
+
+  return (
+    <Modal opened={opened} onClose={handlers.close} title={<Title order={3}>FHIR X-Ray</Title>} size="xl">
+      {requests.length === 0 ? (
+        <Text c="dimmed">No requests yet.</Text>
+      ) : (
+        <ScrollArea.Autosize mah="70vh">
+          <Table layout="fixed" verticalSpacing="xs" horizontalSpacing="sm" stickyHeader>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th w={80}>Method</Table.Th>
+                <Table.Th w={90}>Status</Table.Th>
+                <Table.Th>URL</Table.Th>
+                <Table.Th w={90} ta="right">
+                  Duration
+                </Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {requests
+                .slice()
+                .reverse()
+                .map((request) => (
+                  <RequestRow key={request.requestId} request={request} />
+                ))}
+            </Table.Tbody>
+          </Table>
+        </ScrollArea.Autosize>
+      )}
+    </Modal>
+  );
+}
+
+function RequestRow({ request }: { request: XRayRequest }): JSX.Element {
+  return (
+    <Table.Tr>
+      <Table.Td>
+        <Badge variant="light">{request.method}</Badge>
+      </Table.Td>
+      <Table.Td>
+        <StatusBadge request={request} />
+      </Table.Td>
+      <Table.Td>
+        <Text ff="monospace" size="sm" truncate title={request.url}>
+          {request.url}
+        </Text>
+      </Table.Td>
+      <Table.Td ta="right">
+        <Text c="dimmed" size="xs">
+          {request.finished ? `${Math.round(request.durationMs ?? 0)} ms` : '—'}
+        </Text>
+      </Table.Td>
+    </Table.Tr>
+  );
+}
+
+function StatusBadge({ request }: { request: XRayRequest }): JSX.Element {
+  if (!request.finished) {
+    return (
+      <Badge color="blue" variant="light">
+        pending
+      </Badge>
+    );
+  }
+  if (request.error || (request.status !== undefined && request.status >= 400)) {
+    return (
+      <Badge color="red" variant="light">
+        {request.status ?? 'error'}
+      </Badge>
+    );
+  }
+  return (
+    <Badge color="green" variant="light">
+      {request.status ?? 'ok'}
+    </Badge>
+  );
+}

--- a/examples/medplum-provider/src/main.tsx
+++ b/examples/medplum-provider/src/main.tsx
@@ -12,6 +12,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider, createBrowserRouter } from 'react-router';
 import { App } from './App';
+import { XRay } from './components/XRay';
 
 const medplum = new MedplumClient({
   onUnauthenticated: () => (window.location.href = '/'),
@@ -51,6 +52,7 @@ root.render(
       <MantineProvider theme={theme}>
         <Notifications position="bottom-right" />
         <RouterProvider router={router} />
+        <XRay />
       </MantineProvider>
     </MedplumProvider>
   </StrictMode>

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -27,6 +27,8 @@ import type {
   NewPatientRequest,
   NewProjectRequest,
   NewUserRequest,
+  RequestFinishedEvent,
+  RequestStartedEvent,
 } from './client';
 import { DEFAULT_ACCEPT, MedplumClient } from './client';
 import { createFakeJwt, mockFetch, mockFetchResponse, mockFetchWithStatus } from './client-test-utils';
@@ -4761,6 +4763,95 @@ describe('Client', () => {
         duplex: 'half',
       })
     );
+  });
+
+  describe('Client events', () => {
+    test('requestStarted and requestFinished on success', async () => {
+      const fetch = mockFetch(200, { resourceType: 'Patient', id: '123' });
+      const client = new MedplumClient({ fetch });
+      const started: RequestStartedEvent[] = [];
+      const finished: RequestFinishedEvent[] = [];
+      client.addEventListener('requestStarted', (e) => started.push(e.payload));
+      client.addEventListener('requestFinished', (e) => finished.push(e.payload));
+
+      const patient = await client.readResource('Patient', '123');
+
+      expect(started).toHaveLength(1);
+      expect(started[0]).toMatchObject({
+        method: 'GET',
+        url: 'https://api.medplum.com/fhir/R4/Patient/123',
+      });
+      expect(started[0].requestId).toBeGreaterThan(0);
+      expect(started[0].startTime).toBeGreaterThan(0);
+
+      expect(finished).toHaveLength(1);
+      expect(finished[0]).toMatchObject({
+        requestId: started[0].requestId,
+        method: 'GET',
+        url: 'https://api.medplum.com/fhir/R4/Patient/123',
+        status: 200,
+      });
+      expect(finished[0].response).toBe(patient);
+      expect(finished[0].durationMs).toBeGreaterThanOrEqual(0);
+      expect(finished[0].error).toBeUndefined();
+    });
+
+    test('requestStarted includes the request body', async () => {
+      const fetch = mockFetch(200, { resourceType: 'Patient', id: '123' });
+      const client = new MedplumClient({ fetch });
+      const started: RequestStartedEvent[] = [];
+      client.addEventListener('requestStarted', (e) => started.push(e.payload));
+
+      await client.createResource<Patient>({ resourceType: 'Patient' });
+
+      expect(started).toHaveLength(1);
+      expect(started[0]).toMatchObject({
+        method: 'POST',
+        url: 'https://api.medplum.com/fhir/R4/Patient',
+        body: JSON.stringify({ resourceType: 'Patient' }),
+      });
+    });
+
+    test('requestFinished with error on failed request', async () => {
+      const fetch = mockFetch(404, notFound);
+      const client = new MedplumClient({ fetch });
+      const finished: RequestFinishedEvent[] = [];
+      client.addEventListener('requestFinished', (e) => finished.push(e.payload));
+
+      await expect(client.readResource('Patient', 'missing')).rejects.toThrow('Not found');
+
+      expect(finished).toHaveLength(1);
+      expect(finished[0].status).toBe(404);
+      expect(finished[0].error).toBeInstanceOf(OperationOutcomeError);
+      expect(finished[0].response).toBeUndefined();
+    });
+
+    test('Request events after listener removed', async () => {
+      const fetch = mockFetch(200, { resourceType: 'Patient', id: '123' });
+      const client = new MedplumClient({ fetch });
+      const listener = vi.fn();
+      client.addEventListener('requestStarted', listener);
+      client.removeEventListener('requestStarted', listener);
+
+      await client.readResource('Patient', '123');
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    test('Throwing event listener does not affect the request', async () => {
+      const fetch = mockFetch(200, { resourceType: 'Patient', id: '123' });
+      const client = new MedplumClient({ fetch });
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      client.addEventListener('requestStarted', () => {
+        throw new Error('listener error');
+      });
+
+      const patient = await client.createResource<Patient>({ resourceType: 'Patient' });
+
+      expect(patient).toBeDefined();
+      expect(consoleError).toHaveBeenCalled();
+      consoleError.mockRestore();
+    });
   });
 });
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -925,6 +925,57 @@ export interface RequestProfileSchemaOptions extends MedplumRequestOptions {
 }
 
 /**
+ * Payload of the `requestStarted` event, emitted when the client begins an HTTP round trip.
+ *
+ * Emitted after cache and auto-batch handling, immediately before the request is sent.
+ * Cache hits and requests merged into an auto-batch do not emit events of their own;
+ * the auto-batch itself is visible as a single batch `POST`.
+ */
+export interface RequestStartedEvent {
+  /**
+   * Monotonically increasing id, unique within this client instance.
+   * Correlates `requestStarted` and `requestFinished` events.
+   */
+  requestId: number;
+  /** The HTTP method. */
+  method: string;
+  /** The absolute request URL. */
+  url: string;
+  /** The request body as sent, if any. May contain PHI. */
+  body?: string;
+  /** Start time in milliseconds since the Unix epoch. */
+  startTime: number;
+}
+
+/**
+ * Payload of the `requestFinished` event, emitted when an HTTP round trip settles.
+ *
+ * A round trip that triggers follow-up round trips (token refresh and retry, redirect
+ * following, or polling on HTTP 202 "Accepted") emits nested `requestStarted`/`requestFinished`
+ * pairs for each follow-up round trip; the outer event's `response`/`error` reflect the final
+ * settled result of the chain.
+ */
+export interface RequestFinishedEvent extends RequestStartedEvent {
+  /** Elapsed time in milliseconds. */
+  durationMs: number;
+  /**
+   * The HTTP status code of this round trip, when a response was received.
+   * Undefined on network failure or abort.
+   */
+  status?: number;
+  /**
+   * The parsed response body when the request succeeded.
+   * This is the same object returned to the caller — treat it as read-only. May contain PHI.
+   */
+  response?: unknown;
+  /**
+   * The error when the request failed: an `OperationOutcomeError` for HTTP 4xx/5xx responses,
+   * or the underlying network/abort error.
+   */
+  error?: Error;
+}
+
+/**
  * This map enumerates all the lifecycle events that `MedplumClient` emits and what the shape of the `Event` is.
  */
 export type MedplumClientEventMap = {
@@ -934,6 +985,8 @@ export type MedplumClientEventMap = {
   profileRefreshed: { type: 'profileRefreshed' };
   storageInitialized: { type: 'storageInitialized' };
   storageInitFailed: { type: 'storageInitFailed'; payload: { error: Error } };
+  requestStarted: { type: 'requestStarted'; payload: RequestStartedEvent };
+  requestFinished: { type: 'requestFinished'; payload: RequestFinishedEvent };
 };
 
 /**
@@ -1027,6 +1080,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   private profilePromise?: Promise<any>;
   private sessionDetails?: SessionDetails;
   private currentRateLimits?: string;
+  private requestIdCounter = 0;
   private basicAuth?: string;
   private initPromise: Promise<void>;
   private initComplete = true;
@@ -3614,14 +3668,80 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   }
 
   /**
-   * Makes an HTTP request.
+   * Dispatches an event, isolating listener exceptions from the caller.
+   * Used for events emitted during request processing, where a throwing
+   * listener must not corrupt the in-flight operation.
+   * @param event - The event to dispatch.
+   */
+  private safeDispatchEvent(event: MedplumClientEventMap[keyof MedplumClientEventMap]): void {
+    try {
+      this.dispatchEvent(event);
+    } catch (err) {
+      console.error('MedplumClient event listener error', err);
+    }
+  }
+
+  /**
+   * Makes an HTTP request, emitting `requestStarted`/`requestFinished` events when listeners
+   * are registered. One event pair is emitted per HTTP round trip: retried 5xx responses
+   * settle within a single pair, while token refresh, redirect following, and 202 polling
+   * re-enter this method and emit nested pairs.
    * @param url - The target URL.
    * @param options - Optional fetch request init options.
    * @param state - Optional request state.
    * @returns The JSON content body if available.
    */
   private async request<T>(url: string, options: MedplumRequestOptions = {}, state: RequestState = {}): Promise<T> {
+    if (this.listenerCount('requestStarted') === 0 && this.listenerCount('requestFinished') === 0) {
+      return this.requestImpl(url, options, state);
+    }
+
+    const payload: RequestStartedEvent = {
+      requestId: ++this.requestIdCounter,
+      method: options.method ?? 'GET',
+      url: url.startsWith('http') ? url : concatUrls(this.baseUrl, url),
+      body: typeof options.body === 'string' ? options.body : undefined,
+      startTime: Date.now(),
+    };
+    this.safeDispatchEvent({ type: 'requestStarted', payload });
+
+    const roundTrip: { status?: number } = {};
+    try {
+      const result = await this.requestImpl<T>(url, options, state, roundTrip);
+      this.safeDispatchEvent({
+        type: 'requestFinished',
+        payload: {
+          ...payload,
+          durationMs: Date.now() - payload.startTime,
+          status: roundTrip.status,
+          response: result,
+        },
+      });
+      return result;
+    } catch (err) {
+      this.safeDispatchEvent({
+        type: 'requestFinished',
+        payload: {
+          ...payload,
+          durationMs: Date.now() - payload.startTime,
+          status: roundTrip.status,
+          error: err as Error,
+        },
+      });
+      throw err;
+    }
+  }
+
+  private async requestImpl<T>(
+    url: string,
+    options: MedplumRequestOptions,
+    state: RequestState,
+    roundTrip?: { status?: number }
+  ): Promise<T> {
     const response = await this.wrappedFetch(url, options);
+    if (roundTrip) {
+      roundTrip.status = response.status;
+    }
 
     if (response.status === 401) {
       // Refresh and try again


### PR DESCRIPTION
This is an exploration of what it might look like to add some developer-facing UX for inspecting FHIR requests made in an application.

- We add two new events to the `MedplumClient` implementation that allow consumers to hook in to see requests initiated and completed. 
- We add a provider component that subscribes to those events and allows opening a debug modal showing the requests. (Use cmd+b / ctrl+b to toggle the modal).

Not done yet:
- Only enable this in development environment, not prod
- Limit size of request history (so we don't eventually consume all
  your memory if you leave a tab open)
- Improve diagnostic display; this prototype is intentionally bare-bones
- better display of batch queries - one request/response but many internal elements that should be shown
- What to do about queries resolved from cache? Should those be visible here even though they didn't end up doing a round-trip?

<img width="1973" height="1102" alt="Screenshot 2026-07-10 at 3 25 46 PM" src="https://github.com/user-attachments/assets/c3171a6b-b908-4662-8827-e5a283addf69" />
