### PR TITLE
fix: resolve API Extractor ae-unresolved-link warnings

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -4011,8 +4011,8 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   /**
    * Handles an unauthenticated (HTTP 401) response from the server.
    *
-   * Bounded and terminal: at most {@link MAX_AUTH_ATTEMPTS} attempts per request (1 initial
-   * + 1 recovery, tracked via {@link RequestState.authAttempt}). The recovery re-mints via a
+   * Bounded and terminal: at most `MAX_AUTH_ATTEMPTS` attempts per request (1 initial
+   * + 1 recovery, tracked via `RequestState.authAttempt`). The recovery re-mints via a
    * forced {@link MedplumClient.refresh} (bypassing the {@link MedplumClient.isAuthenticated}
    * short-circuit on the rejected token), single-flight so concurrent 401s share one re-mint.
    * A second 401 is terminal: clear auth, `onUnauthenticated`, reject — never recurse.

--- a/packages/dosespot-react/src/useDoseSpotIFrame.ts
+++ b/packages/dosespot-react/src/useDoseSpotIFrame.ts
@@ -19,11 +19,12 @@ export interface DoseSpotIFrameOptions extends MedicationIFrameOptions {
   readonly onSelfEnrollSuccess?: (result: DoseSpotSelfEnrollmentResult) => void;
 }
 
+/* eslint-disable jsdoc/escape-inline-tags -- TSDoc cross-package {@link @package#symbol} references */
 /**
  * React hook that syncs a patient to DoseSpot and returns the iframe URL.
  *
  * Runs optional self-enrollment, then the patient-sync bot (when `patientId`
- * is set), then the iframe bot — aligned with {@link useMedicationIFrame}
+ * is set), then the iframe bot — aligned with {@link @medplum/react-hooks#useMedicationIFrame}
  * behavior plus DoseSpot-specific enrollment.
  *
  * @param options - Configuration and callback options.

--- a/packages/dosespot-react/src/useDoseSpotPharmacySearch.ts
+++ b/packages/dosespot-react/src/useDoseSpotPharmacySearch.ts
@@ -7,10 +7,11 @@ import { DOSESPOT_ADD_PATIENT_PHARMACY_BOT, DOSESPOT_SEARCH_PHARMACY_BOT } from 
 
 export type UseDoseSpotPharmacySearchReturn = UsePharmacySearchReturn;
 
+/* eslint-disable jsdoc/escape-inline-tags -- TSDoc cross-package {@link @package#symbol} references */
 /**
  * React hook that provides DoseSpot-specific pharmacy search and add-to-favorites functionality.
  *
- * Thin wrapper around the generic {@link usePharmacySearch} hook,
+ * Thin wrapper around the generic {@link @medplum/react-hooks#usePharmacySearch} hook,
  * pre-configured with DoseSpot bot identifiers.
  *
  * @returns An object with `searchPharmacies` and `addToFavorites` callbacks.

--- a/packages/react-hooks/src/useMedicationCart/useMedicationCart.ts
+++ b/packages/react-hooks/src/useMedicationCart/useMedicationCart.ts
@@ -29,14 +29,14 @@ export interface UseMedicationCartReturn {
   /**
    * Persist a draft `MedicationRequest` as a cart line via plain FHIR
    * `createResource` (no custom operation). Vendor staging happens later at
-   * {@link checkout}.
+   * {@link UseMedicationCartReturn.checkout}.
    */
   addToCart: (medicationRequest: MedicationRequest) => Promise<MedicationRequest>;
-  /** True while one or more {@link addToCart} calls are in flight. */
+  /** True while one or more {@link UseMedicationCartReturn.addToCart} calls are in flight. */
   adding: boolean;
   /**
    * Submit draft cart lines to the vendor's batch approval queue and return an
-   * embeddable approval-widget URL. Refuses while {@link adding} is true.
+   * embeddable approval-widget URL. Refuses while {@link UseMedicationCartReturn.adding} is true.
    */
   checkout: (input: MedicationCheckoutRequest) => Promise<MedicationCheckoutResponse>;
   /** Remove a single draft `MedicationRequest` from the patient's vendor cart. */

--- a/packages/scriptsure-react/src/useScriptSureIFrame.ts
+++ b/packages/scriptsure-react/src/useScriptSureIFrame.ts
@@ -6,10 +6,11 @@ import { SCRIPTSURE_IFRAME_BOT, SCRIPTSURE_PATIENT_SYNC_BOT } from './common';
 
 export type ScriptSureIFrameOptions = MedicationIFrameOptions;
 
+/* eslint-disable jsdoc/escape-inline-tags -- TSDoc cross-package {@link @package#symbol} references */
 /**
  * React hook that syncs a patient to ScriptSure and returns the iframe URL.
  *
- * Thin wrapper around the generic {@link useMedicationIFrame} hook,
+ * Thin wrapper around the generic {@link @medplum/react-hooks#useMedicationIFrame} hook,
  * pre-configured with ScriptSure bot identifiers.
  *
  * @param options - Configuration and callback options.

--- a/packages/scriptsure-react/src/useScriptSureOrderSet.ts
+++ b/packages/scriptsure-react/src/useScriptSureOrderSet.ts
@@ -18,12 +18,13 @@ export interface UseScriptSureOrderSetOptions {
 
 export type UseScriptSureOrderSetReturn = UseMedicationOrderSetReturn;
 
+/* eslint-disable jsdoc/escape-inline-tags -- TSDoc cross-package {@link @package#symbol} references */
 /**
  * React hook that returns the ScriptSure order-set prescribing widget URL via
  * the vendor-neutral `$order-set-url` FHIR custom operation
  * (`POST /fhir/R4/PlanDefinition/$order-set-url`).
  *
- * Thin wrapper around {@link useMedicationOrderSet}: forwards
+ * Thin wrapper around {@link @medplum/react-hooks#useMedicationOrderSet}: forwards
  * `scriptSureOrdersetId` as the operation's `vendorOrderSetId` parameter,
  * leaves vendor binding to the deployed `OperationDefinition` →
  * `Bot/scriptsure-order-set-bot` link.

--- a/packages/scriptsure-react/src/useScriptSurePharmacySearch.ts
+++ b/packages/scriptsure-react/src/useScriptSurePharmacySearch.ts
@@ -8,10 +8,11 @@ import type { ScriptSurePharmacySearchParams } from './pharmacy-search';
 
 export type UseScriptSurePharmacySearchReturn = UsePharmacySearchReturn<ScriptSurePharmacySearchParams>;
 
+/* eslint-disable jsdoc/escape-inline-tags -- TSDoc cross-package {@link @package#symbol} references */
 /**
  * React hook that provides ScriptSure-specific pharmacy search and add-to-favorites functionality.
  *
- * Thin wrapper around the generic {@link usePharmacySearch} hook, pre-configured with
+ * Thin wrapper around the generic {@link @medplum/react-hooks#usePharmacySearch} hook, pre-configured with
  * ScriptSure bot identifiers and widened so search params carry ScriptSure-only
  * `specialties` filters for POST /v3/pharmacy/search.
  *


### PR DESCRIPTION
## Summary
- Qualify cross-package TSDoc `@link` targets (e.g. `@medplum/react-hooks#useMedicationIFrame`) so API Extractor can resolve them from DoseSpot/ScriptSure wrappers
- Qualify interface member links in `UseMedicationCartReturn` (fixes cascade warnings in `@medplum/react`)
- Replace `@link` with backticks for private non-exported symbols (`MAX_AUTH_ATTEMPTS`, `RequestState`) in `MedplumClient`