### PR TITLE
Additional database configuration options

### DIFF
--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -293,6 +293,9 @@ export interface MedplumDatabaseConfig {
    */
   disableRunPostDeployMigrations?: boolean;
   maxConnections?: number;
+  minConnections?: number;
+  idleTimeoutMillis?: number;
+  connectionTimeoutMillis?: number;
   disableConnectionConfiguration?: boolean;
 }
 

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -294,8 +294,8 @@ export interface MedplumDatabaseConfig {
   disableRunPostDeployMigrations?: boolean;
   maxConnections?: number;
   minConnections?: number;
-  idleTimeoutMillis?: number;
-  connectionTimeoutMillis?: number;
+  idleTimeoutMs?: number;
+  connectionTimeoutMs?: number;
   disableConnectionConfiguration?: boolean;
 }
 

--- a/packages/server/src/data-warehouse/config.test.ts
+++ b/packages/server/src/data-warehouse/config.test.ts
@@ -70,15 +70,31 @@ describe('buildPostgresConnectionUriFromMedplumDatabaseConfig', () => {
     expect(new URL(uri).searchParams.get('options')).toBe('-c statement_timeout=3000');
   });
 
-  test('converts connectionTimeoutMillis to libpq connect_timeout seconds', () => {
+  test.each([
+    [0, '0'],
+    [500, '1'],
+    [10_999, '10'],
+  ])('converts connectionTimeoutMillis=%i to libpq connect_timeout=%s', (connectionTimeoutMillis, expected) => {
     const uri = buildPgConnectionURI({
       host: 'db.example.com',
       dbname: 'medplum',
       username: 'medplum',
       password: 'secret',
-      connectionTimeoutMillis: 10_999,
+      connectionTimeoutMillis,
     });
-    expect(new URL(uri).searchParams.get('connect_timeout')).toBe('10');
+    expect(new URL(uri).searchParams.get('connect_timeout')).toBe(expected);
+  });
+
+  test('rejects negative connectionTimeoutMillis', () => {
+    expect(() =>
+      buildPgConnectionURI({
+        host: 'db.example.com',
+        dbname: 'medplum',
+        username: 'medplum',
+        password: 'secret',
+        connectionTimeoutMillis: -1,
+      })
+    ).toThrowError(new RangeError('connectionTimeoutMillis must be greater than or equal to 0'));
   });
 
   test('percent-encodes special characters in password', () => {

--- a/packages/server/src/data-warehouse/config.test.ts
+++ b/packages/server/src/data-warehouse/config.test.ts
@@ -100,6 +100,18 @@ describe('appendMedplumDatabaseSslSearchParams', () => {
     expect(params.get('sslmode')).toBe('require');
   });
 
+  test('sets sslmode=require when certificate verification is disabled', () => {
+    const params = new URLSearchParams();
+    appendMedplumDatabaseSslSearchParams(params, { rejectUnauthorized: false });
+    expect(params.get('sslmode')).toBe('require');
+  });
+
+  test('leaves the default sslmode when certificate verification has no CA', () => {
+    const params = new URLSearchParams();
+    appendMedplumDatabaseSslSearchParams(params, { rejectUnauthorized: true });
+    expect(params.has('sslmode')).toBe(false);
+  });
+
   test('sets verify-full with sslrootcert when rejectUnauthorized and ca are set', () => {
     const params = new URLSearchParams();
     appendMedplumDatabaseSslSearchParams(params, {

--- a/packages/server/src/data-warehouse/config.test.ts
+++ b/packages/server/src/data-warehouse/config.test.ts
@@ -74,27 +74,27 @@ describe('buildPostgresConnectionUriFromMedplumDatabaseConfig', () => {
     [0, '0'],
     [500, '1'],
     [10_999, '10'],
-  ])('converts connectionTimeoutMillis=%i to libpq connect_timeout=%s', (connectionTimeoutMillis, expected) => {
+  ])('converts connectionTimeoutMs=%i to libpq connect_timeout=%s', (connectionTimeoutMs, expected) => {
     const uri = buildPgConnectionURI({
       host: 'db.example.com',
       dbname: 'medplum',
       username: 'medplum',
       password: 'secret',
-      connectionTimeoutMillis,
+      connectionTimeoutMs,
     });
     expect(new URL(uri).searchParams.get('connect_timeout')).toBe(expected);
   });
 
-  test('rejects negative connectionTimeoutMillis', () => {
+  test('rejects negative connectionTimeoutMs', () => {
     expect(() =>
       buildPgConnectionURI({
         host: 'db.example.com',
         dbname: 'medplum',
         username: 'medplum',
         password: 'secret',
-        connectionTimeoutMillis: -1,
+        connectionTimeoutMs: -1,
       })
-    ).toThrowError(new RangeError('connectionTimeoutMillis must be greater than or equal to 0'));
+    ).toThrowError(new RangeError('connectionTimeoutMs must be greater than or equal to 0'));
   });
 
   test('percent-encodes special characters in password', () => {

--- a/packages/server/src/data-warehouse/config.test.ts
+++ b/packages/server/src/data-warehouse/config.test.ts
@@ -56,6 +56,7 @@ describe('buildPostgresConnectionUriFromMedplumDatabaseConfig', () => {
     expect(parsed.password).toBe('secret');
     expect(parsed.searchParams.get('application_name')).toBe(DEFAULT_DW_DATABASE_APPLICATION_NAME);
     expect(parsed.searchParams.get('options')).toBe(`-c statement_timeout=${DEFAULT_DW_DATABASE_STATEMENT_TIMEOUT}`);
+    expect(parsed.searchParams.has('connect_timeout')).toBe(false);
   });
 
   test('uses custom queryTimeout in options', () => {
@@ -67,6 +68,17 @@ describe('buildPostgresConnectionUriFromMedplumDatabaseConfig', () => {
       queryTimeout: 3000,
     });
     expect(new URL(uri).searchParams.get('options')).toBe('-c statement_timeout=3000');
+  });
+
+  test('converts connectionTimeoutMillis to libpq connect_timeout seconds', () => {
+    const uri = buildPgConnectionURI({
+      host: 'db.example.com',
+      dbname: 'medplum',
+      username: 'medplum',
+      password: 'secret',
+      connectionTimeoutMillis: 10_999,
+    });
+    expect(new URL(uri).searchParams.get('connect_timeout')).toBe('10');
   });
 
   test('percent-encodes special characters in password', () => {

--- a/packages/server/src/data-warehouse/config.ts
+++ b/packages/server/src/data-warehouse/config.ts
@@ -39,8 +39,9 @@ export function appendMedplumDatabaseSslSearchParams(params: URLSearchParams, ss
 
 /**
  * Builds a PostgreSQL URI for DuckDB `ATTACH (TYPE postgres)` from {@link MedplumDatabaseConfig},
- * including `application_name`, `options=-c statement_timeout=...`, and TLS via `sslmode` / cert paths from
- * {@link MedplumDatabaseConfig.ssl}.
+ * including `application_name`, `connect_timeout`, `options=-c statement_timeout=...`, and TLS via `sslmode` /
+ * cert paths from {@link MedplumDatabaseConfig.ssl}. Pool-only settings such as `minConnections`,
+ * `maxConnections`, and `idleTimeoutMillis` do not apply to this standalone connection URI.
  *
  * @param db - Medplum database settings; host, dbname, username, and password must be set.
  * @returns A PostgreSQL connection URI (`postgresql://...`).
@@ -69,6 +70,9 @@ export function buildPgConnectionURI(db: MedplumDatabaseConfig): string {
   const searchParams = new URLSearchParams();
   searchParams.set('application_name', DEFAULT_DW_DATABASE_APPLICATION_NAME);
   searchParams.set('options', '-c statement_timeout=' + String(timeout));
+  if (db.connectionTimeoutMillis !== undefined) {
+    searchParams.set('connect_timeout', String(Math.floor(db.connectionTimeoutMillis / 1000)));
+  }
   appendMedplumDatabaseSslSearchParams(searchParams, db.ssl);
   // libpq / DuckDB postgres attach do not treat '+' as space in query values; use encodeURIComponent.
   url.search = Array.from(searchParams.entries())

--- a/packages/server/src/data-warehouse/config.ts
+++ b/packages/server/src/data-warehouse/config.ts
@@ -71,7 +71,13 @@ export function buildPgConnectionURI(db: MedplumDatabaseConfig): string {
   searchParams.set('application_name', DEFAULT_DW_DATABASE_APPLICATION_NAME);
   searchParams.set('options', '-c statement_timeout=' + String(timeout));
   if (db.connectionTimeoutMillis !== undefined) {
-    searchParams.set('connect_timeout', String(Math.floor(db.connectionTimeoutMillis / 1000)));
+    if (db.connectionTimeoutMillis < 0) {
+      throw new RangeError('connectionTimeoutMillis must be greater than or equal to 0');
+    }
+    // values less than 1,000ms are rounded up to 1 second
+    const connectTimeoutSeconds =
+      db.connectionTimeoutMillis > 0 ? Math.max(1, Math.floor(db.connectionTimeoutMillis / 1000)) : 0;
+    searchParams.set('connect_timeout', String(connectTimeoutSeconds));
   }
   appendMedplumDatabaseSslSearchParams(searchParams, db.ssl);
   // libpq / DuckDB postgres attach do not treat '+' as space in query values; use encodeURIComponent.

--- a/packages/server/src/data-warehouse/config.ts
+++ b/packages/server/src/data-warehouse/config.ts
@@ -108,18 +108,11 @@ export function getWarehouseSyncPostgresTableNames(
   includeResourceTypes?: string[],
   excludeResourceTypes?: string[]
 ): string[] {
-  const hasIncluded = !!includeResourceTypes?.length;
-  const hasExcluded = !!excludeResourceTypes?.length;
-
-  if (!hasIncluded && !hasExcluded) {
-    return getResourceTypes().map(toHistoryPostgresTableName);
-  }
-
   let types = getResourceTypes();
-  if (hasIncluded) {
+  if (includeResourceTypes?.length) {
     const includedSet = new Set(includeResourceTypes);
     types = types.filter((resourceType) => includedSet.has(resourceType));
-  } else if (hasExcluded) {
+  } else if (excludeResourceTypes?.length) {
     const excludedSet = new Set(excludeResourceTypes);
     types = types.filter((resourceType) => !excludedSet.has(resourceType));
   }

--- a/packages/server/src/data-warehouse/config.ts
+++ b/packages/server/src/data-warehouse/config.ts
@@ -41,7 +41,7 @@ export function appendMedplumDatabaseSslSearchParams(params: URLSearchParams, ss
  * Builds a PostgreSQL URI for DuckDB `ATTACH (TYPE postgres)` from {@link MedplumDatabaseConfig},
  * including `application_name`, `connect_timeout`, `options=-c statement_timeout=...`, and TLS via `sslmode` /
  * cert paths from {@link MedplumDatabaseConfig.ssl}. Pool-only settings such as `minConnections`,
- * `maxConnections`, and `idleTimeoutMillis` do not apply to this standalone connection URI.
+ * `maxConnections`, and `idleTimeoutMs` do not apply to this standalone connection URI.
  *
  * @param db - Medplum database settings; host, dbname, username, and password must be set.
  * @returns A PostgreSQL connection URI (`postgresql://...`).
@@ -70,13 +70,13 @@ export function buildPgConnectionURI(db: MedplumDatabaseConfig): string {
   const searchParams = new URLSearchParams();
   searchParams.set('application_name', DEFAULT_DW_DATABASE_APPLICATION_NAME);
   searchParams.set('options', '-c statement_timeout=' + String(timeout));
-  if (db.connectionTimeoutMillis !== undefined) {
-    if (db.connectionTimeoutMillis < 0) {
-      throw new RangeError('connectionTimeoutMillis must be greater than or equal to 0');
+  if (db.connectionTimeoutMs !== undefined) {
+    if (db.connectionTimeoutMs < 0) {
+      throw new RangeError('connectionTimeoutMs must be greater than or equal to 0');
     }
     // values less than 1,000ms are rounded up to 1 second
     const connectTimeoutSeconds =
-      db.connectionTimeoutMillis > 0 ? Math.max(1, Math.floor(db.connectionTimeoutMillis / 1000)) : 0;
+      db.connectionTimeoutMs > 0 ? Math.max(1, Math.floor(db.connectionTimeoutMs / 1000)) : 0;
     searchParams.set('connect_timeout', String(connectTimeoutSeconds));
   }
   appendMedplumDatabaseSslSearchParams(searchParams, db.ssl);

--- a/packages/server/src/database-config.test.ts
+++ b/packages/server/src/database-config.test.ts
@@ -132,6 +132,7 @@ describe('Database config', () => {
 
     const configCopy = deepClone(config);
     configCopy.databaseProxyEndpoint = 'test';
+    delete configCopy.database.ssl;
 
     const databaseConfig = configCopy.database;
 
@@ -145,6 +146,47 @@ describe('Database config', () => {
         database: databaseConfig.dbname,
         user: databaseConfig.username,
         ssl: { require: true },
+      })
+    );
+  });
+
+  test('RDS proxy preserves existing SSL config', async () => {
+    const config = await loadTestConfig();
+    config.databaseProxyEndpoint = 'test';
+    config.database.ssl = {
+      ca: '__THIS_SHOULD_BE_A_PEM_FILE__',
+      rejectUnauthorized: true,
+    };
+
+    await initDatabase(config);
+
+    expect(poolConfigs[0]).toEqual(
+      expect.objectContaining({
+        host: config.databaseProxyEndpoint,
+        ssl: {
+          ca: '__THIS_SHOULD_BE_A_PEM_FILE__',
+          rejectUnauthorized: true,
+          require: true,
+        },
+      })
+    );
+  });
+
+  test('Custom pool settings', async () => {
+    const config = await loadTestConfig();
+    config.database.maxConnections = 20;
+    config.database.minConnections = 5;
+    config.database.idleTimeoutMillis = 30_000;
+    config.database.connectionTimeoutMillis = 10_000;
+
+    await initDatabase(config);
+
+    expect(poolConfigs[0]).toEqual(
+      expect.objectContaining({
+        max: 20,
+        min: 5,
+        idleTimeoutMillis: 30_000,
+        connectionTimeoutMillis: 10_000,
       })
     );
   });

--- a/packages/server/src/database-config.test.ts
+++ b/packages/server/src/database-config.test.ts
@@ -176,8 +176,8 @@ describe('Database config', () => {
     const config = await loadTestConfig();
     config.database.maxConnections = 20;
     config.database.minConnections = 5;
-    config.database.idleTimeoutMillis = 30_000;
-    config.database.connectionTimeoutMillis = 10_000;
+    config.database.idleTimeoutMs = 30_000;
+    config.database.connectionTimeoutMs = 10_000;
 
     await initDatabase(config);
 
@@ -185,8 +185,8 @@ describe('Database config', () => {
       expect.objectContaining({
         max: 20,
         min: 5,
-        idleTimeoutMillis: 30_000,
-        connectionTimeoutMillis: 10_000,
+        idleTimeoutMs: 30_000,
+        connectionTimeoutMs: 10_000,
       })
     );
   });

--- a/packages/server/src/database-config.test.ts
+++ b/packages/server/src/database-config.test.ts
@@ -185,8 +185,8 @@ describe('Database config', () => {
       expect.objectContaining({
         max: 20,
         min: 5,
-        idleTimeoutMs: 30_000,
-        connectionTimeoutMs: 10_000,
+        idleTimeoutMillis: 30_000,
+        connectionTimeoutMillis: 10_000,
       })
     );
   });

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -4,7 +4,7 @@ import { sleep } from '@medplum/core';
 import type { PoolClient, PoolConfig } from 'pg';
 import { Pool } from 'pg';
 import * as semver from 'semver';
-import type { MedplumDatabaseConfig, MedplumServerConfig } from './config/types';
+import type { MedplumDatabaseConfig, MedplumDatabaseSslConfig, MedplumServerConfig } from './config/types';
 import { globalLogger } from './logger';
 import { getPostDeployVersion, getPreDeployVersion } from './migration-sql';
 import {
@@ -59,7 +59,7 @@ function initPoolConfig(
   proxyEndpoint: string | undefined,
   applicationName = 'medplum-server'
 ): PoolConfig {
-  const poolConfig = {
+  const poolConfig: PoolConfig = {
     host: config.host,
     port: config.port,
     database: config.dbname,
@@ -68,6 +68,9 @@ function initPoolConfig(
     application_name: applicationName,
     ssl: config.ssl,
     max: config.maxConnections ?? DEFAULT_MAX_CONNECTIONS,
+    min: config.minConnections,
+    idleTimeoutMillis: config.idleTimeoutMillis,
+    connectionTimeoutMillis: config.connectionTimeoutMillis,
     options: config.disableConnectionConfiguration
       ? undefined
       : `-c statement_timeout=${config.queryTimeout ?? DEFAULT_STATEMENT_TIMEOUT} -c default_transaction_isolation=${DEFAULT_TRANSACTION_ISOLATION} -c idle_in_transaction_session_timeout=${DEFAULT_IDLE_IN_TRANSACTION_SESSION_TIMEOUT}`,
@@ -75,8 +78,9 @@ function initPoolConfig(
 
   if (proxyEndpoint) {
     poolConfig.host = proxyEndpoint;
-    poolConfig.ssl = poolConfig.ssl ?? {};
-    poolConfig.ssl.require = true;
+    // require SSL when using a proxy endpoint
+    poolConfig.ssl = typeof poolConfig.ssl === 'object' ? poolConfig.ssl : {};
+    (poolConfig.ssl as MedplumDatabaseSslConfig).require = true;
   }
 
   return poolConfig;

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -69,8 +69,8 @@ function initPoolConfig(
     ssl: config.ssl,
     max: config.maxConnections ?? DEFAULT_MAX_CONNECTIONS,
     min: config.minConnections,
-    idleTimeoutMillis: config.idleTimeoutMillis,
-    connectionTimeoutMillis: config.connectionTimeoutMillis,
+    idleTimeoutMillis: config.idleTimeoutMs,
+    connectionTimeoutMillis: config.connectionTimeoutMs,
     options: config.disableConnectionConfiguration
       ? undefined
       : `-c statement_timeout=${config.queryTimeout ?? DEFAULT_STATEMENT_TIMEOUT} -c default_transaction_isolation=${DEFAULT_TRANSACTION_ISOLATION} -c idle_in_transaction_session_timeout=${DEFAULT_IDLE_IN_TRANSACTION_SESSION_TIMEOUT}`,


### PR DESCRIPTION
We've deviated from the the node-postgres names before, e.g. `maxConnections` instead of `max`. We might want to do the same for the timeout options:
* `idleTimeoutMs` instead of `idleTimeoutMillis`
* `connectionTimeoutMs` instead of `connectionTimeoutMillis`

**UPDATE:** Renamed as described above