### PR TITLE
fix(server): suppress access-policy warning for server-scoped subscriptions

### DIFF
--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -240,6 +240,14 @@ async function satisfiesAccessPolicy(
   subscription: Subscription,
   options?: SatisfiesAccessPolicyOpts
 ): Promise<boolean> {
+  // Server-scoped subscriptions (stored in the system project) have no author membership scoped
+  // to this resource's project by design. The access policy check only actually gates delivery
+  // for websocket subscriptions (see the TODO above); for every other channel type the result is
+  // discarded anyway, so skip the lookup entirely instead of running a check that's expected to fail.
+  if (!subscription.meta?.project && subscription.channel.type !== 'websocket') {
+    return true;
+  }
+
   let satisfied = true;
   try {
     // We can assert author because any time a resource is updated, the author will be set to the previous author or if it doesn't exist
@@ -267,13 +275,17 @@ async function satisfiesAccessPolicy(
         );
       }
     } else {
-      const projectReference = getReferenceString(project);
-      const authorReference = getReferenceString(subAuthor);
-      const subReference = getReferenceString(subscription);
-      globalLogger.warn(
-        `[Subscription Access Policy]: No membership for subscription author '${authorReference}' in project '${projectReference}'`,
-        { subscription: subReference, project: projectReference }
-      );
+      // Server-scoped subscriptions (stored in the system project) are expected to lack a
+      // membership in every project their author didn't join, so don't warn about it here.
+      if (subscription.meta?.project) {
+        const projectReference = getReferenceString(project);
+        const authorReference = getReferenceString(subAuthor);
+        const subReference = getReferenceString(subscription);
+        globalLogger.warn(
+          `[Subscription Access Policy]: No membership for subscription author '${authorReference}' in project '${projectReference}'`,
+          { subscription: subReference, project: projectReference }
+        );
+      }
       satisfied = false;
     }
   } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- Server-scoped subscriptions (stored in the system project) have no author membership scoped to any particular project by design, so `satisfiesAccessPolicy` logged a `"No membership for subscription author..."` warning for every resource in every other project.
- Skip the access-policy check entirely for non-websocket channels when the subscription is server-scoped, since the result was already discarded for those channel types.
- Suppress the "no membership" warning when it's a server-scoped subscription, on any channel type, since a missing per-project membership is expected there rather than a misconfiguration.
- Websocket subscriptions still enforce the access policy exactly as before — no change to that filtering behavior.

## Test plan
- [x] `npx tsc --noEmit` on `packages/server` (pre-existing unrelated errors only)
- [x] `npx eslint src/workers/subscription.ts` (clean)
- [ ] `vitest run src/workers/subscription.test.ts` — could not run; no local Postgres/Redis available in this environment


---
_Generated by [Claude Code](https://claude.ai/code/session_01NchUW4HXavcU9Yh4fBi9CX)_