### PR TITLE
fix(server): prevent agent version clobber on connect status update

### DIFF
--- a/packages/server/src/ws/agent.test.ts
+++ b/packages/server/src/ws/agent.test.ts
@@ -490,10 +490,10 @@ describe('Agent WebSockets', () => {
     try {
       await request(server)
         .ws('/ws/agent')
-        .sendJson({ type: 'agent:connect:request', accessToken, agentId: agent.id })
-        .expectJson({ type: 'agent:connect:response' })
+        .sendText(JSON.stringify({ type: 'agent:connect:request', accessToken, agentId: agent.id }))
+        .expectText('{"type":"agent:connect:response"}')
         // Report the agent version via a heartbeat response
-        .sendJson({ type: 'agent:heartbeat:response', version: MEDPLUM_VERSION })
+        .sendText(JSON.stringify({ type: 'agent:heartbeat:response', version: MEDPLUM_VERSION }))
         // Give any (buggy) in-flight status update time to land before closing
         .exec(() => sleep(400))
         .close()

--- a/packages/server/src/ws/agent.test.ts
+++ b/packages/server/src/ws/agent.test.ts
@@ -460,6 +460,64 @@ describe('Agent WebSockets', () => {
     });
   });
 
+  test('Heartbeat version survives slow status update on connect', async () => {
+    // Regression test: the connect handler updates the agent status with a non-atomic
+    // read-modify-write (GET last info, SET merged status). It must complete before the
+    // server sends "agent:connect:response" -- when it ran after, a slow GET reply meant
+    // the merged write could land after the agent's heartbeat response was recorded,
+    // clobbering the reported version with stale info.
+    // Simulate a loaded Redis by delaying the reply of the first agent info GET.
+    const realRedis = getCacheRedis();
+    let delayedOnce = false;
+    const delayedRedis = new Proxy(realRedis, {
+      get(target, prop, receiver) {
+        if (prop === 'get') {
+          return async (key: string): Promise<string | null> => {
+            const result = await target.get(key);
+            if (!delayedOnce && key.includes('medplum:agent:')) {
+              delayedOnce = true;
+              await sleep(300);
+            }
+            return result;
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+    const cacheSpy = vi.spyOn(redisModule, 'getCacheRedis').mockReturnValue(delayedRedis);
+
+    try {
+      await request(server)
+        .ws('/ws/agent')
+        .sendJson({ type: 'agent:connect:request', accessToken, agentId: agent.id })
+        .expectJson({ type: 'agent:connect:response' })
+        // Report the agent version via a heartbeat response
+        .sendJson({ type: 'agent:heartbeat:response', version: MEDPLUM_VERSION })
+        // Give any (buggy) in-flight status update time to land before closing
+        .exec(() => sleep(400))
+        .close()
+        .expectClosed();
+    } finally {
+      cacheSpy.mockRestore();
+    }
+
+    let info: AgentInfo = { status: AgentConnectionState.UNKNOWN, version: 'unknown' };
+    for (let i = 0; i < 5; i++) {
+      await sleep(50);
+      const infoStr = (await getCacheRedis().get(`medplum:agent:${agent.id}:info`)) as string;
+      info = JSON.parse(infoStr) as AgentInfo;
+      if (info.status === AgentConnectionState.DISCONNECTED) {
+        break;
+      }
+    }
+    expect(info).toMatchObject<AgentInfo>({
+      status: AgentConnectionState.DISCONNECTED,
+      version: MEDPLUM_VERSION,
+      lastUpdated: expect.any(String),
+    });
+  });
+
   test('Logs when updating agent status fails on disconnect', async () => {
     const errorSpy = vi.spyOn(globalLogger, 'error').mockImplementation(() => undefined);
     // Simulate Redis being unavailable (e.g. closing during shutdown) so the disconnect

--- a/packages/server/src/ws/agent.ts
+++ b/packages/server/src/ws/agent.ts
@@ -183,14 +183,17 @@ export async function handleAgentConnection(socket: WebSocket, request: Incoming
     });
     await subscribed;
 
+    // Update the agent status in Redis before acknowledging the connection.
+    // The status update is a non-atomic read-modify-write (read last info, write new status),
+    // so it must complete before the agent can send an "agent:heartbeat:response" --
+    // otherwise a stale read here could clobber the version reported by the heartbeat.
+    await updateAgentStatus(AgentConnectionState.CONNECTED);
+
     // Subscribe to heartbeat events
     heartbeat.addEventListener('heartbeat', heartbeatHandler);
 
     // Send connected message
     sendMessage({ type: 'agent:connect:response' });
-
-    // Update the agent status in Redis
-    await updateAgentStatus(AgentConnectionState.CONNECTED);
   }
 
   /**


### PR DESCRIPTION
## Problem

The `Agent WebSockets > Heartbeat` test fails flakily on CI ([example failed run](https://github.com/medplum/medplum/actions/runs/29131268412/job/86487193633)) — there have been multiple instances of this failure:

```
FAIL  src/ws/agent.test.ts > Agent WebSockets > Heartbeat
AssertionError: expected { status: 'disconnected', …(2) } to match object { status: 'disconnected', …(2) }

  {
    "lastUpdated": "2026-07-11T00:01:04.909Z",
    "status": "disconnected",
-   "version": "5.1.26-test",
+   "version": "unknown",
  }
```

This is a **race-condition flake with a real underlying server bug**, not just test timing — the test races against a genuine ordering bug in the agent WebSocket connect handler that can also occur in production (an in-flight status update can erase the version reported by an agent heartbeat).

## Root cause

`handleConnect` sent `agent:connect:response` **before** awaiting `updateAgentStatus(CONNECTED)`. The status update is a non-atomic read-modify-write: `GET` the last agent info (to preserve `version`), then `SET` the merged status.

On a loaded CI Redis, the interleaving is:

1. Connect handler sends `connect:response`, issues its `GET`, and suspends awaiting the reply
2. The agent (test) races ahead — the heartbeat exchange completes and the `agent:heartbeat:response` handler writes `{ status: connected, version: MEDPLUM_VERSION }`
3. The connect handler's slow `GET` reply arrives holding **stale pre-heartbeat info** (`version: 'unknown'`); its continuation writes it back, clobbering the version
4. The close handler reads the clobbered info and writes `{ status: disconnected, version: 'unknown' }` — the exact CI failure

## Fix

- Complete the status update **before** sending `agent:connect:response` (and before registering the heartbeat listener, so a heartbeat tick during the await cannot send `agent:heartbeat:request` ahead of the connect ack). The agent can no longer send a heartbeat response while the read-modify-write is in flight.
- Added a regression test that reproduces the race deterministically by delaying the reply of the first agent info `GET` (simulating loaded CI Redis) — it fails with the exact CI error against the old code and passes with the fix.

## Verification

- Regression test vs. pre-fix code → fails with the exact CI error (`version: "unknown"`)
- Full `src/ws/agent.test.ts` (20 tests) passes, stable across 3 consecutive runs
- `agentstatus` / `agentbulkstatus` operation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)