### PR TITLE
Support project-scoped external JWT bearer authentication

### DIFF
--- a/packages/core/src/base-schema.json
+++ b/packages/core/src/base-schema.json
@@ -4238,8 +4238,21 @@
   },
   "IdentityProvider": {
     "elements": {
+      "issuer": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "jwksUrl": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
       "authorizeUrl": {
-        "min": 1,
         "type": [
           {
             "code": "string"
@@ -4247,7 +4260,6 @@
         ]
       },
       "tokenUrl": {
-        "min": 1,
         "type": [
           {
             "code": "string"
@@ -4262,7 +4274,6 @@
         ]
       },
       "userInfoUrl": {
-        "min": 1,
         "type": [
           {
             "code": "string"
@@ -4284,7 +4295,6 @@
         ]
       },
       "clientId": {
-        "min": 1,
         "type": [
           {
             "code": "string"
@@ -4292,7 +4302,6 @@
         ]
       },
       "clientSecret": {
-        "min": 1,
         "type": [
           {
             "code": "string"

--- a/packages/definitions/src/fhir/r4/fhir.schema.json
+++ b/packages/definitions/src/fhir/r4/fhir.schema.json
@@ -62924,6 +62924,14 @@
     "IdentityProvider": {
       "description": "External Identity Provider (IdP) configuration details.",
       "properties": {
+        "issuer": {
+          "description": "Issuer URL for the external Identity Provider.",
+          "$ref": "#/definitions/string"
+        },
+        "jwksUrl": {
+          "description": "Remote URL for the external Identity Provider JWKS endpoint.",
+          "$ref": "#/definitions/string"
+        },
         "authorizeUrl": {
           "description": "Remote URL for the external Identity Provider authorize endpoint.",
           "$ref": "#/definitions/string"
@@ -62988,14 +62996,7 @@
           ]
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "authorizeUrl",
-        "tokenUrl",
-        "userInfoUrl",
-        "clientId",
-        "clientSecret"
-      ]
+      "additionalProperties": false
     },
     "ProjectMembership_Access": {
       "description": "Extended access configuration using parameterized access policies.",

--- a/packages/definitions/src/fhir/r4/fhir.schema.json
+++ b/packages/definitions/src/fhir/r4/fhir.schema.json
@@ -62928,6 +62928,10 @@
           "description": "Issuer URL for the external Identity Provider.",
           "$ref": "#/definitions/string"
         },
+        "audience": {
+          "description": "Expected audience for tokens issued by the external Identity Provider.",
+          "$ref": "#/definitions/string"
+        },
         "jwksUrl": {
           "description": "Remote URL for the external Identity Provider JWKS endpoint.",
           "$ref": "#/definitions/string"

--- a/packages/definitions/src/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/src/fhir/r4/profiles-medplum.json
@@ -5787,6 +5787,21 @@
             }
           },
           {
+            "id" : "IdentityProvider.audience",
+            "path" : "IdentityProvider.audience",
+            "definition" : "Expected audience for tokens issued by the external Identity Provider.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "string"
+            }],
+            "base" : {
+              "path" : "IdentityProvider.audience",
+              "min" : 0,
+              "max" : "1"
+            }
+          },
+          {
             "id" : "IdentityProvider.jwksUrl",
             "path" : "IdentityProvider.jwksUrl",
             "definition" : "Remote URL for the external Identity Provider JWKS endpoint.",

--- a/packages/definitions/src/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/src/fhir/r4/profiles-medplum.json
@@ -5772,17 +5772,47 @@
             }
           },
           {
+            "id" : "IdentityProvider.issuer",
+            "path" : "IdentityProvider.issuer",
+            "definition" : "Issuer URL for the external Identity Provider.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "string"
+            }],
+            "base" : {
+              "path" : "IdentityProvider.issuer",
+              "min" : 0,
+              "max" : "1"
+            }
+          },
+          {
+            "id" : "IdentityProvider.jwksUrl",
+            "path" : "IdentityProvider.jwksUrl",
+            "definition" : "Remote URL for the external Identity Provider JWKS endpoint.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "string"
+            }],
+            "base" : {
+              "path" : "IdentityProvider.jwksUrl",
+              "min" : 0,
+              "max" : "1"
+            }
+          },
+          {
             "id" : "IdentityProvider.authorizeUrl",
             "path" : "IdentityProvider.authorizeUrl",
             "definition" : "Remote URL for the external Identity Provider authorize endpoint.",
-            "min" : 1,
+            "min" : 0,
             "max" : "1",
             "type" : [{
               "code" : "string"
             }],
             "base" : {
               "path" : "IdentityProvider.authorizeUrl",
-              "min" : 1,
+              "min" : 0,
               "max" : "1"
             }
           },
@@ -5790,14 +5820,14 @@
             "id" : "IdentityProvider.tokenUrl",
             "path" : "IdentityProvider.tokenUrl",
             "definition" : "Remote URL for the external Identity Provider token endpoint.",
-            "min" : 1,
+            "min" : 0,
             "max" : "1",
             "type" : [{
               "code" : "string"
             }],
             "base" : {
               "path" : "IdentityProvider.tokenUrl",
-              "min" : 1,
+              "min" : 0,
               "max" : "1"
             }
           },
@@ -5824,14 +5854,14 @@
             "id" : "IdentityProvider.userInfoUrl",
             "path" : "IdentityProvider.userInfoUrl",
             "definition" : "Remote URL for the external Identity Provider userinfo endpoint.",
-            "min" : 1,
+            "min" : 0,
             "max" : "1",
             "type" : [{
               "code" : "string"
             }],
             "base" : {
               "path" : "IdentityProvider.userInfoUrl",
-              "min" : 1,
+              "min" : 0,
               "max" : "1"
             }
           },
@@ -5875,14 +5905,14 @@
             "id" : "IdentityProvider.clientId",
             "path" : "IdentityProvider.clientId",
             "definition" : "External Identity Provider client ID.",
-            "min" : 1,
+            "min" : 0,
             "max" : "1",
             "type" : [{
               "code" : "string"
             }],
             "base" : {
               "path" : "IdentityProvider.clientId",
-              "min" : 1,
+              "min" : 0,
               "max" : "1"
             }
           },
@@ -5890,14 +5920,14 @@
             "id" : "IdentityProvider.clientSecret",
             "path" : "IdentityProvider.clientSecret",
             "definition" : "External Identity Provider client secret.",
-            "min" : 1,
+            "min" : 0,
             "max" : "1",
             "type" : [{
               "code" : "string"
             }],
             "base" : {
               "path" : "IdentityProvider.clientSecret",
-              "min" : 1,
+              "min" : 0,
               "max" : "1"
             }
           },

--- a/packages/definitions/src/fhir/r4/search-parameters-medplum.json
+++ b/packages/definitions/src/fhir/r4/search-parameters-medplum.json
@@ -299,6 +299,23 @@
       }
     },
     {
+      "fullUrl": "https://medplum.com/fhir/SearchParameter/ClientApplication-identity-provider-issuer",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "ClientApplication-identity-provider-issuer",
+        "url": "https://medplum.com/fhir/SearchParameter/ClientApplication-identity-provider-issuer",
+        "version": "4.0.1",
+        "name": "identity-provider-issuer",
+        "status": "draft",
+        "publisher": "Medplum",
+        "description": "The issuer of the client application's identity provider",
+        "code": "identity-provider-issuer",
+        "base": ["ClientApplication"],
+        "type": "string",
+        "expression": "ClientApplication.identityProvider.issuer"
+      }
+    },
+    {
       "fullUrl": "https://medplum.com/fhir/SearchParameter/JsonWebKey-active",
       "resource": {
         "resourceType": "SearchParameter",

--- a/packages/fhirtypes/dist/IdentityProvider.d.ts
+++ b/packages/fhirtypes/dist/IdentityProvider.d.ts
@@ -16,6 +16,11 @@ export interface IdentityProvider {
   issuer?: string;
 
   /**
+   * Expected audience for tokens issued by the external Identity Provider.
+   */
+  audience?: string;
+
+  /**
    * Remote URL for the external Identity Provider JWKS endpoint.
    */
   jwksUrl?: string;

--- a/packages/fhirtypes/dist/IdentityProvider.d.ts
+++ b/packages/fhirtypes/dist/IdentityProvider.d.ts
@@ -11,14 +11,24 @@
 export interface IdentityProvider {
 
   /**
+   * Issuer URL for the external Identity Provider.
+   */
+  issuer?: string;
+
+  /**
+   * Remote URL for the external Identity Provider JWKS endpoint.
+   */
+  jwksUrl?: string;
+
+  /**
    * Remote URL for the external Identity Provider authorize endpoint.
    */
-  authorizeUrl: string;
+  authorizeUrl?: string;
 
   /**
    * Remote URL for the external Identity Provider token endpoint.
    */
-  tokenUrl: string;
+  tokenUrl?: string;
 
   /**
    * Client Authentication method used by Clients to authenticate to the
@@ -30,7 +40,7 @@ export interface IdentityProvider {
   /**
    * Remote URL for the external Identity Provider userinfo endpoint.
    */
-  userInfoUrl: string;
+  userInfoUrl?: string;
 
   /**
    * Optional userinfo mode. Defaults to standard OIDC userinfo semantics.
@@ -46,12 +56,12 @@ export interface IdentityProvider {
   /**
    * External Identity Provider client ID.
    */
-  clientId: string;
+  clientId?: string;
 
   /**
    * External Identity Provider client secret.
    */
-  clientSecret: string;
+  clientSecret?: string;
 
   /**
    * Optional flag to use PKCE in the token request.

--- a/packages/server/src/auth/external.test.ts
+++ b/packages/server/src/auth/external.test.ts
@@ -297,6 +297,48 @@ describe('External', () => {
     expect(res.body.issue[0].details.text).toBe('Identity provider not found');
   });
 
+  test('Missing token URL', async () => {
+    const client = await createClient(systemRepo, {
+      project,
+      name: 'Missing Token URL',
+      redirectUri,
+      identityProvider: {
+        ...identityProvider,
+        tokenUrl: undefined,
+      },
+    });
+    const url = appendQueryParams('/auth/external', {
+      code: randomUUID(),
+      state: JSON.stringify({ redirectUri, clientId: client.id }),
+    });
+
+    const res = await request(app).get(url);
+    expect(res).toHaveStatus(400);
+    expect(res.body.issue[0].details.text).toBe('Missing token URL for external identity provider');
+  });
+
+  test('Client secret post requires client credentials', async () => {
+    const client = await createClient(systemRepo, {
+      project,
+      name: 'Missing Client Credentials',
+      redirectUri,
+      identityProvider: {
+        ...identityProvider,
+        tokenAuthMethod: OAuthTokenAuthMethod.ClientSecretPost,
+        clientId: undefined,
+        clientSecret: undefined,
+      },
+    });
+    const url = appendQueryParams('/auth/external', {
+      code: randomUUID(),
+      state: JSON.stringify({ redirectUri, clientId: client.id }),
+    });
+
+    const res = await request(app).get(url);
+    expect(res).toHaveStatus(400);
+    expect(res.body.issue[0].details.text).toBe('Missing client ID or client secret for external identity provider');
+  });
+
   test('Invalid project', async () => {
     const url = appendQueryParams('/auth/external', {
       code: randomUUID(),

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -260,6 +260,10 @@ async function verifyExternalCode(
   code: string,
   codeVerifier: string | undefined
 ): Promise<Record<string, unknown>> {
+  if (!idp.tokenUrl) {
+    throw new OperationOutcomeError(badRequest('Missing token URL for external identity provider'));
+  }
+
   const headers: HeadersInit = {
     Accept: ContentType.JSON,
     'Accept-Encoding': 'identity',
@@ -276,6 +280,10 @@ async function verifyExternalCode(
   }
 
   if (idp.tokenAuthMethod === OAuthTokenAuthMethod.ClientSecretPost) {
+    if (!idp.clientId || !idp.clientSecret) {
+      throw new OperationOutcomeError(badRequest('Missing client ID or client secret for external identity provider'));
+    }
+
     params.append('client_id', idp.clientId);
     params.append('client_secret', idp.clientSecret);
   } else {

--- a/packages/server/src/auth/method.ts
+++ b/packages/server/src/auth/method.ts
@@ -47,7 +47,7 @@ export async function isExternalAuth(email: string): Promise<{ domain: string; a
   }
 
   const idp = domainConfig.identityProvider;
-  if (!idp) {
+  if (!idp?.authorizeUrl || !idp.clientId) {
     return undefined;
   }
 

--- a/packages/server/src/migrations/data/data-version-manifest.json
+++ b/packages/server/src/migrations/data/data-version-manifest.json
@@ -153,5 +153,8 @@
   },
   "v41": {
     "serverVersion": "5.1.27"
+  },
+  "v42": {
+    "serverVersion": "5.1.30"
   }
 }

--- a/packages/server/src/migrations/data/index.ts
+++ b/packages/server/src/migrations/data/index.ts
@@ -50,3 +50,4 @@ export * as v38 from './v38';
 export * as v39 from './v39';
 export * as v40 from './v40';
 export * as v41 from './v41';
+export * as v42 from './v42';

--- a/packages/server/src/migrations/data/v42.ts
+++ b/packages/server/src/migrations/data/v42.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
+
+import type { PoolClient } from 'pg';
+import { prepareCustomMigrationJobData, runCustomMigration } from '../../workers/post-deploy-migration';
+import * as fns from '../migrate-functions';
+import type { MigrationActionResult } from '../types';
+import type { CustomPostDeployMigration } from './types';
+
+export const migration: CustomPostDeployMigration = {
+  type: 'custom',
+  prepareJobData: (asyncJob) => prepareCustomMigrationJobData(asyncJob),
+  run: async (repo, job, jobData) => runCustomMigration(repo, job, jobData, callback),
+};
+
+// prettier-ignore
+async function callback(client: PoolClient, results: MigrationActionResult[]): Promise<void> {
+  await fns.idempotentCreateIndex(client, results, 'ClientApplication_identityProviderIssuer_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "ClientApplication_identityProviderIssuer_idx" ON "ClientApplication" ("identityProviderIssuer")`);
+}

--- a/packages/server/src/migrations/schema/index.ts
+++ b/packages/server/src/migrations/schema/index.ts
@@ -122,3 +122,4 @@ export * as v109 from './v109';
 export * as v110 from './v110';
 export * as v111 from './v111';
 export * as v112 from './v112';
+export * as v113 from './v113';

--- a/packages/server/src/migrations/schema/v113.ts
+++ b/packages/server/src/migrations/schema/v113.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
+
+import type { PoolClient } from 'pg';
+import * as fns from '../migrate-functions';
+
+// prettier-ignore
+export async function run(client: PoolClient): Promise<void> {
+  const results: { name: string; durationMs: number }[] = []
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "ClientApplication" ADD COLUMN IF NOT EXISTS "identityProviderIssuer" TEXT`);
+}

--- a/packages/server/src/oauth/external.test.ts
+++ b/packages/server/src/oauth/external.test.ts
@@ -421,7 +421,7 @@ describe('External auth', () => {
       async () => {
         fetchMock.mockImplementation(() => mockFetchJson({ keys: [publicJwk] }));
 
-        const createJwt = (audience: string) =>
+        const createJwt = (audience: string): Promise<string> =>
           new SignJWT({ nonce: randomUUID() })
             .setProtectedHeader({ alg: 'ES256' })
             .setIssuer('https://external-auth.example.com')

--- a/packages/server/src/oauth/external.test.ts
+++ b/packages/server/src/oauth/external.test.ts
@@ -402,6 +402,48 @@ describe('External auth', () => {
     );
   });
 
+  test('JWKS verification enforces configured audience', async () => {
+    const keyPair = await generateKeyPair('ES256');
+    const publicJwk = await exportJWK(keyPair.publicKey);
+    const jwksUrl = 'https://external-auth.example.com/.well-known/audience-jwks.json';
+
+    await withExternalAuthProviders(
+      [
+        {
+          issuer: 'https://external-auth.example.com',
+          identityProvider: {
+            issuer: 'https://external-auth.example.com',
+            audience: 'medplum-client',
+            jwksUrl,
+          },
+        },
+      ],
+      async () => {
+        fetchMock.mockImplementation(() => mockFetchJson({ keys: [publicJwk] }));
+
+        const createJwt = (audience: string) =>
+          new SignJWT({ nonce: randomUUID() })
+            .setProtectedHeader({ alg: 'ES256' })
+            .setIssuer('https://external-auth.example.com')
+            .setAudience(audience)
+            .setSubject(externalSub)
+            .setIssuedAt()
+            .setExpirationTime('2h')
+            .sign(keyPair.privateKey);
+
+        const rejected = await request(app)
+          .get('/oauth2/userinfo')
+          .set('Authorization', 'Bearer ' + (await createJwt('other-client')));
+        expect(rejected).toHaveStatus(401);
+
+        const accepted = await request(app)
+          .get('/oauth2/userinfo')
+          .set('Authorization', 'Bearer ' + (await createJwt('medplum-client')));
+        expect(accepted).toHaveStatus(200);
+      }
+    );
+  });
+
   test('Sub claim with caching', async () => {
     fetchMock.mockImplementationOnce(() => mockFetchJson({ ok: true }));
 

--- a/packages/server/src/oauth/external.test.ts
+++ b/packages/server/src/oauth/external.test.ts
@@ -5,11 +5,13 @@ import { encodeBase64Url, getReferenceString } from '@medplum/core';
 import type { Practitioner, Project, ProjectMembership } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
+import { exportJWK, generateKeyPair, SignJWT } from 'jose';
 import request from 'supertest';
 import { vi } from 'vitest';
 import { inviteUser } from '../admin/invite';
 import { initApp, shutdownApp } from '../app';
-import { loadTestConfig } from '../config/loader';
+import { getConfig, loadTestConfig } from '../config/loader';
+import type { MedplumExternalAuthConfig } from '../config/types';
 import type { SystemRepository } from '../fhir/repo';
 import { getProjectSystemRepo } from '../fhir/repo';
 import { createTestProject } from '../test.setup';
@@ -98,6 +100,153 @@ describe('External auth', () => {
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
     expect(res).toHaveStatus(401);
+  });
+
+  test('Rejects provider without a verification URL', async () => {
+    await withExternalAuthProviders(
+      [
+        {
+          issuer: 'https://external-auth.example.com',
+          identityProvider: { issuer: 'https://external-auth.example.com' },
+        },
+      ],
+      async () => {
+        const jwt = createFakeJwt({
+          iss: 'https://external-auth.example.com',
+          sub: externalSub,
+          nonce: randomUUID(),
+        });
+        const res = await request(app)
+          .get('/oauth2/userinfo')
+          .set('Authorization', 'Bearer ' + jwt);
+        expect(res).toHaveStatus(401);
+      }
+    );
+  });
+
+  test('Project-scoped request maps an identity-less token to the issuer client', async () => {
+    const keyPair = await generateKeyPair('ES256');
+    const publicJwk = await exportJWK(keyPair.publicKey);
+    const jwksUrl = 'https://external-auth.example.com/.well-known/project-jwks.json';
+    const { client, project } = await createTestProject({
+      withClient: true,
+      client: {
+        identityProvider: {
+          issuer: 'https://external-auth.example.com',
+          jwksUrl,
+        },
+      },
+    });
+    await withExternalAuthProviders(undefined, async () => {
+      fetchMock.mockImplementationOnce(() => mockFetchJson({ keys: [publicJwk] }));
+
+      const jwt = await new SignJWT({ nonce: randomUUID() })
+        .setProtectedHeader({ alg: 'ES256' })
+        .setIssuer('https://external-auth.example.com')
+        .setSubject('external-client-subject')
+        .setIssuedAt()
+        .setExpirationTime('2h')
+        .sign(keyPair.privateKey);
+      const res = await request(app)
+        .get(`/projects/${project.id}/oauth2/userinfo`)
+        .set('Authorization', 'Bearer ' + jwt);
+
+      expect(res).toHaveStatus(200);
+      expect(res.body.sub).toBe(client.id);
+    });
+  });
+
+  test('Identity-less token cache is scoped by URL project', async () => {
+    const first = await createTestProject({
+      withClient: true,
+      client: {
+        identityProvider: {
+          issuer: 'https://external-auth.example.com',
+          userInfoUrl: 'https://external-auth.example.com/oauth2/userinfo',
+        },
+      },
+    });
+    const second = await createTestProject({
+      withClient: true,
+      client: {
+        identityProvider: {
+          issuer: 'https://external-auth.example.com',
+          userInfoUrl: 'https://external-auth.example.com/oauth2/userinfo',
+        },
+      },
+    });
+    await withExternalAuthProviders(undefined, async () => {
+      fetchMock
+        .mockImplementationOnce(() => mockFetchJson({ ok: true }))
+        .mockImplementationOnce(() => mockFetchJson({ ok: true }));
+
+      const jwt = createFakeJwt({
+        iss: 'https://external-auth.example.com',
+        nonce: randomUUID(),
+      });
+      const firstResponse = await request(app)
+        .get(`/projects/${first.project.id}/oauth2/userinfo`)
+        .set('Authorization', 'Bearer ' + jwt);
+      const secondResponse = await request(app)
+        .get(`/projects/${second.project.id}/oauth2/userinfo`)
+        .set('Authorization', 'Bearer ' + jwt);
+
+      expect(firstResponse).toHaveStatus(200);
+      expect(firstResponse.body.sub).toBe(first.client.id);
+      expect(secondResponse).toHaveStatus(200);
+      expect(secondResponse.body.sub).toBe(second.client.id);
+    });
+  });
+
+  test('Global provider resolves an identity-less token to the project client', async () => {
+    const { client, project } = await createTestProject({
+      withClient: true,
+      client: {
+        identityProvider: {
+          issuer: 'https://external-auth.example.com',
+          userInfoUrl: 'https://external-auth.example.com/oauth2/userinfo',
+        },
+      },
+    });
+    fetchMock.mockImplementationOnce(() => mockFetchJson({ ok: true }));
+
+    const jwt = createFakeJwt({ iss: 'https://external-auth.example.com', nonce: randomUUID() });
+    const res = await request(app)
+      .get(`/projects/${project.id}/oauth2/userinfo`)
+      .set('Authorization', 'Bearer ' + jwt);
+
+    expect(res).toHaveStatus(200);
+    expect(res.body.sub).toBe(client.id);
+  });
+
+  test('Rejects ambiguous project clients for an external issuer', async () => {
+    const { project } = await createTestProject({
+      withClient: true,
+      client: {
+        identityProvider: {
+          issuer: 'https://ambiguous.example.com',
+          userInfoUrl: 'https://ambiguous.example.com/oauth2/userinfo',
+        },
+      },
+    });
+    const projectRepo = await getProjectSystemRepo(project);
+    await projectRepo.createResource({
+      resourceType: 'ClientApplication',
+      meta: { project: project.id },
+      name: 'Duplicate external issuer',
+      identityProvider: {
+        issuer: 'https://ambiguous.example.com',
+        userInfoUrl: 'https://ambiguous.example.com/oauth2/userinfo',
+      },
+    });
+
+    await withExternalAuthProviders(undefined, async () => {
+      const jwt = createFakeJwt({ iss: 'https://ambiguous.example.com', nonce: randomUUID() });
+      const res = await request(app)
+        .get(`/projects/${project.id}/oauth2/userinfo`)
+        .set('Authorization', 'Bearer ' + jwt);
+      expect(res).toHaveStatus(401);
+    });
   });
 
   test('Remote call to userinfo fails', async () => {
@@ -214,6 +363,43 @@ describe('External auth', () => {
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
     expect(res).toHaveStatus(200);
+  });
+
+  test('Success by JWKS verification', async () => {
+    const keyPair = await generateKeyPair('ES256');
+    const publicJwk = await exportJWK(keyPair.publicKey);
+    const jwksUrl = 'https://external-auth.example.com/.well-known/jwks.json';
+
+    await withExternalAuthProviders(
+      [
+        {
+          issuer: 'https://external-auth.example.com',
+          identityProvider: {
+            issuer: 'https://external-auth.example.com',
+            jwksUrl,
+          },
+        },
+      ],
+      async () => {
+        fetchMock.mockImplementationOnce(() => mockFetchJson({ keys: [publicJwk] }));
+
+        const jwt = await new SignJWT({
+          nonce: randomUUID(),
+        })
+          .setProtectedHeader({ alg: 'ES256' })
+          .setIssuer('https://external-auth.example.com')
+          .setSubject(externalSub)
+          .setIssuedAt()
+          .setExpirationTime('2h')
+          .sign(keyPair.privateKey);
+
+        const res = await request(app)
+          .get(`/oauth2/userinfo`)
+          .set('Authorization', 'Bearer ' + jwt);
+        expect(res.status).toBe(200);
+        expect(fetchMock).toHaveBeenCalledWith(jwksUrl, expect.anything());
+      }
+    );
   });
 
   test('Sub claim with caching', async () => {
@@ -341,4 +527,18 @@ describe('External auth', () => {
 
 function createFakeJwt(claims: Record<string, unknown>): string {
   return `header.${encodeBase64Url(JSON.stringify(claims))}.signature`;
+}
+
+async function withExternalAuthProviders(
+  externalAuthProviders: MedplumExternalAuthConfig[] | undefined,
+  fn: () => Promise<void>
+): Promise<void> {
+  const savedExternalAuthProviders = getConfig().externalAuthProviders;
+  getConfig().externalAuthProviders = externalAuthProviders;
+
+  try {
+    await fn();
+  } finally {
+    getConfig().externalAuthProviders = savedExternalAuthProviders;
+  }
 }

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -2152,6 +2152,29 @@ describe('OAuth2 Token', () => {
     expect(fetchMock).toHaveBeenCalledWith('https://server-config.example.com/oauth2/userinfo', expect.anything());
   });
 
+  test('Token exchange rejects identity provider without user info URL', async () => {
+    const noUserInfoClient = await createClient(systemRepo, {
+      project,
+      name: 'No User Info Client',
+      redirectUri,
+      identityProvider: {
+        issuer: externalAuthIssuer,
+        jwksUrl: 'https://example.com/.well-known/jwks.json',
+      },
+    });
+
+    const res = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: OAuthGrantType.TokenExchange,
+      subject_token_type: OAuthTokenType.AccessToken,
+      client_id: noUserInfoClient.id,
+      subject_token: 'opaque-token',
+    });
+    expect(res).toHaveStatus(400);
+    expect(res.body.error).toBe('invalid_request');
+    expect(res.body.error_description).toBe('Missing user info URL');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test('Token exchange rejects unknown client ID', async () => {
     const res = await request(app).post('/oauth2/token').type('form').send({
       grant_type: OAuthGrantType.TokenExchange,

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -545,6 +545,10 @@ async function tryGetExternalUserInfo(
   idp: IdentityProvider,
   subjectToken: string
 ): Promise<JWTPayload | undefined> {
+  if (!idp.userInfoUrl) {
+    sendTokenError(res, 'invalid_request', 'Missing user info URL', 400);
+    return undefined;
+  }
   try {
     return await getExternalUserInfo(idp.userInfoUrl, subjectToken, idp);
   } catch (err: any) {
@@ -576,7 +580,7 @@ function resolveExternalAuthProvider(clientId: string, client?: ClientApplicatio
 
     const userInfoUrl = externalAuthConfig.userInfoUrl;
     if (userInfoUrl) {
-      return { userInfoUrl } as IdentityProvider;
+      return { userInfoUrl };
     }
   }
 

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -1016,18 +1016,17 @@ export async function getLoginForAccessToken(
   accessToken: string
 ): Promise<AuthenticationResult | undefined> {
   const globalSystemRepo = getGlobalSystemRepo();
-  const externalAuthState = await tryExternalAuth(globalSystemRepo, req, accessToken);
-  if (externalAuthState) {
-    const repo = await getRepoForLogin(externalAuthState);
-    return { authState: externalAuthState, repo };
-  }
-
   let verifyResult: Awaited<ReturnType<typeof verifyJwt>>;
   try {
     const config = getConfig();
     const expectedIssuer = req ? getProjectScopedUrl(req.originalUrl, config.issuer) : config.issuer;
     verifyResult = await verifyJwt(accessToken, expectedIssuer);
   } catch {
+    const externalAuthState = await tryExternalAuth(globalSystemRepo, req, accessToken);
+    if (externalAuthState) {
+      const repo = await getRepoForLogin(externalAuthState);
+      return { authState: externalAuthState, repo };
+    }
     return undefined;
   }
 
@@ -1391,7 +1390,7 @@ async function tryExternalAuthLogin(
  * Ambiguous configurations fail closed.
  *
  * @param projectId - Project ID from the request URL.
- * @param issuer - Verified external token issuer.
+ * @param issuer - Issuer presented by the external token.
  * @returns The matching client application, or undefined unless exactly one client matches.
  */
 async function getExternalBearerClient(
@@ -1401,18 +1400,20 @@ async function getExternalBearerClient(
   const projectRepo = await getProjectSystemRepo(projectId);
   const clients = await projectRepo.searchResources<ClientApplication>({
     resourceType: 'ClientApplication',
-    filters: [{ code: '_project', operator: Operator.EQUALS, value: projectId }],
-    count: 1000,
+    filters: [
+      { code: '_project', operator: Operator.EQUALS, value: projectId },
+      { code: 'identity-provider-issuer', operator: Operator.EXACT, value: issuer },
+    ],
+    count: 2,
   });
-  const matchingClients = clients.filter((client) => client.identityProvider?.issuer === issuer);
-  if (matchingClients.length !== 1) {
-    if (matchingClients.length > 1) {
+  if (clients.length !== 1) {
+    if (clients.length > 1) {
       getLogger().warn('Multiple ClientApplications found for external auth issuer in project', { issuer, projectId });
     }
     return undefined;
   }
 
-  return matchingClients[0];
+  return clients[0];
 }
 
 /**

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -965,7 +965,7 @@ function normalizeExternalUserInfo(body: Record<string, unknown>, idp?: Identity
   };
 }
 
-async function verifyExternalToken(idp: IdentityProvider, token: string, issuer: string): Promise<void> {
+async function verifyExternalToken(idp: IdentityProvider, token: string): Promise<void> {
   if (!idp.jwksUrl) {
     if (!idp.userInfoUrl) {
       throw new OperationOutcomeError(badRequest('Missing user info URL - check your identity provider configuration'));
@@ -973,8 +973,11 @@ async function verifyExternalToken(idp: IdentityProvider, token: string, issuer:
     await getExternalUserInfo(idp.userInfoUrl, token, idp);
     return;
   }
+  if (!idp.issuer) {
+    throw new OperationOutcomeError(badRequest('Missing issuer - check your identity provider configuration'));
+  }
   const jwks = createRemoteJWKSet(new URL(idp.jwksUrl), { [customFetch]: safeFetch });
-  await jwtVerify(token, jwks, { issuer, audience: idp.audience });
+  await jwtVerify(token, jwks, { issuer: idp.issuer, audience: idp.audience });
 }
 
 interface ValidationAssertion {
@@ -1282,7 +1285,7 @@ async function tryExternalAuthLogin(
 
   // Verify the token against the external IDP.
   try {
-    await verifyExternalToken(idp, accessToken, claims.iss as string);
+    await verifyExternalToken(idp, accessToken);
   } catch (err: any) {
     getLogger().warn('Failed to verify external token', err);
     return undefined;

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -34,14 +34,13 @@ import type {
 import bcrypt from 'bcrypt';
 import type { Request } from 'express';
 import type { VerifyOptions } from 'jose';
-import { jwtVerify } from 'jose';
+import { createRemoteJWKSet, customFetch, jwtVerify } from 'jose';
 import assert from 'node:assert/strict';
 import { createHash, timingSafeEqual } from 'node:crypto';
 import type { IncomingMessage } from 'node:http';
 import { authenticator } from 'otplib';
 import { getUserConfiguration } from '../auth/me';
 import { getConfig } from '../config/loader';
-import type { MedplumExternalAuthConfig } from '../config/types';
 import { getAccessPolicyForLogin, getRepoForLogin } from '../fhir/accesspolicy';
 import type { Repository, SystemRepository } from '../fhir/repo';
 import { getGlobalSystemRepo, getProjectSystemRepo } from '../fhir/repo';
@@ -56,7 +55,7 @@ import {
   LoginEvent,
   UserAuthenticationEvent,
 } from '../util/auditevent';
-import { getProjectScopedUrl, safeFetch } from '../util/url';
+import { getProjectIdFromUrl, getProjectScopedUrl, safeFetch } from '../util/url';
 import { getStandardClientById } from './clients';
 import type { MedplumAccessTokenClaims } from './keys';
 import { generateAccessToken, generateIdToken, generateRefreshToken, generateSecret, verifyJwt } from './keys';
@@ -966,6 +965,18 @@ function normalizeExternalUserInfo(body: Record<string, unknown>, idp?: Identity
   };
 }
 
+async function verifyExternalToken(idp: IdentityProvider, token: string, issuer: string): Promise<void> {
+  if (!idp.jwksUrl) {
+    if (!idp.userInfoUrl) {
+      throw new OperationOutcomeError(badRequest('Missing user info URL - check your identity provider configuration'));
+    }
+    await getExternalUserInfo(idp.userInfoUrl, token, idp);
+    return;
+  }
+  const jwks = createRemoteJWKSet(new URL(idp.jwksUrl), { [customFetch]: safeFetch });
+  await jwtVerify(token, jwks, { issuer });
+}
+
 interface ValidationAssertion {
   clientId?: string;
   clientSecret?: string;
@@ -1202,11 +1213,6 @@ async function tryExternalAuth(
   accessToken: string
 ): Promise<AuthState | undefined> {
   const externalAuthProviders = getConfig().externalAuthProviders;
-  if (!externalAuthProviders) {
-    // No external auth providers configured
-    return undefined;
-  }
-
   if (!isJwt(accessToken)) {
     // Not a JWT, so we cannot verify it
     return undefined;
@@ -1214,14 +1220,28 @@ async function tryExternalAuth(
 
   const claims = parseJWTPayload(accessToken);
   const issuer = claims.iss as string;
-  const externalAuthConfig = externalAuthProviders.find((provider) => provider.issuer === issuer);
-  if (!externalAuthConfig) {
+  const projectId = req ? getProjectIdFromUrl(req.originalUrl) : undefined;
+  const externalAuthConfig = externalAuthProviders?.find(
+    (provider) => (provider.identityProvider?.issuer ?? provider.issuer) === issuer
+  );
+  let client: WithId<ClientApplication> | undefined;
+  let idp: IdentityProvider | undefined;
+  if (externalAuthConfig?.identityProvider) {
+    idp = { issuer, userInfoUrl: externalAuthConfig.userInfoUrl, ...externalAuthConfig.identityProvider };
+  } else if (externalAuthConfig?.userInfoUrl) {
+    idp = { issuer, userInfoUrl: externalAuthConfig.userInfoUrl };
+  }
+  if (!idp && projectId) {
+    client = await getExternalBearerClient(projectId, issuer);
+    idp = client?.identityProvider;
+  }
+  if (!idp) {
     // Not a configured external auth provider
     return undefined;
   }
 
   const redis = getCacheRedis();
-  const redisKey = `medplum:ext-auth:${issuer}:${hashCode(accessToken)}`;
+  const redisKey = `medplum:ext-auth:${issuer}:${projectId ?? ''}:${hashCode(accessToken)}`;
   const cachedValue = await redis.get(redisKey);
   let login: Login;
   let project: WithId<Project> | undefined;
@@ -1234,7 +1254,7 @@ async function tryExternalAuth(
     project = await systemRepo.readReference<Project>(membership.project);
   } else {
     // If not cached, try to authenticate the user with the external auth provider
-    const externalAuthState = await tryExternalAuthLogin(systemRepo, req, accessToken, claims, externalAuthConfig);
+    const externalAuthState = await tryExternalAuthLogin(systemRepo, req, accessToken, claims, idp, client);
     if (!externalAuthState) {
       return undefined;
     }
@@ -1251,34 +1271,28 @@ async function tryExternalAuthLogin(
   req: Request | undefined,
   accessToken: string,
   claims: JWTPayload,
-  externalAuthConfig: MedplumExternalAuthConfig
+  idp: IdentityProvider,
+  client: WithId<ClientApplication> | undefined
 ): Promise<Pick<AuthState, 'login' | 'project' | 'membership'> | undefined> {
-  // To ensure broad compatibility, we check for the FHIR user profile in two places:
-  // the standard `fhirUser` claim and `ext.fhirUser` for identity providers
-  // that automatically place custom claims in an `ext` block.
   const extensions = claims.ext as Record<string, unknown> | undefined;
   const profileString = claims.fhirUser ?? extensions?.fhirUser;
-
-  // If neither fhirUser nor sub is present, we cannot identify the user
-  if (!isString(profileString) && !isString(claims.sub)) {
+  const projectId = req ? getProjectIdFromUrl(req.originalUrl) : undefined;
+  if (!isString(profileString) && !isString(claims.sub) && !projectId) {
     return undefined;
   }
 
-  // Validate the token against the external IDP's userinfo endpoint
+  // Verify the token against the external IDP.
   try {
-    const userInfoUrl = externalAuthConfig.identityProvider?.userInfoUrl ?? externalAuthConfig.userInfoUrl;
-    if (!userInfoUrl) {
-      return undefined;
-    }
-    await getExternalUserInfo(userInfoUrl, accessToken, externalAuthConfig.identityProvider);
+    await verifyExternalToken(idp, accessToken, claims.iss as string);
   } catch (err: any) {
-    getLogger().warn('Failed to get external user info', err);
+    getLogger().warn('Failed to verify external token', err);
     return undefined;
   }
 
   let membership: WithId<ProjectMembership> | undefined;
-
-  if (isString(profileString)) {
+  if (client) {
+    membership = await getClientApplicationMembership(systemRepo, client);
+  } else if (isString(profileString)) {
     // Path A: fhirUser claim present - look up profile, then find membership
     // Profile string can be either a reference or a search string
     let searchRequest: SearchRequest<ProfileResource>;
@@ -1308,6 +1322,9 @@ async function tryExternalAuthLogin(
       resourceType: 'ProjectMembership',
       filters: [{ code: 'profile', operator: Operator.EQUALS, value: getReferenceString(profile) }],
     });
+  } else if (!isString(claims.sub)) {
+    client = await getExternalBearerClient(projectId as string, claims.iss as string);
+    membership = client ? await getClientApplicationMembership(systemRepo, client) : undefined;
   } else {
     // Path B: sub claim fallback - look up ProjectMembership by externalId
     // Fetch at most 2 to detect duplicates efficiently; if 2+ exist, the externalId is ambiguous
@@ -1317,7 +1334,7 @@ async function tryExternalAuthLogin(
         {
           code: 'external-id',
           operator: Operator.EXACT,
-          value: claims.sub as string,
+          value: claims.sub,
         },
       ],
       count: 2,
@@ -1366,6 +1383,36 @@ async function tryExternalAuthLogin(
   );
 
   return { login, project, membership };
+}
+
+/**
+ * Resolves an identity-less external bearer token to the client application configured for its issuer.
+ * The project-scoped URL supplies the tenant, while the issuer identifies the client within that project.
+ * Ambiguous configurations fail closed.
+ *
+ * @param projectId - Project ID from the request URL.
+ * @param issuer - Verified external token issuer.
+ * @returns The matching client application, or undefined unless exactly one client matches.
+ */
+async function getExternalBearerClient(
+  projectId: string,
+  issuer: string
+): Promise<WithId<ClientApplication> | undefined> {
+  const projectRepo = await getProjectSystemRepo(projectId);
+  const clients = await projectRepo.searchResources<ClientApplication>({
+    resourceType: 'ClientApplication',
+    filters: [{ code: '_project', operator: Operator.EQUALS, value: projectId }],
+    count: 1000,
+  });
+  const matchingClients = clients.filter((client) => client.identityProvider?.issuer === issuer);
+  if (matchingClients.length !== 1) {
+    if (matchingClients.length > 1) {
+      getLogger().warn('Multiple ClientApplications found for external auth issuer in project', { issuer, projectId });
+    }
+    return undefined;
+  }
+
+  return matchingClients[0];
 }
 
 /**

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -974,7 +974,7 @@ async function verifyExternalToken(idp: IdentityProvider, token: string, issuer:
     return;
   }
   const jwks = createRemoteJWKSet(new URL(idp.jwksUrl), { [customFetch]: safeFetch });
-  await jwtVerify(token, jwks, { issuer });
+  await jwtVerify(token, jwks, { issuer, audience: idp.audience });
 }
 
 interface ValidationAssertion {


### PR DESCRIPTION
This PR allows Medplum to accept externally issued JWTs directly as bearer tokens when the target project is identified by a project-scoped API URL.

For a request such as:

```text
/projects/{projectId}/...
/api/projects/{projectId}/...
```

Medplum can resolve external token verification settings from a `ClientApplication` in that project, verify the JWT against the application's configured JWKS endpoint, and authenticate the request as that client application's project membership.

Existing server-wide external bearer configuration and the existing `fhirUser` / `sub` identity mapping behavior remain supported.

## Motivation

Some external systems issue valid JWT bearer tokens that identify the issuer but do not include a Medplum project, membership, or profile identifier. The ONC Inferno CRD validator is one example.

Before project-scoped API URLs were available, the same external issuer and token shape could not be routed safely to different Medplum projects. A hardcoded membership or a server-wide issuer-to-project mapping would work for only one project and would not provide tenant isolation.

Project-scoped API URLs now provide the missing routing signal. This PR uses that signal to locate the external authentication configuration and client identity within the target project.

## Behavior

External bearer authentication now resolves its configuration in this order:

1. Look for a matching issuer in the existing server-wide `externalAuthProviders` configuration.
2. If no server-wide provider matches and the request uses a project-scoped URL, search that project's `ClientApplication` resources for a unique application whose `identityProvider.issuer` matches the JWT issuer.
3. If neither source produces a provider, reject the token.

When configuration is resolved from a project-local `ClientApplication`:

- the client search runs against the project's physical shard;
- the search is also constrained by `_project` for logical project isolation;
- exactly one client must match the issuer;
- the JWT is verified using the client's `identityProvider.jwksUrl`;
- the request is authenticated as that client's existing `ProjectMembership`;
- the external-auth cache key includes the URL project ID.

Zero or multiple matching clients fail closed.

## IdentityProvider changes

`IdentityProvider` now supports verification-only configurations:

- Adds `issuer`.
- Adds `jwksUrl`.
- Makes browser OAuth fields optional:
  - `authorizeUrl`
  - `tokenUrl`
  - `userInfoUrl`
  - `clientId`
  - `clientSecret`

This allows a client application to describe an external JWT issuer without pretending to be a complete OAuth authorization-code provider.

Code paths that perform browser login or token exchange now validate the optional fields they require and return a configuration error when they are missing.

## Token verification

External bearer tokens are verified as follows:

- If `jwksUrl` is configured, Medplum verifies the JWT signature and issuer using the remote JWKS.
- Otherwise, Medplum preserves the existing userinfo-based verification behavior.
- Outbound userinfo and JWKS requests use `safeFetch`.

## Compatibility

- Existing server-wide `externalAuthProviders` continue to work.
- Existing userinfo-based external bearer authentication continues to work.
- Existing legacy bearer identity mapping remains unchanged:
  - `fhirUser` or `ext.fhirUser` maps through the referenced profile.
  - `sub` maps to `ProjectMembership.externalId`.
- Existing non-project-scoped API routes remain unchanged.
- A project-local client fallback is only available when the request URL contains a project ID.
- Browser OAuth login and token exchange continue to require the endpoint and client fields used by those flows.

## Approaches considered

### Server-wide issuer-to-project configuration

We considered adding project IDs to the server's external provider configuration. That would keep tenant configuration in deployment config, would not scale well for hosted multi-tenant environments, and would duplicate identity already represented by project-local client applications.

### Mapping arbitrary token claims to users or memberships

We explored configurable email, subject, and FHIR-user mapping modes. They did not solve the motivating case because the validator token has no claim that identifies the target Medplum project or membership. The final implementation keeps the existing `fhirUser` and `sub` compatibility paths and uses the project URL plus `ClientApplication` for identity-less tokens.

### Explicit verification-method and audience configuration

We also explored a separate verification-method field and configurable audience validation. Those were broader external-auth features than this change requires. The final implementation selects JWKS verification when `jwksUrl` is present and otherwise preserves userinfo verification.

## Security properties

- JWT signatures are verified against the configured JWKS.
- The JWT issuer must match the configured identity-provider issuer.
- The URL project is included in the external-auth cache key.
- Project-local client lookup uses both the correct physical shard and an explicit `_project` constraint.
- Ambiguous issuer matches within a project are rejected.
- The authenticated identity is an existing client membership; the URL does not create a membership or grant access by itself.
- Existing authenticated project-scope validation still rejects requests where the resolved membership does not belong to the URL project.

