### PR TITLE
Job priority based fair queueing for the async batch queue

### DIFF
--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -105,9 +105,9 @@ export interface MedplumServerConfig {
   /**
    * Enables project-based fair queueing for async batch jobs, so one project's backlog does not
    * starve other projects. Default is `true`; overridable per-project via the
-   * `enableAsyncBatchFairQueue` Project.systemSetting.
+   * `asyncBatchFairQueueEnabled` Project.systemSetting.
    */
-  enableAsyncBatchFairQueue?: boolean;
+  asyncBatchFairQueueEnabled?: boolean;
   /** Milliseconds of delay added per quota unit in async context, in lieu of consuming quota units. */
   asyncDelayScaling?: number;
   /** Optional config for global default for `maxUserWebSocketSubscriptions`; overridable by Project setting: `maxUserWebSocketSubscriptions` */

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -102,6 +102,12 @@ export interface MedplumServerConfig {
   defaultLoginRateLimit?: number;
   /** Number of FHIR interaction rate limit units per minute users can consume by default; overridable by Project settings */
   defaultFhirQuota?: number;
+  /**
+   * Enables project-based fair queueing for async batch jobs, so one project's backlog does not
+   * starve other projects. Default is `true`; overridable per-project via the
+   * `enableAsyncBatchFairQueue` Project.systemSetting.
+   */
+  enableAsyncBatchFairQueue?: boolean;
   /** Milliseconds of delay added per quota unit in async context, in lieu of consuming quota units. */
   asyncDelayScaling?: number;
   /** Optional config for global default for `maxUserWebSocketSubscriptions`; overridable by Project setting: `maxUserWebSocketSubscriptions` */

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -104,7 +104,7 @@ export interface MedplumServerConfig {
   defaultFhirQuota?: number;
   /**
    * Enables project-based fair queueing for async batch jobs, so one project's backlog does not
-   * starve other projects. Default is `true`; overridable per-project via the
+   * starve other projects. Default is `false`; overridable per-project via the
    * `asyncBatchFairQueueEnabled` Project.systemSetting.
    */
   asyncBatchFairQueueEnabled?: boolean;

--- a/packages/server/src/config/utils.ts
+++ b/packages/server/src/config/utils.ts
@@ -185,6 +185,7 @@ const booleanKeys = new Set([
   'mcpEnabled',
   'registerEnabled',
   'serverScopedSubscriptionsEnabled',
+  'asyncBatchFairQueueEnabled',
   'require',
   'rejectUnauthorized',
   'fhirSearchDiscourageSeqScan',

--- a/packages/server/src/workers/batch.test.ts
+++ b/packages/server/src/workers/batch.test.ts
@@ -22,6 +22,7 @@ import { getBinaryStorage } from '../storage/loader';
 import { createTestProject, streamToString, withTestContext } from '../test.setup';
 import type { LegacyBatchJobData, ReentrantBatchJobData } from './batch';
 import { execBatchJob, execLegacyBatchJob, getBatchQueue, initBatchWorker, queueBatchProcessing } from './batch';
+import * as fairqueue from './fairqueue';
 import * as workerUtils from './utils';
 import { queueRegistry } from './utils';
 
@@ -438,10 +439,12 @@ describe('Batch worker', () => {
           queueBatchProcessing(bundle, asyncJob)
         );
 
-        // Enqueued data carries asyncJobId and authState, but NOT the bundle (#9124).
+        // Enqueued data carries asyncJobId and authState, but NOT the bundle (#9124). Fair queueing
+        // is enabled by default, so a priority derived from the project's in-flight count is set.
         expect(queue.add).toHaveBeenCalledWith(
           'BatchJobData',
-          expect.objectContaining<Partial<ReentrantBatchJobData>>({ asyncJobId: asyncJob.id, authState })
+          expect.objectContaining<Partial<ReentrantBatchJobData>>({ asyncJobId: asyncJob.id, authState }),
+          expect.objectContaining({ priority: expect.any(Number) })
         );
         const enqueued = queue.add.mock.calls[0][1] as ReentrantBatchJobData & { bundle?: unknown };
         expect(enqueued.bundle).toBeUndefined();
@@ -463,13 +466,55 @@ describe('Batch worker', () => {
           )
         ).rejects.toThrow('Job queue BatchQueue not available');
       }));
+
+    test('Sets the BullMQ priority from the project in-flight count when fair queueing is enabled', () =>
+      withTestContext(async () => {
+        const queue = getBatchQueue() as any;
+        queue.add.mockClear();
+        // Control the derived priority so the assertion is deterministic.
+        const prioritySpy = vi.spyOn(fairqueue, 'incrementProjectJobPriority').mockResolvedValue(4);
+        const asyncJob = await createAsyncJob();
+
+        await runInAuthenticatedContext(authState, undefined, undefined, undefined, () =>
+          queueBatchProcessing(singleEntryBundle(), asyncJob)
+        );
+
+        expect(prioritySpy).toHaveBeenCalledWith('BatchQueue', authState.project.id);
+        expect(queue.add).toHaveBeenCalledWith('BatchJobData', expect.anything(), { priority: 4 });
+      }));
+
+    test('Does not set a priority or touch the counter when fair queueing is disabled', () =>
+      withTestContext(async () => {
+        const queue = getBatchQueue() as any;
+        queue.add.mockClear();
+        const prioritySpy = vi.spyOn(fairqueue, 'incrementProjectJobPriority');
+        const disabledAuthState: AuthState = {
+          ...authState,
+          project: {
+            ...authState.project,
+            systemSetting: [{ name: 'enableAsyncBatchFairQueue', valueBoolean: false }],
+          },
+        };
+        const asyncJob = await createAsyncJob();
+
+        await runInAuthenticatedContext(disabledAuthState, undefined, undefined, undefined, () =>
+          queueBatchProcessing(singleEntryBundle(), asyncJob)
+        );
+
+        expect(prioritySpy).not.toHaveBeenCalled();
+        // Enqueued with just the name and data — no options/priority argument.
+        expect(queue.add).toHaveBeenCalledTimes(1);
+        expect(queue.add.mock.calls[0]).toHaveLength(2);
+      }));
   });
 
   describe('worker wiring', () => {
-    // Captures the processor function and the `failed` event handler registered by initBatchWorker.
+    // Captures the processor function and the `failed`/`completed` event handlers registered by
+    // initBatchWorker.
     function captureWorker(): {
       processor: (job: Job) => Promise<void>;
       failedHandler: (job: Job | undefined, err: Error) => Promise<void>;
+      completedHandler: (job: Job) => Promise<void>;
     } {
       const { worker } = initBatchWorker(config);
       const processor = vi.mocked(Worker).mock.calls.at(-1)?.[1] as (job: Job) => Promise<void>;
@@ -478,7 +523,8 @@ describe('Batch worker', () => {
         job: Job | undefined,
         err: Error
       ) => Promise<void>;
-      return { processor, failedHandler };
+      const completedHandler = onCalls.find((c) => c[0] === 'completed')?.[1] as (job: Job) => Promise<void>;
+      return { processor, failedHandler, completedHandler };
     }
 
     test('Dispatches re-entrant jobs to execBatchJob', () =>
@@ -577,6 +623,48 @@ describe('Batch worker', () => {
           expect.objectContaining({ jobData: { authState } })
         );
       });
+    });
+
+    describe('fair-queue slot release', () => {
+      test('completed handler releases the slot', () =>
+        withTestContext(async () => {
+          const { completedHandler } = captureWorker();
+          const decrSpy = vi.spyOn(fairqueue, 'decrementProjectJobCount').mockResolvedValue();
+          await completedHandler(makeReentrantJob({ asyncJobId: 'x', authState }));
+          expect(decrSpy).toHaveBeenCalledWith('BatchQueue', authState.project.id);
+        }));
+
+      test('failed handler releases the slot on terminal failure', () =>
+        withTestContext(async () => {
+          const { failedHandler } = captureWorker();
+          const decrSpy = vi.spyOn(fairqueue, 'decrementProjectJobCount').mockResolvedValue();
+          const asyncJob = await createAsyncJob();
+          await failedHandler(makeLegacyJob({ asyncJob, bundle: singleEntryBundle(), authState }), new Error('boom'));
+          expect(decrSpy).toHaveBeenCalledWith('BatchQueue', authState.project.id);
+        }));
+
+      test('failed handler does NOT release the slot for a DelayedError (still in flight)', () =>
+        withTestContext(async () => {
+          const { failedHandler } = captureWorker();
+          const decrSpy = vi.spyOn(fairqueue, 'decrementProjectJobCount').mockResolvedValue();
+          await failedHandler(makeReentrantJob({ asyncJobId: 'x', authState }), new DelayedError());
+          expect(decrSpy).not.toHaveBeenCalled();
+        }));
+
+      test('does not release the slot when fair queueing is disabled', () =>
+        withTestContext(async () => {
+          const { completedHandler } = captureWorker();
+          const decrSpy = vi.spyOn(fairqueue, 'decrementProjectJobCount').mockResolvedValue();
+          const disabledAuthState: AuthState = {
+            ...authState,
+            project: {
+              ...authState.project,
+              systemSetting: [{ name: 'enableAsyncBatchFairQueue', valueBoolean: false }],
+            },
+          };
+          await completedHandler(makeReentrantJob({ asyncJobId: 'x', authState: disabledAuthState }));
+          expect(decrSpy).not.toHaveBeenCalled();
+        }));
     });
   });
 });

--- a/packages/server/src/workers/batch.test.ts
+++ b/packages/server/src/workers/batch.test.ts
@@ -479,7 +479,7 @@ describe('Batch worker', () => {
           queueBatchProcessing(singleEntryBundle(), asyncJob)
         );
 
-        expect(prioritySpy).toHaveBeenCalledWith('BatchQueue', authState.project.id);
+        expect(prioritySpy).toHaveBeenCalledWith(expect.anything(), 'BatchQueue', authState.project.id);
         expect(queue.add).toHaveBeenCalledWith('BatchJobData', expect.anything(), { priority: 4 });
       }));
 
@@ -631,7 +631,7 @@ describe('Batch worker', () => {
           const { completedHandler } = captureWorker();
           const decrSpy = vi.spyOn(fairqueue, 'decrementProjectJobCount').mockResolvedValue();
           await completedHandler(makeReentrantJob({ asyncJobId: 'x', authState }));
-          expect(decrSpy).toHaveBeenCalledWith('BatchQueue', authState.project.id);
+          expect(decrSpy).toHaveBeenCalledWith(expect.anything(), 'BatchQueue', authState.project.id);
         }));
 
       test('failed handler releases the slot on terminal failure', () =>
@@ -640,7 +640,7 @@ describe('Batch worker', () => {
           const decrSpy = vi.spyOn(fairqueue, 'decrementProjectJobCount').mockResolvedValue();
           const asyncJob = await createAsyncJob();
           await failedHandler(makeLegacyJob({ asyncJob, bundle: singleEntryBundle(), authState }), new Error('boom'));
-          expect(decrSpy).toHaveBeenCalledWith('BatchQueue', authState.project.id);
+          expect(decrSpy).toHaveBeenCalledWith(expect.anything(), 'BatchQueue', authState.project.id);
         }));
 
       test('failed handler does NOT release the slot for a DelayedError (still in flight)', () =>

--- a/packages/server/src/workers/batch.test.ts
+++ b/packages/server/src/workers/batch.test.ts
@@ -492,7 +492,7 @@ describe('Batch worker', () => {
           ...authState,
           project: {
             ...authState.project,
-            systemSetting: [{ name: 'enableAsyncBatchFairQueue', valueBoolean: false }],
+            systemSetting: [{ name: 'asyncBatchFairQueueEnabled', valueBoolean: false }],
           },
         };
         const asyncJob = await createAsyncJob();
@@ -659,7 +659,7 @@ describe('Batch worker', () => {
             ...authState,
             project: {
               ...authState.project,
-              systemSetting: [{ name: 'enableAsyncBatchFairQueue', valueBoolean: false }],
+              systemSetting: [{ name: 'asyncBatchFairQueueEnabled', valueBoolean: false }],
             },
           };
           await completedHandler(makeReentrantJob({ asyncJobId: 'x', authState: disabledAuthState }));

--- a/packages/server/src/workers/batch.test.ts
+++ b/packages/server/src/workers/batch.test.ts
@@ -439,12 +439,10 @@ describe('Batch worker', () => {
           queueBatchProcessing(bundle, asyncJob)
         );
 
-        // Enqueued data carries asyncJobId and authState, but NOT the bundle (#9124). Fair queueing
-        // is enabled by default, so a priority derived from the project's in-flight count is set.
+        // Enqueued data carries asyncJobId and authState, but NOT the bundle (#9124).
         expect(queue.add).toHaveBeenCalledWith(
           'BatchJobData',
-          expect.objectContaining<Partial<ReentrantBatchJobData>>({ asyncJobId: asyncJob.id, authState }),
-          expect.objectContaining({ priority: expect.any(Number) })
+          expect.objectContaining<Partial<ReentrantBatchJobData>>({ asyncJobId: asyncJob.id, authState })
         );
         const enqueued = queue.add.mock.calls[0][1] as ReentrantBatchJobData & { bundle?: unknown };
         expect(enqueued.bundle).toBeUndefined();
@@ -473,9 +471,16 @@ describe('Batch worker', () => {
         queue.add.mockClear();
         // Control the derived priority so the assertion is deterministic.
         const prioritySpy = vi.spyOn(fairqueue, 'incrementProjectJobPriority').mockResolvedValue(4);
+        const enabledAuthState: AuthState = {
+          ...authState,
+          project: {
+            ...authState.project,
+            systemSetting: [{ name: 'asyncBatchFairQueueEnabled', valueBoolean: true }],
+          },
+        };
         const asyncJob = await createAsyncJob();
 
-        await runInAuthenticatedContext(authState, undefined, undefined, undefined, () =>
+        await runInAuthenticatedContext(enabledAuthState, undefined, undefined, undefined, () =>
           queueBatchProcessing(singleEntryBundle(), asyncJob)
         );
 
@@ -504,7 +509,7 @@ describe('Batch worker', () => {
         expect(prioritySpy).not.toHaveBeenCalled();
         // Enqueued with just the name and data — no options/priority argument.
         expect(queue.add).toHaveBeenCalledTimes(1);
-        expect(queue.add.mock.calls[0]).toHaveLength(2);
+        expect(queue.add).toHaveBeenCalledWith('BatchJobData', expect.anything());
       }));
   });
 
@@ -626,11 +631,31 @@ describe('Batch worker', () => {
     });
 
     describe('fair-queue slot release', () => {
+      let enabledAuthState: AuthState;
+      let disabledAuthState: AuthState;
+
+      beforeAll(() => {
+        enabledAuthState = {
+          ...authState,
+          project: {
+            ...authState.project,
+            systemSetting: [{ name: 'asyncBatchFairQueueEnabled', valueBoolean: true }],
+          },
+        };
+
+        disabledAuthState = {
+          ...authState,
+          project: {
+            ...authState.project,
+            systemSetting: [{ name: 'asyncBatchFairQueueEnabled', valueBoolean: false }],
+          },
+        };
+      });
       test('completed handler releases the slot', () =>
         withTestContext(async () => {
           const { completedHandler } = captureWorker();
           const decrSpy = vi.spyOn(fairqueue, 'decrementProjectJobCount').mockResolvedValue();
-          await completedHandler(makeReentrantJob({ asyncJobId: 'x', authState }));
+          await completedHandler(makeReentrantJob({ asyncJobId: 'x', authState: enabledAuthState }));
           expect(decrSpy).toHaveBeenCalledWith(expect.anything(), 'BatchQueue', authState.project.id);
         }));
 
@@ -639,7 +664,10 @@ describe('Batch worker', () => {
           const { failedHandler } = captureWorker();
           const decrSpy = vi.spyOn(fairqueue, 'decrementProjectJobCount').mockResolvedValue();
           const asyncJob = await createAsyncJob();
-          await failedHandler(makeLegacyJob({ asyncJob, bundle: singleEntryBundle(), authState }), new Error('boom'));
+          await failedHandler(
+            makeLegacyJob({ asyncJob, bundle: singleEntryBundle(), authState: enabledAuthState }),
+            new Error('boom')
+          );
           expect(decrSpy).toHaveBeenCalledWith(expect.anything(), 'BatchQueue', authState.project.id);
         }));
 
@@ -647,7 +675,7 @@ describe('Batch worker', () => {
         withTestContext(async () => {
           const { failedHandler } = captureWorker();
           const decrSpy = vi.spyOn(fairqueue, 'decrementProjectJobCount').mockResolvedValue();
-          await failedHandler(makeReentrantJob({ asyncJobId: 'x', authState }), new DelayedError());
+          await failedHandler(makeReentrantJob({ asyncJobId: 'x', authState: enabledAuthState }), new DelayedError());
           expect(decrSpy).not.toHaveBeenCalled();
         }));
 
@@ -655,13 +683,6 @@ describe('Batch worker', () => {
         withTestContext(async () => {
           const { completedHandler } = captureWorker();
           const decrSpy = vi.spyOn(fairqueue, 'decrementProjectJobCount').mockResolvedValue();
-          const disabledAuthState: AuthState = {
-            ...authState,
-            project: {
-              ...authState.project,
-              systemSetting: [{ name: 'asyncBatchFairQueueEnabled', valueBoolean: false }],
-            },
-          };
           await completedHandler(makeReentrantJob({ asyncJobId: 'x', authState: disabledAuthState }));
           expect(decrSpy).not.toHaveBeenCalled();
         }));

--- a/packages/server/src/workers/batch.test.ts
+++ b/packages/server/src/workers/batch.test.ts
@@ -21,7 +21,14 @@ import type { AuthState } from '../oauth/middleware';
 import { getBinaryStorage } from '../storage/loader';
 import { createTestProject, streamToString, withTestContext } from '../test.setup';
 import type { LegacyBatchJobData, ReentrantBatchJobData } from './batch';
-import { execBatchJob, execLegacyBatchJob, getBatchQueue, initBatchWorker, queueBatchProcessing } from './batch';
+import {
+  execBatchJob,
+  execLegacyBatchJob,
+  getBatchQueue,
+  initBatchWorker,
+  queueBatchProcessing,
+  queueLegacyBatchProcessing,
+} from './batch';
 import * as fairqueue from './fairqueue';
 import * as workerUtils from './utils';
 import { queueRegistry } from './utils';
@@ -168,6 +175,27 @@ describe('Batch worker', () => {
         expect(results.type).toStrictEqual('batch-response');
         expect(results.entry).toHaveLength(3);
         expect(results.entry?.map((e) => e.response?.status)).toStrictEqual(['201', '201', '201']);
+      }));
+
+    test('Counts per-entry errors on completion', () =>
+      withTestContext(async () => {
+        // One successful create and one failing read, so the completion path's error tally runs.
+        const bundle: Bundle = {
+          resourceType: 'Bundle',
+          type: 'batch',
+          entry: [
+            { request: { method: 'POST', url: 'Patient' }, resource: { resourceType: 'Patient' } },
+            { request: { method: 'GET', url: 'Patient/00000000-0000-4000-8000-000000000000' } },
+          ],
+        };
+        const { asyncJob, job } = await setupReentrantJob(bundle);
+
+        await expect(execBatchJob(job)).resolves.toBeUndefined();
+
+        const finished = await readAsyncJob(asyncJob.id);
+        expect(finished.status).toStrictEqual('completed');
+        const results = await readResultsBundle(finished);
+        expect(results.entry?.map((e) => e.response?.status)).toStrictEqual(['201', '404']);
       }));
 
     test('Assembles completion results from memory without re-reading chunks written this run', () =>
@@ -395,6 +423,28 @@ describe('Batch worker', () => {
         expect(results.entry?.map((e) => e.response?.status)).toStrictEqual(['201', '404']);
       }));
 
+    test('Returns early without attaching results when the response bundle has no entries', () =>
+      withTestContext(async () => {
+        const asyncJob = await createAsyncJob();
+        const job = makeLegacyJob({ asyncJob, bundle: singleEntryBundle(), authState });
+
+        // An ok outcome whose response bundle carries no `entry` makes the worker return early,
+        // before uploading a Binary or completing the job.
+        const { allOk } = await import('@medplum/core');
+        const { FhirRouter } = await import('@medplum/fhir-router');
+        vi.spyOn(FhirRouter.prototype, 'handleRequest').mockResolvedValue([
+          allOk,
+          { resourceType: 'Bundle', type: 'batch-response' },
+        ]);
+
+        await expect(execLegacyBatchJob(job)).resolves.toBeUndefined();
+
+        const finished = await readAsyncJob(asyncJob.id);
+        // completeJob is never reached on the empty-bundle early return, so the status is unchanged.
+        expect(finished.status).toStrictEqual('accepted');
+        expect(finished.output).toBeUndefined();
+      }));
+
     test('Fails the job when the batch request returns a non-ok outcome', () =>
       withTestContext(async () => {
         const asyncJob = await createAsyncJob();
@@ -423,6 +473,20 @@ describe('Batch worker', () => {
         const finished = await readAsyncJob(asyncJob.id);
         expect(finished.status).toStrictEqual('error');
         writeSpy.mockRestore();
+      }));
+
+    test('Swallows a failJob error thrown after an unexpected processing error', () =>
+      withTestContext(async () => {
+        const asyncJob = await createAsyncJob();
+        const job = makeLegacyJob({ asyncJob, bundle: singleEntryBundle(), authState });
+
+        vi.spyOn(getBinaryStorage(), 'writeBinary').mockRejectedValue(new Error('storage exploded'));
+        vi.spyOn(AsyncJobExecutor.prototype, 'failJob').mockRejectedValue(new Error('db down'));
+
+        // Both the processing error and the failJob rejection are caught; execLegacyBatchJob resolves.
+        await expect(execLegacyBatchJob(job)).resolves.toBeUndefined();
+        expect(AsyncJobExecutor.prototype.failJob).toHaveBeenCalled();
+        expect((await readAsyncJob(asyncJob.id)).status).toStrictEqual('accepted');
       }));
   });
 
@@ -513,6 +577,26 @@ describe('Batch worker', () => {
       }));
   });
 
+  describe('queueLegacyBatchProcessing', () => {
+    test('Enqueues legacy job data carrying the bundle inline', () =>
+      withTestContext(async () => {
+        const queue = getBatchQueue() as any;
+        queue.add.mockClear();
+        const bundle = singleEntryBundle();
+        const asyncJob = await createAsyncJob();
+
+        await runInAuthenticatedContext(authState, undefined, undefined, undefined, () =>
+          queueLegacyBatchProcessing(bundle, asyncJob)
+        );
+
+        // Unlike the re-entrant path, the legacy job carries the bundle and asyncJob inline.
+        expect(queue.add).toHaveBeenCalledWith(
+          'BatchJobData',
+          expect.objectContaining<Partial<LegacyBatchJobData>>({ asyncJob, bundle, authState })
+        );
+      }));
+  });
+
   describe('worker wiring', () => {
     // Captures the processor function and the `failed`/`completed` event handlers registered by
     // initBatchWorker.
@@ -531,6 +615,13 @@ describe('Batch worker', () => {
       const completedHandler = onCalls.find((c) => c[0] === 'completed')?.[1] as (job: Job) => Promise<void>;
       return { processor, failedHandler, completedHandler };
     }
+
+    test('Does not create a worker when workerEnabled is false', () => {
+      const result = initBatchWorker(config, { workerEnabled: false });
+      expect(result.worker).toBeUndefined();
+      expect(result.queue).toBeDefined();
+      expect(result.name).toStrictEqual('BatchQueue');
+    });
 
     test('Dispatches re-entrant jobs to execBatchJob', () =>
       withTestContext(async () => {
@@ -568,6 +659,29 @@ describe('Batch worker', () => {
           asyncJob: getReferenceString(asyncJob),
         });
         expect(logFields(makeReentrantJob({ asyncJobId: asyncJob.id, authState }))).toHaveProperty('asyncJob');
+      }));
+
+    test('Verbose logging fields resolve optional profile and on-behalf-of references when present', () =>
+      withTestContext(async () => {
+        const spy = vi.spyOn(workerUtils, 'addVerboseQueueLogging');
+        initBatchWorker(config);
+        const logFields = spy.mock.calls.at(-1)?.[2] as (job: Job) => Record<string, unknown>;
+
+        const profile = { reference: 'Practitioner/p1' };
+        const onBehalfOf = { resourceType: 'Practitioner', id: 'p2' };
+        const onBehalfOfMembership = { resourceType: 'ProjectMembership', id: 'm2' };
+        const richAuthState = {
+          ...authState,
+          profile,
+          onBehalfOf,
+          onBehalfOfMembership,
+        } as unknown as AuthState;
+
+        expect(logFields(makeReentrantJob({ asyncJobId: 'x', authState: richAuthState }))).toMatchObject({
+          profile: getReferenceString(profile),
+          onBehalfOf: getReferenceString(onBehalfOf),
+          onBehalfOfMembership: getReferenceString(onBehalfOfMembership),
+        });
       }));
 
     describe('failed handler', () => {
@@ -657,6 +771,26 @@ describe('Batch worker', () => {
           const decrSpy = vi.spyOn(fairqueue, 'decrementProjectJobCount').mockResolvedValue();
           await completedHandler(makeReentrantJob({ asyncJobId: 'x', authState: enabledAuthState }));
           expect(decrSpy).toHaveBeenCalledWith(expect.anything(), 'BatchQueue', authState.project.id);
+        }));
+
+      test('completed handler releases the slot for a legacy job', () =>
+        withTestContext(async () => {
+          const { completedHandler } = captureWorker();
+          const decrSpy = vi.spyOn(fairqueue, 'decrementProjectJobCount').mockResolvedValue();
+          const asyncJob = await createAsyncJob();
+          // The legacy branch derives the logger from asyncJob.id rather than asyncJobId.
+          await completedHandler(makeLegacyJob({ asyncJob, bundle: singleEntryBundle(), authState: enabledAuthState }));
+          expect(decrSpy).toHaveBeenCalledWith(expect.anything(), 'BatchQueue', authState.project.id);
+        }));
+
+      test('completed handler swallows a decrement failure', () =>
+        withTestContext(async () => {
+          const { completedHandler } = captureWorker();
+          vi.spyOn(fairqueue, 'decrementProjectJobCount').mockRejectedValue(new Error('redis down'));
+          // A failed slot release is logged and swallowed so it never disrupts BullMQ event handling.
+          await expect(
+            completedHandler(makeReentrantJob({ asyncJobId: 'x', authState: enabledAuthState }))
+          ).resolves.toBeUndefined();
         }));
 
       test('failed handler releases the slot on terminal failure', () =>

--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -26,6 +26,7 @@ import { getShardSystemRepo } from '../fhir/repo';
 import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
 import { getLogger } from '../logger';
 import type { AuthState } from '../oauth/middleware';
+import { decrementProjectJobCount, incrementProjectJobPriority, isFairQueueEnabled } from './fairqueue';
 import type { WorkerInitializer, WorkerInitializerOptions } from './utils';
 import {
   addVerboseQueueLogging,
@@ -138,10 +139,11 @@ export const initBatchWorker: WorkerInitializer = (config, options?: WorkerIniti
         return;
       }
 
-      // A delayed/re-queued job is not a failure; nothing to do.
+      // A delayed/re-queued job is not a terminal failure
       if (failedErr instanceof DelayedError) {
         return;
       }
+      // Terminal failure: the job is no longer in flight
 
       // This fires only when the job could not be recovered by re-entrant resume (e.g. it stalled
       // more than maxStalledCount times). Mark the AsyncJob failed if it is still in progress and
@@ -149,6 +151,8 @@ export const initBatchWorker: WorkerInitializer = (config, options?: WorkerIniti
 
       if ('asyncJob' in job.data && job.data.asyncJob) {
         job.data satisfies LegacyBatchJobData;
+        const logger = getBatchLogger(job.data.asyncJob.id, job.id);
+        await releaseFairQueueSlot(logger, job);
         const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be available in job.data.authState in the future
         const exec = new AsyncJobExecutor(systemRepo, job.data.asyncJob);
         await exec.failJob();
@@ -159,18 +163,34 @@ export const initBatchWorker: WorkerInitializer = (config, options?: WorkerIniti
       }
 
       job.data satisfies ReentrantBatchJobData;
+      const logger = getBatchLogger(job.data.asyncJobId, job.id);
       try {
+        await releaseFairQueueSlot(logger, job);
         const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be available in job.data.authState in the future
         const asyncJob = await systemRepo.readResource<AsyncJob>('AsyncJob', job.data.asyncJobId);
         if (isJobActive(asyncJob)) {
           await new AsyncJobExecutor(systemRepo, asyncJob).failJob(failedErr ?? undefined);
         }
       } finally {
-        const logger = getBatchLogger(job.data.asyncJobId, job.id);
         const store = new BatchCheckpointStore(job.data.asyncJobId, logger);
         await store.cleanup(job.data.chunkSeq ?? 0);
       }
     });
+
+    // execBatchJob/execLegacyBatchJob swallow processing errors and return normally (they fail the
+    // AsyncJob internally), so BullMQ reports `completed` for both success and internal-failure
+    // terminal outcomes. Release the fair-queue slot for the project in both cases.
+    worker.on('completed', async (job) => {
+      let logger: ILogger;
+      if ('asyncJob' in job.data) {
+        logger = getBatchLogger(job.data.asyncJob.id, job.id);
+      } else {
+        logger = getBatchLogger(job.data.asyncJobId, job.id);
+      }
+
+      await releaseFairQueueSlot(logger, job);
+    });
+
     addVerboseQueueLogging<BatchJobData>(queue, worker, (job) => {
       const asyncJobRef = 'asyncJob' in job.data ? job.data.asyncJob : { id: job.data.asyncJobId };
       return {
@@ -182,6 +202,7 @@ export const initBatchWorker: WorkerInitializer = (config, options?: WorkerIniti
         onBehalfOf: job.data.authState.onBehalfOf && getReferenceString(job.data.authState.onBehalfOf),
         onBehalfOfMembership:
           job.data.authState.onBehalfOfMembership && getReferenceString(job.data.authState.onBehalfOfMembership),
+        priority: job.priority,
       };
     });
   }
@@ -200,15 +221,46 @@ export function getBatchQueue(): Queue<BatchJobData> | undefined {
 
 /**
  * Adds a batch job to the queue.
+ *
+ * When fair queueing is enabled, the project's in-flight batch count is incremented and used to set
+ * the job's BullMQ priority (lower priority number = higher priority), so a project with a large
+ * backlog yields to projects with fewer in-flight batches. The counter is decremented when the job
+ * reaches a terminal state (see the worker's `completed`/`failed` handlers in {@link initBatchWorker}).
+ * @param logger - The logger instance for logging purposes.
  * @param jobData - The batch job details.
  * @returns The enqueued job.
  */
-async function addBatchJobData(jobData: BatchJobData): Promise<Job<BatchJobData>> {
+async function addBatchJobData(logger: ILogger, jobData: BatchJobData): Promise<Job<BatchJobData>> {
   const queue = queueRegistry.get<BatchJobData>(queueName);
   if (!queue) {
     throw new Error(`Job queue ${queueName} not available`);
   }
+
+  if (isFairQueueEnabled(jobData.authState)) {
+    const priority = await incrementProjectJobPriority(logger, queueName, jobData.authState.project.id);
+    return queue.add(jobName, jobData, { priority });
+  }
+
   return queue.add(jobName, jobData);
+}
+
+/**
+ * Releases a project's fair-queue slot when a batch job reaches a terminal state. Best-effort:
+ * failures are logged and swallowed so they never disrupt BullMQ event handling. A leaked increment
+ * (e.g. this never runs due to a crash) is bounded by the counter's TTL.
+ * @param logger - The logger instance for logging purposes.
+ * @param job - The terminated batch job.
+ */
+async function releaseFairQueueSlot(logger: ILogger, job: Job<BatchJobData>): Promise<void> {
+  if (isFairQueueEnabled(job.data.authState)) {
+    try {
+      await decrementProjectJobCount(logger, queueName, job.data.authState.project.id);
+    } catch (err) {
+      logger.error('Failed to release async batch fair-queue slot', {
+        err: err instanceof Error ? err.message : err,
+      });
+    }
+  }
 }
 
 export async function queueBatchProcessing(bundle: Bundle, asyncJob: WithId<AsyncJob>): Promise<Job<BatchJobData>> {
@@ -216,8 +268,9 @@ export async function queueBatchProcessing(bundle: Bundle, asyncJob: WithId<Asyn
   // Persist the (potentially large) input bundle to durable object storage rather than carrying it
   // in the BullMQ job data (see https://github.com/medplum/medplum/issues/9124). The worker loads
   // it on the first run to preprocess.
-  await new BatchCheckpointStore(asyncJob.id, getBatchLogger(asyncJob.id)).saveInputBundle(bundle);
-  return addBatchJobData({ asyncJobId: asyncJob.id, authState, requestId, traceId });
+  const logger = getBatchLogger(asyncJob.id);
+  await new BatchCheckpointStore(asyncJob.id, logger).saveInputBundle(bundle);
+  return addBatchJobData(logger, { asyncJobId: asyncJob.id, authState, requestId, traceId });
 }
 
 export async function queueLegacyBatchProcessing(
@@ -226,7 +279,7 @@ export async function queueLegacyBatchProcessing(
 ): Promise<Job<BatchJobData>> {
   const { authentication: authState, requestId, traceId } = getAuthenticatedContext();
   const jobData: LegacyBatchJobData = { asyncJob, bundle, authState, requestId, traceId };
-  return addBatchJobData(jobData);
+  return addBatchJobData(getBatchLogger(asyncJob.id), jobData);
 }
 
 /**

--- a/packages/server/src/workers/batch.ts
+++ b/packages/server/src/workers/batch.ts
@@ -26,7 +26,7 @@ import { getShardSystemRepo } from '../fhir/repo';
 import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
 import { getLogger } from '../logger';
 import type { AuthState } from '../oauth/middleware';
-import { decrementProjectJobCount, incrementProjectJobPriority, isFairQueueEnabled } from './fairqueue';
+import { decrementProjectJobPriority, incrementProjectJobPriority, isFairQueueEnabled } from './fairqueue';
 import type { WorkerInitializer, WorkerInitializerOptions } from './utils';
 import {
   addVerboseQueueLogging,
@@ -254,7 +254,7 @@ async function addBatchJobData(logger: ILogger, jobData: BatchJobData): Promise<
 async function releaseFairQueueSlot(logger: ILogger, job: Job<BatchJobData>): Promise<void> {
   if (isFairQueueEnabled(job.data.authState)) {
     try {
-      await decrementProjectJobCount(logger, queueName, job.data.authState.project.id);
+      await decrementProjectJobPriority(logger, queueName, job.data.authState.project.id);
     } catch (err) {
       logger.error('Failed to release async batch fair-queue slot', {
         err: err instanceof Error ? err.message : err,

--- a/packages/server/src/workers/fairqueue.test.ts
+++ b/packages/server/src/workers/fairqueue.test.ts
@@ -111,7 +111,7 @@ describe('Fair queue counter Redis handling', () => {
     expect(await incrementProjectJobPriority(logger, queueName, randomUUID())).toStrictEqual(BULLMQ_MAX_PRIORITY);
   });
 
-  test('logs and falls back to priority 1 when the increment pipeline returns no results', async () => {
+  test('logs and falls back to default priority when the increment pipeline returns no results', async () => {
     const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     mockPipeline(null);
     const projectId = randomUUID();
@@ -123,7 +123,7 @@ describe('Fair queue counter Redis handling', () => {
     );
   });
 
-  test('logs and falls back to priority 1 when the increment command reports an error', async () => {
+  test('logs and falls back to default priority when the increment command reports an error', async () => {
     const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const commandErr = new Error('INCR failed');
     mockPipeline([[commandErr, null]]);

--- a/packages/server/src/workers/fairqueue.test.ts
+++ b/packages/server/src/workers/fairqueue.test.ts
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { ILogger } from '@medplum/core';
+import { randomUUID } from 'node:crypto';
+import type { Mock } from 'vitest';
+import { initAppServices, shutdownApp } from '../app';
+import { getConfig, loadTestConfig } from '../config/loader';
+import { globalLogger } from '../logger';
+import type { AuthState } from '../oauth/middleware';
+import { getRateLimitRedis } from '../redis';
+import { deleteRedisKeys } from '../test.setup';
+import { decrementProjectJobCount, incrementProjectJobPriority, isFairQueueEnabled } from './fairqueue';
+
+const KEY_PREFIX = 'medplum:fairqueue:';
+
+describe('Fair queue counter', () => {
+  const queueName = 'TestQueue';
+  const logger: ILogger = globalLogger;
+  let errorSpy: Mock<(typeof logger)['error']>;
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initAppServices(config);
+    errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    await deleteRedisKeys(getRateLimitRedis(), KEY_PREFIX);
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+    errorSpy.mockRestore();
+  });
+
+  test('increment returns a monotonically increasing priority and sets a TTL', async () => {
+    const projectId = randomUUID();
+    // The Nth in-flight job for a project gets priority N (a lower number = higher priority).
+    expect(await incrementProjectJobPriority(logger, queueName, projectId)).toStrictEqual(1);
+    expect(await incrementProjectJobPriority(logger, queueName, projectId)).toStrictEqual(2);
+    expect(await incrementProjectJobPriority(logger, queueName, projectId)).toStrictEqual(3);
+
+    const ttl = await getRateLimitRedis().pttl(`${KEY_PREFIX}${queueName}:${projectId}`);
+    expect(ttl).toBeGreaterThan(0);
+  });
+
+  test('increment counters are isolated per project', async () => {
+    const projectA = randomUUID();
+    const projectB = randomUUID();
+    expect(await incrementProjectJobPriority(logger, queueName, projectA)).toStrictEqual(1);
+    expect(await incrementProjectJobPriority(logger, queueName, projectA)).toStrictEqual(2);
+    expect(await incrementProjectJobPriority(logger, queueName, projectB)).toStrictEqual(1);
+  });
+
+  test('decrement reduces the count and keeps the zeroed key TTL-bounded', async () => {
+    const projectId = randomUUID();
+    const key = `${KEY_PREFIX}${queueName}:${projectId}`;
+    await incrementProjectJobPriority(logger, queueName, projectId);
+    await incrementProjectJobPriority(logger, queueName, projectId);
+
+    await decrementProjectJobCount(logger, queueName, projectId);
+    expect(await getRateLimitRedis().get(key)).toStrictEqual('1');
+
+    await decrementProjectJobCount(logger, queueName, projectId);
+    // At zero the key remains but stays TTL-bounded, so it self-expires rather than lingering.
+    expect(await getRateLimitRedis().get(key)).toStrictEqual('0');
+    expect(await getRateLimitRedis().pttl(key)).toBeGreaterThan(0);
+  });
+
+  test('decrement of an absent counter sets a TTL so a stray negative self-expires', async () => {
+    const projectId = randomUUID();
+    const key = `${KEY_PREFIX}${queueName}:${projectId}`;
+    await decrementProjectJobCount(logger, queueName, projectId);
+    // DECR on a missing key would otherwise recreate it at -1 with no expiry; the pipelined EXPIRE
+    // bounds it so it cannot linger forever.
+    expect(await getRateLimitRedis().get(key)).toStrictEqual('-1');
+    expect(await getRateLimitRedis().pttl(key)).toBeGreaterThan(0);
+  });
+});
+
+describe('isFairQueueEnabled', () => {
+  const baseAuthState = { project: { resourceType: 'Project', id: randomUUID() } } as unknown as AuthState;
+
+  beforeAll(async () => {
+    await loadTestConfig();
+  });
+
+  test('defaults to enabled when neither config nor project override is set', () => {
+    getConfig().enableAsyncBatchFairQueue = undefined;
+    expect(isFairQueueEnabled(baseAuthState)).toBe(true);
+  });
+
+  test('honors the server config flag when no project override is present', () => {
+    getConfig().enableAsyncBatchFairQueue = false;
+    expect(isFairQueueEnabled(baseAuthState)).toBe(false);
+    getConfig().enableAsyncBatchFairQueue = undefined;
+  });
+
+  test('project systemSetting override wins over the server config flag', () => {
+    getConfig().enableAsyncBatchFairQueue = false;
+    const authState = {
+      project: {
+        resourceType: 'Project',
+        id: randomUUID(),
+        systemSetting: [{ name: 'enableAsyncBatchFairQueue', valueBoolean: true }],
+      },
+    } as unknown as AuthState;
+    expect(isFairQueueEnabled(authState)).toBe(true);
+
+    const disabledAuthState = {
+      project: {
+        resourceType: 'Project',
+        id: randomUUID(),
+        systemSetting: [{ name: 'enableAsyncBatchFairQueue', valueBoolean: false }],
+      },
+    } as unknown as AuthState;
+    getConfig().enableAsyncBatchFairQueue = undefined;
+    expect(isFairQueueEnabled(disabledAuthState)).toBe(false);
+  });
+});

--- a/packages/server/src/workers/fairqueue.test.ts
+++ b/packages/server/src/workers/fairqueue.test.ts
@@ -86,23 +86,23 @@ describe('isFairQueueEnabled', () => {
   });
 
   test('defaults to enabled when neither config nor project override is set', () => {
-    getConfig().enableAsyncBatchFairQueue = undefined;
+    getConfig().asyncBatchFairQueueEnabled = undefined;
     expect(isFairQueueEnabled(baseAuthState)).toBe(true);
   });
 
   test('honors the server config flag when no project override is present', () => {
-    getConfig().enableAsyncBatchFairQueue = false;
+    getConfig().asyncBatchFairQueueEnabled = false;
     expect(isFairQueueEnabled(baseAuthState)).toBe(false);
-    getConfig().enableAsyncBatchFairQueue = undefined;
+    getConfig().asyncBatchFairQueueEnabled = undefined;
   });
 
   test('project systemSetting override wins over the server config flag', () => {
-    getConfig().enableAsyncBatchFairQueue = false;
+    getConfig().asyncBatchFairQueueEnabled = false;
     const authState = {
       project: {
         resourceType: 'Project',
         id: randomUUID(),
-        systemSetting: [{ name: 'enableAsyncBatchFairQueue', valueBoolean: true }],
+        systemSetting: [{ name: 'asyncBatchFairQueueEnabled', valueBoolean: true }],
       },
     } as unknown as AuthState;
     expect(isFairQueueEnabled(authState)).toBe(true);
@@ -111,10 +111,10 @@ describe('isFairQueueEnabled', () => {
       project: {
         resourceType: 'Project',
         id: randomUUID(),
-        systemSetting: [{ name: 'enableAsyncBatchFairQueue', valueBoolean: false }],
+        systemSetting: [{ name: 'asyncBatchFairQueueEnabled', valueBoolean: false }],
       },
     } as unknown as AuthState;
-    getConfig().enableAsyncBatchFairQueue = undefined;
+    getConfig().asyncBatchFairQueueEnabled = undefined;
     expect(isFairQueueEnabled(disabledAuthState)).toBe(false);
   });
 });

--- a/packages/server/src/workers/fairqueue.test.ts
+++ b/packages/server/src/workers/fairqueue.test.ts
@@ -85,14 +85,14 @@ describe('isFairQueueEnabled', () => {
     await loadTestConfig();
   });
 
-  test('defaults to enabled when neither config nor project override is set', () => {
+  test('defaults to disabled when neither config nor project override is set', () => {
     getConfig().asyncBatchFairQueueEnabled = undefined;
-    expect(isFairQueueEnabled(baseAuthState)).toBe(true);
+    expect(isFairQueueEnabled(baseAuthState)).toBe(false);
   });
 
   test('honors the server config flag when no project override is present', () => {
-    getConfig().asyncBatchFairQueueEnabled = false;
-    expect(isFairQueueEnabled(baseAuthState)).toBe(false);
+    getConfig().asyncBatchFairQueueEnabled = true;
+    expect(isFairQueueEnabled(baseAuthState)).toBe(true);
     getConfig().asyncBatchFairQueueEnabled = undefined;
   });
 

--- a/packages/server/src/workers/fairqueue.test.ts
+++ b/packages/server/src/workers/fairqueue.test.ts
@@ -7,9 +7,15 @@ import { initAppServices, shutdownApp } from '../app';
 import { getConfig, loadTestConfig } from '../config/loader';
 import { globalLogger } from '../logger';
 import type { AuthState } from '../oauth/middleware';
+import * as redisModule from '../redis';
 import { getRateLimitRedis } from '../redis';
 import { deleteRedisKeys } from '../test.setup';
-import { decrementProjectJobCount, incrementProjectJobPriority, isFairQueueEnabled } from './fairqueue';
+import {
+  BULLMQ_MAX_PRIORITY,
+  decrementProjectJobCount,
+  incrementProjectJobPriority,
+  isFairQueueEnabled,
+} from './fairqueue';
 
 const KEY_PREFIX = 'medplum:fairqueue:';
 
@@ -75,6 +81,82 @@ describe('Fair queue counter', () => {
     // bounds it so it cannot linger forever.
     expect(await getRateLimitRedis().get(key)).toStrictEqual('-1');
     expect(await getRateLimitRedis().pttl(key)).toBeGreaterThan(0);
+  });
+});
+
+describe('Fair queue counter Redis handling', () => {
+  const queueName = 'TestQueue';
+  const logger: ILogger = globalLogger;
+
+  afterEach(() => {
+    // Restores both the getRateLimitRedis spy and the per-test logger.error spy.
+    vi.restoreAllMocks();
+  });
+
+  // Replaces getRateLimitRedis with a fake whose pipeline .exec() resolves to `execResult`, so the
+  // increment/decrement error branches can be exercised without a real Redis round trip.
+  function mockPipeline(execResult: unknown): void {
+    const pipeline: any = {
+      incr: () => pipeline,
+      decr: () => pipeline,
+      expire: () => pipeline,
+      exec: async () => execResult,
+    };
+    vi.spyOn(redisModule, 'getRateLimitRedis').mockReturnValue({ pipeline: () => pipeline } as any);
+  }
+
+  test('clamps the returned priority to the BullMQ maximum', async () => {
+    // INCR can exceed the valid BullMQ priority range for a project with a very large backlog.
+    mockPipeline([[null, BULLMQ_MAX_PRIORITY + 100]]);
+    expect(await incrementProjectJobPriority(logger, queueName, randomUUID())).toStrictEqual(BULLMQ_MAX_PRIORITY);
+  });
+
+  test('logs and falls back to priority 1 when the increment pipeline returns no results', async () => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    mockPipeline(null);
+    const projectId = randomUUID();
+
+    expect(await incrementProjectJobPriority(logger, queueName, projectId)).toStrictEqual(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to increment fairqueue project job count',
+      expect.objectContaining({ queueName, projectId })
+    );
+  });
+
+  test('logs and falls back to priority 1 when the increment command reports an error', async () => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const commandErr = new Error('INCR failed');
+    mockPipeline([[commandErr, null]]);
+    const projectId = randomUUID();
+
+    // With no usable INCR result the priority defaults to 1.
+    expect(await incrementProjectJobPriority(logger, queueName, projectId)).toStrictEqual(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to increment fairqueue project job count',
+      expect.objectContaining({ queueName, projectId, error: commandErr })
+    );
+  });
+
+  test('logs when the decrement pipeline returns no results', async () => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    mockPipeline(null);
+    const projectId = randomUUID();
+
+    await decrementProjectJobCount(logger, queueName, projectId);
+    expect(errorSpy).toHaveBeenCalledWith('Failed to decrement fairqueue project job count', { queueName, projectId });
+  });
+
+  test('logs when the decrement command reports an error', async () => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const commandErr = new Error('DECR failed');
+    mockPipeline([[commandErr, null]]);
+    const projectId = randomUUID();
+
+    await decrementProjectJobCount(logger, queueName, projectId);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to decrement fairqueue project job count',
+      expect.objectContaining({ queueName, projectId, error: commandErr })
+    );
   });
 });
 

--- a/packages/server/src/workers/fairqueue.test.ts
+++ b/packages/server/src/workers/fairqueue.test.ts
@@ -12,7 +12,7 @@ import { getRateLimitRedis } from '../redis';
 import { deleteRedisKeys } from '../test.setup';
 import {
   BULLMQ_MAX_PRIORITY,
-  decrementProjectJobCount,
+  decrementProjectJobPriority,
   incrementProjectJobPriority,
   isFairQueueEnabled,
 } from './fairqueue';
@@ -64,10 +64,10 @@ describe('Fair queue counter', () => {
     await incrementProjectJobPriority(logger, queueName, projectId);
     await incrementProjectJobPriority(logger, queueName, projectId);
 
-    await decrementProjectJobCount(logger, queueName, projectId);
+    await decrementProjectJobPriority(logger, queueName, projectId);
     expect(await getRateLimitRedis().get(key)).toStrictEqual('1');
 
-    await decrementProjectJobCount(logger, queueName, projectId);
+    await decrementProjectJobPriority(logger, queueName, projectId);
     // At zero the key remains but stays TTL-bounded, so it self-expires rather than lingering.
     expect(await getRateLimitRedis().get(key)).toStrictEqual('0');
     expect(await getRateLimitRedis().pttl(key)).toBeGreaterThan(0);
@@ -76,7 +76,7 @@ describe('Fair queue counter', () => {
   test('decrement of an absent counter sets a TTL so a stray negative self-expires', async () => {
     const projectId = randomUUID();
     const key = `${KEY_PREFIX}${queueName}:${projectId}`;
-    await decrementProjectJobCount(logger, queueName, projectId);
+    await decrementProjectJobPriority(logger, queueName, projectId);
     // DECR on a missing key would otherwise recreate it at -1 with no expiry; the pipelined EXPIRE
     // bounds it so it cannot linger forever.
     expect(await getRateLimitRedis().get(key)).toStrictEqual('-1');
@@ -116,9 +116,9 @@ describe('Fair queue counter Redis handling', () => {
     mockPipeline(null);
     const projectId = randomUUID();
 
-    expect(await incrementProjectJobPriority(logger, queueName, projectId)).toStrictEqual(1);
+    expect(await incrementProjectJobPriority(logger, queueName, projectId)).toStrictEqual(0);
     expect(errorSpy).toHaveBeenCalledWith(
-      'Failed to increment fairqueue project job count',
+      expect.stringContaining('fairqueue'),
       expect.objectContaining({ queueName, projectId })
     );
   });
@@ -130,9 +130,9 @@ describe('Fair queue counter Redis handling', () => {
     const projectId = randomUUID();
 
     // With no usable INCR result the priority defaults to 1.
-    expect(await incrementProjectJobPriority(logger, queueName, projectId)).toStrictEqual(1);
+    expect(await incrementProjectJobPriority(logger, queueName, projectId)).toStrictEqual(0);
     expect(errorSpy).toHaveBeenCalledWith(
-      'Failed to increment fairqueue project job count',
+      expect.stringContaining('fairqueue'),
       expect.objectContaining({ queueName, projectId, error: commandErr })
     );
   });
@@ -142,8 +142,8 @@ describe('Fair queue counter Redis handling', () => {
     mockPipeline(null);
     const projectId = randomUUID();
 
-    await decrementProjectJobCount(logger, queueName, projectId);
-    expect(errorSpy).toHaveBeenCalledWith('Failed to decrement fairqueue project job count', { queueName, projectId });
+    await decrementProjectJobPriority(logger, queueName, projectId);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('fairqueue'), { queueName, projectId });
   });
 
   test('logs when the decrement command reports an error', async () => {
@@ -152,9 +152,9 @@ describe('Fair queue counter Redis handling', () => {
     mockPipeline([[commandErr, null]]);
     const projectId = randomUUID();
 
-    await decrementProjectJobCount(logger, queueName, projectId);
+    await decrementProjectJobPriority(logger, queueName, projectId);
     expect(errorSpy).toHaveBeenCalledWith(
-      'Failed to decrement fairqueue project job count',
+      expect.stringContaining('fairqueue'),
       expect.objectContaining({ queueName, projectId, error: commandErr })
     );
   });

--- a/packages/server/src/workers/fairqueue.ts
+++ b/packages/server/src/workers/fairqueue.ts
@@ -49,7 +49,7 @@ export function isFairQueueEnabled(authState: Readonly<AuthState>): boolean {
   if (override?.valueBoolean !== undefined) {
     return override.valueBoolean;
   }
-  return getConfig().enableAsyncBatchFairQueue !== false;
+  return !!getConfig().enableAsyncBatchFairQueue;
 }
 
 /**

--- a/packages/server/src/workers/fairqueue.ts
+++ b/packages/server/src/workers/fairqueue.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { ILogger } from '@medplum/core';
+import { getConfig } from '../config/loader';
+import type { AuthState } from '../oauth/middleware';
+import { getRateLimitRedis } from '../redis';
+
+/**
+ * Priority-based fair queueing for background jobs.
+ *
+ * A project's in-flight jobs are counted in Redis so that a project with a large backlog is
+ * assigned a LOWER BullMQ priority (a higher priority number) than a project with fewer in-flight
+ * jobs. This prevents one project from starving other projects on a shared queue. See
+ * https://docs.bullmq.io/guide/jobs/prioritized — priorities range 1..2,097,151 where a LOWER
+ * number is a HIGHER priority; 0 means "no priority".
+ *
+ * The counter is incremented when a job is enqueued and decremented when the job reaches a terminal
+ * state. Because it is only used to derive an approximate, best-effort priority, exact accuracy is
+ * not required: every increment and decrement (re)sets a TTL, so a leaked increment (e.g. a process
+ * crash between enqueue and completion) or a stray negative from a decrement self-expires rather
+ * than drifting indefinitely.
+ */
+
+/** Maximum BullMQ priority value (lower number = higher priority). */
+export const BULLMQ_MAX_PRIORITY = 2_097_151;
+
+/**
+ * TTL applied to a project's in-flight counter, refreshed on every increment and decrement. A
+ * generous leak backstop: a stuck counter (leaked increment) or a stray negative simply expires.
+ */
+const FAIR_QUEUE_COUNTER_TTL_SECONDS = 24 * 60 * 60; // 24 hours
+
+/** Project setting name for the per-project override of {@link ServerConfig.enableAsyncBatchFairQueue}. */
+const FAIR_QUEUE_SYSTEM_SETTING = 'enableAsyncBatchFairQueue';
+
+function getFairQueueKey(queueName: string, projectId: string): string {
+  return `medplum:fairqueue:${queueName}:${projectId}`;
+}
+
+/**
+ * Determines whether fair queueing is active for the given auth state. A per-project
+ * `enableAsyncBatchFairQueue` Project setting wins if present; otherwise the server config flag
+ * applies, defaulting to enabled.
+ * @param authState - The auth state the job was submitted under.
+ * @returns True if fair queueing should be applied.
+ */
+export function isFairQueueEnabled(authState: Readonly<AuthState>): boolean {
+  const override = authState.project.systemSetting?.find((s) => s.name === FAIR_QUEUE_SYSTEM_SETTING);
+  if (override?.valueBoolean !== undefined) {
+    return override.valueBoolean;
+  }
+  return getConfig().enableAsyncBatchFairQueue !== false;
+}
+
+/**
+ * Increments the project's in-flight job counter and returns the BullMQ priority to assign the new
+ * job (lower number = higher priority), clamped to the valid range. Refreshes the counter's TTL. The
+ * slot is released via {@link decrementProjectJobCount} when the job reaches a terminal state.
+ * @param logger - The logger instance for logging purposes.
+ * @param queueName - The BullMQ queue name.
+ * @param projectId - The project id the job belongs to.
+ * @returns The BullMQ priority (1..{@link BULLMQ_MAX_PRIORITY}) for the just-enqueued job.
+ */
+export async function incrementProjectJobPriority(
+  logger: ILogger,
+  queueName: string,
+  projectId: string
+): Promise<number> {
+  const redis = getRateLimitRedis();
+  const key = getFairQueueKey(queueName, projectId);
+  const pipeline = redis.pipeline().incr(key).expire(key, FAIR_QUEUE_COUNTER_TTL_SECONDS);
+  const results = await pipeline.exec();
+  if (!results || results[0]?.[0]) {
+    logger.error('Failed to increment fairqueue project job count', { queueName, projectId, error: results?.[0]?.[0] });
+  }
+  // results[0] is [err, incrResult] for the INCR command.
+  const count = (results?.[0]?.[1] as number | undefined) ?? 1;
+  // Clamp to BullMQ's valid range; INCR starts at 1, so the lower bound is defensive.
+  return Math.min(Math.max(count, 1), BULLMQ_MAX_PRIORITY);
+}
+
+/**
+ * Decrements the project's in-flight job counter, refreshing its TTL in the same round trip. The
+ * TTL refresh is what bounds the key: `DECR` on a missing key (e.g. the counter's TTL lapsed while a
+ * long-running job was still in flight) would otherwise recreate it with NO expiry and a negative
+ * value that lingers forever; the pipelined `EXPIRE` ensures any zero/negative key self-expires
+ * instead. Cleanup is therefore deferred to the TTL rather than deleting the key immediately, which
+ * is fine given the key cardinality is bounded by project count.
+ * @param logger - The logger instance for logging purposes.
+ * @param queueName - The BullMQ queue name.
+ * @param projectId - The project id the job belongs to.
+ */
+export async function decrementProjectJobCount(logger: ILogger, queueName: string, projectId: string): Promise<void> {
+  const redis = getRateLimitRedis();
+  const key = getFairQueueKey(queueName, projectId);
+  const pipeline = redis.pipeline().decr(key).expire(key, FAIR_QUEUE_COUNTER_TTL_SECONDS);
+  const results = await pipeline.exec();
+  if (!results) {
+    logger.error('Failed to decrement fairqueue project job count', { queueName, projectId });
+  } else if (results[0]?.[0]) {
+    logger.error('Failed to decrement fairqueue project job count', { queueName, projectId, error: results[0][0] });
+  }
+}

--- a/packages/server/src/workers/fairqueue.ts
+++ b/packages/server/src/workers/fairqueue.ts
@@ -39,8 +39,7 @@ function getFairQueueKey(queueName: string, projectId: string): string {
 
 /**
  * Determines whether fair queueing is active for the given auth state. A per-project
- * `asyncBatchFairQueueEnabled` Project.systemSetting wins if present; otherwise the server config flag
- * applies, defaulting to enabled.
+ * `asyncBatchFairQueueEnabled` Project.systemSetting overrides {@link ServerConfig.asyncBatchFairQueueEnabled}
  * @param authState - The auth state the job was submitted under.
  * @returns True if fair queueing should be applied.
  */
@@ -55,7 +54,7 @@ export function isFairQueueEnabled(authState: Readonly<AuthState>): boolean {
 /**
  * Increments the project's in-flight job counter and returns the BullMQ priority to assign the new
  * job (lower number = higher priority), clamped to the valid range. Refreshes the counter's TTL. The
- * slot is released via {@link decrementProjectJobCount} when the job reaches a terminal state.
+ * slot is released via {@link decrementProjectJobPriority} when the job reaches a terminal state.
  * @param logger - The logger instance for logging purposes.
  * @param queueName - The BullMQ queue name.
  * @param projectId - The project id the job belongs to.
@@ -70,13 +69,16 @@ export async function incrementProjectJobPriority(
   const key = getFairQueueKey(queueName, projectId);
   const pipeline = redis.pipeline().incr(key).expire(key, FAIR_QUEUE_COUNTER_TTL_SECONDS);
   const results = await pipeline.exec();
-  if (!results || results[0]?.[0]) {
-    logger.error('Failed to increment fairqueue project job count', { queueName, projectId, error: results?.[0]?.[0] });
-  }
+
   // results[0] is [err, incrResult] for the INCR command.
-  const count = (results?.[0]?.[1] as number | undefined) ?? 1;
-  // Clamp to BullMQ's valid range; INCR starts at 1, so the lower bound is defensive.
-  return Math.min(Math.max(count, 1), BULLMQ_MAX_PRIORITY);
+  if (!results || results[0]?.[0]) {
+    logger.error('Error incrementing fairqueue priority', { queueName, projectId, error: results?.[0]?.[0] });
+  }
+  // Errors in Redis do not block job processing. Incase of error, default to priority of zero;
+  // effectively emulating behavior when fair queueing is not enabled. This assumes that Redis
+  // errors affect all projects equally
+  const priority = (results?.[0]?.[1] as number | undefined) ?? 0;
+  return Math.min(Math.max(priority, 0), BULLMQ_MAX_PRIORITY); // Clamp to BullMQ's valid range
 }
 
 /**
@@ -90,14 +92,18 @@ export async function incrementProjectJobPriority(
  * @param queueName - The BullMQ queue name.
  * @param projectId - The project id the job belongs to.
  */
-export async function decrementProjectJobCount(logger: ILogger, queueName: string, projectId: string): Promise<void> {
+export async function decrementProjectJobPriority(
+  logger: ILogger,
+  queueName: string,
+  projectId: string
+): Promise<void> {
   const redis = getRateLimitRedis();
   const key = getFairQueueKey(queueName, projectId);
   const pipeline = redis.pipeline().decr(key).expire(key, FAIR_QUEUE_COUNTER_TTL_SECONDS);
   const results = await pipeline.exec();
   if (!results) {
-    logger.error('Failed to decrement fairqueue project job count', { queueName, projectId });
+    logger.error('Error decrementing fairqueue priority', { queueName, projectId });
   } else if (results[0]?.[0]) {
-    logger.error('Failed to decrement fairqueue project job count', { queueName, projectId, error: results[0][0] });
+    logger.error('Error decrementing fairqueue priority', { queueName, projectId, error: results[0][0] });
   }
 }

--- a/packages/server/src/workers/fairqueue.ts
+++ b/packages/server/src/workers/fairqueue.ts
@@ -58,7 +58,7 @@ export function isFairQueueEnabled(authState: Readonly<AuthState>): boolean {
  * @param logger - The logger instance for logging purposes.
  * @param queueName - The BullMQ queue name.
  * @param projectId - The project id the job belongs to.
- * @returns The BullMQ priority (1..{@link BULLMQ_MAX_PRIORITY}) for the just-enqueued job.
+ * @returns The BullMQ priority (0..{@link BULLMQ_MAX_PRIORITY}) for the just-enqueued job.
  */
 export async function incrementProjectJobPriority(
   logger: ILogger,

--- a/packages/server/src/workers/fairqueue.ts
+++ b/packages/server/src/workers/fairqueue.ts
@@ -30,8 +30,8 @@ export const BULLMQ_MAX_PRIORITY = 2_097_151;
  */
 const FAIR_QUEUE_COUNTER_TTL_SECONDS = 24 * 60 * 60; // 24 hours
 
-/** Project setting name for the per-project override of {@link ServerConfig.enableAsyncBatchFairQueue}. */
-const FAIR_QUEUE_SYSTEM_SETTING = 'enableAsyncBatchFairQueue';
+/** Project setting name for the per-project override of {@link ServerConfig.asyncBatchFairQueueEnabled}. */
+const FAIR_QUEUE_SYSTEM_SETTING = 'asyncBatchFairQueueEnabled';
 
 function getFairQueueKey(queueName: string, projectId: string): string {
   return `medplum:fairqueue:${queueName}:${projectId}`;
@@ -39,7 +39,7 @@ function getFairQueueKey(queueName: string, projectId: string): string {
 
 /**
  * Determines whether fair queueing is active for the given auth state. A per-project
- * `enableAsyncBatchFairQueue` Project setting wins if present; otherwise the server config flag
+ * `asyncBatchFairQueueEnabled` Project.systemSetting wins if present; otherwise the server config flag
  * applies, defaulting to enabled.
  * @param authState - The auth state the job was submitted under.
  * @returns True if fair queueing should be applied.
@@ -49,7 +49,7 @@ export function isFairQueueEnabled(authState: Readonly<AuthState>): boolean {
   if (override?.valueBoolean !== undefined) {
     return override.valueBoolean;
   }
-  return !!getConfig().enableAsyncBatchFairQueue;
+  return !!getConfig().asyncBatchFairQueueEnabled;
 }
 
 /**


### PR DESCRIPTION
**UPDATE** - This PR needs some work; priority alone is not enough to get the desired behavior; e.g. newer jobs for a given project will be sequenced before older one still on the queue over time.

An opt-in feature that prevents projects from starving the async batch processing queue by lowering the priority of async batch requests based on how many jobs a project already has in the queue.