### PR TITLE
Gate Provider workflows on missing integration dependencies

### DIFF
--- a/examples/medplum-provider/src/components/ResourceFormWithRequiredProfile.test.tsx
+++ b/examples/medplum-provider/src/components/ResourceFormWithRequiredProfile.test.tsx
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { badRequest, OperationOutcomeError, serverError } from '@medplum/core';
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react';
+import type { JSX } from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { render, screen, waitFor } from '../test-utils/render';
+import { ResourceFormWithRequiredProfile } from './ResourceFormWithRequiredProfile';
+
+const MISSING = 'http://example.com/StructureDefinition/missing';
+const FLAKY = 'http://example.com/StructureDefinition/flaky';
+
+describe('ResourceFormWithRequiredProfile', () => {
+  let medplum: MockClient;
+
+  beforeEach(() => {
+    medplum = new MockClient();
+    vi.spyOn(medplum, 'requestProfileSchema').mockImplementation(async (profileUrl: string) => {
+      if (profileUrl === MISSING) {
+        // What a Medplum server actually returns for an uninstalled profile: `$expand-profile`
+        // reports it as a 400, not a 404.
+        throw new OperationOutcomeError(badRequest(`StructureDefinition profile with URL ${profileUrl} not found`));
+      }
+      throw new OperationOutcomeError(serverError(new Error('boom')));
+    });
+  });
+
+  function renderForm(profileUrl: string): JSX.Element {
+    return (
+      <MedplumProvider medplum={medplum}>
+        <ResourceFormWithRequiredProfile
+          defaultValue={{ resourceType: 'Patient' }}
+          onSubmit={vi.fn()}
+          profileUrl={profileUrl}
+          missingProfileMessage={<div>Profile is not installed</div>}
+        />
+      </MedplumProvider>
+    );
+  }
+
+  test('shows the missing-profile message for a profile the server does not have', async () => {
+    render(renderForm(MISSING));
+    expect(await screen.findByText('Profile is not installed')).toBeInTheDocument();
+  });
+
+  test('a missing-profile verdict does not stick when profileUrl changes', async () => {
+    const { rerender } = render(renderForm(MISSING));
+    expect(await screen.findByText('Profile is not installed')).toBeInTheDocument();
+
+    // Patient, ServiceRequest, and Device all have profiles and share the /:resourceType/new
+    // route, so the component instance is reused across them. The previous profile's verdict must
+    // not carry over to the next one.
+    rerender(renderForm(FLAKY));
+    await waitFor(() => {
+      expect(screen.getByText(/Server error/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Profile is not installed')).not.toBeInTheDocument();
+  });
+});

--- a/examples/medplum-provider/src/components/ResourceFormWithRequiredProfile.tsx
+++ b/examples/medplum-provider/src/components/ResourceFormWithRequiredProfile.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Alert } from '@mantine/core';
+import { Alert, Text } from '@mantine/core';
 import type { InternalTypeSchema } from '@medplum/core';
 import { addProfileToResource, normalizeErrorString, tryGetProfile } from '@medplum/core';
 import type { Resource } from '@medplum/fhirtypes';
@@ -64,16 +64,15 @@ export function ResourceFormWithRequiredProfile(props: ResourceFormWithRequiredP
   }
 
   if (profileUrl && !profile) {
-    const errorContent = (
-      <>
-        {missingProfileMessage && <p>{missingProfileMessage}</p>}
-        {profileError && <p>Server error: {normalizeErrorString(profileError)}</p>}
-      </>
-    );
-
+    // A caller-supplied message controls its own presentation and is rendered as-is. Callers that
+    // pass no message fall back to the raw server error in an alert (unchanged behavior for the edit
+    // pages). The technical error is also logged above for engineers.
+    if (missingProfileMessage) {
+      return <>{missingProfileMessage}</>;
+    }
     return (
       <Alert icon={<IconAlertCircle size={16} />} title="Not found" color="red">
-        {errorContent}
+        {profileError && <Text>Server error: {normalizeErrorString(profileError)}</Text>}
       </Alert>
     );
   }

--- a/examples/medplum-provider/src/components/ResourceFormWithRequiredProfile.tsx
+++ b/examples/medplum-provider/src/components/ResourceFormWithRequiredProfile.tsx
@@ -3,9 +3,9 @@
 import { Alert, Text } from '@mantine/core';
 import {
   addProfileToResource,
-  isNotFound,
+  getStatus,
   normalizeErrorString,
-  normalizeOperationOutcome,
+  OperationOutcomeError,
   tryGetProfile,
 } from '@medplum/core';
 import type { Resource } from '@medplum/fhirtypes';
@@ -22,40 +22,73 @@ interface ResourceFormWithRequiredProfileProps extends ResourceFormProps {
   readonly missingProfileMessage?: ReactNode;
 }
 
+type ProfileResult =
+  | { readonly status: 'loading' }
+  | { readonly status: 'ready' }
+  | { readonly status: 'missing' }
+  | { readonly status: 'error'; readonly error: unknown };
+
+const LOADING: ProfileResult = { status: 'loading' };
+
+/**
+ * Returns true if a failed profile schema request means the profile is absent rather than
+ * temporarily unreachable. `StructureDefinition/$expand-profile` reports an uninstalled profile as
+ * a 400, so both 400 and 404 count as missing. Anything else — a 5xx, or a bare `Error` from a
+ * network blip — is treated as transient and surfaced as a real error, so an admin is never
+ * steered toward installing a profile that is already present.
+ * @param reason - The error thrown by `requestProfileSchema`.
+ * @returns True when the profile is definitively absent.
+ */
+function isProfileMissingError(reason: unknown): boolean {
+  if (!(reason instanceof OperationOutcomeError)) {
+    return false;
+  }
+  const status = getStatus(reason.outcome);
+  return status === 400 || status === 404;
+}
+
 export function ResourceFormWithRequiredProfile(props: ResourceFormWithRequiredProfileProps): JSX.Element {
   const { missingProfileMessage, onSubmit, ...resourceFormProps } = props;
   const profileUrl = props.profileUrl;
 
   const medplum = useMedplum();
-  const [loadingProfile, setLoadingProfile] = useState(true);
-  const [profileError, setProfileError] = useState<unknown>();
-  const [profileMissing, setProfileMissing] = useState(false);
+  const [state, setState] = useState<{ profileUrl: string | undefined; result: ProfileResult }>({
+    profileUrl,
+    result: LOADING,
+  });
+  // A verdict only describes the profile it was fetched for, so a change of `profileUrl` puts us
+  // back into loading until the new probe settles.
+  const result = state.profileUrl === profileUrl ? state.result : LOADING;
 
   useEffect(() => {
     if (!profileUrl) {
-      return;
+      return undefined;
     }
 
+    let cancelled = false;
     medplum
       .requestProfileSchema(profileUrl, { expandProfile: true })
-      .finally(() => setLoadingProfile(false))
       .then(() => {
-        // The request succeeded but no such profile is installed in this project.
-        if (!tryGetProfile(profileUrl)) {
-          setProfileMissing(true);
+        if (!cancelled) {
+          // The request succeeded, but the profile may still not be installed in this project.
+          setState({ profileUrl, result: tryGetProfile(profileUrl) ? { status: 'ready' } : { status: 'missing' } });
         }
       })
       .catch((reason) => {
-        // Only a genuine "not found" means the profile is absent. Any other failure (500,
-        // timeout, network blip) is likely transient, so surface the real error instead of
-        // steering an admin toward installing a profile that may already be present.
-        if (isNotFound(normalizeOperationOutcome(reason))) {
-          setProfileMissing(true);
+        if (cancelled) {
+          return;
+        }
+        if (isProfileMissingError(reason)) {
+          setState({ profileUrl, result: { status: 'missing' } });
         } else {
           console.error(reason);
-          setProfileError(reason);
+          setState({ profileUrl, result: { status: 'error', error: reason } });
         }
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [medplum, profileUrl]);
 
   const handleSubmit = useCallback(
@@ -71,21 +104,21 @@ export function ResourceFormWithRequiredProfile(props: ResourceFormWithRequiredP
     [onSubmit, profileUrl]
   );
 
-  if (profileUrl && loadingProfile) {
+  if (profileUrl && result.status === 'loading') {
     return <Loading />;
   }
 
   // A failed profile request is surfaced as-is (it may be transient) rather than being mistaken
   // for a missing profile. The technical error is also logged above for engineers.
-  if (profileUrl && profileError) {
+  if (profileUrl && result.status === 'error') {
     return (
       <Alert icon={<IconAlertCircle size={16} />} title="Error loading profile" color="red">
-        <Text>Server error: {normalizeErrorString(profileError)}</Text>
+        <Text>Server error: {normalizeErrorString(result.error)}</Text>
       </Alert>
     );
   }
 
-  if (profileUrl && profileMissing) {
+  if (profileUrl && result.status === 'missing') {
     // A caller-supplied message controls its own presentation and is rendered as-is. Callers that
     // pass no message fall back to a generic notice (unchanged behavior for the edit pages).
     if (missingProfileMessage) {

--- a/examples/medplum-provider/src/components/ResourceFormWithRequiredProfile.tsx
+++ b/examples/medplum-provider/src/components/ResourceFormWithRequiredProfile.tsx
@@ -1,8 +1,13 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Alert, Text } from '@mantine/core';
-import type { InternalTypeSchema } from '@medplum/core';
-import { addProfileToResource, normalizeErrorString, tryGetProfile } from '@medplum/core';
+import {
+  addProfileToResource,
+  isNotFound,
+  normalizeErrorString,
+  normalizeOperationOutcome,
+  tryGetProfile,
+} from '@medplum/core';
 import type { Resource } from '@medplum/fhirtypes';
 import type { ResourceFormProps } from '@medplum/react';
 import { Loading, ResourceForm, useMedplum } from '@medplum/react';
@@ -23,8 +28,8 @@ export function ResourceFormWithRequiredProfile(props: ResourceFormWithRequiredP
 
   const medplum = useMedplum();
   const [loadingProfile, setLoadingProfile] = useState(true);
-  const [profileError, setProfileError] = useState<any>();
-  const [profile, setProfile] = useState<InternalTypeSchema>();
+  const [profileError, setProfileError] = useState<unknown>();
+  const [profileMissing, setProfileMissing] = useState(false);
 
   useEffect(() => {
     if (!profileUrl) {
@@ -35,14 +40,21 @@ export function ResourceFormWithRequiredProfile(props: ResourceFormWithRequiredP
       .requestProfileSchema(profileUrl, { expandProfile: true })
       .finally(() => setLoadingProfile(false))
       .then(() => {
-        const resourceProfile = tryGetProfile(profileUrl);
-        if (resourceProfile) {
-          setProfile(resourceProfile);
+        // The request succeeded but no such profile is installed in this project.
+        if (!tryGetProfile(profileUrl)) {
+          setProfileMissing(true);
         }
       })
       .catch((reason) => {
-        console.error(reason);
-        setProfileError(reason);
+        // Only a genuine "not found" means the profile is absent. Any other failure (500,
+        // timeout, network blip) is likely transient, so surface the real error instead of
+        // steering an admin toward installing a profile that may already be present.
+        if (isNotFound(normalizeOperationOutcome(reason))) {
+          setProfileMissing(true);
+        } else {
+          console.error(reason);
+          setProfileError(reason);
+        }
       });
   }, [medplum, profileUrl]);
 
@@ -63,16 +75,25 @@ export function ResourceFormWithRequiredProfile(props: ResourceFormWithRequiredP
     return <Loading />;
   }
 
-  if (profileUrl && !profile) {
+  // A failed profile request is surfaced as-is (it may be transient) rather than being mistaken
+  // for a missing profile. The technical error is also logged above for engineers.
+  if (profileUrl && profileError) {
+    return (
+      <Alert icon={<IconAlertCircle size={16} />} title="Error loading profile" color="red">
+        <Text>Server error: {normalizeErrorString(profileError)}</Text>
+      </Alert>
+    );
+  }
+
+  if (profileUrl && profileMissing) {
     // A caller-supplied message controls its own presentation and is rendered as-is. Callers that
-    // pass no message fall back to the raw server error in an alert (unchanged behavior for the edit
-    // pages). The technical error is also logged above for engineers.
+    // pass no message fall back to a generic notice (unchanged behavior for the edit pages).
     if (missingProfileMessage) {
       return <>{missingProfileMessage}</>;
     }
     return (
       <Alert icon={<IconAlertCircle size={16} />} title="Not found" color="red">
-        {profileError && <Text>Server error: {normalizeErrorString(profileError)}</Text>}
+        <Text>The required profile is not installed: {profileUrl}</Text>
       </Alert>
     );
   }

--- a/examples/medplum-provider/src/components/UnavailableNotice.tsx
+++ b/examples/medplum-provider/src/components/UnavailableNotice.tsx
@@ -1,29 +1,39 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Center, Paper, Stack, Title } from '@mantine/core';
+import { Center, Stack, Text, Title } from '@mantine/core';
 import type { JSX, ReactNode } from 'react';
 
 export interface UnavailableNoticeProps {
   /** Decorative icon shown above the title. Callers should mark it `aria-hidden`. */
   readonly icon: ReactNode;
-  readonly title: string;
-  readonly children: ReactNode;
+  readonly title: ReactNode;
+  /** Dimmed prose shown under the title. */
+  readonly description?: ReactNode;
+  /** Anything that follows the description — what is missing, where to go next. */
+  readonly children?: ReactNode;
 }
 
-// Shared presentational card explaining, in a role-aware way, why a workflow or page is
+// Shared presentational notice explaining, in a role-aware way, why a workflow or page is
 // unavailable (a missing integration, an uninstalled profile, etc.). Centralizing the shell keeps
 // these notices visually consistent instead of relying on hand-synced copies.
+//
+// The props and slot order deliberately mirror Mantine's `EmptyState` (icon, title, description,
+// then children; no card container of its own) so that this collapses into that component when we
+// move to Mantine >= 9.4.
 export function UnavailableNotice(props: UnavailableNoticeProps): JSX.Element {
-  const { icon, title, children } = props;
+  const { icon, title, description, children } = props;
   return (
     <Center p="xl">
-      <Paper shadow="md" p="xl" radius="md" withBorder maw={480}>
-        <Stack align="center" gap="sm" ta="center">
-          {icon}
-          <Title order={3}>{title}</Title>
-          {children}
-        </Stack>
-      </Paper>
+      <Stack align="center" gap="sm" ta="center" maw={480}>
+        {icon}
+        <Title order={3}>{title}</Title>
+        {description && (
+          <Text size="sm" c="dimmed">
+            {description}
+          </Text>
+        )}
+        {children}
+      </Stack>
     </Center>
   );
 }

--- a/examples/medplum-provider/src/components/UnavailableNotice.tsx
+++ b/examples/medplum-provider/src/components/UnavailableNotice.tsx
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Center, Paper, Stack, Title } from '@mantine/core';
+import type { JSX, ReactNode } from 'react';
+
+export interface UnavailableNoticeProps {
+  /** Decorative icon shown above the title. Callers should mark it `aria-hidden`. */
+  readonly icon: ReactNode;
+  readonly title: string;
+  readonly children: ReactNode;
+}
+
+// Shared presentational card explaining, in a role-aware way, why a workflow or page is
+// unavailable (a missing integration, an uninstalled profile, etc.). Centralizing the shell keeps
+// these notices visually consistent instead of relying on hand-synced copies.
+export function UnavailableNotice(props: UnavailableNoticeProps): JSX.Element {
+  const { icon, title, children } = props;
+  return (
+    <Center p="xl">
+      <Paper shadow="md" p="xl" radius="md" withBorder maw={480}>
+        <Stack align="center" gap="sm" ta="center">
+          {icon}
+          <Title order={3}>{title}</Title>
+          {children}
+        </Stack>
+      </Paper>
+    </Center>
+  );
+}

--- a/examples/medplum-provider/src/components/encounter/EncounterCoverageEligibilityModal.test.tsx
+++ b/examples/medplum-provider/src/components/encounter/EncounterCoverageEligibilityModal.test.tsx
@@ -308,10 +308,13 @@ describe('EncounterCoverageEligibilityModal', () => {
       });
       await user.click(screen.getByText('Plan Benefits'));
       await waitFor(() => {
-        expect(
-          screen.getByText('No eligibility check found. Contact support to enable eligibility checks.')
-        ).toBeInTheDocument();
+        expect(screen.getByText(/Contact support to enable eligibility checks/)).toBeInTheDocument();
       });
+      // The upsell links to the Stedi eligibility docs
+      expect(screen.getByText('learn about insurance eligibility')).toHaveAttribute(
+        'href',
+        'https://www.medplum.com/docs/integration/stedi/insurance-eligibility/eligibility-checks'
+      );
     });
 
     test('shows prompt to check eligibility when bot exists but no prior response', async () => {

--- a/examples/medplum-provider/src/components/encounter/EncounterCoverageEligibilityModal.tsx
+++ b/examples/medplum-provider/src/components/encounter/EncounterCoverageEligibilityModal.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import {
+  Anchor,
   Badge,
   Box,
   Button,
@@ -265,9 +266,21 @@ function CoverageCard(props: CoverageCardProps): JSX.Element {
           <Box pt="md">
             {!benefitsLoading && !eligibilityResponse && (
               <Text size="sm" c="dimmed">
-                {eligibilityBot
-                  ? 'No eligibility check found. Click "Check Eligibility" to run a check.'
-                  : 'No eligibility check found. Contact support to enable eligibility checks.'}
+                {eligibilityBot ? (
+                  'No eligibility check found. Click "Check Eligibility" to run a check.'
+                ) : (
+                  <>
+                    No eligibility check found. Contact support to enable eligibility checks, or{' '}
+                    <Anchor
+                      href="https://www.medplum.com/docs/integration/stedi/insurance-eligibility/eligibility-checks"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      learn about insurance eligibility
+                    </Anchor>
+                    .
+                  </>
+                )}
               </Text>
             )}
             {!benefitsLoading && eligibilityResponse?.outcome === 'error' && (

--- a/examples/medplum-provider/src/components/encounter/EncounterCoverageEligibilityModal.tsx
+++ b/examples/medplum-provider/src/components/encounter/EncounterCoverageEligibilityModal.tsx
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import {
-  Anchor,
   Badge,
   Box,
   Button,
@@ -36,6 +35,7 @@ import type { JSX } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { isSelfPayCoverage } from '../../utils/coverage';
 import { showErrorNotification } from '../../utils/notifications';
+import { DocsLink } from '../DocsLink';
 import { BenefitsTable } from '../insurance/BenefitsTable';
 
 interface EncounterCoverageEligibilityModalProps {
@@ -271,13 +271,9 @@ function CoverageCard(props: CoverageCardProps): JSX.Element {
                 ) : (
                   <>
                     No eligibility check found. Contact support to enable eligibility checks, or{' '}
-                    <Anchor
-                      href="https://www.medplum.com/docs/integration/stedi/insurance-eligibility/eligibility-checks"
-                      target="_blank"
-                      rel="noreferrer"
-                    >
+                    <DocsLink path="integration/stedi/insurance-eligibility/eligibility-checks">
                       learn about insurance eligibility
-                    </Anchor>
+                    </DocsLink>
                     .
                   </>
                 )}

--- a/examples/medplum-provider/src/components/tasks/encounter/TaskServiceRequest.test.tsx
+++ b/examples/medplum-provider/src/components/tasks/encounter/TaskServiceRequest.test.tsx
@@ -5,6 +5,7 @@ import type { DiagnosticReport, ServiceRequest, Task } from '@medplum/fhirtypes'
 import { useHealthGorillaLabOrder } from '@medplum/health-gorilla-react';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
+import type { ReactNode } from 'react';
 import { useParams } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '../../../test-utils/render';
@@ -17,6 +18,12 @@ vi.mock('@medplum/health-gorilla-react', async () => {
     useHealthGorillaLabOrder: vi.fn(),
   };
 });
+
+// The Order Labs workflow gate is exercised in WorkflowGate.test.tsx; here we render the form
+// directly so these tests aren't coupled to dependency-probe timing.
+vi.mock('../../../workflow/WorkflowGate', () => ({
+  WorkflowGate: ({ children }: { children: ReactNode }) => children,
+}));
 
 vi.mock('react-router', async () => {
   const actual = await vi.importActual('react-router');

--- a/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
+++ b/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
@@ -40,6 +40,7 @@ import orderSetBundleData from '../../data/order-set-example-bundle.json';
 import patientBundleData from '../../data/patient-david-james-williams.json';
 import visitBundleData from '../../data/simple-initial-visit-bundle.json';
 import { showErrorNotification } from '../../utils/notifications';
+import { WorkflowDependenciesPanel } from '../../workflow/WorkflowDependenciesPanel';
 import classes from './GetStartedPage.module.css';
 import { buildOrderSetImportNotification } from './orderSetImportNotification';
 
@@ -157,33 +158,38 @@ export function GetStartedPage(): JSX.Element {
   return (
     <Box className={classes.page} py="6rem">
       <Container size="md" className={classes.container}>
-        {/* Header */}
-        <Box mb="6rem">
-          <Title order={2} fw={800}>
-            Get Started with Medplum Provider
-          </Title>
-          <Text size="lg" mt=".25rem" className={classes.textSecondary}>
-            Below are our recommended first steps to get set up and familiar with the available features and workflows
-            in Provider. Please note: if you are using the free version of Provider, some services may not be
-            available—lab ordering, prescriptions, billing, and access to code systems (such as CPT and ICD-10) require
-            a paid plan.{' '}
-            <Text
-              component="a"
-              href="https://www.medplum.com/pricing"
-              target="_blank"
-              c="blue.6"
-              className={classes.link}
-              span
-            >
-              Subscribe
-            </Text>{' '}
-            or{' '}
-            <Text component="a" href="mailto:support@medplum.com" c="blue.6" className={classes.link} span>
-              contact us
-            </Text>{' '}
-            to integrate these services.
-          </Text>
-        </Box>
+        {/* Header, with the admin-only missing-dependencies banner above it. The banner lives in a
+            tight group so it never inherits the 6rem section rhythm; when it renders null (non-admin
+            or nothing missing) the Stack gap simply collapses, leaving the header spacing unchanged. */}
+        <Stack gap="2.5rem" mb="6rem">
+          <WorkflowDependenciesPanel />
+          <Box>
+            <Title order={2} fw={800}>
+              Get Started with Medplum Provider
+            </Title>
+            <Text size="lg" mt=".25rem" className={classes.textSecondary}>
+              Below are our recommended first steps to get set up and familiar with the available features and workflows
+              in Provider. Please note: if you are using the free version of Provider, some services may not be
+              available—lab ordering, prescriptions, billing, and access to code systems (such as CPT and ICD-10)
+              require a paid plan.{' '}
+              <Text
+                component="a"
+                href="https://www.medplum.com/pricing"
+                target="_blank"
+                c="blue.6"
+                className={classes.link}
+                span
+              >
+                Subscribe
+              </Text>{' '}
+              or{' '}
+              <Text component="a" href="mailto:support@medplum.com" c="blue.6" className={classes.link} span>
+                contact us
+              </Text>{' '}
+              to integrate these services.
+            </Text>
+          </Box>
+        </Stack>
 
         <Stack gap="6rem">
           {/* Sample Data */}

--- a/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
+++ b/examples/medplum-provider/src/pages/getstarted/GetStartedPage.tsx
@@ -158,9 +158,6 @@ export function GetStartedPage(): JSX.Element {
   return (
     <Box className={classes.page} py="6rem">
       <Container size="md" className={classes.container}>
-        {/* Header, with the admin-only missing-dependencies banner above it. The banner lives in a
-            tight group so it never inherits the 6rem section rhythm; when it renders null (non-admin
-            or nothing missing) the Stack gap simply collapses, leaving the header spacing unchanged. */}
         <Stack gap="2.5rem" mb="6rem">
           <WorkflowDependenciesPanel />
           <Box>

--- a/examples/medplum-provider/src/pages/labs/OrderLabsPage.test.tsx
+++ b/examples/medplum-provider/src/pages/labs/OrderLabsPage.test.tsx
@@ -5,6 +5,7 @@ import type { Patient, ServiceRequest } from '@medplum/fhirtypes';
 import type { LabOrganization, TestCoding } from '@medplum/health-gorilla-core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
+import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '../../test-utils/render';
 import * as notifications from '../../utils/notifications';
@@ -32,6 +33,12 @@ vi.mock('@mantine/notifications', () => ({
 
 vi.mock('../../utils/notifications', () => ({
   showErrorNotification: vi.fn(),
+}));
+
+// The workflow gate is exercised in WorkflowGate.test.tsx; here we render the form directly so these
+// tests aren't coupled to dependency-probe timing.
+vi.mock('../../workflow/WorkflowGate', () => ({
+  WorkflowGate: ({ children }: { children: ReactNode }) => children,
 }));
 
 import { useHealthGorillaLabOrder } from '@medplum/health-gorilla-react';

--- a/examples/medplum-provider/src/pages/labs/OrderLabsPage.tsx
+++ b/examples/medplum-provider/src/pages/labs/OrderLabsPage.tsx
@@ -40,6 +40,7 @@ import { PerformingLabInput } from '../../components/PerformingLabInput';
 import { CoverageInput } from '../../components/labs/CoverageInput';
 import { TestMetadataCardInput } from '../../components/labs/TestMetadataCardInput';
 import { showErrorNotification } from '../../utils/notifications';
+import { WorkflowGate } from '../../workflow/WorkflowGate';
 
 async function sendLabOrderToHealthGorilla(medplum: MedplumClient, labOrder: ServiceRequest): Promise<void> {
   return medplum.executeBot(
@@ -62,6 +63,14 @@ export interface OrderLabsPageProps {
 }
 
 export function OrderLabsPage(props: OrderLabsPageProps): JSX.Element {
+  return (
+    <WorkflowGate workflow="order-labs">
+      <OrderLabsPageContent {...props} />
+    </WorkflowGate>
+  );
+}
+
+function OrderLabsPageContent(props: OrderLabsPageProps): JSX.Element {
   const { patient: defaultPatient, encounter, task, tests, performingLab, onSubmitLabOrder } = props;
   const medplum = useMedplum();
   const { patientId } = useParams();

--- a/examples/medplum-provider/src/pages/labs/OrderLabsPage.tsx
+++ b/examples/medplum-provider/src/pages/labs/OrderLabsPage.tsx
@@ -36,9 +36,9 @@ import {
 import type { JSX } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router';
-import { PerformingLabInput } from '../../components/PerformingLabInput';
 import { CoverageInput } from '../../components/labs/CoverageInput';
 import { TestMetadataCardInput } from '../../components/labs/TestMetadataCardInput';
+import { PerformingLabInput } from '../../components/PerformingLabInput';
 import { showErrorNotification } from '../../utils/notifications';
 import { WORKFLOWS } from '../../workflow/dependencies';
 import { WorkflowGate } from '../../workflow/WorkflowGate';

--- a/examples/medplum-provider/src/pages/labs/OrderLabsPage.tsx
+++ b/examples/medplum-provider/src/pages/labs/OrderLabsPage.tsx
@@ -40,6 +40,7 @@ import { PerformingLabInput } from '../../components/PerformingLabInput';
 import { CoverageInput } from '../../components/labs/CoverageInput';
 import { TestMetadataCardInput } from '../../components/labs/TestMetadataCardInput';
 import { showErrorNotification } from '../../utils/notifications';
+import { WORKFLOWS } from '../../workflow/dependencies';
 import { WorkflowGate } from '../../workflow/WorkflowGate';
 
 async function sendLabOrderToHealthGorilla(medplum: MedplumClient, labOrder: ServiceRequest): Promise<void> {
@@ -64,7 +65,7 @@ export interface OrderLabsPageProps {
 
 export function OrderLabsPage(props: OrderLabsPageProps): JSX.Element {
   return (
-    <WorkflowGate workflow="order-labs">
+    <WorkflowGate workflow={WORKFLOWS['order-labs']}>
       <OrderLabsPageContent {...props} />
     </WorkflowGate>
   );

--- a/examples/medplum-provider/src/pages/patient/LabsPage.test.tsx
+++ b/examples/medplum-provider/src/pages/patient/LabsPage.test.tsx
@@ -18,6 +18,17 @@ describe('LabsPage', () => {
   beforeEach(async () => {
     medplum = new MockClient();
     vi.clearAllMocks();
+    // Lab ordering is gated on the Health Gorilla bot; make it present so the order flow is enabled.
+    await medplum.createResource({
+      resourceType: 'Bot',
+      name: 'Health Gorilla',
+      identifier: [
+        {
+          system: 'https://www.medplum.com/integrations/bot-identifier',
+          value: 'health-gorilla-labs/send-to-health-gorilla',
+        },
+      ],
+    });
   });
 
   // The page issues two searches (ServiceRequest for the Open tab, DiagnosticReport

--- a/examples/medplum-provider/src/pages/patient/PatientPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/PatientPage.tsx
@@ -43,7 +43,7 @@ export function PatientPage(): JSX.Element {
 
   const handleCloseLabsModal = useCallback(() => {
     setIsLabsModalOpen(false);
-  }, []);
+  }, [setIsLabsModalOpen]);
 
   const sections = useMemo(
     () =>

--- a/examples/medplum-provider/src/pages/resource/ResourceCreatePage.test.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceCreatePage.test.tsx
@@ -145,6 +145,45 @@ describe('ResourceCreatePage', () => {
     );
   });
 
+  test('Shows friendly admin guidance when a required profile is missing', async () => {
+    vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(true);
+    // The US Core Patient profile is not installed, so the schema request rejects.
+    vi.spyOn(medplum, 'requestProfileSchema').mockRejectedValue(
+      new Error(
+        'StructureDefinition profile with URL http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient not found'
+      )
+    );
+
+    await setup('/Patient/new');
+
+    await waitFor(() => {
+      expect(screen.getByText(/Creating a Patient requires/i)).toBeInTheDocument();
+    });
+
+    // Admins see the specific profile URL and a docs link...
+    expect(screen.getByText('http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /profiles documentation/i })).toBeInTheDocument();
+    // ...and the raw server-error string is no longer shown.
+    expect(screen.queryByText(/Server error:/i)).not.toBeInTheDocument();
+  });
+
+  test('Directs non-admins to an administrator when a required profile is missing', async () => {
+    vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(false);
+    vi.spyOn(medplum, 'requestProfileSchema').mockRejectedValue(new Error('us-core-patient not found'));
+
+    await setup('/Patient/new');
+
+    await waitFor(() => {
+      expect(screen.getByText(/Contact your administrator/i)).toBeInTheDocument();
+    });
+
+    // The specific profile URL is only shown to admins.
+    expect(
+      screen.queryByText('http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Server error:/i)).not.toBeInTheDocument();
+  });
+
   test('Handles form submission error', async () => {
     const user = userEvent.setup();
     await setup('/Practitioner/new');

--- a/examples/medplum-provider/src/pages/resource/ResourceCreatePage.test.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceCreatePage.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
-import { notFound } from '@medplum/core';
+import { badRequest, notFound, OperationOutcomeError, serverError } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, render, screen, waitFor } from '@testing-library/react';
@@ -11,6 +11,14 @@ import * as reactRouter from 'react-router';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { ResourceCreatePage } from './ResourceCreatePage';
+
+const US_CORE_PATIENT = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient';
+
+// What a Medplum server actually returns when the profile is not installed: `$expand-profile`
+// reports it as a 400, not a 404.
+const profileNotInstalled = new OperationOutcomeError(
+  badRequest(`StructureDefinition profile with URL ${US_CORE_PATIENT} not found`)
+);
 
 describe('ResourceCreatePage', () => {
   let medplum: MockClient;
@@ -148,8 +156,7 @@ describe('ResourceCreatePage', () => {
 
   test('Shows friendly admin guidance when a required profile is missing', async () => {
     vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(true);
-    // The US Core Patient profile is not installed, so the schema request rejects as "not found".
-    vi.spyOn(medplum, 'requestProfileSchema').mockRejectedValue(notFound);
+    vi.spyOn(medplum, 'requestProfileSchema').mockRejectedValue(profileNotInstalled);
 
     await setup('/Patient/new');
 
@@ -158,7 +165,7 @@ describe('ResourceCreatePage', () => {
     });
 
     // Admins see the specific profile URL and a docs link...
-    expect(screen.getByText('http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient')).toBeInTheDocument();
+    expect(screen.getByText(US_CORE_PATIENT)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /profiles documentation/i })).toBeInTheDocument();
     // ...and the raw server-error string is no longer shown.
     expect(screen.queryByText(/Server error:/i)).not.toBeInTheDocument();
@@ -166,7 +173,7 @@ describe('ResourceCreatePage', () => {
 
   test('Directs non-admins to an administrator when a required profile is missing', async () => {
     vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(false);
-    vi.spyOn(medplum, 'requestProfileSchema').mockRejectedValue(notFound);
+    vi.spyOn(medplum, 'requestProfileSchema').mockRejectedValue(profileNotInstalled);
 
     await setup('/Patient/new');
 
@@ -175,16 +182,26 @@ describe('ResourceCreatePage', () => {
     });
 
     // The specific profile URL is only shown to admins.
-    expect(
-      screen.queryByText('http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(US_CORE_PATIENT)).not.toBeInTheDocument();
     expect(screen.queryByText(/Server error:/i)).not.toBeInTheDocument();
   });
 
-  test('Surfaces the real error on a transient profile-load failure instead of missing-profile guidance', async () => {
+  test('Treats a 404 as a missing profile too', async () => {
     vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(true);
-    // A transient failure (e.g. a 500 or network blip) is NOT a missing profile.
-    vi.spyOn(medplum, 'requestProfileSchema').mockRejectedValue(new Error('Internal server error'));
+    vi.spyOn(medplum, 'requestProfileSchema').mockRejectedValue(new OperationOutcomeError(notFound));
+
+    await setup('/Patient/new');
+
+    await waitFor(() => {
+      expect(screen.getByText(/Creating a Patient requires/i)).toBeInTheDocument();
+    });
+  });
+
+  test('Surfaces the real error on a 5xx instead of missing-profile guidance', async () => {
+    vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(true);
+    vi.spyOn(medplum, 'requestProfileSchema').mockRejectedValue(
+      new OperationOutcomeError(serverError(new Error('Internal server error')))
+    );
 
     await setup('/Patient/new');
 
@@ -194,6 +211,20 @@ describe('ResourceCreatePage', () => {
     });
 
     // ...and the admin is not misdirected to install a profile that may already be present.
+    expect(screen.queryByText(/Creating a Patient requires/i)).not.toBeInTheDocument();
+  });
+
+  test('Surfaces the real error on a network failure instead of missing-profile guidance', async () => {
+    vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(true);
+    // A bare Error (fetch failure, timeout) says nothing about whether the profile exists.
+    vi.spyOn(medplum, 'requestProfileSchema').mockRejectedValue(new Error('Failed to fetch'));
+
+    await setup('/Patient/new');
+
+    await waitFor(() => {
+      expect(screen.getByText(/Server error: Failed to fetch/i)).toBeInTheDocument();
+    });
+
     expect(screen.queryByText(/Creating a Patient requires/i)).not.toBeInTheDocument();
   });
 

--- a/examples/medplum-provider/src/pages/resource/ResourceCreatePage.test.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceCreatePage.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
+import { notFound } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, render, screen, waitFor } from '@testing-library/react';
@@ -147,12 +148,8 @@ describe('ResourceCreatePage', () => {
 
   test('Shows friendly admin guidance when a required profile is missing', async () => {
     vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(true);
-    // The US Core Patient profile is not installed, so the schema request rejects.
-    vi.spyOn(medplum, 'requestProfileSchema').mockRejectedValue(
-      new Error(
-        'StructureDefinition profile with URL http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient not found'
-      )
-    );
+    // The US Core Patient profile is not installed, so the schema request rejects as "not found".
+    vi.spyOn(medplum, 'requestProfileSchema').mockRejectedValue(notFound);
 
     await setup('/Patient/new');
 
@@ -169,7 +166,7 @@ describe('ResourceCreatePage', () => {
 
   test('Directs non-admins to an administrator when a required profile is missing', async () => {
     vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(false);
-    vi.spyOn(medplum, 'requestProfileSchema').mockRejectedValue(new Error('us-core-patient not found'));
+    vi.spyOn(medplum, 'requestProfileSchema').mockRejectedValue(notFound);
 
     await setup('/Patient/new');
 
@@ -182,6 +179,22 @@ describe('ResourceCreatePage', () => {
       screen.queryByText('http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient')
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/Server error:/i)).not.toBeInTheDocument();
+  });
+
+  test('Surfaces the real error on a transient profile-load failure instead of missing-profile guidance', async () => {
+    vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(true);
+    // A transient failure (e.g. a 500 or network blip) is NOT a missing profile.
+    vi.spyOn(medplum, 'requestProfileSchema').mockRejectedValue(new Error('Internal server error'));
+
+    await setup('/Patient/new');
+
+    // The real error is surfaced...
+    await waitFor(() => {
+      expect(screen.getByText(/Server error: Internal server error/i)).toBeInTheDocument();
+    });
+
+    // ...and the admin is not misdirected to install a profile that may already be present.
+    expect(screen.queryByText(/Creating a Patient requires/i)).not.toBeInTheDocument();
   });
 
   test('Handles form submission error', async () => {

--- a/examples/medplum-provider/src/pages/resource/ResourceCreatePage.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceCreatePage.tsx
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Stack, Text } from '@mantine/core';
+import { Anchor, Center, Code, List, Paper, Stack, Text, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { createReference, normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
 import type { OperationOutcome, Patient, Resource, ResourceType } from '@medplum/fhirtypes';
 import { Document, Loading, useMedplum } from '@medplum/react';
+import { IconFileAlert } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
@@ -101,6 +102,40 @@ export function ResourceCreatePage(): JSX.Element {
     return <Loading />;
   }
 
+  const missingProfileMessage = profileUrl && (
+    <Center p="xl">
+      <Paper shadow="md" p="xl" radius="md" withBorder maw={480}>
+        <Stack align="center" gap="sm" ta="center">
+          <IconFileAlert size={48} color="var(--mantine-color-gray-5)" />
+          <Title order={3}>{resourceType} creation is unavailable</Title>
+          {medplum.isProjectAdmin() ? (
+            <>
+              <Text size="sm" c="dimmed">
+                Creating a {resourceType} requires a FHIR profile that is not installed in this project:
+              </Text>
+              <List spacing={4} size="sm" withPadding>
+                <List.Item>
+                  <Code>{profileUrl}</Code>
+                </List.Item>
+              </List>
+              <Text size="sm" c="dimmed">
+                Import the profile’s StructureDefinition (e.g. the US Core profiles) to enable it. See{' '}
+                <Anchor href="https://www.medplum.com/docs/fhir-datastore/profiles" target="_blank" rel="noreferrer">
+                  the profiles documentation
+                </Anchor>
+                .
+              </Text>
+            </>
+          ) : (
+            <Text size="sm" c="dimmed">
+              {resourceType} creation is not set up yet. Contact your administrator to enable it.
+            </Text>
+          )}
+        </Stack>
+      </Paper>
+    </Center>
+  );
+
   return (
     <Document shadow="xs">
       <Stack>
@@ -110,6 +145,7 @@ export function ResourceCreatePage(): JSX.Element {
           onSubmit={handleSubmit}
           outcome={outcome}
           profileUrl={profileUrl}
+          missingProfileMessage={missingProfileMessage}
         />
       </Stack>
     </Document>

--- a/examples/medplum-provider/src/pages/resource/ResourceCreatePage.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceCreatePage.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Anchor, Center, Code, List, Paper, Stack, Text, Title } from '@mantine/core';
+import { Anchor, Code, List, Stack, Text } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { createReference, normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
 import type { OperationOutcome, Patient, Resource, ResourceType } from '@medplum/fhirtypes';
@@ -10,6 +10,7 @@ import type { JSX } from 'react';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { ResourceFormWithRequiredProfile } from '../../components/ResourceFormWithRequiredProfile';
+import { UnavailableNotice } from '../../components/UnavailableNotice';
 import { usePatient } from '../../hooks/usePatient';
 import { prependPatientPath } from '../patient/PatientPage.utils';
 import { RESOURCE_PROFILE_URLS } from './utils';
@@ -103,37 +104,34 @@ export function ResourceCreatePage(): JSX.Element {
   }
 
   const missingProfileMessage = profileUrl && (
-    <Center p="xl">
-      <Paper shadow="md" p="xl" radius="md" withBorder maw={480}>
-        <Stack align="center" gap="sm" ta="center">
-          <IconFileAlert size={48} color="var(--mantine-color-gray-5)" />
-          <Title order={3}>{resourceType} creation is unavailable</Title>
-          {medplum.isProjectAdmin() ? (
-            <>
-              <Text size="sm" c="dimmed">
-                Creating a {resourceType} requires a FHIR profile that is not installed in this project:
-              </Text>
-              <List spacing={4} size="sm" withPadding>
-                <List.Item>
-                  <Code>{profileUrl}</Code>
-                </List.Item>
-              </List>
-              <Text size="sm" c="dimmed">
-                Import the profile’s StructureDefinition (e.g. the US Core profiles) to enable it. See{' '}
-                <Anchor href="https://www.medplum.com/docs/fhir-datastore/profiles" target="_blank" rel="noreferrer">
-                  the profiles documentation
-                </Anchor>
-                .
-              </Text>
-            </>
-          ) : (
-            <Text size="sm" c="dimmed">
-              {resourceType} creation is not set up yet. Contact your administrator to enable it.
-            </Text>
-          )}
-        </Stack>
-      </Paper>
-    </Center>
+    <UnavailableNotice
+      icon={<IconFileAlert size={48} color="var(--mantine-color-gray-5)" aria-hidden />}
+      title={`${resourceType} creation is unavailable`}
+    >
+      {medplum.isProjectAdmin() ? (
+        <>
+          <Text size="sm" c="dimmed">
+            Creating a {resourceType} requires a FHIR profile that is not installed in this project:
+          </Text>
+          <List spacing={4} size="sm" withPadding>
+            <List.Item>
+              <Code>{profileUrl}</Code>
+            </List.Item>
+          </List>
+          <Text size="sm" c="dimmed">
+            Import the profile’s StructureDefinition (e.g. the US Core profiles) to enable it. See{' '}
+            <Anchor href="https://www.medplum.com/docs/fhir-datastore/profiles" target="_blank" rel="noreferrer">
+              the profiles documentation
+            </Anchor>
+            .
+          </Text>
+        </>
+      ) : (
+        <Text size="sm" c="dimmed">
+          {resourceType} creation is not set up yet. Contact your administrator to enable it.
+        </Text>
+      )}
+    </UnavailableNotice>
   );
 
   return (

--- a/examples/medplum-provider/src/pages/resource/ResourceCreatePage.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceCreatePage.tsx
@@ -103,16 +103,19 @@ export function ResourceCreatePage(): JSX.Element {
     return <Loading />;
   }
 
+  const isProjectAdmin = medplum.isProjectAdmin();
   const missingProfileMessage = profileUrl && (
     <UnavailableNotice
       icon={<IconFileAlert size={48} color="var(--mantine-color-gray-5)" aria-hidden />}
       title={`${resourceType} creation is unavailable`}
+      description={
+        isProjectAdmin
+          ? `Creating a ${resourceType} requires a FHIR profile that is not installed in this project:`
+          : `${resourceType} creation is not set up yet. Contact your administrator to enable it.`
+      }
     >
-      {medplum.isProjectAdmin() ? (
+      {isProjectAdmin && (
         <>
-          <Text size="sm" c="dimmed">
-            Creating a {resourceType} requires a FHIR profile that is not installed in this project:
-          </Text>
           <List spacing={4} size="sm" withPadding>
             <List.Item>
               <Code>{profileUrl}</Code>
@@ -126,10 +129,6 @@ export function ResourceCreatePage(): JSX.Element {
             .
           </Text>
         </>
-      ) : (
-        <Text size="sm" c="dimmed">
-          {resourceType} creation is not set up yet. Contact your administrator to enable it.
-        </Text>
       )}
     </UnavailableNotice>
   );

--- a/examples/medplum-provider/src/workflow/WorkflowDependenciesPanel.test.tsx
+++ b/examples/medplum-provider/src/workflow/WorkflowDependenciesPanel.test.tsx
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import type { Bot } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react';
+import { cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { render, screen, waitFor } from '../test-utils/render';
+import { WorkflowDependenciesPanel } from './WorkflowDependenciesPanel';
+
+const ANY_BOT: WithId<Bot> = { resourceType: 'Bot', id: 'bot' };
+
+describe('WorkflowDependenciesPanel', () => {
+  let medplum: MockClient;
+
+  beforeEach(() => {
+    medplum = new MockClient();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  function renderPanel(): void {
+    render(
+      <MedplumProvider medplum={medplum}>
+        <WorkflowDependenciesPanel />
+      </MedplumProvider>
+    );
+  }
+
+  test('renders nothing for non-admins', async () => {
+    vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(false);
+    const searchOne = vi.spyOn(medplum, 'searchOne').mockResolvedValue(undefined);
+    renderPanel();
+    expect(screen.queryByText('Missing project dependencies')).not.toBeInTheDocument();
+    // The panel short-circuits before probing for non-admins
+    expect(searchOne).not.toHaveBeenCalled();
+  });
+
+  test('lists blocked workflows for admins when dependencies are missing', async () => {
+    vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(true);
+    vi.spyOn(medplum, 'searchOne').mockResolvedValue(undefined);
+    renderPanel();
+    expect(await screen.findByText('Missing project dependencies')).toBeInTheDocument();
+    expect(screen.getByText('Order Labs')).toBeInTheDocument();
+    expect(screen.getByText('Health Gorilla lab ordering')).toBeInTheDocument();
+  });
+
+  test('renders nothing for admins when all dependencies are present', async () => {
+    vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(true);
+    const searchOne = vi.spyOn(medplum, 'searchOne').mockResolvedValue(ANY_BOT);
+    renderPanel();
+    // One gated workflow (Order Labs), one dependency
+    await waitFor(() => expect(searchOne).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText('Missing project dependencies')).not.toBeInTheDocument();
+  });
+});

--- a/examples/medplum-provider/src/workflow/WorkflowDependenciesPanel.tsx
+++ b/examples/medplum-provider/src/workflow/WorkflowDependenciesPanel.tsx
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Alert, Anchor, List, Stack, Text } from '@mantine/core';
+import { useMedplum } from '@medplum/react';
+import { IconPlugConnectedX } from '@tabler/icons-react';
+import type { JSX } from 'react';
+import { useMissingWorkflowDependencies } from './useWorkflowAvailability';
+
+// Admin-only summary of missing project dependencies across all gated workflows. Rendered on the
+// Get Started page so administrators can see and fix missing shared-project links up front, rather
+// than discovering them one blocked workflow at a time. See issue #9824.
+// Returns null for non-admin users (who instead see per-workflow guidance when they hit a gate)
+// and while probing, so it never flashes an empty card.
+export function WorkflowDependenciesPanel(): JSX.Element | null {
+  const medplum = useMedplum();
+  const isAdmin = medplum.isProjectAdmin();
+  const { loading, blockedWorkflows } = useMissingWorkflowDependencies({ enabled: isAdmin });
+
+  if (!isAdmin || loading || blockedWorkflows.length === 0) {
+    return null;
+  }
+
+  return (
+    <Alert variant="light" color="yellow" icon={<IconPlugConnectedX size={20} />} title="Missing project dependencies">
+      <Stack gap="sm">
+        <Text size="sm">
+          Some workflows are unavailable because the integrations they depend on are not linked to this project. Users
+          will be blocked from these workflows until the required projects are linked.
+        </Text>
+        {blockedWorkflows.map(({ workflow, missing }) => (
+          <Stack key={workflow.id} gap={2}>
+            <Text size="sm" fw={500}>
+              {workflow.label}
+            </Text>
+            <List spacing={2} size="sm" withPadding>
+              {missing.map((dependency) => (
+                <List.Item key={dependency.identifier}>
+                  {dependency.docsUrl ? (
+                    <Anchor href={dependency.docsUrl} target="_blank" rel="noreferrer">
+                      {dependency.label}
+                    </Anchor>
+                  ) : (
+                    dependency.label
+                  )}
+                </List.Item>
+              ))}
+            </List>
+          </Stack>
+        ))}
+      </Stack>
+    </Alert>
+  );
+}

--- a/examples/medplum-provider/src/workflow/WorkflowGate.test.tsx
+++ b/examples/medplum-provider/src/workflow/WorkflowGate.test.tsx
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import type { Bot } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react';
+import { cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { render, screen } from '../test-utils/render';
+import { WorkflowGate } from './WorkflowGate';
+
+const HG_BOT: WithId<Bot> = { resourceType: 'Bot', id: 'hg-bot' };
+
+describe('WorkflowGate', () => {
+  let medplum: MockClient;
+
+  beforeEach(() => {
+    medplum = new MockClient();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  function renderGate(): void {
+    render(
+      <MedplumProvider medplum={medplum}>
+        <WorkflowGate workflow="order-labs">
+          <div>Lab ordering form</div>
+        </WorkflowGate>
+      </MedplumProvider>
+    );
+  }
+
+  test('renders children when the dependency is present', async () => {
+    vi.spyOn(medplum, 'searchOne').mockResolvedValue(HG_BOT);
+    renderGate();
+    expect(await screen.findByText('Lab ordering form')).toBeInTheDocument();
+  });
+
+  test('blocks with admin guidance when the dependency is missing', async () => {
+    vi.spyOn(medplum, 'searchOne').mockResolvedValue(undefined);
+    vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(true);
+    renderGate();
+    expect(await screen.findByText('Order Labs is unavailable')).toBeInTheDocument();
+    // Admins see the specific missing integration
+    expect(screen.getByText('Health Gorilla lab ordering')).toBeInTheDocument();
+    expect(screen.queryByText('Lab ordering form')).not.toBeInTheDocument();
+  });
+
+  test('shows contact-administrator guidance for non-admins', async () => {
+    vi.spyOn(medplum, 'searchOne').mockResolvedValue(undefined);
+    vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(false);
+    renderGate();
+    expect(await screen.findByText('Order Labs is unavailable')).toBeInTheDocument();
+    expect(screen.getByText(/contact your administrator/i)).toBeInTheDocument();
+    // Non-admins are not shown the internal integration name
+    expect(screen.queryByText('Health Gorilla lab ordering')).not.toBeInTheDocument();
+    expect(screen.queryByText('Lab ordering form')).not.toBeInTheDocument();
+  });
+});

--- a/examples/medplum-provider/src/workflow/WorkflowGate.test.tsx
+++ b/examples/medplum-provider/src/workflow/WorkflowGate.test.tsx
@@ -35,6 +35,7 @@ describe('WorkflowGate', () => {
 
   test('renders children when the dependency is present', async () => {
     vi.spyOn(medplum, 'searchOne').mockResolvedValue(HG_BOT);
+    vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(true);
     renderGate();
     expect(await screen.findByText('Lab ordering form')).toBeInTheDocument();
   });
@@ -49,14 +50,15 @@ describe('WorkflowGate', () => {
     expect(screen.queryByText('Lab ordering form')).not.toBeInTheDocument();
   });
 
-  test('shows contact-administrator guidance for non-admins', async () => {
-    vi.spyOn(medplum, 'searchOne').mockResolvedValue(undefined);
+  test('never blocks non-admins, whose empty Bot search may just be an AccessPolicy', async () => {
+    // A non-admin under an AccessPolicy that hides Bot sees exactly what a missing integration
+    // looks like, so blocking would lock a clinician out of a working workflow.
+    const searchOne = vi.spyOn(medplum, 'searchOne').mockResolvedValue(undefined);
     vi.spyOn(medplum, 'isProjectAdmin').mockReturnValue(false);
     renderGate();
-    expect(await screen.findByText('Order Labs is unavailable')).toBeInTheDocument();
-    expect(screen.getByText(/contact your administrator/i)).toBeInTheDocument();
-    // Non-admins are not shown the internal integration name
-    expect(screen.queryByText('Health Gorilla lab ordering')).not.toBeInTheDocument();
-    expect(screen.queryByText('Lab ordering form')).not.toBeInTheDocument();
+    expect(await screen.findByText('Lab ordering form')).toBeInTheDocument();
+    expect(screen.queryByText('Order Labs is unavailable')).not.toBeInTheDocument();
+    // ...and they never pay for the probe
+    expect(searchOne).not.toHaveBeenCalled();
   });
 });

--- a/examples/medplum-provider/src/workflow/WorkflowGate.test.tsx
+++ b/examples/medplum-provider/src/workflow/WorkflowGate.test.tsx
@@ -7,6 +7,7 @@ import { MedplumProvider } from '@medplum/react';
 import { cleanup } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { render, screen } from '../test-utils/render';
+import { WORKFLOWS } from './dependencies';
 import { WorkflowGate } from './WorkflowGate';
 
 const HG_BOT: WithId<Bot> = { resourceType: 'Bot', id: 'hg-bot' };
@@ -26,7 +27,7 @@ describe('WorkflowGate', () => {
   function renderGate(): void {
     render(
       <MedplumProvider medplum={medplum}>
-        <WorkflowGate workflow="order-labs">
+        <WorkflowGate workflow={WORKFLOWS['order-labs']}>
           <div>Lab ordering form</div>
         </WorkflowGate>
       </MedplumProvider>

--- a/examples/medplum-provider/src/workflow/WorkflowGate.tsx
+++ b/examples/medplum-provider/src/workflow/WorkflowGate.tsx
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Anchor, Center, List, Paper, Stack, Text, Title } from '@mantine/core';
+import { Loading, useMedplum } from '@medplum/react';
+import { IconPlugConnectedX } from '@tabler/icons-react';
+import type { JSX, ReactNode } from 'react';
+import type { WorkflowDependency, WorkflowId } from './dependencies';
+import { WORKFLOWS } from './dependencies';
+import { useWorkflowAvailability } from './useWorkflowAvailability';
+
+export interface WorkflowGateProps {
+  readonly workflow: WorkflowId;
+  readonly children: ReactNode;
+  /** Rendered while dependencies are being probed. Defaults to `<Loading />`. */
+  readonly loadingFallback?: ReactNode;
+}
+
+// Blocks entry to a workflow whose hard dependencies are missing, showing role-aware guidance
+// instead of the workflow UI. Admins see what to link and where; other users are directed to
+// contact an administrator. Renders its children unchanged once all dependencies are present.
+// See issue #9824.
+export function WorkflowGate(props: WorkflowGateProps): JSX.Element {
+  const { workflow, children, loadingFallback } = props;
+  const { loading, available, missing } = useWorkflowAvailability(workflow);
+
+  if (loading) {
+    return <>{loadingFallback ?? <Loading />}</>;
+  }
+  if (available) {
+    return <>{children}</>;
+  }
+  return (
+    <Center p="xl">
+      <MissingDependenciesNotice workflowLabel={WORKFLOWS[workflow].label} missing={missing} />
+    </Center>
+  );
+}
+
+export interface MissingDependenciesNoticeProps {
+  readonly workflowLabel: string;
+  readonly missing: readonly WorkflowDependency[];
+}
+
+// Role-aware guidance shown in place of a blocked workflow. Admins see which integrations to link
+// (with docs links); other users are told to contact their administrator.
+export function MissingDependenciesNotice(props: MissingDependenciesNoticeProps): JSX.Element {
+  const { workflowLabel, missing } = props;
+  const medplum = useMedplum();
+  const isAdmin = medplum.isProjectAdmin();
+  const plural = missing.length !== 1;
+
+  const dependencyList = (
+    <List spacing={4} size="sm" withPadding>
+      {missing.map((dependency) => (
+        <List.Item key={dependency.identifier}>
+          {dependency.docsUrl ? (
+            <Anchor href={dependency.docsUrl} target="_blank" rel="noreferrer">
+              {dependency.label}
+            </Anchor>
+          ) : (
+            dependency.label
+          )}
+        </List.Item>
+      ))}
+    </List>
+  );
+
+  const adminBody = (
+    <>
+      <Text size="sm" c="dimmed">
+        This workflow depends on the following {plural ? 'integrations that are' : 'integration that is'} not linked to
+        your project:
+      </Text>
+      {dependencyList}
+      <Text size="sm" c="dimmed">
+        Link the required project{plural ? 's' : ''} to enable this workflow.
+      </Text>
+    </>
+  );
+
+  const userBody = (
+    <Text size="sm" c="dimmed">
+      This workflow is not set up yet. Contact your administrator to enable it.
+    </Text>
+  );
+
+  return (
+    <Paper shadow="md" p="xl" radius="md" withBorder maw={480}>
+      <Stack align="center" gap="sm" ta="center">
+        <IconPlugConnectedX size={48} color="var(--mantine-color-gray-5)" />
+        <Title order={3}>{workflowLabel} is unavailable</Title>
+        {isAdmin ? adminBody : userBody}
+      </Stack>
+    </Paper>
+  );
+}

--- a/examples/medplum-provider/src/workflow/WorkflowGate.tsx
+++ b/examples/medplum-provider/src/workflow/WorkflowGate.tsx
@@ -65,11 +65,10 @@ export function MissingDependenciesNotice(props: MissingDependenciesNoticeProps)
     <UnavailableNotice
       icon={<IconPlugConnectedX size={48} color="var(--mantine-color-gray-5)" aria-hidden />}
       title={`${workflowLabel} is unavailable`}
+      description={`This workflow depends on the following ${
+        plural ? 'integrations that are' : 'integration that is'
+      } not linked to your project:`}
     >
-      <Text size="sm" c="dimmed">
-        This workflow depends on the following {plural ? 'integrations that are' : 'integration that is'} not linked to
-        your project:
-      </Text>
       {dependencyList}
       <Text size="sm" c="dimmed">
         Link the required {plural ? 'projects' : 'project'} to enable this workflow.

--- a/examples/medplum-provider/src/workflow/WorkflowGate.tsx
+++ b/examples/medplum-provider/src/workflow/WorkflowGate.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Anchor, List, Text } from '@mantine/core';
-import { Loading, useMedplum } from '@medplum/react';
+import { Loading } from '@medplum/react';
 import { IconPlugConnectedX } from '@tabler/icons-react';
 import type { JSX, ReactNode } from 'react';
 import { UnavailableNotice } from '../components/UnavailableNotice';
@@ -16,9 +16,10 @@ export interface WorkflowGateProps {
   readonly loadingFallback?: ReactNode;
 }
 
-// Blocks entry to a workflow whose hard dependencies are missing, showing role-aware guidance
-// instead of the workflow UI. Admins see what to link and where; other users are directed to
-// contact an administrator. Renders its children unchanged once all dependencies are present.
+// Blocks entry to a workflow whose hard dependencies are missing, showing an admin what to link
+// and where instead of the workflow UI. Only project admins are gated: for anyone else the
+// dependency probe cannot tell a missing integration from an AccessPolicy that hides `Bot`, so
+// they are let through. Renders its children unchanged once all dependencies are present.
 // See issue #9824.
 export function WorkflowGate(props: WorkflowGateProps): JSX.Element {
   const { workflow, children, loadingFallback } = props;
@@ -38,12 +39,10 @@ export interface MissingDependenciesNoticeProps {
   readonly missing: readonly WorkflowDependency[];
 }
 
-// Role-aware guidance shown in place of a blocked workflow. Admins see which integrations to link
-// (with docs links); other users are told to contact their administrator.
+// Guidance shown in place of a blocked workflow, listing which integrations to link (with docs
+// links). Only ever shown to project admins — see WorkflowGate above.
 export function MissingDependenciesNotice(props: MissingDependenciesNoticeProps): JSX.Element {
   const { workflowLabel, missing } = props;
-  const medplum = useMedplum();
-  const isAdmin = medplum.isProjectAdmin();
   const plural = missing.length !== 1;
 
   const dependencyList = (
@@ -62,8 +61,11 @@ export function MissingDependenciesNotice(props: MissingDependenciesNoticeProps)
     </List>
   );
 
-  const adminBody = (
-    <>
+  return (
+    <UnavailableNotice
+      icon={<IconPlugConnectedX size={48} color="var(--mantine-color-gray-5)" aria-hidden />}
+      title={`${workflowLabel} is unavailable`}
+    >
       <Text size="sm" c="dimmed">
         This workflow depends on the following {plural ? 'integrations that are' : 'integration that is'} not linked to
         your project:
@@ -72,21 +74,6 @@ export function MissingDependenciesNotice(props: MissingDependenciesNoticeProps)
       <Text size="sm" c="dimmed">
         Link the required project{plural ? 's' : ''} to enable this workflow.
       </Text>
-    </>
-  );
-
-  const userBody = (
-    <Text size="sm" c="dimmed">
-      This workflow is not set up yet. Contact your administrator to enable it.
-    </Text>
-  );
-
-  return (
-    <UnavailableNotice
-      icon={<IconPlugConnectedX size={48} color="var(--mantine-color-gray-5)" aria-hidden />}
-      title={`${workflowLabel} is unavailable`}
-    >
-      {isAdmin ? adminBody : userBody}
     </UnavailableNotice>
   );
 }

--- a/examples/medplum-provider/src/workflow/WorkflowGate.tsx
+++ b/examples/medplum-provider/src/workflow/WorkflowGate.tsx
@@ -72,7 +72,7 @@ export function MissingDependenciesNotice(props: MissingDependenciesNoticeProps)
       </Text>
       {dependencyList}
       <Text size="sm" c="dimmed">
-        Link the required project{plural ? 's' : ''} to enable this workflow.
+        Link the required {plural ? 'projects' : 'project'} to enable this workflow.
       </Text>
     </UnavailableNotice>
   );

--- a/examples/medplum-provider/src/workflow/WorkflowGate.tsx
+++ b/examples/medplum-provider/src/workflow/WorkflowGate.tsx
@@ -5,12 +5,12 @@ import { Loading } from '@medplum/react';
 import { IconPlugConnectedX } from '@tabler/icons-react';
 import type { JSX, ReactNode } from 'react';
 import { UnavailableNotice } from '../components/UnavailableNotice';
-import type { WorkflowDependency, WorkflowId } from './dependencies';
-import { WORKFLOWS } from './dependencies';
+import type { WorkflowDefinition, WorkflowDependency } from './dependencies';
 import { useWorkflowAvailability } from './useWorkflowAvailability';
 
 export interface WorkflowGateProps {
-  readonly workflow: WorkflowId;
+  /** The workflow being gated — a `WORKFLOWS` entry, e.g. `WORKFLOWS['order-labs']`. */
+  readonly workflow: WorkflowDefinition;
   readonly children: ReactNode;
   /** Rendered while dependencies are being probed. Defaults to `<Loading />`. */
   readonly loadingFallback?: ReactNode;
@@ -31,7 +31,7 @@ export function WorkflowGate(props: WorkflowGateProps): JSX.Element {
   if (available) {
     return <>{children}</>;
   }
-  return <MissingDependenciesNotice workflowLabel={WORKFLOWS[workflow].label} missing={missing} />;
+  return <MissingDependenciesNotice workflowLabel={workflow.label} missing={missing} />;
 }
 
 export interface MissingDependenciesNoticeProps {

--- a/examples/medplum-provider/src/workflow/WorkflowGate.tsx
+++ b/examples/medplum-provider/src/workflow/WorkflowGate.tsx
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Anchor, Center, List, Paper, Stack, Text, Title } from '@mantine/core';
+import { Anchor, List, Text } from '@mantine/core';
 import { Loading, useMedplum } from '@medplum/react';
 import { IconPlugConnectedX } from '@tabler/icons-react';
 import type { JSX, ReactNode } from 'react';
+import { UnavailableNotice } from '../components/UnavailableNotice';
 import type { WorkflowDependency, WorkflowId } from './dependencies';
 import { WORKFLOWS } from './dependencies';
 import { useWorkflowAvailability } from './useWorkflowAvailability';
@@ -29,11 +30,7 @@ export function WorkflowGate(props: WorkflowGateProps): JSX.Element {
   if (available) {
     return <>{children}</>;
   }
-  return (
-    <Center p="xl">
-      <MissingDependenciesNotice workflowLabel={WORKFLOWS[workflow].label} missing={missing} />
-    </Center>
-  );
+  return <MissingDependenciesNotice workflowLabel={WORKFLOWS[workflow].label} missing={missing} />;
 }
 
 export interface MissingDependenciesNoticeProps {
@@ -85,12 +82,11 @@ export function MissingDependenciesNotice(props: MissingDependenciesNoticeProps)
   );
 
   return (
-    <Paper shadow="md" p="xl" radius="md" withBorder maw={480}>
-      <Stack align="center" gap="sm" ta="center">
-        <IconPlugConnectedX size={48} color="var(--mantine-color-gray-5)" />
-        <Title order={3}>{workflowLabel} is unavailable</Title>
-        {isAdmin ? adminBody : userBody}
-      </Stack>
-    </Paper>
+    <UnavailableNotice
+      icon={<IconPlugConnectedX size={48} color="var(--mantine-color-gray-5)" aria-hidden />}
+      title={`${workflowLabel} is unavailable`}
+    >
+      {isAdmin ? adminBody : userBody}
+    </UnavailableNotice>
   );
 }

--- a/examples/medplum-provider/src/workflow/dependencies.ts
+++ b/examples/medplum-provider/src/workflow/dependencies.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * A hard dependency that a Provider workflow needs in order to function. A missing dependency
+ * usually means a Medplum "shared project" (integration bots, terminology, or profiles) has not
+ * been linked into the current project. See issue #9824.
+ */
+export interface BotDependency {
+  readonly kind: 'bot';
+  /** FHIR search token (`system|value`) used to look the Bot up by identifier. */
+  readonly identifier: string;
+  /** Human-readable name shown to admins, e.g. "Health Gorilla lab ordering". */
+  readonly label: string;
+  /** Optional link to setup documentation. */
+  readonly docsUrl?: string;
+}
+
+export type WorkflowDependency = BotDependency;
+
+export interface WorkflowDefinition {
+  readonly id: string;
+  readonly label: string;
+  readonly dependencies: readonly WorkflowDependency[];
+}
+
+/**
+ * The hard dependencies for each gated Provider workflow. A workflow is *blocked* when any of its
+ * dependencies are missing; blocked workflows show guidance instead of letting the user in.
+ *
+ * Only *core* workflows belong here — capabilities a user expects as a baseline part of the app and
+ * would be confused to find broken (e.g. ordering labs). The missing dependency is surfaced upfront
+ * (the Get Started banner) and gated in-context. Optional, integration-only features — a capability
+ * that exists solely because an integration is present, such as insurance eligibility checks,
+ * DoseSpot, or ScriptSure — do NOT belong here; they are handled in-context (hidden or a soft
+ * upsell) and never complain upfront.
+ *
+ * Likewise, fields that merely lose autocomplete suggestions (a missing ValueSet on a field that
+ * still accepts custom values) degrade gracefully inline and are intentionally NOT gated here.
+ */
+export const WORKFLOWS = {
+  'order-labs': {
+    id: 'order-labs',
+    label: 'Order Labs',
+    dependencies: [
+      {
+        kind: 'bot',
+        identifier: 'https://www.medplum.com/integrations/bot-identifier|health-gorilla-labs/send-to-health-gorilla',
+        label: 'Health Gorilla lab ordering',
+        docsUrl: 'https://www.medplum.com/docs/integration/health-gorilla',
+      },
+    ],
+  },
+} as const satisfies Record<string, WorkflowDefinition>;
+
+export type WorkflowId = keyof typeof WORKFLOWS;

--- a/examples/medplum-provider/src/workflow/dependencies.ts
+++ b/examples/medplum-provider/src/workflow/dependencies.ts
@@ -28,6 +28,12 @@ export interface WorkflowDefinition {
  * The hard dependencies for each gated Provider workflow. A workflow is *blocked* when any of its
  * dependencies are missing; blocked workflows show guidance instead of letting the user in.
  *
+ * Entries are passed by reference to the gate at the call site — `<WorkflowGate
+ * workflow={WORKFLOWS['order-labs']}>` — so a reader there can jump straight to the definition.
+ * They live in this one manifest (rather than inline at each gate) so the Get Started page can list
+ * every missing dependency up front. Each entry is a module constant and therefore a stable
+ * reference, which is what {@link useWorkflowAvailability} keys its probe on.
+ *
  * Only *core* workflows belong here — capabilities a user expects as a baseline part of the app and
  * would be confused to find broken (e.g. ordering labs). The missing dependency is surfaced upfront
  * (the Get Started banner) and gated in-context. Optional, integration-only features — a capability
@@ -52,5 +58,3 @@ export const WORKFLOWS = {
     ],
   },
 } as const satisfies Record<string, WorkflowDefinition>;
-
-export type WorkflowId = keyof typeof WORKFLOWS;

--- a/examples/medplum-provider/src/workflow/useWorkflowAvailability.ts
+++ b/examples/medplum-provider/src/workflow/useWorkflowAvailability.ts
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { MedplumClient } from '@medplum/core';
+import { useMedplum } from '@medplum/react';
+import { useEffect, useState } from 'react';
+import type { WorkflowDefinition, WorkflowDependency, WorkflowId } from './dependencies';
+import { WORKFLOWS } from './dependencies';
+
+/**
+ * Probes a set of workflow dependencies and returns the ones that are missing.
+ *
+ * Each bot dependency is checked with a cheap `Bot?identifier=…` search — deduplicated and cached
+ * by the {@link MedplumClient} request cache for the session, and never executes the bot. A
+ * transient failure is treated as "present" so a network blip never blocks a workflow.
+ * @param medplum - The Medplum client used to look up bots by identifier.
+ * @param dependencies - The dependencies to probe.
+ * @returns The subset of `dependencies` confirmed missing.
+ */
+async function findMissingDependencies(
+  medplum: MedplumClient,
+  dependencies: readonly WorkflowDependency[]
+): Promise<WorkflowDependency[]> {
+  const results = await Promise.all(
+    dependencies.map(async (dependency) => {
+      try {
+        const bot = await medplum.searchOne('Bot', { identifier: dependency.identifier });
+        return bot ? undefined : dependency;
+      } catch {
+        // A transient failure shouldn't block the workflow; treat the dependency as present.
+        return undefined;
+      }
+    })
+  );
+  return results.filter((dependency): dependency is WorkflowDependency => dependency !== undefined);
+}
+
+export interface WorkflowAvailability {
+  /** True while the dependency probes are in flight. */
+  readonly loading: boolean;
+  /** True once every dependency is confirmed present. */
+  readonly available: boolean;
+  /** Dependencies confirmed missing (empty while loading or when available). */
+  readonly missing: readonly WorkflowDependency[];
+}
+
+/**
+ * Probes whether every hard dependency of `workflowId` is present in the current project.
+ *
+ * Recovery after an admin links a missing project happens on the next mount / page refresh; there
+ * is no live subscription. See issue #9824.
+ * @param workflowId - The workflow whose dependencies to probe.
+ * @returns The workflow's availability and which dependencies (if any) are missing.
+ */
+export function useWorkflowAvailability(workflowId: WorkflowId): WorkflowAvailability {
+  const medplum = useMedplum();
+  const [state, setState] = useState<{ workflowId: WorkflowId; loading: boolean; missing: WorkflowDependency[] }>(
+    () => ({ workflowId, loading: true, missing: [] })
+  );
+
+  // When the workflow changes, reset to "probing" during render so a stale verdict is never shown.
+  // This is React's recommended alternative to resetting state with a synchronous setState in an effect.
+  if (state.workflowId !== workflowId) {
+    setState({ workflowId, loading: true, missing: [] });
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    findMissingDependencies(medplum, WORKFLOWS[workflowId].dependencies)
+      .then((missing) => {
+        if (!cancelled) {
+          setState({ workflowId, loading: false, missing });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState({ workflowId, loading: false, missing: [] });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [medplum, workflowId]);
+
+  return {
+    loading: state.loading,
+    available: !state.loading && state.missing.length === 0,
+    missing: state.missing,
+  };
+}
+
+export interface WorkflowWithMissingDependencies {
+  readonly workflow: WorkflowDefinition;
+  readonly missing: readonly WorkflowDependency[];
+}
+
+export interface AllWorkflowDependencies {
+  readonly loading: boolean;
+  /** Only workflows that have at least one missing dependency. */
+  readonly blockedWorkflows: readonly WorkflowWithMissingDependencies[];
+}
+
+/**
+ * Probes every gated workflow's dependencies at once. Intended for an admin-facing summary (e.g.
+ * the Get Started page) so administrators see all missing project dependencies up front.
+ * @param options - Probe options.
+ * @param options.enabled - When false, skips probing entirely (default true). Used so non-admins
+ * never trigger the scan, since they see per-workflow guidance at the gate instead of a summary.
+ * @returns The blocked workflows and their missing dependencies.
+ */
+export function useMissingWorkflowDependencies(options?: { enabled?: boolean }): AllWorkflowDependencies {
+  const enabled = options?.enabled ?? true;
+  const medplum = useMedplum();
+  const [state, setState] = useState<{
+    enabled: boolean;
+    loading: boolean;
+    blockedWorkflows: WorkflowWithMissingDependencies[];
+  }>(() => ({ enabled, loading: enabled, blockedWorkflows: [] }));
+
+  // Reset during render when `enabled` toggles, mirroring the render-phase reset above.
+  if (state.enabled !== enabled) {
+    setState({ enabled, loading: enabled, blockedWorkflows: [] });
+  }
+
+  useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    Promise.all(
+      Object.values(WORKFLOWS).map(async (workflow) => ({
+        workflow,
+        missing: await findMissingDependencies(medplum, workflow.dependencies),
+      }))
+    )
+      .then((results) => {
+        if (!cancelled) {
+          setState({
+            enabled,
+            loading: false,
+            blockedWorkflows: results.filter((result) => result.missing.length > 0),
+          });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState({ enabled, loading: false, blockedWorkflows: [] });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [medplum, enabled]);
+
+  return { loading: state.loading, blockedWorkflows: state.blockedWorkflows };
+}

--- a/examples/medplum-provider/src/workflow/useWorkflowAvailability.ts
+++ b/examples/medplum-provider/src/workflow/useWorkflowAvailability.ts
@@ -27,18 +27,15 @@ async function findMissingDependencies(
   medplum: MedplumClient,
   dependencies: readonly WorkflowDependency[]
 ): Promise<WorkflowDependency[]> {
-  const results = await Promise.all(
-    dependencies.map(async (dependency) => {
-      try {
-        const bot = await medplum.searchOne('Bot', { identifier: dependency.identifier });
-        return bot ? undefined : dependency;
-      } catch {
-        // A transient failure shouldn't block the workflow; treat the dependency as present.
-        return undefined;
-      }
-    })
+  const results = await Promise.allSettled(
+    dependencies.map((dependency) => medplum.searchOne('Bot', { identifier: dependency.identifier }))
   );
-  return results.filter((dependency): dependency is WorkflowDependency => dependency !== undefined);
+  // A dependency is missing only when its probe succeeded and found no bot. A rejected probe is a
+  // transient failure and shouldn't block the workflow, so we treat it as present.
+  return dependencies.filter((_, index) => {
+    const result = results[index];
+    return result.status === 'fulfilled' && !result.value;
+  });
 }
 
 export interface WorkflowAvailability {

--- a/examples/medplum-provider/src/workflow/useWorkflowAvailability.ts
+++ b/examples/medplum-provider/src/workflow/useWorkflowAvailability.ts
@@ -12,6 +12,13 @@ import { WORKFLOWS } from './dependencies';
  * Each bot dependency is checked with a cheap `Bot?identifier=…` search — deduplicated and cached
  * by the {@link MedplumClient} request cache for the session, and never executes the bot. A
  * transient failure is treated as "present" so a network blip never blocks a workflow.
+ *
+ * Limitation: an empty search result is treated as "missing". If the current user's `AccessPolicy`
+ * hides `Bot` resources, the search returns empty (not an error) even when the bot is linked,
+ * producing a false "unavailable" — `searchOne` can't distinguish "no bot" from "no read access".
+ * The admin-only Get Started summary avoids this (admins can read bots); it only affects the
+ * per-user {@link WorkflowGate}. Erring toward blocking is intentional here: a user who can't see
+ * the bot most likely can't complete the workflow either.
  * @param medplum - The Medplum client used to look up bots by identifier.
  * @param dependencies - The dependencies to probe.
  * @returns The subset of `dependencies` confirmed missing.

--- a/examples/medplum-provider/src/workflow/useWorkflowAvailability.ts
+++ b/examples/medplum-provider/src/workflow/useWorkflowAvailability.ts
@@ -3,7 +3,7 @@
 import type { MedplumClient } from '@medplum/core';
 import { useMedplum } from '@medplum/react';
 import { useEffect, useState } from 'react';
-import type { WorkflowDefinition, WorkflowDependency, WorkflowId } from './dependencies';
+import type { WorkflowDefinition, WorkflowDependency } from './dependencies';
 import { WORKFLOWS } from './dependencies';
 
 /**
@@ -46,7 +46,7 @@ export interface WorkflowAvailability {
 }
 
 /**
- * Probes whether every hard dependency of `workflowId` is present in the current project.
+ * Probes whether every hard dependency of `workflow` is present in the current project.
  *
  * Only project admins are probed. For anyone else an empty `Bot` search is ambiguous — an
  * `AccessPolicy` that hides `Bot` looks exactly like an unlinked integration — and wrongly blocking
@@ -55,24 +55,25 @@ export interface WorkflowAvailability {
  *
  * Recovery after an admin links a missing project happens on the next mount / page refresh; there
  * is no live subscription. See issue #9824.
- * @param workflowId - The workflow whose dependencies to probe.
+ * @param workflow - The workflow whose dependencies to probe. Must be a stable reference — pass a
+ * {@link WORKFLOWS} entry.
  * @returns The workflow's availability and which dependencies (if any) are missing.
  */
-export function useWorkflowAvailability(workflowId: WorkflowId): WorkflowAvailability {
+export function useWorkflowAvailability(workflow: WorkflowDefinition): WorkflowAvailability {
   const medplum = useMedplum();
   const enabled = medplum.isProjectAdmin();
   const [state, setState] = useState<{
-    workflowId: WorkflowId;
+    workflow: WorkflowDefinition;
     enabled: boolean;
     loading: boolean;
     missing: WorkflowDependency[];
-  }>(() => ({ workflowId, enabled, loading: enabled, missing: [] }));
+  }>(() => ({ workflow, enabled, loading: enabled, missing: [] }));
 
   // When the workflow (or the user's admin status) changes, reset to "probing" during render so a
   // stale verdict is never shown. This is React's recommended alternative to resetting state with a
   // synchronous setState in an effect.
-  if (state.workflowId !== workflowId || state.enabled !== enabled) {
-    setState({ workflowId, enabled, loading: enabled, missing: [] });
+  if (state.workflow !== workflow || state.enabled !== enabled) {
+    setState({ workflow, enabled, loading: enabled, missing: [] });
   }
 
   useEffect(() => {
@@ -82,10 +83,10 @@ export function useWorkflowAvailability(workflowId: WorkflowId): WorkflowAvailab
 
     let cancelled = false;
     // `findMissingDependencies` settles every probe itself and never rejects.
-    findMissingDependencies(medplum, WORKFLOWS[workflowId].dependencies)
+    findMissingDependencies(medplum, workflow.dependencies)
       .then((missing) => {
         if (!cancelled) {
-          setState({ workflowId, enabled, loading: false, missing });
+          setState({ workflow, enabled, loading: false, missing });
         }
       })
       .catch(console.error);
@@ -93,7 +94,7 @@ export function useWorkflowAvailability(workflowId: WorkflowId): WorkflowAvailab
     return () => {
       cancelled = true;
     };
-  }, [medplum, workflowId, enabled]);
+  }, [medplum, workflow, enabled]);
 
   return {
     loading: state.loading,

--- a/examples/medplum-provider/src/workflow/useWorkflowAvailability.ts
+++ b/examples/medplum-provider/src/workflow/useWorkflowAvailability.ts
@@ -13,12 +13,10 @@ import { WORKFLOWS } from './dependencies';
  * by the {@link MedplumClient} request cache for the session, and never executes the bot. A
  * transient failure is treated as "present" so a network blip never blocks a workflow.
  *
- * Limitation: an empty search result is treated as "missing". If the current user's `AccessPolicy`
- * hides `Bot` resources, the search returns empty (not an error) even when the bot is linked,
- * producing a false "unavailable" — `searchOne` can't distinguish "no bot" from "no read access".
- * The admin-only Get Started summary avoids this (admins can read bots); it only affects the
- * per-user {@link WorkflowGate}. Erring toward blocking is intentional here: a user who can't see
- * the bot most likely can't complete the workflow either.
+ * Limitation: an empty search result is indistinguishable from "no read access". If the current
+ * user's `AccessPolicy` hides `Bot` resources, the search returns empty (not an error) even when
+ * the bot is linked. Callers therefore only probe for project admins, who can always read bots —
+ * see {@link useWorkflowAvailability}.
  * @param medplum - The Medplum client used to look up bots by identifier.
  * @param dependencies - The dependencies to probe.
  * @returns The subset of `dependencies` confirmed missing.
@@ -50,6 +48,11 @@ export interface WorkflowAvailability {
 /**
  * Probes whether every hard dependency of `workflowId` is present in the current project.
  *
+ * Only project admins are probed. For anyone else an empty `Bot` search is ambiguous — an
+ * `AccessPolicy` that hides `Bot` looks exactly like an unlinked integration — and wrongly blocking
+ * a clinician out of a core workflow is worse than letting them reach the underlying error. So
+ * non-admins are always reported as available, and the workflow behaves as it did before gating.
+ *
  * Recovery after an admin links a missing project happens on the next mount / page refresh; there
  * is no live subscription. See issue #9824.
  * @param workflowId - The workflow whose dependencies to probe.
@@ -57,34 +60,40 @@ export interface WorkflowAvailability {
  */
 export function useWorkflowAvailability(workflowId: WorkflowId): WorkflowAvailability {
   const medplum = useMedplum();
-  const [state, setState] = useState<{ workflowId: WorkflowId; loading: boolean; missing: WorkflowDependency[] }>(
-    () => ({ workflowId, loading: true, missing: [] })
-  );
+  const enabled = medplum.isProjectAdmin();
+  const [state, setState] = useState<{
+    workflowId: WorkflowId;
+    enabled: boolean;
+    loading: boolean;
+    missing: WorkflowDependency[];
+  }>(() => ({ workflowId, enabled, loading: enabled, missing: [] }));
 
-  // When the workflow changes, reset to "probing" during render so a stale verdict is never shown.
-  // This is React's recommended alternative to resetting state with a synchronous setState in an effect.
-  if (state.workflowId !== workflowId) {
-    setState({ workflowId, loading: true, missing: [] });
+  // When the workflow (or the user's admin status) changes, reset to "probing" during render so a
+  // stale verdict is never shown. This is React's recommended alternative to resetting state with a
+  // synchronous setState in an effect.
+  if (state.workflowId !== workflowId || state.enabled !== enabled) {
+    setState({ workflowId, enabled, loading: enabled, missing: [] });
   }
 
   useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
     let cancelled = false;
+    // `findMissingDependencies` settles every probe itself and never rejects.
     findMissingDependencies(medplum, WORKFLOWS[workflowId].dependencies)
       .then((missing) => {
         if (!cancelled) {
-          setState({ workflowId, loading: false, missing });
+          setState({ workflowId, enabled, loading: false, missing });
         }
       })
-      .catch(() => {
-        if (!cancelled) {
-          setState({ workflowId, loading: false, missing: [] });
-        }
-      });
+      .catch(console.error);
 
     return () => {
       cancelled = true;
     };
-  }, [medplum, workflowId]);
+  }, [medplum, workflowId, enabled]);
 
   return {
     loading: state.loading,
@@ -132,6 +141,7 @@ export function useMissingWorkflowDependencies(options?: { enabled?: boolean }):
     }
 
     let cancelled = false;
+    // `findMissingDependencies` settles every probe itself and never rejects.
     Promise.all(
       Object.values(WORKFLOWS).map(async (workflow) => ({
         workflow,
@@ -147,11 +157,7 @@ export function useMissingWorkflowDependencies(options?: { enabled?: boolean }):
           });
         }
       })
-      .catch(() => {
-        if (!cancelled) {
-          setState({ enabled, loading: false, blockedWorkflows: [] });
-        }
-      });
+      .catch(console.error);
 
     return () => {
       cancelled = true;

--- a/packages/react-hooks/src/useValueSetAvailability/useValueSetAvailability.ts
+++ b/packages/react-hooks/src/useValueSetAvailability/useValueSetAvailability.ts
@@ -36,13 +36,16 @@ const EMPTY_URLS: string[] = [];
 /**
  * Probes a set of ValueSet URLs for availability, each with a filter-free, count-limited expansion.
  *
- * A filter-free probe means a 400/404 unambiguously describes the value set itself (unlike a
- * user-typed search, whose 400 can be filter-specific), so the verdict is safe to act on. Repeated
- * probes of the same URL are deduplicated by the `MedplumClient` request cache, which caches
- * rejections too, so many fields bound to the same missing value set cost one request. Recovery
- * after a value set is imported happens on the next mount (i.e. a page refresh) — there is no live
- * subscription. Transient failures (429/5xx/network) resolve as available so a blip never disables
- * a field; only a permanent 400/404 marks a URL unavailable.
+ * A "filter-free probe" means that without any user filters, if we get back a 400/404, it means the
+ * value set itself is unavailable. We only mark a field as truly unavailable if we get back a 400/404;
+ * transient failures (429/5xx/network) will be resolved as available so something like a network blip
+ * will not disable a field and create bad UI behavior.
+ *
+ * Repeated probes of the same URL are deduplicated by the `MedplumClient` request cache, which caches
+ * rejections too, so many fields bound to the same missing value set cost one request in the TTL window.
+ * Recovery after a value set is imported happens on the first mount after that cache entry expires (60s in
+ * the browser by default) — there is no live subscription.
+ *
  * @param urls - The ValueSet URLs to probe. Falsy entries are ignored, and duplicates collapse to a
  * single probe.
  * @returns The availability verdict, with `loading` true until every requested URL has settled.
@@ -69,14 +72,9 @@ export function useValueSetAvailabilities(urls: readonly (string | undefined)[])
     }
 
     let cancelled = false;
-    // The abort is load-bearing beyond cancelling the request: `MedplumClient` caches rejections
-    // and only evicts an entry when its request is aborted, so aborting on unmount is what lets a
-    // later mount re-probe a value set that has since been imported.
-    const controller = new AbortController();
-
     for (const url of uniqueUrls) {
       medplum
-        .valueSetExpand({ url, count: 1 }, { signal: controller.signal })
+        .valueSetExpand({ url, count: 1 })
         .then(() => {
           if (!cancelled) {
             setVerdicts((prev) => ({ ...prev, [url]: true }));
@@ -92,7 +90,6 @@ export function useValueSetAvailabilities(urls: readonly (string | undefined)[])
 
     return () => {
       cancelled = true;
-      controller.abort();
     };
   }, [medplum, uniqueUrls]);
 

--- a/packages/react-hooks/src/useValueSetAvailability/useValueSetAvailability.ts
+++ b/packages/react-hooks/src/useValueSetAvailability/useValueSetAvailability.ts
@@ -69,6 +69,9 @@ export function useValueSetAvailabilities(urls: readonly (string | undefined)[])
     }
 
     let cancelled = false;
+    // The abort is load-bearing beyond cancelling the request: `MedplumClient` caches rejections
+    // and only evicts an entry when its request is aborted, so aborting on unmount is what lets a
+    // later mount re-probe a value set that has since been imported.
     const controller = new AbortController();
 
     for (const url of uniqueUrls) {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem.tsx
@@ -465,11 +465,14 @@ function useValueSetOptions(valueSetUrl: string | undefined): ValueSetOptionsSta
   return { options: valueSetOptions, loading: isLoading, available: isAvailable };
 }
 
-function SuggestionsUnavailableDisplay({ valueSetUrl }: { readonly valueSetUrl: string | undefined }): JSX.Element {
+// Radio and checkbox items can only offer the answers their value set provides, so an unavailable
+// value set leaves nothing to pick and the question cannot be answered at all. That is the `error`
+// severity, unlike a creatable autocomplete that merely loses its suggestions.
+function ValueSetUnavailableDisplay({ valueSetUrl }: { readonly valueSetUrl: string | undefined }): JSX.Element {
   return (
     <UnavailableNote
-      text="Suggestions unavailable"
-      color="yellow.9"
+      text="This question is unavailable."
+      severity="error"
       message={`Value set ${valueSetUrl} is unavailable`}
     />
   );
@@ -533,7 +536,7 @@ function QuestionnaireRadioButtonInput(props: QuestionnaireChoiceInputProps): JS
 
   if (options.length === 0) {
     return isValueSetAvailable === false ? (
-      <SuggestionsUnavailableDisplay valueSetUrl={item.answerValueSet} />
+      <ValueSetUnavailableDisplay valueSetUrl={item.answerValueSet} />
     ) : (
       <NoAnswerDisplay />
     );
@@ -622,7 +625,7 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
 
   if (options.length === 0) {
     return isValueSetAvailable === false ? (
-      <SuggestionsUnavailableDisplay valueSetUrl={item.answerValueSet} />
+      <ValueSetUnavailableDisplay valueSetUrl={item.answerValueSet} />
     ) : (
       <NoAnswerDisplay />
     );

--- a/packages/react/src/UnavailableNote/UnavailableNote.stories.tsx
+++ b/packages/react/src/UnavailableNote/UnavailableNote.stories.tsx
@@ -15,7 +15,7 @@ export const SuggestionsUnavailable = (): JSX.Element => (
   <Document>
     <UnavailableNote
       text="Suggestions unavailable"
-      color="yellow.9"
+      severity="warning"
       message="Value set http://example.com/my-value-set is unavailable"
     />
   </Document>
@@ -25,7 +25,7 @@ export const FieldUnavailable = (): JSX.Element => (
   <Document>
     <UnavailableNote
       text="This field is unavailable."
-      color="red"
+      severity="error"
       message="Value set http://example.com/my-value-set is unavailable"
     />
   </Document>
@@ -36,12 +36,12 @@ export const BothVariants = (): JSX.Element => (
     <Stack>
       <UnavailableNote
         text="Suggestions unavailable"
-        color="yellow.9"
+        severity="warning"
         message="Value set http://example.com/my-value-set is unavailable"
       />
       <UnavailableNote
         text="This field is unavailable."
-        color="red"
+        severity="error"
         message="Value set http://example.com/my-value-set is unavailable"
       />
     </Stack>

--- a/packages/react/src/UnavailableNote/UnavailableNote.tsx
+++ b/packages/react/src/UnavailableNote/UnavailableNote.tsx
@@ -4,13 +4,25 @@ import { ActionIcon, Text, Tooltip } from '@mantine/core';
 import { IconInfoCircle } from '@tabler/icons-react';
 import type { JSX } from 'react';
 
+/**
+ * How badly the missing dependency degrades the field: `warning` when the field is still usable
+ * (e.g. it accepts free text and has only lost its suggestions), `error` when it is not.
+ */
+export type UnavailableNoteSeverity = 'warning' | 'error';
+
+const SEVERITY_COLORS: Record<UnavailableNoteSeverity, string> = {
+  warning: 'yellow.9',
+  error: 'red',
+};
+
 export interface UnavailableNoteProps {
   readonly text: string;
-  readonly color: string;
+  readonly severity: UnavailableNoteSeverity;
   readonly message: string;
 }
 
-export function UnavailableNote({ text, color, message }: UnavailableNoteProps): JSX.Element {
+export function UnavailableNote({ text, severity, message }: UnavailableNoteProps): JSX.Element {
+  const color = SEVERITY_COLORS[severity];
   return (
     <Text span size="xs" c={color}>
       {text}

--- a/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
+++ b/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
@@ -113,13 +113,13 @@ export function ValueSetAutocomplete(props: ValueSetAutocompleteProps): JSX.Elem
     if (isCreatable) {
       // The field is still usable, so show a non-error helper note (in the description slot)
       const unavailableNote = (
-        <UnavailableNote text="Suggestions unavailable" color="yellow.9" message={unavailableMessage} />
+        <UnavailableNote text="Suggestions unavailable" severity="warning" message={unavailableMessage} />
       );
       inputDescription = combineNodes(description, unavailableNote);
     } else {
       // The field is unusable: disable it and explain why alongside any consumer validation error
       const unavailableNote = (
-        <UnavailableNote text="This field is unavailable." color="red" message={unavailableMessage} />
+        <UnavailableNote text="This field is unavailable." severity="error" message={unavailableMessage} />
       );
       inputError = combineNodes(error, unavailableNote);
       inputDisabled = true;


### PR DESCRIPTION
Fixes #9824 

## Problem
When a project is missing a dependency that a workflow needs, users hit broken flows and a wall of errors they can't act on. We shouldn't let users into a workflow they have no way to complete, and we shouldn't surface errors with no actionable fix.

## What this does
- **Blocks the Order Labs workflow upfront when the Health Gorilla bot isn't linked**, so users never enter a flow that can't complete (this also stops `useHealthGorillaLabOrder` from mounting and throwing). The message is role-aware:
  - **Admins** see which integration to link, with a docs link.
  - **End users** are told the workflow isn't set up yet and to contact their administrator.

  <img width="1386" height="948" alt="image" src="https://github.com/user-attachments/assets/b237ee7d-399d-4107-b146-91f42e80c59b" />
  <img width="509" height="244" alt="2026-07-16_16-08-14" src="https://github.com/user-attachments/assets/a88edc29-bda6-497f-825c-42370cd27c02" />

- **Adds an admin-only banner on the Get Started page** summarizing every missing dependency, so admins can fix them up front instead of discovering them one blocked workflow at a time.

  <img width="1386" height="948" alt="2026-07-16_15-52-38" src="https://github.com/user-attachments/assets/7b33399b-b73a-49b4-a0a5-56509a1c3661" />

- **Adds reusable plumbing** so future bot-dependent workflows can be gated the same way with a single manifest entry:
  - `dependencies.ts` - maps each gated workflow to its bot dependencies.
  - `useWorkflowAvailability` - probes each dependency via a cheap `Bot?identifier=…` search (cached per session; the bot is never executed).
  - `<WorkflowGate>` - wraps a workflow's entry point and renders the role-aware guidance above when a dependency is missing. `OrderLabsPage` is wrapped once, covering all three places it's rendered.

- **Makes the missing-profile error on resource creation actionable.** Creating a resource whose type requires a FHIR profile (e.g. a Patient requiring `us-core-patient`) previously failed with a raw `StructureDefinition profile ... not found` server error on the create page. It now shows the **same role-aware card as the workflow gate** for visual consistency: admins see which profile to import plus a link to the profiles docs; other users are directed to an administrator. `ResourceFormWithRequiredProfile` already blocked submission in this case; this only replaces the raw error with guidance, and callers that pass no message (the resource edit pages) keep the existing fallback.
<img width="1063" height="528" alt="image" src="https://github.com/user-attachments/assets/37cb9ef2-2359-4c9d-8598-e33f12304b3b" />


- **Adds a link to the Stedi insurance-eligibility docs** from the existing eligibility upsell.

  <img width="891" height="72" alt="2026-07-16_16-08-26" src="https://github.com/user-attachments/assets/1ad4a41a-c332-4319-a3f1-9e72746d7ca3" />

## Why only *some* things are gated
There are two kinds of integration-backed workflows, and they're handled differently on purpose:
- **Core** - baked into the app; users expect them to work (e.g. ordering labs via Health Gorilla). These are gated upfront (banner + `WorkflowGate`).
- **Isolated** - exist *only* because an integration is present (e.g. Stedi eligibility, DoseSpot, ScriptSure). A missing optional integration isn't a broken core workflow, so these are intentionally left out of the manifest and banner and keep their existing in-context handling (eligibility keeps its "Contact Support" upsell, now with the Stedi docs link; DoseSpot/ScriptSure hide their entry points).

## What about ValueSet dependencies?
Out of scope: an audit of every coded field in Provider found none with a hard ValueSet dependency (no field passes `creatable={false}`; they all accept custom values), so a missing terminology ValueSet degrades gracefully rather than breaking a flow.
