### PR TITLE
[MockClient] test cleanup

### DIFF
--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -433,7 +433,12 @@ describe('MockClient', () => {
     const result = await client.createPdf({ docDefinition: { content: ['Hello World'] } });
     expect(result).toBeDefined();
 
+    const originalConsoleLog = console.log;
     console.log = vi.fn();
+    onTestFinished(() => {
+      console.log = originalConsoleLog;
+    });
+
     const client2 = new MockClient({ debug: true });
     const result2 = await client2.createPdf({ docDefinition: { content: ['Hello World'] } });
     expect(result2).toBeDefined();

--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -809,7 +809,6 @@ describe('MockClient', () => {
     });
 
     const membership = await medplum.get('admin/projects/123/members/456');
-    console.log(membership);
     expect(membership).toMatchObject<ProjectMembership>({
       resourceType: 'ProjectMembership',
       id: '456',

--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -59,6 +59,7 @@ describe('MockClient', () => {
     // login and fire a background `auth/me` request, emitting stray debug logs
     // after the test has finished. Clearing storage between tests isolates them.
     localStorage.clear();
+    vi.restoreAllMocks();
   });
 
   test('Simple route', async () => {
@@ -295,12 +296,10 @@ describe('MockClient', () => {
   });
 
   test('Debug mode', async () => {
-    const originalConsoleLog = console.log;
-    console.log = vi.fn();
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const client = new MockClient({ debug: true });
     await client.get('not-found');
-    expect(console.log).toHaveBeenCalled();
-    console.log = originalConsoleLog;
+    expect(consoleLog).toHaveBeenCalled();
   });
 
   test('mockFetchOverride -- Missing one of router, repo, or client throws', () => {
@@ -442,16 +441,11 @@ describe('MockClient', () => {
     const result = await client.createPdf({ docDefinition: { content: ['Hello World'] } });
     expect(result).toBeDefined();
 
-    const originalConsoleLog = console.log;
-    console.log = vi.fn();
-    onTestFinished(() => {
-      console.log = originalConsoleLog;
-    });
-
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const client2 = new MockClient({ debug: true });
     const result2 = await client2.createPdf({ docDefinition: { content: ['Hello World'] } });
     expect(result2).toBeDefined();
-    expect(console.log).toHaveBeenCalled();
+    expect(consoleLog).toHaveBeenCalled();
   });
 
   test('Read resource', async () => {

--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -52,6 +52,15 @@ describe('MockClient', () => {
     });
   });
 
+  afterEach(() => {
+    // MockClient defaults to the shared jsdom `globalThis.localStorage`, so an
+    // `activeLogin` persisted by a login-flow test (e.g. `processCode`) bleeds
+    // into later tests. A subsequent `new MockClient()` would then resume that
+    // login and fire a background `auth/me` request, emitting stray debug logs
+    // after the test has finished. Clearing storage between tests isolates them.
+    localStorage.clear();
+  });
+
   test('Simple route', async () => {
     const client = new MockClient();
     const result = await client.get('fhir/R4/Patient/123');


### PR DESCRIPTION
While working on #9920, I noticed some weirdness when looking to enhance test coverage in here.

- In one test we were stubbing `console.log`, and not cleaning it up. This made some debugging steps working on other tests difficult.
- After clearing that stub, some extra log lines started showing up in the output. 
  - removed an explicit `console.log`
  - cleared LocalStorage between tests, preventing one test from polluting the shared state and causing Mock Clients created with `debug: true` from polluting the logs when they try to resume a session found in the shared localstorage.