### PR TITLE
Fix github actions permissions for OpenSSF Scorecard

### DIFF
--- a/.github/workflows/autofix-ci.yml
+++ b/.github/workflows/autofix-ci.yml
@@ -14,9 +14,9 @@ permissions:
 jobs:
   autofix:
     runs-on: ubuntu-latest
+    # autofix.ci pushes changes via its own GitHub App, not GITHUB_TOKEN
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -31,8 +31,7 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: 'remote:rw'
     permissions:
-      actions: read
-      contents: write
+      contents: read
       id-token: write # Required for OIDC authentication with Azure Trusted Signing
     steps:
       - name: Checkout repository
@@ -230,8 +229,7 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: 'remote:rw'
     permissions:
-      actions: read
-      contents: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -319,8 +317,7 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: 'remote:rw'
     permissions:
-      actions: read
-      contents: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -408,8 +405,7 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: 'remote:rw'
     permissions:
-      actions: read
-      contents: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -23,9 +23,8 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: 'remote:rw'
     permissions:
-      actions: read
-      contents: write
-      id-token: write
+      contents: read
+      id-token: write # Required for OIDC authentication with AWS
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,9 +9,9 @@ jobs:
   chromatic:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # Chromatic authenticates with projectToken, not GITHUB_TOKEN
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,8 @@ on:
     tags:
       - 'v*'
 
+# Every job below declares its own permissions, which replace (not merge with) these
 permissions:
-  id-token: write # Required for OIDC
   contents: read
 
 jobs:
@@ -22,8 +22,7 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: 'remote:rw'
     permissions:
-      actions: read
-      contents: write
+      contents: write # Required to upload release assets
       id-token: write
       pull-requests: write
     steps:
@@ -161,8 +160,7 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: 'remote:rw'
     permissions:
-      actions: read
-      contents: write
+      contents: write # Required to upload release assets
       id-token: write # Required for OIDC authentication with Azure Trusted Signing
     steps:
       - name: Checkout repository
@@ -380,8 +378,7 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: 'remote:rw'
     permissions:
-      actions: read
-      contents: write
+      contents: write # Required to upload release assets
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -473,8 +470,7 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: 'remote:rw'
     permissions:
-      actions: read
-      contents: write
+      contents: write # Required to upload release assets
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,10 +20,9 @@ on:
           - error
           - fatal
 
+# Renovate authenticates with MEDPLUM_BOT_GITHUB_ACCESS_TOKEN, not GITHUB_TOKEN
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   renovate:


### PR DESCRIPTION
Removes unnecessary `GITHUB_TOKEN` write permissions from GitHub Actions workflows to restore the OpenSSF Scorecard `Token-Permissions` check to a passing score.

The check had regressed to a failing score. Reading the current scoring logic in [`ossf/scorecard/checks/evaluation/permissions.go`](https://github.com/ossf/scorecard/blob/main/checks/evaluation/permissions.go) shows that the long list of `Warn: jobLevel 'contents' permission set to 'write'` entries in the report was **not** the cause. Two specific conditions were, and both are fixed here.

No workflow behavior changes. Every permission removed in this PR was verified unused by the steps in that workflow.

## How Scorecard actually scores this

Job-level write permissions are logged as `Warn` but carry **no score penalty** when the workflow declares an explicit read-only top-level block. From the `jobLevelPermissions` branch:

```go
case jobLevelPermissions.Probe:
    dl.Warn(...)                                    // logged, but not yet penalized
    hasWritePermissions["jobLevel"][fPath] = true
    if hasWritePermissions["topLevel"][fPath] {
        score = checker.MinResultScore              // top-level write + job-level write -> 0
        break
    }
    if undeclaredPermissions["topLevel"][fPath] {
        score -= 0.5                                // no top-level block at all -> -0.5
    }
    // explicit top-level read -> no penalty
```

Two things do cost points:

1. **A top-level write on `contents`, `packages`, or `actions`.** The `topLevelPermissions` branch calls `score -= reduceBy(f, dl)`, and `reduceBy` returns `checker.MaxResultScore` (10) for those three tokens. A single occurrence zeroes the entire check.
2. **Any top-level write combined with any job-level write in the same file.** `hasWritePermissions["topLevel"][fPath]` is set for *any* write token — including `id-token: write`, which itself carries no direct penalty — and the job-level branch then hard-sets `score = MinResultScore`.

`renovate.yml` hit condition 1. `publish.yml` hit condition 2. Everything else in the report was noise.

## `permissions.contents` vs `permissions.actions`

These two are easy to conflate, and the difference is why so many `actions: read` lines could be deleted here.

**`contents` governs the repository itself** — Git data and anything derived from it:

| Level | Grants |
| --- | --- |
| `read` | `git clone` / `actions/checkout`, reading files, branches, tags, releases and release assets (`gh release view`) |
| `write` | Pushing commits, creating/deleting branches and tags, creating releases, **uploading release assets** |

**`actions` governs the Actions API surface** — metadata *about* workflows and their runs, not repository content:

| Level | Grants |
| --- | --- |
| `read` | Listing workflow runs, reading run/job logs, enumerating artifacts **belonging to other runs**, reading caches |
| `write` | Cancelling or re-running workflows, deleting artifacts, deleting caches, deleting run logs |

The critical detail: **`actions/upload-artifact` and `actions/download-artifact` do not need the `actions` permission for same-run artifacts.** They talk to the Actions artifact service using the runner's own `ACTIONS_RUNTIME_TOKEN`, which is scoped to the current workflow run and issued independently of `GITHUB_TOKEN`.

`actions: read` becomes necessary only when a step crosses a run boundary — `actions/download-artifact` with an explicit `run-id`, `gh run download`, or reading another run's logs — and, on private or internal repositories, when a step enumerates workflow runs at all. Medplum's repo is public and none of the workflows changed here cross a run boundary, so every `actions: read` in them was inert.

Scorecard groups `contents`, `packages`, and `actions` as its three high-risk tokens because each one offers a distinct route to compromising downstream consumers: `contents` can push malicious code or ship a tampered release, `packages` can publish a malicious artifact, and `actions` can rewrite or erase the CI evidence that would reveal either.

One further gotcha worth internalizing: **a job-level `permissions` block replaces the top-level block outright — the two do not merge.** A job that declares `permissions: { contents: write }` gets `id-token: none`, regardless of what the top level says. This is what made `publish.yml`'s top-level `id-token: write` dead weight rather than load-bearing.

## Changes

### `renovate.yml` — the primary fix

Top-level `contents: write`, `issues: write`, `pull-requests: write` replaced with `contents: read`.

Renovate authenticates with the `MEDPLUM_BOT_GITHUB_ACCESS_TOKEN` secret passed as the action's `token` input. It never uses `GITHUB_TOKEN`, so the entire block was granting write access to nothing. Being at the top level, it triggered `score -= 10`.

### `publish.yml` — the secondary fix

- Removed the top-level `id-token: write`, leaving `contents: read`.
- Removed the redundant `actions: read` from all four jobs.
- Kept `contents: write` on all four jobs, now with an explanatory comment.

All four jobs declare their own `permissions` blocks, so the top-level `id-token: write` reached none of them; the jobs that need OIDC already request it themselves. Its only effect was to set the top-level-write flag that hard-zeroes the score once any job also writes.

The `actions: read` was unused: the `actions/github-script` steps do local `signtool.exe` discovery on the filesystem plus `repos.getReleaseByTag` and `uploadReleaseAsset`, all of which fall under `contents`. `contents: write` is genuinely required for the release asset uploads.

### `build-agent.yml`

All four build jobs: `actions: read` and `contents: write` removed, replaced with `contents: read`. `id-token: write` retained on the Windows job for Azure Trusted Signing OIDC.

This workflow makes no authenticated GitHub API calls at all. It uses `actions/upload-artifact` (runtime token, as described above) and `actions/github-script` for local signtool discovery. It creates no releases — that happens in `publish.yml`.

### `build-deb.yml`

`actions: read` and `contents: write` removed, replaced with `contents: read`. `id-token: write` retained for AWS OIDC.

The `.deb` is published to the APT repository in S3 via `deb-s3` using AWS credentials obtained through `aws-actions/configure-aws-credentials`. Nothing is written back to GitHub.

### `autofix-ci.yml`

Job-level `contents: write` and `pull-requests: write` replaced with `contents: read`.

`autofix-ci/action` is invoked with no inputs. It uploads the computed diff to autofix.ci, and their GitHub App pushes the fix back. Their setup documentation specifies `contents: read` precisely so the runner holds no write capability — the workflow runs untrusted PR code, which makes a read-only token the point rather than an incidental nicety.

### `chromatic.yml`

Job-level `contents: write` and `pull-requests: write` replaced with `contents: read`.

`chromaui/action` receives only `projectToken`. Build statuses are reported by Chromatic's own GitHub App, not through `GITHUB_TOKEN`. `fetch-depth: 0` is retained, since `onlyChanged` needs full Git history.

## Remaining write permissions

After this PR, no workflow declares a top-level write permission of any kind. All remaining writes are job-level and, per the scoring logic above, incur no penalty under an explicit top-level read:

- `contents: write` — `publish.yml` (release asset uploads)
- `id-token: write` — OIDC in `publish.yml`, `build-agent.yml`, `build-deb.yml`, `build-helm-charts.yml`, `deploy.yml`, `staging.yml`, `publish-meta.yml`
- `pull-requests: write` — `build.yml` (Coveralls comments), `labeler.yml`, `assign-pull-request.yml`, `publish.yml`
- `security-events: write` — `codeql-analysis.yml`, `scorecard.yml`
- `contents`/`pull-requests`/`issues`/`id-token: write` — `claude.yml`, which does need them to push commits and comment

## Risk

Low, but CI-visible. Each removal was checked against the steps in its workflow, and the failure mode of a mistake is a loud `403` on the affected step rather than anything silent.

The two paths that warrant attention after merge:

- **`publish.yml`** is the only workflow that still needs `contents: write`, and it runs on tag pushes. Worth watching the next release to confirm asset uploads still succeed.
- **`autofix-ci.yml`** and **`chromatic.yml`** rely on third-party GitHub Apps pushing on their own credentials. Both were verified against vendor documentation and against the fact that neither action is passed a token, but the next PR that triggers an autofix push confirms it end to end.

`renovate.yml` runs on a weekly schedule and also supports `workflow_dispatch`, so it can be dry-run on demand rather than waiting for the next scheduled window.
