### PR TITLE
Validate intake form response before creating the patient

### DIFF
--- a/examples/medplum-provider/src/utils/intake-form.test.ts
+++ b/examples/medplum-provider/src/utils/intake-form.test.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { allOk, badRequest, OperationOutcomeError } from '@medplum/core';
+import { badRequest, OperationOutcomeError } from '@medplum/core';
 import type { Questionnaire, QuestionnaireResponse, QuestionnaireResponseItemAnswer } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
+import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const mockAnswers = {
@@ -113,13 +114,12 @@ describe('onboardPatient', () => {
     vi.clearAllMocks();
   });
 
-  test('creates patient and invokes onboarding helpers', async () => {
-    const validateSpy = vi.spyOn(medplum, 'validateResource').mockResolvedValue(allOk);
-    const createSpy = vi.spyOn(medplum, 'createResource').mockImplementation(async (resource: any) => {
-      if (resource.resourceType === 'Patient') {
-        return { ...resource, id: 'patient-1' };
-      }
-      return resource;
+  test('submits all onboarding resources as a single transaction', async () => {
+    const createSpy = vi.spyOn(medplum, 'createResource');
+    const batchSpy = vi.spyOn(medplum, 'executeBatch').mockResolvedValue({
+      resourceType: 'Bundle',
+      type: 'transaction-response',
+      entry: [{ resource: { resourceType: 'Patient', id: 'patient-1' } }],
     });
 
     const questionnaire = { resourceType: 'Questionnaire' } as Questionnaire;
@@ -128,8 +128,12 @@ describe('onboardPatient', () => {
     const patient = await onboardPatient(medplum, questionnaire, response);
 
     expect(patient.id).toBe('patient-1');
-    expect(validateSpy).toHaveBeenCalledWith(response);
-    expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ resourceType: 'Patient' }));
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(batchSpy).toHaveBeenCalledTimes(1);
+    const bundle = batchSpy.mock.calls[0][0];
+    expect(bundle.type).toBe('transaction');
+    expect(bundle.entry?.some((e) => e.resource?.resourceType === 'Patient')).toBe(true);
+    expect(bundle.entry?.some((e) => e.resource?.resourceType === 'QuestionnaireResponse')).toBe(true);
     expect(mockIntakeUtils.addExtension).toHaveBeenCalledWith(
       expect.objectContaining({}),
       'race-url',
@@ -138,15 +142,15 @@ describe('onboardPatient', () => {
       'ombCategory'
     );
     expect(mockIntakeUtils.addLanguage).toHaveBeenCalledTimes(2);
-    expect(mockIntakeUtils.addCoverage).toHaveBeenCalledWith(medplum, patient, expect.any(Object));
+    expect(mockIntakeUtils.addCoverage).toHaveBeenCalledWith(expect.anything(), expect.any(Object), expect.any(Object));
     expect(mockIntakeUtils.addAllergy).toHaveBeenCalled();
     expect(mockIntakeUtils.addConsent).toHaveBeenCalled();
     expect(mockIntakeUtils.addPharmacy).toHaveBeenCalled();
   });
 
-  test('does not create any resources when the response is invalid', async () => {
-    vi.spyOn(medplum, 'validateResource').mockRejectedValue(new OperationOutcomeError(badRequest('Invalid response')));
+  test('does not create any resources when the transaction fails', async () => {
     const createSpy = vi.spyOn(medplum, 'createResource');
+    vi.spyOn(medplum, 'executeBatch').mockRejectedValue(new OperationOutcomeError(badRequest('Invalid response')));
 
     const questionnaire = { resourceType: 'Questionnaire' } as Questionnaire;
     const response = buildResponseFromAnswers(mockAnswers);
@@ -154,13 +158,11 @@ describe('onboardPatient', () => {
     await expect(onboardPatient(medplum, questionnaire, response)).rejects.toThrow('Invalid response');
 
     expect(createSpy).not.toHaveBeenCalled();
-    expect(mockIntakeUtils.upsertObservation).not.toHaveBeenCalled();
   });
 
-  test('does not create any resources when a coverage group is missing required answers', async () => {
-    vi.spyOn(medplum, 'validateResource').mockResolvedValue(allOk);
-    const createSpy = vi.spyOn(medplum, 'createResource');
-    mockIntakeUtils.getGroupRepeatedAnswers.mockImplementation((_, __, groupId) =>
+  test('rejects before submitting when a coverage group is missing required answers', async () => {
+    const batchSpy = vi.spyOn(medplum, 'executeBatch');
+    (mockIntakeUtils.getGroupRepeatedAnswers as Mock).mockImplementation((_, __, groupId) =>
       groupId === 'coverage-information' ? [{ 'subscriber-id': { valueString: 'sub-1' } }] : []
     );
 
@@ -171,7 +173,7 @@ describe('onboardPatient', () => {
       'Coverage Information is missing required answers'
     );
 
-    expect(createSpy).not.toHaveBeenCalled();
+    expect(batchSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/examples/medplum-provider/src/utils/intake-form.test.ts
+++ b/examples/medplum-provider/src/utils/intake-form.test.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { allOk, badRequest, OperationOutcomeError } from '@medplum/core';
 import type { Questionnaire, QuestionnaireResponse, QuestionnaireResponseItemAnswer } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -113,6 +114,7 @@ describe('onboardPatient', () => {
   });
 
   test('creates patient and invokes onboarding helpers', async () => {
+    const validateSpy = vi.spyOn(medplum, 'validateResource').mockResolvedValue(allOk);
     const createSpy = vi.spyOn(medplum, 'createResource').mockImplementation(async (resource: any) => {
       if (resource.resourceType === 'Patient') {
         return { ...resource, id: 'patient-1' };
@@ -126,6 +128,7 @@ describe('onboardPatient', () => {
     const patient = await onboardPatient(medplum, questionnaire, response);
 
     expect(patient.id).toBe('patient-1');
+    expect(validateSpy).toHaveBeenCalledWith(response);
     expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ resourceType: 'Patient' }));
     expect(mockIntakeUtils.addExtension).toHaveBeenCalledWith(
       expect.objectContaining({}),
@@ -139,6 +142,36 @@ describe('onboardPatient', () => {
     expect(mockIntakeUtils.addAllergy).toHaveBeenCalled();
     expect(mockIntakeUtils.addConsent).toHaveBeenCalled();
     expect(mockIntakeUtils.addPharmacy).toHaveBeenCalled();
+  });
+
+  test('does not create any resources when the response is invalid', async () => {
+    vi.spyOn(medplum, 'validateResource').mockRejectedValue(new OperationOutcomeError(badRequest('Invalid response')));
+    const createSpy = vi.spyOn(medplum, 'createResource');
+
+    const questionnaire = { resourceType: 'Questionnaire' } as Questionnaire;
+    const response = buildResponseFromAnswers(mockAnswers);
+
+    await expect(onboardPatient(medplum, questionnaire, response)).rejects.toThrow('Invalid response');
+
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(mockIntakeUtils.upsertObservation).not.toHaveBeenCalled();
+  });
+
+  test('does not create any resources when a coverage group is missing required answers', async () => {
+    vi.spyOn(medplum, 'validateResource').mockResolvedValue(allOk);
+    const createSpy = vi.spyOn(medplum, 'createResource');
+    mockIntakeUtils.getGroupRepeatedAnswers.mockImplementation((_, __, groupId) =>
+      groupId === 'coverage-information' ? [{ 'subscriber-id': { valueString: 'sub-1' } }] : []
+    );
+
+    const questionnaire = { resourceType: 'Questionnaire' } as Questionnaire;
+    const response = buildResponseFromAnswers(mockAnswers);
+
+    await expect(onboardPatient(medplum, questionnaire, response)).rejects.toThrow(
+      'Coverage Information is missing required answers'
+    );
+
+    expect(createSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/examples/medplum-provider/src/utils/intake-form.ts
+++ b/examples/medplum-provider/src/utils/intake-form.ts
@@ -5,12 +5,22 @@ import {
   addProfileToResource,
   append,
   badRequest,
+  convertToTransactionBundle,
   createReference,
   EMPTY,
+  generateId,
   getQuestionnaireAnswers,
+  isOk,
   OperationOutcomeError,
 } from '@medplum/core';
-import type { Organization, Patient, Questionnaire, QuestionnaireResponse, Reference } from '@medplum/fhirtypes';
+import type {
+  Organization,
+  Patient,
+  Questionnaire,
+  QuestionnaireResponse,
+  Reference,
+  Resource,
+} from '@medplum/fhirtypes';
 import {
   addAllergy,
   addCondition,
@@ -36,13 +46,23 @@ import {
   upsertObservation,
 } from './intake-utils';
 
+function createTransactionRecorder(): { recorder: MedplumClient; resources: Resource[] } {
+  const resources: Resource[] = [];
+  const record = async <T extends Resource>(resource: T): Promise<T> => {
+    const result = { ...resource, id: generateId() };
+    resources.push(result);
+    return result;
+  };
+  const recorder = { createResource: record, upsertResource: record } as unknown as MedplumClient;
+  return { recorder, resources };
+}
+
 export async function onboardPatient(
   medplum: MedplumClient,
   questionnaire: Questionnaire,
   response: QuestionnaireResponse
 ): Promise<Patient> {
-  // Reject invalid responses up front so a validation error cannot leave a partially created patient behind
-  await medplum.validateResource(response);
+  const { recorder, resources } = createTransactionRecorder();
 
   const insuranceProviders = getGroupRepeatedAnswers(questionnaire, response, 'coverage-information');
   for (const provider of insuranceProviders) {
@@ -132,17 +152,15 @@ export async function onboardPatient(
 
   // Create the patient resource
 
-  patient = await medplum.createResource(patient);
+  patient = await recorder.createResource(patient);
 
-  // NOTE: Updating the questionnaire response does not trigger a loop because the bot subscription
-  // is configured for "create"-only event.
   response.subject = createReference(patient);
-  await medplum.createResource(response);
+  await recorder.createResource(response);
 
   // Handle observations
 
   await upsertObservation(
-    medplum,
+    recorder,
     patient,
     observationCodeMapping.sexualOrientation,
     observationCategoryMapping.socialHistory,
@@ -152,7 +170,7 @@ export async function onboardPatient(
   );
 
   await upsertObservation(
-    medplum,
+    recorder,
     patient,
     observationCodeMapping.housingStatus,
     observationCategoryMapping.sdoh,
@@ -161,7 +179,7 @@ export async function onboardPatient(
   );
 
   await upsertObservation(
-    medplum,
+    recorder,
     patient,
     observationCodeMapping.educationLevel,
     observationCategoryMapping.sdoh,
@@ -170,7 +188,7 @@ export async function onboardPatient(
   );
 
   await upsertObservation(
-    medplum,
+    recorder,
     patient,
     observationCodeMapping.smokingStatus,
     observationCategoryMapping.socialHistory,
@@ -180,7 +198,7 @@ export async function onboardPatient(
   );
 
   await upsertObservation(
-    medplum,
+    recorder,
     patient,
     observationCodeMapping.pregnancyStatus,
     observationCategoryMapping.socialHistory,
@@ -190,7 +208,7 @@ export async function onboardPatient(
 
   const estimatedDeliveryDate = convertDateToDateTime(answers['estimated-delivery-date']?.valueDate);
   await upsertObservation(
-    medplum,
+    recorder,
     patient,
     observationCodeMapping.estimatedDeliveryDate,
     observationCategoryMapping.socialHistory,
@@ -202,52 +220,52 @@ export async function onboardPatient(
 
   const allergies = getGroupRepeatedAnswers(questionnaire, response, 'allergies');
   for (const allergy of allergies) {
-    await addAllergy(medplum, patient, allergy);
+    await addAllergy(recorder, patient, allergy);
   }
 
   // Handle medications
 
   const medications = getGroupRepeatedAnswers(questionnaire, response, 'medications');
   for (const medication of medications) {
-    await addMedication(medplum, patient, medication);
+    await addMedication(recorder, patient, medication);
   }
 
   // Handle medical history
 
   const medicalHistory = getGroupRepeatedAnswers(questionnaire, response, 'medical-history');
   for (const history of medicalHistory) {
-    await addCondition(medplum, patient, history);
+    await addCondition(recorder, patient, history);
   }
 
   const familyMemberHistory = getGroupRepeatedAnswers(questionnaire, response, 'family-member-history');
   for (const history of familyMemberHistory) {
-    await addFamilyMemberHistory(medplum, patient, history);
+    await addFamilyMemberHistory(recorder, patient, history);
   }
 
   // Handle vaccination history (immunizations)
 
   const vaccinationHistory = getGroupRepeatedAnswers(questionnaire, response, 'vaccination-history');
   for (const vaccine of vaccinationHistory) {
-    await addImmunization(medplum, patient, vaccine);
+    await addImmunization(recorder, patient, vaccine);
   }
 
   // Handle coverage
 
   for (const provider of insuranceProviders) {
-    await addCoverage(medplum, patient, provider);
+    await addCoverage(recorder, patient, provider);
   }
 
   // Handle preferred pharmacy
 
   const preferredPharmacyReference = answers['preferred-pharmacy-reference']?.valueReference;
   if (preferredPharmacyReference) {
-    await addPharmacy(medplum, patient, preferredPharmacyReference as Reference<Organization>);
+    await addPharmacy(recorder, patient, preferredPharmacyReference as Reference<Organization>);
   }
 
   // Handle consents
 
   await addConsent(
-    medplum,
+    recorder,
     patient,
     !!answers['consent-for-treatment-signature']?.valueBoolean,
     consentScopeMapping.treatment,
@@ -257,7 +275,7 @@ export async function onboardPatient(
   );
 
   await addConsent(
-    medplum,
+    recorder,
     patient,
     !!answers['agreement-to-pay-for-treatment-help']?.valueBoolean,
     consentScopeMapping.treatment,
@@ -267,7 +285,7 @@ export async function onboardPatient(
   );
 
   await addConsent(
-    medplum,
+    recorder,
     patient,
     !!answers['notice-of-privacy-practices-signature']?.valueBoolean,
     consentScopeMapping.patientPrivacy,
@@ -277,7 +295,7 @@ export async function onboardPatient(
   );
 
   await addConsent(
-    medplum,
+    recorder,
     patient,
     !!answers['acknowledgement-for-advance-directives-signature']?.valueBoolean,
     consentScopeMapping.adr,
@@ -286,5 +304,22 @@ export async function onboardPatient(
     convertDateToDateTime(answers['acknowledgement-for-advance-directives-date']?.valueDate)
   );
 
-  return patient;
+  const bundle = convertToTransactionBundle({
+    resourceType: 'Bundle',
+    type: 'collection',
+    entry: resources.map((resource) => ({ resource })),
+  });
+  const result = await medplum.executeBatch(bundle);
+
+  for (const entry of result.entry ?? EMPTY) {
+    if (entry.response?.outcome && !isOk(entry.response.outcome)) {
+      throw new OperationOutcomeError(entry.response.outcome);
+    }
+  }
+
+  const createdPatient = result.entry?.find((entry) => entry.resource?.resourceType === 'Patient')?.resource;
+  if (!createdPatient) {
+    throw new OperationOutcomeError(badRequest('Patient was not created'));
+  }
+  return createdPatient as Patient;
 }

--- a/examples/medplum-provider/src/utils/intake-form.ts
+++ b/examples/medplum-provider/src/utils/intake-form.ts
@@ -1,7 +1,15 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { MedplumClient } from '@medplum/core';
-import { addProfileToResource, append, createReference, EMPTY, getQuestionnaireAnswers } from '@medplum/core';
+import {
+  addProfileToResource,
+  append,
+  badRequest,
+  createReference,
+  EMPTY,
+  getQuestionnaireAnswers,
+  OperationOutcomeError,
+} from '@medplum/core';
 import type { Organization, Patient, Questionnaire, QuestionnaireResponse, Reference } from '@medplum/fhirtypes';
 import {
   addAllergy,
@@ -33,6 +41,20 @@ export async function onboardPatient(
   questionnaire: Questionnaire,
   response: QuestionnaireResponse
 ): Promise<Patient> {
+  // Reject invalid responses up front so a validation error cannot leave a partially created patient behind
+  await medplum.validateResource(response);
+
+  const insuranceProviders = getGroupRepeatedAnswers(questionnaire, response, 'coverage-information');
+  for (const provider of insuranceProviders) {
+    if (
+      !provider['insurance-provider']?.valueReference ||
+      !provider['subscriber-id']?.valueString ||
+      !provider['relationship-to-subscriber']?.valueCoding
+    ) {
+      throw new OperationOutcomeError(badRequest('Coverage Information is missing required answers'));
+    }
+  }
+
   const answers = getQuestionnaireAnswers(response);
 
   let patient: Patient = {
@@ -211,7 +233,6 @@ export async function onboardPatient(
 
   // Handle coverage
 
-  const insuranceProviders = getGroupRepeatedAnswers(questionnaire, response, 'coverage-information');
   for (const provider of insuranceProviders) {
     await addCoverage(medplum, patient, provider);
   }


### PR DESCRIPTION
Closes #8827

 Check everything that can fail before writing anything. Two checks were added at the top of onboardPatient:
1. Ask the server to validate the questionnaire response (same check that would have failed mid-way now runs first).
2. Since the coverage code reads the fields unconditionally, it crashed on partial input. Fix makes sure the insurance section has all answers it needs.


![demo](https://raw.githubusercontent.com/abhinavmir/medplum/assets/intake-fix-demo.gif)
