### PR TITLE
fix(core): use standards-compliant keys() in storage.ts

### DIFF
--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -35,11 +35,12 @@ export class ClientStorage implements IClientStorage {
   clear(): void {
     // We only care about checking the keys for localStorage when a prefix is present
     if (this.storage === globalThis.localStorage && this.prefix) {
-      Object.keys(this.storage)
-        .filter((key) => key.startsWith(this.prefix))
-        .forEach((key) => {
+      for (let i = this.storage.length - 1; i >= 0; i--) {
+        const key = this.storage.key(i);
+        if (key?.startsWith(this.prefix)) {
           this.storage.removeItem(key);
-        });
+        }
+      }
     } else {
       // If not localStorage, then just clear out the whole storage
       this.storage.clear();


### PR DESCRIPTION
In `ClientStorage.clear()`, enumerate prefixed `localStorage` keys with the Web Storage API `key(i)` / `length` loop instead of `Object.keys()`, which is not part of the Storage spec and is unreliable across implementations.

Found accidentally because it fails on Node v26.