### PR TITLE
[React tests] Remove extraneous MemoryRouter wrapper

### DIFF
--- a/packages/react/src/AppShell/AppShell.test.tsx
+++ b/packages/react/src/AppShell/AppShell.test.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { Logo } from '../Logo/Logo';
 import { act, fireEvent, render, screen, selectAutocompleteOption } from '../test-utils/render';
 import type { AppShellAnnouncement } from './AnnouncementBanners';
@@ -17,36 +16,34 @@ async function setup(layoutVersion: 'v1' | 'v2' = 'v1', announcements?: AppShell
 
   await act(async () => {
     render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum} navigate={navigateMock}>
-          <AppShell
-            logo={<Logo size={24} />}
-            version="test.version"
-            layoutVersion={layoutVersion}
-            announcements={announcements}
-            menus={[
-              {
-                title: 'Menu 1',
-                links: [
-                  { label: 'Link 1', href: '/link1' },
-                  { label: 'Link 2', href: '/link2' },
-                  { label: 'Link 3', href: '/link3' },
-                ],
-              },
-              {
-                title: 'Menu 2',
-                links: [
-                  { label: 'Link 4', href: '/link4' },
-                  { label: 'Link 5', href: '/link5' },
-                  { label: 'Link 6', href: '/link6' },
-                ],
-              },
-            ]}
-          >
-            Your application here
-          </AppShell>
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum} navigate={navigateMock}>
+        <AppShell
+          logo={<Logo size={24} />}
+          version="test.version"
+          layoutVersion={layoutVersion}
+          announcements={announcements}
+          menus={[
+            {
+              title: 'Menu 1',
+              links: [
+                { label: 'Link 1', href: '/link1' },
+                { label: 'Link 2', href: '/link2' },
+                { label: 'Link 3', href: '/link3' },
+              ],
+            },
+            {
+              title: 'Menu 2',
+              links: [
+                { label: 'Link 4', href: '/link4' },
+                { label: 'Link 5', href: '/link5' },
+                { label: 'Link 6', href: '/link6' },
+              ],
+            },
+          ]}
+        >
+          Your application here
+        </AppShell>
+      </MedplumProvider>
     );
   });
 }

--- a/packages/react/src/AppShell/Header.test.tsx
+++ b/packages/react/src/AppShell/Header.test.tsx
@@ -4,7 +4,6 @@ import { AppShell as MantineAppShell } from '@mantine/core';
 import { locationUtils } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { Logo } from '../Logo/Logo';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import { Header } from './Header';
@@ -13,16 +12,14 @@ const medplum = new MockClient();
 const navigateMock = vi.fn();
 const closeMock = vi.fn();
 
-async function setup(initialUrl = '/'): Promise<void> {
+async function setup(): Promise<void> {
   await act(async () => {
     render(
-      <MemoryRouter initialEntries={[initialUrl]} initialIndex={0}>
-        <MedplumProvider medplum={medplum} navigate={navigateMock}>
-          <MantineAppShell>
-            <Header logo={<Logo size={24} />} version="test.version" navbarToggle={closeMock} />
-          </MantineAppShell>
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum} navigate={navigateMock}>
+        <MantineAppShell>
+          <Header logo={<Logo size={24} />} version="test.version" navbarToggle={closeMock} />
+        </MantineAppShell>
+      </MedplumProvider>
     );
   });
 }

--- a/packages/react/src/AppShell/HeaderSearchInput.test.tsx
+++ b/packages/react/src/AppShell/HeaderSearchInput.test.tsx
@@ -3,7 +3,6 @@
 import { HomerServiceRequest, HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { randomUUID } from 'crypto';
-import { MemoryRouter } from 'react-router';
 import { act, clickAutocompleteOption, fireEvent, render, screen, typeInAutocomplete } from '../test-utils/render';
 import { HeaderSearchInput } from './HeaderSearchInput';
 
@@ -82,11 +81,9 @@ const navigateMock = vi.fn();
 
 function setup(): void {
   render(
-    <MemoryRouter>
-      <MedplumProvider medplum={medplum} navigate={navigateMock}>
-        <HeaderSearchInput />
-      </MedplumProvider>
-    </MemoryRouter>
+    <MedplumProvider medplum={medplum} navigate={navigateMock}>
+      <HeaderSearchInput />
+    </MedplumProvider>
   );
 }
 

--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.test.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.test.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, render, screen } from '../test-utils/render';
 import type { BackboneElementDisplayProps } from './BackboneElementDisplay';
 import { BackboneElementDisplay } from './BackboneElementDisplay';
@@ -13,11 +12,9 @@ describe('BackboneElementDisplay', () => {
   async function setup(args: BackboneElementDisplayProps): Promise<void> {
     await act(async () =>
       render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <BackboneElementDisplay {...args} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <BackboneElementDisplay {...args} />
+        </MedplumProvider>
       )
     );
   }

--- a/packages/react/src/BackboneElementInput/BackboneElementInput.test.tsx
+++ b/packages/react/src/BackboneElementInput/BackboneElementInput.test.tsx
@@ -4,7 +4,6 @@ import type { InternalSchemaElement, TypeInfo } from '@medplum/core';
 import { globalSchema, loadDataType } from '@medplum/core';
 import { FishPatientResources, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, render, screen, within } from '../test-utils/render';
 import type { BackboneElementInputProps } from './BackboneElementInput';
 import { BackboneElementInput } from './BackboneElementInput';
@@ -66,11 +65,9 @@ describe('BackboneElementInput', () => {
   async function setup(args: BackboneElementInputProps): Promise<void> {
     await act(async () => {
       render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <BackboneElementInput {...args} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <BackboneElementInput {...args} />
+        </MedplumProvider>
       );
     });
   }

--- a/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.test.tsx
+++ b/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.test.tsx
@@ -4,7 +4,6 @@ import { createReference } from '@medplum/core';
 import type { DiagnosticReport, Patient } from '@medplum/fhirtypes';
 import { ExampleSubscription, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, render, screen, waitFor } from '../test-utils/render';
 import type { DefaultResourceTimelineProps } from './DefaultResourceTimeline';
 import { DefaultResourceTimeline } from './DefaultResourceTimeline';
@@ -15,11 +14,9 @@ describe('DefaultResourceTimeline', () => {
   async function setup(args: DefaultResourceTimelineProps): Promise<void> {
     await act(async () => {
       render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <DefaultResourceTimeline {...args} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <DefaultResourceTimeline {...args} />
+        </MedplumProvider>
       );
     });
   }

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.test.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.test.tsx
@@ -4,7 +4,6 @@ import { createReference } from '@medplum/core';
 import type { DiagnosticReport, Observation, Reference } from '@medplum/fhirtypes';
 import { HomerDiagnosticReport, HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import {
   HealthGorillaDiagnosticReport,
   HealthGorillaObservation1,
@@ -82,11 +81,9 @@ describe('DiagnosticReportDisplay', () => {
 
   function setup(args: DiagnosticReportDisplayProps): void {
     render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>
-          <DiagnosticReportDisplay {...args} />
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum}>
+        <DiagnosticReportDisplay {...args} />
+      </MedplumProvider>
     );
   }
 

--- a/packages/react/src/EncounterTimeline/EncounterTimeline.test.tsx
+++ b/packages/react/src/EncounterTimeline/EncounterTimeline.test.tsx
@@ -3,7 +3,6 @@
 import { createReference } from '@medplum/core';
 import { HomerEncounter, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import type { EncounterTimelineProps } from './EncounterTimeline';
 import { EncounterTimeline } from './EncounterTimeline';
@@ -14,11 +13,9 @@ describe('EncounterTimeline', () => {
   async function setup(args: EncounterTimelineProps): Promise<void> {
     await act(async () => {
       render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <EncounterTimeline {...args} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <EncounterTimeline {...args} />
+        </MedplumProvider>
       );
     });
   }

--- a/packages/react/src/FhirPathTable/FhirPathTable.test.tsx
+++ b/packages/react/src/FhirPathTable/FhirPathTable.test.tsx
@@ -3,7 +3,6 @@
 import { PropertyType } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import type { FhirPathTableField, FhirPathTableProps } from './FhirPathTable';
 import { FhirPathTable } from './FhirPathTable';
@@ -95,11 +94,9 @@ describe('FhirPathTable', () => {
   async function setup(args: FhirPathTableProps): Promise<void> {
     await act(async () => {
       render(
-        <MemoryRouter>
-          <MedplumProvider medplum={new MockClient()}>
-            <FhirPathTable {...args} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={new MockClient()}>
+          <FhirPathTable {...args} />
+        </MedplumProvider>
       );
     });
   }

--- a/packages/react/src/LinkTabs/LinkTabs.test.tsx
+++ b/packages/react/src/LinkTabs/LinkTabs.test.tsx
@@ -5,7 +5,6 @@ import type * as MedplumCore from '@medplum/core';
 import { locationUtils } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import type { Mocked } from 'vitest';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import { LinkTabs } from './LinkTabs';
@@ -38,13 +37,11 @@ describe('LinkTabs', () => {
     tabs: ['Overview', 'Timeline', 'Details'],
   };
 
-  function setup(props = {}, initialUrl = '/patient/123/overview'): void {
+  function setup(props = {}): void {
     render(
-      <MemoryRouter initialEntries={[initialUrl]} initialIndex={0}>
-        <MedplumProvider medplum={medplum} navigate={navigateMock}>
-          <LinkTabs {...defaultProps} {...props} />
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum} navigate={navigateMock}>
+        <LinkTabs {...defaultProps} {...props} />
+      </MedplumProvider>
     );
   }
 

--- a/packages/react/src/MeasureReportDisplay/MeasureReportDisplay.test.tsx
+++ b/packages/react/src/MeasureReportDisplay/MeasureReportDisplay.test.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, render, screen } from '../test-utils/render';
 import type { MeasureReportDisplayProps } from './MeasureReportDisplay';
 import { MeasureReportDisplay } from './MeasureReportDisplay';
@@ -12,11 +11,9 @@ const medplum = new MockClient();
 async function setup(args: MeasureReportDisplayProps): Promise<void> {
   await act(async () => {
     render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>
-          <MeasureReportDisplay {...args} />
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum}>
+        <MeasureReportDisplay {...args} />
+      </MedplumProvider>
     );
   });
 }

--- a/packages/react/src/MedplumLink/MedplumLink.test.tsx
+++ b/packages/react/src/MedplumLink/MedplumLink.test.tsx
@@ -3,7 +3,6 @@
 import { locationUtils, MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactElement } from 'react';
-import { MemoryRouter } from 'react-router';
 import { fireEvent, render, screen } from '../test-utils/render';
 import { MedplumLink } from './MedplumLink';
 
@@ -29,11 +28,9 @@ const medplum = new MedplumClient({
 
 function setup(ui: ReactElement): void {
   render(
-    <MemoryRouter>
-      <MedplumProvider medplum={medplum} navigate={vi.fn()}>
-        {ui}
-      </MedplumProvider>
-    </MemoryRouter>
+    <MedplumProvider medplum={medplum} navigate={vi.fn()}>
+      {ui}
+    </MedplumProvider>
   );
 }
 

--- a/packages/react/src/NoteDisplay/NoteDisplay.test.tsx
+++ b/packages/react/src/NoteDisplay/NoteDisplay.test.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, render, screen } from '../test-utils/render';
 import type { NoteDisplayProps } from './NoteDisplay';
 import { NoteDisplay } from './NoteDisplay';
@@ -12,11 +11,9 @@ const medplum = new MockClient();
 describe('NoteDisplay', () => {
   function setup(args: NoteDisplayProps): void {
     render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>
-          <NoteDisplay {...args} />
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum}>
+        <NoteDisplay {...args} />
+      </MedplumProvider>
     );
   }
 

--- a/packages/react/src/PatientAccountsForm/PatientAccountsForm.test.tsx
+++ b/packages/react/src/PatientAccountsForm/PatientAccountsForm.test.tsx
@@ -6,7 +6,6 @@ import { allOk } from '@medplum/core';
 import type { Patient } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import { PatientAccountsForm } from './PatientAccountsForm';
 
@@ -44,14 +43,12 @@ describe('PatientAccountsForm', () => {
 
     await act(async () => {
       render(
-        <MemoryRouter>
-          <MantineProvider>
-            <Notifications />
-            <MedplumProvider medplum={client}>
-              <PatientAccountsForm patient={patient} />
-            </MedplumProvider>
-          </MantineProvider>
-        </MemoryRouter>
+        <MantineProvider>
+          <Notifications />
+          <MedplumProvider medplum={client}>
+            <PatientAccountsForm patient={patient} />
+          </MedplumProvider>
+        </MantineProvider>
       );
     });
     return client;

--- a/packages/react/src/PatientExportForm/PatientExportForm.test.tsx
+++ b/packages/react/src/PatientExportForm/PatientExportForm.test.tsx
@@ -4,7 +4,6 @@ import { Notifications } from '@mantine/notifications';
 import { allOk } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import type { PatientExportFormProps } from './PatientExportForm';
 import { PatientExportForm } from './PatientExportForm';
@@ -13,12 +12,10 @@ describe('PatientExportForm', () => {
   async function setup(args: PatientExportFormProps, medplum = new MockClient()): Promise<void> {
     await act(async () => {
       render(
-        <MemoryRouter>
+        <MedplumProvider medplum={medplum}>
           <Notifications />
-          <MedplumProvider medplum={medplum}>
-            <PatientExportForm {...args} />
-          </MedplumProvider>
-        </MemoryRouter>
+          <PatientExportForm {...args} />
+        </MedplumProvider>
       );
     });
   }

--- a/packages/react/src/PatientHeader/PatientHeader.test.tsx
+++ b/packages/react/src/PatientHeader/PatientHeader.test.tsx
@@ -3,7 +3,6 @@
 import type { Identifier, Patient } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { render, screen } from '../test-utils/render';
 import { PatientHeader } from './PatientHeader';
 import { getDefaultColor } from './PatientHeader.utils';
@@ -13,11 +12,9 @@ const medplum = new MockClient();
 describe('PatientHeader', () => {
   function setup(patient: Patient): void {
     render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>
-          <PatientHeader patient={patient} />
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum}>
+        <PatientHeader patient={patient} />
+      </MedplumProvider>
     );
   }
 

--- a/packages/react/src/PatientSummary/Allergies.test.tsx
+++ b/packages/react/src/PatientSummary/Allergies.test.tsx
@@ -5,7 +5,6 @@ import type { AllergyIntolerance } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen, selectAutocompleteOption } from '../test-utils/render';
 import { Allergies } from './Allergies';
 
@@ -14,11 +13,7 @@ const medplum = new MockClient();
 describe('PatientSummary - Allergies', () => {
   async function setup(children: ReactNode): Promise<void> {
     await act(async () => {
-      render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
-      );
+      render(<MedplumProvider medplum={medplum}>{children}</MedplumProvider>);
     });
   }
 

--- a/packages/react/src/PatientSummary/Insurance.test.tsx
+++ b/packages/react/src/PatientSummary/Insurance.test.tsx
@@ -5,7 +5,6 @@ import type { Coverage, Organization } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import { CoverageItem, Insurance } from './Insurance';
 
@@ -39,11 +38,7 @@ const mockInsuranceOrg: Organization = {
 describe('PatientSummary - Insurance', () => {
   async function setup(children: ReactNode): Promise<void> {
     await act(async () => {
-      render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
-      );
+      render(<MedplumProvider medplum={medplum}>{children}</MedplumProvider>);
     });
   }
 

--- a/packages/react/src/PatientSummary/Labs.test.tsx
+++ b/packages/react/src/PatientSummary/Labs.test.tsx
@@ -4,7 +4,6 @@ import type { DiagnosticReport, ServiceRequest } from '@medplum/fhirtypes';
 import { HomerServiceRequest, HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import { Labs } from './Labs';
 
@@ -13,11 +12,7 @@ const medplum = new MockClient();
 describe('PatientSummary - Labs', () => {
   async function setup(children: ReactNode): Promise<void> {
     await act(async () => {
-      render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
-      );
+      render(<MedplumProvider medplum={medplum}>{children}</MedplumProvider>);
     });
   }
 

--- a/packages/react/src/PatientSummary/Medications.test.tsx
+++ b/packages/react/src/PatientSummary/Medications.test.tsx
@@ -5,7 +5,6 @@ import type { MedicationRequest, MedicationStatement } from '@medplum/fhirtypes'
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen, selectAutocompleteOption } from '../test-utils/render';
 import { Medications } from './Medications';
 
@@ -14,11 +13,7 @@ const medplum = new MockClient();
 describe('PatientSummary - Medications', () => {
   async function setup(children: ReactNode): Promise<void> {
     await act(async () => {
-      render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
-      );
+      render(<MedplumProvider medplum={medplum}>{children}</MedplumProvider>);
     });
   }
 

--- a/packages/react/src/PatientSummary/PatientSummary.test.tsx
+++ b/packages/react/src/PatientSummary/PatientSummary.test.tsx
@@ -3,7 +3,6 @@
 import { createReference } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, render, screen } from '../test-utils/render';
 import type { PatientSummaryProps } from './PatientSummary';
 import { PatientSummary } from './PatientSummary';
@@ -29,11 +28,9 @@ describe('PatientSummary', () => {
   async function setup(args: PatientSummaryProps): Promise<void> {
     await act(async () => {
       render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <PatientSummary {...args} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <PatientSummary {...args} />
+        </MedplumProvider>
       );
     });
   }
@@ -592,11 +589,9 @@ describe('PatientSummary', () => {
   test('Renders null when patient cannot be resolved', async () => {
     const { container } = await act(async () => {
       return render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <PatientSummary patient={{ reference: 'Patient/does-not-exist-xyz' }} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <PatientSummary patient={{ reference: 'Patient/does-not-exist-xyz' }} />
+        </MedplumProvider>
       );
     });
 

--- a/packages/react/src/PatientSummary/Pharmacies.test.tsx
+++ b/packages/react/src/PatientSummary/Pharmacies.test.tsx
@@ -5,7 +5,6 @@ import type { Organization, Patient } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { JSX, ReactNode } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import type { PharmacyDialogBaseProps } from './Pharmacies';
 import { Pharmacies } from './Pharmacies';
@@ -32,11 +31,7 @@ function MockPharmacyDialog(props: PharmacyDialogBaseProps): JSX.Element {
 
 async function setup(children: ReactNode): Promise<void> {
   await act(async () => {
-    render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-      </MemoryRouter>
-    );
+    render(<MedplumProvider medplum={medplum}>{children}</MedplumProvider>);
   });
 }
 
@@ -252,11 +247,9 @@ describe('PatientSummary - Pharmacies', () => {
   test('Returns empty fragment when patient is null', async () => {
     await act(async () => {
       render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <Pharmacies patient={null as unknown as Patient} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <Pharmacies patient={null as unknown as Patient} />
+        </MedplumProvider>
       );
     });
 

--- a/packages/react/src/PatientSummary/PharmacyDialog.test.tsx
+++ b/packages/react/src/PatientSummary/PharmacyDialog.test.tsx
@@ -6,7 +6,6 @@ import type { Organization } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router';
 import type { Mock } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import { PharmacyDialog } from './PharmacyDialog';
@@ -16,11 +15,7 @@ const medplum = new MockClient();
 describe('PharmacyDialog', () => {
   async function setup(children: ReactNode): Promise<void> {
     await act(async () => {
-      render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
-      );
+      render(<MedplumProvider medplum={medplum}>{children}</MedplumProvider>);
     });
   }
 

--- a/packages/react/src/PatientSummary/ProblemList.test.tsx
+++ b/packages/react/src/PatientSummary/ProblemList.test.tsx
@@ -5,7 +5,6 @@ import type { Condition } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen, typeInAutocomplete } from '../test-utils/render';
 import { ProblemList } from './ProblemList';
 
@@ -14,11 +13,7 @@ const medplum = new MockClient();
 describe('PatientSummary - ProblemList', () => {
   async function setup(children: ReactNode): Promise<void> {
     await act(async () => {
-      render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
-      );
+      render(<MedplumProvider medplum={medplum}>{children}</MedplumProvider>);
     });
   }
 

--- a/packages/react/src/PatientSummary/SexualOrientation.test.tsx
+++ b/packages/react/src/PatientSummary/SexualOrientation.test.tsx
@@ -3,7 +3,6 @@
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import { SexualOrientation } from './SexualOrientation';
 
@@ -12,11 +11,7 @@ const medplum = new MockClient();
 describe('PatientSummary - SexualOrientation', () => {
   async function setup(children: ReactNode): Promise<void> {
     await act(async () => {
-      render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
-      );
+      render(<MedplumProvider medplum={medplum}>{children}</MedplumProvider>);
     });
   }
 

--- a/packages/react/src/PatientSummary/SmokingStatus.test.tsx
+++ b/packages/react/src/PatientSummary/SmokingStatus.test.tsx
@@ -3,7 +3,6 @@
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import { SmokingStatus } from './SmokingStatus';
 
@@ -12,11 +11,7 @@ const medplum = new MockClient();
 describe('PatientSummary - SmokingStatus', () => {
   async function setup(children: ReactNode): Promise<void> {
     await act(async () => {
-      render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
-      );
+      render(<MedplumProvider medplum={medplum}>{children}</MedplumProvider>);
     });
   }
 

--- a/packages/react/src/PatientSummary/Vitals.test.tsx
+++ b/packages/react/src/PatientSummary/Vitals.test.tsx
@@ -3,7 +3,6 @@
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import { Vitals } from './Vitals';
 
@@ -12,11 +11,7 @@ const medplum = new MockClient();
 describe('PatientSummary - Vitals', () => {
   async function setup(children: ReactNode): Promise<void> {
     await act(async () => {
-      render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
-      );
+      render(<MedplumProvider medplum={medplum}>{children}</MedplumProvider>);
     });
   }
 

--- a/packages/react/src/PatientTimeline/PatientTimeline.test.tsx
+++ b/packages/react/src/PatientTimeline/PatientTimeline.test.tsx
@@ -3,7 +3,6 @@
 import { createReference } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import type { PatientTimelineProps } from './PatientTimeline';
 import { PatientTimeline } from './PatientTimeline';
@@ -14,11 +13,9 @@ describe('PatientTimeline', () => {
   async function setup(args: PatientTimelineProps): Promise<void> {
     await act(async () => {
       render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <PatientTimeline {...args} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <PatientTimeline {...args} />
+        </MedplumProvider>
       );
     });
   }

--- a/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.test.tsx
+++ b/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.test.tsx
@@ -3,7 +3,6 @@
 import type { ActivityDefinition } from '@medplum/fhirtypes';
 import { ExampleWorkflowPlanDefinition, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, clickAutocompleteOption, fireEvent, render, screen, typeInAutocomplete } from '../test-utils/render';
 import type { PlanDefinitionBuilderProps } from './PlanDefinitionBuilder';
 import { PlanDefinitionBuilder } from './PlanDefinitionBuilder';
@@ -13,11 +12,9 @@ const medplum = new MockClient();
 async function setup(args: PlanDefinitionBuilderProps): Promise<void> {
   await act(async () => {
     render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>
-          <PlanDefinitionBuilder {...args} />
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum}>
+        <PlanDefinitionBuilder {...args} />
+      </MedplumProvider>
     );
   });
 }

--- a/packages/react/src/QuestionnaireForm/AIRealTimeQuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/AIRealTimeQuestionnaireForm.test.tsx
@@ -4,7 +4,6 @@ import type { Project, Questionnaire, QuestionnaireResponse } from '@medplum/fhi
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider, useWhisper } from '@medplum/react-hooks';
 import { useState } from 'react';
-import { MemoryRouter } from 'react-router';
 import type { Mock, MockInstance } from 'vitest';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import type { AIRealTimeQuestionnaireFormProps } from './AIRealTimeQuestionnaireForm';
@@ -99,11 +98,9 @@ async function setup(
 
   await act(async () => {
     render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>
-          <AIRealTimeQuestionnaireForm questionnaire={sampleQuestionnaire} {...props} />
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum}>
+        <AIRealTimeQuestionnaireForm questionnaire={sampleQuestionnaire} {...props} />
+      </MedplumProvider>
     );
   });
 

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -5,7 +5,6 @@ import type { Extension, Questionnaire, QuestionnaireResponse } from '@medplum/f
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider, QUESTIONNAIRE_SIGNATURE_REQUIRED_URL, QuestionnaireItemType } from '@medplum/react-hooks';
 import { randomUUID } from 'crypto';
-import { MemoryRouter } from 'react-router';
 import {
   act,
   clickAutocompleteOption,
@@ -37,11 +36,9 @@ const pageExtension: Extension[] = [
 async function setup(args: QuestionnaireFormProps): Promise<void> {
   await act(async () => {
     render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>
-          <QuestionnaireForm {...args} />
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum}>
+        <QuestionnaireForm {...args} />
+      </MedplumProvider>
     );
   });
 }

--- a/packages/react/src/QuestionnaireResponseDisplay/QuestionnaireResponseDisplay.test.tsx
+++ b/packages/react/src/QuestionnaireResponseDisplay/QuestionnaireResponseDisplay.test.tsx
@@ -3,7 +3,6 @@
 import type { QuestionnaireResponse } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router-dom';
 import { act, render, screen } from '../test-utils/render';
 import { QuestionnaireResponseDisplay } from './QuestionnaireResponseDisplay';
 
@@ -11,11 +10,9 @@ const medplum = new MockClient();
 
 function setup(questionnaireResponse: QuestionnaireResponse | { reference: string; display?: string }): void {
   render(
-    <MemoryRouter>
-      <MedplumProvider medplum={medplum}>
-        <QuestionnaireResponseDisplay questionnaireResponse={questionnaireResponse} />
-      </MedplumProvider>
-    </MemoryRouter>
+    <MedplumProvider medplum={medplum}>
+      <QuestionnaireResponseDisplay questionnaireResponse={questionnaireResponse} />
+    </MedplumProvider>
   );
 }
 

--- a/packages/react/src/ReferenceDisplay/ReferenceDisplay.test.tsx
+++ b/packages/react/src/ReferenceDisplay/ReferenceDisplay.test.tsx
@@ -4,18 +4,13 @@ import type { Reference } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactElement } from 'react';
-import { MemoryRouter } from 'react-router';
 import { render, screen } from '../test-utils/render';
 import { ReferenceDisplay } from './ReferenceDisplay';
 
 const medplum = new MockClient();
 
 function setup(ui: ReactElement): void {
-  render(
-    <MemoryRouter>
-      <MedplumProvider medplum={medplum}>{ui}</MedplumProvider>
-    </MemoryRouter>
-  );
+  render(<MedplumProvider medplum={medplum}>{ui}</MedplumProvider>);
 }
 
 describe('ReferenceDisplay', () => {

--- a/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.test.tsx
+++ b/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.test.tsx
@@ -5,7 +5,6 @@ import type { ObservationDefinition } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { StrictMode } from 'react';
-import { MemoryRouter } from 'react-router';
 import { HDLDefinition, TestosteroneDefinition } from '../stories/referenceLab';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import type { ReferenceRangeEditorProps } from './ReferenceRangeEditor';
@@ -17,11 +16,9 @@ async function setup(args: ReferenceRangeEditorProps): Promise<void> {
   await act(async () => {
     render(
       <StrictMode>
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <ReferenceRangeEditor {...args} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <ReferenceRangeEditor {...args} />
+        </MedplumProvider>
       </StrictMode>
     );
   });

--- a/packages/react/src/RequestGroupDisplay/RequestGroupDisplay.test.tsx
+++ b/packages/react/src/RequestGroupDisplay/RequestGroupDisplay.test.tsx
@@ -3,7 +3,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactElement } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import { RequestGroupDisplay } from './RequestGroupDisplay';
 
@@ -11,11 +10,7 @@ const medplum = new MockClient();
 
 async function setup(ui: ReactElement): Promise<void> {
   await act(async () => {
-    render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>{ui}</MedplumProvider>
-      </MemoryRouter>
-    );
+    render(<MedplumProvider medplum={medplum}>{ui}</MedplumProvider>);
   });
 }
 

--- a/packages/react/src/ResourceAvatar/ResourceAvatar.test.tsx
+++ b/packages/react/src/ResourceAvatar/ResourceAvatar.test.tsx
@@ -3,7 +3,6 @@
 import { createReference } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, render, screen } from '../test-utils/render';
 import type { ResourceAvatarProps } from './ResourceAvatar';
 import { ResourceAvatar } from './ResourceAvatar';
@@ -15,11 +14,9 @@ describe('ResourceAvatar', () => {
   async function setup(args: ResourceAvatarProps): Promise<void> {
     await act(async () => {
       render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <ResourceAvatar {...args} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <ResourceAvatar {...args} />
+        </MedplumProvider>
       );
     });
   }

--- a/packages/react/src/ResourceBadge/ResourceBadge.test.tsx
+++ b/packages/react/src/ResourceBadge/ResourceBadge.test.tsx
@@ -3,7 +3,6 @@
 import { createReference } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { render, screen } from '../test-utils/render';
 import type { ResourceBadgeProps } from './ResourceBadge';
 import { ResourceBadge } from './ResourceBadge';
@@ -12,11 +11,9 @@ const medplum = new MockClient();
 
 function setup(args: ResourceBadgeProps): void {
   render(
-    <MemoryRouter>
-      <MedplumProvider medplum={medplum}>
-        <ResourceBadge {...args} />
-      </MedplumProvider>
-    </MemoryRouter>
+    <MedplumProvider medplum={medplum}>
+      <ResourceBadge {...args} />
+    </MedplumProvider>
   );
 }
 

--- a/packages/react/src/ResourceBlame/ResourceBlame.test.tsx
+++ b/packages/react/src/ResourceBlame/ResourceBlame.test.tsx
@@ -3,7 +3,6 @@
 import type { Bundle } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, render, screen } from '../test-utils/render';
 import type { ResourceBlameProps } from './ResourceBlame';
 import { ResourceBlame } from './ResourceBlame';
@@ -15,11 +14,9 @@ describe('ResourceBlame', () => {
   async function setup(args: ResourceBlameProps): Promise<void> {
     await act(async () => {
       render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <ResourceBlame {...args} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <ResourceBlame {...args} />
+        </MedplumProvider>
       );
     });
   }

--- a/packages/react/src/ResourceBoard/ResourceBoard.test.tsx
+++ b/packages/react/src/ResourceBoard/ResourceBoard.test.tsx
@@ -4,7 +4,6 @@ import type { Bundle, Communication, Resource } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import type { ResourceBoardProps } from './ResourceBoard';
 import { ResourceBoard } from './ResourceBoard';
@@ -56,11 +55,9 @@ describe('ResourceBoard', () => {
           {...props}
         />,
         ({ children }) => (
-          <MemoryRouter>
-            <MedplumProvider medplum={medplum} navigate={mockNavigate}>
-              {children}
-            </MedplumProvider>
-          </MemoryRouter>
+          <MedplumProvider medplum={medplum} navigate={mockNavigate}>
+            {children}
+          </MedplumProvider>
         )
       );
       await Promise.resolve();
@@ -292,11 +289,9 @@ describe('ResourceBoard', () => {
       renderDetail: () => <div />,
     };
     const { rerender } = render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum} navigate={mockNavigate}>
-          <ResourceBoard {...props} />
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum} navigate={mockNavigate}>
+        <ResourceBoard {...props} />
+      </MedplumProvider>
     );
     await waitFor(() => expect(screen.getByTestId('item-a')).toBeInTheDocument());
     expect(medplum.search).toHaveBeenCalledTimes(1);
@@ -304,11 +299,9 @@ describe('ResourceBoard', () => {
     // Same value, new identity: no refetch
     await act(async () => {
       rerender(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum} navigate={mockNavigate}>
-            <ResourceBoard {...props} search={{ resourceType: 'Communication' }} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum} navigate={mockNavigate}>
+          <ResourceBoard {...props} search={{ resourceType: 'Communication' }} />
+        </MedplumProvider>
       );
     });
     expect(medplum.search).toHaveBeenCalledTimes(1);
@@ -316,11 +309,9 @@ describe('ResourceBoard', () => {
     // Different value: refetch
     await act(async () => {
       rerender(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum} navigate={mockNavigate}>
-            <ResourceBoard {...props} search={{ resourceType: 'Communication', offset: 20 }} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum} navigate={mockNavigate}>
+          <ResourceBoard {...props} search={{ resourceType: 'Communication', offset: 20 }} />
+        </MedplumProvider>
       );
     });
     await waitFor(() => expect(medplum.search).toHaveBeenCalledTimes(2));

--- a/packages/react/src/ResourceHistoryTable/ResourceHistoryTable.test.tsx
+++ b/packages/react/src/ResourceHistoryTable/ResourceHistoryTable.test.tsx
@@ -3,7 +3,6 @@
 import type { Bundle } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, render, screen } from '../test-utils/render';
 import type { ResourceHistoryTableProps } from './ResourceHistoryTable';
 import { ResourceHistoryTable } from './ResourceHistoryTable';
@@ -14,11 +13,9 @@ describe('ResourceHistoryTable', () => {
   async function setup(args: ResourceHistoryTableProps): Promise<void> {
     await act(async () => {
       render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <ResourceHistoryTable {...args} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <ResourceHistoryTable {...args} />
+        </MedplumProvider>
       );
     });
   }

--- a/packages/react/src/ResourceName/ResourceName.test.tsx
+++ b/packages/react/src/ResourceName/ResourceName.test.tsx
@@ -3,7 +3,6 @@
 import { createReference } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { render, screen } from '../test-utils/render';
 import type { ResourceNameProps } from './ResourceName';
 import { ResourceName } from './ResourceName';
@@ -13,11 +12,9 @@ const medplum = new MockClient();
 describe('ResourceName', () => {
   function setup(args: ResourceNameProps): void {
     render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>
-          <ResourceName {...args} />
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum}>
+        <ResourceName {...args} />
+      </MedplumProvider>
     );
   }
 

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.test.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.test.tsx
@@ -21,7 +21,6 @@ import type {
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, render, screen, userEvent } from '../test-utils/render';
 import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
 
@@ -116,11 +115,7 @@ describe('ResourcePropertyDisplay', () => {
   });
 
   test('Renders canonical', async () => {
-    await setup(
-      <MemoryRouter>
-        <ResourcePropertyDisplay propertyType={PropertyType.canonical} value="Patient/123" />
-      </MemoryRouter>
-    );
+    await setup(<ResourcePropertyDisplay propertyType={PropertyType.canonical} value="Patient/123" />);
 
     const el = screen.getByText('Patient/123');
     expect(el).toBeInTheDocument();
@@ -425,13 +420,11 @@ describe('ResourcePropertyDisplay', () => {
     };
 
     await setup(
-      <MemoryRouter>
-        <ResourcePropertyDisplay
-          property={{ ...baseProperty, type: [{ code: 'Reference' }] }}
-          propertyType={PropertyType.Reference}
-          value={value}
-        />
-      </MemoryRouter>
+      <ResourcePropertyDisplay
+        property={{ ...baseProperty, type: [{ code: 'Reference' }] }}
+        propertyType={PropertyType.Reference}
+        value={value}
+      />
     );
 
     expect(screen.getByText(value.display as string)).toBeInTheDocument();

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.test.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.test.tsx
@@ -5,7 +5,6 @@ import { createReference } from '@medplum/core';
 import type { Attachment, Bundle, Encounter, Resource, ResourceType } from '@medplum/fhirtypes';
 import { HomerEncounter, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import type { ResourceTimelineProps } from './ResourceTimeline';
 import { ResourceTimeline } from './ResourceTimeline';
@@ -28,11 +27,9 @@ describe('ResourceTimeline', () => {
   async function setup<T extends Resource>(args: ResourceTimelineProps<T>): Promise<void> {
     await act(async () => {
       render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <ResourceTimeline {...args} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <ResourceTimeline {...args} />
+        </MedplumProvider>
       );
     });
   }

--- a/packages/react/src/Scheduler/Scheduler.test.tsx
+++ b/packages/react/src/Scheduler/Scheduler.test.tsx
@@ -5,7 +5,6 @@ import { createReference } from '@medplum/core';
 import type { Period, Schedule, Slot } from '@medplum/fhirtypes';
 import { DrAliceSmithSchedule, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import type { SchedulerProps, SlotSearchFunction } from './Scheduler';
 import { Scheduler } from './Scheduler';
@@ -14,11 +13,9 @@ const medplum = new MockClient();
 
 function setup(props: SchedulerProps): void {
   render(
-    <MemoryRouter>
-      <MedplumProvider medplum={medplum}>
-        <Scheduler {...props} />
-      </MedplumProvider>
-    </MemoryRouter>
+    <MedplumProvider medplum={medplum}>
+      <Scheduler {...props} />
+    </MedplumProvider>
   );
 }
 

--- a/packages/react/src/SearchControl/SearchControl.test.tsx
+++ b/packages/react/src/SearchControl/SearchControl.test.tsx
@@ -5,7 +5,6 @@ import { Operator } from '@medplum/core';
 import type { Bundle } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import type { SearchControlProps } from './SearchControl';
 import { SearchControl } from './SearchControl';
@@ -32,9 +31,7 @@ describe('SearchControl', () => {
     }
     const { rerender: _rerender } = await act(async () =>
       render(<SearchControl {...props} />, ({ children }) => (
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
       ))
     );
     return {

--- a/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
+++ b/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
@@ -6,7 +6,6 @@ import { Operator, globalSchema } from '@medplum/core';
 import type { ResourceType, SearchParameter } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { getFieldDefinitions } from '../SearchControl/SearchControlField';
 import { act, fireEvent, render, screen, userEvent } from '../test-utils/render';
 import type { SearchPopupMenuProps } from './SearchPopupMenu';
@@ -27,16 +26,14 @@ describe('SearchPopupMenu', () => {
     } as SearchPopupMenuProps;
 
     render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>
-          <Menu closeOnItemClick={false}>
-            <Menu.Target>
-              <Button>Toggle menu</Button>
-            </Menu.Target>
-            <SearchPopupMenu {...props} />
-          </Menu>
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum}>
+        <Menu closeOnItemClick={false}>
+          <Menu.Target>
+            <Button>Toggle menu</Button>
+          </Menu.Target>
+          <SearchPopupMenu {...props} />
+        </Menu>
+      </MedplumProvider>
     );
 
     await toggleMenu();

--- a/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.test.tsx
+++ b/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.test.tsx
@@ -3,7 +3,6 @@
 import { createReference } from '@medplum/core';
 import { HomerServiceRequest, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import type { ServiceRequestTimelineProps } from './ServiceRequestTimeline';
 import { ServiceRequestTimeline } from './ServiceRequestTimeline';
@@ -14,11 +13,9 @@ describe('ServiceRequestTimeline', () => {
   async function setup(args: ServiceRequestTimelineProps): Promise<void> {
     await act(async () => {
       render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum} navigate={vi.fn()}>
-            <ServiceRequestTimeline {...args} />
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum} navigate={vi.fn()}>
+          <ServiceRequestTimeline {...args} />
+        </MedplumProvider>
       );
     });
   }

--- a/packages/react/src/SmartAppLaunchLink/SmartAppLaunchLink.test.tsx
+++ b/packages/react/src/SmartAppLaunchLink/SmartAppLaunchLink.test.tsx
@@ -5,17 +5,12 @@ import type { ClientApplication, Encounter, Patient } from '@medplum/fhirtypes';
 import { HomerEncounter, HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import { SmartAppLaunchLink } from './SmartAppLaunchLink';
 
 describe('SmartAppLaunchLink', () => {
   function setup(children: ReactNode, medplum: MockClient): void {
-    render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-      </MemoryRouter>
-    );
+    render(<MedplumProvider medplum={medplum}>{children}</MedplumProvider>);
   }
 
   test('Happy path', async () => {

--- a/packages/react/src/Timeline/Timeline.test.tsx
+++ b/packages/react/src/Timeline/Timeline.test.tsx
@@ -3,7 +3,6 @@
 import type { Communication } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, render, screen } from '../test-utils/render';
 import { Timeline, TimelineItem } from './Timeline';
 
@@ -16,13 +15,11 @@ describe('Timeline', () => {
     } as Communication;
 
     render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>
-          <Timeline>
-            <TimelineItem resource={resource}>test</TimelineItem>
-          </Timeline>
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum}>
+        <Timeline>
+          <TimelineItem resource={resource}>test</TimelineItem>
+        </Timeline>
+      </MedplumProvider>
     );
 
     expect(screen.getByText('test')).toBeDefined();
@@ -41,13 +38,11 @@ describe('Timeline', () => {
 
     await act(async () => {
       render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <Timeline>
-              <TimelineItem resource={resource}>test</TimelineItem>
-            </Timeline>
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <Timeline>
+            <TimelineItem resource={resource}>test</TimelineItem>
+          </Timeline>
+        </MedplumProvider>
       );
     });
 
@@ -65,13 +60,11 @@ describe('Timeline', () => {
 
     await act(async () => {
       render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
-            <Timeline>
-              <TimelineItem resource={resource}>test</TimelineItem>
-            </Timeline>
-          </MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <Timeline>
+            <TimelineItem resource={resource}>test</TimelineItem>
+          </Timeline>
+        </MedplumProvider>
       );
     });
 

--- a/packages/react/src/auth/RegisterForm.test.tsx
+++ b/packages/react/src/auth/RegisterForm.test.tsx
@@ -5,7 +5,6 @@ import type { GoogleCredentialResponse } from '@medplum/core';
 import { allOk, MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { randomUUID, webcrypto } from 'crypto';
-import { MemoryRouter } from 'react-router';
 import { TextEncoder } from 'util';
 import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import type { RegisterFormProps } from './RegisterForm';
@@ -126,13 +125,11 @@ async function setup(props: RegisterFormProps): Promise<void> {
 
   await act(async () => {
     render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>
-          <RegisterForm {...props}>
-            <Title>My Register Form</Title>
-          </RegisterForm>
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum}>
+        <RegisterForm {...props}>
+          <Title>My Register Form</Title>
+        </RegisterForm>
+      </MedplumProvider>
     );
   });
 }

--- a/packages/react/src/auth/SignInForm.test.tsx
+++ b/packages/react/src/auth/SignInForm.test.tsx
@@ -5,7 +5,6 @@ import type { GoogleCredentialResponse } from '@medplum/core';
 import { allOk, badRequest, locationUtils, MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react-hooks';
 import crypto from 'crypto';
-import { MemoryRouter } from 'react-router';
 import { TextEncoder } from 'util';
 import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import type { SignInFormProps } from './SignInForm';
@@ -247,13 +246,11 @@ async function setup(args?: SignInFormProps): Promise<void> {
 
   await act(async () => {
     render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>
-          <SignInForm {...props}>
-            <Title>Sign in to Medplum</Title>
-          </SignInForm>
-        </MedplumProvider>
-      </MemoryRouter>
+      <MedplumProvider medplum={medplum}>
+        <SignInForm {...props}>
+          <Title>Sign in to Medplum</Title>
+        </SignInForm>
+      </MedplumProvider>
     );
   });
 }

--- a/packages/react/src/chat/BaseChat/BaseChat.test.tsx
+++ b/packages/react/src/chat/BaseChat/BaseChat.test.tsx
@@ -9,7 +9,6 @@ import { MedplumProvider } from '@medplum/react-hooks';
 import crypto from 'node:crypto';
 import type { JSX } from 'react';
 import { useState } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen } from '../../test-utils/render';
 import type { BaseChatProps } from './BaseChat';
 import { BaseChat } from './BaseChat';
@@ -97,10 +96,10 @@ describe('BaseChat', () => {
   ): Promise<{ rerender: (props: TestComponentProps) => Promise<void> }> {
     const { rerender: _rerender } = await act(async () =>
       render(<TestComponent {...props} />, ({ children }) => (
-        <MemoryRouter>
+        <MedplumProvider medplum={medplum ?? defaultMedplum}>
           <Notifications />
-          <MedplumProvider medplum={medplum ?? defaultMedplum}>{children}</MedplumProvider>
-        </MemoryRouter>
+          {children}
+        </MedplumProvider>
       ))
     );
     return {

--- a/packages/react/src/chat/BaseChat/DocumentPicker.test.tsx
+++ b/packages/react/src/chat/BaseChat/DocumentPicker.test.tsx
@@ -5,7 +5,6 @@ import type { DocumentReference } from '@medplum/fhirtypes';
 import { DrAliceSmith, HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen, waitFor } from '../../test-utils/render';
 import type { DocumentPickerProps } from './DocumentPicker';
 import { DocumentPicker } from './DocumentPicker';
@@ -25,9 +24,7 @@ describe('DocumentPicker', () => {
   async function setup(props: DocumentPickerProps): Promise<void> {
     await act(async () =>
       render(<DocumentPicker {...props} />, ({ children }: { children: ReactNode }) => (
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
       ))
     );
   }

--- a/packages/react/src/chat/ChatModal/ChatModal.test.tsx
+++ b/packages/react/src/chat/ChatModal/ChatModal.test.tsx
@@ -3,7 +3,6 @@
 import { DrAliceSmith, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import type { JSX } from 'react';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen } from '../../test-utils/render';
 import type { ChatModalProps } from './ChatModal';
 import { ChatModal } from './ChatModal';
@@ -30,9 +29,7 @@ describe('ChatModal', () => {
   ): Promise<{ rerender: (props?: TestComponentProps) => Promise<void> }> {
     const { rerender: _rerender } = await act(async () =>
       render(<TestComponent {...props} />, ({ children }) => (
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum ?? defaultMedplum}>{children}</MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum ?? defaultMedplum}>{children}</MedplumProvider>
       ))
     );
     return {

--- a/packages/react/src/chat/ThreadChat/ThreadChat.test.tsx
+++ b/packages/react/src/chat/ThreadChat/ThreadChat.test.tsx
@@ -8,7 +8,6 @@ import { BartSimpson, DrAliceSmith, HomerSimpson, MockClient } from '@medplum/mo
 // eslint-disable-next-line import/named
 import { MedplumProvider, _subscriptionController } from '@medplum/react-hooks';
 import crypto from 'node:crypto';
-import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen, waitFor } from '../../test-utils/render';
 import type { ThreadChatProps } from './ThreadChat';
 import { ThreadChat } from './ThreadChat';
@@ -146,9 +145,7 @@ describe('ThreadChat', () => {
   ): Promise<{ rerender: (props: ThreadChatProps) => Promise<void> }> {
     const { rerender: _rerender } = await act(async () =>
       render(<ThreadChat {...props} />, ({ children }) => (
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum ?? defaultMedplum}>{children}</MedplumProvider>
-        </MemoryRouter>
+        <MedplumProvider medplum={medplum ?? defaultMedplum}>{children}</MedplumProvider>
       ))
     );
     return {

--- a/packages/react/src/chat/ThreadInbox/NewTopicDialog.test.tsx
+++ b/packages/react/src/chat/ThreadInbox/NewTopicDialog.test.tsx
@@ -5,7 +5,6 @@ import type { Patient } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router';
 import { render, screen, waitFor } from '../../test-utils/render';
 import { NewTopicDialog } from './NewTopicDialog';
 
@@ -32,11 +31,7 @@ describe('NewTopicDialog', () => {
           allowPatientSelection={allowPatientSelection}
         />
       </>,
-      ({ children }) => (
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
-      )
+      ({ children }) => <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
     );
   };
 

--- a/packages/react/src/chat/ThreadInbox/ThreadInbox.test.tsx
+++ b/packages/react/src/chat/ThreadInbox/ThreadInbox.test.tsx
@@ -5,7 +5,6 @@ import type { Communication } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import * as reactHooks from '@medplum/react-hooks';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { act, render, screen, userEvent, waitFor } from '../../test-utils/render';
 import { ThreadInbox } from './ThreadInbox';
 
@@ -69,11 +68,9 @@ describe('ThreadInbox', () => {
           />
         </>,
         ({ children }) => (
-          <MemoryRouter>
-            <MedplumProvider medplum={medplum} navigate={mockNavigate}>
-              {children}
-            </MedplumProvider>
-          </MemoryRouter>
+          <MedplumProvider medplum={medplum} navigate={mockNavigate}>
+            {children}
+          </MedplumProvider>
         )
       );
 

--- a/packages/react/src/chat/ThreadInbox/ThreadListItem.test.tsx
+++ b/packages/react/src/chat/ThreadInbox/ThreadListItem.test.tsx
@@ -4,7 +4,6 @@ import { createReference } from '@medplum/core';
 import type { Communication } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { MemoryRouter } from 'react-router';
 import { render, screen, waitFor } from '../../test-utils/render';
 import { ThreadListItem } from './ThreadListItem';
 
@@ -43,11 +42,7 @@ describe('ThreadListItem', () => {
   const setup = (topic: Communication, lastCommunication: Communication | undefined): void => {
     render(
       <ThreadListItem topic={topic} lastCommunication={lastCommunication} getThreadUri={mockGetThreadUri} />,
-      ({ children }) => (
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
-      )
+      ({ children }) => <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
     );
   };
 


### PR DESCRIPTION
These tests are depending on React Router but are not exercising any aspect of the router. Let's remove these wrappers to simplify the tests a little bit.