### PR TITLE
DAW: multi-practice organizationId threading + practice selection

### DIFF
--- a/examples/medplum-provider/src/App.tsx
+++ b/examples/medplum-provider/src/App.tsx
@@ -23,6 +23,7 @@ import { TaskDetailsModal } from './components/tasks/TaskDetailsModal';
 import { hasScriptSureIdentifier } from './components/utils';
 import { useDoseSpotAccess } from './hooks/useDoseSpotAccess';
 import './index.css';
+import { ScriptSurePracticeProvider } from './scriptsure/ScriptSurePractice';
 
 const SETUP_DISMISSED_KEY = 'medplum-provider-setup-completed';
 const PROVIDER_HIDE_GET_STARTED_SETTING = 'hideGetStarted';
@@ -91,7 +92,7 @@ export function App(): JSX.Element | null {
     return null;
   }
 
-  return (
+  const appShellContent = (
     <AppShell
       logo={<Logo size={24} />}
       pathname={location.pathname}
@@ -275,4 +276,6 @@ export function App(): JSX.Element | null {
       </Suspense>
     </AppShell>
   );
+
+  return hasScriptSure ? <ScriptSurePracticeProvider>{appShellContent}</ScriptSurePracticeProvider> : appShellContent;
 }

--- a/examples/medplum-provider/src/components/meds/quantity-qualifiers.test.ts
+++ b/examples/medplum-provider/src/components/meds/quantity-qualifiers.test.ts
@@ -177,9 +177,9 @@ describe('quantity-qualifiers', () => {
       expect(resolver('gram')).toBe('C48155');
       expect(resolver('TAB')).toBe('C48542');
       expect(resolver('caps')).toBe('C48480');
-      expect(
-        buildDispenseUnitNameResolver([{ potencyUnit: 'C48542', name: 'Tablet dosing unit' }])('Tablet')
-      ).toBe('C48542');
+      expect(buildDispenseUnitNameResolver([{ potencyUnit: 'C48542', name: 'Tablet dosing unit' }])('Tablet')).toBe(
+        'C48542'
+      );
     });
 
     test('returns undefined for unknown/blank names', () => {

--- a/examples/medplum-provider/src/components/meds/quantity-qualifiers.test.ts
+++ b/examples/medplum-provider/src/components/meds/quantity-qualifiers.test.ts
@@ -3,19 +3,24 @@
 
 import { describe, expect, test } from 'vitest';
 import {
+  buildDispenseUnitNameResolver,
   buildQualifierMatcher,
+  extractLeadingSigDispenseUnit,
   getQuantityQualifierLabel,
   inferQuantityQualifierCode,
   inferQuantityQualifierCodeWith,
   mergeQuantityQualifierCatalog,
+  STATIC_DISPENSE_UNIT_NAME_RESOLVER,
   STATIC_QUALIFIER_MATCHER,
 } from './quantity-qualifiers';
 
 describe('quantity-qualifiers', () => {
   test('getQuantityQualifierLabel returns label for known code', () => {
-    expect(getQuantityQualifierLabel('C48542')).toBe('Tablet dosing unit');
-    expect(getQuantityQualifierLabel('C48486')).toBe('Suppository');
-    expect(getQuantityQualifierLabel('  C48483  ')).toBe('Capsule');
+    // Codes verified against the live GET /v3/prescription/quantityqualifier catalog.
+    expect(getQuantityQualifierLabel('C48542')).toBe('Tablet');
+    expect(getQuantityQualifierLabel('C48539')).toBe('Suppository');
+    expect(getQuantityQualifierLabel('  C48480  ')).toBe('Capsule');
+    expect(getQuantityQualifierLabel('C48155')).toBe('Gram');
   });
 
   test('getQuantityQualifierLabel returns undefined for empty/unknown codes', () => {
@@ -27,12 +32,12 @@ describe('quantity-qualifiers', () => {
   test('inferQuantityQualifierCode picks suppository for rectal sigs', () => {
     expect(
       inferQuantityQualifierCode('Insert 1 suppository rectally daily', 'Anusol-HC 25 mg rectal suppository')
-    ).toBe('C48486');
+    ).toBe('C48539');
   });
 
   test('inferQuantityQualifierCode falls back to formulation text when sig is generic', () => {
-    expect(inferQuantityQualifierCode('Use as directed', 'Lidocaine 5% patch')).toBe('C48484');
-    expect(inferQuantityQualifierCode('Use as directed', 'Albuterol HFA inhalation spray')).toBe('C48485');
+    expect(inferQuantityQualifierCode('Use as directed', 'Lidocaine 5% patch')).toBe('C48524');
+    expect(inferQuantityQualifierCode('Use as directed', 'Albuterol HFA inhalation spray')).toBe('C48537');
   });
 
   test('inferQuantityQualifierCode prefers more specific terms', () => {
@@ -87,8 +92,8 @@ describe('quantity-qualifiers', () => {
   });
 
   test('STATIC_QUALIFIER_MATCHER backs the legacy inferQuantityQualifierCode helper', () => {
-    expect(STATIC_QUALIFIER_MATCHER('Insert 1 suppository rectally daily')).toBe('C48486');
-    expect(inferQuantityQualifierCode('Insert 1 suppository rectally daily')).toBe('C48486');
+    expect(STATIC_QUALIFIER_MATCHER('Insert 1 suppository rectally daily')).toBe('C48539');
+    expect(inferQuantityQualifierCode('Insert 1 suppository rectally daily')).toBe('C48539');
   });
 
   test('buildQualifierMatcher prefers dose-form keywords over strength units regardless of catalog name length', () => {
@@ -131,5 +136,61 @@ describe('quantity-qualifiers', () => {
     expect(merged.find((r) => r.code === 'C48542')?.label).toBe('Tablet');
     expect(merged.find((r) => r.code === 'C99999')?.label).toBe('Made-up unit');
     expect(merged).toEqual([...merged].sort((a, b) => a.label.localeCompare(b.label)));
+  });
+
+  describe('extractLeadingSigDispenseUnit', () => {
+    test('reads the unit token from a ScriptSure pre-built sig line', () => {
+      // Verbatim staging shapes: mupirocin ointment and metformin tablet.
+      expect(extractLeadingSigDispenseUnit('30 Gram - Apply to skin three times daily (use small amount)')).toBe(
+        'Gram'
+      );
+      expect(extractLeadingSigDispenseUnit('80 Tablet - Take 2 tablet by mouth four times daily')).toBe('Tablet');
+      expect(extractLeadingSigDispenseUnit('150 Milliliter - Take 5 mL by mouth twice daily')).toBe('Milliliter');
+    });
+
+    test('tolerates decimals and en/em dashes', () => {
+      expect(extractLeadingSigDispenseUnit('2.5 Milliliter – inject subcutaneously')).toBe('Milliliter');
+    });
+
+    test('returns undefined when the line does not lead with <number> <unit> -', () => {
+      expect(extractLeadingSigDispenseUnit('Take as directed')).toBeUndefined();
+      expect(extractLeadingSigDispenseUnit('Apply to affected area')).toBeUndefined();
+      expect(extractLeadingSigDispenseUnit('')).toBeUndefined();
+      expect(extractLeadingSigDispenseUnit(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('buildDispenseUnitNameResolver', () => {
+    const resolver = buildDispenseUnitNameResolver([
+      { potencyUnit: 'C48155', name: 'Gram' },
+      { potencyUnit: 'C48542', name: 'Tablet' },
+      { potencyUnit: 'C48480', name: 'Capsule' },
+      { potencyUnit: 'C28254', name: 'Milliliter' },
+    ]);
+
+    test('resolves a leading sig unit to its NCI code (including "strength" units like Gram)', () => {
+      expect(resolver(extractLeadingSigDispenseUnit('30 Gram - Apply to skin'))).toBe('C48155');
+      expect(resolver(extractLeadingSigDispenseUnit('80 Tablet - Take 2 tablet'))).toBe('C48542');
+    });
+
+    test('is case-insensitive and maps tab/cap abbreviations and "... dosing unit"', () => {
+      expect(resolver('gram')).toBe('C48155');
+      expect(resolver('TAB')).toBe('C48542');
+      expect(resolver('caps')).toBe('C48480');
+      expect(
+        buildDispenseUnitNameResolver([{ potencyUnit: 'C48542', name: 'Tablet dosing unit' }])('Tablet')
+      ).toBe('C48542');
+    });
+
+    test('returns undefined for unknown/blank names', () => {
+      expect(resolver('Widget')).toBeUndefined();
+      expect(resolver('')).toBeUndefined();
+      expect(resolver(undefined)).toBeUndefined();
+    });
+
+    test('STATIC_DISPENSE_UNIT_NAME_RESOLVER resolves Gram and Tablet from the static fallback', () => {
+      expect(STATIC_DISPENSE_UNIT_NAME_RESOLVER('Gram')).toBe('C48155');
+      expect(STATIC_DISPENSE_UNIT_NAME_RESOLVER('Tablet')).toBe('C48542');
+    });
   });
 });

--- a/examples/medplum-provider/src/components/meds/quantity-qualifiers.test.ts
+++ b/examples/medplum-provider/src/components/meds/quantity-qualifiers.test.ts
@@ -5,11 +5,13 @@ import { describe, expect, test } from 'vitest';
 import {
   buildDispenseUnitNameResolver,
   buildQualifierMatcher,
+  DEFAULT_QUANTITY_QUALIFIER,
   extractLeadingSigDispenseUnit,
   getQuantityQualifierLabel,
   inferQuantityQualifierCode,
   inferQuantityQualifierCodeWith,
   mergeQuantityQualifierCatalog,
+  resolveQuantityQualifier,
   STATIC_DISPENSE_UNIT_NAME_RESOLVER,
   STATIC_QUALIFIER_MATCHER,
 } from './quantity-qualifiers';
@@ -191,6 +193,37 @@ describe('quantity-qualifiers', () => {
     test('STATIC_DISPENSE_UNIT_NAME_RESOLVER resolves Gram and Tablet from the static fallback', () => {
       expect(STATIC_DISPENSE_UNIT_NAME_RESOLVER('Gram')).toBe('C48155');
       expect(STATIC_DISPENSE_UNIT_NAME_RESOLVER('Tablet')).toBe('C48542');
+    });
+  });
+
+  describe('resolveQuantityQualifier priority', () => {
+    const resolve = (raw: string | undefined, sigLine: string, formatText?: string): string =>
+      resolveQuantityQualifier(raw, sigLine, formatText, STATIC_QUALIFIER_MATCHER, STATIC_DISPENSE_UNIT_NAME_RESOLVER);
+
+    test('leading sig-unit beats a strength-unit raw code (the metformin-tablet regression)', () => {
+      // ScriptSure sends the Milligram strength code (C28253) on a tablet sig.
+      // The authoritative leading "80 Tablet" token must win over raw.
+      expect(resolve('C28253', '80 Tablet - Take 2 tablet by mouth four times daily')).toBe('C48542');
+    });
+
+    test('leading sig-unit resolves topicals/liquids by weight/volume', () => {
+      expect(resolve(undefined, '30 Gram - Apply to affected area twice daily')).toBe('C48155');
+    });
+
+    test('falls back to a valid NCI raw code when the sig has no leading unit token', () => {
+      expect(resolve('C48155', 'Take as directed')).toBe('C48155');
+    });
+
+    test('ignores a non-NCI raw value and infers from keywords instead', () => {
+      expect(resolve('not-a-code', 'Insert 1 suppository rectally daily')).toBe('C48539');
+    });
+
+    test('falls back to keyword inference when there is no sig unit or raw code', () => {
+      expect(resolve(undefined, 'Insert 1 suppository rectally daily')).toBe('C48539');
+    });
+
+    test('defaults to Tablet when nothing resolves', () => {
+      expect(resolve(undefined, 'Take as directed')).toBe(DEFAULT_QUANTITY_QUALIFIER);
     });
   });
 });

--- a/examples/medplum-provider/src/components/meds/quantity-qualifiers.ts
+++ b/examples/medplum-provider/src/components/meds/quantity-qualifiers.ts
@@ -255,7 +255,8 @@ export const STATIC_QUALIFIER_MATCHER: QualifierMatcher = buildQualifierMatcher(
  * available so newly added DAW codes are picked up automatically.
  *
  * @param textParts - Strings to scan; empty/undefined entries are ignored.
- * @returns NCI code (e.g. `C48486`) or `undefined` when no keyword matches.
+ * @returns NCI code (e.g. `C48539` for Suppository) or `undefined` when no
+ *   keyword matches.
  */
 export function inferQuantityQualifierCode(...textParts: (string | undefined)[]): string | undefined {
   return inferQuantityQualifierCodeWith(STATIC_QUALIFIER_MATCHER, ...textParts);
@@ -375,6 +376,11 @@ export function buildDispenseUnitNameResolver(
     const name = row.name?.trim();
     if (code && name) {
       const key = normalizeUnitName(name);
+      // First-wins on normalized-key collisions (e.g. "Tablet" and "Tablet
+      // dosing unit" both normalize to "tablet"). This is only ambiguous if a
+      // catalog ever carries two such rows with *different* codes; today the
+      // static table and observed live catalog do not, so catalog row order is
+      // not significant in practice.
       if (!byName.has(key)) {
         byName.set(key, code);
       }
@@ -395,3 +401,75 @@ export function buildDispenseUnitNameResolver(
 export const STATIC_DISPENSE_UNIT_NAME_RESOLVER = buildDispenseUnitNameResolver(
   STATIC_QUANTITY_QUALIFIERS.map((r) => ({ potencyUnit: r.code, name: r.label }))
 );
+
+/** Default dispense-unit code when nothing else resolves: `C48542` (Tablet). */
+export const DEFAULT_QUANTITY_QUALIFIER = 'C48542';
+
+/** A resolver mapping a dispense-unit name to an NCI potency-unit code. */
+export type DispenseUnitNameResolver = (unitName: string | undefined) => string | undefined;
+
+/** Matches an NCI Thesaurus code (e.g. `C48155`). */
+const NCI_CODE_RE = /^C\d+$/;
+
+/**
+ * Resolves the dispense unit (NCI potency code) for a sig.
+ *
+ * The ScriptSure drug-format endpoint encodes the dispense unit as the leading
+ * token of the sig line (`"30 Gram - …"`, `"80 Tablet - …"`) and usually omits a
+ * per-sig `quantityQualifier`. When a `raw` qualifier IS present it comes from
+ * that same drug-format sig (not a separately edited resource) and cannot be
+ * trusted blindly — ScriptSure frequently sends a strength-unit code for solid
+ * dose forms — so we prefer the authoritative leading sig-unit token and only
+ * fall back to `raw`, then to free-text keyword inference.
+ *
+ * NOTE: this is deliberate, not a stopgap — the v4 Advanced API (as of the
+ * 2026-07-01 docs capture) exposes NO deterministic per-drug dispense-unit
+ * lookup; `quantityQualifier` is only a caller-supplied write field, and drug
+ * reads return dose-form *text* (`MED_DOSAGE_FORM_DESC`), not an NCI code. The
+ * leading sig token IS the deterministic signal (ScriptSure builds it from the
+ * same quantity-qualifier catalog). See the KB:
+ * wiki/fhir/medication-quantity-qualifiers.md + wiki/contradictions.md.
+ *
+ * Priority:
+ *  1. The leading `"<qty> <unit> - …"` token from the sig line, resolved via the
+ *     live/static catalog (fixes topicals/liquids like `"30 Gram"` → Gram). This
+ *     is the deterministic signal ScriptSure builds from the same catalog, so it
+ *     is preferred over `raw`.
+ *  2. `raw` when ScriptSure/caller supplied a valid NCI code the leading token
+ *     could not resolve. NOTE: ScriptSure's per-sig `quantityQualifier` often
+ *     carries a *strength*-unit code for solid dose forms (e.g. a metformin
+ *     tablet coming back with the Milligram code because the formulation strength
+ *     is "500 mg"), and `NCI_CODE_RE` cannot tell a strength code from a dispense
+ *     code — which is exactly why `raw` must rank below the leading sig-unit token
+ *     rather than above it.
+ *  3. Keyword inference from sig line + formulation label (dose-form / volume).
+ *  4. The static `C48542` Tablet fallback.
+ *
+ * @param raw - Value already on the sig (usually absent for drug-format sigs).
+ * @param sigLine - Sig text shown to the prescriber.
+ * @param formatText - Formulation label (e.g. drug `code.text`) when known.
+ * @param matcher - Catalog-aware matcher used for keyword inference.
+ * @param unitResolver - Catalog-aware name→code resolver for the leading token.
+ * @returns NCI potency-unit code; never empty.
+ */
+export function resolveQuantityQualifier(
+  raw: string | undefined,
+  sigLine: string,
+  formatText: string | undefined,
+  matcher: QualifierMatcher,
+  unitResolver: DispenseUnitNameResolver
+): string {
+  const fromSigUnit = unitResolver(extractLeadingSigDispenseUnit(sigLine));
+  if (fromSigUnit) {
+    return fromSigUnit;
+  }
+  const trimmedRaw = raw?.trim();
+  if (trimmedRaw && NCI_CODE_RE.test(trimmedRaw)) {
+    return trimmedRaw;
+  }
+  const inferred = inferQuantityQualifierCodeWith(matcher, sigLine, formatText);
+  if (inferred) {
+    return inferred;
+  }
+  return trimmedRaw || DEFAULT_QUANTITY_QUALIFIER;
+}

--- a/examples/medplum-provider/src/components/meds/quantity-qualifiers.ts
+++ b/examples/medplum-provider/src/components/meds/quantity-qualifiers.ts
@@ -5,8 +5,19 @@
  * NCI Thesaurus potency-unit codes used by DAW/ScriptSure as quantity qualifiers
  * (`potencyUnit` from GET /v3/prescription/quantityqualifier).
  *
- * This static table is a fallback when the live catalog has not been loaded yet.
- * @see https://github.com/... (DAW docs: get-quantity-qualifiers)
+ * This static table is a fallback for when the live catalog has not loaded yet
+ * (and the sole source for {@link getQuantityQualifierLabel}, which renders a
+ * persisted `MedicationRequest.dispenseRequest.quantity.unit`).
+ *
+ * The codes below are taken verbatim from the live staging catalog
+ * (`GET /v3/prescription/quantityqualifier`). An earlier version of this table
+ * used guessed sequential `C484xx` codes that were mostly WRONG — e.g. it mapped
+ * Gram→C48478, but the catalog says C48478 is **Box** and Gram is **C48155**;
+ * likewise Each, Drop, Capsule, Patch, Milligram, Suppository, Syringe, and Vial
+ * were all bound to the wrong code. That corrupted the dropdown and the details
+ * display. See wiki/contradictions.md ("static quantity-qualifier table codes").
+ *
+ * @see https://scriptsure.stoplight.io/docs/scriptsure-advanced/9tbm26mytiwwy-get-quantity-qualifiers
  */
 export const STATIC_QUANTITY_QUALIFIERS: readonly { readonly code: string; readonly label: string }[] = [
   { code: 'C48473', label: 'Ampule' },
@@ -14,21 +25,29 @@ export const STATIC_QUANTITY_QUALIFIERS: readonly { readonly code: string; reado
   { code: 'C78783', label: 'Applicatorful' },
   { code: 'C48474', label: 'Bag' },
   { code: 'C48475', label: 'Bar' },
-  { code: 'C48480', label: 'Each' },
-  { code: 'C25301', label: 'Day' },
+  { code: 'C48477', label: 'Bottle' },
+  { code: 'C48478', label: 'Box' },
+  { code: 'C48480', label: 'Capsule' },
+  { code: 'C48481', label: 'Cartridge' },
+  { code: 'C48484', label: 'Container' },
+  { code: 'C48491', label: 'Drop' },
+  { code: 'C64933', label: 'Each' },
+  { code: 'C48155', label: 'Gram' },
+  { code: 'C48504', label: 'Kit' },
+  { code: 'C48506', label: 'Lozenge' },
+  { code: 'C48152', label: 'Microgram' },
+  { code: 'C28253', label: 'Milligram' },
   { code: 'C28254', label: 'Milliliter' },
-  { code: 'C48542', label: 'Tablet dosing unit' },
-  { code: 'C48477', label: 'Drop' },
-  { code: 'C48478', label: 'Gram' },
-  { code: 'C48479', label: 'International unit' },
-  { code: 'C48481', label: 'Milligram' },
-  { code: 'C48482', label: 'Microgram' },
-  { code: 'C48483', label: 'Capsule' },
-  { code: 'C48484', label: 'Patch' },
-  { code: 'C48485', label: 'Spray' },
-  { code: 'C48486', label: 'Suppository' },
-  { code: 'C48487', label: 'Syringe' },
-  { code: 'C48488', label: 'Vial' },
+  { code: 'C48521', label: 'Packet' },
+  { code: 'C48524', label: 'Patch' },
+  { code: 'C48537', label: 'Spray' },
+  { code: 'C48539', label: 'Suppository' },
+  { code: 'C48540', label: 'Syringe' },
+  { code: 'C48542', label: 'Tablet' },
+  { code: 'C48548', label: 'Troche' },
+  { code: 'C48549', label: 'Tube' },
+  { code: 'C44278', label: 'Unit' },
+  { code: 'C48551', label: 'Vial' },
 ];
 
 const STATIC_BY_CODE: Readonly<Record<string, string>> = Object.fromEntries(
@@ -281,3 +300,95 @@ export function mergeQuantityQualifierCatalog(
   }
   return [...map.entries()].map(([code, label]) => ({ code, label })).sort((a, b) => a.label.localeCompare(b.label));
 }
+
+/**
+ * Extracts the dispense-unit token from a ScriptSure pre-built sig line.
+ *
+ * The drug-format endpoint (`GET /v3/drugformat/format/{routedMedId}`) does not
+ * return a per-sig `quantityQualifier`; instead every sig line is built as
+ * `"<formatQuantity> <QuantityQualifierName> - <instructions>"`, e.g.
+ * `"30 Gram - Apply to skin three times daily"` or
+ * `"80 Tablet - Take 2 tablet by mouth"`. The token between the leading quantity
+ * and the ` - ` separator is therefore the authoritative dispense unit for the
+ * format (ScriptSure derives it from the same quantity-qualifier catalog we
+ * fetch), and is more reliable than scanning the free instruction text — which
+ * deliberately ignores "gram" (a strength unit inside "500 mg tablet" but the
+ * real dispense unit for topicals sold by weight).
+ *
+ * @param sigLine - Pre-built sig line from a ScriptSure drug format.
+ * @returns The unit token (e.g. `"Gram"`, `"Tablet"`), or undefined when the
+ *   line does not start with the expected `<number> <unit> -` shape.
+ */
+export function extractLeadingSigDispenseUnit(sigLine: string | undefined): string | undefined {
+  if (!sigLine) {
+    return undefined;
+  }
+  const match = /^\s*\d+(?:\.\d+)?\s+([A-Za-z][A-Za-z ]*?)\s+[-–—]/.exec(sigLine);
+  return match?.[1]?.trim() || undefined;
+}
+
+/**
+ * Abbreviations / label variants a leading sig-unit token may use that differ
+ * from the canonical catalog `name`. Keys and values are lowercased.
+ */
+const LEADING_UNIT_NAME_ALIASES: Readonly<Record<string, string>> = {
+  tab: 'tablet',
+  tabs: 'tablet',
+  cap: 'capsule',
+  caps: 'capsule',
+};
+
+/**
+ * Normalizes a unit name for lookup: lowercases, maps common abbreviations
+ * (tab→tablet, cap→capsule), and strips the ScriptSure "... dosing unit" suffix
+ * so `"Tablet dosing unit"` and `"Tablet"` collapse to the same key.
+ * @param name - Raw unit name / token.
+ * @returns Normalized lookup key.
+ */
+function normalizeUnitName(name: string): string {
+  const lowered = name.trim().toLowerCase().replace(/\s+dosing unit$/, '');
+  return LEADING_UNIT_NAME_ALIASES[lowered] ?? lowered;
+}
+
+/**
+ * Builds a resolver mapping a dispense-unit *name* (typically the token from
+ * {@link extractLeadingSigDispenseUnit}) to its NCI potency-unit code.
+ *
+ * Unlike {@link buildQualifierMatcher}, this does NOT drop "strength-style"
+ * units such as Gram or Milligram: in the leading dispense position those ARE
+ * the dispense unit, so whatever the catalog names is trusted. Names are
+ * normalized via {@link normalizeUnitName} so `"Tablet"`, `"tab"`, and
+ * `"Tablet dosing unit"` all resolve.
+ *
+ * @param catalog - Live and/or static rows ({ potencyUnit, name }).
+ * @returns A function mapping a unit name to its code, or undefined.
+ */
+export function buildDispenseUnitNameResolver(
+  catalog: readonly { potencyUnit: string; name: string }[]
+): (unitName: string | undefined) => string | undefined {
+  const byName = new Map<string, string>();
+  for (const row of catalog) {
+    const code = row.potencyUnit?.trim();
+    const name = row.name?.trim();
+    if (code && name) {
+      const key = normalizeUnitName(name);
+      if (!byName.has(key)) {
+        byName.set(key, code);
+      }
+    }
+  }
+  return (unitName) => {
+    if (!unitName?.trim()) {
+      return undefined;
+    }
+    return byName.get(normalizeUnitName(unitName));
+  };
+}
+
+/**
+ * Default name resolver built from the static fallback catalog, used until the
+ * live `/v3/prescription/quantityqualifier` response loads.
+ */
+export const STATIC_DISPENSE_UNIT_NAME_RESOLVER = buildDispenseUnitNameResolver(
+  STATIC_QUANTITY_QUALIFIERS.map((r) => ({ potencyUnit: r.code, name: r.label }))
+);

--- a/examples/medplum-provider/src/components/meds/quantity-qualifiers.ts
+++ b/examples/medplum-provider/src/components/meds/quantity-qualifiers.ts
@@ -346,7 +346,10 @@ const LEADING_UNIT_NAME_ALIASES: Readonly<Record<string, string>> = {
  * @returns Normalized lookup key.
  */
 function normalizeUnitName(name: string): string {
-  const lowered = name.trim().toLowerCase().replace(/\s+dosing unit$/, '');
+  const lowered = name
+    .trim()
+    .toLowerCase()
+    .replace(/\s+dosing unit$/, '');
   return LEADING_UNIT_NAME_ALIASES[lowered] ?? lowered;
 }
 

--- a/examples/medplum-provider/src/components/pharmacy/ScriptSurePharmacyDialog.tsx
+++ b/examples/medplum-provider/src/components/pharmacy/ScriptSurePharmacyDialog.tsx
@@ -52,7 +52,7 @@ function ScriptSureSpecialtyFilters({ value, onChange }: ScriptSureSpecialtyFilt
  *
  * Composes the generic {@link PharmacyDialog} with ScriptSure bot identifiers and
  * passes `specialties` to POST /v3/pharmacy/search (e.g. Retail + ZIP for nearby pickers).
- * Also injects the selected practice `organizationId` (multi-practice) into both the
+ * Also injects the selected practice `Organization` reference into both the
  * search and add-to-favorites operations.
  *
  * @param props - The base pharmacy dialog props (patient, onSubmit, onClose).
@@ -60,7 +60,7 @@ function ScriptSureSpecialtyFilters({ value, onChange }: ScriptSureSpecialtyFilt
  */
 export function ScriptSurePharmacyDialog(props: PharmacyDialogBaseProps): JSX.Element {
   const { searchPharmacies, addToFavorites } = useScriptSurePharmacySearch();
-  const { selectedOrganizationId } = useScriptSurePractice();
+  const { selectedOrganization } = useScriptSurePractice();
   const [specialties, setSpecialties] = useState<ScriptSurePharmacySpecialty[]>([
     ...SCRIPTSURE_DEFAULT_PHARMACY_SPECIALTIES,
   ]);
@@ -71,14 +71,13 @@ export function ScriptSurePharmacyDialog(props: PharmacyDialogBaseProps): JSX.El
   );
 
   const handleSearch = useCallback(
-    (params: ScriptSurePharmacySearchParams) => searchPharmacies({ ...params, organizationId: selectedOrganizationId }),
-    [searchPharmacies, selectedOrganizationId]
+    (params: ScriptSurePharmacySearchParams) => searchPharmacies({ ...params, organization: selectedOrganization }),
+    [searchPharmacies, selectedOrganization]
   );
 
   const handleAddToFavorites = useCallback(
-    (params: Parameters<typeof addToFavorites>[0]) =>
-      addToFavorites({ ...params, organizationId: selectedOrganizationId }),
-    [addToFavorites, selectedOrganizationId]
+    (params: Parameters<typeof addToFavorites>[0]) => addToFavorites({ ...params, organization: selectedOrganization }),
+    [addToFavorites, selectedOrganization]
   );
 
   const specialtyFilters = useMemo(

--- a/examples/medplum-provider/src/components/pharmacy/ScriptSurePharmacyDialog.tsx
+++ b/examples/medplum-provider/src/components/pharmacy/ScriptSurePharmacyDialog.tsx
@@ -12,6 +12,7 @@ import {
 } from '@medplum/scriptsure-react';
 import type { JSX } from 'react';
 import { useCallback, useMemo, useState } from 'react';
+import { useScriptSurePractice } from '../../scriptsure/ScriptSurePractice';
 
 /** ScriptSure search-field placeholders reflecting SureScripts directory constraints. */
 const SCRIPTSURE_SEARCH_PLACEHOLDERS: PharmacySearchFieldPlaceholders = {
@@ -51,12 +52,15 @@ function ScriptSureSpecialtyFilters({ value, onChange }: ScriptSureSpecialtyFilt
  *
  * Composes the generic {@link PharmacyDialog} with ScriptSure bot identifiers and
  * passes `specialties` to POST /v3/pharmacy/search (e.g. Retail + ZIP for nearby pickers).
+ * Also injects the selected practice `organizationId` (multi-practice) into both the
+ * search and add-to-favorites operations.
  *
  * @param props - The base pharmacy dialog props (patient, onSubmit, onClose).
  * @returns The ScriptSure pharmacy dialog component.
  */
 export function ScriptSurePharmacyDialog(props: PharmacyDialogBaseProps): JSX.Element {
   const { searchPharmacies, addToFavorites } = useScriptSurePharmacySearch();
+  const { selectedOrganizationId } = useScriptSurePractice();
   const [specialties, setSpecialties] = useState<ScriptSurePharmacySpecialty[]>([
     ...SCRIPTSURE_DEFAULT_PHARMACY_SPECIALTIES,
   ]);
@@ -67,8 +71,14 @@ export function ScriptSurePharmacyDialog(props: PharmacyDialogBaseProps): JSX.El
   );
 
   const handleSearch = useCallback(
-    (params: ScriptSurePharmacySearchParams) => searchPharmacies(params),
-    [searchPharmacies]
+    (params: ScriptSurePharmacySearchParams) => searchPharmacies({ ...params, organizationId: selectedOrganizationId }),
+    [searchPharmacies, selectedOrganizationId]
+  );
+
+  const handleAddToFavorites = useCallback(
+    (params: Parameters<typeof addToFavorites>[0]) =>
+      addToFavorites({ ...params, organizationId: selectedOrganizationId }),
+    [addToFavorites, selectedOrganizationId]
   );
 
   const specialtyFilters = useMemo(
@@ -80,7 +90,7 @@ export function ScriptSurePharmacyDialog(props: PharmacyDialogBaseProps): JSX.El
     <PharmacyDialog
       {...props}
       onSearch={handleSearch}
-      onAddToFavorites={addToFavorites}
+      onAddToFavorites={handleAddToFavorites}
       getExtraSearchParams={getExtraSearchParams}
       renderBeforeSearchButton={specialtyFilters}
       searchPlaceholders={SCRIPTSURE_SEARCH_PLACEHOLDERS}

--- a/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
+++ b/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
@@ -41,6 +41,7 @@ import patientBundleData from '../../data/patient-david-james-williams.json';
 import visitBundleData from '../../data/simple-initial-visit-bundle.json';
 import { showErrorNotification } from '../../utils/notifications';
 import classes from './GetStartedPage.module.css';
+import { buildOrderSetImportNotification } from './orderSetImportNotification';
 
 export function GetStartedPage(): JSX.Element {
   const medplum = useMedplum();
@@ -136,25 +137,7 @@ export function GetStartedPage(): JSX.Element {
       const pdId = pdLocation?.split('/')[1];
       const syncResult = pdId ? await syncOrderSet(pdId) : undefined;
 
-      if (syncResult && syncResult.failedCount > 0) {
-        const failedTitles = syncResult.results
-          .filter((r) => r.status === 'failed')
-          .map((r) => r.actionTitle ?? r.activityDefinitionUrl ?? 'medication')
-          .join(', ');
-        showNotification({
-          color: 'yellow',
-          title: 'Order set partially synced',
-          message: `Imported ${resourceCount} resources, but ${syncResult.failedCount} of ${
-            syncResult.syncedCount + syncResult.failedCount
-          } medications failed to sync and will not appear when prescribing: ${failedTitles}`,
-        });
-      } else {
-        showNotification({
-          color: 'green',
-          title: 'Success',
-          message: `Imported ${resourceCount} resources for Geriatric T2DM Order Set`,
-        });
-      }
+      showNotification({ ...buildOrderSetImportNotification(resourceCount, syncResult) });
     } catch (error) {
       showErrorNotification(error);
     } finally {

--- a/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
+++ b/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
@@ -134,15 +134,27 @@ export function GetStartedPage(): JSX.Element {
       const pdLocation = result.entry?.find((e) => e.response?.location?.startsWith('PlanDefinition/'))?.response
         ?.location;
       const pdId = pdLocation?.split('/')[1];
-      if (pdId) {
-        await syncOrderSet(pdId);
-      }
+      const syncResult = pdId ? await syncOrderSet(pdId) : undefined;
 
-      showNotification({
-        color: 'green',
-        title: 'Success',
-        message: `Imported ${resourceCount} resources for Geriatric T2DM Order Set`,
-      });
+      if (syncResult && syncResult.failedCount > 0) {
+        const failedTitles = syncResult.results
+          .filter((r) => r.status === 'failed')
+          .map((r) => r.actionTitle ?? r.activityDefinitionUrl ?? 'medication')
+          .join(', ');
+        showNotification({
+          color: 'yellow',
+          title: 'Order set partially synced',
+          message: `Imported ${resourceCount} resources, but ${syncResult.failedCount} of ${
+            syncResult.syncedCount + syncResult.failedCount
+          } medications failed to sync and will not appear when prescribing: ${failedTitles}`,
+        });
+      } else {
+        showNotification({
+          color: 'green',
+          title: 'Success',
+          message: `Imported ${resourceCount} resources for Geriatric T2DM Order Set`,
+        });
+      }
     } catch (error) {
       showErrorNotification(error);
     } finally {

--- a/examples/medplum-provider/src/pages/getstarted/orderSetImportNotification.test.ts
+++ b/examples/medplum-provider/src/pages/getstarted/orderSetImportNotification.test.ts
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { OrderSetSyncResponse } from '@medplum/core';
+import { describe, expect, test } from 'vitest';
+import { buildOrderSetImportNotification } from './orderSetImportNotification';
+
+function syncResponse(overrides: Partial<OrderSetSyncResponse>): OrderSetSyncResponse {
+  return {
+    mode: 'created',
+    syncedCount: 0,
+    failedCount: 0,
+    results: [],
+    ...overrides,
+  };
+}
+
+describe('buildOrderSetImportNotification', () => {
+  test('reports success when there is no sync result', () => {
+    const n = buildOrderSetImportNotification(12, undefined);
+    expect(n.color).toBe('green');
+    expect(n.title).toBe('Success');
+    expect(n.message).toContain('Imported 12 resources');
+  });
+
+  test('reports success when all medications synced', () => {
+    const n = buildOrderSetImportNotification(
+      12,
+      syncResponse({ syncedCount: 3, failedCount: 0, results: [{ status: 'synced', actionTitle: 'Jardiance' }] })
+    );
+    expect(n.color).toBe('green');
+    expect(n.title).toBe('Success');
+  });
+
+  test('warns and lists failed medications on partial sync', () => {
+    const n = buildOrderSetImportNotification(
+      12,
+      syncResponse({
+        syncedCount: 1,
+        failedCount: 2,
+        results: [
+          { status: 'synced', actionTitle: 'Jardiance' },
+          { status: 'failed', actionTitle: 'Ozempic' },
+          { status: 'failed', activityDefinitionUrl: 'ActivityDefinition/xyz' },
+        ],
+      })
+    );
+    expect(n.color).toBe('yellow');
+    expect(n.title).toBe('Order set partially synced');
+    expect(n.message).toContain('2 of 3 medications failed');
+    expect(n.message).toContain('Ozempic');
+    expect(n.message).toContain('ActivityDefinition/xyz');
+  });
+
+  test('falls back to "medication" when a failed result has no title or url', () => {
+    const n = buildOrderSetImportNotification(
+      1,
+      syncResponse({ syncedCount: 0, failedCount: 1, results: [{ status: 'failed' }] })
+    );
+    expect(n.message).toContain('medication');
+  });
+});

--- a/examples/medplum-provider/src/pages/getstarted/orderSetImportNotification.ts
+++ b/examples/medplum-provider/src/pages/getstarted/orderSetImportNotification.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { OrderSetSyncResponse } from '@medplum/core';
+
+/** Mantine notification payload for the order-set import result. */
+export interface OrderSetImportNotification {
+  readonly color: string;
+  readonly title: string;
+  readonly message: string;
+}
+
+/**
+ * Builds the notification shown after importing the demo order set.
+ *
+ * When the `$sync-orderset` operation reports that some medications failed to
+ * sync to the e-prescribing vendor, surface a warning listing them — otherwise
+ * the order set would silently apply with fewer meds than the PlanDefinition
+ * requested. Otherwise report success.
+ *
+ * @param resourceCount - Number of resources imported by the batch.
+ * @param syncResult - Decoded `$sync-orderset` response, or undefined when the
+ *   operation is not deployed / no PlanDefinition was created.
+ * @returns The notification color, title, and message.
+ */
+export function buildOrderSetImportNotification(
+  resourceCount: number,
+  syncResult: OrderSetSyncResponse | undefined
+): OrderSetImportNotification {
+  if (syncResult && syncResult.failedCount > 0) {
+    const failedTitles = syncResult.results
+      .filter((r) => r.status === 'failed')
+      .map((r) => r.actionTitle ?? r.activityDefinitionUrl ?? 'medication')
+      .join(', ');
+    return {
+      color: 'yellow',
+      title: 'Order set partially synced',
+      message: `Imported ${resourceCount} resources, but ${syncResult.failedCount} of ${
+        syncResult.syncedCount + syncResult.failedCount
+      } medications failed to sync and will not appear when prescribing: ${failedTitles}`,
+    };
+  }
+  return {
+    color: 'green',
+    title: 'Success',
+    message: `Imported ${resourceCount} resources for Geriatric T2DM Order Set`,
+  };
+}

--- a/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
@@ -59,20 +59,18 @@ import { IconShoppingCart } from '@tabler/icons-react';
 import type { JSX, ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
-import type { QualifierMatcher } from '../../components/meds/quantity-qualifiers';
+import type { DispenseUnitNameResolver, QualifierMatcher } from '../../components/meds/quantity-qualifiers';
 import {
   buildDispenseUnitNameResolver,
   buildQualifierMatcher,
-  extractLeadingSigDispenseUnit,
-  inferQuantityQualifierCodeWith,
+  DEFAULT_QUANTITY_QUALIFIER,
   mergeQuantityQualifierCatalog,
+  resolveQuantityQualifier,
   STATIC_DISPENSE_UNIT_NAME_RESOLVER,
   STATIC_QUALIFIER_MATCHER,
 } from '../../components/meds/quantity-qualifiers';
 import { showErrorNotification } from '../../utils/notifications';
 import { OrderSetTabPanel } from './OrderSetTabPanel';
-
-const DEFAULT_QUANTITY_QUALIFIER = 'C48542';
 
 function todayYmd(): string {
   return new Date().toISOString().slice(0, 10);
@@ -374,67 +372,6 @@ interface ParsedSig {
   quantityQualifier: string;
   /** Raw value from ScriptSure (undefined when the API omitted it). Useful for callers that want to distinguish "explicit" from "inferred". */
   quantityQualifierRaw: string | undefined;
-}
-
-/** A resolver mapping a dispense-unit name to an NCI potency-unit code. */
-type DispenseUnitNameResolver = (unitName: string | undefined) => string | undefined;
-
-/** Matches an NCI Thesaurus code (e.g. `C48155`). */
-const NCI_CODE_RE = /^C\d+$/;
-
-/**
- * Resolves the dispense unit (NCI potency code) for a sig.
- *
- * The ScriptSure drug-format endpoint does not send a per-sig
- * `quantityQualifier`; the dispense unit is encoded as the leading token of the
- * sig line (`"30 Gram - …"`, `"80 Tablet - …"`). So the qualifier is only
- * "present" when some other path (e.g. an edited/persisted MedicationRequest)
- * supplied it — in which case we trust it. Otherwise we infer, preferring the
- * authoritative leading sig-unit token over free-text keyword inference.
- *
- * NOTE: this is deliberate, not a stopgap — the v4 Advanced API (as of the
- * 2026-07-01 docs capture) exposes NO deterministic per-drug dispense-unit
- * lookup; `quantityQualifier` is only a caller-supplied write field, and drug
- * reads return dose-form *text* (`MED_DOSAGE_FORM_DESC`), not an NCI code. The
- * leading sig token IS the deterministic signal (ScriptSure builds it from the
- * same quantity-qualifier catalog). See the KB:
- * wiki/fhir/medication-quantity-qualifiers.md + wiki/contradictions.md.
- *
- * Priority:
- *  1. `raw` when ScriptSure/caller genuinely supplied a valid NCI code
- *     (the qualifier "wins when present").
- *  2. The leading `"<qty> <unit> - …"` token from the sig line, resolved via the
- *     live/static catalog (fixes topicals/liquids like `"30 Gram"` → Gram).
- *  3. Keyword inference from sig line + formulation label (dose-form / volume).
- *  4. The static `C48542` Tablet fallback.
- *
- * @param raw - Value already on the sig (usually absent for drug-format sigs).
- * @param sigLine - Sig text shown to the prescriber.
- * @param formatText - Formulation label (e.g. drug `code.text`) when known.
- * @param matcher - Catalog-aware matcher used for keyword inference.
- * @param unitResolver - Catalog-aware name→code resolver for the leading token.
- * @returns NCI potency-unit code; never empty.
- */
-function resolveQuantityQualifier(
-  raw: string | undefined,
-  sigLine: string,
-  formatText: string | undefined,
-  matcher: QualifierMatcher,
-  unitResolver: DispenseUnitNameResolver
-): string {
-  const trimmedRaw = raw?.trim();
-  if (trimmedRaw && NCI_CODE_RE.test(trimmedRaw)) {
-    return trimmedRaw;
-  }
-  const fromSigUnit = unitResolver(extractLeadingSigDispenseUnit(sigLine));
-  if (fromSigUnit) {
-    return fromSigUnit;
-  }
-  const inferred = inferQuantityQualifierCodeWith(matcher, sigLine, formatText);
-  if (inferred) {
-    return inferred;
-  }
-  return trimmedRaw || DEFAULT_QUANTITY_QUALIFIER;
 }
 
 function parseScriptSureSigs(

--- a/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
@@ -657,7 +657,7 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
   const medplum = useMedplum();
   const { patientId } = useParams();
   const { searchMedications, orderMedication } = useScriptSureOrderMedication();
-  const { selectedOrganizationId } = useScriptSurePractice();
+  const { selectedOrganization } = useScriptSurePractice();
 
   const [patient, setPatient] = useState(patientProp);
   const [requester, setRequester] = useState<Practitioner | undefined>();
@@ -1031,7 +1031,7 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
         pharmacyOrganizationId: pharmacyOrg?.id,
         writtenDate: writtenDateYmd,
         fillDate: fillDateYmd.trim() || undefined,
-        organizationId: selectedOrganizationId,
+        organization: selectedOrganization,
       });
 
       onOrderComplete?.({ launchUrl: res.launchUrl, medicationRequestId: res.medicationRequestId });
@@ -1117,7 +1117,7 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
         fillDate: compoundFillYmd.trim() || undefined,
         durationDays: compoundDaysSupply,
         pharmacyNote: compoundNotesPharmacist.trim() || undefined,
-        organizationId: selectedOrganizationId,
+        organization: selectedOrganization,
       });
       onOrderComplete?.({ launchUrl: res.launchUrl, medicationRequestId: res.medicationRequestId });
     } catch (e) {

--- a/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
@@ -48,6 +48,7 @@ import { AsyncAutocomplete, Panel, ResourceInput, useMedplum } from '@medplum/re
 import { useSearchResources } from '@medplum/react-hooks';
 import {
   loadScriptSureQuantityQualifiers,
+  SCRIPTSURE_GCN_SEQNO_SYSTEM,
   SCRIPTSURE_GENERIC_NAME_EXTENSION,
   SCRIPTSURE_NAME_TYPE_EXTENSION,
   SCRIPTSURE_ROUTED_MED_ID_SYSTEM,
@@ -60,9 +61,12 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import type { QualifierMatcher } from '../../components/meds/quantity-qualifiers';
 import {
+  buildDispenseUnitNameResolver,
   buildQualifierMatcher,
+  extractLeadingSigDispenseUnit,
   inferQuantityQualifierCodeWith,
   mergeQuantityQualifierCatalog,
+  STATIC_DISPENSE_UNIT_NAME_RESOLVER,
   STATIC_QUALIFIER_MATCHER,
 } from '../../components/meds/quantity-qualifiers';
 import { showErrorNotification } from '../../utils/notifications';
@@ -372,44 +376,72 @@ interface ParsedSig {
   quantityQualifierRaw: string | undefined;
 }
 
+/** A resolver mapping a dispense-unit name to an NCI potency-unit code. */
+type DispenseUnitNameResolver = (unitName: string | undefined) => string | undefined;
+
+/** Matches an NCI Thesaurus code (e.g. `C48155`). */
+const NCI_CODE_RE = /^C\d+$/;
+
 /**
  * Resolves the dispense unit (NCI potency code) for a sig.
  *
- * The matcher only fires for dose-form keywords (tablet, capsule, suppository,
- * patch, …) and `mL`. It never tags a strength unit like `mg`, so when it
- * returns something we can trust it more than ScriptSure's per-sig
- * `quantityQualifier` — which in practice often carries a strength-unit code
- * for solid dose forms (e.g. metformin tablets coming back with the milligram
- * code because the formulation strength is "500 mg").
+ * The ScriptSure drug-format endpoint does not send a per-sig
+ * `quantityQualifier`; the dispense unit is encoded as the leading token of the
+ * sig line (`"30 Gram - …"`, `"80 Tablet - …"`). So the qualifier is only
+ * "present" when some other path (e.g. an edited/persisted MedicationRequest)
+ * supplied it — in which case we trust it. Otherwise we infer, preferring the
+ * authoritative leading sig-unit token over free-text keyword inference.
+ *
+ * NOTE: this is deliberate, not a stopgap — the v4 Advanced API (as of the
+ * 2026-07-01 docs capture) exposes NO deterministic per-drug dispense-unit
+ * lookup; `quantityQualifier` is only a caller-supplied write field, and drug
+ * reads return dose-form *text* (`MED_DOSAGE_FORM_DESC`), not an NCI code. The
+ * leading sig token IS the deterministic signal (ScriptSure builds it from the
+ * same quantity-qualifier catalog). See the KB:
+ * wiki/fhir/medication-quantity-qualifiers.md + wiki/contradictions.md.
  *
  * Priority:
- *  1. Keyword inference from sig line + formulation label (only fires on a
- *     dose-form / volume keyword).
- *  2. Whatever ScriptSure sent on the sig (when non-empty and not the bot's
- *     "I had nothing, defaulting to tablet" sentinel).
- *  3. The static `C48542` Tablet fallback.
+ *  1. `raw` when ScriptSure/caller genuinely supplied a valid NCI code
+ *     (the qualifier "wins when present").
+ *  2. The leading `"<qty> <unit> - …"` token from the sig line, resolved via the
+ *     live/static catalog (fixes topicals/liquids like `"30 Gram"` → Gram).
+ *  3. Keyword inference from sig line + formulation label (dose-form / volume).
+ *  4. The static `C48542` Tablet fallback.
  *
- * @param raw - Value returned by ScriptSure on the sig (may be undefined).
+ * @param raw - Value already on the sig (usually absent for drug-format sigs).
  * @param sigLine - Sig text shown to the prescriber.
  * @param formatText - Formulation label (e.g. drug `code.text`) when known.
- * @param matcher - Catalog-aware matcher (live `/v3/prescription/quantityqualifier`
- *   or static fallback) used for keyword inference.
+ * @param matcher - Catalog-aware matcher used for keyword inference.
+ * @param unitResolver - Catalog-aware name→code resolver for the leading token.
  * @returns NCI potency-unit code; never empty.
  */
 function resolveQuantityQualifier(
   raw: string | undefined,
   sigLine: string,
   formatText: string | undefined,
-  matcher: QualifierMatcher
+  matcher: QualifierMatcher,
+  unitResolver: DispenseUnitNameResolver
 ): string {
+  const trimmedRaw = raw?.trim();
+  if (trimmedRaw && NCI_CODE_RE.test(trimmedRaw)) {
+    return trimmedRaw;
+  }
+  const fromSigUnit = unitResolver(extractLeadingSigDispenseUnit(sigLine));
+  if (fromSigUnit) {
+    return fromSigUnit;
+  }
   const inferred = inferQuantityQualifierCodeWith(matcher, sigLine, formatText);
   if (inferred) {
     return inferred;
   }
-  return raw?.trim() || DEFAULT_QUANTITY_QUALIFIER;
+  return trimmedRaw || DEFAULT_QUANTITY_QUALIFIER;
 }
 
-function parseScriptSureSigs(medication: Medication, matcher: QualifierMatcher): ParsedSig[] {
+function parseScriptSureSigs(
+  medication: Medication,
+  matcher: QualifierMatcher,
+  unitResolver: DispenseUnitNameResolver
+): ParsedSig[] {
   const formatText = medication.code?.text;
   const out: ParsedSig[] = [];
   for (const ext of medication.extension ?? []) {
@@ -424,7 +456,7 @@ function parseScriptSureSigs(medication: Medication, matcher: QualifierMatcher):
       out.push({
         sigLine,
         quantity,
-        quantityQualifier: resolveQuantityQualifier(quantityQualifierRaw, sigLine, formatText, matcher),
+        quantityQualifier: resolveQuantityQualifier(quantityQualifierRaw, sigLine, formatText, matcher, unitResolver),
         quantityQualifierRaw,
       });
     }
@@ -523,8 +555,18 @@ function medicationToCodeableConcept(
   format: Medication,
   drug?: Medication
 ): MedicationRequest['medicationCodeableConcept'] {
+  const coding = [...(format.code?.coding ?? [])];
+  // The drug-format Medication carries its single GCN_SEQNO as an identifier
+  // (not a code.coding). Promote it to a coding so the draft MR carries the
+  // FDB clinical-formulation key: the ScriptSure prescription webhook reconciles
+  // draft→sent by GCN when the NDC drifts (#9300) or a generic is substituted
+  // (brand/generic share a GCN). See scriptsure-react SCRIPTSURE_GCN_SEQNO_SYSTEM.
+  const gcn = getIdentifier(format, SCRIPTSURE_GCN_SEQNO_SYSTEM);
+  if (gcn && !coding.some((c) => c.system === SCRIPTSURE_GCN_SEQNO_SYSTEM)) {
+    coding.push({ system: SCRIPTSURE_GCN_SEQNO_SYSTEM, code: gcn });
+  }
   return {
-    coding: format.code?.coding,
+    coding,
     text: composeMedicationName(drug, format),
   };
 }
@@ -635,13 +677,18 @@ interface FormulationSigChoice {
  * @param formats - Deduped Medication[] from `searchMedications({ routedMedId })`.
  * @param matcher - Quantity-qualifier matcher used by `parseScriptSureSigs` to
  *   resolve dispense units when ScriptSure omits them on a sig.
+ * @param unitResolver - Name→code resolver for the leading sig-unit token.
  * @returns One row per selectable formulation+sig pair.
  */
-function buildFormulationSigChoices(formats: Medication[], matcher: QualifierMatcher): FormulationSigChoice[] {
+function buildFormulationSigChoices(
+  formats: Medication[],
+  matcher: QualifierMatcher,
+  unitResolver: DispenseUnitNameResolver
+): FormulationSigChoice[] {
   const out: FormulationSigChoice[] = [];
   formats.forEach((fm, fi) => {
     const formatLabel = fm.code?.text ?? `Option ${fi + 1}`;
-    const sigs = parseScriptSureSigs(fm, matcher);
+    const sigs = parseScriptSureSigs(fm, matcher, unitResolver);
     if (sigs.length === 0) {
       out.push({
         formatIndex: fi,
@@ -770,6 +817,16 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
     return buildQualifierMatcher(qualifierCatalog.map((r) => ({ potencyUnit: r.code, name: r.label })));
   }, [qualifierCatalog]);
 
+  // Name→code resolver for the leading sig-unit token ("30 Gram" → C48155),
+  // built from the same live catalog; falls back to the static resolver until
+  // the bot call resolves.
+  const unitNameResolver = useMemo<DispenseUnitNameResolver>(() => {
+    if (qualifierCatalog.length === 0) {
+      return STATIC_DISPENSE_UNIT_NAME_RESOLVER;
+    }
+    return buildDispenseUnitNameResolver(qualifierCatalog.map((r) => ({ potencyUnit: r.code, name: r.label })));
+  }, [qualifierCatalog]);
+
   useEffect(() => {
     if (patientProp) {
       return undefined;
@@ -845,13 +902,13 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
   }, [termMedication, searchMedications]);
 
   const sigOptions = useMemo(
-    () => (selectedFormat ? parseScriptSureSigs(selectedFormat, qualifierMatcher) : []),
-    [selectedFormat, qualifierMatcher]
+    () => (selectedFormat ? parseScriptSureSigs(selectedFormat, qualifierMatcher, unitNameResolver) : []),
+    [selectedFormat, qualifierMatcher, unitNameResolver]
   );
 
   const formulationSigChoices = useMemo(
-    () => buildFormulationSigChoices(formatMedications, qualifierMatcher),
-    [formatMedications, qualifierMatcher]
+    () => buildFormulationSigChoices(formatMedications, qualifierMatcher, unitNameResolver),
+    [formatMedications, qualifierMatcher, unitNameResolver]
   );
 
   const selectedChoiceKey = useMemo(() => {
@@ -1080,7 +1137,7 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
         showErrorNotification('Each compound line needs a selected formulation');
         return;
       }
-      const sigs = parseScriptSureSigs(line.formatMed, qualifierMatcher);
+      const sigs = parseScriptSureSigs(line.formatMed, qualifierMatcher, unitNameResolver);
       const sigLine3 = sigs[0]?.sigLine ?? 'Take as directed';
       drugs.push(
         medicationToOrderDrugInput(line.formatMed, {

--- a/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
@@ -69,6 +69,7 @@ import {
   STATIC_DISPENSE_UNIT_NAME_RESOLVER,
   STATIC_QUALIFIER_MATCHER,
 } from '../../components/meds/quantity-qualifiers';
+import { ScriptSurePracticeSwitcher, useScriptSurePractice } from '../../scriptsure/ScriptSurePractice';
 import { showErrorNotification } from '../../utils/notifications';
 import { OrderSetTabPanel } from './OrderSetTabPanel';
 
@@ -656,6 +657,7 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
   const medplum = useMedplum();
   const { patientId } = useParams();
   const { searchMedications, orderMedication } = useScriptSureOrderMedication();
+  const { selectedOrganizationId } = useScriptSurePractice();
 
   const [patient, setPatient] = useState(patientProp);
   const [requester, setRequester] = useState<Practitioner | undefined>();
@@ -1029,6 +1031,7 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
         pharmacyOrganizationId: pharmacyOrg?.id,
         writtenDate: writtenDateYmd,
         fillDate: fillDateYmd.trim() || undefined,
+        organizationId: selectedOrganizationId,
       });
 
       onOrderComplete?.({ launchUrl: res.launchUrl, medicationRequestId: res.medicationRequestId });
@@ -1114,6 +1117,7 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
         fillDate: compoundFillYmd.trim() || undefined,
         durationDays: compoundDaysSupply,
         pharmacyNote: compoundNotesPharmacist.trim() || undefined,
+        organizationId: selectedOrganizationId,
       });
       onOrderComplete?.({ launchUrl: res.launchUrl, medicationRequestId: res.medicationRequestId });
     } catch (e) {
@@ -1126,6 +1130,9 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
   return (
     <Container size="md">
       <Panel>
+        <Group justify="flex-end" mb="sm">
+          <ScriptSurePracticeSwitcher />
+        </Group>
         <Tabs value={activeTab} onChange={(v) => setActiveTab(v ?? 'single')}>
           <Tabs.List>
             <Tabs.Tab value="single">Single medication</Tabs.Tab>

--- a/examples/medplum-provider/src/pages/meds/OrderSetTabPanel.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderSetTabPanel.tsx
@@ -183,7 +183,7 @@ export function OrderSetPreflightSummary(props: Readonly<OrderSetPreflightSummar
 export function OrderSetTabPanel(props: Readonly<OrderSetTabPanelProps>): JSX.Element {
   const { patient, requester, onPatientChange, onRequesterChange, onOrderComplete } = props;
   const medplum = useMedplum();
-  const { selectedOrganizationId } = useScriptSurePractice();
+  const { selectedOrganization } = useScriptSurePractice();
 
   const [planDefinition, setPlanDefinition] = useState<PlanDefinition | undefined>();
   const [scriptSureIdEscape, setScriptSureIdEscape] = useState<number | undefined>();
@@ -202,7 +202,7 @@ export function OrderSetTabPanel(props: Readonly<OrderSetTabPanelProps>): JSX.El
     patientId: patient?.id,
     planDefinitionId: planDefinitionIdInput,
     scriptSureOrdersetId: planDefinitionIdInput ? undefined : scriptSureIdEscape,
-    organizationId: selectedOrganizationId,
+    organization: selectedOrganization,
   });
 
   const submitDisabled = !patient?.id || !requester || (!planDefinitionIdInput && scriptSureIdEscape === undefined);

--- a/examples/medplum-provider/src/pages/meds/OrderSetTabPanel.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderSetTabPanel.tsx
@@ -21,6 +21,7 @@ import { ResourceInput, useMedplum } from '@medplum/react';
 import { SCRIPTSURE_ORDERSET_ID_SYSTEM, useScriptSureOrderSet } from '@medplum/scriptsure-react';
 import type { JSX } from 'react';
 import { useCallback, useState } from 'react';
+import { useScriptSurePractice } from '../../scriptsure/ScriptSurePractice';
 import { showErrorNotification } from '../../utils/notifications';
 import { OptionalContextFields } from './OrderMedicationPage';
 
@@ -182,6 +183,7 @@ export function OrderSetPreflightSummary(props: Readonly<OrderSetPreflightSummar
 export function OrderSetTabPanel(props: Readonly<OrderSetTabPanelProps>): JSX.Element {
   const { patient, requester, onPatientChange, onRequesterChange, onOrderComplete } = props;
   const medplum = useMedplum();
+  const { selectedOrganizationId } = useScriptSurePractice();
 
   const [planDefinition, setPlanDefinition] = useState<PlanDefinition | undefined>();
   const [scriptSureIdEscape, setScriptSureIdEscape] = useState<number | undefined>();
@@ -200,6 +202,7 @@ export function OrderSetTabPanel(props: Readonly<OrderSetTabPanelProps>): JSX.El
     patientId: patient?.id,
     planDefinitionId: planDefinitionIdInput,
     scriptSureOrdersetId: planDefinitionIdInput ? undefined : scriptSureIdEscape,
+    organizationId: selectedOrganizationId,
   });
 
   const submitDisabled = !patient?.id || !requester || (!planDefinitionIdInput && scriptSureIdEscape === undefined);

--- a/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
@@ -76,7 +76,7 @@ export function MedicationsPage(): JSX.Element {
   const medplum = useMedplum();
   const { orderMedication } = useScriptSureOrderMedication();
   const { addToCart, adding, checkout, removeFromCart, clearCart } = useScriptSureCart();
-  const { selectedOrganizationId } = useScriptSurePractice();
+  const { selectedOrganization } = useScriptSurePractice();
 
   const [searchParams, setSearchParams] = useSearchParams();
   const statusParam = searchParams.get('status') ?? TAB_TO_STATUS_PARAM[DEFAULT_TAB];
@@ -338,7 +338,7 @@ export function MedicationsPage(): JSX.Element {
       // chart surface handles every state (queued, sent, etc.).
       const res = await medplum.executeBot(SCRIPTSURE_IFRAME_BOT, {
         patientId,
-        organizationId: selectedOrganizationId,
+        organization: selectedOrganization,
       });
       if (!res?.url) {
         throw new Error('ScriptSure did not return a prescriptions URL');
@@ -351,7 +351,7 @@ export function MedicationsPage(): JSX.Element {
     } catch (e) {
       showErrorNotification(e);
     }
-  }, [patientId, currentOrder, medplum, fetchData, selectedOrganizationId]);
+  }, [patientId, currentOrder, medplum, fetchData, selectedOrganization]);
 
   const refreshLaunchUrl = useCallback(async (): Promise<string | undefined> => {
     if (!patientId) {
@@ -362,7 +362,7 @@ export function MedicationsPage(): JSX.Element {
     if (iframeMode === 'chart') {
       const res = await medplum.executeBot(SCRIPTSURE_IFRAME_BOT, {
         patientId,
-        organizationId: selectedOrganizationId,
+        organization: selectedOrganization,
       });
       return res?.url ?? iframeUrlRef.current;
     }
@@ -370,9 +370,9 @@ export function MedicationsPage(): JSX.Element {
     if (!mrId) {
       return iframeUrlRef.current;
     }
-    const res = await orderMedication({ patientId, medicationRequestId: mrId, organizationId: selectedOrganizationId });
+    const res = await orderMedication({ patientId, medicationRequestId: mrId, organization: selectedOrganization });
     return res.launchUrl;
-  }, [patientId, currentOrder, iframePollMrId, iframeMode, medplum, orderMedication, selectedOrganizationId]);
+  }, [patientId, currentOrder, iframePollMrId, iframeMode, medplum, orderMedication, selectedOrganization]);
 
   const handleIframeFhirSynced = useCallback((): void => {
     setIframeModalOpened(false);
@@ -473,7 +473,7 @@ export function MedicationsPage(): JSX.Element {
       const res = await checkout({
         patientId: checkoutPatientId,
         medicationRequestIds,
-        organizationId: selectedOrganizationId,
+        organization: selectedOrganization,
       });
       const failed = res.items.filter((i) => i.status === 'failed');
       const queuedIds = res.items.filter((i) => i.status === 'queued').map((i) => i.medicationRequestId);
@@ -500,7 +500,7 @@ export function MedicationsPage(): JSX.Element {
     } finally {
       setCheckingOut(false);
     }
-  }, [patient, total, fetchAllDraftIds, checkout, fetchData, selectedOrganizationId]);
+  }, [patient, total, fetchAllDraftIds, checkout, fetchData, selectedOrganization]);
 
   const handleRemoveFromCart = useCallback(
     async (mrId: string): Promise<void> => {

--- a/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/MedicationsPage.tsx
@@ -43,6 +43,7 @@ import { MedSelectEmpty } from '../../components/meds/MedSelectEmpty';
 import { PrescriptionIFrameModal } from '../../components/meds/PrescriptionIFrameModal';
 import { hasDoseSpotIdentifier, hasScriptSureIdentifier } from '../../components/utils';
 import { usePatient } from '../../hooks/usePatient';
+import { useScriptSurePractice } from '../../scriptsure/ScriptSurePractice';
 import { showErrorNotification } from '../../utils/notifications';
 import { OrderMedicationPage } from '../meds/OrderMedicationPage';
 import classes from './MedsPage.module.css';
@@ -75,6 +76,7 @@ export function MedicationsPage(): JSX.Element {
   const medplum = useMedplum();
   const { orderMedication } = useScriptSureOrderMedication();
   const { addToCart, adding, checkout, removeFromCart, clearCart } = useScriptSureCart();
+  const { selectedOrganizationId } = useScriptSurePractice();
 
   const [searchParams, setSearchParams] = useSearchParams();
   const statusParam = searchParams.get('status') ?? TAB_TO_STATUS_PARAM[DEFAULT_TAB];
@@ -334,7 +336,10 @@ export function MedicationsPage(): JSX.Element {
       // widget is only designed for the initial prescribing flow and cannot
       // approve/deny an order that was added to the queue (issue #9300); the
       // chart surface handles every state (queued, sent, etc.).
-      const res = await medplum.executeBot(SCRIPTSURE_IFRAME_BOT, { patientId });
+      const res = await medplum.executeBot(SCRIPTSURE_IFRAME_BOT, {
+        patientId,
+        organizationId: selectedOrganizationId,
+      });
       if (!res?.url) {
         throw new Error('ScriptSure did not return a prescriptions URL');
       }
@@ -346,7 +351,7 @@ export function MedicationsPage(): JSX.Element {
     } catch (e) {
       showErrorNotification(e);
     }
-  }, [patientId, currentOrder, medplum, fetchData]);
+  }, [patientId, currentOrder, medplum, fetchData, selectedOrganizationId]);
 
   const refreshLaunchUrl = useCallback(async (): Promise<string | undefined> => {
     if (!patientId) {
@@ -355,16 +360,19 @@ export function MedicationsPage(): JSX.Element {
     // Refresh from whichever surface is currently shown so an expired session
     // token is replaced with a matching URL (single-order widget vs chart).
     if (iframeMode === 'chart') {
-      const res = await medplum.executeBot(SCRIPTSURE_IFRAME_BOT, { patientId });
+      const res = await medplum.executeBot(SCRIPTSURE_IFRAME_BOT, {
+        patientId,
+        organizationId: selectedOrganizationId,
+      });
       return res?.url ?? iframeUrlRef.current;
     }
     const mrId = iframePollMrId ?? currentOrder?.id;
     if (!mrId) {
       return iframeUrlRef.current;
     }
-    const res = await orderMedication({ patientId, medicationRequestId: mrId });
+    const res = await orderMedication({ patientId, medicationRequestId: mrId, organizationId: selectedOrganizationId });
     return res.launchUrl;
-  }, [patientId, currentOrder, iframePollMrId, iframeMode, medplum, orderMedication]);
+  }, [patientId, currentOrder, iframePollMrId, iframeMode, medplum, orderMedication, selectedOrganizationId]);
 
   const handleIframeFhirSynced = useCallback((): void => {
     setIframeModalOpened(false);
@@ -462,7 +470,11 @@ export function MedicationsPage(): JSX.Element {
       if (medicationRequestIds.length === 0) {
         return;
       }
-      const res = await checkout({ patientId: checkoutPatientId, medicationRequestIds });
+      const res = await checkout({
+        patientId: checkoutPatientId,
+        medicationRequestIds,
+        organizationId: selectedOrganizationId,
+      });
       const failed = res.items.filter((i) => i.status === 'failed');
       const queuedIds = res.items.filter((i) => i.status === 'queued').map((i) => i.medicationRequestId);
       if (failed.length > 0) {
@@ -488,7 +500,7 @@ export function MedicationsPage(): JSX.Element {
     } finally {
       setCheckingOut(false);
     }
-  }, [patient, total, fetchAllDraftIds, checkout, fetchData]);
+  }, [patient, total, fetchAllDraftIds, checkout, fetchData, selectedOrganizationId]);
 
   const handleRemoveFromCart = useCallback(
     async (mrId: string): Promise<void> => {

--- a/examples/medplum-provider/src/pages/patient/ScriptSureTab.test.tsx
+++ b/examples/medplum-provider/src/pages/patient/ScriptSureTab.test.tsx
@@ -4,6 +4,7 @@ import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
+import type * as ScriptSureReactModule from '@medplum/scriptsure-react';
 import { useScriptSureIFrame } from '@medplum/scriptsure-react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
@@ -14,11 +15,13 @@ import { ScriptSureTab } from './ScriptSureTab';
 const mockIframeUrl = 'https://scriptsure.example.com/chart/123/prescriptions';
 const mockRenderedIframeUrl = applyDarkmode(mockIframeUrl, 'light');
 
-vi.mock('@medplum/scriptsure-react', () => ({
-  useScriptSureIFrame: vi.fn(() => mockIframeUrl),
-  SCRIPTSURE_IFRAME_BOT: { system: 'https://www.medplum.com/bots', value: 'scriptsure-iframe-bot' },
-  SCRIPTSURE_PATIENT_SYNC_BOT: { system: 'https://www.medplum.com/bots', value: 'scriptsure-patient-sync-bot' },
-}));
+vi.mock('@medplum/scriptsure-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof ScriptSureReactModule>();
+  return {
+    ...actual,
+    useScriptSureIFrame: vi.fn(() => mockIframeUrl),
+  };
+});
 
 describe('ScriptSureTab', () => {
   let medplum: MockClient;

--- a/examples/medplum-provider/src/pages/patient/ScriptSureTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/ScriptSureTab.tsx
@@ -12,7 +12,7 @@ import { useScriptSurePractice } from '../../scriptsure/ScriptSurePractice';
 
 export function ScriptSureTab(): JSX.Element {
   const { patientId } = useParams();
-  const { selectedOrganizationId } = useScriptSurePractice();
+  const { selectedOrganization } = useScriptSurePractice();
   const syncedRef = useRef(false);
   const iframeLoadedRef = useRef(false);
 
@@ -29,7 +29,7 @@ export function ScriptSureTab(): JSX.Element {
 
   const iframeUrl = useScriptSureIFrame({
     patientId,
-    organizationId: selectedOrganizationId,
+    organization: selectedOrganization,
     onPatientSyncSuccess: () => {
       syncedRef.current = true;
       checkAndNotify();

--- a/examples/medplum-provider/src/pages/patient/ScriptSureTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/ScriptSureTab.tsx
@@ -8,9 +8,11 @@ import type { JSX } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router';
 import { applyDarkmode } from '../../components/meds/applyDarkmode';
+import { useScriptSurePractice } from '../../scriptsure/ScriptSurePractice';
 
 export function ScriptSureTab(): JSX.Element {
   const { patientId } = useParams();
+  const { selectedOrganizationId } = useScriptSurePractice();
   const syncedRef = useRef(false);
   const iframeLoadedRef = useRef(false);
 
@@ -27,6 +29,7 @@ export function ScriptSureTab(): JSX.Element {
 
   const iframeUrl = useScriptSureIFrame({
     patientId,
+    organizationId: selectedOrganizationId,
     onPatientSyncSuccess: () => {
       syncedRef.current = true;
       checkAndNotify();

--- a/examples/medplum-provider/src/scriptsure/ScriptSurePractice.test.tsx
+++ b/examples/medplum-provider/src/scriptsure/ScriptSurePractice.test.tsx
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { MantineProvider } from '@mantine/core';
+import type { Organization } from '@medplum/fhirtypes';
+import type * as ScriptSureReactModule from '@medplum/scriptsure-react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { ScriptSurePracticeSwitcher } from './ScriptSurePractice';
+
+const SELECT_INPUT = 'input[aria-label="ScriptSure practice location"]';
+
+const setSelectedOrganizationId = vi.fn();
+let mockContext: ScriptSureReactModule.ScriptSurePracticeContextValue;
+
+vi.mock('@medplum/scriptsure-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof ScriptSureReactModule>();
+  return {
+    ...actual,
+    useScriptSurePractice: () => mockContext,
+  };
+});
+
+function org(id: string, name: string): Organization {
+  return { resourceType: 'Organization', id, name };
+}
+
+function setup(): ReturnType<typeof render> {
+  return render(
+    <MantineProvider>
+      <ScriptSurePracticeSwitcher />
+    </MantineProvider>
+  );
+}
+
+describe('ScriptSurePracticeSwitcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockContext = {
+      practices: [],
+      selectedOrganizationId: undefined,
+      setSelectedOrganizationId,
+      loading: false,
+    };
+  });
+
+  test('renders nothing when the prescriber has fewer than two practices', () => {
+    mockContext = { ...mockContext, practices: [org('org-1', 'Practice A')], selectedOrganizationId: 'org-1' };
+    const { container } = setup();
+    expect(container.querySelector(SELECT_INPUT)).toBeNull();
+  });
+
+  test('renders the selector with the affiliated practices when there are two or more', () => {
+    mockContext = {
+      ...mockContext,
+      practices: [org('org-1', 'Practice A'), org('org-2', 'Practice B')],
+      selectedOrganizationId: 'org-2',
+    };
+    const { container } = setup();
+    const select = container.querySelector<HTMLInputElement>(SELECT_INPUT);
+    expect(select).toBeInTheDocument();
+    expect(select).toHaveValue('Practice B');
+  });
+
+  test('calls setSelectedOrganizationId when a different practice is chosen', async () => {
+    mockContext = {
+      ...mockContext,
+      practices: [org('org-1', 'Practice A'), org('org-2', 'Practice B')],
+      selectedOrganizationId: 'org-1',
+    };
+    const { container } = setup();
+    const select = container.querySelector<HTMLInputElement>(SELECT_INPUT) as HTMLInputElement;
+    fireEvent.click(select);
+    const listbox = await screen.findByRole('listbox');
+    fireEvent.click(within(listbox).getByText('Practice B'));
+    expect(setSelectedOrganizationId).toHaveBeenCalledWith('org-2');
+  });
+});

--- a/examples/medplum-provider/src/scriptsure/ScriptSurePractice.test.tsx
+++ b/examples/medplum-provider/src/scriptsure/ScriptSurePractice.test.tsx
@@ -38,6 +38,7 @@ describe('ScriptSurePracticeSwitcher', () => {
     mockContext = {
       practices: [],
       selectedOrganizationId: undefined,
+      selectedOrganization: undefined,
       setSelectedOrganizationId,
       loading: false,
     };

--- a/examples/medplum-provider/src/scriptsure/ScriptSurePractice.tsx
+++ b/examples/medplum-provider/src/scriptsure/ScriptSurePractice.tsx
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Select } from '@mantine/core';
+import { useScriptSurePractice } from '@medplum/scriptsure-react';
+import type { JSX } from 'react';
+
+// The affiliation-scoped practice context + hook are vendor-neutral and live in
+// `@medplum/scriptsure-react` so any consumer gets the same discovery/selection
+// behavior. Re-exported here for existing imports; this file only owns the
+// Mantine-specific switcher UI.
+export { ScriptSurePracticeProvider, useScriptSurePractice } from '@medplum/scriptsure-react';
+export type { ScriptSurePracticeContextValue } from '@medplum/scriptsure-react';
+
+/**
+ * Compact practice-location switcher for the app shell. Renders nothing when the
+ * prescriber has fewer than two ScriptSure practices (single-practice projects
+ * need no picker; the backend resolves the practice automatically).
+ *
+ * @returns The switcher element, or null.
+ */
+export function ScriptSurePracticeSwitcher(): JSX.Element | null {
+  const { practices, selectedOrganizationId, setSelectedOrganizationId } = useScriptSurePractice();
+  if (practices.length < 2) {
+    return null;
+  }
+  return (
+    <Select
+      aria-label="ScriptSure practice location"
+      placeholder="Select location"
+      size="xs"
+      w={220}
+      data={practices.map((o) => ({
+        value: o.id as string,
+        label: o.name ?? `Practice ${o.id}`,
+      }))}
+      value={selectedOrganizationId ?? null}
+      onChange={(v) => setSelectedOrganizationId(v ?? undefined)}
+    />
+  );
+}

--- a/packages/core/src/medication-order-utils.test.ts
+++ b/packages/core/src/medication-order-utils.test.ts
@@ -38,6 +38,7 @@ import {
   parametersToMedicationCheckoutResponse,
   parametersToMedicationOrderResponse,
   parametersToMedicationOrderSetResponse,
+  parametersToOrderSetSyncResponse,
 } from './medication-order-utils';
 
 const TEST_EXT = {
@@ -513,6 +514,19 @@ describe('Custom FHIR operation Parameters helpers', () => {
     ]);
   });
 
+  test('medicationCheckoutRequestToParameters emits organizationId when provided', () => {
+    const result = medicationCheckoutRequestToParameters({
+      patientId: 'pat-1',
+      medicationRequestIds: ['mr-1'],
+      organizationId: 'org-7',
+    });
+    expect(result.parameter).toEqual([
+      { name: 'patientId', valueId: 'pat-1' },
+      { name: 'medicationRequestIds', valueId: 'mr-1' },
+      { name: 'organizationId', valueString: 'org-7' },
+    ]);
+  });
+
   test('parametersToMedicationCheckoutResponse round-trips the checkout response shape', () => {
     const expected: MedicationCheckoutResponse = {
       approvalUrl: 'https://ui.example.com/widgets/medcart/24057?sessiontoken=tok',
@@ -675,5 +689,75 @@ describe('Custom FHIR operation Parameters helpers', () => {
       };
       expect(() => parametersToMedicationCartManageResponse(params)).toThrow(INVALID_MEDICATION_CART_RESPONSE);
     });
+  });
+
+  test('parametersToOrderSetSyncResponse decodes counts + repeating per-action results', () => {
+    const params: Parameters = {
+      resourceType: 'Parameters',
+      parameter: [
+        { name: 'mode', valueCode: 'created' },
+        { name: 'planDefinitionId', valueId: 'pd-1' },
+        { name: 'scriptSureOrdersetId', valueInteger: 379 },
+        { name: 'syncedCount', valueInteger: 1 },
+        { name: 'failedCount', valueInteger: 1 },
+        {
+          name: 'results',
+          part: [
+            { name: 'actionTitle', valueString: 'Jardiance' },
+            { name: 'activityDefinitionUrl', valueCanonical: 'https://x/ActivityDefinition/j|1.0.0' },
+            { name: 'scriptSureSequenceId', valueInteger: 1011 },
+            { name: 'status', valueCode: 'synced' },
+          ],
+        },
+        {
+          name: 'results',
+          part: [
+            { name: 'actionTitle', valueString: 'Ozempic' },
+            { name: 'status', valueCode: 'failed' },
+            { name: 'error', valueString: 'drug not in FDB' },
+          ],
+        },
+      ],
+    };
+    expect(parametersToOrderSetSyncResponse(params)).toEqual({
+      mode: 'created',
+      planDefinitionId: 'pd-1',
+      scriptSureOrdersetId: 379,
+      syncedCount: 1,
+      failedCount: 1,
+      results: [
+        {
+          actionTitle: 'Jardiance',
+          activityDefinitionUrl: 'https://x/ActivityDefinition/j|1.0.0',
+          scriptSureSequenceId: 1011,
+          scriptSureOrderId: undefined,
+          status: 'synced',
+          error: undefined,
+        },
+        {
+          actionTitle: 'Ozempic',
+          activityDefinitionUrl: undefined,
+          scriptSureSequenceId: undefined,
+          scriptSureOrderId: undefined,
+          status: 'failed',
+          error: 'drug not in FDB',
+        },
+      ],
+    });
+  });
+
+  test('parametersToOrderSetSyncResponse derives counts from results when scalars absent', () => {
+    const params: Parameters = {
+      resourceType: 'Parameters',
+      parameter: [
+        { name: 'mode', valueCode: 'noop-already-synced' },
+        { name: 'results', part: [{ name: 'status', valueCode: 'synced' }] },
+        { name: 'results', part: [{ name: 'status', valueCode: 'failed' }] },
+      ],
+    };
+    const decoded = parametersToOrderSetSyncResponse(params);
+    expect(decoded.mode).toBe('noop-already-synced');
+    expect(decoded.syncedCount).toBe(1);
+    expect(decoded.failedCount).toBe(1);
   });
 });

--- a/packages/core/src/medication-order-utils.test.ts
+++ b/packages/core/src/medication-order-utils.test.ts
@@ -303,6 +303,7 @@ describe('Custom FHIR operation Parameters helpers', () => {
       pharmacyNote: 'Call patient first',
       patientInstruction: 'With food',
       appId: 'provider-app',
+      organization: { reference: 'Organization/practice-1' },
     };
     const result = medicationOrderRequestToParameters(req);
     expect(result.parameter).toContainEqual({ name: 'medicationRequestId', valueId: 'mr-1' });
@@ -317,6 +318,7 @@ describe('Custom FHIR operation Parameters helpers', () => {
     expect(result.parameter).toContainEqual({ name: 'pharmacyNote', valueString: 'Call patient first' });
     expect(result.parameter).toContainEqual({ name: 'patientInstruction', valueString: 'With food' });
     expect(result.parameter).toContainEqual({ name: 'appId', valueString: 'provider-app' });
+    expect(result.parameter).toContainEqual({ name: 'organizationId', valueString: 'practice-1' });
 
     const drugs = result.parameter?.find((p) => p.name === 'drugs');
     expect(drugs?.part).toContainEqual({ name: 'routedMedId', valueInteger: 6876 });
@@ -401,6 +403,7 @@ describe('Custom FHIR operation Parameters helpers', () => {
       patientId: 'pat-1',
       planDefinitionId: 'pd-1',
       appId: 'provider-app',
+      organization: { reference: 'Organization/practice-1' },
     };
     const result = medicationOrderSetRequestToParameters(req);
     expect(result.resourceType).toBe('Parameters');
@@ -408,6 +411,7 @@ describe('Custom FHIR operation Parameters helpers', () => {
       { name: 'patientId', valueId: 'pat-1' },
       { name: 'planDefinitionId', valueId: 'pd-1' },
       { name: 'appId', valueString: 'provider-app' },
+      { name: 'organizationId', valueString: 'practice-1' },
     ]);
   });
 
@@ -518,7 +522,7 @@ describe('Custom FHIR operation Parameters helpers', () => {
     const result = medicationCheckoutRequestToParameters({
       patientId: 'pat-1',
       medicationRequestIds: ['mr-1'],
-      organizationId: 'org-7',
+      organization: { reference: 'Organization/org-7' },
     });
     expect(result.parameter).toEqual([
       { name: 'patientId', valueId: 'pat-1' },

--- a/packages/core/src/medication-order-utils.ts
+++ b/packages/core/src/medication-order-utils.ts
@@ -119,6 +119,11 @@ export interface MedicationOrderRequest {
   /** Free-text patient instructions (additional sig); maps to dosageInstruction[0].patientInstruction when using MR path. */
   readonly patientInstruction?: string;
   readonly appId?: string;
+  /**
+   * Selected practice-location Organization (id or `Organization/{id}` reference) for
+   * multi-practice deployments. The vendor bot resolves the vendor practice from it.
+   */
+  readonly organizationId?: string;
 }
 
 /**
@@ -154,6 +159,11 @@ export interface MedicationOrderSetRequest {
    */
   readonly vendorOrderSetId?: number | string;
   readonly appId?: string;
+  /**
+   * Selected practice-location Organization (id or `Organization/{id}` reference) for
+   * multi-practice deployments. The vendor bot resolves the vendor practice from it.
+   */
+  readonly organizationId?: string;
 }
 
 /**
@@ -186,6 +196,11 @@ export interface MedicationSearchParams {
   readonly includeCode?: boolean;
   /** When true, drug-search bot returns quantity qualifiers from GET /v3/prescription/quantityqualifier instead of Medication[]. */
   readonly quantityQualifiers?: boolean;
+  /**
+   * Selected practice-location Organization (id or `Organization/{id}` reference) for
+   * multi-practice deployments. The vendor bot resolves the vendor practice from it.
+   */
+  readonly organizationId?: string;
 }
 
 /**
@@ -387,6 +402,9 @@ export function medicationSearchParamsToParameters(params: MedicationSearchParam
   if (params.quantityQualifiers !== undefined) {
     parameter.push(param('quantityQualifiers', 'valueBoolean', params.quantityQualifiers));
   }
+  if (params.organizationId !== undefined) {
+    parameter.push(param('organizationId', 'valueString', params.organizationId));
+  }
   return { resourceType: 'Parameters', parameter };
 }
 
@@ -525,6 +543,9 @@ export function medicationOrderRequestToParameters(req: MedicationOrderRequest):
   if (req.appId !== undefined) {
     parameter.push(param('appId', 'valueString', req.appId));
   }
+  if (req.organizationId !== undefined) {
+    parameter.push(param('organizationId', 'valueString', req.organizationId));
+  }
 
   return { resourceType: 'Parameters', parameter };
 }
@@ -587,6 +608,9 @@ export function medicationOrderSetRequestToParameters(req: MedicationOrderSetReq
   }
   if (req.appId !== undefined) {
     parameter.push(param('appId', 'valueString', req.appId));
+  }
+  if (req.organizationId !== undefined) {
+    parameter.push(param('organizationId', 'valueString', req.organizationId));
   }
   return { resourceType: 'Parameters', parameter };
 }
@@ -669,6 +693,12 @@ export interface MedicationCheckoutRequest {
   readonly patientId: string;
   readonly medicationRequestIds: string[];
   readonly appId?: string;
+  /**
+   * Selected practice-location Organization (id or `Organization/{id}` reference)
+   * for multi-practice deployments. The vendor bot resolves the vendor practice
+   * from it; omit for single-practice prescribers (backend resolves by affiliation).
+   */
+  readonly organizationId?: string;
 }
 
 /**
@@ -721,6 +751,9 @@ export function medicationCheckoutRequestToParameters(req: MedicationCheckoutReq
   }
   if (req.appId !== undefined) {
     parameter.push(param('appId', 'valueString', req.appId));
+  }
+  if (req.organizationId !== undefined) {
+    parameter.push(param('organizationId', 'valueString', req.organizationId));
   }
   return { resourceType: 'Parameters', parameter };
 }
@@ -965,4 +998,94 @@ export function parametersToMedicationCartManageResponse(params: Parameters): Me
     throw new Error(INVALID_MEDICATION_CART_RESPONSE);
   }
   return candidate;
+}
+
+// ============================================================================
+// Order-set sync ($sync-orderset)
+// ============================================================================
+
+/**
+ * Per-action outcome from the vendor-neutral `$sync-orderset` operation. A
+ * `'failed'` row carries `error` and was NOT added to the vendor order set, so
+ * a later apply/signing session would open with fewer meds than the
+ * `PlanDefinition` requested — callers must surface these.
+ */
+export interface OrderSetSyncSequenceResult {
+  readonly actionTitle?: string;
+  readonly activityDefinitionUrl?: string;
+  readonly scriptSureSequenceId?: number;
+  readonly scriptSureOrderId?: number;
+  readonly status: 'synced' | 'failed';
+  readonly error?: string;
+}
+
+/**
+ * Vendor-neutral decoded response from the `$sync-orderset` custom operation
+ * (`POST /fhir/R4/PlanDefinition/$sync-orderset`). `failedCount > 0` means the
+ * synced vendor order set carries fewer meds than the `PlanDefinition`.
+ */
+export interface OrderSetSyncResponse {
+  readonly mode: 'created' | 'noop-already-synced';
+  readonly planDefinitionId?: string;
+  readonly scriptSureOrdersetId?: number;
+  readonly syncedCount: number;
+  readonly failedCount: number;
+  readonly results: OrderSetSyncSequenceResult[];
+}
+
+/**
+ * Decodes one repeating `results` part list from the `$sync-orderset` response
+ * into a typed {@link OrderSetSyncSequenceResult}.
+ *
+ * @param parts - The `part[]` entries of a single `results` output parameter.
+ * @returns The decoded per-action row.
+ */
+function partsToSyncSequenceResult(parts: ParametersParameter[]): OrderSetSyncSequenceResult {
+  const map: Record<string, unknown> = {};
+  for (const part of parts) {
+    if (part.name) {
+      map[part.name] = readParameterValue(part);
+    }
+  }
+  return {
+    actionTitle: typeof map.actionTitle === 'string' ? map.actionTitle : undefined,
+    activityDefinitionUrl: typeof map.activityDefinitionUrl === 'string' ? map.activityDefinitionUrl : undefined,
+    scriptSureSequenceId: typeof map.scriptSureSequenceId === 'number' ? map.scriptSureSequenceId : undefined,
+    scriptSureOrderId: typeof map.scriptSureOrderId === 'number' ? map.scriptSureOrderId : undefined,
+    status: map.status === 'failed' ? 'failed' : 'synced',
+    error: typeof map.error === 'string' ? map.error : undefined,
+  };
+}
+
+/**
+ * Decodes the `Parameters` response from the `$sync-orderset` custom operation
+ * into a typed {@link OrderSetSyncResponse}, including the repeating per-action
+ * `results` rows the server previously dropped.
+ *
+ * @param params - The `Parameters` resource returned by the operation.
+ * @returns A vendor-neutral {@link OrderSetSyncResponse}.
+ */
+export function parametersToOrderSetSyncResponse(params: Parameters): OrderSetSyncResponse {
+  const map: Record<string, unknown> = {};
+  const results: OrderSetSyncSequenceResult[] = [];
+  for (const p of params.parameter ?? []) {
+    if (!p.name) {
+      continue;
+    }
+    if (p.name === 'results' && p.part?.length) {
+      results.push(partsToSyncSequenceResult(p.part));
+    } else {
+      map[p.name] = readParameterValue(p);
+    }
+  }
+  return {
+    mode: map.mode === 'noop-already-synced' ? 'noop-already-synced' : 'created',
+    planDefinitionId: typeof map.planDefinitionId === 'string' ? map.planDefinitionId : undefined,
+    scriptSureOrdersetId: typeof map.scriptSureOrdersetId === 'number' ? map.scriptSureOrdersetId : undefined,
+    syncedCount:
+      typeof map.syncedCount === 'number' ? map.syncedCount : results.filter((r) => r.status === 'synced').length,
+    failedCount:
+      typeof map.failedCount === 'number' ? map.failedCount : results.filter((r) => r.status === 'failed').length,
+    results,
+  };
 }

--- a/packages/core/src/medication-order-utils.ts
+++ b/packages/core/src/medication-order-utils.ts
@@ -5,11 +5,13 @@ import type {
   CodeableConcept,
   Medication,
   MedicationRequest,
+  Organization,
   Parameters,
   ParametersParameter,
+  Reference,
 } from '@medplum/fhirtypes';
 import { isResource } from './types';
-import { getExtensionValue, getIdentifier } from './utils';
+import { getExtensionValue, getIdentifier, resolveId } from './utils';
 
 /** Re-export common coding systems used with medication-order drug search. */
 export { NDC, RXNORM } from './constants';
@@ -119,11 +121,8 @@ export interface MedicationOrderRequest {
   /** Free-text patient instructions (additional sig); maps to dosageInstruction[0].patientInstruction when using MR path. */
   readonly patientInstruction?: string;
   readonly appId?: string;
-  /**
-   * Selected practice-location Organization (id or `Organization/{id}` reference) for
-   * multi-practice deployments. The vendor bot resolves the vendor practice from it.
-   */
-  readonly organizationId?: string;
+  /** Selected practice location for multi-practice deployments. */
+  readonly organization?: Reference<Organization>;
 }
 
 /**
@@ -159,11 +158,8 @@ export interface MedicationOrderSetRequest {
    */
   readonly vendorOrderSetId?: number | string;
   readonly appId?: string;
-  /**
-   * Selected practice-location Organization (id or `Organization/{id}` reference) for
-   * multi-practice deployments. The vendor bot resolves the vendor practice from it.
-   */
-  readonly organizationId?: string;
+  /** Selected practice location for multi-practice deployments. */
+  readonly organization?: Reference<Organization>;
 }
 
 /**
@@ -196,11 +192,6 @@ export interface MedicationSearchParams {
   readonly includeCode?: boolean;
   /** When true, drug-search bot returns quantity qualifiers from GET /v3/prescription/quantityqualifier instead of Medication[]. */
   readonly quantityQualifiers?: boolean;
-  /**
-   * Selected practice-location Organization (id or `Organization/{id}` reference) for
-   * multi-practice deployments. The vendor bot resolves the vendor practice from it.
-   */
-  readonly organizationId?: string;
 }
 
 /**
@@ -402,9 +393,6 @@ export function medicationSearchParamsToParameters(params: MedicationSearchParam
   if (params.quantityQualifiers !== undefined) {
     parameter.push(param('quantityQualifiers', 'valueBoolean', params.quantityQualifiers));
   }
-  if (params.organizationId !== undefined) {
-    parameter.push(param('organizationId', 'valueString', params.organizationId));
-  }
   return { resourceType: 'Parameters', parameter };
 }
 
@@ -543,8 +531,9 @@ export function medicationOrderRequestToParameters(req: MedicationOrderRequest):
   if (req.appId !== undefined) {
     parameter.push(param('appId', 'valueString', req.appId));
   }
-  if (req.organizationId !== undefined) {
-    parameter.push(param('organizationId', 'valueString', req.organizationId));
+  const organizationId = resolveId(req.organization);
+  if (organizationId !== undefined) {
+    parameter.push(param('organizationId', 'valueString', organizationId));
   }
 
   return { resourceType: 'Parameters', parameter };
@@ -609,8 +598,9 @@ export function medicationOrderSetRequestToParameters(req: MedicationOrderSetReq
   if (req.appId !== undefined) {
     parameter.push(param('appId', 'valueString', req.appId));
   }
-  if (req.organizationId !== undefined) {
-    parameter.push(param('organizationId', 'valueString', req.organizationId));
+  const organizationId = resolveId(req.organization);
+  if (organizationId !== undefined) {
+    parameter.push(param('organizationId', 'valueString', organizationId));
   }
   return { resourceType: 'Parameters', parameter };
 }
@@ -693,12 +683,8 @@ export interface MedicationCheckoutRequest {
   readonly patientId: string;
   readonly medicationRequestIds: string[];
   readonly appId?: string;
-  /**
-   * Selected practice-location Organization (id or `Organization/{id}` reference)
-   * for multi-practice deployments. The vendor bot resolves the vendor practice
-   * from it; omit for single-practice prescribers (backend resolves by affiliation).
-   */
-  readonly organizationId?: string;
+  /** Selected practice location; omit for single-practice prescribers. */
+  readonly organization?: Reference<Organization>;
 }
 
 /**
@@ -752,8 +738,9 @@ export function medicationCheckoutRequestToParameters(req: MedicationCheckoutReq
   if (req.appId !== undefined) {
     parameter.push(param('appId', 'valueString', req.appId));
   }
-  if (req.organizationId !== undefined) {
-    parameter.push(param('organizationId', 'valueString', req.organizationId));
+  const organizationId = resolveId(req.organization);
+  if (organizationId !== undefined) {
+    parameter.push(param('organizationId', 'valueString', organizationId));
   }
   return { resourceType: 'Parameters', parameter };
 }

--- a/packages/core/src/pharmacy-utils.ts
+++ b/packages/core/src/pharmacy-utils.ts
@@ -33,11 +33,8 @@ export interface PharmacySearchParams {
   address?: string;
   phoneOrFax?: string;
   ncpdpID?: string;
-  /**
-   * Selected practice-location Organization (id or `Organization/{id}` reference) for
-   * multi-practice deployments. The vendor bot resolves the vendor practice from it.
-   */
-  organizationId?: string;
+  /** Selected practice location for multi-practice deployments. */
+  organization?: Reference<Organization>;
 }
 
 /**
@@ -47,11 +44,8 @@ export interface AddFavoriteParams {
   patientId: string;
   pharmacy: Organization;
   setAsPrimary: boolean;
-  /**
-   * Selected practice-location Organization (id or `Organization/{id}` reference) for
-   * multi-practice deployments. The vendor bot resolves the vendor practice from it.
-   */
-  organizationId?: string;
+  /** Selected practice location for multi-practice deployments. */
+  organization?: Reference<Organization>;
 }
 
 /**

--- a/packages/core/src/pharmacy-utils.ts
+++ b/packages/core/src/pharmacy-utils.ts
@@ -33,6 +33,11 @@ export interface PharmacySearchParams {
   address?: string;
   phoneOrFax?: string;
   ncpdpID?: string;
+  /**
+   * Selected practice-location Organization (id or `Organization/{id}` reference) for
+   * multi-practice deployments. The vendor bot resolves the vendor practice from it.
+   */
+  organizationId?: string;
 }
 
 /**
@@ -42,6 +47,11 @@ export interface AddFavoriteParams {
   patientId: string;
   pharmacy: Organization;
   setAsPrimary: boolean;
+  /**
+   * Selected practice-location Organization (id or `Organization/{id}` reference) for
+   * multi-practice deployments. The vendor bot resolves the vendor practice from it.
+   */
+  organizationId?: string;
 }
 
 /**

--- a/packages/docs/docs/integration/scriptsure/multiple-locations.md
+++ b/packages/docs/docs/integration/scriptsure/multiple-locations.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 10
+---
+
+# Multiple Practice Locations
+
+:::caution[Beta]
+The ScriptSure integration is in beta. Features and APIs may change.
+:::
+
+A single Medplum Project can serve many ScriptSure practice locations. This guide describes the data model and how prescribing resolves the correct practice per request.
+
+## Data model
+
+ScriptSure's administrative hierarchy is **Organization → Business Unit → Practice → User**. Medplum maps it as follows:
+
+| ScriptSure entity | Medplum representation |
+|---|---|
+| Organization | The Medplum **Project** (id held in the `SCRIPTSURE_DEFAULT_ORG_ID` project secret) |
+| Business Unit | An **`Organization`** with identifier `https://scriptsure.com/business-unit-id` and `type` coding `https://scriptsure.com/organization-type` = `business-unit` |
+| Practice | An **`Organization`** with identifier `https://scriptsure.com/practice-id` (and optional facility NPI), `partOf` its Business Unit Organization, `type` = `practice` |
+| Prescriber ↔ Practice | A **`PractitionerRole`** whose `organization` references the Practice Organization |
+
+Example Practice Organization:
+
+```json
+{
+  "resourceType": "Organization",
+  "name": "Downtown Clinic",
+  "type": [{ "coding": [{ "system": "https://scriptsure.com/organization-type", "code": "practice" }] }],
+  "partOf": { "reference": "Organization/<business-unit-org-id>" },
+  "identifier": [
+    { "system": "https://scriptsure.com/practice-id", "value": "6159" },
+    { "system": "http://hl7.org/fhir/sid/us-npi", "value": "1097724946" }
+  ]
+}
+```
+
+## How the practice is resolved per request
+
+Each prescribing call resolves the target practice in this order:
+
+1. **Explicit `organizationId`** — the Provider App passes the selected practice Organization id on the operation (e.g. `$order-medication`, `$order-set-url`, `$drug-search`) or bot input.
+2. **Prescriber affiliation** — the prescriber's single ScriptSure practice Organization (via `PractitionerRole.organization` / `ProjectMembership.access`). If the prescriber is affiliated with more than one practice and no `organizationId` was passed, the request errors asking the caller to choose a location.
+3. **Legacy secret** — the `SCRIPTSURE_PRACTICE_ID` / `SCRIPTSURE_BUSINESS_UNIT_ID` project secrets (backward compatibility for single-practice projects).
+
+The Provider App shows a **location switcher** (top of the prescribe screen) when the prescriber has more than one ScriptSure practice; the selection is passed as `organizationId`.
+
+## Provisioning the Organizations
+
+You can create the practice/business-unit Organizations in two ways:
+
+- **Entity webhook (recommended for ongoing sync).** In the ScriptSure console, open the Organization / Business Unit / Practice profile and click **SEND ENTITY WEBHOOK**. Point the entity webhook endpoint (at the Organization level) at the `scriptsure-entity-webhook-bot`. It idempotently upserts the two-level Organizations, prescriber `PractitionerRole` affiliations, and the ScriptSure user id on each prescriber's `ProjectMembership`.
+- **Migration from existing secrets.** For a project already using a single `SCRIPTSURE_PRACTICE_ID`, run the migration to create the two-level Organizations from the secrets (additive; the secrets remain the fallback).
+
+## Prescriber enrollment
+
+Each prescriber must be associated with the practice(s) they prescribe from on the ScriptSure side, and have:
+
+- a `ProjectMembership` identifier with `system` = the ScriptSure platform URL and `value` = their ScriptSure user id, and
+- a `PractitionerRole` referencing each practice `Organization` (created automatically by the entity webhook bot, or manually).

--- a/packages/react-hooks/src/useMedicationIFrame/useMedicationIFrame.test.tsx
+++ b/packages/react-hooks/src/useMedicationIFrame/useMedicationIFrame.test.tsx
@@ -30,7 +30,7 @@ describe('useMedicationIFrame', () => {
       () =>
         useMedicationIFrame(SYNC_BOT, IFRAME_BOT, {
           patientId: 'pat-1',
-          organizationId: 'org-1',
+          organization: { reference: 'Organization/org-1' },
           onPatientSyncSuccess,
           onIframeSuccess,
         }),

--- a/packages/react-hooks/src/useMedicationIFrame/useMedicationIFrame.test.tsx
+++ b/packages/react-hooks/src/useMedicationIFrame/useMedicationIFrame.test.tsx
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { Identifier } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { JSX, ReactNode } from 'react';
+import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
+import { useMedicationIFrame } from './useMedicationIFrame';
+
+const SYNC_BOT: Identifier = { system: 'https://example.com/bot', value: 'sync' };
+const IFRAME_BOT: Identifier = { system: 'https://example.com/bot', value: 'iframe' };
+
+function wrapper(medplum: MockClient) {
+  return function Wrapper(props: { children: ReactNode }): JSX.Element {
+    return <MedplumProvider medplum={medplum}>{props.children}</MedplumProvider>;
+  };
+}
+
+describe('useMedicationIFrame', () => {
+  test('syncs the patient then returns the iframe url, threading organizationId', async () => {
+    const medplum = new MockClient();
+    const executeBot = vi
+      .spyOn(medplum, 'executeBot')
+      .mockResolvedValueOnce({}) // patient sync
+      .mockResolvedValueOnce({ url: 'https://vendor.example/chart' }); // iframe
+    const onPatientSyncSuccess = vi.fn();
+    const onIframeSuccess = vi.fn();
+
+    const { result } = renderHook(
+      () =>
+        useMedicationIFrame(SYNC_BOT, IFRAME_BOT, {
+          patientId: 'pat-1',
+          organizationId: 'org-1',
+          onPatientSyncSuccess,
+          onIframeSuccess,
+        }),
+      { wrapper: wrapper(medplum) }
+    );
+
+    await waitFor(() => expect(result.current).toBe('https://vendor.example/chart'));
+    expect(executeBot).toHaveBeenNthCalledWith(1, SYNC_BOT, { patientId: 'pat-1', organizationId: 'org-1' });
+    expect(executeBot).toHaveBeenNthCalledWith(2, IFRAME_BOT, { patientId: 'pat-1', organizationId: 'org-1' });
+    expect(onPatientSyncSuccess).toHaveBeenCalledTimes(1);
+    expect(onIframeSuccess).toHaveBeenCalledWith('https://vendor.example/chart');
+  });
+
+  test('skips patient sync when no patientId is provided', async () => {
+    const medplum = new MockClient();
+    const executeBot = vi.spyOn(medplum, 'executeBot').mockResolvedValue({ url: 'https://vendor.example/chart' });
+
+    const { result } = renderHook(() => useMedicationIFrame(SYNC_BOT, IFRAME_BOT, {}), { wrapper: wrapper(medplum) });
+
+    await waitFor(() => expect(result.current).toBe('https://vendor.example/chart'));
+    expect(executeBot).toHaveBeenCalledTimes(1);
+    expect(executeBot).toHaveBeenCalledWith(IFRAME_BOT, { patientId: undefined, organizationId: undefined });
+  });
+
+  test('invokes onError when a bot execution fails', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'executeBot').mockRejectedValue(new Error('bot boom'));
+    const onError = vi.fn();
+
+    renderHook(() => useMedicationIFrame(SYNC_BOT, IFRAME_BOT, { patientId: 'pat-1', onError }), {
+      wrapper: wrapper(medplum),
+    });
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(expect.any(Error)));
+  });
+});

--- a/packages/react-hooks/src/useMedicationIFrame/useMedicationIFrame.ts
+++ b/packages/react-hooks/src/useMedicationIFrame/useMedicationIFrame.ts
@@ -6,6 +6,8 @@ import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
 
 export interface MedicationIFrameOptions {
   readonly patientId?: string;
+  /** Selected practice-location Organization (id or reference) for multi-practice deployments. */
+  readonly organizationId?: string;
   readonly onPatientSyncSuccess?: () => void;
   readonly onIframeSuccess?: (url: string) => void;
   readonly onError?: (err: unknown) => void;
@@ -32,7 +34,7 @@ export function useMedicationIFrame(
   options: MedicationIFrameOptions
 ): string | undefined {
   const medplum = useMedplum();
-  const { patientId, onPatientSyncSuccess, onIframeSuccess, onError } = options;
+  const { patientId, organizationId, onPatientSyncSuccess, onIframeSuccess, onError } = options;
   const [iframeUrl, setIframeUrl] = useState<string | undefined>(undefined);
 
   const onPatientSyncSuccessRef = useRef(onPatientSyncSuccess);
@@ -51,13 +53,13 @@ export function useMedicationIFrame(
     const run = async (): Promise<void> => {
       try {
         if (patientId) {
-          await medplum.executeBot(syncBotIdentifier, { patientId });
+          await medplum.executeBot(syncBotIdentifier, { patientId, organizationId });
           if (cancelled) {
             return;
           }
           onPatientSyncSuccessRef.current?.();
         }
-        const result = await medplum.executeBot(iframeBotIdentifier, { patientId });
+        const result = await medplum.executeBot(iframeBotIdentifier, { patientId, organizationId });
         if (cancelled) {
           return;
         }
@@ -79,7 +81,7 @@ export function useMedicationIFrame(
     return (): void => {
       cancelled = true;
     };
-  }, [medplum, syncBotIdentifier, iframeBotIdentifier, patientId]);
+  }, [medplum, syncBotIdentifier, iframeBotIdentifier, patientId, organizationId]);
 
   return iframeUrl;
 }

--- a/packages/react-hooks/src/useMedicationIFrame/useMedicationIFrame.ts
+++ b/packages/react-hooks/src/useMedicationIFrame/useMedicationIFrame.ts
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { Identifier } from '@medplum/fhirtypes';
+import { resolveId } from '@medplum/core';
+import type { Identifier, Organization, Reference } from '@medplum/fhirtypes';
 import { useEffect, useRef, useState } from 'react';
 import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
 
 export interface MedicationIFrameOptions {
   readonly patientId?: string;
-  /** Selected practice-location Organization (id or reference) for multi-practice deployments. */
-  readonly organizationId?: string;
+  /** Selected practice location for multi-practice deployments. */
+  readonly organization?: Reference<Organization>;
   readonly onPatientSyncSuccess?: () => void;
   readonly onIframeSuccess?: (url: string) => void;
   readonly onError?: (err: unknown) => void;
@@ -34,7 +35,8 @@ export function useMedicationIFrame(
   options: MedicationIFrameOptions
 ): string | undefined {
   const medplum = useMedplum();
-  const { patientId, organizationId, onPatientSyncSuccess, onIframeSuccess, onError } = options;
+  const { patientId, organization, onPatientSyncSuccess, onIframeSuccess, onError } = options;
+  const organizationId = resolveId(organization);
   const [iframeUrl, setIframeUrl] = useState<string | undefined>(undefined);
 
   const onPatientSyncSuccessRef = useRef(onPatientSyncSuccess);

--- a/packages/react-hooks/src/useMedicationOrderSet/useMedicationOrderSet.ts
+++ b/packages/react-hooks/src/useMedicationOrderSet/useMedicationOrderSet.ts
@@ -7,7 +7,7 @@ import {
   medicationOrderSetRequestToParameters,
   parametersToMedicationOrderSetResponse,
 } from '@medplum/core';
-import type { Parameters } from '@medplum/fhirtypes';
+import type { Organization, Parameters, Reference } from '@medplum/fhirtypes';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
 
@@ -19,8 +19,8 @@ export interface UseMedicationOrderSetOptions {
   /** Vendor-side order set id, when picked directly (escape hatch when no synced PD exists yet). */
   readonly vendorOrderSetId?: number | string;
   readonly appId?: string;
-  /** Selected practice-location Organization (id or reference) for multi-practice deployments. */
-  readonly organizationId?: string;
+  /** Selected practice location for multi-practice deployments. */
+  readonly organization?: Reference<Organization>;
 }
 
 export interface UseMedicationOrderSetReturn {
@@ -68,7 +68,7 @@ export interface UseMedicationOrderSetReturn {
  */
 export function useMedicationOrderSet(options: UseMedicationOrderSetOptions): UseMedicationOrderSetReturn {
   const medplum = useMedplum();
-  const { patientId, planDefinitionId, vendorOrderSetId, appId, organizationId } = options;
+  const { patientId, planDefinitionId, vendorOrderSetId, appId, organization } = options;
 
   const [url, setUrl] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(false);
@@ -76,8 +76,8 @@ export function useMedicationOrderSet(options: UseMedicationOrderSetOptions): Us
 
   // Latest options snapshot so `refresh` always uses current values without
   // re-creating the callback when only the inputs change.
-  const optionsRef = useRef({ patientId, planDefinitionId, vendorOrderSetId, appId, organizationId });
-  optionsRef.current = { patientId, planDefinitionId, vendorOrderSetId, appId, organizationId };
+  const optionsRef = useRef({ patientId, planDefinitionId, vendorOrderSetId, appId, organization });
+  optionsRef.current = { patientId, planDefinitionId, vendorOrderSetId, appId, organization };
 
   const buildRequest = (): MedicationOrderSetRequest | undefined => {
     const o = optionsRef.current;
@@ -94,7 +94,7 @@ export function useMedicationOrderSet(options: UseMedicationOrderSetOptions): Us
       planDefinitionId: hasPd ? o.planDefinitionId : undefined,
       vendorOrderSetId: hasVendorId ? o.vendorOrderSetId : undefined,
       appId: o.appId,
-      organizationId: o.organizationId,
+      organization: o.organization,
     };
     return req;
   };
@@ -198,7 +198,7 @@ export function useMedicationOrderSet(options: UseMedicationOrderSetOptions): Us
     return (): void => {
       cancelled = true;
     };
-  }, [callOperation, patientId, planDefinitionId, vendorOrderSetId, appId, organizationId]);
+  }, [callOperation, patientId, planDefinitionId, vendorOrderSetId, appId, organization]);
 
   return { url, loading, error, refresh };
 }

--- a/packages/react-hooks/src/useMedicationOrderSet/useMedicationOrderSet.ts
+++ b/packages/react-hooks/src/useMedicationOrderSet/useMedicationOrderSet.ts
@@ -19,6 +19,8 @@ export interface UseMedicationOrderSetOptions {
   /** Vendor-side order set id, when picked directly (escape hatch when no synced PD exists yet). */
   readonly vendorOrderSetId?: number | string;
   readonly appId?: string;
+  /** Selected practice-location Organization (id or reference) for multi-practice deployments. */
+  readonly organizationId?: string;
 }
 
 export interface UseMedicationOrderSetReturn {
@@ -66,7 +68,7 @@ export interface UseMedicationOrderSetReturn {
  */
 export function useMedicationOrderSet(options: UseMedicationOrderSetOptions): UseMedicationOrderSetReturn {
   const medplum = useMedplum();
-  const { patientId, planDefinitionId, vendorOrderSetId, appId } = options;
+  const { patientId, planDefinitionId, vendorOrderSetId, appId, organizationId } = options;
 
   const [url, setUrl] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(false);
@@ -74,8 +76,8 @@ export function useMedicationOrderSet(options: UseMedicationOrderSetOptions): Us
 
   // Latest options snapshot so `refresh` always uses current values without
   // re-creating the callback when only the inputs change.
-  const optionsRef = useRef({ patientId, planDefinitionId, vendorOrderSetId, appId });
-  optionsRef.current = { patientId, planDefinitionId, vendorOrderSetId, appId };
+  const optionsRef = useRef({ patientId, planDefinitionId, vendorOrderSetId, appId, organizationId });
+  optionsRef.current = { patientId, planDefinitionId, vendorOrderSetId, appId, organizationId };
 
   const buildRequest = (): MedicationOrderSetRequest | undefined => {
     const o = optionsRef.current;
@@ -92,6 +94,7 @@ export function useMedicationOrderSet(options: UseMedicationOrderSetOptions): Us
       planDefinitionId: hasPd ? o.planDefinitionId : undefined,
       vendorOrderSetId: hasVendorId ? o.vendorOrderSetId : undefined,
       appId: o.appId,
+      organizationId: o.organizationId,
     };
     return req;
   };
@@ -195,7 +198,7 @@ export function useMedicationOrderSet(options: UseMedicationOrderSetOptions): Us
     return (): void => {
       cancelled = true;
     };
-  }, [callOperation, patientId, planDefinitionId, vendorOrderSetId, appId]);
+  }, [callOperation, patientId, planDefinitionId, vendorOrderSetId, appId, organizationId]);
 
   return { url, loading, error, refresh };
 }

--- a/packages/react-hooks/src/usePharmacySearch/usePharmacySearch.test.tsx
+++ b/packages/react-hooks/src/usePharmacySearch/usePharmacySearch.test.tsx
@@ -27,7 +27,10 @@ describe('usePharmacySearch', () => {
 
     let orgs: Organization[] = [];
     await act(async () => {
-      orgs = await result.current.searchPharmacies({ name: 'Test', organizationId: 'org-1' });
+      orgs = await result.current.searchPharmacies({
+        name: 'Test',
+        organization: { reference: 'Organization/org-1' },
+      });
     });
 
     expect(orgs).toEqual([PHARMACY]);
@@ -45,7 +48,7 @@ describe('usePharmacySearch', () => {
     });
   });
 
-  test('addToFavorites threads organizationId through to the add bot', async () => {
+  test('addToFavorites resolves the practice reference for the add bot', async () => {
     const medplum = new MockClient();
     const response: AddPharmacyResponse = { success: true, message: 'ok', organization: PHARMACY };
     const executeBot = vi.spyOn(medplum, 'executeBot').mockResolvedValue(response);
@@ -58,7 +61,7 @@ describe('usePharmacySearch', () => {
         patientId: 'pat-1',
         pharmacy: PHARMACY,
         setAsPrimary: true,
-        organizationId: 'org-9',
+        organization: { reference: 'Organization/org-9' },
       });
     });
 

--- a/packages/react-hooks/src/usePharmacySearch/usePharmacySearch.test.tsx
+++ b/packages/react-hooks/src/usePharmacySearch/usePharmacySearch.test.tsx
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { AddPharmacyResponse } from '@medplum/core';
+import type { Identifier, Organization } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { act, renderHook } from '@testing-library/react';
+import type { JSX, ReactNode } from 'react';
+import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
+import { usePharmacySearch } from './usePharmacySearch';
+
+const SEARCH_BOT: Identifier = { system: 'https://example.com/bot', value: 'search' };
+const ADD_BOT: Identifier = { system: 'https://example.com/bot', value: 'add' };
+const PHARMACY: Organization = { resourceType: 'Organization', id: 'pharm-1', name: 'Test Pharmacy' };
+
+function wrapper(medplum: MockClient) {
+  return function Wrapper(props: { children: ReactNode }): JSX.Element {
+    return <MedplumProvider medplum={medplum}>{props.children}</MedplumProvider>;
+  };
+}
+
+describe('usePharmacySearch', () => {
+  test('searchPharmacies returns organizations from the search bot', async () => {
+    const medplum = new MockClient();
+    const executeBot = vi.spyOn(medplum, 'executeBot').mockResolvedValue([PHARMACY]);
+
+    const { result } = renderHook(() => usePharmacySearch(SEARCH_BOT, ADD_BOT), { wrapper: wrapper(medplum) });
+
+    let orgs: Organization[] = [];
+    await act(async () => {
+      orgs = await result.current.searchPharmacies({ name: 'Test', organizationId: 'org-1' });
+    });
+
+    expect(orgs).toEqual([PHARMACY]);
+    expect(executeBot).toHaveBeenCalledWith(SEARCH_BOT, { name: 'Test', organizationId: 'org-1' });
+  });
+
+  test('searchPharmacies throws on an invalid response', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'executeBot').mockResolvedValue({ not: 'an array' });
+
+    const { result } = renderHook(() => usePharmacySearch(SEARCH_BOT, ADD_BOT), { wrapper: wrapper(medplum) });
+
+    await act(async () => {
+      await expect(result.current.searchPharmacies({ name: 'Test' })).rejects.toThrow('Invalid response');
+    });
+  });
+
+  test('addToFavorites threads organizationId through to the add bot', async () => {
+    const medplum = new MockClient();
+    const response: AddPharmacyResponse = { success: true, message: 'ok', organization: PHARMACY };
+    const executeBot = vi.spyOn(medplum, 'executeBot').mockResolvedValue(response);
+
+    const { result } = renderHook(() => usePharmacySearch(SEARCH_BOT, ADD_BOT), { wrapper: wrapper(medplum) });
+
+    let res: AddPharmacyResponse | undefined;
+    await act(async () => {
+      res = await result.current.addToFavorites({
+        patientId: 'pat-1',
+        pharmacy: PHARMACY,
+        setAsPrimary: true,
+        organizationId: 'org-9',
+      });
+    });
+
+    expect(res).toEqual(response);
+    expect(executeBot).toHaveBeenCalledWith(ADD_BOT, {
+      patientId: 'pat-1',
+      pharmacy: PHARMACY,
+      setAsPrimary: true,
+      organizationId: 'org-9',
+    });
+  });
+
+  test('addToFavorites throws on an invalid response', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'executeBot').mockResolvedValue({ unexpected: true });
+
+    const { result } = renderHook(() => usePharmacySearch(SEARCH_BOT, ADD_BOT), { wrapper: wrapper(medplum) });
+
+    await act(async () => {
+      await expect(
+        result.current.addToFavorites({ patientId: 'pat-1', pharmacy: PHARMACY, setAsPrimary: false })
+      ).rejects.toThrow('Invalid response');
+    });
+  });
+});

--- a/packages/react-hooks/src/usePharmacySearch/usePharmacySearch.ts
+++ b/packages/react-hooks/src/usePharmacySearch/usePharmacySearch.ts
@@ -52,6 +52,7 @@ export function usePharmacySearch<T extends PharmacySearchParams = PharmacySearc
         patientId: params.patientId,
         pharmacy: params.pharmacy,
         setAsPrimary: params.setAsPrimary,
+        organizationId: params.organizationId,
       });
 
       if (!isAddPharmacyResponse(response)) {

--- a/packages/react-hooks/src/usePharmacySearch/usePharmacySearch.ts
+++ b/packages/react-hooks/src/usePharmacySearch/usePharmacySearch.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { AddFavoriteParams, AddPharmacyResponse, PharmacySearchParams } from '@medplum/core';
-import { isAddPharmacyResponse, isOrganizationArray } from '@medplum/core';
+import { isAddPharmacyResponse, isOrganizationArray, resolveId } from '@medplum/core';
 import type { Identifier, Organization } from '@medplum/fhirtypes';
 import { useCallback } from 'react';
 import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
@@ -35,7 +35,12 @@ export function usePharmacySearch<T extends PharmacySearchParams = PharmacySearc
 
   const searchPharmacies = useCallback(
     async (params: T): Promise<Organization[]> => {
-      const response = await medplum.executeBot(searchBotIdentifier, params);
+      const { organization, ...searchParams } = params;
+      const organizationId = resolveId(organization);
+      const response = await medplum.executeBot(
+        searchBotIdentifier,
+        organizationId ? { ...searchParams, organizationId } : searchParams
+      );
 
       if (!isOrganizationArray(response)) {
         throw new Error('Invalid response from pharmacy search');
@@ -52,7 +57,7 @@ export function usePharmacySearch<T extends PharmacySearchParams = PharmacySearc
         patientId: params.patientId,
         pharmacy: params.pharmacy,
         setAsPrimary: params.setAsPrimary,
-        organizationId: params.organizationId,
+        organizationId: resolveId(params.organization),
       });
 
       if (!isAddPharmacyResponse(response)) {

--- a/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.test.tsx
+++ b/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.test.tsx
@@ -32,6 +32,50 @@ describe('useSyncOrderSet', () => {
     expect(body).toEqual({ planDefinitionId: 'plan-def-123' });
   });
 
+  test('decodes per-action results and counts so partial failures surface', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'post').mockResolvedValue({
+      resourceType: 'Parameters',
+      parameter: [
+        { name: 'mode', valueCode: 'created' },
+        { name: 'scriptSureOrdersetId', valueInteger: 379 },
+        { name: 'syncedCount', valueInteger: 1 },
+        { name: 'failedCount', valueInteger: 1 },
+        {
+          name: 'results',
+          part: [
+            { name: 'actionTitle', valueString: 'Jardiance' },
+            { name: 'status', valueCode: 'synced' },
+            { name: 'scriptSureSequenceId', valueInteger: 1011 },
+          ],
+        },
+        {
+          name: 'results',
+          part: [
+            { name: 'actionTitle', valueString: 'Ozempic' },
+            { name: 'status', valueCode: 'failed' },
+            { name: 'error', valueString: 'drug not in FDB' },
+          ],
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useSyncOrderSet(), { wrapper: wrapper(medplum) });
+
+    let response: Awaited<ReturnType<ReturnType<typeof useSyncOrderSet>>>;
+    await act(async () => {
+      response = await result.current('plan-def-123');
+    });
+
+    expect(response?.mode).toBe('created');
+    expect(response?.scriptSureOrdersetId).toBe(379);
+    expect(response?.syncedCount).toBe(1);
+    expect(response?.failedCount).toBe(1);
+    expect(response?.results).toHaveLength(2);
+    expect(response?.results[0]).toMatchObject({ actionTitle: 'Jardiance', status: 'synced' });
+    expect(response?.results[1]).toMatchObject({ actionTitle: 'Ozempic', status: 'failed', error: 'drug not in FDB' });
+  });
+
   test('silently no-ops when operation is not deployed (not-found)', async () => {
     const medplum = new MockClient();
     vi.spyOn(medplum, 'post').mockRejectedValue(

--- a/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.test.tsx
+++ b/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.test.tsx
@@ -32,6 +32,19 @@ describe('useSyncOrderSet', () => {
     expect(body).toEqual({ planDefinitionId: 'plan-def-123' });
   });
 
+  test('threads organizationId to $sync-orderset for multi-practice deployments', async () => {
+    const medplum = new MockClient();
+    const post = vi.spyOn(medplum, 'post').mockResolvedValue({ resourceType: 'Parameters', parameter: [] });
+
+    const { result } = renderHook(() => useSyncOrderSet(), { wrapper: wrapper(medplum) });
+
+    await act(async () => {
+      await result.current('plan-def-123', 'org-9');
+    });
+
+    expect(post.mock.calls[0][1]).toEqual({ planDefinitionId: 'plan-def-123', organizationId: 'org-9' });
+  });
+
   test('decodes per-action results and counts so partial failures surface', async () => {
     const medplum = new MockClient();
     vi.spyOn(medplum, 'post').mockResolvedValue({
@@ -74,6 +87,17 @@ describe('useSyncOrderSet', () => {
     expect(response?.results).toHaveLength(2);
     expect(response?.results[0]).toMatchObject({ actionTitle: 'Jardiance', status: 'synced' });
     expect(response?.results[1]).toMatchObject({ actionTitle: 'Ozempic', status: 'failed', error: 'drug not in FDB' });
+  });
+
+  test('resolves undefined when the response is not a Parameters resource', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'post').mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useSyncOrderSet(), { wrapper: wrapper(medplum) });
+
+    await act(async () => {
+      await expect(result.current('plan-def-123')).resolves.toBeUndefined();
+    });
   });
 
   test('silently no-ops when operation is not deployed (not-found)', async () => {

--- a/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.test.tsx
+++ b/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.test.tsx
@@ -39,7 +39,7 @@ describe('useSyncOrderSet', () => {
     const { result } = renderHook(() => useSyncOrderSet(), { wrapper: wrapper(medplum) });
 
     await act(async () => {
-      await result.current('plan-def-123', 'org-9');
+      await result.current('plan-def-123', { reference: 'Organization/org-9' });
     });
 
     expect(post.mock.calls[0][1]).toEqual({ planDefinitionId: 'plan-def-123', organizationId: 'org-9' });

--- a/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.ts
+++ b/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { OrderSetSyncResponse } from '@medplum/core';
-import { OperationOutcomeError, isResource, parametersToOrderSetSyncResponse } from '@medplum/core';
-import type { Parameters } from '@medplum/fhirtypes';
+import { OperationOutcomeError, isResource, parametersToOrderSetSyncResponse, resolveId } from '@medplum/core';
+import type { Organization, Parameters, Reference } from '@medplum/fhirtypes';
 import { useCallback } from 'react';
 import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
 
@@ -20,20 +20,23 @@ import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
  * e-prescribing vendor is configured for the project), so callers do not need to
  * guard against missing integrations.
  *
- * @returns A stable `syncOrderSet(planDefinitionId, organizationId?)` callback.
+ * @returns A stable `syncOrderSet(planDefinitionId, organization?)` callback.
  */
 export function useSyncOrderSet(): (
   planDefinitionId: string,
-  organizationId?: string
+  organization?: Reference<Organization>
 ) => Promise<OrderSetSyncResponse | undefined> {
   const medplum = useMedplum();
 
   return useCallback(
-    async (planDefinitionId: string, organizationId?: string): Promise<OrderSetSyncResponse | undefined> => {
+    async (
+      planDefinitionId: string,
+      organization?: Reference<Organization>
+    ): Promise<OrderSetSyncResponse | undefined> => {
       try {
         const response = await medplum.post(medplum.fhirUrl('PlanDefinition', '$sync-orderset'), {
           planDefinitionId,
-          organizationId,
+          organizationId: resolveId(organization),
         });
         if (!isResource<Parameters>(response, 'Parameters')) {
           return undefined;

--- a/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.ts
+++ b/packages/react-hooks/src/useSyncOrderSet/useSyncOrderSet.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { OperationOutcomeError } from '@medplum/core';
+import type { OrderSetSyncResponse } from '@medplum/core';
+import { OperationOutcomeError, isResource, parametersToOrderSetSyncResponse } from '@medplum/core';
+import type { Parameters } from '@medplum/fhirtypes';
 import { useCallback } from 'react';
 import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
 
@@ -9,23 +11,38 @@ import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
  * to the configured e-prescribing vendor via the `$sync-orderset` custom FHIR operation
  * (`POST /fhir/R4/PlanDefinition/$sync-orderset`).
  *
- * Silently no-ops when the operation is not deployed (i.e. no e-prescribing vendor
- * is configured for the project), so callers do not need to guard against missing
- * integrations.
+ * Resolves with the decoded `OrderSetSyncResponse` so callers can surface
+ * per-action failures (`results[i].status === 'failed'` / `failedCount > 0`) —
+ * without this, an order set that only partially synced would silently apply
+ * with fewer meds than the PlanDefinition requested.
  *
- * @returns A stable `syncOrderSet(planDefinitionId)` callback.
+ * Resolves with `undefined` when the operation is not deployed (i.e. no
+ * e-prescribing vendor is configured for the project), so callers do not need to
+ * guard against missing integrations.
+ *
+ * @returns A stable `syncOrderSet(planDefinitionId, organizationId?)` callback.
  */
-export function useSyncOrderSet(): (planDefinitionId: string) => Promise<void> {
+export function useSyncOrderSet(): (
+  planDefinitionId: string,
+  organizationId?: string
+) => Promise<OrderSetSyncResponse | undefined> {
   const medplum = useMedplum();
 
   return useCallback(
-    async (planDefinitionId: string): Promise<void> => {
+    async (planDefinitionId: string, organizationId?: string): Promise<OrderSetSyncResponse | undefined> => {
       try {
-        await medplum.post(medplum.fhirUrl('PlanDefinition', '$sync-orderset'), { planDefinitionId });
+        const response = await medplum.post(medplum.fhirUrl('PlanDefinition', '$sync-orderset'), {
+          planDefinitionId,
+          organizationId,
+        });
+        if (!isResource<Parameters>(response, 'Parameters')) {
+          return undefined;
+        }
+        return parametersToOrderSetSyncResponse(response);
       } catch (err: unknown) {
         // If the operation isn't deployed, silently skip — project has no e-prescribing vendor configured.
         if (err instanceof OperationOutcomeError && err.outcome.issue?.some((i) => i.code === 'not-found')) {
-          return;
+          return undefined;
         }
         throw err;
       }

--- a/packages/scriptsure-react/src/common.test.ts
+++ b/packages/scriptsure-react/src/common.test.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from 'vitest';
+import { SCRIPTSURE_GCN_SEQNO_SYSTEM } from './common';
+
+describe('common identifier systems', () => {
+  // The GCN_SEQNO coding stamped on a draft MedicationRequest (via this constant)
+  // is matched by the medplum-ee prescription webhook bot to reconcile draft->sent
+  // prescriptions. The bot hard-codes the same literal in
+  // medplum-ee/packages/scriptsure/src/common/utils.ts; if the two ever drift the
+  // reconciliation silently no-ops. Pin the value so a rename can't do that quietly.
+  test('SCRIPTSURE_GCN_SEQNO_SYSTEM matches the medplum-ee bot literal', () => {
+    expect(SCRIPTSURE_GCN_SEQNO_SYSTEM).toBe('https://scriptsure.com/gcn-seqno');
+  });
+});

--- a/packages/scriptsure-react/src/common.ts
+++ b/packages/scriptsure-react/src/common.ts
@@ -36,6 +36,17 @@ export const SCRIPTSURE_ORDER_MEDICATION_BOT: Identifier = {
 /** Identifier system for ScriptSure ROUTED_MED_ID on in-memory Medication resources from drug search. */
 export const SCRIPTSURE_ROUTED_MED_ID_SYSTEM = 'https://scriptsure.com/routed-med-id';
 
+/**
+ * Identifier/coding system for the FDB GCN Sequence Number (`GCN_SEQNO`) — the
+ * clinical-formulation key (ingredient+strength+dose-form+route), independent of
+ * brand and NDC. Stamped as a `medicationCodeableConcept.coding` on the draft
+ * MedicationRequest so the ScriptSure prescription webhook can reconcile a draft
+ * to its sent prescription even when the NDC drifts or the pharmacy substitutes a
+ * generic (brand and generic share the same GCN). Mirrors the medplum-ee bot
+ * constant of the same name.
+ */
+export const SCRIPTSURE_GCN_SEQNO_SYSTEM = 'https://scriptsure.com/gcn-seqno';
+
 export const SCRIPTSURE_PENDING_ORDER_ID_SYSTEM = 'https://scriptsure.com/pending-order-id';
 
 export const SCRIPTSURE_PENDING_ORDER_STATUS_EXTENSION = 'https://scriptsure.com/pending-order-status';

--- a/packages/scriptsure-react/src/common.ts
+++ b/packages/scriptsure-react/src/common.ts
@@ -118,6 +118,19 @@ export const SCRIPTSURE_ADD_PATIENT_PHARMACY_BOT: Identifier = {
 
 export const SCRIPTSURE_PATIENT_ID_SYSTEM = 'https://scriptsure.com/patient-id';
 
+/**
+ * Identifier system for the ScriptSure `practiceId` stamped on the Practice-level
+ * Medplum `Organization`. Used by the practice/location selector to discover the
+ * prescriber's ScriptSure practices and pass the chosen `organizationId` to bots.
+ */
+export const SCRIPTSURE_PRACTICE_ID_SYSTEM = 'https://scriptsure.com/practice-id';
+
+/** Identifier system for the ScriptSure `businessUnitId` on the BU-level Medplum `Organization`. */
+export const SCRIPTSURE_BUSINESS_UNIT_ID_SYSTEM = 'https://scriptsure.com/business-unit-id';
+
+/** `Organization.type` coding system discriminating ScriptSure entity Organizations (`business-unit` | `practice`). */
+export const SCRIPTSURE_ORGANIZATION_TYPE_SYSTEM = 'https://scriptsure.com/organization-type';
+
 /** Base URL for ScriptSure-specific extensions on in-memory Medication resources (e.g. `/sig`). */
 export const SCRIPTSURE_SYSTEM = 'https://scriptsure.com';
 

--- a/packages/scriptsure-react/src/index.ts
+++ b/packages/scriptsure-react/src/index.ts
@@ -8,3 +8,4 @@ export * from './useScriptSureIFrame';
 export * from './useScriptSureOrderMedication';
 export * from './useScriptSureOrderSet';
 export * from './useScriptSurePharmacySearch';
+export * from './useScriptSurePractice';

--- a/packages/scriptsure-react/src/useScriptSureOrderSet.ts
+++ b/packages/scriptsure-react/src/useScriptSureOrderSet.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { Organization, Reference } from '@medplum/fhirtypes';
 import type { UseMedicationOrderSetReturn } from '@medplum/react-hooks';
 import { useMedicationOrderSet } from '@medplum/react-hooks';
 
@@ -11,8 +12,8 @@ export interface UseScriptSureOrderSetOptions {
   /** ScriptSure orderset id (escape hatch when no synced PD exists yet). */
   readonly scriptSureOrdersetId?: number;
   readonly appId?: string;
-  /** Selected practice-location Organization (id or reference) for multi-practice deployments. */
-  readonly organizationId?: string;
+  /** Selected practice location for multi-practice deployments. */
+  readonly organization?: Reference<Organization>;
 }
 
 export type UseScriptSureOrderSetReturn = UseMedicationOrderSetReturn;
@@ -40,6 +41,6 @@ export function useScriptSureOrderSet(options: UseScriptSureOrderSetOptions): Us
     planDefinitionId: options.planDefinitionId,
     vendorOrderSetId: options.scriptSureOrdersetId,
     appId: options.appId,
-    organizationId: options.organizationId,
+    organization: options.organization,
   });
 }

--- a/packages/scriptsure-react/src/useScriptSureOrderSet.ts
+++ b/packages/scriptsure-react/src/useScriptSureOrderSet.ts
@@ -11,6 +11,8 @@ export interface UseScriptSureOrderSetOptions {
   /** ScriptSure orderset id (escape hatch when no synced PD exists yet). */
   readonly scriptSureOrdersetId?: number;
   readonly appId?: string;
+  /** Selected practice-location Organization (id or reference) for multi-practice deployments. */
+  readonly organizationId?: string;
 }
 
 export type UseScriptSureOrderSetReturn = UseMedicationOrderSetReturn;
@@ -38,5 +40,6 @@ export function useScriptSureOrderSet(options: UseScriptSureOrderSetOptions): Us
     planDefinitionId: options.planDefinitionId,
     vendorOrderSetId: options.scriptSureOrdersetId,
     appId: options.appId,
+    organizationId: options.organizationId,
   });
 }

--- a/packages/scriptsure-react/src/useScriptSurePractice.test.tsx
+++ b/packages/scriptsure-react/src/useScriptSurePractice.test.tsx
@@ -53,6 +53,7 @@ describe('useScriptSurePractice', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.practices.map((p) => p.id)).toEqual(['org-1']);
     expect(result.current.selectedOrganizationId).toBe('org-1');
+    expect(result.current.selectedOrganization).toEqual({ reference: 'Organization/org-1' });
   });
 
   test('does not auto-select when the prescriber has multiple affiliations', async () => {
@@ -202,6 +203,27 @@ describe('useScriptSurePractice', () => {
     expect(result.current.practices.map((p) => p.id)).toEqual(['org-1']);
   });
 
+  test('keeps readable practices when one Organization reference fails', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'getProfile').mockReturnValue(PRACTITIONER);
+    vi.spyOn(medplum, 'searchResources').mockResolvedValue([
+      { resourceType: 'PractitionerRole', organization: { reference: 'Organization/org-missing' } },
+      { resourceType: 'PractitionerRole', organization: { reference: 'Organization/org-1' } },
+    ] as Awaited<ReturnType<typeof medplum.searchResources>>);
+    vi.spyOn(medplum, 'readReference').mockImplementation((async (ref: { reference: string }) => {
+      if (ref.reference === 'Organization/org-missing') {
+        throw new Error('not found');
+      }
+      return practiceOrg('org-1', '7256');
+    }) as typeof medplum.readReference);
+
+    const { result } = setup(medplum);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.practices.map((p) => p.id)).toEqual(['org-1']);
+    expect(result.current.selectedOrganization).toEqual({ reference: 'Organization/org-1' });
+  });
+
   test('setSelectedOrganizationId persists a selection and clears it', async () => {
     const medplum = new MockClient();
     vi.spyOn(medplum, 'getProfile').mockReturnValue(PRACTITIONER);
@@ -224,6 +246,7 @@ describe('useScriptSurePractice', () => {
 
     act(() => result.current.setSelectedOrganizationId(undefined));
     expect(result.current.selectedOrganizationId).toBeUndefined();
+    expect(result.current.selectedOrganization).toBeUndefined();
     expect(localStorage.getItem('medplum.scriptsure.selectedPracticeOrganization')).toBeNull();
   });
 
@@ -236,6 +259,7 @@ describe('useScriptSurePractice', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.practices).toEqual([]);
+    expect(result.current.selectedOrganization).toBeUndefined();
     expect(result.current.selectedOrganizationId).toBeUndefined();
   });
 

--- a/packages/scriptsure-react/src/useScriptSurePractice.test.tsx
+++ b/packages/scriptsure-react/src/useScriptSurePractice.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Organization, Practitioner, PractitionerRole, ProjectMembership } from '@medplum/fhirtypes';
+import type { Organization, Practitioner, ProjectMembership } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { RenderHookResult } from '@testing-library/react';
@@ -145,7 +145,7 @@ describe('useScriptSurePractice', () => {
       resourceType: 'PractitionerRole',
       id: 'role-1',
       practitioner: { reference: 'Practitioner/prac-1' },
-    } as PractitionerRole);
+    } as unknown as ReturnType<typeof medplum.getProfile>);
     const searchSpy = vi
       .spyOn(medplum, 'searchResources')
       .mockResolvedValue([
@@ -168,7 +168,9 @@ describe('useScriptSurePractice', () => {
   test('discovers practices from ProjectMembership.access organization parameters', async () => {
     const medplum = new MockClient();
     vi.spyOn(medplum, 'getProfile').mockReturnValue(PRACTITIONER);
-    vi.spyOn(medplum, 'searchResources').mockResolvedValue([] as Awaited<ReturnType<typeof medplum.searchResources>>);
+    vi.spyOn(medplum, 'searchResources').mockResolvedValue(
+      [] as unknown as Awaited<ReturnType<typeof medplum.searchResources>>
+    );
     vi.spyOn(medplum, 'getProjectMembership').mockReturnValue({
       resourceType: 'ProjectMembership',
       access: [{ parameter: [{ name: 'organization', valueReference: { reference: 'Organization/org-9' } }] }],

--- a/packages/scriptsure-react/src/useScriptSurePractice.test.tsx
+++ b/packages/scriptsure-react/src/useScriptSurePractice.test.tsx
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Organization, Practitioner } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { JSX, ReactNode } from 'react';
+import { SCRIPTSURE_PRACTICE_ID_SYSTEM } from './common';
+import type { ScriptSurePracticeContextValue } from './useScriptSurePractice';
+import { ScriptSurePracticeProvider, useScriptSurePractice } from './useScriptSurePractice';
+
+const PRACTITIONER: Practitioner = { resourceType: 'Practitioner', id: 'prac-1' };
+
+function practiceOrg(id: string, practiceId: string): Organization {
+  return {
+    resourceType: 'Organization',
+    id,
+    name: `Practice ${practiceId}`,
+    identifier: [{ system: SCRIPTSURE_PRACTICE_ID_SYSTEM, value: practiceId }],
+  };
+}
+
+describe('useScriptSurePractice', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  function setup(medplum: MockClient): RenderHookResult<ScriptSurePracticeContextValue, unknown> {
+    function wrapper({ children }: { children: ReactNode }): JSX.Element {
+      return (
+        <MedplumProvider medplum={medplum}>
+          <ScriptSurePracticeProvider>{children}</ScriptSurePracticeProvider>
+        </MedplumProvider>
+      );
+    }
+    return renderHook(() => useScriptSurePractice(), { wrapper });
+  }
+
+  test('auto-selects the sole affiliated practice and lists only affiliations', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'getProfile').mockReturnValue(PRACTITIONER);
+    const org = practiceOrg('org-1', '7256');
+    vi.spyOn(medplum, 'searchResources').mockResolvedValue([
+      { resourceType: 'PractitionerRole', organization: { reference: 'Organization/org-1' } },
+    ] as Awaited<ReturnType<typeof medplum.searchResources>>);
+    vi.spyOn(medplum, 'readReference').mockResolvedValue(org as Awaited<ReturnType<typeof medplum.readReference>>);
+
+    const { result } = setup(medplum);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.practices.map((p) => p.id)).toEqual(['org-1']);
+    expect(result.current.selectedOrganizationId).toBe('org-1');
+  });
+
+  test('does not auto-select when the prescriber has multiple affiliations', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'getProfile').mockReturnValue(PRACTITIONER);
+    vi.spyOn(medplum, 'searchResources').mockResolvedValue([
+      { resourceType: 'PractitionerRole', organization: { reference: 'Organization/org-1' } },
+      { resourceType: 'PractitionerRole', organization: { reference: 'Organization/org-2' } },
+    ] as Awaited<ReturnType<typeof medplum.searchResources>>);
+    vi.spyOn(medplum, 'readReference').mockImplementation((async (ref: { reference: string }) =>
+      practiceOrg(
+        ref.reference.slice('Organization/'.length),
+        ref.reference.endsWith('1') ? '7256' : '7257'
+      )) as typeof medplum.readReference);
+
+    const { result } = setup(medplum);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.practices.map((p) => p.id).sort()).toEqual(['org-1', 'org-2']);
+    expect(result.current.selectedOrganizationId).toBeUndefined();
+  });
+
+  test('excludes organizations without a practice-id identifier', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'getProfile').mockReturnValue(PRACTITIONER);
+    vi.spyOn(medplum, 'searchResources').mockResolvedValue([
+      { resourceType: 'PractitionerRole', organization: { reference: 'Organization/org-1' } },
+      { resourceType: 'PractitionerRole', organization: { reference: 'Organization/org-bare' } },
+    ] as Awaited<ReturnType<typeof medplum.searchResources>>);
+    vi.spyOn(medplum, 'readReference').mockImplementation((async (ref: { reference: string }) =>
+      ref.reference === 'Organization/org-1'
+        ? practiceOrg('org-1', '7256')
+        : ({
+            resourceType: 'Organization',
+            id: 'org-bare',
+            name: 'Not a practice',
+          } as Organization)) as typeof medplum.readReference);
+
+    const { result } = setup(medplum);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.practices.map((p) => p.id)).toEqual(['org-1']);
+    expect(result.current.selectedOrganizationId).toBe('org-1');
+  });
+
+  test('ignores a stored selection that is no longer an affiliation', async () => {
+    localStorage.setItem('medplum.scriptsure.selectedPracticeOrganization', 'org-stale');
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'getProfile').mockReturnValue(PRACTITIONER);
+    vi.spyOn(medplum, 'searchResources').mockResolvedValue([
+      { resourceType: 'PractitionerRole', organization: { reference: 'Organization/org-1' } },
+      { resourceType: 'PractitionerRole', organization: { reference: 'Organization/org-2' } },
+    ] as Awaited<ReturnType<typeof medplum.searchResources>>);
+    vi.spyOn(medplum, 'readReference').mockImplementation((async (ref: { reference: string }) =>
+      practiceOrg(
+        ref.reference.slice('Organization/'.length),
+        ref.reference.endsWith('1') ? '7256' : '7257'
+      )) as typeof medplum.readReference);
+
+    const { result } = setup(medplum);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // Stale stored id is dropped (not in the affiliation set), and >1 affiliation → no auto-select.
+    expect(result.current.selectedOrganizationId).toBeUndefined();
+  });
+});

--- a/packages/scriptsure-react/src/useScriptSurePractice.test.tsx
+++ b/packages/scriptsure-react/src/useScriptSurePractice.test.tsx
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Organization, Practitioner } from '@medplum/fhirtypes';
+import type { Organization, Practitioner, PractitionerRole, ProjectMembership } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { RenderHookResult } from '@testing-library/react';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import type { JSX, ReactNode } from 'react';
 import { SCRIPTSURE_PRACTICE_ID_SYSTEM } from './common';
 import type { ScriptSurePracticeContextValue } from './useScriptSurePractice';
@@ -117,5 +117,130 @@ describe('useScriptSurePractice', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     // Stale stored id is dropped (not in the affiliation set), and >1 affiliation → no auto-select.
     expect(result.current.selectedOrganizationId).toBeUndefined();
+  });
+
+  test('restores a stored selection that is still an affiliation', async () => {
+    localStorage.setItem('medplum.scriptsure.selectedPracticeOrganization', 'org-2');
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'getProfile').mockReturnValue(PRACTITIONER);
+    vi.spyOn(medplum, 'searchResources').mockResolvedValue([
+      { resourceType: 'PractitionerRole', organization: { reference: 'Organization/org-1' } },
+      { resourceType: 'PractitionerRole', organization: { reference: 'Organization/org-2' } },
+    ] as Awaited<ReturnType<typeof medplum.searchResources>>);
+    vi.spyOn(medplum, 'readReference').mockImplementation((async (ref: { reference: string }) =>
+      practiceOrg(
+        ref.reference.slice('Organization/'.length),
+        ref.reference.endsWith('1') ? '7256' : '7257'
+      )) as typeof medplum.readReference);
+
+    const { result } = setup(medplum);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.selectedOrganizationId).toBe('org-2');
+  });
+
+  test('resolves the Practitioner id when the profile is a PractitionerRole', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'getProfile').mockReturnValue({
+      resourceType: 'PractitionerRole',
+      id: 'role-1',
+      practitioner: { reference: 'Practitioner/prac-1' },
+    } as PractitionerRole);
+    const searchSpy = vi
+      .spyOn(medplum, 'searchResources')
+      .mockResolvedValue([
+        { resourceType: 'PractitionerRole', organization: { reference: 'Organization/org-1' } },
+      ] as Awaited<ReturnType<typeof medplum.searchResources>>);
+    vi.spyOn(medplum, 'readReference').mockResolvedValue(
+      practiceOrg('org-1', '7256') as Awaited<ReturnType<typeof medplum.readReference>>
+    );
+
+    const { result } = setup(medplum);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(searchSpy).toHaveBeenCalledWith(
+      'PractitionerRole',
+      expect.objectContaining({ practitioner: 'Practitioner/prac-1' })
+    );
+    expect(result.current.selectedOrganizationId).toBe('org-1');
+  });
+
+  test('discovers practices from ProjectMembership.access organization parameters', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'getProfile').mockReturnValue(PRACTITIONER);
+    vi.spyOn(medplum, 'searchResources').mockResolvedValue([] as Awaited<ReturnType<typeof medplum.searchResources>>);
+    vi.spyOn(medplum, 'getProjectMembership').mockReturnValue({
+      resourceType: 'ProjectMembership',
+      access: [{ parameter: [{ name: 'organization', valueReference: { reference: 'Organization/org-9' } }] }],
+    } as ProjectMembership);
+    vi.spyOn(medplum, 'readReference').mockResolvedValue(
+      practiceOrg('org-9', '9001') as Awaited<ReturnType<typeof medplum.readReference>>
+    );
+
+    const { result } = setup(medplum);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.practices.map((p) => p.id)).toEqual(['org-9']);
+    expect(result.current.selectedOrganizationId).toBe('org-9');
+  });
+
+  test('excludes inactive PractitionerRole affiliations', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'getProfile').mockReturnValue(PRACTITIONER);
+    vi.spyOn(medplum, 'searchResources').mockResolvedValue([
+      { resourceType: 'PractitionerRole', active: false, organization: { reference: 'Organization/org-inactive' } },
+      { resourceType: 'PractitionerRole', organization: { reference: 'Organization/org-1' } },
+    ] as Awaited<ReturnType<typeof medplum.searchResources>>);
+    vi.spyOn(medplum, 'readReference').mockImplementation((async (ref: { reference: string }) =>
+      practiceOrg(ref.reference.slice('Organization/'.length), '7256')) as typeof medplum.readReference);
+
+    const { result } = setup(medplum);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.practices.map((p) => p.id)).toEqual(['org-1']);
+  });
+
+  test('setSelectedOrganizationId persists a selection and clears it', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'getProfile').mockReturnValue(PRACTITIONER);
+    vi.spyOn(medplum, 'searchResources').mockResolvedValue([
+      { resourceType: 'PractitionerRole', organization: { reference: 'Organization/org-1' } },
+      { resourceType: 'PractitionerRole', organization: { reference: 'Organization/org-2' } },
+    ] as Awaited<ReturnType<typeof medplum.searchResources>>);
+    vi.spyOn(medplum, 'readReference').mockImplementation((async (ref: { reference: string }) =>
+      practiceOrg(
+        ref.reference.slice('Organization/'.length),
+        ref.reference.endsWith('1') ? '7256' : '7257'
+      )) as typeof medplum.readReference);
+
+    const { result } = setup(medplum);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.setSelectedOrganizationId('org-2'));
+    expect(result.current.selectedOrganizationId).toBe('org-2');
+    expect(localStorage.getItem('medplum.scriptsure.selectedPracticeOrganization')).toBe('org-2');
+
+    act(() => result.current.setSelectedOrganizationId(undefined));
+    expect(result.current.selectedOrganizationId).toBeUndefined();
+    expect(localStorage.getItem('medplum.scriptsure.selectedPracticeOrganization')).toBeNull();
+  });
+
+  test('falls back to no practices when affiliation discovery fails', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'getProfile').mockReturnValue(PRACTITIONER);
+    vi.spyOn(medplum, 'searchResources').mockRejectedValue(new Error('boom'));
+
+    const { result } = setup(medplum);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.practices).toEqual([]);
+    expect(result.current.selectedOrganizationId).toBeUndefined();
+  });
+
+  test('default context setter is a no-op when used outside the provider', () => {
+    const { result } = renderHook(() => useScriptSurePractice());
+    expect(result.current.practices).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(() => result.current.setSelectedOrganizationId('x')).not.toThrow();
   });
 });

--- a/packages/scriptsure-react/src/useScriptSurePractice.tsx
+++ b/packages/scriptsure-react/src/useScriptSurePractice.tsx
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { Organization, Practitioner, PractitionerRole } from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react-hooks';
+import type { JSX, ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { SCRIPTSURE_PRACTICE_ID_SYSTEM } from './common';
+
+const STORAGE_KEY = 'medplum.scriptsure.selectedPracticeOrganization';
+
+/** The current ScriptSure practice-location selection for the signed-in prescriber. */
+export interface ScriptSurePracticeContextValue {
+  /**
+   * The prescriber's ScriptSure practice `Organization`s — discovered from their
+   * own affiliations (`PractitionerRole.organization` + `ProjectMembership.access`
+   * organization parameters), filtered to those carrying a `practice-id` identifier.
+   * Never the project-wide list.
+   */
+  readonly practices: Organization[];
+  /** The selected practice Organization id (bare id, passed to bots as `organizationId`), or undefined. */
+  readonly selectedOrganizationId: string | undefined;
+  /** Selects a practice Organization (persisted to localStorage). */
+  readonly setSelectedOrganizationId: (id: string | undefined) => void;
+  readonly loading: boolean;
+}
+
+const ScriptSurePracticeContext = createContext<ScriptSurePracticeContextValue>({
+  practices: [],
+  selectedOrganizationId: undefined,
+  setSelectedOrganizationId: () => undefined,
+  loading: false,
+});
+
+function addOrganizationReference(refs: Set<string>, reference: string | undefined): void {
+  if (reference?.startsWith('Organization/')) {
+    refs.add(reference);
+  }
+}
+
+function hasPracticeIdentifier(org: Organization): boolean {
+  return Boolean(org.identifier?.some((i) => i.system === SCRIPTSURE_PRACTICE_ID_SYSTEM && i.value));
+}
+
+/**
+ * Resolves the signed-in prescriber's `Practitioner.id` from the current profile,
+ * whether the profile is a `Practitioner` or a `PractitionerRole`.
+ *
+ * @param profile - The current Medplum profile resource.
+ * @returns The Practitioner id, or undefined when it cannot be resolved.
+ */
+function resolvePractitionerId(profile: Practitioner | PractitionerRole | undefined): string | undefined {
+  if (profile?.resourceType === 'Practitioner') {
+    return profile.id;
+  }
+  if (profile?.resourceType === 'PractitionerRole') {
+    return profile.practitioner?.reference?.slice('Practitioner/'.length) || undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Provides the signed-in prescriber's current ScriptSure practice-location
+ * selection, discovered from **their own affiliations** — mirroring the server's
+ * multi-practice resolver so the UI never offers a practice the prescriber is not
+ * a member of.
+ *
+ * Discovery: active `PractitionerRole.organization` references for the current
+ * `Practitioner` plus any `ProjectMembership.access[].parameter` named
+ * `organization`, resolved to `Organization`s and filtered to those carrying a
+ * `practice-id` identifier. The sole practice is auto-selected; a previously used
+ * selection is restored only when it is still in the affiliation set.
+ *
+ * @param props - Component props.
+ * @param props.children - Child nodes rendered within the provider.
+ * @returns The context provider element.
+ */
+export function ScriptSurePracticeProvider(props: { readonly children: ReactNode }): JSX.Element {
+  const medplum = useMedplum();
+  const [practices, setPractices] = useState<Organization[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedOrganizationId, setSelected] = useState<string | undefined>(
+    () => localStorage.getItem(STORAGE_KEY) ?? undefined
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+
+    const loadAffiliatedPractices = async (): Promise<Organization[]> => {
+      const profile = medplum.getProfile() as Practitioner | PractitionerRole | undefined;
+      const practitionerId = resolvePractitionerId(profile);
+      const references = new Set<string>();
+
+      if (practitionerId) {
+        const roles = await medplum.searchResources('PractitionerRole', {
+          practitioner: `Practitioner/${practitionerId}`,
+          _count: '100',
+        });
+        for (const role of roles) {
+          // `active` is not a standard R4 PractitionerRole search param — filter in code.
+          if (role.active !== false) {
+            addOrganizationReference(references, role.organization?.reference);
+          }
+        }
+      }
+
+      const membership = medplum.getProjectMembership();
+      for (const access of membership?.access ?? []) {
+        for (const param of access.parameter ?? []) {
+          if (param.name === 'organization') {
+            addOrganizationReference(references, param.valueReference?.reference);
+          }
+        }
+      }
+
+      const orgs = await Promise.all(
+        [...references].map((reference) => medplum.readReference<Organization>({ reference }))
+      );
+      const seen = new Set<string>();
+      const result: Organization[] = [];
+      for (const org of orgs) {
+        if (org.id && !seen.has(org.id) && hasPracticeIdentifier(org)) {
+          seen.add(org.id);
+          result.push(org);
+        }
+      }
+      return result;
+    };
+
+    loadAffiliatedPractices()
+      .then((orgs) => {
+        if (cancelled) {
+          return;
+        }
+        setPractices(orgs);
+        // Default: keep a stored id only if it is still an affiliation; else the sole practice.
+        setSelected((current) => {
+          if (current && orgs.some((o) => o.id === current)) {
+            return current;
+          }
+          return orgs.length === 1 ? orgs[0].id : undefined;
+        });
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setPractices([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return (): void => {
+      cancelled = true;
+    };
+  }, [medplum]);
+
+  const setSelectedOrganizationId = useCallback((id: string | undefined): void => {
+    setSelected(id);
+    if (id) {
+      localStorage.setItem(STORAGE_KEY, id);
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  const value = useMemo<ScriptSurePracticeContextValue>(
+    () => ({ practices, selectedOrganizationId, setSelectedOrganizationId, loading }),
+    [practices, selectedOrganizationId, setSelectedOrganizationId, loading]
+  );
+
+  return <ScriptSurePracticeContext.Provider value={value}>{props.children}</ScriptSurePracticeContext.Provider>;
+}
+
+/**
+ * Hook returning the current ScriptSure practice selection + setter.
+ *
+ * @returns The practice context value.
+ */
+export function useScriptSurePractice(): ScriptSurePracticeContextValue {
+  return useContext(ScriptSurePracticeContext);
+}

--- a/packages/scriptsure-react/src/useScriptSurePractice.tsx
+++ b/packages/scriptsure-react/src/useScriptSurePractice.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { Organization, Practitioner, PractitionerRole } from '@medplum/fhirtypes';
+import { getIdentifier, resolveId } from '@medplum/core';
+import type { Organization, Practitioner, PractitionerRole, Reference } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import type { JSX, ReactNode } from 'react';
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
@@ -17,8 +18,10 @@ export interface ScriptSurePracticeContextValue {
    * Never the project-wide list.
    */
   readonly practices: Organization[];
-  /** The selected practice Organization id (bare id, passed to bots as `organizationId`), or undefined. */
+  /** Bare Organization id used by the selector and persisted in localStorage. */
   readonly selectedOrganizationId: string | undefined;
+  /** FHIR reference for the selected practice, suitable for operation and hook inputs. */
+  readonly selectedOrganization: Reference<Organization> | undefined;
   /** Selects a practice Organization (persisted to localStorage). */
   readonly setSelectedOrganizationId: (id: string | undefined) => void;
   readonly loading: boolean;
@@ -27,6 +30,7 @@ export interface ScriptSurePracticeContextValue {
 const ScriptSurePracticeContext = createContext<ScriptSurePracticeContextValue>({
   practices: [],
   selectedOrganizationId: undefined,
+  selectedOrganization: undefined,
   setSelectedOrganizationId: () => undefined,
   loading: false,
 });
@@ -38,7 +42,7 @@ function addOrganizationReference(refs: Set<string>, reference: string | undefin
 }
 
 function hasPracticeIdentifier(org: Organization): boolean {
-  return Boolean(org.identifier?.some((i) => i.system === SCRIPTSURE_PRACTICE_ID_SYSTEM && i.value));
+  return Boolean(getIdentifier(org, SCRIPTSURE_PRACTICE_ID_SYSTEM));
 }
 
 /**
@@ -53,7 +57,7 @@ function resolvePractitionerId(profile: Practitioner | PractitionerRole | undefi
     return profile.id;
   }
   if (profile?.resourceType === 'PractitionerRole') {
-    return profile.practitioner?.reference?.slice('Practitioner/'.length) || undefined;
+    return resolveId(profile.practitioner);
   }
   return undefined;
 }
@@ -84,7 +88,6 @@ export function ScriptSurePracticeProvider(props: { readonly children: ReactNode
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
 
     const loadAffiliatedPractices = async (): Promise<Organization[]> => {
       const profile = medplum.getProfile() as Practitioner | PractitionerRole | undefined;
@@ -113,12 +116,16 @@ export function ScriptSurePracticeProvider(props: { readonly children: ReactNode
         }
       }
 
-      const orgs = await Promise.all(
+      const settledOrgs = await Promise.allSettled(
         [...references].map((reference) => medplum.readReference<Organization>({ reference }))
       );
       const seen = new Set<string>();
       const result: Organization[] = [];
-      for (const org of orgs) {
+      for (const settledOrg of settledOrgs) {
+        if (settledOrg.status === 'rejected') {
+          continue;
+        }
+        const org = settledOrg.value;
         if (org.id && !seen.has(org.id) && hasPracticeIdentifier(org)) {
           seen.add(org.id);
           result.push(org);
@@ -127,30 +134,31 @@ export function ScriptSurePracticeProvider(props: { readonly children: ReactNode
       return result;
     };
 
-    loadAffiliatedPractices()
-      .then((orgs) => {
-        if (cancelled) {
-          return;
+    const updateAffiliatedPractices = async (): Promise<void> => {
+      setLoading(true);
+      try {
+        const orgs = await loadAffiliatedPractices();
+        if (!cancelled) {
+          setPractices(orgs);
+          // Default: keep a stored id only if it is still an affiliation; else the sole practice.
+          setSelected((current) => {
+            if (current && orgs.some((o) => o.id === current)) {
+              return current;
+            }
+            return orgs.length === 1 ? orgs[0].id : undefined;
+          });
         }
-        setPractices(orgs);
-        // Default: keep a stored id only if it is still an affiliation; else the sole practice.
-        setSelected((current) => {
-          if (current && orgs.some((o) => o.id === current)) {
-            return current;
-          }
-          return orgs.length === 1 ? orgs[0].id : undefined;
-        });
-      })
-      .catch(() => {
+      } catch {
         if (!cancelled) {
           setPractices([]);
         }
-      })
-      .finally(() => {
+      } finally {
         if (!cancelled) {
           setLoading(false);
         }
-      });
+      }
+    };
+    updateAffiliatedPractices().catch(() => undefined);
 
     return (): void => {
       cancelled = true;
@@ -166,9 +174,14 @@ export function ScriptSurePracticeProvider(props: { readonly children: ReactNode
     }
   }, []);
 
+  const selectedOrganization = useMemo<Reference<Organization> | undefined>(
+    () => (selectedOrganizationId ? { reference: `Organization/${selectedOrganizationId}` } : undefined),
+    [selectedOrganizationId]
+  );
+
   const value = useMemo<ScriptSurePracticeContextValue>(
-    () => ({ practices, selectedOrganizationId, setSelectedOrganizationId, loading }),
-    [practices, selectedOrganizationId, setSelectedOrganizationId, loading]
+    () => ({ practices, selectedOrganizationId, selectedOrganization, setSelectedOrganizationId, loading }),
+    [practices, selectedOrganizationId, selectedOrganization, setSelectedOrganizationId, loading]
   );
 
   return <ScriptSurePracticeContext.Provider value={value}>{props.children}</ScriptSurePracticeContext.Provider>;


### PR DESCRIPTION
## Summary

Split out of #9858 (part 2 of 2). **Stacked on #9860** — review/merge that first; this PR's base is `oleg-daw-uom-dispense-unit`, so the diff shown here is only the multi-practice + order-set slice.

Support Medplum projects that model multiple ScriptSure practice locations as `Organization`s. A prescriber selects the practice per prescribing session and the chosen Organization id is threaded through the vendor-neutral prescribing flows.

- **`@medplum/core`:** `organizationId` on `MedicationOrderRequest` / `MedicationOrderSetRequest` / `MedicationSearchParams` / `MedicationCheckoutRequest` + pharmacy params, emitted by their `Parameters` converters.
- **`@medplum/react-hooks`:** thread `organizationId` through the medication order, order-set, iframe, and pharmacy hooks.
- **`@medplum/scriptsure-react`:** headless `useScriptSurePractice` / `ScriptSurePracticeProvider`, scoped to the signed-in prescriber's own affiliations (`PractitionerRole.organization` + `ProjectMembership.access` org params, filtered to `practice-id` Organizations). Sole practice auto-selects (switcher hidden when < 2); a localStorage selection is restored only when still in the affiliation set. Adds practice / business-unit / org-type identifier systems.
- **`medplum-provider`:** `ScriptSurePracticeProvider` + Mantine `ScriptSurePracticeSwitcher` wired into App, OrderMedicationPage, OrderSetTabPanel, ScriptSureTab, MedicationsPage checkout, and the pharmacy dialog; docs page for multiple practice locations.

**Also bundled:** order-set partial-sync surfacing — `useSyncOrderSet` now resolves the decoded `OrderSetSyncResponse` (via new core `parametersToOrderSetSyncResponse`) so `GetStartedPage` warns when some medications fail to sync instead of silently applying fewer meds. Co-located here because it shares the same core converter file and `$sync-orderset` call site as the `organizationId` threading.

## Test plan

- [ ] Build/typecheck `@medplum/core`, `@medplum/react-hooks`, `@medplum/scriptsure-react`, example (green locally)
- [ ] Single-practice prescriber: switcher hidden, sole practice auto-selected
- [ ] Multi-practice prescriber: switcher lists only affiliated practices; selection persists; `organizationId` reaches order / order-set / checkout / pharmacy calls
- [ ] Order-set import with a failing action shows the partial-sync warning

Server-side resolver + bots verified on staging (medplum-ee `resolver-smoke` / `provision-smoke`).