### PR TITLE
Add resource type header on resource list page (#9919)

### DIFF
--- a/packages/app/src/HomePage.test.tsx
+++ b/packages/app/src/HomePage.test.tsx
@@ -45,6 +45,12 @@ describe('HomePage', () => {
     expect(await screen.findByTestId('search-control')).toBeInTheDocument();
   });
 
+  test('Renders resource type header', async () => {
+    await setup('/Bot');
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Bot' })).toBeInTheDocument();
+  });
+
   test('Next page button', async () => {
     await setup();
     expect(await screen.findByLabelText('Next page')).toBeInTheDocument();

--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Paper } from '@mantine/core';
+import { Paper, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import type { SearchRequest } from '@medplum/core';
 import { formatSearchQuery, normalizeErrorString, parseSearchRequest } from '@medplum/core';
@@ -45,6 +45,9 @@ export function HomePage(): JSX.Element {
 
   return (
     <Paper shadow="xs" m="md" p="xs" className={classes.paper}>
+      <Title order={3} mb="sm">
+        {search.resourceType}
+      </Title>
       <SearchControl
         checkboxesEnabled={true}
         search={search}


### PR DESCRIPTION
## What
Adds a header showing the resource type name (e.g. "Bot") above the resource table in HomePage.tsx — the resource list/search view. This is distinct from PR #9922, which addresses the single-resource detail page (ResourcePage.tsx).

## Why
Closes #9919 (list view aspect)

## Changes
- Added `<Title order={3} mb="sm">{search.resourceType}</Title>` above `<SearchControl>` in HomePage.tsx
- Confirmed no existing helper maps ResourceType → display label elsewhere in the app; raw ResourceType strings are used as-is throughout the codebase for display purposes

## Testing
- Added new test `Renders resource type header` in HomePage.test.tsx, asserting the heading renders with the correct resourceType name
- Full HomePage.test.tsx suite passes (15/15)
- `tsc --noEmit` and `eslint` pass with no errors