### PR TITLE
fix(warehouse): use systemResourceProjectId for missing meta.project resources

### DIFF
--- a/packages/server/src/data-warehouse/warehouse-sql.int.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.int.test.ts
@@ -6,6 +6,7 @@
 import { DuckDBInstance } from '@duckdb/node-api';
 import pg from 'pg';
 import { loadTestConfig } from '../config/loader';
+import { systemResourceProjectId } from '../constants';
 import { SqlBuilder } from '../fhir/sql';
 import { buildPgConnectionURI } from './config';
 import type { DuckdbConnection } from './warehouse-sql';
@@ -27,6 +28,9 @@ const DEST_TABLE = 'wh_sql_int_dest';
 const PATIENT_ID = '6e586f88-710f-42b2-9cc2-285496264c99';
 const VERSION_ID = 'c227e03f-b6d5-44f7-b191-8571ed508d7e';
 const PROJECT_ID = '71b6dae7-1e96-47ed-babb-c1a0e58a885f';
+
+const LOGIN_ID = 'a1b2c3d4-e5f6-4789-a012-3456789abcde';
+const LOGIN_VERSION_ID = 'b2c3d4e5-f6a7-4890-b123-456789abcdef';
 
 describe('warehouse SQL (integration)', () => {
   let host: string;
@@ -57,7 +61,7 @@ describe('warehouse SQL (integration)', () => {
         );
       `);
       await client.query(
-        `INSERT INTO "${HISTORY_TABLE}" (id, "versionId", content, "lastUpdated") VALUES ($1, $2, $3, $4)`,
+        `INSERT INTO "${HISTORY_TABLE}" (id, "versionId", content, "lastUpdated") VALUES ($1, $2, $3, $4), ($5, $6, $7, $8)`,
         [
           PATIENT_ID,
           VERSION_ID,
@@ -65,6 +69,15 @@ describe('warehouse SQL (integration)', () => {
             resourceType: 'Patient',
             id: PATIENT_ID,
             meta: { project: PROJECT_ID },
+          }),
+          '2024-06-01T12:00:00.000Z',
+          LOGIN_ID,
+          LOGIN_VERSION_ID,
+          JSON.stringify({
+            resourceType: 'Login',
+            id: LOGIN_ID,
+            authMethod: 'password',
+            // Intentionally no meta.project (protected resource)
           }),
           '2024-06-01T12:00:00.000Z',
         ]
@@ -107,14 +120,17 @@ describe('warehouse SQL (integration)', () => {
       `);
 
       const rowCount = await runParameterizedWarehouseSql(connection, insertQuery);
-      expect(rowCount).toBe(1);
+      expect(rowCount).toBe(2);
 
       const readSql = new SqlBuilder();
-      readSql.append(`SELECT id, project_id FROM "${DEST_TABLE}"`);
+      readSql.append(`SELECT id, project_id FROM "${DEST_TABLE}" ORDER BY id`);
       const readResult = await runParameterizedWarehouseSqlReadAll(connection, readSql);
-      const row = readResult.getRowObjectsJson()[0] as { id: string; project_id: string };
-      expect(row.id).toBe(PATIENT_ID);
-      expect(row.project_id).toBe(PROJECT_ID);
+      const rows = readResult.getRowObjectsJson() as { id: string; project_id: string }[];
+      expect(rows).toHaveLength(2);
+
+      const byId = Object.fromEntries(rows.map((row) => [row.id, row.project_id]));
+      expect(byId[PATIENT_ID]).toBe(PROJECT_ID);
+      expect(byId[LOGIN_ID]).toBe(systemResourceProjectId);
     } finally {
       connection.closeSync();
       instance.closeSync();

--- a/packages/server/src/data-warehouse/warehouse-sql.test.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { systemResourceProjectId } from '../constants';
 import { Condition, Conjunction, Constant, SqlBuilder } from '../fhir/sql';
 import type { DuckdbConnection } from './warehouse-sql';
 import {
@@ -11,6 +12,8 @@ import {
   fetchIcebergWatermark,
 } from './warehouse-sql';
 
+const PROJECT_ID_SELECT = `COALESCE(json_extract_string("src"."content"::JSON, '$.meta.project'), '${systemResourceProjectId}') AS "project_id"`;
+
 describe('warehouse SQL query builders', () => {
   test('buildProjectedSelectFromHistoryTableQueryWithSubquery keeps json_extract_string in outer DuckDB layer', () => {
     const sourcePredicate = new Constant(`"lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z'`);
@@ -19,7 +22,7 @@ describe('warehouse SQL query builders', () => {
     sql.appendExpression(query);
 
     expect(sql.toString()).toBe(
-      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1 AND "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z')) AS "src"`
+      `SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", ${PROJECT_ID_SELECT} FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1 AND "lastUpdated" > TIMESTAMPTZ '2024-01-01T00:00:00.000Z')) AS "src"`
     );
     expect(sql.getValues()).toStrictEqual(['']);
   });
@@ -28,7 +31,7 @@ describe('warehouse SQL query builders', () => {
     const projectedSelectQuery = buildSelectFromHistoryTableQuery('Patient_History');
     const insertQuery = buildInsertIntoSelectQuery('iceberg_catalog.default.patient_history', projectedSelectQuery);
     expect(insertQuery.toString()).toBe(
-      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", json_extract_string("src"."content"::JSON, '$.meta.project') AS project_id FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1)) AS "src"`
+      `INSERT INTO "iceberg_catalog"."default"."patient_history" ("id", "version_id", "content", "last_updated", "project_id") SELECT "src"."id", "src"."version_id", "src"."content", "src"."last_updated", ${PROJECT_ID_SELECT} FROM (SELECT "pg_db"."Patient_History"."id", "pg_db"."Patient_History"."versionId" AS "version_id", "pg_db"."Patient_History"."content", "pg_db"."Patient_History"."lastUpdated" AS "last_updated" FROM "pg_db"."Patient_History" WHERE ("pg_db"."Patient_History"."content" IS NOT NULL AND "pg_db"."Patient_History"."content" <> $1)) AS "src"`
     );
     expect(insertQuery.getValues()).toStrictEqual(['']);
   });

--- a/packages/server/src/data-warehouse/warehouse-sql.ts
+++ b/packages/server/src/data-warehouse/warehouse-sql.ts
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { systemResourceProjectId } from '../constants';
 import type { Expression } from '../fhir/sql';
 import {
   Column,
   Condition,
   Conjunction,
+  Constant,
   InsertQuery,
   Parameter,
   SelectQuery,
@@ -176,8 +178,12 @@ export function buildInsertIntoSelectQuery(
 }
 
 /**
- * Constructs a SQL `SELECT` query from a Medplum history Postgres table and extracts the project_id.
- * using the DuckDB's JSON functionality.  This minimizes the load on the source database.
+ * Constructs a SQL `SELECT` query from a Medplum history Postgres table and extracts the project_id
+ * using DuckDB's JSON functionality. This minimizes the load on the source database.
+ *
+ * When `meta.project` is absent from history JSON (protected resources, server-scoped User/Subscription,
+ * system-repo creates, delete tombstones, legacy rows), falls back to {@link systemResourceProjectId}
+ * to match main-table `projectId` and `_project:missing` search semantics.
  *
  * @param sourceHistoryTable - Postgres table identifier exactly as stored (e.g. `Patient_History`).
  * @param sourcePredicate - Optional SQL boolean expression (joined with `AND` after non-empty content filter).
@@ -201,14 +207,23 @@ export function buildSelectFromHistoryTableQuery(
     inner.whereExpr(sourcePredicate);
   }
 
-  const projectIdExpression = `json_extract_string("src"."content"::JSON, '${PROJECT_ID_JSON_PATH}')`;
+  // DuckDB JSON extract + COALESCE; SelectQuery columns are Column-only, so render SqlFunction then attach alias.
+  const projectIdExpr = new SqlFunction('COALESCE', [
+    new SqlFunction('json_extract_string', [
+      new Constant('"src"."content"::JSON'),
+      new Constant(`'${PROJECT_ID_JSON_PATH}'`),
+    ]),
+    new Constant(`'${systemResourceProjectId}'`),
+  ]);
+  const projectIdSql = new SqlBuilder();
+  projectIdSql.appendExpression(projectIdExpr);
 
   return new SelectQuery('src', inner)
     .column('id')
     .column('version_id')
     .column('content')
     .column('last_updated')
-    .raw(`${projectIdExpression} AS project_id`);
+    .column(new Column(undefined, projectIdSql.toString(), true, 'project_id'));
 }
 
 export function buildProjectedSelectFromHistoryTable(


### PR DESCRIPTION
## Summary
- Currently, some resources have a null `$.meta.project`
-  This PR uses `systemResourceProjectId` in that case when syncing to the data warehouse