### PR TITLE
Fix Docusaurus admonitions

### DIFF
--- a/packages/docs/docs/integration/health-gorilla/user-management.md
+++ b/packages/docs/docs/integration/health-gorilla/user-management.md
@@ -46,7 +46,7 @@ curl -X POST "https://api.medplum.com/fhir/R4/Bot/$execute?identifier=https://ww
   }'
 ```
 
-:::info Multiple Locations
+:::info[Multiple Locations]
 If you are operating a Management Services Organization (MSO) or a practice with multiple locations, the sync process involves additional steps for mapping lab account numbers to specific practice locations. See the [Multiple Locations](./multiple-locations) guide for more details.
 :::
 

--- a/packages/docs/docs/react/use-subscription.mdx
+++ b/packages/docs/docs/react/use-subscription.mdx
@@ -15,7 +15,7 @@ given callback when an event notification is triggered.
 Subscriptions created with this hook are lightweight, share a single WebSocket connection per instance of `MedplumClient`, and are automatically
 untracked and cleaned up when the containing component is no longer mounted.
 
-:::info Access Policy Requirements
+:::info[Access Policy Requirements]
 Users must have permission to create `Subscription` resources and read access to the subscribed resource types. See [WebSocket Subscriptions access policy](/docs/access/access-policies#websocket-subscriptions-usesubscription-hook) for details.
 :::
 


### PR DESCRIPTION
This style of admonition worked in Docusaurus 2.x, but in 3.x it results in the literal string ":::info" being rendered into the document.

Wrapping title text in square brackets is the new style to make the admonitions correct.