### PR TITLE
[Inferno] Add introspect URL to CapabilityStatement

### DIFF
--- a/packages/server/src/fhir/metadata.ts
+++ b/packages/server/src/fhir/metadata.ts
@@ -258,6 +258,10 @@ function buildSecurity(config: MedplumServerConfig): CapabilityStatementRestSecu
             url: 'token',
             valueUri: config.tokenUrl,
           },
+          {
+            url: 'introspect',
+            valueUri: config.introspectUrl,
+          },
         ],
       },
     ],


### PR DESCRIPTION
We currently advertise our OAuth "introspect" URL in `.well-known` but not in the `/metadata` `CapabilityStatment`, which apparently is a problem for Inferno:

<img width="707" height="531" alt="image" src="https://github.com/user-attachments/assets/6e07ff74-da14-4d1a-9c2d-cb939c618742" />


Spec: https://build.fhir.org/ig/HL7/fhir-extensions/StructureDefinition-oauth-uris.html