### PR TITLE
test(server): make "Job not found" say what was missing and what was enqueued

### DIFF
--- a/packages/server/src/workers/test-utils.ts
+++ b/packages/server/src/workers/test-utils.ts
@@ -25,7 +25,8 @@ export async function findAndExecDispatchJob(resource: Resource, interaction: Ba
     (jobData) =>
       jobData.interaction === interaction &&
       jobData.resourceType === resource.resourceType &&
-      jobData.id === resource.id
+      jobData.id === resource.id,
+    `dispatch job for ${resource.resourceType}/${resource.id} ${interaction}`
   );
 }
 
@@ -52,7 +53,9 @@ export async function findAndExecSubscriptionJob(
       jobData.interaction === interaction &&
       jobData.resourceType === resource.resourceType &&
       jobData.id === resource.id &&
-      (!subscription || jobData.subscriptionId === subscription.id)
+      (!subscription || jobData.subscriptionId === subscription.id),
+    `subscription job for ${resource.resourceType}/${resource.id} ${interaction}` +
+      (subscription ? ` matching Subscription/${subscription.id}` : '')
   );
 }
 
@@ -74,7 +77,8 @@ export async function findAndExecDownloadJob(
     getDownloadQueue,
     execDownloadJob,
     (jobData) =>
-      jobData.resourceType === resource.resourceType && jobData.id === resource.id && (!url || jobData.url === url)
+      jobData.resourceType === resource.resourceType && jobData.id === resource.id && (!url || jobData.url === url),
+    `download job for ${resource.resourceType}/${resource.id} ${interaction}` + (url ? ` matching ${url}` : '')
   );
 }
 
@@ -84,21 +88,36 @@ export async function findAndExecDownloadJob(
  * @param getQueue - A function that returns the queue to search for the job. This is necessary because the queue may not be initialized at the time this function is called.
  * @param execJob - A function that executes the job. This is necessary because the job processing logic is defined in the worker, and we want to reuse that logic in our tests.
  * @param matchJob - A function that matches the job data to find the correct job to execute. This is necessary because there may be multiple jobs in the queue, and we want to find the one that matches our criteria.
+ * @param description - Human-readable description of what was being looked for, used in the "Job not found" error.
  * @returns The list of jobs that were executed (there may be more than one if the job was retried).
  */
 async function findAndExecJob(
   getQueue: () => Queue | undefined,
   execJob: (job: Job) => Promise<void>,
-  matchJob: (jobData: any) => boolean
+  matchJob: (jobData: any) => boolean,
+  description: string
 ): Promise<Job[]> {
   const queue = getQueue();
   if (!queue) {
     throw new Error('Queue not initialized');
   }
 
-  const jobData = (queue.add as Mock).mock.calls.find(([_jobName, data]) => matchJob(data))?.[1];
+  const enqueued = (queue.add as Mock).mock.calls.map(([_jobName, data]) => data);
+  const jobData = enqueued.find((data) => matchJob(data));
   if (!jobData) {
-    throw new Error('Job not found');
+    // Say what was being looked for and what was enqueued instead. A bare "Job not found" cannot
+    // distinguish "the subscription was never matched" from "the dispatch job swallowed an error and
+    // enqueued nothing at all", which is the difference between a real bug and a flake.
+    //
+    // Note that `execDispatchJob` catches and only logs errors from `addSubscriptionJobs` /
+    // `addDownloadJobs` / `addCronJobs`, so when nothing was enqueued at all, check the logs for
+    // "Error adding <x> jobs" -- the real cause is there, not here.
+    //
+    // The mock accumulates for the lifetime of the queue, so only the most recent jobs are relevant.
+    throw new Error(
+      `Job not found: no ${description}. ` +
+        `${enqueued.length} job(s) enqueued on this queue, most recent last: ${JSON.stringify(enqueued.slice(-10))}`
+    );
   }
 
   const result: Job[] = [];


### PR DESCRIPTION
## The failure

[This CI run](https://github.com/medplum/medplum/actions/runs/30109653164/attempts/1) failed with:

```
FAIL  src/workers/subscription.test.ts > Subscription Worker > Server-scoped subscription fires across projects when enabled
Error: Job not found
 ❯ findAndExecJob src/workers/test-utils.ts:101:11
 ❯ Module.findAndExecSubscriptionJob src/workers/test-utils.ts:48:10
 ❯ src/workers/subscription.test.ts:682:9
```

**I was not able to reproduce it** — 25 sequential runs of the file plus a full local suite run all pass, so it needs the parallelism of a full CI run. This PR therefore does not claim to fix the flake. It makes the next occurrence diagnosable, because the current message makes it impossible to tell which of two very different things happened.

## Why the message was useless

`Job not found` cannot distinguish:

1. **The subscription was evaluated and skipped** — a config/search problem. Every skip reason in `addSubscriptionJobs` is logged at `debug`, so nothing shows up.
2. **The dispatch job swallowed an error and enqueued nothing at all.** `execDispatchJob` catches errors from `addSubscriptionJobs` and only logs them ([dispatch.ts:146-154](https://github.com/medplum/medplum/blob/main/packages/server/src/workers/dispatch.ts#L146-L154)), so a transient failure looks identical to "no subscription matched". The same CI job hit a `40001 could not serialize access due to read/write dependencies among transactions` in `project.test.ts`, so it was under real DB contention.

## Change

`findAndExecJob` now reports what it was looking for and what was enqueued instead. Actual output, from deliberately breaking the assertion in the "does not fire when disabled" test:

```
Job not found: no subscription job for Patient/8c2640d5-c7c5-4a3b-a0a5-2724cf9753d2 create
matching Subscription/ff8f2a9c-db41-4fc4-9eb6-9c588c0c784f. 1 job(s) enqueued on this queue,
most recent last: [{"subscriptionId":"d497cd0a-fc6d-4286-9bf1-706f1447f60e",
"resourceType":"Patient","channelType":"rest-hook","id":"8c2640d5-...","interaction":"create",...}]
```

That separates the two cases directly: a job enqueued for a *different* subscription means evaluation ran and skipped this one (case 1), while no jobs at all for the resource points at case 2, and the comment tells you to go look for `Error adding <x> jobs` in the logs.

Applies to all three helpers (dispatch, subscription, download). One file, +25/−6. The existing `rejects.toThrow('Job not found')` assertions still match on the prefix.

## Two follow-ups I did not change here

Both are production behavior changes and want a maintainer's call:

1. **`execDispatchJob`'s catch blocks defeat the retry the dispatch worker was built for.** Its own header comment says the worker exists because doing this work inline "made it difficult to retry failed dispatches" — but catching and logging means a transient error permanently drops the subscription, download, and cron fan-out for that resource change, with no retry. Rethrowing (after attempting all three) would let BullMQ retry, at the cost of re-enqueueing already-enqueued jobs.

2. **`getSubscriptions` caps at `count: 1000` with no sort order**, over `_project eq <projectId> or _project pr false`. Because `_project pr false` resolves to `projectId = systemResourceProjectId`, the server-scoped half is a single global bucket shared by every project. Once a project plus that bucket exceed 1000 active subscriptions, some silently stop firing, and which ones is not deterministic. It also makes this test fragile on long-lived dev databases: my local `medplum_test` has already accumulated 17 leaked project-less active subscriptions.

## Test plan

```
cd packages/server
npx vitest run src/workers src/ws/subscriptions.test.ts --no-coverage   # 12 files passed, 258 tests
npx tsc --noEmit                                                        # clean
npx eslint src/workers/test-utils.ts src/workers/subscription.test.ts    # clean
npx prettier --check src/workers/test-utils.ts src/workers/subscription.test.ts
```

`src/workers/reindex.test.ts` fails locally with `permission denied for table User` — pre-existing local DB grant state, reproduces on unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)