### PR TITLE
Gracefully handle reading Binary with no content

### DIFF
--- a/packages/server/src/fhir/binary.test.ts
+++ b/packages/server/src/fhir/binary.test.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { ContentType, createReference } from '@medplum/core';
+import { ContentType, Logger, createReference } from '@medplum/core';
 import type { Binary, Bundle, DocumentReference, OperationOutcomeIssue } from '@medplum/fhirtypes';
 import express from 'express';
 import type { Duplex } from 'stream';
 import { Readable } from 'stream';
 import request from 'supertest';
+import { vi } from 'vitest';
 import zlib from 'zlib';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
@@ -55,6 +56,39 @@ describe('Binary', () => {
       .get('/fhir/R4/Binary/2e9dfab6-a3af-4e5b-9324-483b4c333737')
       .set('Authorization', 'Bearer ' + accessToken);
     expect(res).toHaveStatus(404);
+  });
+
+  test('Read binary without stored content', async () => {
+    const res = await request(app)
+      .post('/fhir/R4/Binary')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({ resourceType: 'Binary', contentType: ContentType.TEXT });
+    expect(res).toHaveStatus(201);
+
+    const binary = res.body as Binary;
+    const loggerErrorSpy = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+    try {
+      const res2 = await request(app)
+        .get('/fhir/R4/Binary/' + binary.id)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Accept', ContentType.JSON);
+      expect(res2).toHaveStatus(404);
+      expect(res2.headers['content-type']).toContain(ContentType.FHIR_JSON);
+      expect(res2.headers.etag).toBeUndefined();
+      expect(res2.headers['last-modified']).toBeUndefined();
+      expect(res2.body.resourceType).toStrictEqual('OperationOutcome');
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Error reading Binary content',
+        expect.objectContaining({
+          binary: `Binary/${binary.id}`,
+          err: expect.any(Error),
+          versionId: binary.meta?.versionId,
+        })
+      );
+    } finally {
+      loggerErrorSpy.mockRestore();
+    }
   });
 
   test('Update and read binary', async () => {

--- a/packages/server/src/fhir/response.ts
+++ b/packages/server/src/fhir/response.ts
@@ -1,12 +1,15 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { ContentType, concatUrls, getStatus, isCreated } from '@medplum/core';
+import { ContentType, concatUrls, getStatus, isCreated, notFound } from '@medplum/core';
 import type { FhirResponseOptions } from '@medplum/fhir-router';
 import type { Binary, OperationOutcome, Resource } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
+import { pipeline } from 'node:stream/promises';
 import { getConfig } from '../config/loader';
 import { AuthenticatedRequestContext, tryGetRequestContext } from '../context';
+import { getLogger } from '../logger';
 import { getBinaryStorage } from '../storage/loader';
+import { sendOutcome } from './outcomes';
 import { RewriteMode, rewriteAttachments } from './rewrite';
 
 export function isFhirJsonContentType(req: Request): boolean {
@@ -31,13 +34,38 @@ export function sendResponseHeaders(_req: Request, res: Response, outcome: Opera
   res.status(getStatus(outcome));
 }
 
-export async function sendBinaryResponse(res: Response, binaryResource: Binary): Promise<void> {
-  res.contentType(binaryResource.contentType);
-  if (binaryResource.data) {
-    res.send(Buffer.from(binaryResource.data, 'base64'));
-  } else {
+export async function sendBinaryResponse(
+  req: Request,
+  res: Response,
+  outcome: OperationOutcome,
+  binaryResource: Binary
+): Promise<void> {
+  try {
+    if (binaryResource.data) {
+      sendResponseHeaders(req, res, outcome, binaryResource);
+      res.contentType(binaryResource.contentType);
+      res.send(Buffer.from(binaryResource.data, 'base64'));
+      return;
+    }
+
     const stream = await getBinaryStorage().readBinary(binaryResource);
-    stream.pipe(res);
+    sendResponseHeaders(req, res, outcome, binaryResource);
+    res.contentType(binaryResource.contentType);
+    await pipeline(stream, res);
+  } catch (err) {
+    getLogger().error('Error reading Binary content', {
+      err,
+      binary: binaryResource.id ? `Binary/${binaryResource.id}` : undefined,
+      versionId: binaryResource.meta?.versionId,
+    });
+    if (!res.headersSent) {
+      res.removeHeader('ETag');
+      res.removeHeader('Last-Modified');
+      res.removeHeader('Content-Type');
+      sendOutcome(res, notFound);
+      return;
+    }
+    throw err;
   }
 }
 
@@ -48,8 +76,6 @@ export async function sendFhirResponse(
   body: Resource,
   options?: FhirResponseOptions
 ): Promise<void> {
-  sendResponseHeaders(req, res, outcome, body);
-
   if (
     body.resourceType === 'Binary' &&
     ((req.method === 'GET' && !req.get('Accept')?.startsWith(ContentType.FHIR_JSON)) || options?.forceRawBinaryResponse)
@@ -57,9 +83,11 @@ export async function sendFhirResponse(
     // When the read request has some other type in the Accept header,
     // then the content should be returned with the content type stated in the resource in the Content-Type header.
     // E.g. if the content type in the resource is "application/pdf", then the content should be returned as a PDF directly.
-    await sendBinaryResponse(res, body);
+    await sendBinaryResponse(req, res, outcome, body);
     return;
   }
+
+  sendResponseHeaders(req, res, outcome, body);
 
   let result = body;
 


### PR DESCRIPTION
Matches the 404 behavior of the pre-signed read URLs. Previously this would result in a 500 response in part because the status and headers were prematurely set in `sendResponseHeaders` before establishing the content read stream.