### PR TITLE
[core]: Improve EventTarget listener exception safety 

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -4907,6 +4907,13 @@ describe('Client', () => {
       expect(fetch).toHaveBeenCalledTimes(2);
     });
   });
+
+  test('setEventListenerErrorHandler refines the type based on client-supported event types', () => {
+    const client = new MedplumClient();
+    client.setEventListenerErrorHandler((error, event) => {
+      expectTypeOf(event.type).toEqualTypeOf<keyof MedplumClientEventMap>();
+    });
+  });
 });
 
 describe('Passed in async-backed `ClientStorage`', () => {

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -4907,13 +4907,6 @@ describe('Client', () => {
       expect(fetch).toHaveBeenCalledTimes(2);
     });
   });
-
-  test('setEventListenerErrorHandler refines the type based on client-supported event types', () => {
-    const client = new MedplumClient();
-    client.setEventListenerErrorHandler((error, event) => {
-      expectTypeOf(event.type).toEqualTypeOf<keyof MedplumClientEventMap>();
-    });
-  });
 });
 
 describe('Passed in async-backed `ClientStorage`', () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3708,11 +3708,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    */
   private dispatchResourceModified(payload: ResourceModifiedEvent): void {
     if (this.listenerCount('resourceModified') > 0) {
-      try {
-        this.dispatchEvent({ type: 'resourceModified', payload });
-      } catch (err) {
-        console.error("[MedplumClient] A 'resourceModified' event listener threw an error ", err);
-      }
+      this.dispatchEvent({ type: 'resourceModified', payload });
     }
   }
 

--- a/packages/core/src/eventtarget.test.ts
+++ b/packages/core/src/eventtarget.test.ts
@@ -105,7 +105,7 @@ describe('EventTarget', () => {
 
     // Test the default error handler
     expect(consoleError).toHaveBeenCalledTimes(1);
-    expect(consoleError).toHaveBeenCalledWith('Unhandled error in event listener', error);
+    expect(consoleError).toHaveBeenCalledWith('Unhandled error in "test" event listener', error);
   });
 
   test('With an eventListenerErrorHandler', () => {

--- a/packages/core/src/eventtarget.test.ts
+++ b/packages/core/src/eventtarget.test.ts
@@ -88,7 +88,6 @@ describe('EventTarget', () => {
   });
 
   test('When an event listener throws an error', () => {
-    // The default error handler logs to console.error
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const error = new Error('Oh no');
     const listener1 = vi.fn().mockThrow(error);
@@ -103,59 +102,8 @@ describe('EventTarget', () => {
     expect(listener1).toHaveBeenCalled();
     expect(listener2).toHaveBeenCalled();
 
-    // Test the default error handler
     expect(consoleError).toHaveBeenCalledTimes(1);
     expect(consoleError).toHaveBeenCalledWith('Unhandled error in "test" event listener', error);
-  });
-
-  test('With an eventListenerErrorHandler', () => {
-    // The default error handler logs to console.error
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    const error = new Error('Oh no');
-    const listener1 = vi.fn().mockThrow(error);
-    const listener2 = vi.fn();
-
-    const target = new EventTarget();
-    target.addEventListener('test', listener1);
-    target.addEventListener('test', listener2);
-
-    const eventListenerErrorHandler = vi.fn();
-    target.setEventListenerErrorHandler(eventListenerErrorHandler);
-
-    const event = { type: 'test', extraData: 123 };
-    expect(() => target.dispatchEvent(event)).not.toThrow();
-
-    expect(listener1).toHaveBeenCalled();
-    expect(listener2).toHaveBeenCalled();
-
-    expect(eventListenerErrorHandler).toHaveBeenCalledTimes(1);
-    expect(eventListenerErrorHandler).toHaveBeenCalledWith(error, event);
-
-    expect(consoleError).not.toHaveBeenCalled();
-  });
-
-  test('opting in to synchronous event listener errors', () => {
-    // This usage is *strongly discouraged*, but is provided as a backwards
-    // compatibility shim for any users who were relying on this style of
-    // exception bubbling.
-
-    const error = new Error('Oh no');
-    const myCallback1 = vi.fn().mockThrow(error);
-    const myCallback2 = vi.fn();
-    const target = new EventTarget();
-    target.setEventListenerErrorHandler((err) => {
-      throw err;
-    });
-    target.addEventListener('test', myCallback1);
-    target.addEventListener('test', myCallback2);
-
-    const event = { type: 'test' };
-
-    expect(() => {
-      target.dispatchEvent(event);
-    }).toThrow(error);
-    expect(myCallback1).toHaveBeenCalled();
-    expect(myCallback2).not.toHaveBeenCalled();
   });
 });
 
@@ -236,24 +184,5 @@ describe('TypedEventTarget', () => {
     target.removeAllListeners();
     expect(target.listenerCount('test1')).toStrictEqual(0);
     expect(target.listenerCount('test2')).toStrictEqual(0);
-  });
-
-  test('Setting an event listener error handler', () => {
-    const error = new Error('Oh no');
-    const myCallback1 = vi.fn().mockThrow(error);
-    const myCallback2 = vi.fn();
-    const eventListenerErrorHandler = vi.fn();
-    const target = new TypedEventTarget<{ test: { type: 'test' } }>();
-    target.setEventListenerErrorHandler(eventListenerErrorHandler);
-    target.addEventListener('test', myCallback1);
-    target.addEventListener('test', myCallback2);
-
-    const event = { type: 'test' } as const;
-    target.dispatchEvent(event);
-
-    expect(myCallback1).toHaveBeenCalled();
-    expect(myCallback2).toHaveBeenCalled();
-    expect(eventListenerErrorHandler).toHaveBeenCalledTimes(1);
-    expect(eventListenerErrorHandler).toHaveBeenCalledWith(error, event);
   });
 });

--- a/packages/core/src/eventtarget.test.ts
+++ b/packages/core/src/eventtarget.test.ts
@@ -3,6 +3,10 @@
 import { vi } from 'vitest';
 import { EventTarget, TypedEventTarget } from './eventtarget';
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe('EventTarget', () => {
   test('No listeners', () => {
     const target = new EventTarget();
@@ -81,6 +85,77 @@ describe('EventTarget', () => {
     target.removeAllListeners();
     expect(target.listenerCount('test1')).toStrictEqual(0);
     expect(target.listenerCount('test2')).toStrictEqual(0);
+  });
+
+  test('When an event listener throws an error', () => {
+    // The default error handler logs to console.error
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const error = new Error('Oh no');
+    const listener1 = vi.fn().mockThrow(error);
+    const listener2 = vi.fn();
+
+    const target = new EventTarget();
+    target.addEventListener('test', listener1);
+    target.addEventListener('test', listener2);
+
+    expect(() => target.dispatchEvent({ type: 'test' })).not.toThrow();
+
+    expect(listener1).toHaveBeenCalled();
+    expect(listener2).toHaveBeenCalled();
+
+    // Test the default error handler
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith('Unhandled error in event listener', error);
+  });
+
+  test('With an eventListenerErrorHandler', () => {
+    // The default error handler logs to console.error
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const error = new Error('Oh no');
+    const listener1 = vi.fn().mockThrow(error);
+    const listener2 = vi.fn();
+
+    const target = new EventTarget();
+    target.addEventListener('test', listener1);
+    target.addEventListener('test', listener2);
+
+    const eventListenerErrorHandler = vi.fn();
+    target.setEventListenerErrorHandler(eventListenerErrorHandler);
+
+    const event = { type: 'test', extraData: 123 };
+    expect(() => target.dispatchEvent(event)).not.toThrow();
+
+    expect(listener1).toHaveBeenCalled();
+    expect(listener2).toHaveBeenCalled();
+
+    expect(eventListenerErrorHandler).toHaveBeenCalledTimes(1);
+    expect(eventListenerErrorHandler).toHaveBeenCalledWith(error, event);
+
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  test('opting in to synchronous event listener errors', () => {
+    // This usage is *strongly discouraged*, but is provided as a backwards
+    // compatibility shim for any users who were relying on this style of
+    // exception bubbling.
+
+    const error = new Error('Oh no');
+    const myCallback1 = vi.fn().mockThrow(error);
+    const myCallback2 = vi.fn();
+    const target = new EventTarget();
+    target.setEventListenerErrorHandler((err) => {
+      throw err;
+    });
+    target.addEventListener('test', myCallback1);
+    target.addEventListener('test', myCallback2);
+
+    const event = { type: 'test' };
+
+    expect(() => {
+      target.dispatchEvent(event);
+    }).toThrow(error);
+    expect(myCallback1).toHaveBeenCalled();
+    expect(myCallback2).not.toHaveBeenCalled();
   });
 });
 
@@ -161,5 +236,24 @@ describe('TypedEventTarget', () => {
     target.removeAllListeners();
     expect(target.listenerCount('test1')).toStrictEqual(0);
     expect(target.listenerCount('test2')).toStrictEqual(0);
+  });
+
+  test('Setting an event listener error handler', () => {
+    const error = new Error('Oh no');
+    const myCallback1 = vi.fn().mockThrow(error);
+    const myCallback2 = vi.fn();
+    const eventListenerErrorHandler = vi.fn();
+    const target = new TypedEventTarget<{ test: { type: 'test' } }>();
+    target.setEventListenerErrorHandler(eventListenerErrorHandler);
+    target.addEventListener('test', myCallback1);
+    target.addEventListener('test', myCallback2);
+
+    const event = { type: 'test' } as const;
+    target.dispatchEvent(event);
+
+    expect(myCallback1).toHaveBeenCalled();
+    expect(myCallback2).toHaveBeenCalled();
+    expect(eventListenerErrorHandler).toHaveBeenCalledTimes(1);
+    expect(eventListenerErrorHandler).toHaveBeenCalledWith(error, event);
   });
 });

--- a/packages/core/src/eventtarget.ts
+++ b/packages/core/src/eventtarget.ts
@@ -16,8 +16,8 @@ export type EventListener = (e: Event) => void;
 
 export type EventListenerErrorHandler = (error: unknown, event: Event) => void;
 
-export const defaultEventListenerErrorHandler: EventListenerErrorHandler = (error) => {
-  console.error('Unhandled error in event listener', error);
+export const defaultEventListenerErrorHandler: EventListenerErrorHandler = (error, event) => {
+  console.error(`Unhandled error in "${event.type}" event listener`, error);
 };
 
 export class EventTarget {

--- a/packages/core/src/eventtarget.ts
+++ b/packages/core/src/eventtarget.ts
@@ -14,11 +14,23 @@ export interface Event {
 
 export type EventListener = (e: Event) => void;
 
+export type EventListenerErrorHandler = (error: unknown, event: Event) => void;
+
+export const defaultEventListenerErrorHandler: EventListenerErrorHandler = (error) => {
+  console.error('Unhandled error in event listener', error);
+};
+
 export class EventTarget {
   private readonly listeners: Record<string, EventListener[]>;
+  private eventListenerErrorHandler: EventListenerErrorHandler;
 
   constructor() {
     this.listeners = {};
+    this.eventListenerErrorHandler = defaultEventListenerErrorHandler;
+  }
+
+  setEventListenerErrorHandler(callback: EventListenerErrorHandler): void {
+    this.eventListenerErrorHandler = callback;
   }
 
   addEventListener(type: string, callback: EventListener): void {
@@ -44,7 +56,11 @@ export class EventTarget {
   dispatchEvent(event: Event): boolean {
     const array = this.listeners[event.type];
     for (const listener of array ?? EMPTY) {
-      listener.call(this, event);
+      try {
+        listener.call(this, event);
+      } catch (err) {
+        this.eventListenerErrorHandler(err, event);
+      }
     }
     return !event.defaultPrevented;
   }
@@ -69,6 +85,10 @@ export class TypedEventTarget<TEvents extends Record<string, Event>> {
 
   dispatchEvent<TEventType extends keyof TEvents>(event: TEvents[TEventType]): void {
     this.emitter.dispatchEvent(event);
+  }
+
+  setEventListenerErrorHandler(callback: (error: unknown, event: TEvents[keyof TEvents]) => void): void {
+    this.emitter.setEventListenerErrorHandler(callback as EventListenerErrorHandler);
   }
 
   addEventListener<TEventType extends keyof TEvents>(

--- a/packages/core/src/eventtarget.ts
+++ b/packages/core/src/eventtarget.ts
@@ -14,23 +14,11 @@ export interface Event {
 
 export type EventListener = (e: Event) => void;
 
-export type EventListenerErrorHandler = (error: unknown, event: Event) => void;
-
-export const defaultEventListenerErrorHandler: EventListenerErrorHandler = (error, event) => {
-  console.error(`Unhandled error in "${event.type}" event listener`, error);
-};
-
 export class EventTarget {
   private readonly listeners: Record<string, EventListener[]>;
-  private eventListenerErrorHandler: EventListenerErrorHandler;
 
   constructor() {
     this.listeners = {};
-    this.eventListenerErrorHandler = defaultEventListenerErrorHandler;
-  }
-
-  setEventListenerErrorHandler(callback: EventListenerErrorHandler): void {
-    this.eventListenerErrorHandler = callback;
   }
 
   addEventListener(type: string, callback: EventListener): void {
@@ -59,7 +47,7 @@ export class EventTarget {
       try {
         listener.call(this, event);
       } catch (err) {
-        this.eventListenerErrorHandler(err, event);
+        console.error(`Unhandled error in "${event.type}" event listener`, err);
       }
     }
     return !event.defaultPrevented;
@@ -85,10 +73,6 @@ export class TypedEventTarget<TEvents extends Record<string, Event>> {
 
   dispatchEvent<TEventType extends keyof TEvents>(event: TEvents[TEventType]): void {
     this.emitter.dispatchEvent(event);
-  }
-
-  setEventListenerErrorHandler(callback: (error: unknown, event: TEvents[keyof TEvents]) => void): void {
-    this.emitter.setEventListenerErrorHandler(callback as EventListenerErrorHandler);
   }
 
   addEventListener<TEventType extends keyof TEvents>(


### PR DESCRIPTION
When an EventTarget listener throws an error, it should not prevent the EventTarget from invoking other listeners registered for the same event type.

In this commit we wrap event listener invocation with a `try/catch`, so that each listener is more isolated from failures in others.

Breaking change
---------------

Previously, errors in event listeners would be synchronously thrown; they will now be caught and logged to `console.error`. It is recommended that event listener authors wrap their listener code in a `try`/`catch` block and perform their own error handling. This allows the application to use its own context to take the most appropriate action in response to the exception.