### PR TITLE
Tweak DiagnosticReportDisplay critical dark mode style

### DIFF
--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.module.css
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.module.css
@@ -10,9 +10,9 @@
 }
 
 .criticalRow {
-  background: light-dark(var(--mantine-color-red-1), var(--mantine-color-red-7));
+  background: light-dark(var(--mantine-color-red-0), oklch(from var(--mantine-color-red-8) l c h / 0.2));
   border: 0.1px solid var(--mantine-color-red-5);
-  color: var(--mantine-color-red-5);
+  color: light-dark(var(--mantine-color-red-5), var(--mantine-color-red-0));
   font-weight: 500;
 
   & td {


### PR DESCRIPTION
Spotted during Provider-Sync meeting today; the contrast here made this very difficult to read. Let's improve it.

We don't have a great option for a red background with high contrast text; working with @kevinwadeshaw we styled red-8 @ 20% opacity to provide a nice background highlight based on a theme color, while still giving us room to put a high contrast text in front of it.

## Before
<img width="1840" height="1196" alt="Screenshot 2026-07-14 at 2 43 53 PM" src="https://github.com/user-attachments/assets/c03d2244-76b9-4f3f-b95f-f7b318618d78" />

## After
<img width="1840" height="1196" alt="Screenshot 2026-07-14 at 2 43 45 PM" src="https://github.com/user-attachments/assets/d229957b-1d41-4dfb-86b5-5a76a915647e" />