### PR TITLE
[Provider] Add "Availability Management" mode

### DIFF
--- a/examples/medplum-provider/src/components/Calendar.test.tsx
+++ b/examples/medplum-provider/src/components/Calendar.test.tsx
@@ -72,6 +72,7 @@ describe('Calendar', () => {
         onSelectAppointment={onSelectAppointment}
         onDoubleClickAppointment={onDoubleClickAppointment}
         onRangeChange={onRangeChange}
+        focus="Appointment"
       />
     );
   };

--- a/examples/medplum-provider/src/components/Calendar.tsx
+++ b/examples/medplum-provider/src/components/Calendar.tsx
@@ -23,7 +23,7 @@ import classes from './Calendar.module.css';
 
 type ExtendedEvent = { type: 'appointment'; appointment: Appointment } | { type: 'slot'; slot: Slot };
 
-function appointmentsToEvents(appointments: Appointment[]): EventInput[] {
+function appointmentsToEvents(appointments: Appointment[], options: { background: boolean }): EventInput[] {
   return appointments
     .filter((appointment) => appointment.status !== 'cancelled' && appointment.start && appointment.end)
     .map((appointment) => {
@@ -43,11 +43,12 @@ function appointmentsToEvents(appointments: Appointment[]): EventInput[] {
         extendedProps: { type: 'appointment', appointment } satisfies ExtendedEvent,
         interactive: true,
         className: cx(classes.appointment, classes[appointment.status]),
+        display: options.background ? 'background' : 'auto',
       };
     });
 }
 
-function slotsToEvents(slots: Slot[]): EventInput[] {
+function slotsToEvents(slots: Slot[], options: { background: boolean }): EventInput[] {
   return slots.map((slot) => ({
     id: slot.id,
     start: slot.start,
@@ -56,7 +57,7 @@ function slotsToEvents(slots: Slot[]): EventInput[] {
     extendedProps: { type: 'slot', slot } satisfies ExtendedEvent,
     interactive: false,
     className: cx(classes.slot, classes[slot.status]),
-    display: 'background',
+    display: options.background ? 'background' : 'auto',
   }));
 }
 
@@ -69,6 +70,7 @@ export function Calendar(props: {
   onDoubleClickAppointment?: (appointment: Appointment) => void;
   onRangeChange?: (range: Range) => void;
   className?: string;
+  focus: 'Appointment' | 'Slot';
 }): JSX.Element {
   const colorScheme = useComputedColorScheme();
   const controller = useCalendarController();
@@ -137,8 +139,11 @@ export function Calendar(props: {
       return true;
     });
 
-    return [...appointmentsToEvents(props.appointments), ...slotsToEvents(filteredSlots)];
-  }, [props.appointments, props.slots]);
+    return [
+      ...appointmentsToEvents(props.appointments, { background: props.focus !== 'Appointment' }),
+      ...slotsToEvents(filteredSlots, { background: props.focus !== 'Slot' }),
+    ];
+  }, [props.appointments, props.slots, props.focus]);
 
   return (
     <div data-testid="calendar" className={cx(classes.wrapper, props.className)}>

--- a/examples/medplum-provider/src/components/schedule/AvailabilityManager.module.css
+++ b/examples/medplum-provider/src/components/schedule/AvailabilityManager.module.css
@@ -1,0 +1,18 @@
+.container {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  gap: var(--mantine-spacing-sm);
+}
+
+.calendarPane {
+  flex-grow: 1;
+  min-height: 0;
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.sidePane {
+  flex-basis: 25%;
+}
+

--- a/examples/medplum-provider/src/components/schedule/AvailabilityManager.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/AvailabilityManager.test.tsx
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { MantineProvider } from '@mantine/core';
+import { Notifications } from '@mantine/notifications';
+import type { WithId } from '@medplum/core';
+import { createReference } from '@medplum/core';
+import type { Slot } from '@medplum/fhirtypes';
+import { DrAliceSmithSchedule, MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { AvailabilityManager } from './AvailabilityManager';
+
+describe('AvailabilityManager', () => {
+  let medplum: MockClient;
+
+  // Anchor test data to today so the Slots fall inside the calendar's initial visible range.
+  const now = new Date();
+  const baseDate = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 10, 0, 0);
+
+  const createSlot = (overrides: Partial<Slot> = {}): WithId<Slot> => ({
+    resourceType: 'Slot',
+    id: 'test-slot-1',
+    status: 'busy',
+    schedule: createReference(DrAliceSmithSchedule),
+    start: new Date(baseDate.getTime()).toISOString(),
+    end: new Date(baseDate.getTime() + 30 * 60 * 1000).toISOString(),
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    medplum = new MockClient();
+    vi.clearAllMocks();
+
+    // The hook searches for Slots by schedule + range; default to none unless a test overrides.
+    medplum.searchResources = vi.fn().mockResolvedValue([]);
+  });
+
+  const setup = async (): Promise<ReturnType<typeof render>> => {
+    const result = render(<AvailabilityManager schedule={DrAliceSmithSchedule} />, {
+      wrapper: ({ children }) => (
+        <MemoryRouter>
+          <MedplumProvider medplum={medplum}>
+            <MantineProvider>
+              <Notifications />
+              {children}
+            </MantineProvider>
+          </MedplumProvider>
+        </MemoryRouter>
+      ),
+    });
+    // Wait for the calendar (and its toolbar) to mount.
+    await waitFor(() => {
+      expect(screen.getByText('Today')).toBeInTheDocument();
+    });
+    return result;
+  };
+
+  describe('Initial rendering', () => {
+    test('renders the panel, help text, and calendar', async () => {
+      await setup();
+
+      expect(screen.getByText('Availability Manager')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Add Blocked Time' })).toBeInTheDocument();
+      expect(screen.getByText(/Click and drag across the calendar/i)).toBeInTheDocument();
+      expect(screen.getByTestId('calendar')).toBeInTheDocument();
+    });
+
+    test('searches for Slots on this schedule within the visible range', async () => {
+      await setup();
+
+      await waitFor(() => {
+        expect(medplum.searchResources).toHaveBeenCalledWith(
+          'Slot',
+          expect.arrayContaining([['schedule', `Schedule/${DrAliceSmithSchedule.id}`]])
+        );
+      });
+    });
+
+    test('renders loaded Slots on the calendar', async () => {
+      medplum.searchResources = vi.fn().mockResolvedValue([createSlot({ status: 'busy' })]);
+      await setup();
+
+      expect(await screen.findByText('Blocked')).toBeInTheDocument();
+    });
+  });
+
+  describe('Add Blocked Time', () => {
+    test('opens the create drawer when clicked', async () => {
+      await setup();
+
+      expect(screen.queryByText('Create Slot')).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add Blocked Time' }));
+
+      // Drawer form fields become visible (the drawer mounts via a transition).
+      expect(await screen.findByLabelText(/Start/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/End/)).toBeInTheDocument();
+      // "Create Slot" appears as both the drawer title and the submit button.
+      expect(screen.getByRole('button', { name: 'Create Slot' })).toBeInTheDocument();
+    });
+
+    test('creates a new Slot and shows a success notification', async () => {
+      const createResource = vi.spyOn(medplum, 'createResource').mockResolvedValue(createSlot());
+      await setup();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add Blocked Time' }));
+      await screen.findByLabelText(/Start/);
+
+      // Fill in the required start/end times before submitting.
+      const startInput = screen.getByLabelText(/Start/);
+      const endInput = screen.getByLabelText(/End/);
+      await userEvent.type(startInput, '2026-08-01T09:00');
+      await userEvent.type(endInput, '2026-08-01T09:30');
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create Slot' }));
+
+      await waitFor(() => {
+        expect(createResource).toHaveBeenCalledWith(expect.objectContaining({ resourceType: 'Slot', status: 'busy' }));
+      });
+      expect(await screen.findByText('Slot created')).toBeInTheDocument();
+
+      // Drawer closes on success.
+      await waitFor(() => {
+        expect(screen.queryByText('Create Slot')).not.toBeInTheDocument();
+      });
+    });
+
+    test('keeps the drawer open and shows an error notification when the save fails', async () => {
+      const createResource = vi.spyOn(medplum, 'createResource').mockRejectedValue(new Error('Network error'));
+      await setup();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add Blocked Time' }));
+      await screen.findByLabelText(/Start/);
+
+      const startInput = screen.getByLabelText(/Start/);
+      const endInput = screen.getByLabelText(/End/);
+      await userEvent.type(startInput, '2026-08-01T09:00');
+      await userEvent.type(endInput, '2026-08-01T09:30');
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create Slot' }));
+
+      await waitFor(() => {
+        expect(createResource).toHaveBeenCalled();
+      });
+      expect(await screen.findByText('Network error')).toBeInTheDocument();
+      // Drawer stays open so the user can retry.
+      expect(screen.getByRole('button', { name: 'Create Slot' })).toBeInTheDocument();
+    });
+  });
+
+  describe('Editing an existing Slot', () => {
+    test('updates the Slot and shows a success notification', async () => {
+      const slot = createSlot({ status: 'busy' });
+      medplum.searchResources = vi.fn().mockResolvedValue([slot]);
+      const updateResource = vi.spyOn(medplum, 'updateResource').mockResolvedValue(slot);
+      await setup();
+
+      await userEvent.click(await screen.findByText('Blocked'));
+      await userEvent.click(await screen.findByRole('button', { name: 'Update Slot' }));
+
+      await waitFor(() => {
+        expect(updateResource).toHaveBeenCalledWith(expect.objectContaining({ id: slot.id }));
+      });
+      expect(await screen.findByText('Slot updated')).toBeInTheDocument();
+    });
+  });
+
+  describe('Drawer dismissal', () => {
+    test('closes the drawer without saving when dismissed', async () => {
+      const createResource = vi.spyOn(medplum, 'createResource');
+      await setup();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add Blocked Time' }));
+      expect(await screen.findByLabelText(/Start/)).toBeInTheDocument();
+
+      // Dismiss the drawer with Escape.
+      await userEvent.keyboard('{Escape}');
+
+      await waitFor(() => {
+        expect(screen.queryByLabelText(/Start/)).not.toBeInTheDocument();
+      });
+      expect(createResource).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/examples/medplum-provider/src/components/schedule/AvailabilityManager.tsx
+++ b/examples/medplum-provider/src/components/schedule/AvailabilityManager.tsx
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Box, Button, Drawer, LoadingOverlay, Stack, Text, Title } from '@mantine/core';
+import type { WithId } from '@medplum/core';
+import { createReference, isResourceWithId } from '@medplum/core';
+import type { Schedule, Slot } from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react';
+import type { JSX } from 'react';
+import { useState } from 'react';
+import { useSchedulingSlots } from '../../hooks/useSchedulingResources';
+import type { Range } from '../../types/scheduling';
+import { showErrorNotification, showSuccessNotification } from '../../utils/notifications';
+import { Calendar } from '../Calendar';
+import classes from './AvailabilityManager.module.css';
+import { SlotForm } from './SlotForm';
+
+export interface AvailabilityManagerProps {
+  schedule: WithId<Schedule>;
+}
+
+export function AvailabilityManager(props: AvailabilityManagerProps): JSX.Element {
+  const [range, setRange] = useState<Range | undefined>(undefined);
+  const [selectedSlot, setSelectedSlot] = useState<Slot | undefined>(undefined);
+  const { slots, loading } = useSchedulingSlots([props.schedule], range);
+
+  const medplum = useMedplum();
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSubmit = async (slot: Slot): Promise<void> => {
+    setIsSaving(true);
+    const isUpdate = isResourceWithId(slot);
+    try {
+      if (isUpdate) {
+        await medplum.updateResource(slot);
+      } else {
+        await medplum.createResource(slot);
+      }
+      showSuccessNotification({
+        title: 'Success',
+        message: isUpdate ? 'Slot updated' : 'Slot created',
+      });
+      setSelectedSlot(undefined);
+    } catch (err) {
+      showErrorNotification(err);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleSelectInterval = (range: Range): void => {
+    setSelectedSlot({
+      resourceType: 'Slot',
+      schedule: createReference(props.schedule),
+      status: 'busy',
+      start: range.start.toISOString(),
+      end: range.end.toISOString(),
+    });
+  };
+
+  return (
+    <>
+      <div className={classes.container}>
+        <Stack gap="sm" h="100%" className={classes.calendarPane}>
+          <Box pos="relative" h="100%">
+            <LoadingOverlay visible={loading} />
+            <Calendar
+              slots={slots ?? []}
+              appointments={[]}
+              onRangeChange={setRange}
+              onSelectInterval={handleSelectInterval}
+              focus="Slot"
+              onSelectSlot={setSelectedSlot}
+            />
+          </Box>
+        </Stack>
+        <Stack gap="sm" className={classes.sidePane}>
+          <Title order={4}>Availability Manager</Title>
+          <Button
+            fullWidth
+            onClick={() =>
+              setSelectedSlot({
+                resourceType: 'Slot',
+                schedule: createReference(props.schedule),
+                status: 'busy',
+                start: '',
+                end: '',
+              })
+            }
+          >
+            Add Blocked Time
+          </Button>
+          <Text size="sm" c="dimmed">
+            Click and drag across the calendar to select a block of time, then set it to <strong>Free</strong> to open
+            it for scheduling or <strong>Busy</strong> to block it off.
+          </Text>
+        </Stack>
+      </div>
+      <Drawer
+        opened={!!selectedSlot}
+        onClose={() => setSelectedSlot(undefined)}
+        position="right"
+        title={
+          <Text size="xl" fw={700}>
+            {isResourceWithId(selectedSlot) ? 'Edit Slot' : 'Create Slot'}
+          </Text>
+        }
+      >
+        {selectedSlot && <SlotForm slot={selectedSlot} isLoading={isSaving} onSubmit={handleSubmit} />}
+      </Drawer>
+    </>
+  );
+}

--- a/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
@@ -140,6 +140,7 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
               appointments={appointments ?? []}
               onRangeChange={setRange}
               onDoubleClickAppointment={handleDoubleClickAppointment}
+              focus="Appointment"
             />
           </Box>
           <Text size="sm" color="dimmed" fs="italic">

--- a/examples/medplum-provider/src/components/schedule/SlotForm.tsx
+++ b/examples/medplum-provider/src/components/schedule/SlotForm.tsx
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Button, Flex, Select, Stack, Textarea } from '@mantine/core';
+import { isResourceWithId } from '@medplum/core';
+import type { Slot } from '@medplum/fhirtypes';
+import { DateTimeInput, Form } from '@medplum/react';
+import { IconCirclePlus } from '@tabler/icons-react';
+import type { JSX } from 'react';
+import { useState } from 'react';
+
+interface SlotFormProps {
+  slot: Slot;
+  isLoading: boolean;
+  onSubmit: (slot: Slot) => void;
+}
+
+export function SlotForm(props: SlotFormProps): JSX.Element {
+  const { isLoading } = props;
+  const { slot } = props;
+  const [status, setStatus] = useState<Slot['status']>(slot.status);
+  const [comment, setComment] = useState(slot.comment);
+  const [start, setStart] = useState(slot.start);
+  const [end, setEnd] = useState(slot.end);
+
+  const handleSubmit = (): void => {
+    props.onSubmit({
+      ...slot,
+      status,
+      start,
+      end,
+      comment,
+    });
+  };
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Flex direction="column" gap="md" h="100%" justify="space-between">
+        <Stack gap="md" h="100%">
+          <DateTimeInput name="start" label="Start" defaultValue={start} required onChange={setStart} />
+
+          <DateTimeInput name="end" label="End" defaultValue={end} required onChange={setEnd} />
+
+          <Select
+            label="Status"
+            value={status}
+            onChange={(value) => setStatus(value as Slot['status'])}
+            data={[
+              { value: 'busy', label: 'Busy' },
+              { value: 'free', label: 'Free' },
+            ]}
+          />
+
+          <Textarea label="Comment" value={comment} onChange={(event) => setComment(event.currentTarget.value)} />
+        </Stack>
+
+        <Button fullWidth type="submit" loading={isLoading} leftSection={<IconCirclePlus />}>
+          {isResourceWithId(slot) ? 'Update Slot' : 'Create Slot'}
+        </Button>
+      </Flex>
+    </Form>
+  );
+}

--- a/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
+++ b/examples/medplum-provider/src/pages/schedule/SchedulePage.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { ActionIcon, Alert, Box, Button, Center, Group, Loader, Stack, Text } from '@mantine/core';
+import { ActionIcon, Alert, Box, Button, Center, Group, Loader, SegmentedControl, Stack, Text } from '@mantine/core';
 import type { WithId } from '@medplum/core';
 import { createReference, isNotFound, normalizeOperationOutcome } from '@medplum/core';
 import type { OperationOutcome, Practitioner, Reference, Schedule } from '@medplum/fhirtypes';
@@ -9,9 +9,13 @@ import { IconAlertCircle, IconSettings } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
+import { AvailabilityManager } from '../../components/schedule/AvailabilityManager';
 import { ScheduleDetails } from '../../components/schedule/ScheduleDetails';
+import { assertNever } from '../../utils/assert';
 import { showErrorNotification } from '../../utils/notifications';
 import classes from './SchedulePage.module.css';
+
+type Mode = 'Scheduling' | 'Availability';
 
 /**
  * Schedule page that displays the practitioner's schedule.
@@ -25,6 +29,7 @@ export function SchedulePage(): JSX.Element | null {
   const profile = useMedplumProfile() as Practitioner;
   const project = medplum.getProject();
   const [schedule, setSchedule] = useState<WithId<Schedule> | undefined>();
+  const [mode, setMode] = useState<Mode>('Scheduling');
 
   const [selectedActor, setSelectedActor] = useState<Reference<Practitioner> | undefined>(
     // When mounting, if no schedule was selected via the URL parameters, default
@@ -189,7 +194,13 @@ export function SchedulePage(): JSX.Element | null {
       mainContent = <OperationOutcomeAlert outcome={readOutcome} m="xl" />;
     }
   } else if (schedule) {
-    mainContent = <ScheduleDetails schedule={schedule} />;
+    if (mode === 'Scheduling') {
+      mainContent = <ScheduleDetails schedule={schedule} />;
+    } else if (mode === 'Availability') {
+      mainContent = <AvailabilityManager schedule={schedule} />;
+    } else {
+      assertNever(mode);
+    }
   } else if (selectedActor) {
     const noScheduleText = selectedActor.display
       ? `No schedule found for ${selectedActor.display}.`
@@ -218,15 +229,22 @@ export function SchedulePage(): JSX.Element | null {
             disabled={isLoadingById}
           />
         </Box>
-        {schedule && schedulingEnabled && (
-          <ActionIcon
-            variant="subtle"
-            aria-label="Schedule settings"
-            onClick={() => navigate(`/Calendar/Schedule/${id}/settings`)}
-          >
-            <IconSettings />
-          </ActionIcon>
-        )}
+        <Group align="center">
+          {schedule && schedulingEnabled && (
+            <ActionIcon
+              variant="subtle"
+              aria-label="Schedule settings"
+              onClick={() => navigate(`/Calendar/Schedule/${id}/settings`)}
+            >
+              <IconSettings />
+            </ActionIcon>
+          )}
+          <SegmentedControl
+            value={mode}
+            onChange={(newMode) => setMode(newMode as Mode)}
+            data={['Scheduling', 'Availability'] satisfies Mode[]}
+          />
+        </Group>
       </Group>
       {mainContent}
     </Stack>


### PR DESCRIPTION
Adds a toggle to the Schedule Page to enter "Availability Management" mode. In this mode the calendar focuses on Slot resources, and allows the viewer to create new Slot resources to manage when they are free or busy.

- Adds an `<AvailabilityManager>` component to wrap all this behavior

- Adds a `<SlotForm>` component to show a focused editing experience

- Click on an existing slot in the calendar to edit it

- Drag over a time range to pre-populate a new slot form for that time range

https://github.com/user-attachments/assets/e88218f9-1d4e-4c9b-a243-d1e1f3f236bd

DRAFT: Stacked on top of #9931, to be rebased after that merges.