### PR TITLE
Extract useSchedulingResources hook

### DIFF
--- a/examples/medplum-provider/src/components/schedule/ScheduleDetails.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/ScheduleDetails.test.tsx
@@ -3,7 +3,7 @@
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import type { WithId } from '@medplum/core';
-import type { Appointment, Schedule, Slot } from '@medplum/fhirtypes';
+import type { Schedule } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -77,77 +77,6 @@ describe('ScheduleDetails', () => {
       await setup(mockSchedule);
       const title = screen.getByText(/\w+\s+\d{4}/);
       expect(title).toBeInTheDocument();
-    });
-  });
-
-  describe('Calendar Events', () => {
-    test('searches for slots when date range is set', async () => {
-      const mockSlots: Slot[] = [
-        {
-          resourceType: 'Slot',
-          id: 'slot-1',
-          schedule: { reference: 'Schedule/schedule-1' },
-          status: 'free',
-          start: '2024-01-15T10:00:00Z',
-          end: '2024-01-15T10:30:00Z',
-        },
-      ];
-
-      medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
-        if (resourceType === 'Slot') {
-          return Promise.resolve(mockSlots);
-        }
-        return Promise.resolve([]);
-      });
-
-      await setup(mockSchedule);
-
-      await waitFor(
-        () => {
-          const slotCalls = (medplum.searchResources as ReturnType<typeof vi.fn>).mock.calls.filter(
-            (call) => call[0] === 'Slot'
-          );
-          expect(slotCalls.length).toBeGreaterThan(0);
-        },
-        { timeout: 5000 }
-      );
-    });
-
-    test('searches for appointments when date range is set', async () => {
-      const mockAppointments: Appointment[] = [
-        {
-          resourceType: 'Appointment',
-          id: 'appt-1',
-          status: 'booked',
-          start: '2024-01-15T10:00:00Z',
-          end: '2024-01-15T10:30:00Z',
-          participant: [
-            {
-              actor: { reference: 'Practitioner/practitioner-1' },
-              status: 'accepted',
-            },
-          ],
-        },
-      ];
-
-      medplum.searchResources = vi.fn().mockImplementation((resourceType: string) => {
-        if (resourceType === 'Appointment') {
-          return Promise.resolve(mockAppointments);
-        }
-        return Promise.resolve([]);
-      });
-
-      await setup(mockSchedule);
-
-      await waitFor(
-        () => {
-          const appointmentCalls = (medplum.searchResources as ReturnType<typeof vi.fn>).mock.calls.filter(
-            (call) => call[0] === 'Appointment'
-          );
-          expect(appointmentCalls.length).toBeGreaterThan(0);
-        },
-        { timeout: 5000 }
-      );
     });
   });
 

--- a/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
@@ -1,17 +1,18 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Drawer, Stack, Text } from '@mantine/core';
+import { Box, Drawer, LoadingOverlay, Stack, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import type { WithId } from '@medplum/core';
 import { getReferenceString, isReference, isResourceWithId } from '@medplum/core';
 import type { Appointment, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
 import { useMedplum, useResourceModified } from '@medplum/react';
 import type { JSX } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { Calendar } from '../../components/Calendar';
 import { AppointmentDetails } from '../../components/schedule/AppointmentDetails';
 import { CreateVisit } from '../../components/schedule/CreateVisit';
+import { useSchedulingResources } from '../../hooks/useSchedulingResources';
 import type { Range } from '../../types/scheduling';
 import { encounterUrl } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
@@ -31,130 +32,25 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
   const [createAppointmentOpened, createAppointmentHandlers] = useDisclosure(false);
   const [appointmentDetailsOpened, appointmentDetailsHandlers] = useDisclosure(false);
   const [range, setRange] = useState<Range | undefined>(undefined);
-  const [slots, setSlots] = useState<Slot[] | undefined>(undefined);
-  const [appointments, setAppointments] = useState<WithId<Appointment>[] | undefined>(undefined);
 
   const [appointmentSlot, setAppointmentSlot] = useState<Range>();
   const [appointmentDetails, setAppointmentDetails] = useState<WithId<Appointment> | undefined>(undefined);
 
-  // The predicates that scope this calendar's data. Both the searches below and the
-  // `useResourceModified` handlers use these so the optimistic updates stay consistent
-  // with what a refetch would return.
-  const scheduleRef = getReferenceString(schedule);
-  const actorRef = schedule.actor[0]?.reference;
+  const { slots, appointments, loading } = useSchedulingResources([schedule], range);
 
-  // Keep the calendar's slots in sync with any Slot this client modifies, e.g. the
-  // slots created when booking a visit from the FindPane or soft-deleted when cancelling
-  // one from the appointment details drawer.
-  useResourceModified('Slot', (event) => {
-    if (event.operation === 'delete') {
-      // Deletes don't carry a resource, only the id of what went away.
-      if (event.id) {
-        setSlots((state) => state?.filter((slot) => slot.id !== event.id));
-      }
-      return;
-    }
+  const practitioner = schedule.actor.find((actor) => isReference<Practitioner>(actor, 'Practitioner'));
 
-    const slot = event.resource;
-    if (!slot) {
-      return;
-    }
-    // Ignore slots that belong to a different schedule than the one shown here.
-    if (slot.schedule.reference !== scheduleRef) {
-      return;
-    }
-
-    setSlots((state) => {
-      // `create` prepends the new slot; `update`/`patch` replace it in place and leave
-      // an unloaded range untouched.
-      if (event.operation === 'create') {
-        const current = state ?? [];
-        return current.some((existing) => existing.id === slot.id) ? current : [slot, ...current];
-      }
-      return state?.map((existing) => (existing.id === slot.id ? slot : existing));
-    });
-  });
-
-  // Likewise keep the calendar's appointments in sync with any Appointment this client
-  // modifies, and mirror the change into the open appointment details drawer.
   useResourceModified('Appointment', (event) => {
-    if (event.operation === 'delete') {
-      if (event.id) {
-        setAppointments((state) => state?.filter((appointment) => appointment.id !== event.id));
-        setAppointmentDetails((existing) => (existing?.id === event.id ? undefined : existing));
-      }
+    if (event.id !== appointmentDetails?.id) {
       return;
     }
+    setAppointmentDetails(event.resource);
 
-    const appointment = event.resource;
-    if (!appointment) {
-      return;
-    }
-    // Ignore appointments that don't involve this schedule's actor, mirroring the
-    // `actor` filter used by the search below.
-    if (!actorRef || !appointment.participant.some((p) => p.actor?.reference === actorRef)) {
-      return;
-    }
-
-    setAppointments((state) => {
-      if (event.operation === 'create') {
-        const current = state ?? [];
-        return current.some((existing) => existing.id === appointment.id) ? current : [...current, appointment];
-      }
-      return state?.map((existing) => (existing.id === appointment.id ? appointment : existing));
-    });
-    setAppointmentDetails((existing) => (existing?.id === appointment.id ? appointment : existing));
-    // A cancelled appointment can no longer be acted on, so close its details drawer.
-    if (appointment.status === 'cancelled') {
+    // If the selected appointment was cancelled or deleted, close the drawer.
+    if (!event || event.resource?.status === 'cancelled') {
       appointmentDetailsHandlers.close();
     }
   });
-
-  useEffect(() => {
-    if (!range) {
-      return () => {};
-    }
-    let active = true;
-
-    medplum
-      .searchResources('Slot', [
-        ['_count', '1000'],
-        ['schedule', scheduleRef],
-        ['start', `ge${range.start.toISOString()}`],
-        ['start', `le${range.end.toISOString()}`],
-        ['status:not', 'entered-in-error'],
-      ])
-      .then((rawSlots) => active && setSlots(rawSlots))
-      .catch((error: unknown) => active && showErrorNotification(error));
-
-    return () => {
-      active = false;
-    };
-  }, [medplum, scheduleRef, range]);
-
-  // Find appointments visible in the current range
-  useEffect(() => {
-    if (!actorRef || !range) {
-      return () => {};
-    }
-    let active = true;
-
-    medplum
-      .searchResources('Appointment', [
-        ['_count', '1000'],
-        ['actor', actorRef],
-        ['date', `ge${range.start.toISOString()}`],
-        ['date', `le${range.end.toISOString()}`],
-      ])
-      .then((appointments) => active && setAppointments(appointments))
-      .catch((error: unknown) => active && showErrorNotification(error));
-
-    return () => {
-      active = false;
-    };
-  }, [medplum, actorRef, range]);
-
-  const practitioner = schedule.actor.find((actor) => isReference<Practitioner>(actor, 'Practitioner'));
 
   // When a date/time interval is selected, set the event object and open the
   // create appointment modal
@@ -187,8 +83,6 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
     [createAppointmentHandlers, practitioner]
   );
 
-  // The calendar's slots and appointments update through the `useResourceModified`
-  // subscriptions above; this callback only handles the UI response to a successful booking.
   const handleBookSuccess = useCallback(
     (results: { appointment: WithId<Appointment>; slots: Slot[] }) => {
       setAppointmentDetails(results.appointment);
@@ -236,15 +130,18 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
     <>
       <div className={classes.container}>
         <Stack className={classes.calendarPane}>
-          <Calendar
-            onSelectInterval={handleSelectInterval}
-            onSelectAppointment={handleSelectAppointment}
-            onSelectSlot={handleSelectSlot}
-            slots={mergedSlots}
-            appointments={appointments ?? []}
-            onRangeChange={setRange}
-            onDoubleClickAppointment={handleDoubleClickAppointment}
-          />
+          <Box pos="relative" h="100%">
+            <LoadingOverlay visible={loading} />
+            <Calendar
+              onSelectInterval={handleSelectInterval}
+              onSelectAppointment={handleSelectAppointment}
+              onSelectSlot={handleSelectSlot}
+              slots={mergedSlots}
+              appointments={appointments ?? []}
+              onRangeChange={setRange}
+              onDoubleClickAppointment={handleDoubleClickAppointment}
+            />
+          </Box>
           <Text size="sm" color="dimmed" fs="italic">
             Hint: Double-click on an appointment to jump to the encounter details.
           </Text>

--- a/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
@@ -47,7 +47,7 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
     setAppointmentDetails(event.resource);
 
     // If the selected appointment was cancelled or deleted, close the drawer.
-    if (!event || event.resource?.status === 'cancelled') {
+    if (event.resource?.status === 'cancelled' || event.operation === 'delete') {
       appointmentDetailsHandlers.close();
     }
   });

--- a/examples/medplum-provider/src/hooks/useSchedulingResources.test.tsx
+++ b/examples/medplum-provider/src/hooks/useSchedulingResources.test.tsx
@@ -28,6 +28,11 @@ const SCHEDULE_B: WithId<Schedule> = {
   id: 'schedule-b',
   actor: [{ reference: 'Practitioner/pract-b' }],
 };
+const SCHEDULE_C: WithId<Schedule> = {
+  resourceType: 'Schedule',
+  id: 'schedule-c',
+  actor: [{ reference: 'Practitioner/pract-c' }],
+};
 const RANGE: Range = {
   start: new Date('2024-01-01T00:00:00.000Z'),
   end: new Date('2024-01-31T00:00:00.000Z'),
@@ -179,6 +184,50 @@ describe('useSchedulingSlots', () => {
 
       await waitFor(() => expect(vi.mocked(showErrorNotification)).toHaveBeenCalled());
       await waitFor(() => expect(result.current.loading).toBe(false));
+    });
+
+    test('searches are not triggered by unstable wrappers', async () => {
+      medplum.searchResources = vi.fn();
+      const { rerender } = await act(async () => setup(useSchedulingSlots, [SCHEDULE_A, SCHEDULE_B], { ...RANGE }));
+
+      // one search per schedule emitted
+      expect(medplum.searchResources).toHaveBeenCalledTimes(2);
+
+      // re-render with the same objects in new outer wrapping list/objects
+      await act(() => rerender({ schedules: [SCHEDULE_A, SCHEDULE_B], range: { ...RANGE } }));
+
+      // no new searches emitted
+      expect(medplum.searchResources).toHaveBeenCalledTimes(2);
+
+      // re-render with a new schedule added
+      await act(() => rerender({ schedules: [SCHEDULE_A, SCHEDULE_B, SCHEDULE_C], range: { ...RANGE } }));
+
+      // effect re-runs search for each schedule
+      expect(medplum.searchResources).toHaveBeenCalledTimes(5);
+
+      // re-render with a range change
+      const newRange = {
+        start: new Date('2024-01-07T00:00:00.000Z'),
+        end: new Date('2024-01-14T00:00:00.000Z'),
+      };
+      await act(() => rerender({ schedules: [SCHEDULE_A, SCHEDULE_B, SCHEDULE_C], range: { ...newRange } }));
+
+      // effect re-runs search for each schedule
+      expect(medplum.searchResources).toHaveBeenCalledTimes(8);
+
+      // re-render with same range but new `Date` instances
+      await act(() =>
+        rerender({
+          schedules: [SCHEDULE_A, SCHEDULE_B, SCHEDULE_C],
+          range: {
+            start: new Date('2024-01-07T00:00:00.000Z'),
+            end: new Date('2024-01-14T00:00:00.000Z'),
+          },
+        })
+      );
+
+      // no new searches run
+      expect(medplum.searchResources).toHaveBeenCalledTimes(8);
     });
   });
 
@@ -392,6 +441,52 @@ describe('useSchedulingAppointments', () => {
 
       await waitFor(() => expect(vi.mocked(showErrorNotification)).toHaveBeenCalled());
       await waitFor(() => expect(result.current.loading).toBe(false));
+    });
+
+    test('searches are not triggered by unstable wrappers', async () => {
+      medplum.searchResources = vi.fn();
+      const { rerender } = await act(async () =>
+        setup(useSchedulingAppointments, [SCHEDULE_A, SCHEDULE_B], { ...RANGE })
+      );
+
+      // one search per schedule.actor emitted
+      expect(medplum.searchResources).toHaveBeenCalledTimes(2);
+
+      // re-render with the same objects in new outer wrapping list/objects
+      await act(() => rerender({ schedules: [SCHEDULE_A, SCHEDULE_B], range: { ...RANGE } }));
+
+      // no new searches emitted
+      expect(medplum.searchResources).toHaveBeenCalledTimes(2);
+
+      // re-render with a new schedule added
+      await act(() => rerender({ schedules: [SCHEDULE_A, SCHEDULE_B, SCHEDULE_C], range: { ...RANGE } }));
+
+      // effect re-runs search for each schedule
+      expect(medplum.searchResources).toHaveBeenCalledTimes(5);
+
+      // re-render with a range change
+      const newRange = {
+        start: new Date('2024-01-07T00:00:00.000Z'),
+        end: new Date('2024-01-14T00:00:00.000Z'),
+      };
+      await act(() => rerender({ schedules: [SCHEDULE_A, SCHEDULE_B, SCHEDULE_C], range: { ...newRange } }));
+
+      // effect re-runs search for each schedule
+      expect(medplum.searchResources).toHaveBeenCalledTimes(8);
+
+      // re-render with same range but new `Date` instances
+      await act(() =>
+        rerender({
+          schedules: [SCHEDULE_A, SCHEDULE_B, SCHEDULE_C],
+          range: {
+            start: new Date('2024-01-07T00:00:00.000Z'),
+            end: new Date('2024-01-14T00:00:00.000Z'),
+          },
+        })
+      );
+
+      // no new searches run
+      expect(medplum.searchResources).toHaveBeenCalledTimes(8);
     });
   });
 

--- a/examples/medplum-provider/src/hooks/useSchedulingResources.test.tsx
+++ b/examples/medplum-provider/src/hooks/useSchedulingResources.test.tsx
@@ -283,7 +283,7 @@ describe('useSchedulingSlots', () => {
         });
       });
 
-      expect(result.current.slots).toEqual([created, slotA]);
+      expect(result.current.slots).toEqual([slotA, created]);
     });
 
     test('ignores a created Slot for an untracked schedule', async () => {

--- a/examples/medplum-provider/src/hooks/useSchedulingResources.test.tsx
+++ b/examples/medplum-provider/src/hooks/useSchedulingResources.test.tsx
@@ -286,6 +286,31 @@ describe('useSchedulingSlots', () => {
       expect(result.current.slots).toEqual([slotA, created]);
     });
 
+    test('ignores a created Slot that falls outside the range', async () => {
+      configureSearch({ slotsBySchedule: { 'Schedule/schedule-a': [slotA] } });
+      const { result } = setup(useSchedulingSlots, [SCHEDULE_A], RANGE);
+      await waitFor(() => expect(result.current.slots).toEqual([slotA]));
+
+      // Same tracked schedule, but its start is past the range's end, so a refetch
+      // wouldn't return it.
+      const outside: WithId<Slot> = {
+        ...slotA,
+        id: 'slot-outside',
+        start: '2024-02-15T10:00:00.000Z',
+        end: '2024-02-15T10:30:00.000Z',
+      };
+      act(() => {
+        medplum.notifyResourceModified({
+          resourceType: 'Slot',
+          operation: 'create',
+          id: outside.id,
+          resource: outside,
+        });
+      });
+
+      expect(result.current.slots).toEqual([slotA]);
+    });
+
     test('ignores a created Slot for an untracked schedule', async () => {
       configureSearch({ slotsBySchedule: { 'Schedule/schedule-a': [slotA] } });
       const { result } = setup(useSchedulingSlots, [SCHEDULE_A], RANGE);
@@ -536,6 +561,7 @@ describe('useSchedulingAppointments', () => {
         resourceType: 'Appointment',
         id: 'appt-new',
         status: 'booked',
+        start: '2024-01-15T10:00:00.000Z',
         participant: [{ actor: { reference: 'Practitioner/pract-a' }, status: 'accepted' }],
       };
       act(() => {
@@ -548,6 +574,32 @@ describe('useSchedulingAppointments', () => {
       });
 
       expect(result.current.appointments).toEqual([apptA, created]);
+    });
+
+    test('ignores a created Appointment that falls outside the range', async () => {
+      configureSearch({ appointmentsByActor: { 'Practitioner/pract-a': [apptA] } });
+      const { result } = setup(useSchedulingAppointments, [SCHEDULE_A], RANGE);
+      await waitFor(() => expect(result.current.appointments).toEqual([apptA]));
+
+      // Tracked actor, but its start is past the range's end, so a refetch wouldn't
+      // return it.
+      const outside: WithId<Appointment> = {
+        resourceType: 'Appointment',
+        id: 'appt-outside',
+        status: 'booked',
+        start: '2024-02-15T10:00:00.000Z',
+        participant: [{ actor: { reference: 'Practitioner/pract-a' }, status: 'accepted' }],
+      };
+      act(() => {
+        medplum.notifyResourceModified({
+          resourceType: 'Appointment',
+          operation: 'create',
+          id: outside.id,
+          resource: outside,
+        });
+      });
+
+      expect(result.current.appointments).toEqual([apptA]);
     });
 
     test('ignores a created Appointment whose actor is not tracked', async () => {

--- a/examples/medplum-provider/src/hooks/useSchedulingResources.test.tsx
+++ b/examples/medplum-provider/src/hooks/useSchedulingResources.test.tsx
@@ -1,0 +1,548 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { QueryTypes, WithId } from '@medplum/core';
+import { getQueryString } from '@medplum/core';
+import type { Appointment, ResourceType, Schedule, Slot } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { JSX, ReactNode } from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { Range } from '../types/scheduling';
+import { showErrorNotification } from '../utils/notifications';
+import { useSchedulingAppointments, useSchedulingResources, useSchedulingSlots } from './useSchedulingResources';
+
+// Mock the notification helper so error-path tests can assert on it without a
+// Mantine <Notifications> provider.
+vi.mock('../utils/notifications', () => ({
+  showErrorNotification: vi.fn(),
+}));
+
+const SCHEDULE_A: WithId<Schedule> = {
+  resourceType: 'Schedule',
+  id: 'schedule-a',
+  actor: [{ reference: 'Practitioner/pract-a' }],
+};
+const SCHEDULE_B: WithId<Schedule> = {
+  resourceType: 'Schedule',
+  id: 'schedule-b',
+  actor: [{ reference: 'Practitioner/pract-b' }],
+};
+const RANGE: Range = {
+  start: new Date('2024-01-01T00:00:00.000Z'),
+  end: new Date('2024-01-31T00:00:00.000Z'),
+};
+
+const slotA: WithId<Slot> = {
+  resourceType: 'Slot',
+  id: 'slot-a',
+  schedule: { reference: 'Schedule/schedule-a' },
+  status: 'free',
+  start: '2024-01-15T10:00:00.000Z',
+  end: '2024-01-15T10:30:00.000Z',
+};
+const slotB: WithId<Slot> = {
+  resourceType: 'Slot',
+  id: 'slot-b',
+  schedule: { reference: 'Schedule/schedule-b' },
+  status: 'free',
+  start: '2024-01-16T10:00:00.000Z',
+  end: '2024-01-16T10:30:00.000Z',
+};
+
+const apptA: WithId<Appointment> = {
+  resourceType: 'Appointment',
+  id: 'appt-a',
+  status: 'booked',
+  participant: [{ actor: { reference: 'Practitioner/pract-a' }, status: 'accepted' }],
+};
+const apptB: WithId<Appointment> = {
+  resourceType: 'Appointment',
+  id: 'appt-b',
+  status: 'booked',
+  participant: [{ actor: { reference: 'Practitioner/pract-b' }, status: 'accepted' }],
+};
+
+let medplum: MockClient;
+
+beforeEach(() => {
+  medplum = new MockClient();
+  vi.clearAllMocks();
+});
+
+const wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+  <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
+);
+
+// Render any of the scheduling hooks with the shared provider, keeping `schedules`
+// and `range` as rerender-able props.
+function setup<T>(
+  hook: (schedules: WithId<Schedule>[], range: Range | undefined) => T,
+  schedules: WithId<Schedule>[],
+  range: Range | undefined
+): ReturnType<typeof renderHook<T, { schedules: WithId<Schedule>[]; range: Range | undefined }>> {
+  return renderHook(({ schedules, range }) => hook(schedules, range), {
+    wrapper,
+    initialProps: { schedules, range },
+  });
+}
+
+// Stub `searchResources` to return per-schedule Slots and per-actor Appointments.
+// Returns an object keyed by ResourceType with a URLSearchParams entry for each
+// invocation of that type.
+function configureSearch(options: {
+  slotsBySchedule?: Record<string, WithId<Slot>[]>;
+  appointmentsByActor?: Record<string, WithId<Appointment>[]>;
+}): Partial<Record<ResourceType, URLSearchParams[]>> {
+  const { slotsBySchedule = {}, appointmentsByActor = {} } = options;
+  const callsByResourceType: Partial<Record<ResourceType, URLSearchParams[]>> = {};
+  const mock = vi.fn().mockImplementation((resourceType: ResourceType, query: QueryTypes) => {
+    const params = new URLSearchParams(getQueryString(query));
+    callsByResourceType[resourceType] ??= [];
+    callsByResourceType[resourceType].push(params);
+    if (resourceType === 'Slot') {
+      const ref = params.get('schedule');
+      return Promise.resolve(ref ? (slotsBySchedule[ref] ?? []) : []);
+    }
+    if (resourceType === 'Appointment') {
+      const ref = params.get('actor');
+      return Promise.resolve(ref ? (appointmentsByActor[ref] ?? []) : []);
+    }
+    return Promise.resolve([]);
+  });
+  medplum.searchResources = mock;
+  return callsByResourceType;
+}
+
+describe('useSchedulingSlots', () => {
+  describe('fetching', () => {
+    test('does not search when the range is undefined', () => {
+      medplum.searchResources = vi.fn();
+
+      const { result } = setup(useSchedulingSlots, [SCHEDULE_A], undefined);
+
+      expect(medplum.searchResources).not.toHaveBeenCalled();
+      expect(result.current.slots).toBeUndefined();
+      expect(result.current.loading).toBe(false);
+    });
+
+    test('searches slots for a single schedule', async () => {
+      const searches = configureSearch({ slotsBySchedule: { 'Schedule/schedule-a': [slotA] } });
+
+      const { result } = setup(useSchedulingSlots, [SCHEDULE_A], RANGE);
+
+      await waitFor(() => expect(result.current.slots).toEqual([slotA]));
+
+      // One Slot query scoped to the schedule, bounded by the range.
+      expect(searches['Slot']).toHaveLength(1);
+      expect(searches['Slot']?.[0].toString()).toEqual(
+        getQueryString([
+          ['_count', '1000'],
+          ['schedule', 'Schedule/schedule-a'],
+          ['start', `ge${RANGE.start.toISOString()}`],
+          ['start', `le${RANGE.end.toISOString()}`],
+          ['status:not', 'entered-in-error'],
+        ])
+      );
+    });
+
+    test('emits one Slot query per schedule and merges the results', async () => {
+      const searches = configureSearch({
+        slotsBySchedule: { 'Schedule/schedule-a': [slotA], 'Schedule/schedule-b': [slotB] },
+      });
+
+      const { result } = setup(useSchedulingSlots, [SCHEDULE_A, SCHEDULE_B], RANGE);
+
+      await waitFor(() => expect(result.current.slots).toHaveLength(2));
+
+      expect(searches['Slot']).toHaveLength(2);
+      expect(searches['Slot']?.map((params) => params.get('schedule'))).toEqual(
+        expect.arrayContaining(['Schedule/schedule-a', 'Schedule/schedule-b'])
+      );
+      expect(result.current.slots).toEqual(expect.arrayContaining([slotA, slotB]));
+    });
+
+    test('dedupes duplicate schedule references into a single Slot query', async () => {
+      const searches = configureSearch({ slotsBySchedule: { 'Schedule/schedule-a': [slotA] } });
+
+      const { result } = setup(useSchedulingSlots, [SCHEDULE_A, SCHEDULE_A], RANGE);
+
+      await waitFor(() => expect(result.current.slots).toEqual([slotA]));
+
+      expect(searches['Slot']).toHaveLength(1);
+    });
+
+    test('reports errors and stops loading when a search fails', async () => {
+      medplum.searchResources = vi.fn().mockRejectedValue(new Error('boom'));
+
+      const { result } = setup(useSchedulingSlots, [SCHEDULE_A], RANGE);
+
+      await waitFor(() => expect(vi.mocked(showErrorNotification)).toHaveBeenCalled());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+    });
+  });
+
+  describe('loading', () => {
+    test('is false when there is no range', () => {
+      const { result } = setup(useSchedulingSlots, [SCHEDULE_A], undefined);
+      expect(result.current.loading).toBe(false);
+    });
+
+    test('is true while a fetch is in progress and false once it settles', async () => {
+      // A promise we hold open to keep the fetch in flight while asserting `loading`.
+      const gate = Promise.withResolvers<WithId<Slot>[]>();
+      medplum.searchResources = vi.fn().mockReturnValue(gate.promise);
+
+      const { result } = setup(useSchedulingSlots, [SCHEDULE_A], RANGE);
+
+      await waitFor(() => expect(result.current.loading).toBe(true));
+
+      await act(async () => {
+        gate.resolve([]);
+      });
+
+      expect(result.current.loading).toBe(false);
+    });
+
+    test('clears loading when the range is cleared before the fetch settles', async () => {
+      // A search that never resolves keeps the fetch in flight.
+      medplum.searchResources = vi.fn().mockReturnValue(new Promise<WithId<Slot>[]>(() => {}));
+
+      const { result, rerender } = setup(useSchedulingSlots, [SCHEDULE_A], RANGE);
+
+      await waitFor(() => expect(result.current.loading).toBe(true));
+
+      rerender({ schedules: [SCHEDULE_A], range: undefined });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+    });
+  });
+
+  describe('live updates from useResourceModified', () => {
+    test('prepends a created Slot that belongs to a tracked schedule', async () => {
+      configureSearch({ slotsBySchedule: { 'Schedule/schedule-a': [slotA] } });
+      const { result } = setup(useSchedulingSlots, [SCHEDULE_A], RANGE);
+      await waitFor(() => expect(result.current.slots).toEqual([slotA]));
+
+      const created: WithId<Slot> = { ...slotA, id: 'slot-new' };
+      act(() => {
+        medplum.notifyResourceModified({
+          resourceType: 'Slot',
+          operation: 'create',
+          id: created.id,
+          resource: created,
+        });
+      });
+
+      expect(result.current.slots).toEqual([created, slotA]);
+    });
+
+    test('ignores a created Slot for an untracked schedule', async () => {
+      configureSearch({ slotsBySchedule: { 'Schedule/schedule-a': [slotA] } });
+      const { result } = setup(useSchedulingSlots, [SCHEDULE_A], RANGE);
+      await waitFor(() => expect(result.current.slots).toEqual([slotA]));
+
+      const foreign: WithId<Slot> = { ...slotA, id: 'slot-foreign', schedule: { reference: 'Schedule/other' } };
+      act(() => {
+        medplum.notifyResourceModified({
+          resourceType: 'Slot',
+          operation: 'create',
+          id: foreign.id,
+          resource: foreign,
+        });
+      });
+
+      expect(result.current.slots).toEqual([slotA]);
+    });
+
+    test('replaces an updated Slot in place', async () => {
+      configureSearch({ slotsBySchedule: { 'Schedule/schedule-a': [slotA] } });
+      const { result } = setup(useSchedulingSlots, [SCHEDULE_A], RANGE);
+      await waitFor(() => expect(result.current.slots).toEqual([slotA]));
+
+      const updated: WithId<Slot> = { ...slotA, status: 'busy' };
+      act(() => {
+        medplum.notifyResourceModified({
+          resourceType: 'Slot',
+          operation: 'update',
+          id: updated.id,
+          resource: updated,
+        });
+      });
+
+      expect(result.current.slots).toEqual([updated]);
+    });
+
+    test('removes a deleted Slot by id', async () => {
+      configureSearch({ slotsBySchedule: { 'Schedule/schedule-a': [slotA] } });
+      const { result } = setup(useSchedulingSlots, [SCHEDULE_A], RANGE);
+      await waitFor(() => expect(result.current.slots).toEqual([slotA]));
+
+      act(() => {
+        medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'delete', id: slotA.id });
+      });
+
+      expect(result.current.slots).toEqual([]);
+    });
+  });
+});
+
+describe('useSchedulingAppointments', () => {
+  describe('fetching', () => {
+    test('does not search when the range is undefined', () => {
+      medplum.searchResources = vi.fn();
+
+      const { result } = setup(useSchedulingAppointments, [SCHEDULE_A], undefined);
+
+      expect(medplum.searchResources).not.toHaveBeenCalled();
+      expect(result.current.appointments).toBeUndefined();
+      expect(result.current.loading).toBe(false);
+    });
+
+    test('does not search when no schedule has an actor', () => {
+      medplum.searchResources = vi.fn();
+      const actorless: WithId<Schedule> = { resourceType: 'Schedule', id: 'schedule-actorless', actor: [] };
+
+      const { result } = setup(useSchedulingAppointments, [actorless], RANGE);
+
+      expect(medplum.searchResources).not.toHaveBeenCalled();
+      expect(result.current.appointments).toBeUndefined();
+      expect(result.current.loading).toBe(false);
+    });
+
+    test('searches appointments for a single schedule', async () => {
+      const searches = configureSearch({ appointmentsByActor: { 'Practitioner/pract-a': [apptA] } });
+
+      const { result } = setup(useSchedulingAppointments, [SCHEDULE_A], RANGE);
+
+      await waitFor(() => expect(result.current.appointments).toEqual([apptA]));
+
+      // One Appointment query scoped to the schedule's actor, bounded by the range.
+      expect(searches['Appointment']).toHaveLength(1);
+      expect(searches['Appointment']?.[0].toString()).toEqual(
+        getQueryString([
+          ['_count', '1000'],
+          ['actor', 'Practitioner/pract-a'],
+          ['date', `ge${RANGE.start.toISOString()}`],
+          ['date', `le${RANGE.end.toISOString()}`],
+        ])
+      );
+    });
+
+    test('emits one Appointment query per schedule actor and merges the results', async () => {
+      const searches = configureSearch({
+        appointmentsByActor: { 'Practitioner/pract-a': [apptA], 'Practitioner/pract-b': [apptB] },
+      });
+
+      const { result } = setup(useSchedulingAppointments, [SCHEDULE_A, SCHEDULE_B], RANGE);
+
+      await waitFor(() => expect(result.current.appointments).toHaveLength(2));
+
+      expect(searches['Appointment']).toHaveLength(2);
+      expect(result.current.appointments).toEqual(expect.arrayContaining([apptA, apptB]));
+    });
+
+    test('dedupes schedules that share an actor into a single Appointment query', async () => {
+      const scheduleC: WithId<Schedule> = {
+        resourceType: 'Schedule',
+        id: 'schedule-c',
+        actor: [{ reference: 'Practitioner/shared' }],
+      };
+      const scheduleD: WithId<Schedule> = {
+        resourceType: 'Schedule',
+        id: 'schedule-d',
+        actor: [{ reference: 'Practitioner/shared' }],
+      };
+      const searches = configureSearch({ appointmentsByActor: { 'Practitioner/shared': [apptA] } });
+
+      const { result } = setup(useSchedulingAppointments, [scheduleC, scheduleD], RANGE);
+
+      await waitFor(() => expect(result.current.appointments).toEqual([apptA]));
+
+      // The shared actor is only queried once.
+      expect(searches['Appointment']).toHaveLength(1);
+    });
+
+    test('dedupes an appointment returned for more than one schedule', async () => {
+      const shared: WithId<Appointment> = {
+        resourceType: 'Appointment',
+        id: 'appt-shared',
+        status: 'booked',
+        participant: [
+          { actor: { reference: 'Practitioner/pract-a' }, status: 'accepted' },
+          { actor: { reference: 'Practitioner/pract-b' }, status: 'accepted' },
+        ],
+      };
+      const searches = configureSearch({
+        appointmentsByActor: { 'Practitioner/pract-a': [shared], 'Practitioner/pract-b': [shared] },
+      });
+
+      const { result } = setup(useSchedulingAppointments, [SCHEDULE_A, SCHEDULE_B], RANGE);
+
+      await waitFor(() => expect(result.current.appointments).toBeDefined());
+
+      expect(searches['Appointment']).toHaveLength(2);
+      expect(result.current.appointments).toEqual([shared]);
+    });
+
+    test('reports errors and stops loading when a search fails', async () => {
+      medplum.searchResources = vi.fn().mockRejectedValue(new Error('boom'));
+
+      const { result } = setup(useSchedulingAppointments, [SCHEDULE_A], RANGE);
+
+      await waitFor(() => expect(vi.mocked(showErrorNotification)).toHaveBeenCalled());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+    });
+  });
+
+  describe('loading', () => {
+    test('is false when there is no range', () => {
+      const { result } = setup(useSchedulingAppointments, [SCHEDULE_A], undefined);
+      expect(result.current.loading).toBe(false);
+    });
+
+    test('is true while a fetch is in progress and false once it settles', async () => {
+      // A promise we hold open to keep the fetch in flight while asserting `loading`.
+      const gate = Promise.withResolvers<WithId<Appointment>[]>();
+      medplum.searchResources = vi.fn().mockReturnValue(gate.promise);
+
+      const { result } = setup(useSchedulingAppointments, [SCHEDULE_A], RANGE);
+
+      await waitFor(() => expect(result.current.loading).toBe(true));
+
+      await act(async () => {
+        gate.resolve([]);
+      });
+
+      expect(result.current.loading).toBe(false);
+    });
+
+    test('clears loading when the range is cleared before the fetch settles', async () => {
+      // A search that never resolves keeps the fetch in flight.
+      medplum.searchResources = vi.fn().mockReturnValue(new Promise<WithId<Appointment>[]>(() => {}));
+
+      const { result, rerender } = setup(useSchedulingAppointments, [SCHEDULE_A], RANGE);
+
+      await waitFor(() => expect(result.current.loading).toBe(true));
+
+      rerender({ schedules: [SCHEDULE_A], range: undefined });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+    });
+  });
+
+  describe('live updates from useResourceModified', () => {
+    test('appends a created Appointment when its actor matches a schedule', async () => {
+      configureSearch({ appointmentsByActor: { 'Practitioner/pract-a': [apptA] } });
+      const { result } = setup(useSchedulingAppointments, [SCHEDULE_A], RANGE);
+      await waitFor(() => expect(result.current.appointments).toEqual([apptA]));
+
+      const created: WithId<Appointment> = {
+        resourceType: 'Appointment',
+        id: 'appt-new',
+        status: 'booked',
+        participant: [{ actor: { reference: 'Practitioner/pract-a' }, status: 'accepted' }],
+      };
+      act(() => {
+        medplum.notifyResourceModified({
+          resourceType: 'Appointment',
+          operation: 'create',
+          id: created.id,
+          resource: created,
+        });
+      });
+
+      expect(result.current.appointments).toEqual([apptA, created]);
+    });
+
+    test('ignores a created Appointment whose actor is not tracked', async () => {
+      configureSearch({ appointmentsByActor: { 'Practitioner/pract-a': [apptA] } });
+      const { result } = setup(useSchedulingAppointments, [SCHEDULE_A], RANGE);
+      await waitFor(() => expect(result.current.appointments).toEqual([apptA]));
+
+      const foreign: WithId<Appointment> = {
+        resourceType: 'Appointment',
+        id: 'appt-foreign',
+        status: 'booked',
+        participant: [{ actor: { reference: 'Practitioner/stranger' }, status: 'accepted' }],
+      };
+      act(() => {
+        medplum.notifyResourceModified({
+          resourceType: 'Appointment',
+          operation: 'create',
+          id: foreign.id,
+          resource: foreign,
+        });
+      });
+
+      expect(result.current.appointments).toEqual([apptA]);
+    });
+
+    test('replaces an updated Appointment in place', async () => {
+      configureSearch({ appointmentsByActor: { 'Practitioner/pract-a': [apptA] } });
+      const { result } = setup(useSchedulingAppointments, [SCHEDULE_A], RANGE);
+      await waitFor(() => expect(result.current.appointments).toEqual([apptA]));
+
+      const updated: WithId<Appointment> = { ...apptA, status: 'cancelled' };
+      act(() => {
+        medplum.notifyResourceModified({
+          resourceType: 'Appointment',
+          operation: 'update',
+          id: updated.id,
+          resource: updated,
+        });
+      });
+
+      expect(result.current.appointments).toEqual([updated]);
+    });
+
+    test('removes a deleted Appointment by id', async () => {
+      configureSearch({ appointmentsByActor: { 'Practitioner/pract-a': [apptA] } });
+      const { result } = setup(useSchedulingAppointments, [SCHEDULE_A], RANGE);
+      await waitFor(() => expect(result.current.appointments).toEqual([apptA]));
+
+      act(() => {
+        medplum.notifyResourceModified({ resourceType: 'Appointment', operation: 'delete', id: apptA.id });
+      });
+
+      expect(result.current.appointments).toEqual([]);
+    });
+  });
+});
+
+describe('useSchedulingResources', () => {
+  test('combines slots and appointments from both hooks', async () => {
+    configureSearch({
+      slotsBySchedule: { 'Schedule/schedule-a': [slotA] },
+      appointmentsByActor: { 'Practitioner/pract-a': [apptA] },
+    });
+
+    const { result } = setup(useSchedulingResources, [SCHEDULE_A], RANGE);
+
+    await waitFor(() => {
+      expect(result.current.slots).toEqual([slotA]);
+      expect(result.current.appointments).toEqual([apptA]);
+    });
+  });
+
+  test('stays loading until both the slot and appointment fetches settle', async () => {
+    // Slots resolve immediately; appointments stay in flight behind the gate.
+    const gate = Promise.withResolvers<WithId<Appointment>[]>();
+    medplum.searchResources = vi.fn().mockImplementation((resourceType: ResourceType) => {
+      return resourceType === 'Appointment' ? gate.promise : Promise.resolve([]);
+    });
+
+    const { result } = setup(useSchedulingResources, [SCHEDULE_A], RANGE);
+
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    // With slots done but appointments still pending, the combined flag stays true.
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      gate.resolve([]);
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/examples/medplum-provider/src/hooks/useSchedulingResources.ts
+++ b/examples/medplum-provider/src/hooks/useSchedulingResources.ts
@@ -8,6 +8,18 @@ import { useEffect, useState } from 'react';
 import type { Range } from '../types/scheduling';
 import { showErrorNotification } from '../utils/notifications';
 
+// Whether an instant falls within the loaded range, matching the inclusive `ge`/`le`
+// bounds of the searches below. Used to keep created resources from a live update out of
+// state when they fall outside the range of the hook — a refetch wouldn't return
+// them, so appending them would drift from what the search reflects.
+function isWithinRange(instant: string | undefined, range: Range | undefined): boolean {
+  if (!instant || !range) {
+    return false;
+  }
+  const time = new Date(instant).getTime();
+  return time >= range.start.getTime() && time <= range.end.getTime();
+}
+
 export interface UseSchedulingResourcesResult {
   appointments: WithId<Appointment>[] | undefined;
   slots: WithId<Slot>[] | undefined;
@@ -74,9 +86,12 @@ export function useSchedulingSlots(schedules: WithId<Schedule>[], range: Range |
     }
 
     setSlots((state) => {
-      // `create` appends the new slot; `update`/`patch` replace it in place and leave
-      // an unloaded range untouched.
+      // `create` appends the new slot when it lands in hook's `range`; `update`/`patch`
+      // replace it in place and leave an unloaded range untouched.
       if (event.operation === 'create') {
+        if (!isWithinRange(slot.start, range)) {
+          return state;
+        }
         const current = state ?? [];
         return current.some((existing) => existing.id === slot.id) ? current : [...current, slot];
       }
@@ -184,6 +199,9 @@ export function useSchedulingAppointments(
 
     setAppointments((state) => {
       if (event.operation === 'create') {
+        if (!isWithinRange(appointment.start, range)) {
+          return state;
+        }
         const current = state ?? [];
         return current.some((existing) => existing.id === appointment.id) ? current : [...current, appointment];
       }

--- a/examples/medplum-provider/src/hooks/useSchedulingResources.ts
+++ b/examples/medplum-provider/src/hooks/useSchedulingResources.ts
@@ -49,6 +49,8 @@ export function useSchedulingSlots(schedules: WithId<Schedule>[], range: Range |
   // Stable keys so the searches below only re-run when the set of predicates actually
   // changes, rather than on every render when the parent passes a new array instance.
   const scheduleRefsKey = scheduleRefs.join(',');
+  const rangeStart = range?.start?.toISOString();
+  const rangeEnd = range?.end?.toISOString();
 
   // Keep the calendar's slots in sync with any Slot this client modifies, e.g. the
   // slots created when booking a visit from the FindPane or soft-deleted when cancelling
@@ -83,22 +85,24 @@ export function useSchedulingSlots(schedules: WithId<Schedule>[], range: Range |
   });
 
   useEffect(() => {
-    if (!range) {
+    if (!rangeStart || !rangeEnd) {
       return () => {};
     }
     let active = true;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional loading flag
     setLoading(true);
 
+    const refs = scheduleRefsKey.split(',');
+
     // Emit one Slot search per schedule so MedplumClient can cache each schedule's
     // results independently.
     Promise.all(
-      scheduleRefs.map((scheduleRef) =>
+      refs.map((scheduleRef) =>
         medplum.searchResources('Slot', [
           ['_count', '1000'],
           ['schedule', scheduleRef],
-          ['start', `ge${range.start.toISOString()}`],
-          ['start', `le${range.end.toISOString()}`],
+          ['start', `ge${rangeStart}`],
+          ['start', `le${rangeEnd}`],
           ['status:not', 'entered-in-error'],
         ])
       )
@@ -115,8 +119,7 @@ export function useSchedulingSlots(schedules: WithId<Schedule>[], range: Range |
       active = false;
       setLoading(false);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- scheduleRefsKey captures scheduleRefs
-  }, [medplum, scheduleRefsKey, range]);
+  }, [medplum, scheduleRefsKey, rangeStart, rangeEnd]);
 
   return {
     slots,
@@ -151,6 +154,8 @@ export function useSchedulingAppointments(
   const actorRefs = [
     ...new Set(schedules.flatMap((schedule) => schedule.actor.map((ref) => getReferenceString(ref))).filter(isDefined)),
   ];
+  const rangeStart = range?.start?.toISOString();
+  const rangeEnd = range?.end?.toISOString();
 
   // Stable keys so the searches below only re-run when the set of predicates actually
   // changes, rather than on every render when the parent passes a new array instance.
@@ -188,22 +193,24 @@ export function useSchedulingAppointments(
 
   // Find appointments visible in the current range
   useEffect(() => {
-    if (actorRefs.length === 0 || !range) {
+    if (actorRefsKey.length === 0 || !rangeStart || !rangeEnd) {
       return () => {};
     }
     let active = true;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional loading flag
     setLoading(true);
 
+    const refs = actorRefsKey.split(',');
+
     // Emit one Appointment search per schedule actor, again so each schedule's results
     // can be cached independently.
     Promise.all(
-      actorRefs.map((actorRef) =>
+      refs.map((actorRef) =>
         medplum.searchResources('Appointment', [
           ['_count', '1000'],
           ['actor', actorRef],
-          ['date', `ge${range.start.toISOString()}`],
-          ['date', `le${range.end.toISOString()}`],
+          ['date', `ge${rangeStart}`],
+          ['date', `le${rangeEnd}`],
         ])
       )
     )
@@ -230,8 +237,7 @@ export function useSchedulingAppointments(
       active = false;
       setLoading(false);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- actorRefsKey captures actorRefs
-  }, [medplum, actorRefsKey, range]);
+  }, [medplum, actorRefsKey, rangeStart, rangeEnd]);
 
   return {
     appointments,

--- a/examples/medplum-provider/src/hooks/useSchedulingResources.ts
+++ b/examples/medplum-provider/src/hooks/useSchedulingResources.ts
@@ -74,11 +74,11 @@ export function useSchedulingSlots(schedules: WithId<Schedule>[], range: Range |
     }
 
     setSlots((state) => {
-      // `create` prepends the new slot; `update`/`patch` replace it in place and leave
+      // `create` appends the new slot; `update`/`patch` replace it in place and leave
       // an unloaded range untouched.
       if (event.operation === 'create') {
         const current = state ?? [];
-        return current.some((existing) => existing.id === slot.id) ? current : [slot, ...current];
+        return current.some((existing) => existing.id === slot.id) ? current : [...current, slot];
       }
       return state?.map((existing) => (existing.id === slot.id ? slot : existing));
     });

--- a/examples/medplum-provider/src/hooks/useSchedulingResources.ts
+++ b/examples/medplum-provider/src/hooks/useSchedulingResources.ts
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import { getReferenceString, isDefined } from '@medplum/core';
+import type { Appointment, Schedule, Slot } from '@medplum/fhirtypes';
+import { useMedplum, useResourceModified } from '@medplum/react';
+import { useEffect, useState } from 'react';
+import type { Range } from '../types/scheduling';
+import { showErrorNotification } from '../utils/notifications';
+
+export interface UseSchedulingResourcesResult {
+  appointments: WithId<Appointment>[] | undefined;
+  slots: WithId<Slot>[] | undefined;
+  loading: boolean;
+}
+
+export interface UseSchedulingSlotsResult {
+  slots: WithId<Slot>[] | undefined;
+  loading: boolean;
+}
+
+export interface UseSchedulingAppointmentsResult {
+  appointments: WithId<Appointment>[] | undefined;
+  loading: boolean;
+}
+
+/**
+ * Loads the Slots for a set of schedules within a date range and keeps them live.
+ *
+ * Emits one Slot search per schedule so MedplumClient can cache each schedule's results
+ * independently, then subscribes via `useResourceModified` so Slots this client creates,
+ * updates, or deletes are reflected optimistically without a refetch.
+ *
+ * @param schedules - The schedules whose Slots should be loaded.
+ * @param range - The date range to search within; no search runs while this is undefined.
+ * @returns The loaded Slots (undefined until the first fetch resolves) and a loading flag.
+ */
+export function useSchedulingSlots(schedules: WithId<Schedule>[], range: Range | undefined): UseSchedulingSlotsResult {
+  const medplum = useMedplum();
+  const [slots, setSlots] = useState<WithId<Slot>[] | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+
+  // The predicate that scopes this calendar's data. The FHIR search and the
+  // `useResourceModified` handler both use this so the optimistic updates stay consistent
+  // with what a refetch would return. Deduped so duplicate schedules don't issue the same
+  // Slot query twice.
+  const scheduleRefs = [...new Set(schedules.map((schedule) => getReferenceString(schedule)))];
+
+  // Stable keys so the searches below only re-run when the set of predicates actually
+  // changes, rather than on every render when the parent passes a new array instance.
+  const scheduleRefsKey = scheduleRefs.join(',');
+
+  // Keep the calendar's slots in sync with any Slot this client modifies, e.g. the
+  // slots created when booking a visit from the FindPane or soft-deleted when cancelling
+  // one from the appointment details drawer.
+  useResourceModified('Slot', (event) => {
+    if (event.operation === 'delete') {
+      // Deletes don't carry a resource, only the id of what went away.
+      if (event.id) {
+        setSlots((state) => state?.filter((slot) => slot.id !== event.id));
+      }
+      return;
+    }
+
+    const slot = event.resource;
+    if (!slot) {
+      return;
+    }
+    // Ignore slots that belong to a schedule other than the ones shown here.
+    if (!slot.schedule.reference || !scheduleRefs.includes(slot.schedule.reference)) {
+      return;
+    }
+
+    setSlots((state) => {
+      // `create` prepends the new slot; `update`/`patch` replace it in place and leave
+      // an unloaded range untouched.
+      if (event.operation === 'create') {
+        const current = state ?? [];
+        return current.some((existing) => existing.id === slot.id) ? current : [slot, ...current];
+      }
+      return state?.map((existing) => (existing.id === slot.id ? slot : existing));
+    });
+  });
+
+  useEffect(() => {
+    if (!range) {
+      return () => {};
+    }
+    let active = true;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional loading flag
+    setLoading(true);
+
+    // Emit one Slot search per schedule so MedplumClient can cache each schedule's
+    // results independently.
+    Promise.all(
+      scheduleRefs.map((scheduleRef) =>
+        medplum.searchResources('Slot', [
+          ['_count', '1000'],
+          ['schedule', scheduleRef],
+          ['start', `ge${range.start.toISOString()}`],
+          ['start', `le${range.end.toISOString()}`],
+          ['status:not', 'entered-in-error'],
+        ])
+      )
+    )
+      .then((results) => active && setSlots(results.flat()))
+      .catch((error: unknown) => active && showErrorNotification(error))
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+      setLoading(false);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- scheduleRefsKey captures scheduleRefs
+  }, [medplum, scheduleRefsKey, range]);
+
+  return {
+    slots,
+    loading,
+  };
+}
+
+/**
+ * Loads the Appointments for a set of schedules within a date range and keeps them live.
+ *
+ * Searches by the schedules' actors, deduping shared actors so each is queried once, and
+ * merges the per-actor results by id. Subscribes via `useResourceModified` so Appointments
+ * this client creates, updates, or deletes are reflected optimistically without a refetch.
+ *
+ * @param schedules - The schedules whose actors' Appointments should be loaded.
+ * @param range - The date range to search within; no search runs while this is undefined
+ *   or none of the schedules have an actor.
+ * @returns The loaded Appointments (undefined until the first fetch resolves) and a loading flag.
+ */
+export function useSchedulingAppointments(
+  schedules: WithId<Schedule>[],
+  range: Range | undefined
+): UseSchedulingAppointmentsResult {
+  const medplum = useMedplum();
+  const [appointments, setAppointments] = useState<WithId<Appointment>[] | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+
+  // The predicate that scopes this calendar's data. The FHIR search and the
+  // `useResourceModified` handler both use this so the optimistic updates stay consistent
+  // with what a refetch would return. Deduped so schedules that share an actor don't
+  // issue the same Appointment query twice.
+  const actorRefs = [
+    ...new Set(schedules.flatMap((schedule) => schedule.actor.map((ref) => getReferenceString(ref))).filter(isDefined)),
+  ];
+
+  // Stable keys so the searches below only re-run when the set of predicates actually
+  // changes, rather than on every render when the parent passes a new array instance.
+  const actorRefsKey = actorRefs.join(',');
+
+  // Keep the calendar's appointments in sync with any Appointment this client
+  // modifies.
+  useResourceModified('Appointment', (event) => {
+    if (event.operation === 'delete') {
+      if (event.id) {
+        setAppointments((state) => state?.filter((appointment) => appointment.id !== event.id));
+      }
+      return;
+    }
+
+    const appointment = event.resource;
+    if (!appointment) {
+      return;
+    }
+
+    // Ignore appointments that don't involve any of these schedules' actors, mirroring
+    // the `actor` filter used by the search below.
+    if (!appointment.participant.some((p) => p.actor?.reference && actorRefs.includes(p.actor.reference))) {
+      return;
+    }
+
+    setAppointments((state) => {
+      if (event.operation === 'create') {
+        const current = state ?? [];
+        return current.some((existing) => existing.id === appointment.id) ? current : [...current, appointment];
+      }
+      return state?.map((existing) => (existing.id === appointment.id ? appointment : existing));
+    });
+  });
+
+  // Find appointments visible in the current range
+  useEffect(() => {
+    if (actorRefs.length === 0 || !range) {
+      return () => {};
+    }
+    let active = true;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional loading flag
+    setLoading(true);
+
+    // Emit one Appointment search per schedule actor, again so each schedule's results
+    // can be cached independently.
+    Promise.all(
+      actorRefs.map((actorRef) =>
+        medplum.searchResources('Appointment', [
+          ['_count', '1000'],
+          ['actor', actorRef],
+          ['date', `ge${range.start.toISOString()}`],
+          ['date', `le${range.end.toISOString()}`],
+        ])
+      )
+    )
+      .then((results) => {
+        if (!active) {
+          return;
+        }
+        // The same appointment can involve actors from more than one schedule, so dedupe
+        // by id when combining the per-schedule results.
+        const byId = new Map<string, WithId<Appointment>>();
+        for (const appointment of results.flat()) {
+          byId.set(appointment.id, appointment);
+        }
+        setAppointments([...byId.values()]);
+      })
+      .catch((error: unknown) => active && showErrorNotification(error))
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+      setLoading(false);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- actorRefsKey captures actorRefs
+  }, [medplum, actorRefsKey, range]);
+
+  return {
+    appointments,
+    loading,
+  };
+}
+
+/**
+ * Loads both the Slots and Appointments for a set of schedules within a date range.
+ *
+ * A thin composition of {@link useSchedulingSlots} and {@link useSchedulingAppointments}
+ * for callers that need both; `loading` is true while either underlying fetch is in flight.
+ *
+ * @param schedules - The schedules whose Slots and Appointments should be loaded.
+ * @param range - The date range to search within; no search runs while this is undefined.
+ * @returns The loaded Slots and Appointments (each undefined until its first fetch resolves)
+ *   and a combined loading flag.
+ */
+export function useSchedulingResources(
+  schedules: WithId<Schedule>[],
+  range: Range | undefined
+): UseSchedulingResourcesResult {
+  const slotsResult = useSchedulingSlots(schedules, range);
+  const appointmentsResult = useSchedulingAppointments(schedules, range);
+
+  return {
+    slots: slotsResult.slots,
+    appointments: appointmentsResult.appointments,
+    loading: slotsResult.loading || appointmentsResult.loading,
+  };
+}


### PR DESCRIPTION
This encapsulates fetching the appointment/slot data, managing the state and subscribing to events needed to keep it all in sync.

Implementation notes:
- To handle future multi-schedule UI, we make this hook take an array of Schedule resources instead of just one.

- Minor functional change: we're now fetching Appointment records related to any of the Schedule's actors, instead of assuming that the Schedule resource has exactly one actor and reading `schedule.actor[0]`. Medplum still recommends using one Actor per Schedule (our scheduling API endpoints like `$book` assume that this is the case), but our UI does not need to enforce that restriction to render components like calendar widgets.

- We emit one `Appointment` and one `Slot` query per input schedule. This means that each one can be cached independently in the MedplumClient query cache, and actions like selecting or unselecting a single Schedule for display don't need to re-fetch all the other Appointment/Slot resources that we have already loaded.

- We do some slightly awkward maneuvering around exhaustive-deps; we convert our input Schedule resources into stable strings to avoid re-fetching when unstable inputs are passed in. This makes the single-schedule use case (i.e. `useSchedulingResources([schedule], range)`) nice to consume without explicit memoization of that list.

For rapid iteration, this is being developed in `/examples/medplum-provider`, with the intent of moving into `/packages/react-hooks` after it feels it has stabilized.