### PR TITLE
[React Hooks]  `useSubscription` tests project feature enablement

### DIFF
--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.test.tsx
@@ -308,13 +308,18 @@ describe('SchedulePage', () => {
 
   describe('Settings gear icon', () => {
     test('when the scheduling feature is disabled the gear icon is hidden', async () => {
+      medplum.mock.setProject({
+        resourceType: 'Project',
+        id: 'project-123',
+        features: [],
+      });
       await act(async () => setup());
       await waitFor(() => expect(screen.getByText('Today')).toBeInTheDocument());
       expect(screen.queryByRole('button', { name: 'Schedule settings' })).not.toBeInTheDocument();
     });
 
     test('when the scheduling feature is enabled the gear icon is visible', async () => {
-      medplum.getProject = vi.fn().mockReturnValue({
+      medplum.mock.setProject({
         resourceType: 'Project',
         id: 'project-123',
         features: ['scheduling'],

--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -982,6 +982,13 @@ describe('MockClient', () => {
     expect(medplum.getProfile()).toBe(profile);
   });
 
+  test('mock.setProject()', () => {
+    const medplum = new MockClient();
+    const project = { resourceType: 'Project' } as const;
+    medplum.mock.setProject(project);
+    expect(medplum.getProject()).toBe(project);
+  });
+
   test('mock.setAgentAvailable()', () => {
     const medplum = new MockClient();
     expect(() => medplum.mock.setAgentAvailable(true)).not.toThrow();

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -30,6 +30,7 @@ import type {
   Binary,
   Bot,
   Device,
+  Project,
   Reference,
   Resource,
   SearchParameter,
@@ -103,6 +104,12 @@ export interface MockClientOptions extends Pick<
    */
   readonly profile?: ReturnType<MedplumClient['getProfile']> | null;
   /**
+   * Override the active project returned by `getProject()`. Defaults to `TestProject`,
+   * which has all features enabled. Specifying null results in `getProject()` returning
+   * undefined, as if there were no active project.
+   */
+  readonly project?: Project | null;
+  /**
    * Override the `MockFetchClient` used by this `MockClient`.
    */
   readonly mockFetchOverride?: MockFetchOverrideOptions;
@@ -120,6 +127,7 @@ export type MockFetchOverrideOptions = {
 interface MockClientTestMethods {
   withSeeding: <T>(fn: () => T | Promise<T>) => Promise<T>;
   setProfile: (profile: ProfileResource | undefined) => void;
+  setProject: (project: Project | undefined) => void;
   setAgentAvailable: (value: boolean) => void;
   setSubscriptionManager: (subManager: MockSubscriptionManager) => void;
 }
@@ -132,6 +140,7 @@ export class MockClient extends MedplumClient {
   activeLoginOverride?: LoginState;
   private agentAvailable = true;
   private profile: ReturnType<MedplumClient['getProfile']>;
+  private project: Project | undefined;
   subManager: MockSubscriptionManager | undefined;
 
   constructor(clientOptions?: MockClientOptions) {
@@ -180,6 +189,8 @@ export class MockClient extends MedplumClient {
     this.client = client;
     // if null is specified, treat it as if no one is logged in
     this.profile = clientOptions?.profile === null ? undefined : (clientOptions?.profile ?? DrAliceSmith);
+    // if null is specified, treat it as if there is no active project
+    this.project = clientOptions?.project === null ? undefined : (clientOptions?.project ?? TestProject);
     this.debug = !!clientOptions?.debug;
   }
 
@@ -193,6 +204,10 @@ export class MockClient extends MedplumClient {
       },
       setProfile: (profile: ProfileResource | undefined): void => {
         this.profile = profile;
+        this.dispatchEvent({ type: 'change' });
+      },
+      setProject: (project: Project | undefined): void => {
+        this.project = project;
         this.dispatchEvent({ type: 'change' });
       },
       setAgentAvailable: (value: boolean): void => {
@@ -226,6 +241,10 @@ export class MockClient extends MedplumClient {
 
   getProfile(): ProfileResource | undefined {
     return this.profile;
+  }
+
+  getProject(): Project | undefined {
+    return this.project;
   }
 
   getUserConfiguration(): WithId<UserConfiguration> | undefined {

--- a/packages/mock/src/mocks/index.ts
+++ b/packages/mock/src/mocks/index.ts
@@ -3,6 +3,7 @@
 export * from './accesspolicy';
 export * from './alice';
 export * from './bot';
+export * from './project';
 export * from './questionnaire';
 export * from './simpsons';
 export * from './subscription';

--- a/packages/mock/src/mocks/project.ts
+++ b/packages/mock/src/mocks/project.ts
@@ -4,11 +4,31 @@ import { createReference } from '@medplum/core';
 import type { Project, ProjectMembership } from '@medplum/fhirtypes';
 import { DrAliceSmith } from './alice';
 
-export const TestProject: Project = {
+export const TestProject = {
   resourceType: 'Project',
   id: '123',
   name: 'Project 123',
-};
+  // The mock project represents an established, fully-provisioned project so that
+  // feature-gated components "just work" under test. Individual tests can override
+  // `getProject()` (e.g. with `features: []`) to exercise the feature-disabled paths.
+  features: [
+    'ai',
+    'ai-realtime',
+    'aws-comprehend',
+    'aws-textract',
+    'bots',
+    'cron',
+    'email',
+    'google-auth-required',
+    'graphql-introspection',
+    'scheduling',
+    'websocket-subscriptions',
+    'transaction-bundles',
+    'validate-terminology',
+    'range-search',
+    'log-streaming',
+  ],
+} satisfies Project;
 
 export const TestProjectMembership: ProjectMembership = {
   resourceType: 'ProjectMembership',

--- a/packages/react-hooks/src/useSubscription/useSubscription.test.tsx
+++ b/packages/react-hooks/src/useSubscription/useSubscription.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { SubscriptionEmitter, generateId } from '@medplum/core';
 import type { Bundle } from '@medplum/fhirtypes';
-import { MockClient } from '@medplum/mock';
+import { MockClient, TestProject } from '@medplum/mock';
 import { act, render, screen } from '@testing-library/react';
 import type { JSX, ReactNode } from 'react';
 import { StrictMode, useCallback, useState } from 'react';
@@ -91,14 +91,16 @@ describe('useSubscription()', () => {
 
   function setup(
     children: ReactNode,
-    strict = false
+    options?: { strict?: boolean; client?: MockClient }
   ): {
     unmount: ReturnType<typeof render>['unmount'];
     rerender: (element: JSX.Element) => void;
   } {
+    const strict = options?.strict ?? false;
+    const client = options?.client ?? medplum;
     const defaultWrapper = (children: ReactNode): JSX.Element => (
       <MemoryRouter>
-        <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
+        <MedplumProvider medplum={client}>{children}</MedplumProvider>
       </MemoryRouter>
     );
 
@@ -179,7 +181,7 @@ describe('useSubscription()', () => {
     const emitter = medplum.getSubscriptionManager().addCriteria('Communication');
     expect(medplum.getSubscriptionManager().getCriteriaCount()).toEqual(1);
 
-    setup(<TestComponent criteria="Communication" />, true);
+    setup(<TestComponent criteria="Communication" />, { strict: true });
     await advanceDebounce(5000);
     expect(medplum.getSubscriptionManager().getCriteriaCount()).toEqual(1);
     expect(medplum.getSubscriptionManager().getEmitter('Communication')).toBe(emitter);
@@ -551,6 +553,17 @@ describe('useSubscription()', () => {
 
     getProfileSpy.mockRestore();
     subscribeSpy.mockRestore();
+  });
+
+  test('Is a no-op when the active project is missing the `websocket-subscriptions` feature', async () => {
+    const client = new MockClient({ project: { ...TestProject, features: [] } });
+    const subscribeSpy = vi.spyOn(client, 'subscribeToCriteria');
+
+    setup(<TestComponent criteria="Communication" />, { client });
+
+    // No subscription should be created while the feature is disabled
+    expect(subscribeSpy).not.toHaveBeenCalled();
+    expect(client.getSubscriptionManager().getCriteriaCount()).toEqual(0);
   });
 
   test('WebSocket disconnects and reconnects', async () => {

--- a/packages/react-hooks/src/useSubscription/useSubscription.ts
+++ b/packages/react-hooks/src/useSubscription/useSubscription.ts
@@ -44,12 +44,17 @@ export function useSubscription(
   options?: UseSubscriptionOptions
 ): void {
   const medplum = useMedplum();
+  const project = medplum.getProject();
   const profile = useMedplumProfile();
+
   // When the user is not authenticated, the subscription becomes a no-op. Subscribing would
   // create a `Subscription` resource and request a WebSocket binding token, both of which 401
-  // without a profile. Treating criteria as `undefined` skips all subscription work; when the
+  // without a profile. Also disabled when the active project does not have the feature flag.
+  const enabled = profile && project?.features?.includes('websocket-subscriptions');
+
+  // Treating criteria as `undefined` skips all subscription work; when the
   // user authenticates, `profile` changes and the effect re-runs to subscribe.
-  const effectiveCriteria = profile ? criteria : undefined;
+  const effectiveCriteria = enabled ? criteria : undefined;
   const [emitter, setEmitter] = useState<SubscriptionEmitter>();
   // We don't memoize the entire options object since it contains callbacks and if the callbacks change identity, we don't want to trigger a resubscribe to criteria
   const [memoizedSubProps, setMemoizedSubProps] = useState(options?.subscriptionProps);

--- a/packages/react/src/AppShell/Header.test.tsx
+++ b/packages/react/src/AppShell/Header.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { AppShell as MantineAppShell } from '@mantine/core';
 import { locationUtils } from '@medplum/core';
-import { MockClient } from '@medplum/mock';
+import { MockClient, TestProject } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { Logo } from '../Logo/Logo';
 import { act, fireEvent, render, screen } from '../test-utils/render';
@@ -12,10 +12,10 @@ const medplum = new MockClient();
 const navigateMock = vi.fn();
 const closeMock = vi.fn();
 
-async function setup(): Promise<void> {
+async function setup(client?: MockClient): Promise<void> {
   await act(async () => {
     render(
-      <MedplumProvider medplum={medplum} navigate={navigateMock}>
+      <MedplumProvider medplum={client ?? medplum} navigate={navigateMock}>
         <MantineAppShell>
           <Header logo={<Logo size={24} />} version="test.version" navbarToggle={closeMock} />
         </MantineAppShell>
@@ -36,6 +36,7 @@ describe('Header', () => {
       vi.runOnlyPendingTimers();
     });
     vi.useRealTimers();
+    window.localStorage.clear();
   });
 
   test('Renders', async () => {
@@ -44,6 +45,10 @@ describe('Header', () => {
   });
 
   test('Renders active project name', async () => {
+    // Simulate state where `auth/me` has not finished and so the explicit
+    // project resource has not loaded. In that case, we read the active project
+    // name from localStorage via `getActiveLogin()`
+    const medplum = new MockClient({ project: null });
     window.localStorage.setItem(
       'activeLogin',
       JSON.stringify({
@@ -60,12 +65,22 @@ describe('Header', () => {
       })
     );
 
-    await setup();
-
-    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    await setup(medplum);
     expect(screen.getByText('My Project')).toBeInTheDocument();
 
+    // Simulate auth loading completing. The displayed active project name
+    // should now use the value from that result. These will usually match,
+    // but could differ if the project has been renamed since the local
+    // storage was last written to.
+    await act(() => medplum.mock.setProject(TestProject));
+    expect(screen.getByText(TestProject.name)).toBeInTheDocument();
+
     window.localStorage.removeItem('activeLogin');
+  });
+
+  test('Renders user name', async () => {
+    await setup();
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
   });
 
   test('Open and close the user menu', async () => {
@@ -141,7 +156,7 @@ describe('Header', () => {
       fireEvent.click(screen.getByText('Alice Smith'));
     });
 
-    expect((await screen.findAllByText('My Project')).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText('Project 123')).length).toBeGreaterThan(0);
     expect(await screen.findByText('My Other Project')).toBeInTheDocument();
 
     // Click on other project to switch

--- a/packages/react/src/AppShell/Navbar.test.tsx
+++ b/packages/react/src/AppShell/Navbar.test.tsx
@@ -3,7 +3,7 @@
 import { AppShell as MantineAppShell } from '@mantine/core';
 import type { WithId } from '@medplum/core';
 import type { Communication, UserConfiguration } from '@medplum/fhirtypes';
-import { MockClient } from '@medplum/mock';
+import { MockClient, TestProject } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { IconMail, IconStar } from '@tabler/icons-react';
 import 'vitest-websocket-mock';
@@ -82,6 +82,7 @@ describe('Navbar', () => {
     vi.useFakeTimers();
     navigateMock.mockClear();
     closeMock.mockClear();
+    localStorage.clear();
   });
 
   afterEach(async () => {
@@ -89,6 +90,7 @@ describe('Navbar', () => {
       vi.runOnlyPendingTimers();
     });
     vi.useRealTimers();
+    localStorage.clear();
   });
 
   test('Renders', async () => {
@@ -96,7 +98,11 @@ describe('Navbar', () => {
     expect(screen.getByText('Menu 1')).toBeInTheDocument();
   });
 
-  test('Renders user name and active project name', async () => {
+  test('Renders active project name', async () => {
+    // Simulate state where `auth/me` has not finished and so the explicit
+    // project resource has not loaded. In that case, we read the active project
+    // name from localStorage via `getActiveLogin()`
+    const client = new MockClient({ project: null });
     window.localStorage.setItem(
       'activeLogin',
       JSON.stringify({
@@ -116,6 +122,35 @@ describe('Navbar', () => {
     const initialUrl = new URL('/', 'http://localhost');
     await act(async () => {
       render(
+        <MedplumProvider medplum={client} navigate={navigateMock}>
+          <MantineAppShell>
+            <Navbar
+              logo={<div>Logo</div>}
+              pathname={initialUrl.pathname}
+              searchParams={initialUrl.searchParams}
+              navbarToggle={toggleMock}
+              closeNavbar={closeMock}
+              userMenuEnabled={true}
+            />
+          </MantineAppShell>
+        </MedplumProvider>
+      );
+    });
+
+    expect(screen.getByText('My Project')).toBeInTheDocument();
+
+    // Simulate auth loading completing. The displayed active project name
+    // should now use the value from that result. These will usually match,
+    // but could differ if the project has been renamed since the local
+    // storage was last written to.
+    await act(() => client.mock.setProject(TestProject));
+    expect(screen.getByText(TestProject.name)).toBeInTheDocument();
+  });
+
+  test('Renders user name', async () => {
+    const initialUrl = new URL('/', 'http://localhost');
+    await act(async () => {
+      render(
         <MedplumProvider medplum={medplum} navigate={navigateMock}>
           <MantineAppShell>
             <Navbar
@@ -132,9 +167,6 @@ describe('Navbar', () => {
     });
 
     expect(screen.getByText('Alice Smith')).toBeInTheDocument();
-    expect(screen.getByText('My Project')).toBeInTheDocument();
-
-    window.localStorage.removeItem('activeLogin');
   });
 
   test('Highlighted link', async () => {


### PR DESCRIPTION
Starting in a fresh project that doesn't have this feature enabled and using a component with this hook can put some noisy errors in the console. Adding this check short circuits early when the feature is not explicitly enabled for the active project.