### PR TITLE
Move MockClient control methods into `.mock` namespace

### DIFF
--- a/examples/medplum-provider/src/pages/SignInPage.test.tsx
+++ b/examples/medplum-provider/src/pages/SignInPage.test.tsx
@@ -65,7 +65,7 @@ describe('SignInPage', () => {
     const client = setup();
 
     vi.spyOn(client, 'processCode').mockImplementation(async () => {
-      (client as MockClient).setProfile(DrAliceSmith);
+      (client as MockClient).mock.setProfile(DrAliceSmith);
       return DrAliceSmith;
     });
 

--- a/examples/medplum-provider/src/pages/meds/OrderMedicationPage.test.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderMedicationPage.test.tsx
@@ -65,7 +65,7 @@ describe('OrderMedicationPage', () => {
 
   test('soft-deletes the draft MedicationRequest (status=unknown + statusReason) when the order bot fails', async () => {
     const medplum = new MockClient();
-    medplum.setProfile(DrAliceSmith);
+    medplum.mock.setProfile(DrAliceSmith);
 
     // Drug name search returns a single in-memory Medication. Important: no routed-med-id
     // so the page's "expand to formulations" effect short-circuits to selectedFormat = termMedication
@@ -149,7 +149,7 @@ describe('OrderMedicationPage', () => {
 
   test('medication title combines the drug name with the selected formulation, not just the strength', async () => {
     const medplum = new MockClient();
-    medplum.setProfile(DrAliceSmith);
+    medplum.mock.setProfile(DrAliceSmith);
 
     // Drug-name search row: carries the product name + a routed-med-id so the
     // page expands to formulations (the path that previously dropped the name).
@@ -219,7 +219,7 @@ describe('OrderMedicationPage', () => {
 
   test('Add to cart creates the draft MedicationRequest without calling $order-medication or opening a widget', async () => {
     const medplum = new MockClient();
-    medplum.setProfile(DrAliceSmith);
+    medplum.mock.setProfile(DrAliceSmith);
 
     const searchHit: Medication = {
       resourceType: 'Medication',
@@ -277,7 +277,7 @@ describe('OrderMedicationPage', () => {
 
   test('does not show Add to cart when onAddedToCart is not provided', async () => {
     const medplum = new MockClient();
-    medplum.setProfile(DrAliceSmith);
+    medplum.mock.setProfile(DrAliceSmith);
     searchMedicationsMock.mockResolvedValue([]);
 
     await act(async () => {

--- a/packages/app/src/resource/ToolsPage.test.tsx
+++ b/packages/app/src/resource/ToolsPage.test.tsx
@@ -223,7 +223,7 @@ describe('ToolsPage', () => {
   });
 
   test('Displays error notification whenever agent unreachable', async () => {
-    medplum.setAgentAvailable(false);
+    medplum.mock.setAgentAvailable(false);
 
     // load agent tools page
     setup(`/${getReferenceString(agent)}/tools`);
@@ -237,7 +237,7 @@ describe('ToolsPage', () => {
 
     await expect(screen.findByText('Timeout')).resolves.toBeInTheDocument();
 
-    medplum.setAgentAvailable(true);
+    medplum.mock.setAgentAvailable(true);
   });
 
   test('Setting count for ping', async () => {

--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -858,12 +858,12 @@ describe('MockClient', () => {
     expect(homer.name[0].family).toStrictEqual('Simpson');
   });
 
-  test('setProfile()', async () => {
+  test('.mock.setProfile()', async () => {
     const medplum = new MockClient({ profile: null });
     expect(medplum.getProfile()).toBeUndefined();
     const callback = vi.fn();
     medplum.addEventListener('change', callback);
-    medplum.setProfile(DrAliceSmith);
+    medplum.mock.setProfile(DrAliceSmith);
     expect(medplum.getProfile()).toStrictEqual(DrAliceSmith);
     expect(callback).toHaveBeenCalledTimes(1);
   });
@@ -900,11 +900,11 @@ describe('MockClient', () => {
     const medplum = new MockClient();
     const agent = await medplum.createResource<Agent>({ resourceType: 'Agent', status: 'active', name: 'Agente' });
     await expect(medplum.pushToAgent(agent, '8.8.8.8', 'PING', ContentType.PING, true)).resolves.toBeDefined();
-    medplum.setAgentAvailable(false);
+    medplum.mock.setAgentAvailable(false);
     await expect(medplum.pushToAgent(agent, '8.8.8.8', 'PING', ContentType.PING, true)).rejects.toThrow(
       OperationOutcomeError
     );
-    medplum.setAgentAvailable(true);
+    medplum.mock.setAgentAvailable(true);
     await expect(medplum.pushToAgent(agent, '8.8.8.8', 'PING', ContentType.PING, true)).resolves.toBeDefined();
   });
 

--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -7,6 +7,7 @@ import {
   ClientStorage,
   ContentType,
   getReferenceString,
+  getWebSocketUrl,
   indexSearchParameterBundle,
   indexStructureDefinitionBundle,
   MemoryStorage,
@@ -946,6 +947,76 @@ describe('MockClient', () => {
     });
     expect(attachment).toBeDefined();
     expect(attachment.url).toBeDefined();
+  });
+
+  test('mock.withSeeding()', async () => {
+    const medplum = new MockClient();
+    const lastUpdated = '2020-01-01T14:00:00Z';
+    const result = await medplum.mock.withSeeding(() =>
+      medplum.createResource({
+        resourceType: 'Patient',
+        meta: { lastUpdated },
+      })
+    );
+    expect(result.meta).toHaveProperty('lastUpdated', lastUpdated);
+  });
+
+  test('mock.setSubscriptionManager()', async () => {
+    const medplum = new MockClient();
+    const manager = new MockSubscriptionManager(medplum, getWebSocketUrl(medplum.getBaseUrl(), '/ws/subscriptions-r4'));
+    medplum.mock.setSubscriptionManager(manager);
+    expect(medplum.getSubscriptionManager()).toBe(manager);
+  });
+
+  test('mock.setProfile()', () => {
+    const medplum = new MockClient();
+    const profile = { resourceType: 'Practitioner' } as const;
+    medplum.mock.setProfile(profile);
+    expect(medplum.getProfile()).toBe(profile);
+  });
+
+  test('mock.setAgentAvailable()', () => {
+    const medplum = new MockClient();
+    expect(() => medplum.mock.setAgentAvailable(true)).not.toThrow();
+    expect(() => medplum.mock.setAgentAvailable(false)).not.toThrow();
+  });
+
+  // To be removed in Medlpum v6; https://github.com/medplum/medplum/issues/9945
+  describe('deprecated methods', () => {
+    test('withSeeding()', async () => {
+      const medplum = new MockClient();
+      const lastUpdated = '2020-01-01T14:00:00Z';
+      const result = await medplum.withSeeding(() =>
+        medplum.createResource({
+          resourceType: 'Patient',
+          meta: { lastUpdated },
+        })
+      );
+      expect(result.meta).toHaveProperty('lastUpdated', lastUpdated);
+    });
+
+    test('setSubscriptionManager()', () => {
+      const medplum = new MockClient();
+      const manager = new MockSubscriptionManager(
+        medplum,
+        getWebSocketUrl(medplum.getBaseUrl(), '/ws/subscriptions-r4')
+      );
+      medplum.setSubscriptionManager(manager);
+      expect(medplum.getSubscriptionManager()).toBe(manager);
+    });
+
+    test('setProfile()', () => {
+      const medplum = new MockClient();
+      const profile = { resourceType: 'Practitioner' } as const;
+      medplum.setProfile(profile);
+      expect(medplum.getProfile()).toBe(profile);
+    });
+
+    test('setAgentAvailable()', () => {
+      const medplum = new MockClient();
+      expect(() => medplum.setAgentAvailable(true)).not.toThrow();
+      expect(() => medplum.setAgentAvailable(false)).not.toThrow();
+    });
   });
 });
 

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -117,6 +117,13 @@ export type MockFetchOverrideOptions = {
   repo: MemoryRepository;
 };
 
+interface MockClientTestMethods {
+  withSeeding: <T>(fn: () => T | Promise<T>) => Promise<T>;
+  setProfile: (profile: ProfileResource | undefined) => void;
+  setAgentAvailable: (value: boolean) => void;
+  setSubscriptionManager: (subManager: MockSubscriptionManager) => void;
+}
+
 export class MockClient extends MedplumClient {
   readonly router: FhirRouter;
   readonly repo: MemoryRepository;
@@ -176,13 +183,45 @@ export class MockClient extends MedplumClient {
     this.debug = !!clientOptions?.debug;
   }
 
+  // A container for functions that mutate this mock client's state; we keep these
+  // methods in this extra namespace to make clear that these are not part of the
+  // normal MedplumClient API.
+  get mock(): MockClientTestMethods {
+    return {
+      withSeeding: <T>(fn: () => T | Promise<T>): Promise<T> => {
+        return this.repo.withSeeding(fn);
+      },
+      setProfile: (profile: ProfileResource | undefined): void => {
+        this.profile = profile;
+        this.dispatchEvent({ type: 'change' });
+      },
+      setAgentAvailable: (value: boolean): void => {
+        this.agentAvailable = value;
+      },
+      setSubscriptionManager: (subManager: MockSubscriptionManager): void => {
+        if (this.subManager) {
+          this.subManager.closeWebSocket();
+        }
+        this.subManager = subManager;
+      },
+    };
+  }
+
   clear(): void {
     super.clear();
     this.activeLoginOverride = undefined;
   }
 
+  /**
+   * Run a function in "seeding" mode, allowing it to set metadata like
+   * `versionId` that normally would be dropped.
+   *
+   * @deprecated - Use `.mock.withSeeding()` instead
+   * @param fn - The callback to run in "seeding" mode
+   * @returns The return value from `fn`
+   */
   withSeeding<T>(fn: () => T | Promise<T>): Promise<T> {
-    return this.repo.withSeeding(fn);
+    return this.mock.withSeeding(fn);
   }
 
   getProfile(): ProfileResource | undefined {
@@ -217,9 +256,13 @@ export class MockClient extends MedplumClient {
     this.activeLoginOverride = activeLoginOverride;
   }
 
+  /**
+   * Overrides the active profile.
+   * @deprecated - Use `.mock.setProfile()` instead
+   * @param profile - The profile to set as active for this client
+   */
   setProfile(profile: ProfileResource | undefined): void {
-    this.profile = profile;
-    this.dispatchEvent({ type: 'change' });
+    this.mock.setProfile(profile);
   }
 
   getActiveLogin(): LoginState | undefined {
@@ -356,8 +399,14 @@ round-trip min/avg/max/stddev = 10.977/14.975/23.159/4.790 ms
     return undefined;
   }
 
+  /**
+   * Updates internal test state used by `pushToAgent` mocking.
+   *
+   * @deprecated - Use `.mock.setAgentAvailable()` instead
+   * @param value - boolean
+   */
   setAgentAvailable(value: boolean): void {
-    this.agentAvailable = value;
+    this.mock.setAgentAvailable(value);
   }
 
   getSubscriptionManager(): MockSubscriptionManager {
@@ -369,11 +418,14 @@ round-trip min/avg/max/stddev = 10.977/14.975/23.159/4.790 ms
     return this.subManager;
   }
 
+  /**
+   * Sets a MockSubscriptionManager that this MockClient should use.
+   *
+   * @deprecated - Use `.mock.setSubscriptionManager()` instead
+   * @param subManager - A MockSubscriptionManager to attach to this MockClient
+   */
   setSubscriptionManager(subManager: MockSubscriptionManager): void {
-    if (this.subManager) {
-      this.subManager.closeWebSocket();
-    }
-    this.subManager = subManager;
+    this.mock.setSubscriptionManager(subManager);
   }
 
   subscribeToCriteria(criteria: string, subscriptionProps?: Partial<Subscription>): SubscriptionEmitter {

--- a/packages/mock/src/repo.test.ts
+++ b/packages/mock/src/repo.test.ts
@@ -52,7 +52,7 @@ describe('Mock Repo', () => {
     const client = new MockClient();
     const id = randomUUID();
     const versionId = randomUUID();
-    const result = await client.withSeeding(() =>
+    const result = await client.mock.withSeeding(() =>
       client.createResource({
         resourceType: 'Patient',
         id,

--- a/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.test.tsx
+++ b/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.test.tsx
@@ -53,7 +53,7 @@ describe('DefaultResourceTimeline', () => {
     const p = await medplum.createResource<Patient>({ resourceType: 'Patient' });
 
     // Use seeding mode so the mock client's DB accepts the `lastUpdated` timestamp
-    const dr1 = await medplum.withSeeding(() =>
+    const dr1 = await medplum.mock.withSeeding(() =>
       medplum.createResource<DiagnosticReport>({
         resourceType: 'DiagnosticReport',
         meta: {
@@ -67,7 +67,7 @@ describe('DefaultResourceTimeline', () => {
     );
 
     // Use seeding mode so the mock client's DB accepts the `lastUpdated` timestamp
-    const dr2 = await medplum.withSeeding(() =>
+    const dr2 = await medplum.mock.withSeeding(() =>
       medplum.updateResource<DiagnosticReport>({
         ...dr1,
         meta: {

--- a/packages/react/src/chat/BaseChat/BaseChat.test.tsx
+++ b/packages/react/src/chat/BaseChat/BaseChat.test.tsx
@@ -82,7 +82,7 @@ describe('BaseChat', () => {
       getWebSocketUrl(defaultMedplum.getBaseUrl(), '/ws/subscriptions-r4'),
       { mockReconnectingWebSocket: true }
     );
-    defaultMedplum.setSubscriptionManager(defaultSubManager);
+    defaultMedplum.mock.setSubscriptionManager(defaultSubManager);
   });
 
   function TestComponent(props: TestComponentProps): JSX.Element | null {
@@ -132,7 +132,7 @@ describe('BaseChat', () => {
 
   test('Loads initial messages and can receive new ones', async () => {
     const medplum = new MockClient({ profile: HomerSimpson });
-    medplum.setSubscriptionManager(defaultSubManager);
+    medplum.mock.setSubscriptionManager(defaultSubManager);
     await Promise.all([
       createCommunication(medplum, { sender: drAliceReference, recipient: [homerReference] }),
       createCommunication(medplum),
@@ -312,7 +312,7 @@ describe('BaseChat', () => {
     expect(screen.getByText('Hello again!')).toBeInTheDocument();
 
     await act(async () => {
-      medplum.setProfile(BartSimpson);
+      medplum.mock.setProfile(BartSimpson);
       await rerender(baseProps);
     });
 
@@ -342,7 +342,7 @@ describe('BaseChat', () => {
 
   test('Notifies user when disconnected and reconnected, refetches message after reconnect', async () => {
     const medplum = new MockClient({ profile: DrAliceSmith });
-    medplum.setSubscriptionManager(defaultSubManager);
+    medplum.mock.setSubscriptionManager(defaultSubManager);
 
     await Promise.all([
       createCommunication(medplum, { sender: drAliceReference, recipient: [homerReference] }),
@@ -406,7 +406,7 @@ describe('BaseChat', () => {
 
   test('Displays an error notification when a subscription error occurs', async () => {
     const medplum = new MockClient({ profile: DrAliceSmith });
-    medplum.setSubscriptionManager(defaultSubManager);
+    medplum.mock.setSubscriptionManager(defaultSubManager);
 
     const baseProps = {
       title: 'Test Chat',
@@ -443,7 +443,7 @@ describe('BaseChat', () => {
 
   test('Calls onError cb when `onError` is specified', async () => {
     const medplum = new MockClient({ profile: DrAliceSmith });
-    medplum.setSubscriptionManager(defaultSubManager);
+    medplum.mock.setSubscriptionManager(defaultSubManager);
 
     const baseProps = {
       title: 'Test Chat',
@@ -481,7 +481,7 @@ describe('BaseChat', () => {
 
   test('Day sections are displayed when messages span multiple days', async () => {
     const medplum = new MockClient({ profile: DrAliceSmith });
-    medplum.setSubscriptionManager(defaultSubManager);
+    medplum.mock.setSubscriptionManager(defaultSubManager);
 
     const today = new Date();
     const yesterday = new Date(today);
@@ -546,7 +546,7 @@ describe('BaseChat', () => {
 
   test('Day sections are not duplicated for messages on the same day', async () => {
     const medplum = new MockClient({ profile: DrAliceSmith });
-    medplum.setSubscriptionManager(defaultSubManager);
+    medplum.mock.setSubscriptionManager(defaultSubManager);
 
     const today = new Date();
     const todayMorning = new Date(today);
@@ -593,7 +593,7 @@ describe('BaseChat', () => {
 
   test('Scrolls to bottom when new messages arrive', async () => {
     const medplum = new MockClient({ profile: DrAliceSmith });
-    medplum.setSubscriptionManager(defaultSubManager);
+    medplum.mock.setSubscriptionManager(defaultSubManager);
 
     const mockScrollTo = vi.fn();
     Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
@@ -661,7 +661,7 @@ describe('BaseChat', () => {
 
   test('BaseChat returns null when profile is null', async () => {
     const medplum = new MockClient({ profile: null });
-    medplum.setSubscriptionManager(defaultSubManager);
+    medplum.mock.setSubscriptionManager(defaultSubManager);
 
     await setup(
       {
@@ -698,7 +698,7 @@ describe('BaseChat', () => {
 
   test('Messages with contentAttachment show filename and icon', async () => {
     const medplum = new MockClient({ profile: DrAliceSmith });
-    medplum.setSubscriptionManager(defaultSubManager);
+    medplum.mock.setSubscriptionManager(defaultSubManager);
 
     await createCommunication(medplum, {
       sender: homerReference,
@@ -722,7 +722,7 @@ describe('BaseChat', () => {
 
   test('Messages with contentReference show document title', async () => {
     const medplum = new MockClient({ profile: DrAliceSmith });
-    medplum.setSubscriptionManager(defaultSubManager);
+    medplum.mock.setSubscriptionManager(defaultSubManager);
 
     const docRef = await medplum.createResource<DocumentReference>({
       resourceType: 'DocumentReference',
@@ -747,7 +747,7 @@ describe('BaseChat', () => {
 
   test('3-dots menu appears for messages with attachment', async () => {
     const medplum = new MockClient({ profile: DrAliceSmith });
-    medplum.setSubscriptionManager(defaultSubManager);
+    medplum.mock.setSubscriptionManager(defaultSubManager);
 
     await createCommunication(medplum, {
       sender: homerReference,
@@ -778,7 +778,7 @@ describe('BaseChat', () => {
   test('onViewInDocuments called when View in Documents clicked', async () => {
     const onViewInDocuments = vi.fn();
     const medplum = new MockClient({ profile: DrAliceSmith });
-    medplum.setSubscriptionManager(defaultSubManager);
+    medplum.mock.setSubscriptionManager(defaultSubManager);
 
     const docRef = await medplum.createResource<DocumentReference>({
       resourceType: 'DocumentReference',
@@ -809,7 +809,7 @@ describe('BaseChat', () => {
   test('Download opens new tab with safe https URL', async () => {
     const mockOpen = vi.spyOn(window, 'open').mockReturnValue(null);
     const medplum = new MockClient({ profile: DrAliceSmith });
-    medplum.setSubscriptionManager(defaultSubManager);
+    medplum.mock.setSubscriptionManager(defaultSubManager);
 
     await createCommunication(medplum, {
       sender: homerReference,
@@ -832,7 +832,7 @@ describe('BaseChat', () => {
   test('Download blocked for non-http URLs', async () => {
     const mockOpen = vi.spyOn(window, 'open').mockReturnValue(null);
     const medplum = new MockClient({ profile: DrAliceSmith });
-    medplum.setSubscriptionManager(defaultSubManager);
+    medplum.mock.setSubscriptionManager(defaultSubManager);
 
     await createCommunication(medplum, {
       sender: homerReference,
@@ -854,7 +854,7 @@ describe('BaseChat', () => {
 
   test('BaseChat handles multiple communications with undefined sent date via subscription', async () => {
     const medplum = new MockClient({ profile: DrAliceSmith });
-    medplum.setSubscriptionManager(defaultSubManager);
+    medplum.mock.setSubscriptionManager(defaultSubManager);
 
     await createCommunication(medplum, {
       sender: drAliceReference,

--- a/packages/react/src/chat/ChatModal/ChatModal.test.tsx
+++ b/packages/react/src/chat/ChatModal/ChatModal.test.tsx
@@ -45,7 +45,7 @@ describe('ChatModal', () => {
     expect(screen.queryByRole('button', { name: 'Open chat' })).not.toBeInTheDocument();
 
     act(() => {
-      medplum.setProfile(DrAliceSmith);
+      medplum.mock.setProfile(DrAliceSmith);
     });
 
     await rerender();

--- a/packages/react/src/chat/ThreadInbox/ParticipantFilter.test.tsx
+++ b/packages/react/src/chat/ThreadInbox/ParticipantFilter.test.tsx
@@ -41,7 +41,7 @@ describe('ParticipantFilter', () => {
     selectedParticipants: Reference<Patient | Practitioner>[] = []
   ): Promise<UserEvent> => {
     if (medplum.getProfile() === DrAliceSmith) {
-      medplum.setProfile(mockPractitioner);
+      medplum.mock.setProfile(mockPractitioner);
     }
 
     await medplum.updateResource(mockPractitioner as WithId<Practitioner>);
@@ -450,7 +450,7 @@ describe('ParticipantFilter', () => {
 
   test('handles no profile (logged out state)', async () => {
     const medplum = new MockClient();
-    medplum.setProfile(undefined);
+    medplum.mock.setProfile(undefined);
 
     const user = await setup(medplum);
 


### PR DESCRIPTION
When reading some tests, it's not always obvious that some methods (particularly ones like `.setProfile()`) are part of the MockClient testing API, and not part of the actual MedplumClient surface.

Moving these methods into a `.mock` namespace makes it clear that these methods are affecting the behavior of the MockClient, and not representative of a method that would be called on the actual instance.

I've deprecated the existing methods, and we should remove them in a future major release.