### PR TITLE
Add resource type header to resource page

### DIFF
--- a/packages/app/src/HomePage.test.tsx
+++ b/packages/app/src/HomePage.test.tsx
@@ -40,6 +40,12 @@ describe('HomePage', () => {
     expect(await screen.findByTestId('search-control')).toBeInTheDocument();
   });
 
+  test('Renders resource type header', async () => {
+    await setup('/Bot');
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
+    expect(screen.getByText('Bot')).toBeInTheDocument();
+  });
+
   test('Renders with resourceType and fields', async () => {
     await setup('/Patient?_fields=id,_lastUpdated,name,birthDate,gender');
     expect(await screen.findByTestId('search-control')).toBeInTheDocument();

--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Paper } from '@mantine/core';
+import { Paper, Text } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import type { SearchRequest } from '@medplum/core';
 import { formatSearchQuery, normalizeErrorString, parseSearchRequest } from '@medplum/core';
@@ -45,6 +45,9 @@ export function HomePage(): JSX.Element {
 
   return (
     <Paper shadow="xs" m="md" p="xs" className={classes.paper}>
+      <Text p="xs" pb={0} fw={500}>
+        {search.resourceType}
+      </Text>
       <SearchControl
         checkboxesEnabled={true}
         search={search}


### PR DESCRIPTION
Fixes #9919.

## Summary

Adds a header to the resource list/search page (`HomePage.tsx`, e.g. `/Bot`) showing the resource type, so it's clear what you're looking at even for resource types that aren't in the primary sidebar. Follows the same header pattern already used on `CreateResourcePage`.

## Changes

- `packages/app/src/HomePage.tsx`: adds a `Text` header above `SearchControl` showing `search.resourceType`.
- `packages/app/src/HomePage.test.tsx`: adds a test asserting the header renders for a non-sidebar resource type (`Bot`).

## Test plan

- `tsc --noEmit` on `packages/app`: clean.
- `eslint` on the two changed files: 0 errors (1 pre-existing, unrelated warning on an untouched line).
- `vitest run src/HomePage.test.tsx`: 15/15 passing.
- `vitest run src/resource/ResourcePage.test.tsx`: 17/17 passing (confirms no leftover changes from the earlier revision).
