### PR TITLE
docs: add Stedi test mode link to hackathon resources

### DIFF
--- a/packages/docs/blog/2026-08-01-yc-medplum-hackathon.mdx
+++ b/packages/docs/blog/2026-08-01-yc-medplum-hackathon.mdx
@@ -47,6 +47,7 @@ Get building:
 
 - [Medplum docs](/docs) - the open source healthcare developer platform
 - [Building on Medplum with AI coding assistants](/docs/building-with-ai-coding-assistants)
+- [Stedi test mode](https://www.stedi.com/docs/healthcare/test-mode) - build and test healthcare APIs without real payers
 
 <div className="responsive-iframe-wrapper">
   <iframe width="560" height="315" src="https://www.youtube.com/embed/n60OMw5J1cI" title="Getting Started with Medplum" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>


### PR DESCRIPTION
Adds a Stedi test mode docs link under Resources for Hackers.