### PR TITLE
chore(deps): pin es-module-lexer to 2.3.1 to fix memory issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25229,9 +25229,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "trailingComma": "es5"
   },
   "overrides": {
+    "es-module-lexer": "2.3.1",
     "esbuild": "0.28.1",
     "typescript": "6.0.3",
     "vite": "8.1.0",


### PR DESCRIPTION
## Summary
- Fixes the memory error in [guybedford/es-module-lexer#214](https://github.com/guybedford/es-module-lexer/issues/214)
- Split out of https://github.com/medplum/medplum/pull/9836
- This PR is _intentionally_ `package.json`-only so future updates (like #9836) don’t drift back under ranges like `import-in-the-middle’s ^2.2.0`. There’s no version resolution change left for the lockfile to record.

## Original Errors

```
- Failed to parse '.../ObservableAPI.js'
  cause: RangeError: WebAssembly.Memory.grow(): Maximum memory size exceeded
    at parse (es-module-lexer)
    at lexEsm (import-in-the-middle)
```
```
(node:43639) Warning: Error: 'import-in-the-middle' failed to wrap 'file:///Users/user/medplum/node_modules/@kubernetes/client-node/dist/gen/types/ObservableAPI.js'
    at onWrapFailure (/Users/user/medplum/node_modules/import-in-the-middle/create-hook.mjs:687:17)
    at getSourceSync (/Users/user/medplum/node_modules/import-in-the-middle/create-hook.mjs:728:9)
    at loadSync (/Users/user/medplum/node_modules/import-in-the-middle/create-hook.mjs:779:22)
    ... 2 lines matching cause stack trace ...
    at #loadSync (node:internal/modules/esm/loader:825:16)
    at ModuleLoader.load (node:internal/modules/esm/loader:783:26)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:494:31)
    at #getOrCreateModuleJobAfterResolve (node:internal/modules/esm/loader:560:36)
    at afterResolve (node:internal/modules/esm/loader:607:52) {
  cause: Error: Failed to parse 'file:///Users/user/medplum/node_modules/@kubernetes/client-node/dist/gen/types/ObservableAPI.js'
      at getExports (/Users/user/medplum/node_modules/import-in-the-middle/lib/get-exports.mjs:305:17)
      at getExports.next (<anonymous>)
      ... 5 lines matching cause stack trace ...
      at nextStep (node:internal/modules/customization_hooks:189:26)
      at loadWithHooks (node:internal/modules/customization_hooks:374:18)
      at #loadSync (node:internal/modules/esm/loader:825:16) {
    cause: RangeError: WebAssembly.Memory.grow(): Maximum memory size exceeded
        at parse (/Users/user/medplum/node_modules/es-module-lexer/dist/lexer.cjs:1:632)
        at lexEsm (/Users/user/medplum/node_modules/import-in-the-middle/lib/get-esm-exports.mjs:131:49)
        at getExports (/Users/user/medplum/node_modules/import-in-the-middle/lib/get-exports.mjs:288:46)
        at getExports.next (<anonymous>)
        at processModule (/Users/user/medplum/node_modules/import-in-the-middle/create-hook.mjs:268:31)
        at processModule.next (<anonymous>)
        at driveSync (/Users/user/medplum/node_modules/import-in-the-middle/lib/io.mjs:48:43)
        at getSourceSync (/Users/user/medplum/node_modules/import-in-the-middle/create-hook.mjs:722:47)
        at loadSync (/Users/user/medplum/node_modules/import-in-the-middle/create-hook.mjs:779:22)
        at nextStep (node:internal/modules/customization_hooks:189:26)
  }
}
```