### PR TITLE
Visually separate elements from metadata fields

### DIFF
--- a/packages/react/src/SearchControl/SearchUtils.tsx
+++ b/packages/react/src/SearchControl/SearchUtils.tsx
@@ -511,6 +511,27 @@ export function buildFieldNameString(key: string): string {
 }
 
 /**
+ * Returns true if the given search parameter code refers to a resource metadata field.
+ * @param code - The search parameter code.
+ * @returns True if the code is a meta search parameter.
+ */
+export function isMetaSearchParam(code: string): boolean {
+  return code.startsWith('_');
+}
+
+/**
+ * Returns a display label for a search parameter code.
+ *
+ * Meta fields keep their underscore-prefixed code so they don't collide with same-named
+ * elements (e.g. `ProjectMembership.project` vs `_project`).
+ * @param code - The search parameter code.
+ * @returns The display label for the search parameter.
+ */
+export function buildSearchParamFieldLabel(code: string): string {
+  return isMetaSearchParam(code) ? code : buildFieldNameString(code);
+}
+
+/**
  * Returns a fragment to be displayed in the search table for the value.
  * @param resource - The parent resource.
  * @param field - The search code or FHIRPath expression.

--- a/packages/react/src/SearchFilterEditor/SearchFilterEditor.test.tsx
+++ b/packages/react/src/SearchFilterEditor/SearchFilterEditor.test.tsx
@@ -237,7 +237,7 @@ describe('SearchFilterEditor', () => {
       />
     );
 
-    expect(screen.queryByDisplayValue('not-a-code')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('not-a-code')).toBeNull();
   });
 
   test('_lastUpdated filter', async () => {
@@ -263,10 +263,32 @@ describe('SearchFilterEditor', () => {
     );
 
     // Wait for the resource to load
-    await waitFor(() => screen.queryAllByText('Last Updated').length > 0);
+    await waitFor(() => screen.queryAllByText('_lastUpdated').length > 0);
 
     const input = screen.getByTestId<HTMLInputElement>('filter-0-row-filter-value');
     expect(input.value).toMatch(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})$/);
+  });
+
+  test('Meta fields are disambiguated from same-named elements', async () => {
+    // ProjectMembership has both `project`/`profile` elements and `_project`/`_profile` meta fields.
+    const currSearch: SearchRequest = {
+      resourceType: 'ProjectMembership',
+      filters: [{ code: '', operator: Operator.EQUALS, value: '' }],
+    };
+
+    await setup(<SearchFilterEditor search={currSearch} visible={true} onOk={vi.fn()} onCancel={vi.fn()} />);
+
+    const fieldInput = screen.getByTestId<HTMLSelectElement>('filter-0-row-filter-field');
+    const optionLabels = Array.from(fieldInput.options).map((o) => o.textContent);
+
+    expect(optionLabels.filter((label) => label === 'Project')).toHaveLength(1);
+    expect(optionLabels.filter((label) => label === '_project')).toHaveLength(1);
+    expect(optionLabels.filter((label) => label === 'Profile')).toHaveLength(1);
+    expect(optionLabels.filter((label) => label === '_profile')).toHaveLength(1);
+
+    const groups = Array.from(fieldInput.querySelectorAll('optgroup')).map((g) => g.label);
+    expect(groups).toContain('Fields');
+    expect(groups).toContain('Metadata');
   });
 
   test('Quantity filter', async () => {

--- a/packages/react/src/SearchFilterEditor/SearchFilterEditor.tsx
+++ b/packages/react/src/SearchFilterEditor/SearchFilterEditor.tsx
@@ -12,10 +12,11 @@ import { Form } from '../Form/Form';
 import { SubmitButton } from '../Form/SubmitButton';
 import {
   addFilter,
-  buildFieldNameString,
+  buildSearchParamFieldLabel,
   deleteFilter,
   getOpString,
   getSearchOperators,
+  isMetaSearchParam,
   setFilters,
 } from '../SearchControl/SearchUtils';
 import { SearchFilterValueInput } from '../SearchFilterValueInput/SearchFilterValueInput';
@@ -127,6 +128,17 @@ function FilterRowInput(props: FilterRowInputProps): JSX.Element {
   const searchParam = props.searchParams[value.code];
   const operators = searchParam && getSearchOperators(searchParam);
 
+  const fieldOptions = [];
+  const metaOptions = [];
+  for (const param of Object.keys(props.searchParams)) {
+    const option = { value: param, label: buildSearchParamFieldLabel(param) };
+    if (isMetaSearchParam(param)) {
+      metaOptions.push(option);
+    } else {
+      fieldOptions.push(option);
+    }
+  }
+
   return (
     <tr>
       <td>
@@ -136,7 +148,8 @@ function FilterRowInput(props: FilterRowInputProps): JSX.Element {
           onChange={(e) => setFilterCode(e.currentTarget.value)}
           data={[
             '',
-            ...Object.keys(props.searchParams).map((param) => ({ value: param, label: buildFieldNameString(param) })),
+            ...(fieldOptions.length > 0 ? [{ group: 'Fields', items: fieldOptions }] : []),
+            ...(metaOptions.length > 0 ? [{ group: 'Metadata', items: metaOptions }] : []),
           ]}
         />
       </td>


### PR DESCRIPTION
Fix #9912 

This PR makes it so that when you're adding filters to a resource, the **Elements** (e.g. `ProjectMembership.Project`) and the **Metadata** fields (e.g. `_project`) will be visually separated in the options dropdown that gets displayed. Previously, these would both look identical, creating confusion in situations where a resource has an element with the same name as a meta field. 

<img width="288" height="676" alt="image" src="https://github.com/user-attachments/assets/86097740-a361-49cb-8a72-e5b8e94964f3" />
