### PR TITLE
fix(app): prevent registration loop in project sign-in

### DIFF
--- a/packages/app/src/SignInPage.test.tsx
+++ b/packages/app/src/SignInPage.test.tsx
@@ -92,6 +92,18 @@ describe('SignInPage', () => {
     });
   });
 
+  test('Does not loop back to registration while creating a new project', async () => {
+    getConfig().registerEnabled = true;
+    setup('/signin', new MockClient({ profile: DrAliceSmith }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Register'));
+    });
+
+    expect(await screen.findByText('Sign in again to create a new project')).toBeInTheDocument();
+    expect(screen.queryByText('Register')).not.toBeInTheDocument();
+  });
+
   test('Register disabled', async () => {
     getConfig().registerEnabled = false;
     setup();

--- a/packages/app/src/SignInPage.tsx
+++ b/packages/app/src/SignInPage.tsx
@@ -12,6 +12,8 @@ export function SignInPage(): JSX.Element {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const config = getConfig();
+  const projectId = searchParams.get('project') || undefined;
+  const isCreatingNewProject = projectId === 'new';
 
   const navigateToNext = useCallback(() => {
     // only redirect to next if it is a pathname to avoid redirecting
@@ -30,18 +32,22 @@ export function SignInPage(): JSX.Element {
     <SignInForm
       onSuccess={() => navigateToNext()}
       onForgotPassword={() => navigate('/resetpassword')?.catch(console.error)}
-      onRegister={isRegisterEnabled() ? () => navigate('/register')?.catch(console.error) : undefined}
+      onRegister={
+        isRegisterEnabled() && !(profile && isCreatingNewProject)
+          ? () => navigate('/register')?.catch(console.error)
+          : undefined
+      }
       googleClientId={config.googleClientId}
       login={searchParams.get('login') || undefined}
-      projectId={searchParams.get('project') || undefined}
+      projectId={projectId}
     >
       <Logo size={32} />
-      {searchParams.get('project') !== 'new' && (
+      {!isCreatingNewProject && (
         <Title order={3} py="lg" ta="center">
           Sign in to {getAppName()}
         </Title>
       )}
-      {searchParams.get('project') === 'new' && (
+      {isCreatingNewProject && (
         <Title order={3} py="lg" ta="center">
           Sign in again to create a new project
         </Title>


### PR DESCRIPTION
## Summary

- prevent the authenticated project-switch flow from looping back through the Register link
- keep the Register action available for logged-out users
- preserve the authenticated new-project form and add a focused regression test

## Validation

- Terra implementation and independent review: PASS
- SignInPage vitest: 11/11 PASS
- RegisterPage vitest: 4/4 PASS
- ESLint and diff checks: PASS
- Full TypeScript validation is blocked by existing workspace package-link errors

Fixes #9787

Generated-By: Terra