### PR TITLE
Don't require a care template when creating an encounter

### DIFF
--- a/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/AppointmentDetails.test.tsx
@@ -330,7 +330,7 @@ describe('AppointmentDetails', () => {
         expect(screen.getByText('Set Up Encounter')).toBeInTheDocument();
         expect(screen.getByLabelText(/Encounter Class/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/Care template/i)).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
       });
     });
 

--- a/examples/medplum-provider/src/components/schedule/CreateEncounterForm.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateEncounterForm.test.tsx
@@ -69,16 +69,16 @@ describe('CreateEncounterForm', () => {
     expect(screen.getByText('Set Up Encounter')).toBeInTheDocument();
     expect(screen.getByLabelText(/Encounter Class/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Care template/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
   });
 
-  test('Apply button is disabled when class is not selected', async () => {
+  test('Continue button is disabled when class is not selected', async () => {
     setup(appointment);
 
-    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
   });
 
-  test('Apply button is enabled once class is selected without a care template', async () => {
+  test('Continue button is enabled once class is selected without a care template', async () => {
     const user = userEvent.setup();
     setup(appointment);
 
@@ -90,7 +90,7 @@ describe('CreateEncounterForm', () => {
     await user.click(screen.getByText('Test Display'));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Apply' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Continue' })).not.toBeDisabled();
     });
   });
 
@@ -113,9 +113,9 @@ describe('CreateEncounterForm', () => {
     await user.click(screen.getByText('Test Display'));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Apply' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Continue' })).not.toBeDisabled();
     });
-    await user.click(screen.getByRole('button', { name: 'Apply' }));
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
 
     await waitFor(() => {
       expect(createEncounter).toHaveBeenCalledWith(
@@ -224,9 +224,9 @@ describe('CreateEncounterForm', () => {
     await user.click(screen.getByText('Test Plan'));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Apply' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Continue' })).not.toBeDisabled();
     });
-    await user.click(screen.getByRole('button', { name: 'Apply' }));
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
 
     await waitFor(() => {
       expect(showErrorNotification).toHaveBeenCalledWith(encounterError);

--- a/examples/medplum-provider/src/components/schedule/CreateEncounterForm.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateEncounterForm.test.tsx
@@ -72,10 +72,61 @@ describe('CreateEncounterForm', () => {
     expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
   });
 
-  test('Apply button is disabled when class and care template are not selected', async () => {
+  test('Apply button is disabled when class is not selected', async () => {
     setup(appointment);
 
     expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+  });
+
+  test('Apply button is enabled once class is selected without a care template', async () => {
+    const user = userEvent.setup();
+    setup(appointment);
+
+    const classInput = screen.getByLabelText(/Encounter Class/i);
+    await user.type(classInput, 'Test');
+    await waitFor(() => {
+      expect(screen.getByText('Test Display')).toBeInTheDocument();
+    });
+    await user.click(screen.getByText('Test Display'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Apply' })).not.toBeDisabled();
+    });
+  });
+
+  test('calls createEncounter without a care template selected', async () => {
+    const user = userEvent.setup();
+    vi.mocked(createEncounter).mockResolvedValue({
+      resourceType: 'Encounter',
+      id: 'enc-1',
+      status: 'planned',
+      class: {},
+    });
+
+    setup(appointment);
+
+    const classInput = screen.getByLabelText(/Encounter Class/i);
+    await user.type(classInput, 'Test');
+    await waitFor(() => {
+      expect(screen.getByText('Test Display')).toBeInTheDocument();
+    });
+    await user.click(screen.getByText('Test Display'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Apply' })).not.toBeDisabled();
+    });
+    await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+    await waitFor(() => {
+      expect(createEncounter).toHaveBeenCalledWith(
+        medplum,
+        expect.anything(),
+        patientRef,
+        undefined,
+        appointment,
+        practitionerRef
+      );
+    });
   });
 
   test('shows alert when no practitioner is in appointment.participants', async () => {

--- a/examples/medplum-provider/src/components/schedule/CreateEncounterForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateEncounterForm.tsx
@@ -39,7 +39,7 @@ export function CreateEncounterForm(props: CreateEncounterFormProps): JSX.Elemen
   );
 
   const handleSubmit = useCallback(async () => {
-    if (!encounterClass || !planDefinition) {
+    if (!encounterClass) {
       showNotification({
         color: 'yellow',
         icon: <IconAlertSquareRounded />,
@@ -117,12 +117,11 @@ export function CreateEncounterForm(props: CreateEncounterFormProps): JSX.Elemen
           resourceType="PlanDefinition"
           label="Care template"
           onChange={setPlanDefinition}
-          required={true}
         />
 
         <PlanDefinitionSummary planDefinition={planDefinition} />
 
-        <Button fullWidth type="submit" disabled={!planDefinition || !encounterClass}>
+        <Button fullWidth type="submit" disabled={!encounterClass}>
           Apply
         </Button>
       </Stack>

--- a/examples/medplum-provider/src/components/schedule/CreateEncounterForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateEncounterForm.tsx
@@ -122,7 +122,7 @@ export function CreateEncounterForm(props: CreateEncounterFormProps): JSX.Elemen
         <PlanDefinitionSummary planDefinition={planDefinition} />
 
         <Button fullWidth type="submit" disabled={!encounterClass}>
-          Apply
+          Continue
         </Button>
       </Stack>
     </Form>

--- a/examples/medplum-provider/src/components/schedule/CreateVisit.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateVisit.tsx
@@ -55,7 +55,7 @@ export function CreateVisit(props: CreateVisitProps): JSX.Element {
   }, [appointmentSlot]);
 
   async function handleSubmit(): Promise<void> {
-    if (!patient || !planDefinitionData || !encounterClass || !start || !end) {
+    if (!patient || !encounterClass || !start || !end) {
       showNotification({
         color: 'yellow',
         icon: <IconAlertSquareRounded />,
@@ -148,7 +148,6 @@ export function CreateVisit(props: CreateVisitProps): JSX.Element {
             onChange={(value) => {
               setPlanDefinitionData(value as PlanDefinition);
             }}
-            required={true}
           />
         </Stack>
 

--- a/examples/medplum-provider/src/pages/encounter/EncounterModal.tsx
+++ b/examples/medplum-provider/src/pages/encounter/EncounterModal.tsx
@@ -34,7 +34,7 @@ export const EncounterModal = (): JSX.Element => {
   });
 
   const handleCreateEncounter = async (): Promise<void> => {
-    if (!patient || !encounterClass || !start || !end || !status || !planDefinitionData || !practitioner) {
+    if (!patient || !encounterClass || !start || !end || !status || !practitioner) {
       showNotification({
         color: 'yellow',
         icon: <IconAlertSquareRounded />,
@@ -157,9 +157,9 @@ export const EncounterModal = (): JSX.Element => {
 
                 <ResourceInput
                   name="plandefinition"
+                  label="Care template"
                   resourceType="PlanDefinition"
                   onChange={(value) => setPlanDefinitionData(value as PlanDefinition)}
-                  required={true}
                 />
 
                 <PlanDefinitionSummary planDefinition={planDefinitionData} />

--- a/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
+++ b/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
@@ -251,7 +251,8 @@ export function GetStartedPage(): JSX.Element {
                     A simple note template for a first patient visit that includes tasks and questionnaires.
                   </Text>
                   <Text size="xs" c="dimmed" mb="sm">
-                    Note: a Care Template (aka PlanDefinition FHIR resource) is required for creating visits.
+                    Note: a Care Template (aka PlanDefinition FHIR resource) is optional, but tasks from it will be
+                    automatically added to a visit if one is selected.
                   </Text>
                 </Stack>
                 <Button

--- a/examples/medplum-provider/src/utils/encounter.ts
+++ b/examples/medplum-provider/src/utils/encounter.ts
@@ -75,7 +75,7 @@ export async function createEncounter(
   medplum: MedplumClient,
   classification: Coding,
   patient: Patient | Reference<Patient>,
-  planDefinition: PlanDefinition,
+  planDefinition: PlanDefinition | undefined,
   appointment: Appointment,
   practitioner: Practitioner | Reference<Practitioner>
 ): Promise<WithId<Encounter>> {
@@ -104,16 +104,19 @@ export async function createEncounter(
 
   await medplum.createResource(clinicalImpressionData);
 
-  await medplum.post(medplum.fhirUrl('PlanDefinition', planDefinition.id as string, '$apply'), {
-    resourceType: 'Parameters',
-    parameter: [
-      { name: 'subject', valueString: getReferenceString(patient) },
-      { name: 'encounter', valueString: getReferenceString(encounter) },
-      { name: 'practitioner', valueString: getReferenceString(practitioner) },
-    ],
-  });
+  if (planDefinition) {
+    await medplum.post(medplum.fhirUrl('PlanDefinition', planDefinition.id as string, '$apply'), {
+      resourceType: 'Parameters',
+      parameter: [
+        { name: 'subject', valueString: getReferenceString(patient) },
+        { name: 'encounter', valueString: getReferenceString(encounter) },
+        { name: 'practitioner', valueString: getReferenceString(practitioner) },
+      ],
+    });
 
-  await createChargeItemFromPlanDefinition(medplum, encounter, patientRef, planDefinition);
+    await createChargeItemFromPlanDefinition(medplum, encounter, patientRef, planDefinition);
+  }
+
   await handleChargeItemsFromTasks(medplum, encounter, patientRef);
 
   return encounter;


### PR DESCRIPTION
Fixes #9816

## Summary
No longer require a Care Template to be filled out when creating an encounter. Encounters can be created from three places: 
- `EncounterModal.tsx` - "new encounter" modal in patient screen
- `CreateVisit.tsx` - schedule "create visit" flow 
- `CreateEncounterForm.tsx` - post-booking "set up encounter" form
  - (Note: This form is tricky to open because it requires an appointment that's not linked to an encounter. All Provider workflows create an Appointment and Encounter together.) 

We'll also update the starting page to remove the blurb about a care template being "required". 