### PR TITLE
DAW: correct quantity-qualifier catalog + dispense-unit resolution

### DIFF
--- a/examples/medplum-provider/src/components/meds/quantity-qualifiers.test.ts
+++ b/examples/medplum-provider/src/components/meds/quantity-qualifiers.test.ts
@@ -177,9 +177,9 @@ describe('quantity-qualifiers', () => {
       expect(resolver('gram')).toBe('C48155');
       expect(resolver('TAB')).toBe('C48542');
       expect(resolver('caps')).toBe('C48480');
-      expect(
-        buildDispenseUnitNameResolver([{ potencyUnit: 'C48542', name: 'Tablet dosing unit' }])('Tablet')
-      ).toBe('C48542');
+      expect(buildDispenseUnitNameResolver([{ potencyUnit: 'C48542', name: 'Tablet dosing unit' }])('Tablet')).toBe(
+        'C48542'
+      );
     });
 
     test('returns undefined for unknown/blank names', () => {

--- a/examples/medplum-provider/src/components/meds/quantity-qualifiers.test.ts
+++ b/examples/medplum-provider/src/components/meds/quantity-qualifiers.test.ts
@@ -3,19 +3,24 @@
 
 import { describe, expect, test } from 'vitest';
 import {
+  buildDispenseUnitNameResolver,
   buildQualifierMatcher,
+  extractLeadingSigDispenseUnit,
   getQuantityQualifierLabel,
   inferQuantityQualifierCode,
   inferQuantityQualifierCodeWith,
   mergeQuantityQualifierCatalog,
+  STATIC_DISPENSE_UNIT_NAME_RESOLVER,
   STATIC_QUALIFIER_MATCHER,
 } from './quantity-qualifiers';
 
 describe('quantity-qualifiers', () => {
   test('getQuantityQualifierLabel returns label for known code', () => {
-    expect(getQuantityQualifierLabel('C48542')).toBe('Tablet dosing unit');
-    expect(getQuantityQualifierLabel('C48486')).toBe('Suppository');
-    expect(getQuantityQualifierLabel('  C48483  ')).toBe('Capsule');
+    // Codes verified against the live GET /v3/prescription/quantityqualifier catalog.
+    expect(getQuantityQualifierLabel('C48542')).toBe('Tablet');
+    expect(getQuantityQualifierLabel('C48539')).toBe('Suppository');
+    expect(getQuantityQualifierLabel('  C48480  ')).toBe('Capsule');
+    expect(getQuantityQualifierLabel('C48155')).toBe('Gram');
   });
 
   test('getQuantityQualifierLabel returns undefined for empty/unknown codes', () => {
@@ -27,12 +32,12 @@ describe('quantity-qualifiers', () => {
   test('inferQuantityQualifierCode picks suppository for rectal sigs', () => {
     expect(
       inferQuantityQualifierCode('Insert 1 suppository rectally daily', 'Anusol-HC 25 mg rectal suppository')
-    ).toBe('C48486');
+    ).toBe('C48539');
   });
 
   test('inferQuantityQualifierCode falls back to formulation text when sig is generic', () => {
-    expect(inferQuantityQualifierCode('Use as directed', 'Lidocaine 5% patch')).toBe('C48484');
-    expect(inferQuantityQualifierCode('Use as directed', 'Albuterol HFA inhalation spray')).toBe('C48485');
+    expect(inferQuantityQualifierCode('Use as directed', 'Lidocaine 5% patch')).toBe('C48524');
+    expect(inferQuantityQualifierCode('Use as directed', 'Albuterol HFA inhalation spray')).toBe('C48537');
   });
 
   test('inferQuantityQualifierCode prefers more specific terms', () => {
@@ -87,8 +92,8 @@ describe('quantity-qualifiers', () => {
   });
 
   test('STATIC_QUALIFIER_MATCHER backs the legacy inferQuantityQualifierCode helper', () => {
-    expect(STATIC_QUALIFIER_MATCHER('Insert 1 suppository rectally daily')).toBe('C48486');
-    expect(inferQuantityQualifierCode('Insert 1 suppository rectally daily')).toBe('C48486');
+    expect(STATIC_QUALIFIER_MATCHER('Insert 1 suppository rectally daily')).toBe('C48539');
+    expect(inferQuantityQualifierCode('Insert 1 suppository rectally daily')).toBe('C48539');
   });
 
   test('buildQualifierMatcher prefers dose-form keywords over strength units regardless of catalog name length', () => {
@@ -131,5 +136,61 @@ describe('quantity-qualifiers', () => {
     expect(merged.find((r) => r.code === 'C48542')?.label).toBe('Tablet');
     expect(merged.find((r) => r.code === 'C99999')?.label).toBe('Made-up unit');
     expect(merged).toEqual([...merged].sort((a, b) => a.label.localeCompare(b.label)));
+  });
+
+  describe('extractLeadingSigDispenseUnit', () => {
+    test('reads the unit token from a ScriptSure pre-built sig line', () => {
+      // Verbatim staging shapes: mupirocin ointment and metformin tablet.
+      expect(extractLeadingSigDispenseUnit('30 Gram - Apply to skin three times daily (use small amount)')).toBe(
+        'Gram'
+      );
+      expect(extractLeadingSigDispenseUnit('80 Tablet - Take 2 tablet by mouth four times daily')).toBe('Tablet');
+      expect(extractLeadingSigDispenseUnit('150 Milliliter - Take 5 mL by mouth twice daily')).toBe('Milliliter');
+    });
+
+    test('tolerates decimals and en/em dashes', () => {
+      expect(extractLeadingSigDispenseUnit('2.5 Milliliter – inject subcutaneously')).toBe('Milliliter');
+    });
+
+    test('returns undefined when the line does not lead with <number> <unit> -', () => {
+      expect(extractLeadingSigDispenseUnit('Take as directed')).toBeUndefined();
+      expect(extractLeadingSigDispenseUnit('Apply to affected area')).toBeUndefined();
+      expect(extractLeadingSigDispenseUnit('')).toBeUndefined();
+      expect(extractLeadingSigDispenseUnit(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('buildDispenseUnitNameResolver', () => {
+    const resolver = buildDispenseUnitNameResolver([
+      { potencyUnit: 'C48155', name: 'Gram' },
+      { potencyUnit: 'C48542', name: 'Tablet' },
+      { potencyUnit: 'C48480', name: 'Capsule' },
+      { potencyUnit: 'C28254', name: 'Milliliter' },
+    ]);
+
+    test('resolves a leading sig unit to its NCI code (including "strength" units like Gram)', () => {
+      expect(resolver(extractLeadingSigDispenseUnit('30 Gram - Apply to skin'))).toBe('C48155');
+      expect(resolver(extractLeadingSigDispenseUnit('80 Tablet - Take 2 tablet'))).toBe('C48542');
+    });
+
+    test('is case-insensitive and maps tab/cap abbreviations and "... dosing unit"', () => {
+      expect(resolver('gram')).toBe('C48155');
+      expect(resolver('TAB')).toBe('C48542');
+      expect(resolver('caps')).toBe('C48480');
+      expect(
+        buildDispenseUnitNameResolver([{ potencyUnit: 'C48542', name: 'Tablet dosing unit' }])('Tablet')
+      ).toBe('C48542');
+    });
+
+    test('returns undefined for unknown/blank names', () => {
+      expect(resolver('Widget')).toBeUndefined();
+      expect(resolver('')).toBeUndefined();
+      expect(resolver(undefined)).toBeUndefined();
+    });
+
+    test('STATIC_DISPENSE_UNIT_NAME_RESOLVER resolves Gram and Tablet from the static fallback', () => {
+      expect(STATIC_DISPENSE_UNIT_NAME_RESOLVER('Gram')).toBe('C48155');
+      expect(STATIC_DISPENSE_UNIT_NAME_RESOLVER('Tablet')).toBe('C48542');
+    });
   });
 });

--- a/examples/medplum-provider/src/components/meds/quantity-qualifiers.test.ts
+++ b/examples/medplum-provider/src/components/meds/quantity-qualifiers.test.ts
@@ -5,11 +5,13 @@ import { describe, expect, test } from 'vitest';
 import {
   buildDispenseUnitNameResolver,
   buildQualifierMatcher,
+  DEFAULT_QUANTITY_QUALIFIER,
   extractLeadingSigDispenseUnit,
   getQuantityQualifierLabel,
   inferQuantityQualifierCode,
   inferQuantityQualifierCodeWith,
   mergeQuantityQualifierCatalog,
+  resolveQuantityQualifier,
   STATIC_DISPENSE_UNIT_NAME_RESOLVER,
   STATIC_QUALIFIER_MATCHER,
 } from './quantity-qualifiers';
@@ -191,6 +193,37 @@ describe('quantity-qualifiers', () => {
     test('STATIC_DISPENSE_UNIT_NAME_RESOLVER resolves Gram and Tablet from the static fallback', () => {
       expect(STATIC_DISPENSE_UNIT_NAME_RESOLVER('Gram')).toBe('C48155');
       expect(STATIC_DISPENSE_UNIT_NAME_RESOLVER('Tablet')).toBe('C48542');
+    });
+  });
+
+  describe('resolveQuantityQualifier priority', () => {
+    const resolve = (raw: string | undefined, sigLine: string, formatText?: string): string =>
+      resolveQuantityQualifier(raw, sigLine, formatText, STATIC_QUALIFIER_MATCHER, STATIC_DISPENSE_UNIT_NAME_RESOLVER);
+
+    test('leading sig-unit beats a strength-unit raw code (the metformin-tablet regression)', () => {
+      // ScriptSure sends the Milligram strength code (C28253) on a tablet sig.
+      // The authoritative leading "80 Tablet" token must win over raw.
+      expect(resolve('C28253', '80 Tablet - Take 2 tablet by mouth four times daily')).toBe('C48542');
+    });
+
+    test('leading sig-unit resolves topicals/liquids by weight/volume', () => {
+      expect(resolve(undefined, '30 Gram - Apply to affected area twice daily')).toBe('C48155');
+    });
+
+    test('falls back to a valid NCI raw code when the sig has no leading unit token', () => {
+      expect(resolve('C48155', 'Take as directed')).toBe('C48155');
+    });
+
+    test('ignores a non-NCI raw value and infers from keywords instead', () => {
+      expect(resolve('not-a-code', 'Insert 1 suppository rectally daily')).toBe('C48539');
+    });
+
+    test('falls back to keyword inference when there is no sig unit or raw code', () => {
+      expect(resolve(undefined, 'Insert 1 suppository rectally daily')).toBe('C48539');
+    });
+
+    test('defaults to Tablet when nothing resolves', () => {
+      expect(resolve(undefined, 'Take as directed')).toBe(DEFAULT_QUANTITY_QUALIFIER);
     });
   });
 });

--- a/examples/medplum-provider/src/components/meds/quantity-qualifiers.ts
+++ b/examples/medplum-provider/src/components/meds/quantity-qualifiers.ts
@@ -255,7 +255,8 @@ export const STATIC_QUALIFIER_MATCHER: QualifierMatcher = buildQualifierMatcher(
  * available so newly added DAW codes are picked up automatically.
  *
  * @param textParts - Strings to scan; empty/undefined entries are ignored.
- * @returns NCI code (e.g. `C48486`) or `undefined` when no keyword matches.
+ * @returns NCI code (e.g. `C48539` for Suppository) or `undefined` when no
+ *   keyword matches.
  */
 export function inferQuantityQualifierCode(...textParts: (string | undefined)[]): string | undefined {
   return inferQuantityQualifierCodeWith(STATIC_QUALIFIER_MATCHER, ...textParts);
@@ -375,6 +376,11 @@ export function buildDispenseUnitNameResolver(
     const name = row.name?.trim();
     if (code && name) {
       const key = normalizeUnitName(name);
+      // First-wins on normalized-key collisions (e.g. "Tablet" and "Tablet
+      // dosing unit" both normalize to "tablet"). This is only ambiguous if a
+      // catalog ever carries two such rows with *different* codes; today the
+      // static table and observed live catalog do not, so catalog row order is
+      // not significant in practice.
       if (!byName.has(key)) {
         byName.set(key, code);
       }
@@ -395,3 +401,75 @@ export function buildDispenseUnitNameResolver(
 export const STATIC_DISPENSE_UNIT_NAME_RESOLVER = buildDispenseUnitNameResolver(
   STATIC_QUANTITY_QUALIFIERS.map((r) => ({ potencyUnit: r.code, name: r.label }))
 );
+
+/** Default dispense-unit code when nothing else resolves: `C48542` (Tablet). */
+export const DEFAULT_QUANTITY_QUALIFIER = 'C48542';
+
+/** A resolver mapping a dispense-unit name to an NCI potency-unit code. */
+export type DispenseUnitNameResolver = (unitName: string | undefined) => string | undefined;
+
+/** Matches an NCI Thesaurus code (e.g. `C48155`). */
+const NCI_CODE_RE = /^C\d+$/;
+
+/**
+ * Resolves the dispense unit (NCI potency code) for a sig.
+ *
+ * The ScriptSure drug-format endpoint encodes the dispense unit as the leading
+ * token of the sig line (`"30 Gram - …"`, `"80 Tablet - …"`) and usually omits a
+ * per-sig `quantityQualifier`. When a `raw` qualifier IS present it comes from
+ * that same drug-format sig (not a separately edited resource) and cannot be
+ * trusted blindly — ScriptSure frequently sends a strength-unit code for solid
+ * dose forms — so we prefer the authoritative leading sig-unit token and only
+ * fall back to `raw`, then to free-text keyword inference.
+ *
+ * NOTE: this is deliberate, not a stopgap — the v4 Advanced API (as of the
+ * 2026-07-01 docs capture) exposes NO deterministic per-drug dispense-unit
+ * lookup; `quantityQualifier` is only a caller-supplied write field, and drug
+ * reads return dose-form *text* (`MED_DOSAGE_FORM_DESC`), not an NCI code. The
+ * leading sig token IS the deterministic signal (ScriptSure builds it from the
+ * same quantity-qualifier catalog). See the KB:
+ * wiki/fhir/medication-quantity-qualifiers.md + wiki/contradictions.md.
+ *
+ * Priority:
+ *  1. The leading `"<qty> <unit> - …"` token from the sig line, resolved via the
+ *     live/static catalog (fixes topicals/liquids like `"30 Gram"` → Gram). This
+ *     is the deterministic signal ScriptSure builds from the same catalog, so it
+ *     is preferred over `raw`.
+ *  2. `raw` when ScriptSure/caller supplied a valid NCI code the leading token
+ *     could not resolve. NOTE: ScriptSure's per-sig `quantityQualifier` often
+ *     carries a *strength*-unit code for solid dose forms (e.g. a metformin
+ *     tablet coming back with the Milligram code because the formulation strength
+ *     is "500 mg"), and `NCI_CODE_RE` cannot tell a strength code from a dispense
+ *     code — which is exactly why `raw` must rank below the leading sig-unit token
+ *     rather than above it.
+ *  3. Keyword inference from sig line + formulation label (dose-form / volume).
+ *  4. The static `C48542` Tablet fallback.
+ *
+ * @param raw - Value already on the sig (usually absent for drug-format sigs).
+ * @param sigLine - Sig text shown to the prescriber.
+ * @param formatText - Formulation label (e.g. drug `code.text`) when known.
+ * @param matcher - Catalog-aware matcher used for keyword inference.
+ * @param unitResolver - Catalog-aware name→code resolver for the leading token.
+ * @returns NCI potency-unit code; never empty.
+ */
+export function resolveQuantityQualifier(
+  raw: string | undefined,
+  sigLine: string,
+  formatText: string | undefined,
+  matcher: QualifierMatcher,
+  unitResolver: DispenseUnitNameResolver
+): string {
+  const fromSigUnit = unitResolver(extractLeadingSigDispenseUnit(sigLine));
+  if (fromSigUnit) {
+    return fromSigUnit;
+  }
+  const trimmedRaw = raw?.trim();
+  if (trimmedRaw && NCI_CODE_RE.test(trimmedRaw)) {
+    return trimmedRaw;
+  }
+  const inferred = inferQuantityQualifierCodeWith(matcher, sigLine, formatText);
+  if (inferred) {
+    return inferred;
+  }
+  return trimmedRaw || DEFAULT_QUANTITY_QUALIFIER;
+}

--- a/examples/medplum-provider/src/components/meds/quantity-qualifiers.ts
+++ b/examples/medplum-provider/src/components/meds/quantity-qualifiers.ts
@@ -5,8 +5,19 @@
  * NCI Thesaurus potency-unit codes used by DAW/ScriptSure as quantity qualifiers
  * (`potencyUnit` from GET /v3/prescription/quantityqualifier).
  *
- * This static table is a fallback when the live catalog has not been loaded yet.
- * @see https://github.com/... (DAW docs: get-quantity-qualifiers)
+ * This static table is a fallback for when the live catalog has not loaded yet
+ * (and the sole source for {@link getQuantityQualifierLabel}, which renders a
+ * persisted `MedicationRequest.dispenseRequest.quantity.unit`).
+ *
+ * The codes below are taken verbatim from the live staging catalog
+ * (`GET /v3/prescription/quantityqualifier`). An earlier version of this table
+ * used guessed sequential `C484xx` codes that were mostly WRONG — e.g. it mapped
+ * Gram→C48478, but the catalog says C48478 is **Box** and Gram is **C48155**;
+ * likewise Each, Drop, Capsule, Patch, Milligram, Suppository, Syringe, and Vial
+ * were all bound to the wrong code. That corrupted the dropdown and the details
+ * display. See wiki/contradictions.md ("static quantity-qualifier table codes").
+ *
+ * @see https://scriptsure.stoplight.io/docs/scriptsure-advanced/9tbm26mytiwwy-get-quantity-qualifiers
  */
 export const STATIC_QUANTITY_QUALIFIERS: readonly { readonly code: string; readonly label: string }[] = [
   { code: 'C48473', label: 'Ampule' },
@@ -14,21 +25,29 @@ export const STATIC_QUANTITY_QUALIFIERS: readonly { readonly code: string; reado
   { code: 'C78783', label: 'Applicatorful' },
   { code: 'C48474', label: 'Bag' },
   { code: 'C48475', label: 'Bar' },
-  { code: 'C48480', label: 'Each' },
-  { code: 'C25301', label: 'Day' },
+  { code: 'C48477', label: 'Bottle' },
+  { code: 'C48478', label: 'Box' },
+  { code: 'C48480', label: 'Capsule' },
+  { code: 'C48481', label: 'Cartridge' },
+  { code: 'C48484', label: 'Container' },
+  { code: 'C48491', label: 'Drop' },
+  { code: 'C64933', label: 'Each' },
+  { code: 'C48155', label: 'Gram' },
+  { code: 'C48504', label: 'Kit' },
+  { code: 'C48506', label: 'Lozenge' },
+  { code: 'C48152', label: 'Microgram' },
+  { code: 'C28253', label: 'Milligram' },
   { code: 'C28254', label: 'Milliliter' },
-  { code: 'C48542', label: 'Tablet dosing unit' },
-  { code: 'C48477', label: 'Drop' },
-  { code: 'C48478', label: 'Gram' },
-  { code: 'C48479', label: 'International unit' },
-  { code: 'C48481', label: 'Milligram' },
-  { code: 'C48482', label: 'Microgram' },
-  { code: 'C48483', label: 'Capsule' },
-  { code: 'C48484', label: 'Patch' },
-  { code: 'C48485', label: 'Spray' },
-  { code: 'C48486', label: 'Suppository' },
-  { code: 'C48487', label: 'Syringe' },
-  { code: 'C48488', label: 'Vial' },
+  { code: 'C48521', label: 'Packet' },
+  { code: 'C48524', label: 'Patch' },
+  { code: 'C48537', label: 'Spray' },
+  { code: 'C48539', label: 'Suppository' },
+  { code: 'C48540', label: 'Syringe' },
+  { code: 'C48542', label: 'Tablet' },
+  { code: 'C48548', label: 'Troche' },
+  { code: 'C48549', label: 'Tube' },
+  { code: 'C44278', label: 'Unit' },
+  { code: 'C48551', label: 'Vial' },
 ];
 
 const STATIC_BY_CODE: Readonly<Record<string, string>> = Object.fromEntries(
@@ -281,3 +300,95 @@ export function mergeQuantityQualifierCatalog(
   }
   return [...map.entries()].map(([code, label]) => ({ code, label })).sort((a, b) => a.label.localeCompare(b.label));
 }
+
+/**
+ * Extracts the dispense-unit token from a ScriptSure pre-built sig line.
+ *
+ * The drug-format endpoint (`GET /v3/drugformat/format/{routedMedId}`) does not
+ * return a per-sig `quantityQualifier`; instead every sig line is built as
+ * `"<formatQuantity> <QuantityQualifierName> - <instructions>"`, e.g.
+ * `"30 Gram - Apply to skin three times daily"` or
+ * `"80 Tablet - Take 2 tablet by mouth"`. The token between the leading quantity
+ * and the ` - ` separator is therefore the authoritative dispense unit for the
+ * format (ScriptSure derives it from the same quantity-qualifier catalog we
+ * fetch), and is more reliable than scanning the free instruction text — which
+ * deliberately ignores "gram" (a strength unit inside "500 mg tablet" but the
+ * real dispense unit for topicals sold by weight).
+ *
+ * @param sigLine - Pre-built sig line from a ScriptSure drug format.
+ * @returns The unit token (e.g. `"Gram"`, `"Tablet"`), or undefined when the
+ *   line does not start with the expected `<number> <unit> -` shape.
+ */
+export function extractLeadingSigDispenseUnit(sigLine: string | undefined): string | undefined {
+  if (!sigLine) {
+    return undefined;
+  }
+  const match = /^\s*\d+(?:\.\d+)?\s+([A-Za-z][A-Za-z ]*?)\s+[-–—]/.exec(sigLine);
+  return match?.[1]?.trim() || undefined;
+}
+
+/**
+ * Abbreviations / label variants a leading sig-unit token may use that differ
+ * from the canonical catalog `name`. Keys and values are lowercased.
+ */
+const LEADING_UNIT_NAME_ALIASES: Readonly<Record<string, string>> = {
+  tab: 'tablet',
+  tabs: 'tablet',
+  cap: 'capsule',
+  caps: 'capsule',
+};
+
+/**
+ * Normalizes a unit name for lookup: lowercases, maps common abbreviations
+ * (tab→tablet, cap→capsule), and strips the ScriptSure "... dosing unit" suffix
+ * so `"Tablet dosing unit"` and `"Tablet"` collapse to the same key.
+ * @param name - Raw unit name / token.
+ * @returns Normalized lookup key.
+ */
+function normalizeUnitName(name: string): string {
+  const lowered = name.trim().toLowerCase().replace(/\s+dosing unit$/, '');
+  return LEADING_UNIT_NAME_ALIASES[lowered] ?? lowered;
+}
+
+/**
+ * Builds a resolver mapping a dispense-unit *name* (typically the token from
+ * {@link extractLeadingSigDispenseUnit}) to its NCI potency-unit code.
+ *
+ * Unlike {@link buildQualifierMatcher}, this does NOT drop "strength-style"
+ * units such as Gram or Milligram: in the leading dispense position those ARE
+ * the dispense unit, so whatever the catalog names is trusted. Names are
+ * normalized via {@link normalizeUnitName} so `"Tablet"`, `"tab"`, and
+ * `"Tablet dosing unit"` all resolve.
+ *
+ * @param catalog - Live and/or static rows ({ potencyUnit, name }).
+ * @returns A function mapping a unit name to its code, or undefined.
+ */
+export function buildDispenseUnitNameResolver(
+  catalog: readonly { potencyUnit: string; name: string }[]
+): (unitName: string | undefined) => string | undefined {
+  const byName = new Map<string, string>();
+  for (const row of catalog) {
+    const code = row.potencyUnit?.trim();
+    const name = row.name?.trim();
+    if (code && name) {
+      const key = normalizeUnitName(name);
+      if (!byName.has(key)) {
+        byName.set(key, code);
+      }
+    }
+  }
+  return (unitName) => {
+    if (!unitName?.trim()) {
+      return undefined;
+    }
+    return byName.get(normalizeUnitName(unitName));
+  };
+}
+
+/**
+ * Default name resolver built from the static fallback catalog, used until the
+ * live `/v3/prescription/quantityqualifier` response loads.
+ */
+export const STATIC_DISPENSE_UNIT_NAME_RESOLVER = buildDispenseUnitNameResolver(
+  STATIC_QUANTITY_QUALIFIERS.map((r) => ({ potencyUnit: r.code, name: r.label }))
+);

--- a/examples/medplum-provider/src/components/meds/quantity-qualifiers.ts
+++ b/examples/medplum-provider/src/components/meds/quantity-qualifiers.ts
@@ -346,7 +346,10 @@ const LEADING_UNIT_NAME_ALIASES: Readonly<Record<string, string>> = {
  * @returns Normalized lookup key.
  */
 function normalizeUnitName(name: string): string {
-  const lowered = name.trim().toLowerCase().replace(/\s+dosing unit$/, '');
+  const lowered = name
+    .trim()
+    .toLowerCase()
+    .replace(/\s+dosing unit$/, '');
   return LEADING_UNIT_NAME_ALIASES[lowered] ?? lowered;
 }
 

--- a/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
@@ -59,20 +59,18 @@ import { IconShoppingCart } from '@tabler/icons-react';
 import type { JSX, ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
-import type { QualifierMatcher } from '../../components/meds/quantity-qualifiers';
+import type { DispenseUnitNameResolver, QualifierMatcher } from '../../components/meds/quantity-qualifiers';
 import {
   buildDispenseUnitNameResolver,
   buildQualifierMatcher,
-  extractLeadingSigDispenseUnit,
-  inferQuantityQualifierCodeWith,
+  DEFAULT_QUANTITY_QUALIFIER,
   mergeQuantityQualifierCatalog,
+  resolveQuantityQualifier,
   STATIC_DISPENSE_UNIT_NAME_RESOLVER,
   STATIC_QUALIFIER_MATCHER,
 } from '../../components/meds/quantity-qualifiers';
 import { showErrorNotification } from '../../utils/notifications';
 import { OrderSetTabPanel } from './OrderSetTabPanel';
-
-const DEFAULT_QUANTITY_QUALIFIER = 'C48542';
 
 function todayYmd(): string {
   return new Date().toISOString().slice(0, 10);
@@ -374,67 +372,6 @@ interface ParsedSig {
   quantityQualifier: string;
   /** Raw value from ScriptSure (undefined when the API omitted it). Useful for callers that want to distinguish "explicit" from "inferred". */
   quantityQualifierRaw: string | undefined;
-}
-
-/** A resolver mapping a dispense-unit name to an NCI potency-unit code. */
-type DispenseUnitNameResolver = (unitName: string | undefined) => string | undefined;
-
-/** Matches an NCI Thesaurus code (e.g. `C48155`). */
-const NCI_CODE_RE = /^C\d+$/;
-
-/**
- * Resolves the dispense unit (NCI potency code) for a sig.
- *
- * The ScriptSure drug-format endpoint does not send a per-sig
- * `quantityQualifier`; the dispense unit is encoded as the leading token of the
- * sig line (`"30 Gram - …"`, `"80 Tablet - …"`). So the qualifier is only
- * "present" when some other path (e.g. an edited/persisted MedicationRequest)
- * supplied it — in which case we trust it. Otherwise we infer, preferring the
- * authoritative leading sig-unit token over free-text keyword inference.
- *
- * NOTE: this is deliberate, not a stopgap — the v4 Advanced API (as of the
- * 2026-07-01 docs capture) exposes NO deterministic per-drug dispense-unit
- * lookup; `quantityQualifier` is only a caller-supplied write field, and drug
- * reads return dose-form *text* (`MED_DOSAGE_FORM_DESC`), not an NCI code. The
- * leading sig token IS the deterministic signal (ScriptSure builds it from the
- * same quantity-qualifier catalog). See the KB:
- * wiki/fhir/medication-quantity-qualifiers.md + wiki/contradictions.md.
- *
- * Priority:
- *  1. `raw` when ScriptSure/caller genuinely supplied a valid NCI code
- *     (the qualifier "wins when present").
- *  2. The leading `"<qty> <unit> - …"` token from the sig line, resolved via the
- *     live/static catalog (fixes topicals/liquids like `"30 Gram"` → Gram).
- *  3. Keyword inference from sig line + formulation label (dose-form / volume).
- *  4. The static `C48542` Tablet fallback.
- *
- * @param raw - Value already on the sig (usually absent for drug-format sigs).
- * @param sigLine - Sig text shown to the prescriber.
- * @param formatText - Formulation label (e.g. drug `code.text`) when known.
- * @param matcher - Catalog-aware matcher used for keyword inference.
- * @param unitResolver - Catalog-aware name→code resolver for the leading token.
- * @returns NCI potency-unit code; never empty.
- */
-function resolveQuantityQualifier(
-  raw: string | undefined,
-  sigLine: string,
-  formatText: string | undefined,
-  matcher: QualifierMatcher,
-  unitResolver: DispenseUnitNameResolver
-): string {
-  const trimmedRaw = raw?.trim();
-  if (trimmedRaw && NCI_CODE_RE.test(trimmedRaw)) {
-    return trimmedRaw;
-  }
-  const fromSigUnit = unitResolver(extractLeadingSigDispenseUnit(sigLine));
-  if (fromSigUnit) {
-    return fromSigUnit;
-  }
-  const inferred = inferQuantityQualifierCodeWith(matcher, sigLine, formatText);
-  if (inferred) {
-    return inferred;
-  }
-  return trimmedRaw || DEFAULT_QUANTITY_QUALIFIER;
 }
 
 function parseScriptSureSigs(

--- a/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
@@ -48,6 +48,7 @@ import { AsyncAutocomplete, Panel, ResourceInput, useMedplum } from '@medplum/re
 import { useSearchResources } from '@medplum/react-hooks';
 import {
   loadScriptSureQuantityQualifiers,
+  SCRIPTSURE_GCN_SEQNO_SYSTEM,
   SCRIPTSURE_GENERIC_NAME_EXTENSION,
   SCRIPTSURE_NAME_TYPE_EXTENSION,
   SCRIPTSURE_ROUTED_MED_ID_SYSTEM,
@@ -60,9 +61,12 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import type { QualifierMatcher } from '../../components/meds/quantity-qualifiers';
 import {
+  buildDispenseUnitNameResolver,
   buildQualifierMatcher,
+  extractLeadingSigDispenseUnit,
   inferQuantityQualifierCodeWith,
   mergeQuantityQualifierCatalog,
+  STATIC_DISPENSE_UNIT_NAME_RESOLVER,
   STATIC_QUALIFIER_MATCHER,
 } from '../../components/meds/quantity-qualifiers';
 import { showErrorNotification } from '../../utils/notifications';
@@ -372,44 +376,72 @@ interface ParsedSig {
   quantityQualifierRaw: string | undefined;
 }
 
+/** A resolver mapping a dispense-unit name to an NCI potency-unit code. */
+type DispenseUnitNameResolver = (unitName: string | undefined) => string | undefined;
+
+/** Matches an NCI Thesaurus code (e.g. `C48155`). */
+const NCI_CODE_RE = /^C\d+$/;
+
 /**
  * Resolves the dispense unit (NCI potency code) for a sig.
  *
- * The matcher only fires for dose-form keywords (tablet, capsule, suppository,
- * patch, …) and `mL`. It never tags a strength unit like `mg`, so when it
- * returns something we can trust it more than ScriptSure's per-sig
- * `quantityQualifier` — which in practice often carries a strength-unit code
- * for solid dose forms (e.g. metformin tablets coming back with the milligram
- * code because the formulation strength is "500 mg").
+ * The ScriptSure drug-format endpoint does not send a per-sig
+ * `quantityQualifier`; the dispense unit is encoded as the leading token of the
+ * sig line (`"30 Gram - …"`, `"80 Tablet - …"`). So the qualifier is only
+ * "present" when some other path (e.g. an edited/persisted MedicationRequest)
+ * supplied it — in which case we trust it. Otherwise we infer, preferring the
+ * authoritative leading sig-unit token over free-text keyword inference.
+ *
+ * NOTE: this is deliberate, not a stopgap — the v4 Advanced API (as of the
+ * 2026-07-01 docs capture) exposes NO deterministic per-drug dispense-unit
+ * lookup; `quantityQualifier` is only a caller-supplied write field, and drug
+ * reads return dose-form *text* (`MED_DOSAGE_FORM_DESC`), not an NCI code. The
+ * leading sig token IS the deterministic signal (ScriptSure builds it from the
+ * same quantity-qualifier catalog). See the KB:
+ * wiki/fhir/medication-quantity-qualifiers.md + wiki/contradictions.md.
  *
  * Priority:
- *  1. Keyword inference from sig line + formulation label (only fires on a
- *     dose-form / volume keyword).
- *  2. Whatever ScriptSure sent on the sig (when non-empty and not the bot's
- *     "I had nothing, defaulting to tablet" sentinel).
- *  3. The static `C48542` Tablet fallback.
+ *  1. `raw` when ScriptSure/caller genuinely supplied a valid NCI code
+ *     (the qualifier "wins when present").
+ *  2. The leading `"<qty> <unit> - …"` token from the sig line, resolved via the
+ *     live/static catalog (fixes topicals/liquids like `"30 Gram"` → Gram).
+ *  3. Keyword inference from sig line + formulation label (dose-form / volume).
+ *  4. The static `C48542` Tablet fallback.
  *
- * @param raw - Value returned by ScriptSure on the sig (may be undefined).
+ * @param raw - Value already on the sig (usually absent for drug-format sigs).
  * @param sigLine - Sig text shown to the prescriber.
  * @param formatText - Formulation label (e.g. drug `code.text`) when known.
- * @param matcher - Catalog-aware matcher (live `/v3/prescription/quantityqualifier`
- *   or static fallback) used for keyword inference.
+ * @param matcher - Catalog-aware matcher used for keyword inference.
+ * @param unitResolver - Catalog-aware name→code resolver for the leading token.
  * @returns NCI potency-unit code; never empty.
  */
 function resolveQuantityQualifier(
   raw: string | undefined,
   sigLine: string,
   formatText: string | undefined,
-  matcher: QualifierMatcher
+  matcher: QualifierMatcher,
+  unitResolver: DispenseUnitNameResolver
 ): string {
+  const trimmedRaw = raw?.trim();
+  if (trimmedRaw && NCI_CODE_RE.test(trimmedRaw)) {
+    return trimmedRaw;
+  }
+  const fromSigUnit = unitResolver(extractLeadingSigDispenseUnit(sigLine));
+  if (fromSigUnit) {
+    return fromSigUnit;
+  }
   const inferred = inferQuantityQualifierCodeWith(matcher, sigLine, formatText);
   if (inferred) {
     return inferred;
   }
-  return raw?.trim() || DEFAULT_QUANTITY_QUALIFIER;
+  return trimmedRaw || DEFAULT_QUANTITY_QUALIFIER;
 }
 
-function parseScriptSureSigs(medication: Medication, matcher: QualifierMatcher): ParsedSig[] {
+function parseScriptSureSigs(
+  medication: Medication,
+  matcher: QualifierMatcher,
+  unitResolver: DispenseUnitNameResolver
+): ParsedSig[] {
   const formatText = medication.code?.text;
   const out: ParsedSig[] = [];
   for (const ext of medication.extension ?? []) {
@@ -424,7 +456,7 @@ function parseScriptSureSigs(medication: Medication, matcher: QualifierMatcher):
       out.push({
         sigLine,
         quantity,
-        quantityQualifier: resolveQuantityQualifier(quantityQualifierRaw, sigLine, formatText, matcher),
+        quantityQualifier: resolveQuantityQualifier(quantityQualifierRaw, sigLine, formatText, matcher, unitResolver),
         quantityQualifierRaw,
       });
     }
@@ -523,8 +555,18 @@ function medicationToCodeableConcept(
   format: Medication,
   drug?: Medication
 ): MedicationRequest['medicationCodeableConcept'] {
+  const coding = [...(format.code?.coding ?? [])];
+  // The drug-format Medication carries its single GCN_SEQNO as an identifier
+  // (not a code.coding). Promote it to a coding so the draft MR carries the
+  // FDB clinical-formulation key: the ScriptSure prescription webhook reconciles
+  // draft→sent by GCN when the NDC drifts (#9300) or a generic is substituted
+  // (brand/generic share a GCN). See scriptsure-react SCRIPTSURE_GCN_SEQNO_SYSTEM.
+  const gcn = getIdentifier(format, SCRIPTSURE_GCN_SEQNO_SYSTEM);
+  if (gcn && !coding.some((c) => c.system === SCRIPTSURE_GCN_SEQNO_SYSTEM)) {
+    coding.push({ system: SCRIPTSURE_GCN_SEQNO_SYSTEM, code: gcn });
+  }
   return {
-    coding: format.code?.coding,
+    coding,
     text: composeMedicationName(drug, format),
   };
 }
@@ -635,13 +677,18 @@ interface FormulationSigChoice {
  * @param formats - Deduped Medication[] from `searchMedications({ routedMedId })`.
  * @param matcher - Quantity-qualifier matcher used by `parseScriptSureSigs` to
  *   resolve dispense units when ScriptSure omits them on a sig.
+ * @param unitResolver - Name→code resolver for the leading sig-unit token.
  * @returns One row per selectable formulation+sig pair.
  */
-function buildFormulationSigChoices(formats: Medication[], matcher: QualifierMatcher): FormulationSigChoice[] {
+function buildFormulationSigChoices(
+  formats: Medication[],
+  matcher: QualifierMatcher,
+  unitResolver: DispenseUnitNameResolver
+): FormulationSigChoice[] {
   const out: FormulationSigChoice[] = [];
   formats.forEach((fm, fi) => {
     const formatLabel = fm.code?.text ?? `Option ${fi + 1}`;
-    const sigs = parseScriptSureSigs(fm, matcher);
+    const sigs = parseScriptSureSigs(fm, matcher, unitResolver);
     if (sigs.length === 0) {
       out.push({
         formatIndex: fi,
@@ -770,6 +817,16 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
     return buildQualifierMatcher(qualifierCatalog.map((r) => ({ potencyUnit: r.code, name: r.label })));
   }, [qualifierCatalog]);
 
+  // Name→code resolver for the leading sig-unit token ("30 Gram" → C48155),
+  // built from the same live catalog; falls back to the static resolver until
+  // the bot call resolves.
+  const unitNameResolver = useMemo<DispenseUnitNameResolver>(() => {
+    if (qualifierCatalog.length === 0) {
+      return STATIC_DISPENSE_UNIT_NAME_RESOLVER;
+    }
+    return buildDispenseUnitNameResolver(qualifierCatalog.map((r) => ({ potencyUnit: r.code, name: r.label })));
+  }, [qualifierCatalog]);
+
   useEffect(() => {
     if (patientProp) {
       return undefined;
@@ -845,13 +902,13 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
   }, [termMedication, searchMedications]);
 
   const sigOptions = useMemo(
-    () => (selectedFormat ? parseScriptSureSigs(selectedFormat, qualifierMatcher) : []),
-    [selectedFormat, qualifierMatcher]
+    () => (selectedFormat ? parseScriptSureSigs(selectedFormat, qualifierMatcher, unitNameResolver) : []),
+    [selectedFormat, qualifierMatcher, unitNameResolver]
   );
 
   const formulationSigChoices = useMemo(
-    () => buildFormulationSigChoices(formatMedications, qualifierMatcher),
-    [formatMedications, qualifierMatcher]
+    () => buildFormulationSigChoices(formatMedications, qualifierMatcher, unitNameResolver),
+    [formatMedications, qualifierMatcher, unitNameResolver]
   );
 
   const selectedChoiceKey = useMemo(() => {
@@ -1080,7 +1137,7 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
         showErrorNotification('Each compound line needs a selected formulation');
         return;
       }
-      const sigs = parseScriptSureSigs(line.formatMed, qualifierMatcher);
+      const sigs = parseScriptSureSigs(line.formatMed, qualifierMatcher, unitNameResolver);
       const sigLine3 = sigs[0]?.sigLine ?? 'Take as directed';
       drugs.push(
         medicationToOrderDrugInput(line.formatMed, {

--- a/packages/scriptsure-react/src/common.test.ts
+++ b/packages/scriptsure-react/src/common.test.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from 'vitest';
+import { SCRIPTSURE_GCN_SEQNO_SYSTEM } from './common';
+
+describe('common identifier systems', () => {
+  // The GCN_SEQNO coding stamped on a draft MedicationRequest (via this constant)
+  // is matched by the medplum-ee prescription webhook bot to reconcile draft->sent
+  // prescriptions. The bot hard-codes the same literal in
+  // medplum-ee/packages/scriptsure/src/common/utils.ts; if the two ever drift the
+  // reconciliation silently no-ops. Pin the value so a rename can't do that quietly.
+  test('SCRIPTSURE_GCN_SEQNO_SYSTEM matches the medplum-ee bot literal', () => {
+    expect(SCRIPTSURE_GCN_SEQNO_SYSTEM).toBe('https://scriptsure.com/gcn-seqno');
+  });
+});

--- a/packages/scriptsure-react/src/common.ts
+++ b/packages/scriptsure-react/src/common.ts
@@ -36,6 +36,17 @@ export const SCRIPTSURE_ORDER_MEDICATION_BOT: Identifier = {
 /** Identifier system for ScriptSure ROUTED_MED_ID on in-memory Medication resources from drug search. */
 export const SCRIPTSURE_ROUTED_MED_ID_SYSTEM = 'https://scriptsure.com/routed-med-id';
 
+/**
+ * Identifier/coding system for the FDB GCN Sequence Number (`GCN_SEQNO`) — the
+ * clinical-formulation key (ingredient+strength+dose-form+route), independent of
+ * brand and NDC. Stamped as a `medicationCodeableConcept.coding` on the draft
+ * MedicationRequest so the ScriptSure prescription webhook can reconcile a draft
+ * to its sent prescription even when the NDC drifts or the pharmacy substitutes a
+ * generic (brand and generic share the same GCN). Mirrors the medplum-ee bot
+ * constant of the same name.
+ */
+export const SCRIPTSURE_GCN_SEQNO_SYSTEM = 'https://scriptsure.com/gcn-seqno';
+
 export const SCRIPTSURE_PENDING_ORDER_ID_SYSTEM = 'https://scriptsure.com/pending-order-id';
 
 export const SCRIPTSURE_PENDING_ORDER_STATUS_EXTENSION = 'https://scriptsure.com/pending-order-status';


### PR DESCRIPTION
## Summary

Split out of #9858 (part 1 of 2) — the prescribing-accuracy fixes, independent of multi-practice.

- **Fix the static NCI potency-unit table.** The previous table used guessed sequential `C484xx` codes that were mostly wrong (e.g. Gram mapped to `C48478`/Box; Each, Drop, Capsule, Patch, Milligram, Suppository, Syringe, Vial all bound to the wrong code), corrupting the dispense-unit dropdown and the persisted `MedicationRequest.dispenseRequest.quantity.unit` display. Codes are now taken verbatim from the live `/v3/prescription/quantityqualifier` catalog.
- **Leading-sig-unit dispense resolution.** The drug-format endpoint encodes the dispense unit as the leading token of each sig line (`"30 Gram - ..."`, `"80 Tablet - ..."`), which is more reliable than free-text keyword inference for topicals/liquids. New `extractLeadingSigDispenseUnit` + `buildDispenseUnitNameResolver` (+ `STATIC_DISPENSE_UNIT_NAME_RESOLVER`) feed a reworked `resolveQuantityQualifier` priority: valid caller-supplied NCI code > leading sig unit > keyword inference > Tablet fallback.
- **GCN_SEQNO coding promotion.** Promote the drug-format `GCN_SEQNO` identifier to a `medicationCodeableConcept.coding` on the draft `MedicationRequest` so the ScriptSure prescription webhook can reconcile draft→sent by clinical formulation when the NDC drifts or a generic is substituted. Adds `SCRIPTSURE_GCN_SEQNO_SYSTEM` to `@medplum/scriptsure-react`.

## Test plan

- [ ] `@medplum/core` + example build/typecheck (green locally)
- [ ] Verify dispense-unit dropdown shows correct units for tablet, topical (gram), and liquid (mL) drugs
- [ ] Verify persisted `quantity.unit` renders the correct label

Part 2 (multi-practice `organizationId` + practice selection) stacks on top of this branch.