### PR TITLE
Add toHaveStatus matcher

### DIFF
--- a/packages/server/src/test-matchers.test.ts
+++ b/packages/server/src/test-matchers.test.ts
@@ -64,3 +64,29 @@ describe('toEqualUnordered', () => {
     expect(() => expect({ arr: [3, 1, 2] }).toEqual({ arr: expect.not.toEqualUnordered([1, 2, 3]) })).toThrow();
   });
 });
+
+describe('toHaveStatus', () => {
+  test('passes when status matches', () => {
+    expect({ status: 200, body: {}, text: '' }).toHaveStatus(200);
+  });
+
+  test('fails with response body in message when status differs', () => {
+    expect(() =>
+      expect({ status: 400, body: { issue: [{ details: { text: 'Bad request' } }] }, text: '' }).toHaveStatus(200)
+    ).toThrow(/Expected status 200, received 400[\s\S]*Bad request/);
+  });
+
+  test('falls back to response text when body is not serializable', () => {
+    const body: Record<string, unknown> = {};
+    body.self = body;
+    expect(() => expect({ status: 500, body, text: 'raw text' }).toHaveStatus(200)).toThrow(/raw text/);
+  });
+
+  test('negated form passes when status differs', () => {
+    expect({ status: 404, body: {}, text: '' }).not.toHaveStatus(200);
+  });
+
+  test('negated form fails when status matches', () => {
+    expect(() => expect({ status: 200, body: {}, text: '' }).not.toHaveStatus(200)).toThrow(/not to be 200/);
+  });
+});

--- a/packages/server/src/test-matchers.ts
+++ b/packages/server/src/test-matchers.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { Response } from 'supertest';
 import { expect } from 'vitest';
 
 interface CustomMatchers<R = unknown> {
@@ -9,6 +10,12 @@ interface CustomMatchers<R = unknown> {
    * regardless of order. Supports asymmetric matchers in `expected`.
    */
   toEqualUnordered(expected: readonly unknown[]): R;
+
+  /**
+   * Passes when the supertest response has the expected HTTP status code.
+   * On failure, the message includes the response body.
+   */
+  toHaveStatus(expected: number): R;
 }
 
 declare module 'vitest' {
@@ -54,6 +61,26 @@ expect.extend({
       message: () =>
         `expected received array not to equal (unordered) ${utils.printExpected(expected)}\n\n` +
         `Received: ${utils.printReceived(received)}`,
+    };
+  },
+
+  toHaveStatus(received: Response, expected: number) {
+    const pass = received.status === expected;
+    if (pass) {
+      return {
+        pass: true,
+        message: () => `Expected status not to be ${expected}`,
+      };
+    }
+    let bodyStr: string;
+    try {
+      bodyStr = JSON.stringify(received.body, null, 2);
+    } catch {
+      bodyStr = received.text ?? '(empty)';
+    }
+    return {
+      pass: false,
+      message: () => `Expected status ${expected}, received ${received.status}\n\nResponse body:\n${bodyStr}`,
     };
   },
 });


### PR DESCRIPTION
We should start adopting this when checking response status so that the body of the response will be shown to help track down flaky tests.