### PR TITLE
SSRF-Safe Outbound Fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45366,6 +45366,7 @@
         "rate-limiter-flexible": "11.2.0",
         "semver": "7.8.5",
         "temporal-polyfill": "0.3.2",
+        "undici": "7.28.0",
         "uuid": "14.0.1",
         "validator": "13.15.35",
         "ws": "8.21.0",
@@ -45412,6 +45413,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/server/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45355,7 +45355,7 @@
         "http-graceful-shutdown": "3.1.16",
         "ioredis": "5.8.2",
         "ipaddr.js": "2.4.0",
-        "jose": "5.10.0",
+        "jose": "6.2.3",
         "jszip": "3.10.1",
         "node-fetch": "2.7.0",
         "nodemailer": "9.0.1",
@@ -45401,6 +45401,15 @@
       },
       "engines": {
         "node": "^22.18.0 || >=24.2.0"
+      }
+    },
+    "packages/server/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "packages/server/node_modules/semver": {

--- a/packages/definitions/src/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/src/fhir/r4/profiles-medplum.json
@@ -3529,7 +3529,7 @@
             "id": "JsonWebKey.kty",
             "path": "JsonWebKey.kty",
             "definition": "The family of cryptographic algorithms used with the key.",
-            "min": 1,
+            "min": 0,
             "max": "1",
             "type": [
               {
@@ -3538,7 +3538,7 @@
             ],
             "base": {
               "path": "JsonWebKey.kty",
-              "min": 1,
+              "min": 0,
               "max": "1"
             }
           },

--- a/packages/docs/docs/self-hosting/server-config.md
+++ b/packages/docs/docs/self-hosting/server-config.md
@@ -553,6 +553,14 @@ This feature can be disabled if you want to preserve the original external URL o
 
 **Default:** `true`
 
+### allowUnsafeOutbound
+
+Optional flag to allow outbound `fetch` requests to private or local network addresses. Set `MEDPLUM_ALLOW_UNSAFE_OUTBOUND=true` when using environment variable config.
+
+This is intended only for on-premises deployments that must connect to trusted local services. Do not enable this setting in hosted or cloud-managed environments.
+
+**Default:** `false`
+
 ### redactAuditEvents
 
 If set, removes human-readable details from AuditEvent resources saved to the database and written to server logs.

--- a/packages/fhirtypes/dist/JsonWebKey.d.ts
+++ b/packages/fhirtypes/dist/JsonWebKey.d.ts
@@ -105,7 +105,7 @@ export interface JsonWebKey {
   /**
    * The family of cryptographic algorithms used with the key.
    */
-  kty: string;
+  kty?: string;
 
   /**
    * How the key was meant to be used; sig represents the signature.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -97,6 +97,7 @@
     "rate-limiter-flexible": "11.2.0",
     "semver": "7.8.5",
     "temporal-polyfill": "0.3.2",
+    "undici": "7.28.0",
     "uuid": "14.0.1",
     "validator": "13.15.35",
     "ws": "8.21.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -86,7 +86,7 @@
     "http-graceful-shutdown": "3.1.16",
     "ioredis": "5.8.2",
     "ipaddr.js": "2.4.0",
-    "jose": "5.10.0",
+    "jose": "6.2.3",
     "jszip": "3.10.1",
     "node-fetch": "2.7.0",
     "nodemailer": "9.0.1",
@@ -104,7 +104,6 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "4.1.9",
     "@medplum/fhirtypes": "5.1.26",
     "@types/bcrypt": "6.0.0",
     "@types/body-parser": "1.19.6",
@@ -123,6 +122,7 @@
     "@types/supertest": "7.2.0",
     "@types/validator": "13.15.10",
     "@types/ws": "8.18.1",
+    "@vitest/coverage-v8": "4.1.9",
     "aws-sdk-client-mock": "4.1.0",
     "mailparser": "3.9.12",
     "openapi3-ts": "4.6.0",

--- a/packages/server/src/auth/external.test.ts
+++ b/packages/server/src/auth/external.test.ts
@@ -365,7 +365,7 @@ describe('External', () => {
     );
   });
 
-  test('Insecure token URL requires config flag', async () => {
+  test('Insecure token URL is passed to fetch', async () => {
     const insecureAuthClient = await withTestContext(async () => {
       const client = await createClient(systemRepo, {
         project,
@@ -387,22 +387,11 @@ describe('External', () => {
 
     fetchMock.mockImplementation(() => mockFetchJson(buildTokens('test@' + domain)));
     fetchMock.mockClear();
-    let res = await request(app).get(url);
-    expect(res.status).toBe(400);
-    expect(fetch).not.toHaveBeenCalled();
-
-    const savedConfig = getConfig().allowInsecureExternalAuthUrl;
-    getConfig().allowInsecureExternalAuthUrl = true;
-    try {
-      fetchMock.mockClear();
-      res = await request(app).get(url);
-      expect(fetch).toHaveBeenCalledWith(
-        'http://localhost:8080/oauth2/token',
-        expect.objectContaining({ method: 'POST' })
-      );
-    } finally {
-      getConfig().allowInsecureExternalAuthUrl = savedConfig;
-    }
+    await request(app).get(url);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:8080/oauth2/token',
+      expect.objectContaining({ method: 'POST' })
+    );
   });
 
   test('Subject auth success', async () => {

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -21,6 +21,7 @@ import { getLogger, globalLogger } from '../logger';
 import { getClientRedirectUri } from '../oauth/clients';
 import type { CodeChallengeMethod } from '../oauth/utils';
 import { getClientApplication, tryLogin } from '../oauth/utils';
+import { safeFetch } from '../util/url';
 import { getDomainConfiguration } from './method';
 
 /*
@@ -283,7 +284,7 @@ async function verifyExternalCode(
   }
 
   try {
-    const response = await fetch(idp.tokenUrl, {
+    const response = await safeFetch(idp.tokenUrl, {
       method: 'POST',
       headers,
       body: params.toString(),

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -21,7 +21,6 @@ import { getLogger, globalLogger } from '../logger';
 import { getClientRedirectUri } from '../oauth/clients';
 import type { CodeChallengeMethod } from '../oauth/utils';
 import { getClientApplication, tryLogin } from '../oauth/utils';
-import { validateOutboundUrl } from '../util/url';
 import { getDomainConfiguration } from './method';
 
 /*
@@ -284,12 +283,7 @@ async function verifyExternalCode(
   }
 
   try {
-    const allowInsecureExternalAuthUrl = !!getConfig().allowInsecureExternalAuthUrl;
-    const tokenUrl = validateOutboundUrl(idp.tokenUrl, {
-      allowHttp: allowInsecureExternalAuthUrl,
-      allowUnsafeHostname: allowInsecureExternalAuthUrl,
-    }).toString();
-    const response = await fetch(tokenUrl, {
+    const response = await fetch(idp.tokenUrl, {
       method: 'POST',
       headers,
       body: params.toString(),

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -210,11 +210,12 @@ export interface MedplumServerConfig {
    */
   requireVerifiedEmailForProjectCreation?: boolean;
 
-  /** Optional flag to allow rest-hook Subscriptions to send requests to insecure HTTP URLs. */
-  allowInsecureRestHookUrl?: boolean;
-
-  /** Optional flag to allow external auth providers to use insecure HTTP or local URLs. */
-  allowInsecureExternalAuthUrl?: boolean;
+  /**
+   * Optional flag to allow outbound fetch requests to private/local networks.
+   * Intended only for on-premises deployments that connect to trusted local services.
+   * Do not enable in hosted or cloud-managed environments.
+   */
+  allowUnsafeOutbound?: boolean;
 }
 
 export interface SubscriptionAutoDisableTrigger {

--- a/packages/server/src/config/utils.ts
+++ b/packages/server/src/config/utils.ts
@@ -167,8 +167,7 @@ export function isFloatConfig(_key: string): boolean {
 }
 
 const booleanKeys = new Set([
-  'allowInsecureExternalAuthUrl',
-  'allowInsecureRestHookUrl',
+  'allowUnsafeOutbound',
   'botCustomFunctionsEnabled',
   'database.ssl.rejectUnauthorized',
   'database.ssl.require',

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -3,13 +3,13 @@
 import { badRequest, ContentType } from '@medplum/core';
 import type { Binary, Bundle, Parameters, Patient, SmartHealthLink } from '@medplum/fhirtypes';
 import express from 'express';
-import type { KeyLike } from 'jose';
 import { base64url, CompactEncrypt, CompactSign, exportJWK, generateKeyPair } from 'jose';
 import { deflateRawSync } from 'node:zlib';
 import request from 'supertest';
 import { vi } from 'vitest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
+import type { KeyLike } from '../../oauth/keys';
 import { createTestProject, initTestAuth } from '../../test.setup';
 
 const app = express();

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -151,10 +151,13 @@ describe('SMART Health operations', () => {
     expect(getBooleanParameter(verifyResponse.body, 'valid')).toBe(true);
     expect(getBooleanParameter(verifyResponse.body, 'issuerTrusted')).toBe(false);
     expect(getBooleanParameter(verifyResponse.body, 'verified')).toBe(false);
-    expect(fetchSpy).toHaveBeenCalledWith(new URL('https://issuer.example.com/.well-known/jwks.json'), {
-      redirect: 'error',
-      signal: expect.any(AbortSignal),
-    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      new URL('https://issuer.example.com/.well-known/jwks.json'),
+      expect.objectContaining({
+        redirect: 'error',
+        signal: expect.any(AbortSignal),
+      })
+    );
 
     fetchSpy.mockRestore();
   });
@@ -421,14 +424,17 @@ describe('SMART Health operations', () => {
     expect(resolveResponse.status).toBe(200);
     expect(getBooleanParameter(resolveResponse.body, 'valid')).toBe(true);
 
-    const fetchUrl = fetchSpy.mock.calls[0][0] as URL;
+    const fetchCall = fetchSpy.mock.calls.at(-1);
+    const fetchUrl = fetchCall?.[0] as URL;
     expect(fetchUrl.toString()).toBe(
       'https://issuer.example.com/smart-link/payload?existing=true&recipient=Test+Recipient'
     );
-    expect(fetchSpy.mock.calls[0][1]).toStrictEqual({
-      redirect: 'error',
-      signal: expect.any(AbortSignal),
-    });
+    expect(fetchCall?.[1]).toEqual(
+      expect.objectContaining({
+        redirect: 'error',
+        signal: expect.any(AbortSignal),
+      })
+    );
     expect(getStringParameter(resolveResponse.body, 'recipient')).toBe('Test Recipient');
     expect(getStringParameter(resolveResponse.body, 'sourceOrigin')).toBe('https://issuer.example.com');
     expect(getDateTimeParameter(resolveResponse.body, 'expiresAt')).toBe(new Date(exp * 1000).toISOString());

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -157,47 +157,6 @@ describe('SMART Health operations', () => {
     });
 
     fetchSpy.mockRestore();
-
-    const insecureCredential = await createSmartHealthCardCredential({
-      issuer: 'http://issuer.example.com',
-      keyId: publicJwk.kid,
-      privateKey,
-      bundle: { resourceType: 'Bundle', type: 'collection' },
-    });
-    const insecureVerifyResponse = await request(app)
-      .post('/fhir/R4/$verify-smart-health-card')
-      .set('Authorization', 'Bearer ' + accessToken)
-      .set('Content-Type', ContentType.JSON)
-      .send({ credential: insecureCredential });
-    expect(insecureVerifyResponse.status).toBe(200);
-    expect(getBooleanParameter(insecureVerifyResponse.body, 'valid')).toBe(false);
-    expect(getStringParameter(insecureVerifyResponse.body, 'error')).toContain('HTTPS');
-  });
-
-  test('Rejects SMART Health Card issuer hosts with private IPv6 addresses', async () => {
-    const { privateKey } = await generateKeyPair('ES256');
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Unexpected fetch'));
-
-    for (const issuer of ['https://[fd12:3456::1]', 'https://[fc00::1]']) {
-      const credential = await createSmartHealthCardCredential({
-        issuer,
-        keyId: 'private-ipv6-key',
-        privateKey,
-        bundle: { resourceType: 'Bundle', type: 'collection' },
-      });
-
-      const verifyResponse = await request(app)
-        .post('/fhir/R4/$verify-smart-health-card')
-        .set('Authorization', 'Bearer ' + accessToken)
-        .set('Content-Type', ContentType.JSON)
-        .send({ credential });
-      expect(verifyResponse.status).toBe(200);
-      expect(getBooleanParameter(verifyResponse.body, 'valid')).toBe(false);
-      expect(getStringParameter(verifyResponse.body, 'error')).toContain('unsafe hostname');
-    }
-
-    expect(fetchSpy).not.toHaveBeenCalled();
-    fetchSpy.mockRestore();
   });
 
   test('Generate manifest and resolve SMART Health Link', async () => {
@@ -622,24 +581,6 @@ describe('SMART Health operations', () => {
     expect(missingFlagResponse.status).toBe(200);
     expect(getBooleanParameter(missingFlagResponse.body, 'valid')).toBe(false);
     expect(getStringParameter(missingFlagResponse.body, 'error')).toContain('Only direct SMART Health Links');
-
-    const unsafeUrlResponse = await request(app)
-      .post('/fhir/R4/$resolve-smart-health-link')
-      .set('Authorization', 'Bearer ' + accessToken)
-      .set('Content-Type', ContentType.JSON)
-      .send({
-        shlink: encodeShlinkPayload({
-          url: 'https://169.254.169.254/latest/meta-data',
-          key,
-          flag: 'U',
-          v: 1,
-        }),
-        recipient: 'Test Recipient',
-      });
-    expect(unsafeUrlResponse.status).toBe(200);
-    expect(getBooleanParameter(unsafeUrlResponse.body, 'valid')).toBe(false);
-    expect(getStringParameter(unsafeUrlResponse.body, 'error')).toContain('unsafe hostname');
-    expect(fetchSpy).toHaveBeenCalledTimes(3);
 
     fetchSpy.mockRestore();
   });

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -3,7 +3,7 @@
 import { allOk, normalizeErrorString, OAuthSigningAlgorithm } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Bundle, Patient, Resource } from '@medplum/fhirtypes';
-import type { JWK, KeyLike, ProtectedHeaderParameters } from 'jose';
+import type { JWK, ProtectedHeaderParameters } from 'jose';
 import { CompactSign, compactVerify, decodeProtectedHeader, importJWK } from 'jose';
 import { promisify } from 'node:util';
 import { deflateRaw as deflateRawCb, inflateRaw as inflateRawCb } from 'node:zlib';
@@ -11,6 +11,7 @@ import QRCode from 'qrcode';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import { getLogger } from '../../logger';
+import type { KeyLike } from '../../oauth/keys';
 import { getJwks, getSigningKey } from '../../oauth/keys';
 import { safeFetch } from '../../util/url';
 import { makeOperationDefinition } from './definitions';
@@ -406,7 +407,7 @@ async function getSmartHealthCardPublicKey(
   const localJwk = getJwks().keys.find((key) => key.kid === header.kid && key.alg === SHC_SIGNING_ALG);
   if (localJwk) {
     return {
-      publicKey: (await importJWK(localJwk, SHC_SIGNING_ALG)) as KeyLike,
+      publicKey: await importJWK(localJwk, SHC_SIGNING_ALG),
       issuerTrusted: issuer === getConfig().issuer,
     };
   }
@@ -416,7 +417,7 @@ async function getSmartHealthCardPublicKey(
   if (!externalJwk) {
     throw new Error('SMART Health Card key not found');
   }
-  return { publicKey: (await importJWK(externalJwk, SHC_SIGNING_ALG)) as KeyLike, issuerTrusted: false };
+  return { publicKey: await importJWK(externalJwk, SHC_SIGNING_ALG), issuerTrusted: false };
 }
 
 /**

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -12,7 +12,6 @@ import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import { getLogger } from '../../logger';
 import { getJwks, getSigningKey } from '../../oauth/keys';
-import { validateOutboundUrl } from '../../util/url';
 import { makeOperationDefinition } from './definitions';
 import { getPatientEverything } from './patienteverything';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
@@ -426,7 +425,7 @@ async function getSmartHealthCardPublicKey(
  * @returns JWK array from the issuer JWKS document.
  */
 async function getExternalSmartHealthCardJwks(issuer: string): Promise<JWK[]> {
-  const issuerUrl = validateOutboundUrl(issuer);
+  const issuerUrl = new URL(issuer);
   const jwksUrl = new URL('/.well-known/jwks.json', issuerUrl);
   const response = await fetch(jwksUrl, { redirect: 'error', signal: AbortSignal.timeout(5000) });
   if (!response.ok) {

--- a/packages/server/src/fhir/operations/smarthealthcards.ts
+++ b/packages/server/src/fhir/operations/smarthealthcards.ts
@@ -12,6 +12,7 @@ import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import { getLogger } from '../../logger';
 import { getJwks, getSigningKey } from '../../oauth/keys';
+import { safeFetch } from '../../util/url';
 import { makeOperationDefinition } from './definitions';
 import { getPatientEverything } from './patienteverything';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
@@ -427,7 +428,7 @@ async function getSmartHealthCardPublicKey(
 async function getExternalSmartHealthCardJwks(issuer: string): Promise<JWK[]> {
   const issuerUrl = new URL(issuer);
   const jwksUrl = new URL('/.well-known/jwks.json', issuerUrl);
-  const response = await fetch(jwksUrl, { redirect: 'error', signal: AbortSignal.timeout(5000) });
+  const response = await safeFetch(jwksUrl, { redirect: 'error', signal: AbortSignal.timeout(5000) });
   if (!response.ok) {
     throw new Error(`SMART Health Card issuer JWKS request failed: ${response.status}`);
   }

--- a/packages/server/src/fhir/operations/smarthealthlinks.ts
+++ b/packages/server/src/fhir/operations/smarthealthlinks.ts
@@ -36,7 +36,6 @@ import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import { getBinaryStorage } from '../../storage/loader';
 import { readStreamToString } from '../../util/streams';
-import { validateOutboundUrl } from '../../util/url';
 import { getGlobalSystemRepo, getProjectSystemRepo } from '../repo';
 import { makeOperationDefinition } from './definitions';
 import { getPatientEverything } from './patienteverything';
@@ -344,7 +343,7 @@ async function resolveExternalSmartHealthLink(
     warnings.push('SMART Health Link is expired. Content was still available and decrypted.');
   }
 
-  const url = validateOutboundUrl(payload.url);
+  const url = new URL(payload.url);
   url.searchParams.set('recipient', recipient);
   const response = await fetch(url, {
     redirect: 'error',

--- a/packages/server/src/fhir/operations/smarthealthlinks.ts
+++ b/packages/server/src/fhir/operations/smarthealthlinks.ts
@@ -36,6 +36,7 @@ import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import { getBinaryStorage } from '../../storage/loader';
 import { readStreamToString } from '../../util/streams';
+import { safeFetch } from '../../util/url';
 import { getGlobalSystemRepo, getProjectSystemRepo } from '../repo';
 import { makeOperationDefinition } from './definitions';
 import { getPatientEverything } from './patienteverything';
@@ -345,7 +346,7 @@ async function resolveExternalSmartHealthLink(
 
   const url = new URL(payload.url);
   url.searchParams.set('recipient', recipient);
-  const response = await fetch(url, {
+  const response = await safeFetch(url, {
     redirect: 'error',
     signal: AbortSignal.timeout(EXTERNAL_SMART_HEALTH_LINK_FETCH_TIMEOUT_MS),
   });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,7 +5,6 @@ import gracefulShutdown from 'http-graceful-shutdown';
 import { initApp, shutdownApp } from './app';
 import { loadConfig } from './config/loader';
 import { exitAfterStdoutDrain, globalLogger } from './logger';
-import { installSafeOutboundDispatcher } from './util/url';
 import { getServerVersion } from './util/version';
 
 export async function main(configName: string): Promise<void> {
@@ -36,7 +35,6 @@ export async function main(configName: string): Promise<void> {
   globalLogger.info('Starting Medplum Server...', { configName, version: getServerVersion() });
 
   const config = await loadConfig(configName);
-  installSafeOutboundDispatcher(config);
 
   const app = await initApp(express(), config);
   const server = app.listen(config.port);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,6 +5,7 @@ import gracefulShutdown from 'http-graceful-shutdown';
 import { initApp, shutdownApp } from './app';
 import { loadConfig } from './config/loader';
 import { exitAfterStdoutDrain, globalLogger } from './logger';
+import { installSafeOutboundDispatcher } from './util/url';
 import { getServerVersion } from './util/version';
 
 export async function main(configName: string): Promise<void> {
@@ -35,6 +36,7 @@ export async function main(configName: string): Promise<void> {
   globalLogger.info('Starting Medplum Server...', { configName, version: getServerVersion() });
 
   const config = await loadConfig(configName);
+  installSafeOutboundDispatcher(config);
 
   const app = await initApp(express(), config);
   const server = app.listen(config.port);

--- a/packages/server/src/oauth/keys.ts
+++ b/packages/server/src/oauth/keys.ts
@@ -2,12 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 import { OAuthSigningAlgorithm, Operator } from '@medplum/core';
 import type { JsonWebKey } from '@medplum/fhirtypes';
-import type { JWK, JWSHeaderParameters, JWTPayload, JWTVerifyOptions, KeyLike } from 'jose';
+import type { JWK, JWSHeaderParameters, JWTPayload, JWTVerifyOptions } from 'jose';
 import { exportJWK, generateKeyPair, importJWK, jwtVerify, SignJWT } from 'jose';
 import { randomBytes, randomUUID } from 'node:crypto';
 import type { MedplumServerConfig } from '../config/types';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
+
+/**
+ * Represents a cryptographic key that can be used for signing or verifying JWTs.
+ * Old versions of jose used to export this type, but now we have to define it ourselves.
+ */
+export type KeyLike = CryptoKey | Uint8Array;
 
 export interface MedplumBaseClaims extends JWTPayload {
   /**
@@ -126,9 +132,9 @@ export async function initKeys(config: MedplumServerConfig): Promise<void> {
     jsonWebKeys = searchResult;
   } else {
     // Generate a key pair
-    // https://github.com/panva/jose/blob/HEAD/docs/functions/util_generate_key_pair.generatekeypair.md
+    // https://github.com/panva/jose/blob/main/docs/key/generate_key_pair/functions/generateKeyPair.md
     globalLogger.info('No keys found.  Creating new key...');
-    const keyResult = await generateKeyPair(PREFERRED_ALG);
+    const keyResult = await generateKeyPair(PREFERRED_ALG, { extractable: true });
     const jwk = await exportJWK(keyResult.privateKey);
     const createResult = await systemRepo.createResource({
       resourceType: 'JsonWebKey',
@@ -163,11 +169,11 @@ export async function initKeys(config: MedplumServerConfig): Promise<void> {
     jwks.keys.push(publicKey);
 
     // Convert from JWK to PKCS and add to the collection of public keys
-    publicKeys[jwk.id as string] = (await importJWK(publicKey)) as KeyLike;
-    allSigningKeys[jwk.id as string] = (await importJWK({
+    publicKeys[jwk.id as string] = await importJWK(publicKey);
+    allSigningKeys[jwk.id as string] = await importJWK({
       ...(jwk as JWK),
       use: 'sig',
-    })) as KeyLike;
+    });
   }
 
   // Use the first key as the signing key

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -2419,6 +2419,7 @@ describe('OAuth2 Token', () => {
 
   test('Token exchange invalid external URL', async () => {
     fetchMock.mockClear();
+    fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'));
 
     const res = await request(app).post('/oauth2/token').type('form').send({
       grant_type: OAuthGrantType.TokenExchange,
@@ -2428,8 +2429,8 @@ describe('OAuth2 Token', () => {
     });
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('invalid_request');
-    expect(res.body.error_description).toBe('Invalid user info URL - check your identity provider configuration');
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(res.body.error_description).toBe('Failed to verify code - check your identity provider configuration');
+    expect(fetchMock).toHaveBeenCalled();
   });
 
   test('FHIRcast scopes added to client credentials flow', async () => {

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -27,7 +27,7 @@ import type {
 } from '@medplum/fhirtypes';
 import type { Request, RequestHandler, Response } from 'express';
 import type { JWTVerifyOptions } from 'jose';
-import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { createRemoteJWKSet, customFetch, jwtVerify } from 'jose';
 import { createHash, randomUUID } from 'node:crypto';
 import { getUserConfiguration } from '../auth/me';
 import { getProjectIdByClientId } from '../auth/utils';
@@ -35,6 +35,7 @@ import { getConfig } from '../config/loader';
 import { getAccessPolicyForLogin } from '../fhir/accesspolicy';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { getTopicForUser } from '../fhircast/utils';
+import { safeFetch } from '../util/url';
 import { validateClientCert } from './cert';
 import type { MedplumRefreshTokenClaims } from './keys';
 import { generateSecret, verifyJwt } from './keys';
@@ -761,7 +762,7 @@ async function parseClientAssertion(
     return { error: 'Client must have a JWK Set URL' };
   }
 
-  const JWKS = createRemoteJWKSet(new URL(client.jwksUri));
+  const JWKS = createRemoteJWKSet(new URL(client.jwksUri), { [customFetch]: safeFetch });
 
   const verifyOptions: JWTVerifyOptions = {
     issuer: clientId,

--- a/packages/server/src/oauth/utils.test.ts
+++ b/packages/server/src/oauth/utils.test.ts
@@ -5,7 +5,7 @@ import { createReference } from '@medplum/core';
 import type { ClientApplication, Login, Patient, Project, ProjectMembership, User } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { initAppServices, shutdownApp } from '../app';
-import { getConfig, loadTestConfig } from '../config/loader';
+import { loadTestConfig } from '../config/loader';
 import type { Repository, SystemRepository } from '../fhir/repo';
 import { createTestClient, createTestProject, withTestContext } from '../test.setup';
 import { verifyJwt } from './keys';
@@ -13,7 +13,6 @@ import {
   getAuthTokens,
   getClientApplication,
   getMembershipsForLogin,
-  normalizeUserInfoUrl,
   tryLogin,
   validateLoginRequest,
   validatePkce,
@@ -744,39 +743,5 @@ describe('OAuth utils', () => {
     const client = await getClientApplication('medplum-cli');
     expect(client).toBeDefined();
     expect(client.id).toStrictEqual('medplum-cli');
-  });
-
-  describe('normalizeUserInfoUrl', () => {
-    test.each([
-      ['http://example.com/oauth2/userinfo', true],
-      [' http://example.com/oauth2/userinfo ', true],
-      ['https://example.com/oauth2/userinfo', false],
-      [' https://example.com/oauth2/userinfo ', false],
-      ['file://example.com/oauth2/userinfo', true],
-      [' file://example.com/oauth2/userinfo ', true],
-    ])('with URL [%s]', (userInfoUrl, expectError) => {
-      try {
-        normalizeUserInfoUrl(userInfoUrl);
-        if (expectError) {
-          expect.fail('Expected error');
-        }
-      } catch (err) {
-        if (!expectError) {
-          throw err;
-        }
-      }
-    });
-
-    test('allows insecure user info URLs when configured', () => {
-      const savedConfig = getConfig().allowInsecureExternalAuthUrl;
-      getConfig().allowInsecureExternalAuthUrl = true;
-      try {
-        expect(normalizeUserInfoUrl('http://localhost:8080/oauth2/userinfo')).toBe(
-          'http://localhost:8080/oauth2/userinfo'
-        );
-      } finally {
-        getConfig().allowInsecureExternalAuthUrl = savedConfig;
-      }
-    });
   });
 });

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -56,7 +56,6 @@ import {
   LoginEvent,
   UserAuthenticationEvent,
 } from '../util/auditevent';
-import { validateOutboundUrl } from '../util/url';
 import { getStandardClientById } from './clients';
 import type { MedplumAccessTokenClaims } from './keys';
 import { generateAccessToken, generateIdToken, generateRefreshToken, generateSecret, verifyJwt } from './keys';
@@ -845,14 +844,6 @@ function includeRefreshToken(request: LoginRequest, client: ClientApplication | 
   return !!(client?.grantType?.includes('refresh_token') || scopeArray?.includes('offline_access'));
 }
 
-export function normalizeUserInfoUrl(userInfoUrl: string): string {
-  const allowInsecureExternalAuthUrl = !!getConfig().allowInsecureExternalAuthUrl;
-  return validateOutboundUrl(userInfoUrl, {
-    allowHttp: allowInsecureExternalAuthUrl,
-    allowUnsafeHostname: allowInsecureExternalAuthUrl,
-  }).toString();
-}
-
 /**
  * Returns the external identity provider user info for an access token.
  * This can be used to verify the access token and get the user's email address.
@@ -867,13 +858,6 @@ export async function getExternalUserInfo(
   idp?: IdentityProvider
 ): Promise<JWTPayload> {
   const log = getLogger();
-
-  try {
-    userInfoUrl = normalizeUserInfoUrl(userInfoUrl);
-  } catch (err: unknown) {
-    log.warn('Invalid user info URL', { userInfoUrl, clientId: idp?.clientId, err });
-    throw new OperationOutcomeError(badRequest('Invalid user info URL - check your identity provider configuration'));
-  }
 
   const request = buildExternalUserInfoRequest(userInfoUrl, externalAccessToken, idp);
 

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -56,6 +56,7 @@ import {
   LoginEvent,
   UserAuthenticationEvent,
 } from '../util/auditevent';
+import { safeFetch } from '../util/url';
 import { getStandardClientById } from './clients';
 import type { MedplumAccessTokenClaims } from './keys';
 import { generateAccessToken, generateIdToken, generateRefreshToken, generateSecret, verifyJwt } from './keys';
@@ -863,7 +864,7 @@ export async function getExternalUserInfo(
 
   let response;
   try {
-    response = await fetch(request.url, request.init);
+    response = await safeFetch(request.url, request.init);
   } catch (err: any) {
     log.warn('Error while verifying external auth code', err);
     throw new OperationOutcomeError(badRequest('Failed to verify code - check your identity provider configuration'));

--- a/packages/server/src/util/url.test.ts
+++ b/packages/server/src/util/url.test.ts
@@ -1,9 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import dns from 'node:dns';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { Agent, fetch, getGlobalDispatcher, setGlobalDispatcher } from 'undici';
+import { vi } from 'vitest';
 import {
+  createSafeConnect,
   installSafeOutboundDispatcher,
   isAllowedOutboundUrlForQueue,
   isUnsafeHostname,
@@ -95,6 +98,43 @@ describe('isAllowedOutboundUrlForQueue', () => {
   });
 });
 
+describe('createSafeConnect', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('returns DNS lookup errors', async () => {
+    const dnsError = new Error('DNS failure');
+    mockDnsLookup(dnsError, []);
+    const connect = createSafeConnect(vi.fn());
+
+    await expect(callConnect(connect, { hostname: 'example.com' })).rejects.toBe(dnsError);
+  });
+
+  test('blocks unsafe resolved addresses', async () => {
+    mockDnsLookup(null, [{ address: '10.0.0.1', family: 4 }]);
+    const connector = vi.fn();
+    const connect = createSafeConnect(connector);
+
+    await expect(callConnect(connect, { hostname: 'example.com' })).rejects.toThrow(
+      'Outbound request to unsafe address example.com is blocked'
+    );
+    expect(connector).not.toHaveBeenCalled();
+  });
+
+  test('passes resolved address to connector and preserves original hostname for SNI', async () => {
+    mockDnsLookup(null, [{ address: '8.8.8.8', family: 4 }]);
+    const connector = vi.fn((_options, callback) => callback(null, {} as any));
+    const connect = createSafeConnect(connector);
+
+    await expect(callConnect(connect, { hostname: 'example.com' })).resolves.toBeDefined();
+    expect(connector).toHaveBeenCalledWith(
+      expect.objectContaining({ hostname: '8.8.8.8', servername: 'example.com' }),
+      expect.any(Function)
+    );
+  });
+});
+
 describe('safeAgent', () => {
   test('requires HTTPS', async () => {
     await expect(fetch('http://example.com/', { dispatcher: safeAgent })).rejects.toThrow('fetch failed');
@@ -156,4 +196,29 @@ function close(server: ReturnType<typeof createServer>): Promise<void> {
   return new Promise((resolve, reject) => {
     server.close((err) => (err ? reject(err) : resolve()));
   });
+}
+
+function callConnect(
+  connect: ReturnType<typeof createSafeConnect>,
+  options: Partial<Parameters<ReturnType<typeof createSafeConnect>>[0]>
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    connect(
+      {
+        protocol: 'https:',
+        hostname: 'example.com',
+        port: '443',
+        ...options,
+      },
+      (err, socket) => (err ? reject(err) : resolve(socket))
+    );
+  });
+}
+
+function mockDnsLookup(err: Error | null, addresses: dns.LookupAddress[]): void {
+  vi.spyOn(dns, 'lookup').mockImplementation(((...args: unknown[]) => {
+    const callback = args[2] as (err: Error | null, addresses: dns.LookupAddress[]) => void;
+    callback(err, addresses);
+    return {} as any;
+  }) as any);
 }

--- a/packages/server/src/util/url.test.ts
+++ b/packages/server/src/util/url.test.ts
@@ -3,11 +3,10 @@
 import dns from 'node:dns';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { Agent, fetch, getGlobalDispatcher, setGlobalDispatcher } from 'undici';
+import { fetch } from 'undici';
 import { vi } from 'vitest';
 import {
   createSafeConnect,
-  installSafeOutboundDispatcher,
   isAllowedOutboundUrlForQueue,
   isUnsafeHostname,
   isUnsafeIpAddress,
@@ -155,30 +154,6 @@ describe('safeAgent', () => {
 
   test('blocks private literal targets', async () => {
     await expect(fetch('https://127.0.0.1/', { dispatcher: safeAgent })).rejects.toThrow('fetch failed');
-  });
-});
-
-describe('installSafeOutboundDispatcher', () => {
-  test('skips installation when unsafe outbound requests are allowed', async () => {
-    const originalDispatcher = getGlobalDispatcher();
-    const unsafeAgent = new Agent();
-    const server = createServer((_req, res) => res.end('ok'));
-
-    setGlobalDispatcher(unsafeAgent);
-    await listen(server);
-
-    try {
-      expect(installSafeOutboundDispatcher({ allowUnsafeOutbound: true })).toBe(false);
-      expect(getGlobalDispatcher()).toBe(unsafeAgent);
-
-      const response = await fetch(`http://127.0.0.1:${getPort(server)}`);
-      expect(response.status).toBe(200);
-      expect(await response.text()).toBe('ok');
-    } finally {
-      setGlobalDispatcher(originalDispatcher);
-      await close(server);
-      await unsafeAgent.close();
-    }
   });
 });
 

--- a/packages/server/src/util/url.test.ts
+++ b/packages/server/src/util/url.test.ts
@@ -1,6 +1,16 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { isUnsafeHostname, isUnsafeIpAddress, validateOutboundUrl } from './url';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { Agent, fetch, getGlobalDispatcher, setGlobalDispatcher } from 'undici';
+import {
+  installSafeOutboundDispatcher,
+  isAllowedOutboundUrlForQueue,
+  isUnsafeHostname,
+  isUnsafeIpAddress,
+  safeAgent,
+  validateOutboundUrl,
+} from './url';
 
 describe('validateOutboundUrl', () => {
   test('parses HTTPS URLs', () => {
@@ -54,6 +64,8 @@ describe('isUnsafeIpAddress', () => {
     expect(isUnsafeIpAddress('fe80::1')).toBe(true);
     expect(isUnsafeIpAddress('fc00::1')).toBe(true);
     expect(isUnsafeIpAddress('::ffff:7f00:1')).toBe(true);
+    expect(isUnsafeIpAddress('::ffff:10.0.0.1')).toBe(true);
+    expect(isUnsafeIpAddress('::ffff:192.168.1.1')).toBe(true);
   });
 
   test('allows public addresses', () => {
@@ -61,3 +73,87 @@ describe('isUnsafeIpAddress', () => {
     expect(isUnsafeIpAddress('2001:4860:4860::8888')).toBe(false);
   });
 });
+
+describe('isAllowedOutboundUrlForQueue', () => {
+  test('allows safe HTTPS URLs by default', () => {
+    expect(isAllowedOutboundUrlForQueue('https://example.com/path', {})).toBe(true);
+  });
+
+  test('rejects known unsafe URLs by default', () => {
+    expect(isAllowedOutboundUrlForQueue('http://example.com/path', {})).toBe(false);
+    expect(isAllowedOutboundUrlForQueue('https://localhost/path', {})).toBe(false);
+    expect(isAllowedOutboundUrlForQueue('https://127.0.0.1/path', {})).toBe(false);
+    expect(isAllowedOutboundUrlForQueue('not a url', {})).toBe(false);
+  });
+
+  test('allows HTTP and unsafe hostnames when unsafe outbound is enabled', () => {
+    expect(isAllowedOutboundUrlForQueue('http://localhost/path', { allowUnsafeOutbound: true })).toBe(true);
+  });
+
+  test('rejects unsupported protocols when unsafe outbound is enabled', () => {
+    expect(isAllowedOutboundUrlForQueue('file://example.com/path', { allowUnsafeOutbound: true })).toBe(false);
+  });
+});
+
+describe('safeAgent', () => {
+  test('requires HTTPS', async () => {
+    await expect(fetch('http://example.com/', { dispatcher: safeAgent })).rejects.toThrow('fetch failed');
+  });
+
+  test('blocks localhost fetches before opening a socket', async () => {
+    const server = createServer((_req, res) => res.end('ok'));
+    await listen(server);
+
+    try {
+      await expect(fetch(`https://localhost:${getPort(server)}`, { dispatcher: safeAgent })).rejects.toThrow(
+        'fetch failed'
+      );
+    } finally {
+      await close(server);
+    }
+  });
+
+  test('blocks private literal targets', async () => {
+    await expect(fetch('https://127.0.0.1/', { dispatcher: safeAgent })).rejects.toThrow('fetch failed');
+  });
+});
+
+describe('installSafeOutboundDispatcher', () => {
+  test('skips installation when unsafe outbound requests are allowed', async () => {
+    const originalDispatcher = getGlobalDispatcher();
+    const unsafeAgent = new Agent();
+    const server = createServer((_req, res) => res.end('ok'));
+
+    setGlobalDispatcher(unsafeAgent);
+    await listen(server);
+
+    try {
+      expect(installSafeOutboundDispatcher({ allowUnsafeOutbound: true })).toBe(false);
+      expect(getGlobalDispatcher()).toBe(unsafeAgent);
+
+      const response = await fetch(`http://127.0.0.1:${getPort(server)}`);
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe('ok');
+    } finally {
+      setGlobalDispatcher(originalDispatcher);
+      await close(server);
+      await unsafeAgent.close();
+    }
+  });
+});
+
+function getPort(server: ReturnType<typeof createServer>): number {
+  return (server.address() as AddressInfo).port;
+}
+
+function listen(server: ReturnType<typeof createServer>): Promise<void> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+}
+
+function close(server: ReturnType<typeof createServer>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}

--- a/packages/server/src/util/url.ts
+++ b/packages/server/src/util/url.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import ipaddr from 'ipaddr.js';
 import dns from 'node:dns';
-import { Agent, buildConnector, setGlobalDispatcher } from 'undici';
+import { Agent, buildConnector } from 'undici';
+import type { Dispatcher } from 'undici';
+import { getConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
 
 export interface OutboundUrlValidationOptions {
@@ -11,6 +13,10 @@ export interface OutboundUrlValidationOptions {
 }
 
 const connector = buildConnector({});
+
+// The DOM RequestInit type used by built-in fetch does not include Undici's
+// dispatcher option, even though Node's fetch accepts it.
+type FetchInitWithDispatcher = RequestInit & { dispatcher?: Dispatcher };
 
 export function createSafeConnect(connect: buildConnector.connector = connector): buildConnector.connector {
   return (options, callback) => {
@@ -46,16 +52,16 @@ export const safeAgent = new Agent({
 });
 
 /**
- * Installs the global SSRF-safe dispatcher unless unsafe outbound requests are explicitly allowed.
- * @param config - Server configuration.
- * @returns True if the safe dispatcher was installed.
+ * Performs an outbound fetch with SSRF-safe connection handling unless unsafe outbound requests are explicitly allowed.
+ * @param input - Fetch input.
+ * @param init - Fetch options.
+ * @returns Fetch response.
  */
-export function installSafeOutboundDispatcher(config: Pick<MedplumServerConfig, 'allowUnsafeOutbound'>): boolean {
-  if (config.allowUnsafeOutbound) {
-    return false;
+export function safeFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  if (getConfig().allowUnsafeOutbound) {
+    return fetch(input, init);
   }
-  setGlobalDispatcher(safeAgent);
-  return true;
+  return fetch(input, { ...init, dispatcher: safeAgent } as FetchInitWithDispatcher);
 }
 
 /**

--- a/packages/server/src/util/url.ts
+++ b/packages/server/src/util/url.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import ipaddr from 'ipaddr.js';
 import dns from 'node:dns';
-import { Agent, buildConnector } from 'undici';
 import type { Dispatcher } from 'undici';
+import { Agent, buildConnector } from 'undici';
 import { getConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
 

--- a/packages/server/src/util/url.ts
+++ b/packages/server/src/util/url.ts
@@ -12,8 +12,8 @@ export interface OutboundUrlValidationOptions {
 
 const connector = buildConnector({});
 
-export const safeAgent = new Agent({
-  connect(options, callback) {
+export function createSafeConnect(connect: buildConnector.connector = connector): buildConnector.connector {
+  return (options, callback) => {
     if (options.protocol !== 'https:') {
       callback(new Error('Outbound request blocked: HTTPS is required'), null);
       return;
@@ -36,9 +36,13 @@ export const safeAgent = new Agent({
       }
 
       const [{ address }] = addresses;
-      connector({ ...options, hostname: address, servername: options.hostname }, callback);
+      connect({ ...options, hostname: address, servername: options.hostname }, callback);
     });
-  },
+  };
+}
+
+export const safeAgent = new Agent({
+  connect: createSafeConnect(),
 });
 
 /**

--- a/packages/server/src/util/url.ts
+++ b/packages/server/src/util/url.ts
@@ -1,10 +1,79 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import ipaddr from 'ipaddr.js';
+import dns from 'node:dns';
+import { Agent, buildConnector, setGlobalDispatcher } from 'undici';
+import type { MedplumServerConfig } from '../config/types';
 
 export interface OutboundUrlValidationOptions {
   readonly allowHttp?: boolean;
   readonly allowUnsafeHostname?: boolean;
+}
+
+const connector = buildConnector({});
+
+export const safeAgent = new Agent({
+  connect(options, callback) {
+    if (options.protocol !== 'https:') {
+      callback(new Error('Outbound request blocked: HTTPS is required'), null);
+      return;
+    }
+
+    if (isUnsafeHostname(options.hostname)) {
+      callback(new Error(`Outbound request to unsafe hostname ${options.hostname} is blocked`), null);
+      return;
+    }
+
+    dns.lookup(options.hostname, { all: true }, (err, addresses) => {
+      if (err) {
+        callback(err, null);
+        return;
+      }
+
+      if (addresses.some(({ address }) => isUnsafeIpAddress(address))) {
+        callback(new Error(`Outbound request to unsafe address ${options.hostname} is blocked`), null);
+        return;
+      }
+
+      const [{ address }] = addresses;
+      connector({ ...options, hostname: address, servername: options.hostname }, callback);
+    });
+  },
+});
+
+/**
+ * Installs the global SSRF-safe dispatcher unless unsafe outbound requests are explicitly allowed.
+ * @param config - Server configuration.
+ * @returns True if the safe dispatcher was installed.
+ */
+export function installSafeOutboundDispatcher(config: Pick<MedplumServerConfig, 'allowUnsafeOutbound'>): boolean {
+  if (config.allowUnsafeOutbound) {
+    return false;
+  }
+  setGlobalDispatcher(safeAgent);
+  return true;
+}
+
+/**
+ * Performs static outbound URL checks before enqueueing async jobs.
+ * This prevents known-bad jobs from consuming retry attempts while leaving DNS and redirect safety to safeAgent.
+ * @param value - URL string.
+ * @param config - Server configuration.
+ * @returns True if the URL should be queued for outbound fetch.
+ */
+export function isAllowedOutboundUrlForQueue(
+  value: string,
+  config: Pick<MedplumServerConfig, 'allowUnsafeOutbound'>
+): boolean {
+  try {
+    validateOutboundUrl(value, {
+      allowHttp: config.allowUnsafeOutbound,
+      allowUnsafeHostname: config.allowUnsafeOutbound,
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/server/src/workers/download.test.ts
+++ b/packages/server/src/workers/download.test.ts
@@ -60,12 +60,15 @@ describe('Download Worker', () => {
 
         await findAndExecDownloadJob(media, 'create');
 
-        expect(fetchMock).toHaveBeenCalledWith(url, {
-          headers: {
-            'x-trace-id': '00-12345678901234567890123456789012-3456789012345678-01',
-            traceparent: '00-12345678901234567890123456789012-3456789012345678-01',
-          },
-        });
+        expect(fetchMock).toHaveBeenCalledWith(
+          url,
+          expect.objectContaining({
+            headers: {
+              'x-trace-id': '00-12345678901234567890123456789012-3456789012345678-01',
+              traceparent: '00-12345678901234567890123456789012-3456789012345678-01',
+            },
+          })
+        );
 
         const updatedMedia = await repo.readResource<Media>('Media', media.id);
         expect(updatedMedia.content?.url).toMatch(/^Binary\//);

--- a/packages/server/src/workers/download.test.ts
+++ b/packages/server/src/workers/download.test.ts
@@ -28,6 +28,7 @@ describe('Download Worker', () => {
   beforeEach(async () => {
     fetchMock.mockClear();
     getConfig().autoDownloadEnabled = true;
+    getConfig().allowUnsafeOutbound = false;
   });
 
   test('Download external URL', () =>
@@ -87,7 +88,7 @@ describe('Download Worker', () => {
       await expect(findAndExecDownloadJob(media, 'create')).rejects.toThrow('Job not found');
     }));
 
-  test('Ignore HTTP URL', () =>
+  test('Ignore HTTP URL by default', () =>
     withTestContext(async () => {
       const media = await repo.createResource<Media>({
         resourceType: 'Media',
@@ -99,6 +100,23 @@ describe('Download Worker', () => {
       });
       expect(media).toBeDefined();
       await expect(findAndExecDownloadJob(media, 'create')).rejects.toThrow('Job not found');
+    }));
+
+  test('Queue HTTP URL when unsafe outbound is allowed', () =>
+    withTestContext(async () => {
+      getConfig().allowUnsafeOutbound = true;
+
+      const media = await repo.createResource<Media>({
+        resourceType: 'Media',
+        status: 'completed',
+        content: {
+          contentType: ContentType.TEXT,
+          url: 'http://localhost/download',
+        },
+      });
+      expect(media).toBeDefined();
+      const jobs = await findAndExecDownloadJob(media, 'create');
+      expect(jobs[0].data.url).toBe('http://localhost/download');
     }));
 
   test('Retry on 400', () =>

--- a/packages/server/src/workers/download.ts
+++ b/packages/server/src/workers/download.ts
@@ -22,7 +22,7 @@ import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
 import { getLogger, globalLogger } from '../logger';
 import { getBinaryStorage } from '../storage/loader';
 import { parseTraceparent } from '../traceparent';
-import { validateOutboundUrl } from '../util/url';
+import { isAllowedOutboundUrlForQueue } from '../util/url';
 import type { WorkerInitializer, WorkerInitializerOptions } from './utils';
 import { defaultQueueOptions, getWorkerBullmqConfig, queueRegistry } from './utils';
 
@@ -162,9 +162,7 @@ function isExternalUrl(url: string | undefined): url is string {
   ) {
     return false;
   }
-  try {
-    validateOutboundUrl(url);
-  } catch {
+  if (!isAllowedOutboundUrlForQueue(url, getConfig())) {
     return false;
   }
   return true;
@@ -245,7 +243,6 @@ export async function execDownloadJob<T extends Resource = Resource>(job: Job<Do
   if (!isUrlAllowedByProject(project, url)) {
     return;
   }
-  validateOutboundUrl(url);
 
   const headers: HeadersInit = {};
   const traceId = job.data.traceId;

--- a/packages/server/src/workers/download.ts
+++ b/packages/server/src/workers/download.ts
@@ -22,7 +22,7 @@ import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
 import { getLogger, globalLogger } from '../logger';
 import { getBinaryStorage } from '../storage/loader';
 import { parseTraceparent } from '../traceparent';
-import { isAllowedOutboundUrlForQueue } from '../util/url';
+import { isAllowedOutboundUrlForQueue, safeFetch } from '../util/url';
 import type { WorkerInitializer, WorkerInitializerOptions } from './utils';
 import { defaultQueueOptions, getWorkerBullmqConfig, queueRegistry } from './utils';
 
@@ -257,7 +257,7 @@ export async function execDownloadJob<T extends Resource = Resource>(job: Job<Do
 
   try {
     log.info('Requesting content at: ' + url);
-    const response = await fetch(url, {
+    const response = await safeFetch(url, {
       headers,
     });
 

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -101,6 +101,7 @@ describe('Subscription Worker', () => {
 
   beforeEach(async () => {
     fetchMock.mockClear();
+    getConfig().allowUnsafeOutbound = false;
 
     // Create one simple project with no advanced features enabled
     const { client, repo: _repo } = await withTestContext(() =>
@@ -548,7 +549,7 @@ describe('Subscription Worker', () => {
       await expect(findAndExecSubscriptionJob(patient, 'create')).rejects.toThrow('Job not found');
     }));
 
-  test('Reject insecure rest-hook URLs by default', () =>
+  test('Ignore insecure rest-hook URLs by default', () =>
     withTestContext(async () => {
       const subscription = await repo.createResource<Subscription>({
         resourceType: 'Subscription',
@@ -568,49 +569,42 @@ describe('Subscription Worker', () => {
       });
       expect(patient).toBeDefined();
 
-      await expect(findAndExecSubscriptionJob(patient, 'create')).rejects.toThrow('HTTPS is required');
-      expect(fetch).not.toHaveBeenCalled();
+      await expect(findAndExecSubscriptionJob(patient, 'create')).rejects.toThrow('Job not found');
     }));
 
-  test('Allow insecure rest-hook URLs when configured', () =>
+  test('Send insecure rest-hook URLs to fetch when unsafe outbound is allowed', () =>
     withTestContext(async () => {
+      getConfig().allowUnsafeOutbound = true;
       const url = 'http://localhost:8080/subscription';
-      const savedConfig = getConfig().allowInsecureRestHookUrl;
-      getConfig().allowInsecureRestHookUrl = true;
+      const subscription = await repo.createResource<Subscription>({
+        resourceType: 'Subscription',
+        reason: 'test',
+        status: 'active',
+        criteria: 'Patient',
+        channel: {
+          type: 'rest-hook',
+          endpoint: url,
+        },
+      });
+      expect(subscription).toBeDefined();
 
-      try {
-        const subscription = await repo.createResource<Subscription>({
-          resourceType: 'Subscription',
-          reason: 'test',
-          status: 'active',
-          criteria: 'Patient',
-          channel: {
-            type: 'rest-hook',
-            endpoint: url,
-          },
-        });
-        expect(subscription).toBeDefined();
+      const patient = await repo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['Alice'], family: 'Smith' }],
+      });
+      expect(patient).toBeDefined();
 
-        const patient = await repo.createResource<Patient>({
-          resourceType: 'Patient',
-          name: [{ given: ['Alice'], family: 'Smith' }],
-        });
-        expect(patient).toBeDefined();
+      fetchMock.mockImplementation(() => mockFetchStatus(200));
 
-        fetchMock.mockImplementation(() => mockFetchStatus(200));
+      await findAndExecSubscriptionJob(patient, 'create');
 
-        await findAndExecSubscriptionJob(patient, 'create');
-
-        expect(fetch).toHaveBeenCalledWith(
-          url,
-          expect.objectContaining({
-            method: 'POST',
-            body: stringify(patient),
-          })
-        );
-      } finally {
-        getConfig().allowInsecureRestHookUrl = savedConfig;
-      }
+      expect(fetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          method: 'POST',
+          body: stringify(patient),
+        })
+      );
     }));
 
   // Skip test

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -56,7 +56,7 @@ import { cleanupActiveSubs, getActiveSubscriptions, publish, removeActiveSubscri
 import { getCacheRedis } from '../redis';
 import { parseTraceparent } from '../traceparent';
 import { AuditEventOutcome, createSubscriptionAuditEvent } from '../util/auditevent';
-import { isAllowedOutboundUrlForQueue } from '../util/url';
+import { isAllowedOutboundUrlForQueue, safeFetch } from '../util/url';
 import type { SubEventsOptions } from '../ws/subscriptions';
 import {
   clearSubscriptionFailures,
@@ -741,7 +741,12 @@ async function sendRestHook(
       projectId: subscription.meta?.project,
     });
     log.debug('Rest hook headers: ' + JSON.stringify(headers, undefined, 2));
-    const response = await fetch(url, { method: 'POST', headers, body, signal: AbortSignal.timeout(REQUEST_TIMEOUT) });
+    const response = await safeFetch(url, {
+      method: 'POST',
+      headers,
+      body,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT),
+    });
     fetchEndTime = Date.now();
     log.info('Received rest hook response', {
       status: response.status,

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -56,7 +56,7 @@ import { cleanupActiveSubs, getActiveSubscriptions, publish, removeActiveSubscri
 import { getCacheRedis } from '../redis';
 import { parseTraceparent } from '../traceparent';
 import { AuditEventOutcome, createSubscriptionAuditEvent } from '../util/auditevent';
-import { validateOutboundUrl } from '../util/url';
+import { isAllowedOutboundUrlForQueue } from '../util/url';
 import type { SubEventsOptions } from '../ws/subscriptions';
 import {
   clearSubscriptionFailures,
@@ -390,6 +390,13 @@ export async function addSubscriptionJobs(
       if (subscription.channel.type === 'websocket') {
         wsSubEvents.push([subscription.id, { includeResource: true }]);
         continue;
+      }
+      if (subscription.channel.type === 'rest-hook') {
+        const endpoint = subscription.channel.endpoint;
+        if (!endpoint?.startsWith('Bot/') && !isAllowedOutboundUrlForQueue(endpoint ?? '', getConfig())) {
+          logFn(`Subscription rest-hook URL is not allowed for outbound fetch`);
+          continue;
+        }
       }
       await addSubscriptionJobData({
         subscriptionId: subscription.id,
@@ -728,7 +735,6 @@ async function sendRestHook(
     systemRepo = getGlobalSystemRepo(); // SHARDING is global correct if no project?
   }
   try {
-    validateRestHookUrl(url);
     log.info('Sending rest hook', {
       url,
       subscriptionId: subscription.id,
@@ -784,14 +790,6 @@ async function sendRestHook(
   if (error) {
     throw error;
   }
-}
-
-function validateRestHookUrl(url: string): void {
-  const allowInsecureRestHookUrl = !!getConfig().allowInsecureRestHookUrl;
-  validateOutboundUrl(url, {
-    allowHttp: allowInsecureRestHookUrl,
-    allowUnsafeHostname: allowInsecureRestHookUrl,
-  });
 }
 
 /**

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -95,13 +95,12 @@ fi
 # commander - v13 has backwards-incompatible changes which require a decent amount of refactoring to get our current code to work. We are considering migrating off of commander but for now we should just freeze it
 # eslint - version 10 is incompatible with some plugins we use, holding back until we can upgrade all at once and test
 # hibp - version 15 is ESM-only and we can't use it until we configure Jest/Babel to work with ESM packages
-# jose - version 6+ requires ESM (depending on the precise NodeJS version), holding back until server supports ESM
 # node-fetch - version 3+ requires ESM, holding back until server supports ESM
 # zod - version 4+ is incompatible with MCP SDK
 # otplib - version 13+ requires ESM, holding back until server supports ESM
 # temporal-polyfill - version 1.0.0 is actually an old version, holding back to 0.3.0 which is the latest stable version
 # @mantine/* - version 9 has a few small backwards-incompatible changes, namely affecting at least our `PatientSummary` component, which would make it hard to support both Mantine 8 and 9 simultaneously
-MAJOR_EXCLUDE="@types/node @types/node-fetch commander eslint hibp jose node-fetch npm zod otplib temporal-polyfill @mantine/*"
+MAJOR_EXCLUDE="@types/node @types/node-fetch commander eslint hibp node-fetch npm zod otplib temporal-polyfill @mantine/*"
 
 if [ "$LAST_STEP" -lt 1 ]; then
     # First, only upgrade patch and minor versions


### PR DESCRIPTION
- Add a shared undici `safeAgent` that resolves outbound hostnames, blocks unsafe resolved IPs, and connects to the resolved address directly.
- Install the safe agent as the global dispatcher during server bootstrap unless `allowUnsafeOutbound` is enabled.
- Replace per-call outbound URL validation on fetch paths with dispatcher-level enforcement, while keeping lightweight static checks where they prevent known-bad queue jobs or preserve SMART Health operation error messages.
- Replace legacy `allowInsecureExternalAuthUrl` and `allowInsecureRestHookUrl` config flags with the deployment-level `allowUnsafeOutbound` escape hatch.

## Details

The safe dispatcher closes two SSRF gaps in hosted deployments:

- DNS rebinding: the dispatcher performs DNS lookup in the connect hook and validates the resolved address before opening the socket.
- Redirects: undici applies the dispatcher to each connection, including redirect hops.

For background workers, static pre-queue filtering remains in place for download and rest-hook subscription URLs. This avoids enqueueing jobs that are known to fail and prevents needless retry consumption. The dispatcher remains the authoritative connection-time protection for DNS and redirect behavior.

## Configuration

New server config:

- `allowUnsafeOutbound?: boolean`
- Env var: `MEDPLUM_ALLOW_UNSAFE_OUTBOUND=true`

This is intended only for self-hosted or on-premises deployments that need outbound access to trusted local/private services. It should not be enabled in hosted or cloud-managed environments.

Removed server config:

- `allowInsecureExternalAuthUrl`
- `allowInsecureRestHookUrl`
