### PR TITLE
Clarify and normalize BullMQ worker config helpers

### DIFF
--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -116,7 +116,7 @@ export const initBatchWorker: WorkerInitializer = (config, options?: WorkerIniti
 
   let worker: Worker<BatchJobData> | undefined;
   if (options?.workerEnabled !== false) {
-    const workerBullmq = getWorkerBullmqConfig(config, 'batch');
+    const workerOptions = getWorkerBullmqConfig(config, 'batch', { concurrency: 15 });
     worker = new Worker<BatchJobData>(
       queueName,
       (job) => {
@@ -131,11 +131,7 @@ export const initBatchWorker: WorkerInitializer = (config, options?: WorkerIniti
           }
         });
       },
-      {
-        ...defaultOptions,
-        concurrency: 1,
-        ...workerBullmq,
-      }
+      { ...defaultOptions, ...workerOptions }
     );
 
     worker.on('failed', async (job, failedErr) => {

--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -105,18 +105,17 @@ const defaultCheckpointEntries = 10;
 const defaultCheckpointIntervalMs = 5000;
 
 export const initBatchWorker: WorkerInitializer = (config, options?: WorkerInitializerOptions) => {
-  const defaultOptions = defaultQueueOptions(config);
+  const queueOptions = defaultQueueOptions(config);
   const queue = new Queue<BatchJobData>(queueName, {
-    ...defaultOptions,
+    ...queueOptions,
     defaultJobOptions: {
-      ...defaultOptions.defaultJobOptions,
+      ...queueOptions.defaultJobOptions,
       attempts: 1,
     },
   });
 
   let worker: Worker<BatchJobData> | undefined;
   if (options?.workerEnabled !== false) {
-    const workerOptions = getWorkerBullmqConfig(config, 'batch', { concurrency: 15 });
     worker = new Worker<BatchJobData>(
       queueName,
       (job) => {
@@ -131,7 +130,7 @@ export const initBatchWorker: WorkerInitializer = (config, options?: WorkerIniti
           }
         });
       },
-      { ...defaultOptions, ...workerOptions }
+      getWorkerBullmqConfig(config, 'batch', queueOptions, { concurrency: 15 })
     );
 
     worker.on('failed', async (job, failedErr) => {

--- a/packages/server/src/workers/cron.ts
+++ b/packages/server/src/workers/cron.ts
@@ -30,18 +30,12 @@ export interface CronJobData {
 const queueName = 'CronQueue';
 
 export const initCronWorker: WorkerInitializer = (config, options?: WorkerInitializerOptions) => {
-  const defaultOptions = defaultQueueOptions(config);
-  const queue = new Queue<CronJobData>(queueName, {
-    ...defaultOptions,
-  });
+  const queueOptions = defaultQueueOptions(config);
+  const queue = new Queue<CronJobData>(queueName, queueOptions);
 
   let worker: Worker<CronJobData> | undefined;
   if (options?.workerEnabled !== false) {
-    const workerBullmq = getWorkerBullmqConfig(config, 'cron');
-    worker = new Worker<CronJobData>(queueName, execBot, {
-      ...defaultOptions,
-      ...workerBullmq,
-    });
+    worker = new Worker<CronJobData>(queueName, execBot, getWorkerBullmqConfig(config, 'cron', queueOptions));
     worker.on('completed', (job) => globalLogger.info(`Completed job ${job.id} successfully`));
     worker.on('failed', (job, err) => globalLogger.info(`Failed job ${job?.id} with ${err}`));
   }

--- a/packages/server/src/workers/data-warehouse-sync.ts
+++ b/packages/server/src/workers/data-warehouse-sync.ts
@@ -73,20 +73,19 @@ export const initDataWarehouseSyncWorker: WorkerInitializer = (config, options?:
     return { queue: undefined, worker: undefined, name: DataWarehouseSyncQueueName };
   }
 
-  const defaultOptions = defaultQueueOptions(config);
+  const queueOptions = defaultQueueOptions(config);
   const queue = new Queue<DataWarehouseSyncJobData>(DataWarehouseSyncQueueName, {
-    ...defaultOptions,
-    defaultJobOptions: { ...defaultOptions.defaultJobOptions, attempts: 1 },
+    ...queueOptions,
+    defaultJobOptions: { ...queueOptions.defaultJobOptions, attempts: 1 },
   });
 
-  const workerBullmq = getWorkerBullmqConfig(config, 'data-warehouse-sync', {
-    lockDuration: DATA_WAREHOUSE_SYNC_LOCK_DURATION_MS,
-    concurrency: 1, // Data warehouse sync is intentionally serialized.
-  });
   const worker = new Worker<DataWarehouseSyncJobData>(
     DataWarehouseSyncQueueName,
     async (job) => processDataWarehouseSyncJob(config, job),
-    { ...defaultOptions, ...workerBullmq }
+    getWorkerBullmqConfig(config, 'data-warehouse-sync', queueOptions, {
+      lockDuration: DATA_WAREHOUSE_SYNC_LOCK_DURATION_MS,
+      concurrency: 1, // Data warehouse sync is intentionally serialized.
+    })
   );
   addVerboseQueueLogging<DataWarehouseSyncJobData>(queue, worker, (job) => ({
     trigger: job.data.trigger,

--- a/packages/server/src/workers/data-warehouse-sync.ts
+++ b/packages/server/src/workers/data-warehouse-sync.ts
@@ -79,17 +79,14 @@ export const initDataWarehouseSyncWorker: WorkerInitializer = (config, options?:
     defaultJobOptions: { ...defaultOptions.defaultJobOptions, attempts: 1 },
   });
 
-  const workerBullmq = getWorkerBullmqConfig(config, 'data-warehouse-sync') ?? {};
+  const workerBullmq = getWorkerBullmqConfig(config, 'data-warehouse-sync', {
+    lockDuration: DATA_WAREHOUSE_SYNC_LOCK_DURATION_MS,
+    concurrency: 1, // Data warehouse sync is intentionally serialized.
+  });
   const worker = new Worker<DataWarehouseSyncJobData>(
     DataWarehouseSyncQueueName,
     async (job) => processDataWarehouseSyncJob(config, job),
-    {
-      ...defaultOptions,
-      ...workerBullmq,
-      lockDuration: workerBullmq.lockDuration ?? DATA_WAREHOUSE_SYNC_LOCK_DURATION_MS,
-      // Data warehouse sync is intentionally serialized.
-      concurrency: 1,
-    }
+    { ...defaultOptions, ...workerBullmq }
   );
   addVerboseQueueLogging<DataWarehouseSyncJobData>(queue, worker, (job) => ({
     trigger: job.data.trigger,

--- a/packages/server/src/workers/dispatch.ts
+++ b/packages/server/src/workers/dispatch.ts
@@ -40,21 +40,15 @@ const queueName = 'DispatchQueue';
 const jobName = 'DispatchJobData';
 
 export const initDispatchWorker: WorkerInitializer = (config, options?: WorkerInitializerOptions) => {
-  const defaultOptions = defaultQueueOptions(config);
-  const queue = new Queue<DispatchJobData>(queueName, {
-    ...defaultOptions,
-  });
+  const queueOptions = defaultQueueOptions(config);
+  const queue = new Queue<DispatchJobData>(queueName, queueOptions);
 
   let worker: Worker<DispatchJobData> | undefined;
   if (options?.workerEnabled !== false) {
-    const workerBullmq = getWorkerBullmqConfig(config, 'dispatch');
     worker = new Worker<DispatchJobData>(
       queueName,
       (job) => tryRunInRequestContext(job.data.requestId, job.data.traceId, () => execDispatchJob(job)),
-      {
-        ...defaultOptions,
-        ...workerBullmq,
-      }
+      getWorkerBullmqConfig(config, 'dispatch', queueOptions)
     );
   }
 

--- a/packages/server/src/workers/download.ts
+++ b/packages/server/src/workers/download.ts
@@ -49,21 +49,15 @@ const queueName = 'DownloadQueue';
 const jobName = 'DownloadJobData';
 
 export const initDownloadWorker: WorkerInitializer = (config, options?: WorkerInitializerOptions) => {
-  const defaultOptions = defaultQueueOptions(config);
-  const queue = new Queue<DownloadJobData>(queueName, {
-    ...defaultOptions,
-  });
+  const queueOptions = defaultQueueOptions(config);
+  const queue = new Queue<DownloadJobData>(queueName, queueOptions);
 
   let worker: Worker<DownloadJobData> | undefined;
   if (options?.workerEnabled !== false) {
-    const workerBullmq = getWorkerBullmqConfig(config, 'download');
     worker = new Worker<DownloadJobData>(
       queueName,
       (job) => tryRunInRequestContext(job.data.requestId, job.data.traceId, () => execDownloadJob(job)),
-      {
-        ...defaultOptions,
-        ...workerBullmq,
-      }
+      getWorkerBullmqConfig(config, 'download', queueOptions)
     );
     worker.on('completed', (job) => globalLogger.info(`Completed job ${job.id} successfully`));
     worker.on('failed', (job, err) => globalLogger.info(`Failed job ${job?.id} with ${err}`));

--- a/packages/server/src/workers/lambda-cleaner.ts
+++ b/packages/server/src/workers/lambda-cleaner.ts
@@ -49,19 +49,18 @@ export interface LambdaCleanerSummary extends DeleteOldLambdaVersionStats {
 export const LambdaCleanerQueueName = 'LambdaCleanerQueue';
 
 export const initLambdaCleanerWorker: WorkerInitializer = (config, options?: WorkerInitializerOptions) => {
-  const defaultOptions = defaultQueueOptions(config);
+  const queueOptions = defaultQueueOptions(config);
   const queue = new Queue<LambdaCleanerJobData>(LambdaCleanerQueueName, {
-    ...defaultOptions,
-    defaultJobOptions: { ...defaultOptions.defaultJobOptions, attempts: 1 },
+    ...queueOptions,
+    defaultJobOptions: { ...queueOptions.defaultJobOptions, attempts: 1 },
   });
 
   let worker: Worker<LambdaCleanerJobData> | undefined;
   if (options?.workerEnabled !== false) {
-    const workerConfig = getWorkerBullmqConfig(config, 'lambda-cleaner', { concurrency: 1 });
     worker = new Worker<LambdaCleanerJobData>(
       LambdaCleanerQueueName,
       (job) => tryRunInRequestContext(job.data.requestId, job.data.traceId, () => lambdaCleanerJobProcessor(job)),
-      { ...defaultOptions, ...workerConfig }
+      getWorkerBullmqConfig(config, 'lambda-cleaner', queueOptions, { concurrency: 1 })
     );
     addVerboseQueueLogging<LambdaCleanerJobData>(queue, worker, (job) => ({
       asyncJob: `AsyncJob/${job.data.asyncJob.id}`,

--- a/packages/server/src/workers/lambda-cleaner.ts
+++ b/packages/server/src/workers/lambda-cleaner.ts
@@ -57,11 +57,11 @@ export const initLambdaCleanerWorker: WorkerInitializer = (config, options?: Wor
 
   let worker: Worker<LambdaCleanerJobData> | undefined;
   if (options?.workerEnabled !== false) {
-    const workerConfig = getWorkerBullmqConfig(config, 'lambda-cleaner');
+    const workerConfig = getWorkerBullmqConfig(config, 'lambda-cleaner', { concurrency: 1 });
     worker = new Worker<LambdaCleanerJobData>(
       LambdaCleanerQueueName,
       (job) => tryRunInRequestContext(job.data.requestId, job.data.traceId, () => lambdaCleanerJobProcessor(job)),
-      { ...defaultOptions, concurrency: 1, ...workerConfig }
+      { ...defaultOptions, ...workerConfig }
     );
     addVerboseQueueLogging<LambdaCleanerJobData>(queue, worker, (job) => ({
       asyncJob: `AsyncJob/${job.data.asyncJob.id}`,

--- a/packages/server/src/workers/post-deploy-migration.ts
+++ b/packages/server/src/workers/post-deploy-migration.ts
@@ -53,22 +53,21 @@ function getJobDataLoggingFields(job: Job<PostDeployJobData>): Record<string, st
 }
 
 export const initPostDeployMigrationWorker: WorkerInitializer = (config, options?: WorkerInitializerOptions) => {
-  const defaultOptions = defaultQueueOptions(config);
+  const queueOptions = defaultQueueOptions(config);
   const queue = new Queue<PostDeployJobData>(PostDeployMigrationQueueName, {
-    ...defaultOptions,
+    ...queueOptions,
     defaultJobOptions: {
-      ...defaultOptions.defaultJobOptions,
+      ...queueOptions.defaultJobOptions,
       attempts: 1, // No retries
     },
   });
 
   let worker: Worker<PostDeployJobData> | undefined;
   if (options?.workerEnabled !== false) {
-    const workerBullmq = getWorkerBullmqConfig(config, 'post-deploy-migration', { concurrency: 1 });
     worker = new Worker<PostDeployJobData>(
       PostDeployMigrationQueueName,
       async (job) => tryRunInRequestContext(job.data.requestId, job.data.traceId, async () => jobProcessor(job)),
-      { ...defaultOptions, ...workerBullmq }
+      getWorkerBullmqConfig(config, 'post-deploy-migration', queueOptions, { concurrency: 1 })
     );
     addVerboseQueueLogging<PostDeployJobData>(queue, worker, getJobDataLoggingFields);
   }

--- a/packages/server/src/workers/post-deploy-migration.ts
+++ b/packages/server/src/workers/post-deploy-migration.ts
@@ -64,14 +64,11 @@ export const initPostDeployMigrationWorker: WorkerInitializer = (config, options
 
   let worker: Worker<PostDeployJobData> | undefined;
   if (options?.workerEnabled !== false) {
-    const workerBullmq = getWorkerBullmqConfig(config, 'post-deploy-migration');
+    const workerBullmq = getWorkerBullmqConfig(config, 'post-deploy-migration', { concurrency: 1 });
     worker = new Worker<PostDeployJobData>(
       PostDeployMigrationQueueName,
       async (job) => tryRunInRequestContext(job.data.requestId, job.data.traceId, async () => jobProcessor(job)),
-      {
-        ...workerBullmq,
-        ...defaultOptions,
-      }
+      { ...defaultOptions, ...workerBullmq }
     );
     addVerboseQueueLogging<PostDeployJobData>(queue, worker, getJobDataLoggingFields);
   }

--- a/packages/server/src/workers/reindex.ts
+++ b/packages/server/src/workers/reindex.ts
@@ -107,14 +107,10 @@ export const initReindexWorker: WorkerInitializer = (config, options?: WorkerIni
 
   let worker: Worker<ReindexJobData> | undefined;
   if (options?.workerEnabled !== false) {
-    const workerBullmq = getWorkerBullmqConfig(config, 'reindex');
     worker = new Worker<ReindexJobData>(
       ReindexQueueName,
       async (job) => tryRunInRequestContext(job.data.requestId, job.data.traceId, async () => jobProcessor(job)),
-      {
-        ...defaultOptions,
-        ...workerBullmq,
-      }
+      getWorkerBullmqConfig(config, 'reindex', defaultOptions)
     );
     addVerboseQueueLogging<ReindexJobData>(queue, worker, (job) => ({
       asyncJob: 'AsyncJob/' + job.data.asyncJobId,

--- a/packages/server/src/workers/set-accounts.ts
+++ b/packages/server/src/workers/set-accounts.ts
@@ -34,24 +34,18 @@ const queueName = 'SetAccountsQueue';
 const jobName = 'SetAccountsJobData';
 
 export const initSetAccountsWorker: WorkerInitializer = (config, options?: WorkerInitializerOptions) => {
-  const defaultOptions = defaultQueueOptions(config);
-  const queue = new Queue<SetAccountsJobData>(queueName, {
-    ...defaultOptions,
-  });
+  const queueOptions = defaultQueueOptions(config);
+  const queue = new Queue<SetAccountsJobData>(queueName, queueOptions);
 
   let worker: Worker<SetAccountsJobData> | undefined;
   if (options?.workerEnabled !== false) {
-    const workerBullmq = getWorkerBullmqConfig(config, 'set-accounts');
     worker = new Worker<SetAccountsJobData>(
       queueName,
       (job) => {
         const { authState, requestId, traceId } = job.data;
         return runInAuthenticatedContext(authState, requestId, traceId, { async: true }, () => execSetAccountsJob(job));
       },
-      {
-        ...defaultOptions,
-        ...workerBullmq,
-      }
+      getWorkerBullmqConfig(config, 'set-accounts', queueOptions)
     );
     addVerboseQueueLogging<SetAccountsJobData>(queue, worker, (job) => ({
       asyncJob: 'AsyncJob/' + job.data.asyncJob.id,

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -161,7 +161,6 @@ export const initSubscriptionWorker: WorkerInitializer = (config, options?: Work
 
   let worker: Worker<SubscriptionJobData> | undefined;
   if (options?.workerEnabled !== false) {
-    const workerBullmq = getWorkerBullmqConfig(config, 'subscription');
     worker = new Worker<SubscriptionJobData>(
       queueName,
       (job) =>
@@ -171,8 +170,7 @@ export const initSubscriptionWorker: WorkerInitializer = (config, options?: Work
             )
           : tryRunInRequestContext(job.data.requestId, job.data.traceId, () => execSubscriptionJob(job)),
       {
-        ...defaultOptions,
-        ...workerBullmq,
+        ...getWorkerBullmqConfig(config, 'subscription', defaultOptions),
         settings: {
           backoffStrategy: (attemptsMade: number, type?: string, _err?: Error, _job?: MinimalJob) => {
             if (type !== 'cappedExponential') {

--- a/packages/server/src/workers/utils.test.ts
+++ b/packages/server/src/workers/utils.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { Subscription } from '@medplum/fhirtypes';
-import type { Job, Worker } from 'bullmq';
+import type { Job, QueueOptions, Worker } from 'bullmq';
 import { Queue } from 'bullmq';
 import EventEmitter from 'node:events';
 import { vi } from 'vitest';
@@ -343,23 +343,25 @@ describe('worker utils', () => {
   });
 
   describe('getWorkerBullmqConfig', () => {
-    test('returns global bullmq config when no per-worker overrides', () => {
+    const defaultOptions: QueueOptions = { connection: { host: 'test-redis' } };
+
+    test('returns default options plus global bullmq config when no per-worker overrides', () => {
       const config = {
         bullmq: { concurrency: 20, removeOnComplete: { count: 1 }, removeOnFail: { count: 1 } },
       } as MedplumServerConfig;
 
-      const result = getWorkerBullmqConfig(config, 'subscription');
-      expect(result).toStrictEqual(config.bullmq);
+      const result = getWorkerBullmqConfig(config, 'subscription', defaultOptions);
+      expect(result).toStrictEqual({ ...defaultOptions, ...config.bullmq });
     });
 
-    test('returns global bullmq config when workers config exists but no bullmq overrides for this worker', () => {
+    test('returns default options plus global bullmq config when workers config exists but no bullmq overrides for this worker', () => {
       const config = {
         bullmq: { concurrency: 20, removeOnComplete: { count: 1 }, removeOnFail: { count: 1 } },
         workers: { enabled: ['subscription'] },
       } as MedplumServerConfig;
 
-      const result = getWorkerBullmqConfig(config, 'subscription');
-      expect(result).toStrictEqual(config.bullmq);
+      const result = getWorkerBullmqConfig(config, 'subscription', defaultOptions);
+      expect(result).toStrictEqual({ ...defaultOptions, ...config.bullmq });
     });
 
     test('merges per-worker bullmq overrides on top of global config', () => {
@@ -372,8 +374,9 @@ describe('worker utils', () => {
         },
       } as MedplumServerConfig;
 
-      const result = getWorkerBullmqConfig(config, 'subscription');
+      const result = getWorkerBullmqConfig(config, 'subscription', defaultOptions);
       expect(result).toStrictEqual({
+        ...defaultOptions,
         concurrency: 50,
         removeOnComplete: { count: 1 },
         removeOnFail: { count: 1 },
@@ -385,8 +388,9 @@ describe('worker utils', () => {
         bullmq: { concurrency: 20, removeOnComplete: { count: 1 }, removeOnFail: { count: 1 } },
       } as MedplumServerConfig;
 
-      const result = getWorkerBullmqConfig(config, 'batch', { concurrency: 1 });
+      const result = getWorkerBullmqConfig(config, 'batch', defaultOptions, { concurrency: 1 });
       expect(result).toStrictEqual({
+        ...defaultOptions,
         concurrency: 1,
         removeOnComplete: { count: 1 },
         removeOnFail: { count: 1 },
@@ -403,8 +407,9 @@ describe('worker utils', () => {
         },
       } as MedplumServerConfig;
 
-      const result = getWorkerBullmqConfig(config, 'batch', { concurrency: 1 });
+      const result = getWorkerBullmqConfig(config, 'batch', defaultOptions, { concurrency: 1 });
       expect(result).toStrictEqual({
+        ...defaultOptions,
         concurrency: 5,
         removeOnComplete: { count: 1 },
         removeOnFail: { count: 1 },
@@ -421,8 +426,8 @@ describe('worker utils', () => {
         },
       } as MedplumServerConfig;
 
-      const result = getWorkerBullmqConfig(config, 'download');
-      expect(result).toStrictEqual(config.bullmq);
+      const result = getWorkerBullmqConfig(config, 'download', defaultOptions);
+      expect(result).toStrictEqual({ ...defaultOptions, ...config.bullmq });
     });
   });
 });

--- a/packages/server/src/workers/utils.test.ts
+++ b/packages/server/src/workers/utils.test.ts
@@ -380,6 +380,37 @@ describe('worker utils', () => {
       });
     });
 
+    test('worker defaults supersede global bullmq config', () => {
+      const config = {
+        bullmq: { concurrency: 20, removeOnComplete: { count: 1 }, removeOnFail: { count: 1 } },
+      } as MedplumServerConfig;
+
+      const result = getWorkerBullmqConfig(config, 'batch', { concurrency: 1 });
+      expect(result).toStrictEqual({
+        concurrency: 1,
+        removeOnComplete: { count: 1 },
+        removeOnFail: { count: 1 },
+      });
+    });
+
+    test('per-worker overrides supersede worker defaults', () => {
+      const config = {
+        bullmq: { concurrency: 20, removeOnComplete: { count: 1 }, removeOnFail: { count: 1 } },
+        workers: {
+          bullmq: {
+            batch: { concurrency: 5 },
+          },
+        },
+      } as MedplumServerConfig;
+
+      const result = getWorkerBullmqConfig(config, 'batch', { concurrency: 1 });
+      expect(result).toStrictEqual({
+        concurrency: 5,
+        removeOnComplete: { count: 1 },
+        removeOnFail: { count: 1 },
+      });
+    });
+
     test('per-worker overrides do not affect other workers', () => {
       const config = {
         bullmq: { concurrency: 20, removeOnComplete: { count: 1 }, removeOnFail: { count: 1 } },

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -3,7 +3,7 @@
 import type { WithId } from '@medplum/core';
 import { getExtension, Operator } from '@medplum/core';
 import type { AsyncJob, Parameters, ProjectMembership, Reference, Subscription } from '@medplum/fhirtypes';
-import type { ConnectionOptions, Job, Queue, QueueOptions, Worker } from 'bullmq';
+import type { ConnectionOptions, Job, Queue, QueueOptions, Worker, WorkerOptions } from 'bullmq';
 import { DelayedError } from 'bullmq';
 import * as semver from 'semver';
 import type { MedplumBullmqConfig, MedplumServerConfig, WorkerName } from '../config/types';
@@ -282,26 +282,30 @@ export async function moveToDelayedAndThrow(job: Job, reason: string): Promise<n
 }
 
 /**
- * Builds the effective bullmq config for a worker by merging, in increasing order of precedence:
- * the global `bullmq` server config, worker-specific defaults from code, and the per-worker
- * `workers.bullmq.<workerName>` server config.
+ * Builds the effective `Worker` options by merging, in increasing order of precedence: the given
+ * default queue options (for the shared `connection`), the global `bullmq` server config,
+ * worker-specific defaults from code, and the per-worker `workers.bullmq.<workerName>` server
+ * config.
  * @param config - The server config.
  * @param workerName - The worker to build the config for.
+ * @param queueOptions - The queue options for this worker, typically returned by
+ * {@link defaultQueueOptions}
  * @param workerDefaults - Worker-specific defaults that supersede the global `bullmq` server
  * config (including the defaults added by `addDefaults`) but are overridden by the per-worker
  * `workers.bullmq.<workerName>` server config.
- * @returns The merged bullmq config for the worker.
+ * @returns The merged `Worker` options for the worker.
  */
 export function getWorkerBullmqConfig(
   config: MedplumServerConfig,
   workerName: WorkerName,
+  queueOptions: QueueOptions,
   workerDefaults?: Partial<MedplumBullmqConfig>
-): Partial<MedplumBullmqConfig> | undefined {
+): WorkerOptions {
   const perWorker = config.workers?.bullmq?.[workerName];
-  if (perWorker || workerDefaults) {
-    return { ...config.bullmq, ...workerDefaults, ...perWorker };
-  }
-  return config.bullmq;
+  // `queueOptions.defaultJobOptions` field and potentially others is not a valid `WorkerOptions`
+  // property. It rides along as an inert excess key on the returned object (harmless, since `Worker`
+  // ignores unrecognized options)
+  return { ...queueOptions, ...config.bullmq, ...workerDefaults, ...perWorker };
 }
 
 export function getBullmqRedisConnectionOptions(config: MedplumServerConfig): ConnectionOptions {

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -281,13 +281,25 @@ export async function moveToDelayedAndThrow(job: Job, reason: string): Promise<n
   throw new Error('Cannot delay Post-deploy migration job since job.token is not available');
 }
 
+/**
+ * Builds the effective bullmq config for a worker by merging, in increasing order of precedence:
+ * the global `bullmq` server config, worker-specific defaults from code, and the per-worker
+ * `workers.bullmq.<workerName>` server config.
+ * @param config - The server config.
+ * @param workerName - The worker to build the config for.
+ * @param workerDefaults - Worker-specific defaults that supersede the global `bullmq` server
+ * config (including the defaults added by `addDefaults`) but are overridden by the per-worker
+ * `workers.bullmq.<workerName>` server config.
+ * @returns The merged bullmq config for the worker.
+ */
 export function getWorkerBullmqConfig(
   config: MedplumServerConfig,
-  workerName: WorkerName
+  workerName: WorkerName,
+  workerDefaults?: Partial<MedplumBullmqConfig>
 ): Partial<MedplumBullmqConfig> | undefined {
   const perWorker = config.workers?.bullmq?.[workerName];
-  if (perWorker) {
-    return { ...config.bullmq, ...perWorker };
+  if (perWorker || workerDefaults) {
+    return { ...config.bullmq, ...workerDefaults, ...perWorker };
   }
   return config.bullmq;
 }


### PR DESCRIPTION
Stemmed primarily from the realization that the effective `concurrency` of the `batch` worker was the default `20` instead of the intended `1`. Along with the helper signature changes, `batch` currency defaults to `15`.