### PR TITLE
Align patient matching docs with match operation

### DIFF
--- a/packages/docs/docs/fhir-datastore/patient-deduplication/matching.mdx
+++ b/packages/docs/docs/fhir-datastore/patient-deduplication/matching.mdx
@@ -5,15 +5,15 @@ sidebar_label: Matching
 
 import ExampleCode from '!!raw-loader!@site/..//examples/src/fhir-datastore/patient-deduplication/matching.ts';
 import MedplumCodeBlock from '@site/src/components/MedplumCodeBlock';
-import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
 
 # Matching {/* #matching-rules */}
 
 The best deduplication systems use a library of matching rules with different strengths and weaknesses. While the effectiveness of different patient matching rules will vary depending on the clinical context, here we suggest some rules to get you started.
 
-:::tip Built-in matching
-Medplum provides a built-in [Patient $match](/docs/api/fhir/operations/patient-match) operation that scores candidates using weighted demographics (identifier, phone, email, name, birth date, gender). It's a good starting point before building custom matching rules.
+:::tip[Built-in matching]
+Medplum provides a built-in [Patient $match](/docs/api/fhir/operations/patient-match) operation based on the **CMS Patient Matching framework**. Rather than an ad-hoc weighted heuristic, it compares a fixed set of identity factors (name, birth date, phone, email, SSN/ITIN, and identifiers) against approved attribute combinations. It's a good starting point before building custom matching rules.
 :::
 
 These have been trialed in previous deduplication projects, and are rated by their false positive rates (i.e. incorrect matches) and false negative rates (i.e. missed matches). Note that three matching identifiers is the standard.


### PR DESCRIPTION
The "Built-in matching" tip on the patient deduplication Matching (`packages/docs/docs/fhir-datastore/patient-deduplication/matching.mdx`) page described the Patient/$match operation in a way that contradicted its own technical reference (`packages/docs/docs/api/fhir/operations/patient-match.md`):

- It said matching used weighted demographics, but the operation is based on the CMS Patient Matching framework — the reference explicitly states it is not an ad-hoc weighted heuristic and the score is not a probability.
- It listed gender as a matching factor, but the reference explicitly notes gender is not used.

This updates the tip to describe the CMS-framework approach and the correct set of identity factors, so the two pages are consistent.

No behavior change — documentation only.

Before:

<img width="1009" height="392" alt="image" src="https://github.com/user-attachments/assets/bf3f1bb3-1754-4aa4-9b48-110b847e0986" />


After:

<img width="1016" height="414" alt="image" src="https://github.com/user-attachments/assets/1928b58b-d3f6-4881-8cde-f52753e155fd" />
