### PR TITLE
feat(server): add OpenTelemetry metrics for data warehouse sync process

### DIFF
--- a/packages/server/src/data-warehouse/sync.test.ts
+++ b/packages/server/src/data-warehouse/sync.test.ts
@@ -1,13 +1,16 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { DuckDBInstance } from '@duckdb/node-api';
+import type { MockInstance } from 'vitest';
 import { vi } from 'vitest';
 import type { Expression } from '../fhir/sql';
 import { Condition, SqlBuilder } from '../fhir/sql';
+import * as otelModule from '../otel/otel';
 import type { DataWarehouseDestination } from './destination';
 import { LocalParquetWarehouseDestination } from './destination';
 import type { SyncOptions } from './sync';
-import { buildWarehouseSourcePredicate } from './sync';
+import { buildWarehouseSourcePredicate, syncData } from './sync';
 import { buildStartDatePredicate } from './warehouse-sql';
 
 const tableSpec = { postgresTable: 'Patient_History', icebergTable: 'patient_history' };
@@ -100,5 +103,73 @@ describe('buildWarehouseSourcePredicate', () => {
       sql: `("lastUpdated" > $1 AND "lastUpdated" >= $2)`,
       values: [watermark, startDate],
     });
+  });
+});
+
+describe('syncData OpenTelemetry metrics', () => {
+  let createSpy: MockInstance<(typeof DuckDBInstance)['create']>;
+  let recordHistogramValueSpy: MockInstance<typeof otelModule.recordHistogramValue>;
+  let incrementCounterSpy: MockInstance<typeof otelModule.incrementCounter>;
+
+  beforeEach(() => {
+    const duckConnection = {
+      run: vi.fn().mockResolvedValue(undefined),
+      closeSync: vi.fn(),
+    };
+    createSpy = vi.spyOn(DuckDBInstance, 'create').mockResolvedValue({
+      connect: vi.fn().mockResolvedValue(duckConnection),
+      closeSync: vi.fn(),
+    } as never);
+    recordHistogramValueSpy = vi.spyOn(otelModule, 'recordHistogramValue').mockImplementation(() => true);
+    incrementCounterSpy = vi.spyOn(otelModule, 'incrementCounter').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    createSpy.mockRestore();
+    recordHistogramValueSpy.mockRestore();
+    incrementCounterSpy.mockRestore();
+  });
+
+  function makeMockDestination(rowsInserted: number): DataWarehouseDestination {
+    return {
+      type: 'local',
+      getSetupQueries: () => [],
+      getPostgresAttachQueries: () => [],
+      ensureTargetExists: vi.fn().mockResolvedValue(undefined),
+      buildSourcePredicate: vi.fn().mockResolvedValue(undefined),
+      writeRows: vi.fn().mockResolvedValue(rowsInserted),
+      getDestinationName: (spec) => spec.icebergTable,
+    };
+  }
+
+  test('records table sync histograms and counters', async () => {
+    const destination = makeMockDestination(5);
+
+    const result = await syncData(
+      makeSyncOptions({
+        destination,
+        database: { host: 'localhost', port: 5432, dbname: 'medplum', username: 'medplum', password: 'medplum' },
+      })
+    );
+
+    expect(result.tables).toHaveLength(1);
+    expect(result.tables[0]).toMatchObject({
+      destination: 'patient_history',
+      rowsInserted: 5,
+    });
+
+    const attrs = { attributes: { table: 'patient_history' } };
+    expect(recordHistogramValueSpy).toHaveBeenCalledWith(
+      'medplum.datawarehouse.table.syncDuration',
+      expect.any(Number),
+      attrs
+    );
+    expect(recordHistogramValueSpy).toHaveBeenCalledWith(
+      'medplum.datawarehouse.table.watermarkDuration',
+      expect.any(Number),
+      attrs
+    );
+    expect(recordHistogramValueSpy).toHaveBeenCalledWith('medplum.datawarehouse.table.rowsInserted', 5, attrs);
+    expect(incrementCounterSpy).toHaveBeenCalledWith('medplum.datawarehouse.table.count', attrs);
   });
 });

--- a/packages/server/src/data-warehouse/sync.ts
+++ b/packages/server/src/data-warehouse/sync.ts
@@ -9,6 +9,7 @@ import type { MedplumDatabaseConfig } from '../config/types';
 import type { Expression } from '../fhir/sql';
 import { Conjunction } from '../fhir/sql';
 import { globalLogger } from '../logger';
+import { incrementCounter, recordHistogramValue } from '../otel/otel';
 import type { WarehouseSourceTable } from './config';
 import { buildPgConnectionURI } from './config';
 import type { DataWarehouseDestination } from './destination';
@@ -121,6 +122,14 @@ async function withWarehouseConnection<T>(
   }
 }
 
+function recordTableSyncMetrics(result: SyncTableResult): void {
+  const attrs = { attributes: { table: result.destination } };
+  recordHistogramValue('medplum.datawarehouse.table.syncDuration', result.syncDurationMs / 1000, attrs);
+  recordHistogramValue('medplum.datawarehouse.table.watermarkDuration', result.watermarkDurationMs / 1000, attrs);
+  recordHistogramValue('medplum.datawarehouse.table.rowsInserted', result.rowsInserted, attrs);
+  incrementCounter('medplum.datawarehouse.table.count', attrs);
+}
+
 async function syncWarehouseTable(
   connection: WarehouseSyncDuckdbConnection,
   options: SyncOptions,
@@ -178,12 +187,14 @@ async function syncWarehouseTable(
     );
   }
 
-  return {
+  const result: SyncTableResult = {
     destination,
     rowsInserted,
     syncDurationMs,
     watermarkDurationMs,
   };
+  recordTableSyncMetrics(result);
+  return result;
 }
 
 async function runWarehouseTableSync(

--- a/packages/server/src/workers/data-warehouse-sync.test.ts
+++ b/packages/server/src/workers/data-warehouse-sync.test.ts
@@ -29,6 +29,7 @@ import { buildPgConnectionURI } from '../data-warehouse/config';
 import * as syncModule from '../data-warehouse/sync';
 import * as database from '../database';
 import { locks } from '../database';
+import * as otelModule from '../otel/otel';
 import {
   DataWarehouseSyncQueueName,
   DataWarehouseSyncSchedulerId,
@@ -333,6 +334,7 @@ describe('data-warehouse sync worker', () => {
 
     test('skips sync when advisory lock is not available', async () => {
       vi.spyOn(database, 'acquireAdvisoryLock').mockResolvedValueOnce(false);
+      const incrementCounterSpy = vi.spyOn(otelModule, 'incrementCounter').mockImplementation(() => true);
 
       await processDataWarehouseSyncJob(config, {
         id: 'job-1',
@@ -342,6 +344,27 @@ describe('data-warehouse sync worker', () => {
 
       expect(syncModule.syncData).not.toHaveBeenCalled();
       expect(database.releaseAdvisoryLock).not.toHaveBeenCalled();
+      expect(incrementCounterSpy).toHaveBeenCalledWith('medplum.datawarehouse.job.count', {
+        attributes: { result: 'skipped', trigger: 'scheduler' },
+      });
+    });
+
+    test('records job count and duration metrics on successful sync', async () => {
+      const incrementCounterSpy = vi.spyOn(otelModule, 'incrementCounter').mockImplementation(() => true);
+      const recordHistogramValueSpy = vi.spyOn(otelModule, 'recordHistogramValue').mockImplementation(() => true);
+
+      await processDataWarehouseSyncJob(config, {
+        id: 'job-1',
+        data: { trigger: 'scheduler' },
+        updateProgress: vi.fn(),
+      } as any);
+
+      expect(incrementCounterSpy).toHaveBeenCalledWith('medplum.datawarehouse.job.count', {
+        attributes: { result: 'success', trigger: 'scheduler' },
+      });
+      expect(recordHistogramValueSpy).toHaveBeenCalledWith('medplum.datawarehouse.job.duration', expect.any(Number), {
+        attributes: { trigger: 'scheduler' },
+      });
     });
 
     test('calls syncData with resolved database config', async () => {

--- a/packages/server/src/workers/data-warehouse-sync.ts
+++ b/packages/server/src/workers/data-warehouse-sync.ts
@@ -19,6 +19,7 @@ import {
   withPoolClient,
 } from '../database';
 import { globalLogger } from '../logger';
+import { incrementCounter, recordHistogramValue } from '../otel/otel';
 import type { WorkerInitializer, WorkerInitializerOptions } from './utils';
 import { addVerboseQueueLogging, defaultQueueOptions, getWorkerBullmqConfig, queueRegistry } from './utils';
 
@@ -167,6 +168,9 @@ export async function processDataWarehouseSyncJob(
           startDate: syncConfig?.startDate,
           subsystem: 'data-warehouse-sync',
         });
+        incrementCounter('medplum.datawarehouse.job.count', {
+          attributes: { result: 'skipped', trigger: job.data.trigger },
+        });
         return;
       }
 
@@ -227,6 +231,13 @@ export async function processDataWarehouseSyncJob(
         jobEndTime: jobEndTime.toISOString(),
         durationSeconds,
         subsystem: 'data-warehouse-sync',
+      });
+
+      incrementCounter('medplum.datawarehouse.job.count', {
+        attributes: { result: 'success', trigger: job.data.trigger },
+      });
+      recordHistogramValue('medplum.datawarehouse.job.duration', durationSeconds, {
+        attributes: { trigger: job.data.trigger },
       });
     } catch (err) {
       globalLogger.error('Data warehouse sync failed', {


### PR DESCRIPTION


### Per-table Metrics
- `medplum.datawarehouse.table.syncDuration` (histogram, seconds) — attr `table`
- `medplum.datawarehouse.table.watermarkDuration` (histogram, seconds) — attr `table`
- `medplum.datawarehouse.table.rowsInserted` (histogram) — attr `table`
- `medplum.datawarehouse.table.rows` (counter, add n when rows > 0) — attr `table`
- `medplum.datawarehouse.table.count` (counter) — attr `table`

### Job-level (in `processDataWarehouseSyncJob`)
- `medplum.datawarehouse.job.duration` (histogram, seconds) — attr `trigger`
- `medplum.datawarehouse.job.skipped` (counter) when advisory lock is not acquired — attr `reason: in-progress`

