### PR TITLE
[Provider]: Add availability overlay during scheduling

### DIFF
--- a/examples/medplum-provider/src/components/schedule/FindPane.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/FindPane.test.tsx
@@ -268,36 +268,6 @@ describe('FindPane', () => {
     });
   });
 
-  describe('Auto-Selection with Single Service', () => {
-    test('auto-selects when there is exactly one schedulable service', async () => {
-      const schedule = createScheduleWithServices([healthcareService]);
-
-      await act(async () => {
-        setup({ schedule });
-      });
-
-      // Should immediately show the service type name, not the selection UI
-      expect(screen.getByText('Annual Checkup')).toBeInTheDocument();
-      expect(screen.queryByText('Schedule…')).not.toBeInTheDocument();
-
-      // Should fetch slots automatically
-      expect(medplum.get).toHaveBeenCalled();
-    });
-
-    test('does not show dismiss button when auto-selected with single option', async () => {
-      const schedule = createScheduleWithServices([healthcareService]);
-
-      await act(async () => {
-        setup({ schedule });
-      });
-
-      expect(screen.getByText('Annual Checkup')).toBeInTheDocument();
-
-      // Dismiss button should not be present
-      expect(screen.queryByLabelText('Clear selection')).not.toBeInTheDocument();
-    });
-  });
-
   describe('Appointment Selection', () => {
     test('Displays a form for the chosen appointment', async () => {
       const user = userEvent.setup();
@@ -505,8 +475,11 @@ describe('FindPane', () => {
     test('navigates to the encounter page and does not call onSuccess when an encounter is returned', async () => {
       const user = userEvent.setup();
       const onSuccess = vi.fn();
-      // Single service → auto-selected; $find returns mock appointments from the outer beforeEach.
+      // $find returns mock appointments from the outer beforeEach.
       setupWithRoutes(createScheduleWithServices([serviceWithEncounterConfig]), onSuccess);
+
+      // Select the service to trigger the $find search
+      await user.click(await screen.findByText('Encounter Service'));
 
       // Click the first appointment slot that appeared from $find (there are two)
       const apptButtons = await screen.findAllByRole('button', { name: /2024/i });
@@ -522,8 +495,10 @@ describe('FindPane', () => {
       const user = userEvent.setup();
       const onSuccess = vi.fn();
       // healthcareService has no encounter extensions → bookEncounter returns undefined.
-      // Single service → auto-selected, so we go straight to waiting for the appointment buttons.
       setupWithRoutes(createScheduleWithServices([healthcareService]), onSuccess);
+
+      // Select the service to trigger the $find search
+      await user.click(await screen.findByText('Annual Checkup'));
 
       const apptButtons = await screen.findAllByRole('button', { name: /2024/i });
       await user.click(apptButtons[0]);

--- a/examples/medplum-provider/src/components/schedule/FindPane.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/FindPane.test.tsx
@@ -24,6 +24,8 @@ import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
+import { useState } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { createEncounter } from '../../utils/encounter';
@@ -121,6 +123,27 @@ describe('FindPane', () => {
     onSuccess?: (results: { appointment: Appointment; slots: Slot[] }) => void;
   };
 
+  // The selected HealthcareService is now hoisted to <ScheduleDetails>, so tests
+  // drive FindPane through a stateful harness that owns that state the same way.
+  type FindPaneHarnessProps = {
+    schedule: WithId<Schedule>;
+    range: { start: Date; end: Date };
+    onSuccess: (results: { appointment: Appointment; slots: Slot[] }) => void;
+  };
+
+  const FindPaneHarness = (props: FindPaneHarnessProps): JSX.Element => {
+    const [healthcareService, setHealthcareService] = useState<WithId<HealthcareService> | undefined>(undefined);
+    return (
+      <FindPane
+        schedule={props.schedule}
+        range={props.range}
+        onSuccess={props.onSuccess}
+        healthcareService={healthcareService}
+        onSelectHealthcareService={setHealthcareService}
+      />
+    );
+  };
+
   const setup = (options: SetupOptions = {}): ReturnType<typeof render> => {
     const {
       schedule = createScheduleWithServices([healthcareService, healthcareService2]),
@@ -134,7 +157,7 @@ describe('FindPane', () => {
           <MantineProvider>
             <Notifications />
             <div data-testid="FindPaneTestWrapper">
-              <FindPane schedule={schedule} range={range} onSuccess={onSuccess} />
+              <FindPaneHarness schedule={schedule} range={range} onSuccess={onSuccess} />
             </div>
           </MantineProvider>
         </MedplumProvider>
@@ -240,18 +263,6 @@ describe('FindPane', () => {
   });
 
   describe('Dismiss Functionality', () => {
-    test('shows dismiss button when service type is selected and multiple options exist', async () => {
-      const user = userEvent.setup();
-
-      await act(async () => {
-        setup();
-      });
-
-      await user.click(screen.getByText('Annual Checkup'));
-
-      expect(screen.getByLabelText('Clear selection')).toBeInTheDocument();
-    });
-
     test('clears selection when dismissed', async () => {
       const user = userEvent.setup();
 
@@ -450,7 +461,7 @@ describe('FindPane', () => {
               <Routes>
                 <Route
                   path="/find"
-                  element={<FindPane schedule={schedule} range={defaultRange} onSuccess={onSuccess} />}
+                  element={<FindPaneHarness schedule={schedule} range={defaultRange} onSuccess={onSuccess} />}
                 />
                 <Route
                   path="/Patient/:patientId/Encounter/:encounterId"

--- a/examples/medplum-provider/src/components/schedule/FindPane.tsx
+++ b/examples/medplum-provider/src/components/schedule/FindPane.tsx
@@ -28,6 +28,8 @@ type FindPaneProps = {
   schedule: WithId<Schedule>;
   range: Range;
   onSuccess: (results: { appointment: WithId<Appointment>; slots: WithId<Slot>[] }) => void;
+  healthcareService: WithId<HealthcareService> | undefined;
+  onSelectHealthcareService: (healthcareService: WithId<HealthcareService> | undefined) => void;
   className?: string;
 };
 
@@ -55,8 +57,7 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
   const navigate = useNavigate();
   const [appointments, setAppointments] = useState<readonly Appointment[] | undefined>(undefined);
   const [chosenAppointment, setChosenAppointment] = useState<Appointment | undefined>(undefined);
-  const [selectedHealthcareService, setSelectedHealthcareService] = useState<WithId<HealthcareService> | undefined>();
-  const { schedule, range, onSuccess } = props;
+  const { schedule, range, healthcareService, onSelectHealthcareService, onSuccess } = props;
 
   const [healthcareServices, setHealthcareServices] = useState<WithId<HealthcareService>[] | undefined>();
 
@@ -89,7 +90,7 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
   const earliestSchedulable = useSchedulingStartsAt({ minimumNoticeMinutes: 30 });
 
   useEffect(() => {
-    if (!schedule || !selectedHealthcareService) {
+    if (!schedule || !healthcareService) {
       return () => {};
     }
 
@@ -106,7 +107,7 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
     const url = medplum.fhirUrl('Appointment', '$find');
     url.searchParams.append('start', start);
     url.searchParams.append('end', end);
-    url.searchParams.append('service-type-reference', getReferenceString(selectedHealthcareService));
+    url.searchParams.append('service-type-reference', getReferenceString(healthcareService));
     url.searchParams.append('schedule', getReferenceString(schedule));
 
     medplum
@@ -138,12 +139,12 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
         controller.abort();
       }
     };
-  }, [medplum, schedule, selectedHealthcareService, range, earliestSchedulable]);
+  }, [medplum, schedule, healthcareService, range, earliestSchedulable]);
 
   const handleDismiss = useCallback(() => {
-    setSelectedHealthcareService(undefined);
+    onSelectHealthcareService(undefined);
     setAppointments(EMPTY);
-  }, []);
+  }, [onSelectHealthcareService]);
 
   const handleBookSuccess = useCallback(
     async (results: {
@@ -158,24 +159,24 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
         return;
       }
 
-      setSelectedHealthcareService(undefined);
+      onSelectHealthcareService(undefined);
       setAppointments([]);
       setChosenAppointment(undefined);
       onSuccess(results);
     },
-    [onSuccess, navigate]
+    [onSuccess, onSelectHealthcareService, navigate]
   );
 
   if (!scheduleableServices?.length) {
     return null;
   }
 
-  if (selectedHealthcareService && chosenAppointment) {
+  if (healthcareService && chosenAppointment) {
     return (
       <Stack gap="sm" justify="flex-start" className={props.className}>
         <Title order={4}>
           <Group justify="space-between">
-            <HealthcareServiceDisplay value={selectedHealthcareService} />
+            <HealthcareServiceDisplay value={healthcareService} />
             <Button variant="subtle" onClick={() => setChosenAppointment(undefined)} aria-label="Clear selection">
               <IconX size={20} />
             </Button>
@@ -183,19 +184,19 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
         </Title>
         <BookAppointmentForm
           appointment={chosenAppointment}
-          healthcareService={selectedHealthcareService}
+          healthcareService={healthcareService}
           onSuccess={handleBookSuccess}
         />
       </Stack>
     );
   }
 
-  if (selectedHealthcareService) {
+  if (healthcareService) {
     return (
       <Stack gap="sm" justify="flex-start" className={props.className}>
         <Title order={4}>
           <Group justify="space-between">
-            <HealthcareServiceDisplay value={selectedHealthcareService} />
+            <HealthcareServiceDisplay value={healthcareService} />
             <Button variant="subtle" onClick={handleDismiss} aria-label="Clear selection">
               <IconX size={20} />
             </Button>
@@ -231,7 +232,7 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
           variant="outline"
           rightSection={<IconChevronRight size={12} />}
           justify="space-between"
-          onClick={() => setSelectedHealthcareService(service)}
+          onClick={() => props.onSelectHealthcareService(service)}
         >
           <HealthcareServiceDisplay value={service} />
         </Button>

--- a/examples/medplum-provider/src/components/schedule/FindPane.tsx
+++ b/examples/medplum-provider/src/components/schedule/FindPane.tsx
@@ -85,14 +85,6 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
     [healthcareServices]
   );
 
-  useEffect(() => {
-    // If there is exactly one option, select it immediately instead of forcing user
-    // to select it
-    if (scheduleableServices?.length === 1) {
-      setSelectedHealthcareService(scheduleableServices[0]);
-    }
-  }, [scheduleableServices]);
-
   // Ensure that we are searching for appointments in the future by at least 30 minutes.
   const earliestSchedulable = useSchedulingStartsAt({ minimumNoticeMinutes: 30 });
 
@@ -204,11 +196,9 @@ export function FindPane(props: FindPaneProps): JSX.Element | null {
         <Title order={4}>
           <Group justify="space-between">
             <HealthcareServiceDisplay value={selectedHealthcareService} />
-            {scheduleableServices.length > 1 && (
-              <Button variant="subtle" onClick={handleDismiss} aria-label="Clear selection">
-                <IconX size={20} />
-              </Button>
-            )}
+            <Button variant="subtle" onClick={handleDismiss} aria-label="Clear selection">
+              <IconX size={20} />
+            </Button>
           </Group>
         </Title>
         {(appointments ?? EMPTY).map((appointment) => (

--- a/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
@@ -4,9 +4,9 @@ import { Box, Drawer, LoadingOverlay, Stack, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import type { WithId } from '@medplum/core';
 import { getReferenceString, isReference, isResourceWithId } from '@medplum/core';
-import type { Appointment, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
+import type { Appointment, HealthcareService, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
 import { useMedplum, useResourceModified } from '@medplum/react';
-import { Calendar } from '@medplum/react-scheduling';
+import { Calendar, getEffectiveAvailability } from '@medplum/react-scheduling';
 import type { JSX } from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -35,6 +35,9 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
 
   const [appointmentSlot, setAppointmentSlot] = useState<Range>();
   const [appointmentDetails, setAppointmentDetails] = useState<WithId<Appointment> | undefined>(undefined);
+  const [healthcareService, setHealthcareService] = useState<WithId<HealthcareService> | undefined>(undefined);
+
+  const availableTime = getEffectiveAvailability(healthcareService, schedule);
 
   const { slots, appointments, loading } = useSchedulingResources([schedule], range);
 
@@ -140,6 +143,7 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
               appointments={appointments ?? []}
               onRangeChange={setRange}
               onDoubleClickAppointment={handleDoubleClickAppointment}
+              availableTime={availableTime}
             />
           </Box>
           <Text size="sm" color="dimmed" fs="italic">
@@ -154,6 +158,8 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
             range={range}
             onSuccess={handleBookSuccess}
             className={classes.findPane}
+            healthcareService={healthcareService}
+            onSelectHealthcareService={setHealthcareService}
           />
         )}
       </div>

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
@@ -500,11 +500,11 @@ describe('$find/$book component integration tests', () => {
       setup('/Calendar/Schedule/alice-smith-schedule');
     });
 
-    // Pane header shows selected service type
-    expect(screen.getByText('Annual Checkup')).toBeInTheDocument();
+    // Select the service type to trigger the $find search
+    await user.click(screen.getByText('Annual Checkup'));
 
     // Click on an appointment button from the find pane
-    const slotButtons = screen.getAllByText(/1\/16\/2024/);
+    const slotButtons = await screen.findAllByText(/1\/16\/2024/);
     expect(slotButtons.length).toEqual(1);
     await user.click(slotButtons[0]);
 

--- a/packages/react-scheduling/src/Calendar/Calendar.module.css
+++ b/packages/react-scheduling/src/Calendar/Calendar.module.css
@@ -123,3 +123,7 @@
     color: var(--cal-color);
   }
 }
+
+.nonBusinessHours {
+  background-color: light-dark(#0000000A, #FFFFFF2A);
+}

--- a/packages/react-scheduling/src/Calendar/Calendar.stories.tsx
+++ b/packages/react-scheduling/src/Calendar/Calendar.stories.tsx
@@ -16,3 +16,21 @@ export const Basic = (): JSX.Element => (
     <Calendar slots={[]} appointments={[]} />
   </div>
 );
+
+export const WithAvailabilityOverlay = (): JSX.Element => (
+  <div style={{ height: 600, padding: '1em' }}>
+    <Calendar
+      availableTime={[
+        {
+          daysOfWeek: ['mon', 'tue', 'wed'],
+          availableStartTime: '09:00:00',
+          availableEndTime: '17:00:00',
+        },
+        {
+          daysOfWeek: ['fri'],
+          allDay: true,
+        },
+      ]}
+    />
+  </div>
+);

--- a/packages/react-scheduling/src/Calendar/Calendar.test.tsx
+++ b/packages/react-scheduling/src/Calendar/Calendar.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { Appointment, Slot } from '@medplum/fhirtypes';
+import type { Appointment, HealthcareServiceAvailableTime, Slot } from '@medplum/fhirtypes';
 import { describe, expect, test, vi } from 'vitest';
 import { render, screen, userEvent } from '../test-utils/render';
 import type { DateTimeRange } from '../types';
@@ -49,6 +49,7 @@ describe('Calendar', () => {
   const setup = ({
     slots = [],
     appointments = [],
+    availableTime,
     onSelectInterval,
     onSelectSlot,
     onSelectAppointment,
@@ -57,6 +58,7 @@ describe('Calendar', () => {
   }: {
     slots?: Slot[];
     appointments?: Appointment[];
+    availableTime?: HealthcareServiceAvailableTime[];
     onSelectInterval?: () => void;
     onSelectSlot?: (slot: Slot) => void;
     onSelectAppointment?: (appointment: Appointment) => void;
@@ -67,6 +69,7 @@ describe('Calendar', () => {
       <Calendar
         slots={slots}
         appointments={appointments}
+        availableTime={availableTime}
         onSelectInterval={onSelectInterval}
         onSelectSlot={onSelectSlot}
         onSelectAppointment={onSelectAppointment}
@@ -75,6 +78,11 @@ describe('Calendar', () => {
       />
     );
   };
+
+  // Week view always lays out columns Sun..Sat regardless of which week is showing,
+  // so day-of-week behavior can be asserted by position without depending on "today".
+  const getWeekGridCells = (container: HTMLElement): Element[] =>
+    Array.from(container.querySelectorAll('[role="gridcell"][data-date]'));
 
   describe('CalendarToolbar', () => {
     test('renders toolbar with navigation buttons', async () => {
@@ -457,6 +465,85 @@ describe('Calendar', () => {
       // Switch to month view
       await userEvent.click(screen.getByText('Month'));
       expect(onRangeChange.mock.calls.length).toBeGreaterThan(initialCallCount);
+    });
+  });
+
+  describe('availableTime prop', () => {
+    test('renders no non-business-hours overlay when availableTime is not provided', async () => {
+      const { container } = setup();
+
+      expect(container.querySelectorAll('.nonBusinessHours')).toHaveLength(0);
+    });
+
+    test('highlights days outside availableTime, and both sides of the day for partial availability', async () => {
+      const { container } = setup({
+        availableTime: [{ daysOfWeek: ['mon'], availableStartTime: '09:00:00', availableEndTime: '17:00:00' }],
+      });
+
+      const cells = getWeekGridCells(container);
+      expect(cells).toHaveLength(7);
+
+      // DayIndexer order is [sun, mon, tue, wed, thu, fri, sat]
+      const overlayCountsByDay = cells.map((cell) => cell.querySelectorAll('.nonBusinessHours').length);
+
+      // Monday has business hours in the middle of the day, so it is bounded by
+      // a non-business overlay both before 9am and after 5pm.
+      expect(overlayCountsByDay[1]).toBe(2);
+
+      // Every other day of the week has no availableTime entry at all, so the
+      // entire day is a single non-business overlay.
+      expect(overlayCountsByDay[0]).toBe(1);
+      expect(overlayCountsByDay[2]).toBe(1);
+      expect(overlayCountsByDay[3]).toBe(1);
+      expect(overlayCountsByDay[4]).toBe(1);
+      expect(overlayCountsByDay[5]).toBe(1);
+      expect(overlayCountsByDay[6]).toBe(1);
+    });
+
+    test('does not highlight a day marked allDay', async () => {
+      const { container } = setup({
+        availableTime: [{ daysOfWeek: ['fri'], allDay: true }],
+      });
+
+      const cells = getWeekGridCells(container);
+      const overlayCountsByDay = cells.map((cell) => cell.querySelectorAll('.nonBusinessHours').length);
+
+      // Friday is available all day, so it has no non-business overlay.
+      expect(overlayCountsByDay[5]).toBe(0);
+
+      // The rest of the week is still fully non-business.
+      expect(overlayCountsByDay[0]).toBe(1);
+      expect(overlayCountsByDay[1]).toBe(1);
+      expect(overlayCountsByDay[2]).toBe(1);
+      expect(overlayCountsByDay[3]).toBe(1);
+      expect(overlayCountsByDay[4]).toBe(1);
+      expect(overlayCountsByDay[6]).toBe(1);
+    });
+
+    test('combines multiple availableTime entries across days', async () => {
+      const { container } = setup({
+        availableTime: [
+          {
+            daysOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri'],
+            availableStartTime: '09:00:00',
+            availableEndTime: '17:00:00',
+          },
+          { daysOfWeek: ['sat'], allDay: true },
+        ],
+      });
+
+      const cells = getWeekGridCells(container);
+      const overlayCountsByDay = cells.map((cell) => cell.querySelectorAll('.nonBusinessHours').length);
+
+      expect(overlayCountsByDay).toEqual([
+        1, // sun: not covered, fully non-business
+        2, // mon: bounded before/after business hours
+        2, // tue
+        2, // wed
+        2, // thu
+        2, // fri
+        0, // sat: allDay
+      ]);
     });
   });
 });

--- a/packages/react-scheduling/src/Calendar/Calendar.tsx
+++ b/packages/react-scheduling/src/Calendar/Calendar.tsx
@@ -183,7 +183,7 @@ export function Calendar(props: CalendarProps): JSX.Element {
     return [...appointmentsToEvents(appointments), ...slotsToEvents(filteredSlots)];
   }, [props.appointments, props.slots]);
 
-  const businessHours = props.availableTime?.map(availableTimeToBusinessHoursEntry).flat();
+  const businessHours = props.availableTime?.flatMap(availableTimeToBusinessHoursEntry);
 
   return (
     <div data-testid="calendar" className={cx(classes.wrapper, props.className)}>

--- a/packages/react-scheduling/src/Calendar/Calendar.tsx
+++ b/packages/react-scheduling/src/Calendar/Calendar.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { BusinessHoursInput, EventApi, EventInput } from '@fullcalendar/react';
+import type { EventApi, EventInput } from '@fullcalendar/react';
 import FullCalendar, { useCalendarController } from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/react/daygrid';
 import interactionPlugin from '@fullcalendar/react/interaction';
@@ -19,47 +19,9 @@ import type { JSX } from 'react';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { DateTimeRange } from '../types';
 import classes from './Calendar.module.css';
+import { availableTimeToBusinessHoursEntry } from './Calendar.utils';
 
 type ExtendedEvent = { type: 'appointment'; appointment: Appointment } | { type: 'slot'; slot: Slot };
-
-const DayIndexer = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
-
-function availableTimeToBusinessHoursEntry(availableTime: HealthcareServiceAvailableTime): BusinessHoursInput[] {
-  const startTime = availableTime.allDay ? '00:00:00' : availableTime.availableStartTime;
-  const endTime = availableTime.allDay ? '24:00:00' : availableTime.availableEndTime;
-
-  if (!startTime || !endTime || !availableTime.daysOfWeek) {
-    return [];
-  }
-
-  const daysOfWeek = availableTime.daysOfWeek.map((day) => DayIndexer.indexOf(day));
-
-  // When endTime is less than or equal to startTime, the interval wraps past
-  // midnight into the following day. Split it into two entries: startTime →
-  // midnight on the given days, and midnight → endTime on the subsequent days.
-  if (endTime <= startTime) {
-    return [
-      {
-        daysOfWeek,
-        startTime,
-        endTime: '24:00:00',
-      },
-      {
-        daysOfWeek: daysOfWeek.map((day) => (day + 1) % 7),
-        startTime: '00:00:00',
-        endTime,
-      },
-    ];
-  }
-
-  return [
-    {
-      daysOfWeek,
-      startTime,
-      endTime,
-    },
-  ];
-}
 
 function appointmentsToEvents(appointments: Appointment[]): EventInput[] {
   return appointments

--- a/packages/react-scheduling/src/Calendar/Calendar.tsx
+++ b/packages/react-scheduling/src/Calendar/Calendar.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { EventApi, EventInput } from '@fullcalendar/react';
+import type { BusinessHoursInput, EventApi, EventInput } from '@fullcalendar/react';
 import FullCalendar, { useCalendarController } from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/react/daygrid';
 import interactionPlugin from '@fullcalendar/react/interaction';
@@ -12,7 +12,7 @@ import timeGridPlugin from '@fullcalendar/react/timegrid';
 import { Button, Group, SegmentedControl, Title, useComputedColorScheme } from '@mantine/core';
 import { useDebouncedCallback } from '@mantine/hooks';
 import { assertNever, EMPTY, getReferenceString } from '@medplum/core';
-import type { Appointment, Slot } from '@medplum/fhirtypes';
+import type { Appointment, HealthcareServiceAvailableTime, Slot } from '@medplum/fhirtypes';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import cx from 'clsx';
 import type { JSX } from 'react';
@@ -21,6 +21,45 @@ import type { DateTimeRange } from '../types';
 import classes from './Calendar.module.css';
 
 type ExtendedEvent = { type: 'appointment'; appointment: Appointment } | { type: 'slot'; slot: Slot };
+
+const DayIndexer = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+
+function availableTimeToBusinessHoursEntry(availableTime: HealthcareServiceAvailableTime): BusinessHoursInput[] {
+  const startTime = availableTime.allDay ? '00:00:00' : availableTime.availableStartTime;
+  const endTime = availableTime.allDay ? '24:00:00' : availableTime.availableEndTime;
+
+  if (!startTime || !endTime || !availableTime.daysOfWeek) {
+    return [];
+  }
+
+  const daysOfWeek = availableTime.daysOfWeek.map((day) => DayIndexer.indexOf(day));
+
+  // When endTime is less than or equal to startTime, the interval wraps past
+  // midnight into the following day. Split it into two entries: startTime →
+  // midnight on the given days, and midnight → endTime on the subsequent days.
+  if (endTime <= startTime) {
+    return [
+      {
+        daysOfWeek,
+        startTime,
+        endTime: '24:00:00',
+      },
+      {
+        daysOfWeek: daysOfWeek.map((day) => (day + 1) % 7),
+        startTime: '00:00:00',
+        endTime,
+      },
+    ];
+  }
+
+  return [
+    {
+      daysOfWeek,
+      startTime,
+      endTime,
+    },
+  ];
+}
 
 function appointmentsToEvents(appointments: Appointment[]): EventInput[] {
   return appointments
@@ -68,6 +107,7 @@ export interface CalendarProps {
   onDoubleClickAppointment?: (appointment: Appointment) => void;
   onRangeChange?: (range: DateTimeRange) => void;
   className?: string;
+  availableTime?: HealthcareServiceAvailableTime[];
 }
 
 export function Calendar(props: CalendarProps): JSX.Element {
@@ -142,6 +182,8 @@ export function Calendar(props: CalendarProps): JSX.Element {
 
     return [...appointmentsToEvents(appointments), ...slotsToEvents(filteredSlots)];
   }, [props.appointments, props.slots]);
+
+  const businessHours = props.availableTime?.map(availableTimeToBusinessHoursEntry).flat();
 
   return (
     <div data-testid="calendar" className={cx(classes.wrapper, props.className)}>
@@ -219,6 +261,8 @@ export function Calendar(props: CalendarProps): JSX.Element {
             info.el.addEventListener('dblclick', handleDblClick);
           }
         }}
+        businessHours={businessHours}
+        nonBusinessHoursClass={classes.nonBusinessHours}
       />
     </div>
   );

--- a/packages/react-scheduling/src/Calendar/Calendar.utils.test.ts
+++ b/packages/react-scheduling/src/Calendar/Calendar.utils.test.ts
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { availableTimeToBusinessHoursEntry } from './Calendar.utils';
+
+describe('availableTimeToBusinessHoursEntry', () => {
+  test('converts a simple weekday range', () => {
+    const result = availableTimeToBusinessHoursEntry({
+      daysOfWeek: ['mon', 'wed', 'fri'],
+      availableStartTime: '09:00:00',
+      availableEndTime: '17:00:00',
+    });
+
+    expect(result).toEqual([
+      {
+        daysOfWeek: [1, 3, 5],
+        startTime: '09:00:00',
+        endTime: '17:00:00',
+      },
+    ]);
+  });
+
+  test('converts allDay to the full 00:00-24:00 range', () => {
+    const result = availableTimeToBusinessHoursEntry({
+      daysOfWeek: ['sun'],
+      allDay: true,
+    });
+
+    expect(result).toEqual([
+      {
+        daysOfWeek: [0],
+        startTime: '00:00:00',
+        endTime: '24:00:00',
+      },
+    ]);
+  });
+
+  test('returns no entries when daysOfWeek is missing', () => {
+    expect(
+      availableTimeToBusinessHoursEntry({ availableStartTime: '09:00:00', availableEndTime: '17:00:00' })
+    ).toStrictEqual([]);
+  });
+
+  test('returns no entries when start/end times are missing and not allDay', () => {
+    expect(availableTimeToBusinessHoursEntry({ daysOfWeek: ['mon'] })).toStrictEqual([]);
+  });
+
+  test('splits a range that wraps past midnight into two entries', () => {
+    const result = availableTimeToBusinessHoursEntry({
+      daysOfWeek: ['fri'],
+      availableStartTime: '22:00:00',
+      availableEndTime: '06:00:00',
+    });
+
+    expect(result).toEqual([
+      {
+        daysOfWeek: [5], // fri
+        startTime: '22:00:00',
+        endTime: '24:00:00',
+      },
+      {
+        daysOfWeek: [6], // sat
+        startTime: '00:00:00',
+        endTime: '06:00:00',
+      },
+    ]);
+  });
+
+  test('wraps the following day back to Sunday when the range starts on Saturday', () => {
+    const result = availableTimeToBusinessHoursEntry({
+      daysOfWeek: ['sat'],
+      availableStartTime: '22:00:00',
+      availableEndTime: '06:00:00',
+    });
+
+    expect(result[1]).toMatchObject({
+      daysOfWeek: [0], // sat + 1 wraps around to sun
+      startTime: '00:00:00',
+      endTime: '06:00:00',
+    });
+  });
+
+  test('treats an exactly-equal start/end time as wrapping (24-hour range)', () => {
+    const result = availableTimeToBusinessHoursEntry({
+      daysOfWeek: ['mon'],
+      availableStartTime: '09:00:00',
+      availableEndTime: '09:00:00',
+    });
+
+    expect(result).toEqual([
+      { daysOfWeek: [1], startTime: '09:00:00', endTime: '24:00:00' },
+      { daysOfWeek: [2], startTime: '00:00:00', endTime: '09:00:00' },
+    ]);
+  });
+});

--- a/packages/react-scheduling/src/Calendar/Calendar.utils.ts
+++ b/packages/react-scheduling/src/Calendar/Calendar.utils.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { BusinessHoursInput } from '@fullcalendar/react';
+import type { HealthcareServiceAvailableTime } from '@medplum/fhirtypes';
+
+const DayIndexer = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+
+export function availableTimeToBusinessHoursEntry(availableTime: HealthcareServiceAvailableTime): BusinessHoursInput[] {
+  const startTime = availableTime.allDay ? '00:00:00' : availableTime.availableStartTime;
+  const endTime = availableTime.allDay ? '24:00:00' : availableTime.availableEndTime;
+
+  if (!startTime || !endTime || !availableTime.daysOfWeek) {
+    return [];
+  }
+
+  const daysOfWeek = availableTime.daysOfWeek.map((day) => DayIndexer.indexOf(day));
+
+  // When endTime is less than or equal to startTime, the interval wraps past
+  // midnight into the following day. Split it into two entries: startTime →
+  // midnight on the given days, and midnight → endTime on the subsequent days.
+  if (endTime <= startTime) {
+    return [
+      {
+        daysOfWeek,
+        startTime,
+        endTime: '24:00:00',
+      },
+      {
+        daysOfWeek: daysOfWeek.map((day) => (day + 1) % 7),
+        startTime: '00:00:00',
+        endTime,
+      },
+    ];
+  }
+
+  return [
+    {
+      daysOfWeek,
+      startTime,
+      endTime,
+    },
+  ];
+}


### PR DESCRIPTION
- Hoist the selected HealthcareService state up to `<ScheduleDetails>`, so that it can extract availability information and pass it into the Calendar widget

- Update the Calendar widget to highlight the available time (via the FullCalendar "business hours" feature)

- We stop auto-selecting a healthcare-service when there is only one, as it makes the availability highlight a bit confusing and not dismiss-able. Now you have to explicitly click in to the service to see the highlight appear.

## Implementation Notes
- A Schedule may have may Scheduling Parameter extensions, which may each have many `availability` sub-extensions, which may each have many `availableTime` sub-sub-extensions. This makes some of the data handling work here tricky.
- We support `availableStartTime` + `availableEndTime` or `allDay` options within the `availableTime` entries
- If the end time is less than the start time, we consider it to wrap to the next day. Example: "22:00:00 - 06:00:00" is an eight hour shift from 10pm - 6am the following day.

## Screenshots

The screenshots are slightly out of date - they include some footer information that showed the source of scheduling information. I've removed that to keep this PR more tightly scoped, and intend to follow up on revealing scheduling configuration more thoughtfully later.

- A schedule type with no availability info set is 24/7 available
<img width="1531" height="933" alt="Screenshot 2026-07-15 at 7 01 05 PM" src="https://github.com/user-attachments/assets/813cccbf-9131-4ed6-800d-d53f42192f63" />

- HealthcareService availability can be highlighted
<img width="1531" height="933" alt="Screenshot 2026-07-15 at 7 02 03 PM" src="https://github.com/user-attachments/assets/ded93580-ddf6-43e2-a84a-ae3eab485e45" />

- Per-Schedule overrides of the availability take precedence over HealthcareService availability
<img width="1531" height="933" alt="Screenshot 2026-07-15 at 7 03 26 PM" src="https://github.com/user-attachments/assets/116fe9d5-1edb-46b7-8728-1991727f7f70" />
