### PR TITLE
fix(server): enforce maximum password length across all endpoints

### DIFF
--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -31,6 +31,7 @@ import { authenticator } from 'otplib';
 import { resetPassword } from '../auth/resetpassword';
 import { bcryptHashPassword, createProjectMembership } from '../auth/utils';
 import { getConfig } from '../config/loader';
+import { MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH } from '../constants';
 import { getAuthenticatedContext, tryGetRequestContext } from '../context';
 import { sendEmail } from '../email/email';
 import type { SystemRepository } from '../fhir/repo';
@@ -55,6 +56,12 @@ export const inviteValidator = makeValidationMiddleware([
     .optional()
     .matches(/^Patient\/[^/]+$/)
     .withMessage('Patient must be a reference to a Patient resource'),
+  body('password')
+    .optional()
+    .isLength({ min: MIN_PASSWORD_LENGTH })
+    .withMessage(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`)
+    .isByteLength({ max: MAX_PASSWORD_LENGTH })
+    .withMessage(`Password must be no more than ${MAX_PASSWORD_LENGTH} characters`),
 ]);
 
 export async function inviteHandler(req: Request, res: Response): Promise<void> {

--- a/packages/server/src/admin/project.test.ts
+++ b/packages/server/src/admin/project.test.ts
@@ -657,7 +657,7 @@ describe('Project Admin routes', () => {
       });
 
     expect(res).toHaveStatus(400);
-    expect(res.body.issue[0].details.text).toBe('Invalid password, must be at least 8 characters');
+    expect(res.body.issue[0].details.text).toBe('Password must be at least 8 characters');
   });
 
   test('Set password user not found', async () => {

--- a/packages/server/src/admin/project.ts
+++ b/packages/server/src/admin/project.ts
@@ -10,6 +10,7 @@ import { resetPassword } from '../auth/resetpassword';
 import { setPassword } from '../auth/setpassword';
 import type { MfaMethod } from '../auth/utils';
 import { getEnrolledMfaMethods } from '../auth/utils';
+import { MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH } from '../constants';
 import { getAuthenticatedContext } from '../context';
 import { sendEmail } from '../email/email';
 import { reconcileDefaultAccessPolicy } from '../fhir/accesspolicy';
@@ -31,7 +32,11 @@ projectAdminRouter.post(
   '/setpassword',
   [
     body('email').isEmail().withMessage('Valid email address is required'),
-    body('password').isLength({ min: 8 }).withMessage('Invalid password, must be at least 8 characters'),
+    body('password')
+      .isLength({ min: MIN_PASSWORD_LENGTH })
+      .withMessage(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`)
+      .isByteLength({ max: MAX_PASSWORD_LENGTH })
+      .withMessage(`Password must be no more than ${MAX_PASSWORD_LENGTH} characters`),
   ],
   async (req: Request, res: Response) => {
     const errors = validationResult(req);

--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -853,7 +853,7 @@ describe('Super Admin routes', () => {
       });
 
     expect(res).toHaveStatus(400);
-    expect(res.body.issue[0].details.text).toBe('Invalid password, must be at least 8 characters');
+    expect(res.body.issue[0].details.text).toBe('Password must be at least 8 characters');
   });
 
   test('Set password user not found', async () => {

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -19,6 +19,7 @@ import { assert } from 'node:console';
 import { setPassword } from '../auth/setpassword';
 import { LAMBDA_NAME_REGEX_PATTERN } from '../cloud/aws/deploy';
 import { getConfig } from '../config/loader';
+import { MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH } from '../constants';
 import { requireSuperAdmin } from '../context';
 import { DatabaseMode, getDatabasePool } from '../database';
 import { AsyncJobExecutor, sendAsyncResponse } from '../fhir/operations/utils/asyncjobexecutor';
@@ -285,7 +286,11 @@ superAdminRouter.post(
   '/setpassword',
   [
     body('email').isEmail().withMessage('Valid email address is required'),
-    body('password').isLength({ min: 8 }).withMessage('Invalid password, must be at least 8 characters'),
+    body('password')
+      .isLength({ min: MIN_PASSWORD_LENGTH })
+      .withMessage(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`)
+      .isByteLength({ max: MAX_PASSWORD_LENGTH })
+      .withMessage(`Password must be no more than ${MAX_PASSWORD_LENGTH} characters`),
   ],
   async (req: Request, res: Response) => {
     const { repo } = requireSuperAdmin();

--- a/packages/server/src/auth/changepassword.ts
+++ b/packages/server/src/auth/changepassword.ts
@@ -6,6 +6,7 @@ import type { Reference, User } from '@medplum/fhirtypes';
 import bcrypt from 'bcrypt';
 import type { Request, Response } from 'express';
 import { body } from 'express-validator';
+import { MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH } from '../constants';
 import { getAuthenticatedContext } from '../context';
 import { sendOutcome } from '../fhir/outcomes';
 import type { SystemRepository } from '../fhir/repo';
@@ -14,7 +15,11 @@ import { setPassword } from './setpassword';
 
 export const changePasswordValidator = makeValidationMiddleware([
   body('oldPassword').notEmpty().withMessage('Missing oldPassword'),
-  body('newPassword').isLength({ min: 8 }).withMessage('Invalid password, must be at least 8 characters'),
+  body('newPassword')
+    .isLength({ min: MIN_PASSWORD_LENGTH })
+    .withMessage(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`)
+    .isByteLength({ max: MAX_PASSWORD_LENGTH })
+    .withMessage(`Password must be no more than ${MAX_PASSWORD_LENGTH} characters`),
 ]);
 
 export async function changePasswordHandler(req: Request, res: Response): Promise<void> {

--- a/packages/server/src/auth/login.test.ts
+++ b/packages/server/src/auth/login.test.ts
@@ -136,7 +136,7 @@ describe('Login', () => {
     });
     expect(res).toHaveStatus(400);
     expect(res.body.issue).toBeDefined();
-    expect(res.body.issue[0].details.text).toBe('Invalid password, must be at least 8 characters');
+    expect(res.body.issue[0].details.text).toBe('Password must be at least 8 characters');
   });
 
   test('Wrong password', async () => {

--- a/packages/server/src/auth/login.ts
+++ b/packages/server/src/auth/login.ts
@@ -4,6 +4,7 @@ import type { ResourceType } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import { body } from 'express-validator';
 import { randomUUID } from 'node:crypto';
+import { MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH } from '../constants';
 import { getLogger } from '../logger';
 import { tryLogin } from '../oauth/utils';
 import { makeValidationMiddleware } from '../util/validator';
@@ -11,7 +12,11 @@ import { getProjectIdByClientId, sendLoginResult } from './utils';
 
 export const loginValidator = makeValidationMiddleware([
   body('email').isEmail().withMessage('Valid email address is required'),
-  body('password').isLength({ min: 8 }).withMessage('Invalid password, must be at least 8 characters'),
+  body('password')
+    .isLength({ min: MIN_PASSWORD_LENGTH })
+    .withMessage(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`)
+    .isByteLength({ max: MAX_PASSWORD_LENGTH })
+    .withMessage(`Password must be no more than ${MAX_PASSWORD_LENGTH} characters`),
 ]);
 
 export async function loginHandler(req: Request, res: Response): Promise<void> {

--- a/packages/server/src/auth/newuser.test.ts
+++ b/packages/server/src/auth/newuser.test.ts
@@ -122,7 +122,7 @@ describe('New user', () => {
 
     const res = await request(app).post('/auth/newuser').type('json').send(registerRequest);
     expect(res).toHaveStatus(400);
-    expect(res.body.issue[0].details.text).toBe('Password must be between 8 and 72 characters');
+    expect(res.body.issue[0].details.text).toBe('Password must be at least 8 characters');
   });
 
   test('Password too long', async () => {
@@ -136,7 +136,7 @@ describe('New user', () => {
 
     const res = await request(app).post('/auth/newuser').type('json').send(registerRequest);
     expect(res).toHaveStatus(400);
-    expect(res.body.issue[0].details.text).toBe('Password must be between 8 and 72 characters');
+    expect(res.body.issue[0].details.text).toBe('Password must be no more than 72 characters');
   });
 
   test('Multibyte password too long', async () => {
@@ -153,7 +153,24 @@ describe('New user', () => {
 
     const res = await request(app).post('/auth/newuser').type('json').send(registerRequest);
     expect(res).toHaveStatus(400);
-    expect(res.body.issue[0].details.text).toBe('Password must be between 8 and 72 characters');
+    expect(res.body.issue[0].details.text).toBe('Password must be no more than 72 characters');
+  });
+
+  test('Multibyte password too short', async () => {
+    // Two emoji: 2 characters but 8 bytes. The minimum is measured in
+    // characters, so this is rejected as too short even though it clears the
+    // byte-length check.
+    const registerRequest = {
+      firstName: 'George',
+      lastName: 'Washington',
+      email: `george${randomUUID()}@example.com`,
+      password: '🔑🔓',
+      recaptchaToken: 'xyz',
+    };
+
+    const res = await request(app).post('/auth/newuser').type('json').send(registerRequest);
+    expect(res).toHaveStatus(400);
+    expect(res.body.issue[0].details.text).toBe('Password must be at least 8 characters');
   });
 
   test('Breached password', async () => {

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -8,6 +8,7 @@ import { body } from 'express-validator';
 import { pwnedPassword } from 'hibp';
 import { randomUUID } from 'node:crypto';
 import { getConfig } from '../config/loader';
+import { MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH } from '../constants';
 import { sendEmail } from '../email/email';
 import { sendOutcome } from '../fhir/outcomes';
 import { getGlobalSystemRepo } from '../fhir/repo';
@@ -25,7 +26,11 @@ export const newUserValidator = makeValidationMiddleware([
     .withMessage('Valid email address between 3 and 72 characters is required')
     .isLength({ min: 3, max: 72 })
     .withMessage('Valid email address between 3 and 72 characters is required'),
-  body('password').isByteLength({ min: 8, max: 72 }).withMessage('Password must be between 8 and 72 characters'),
+  body('password')
+    .isLength({ min: MIN_PASSWORD_LENGTH })
+    .withMessage(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`)
+    .isByteLength({ max: MAX_PASSWORD_LENGTH })
+    .withMessage(`Password must be no more than ${MAX_PASSWORD_LENGTH} characters`),
 ]);
 
 /**

--- a/packages/server/src/auth/setpassword.test.ts
+++ b/packages/server/src/auth/setpassword.test.ts
@@ -317,6 +317,19 @@ describe('Set Password', () => {
     expect(res).toHaveStatus(400);
   });
 
+  test('Password too long', async () => {
+    const res = await request(app)
+      .post('/auth/setpassword')
+      .type('json')
+      .send({
+        id: randomUUID(),
+        secret: generateSecret(16),
+        password: 'a'.repeat(73),
+      });
+    expect(res).toHaveStatus(400);
+    expect(res.body.issue[0].details.text).toBe('Password must be no more than 72 characters');
+  });
+
   test('Not found', async () => {
     const res = await request(app)
       .post('/auth/setpassword')

--- a/packages/server/src/auth/setpassword.ts
+++ b/packages/server/src/auth/setpassword.ts
@@ -6,6 +6,7 @@ import type { Login, User, UserSecurityRequest } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import { body } from 'express-validator';
 import { pwnedPassword } from 'hibp';
+import { MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH } from '../constants';
 import { sendOutcome } from '../fhir/outcomes';
 import type { SystemRepository } from '../fhir/repo';
 import { getGlobalSystemRepo } from '../fhir/repo';
@@ -16,7 +17,11 @@ import { bcryptHashPassword } from './utils';
 export const setPasswordValidator = makeValidationMiddleware([
   body('id').isUUID().withMessage('Invalid request ID'),
   body('secret').notEmpty().withMessage('Missing secret'),
-  body('password').isLength({ min: 8 }).withMessage('Invalid password, must be at least 8 characters'),
+  body('password')
+    .isLength({ min: MIN_PASSWORD_LENGTH })
+    .withMessage(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`)
+    .isByteLength({ max: MAX_PASSWORD_LENGTH })
+    .withMessage(`Password must be no more than ${MAX_PASSWORD_LENGTH} characters`),
 ]);
 
 export async function setPasswordHandler(req: Request, res: Response): Promise<void> {

--- a/packages/server/src/auth/utils.test.ts
+++ b/packages/server/src/auth/utils.test.ts
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { OperationOutcomeError } from '@medplum/core';
 import type { Project, User } from '@medplum/fhirtypes';
-import { isMfaRequired } from './utils';
+import { MAX_PASSWORD_LENGTH } from '../constants';
+import { bcryptHashPassword, isMfaRequired } from './utils';
 
 describe('isMfaRequired', () => {
   function createMfaTestUser(mfaRequired?: boolean): User {
@@ -38,5 +40,26 @@ describe('isMfaRequired', () => {
     expect(isMfaRequired(createMfaTestUser(true), undefined)).toBe(true);
     // A project that does not require MFA leaves an unset user unaffected.
     expect(isMfaRequired(createMfaTestUser(), projectWithSetting(false))).toBe(false);
+  });
+});
+
+describe('bcryptHashPassword', () => {
+  // The guard runs before bcrypt.hash (and before getConfig), so these cases
+  // do not require server config to be loaded.
+  test('Rejects a password longer than the maximum byte length', () => {
+    const tooLong = 'a'.repeat(MAX_PASSWORD_LENGTH + 1);
+    expect(() => bcryptHashPassword(tooLong)).toThrow(OperationOutcomeError);
+    expect(() => bcryptHashPassword(tooLong)).toThrow(
+      `Password must be no more than ${MAX_PASSWORD_LENGTH} characters`
+    );
+  });
+
+  test('Measures length in bytes, not code points', () => {
+    // Each '😀' is 4 UTF-8 bytes, so 19 of them (76 bytes) exceeds the 72-byte
+    // limit despite being only 19 code points long.
+    const multibyte = '😀'.repeat(19);
+    expect(multibyte.length).toBeLessThanOrEqual(MAX_PASSWORD_LENGTH);
+    expect(Buffer.byteLength(multibyte, 'utf8')).toBeGreaterThan(MAX_PASSWORD_LENGTH);
+    expect(() => bcryptHashPassword(multibyte)).toThrow(OperationOutcomeError);
   });
 });

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -24,7 +24,7 @@ import { randomInt } from 'node:crypto';
 import { authenticator } from 'otplib';
 import { toDataURL } from 'qrcode';
 import { getConfig } from '../config/loader';
-import { EMAIL_MFA_CODE_EXPIRATION_MS } from '../constants';
+import { EMAIL_MFA_CODE_EXPIRATION_MS, MAX_PASSWORD_LENGTH } from '../constants';
 import { sendEmail } from '../email/email';
 import { sendOutcome } from '../fhir/outcomes';
 import type { SystemRepository } from '../fhir/repo';
@@ -377,10 +377,18 @@ export function getProjectByRecaptchaSiteKey(
 
 /**
  * Returns the bcrypt hash of the password.
+ *
+ * Rejects passwords longer than {@link MAX_PASSWORD_LENGTH} bytes as a
+ * defense-in-depth backstop. Route validators are the front line, but enforcing
+ * the cap at the single hashing chokepoint means any current or future caller is
+ * protected regardless of the route it came through.
  * @param password - The input password.
  * @returns The bcrypt hash of the password.
  */
 export function bcryptHashPassword(password: string): Promise<string> {
+  if (Buffer.byteLength(password, 'utf8') > MAX_PASSWORD_LENGTH) {
+    throw new OperationOutcomeError(badRequest(`Password must be no more than ${MAX_PASSWORD_LENGTH} characters`));
+  }
   return bcrypt.hash(password, getConfig().bcryptHashSalt);
 }
 

--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -35,3 +35,18 @@ export const WEBSOCKET_SUB_PUBLISH_CHANNEL = 'medplum:subscriptions:r4:websocket
  * How long a single-use email MFA code remains valid before it expires, in milliseconds.
  */
 export const EMAIL_MFA_CODE_EXPIRATION_MS = 20 * 60 * 1000; // 20 minutes
+
+/**
+ * Minimum accepted password length, in bytes.
+ */
+export const MIN_PASSWORD_LENGTH = 8;
+
+/**
+ * Maximum accepted password length, in bytes.
+ *
+ * bcrypt only consumes the first 72 bytes of its input and silently ignores the
+ * rest, so anything longer provides a false sense of security (and needlessly
+ * hashes/copies data). We cap at 72 bytes so the truncation is explicit rather
+ * than silent, and to bound work on the hashing path.
+ */
+export const MAX_PASSWORD_LENGTH = 72;


### PR DESCRIPTION
Cap password length at 72 bytes (bcrypt's effective limit) consistently across every password entry point, and add a defense-in-depth check at the bcrypt hashing chokepoint so any current or future caller is protected regardless of route.

Previously only the newuser endpoint enforced a maximum; setpassword, changepassword, login, and the admin super/project/invite endpoints only checked a minimum. bcrypt silently truncates past 72 bytes, so unbounded input was both a footgun and wasted work.

Adds shared MIN_PASSWORD_LENGTH/MAX_PASSWORD_LENGTH constants so the values cannot drift apart again.

Addresses external report of unbounded password length. Note bcrypt only consumes the first 72 bytes and requests are already body-size capped, so there was no actual DoS; this is input-validation hardening.