### PR TITLE
fix(react): handle unresolvable JSON patch paths in ResourceDiffTable

### DIFF
--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { MedicationRequest, Patient } from '@medplum/fhirtypes';
+import type { MedicationRequest, Patient, Practitioner } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, render, screen } from '../test-utils/render';
@@ -213,6 +213,39 @@ describe('ResourceDiffTable', () => {
 
     const operations = screen.getAllByText('Replace identifier');
     expect(operations).toHaveLength(1);
+  });
+
+  test('Array reorder with out-of-range patch index', async () => {
+    // Reordering array elements produces a JSON patch such as:
+    //   [{ op: 'add', path: '/telecom/0' }, { op: 'remove', path: '/telecom/2' }]
+    // JSON Patch paths are sequential, so "/telecom/2" only exists after the "add" is applied.
+    // Evaluating "telecom[2]" statically against the original resource resolves to nothing.
+    // This previously crashed with "Cannot read properties of undefined (reading 'type')".
+    const original: Practitioner = {
+      resourceType: 'Practitioner',
+      id: '123',
+      meta: { versionId: '456' },
+      telecom: [
+        { system: 'phone', value: '555-555-1234' },
+        { use: 'work', system: 'email', value: 'alice@example.com' },
+      ],
+    };
+
+    const revised: Practitioner = {
+      ...original,
+      meta: { versionId: '457' },
+      telecom: [
+        { system: 'email', value: 'alice@example.com' },
+        { system: 'phone', value: '555-555-1234' },
+      ],
+    };
+
+    await act(async () => {
+      setup({ original, revised });
+    });
+
+    expect(await screen.findByText('Add telecom[0]')).toBeInTheDocument();
+    expect(screen.getByText('Remove telecom[2]')).toBeInTheDocument();
   });
 
   test('Change attachment URL', async () => {

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
@@ -184,6 +184,9 @@ describe('ResourceDiffTable', () => {
 
     const operations = screen.getAllByText('Remove identifier[1]');
     expect(operations).toHaveLength(1);
+
+    // The removed value is shown in the "Before" column
+    expect(screen.getByText('http://example.com/bar: 456')).toBeInTheDocument();
   });
 
   test('Combine patch operations on array remove', async () => {
@@ -219,8 +222,9 @@ describe('ResourceDiffTable', () => {
     // Reordering array elements produces a JSON patch such as:
     //   [{ op: 'add', path: '/telecom/0' }, { op: 'remove', path: '/telecom/2' }]
     // JSON Patch paths are sequential, so "/telecom/2" only exists after the "add" is applied.
-    // Evaluating "telecom[2]" statically against the original resource resolves to nothing.
-    // This previously crashed with "Cannot read properties of undefined (reading 'type')".
+    // Evaluating "telecom[2]" statically against the original resource resolves to nothing,
+    // which previously crashed with "Cannot read properties of undefined (reading 'type')".
+    // Evaluating against sequentially patched states resolves both operations to real values.
     const original: Practitioner = {
       resourceType: 'Practitioner',
       id: '123',
@@ -244,8 +248,14 @@ describe('ResourceDiffTable', () => {
       setup({ original, revised });
     });
 
+    // The "add" row shows the inserted value, evaluated after the operation is applied
     expect(await screen.findByText('Add telecom[0]')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com [email]')).toBeInTheDocument();
+
+    // The "remove" row shows the removed value, evaluated against the intermediate state
+    // [email, phone, work-email] in which index 2 actually exists
     expect(screen.getByText('Remove telecom[2]')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com [work email]')).toBeInTheDocument();
   });
 
   test('Change attachment URL', async () => {

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
@@ -166,8 +166,12 @@ function touchUpValue(
   property: InternalSchemaElement | undefined,
   input: TypedValue[] | TypedValue | undefined
 ): TypedValue | undefined {
-  if (!input) {
-    return input;
+  if (!input || (Array.isArray(input) && input.length === 0)) {
+    // Empty array means the FHIRPath expression did not resolve to a value.
+    // This can happen when array elements are reordered, inserted, or removed,
+    // because JSON Patch paths are sequential (each operation assumes the prior
+    // operations were already applied), but we evaluate them statically.
+    return undefined;
   }
   return {
     type: Array.isArray(input) ? input[0].type : input.type,

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
@@ -3,9 +3,11 @@
 import { Table } from '@mantine/core';
 import type { InternalSchemaElement, Operation, TypedValue } from '@medplum/core';
 import {
+  applyPatch,
   arrayify,
   capitalize,
   createPatch,
+  deepClone,
   evalFhirPathTyped,
   getSearchParameterDetails,
   toTypedValue,
@@ -43,19 +45,44 @@ export function ResourceDiffTable(props: ResourceDiffTableProps): JSX.Element | 
     const typedRevised = [toTypedValue(revised)];
     const result = [];
 
-    // First, we filter and consolidate the patch operations
-    // We can do this because we do not use the "value" field in the patch operations
     // Remove patch operations on meta elements such as "meta.lastUpdated" and "meta.versionId"
-    // Consolidate patch operations on arrays
-    const patch = mergePatchOperations(createPatch(original, revised));
+    const patch = createPatch(original, revised).filter((op) => !isIgnoredPath(op.path));
 
-    // Next, convert the patch operations to a diff table
+    // JSON patch operation paths are sequential -- each operation assumes the prior operations
+    // were already applied. Apply the operations one at a time to an intermediate state, and
+    // evaluate each path against the state just before the operation (for removed/replaced
+    // values) and just after it (for added/replaced values), so paths produced by array
+    // reorders, inserts, and removes always resolve to the true values.
+    const state = deepClone(original);
+    const consolidatedPaths = new Set<string>();
+
     for (const op of patch) {
-      const path = op.path;
-      const fhirPath = jsonPathToFhirPath(path);
+      const consolidatedPath = getConsolidatedPath(op, patch);
+      if (consolidatedPath) {
+        // Multiple add/remove operations on the same array path are consolidated into a single
+        // "replace" row showing the whole array before and after.
+        if (!consolidatedPaths.has(consolidatedPath)) {
+          consolidatedPaths.add(consolidatedPath);
+          const fhirPath = jsonPathToFhirPath(consolidatedPath);
+          const property = tryGetElementDefinition(original.resourceType, fhirPath);
+          result.push({
+            key: `op-replace-${consolidatedPath}`,
+            name: `Replace ${fhirPath}`,
+            path: property?.path ?? original.resourceType + '.' + fhirPath,
+            property: property,
+            originalValue: touchUpValue(property, evalFhirPathTyped(fhirPath, typedOriginal)),
+            revisedValue: touchUpValue(property, evalFhirPathTyped(fhirPath, typedRevised)),
+          });
+        }
+        applyPatch(state, [op]);
+        continue;
+      }
+
+      const fhirPath = jsonPathToFhirPath(op.path);
       const property = tryGetElementDefinition(original.resourceType, fhirPath);
-      const originalValue = op.op === 'add' ? undefined : evalFhirPathTyped(fhirPath, typedOriginal);
-      const revisedValue = op.op === 'remove' ? undefined : evalFhirPathTyped(fhirPath, typedRevised);
+      const originalValue = op.op === 'add' ? undefined : evalFhirPathTyped(fhirPath, [toTypedValue(state)]);
+      applyPatch(state, [op]);
+      const revisedValue = op.op === 'remove' ? undefined : evalFhirPathTyped(fhirPath, [toTypedValue(state)]);
       result.push({
         key: `op-${op.op}-${op.path}`,
         name: `${capitalize(op.op)} ${fhirPath}`,
@@ -92,31 +119,24 @@ export function ResourceDiffTable(props: ResourceDiffTableProps): JSX.Element | 
   );
 }
 
-function mergePatchOperations(patch: Operation[]): Operation[] {
-  const result: Operation[] = [];
-  for (const patchOperation of patch) {
-    const { op, path } = patchOperation;
-    if (
-      path.startsWith('/meta/author') ||
-      path.startsWith('/meta/compartment') ||
-      path.startsWith('/meta/lastUpdated') ||
-      path.startsWith('/meta/versionId')
-    ) {
-      continue;
-    }
-    const count = patch.filter((el) => el.op === op && el.path === path).length;
-    const resultOperation = { op, path } as Operation;
-    if (count > 1 && (op === 'add' || op === 'remove') && /\/[0-9-]+$/.test(path)) {
+function isIgnoredPath(path: string): boolean {
+  return (
+    path.startsWith('/meta/author') ||
+    path.startsWith('/meta/compartment') ||
+    path.startsWith('/meta/lastUpdated') ||
+    path.startsWith('/meta/versionId')
+  );
+}
+
+function getConsolidatedPath(op: Operation, patch: Operation[]): string | undefined {
+  if ((op.op === 'add' || op.op === 'remove') && /\/[0-9-]+$/.test(op.path)) {
+    const count = patch.filter((el) => el.op === op.op && el.path === op.path).length;
+    if (count > 1) {
       // Remove everything after the last slash
-      resultOperation.op = 'replace';
-      resultOperation.path = path.replace(/\/[^/]+$/, '');
-    }
-    if (!result.some((el) => el.op === resultOperation.op && el.path === resultOperation.path)) {
-      // Only add the operation if it doesn't already exist
-      result.push(resultOperation);
+      return op.path.replace(/\/[^/]+$/, '');
     }
   }
-  return result;
+  return undefined;
 }
 
 function jsonPathToFhirPath(path: string): string {
@@ -168,9 +188,8 @@ function touchUpValue(
 ): TypedValue | undefined {
   if (!input || (Array.isArray(input) && input.length === 0)) {
     // Empty array means the FHIRPath expression did not resolve to a value.
-    // This can happen when array elements are reordered, inserted, or removed,
-    // because JSON Patch paths are sequential (each operation assumes the prior
-    // operations were already applied), but we evaluate them statically.
+    // Operations are evaluated against sequentially patched states, so this should
+    // not normally happen, but render an empty cell rather than crash if it does.
     return undefined;
   }
   return {


### PR DESCRIPTION
Fixes #9900

`ResourceDiffTable` evaluated JSON patch operation paths statically against the original/revised resources, but JSON patch paths are sequential — each operation assumes the prior operations were already applied. When an edit reorders, inserts, or removes array elements (e.g. `telecom`, `extension`), an operation like `remove /telecom/2` can reference an index that does not exist in either stored version. `evalFhirPathTyped` then returned an empty array, which passed the `!input` guard in `touchUpValue` and crashed on `input[0].type`:

```
Cannot read properties of undefined (reading 'type')
```

Per review feedback, this now applies the patch operations one at a time to an intermediate state and evaluates each operation's path against the state just before the operation (for removed/replaced values) and just after it (for added/replaced values), so every diff row shows the true value. A reorder now renders as `Add telecom[0]` / `Remove telecom[2]` with the actual moved values instead of empty cells or a crash. Consolidated array rewrites (multiple adds/removes on the same array) keep the existing behavior of showing the whole array before and after, and the empty-eval guard in `touchUpValue` remains as a defensive fallback.

The regression test reproduces the crash on `main` (reordering two telecom entries produces `add /telecom/0` + `remove /telecom/2`) and asserts that both rows now render the true values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)