### PR TITLE
Re-enable `temporal-polyfill` upgrades

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -526,17 +526,6 @@
         "temporal-polyfill": "^1.0.1"
       }
     },
-    "examples/medplum-provider/node_modules/temporal-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.1.tgz",
-      "integrity": "sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "temporal-spec": "1.0.0",
-        "temporal-utils": "1.0.1"
-      }
-    },
     "examples/medplum-questionnaire-hooks": {
       "version": "5.1.26",
       "devDependencies": {
@@ -40667,32 +40656,25 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
-      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.1.tgz",
+      "integrity": "sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==",
       "license": "MIT",
       "dependencies": {
-        "temporal-spec": "0.3.1"
+        "temporal-spec": "1.0.0",
+        "temporal-utils": "1.0.1"
       }
-    },
-    "node_modules/temporal-polyfill/node_modules/temporal-spec": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
-      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
-      "license": "ISC"
     },
     "node_modules/temporal-spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.0.tgz",
       "integrity": "sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/temporal-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.1.tgz",
       "integrity": "sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/terser": {
@@ -44942,7 +44924,7 @@
         "qrcode": "1.5.4",
         "rate-limiter-flexible": "11.2.0",
         "semver": "7.8.5",
-        "temporal-polyfill": "0.3.2",
+        "temporal-polyfill": "1.0.1",
         "undici": "7.28.0",
         "uuid": "14.0.1",
         "validator": "13.15.35",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -98,7 +98,7 @@
     "qrcode": "1.5.4",
     "rate-limiter-flexible": "11.2.0",
     "semver": "7.8.5",
-    "temporal-polyfill": "0.3.2",
+    "temporal-polyfill": "1.0.1",
     "undici": "7.28.0",
     "uuid": "14.0.1",
     "validator": "13.15.35",

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -98,9 +98,8 @@ fi
 # node-fetch - version 3+ requires ESM, holding back until server supports ESM
 # zod - version 4+ is incompatible with MCP SDK
 # otplib - version 13+ requires ESM, holding back until server supports ESM
-# temporal-polyfill - version 1.0.0 is actually an old version, holding back to 0.3.0 which is the latest stable version
 # @mantine/* - version 9 has a few small backwards-incompatible changes, namely affecting at least our `PatientSummary` component, which would make it hard to support both Mantine 8 and 9 simultaneously
-MAJOR_EXCLUDE="@types/node @types/node-fetch commander eslint hibp node-fetch npm zod otplib temporal-polyfill @mantine/*"
+MAJOR_EXCLUDE="@types/node @types/node-fetch commander eslint hibp node-fetch npm zod otplib @mantine/*"
 
 if [ "$LAST_STEP" -lt 1 ]; then
     # First, only upgrade patch and minor versions


### PR DESCRIPTION
This package has now released a v1.0.1 release, which is considered latest - previously v1.0.0 was published as a placeholder, and not intended to be used (see https://github.com/fullcalendar/temporal-polyfill/issues/88 for details).

With that change we can ungate this, as our tooling will correctly find upgrades it can apply automatically going forwards.