### PR TITLE
Support multiple subscription-supported-interaction extensions

### DIFF
--- a/packages/core/src/subscriptions/index.test.ts
+++ b/packages/core/src/subscriptions/index.test.ts
@@ -3,7 +3,7 @@
 import type { Bundle, Communication, Parameters, Subscription, SubscriptionChannel } from '@medplum/fhirtypes';
 import { vi } from 'vitest';
 import { WS } from 'vitest-websocket-mock';
-import type { CriteriaState, SubscriptionEventMap } from '.';
+import type { BackgroundJobInteraction, CriteriaState, SubscriptionEventMap } from '.';
 import { resourceMatchesSubscriptionCriteria, SubscriptionEmitter, SubscriptionManager } from '.';
 import { MockMedplumClient } from '../client-test-utils';
 import { generateId } from '../crypto';
@@ -2043,5 +2043,46 @@ describe('resourceMatchesSubscriptionCriteria', () => {
         expect(log).not.toHaveBeenCalledWith(expect.stringContaining('Subscription suppressed'));
       }
     });
+  });
+
+  describe('Supported interaction matching logic', () => {
+    const SUPPORTED_INTERACTION_URL = 'https://medplum.com/fhir/StructureDefinition/subscription-supported-interaction';
+
+    function buildSubscription(interactions: BackgroundJobInteraction[]): Subscription {
+      return {
+        resourceType: 'Subscription',
+        status: 'active',
+        reason: 'test subscription',
+        criteria: 'Communication',
+        channel: { type: 'rest-hook', endpoint: 'Bot/123' },
+        extension: interactions.map((valueCode) => ({ url: SUPPORTED_INTERACTION_URL, valueCode })),
+      };
+    }
+
+    test.each([
+      // No extension → every interaction is supported (including delete)
+      { interactions: [], received: 'create', expected: true },
+      { interactions: [], received: 'update', expected: true },
+      { interactions: [], received: 'delete', expected: true },
+      // Single extension → only the declared interaction is supported
+      { interactions: ['create'], received: 'create', expected: true },
+      { interactions: ['create'], received: 'update', expected: false },
+      { interactions: ['create'], received: 'delete', expected: false },
+      // Multiple extensions → any declared interaction is supported, others (e.g. delete) are not
+      { interactions: ['create', 'update'], received: 'create', expected: true },
+      { interactions: ['create', 'update'], received: 'update', expected: true },
+      { interactions: ['create', 'update'], received: 'delete', expected: false },
+    ] as { interactions: BackgroundJobInteraction[]; received: BackgroundJobInteraction; expected: boolean }[])(
+      'interactions=$interactions received=$received → $expected',
+      async ({ interactions, received, expected }) => {
+        const matches = await resourceMatchesSubscriptionCriteria({
+          resource: { id: '123', resourceType: 'Communication', status: 'in-progress' },
+          subscription: buildSubscription(interactions),
+          context: { interaction: received },
+          getPreviousResource: async () => undefined,
+        });
+        expect(matches).toStrictEqual(expected);
+      }
+    );
   });
 });

--- a/packages/core/src/subscriptions/index.ts
+++ b/packages/core/src/subscriptions/index.ts
@@ -12,7 +12,7 @@ import { normalizeErrorString, OperationOutcomeError, validationError } from '..
 import { matchesSearchRequest } from '../search/match';
 import { parseSearchRequest } from '../search/search';
 import type { ProfileResource, WithId } from '../utils';
-import { deepEquals, extractAccountReferences, getExtension, getReferenceString, resolveId } from '../utils';
+import { deepEquals, EMPTY, extractAccountReferences, getExtension, getReferenceString, resolveId } from '../utils';
 import type { IReconnectingWebSocket, IReconnectingWebSocketCtor } from '../websockets/reconnecting-websocket';
 import { ReconnectingWebSocket } from '../websockets/reconnecting-websocket';
 import {
@@ -755,14 +755,22 @@ export async function resourceMatchesSubscriptionCriteria({
   // A Subscription can declare one or more `subscription-supported-interaction` extensions.
   // When present, the interaction is only supported if it matches one of the declared codes.
   // When absent, all interactions ("create", "update", "delete") are supported by default.
-  const supportedInteractions = (subscription.extension ?? [])
-    .filter((e) => e.url === 'https://medplum.com/fhir/StructureDefinition/subscription-supported-interaction')
-    .map((e) => e.valueCode)
-    .filter((code): code is string => code !== undefined);
-  if (supportedInteractions.length > 0 && !supportedInteractions.includes(context.interaction)) {
-    logger?.debug(
-      `Ignore rest hook for different interaction (wanted one of [${supportedInteractions.join(', ')}], received "${context.interaction}")`
-    );
+  let specifiedInteractions = false;
+  let supportsInteraction = false;
+  for (const ext of subscription.extension ?? EMPTY) {
+    if (ext.url === 'https://medplum.com/fhir/StructureDefinition/subscription-supported-interaction') {
+      specifiedInteractions = true;
+      if (ext.valueCode === context.interaction) {
+        supportsInteraction = true;
+        break;
+      }
+    }
+  }
+  if (specifiedInteractions && !supportsInteraction) {
+    logger?.debug(`Ignored rest hook for unsupported interaction`, {
+      subscription: subscription.id,
+      interaction: context.interaction,
+    });
     return false;
   }
 

--- a/packages/core/src/subscriptions/index.ts
+++ b/packages/core/src/subscriptions/index.ts
@@ -752,13 +752,16 @@ export async function resourceMatchesSubscriptionCriteria({
     return false;
   }
 
-  const supportedInteractionExtension = getExtension(
-    subscription,
-    'https://medplum.com/fhir/StructureDefinition/subscription-supported-interaction'
-  );
-  if (supportedInteractionExtension && supportedInteractionExtension.valueCode !== context.interaction) {
+  // A Subscription can declare one or more `subscription-supported-interaction` extensions.
+  // When present, the interaction is only supported if it matches one of the declared codes.
+  // When absent, all interactions ("create", "update", "delete") are supported by default.
+  const supportedInteractions = (subscription.extension ?? [])
+    .filter((e) => e.url === 'https://medplum.com/fhir/StructureDefinition/subscription-supported-interaction')
+    .map((e) => e.valueCode)
+    .filter((code): code is string => code !== undefined);
+  if (supportedInteractions.length > 0 && !supportedInteractions.includes(context.interaction)) {
     logger?.debug(
-      `Ignore rest hook for different interaction (wanted "${supportedInteractionExtension.valueCode}", received "${context.interaction}")`
+      `Ignore rest hook for different interaction (wanted one of [${supportedInteractions.join(', ')}], received "${context.interaction}")`
     );
     return false;
   }

--- a/packages/docs/docs/subscriptions/subscription-extensions.md
+++ b/packages/docs/docs/subscriptions/subscription-extensions.md
@@ -66,15 +66,13 @@ Below are explanations of the different extensions Medplum Provides
 ## Interactions
 
 :::caution[Note]
-By default, FHIR Subscriptions will execute on "create" and "update" operations.
+By default, FHIR Subscriptions will execute on all "create", "update", and "delete" operations. To restrict a Subscription to a subset of these interactions, use one or more `subscription-supported-interaction` extensions as described below.
 :::
 
 You can use extensions as follows for more fine-grained control over when Subscriptions execute. To confirm if your Subscriptions are executing, navigate to `https://app.medplum.com/Subscription/<id>/event` to view related [AuditEvents](/docs/api/fhir/resources/auditevent). Note that if you configure the subscription to use `log`-only destination for AuditEvents (see [AuditEvent Destination](#auditevent-destination) below), these events will not appear in the UI.
 
-:::caution[Note]
-Only **one** `subscription-supported-interaction` extension is supported per Subscription. If you need to listen for multiple interaction types (e.g., both "create" and "update"), you should either use the default behavior (which fires on both "create" and "update") or create separate Subscription resources for each interaction type.
-
-Adding multiple `subscription-supported-interaction` extensions to a single Subscription will result in only the first one being evaluated, and the Subscription will revert to default behavior for any unrecognized configuration.
+:::note
+A Subscription may declare **multiple** `subscription-supported-interaction` extensions. When one or more are present, the Subscription will only execute for the listed interactions. For example, adding one extension with `valueCode` of `create` and another with `valueCode` of `update` will fire on "create" and "update" but **not** "delete". When no `subscription-supported-interaction` extension is present, the Subscription fires on all interactions ("create", "update", and "delete").
 :::
 
 ### Subscriptions for "create"-only or "update"-only events
@@ -113,6 +111,31 @@ You can also restrict the FHIR Subscription to only execute on "update", using t
     "endpoint": "https://example.com/webhook"
   },
   "extension": [
+    {
+      "url": "https://medplum.com/fhir/StructureDefinition/subscription-supported-interaction",
+      "valueCode": "update"
+    }
+  ]
+}
+```
+
+To listen for more than one interaction while excluding the others (for example, "create" and "update" but not "delete"), include a separate `subscription-supported-interaction` extension for each interaction you want:
+
+```json
+{
+  "resourceType": "Subscription",
+  "reason": "test",
+  "status": "active",
+  "criteria": "Patient",
+  "channel": {
+    "type": "rest-hook",
+    "endpoint": "https://example.com/webhook"
+  },
+  "extension": [
+    {
+      "url": "https://medplum.com/fhir/StructureDefinition/subscription-supported-interaction",
+      "valueCode": "create"
+    },
     {
       "url": "https://medplum.com/fhir/StructureDefinition/subscription-supported-interaction",
       "valueCode": "update"


### PR DESCRIPTION
Fixes #8490.

## Problem

Two issues raised in #8490:

1. A Subscription could not be configured with two `subscription-supported-interaction` extensions (e.g. one for `create` and one for `update`) to fire on those interactions while excluding `delete`. `resourceMatchesSubscriptionCriteria` used `getExtension`, which returns only the **first** matching extension, so any additional interaction extensions were silently ignored.
2. The docs stated that barebones Subscriptions (with no interaction extension) fire only on `create` and `update`, but they actually fire on `delete` too.

## Changes

- **`packages/core/src/subscriptions/index.ts`** — collect **all** `subscription-supported-interaction` extensions and match the current interaction against the full set. When one or more are present, only the listed interactions fire; when none are present, all interactions (`create`/`update`/`delete`) fire. Backward compatible for the zero- and single-extension cases. This function is shared by the server subscription worker and precommit checks, so both paths are covered.
- **`packages/core/src/subscriptions/index.test.ts`** — added a parameterized test covering no-extension (all interactions incl. delete), single-extension, and multi-extension (`create`+`update` excludes `delete`) cases.
- **`packages/docs/docs/subscriptions/subscription-extensions.md`** — corrected the default-behavior note to include `delete`, replaced the "only one extension supported" note with guidance on declaring multiple interactions, and added a multi-interaction example.

## Notes

This does not change the default behavior — extension-less Subscriptions still fire on `delete`; that behavior is now documented rather than changed.

## Testing

- `npx vitest run src/subscriptions/index.test.ts` — 73 passed
- `npx tsc --noEmit` on core — clean
- Server worker tests require a database and were not run locally; they only use single-extension configs, which are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)