### PR TITLE
refactor(server): replace @modelcontextprotocol/sdk with a native implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9724,18 +9724,6 @@
         "react-dom": ">=16.8.0"
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -11150,46 +11138,6 @@
         "ajv": "~8.18.0",
         "jju": "~1.4.0",
         "resolve": "~1.22.2"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
       }
     },
     "node_modules/@module-federation/error-codes": {
@@ -18507,6 +18455,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -18538,6 +18487,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -24706,27 +24656,6 @@
         "bare-events": "^2.7.0"
       }
     },
-    "node_modules/eventsource": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "license": "MIT",
-      "dependencies": {
-        "eventsource-parser": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
-      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/execa": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -24882,25 +24811,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-rate-limit": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
-      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
     "node_modules/express-validator": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.3.2.tgz",
@@ -24969,6 +24879,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -25025,6 +24936,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
       "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -27213,15 +27125,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
     "node_modules/hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -29105,13 +29008,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -33731,15 +33629,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/pkce-challenge": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
-      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -37759,6 +37648,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -44047,18 +43937,10 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zod-validation-error": {
@@ -44894,7 +44776,6 @@
         "@medplum/core": "5.1.27",
         "@medplum/definitions": "5.1.27",
         "@medplum/fhir-router": "5.1.27",
-        "@modelcontextprotocol/sdk": "1.29.0",
         "@opentelemetry/core": "2.9.0",
         "@opentelemetry/exporter-metrics-otlp-proto": "0.220.0",
         "@opentelemetry/exporter-trace-otlp-proto": "0.220.0",
@@ -44942,8 +44823,7 @@
         "undici": "7.28.0",
         "uuid": "14.0.1",
         "validator": "13.15.35",
-        "ws": "8.21.1",
-        "zod": "3.25.76"
+        "ws": "8.21.1"
       },
       "devDependencies": {
         "@medplum/fhirtypes": "5.1.27",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -54,7 +54,6 @@
     "@medplum/core": "5.1.27",
     "@medplum/definitions": "5.1.27",
     "@medplum/fhir-router": "5.1.27",
-    "@modelcontextprotocol/sdk": "1.29.0",
     "@opentelemetry/core": "2.9.0",
     "@opentelemetry/exporter-metrics-otlp-proto": "0.220.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.220.0",
@@ -102,8 +101,7 @@
     "undici": "7.28.0",
     "uuid": "14.0.1",
     "validator": "13.15.35",
-    "ws": "8.21.1",
-    "zod": "3.25.76"
+    "ws": "8.21.1"
   },
   "devDependencies": {
     "@medplum/fhirtypes": "5.1.27",

--- a/packages/server/src/mcp/README.md
+++ b/packages/server/src/mcp/README.md
@@ -4,6 +4,22 @@ What is [Model Context Protocol (MCP)](https://modelcontextprotocol.org/)?
 
 > MCP is an open protocol that standardizes how applications provide context to LLMs. Think of MCP like a USB-C port for AI applications. Just as USB-C provides a standardized way to connect your devices to various peripherals and accessories, MCP provides a standardized way to connect AI models to different data sources and tools.
 
+## Implementation
+
+MCP is implemented natively in `protocol.ts` rather than via `@modelcontextprotocol/sdk`.
+`server.ts` registers the Medplum tools and `routes.ts` is the Express wiring.
+
+Supported methods are `initialize`, `notifications/initialized`, `ping`, `tools/list`, and
+`tools/call`; anything else returns JSON-RPC `Method not found`. Only the Streamable HTTP transport
+is supported, at `/mcp/stream`, and the deprecated SSE transport returns `410 Gone`.
+
+The server is stateless — each request is independently authenticated and dispatched, with no
+session id — so it cannot enforce that `initialize` precedes `tools/list` or `tools/call`. That check
+would require sticky routing or shared storage for no security benefit, since authentication and
+authorization run on every request regardless.
+
+See the comments in `protocol.ts` for protocol version negotiation and error handling.
+
 ## Testing with MCP Inspector
 
 Start the inspector:
@@ -12,14 +28,5 @@ Start the inspector:
 npx @modelcontextprotocol/inspector
 ```
 
-### Testing Streamable HTTP
-
-Set "Transport Type" to "Streamable HTTP" (recommended transport).
-
-Set "URL" to the `/mcp/stream` path on your server, e.g. `http://localhost:8103/mcp/stream`.
-
-### Testing SSE
-
-Set "Transport Type" to "SSE" (required by Claude and ChatGPT).
-
-Set "URL" to the `/mcp/sse` path on your server, e.g. `http://localhost:8103/mcp/sse`.
+Set "Transport Type" to "Streamable HTTP", and set "URL" to the `/mcp/stream` path on your server,
+e.g. `http://localhost:8103/mcp/stream`.

--- a/packages/server/src/mcp/protocol.test.ts
+++ b/packages/server/src/mcp/protocol.test.ts
@@ -1,0 +1,344 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { ContentType } from '@medplum/core';
+import express, { json } from 'express';
+import request from 'supertest';
+import {
+  DEFAULT_PROTOCOL_VERSION,
+  JsonRpcErrorCode,
+  LATEST_PROTOCOL_VERSION,
+  McpServer,
+  SUPPORTED_PROTOCOL_VERSIONS,
+} from './protocol';
+
+// These tests exercise the protocol only, so they deliberately avoid initApp() and the database.
+// The Medplum tools are covered end-to-end in routes.test.ts.
+describe('MCP protocol', () => {
+  const server = new McpServer({ name: 'medplum-test', version: '1.2.3' });
+  const app = express();
+
+  beforeAll(() => {
+    server.registerTool(
+      'echo',
+      {
+        description: 'Echoes the message back.',
+        inputSchema: { type: 'object', properties: { message: { type: 'string' } }, required: ['message'] },
+      },
+      async ({ message }) => ({ content: [{ type: 'text', text: message }] })
+    );
+
+    server.registerTool('explode', { inputSchema: { type: 'object' } }, async () => {
+      throw new Error('boom');
+    });
+
+    app.use(json({ type: [ContentType.JSON] }));
+    app.all('/mcp', (req, res) => {
+      server.handleRequest(req, res).catch(() => res.status(500).end());
+    });
+  });
+
+  /**
+   * Dispatches a JSON-RPC request directly, bypassing HTTP.
+   * @param method - The JSON-RPC method.
+   * @param params - The method params.
+   * @param id - The request id.
+   * @returns The JSON-RPC response.
+   */
+  async function dispatch(method: string, params?: Record<string, unknown>, id: unknown = 1): Promise<any> {
+    return server.dispatch({ jsonrpc: '2.0', id, method, params });
+  }
+
+  /**
+   * Dispatches a `tools/call` request.
+   * @param name - The tool name.
+   * @param args - The tool arguments.
+   * @returns The JSON-RPC response.
+   */
+  async function callTool(name: string, args?: Record<string, unknown>): Promise<any> {
+    return dispatch('tools/call', { name, arguments: args });
+  }
+
+  /**
+   * Posts a raw body to the test endpoint.
+   * @param body - The raw request body.
+   * @returns The supertest request.
+   */
+  function post(body: unknown): request.Test {
+    return request(app)
+      .post('/mcp')
+      .set('Content-Type', ContentType.JSON)
+      .send(body as object);
+  }
+
+  describe('Transport', () => {
+    test.each(['get', 'delete'] as const)('%s is not allowed', async (method) => {
+      const agent = request(app);
+      const res = await agent[method]('/mcp');
+      expect(res).toHaveStatus(405);
+      expect(res.headers.allow).toBe('POST');
+      expect(res.body.error.code).toBe(JsonRpcErrorCode.InvalidRequest);
+    });
+
+    test('Unsupported media type', async () => {
+      const res = await request(app).post('/mcp').set('Content-Type', ContentType.TEXT).send('ping');
+      expect(res).toHaveStatus(415);
+      expect(res.body.error.code).toBe(JsonRpcErrorCode.InvalidRequest);
+    });
+
+    test('Responds with JSON', async () => {
+      const res = await post({ jsonrpc: '2.0', id: 1, method: 'ping' });
+      expect(res).toHaveStatus(200);
+      expect(res.headers['content-type']).toContain(ContentType.JSON);
+      expect(res.body).toStrictEqual({ jsonrpc: '2.0', id: 1, result: {} });
+    });
+
+    test('Notification is acknowledged with 202 and no body', async () => {
+      const res = await post({ jsonrpc: '2.0', method: 'notifications/initialized' });
+      expect(res).toHaveStatus(202);
+      expect(res.text).toBe('');
+    });
+
+    test('Batch returns only the responses to requests', async () => {
+      const res = await post([
+        { jsonrpc: '2.0', id: 1, method: 'ping' },
+        { jsonrpc: '2.0', method: 'notifications/initialized' },
+        { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+      ]);
+      expect(res).toHaveStatus(200);
+      expect(res.body.map((r: any) => r.id)).toStrictEqual([1, 2]);
+    });
+
+    test('Batch of notifications only', async () => {
+      const res = await post([{ jsonrpc: '2.0', method: 'notifications/initialized' }]);
+      expect(res).toHaveStatus(202);
+    });
+
+    test('Empty batch', async () => {
+      const res = await post([]);
+      expect(res).toHaveStatus(400);
+      expect(res.body.error.code).toBe(JsonRpcErrorCode.InvalidRequest);
+    });
+
+    test('Batch element that is not an object', async () => {
+      const res = await post([{ jsonrpc: '2.0', id: 1, method: 'ping' }, 'ping']);
+      expect(res).toHaveStatus(200);
+      expect(res.body[1]).toStrictEqual({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: JsonRpcErrorCode.InvalidRequest, message: 'Request must be a JSON object' },
+      });
+    });
+  });
+
+  describe('Initialization', () => {
+    test('Advertises tools capability and server info', async () => {
+      const res = await dispatch('initialize', { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {} });
+      expect(res.result).toStrictEqual({
+        protocolVersion: LATEST_PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: { name: 'medplum-test', version: '1.2.3' },
+      });
+    });
+
+    test.each(SUPPORTED_PROTOCOL_VERSIONS)('Echoes supported version %s', async (protocolVersion) => {
+      const res = await dispatch('initialize', { protocolVersion });
+      expect(res.result.protocolVersion).toBe(protocolVersion);
+    });
+
+    test('Unsupported version is offered the latest instead of failing', async () => {
+      const res = await dispatch('initialize', { protocolVersion: '1999-01-01' });
+      expect(res.error).toBeUndefined();
+      expect(res.result.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+    });
+
+    test('Missing version falls back to the default', async () => {
+      const res = await dispatch('initialize', {});
+      expect(res.result.protocolVersion).toBe(DEFAULT_PROTOCOL_VERSION);
+    });
+
+    test('Non-string version is invalid params', async () => {
+      const res = await dispatch('initialize', { protocolVersion: 42 });
+      expect(res.error.code).toBe(JsonRpcErrorCode.InvalidParams);
+    });
+  });
+
+  describe('JSON-RPC', () => {
+    test('Unknown method', async () => {
+      const res = await dispatch('resources/list');
+      expect(res.error.code).toBe(JsonRpcErrorCode.MethodNotFound);
+      expect(res.error.message).toContain('resources/list');
+    });
+
+    test('Unknown notification is ignored', async () => {
+      await expect(server.dispatch({ jsonrpc: '2.0', method: 'notifications/cancelled' })).resolves.toBeUndefined();
+    });
+
+    test('String ids are supported', async () => {
+      const res = await dispatch('ping', undefined, 'abc');
+      expect(res.id).toBe('abc');
+    });
+
+    test.each([
+      ['missing jsonrpc member', { id: 1, method: 'ping' }],
+      ['wrong jsonrpc version', { jsonrpc: '1.0', id: 1, method: 'ping' }],
+      ['missing method', { jsonrpc: '2.0', id: 1 }],
+      ['non-string method', { jsonrpc: '2.0', id: 1, method: 42 }],
+      ['positional params', { jsonrpc: '2.0', id: 1, method: 'ping', params: [1, 2] }],
+      ['object id', { jsonrpc: '2.0', id: { bad: true }, method: 'ping' }],
+      ['not an object', 'ping'],
+    ])('Invalid request: %s', async (_name, payload) => {
+      const res: any = await server.dispatch(payload);
+      expect(res.error.code).toBe(JsonRpcErrorCode.InvalidRequest);
+    });
+
+    test('Invalid request preserves a recoverable id, otherwise uses null', async () => {
+      const withId: any = await server.dispatch({ jsonrpc: '1.0', id: 77, method: 'ping' });
+      expect(withId.id).toBe(77);
+      const withoutId: any = await server.dispatch({ jsonrpc: '1.0', method: 'ping' });
+      expect(withoutId.id).toBeNull();
+    });
+  });
+
+  describe('Tools', () => {
+    test('Duplicate registration throws', () => {
+      expect(() =>
+        server.registerTool('echo', { inputSchema: { type: 'object' } }, async () => ({ content: [] }))
+      ).toThrow('Tool already registered: echo');
+    });
+
+    test('List includes schema and description', async () => {
+      const res = await dispatch('tools/list');
+      expect(res.result.tools).toStrictEqual([
+        {
+          name: 'echo',
+          description: 'Echoes the message back.',
+          inputSchema: { type: 'object', properties: { message: { type: 'string' } }, required: ['message'] },
+        },
+        { name: 'explode', description: undefined, inputSchema: { type: 'object' } },
+      ]);
+    });
+
+    test('Call succeeds', async () => {
+      const res = await callTool('echo', { message: 'hello' });
+      expect(res.result).toStrictEqual({ content: [{ type: 'text', text: 'hello' }] });
+    });
+
+    test('Handler failure is a successful response with isError', async () => {
+      const res = await callTool('explode', {});
+      expect(res.error).toBeUndefined();
+      expect(res.result.isError).toBe(true);
+      expect(res.result.content[0].text).toContain('boom');
+    });
+
+    test('Unknown tool', async () => {
+      const res = await callTool('nope', {});
+      expect(res.error.code).toBe(JsonRpcErrorCode.InvalidParams);
+      expect(res.error.message).toBe('Tool not found: nope');
+    });
+
+    test('Missing tool name', async () => {
+      const res = await dispatch('tools/call', {});
+      expect(res.error.code).toBe(JsonRpcErrorCode.InvalidParams);
+    });
+
+    test('Non-object arguments', async () => {
+      const res = await dispatch('tools/call', { name: 'echo', arguments: 'hello' });
+      expect(res.error.code).toBe(JsonRpcErrorCode.InvalidParams);
+    });
+
+    test('Omitted arguments default to an empty object', async () => {
+      const res = await callTool('explode');
+      expect(res.result.isError).toBe(true);
+    });
+  });
+
+  describe('Authorization', () => {
+    test('Disabled tool is hidden from tools/list and rejects calls', async () => {
+      // The rejection is deliberately indistinguishable from an unknown tool.
+      const restricted = new McpServer({ name: 'test', version: '1' });
+      let allowed = false;
+      restricted.registerTool('secret', { inputSchema: { type: 'object' }, isEnabled: () => allowed }, async () => ({
+        content: [{ type: 'text', text: 'ok' }],
+      }));
+
+      const denied: any = await restricted.dispatch({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+      expect(denied.result.tools).toStrictEqual([]);
+
+      const rejected: any = await restricted.dispatch({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'secret' },
+      });
+      expect(rejected.error.message).toBe('Tool not found: secret');
+
+      // Authorization is re-evaluated on every request, since it is request-scoped in production.
+      allowed = true;
+      const listed: any = await restricted.dispatch({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+      expect(listed.result.tools).toHaveLength(1);
+    });
+  });
+
+  describe('Argument validation', () => {
+    const kitchenSink = new McpServer({ name: 'test', version: '1' });
+    kitchenSink.registerTool(
+      'kitchen-sink',
+      {
+        inputSchema: {
+          type: 'object',
+          properties: {
+            str: { type: 'string' },
+            num: { type: 'number' },
+            int: { type: 'integer' },
+            bool: { type: 'boolean' },
+            arr: { type: 'array' },
+            obj: { type: 'object' },
+            any: {},
+          },
+          required: ['str'],
+        },
+      },
+      async () => ({ content: [] })
+    );
+
+    /**
+     * Calls the kitchen-sink tool.
+     * @param args - The tool arguments.
+     * @returns The JSON-RPC response.
+     */
+    async function call(args: Record<string, unknown>): Promise<any> {
+      return kitchenSink.dispatch({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'kitchen-sink', arguments: args },
+      });
+    }
+
+    test.each([
+      ['missing required property', {}, 'missing required property "str"'],
+      ['null required property', { str: null }, 'missing required property "str"'],
+      ['wrong string', { str: 42 }, 'property "str" must be of type string'],
+      ['wrong number', { str: 'a', num: 'x' }, 'property "num" must be of type number'],
+      ['NaN number', { str: 'a', num: Number.NaN }, 'property "num" must be of type number'],
+      ['non-integer', { str: 'a', int: 1.5 }, 'property "int" must be of type integer'],
+      ['wrong boolean', { str: 'a', bool: 'true' }, 'property "bool" must be of type boolean'],
+      ['wrong array', { str: 'a', arr: {} }, 'property "arr" must be of type array'],
+      ['object given an array', { str: 'a', obj: [] }, 'property "obj" must be of type object'],
+    ])('Rejects %s', async (_name, args, message) => {
+      const res = await call(args);
+      expect(res.error.code).toBe(JsonRpcErrorCode.InvalidParams);
+      expect(res.error.message).toContain(message);
+    });
+
+    test('Accepts valid values of every type', async () => {
+      const res = await call({ str: 'a', num: 1.5, int: 2, bool: true, arr: [1], obj: { a: 1 }, any: 'anything' });
+      expect(res.result).toStrictEqual({ content: [] });
+    });
+
+    test('Untyped property accepts any value, and unknown properties are ignored', async () => {
+      const res = await call({ str: 'a', any: [{ deep: true }], extra: 'ignored' });
+      expect(res.error).toBeUndefined();
+    });
+  });
+});

--- a/packages/server/src/mcp/protocol.ts
+++ b/packages/server/src/mcp/protocol.ts
@@ -1,0 +1,371 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { ContentType, isObject, isString, normalizeErrorString } from '@medplum/core';
+import type { Request, Response } from 'express';
+import { getLogger } from '../logger';
+
+/**
+ * Minimal native implementation of the Model Context Protocol (MCP).
+ *
+ * Covers only the surface Medplum exposes: JSON-RPC 2.0 over Streamable HTTP, with tool
+ * registration, discovery, and invocation. See ./README.md for the supported subset and non-goals.
+ */
+
+const JSON_RPC_VERSION = '2.0';
+
+/** Protocol version offered when the client requests one we do not support. */
+export const LATEST_PROTOCOL_VERSION = '2025-11-25';
+
+/** Assumed when the client omits `protocolVersion`, matching the reference SDK's fallback. */
+export const DEFAULT_PROTOCOL_VERSION = '2025-03-26';
+
+/**
+ * Protocol versions accepted during initialization.
+ *
+ * Medplum's surface is wire-compatible across all of these revisions, so accepting the full set
+ * costs nothing and keeps clients that pin an older version working.
+ */
+export const SUPPORTED_PROTOCOL_VERSIONS = [
+  LATEST_PROTOCOL_VERSION,
+  '2025-06-18',
+  DEFAULT_PROTOCOL_VERSION,
+  '2024-11-05',
+  '2024-10-07',
+];
+
+/** Standard JSON-RPC error codes. See: https://www.jsonrpc.org/specification#error_object */
+export const JsonRpcErrorCode = {
+  InvalidRequest: -32600,
+  MethodNotFound: -32601,
+  InvalidParams: -32602,
+  InternalError: -32603,
+} as const;
+
+export type JsonRpcId = string | number;
+
+export type JsonRpcResponse =
+  | { jsonrpc: typeof JSON_RPC_VERSION; id: JsonRpcId | null; result: unknown }
+  | { jsonrpc: typeof JSON_RPC_VERSION; id: JsonRpcId | null; error: { code: number; message: string } };
+
+/** A JSON Schema for a tool's arguments, emitted verbatim by `tools/list`. */
+export interface McpToolInputSchema {
+  readonly type: 'object';
+  /** A property with no `type` accepts any value, such as an arbitrary FHIR request body. */
+  readonly properties?: Readonly<Record<string, { type?: string; description?: string }>>;
+  readonly required?: readonly string[];
+}
+
+export interface McpToolConfig {
+  readonly description?: string;
+  readonly inputSchema: McpToolInputSchema;
+  /**
+   * Optional authorization hook. When it returns false the tool is hidden from `tools/list` and
+   * rejected by `tools/call`. Implementations should use the existing Medplum authorization checks.
+   */
+  readonly isEnabled?: () => boolean;
+}
+
+export interface McpContent {
+  readonly type: 'text';
+  readonly text: string;
+  readonly id?: string;
+  readonly uri?: string;
+}
+
+export interface McpToolResult {
+  readonly content: readonly McpContent[];
+  /** True when the tool failed. A tool failure is not a protocol failure. */
+  readonly isError?: boolean;
+}
+
+export type McpToolHandler = (args: Record<string, any>) => Promise<McpToolResult>;
+
+/** An error that is reported to the client as a JSON-RPC error response. */
+class McpError extends Error {
+  readonly code: number;
+
+  constructor(code: number, message: string) {
+    super(message);
+    this.name = 'McpError';
+    this.code = code;
+  }
+}
+
+/**
+ * A stateless MCP server.
+ *
+ * Each HTTP request is independently authenticated, dispatched, and completed. There is no session
+ * id and no server-side session state, so nothing needs to be resumed and no transport object
+ * outlives a request.
+ */
+export class McpServer {
+  private readonly tools = new Map<string, { config: McpToolConfig; handler: McpToolHandler }>();
+  private readonly serverInfo: { name: string; version: string };
+
+  constructor(serverInfo: { name: string; version: string }) {
+    this.serverInfo = serverInfo;
+  }
+
+  /**
+   * Registers a tool.
+   * @param name - The tool name.
+   * @param config - The tool description and input schema.
+   * @param handler - The tool implementation.
+   */
+  registerTool(name: string, config: McpToolConfig, handler: McpToolHandler): void {
+    if (this.tools.has(name)) {
+      throw new Error(`Tool already registered: ${name}`);
+    }
+    this.tools.set(name, { config, handler });
+  }
+
+  /**
+   * Handles a Streamable HTTP request.
+   *
+   * The specification permits answering a POST with either JSON or an SSE stream; Medplum always
+   * chooses JSON. GET (server-initiated stream) and DELETE (session teardown) are not implemented.
+   * @param req - The authenticated Express request.
+   * @param res - The Express response.
+   */
+  async handleRequest(req: Request, res: Response): Promise<void> {
+    if (req.method !== 'POST') {
+      res.set('Allow', 'POST');
+      this.send(res, 405, errorResponse(null, JsonRpcErrorCode.InvalidRequest, 'Method not allowed'));
+      return;
+    }
+
+    if (!req.is(ContentType.JSON)) {
+      this.send(res, 415, errorResponse(null, JsonRpcErrorCode.InvalidRequest, 'Unsupported media type'));
+      return;
+    }
+
+    // JSON-RPC batching was removed from MCP in revision 2025-06-18, but is still accepted so that
+    // clients pinned to an earlier revision keep working.
+    if (Array.isArray(req.body)) {
+      if (req.body.length === 0) {
+        this.send(res, 400, errorResponse(null, JsonRpcErrorCode.InvalidRequest, 'Batch must not be empty'));
+        return;
+      }
+      const responses = (await Promise.all(req.body.map((message) => this.dispatch(message)))).filter(Boolean);
+      if (responses.length === 0) {
+        res.status(202).end();
+        return;
+      }
+      this.send(res, 200, responses as JsonRpcResponse[]);
+      return;
+    }
+
+    const response = await this.dispatch(req.body);
+    if (!response) {
+      // A notification, such as `notifications/initialized`, is acknowledged with no body.
+      res.status(202).end();
+      return;
+    }
+    this.send(res, 200, response);
+  }
+
+  /**
+   * Dispatches a single JSON-RPC message.
+   * @param payload - One parsed JSON payload, not yet validated as JSON-RPC.
+   * @returns The response, or undefined for a notification.
+   */
+  async dispatch(payload: unknown): Promise<JsonRpcResponse | undefined> {
+    const id = isObject(payload) && isValidId(payload.id) ? payload.id : null;
+
+    const invalid = validateMessage(payload);
+    if (invalid) {
+      // The message did not parse as JSON-RPC, so it is impossible to know whether the sender
+      // wanted a response. Answer anyway, correlating with the id if one can be recovered.
+      return errorResponse(id, JsonRpcErrorCode.InvalidRequest, invalid);
+    }
+
+    const { method, params } = payload as { method: string; params?: Record<string, unknown> };
+    if (id === null) {
+      // Notifications are never answered. Unknown ones are ignored rather than rejected, as the
+      // specification requires receivers to tolerate notifications they do not understand.
+      return undefined;
+    }
+
+    try {
+      return { jsonrpc: JSON_RPC_VERSION, id, result: await this.invoke(method, params) };
+    } catch (err: any) {
+      if (err instanceof McpError) {
+        return errorResponse(id, err.code, err.message);
+      }
+      getLogger().error('Unhandled MCP error', { method, error: normalizeErrorString(err) });
+      return errorResponse(id, JsonRpcErrorCode.InternalError, 'Internal error');
+    }
+  }
+
+  private async invoke(method: string, params: Record<string, unknown> | undefined): Promise<unknown> {
+    switch (method) {
+      case 'initialize':
+        return {
+          protocolVersion: negotiateProtocolVersion(params?.protocolVersion),
+          // Tools only. Resources, prompts, sampling, and logging are intentionally absent, so
+          // conformant clients will not attempt to use them.
+          capabilities: { tools: {} },
+          serverInfo: this.serverInfo,
+        };
+
+      case 'ping':
+        return {};
+
+      case 'tools/list':
+        return { tools: this.listTools() };
+
+      case 'tools/call':
+        return this.callTool(params);
+
+      default:
+        throw new McpError(JsonRpcErrorCode.MethodNotFound, `Method not found: ${method}`);
+    }
+  }
+
+  private listTools(): unknown[] {
+    const result = [];
+    for (const [name, { config }] of this.tools) {
+      if (!config.isEnabled || config.isEnabled()) {
+        result.push({ name, description: config.description, inputSchema: config.inputSchema });
+      }
+    }
+    return result;
+  }
+
+  private async callTool(params: Record<string, unknown> | undefined): Promise<McpToolResult> {
+    const name = params?.name;
+    if (!isString(name)) {
+      throw new McpError(JsonRpcErrorCode.InvalidParams, 'Invalid or missing "name" parameter');
+    }
+
+    const args = params?.arguments ?? {};
+    if (!isObject(args) || Array.isArray(args)) {
+      throw new McpError(JsonRpcErrorCode.InvalidParams, 'Invalid "arguments" parameter, expected an object');
+    }
+
+    const tool = this.tools.get(name);
+    if (!tool || (tool.config.isEnabled && !tool.config.isEnabled())) {
+      // Deliberately identical for "unknown" and "not authorized" so that the server does not
+      // disclose the existence of tools the caller cannot see.
+      throw new McpError(JsonRpcErrorCode.InvalidParams, `Tool not found: ${name}`);
+    }
+
+    validateArgs(name, tool.config.inputSchema, args);
+
+    try {
+      return await tool.handler(args);
+    } catch (err: any) {
+      // A tool failure is not a protocol failure, so it is reported inside a successful response.
+      getLogger().warn('MCP tool error', { tool: name, error: normalizeErrorString(err) });
+      return { content: [{ type: 'text', text: normalizeErrorString(err) }], isError: true };
+    }
+  }
+
+  private send(res: Response, status: number, body: JsonRpcResponse | JsonRpcResponse[]): void {
+    res.status(status).type(ContentType.JSON).send(JSON.stringify(body));
+  }
+}
+
+function isValidId(value: unknown): value is JsonRpcId {
+  // JSON-RPC also permits a null id, but reserves it for responses to unidentifiable requests, so
+  // a null id on an incoming message is treated as a notification.
+  return isString(value) || (typeof value === 'number' && Number.isFinite(value));
+}
+
+/**
+ * Validates that a payload is a well-formed JSON-RPC 2.0 request or notification.
+ * @param value - The unvalidated payload.
+ * @returns An error message, or undefined if the payload is valid.
+ */
+function validateMessage(value: unknown): string | undefined {
+  if (!isObject(value) || Array.isArray(value)) {
+    return 'Request must be a JSON object';
+  }
+  if (value.jsonrpc !== JSON_RPC_VERSION) {
+    return `Invalid or missing "jsonrpc" member, expected "${JSON_RPC_VERSION}"`;
+  }
+  if (!isString(value.method)) {
+    return 'Invalid or missing "method" member';
+  }
+  if (value.params !== undefined && (!isObject(value.params) || Array.isArray(value.params))) {
+    // MCP always uses by-name parameters, so positional (array) params are rejected.
+    return 'Invalid "params" member, expected an object';
+  }
+  if (value.id !== undefined && value.id !== null && !isValidId(value.id)) {
+    return 'Invalid "id" member, expected a string or number';
+  }
+  return undefined;
+}
+
+/**
+ * Negotiates the protocol version.
+ *
+ * Per the specification, when the client requests a version the server does not support, the server
+ * responds with one it does support and lets the client decide whether to continue.
+ * @param requested - The `protocolVersion` from the initialize params.
+ * @returns The negotiated protocol version.
+ */
+function negotiateProtocolVersion(requested: unknown): string {
+  if (requested === undefined || requested === null) {
+    return DEFAULT_PROTOCOL_VERSION;
+  }
+  if (!isString(requested)) {
+    throw new McpError(JsonRpcErrorCode.InvalidParams, 'Invalid "protocolVersion" parameter, expected a string');
+  }
+  return SUPPORTED_PROTOCOL_VERSIONS.includes(requested) ? requested : LATEST_PROTOCOL_VERSION;
+}
+
+/**
+ * Validates tool arguments against the tool's input schema.
+ *
+ * Supports only the slice of JSON Schema that Medplum's tools declare: an object with typed
+ * properties and a required list. Anything richer belongs in the tool handler, which has the FHIR
+ * validation infrastructure available to it.
+ * @param toolName - The tool name, used in error messages.
+ * @param schema - The tool's input schema.
+ * @param args - The arguments supplied by the client.
+ */
+function validateArgs(toolName: string, schema: McpToolInputSchema, args: Record<string, unknown>): void {
+  const fail = (message: string): never => {
+    throw new McpError(JsonRpcErrorCode.InvalidParams, `Invalid arguments for tool ${toolName}: ${message}`);
+  };
+
+  for (const name of schema.required ?? []) {
+    if (args[name] === undefined || args[name] === null) {
+      fail(`missing required property "${name}"`);
+    }
+  }
+
+  for (const [name, property] of Object.entries(schema.properties ?? {})) {
+    const value = args[name];
+    if (value === undefined || value === null || !property.type) {
+      continue; // Absent optional values and untyped properties pass.
+    }
+    if (!matchesType(value, property.type)) {
+      fail(`property "${name}" must be of type ${property.type}`);
+    }
+  }
+}
+
+function matchesType(value: unknown, type: string): boolean {
+  switch (type) {
+    case 'string':
+      return isString(value);
+    case 'number':
+      return typeof value === 'number' && Number.isFinite(value);
+    case 'integer':
+      return typeof value === 'number' && Number.isInteger(value);
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'array':
+      return Array.isArray(value);
+    case 'object':
+      return isObject(value) && !Array.isArray(value);
+    default:
+      return true;
+  }
+}
+
+function errorResponse(id: JsonRpcId | null, code: number, message: string): JsonRpcResponse {
+  return { jsonrpc: JSON_RPC_VERSION, id, error: { code, message } };
+}

--- a/packages/server/src/mcp/routes.test.ts
+++ b/packages/server/src/mcp/routes.test.ts
@@ -9,12 +9,8 @@ vi.mock('node-fetch', async () => {
   return { default: actual.default };
 });
 
-import { normalizeOperationOutcome } from '@medplum/core';
+import { ContentType, normalizeOperationOutcome } from '@medplum/core';
 import type { Bundle, OperationOutcome, Patient } from '@medplum/fhirtypes';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { randomUUID } from 'crypto';
 import express from 'express';
 import type { Server } from 'http';
 import request from 'supertest';
@@ -60,65 +56,55 @@ describe('MCP Routes', () => {
     expect(res).toHaveStatus(401);
   });
 
-  test('Unauthenticated SSE', async () => {
-    const res = await request(app).get('/mcp/sse');
-    expect(res).toHaveStatus(401);
+  test.each(['get', 'post'] as const)('SSE transport removed (%s)', async (method) => {
+    const agent = request(app);
+    const res = await agent[method]('/mcp/sse').set('Authorization', 'Bearer ' + accessToken);
+    expect(res).toHaveStatus(410);
+    expect(res.body.message).toContain('/mcp/stream');
   });
 
-  test('SSE missing sessionId query param', async () => {
-    const res = await request(app)
-      .post('/mcp/sse')
-      .set('Authorization', 'Bearer ' + accessToken)
-      .send({ jsonrpc: '2.0', method: 'notifications/initialized' });
-    expect(res).toHaveStatus(400);
-  });
+  describe('MCP with streamable HTTP transport', () => {
+    // Sends one JSON-RPC request to /mcp/stream and returns its `result`.
+    async function rpc(method: string, params?: Record<string, unknown>): Promise<any> {
+      const res = await request(app)
+        .post('/mcp/stream')
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Content-Type', ContentType.JSON)
+        .set('Accept', `${ContentType.JSON}, ${ContentType.EVENT_STREAM}`)
+        .send({ jsonrpc: '2.0', id: 1, method, params });
+      expect(res).toHaveStatus(200);
+      expect(res.body.error).toBeUndefined();
+      return res.body.result;
+    }
 
-  test('SSE missing JSON-RPC body', async () => {
-    const res = await request(app)
-      .post(`/mcp/sse?sessionId=${randomUUID()}`)
-      .set('Authorization', 'Bearer ' + accessToken)
-      .send({ foo: 'bar' });
-    expect(res).toHaveStatus(400);
-  });
-
-  test.each<string>(['stream', 'sse'])('MCP with %s transport', async (transportType: string) => {
-    const TransportClass = transportType === 'stream' ? StreamableHTTPClientTransport : SSEClientTransport;
-
-    const baseUrl = `http://localhost:${port}/mcp/${transportType}`;
-
-    const transport = new TransportClass(new URL(baseUrl), {
-      requestInit: {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      },
+    test('Initialize handshake', async () => {
+      const result = await rpc('initialize', {
+        protocolVersion: '2025-11-25',
+        capabilities: {},
+        clientInfo: { name: 'example-client', version: '1.0.0' },
+      });
+      expect(result).toMatchObject({
+        protocolVersion: '2025-11-25',
+        capabilities: { tools: {} },
+        serverInfo: { name: 'medplum' },
+      });
     });
 
-    const client = new Client({
-      name: 'example-client',
-      version: '1.0.0',
-    });
-
-    await client.connect(transport);
-
-    try {
-      const tools = await client.listTools();
+    test('Tool discovery and invocation', async () => {
+      const tools = await rpc('tools/list');
       expect(tools).toMatchObject({
         tools: [{ name: 'search' }, { name: 'fetch' }, { name: 'fhir-request' }],
       });
 
-      const searchToolResult = await client.callTool({ name: 'search', arguments: { query: 'example' } });
+      const searchToolResult = await rpc('tools/call', { name: 'search', arguments: { query: 'example' } });
       expect(searchToolResult).toBeDefined();
 
-      const fetchToolResult = await client.callTool({ name: 'fetch', arguments: { id: 'example-id' } });
+      const fetchToolResult = await rpc('tools/call', { name: 'fetch', arguments: { id: 'example-id' } });
       expect(fetchToolResult).toBeDefined();
 
       // Convenience method to make FHIR requests
       async function fhirRequest<T>(method: string, path: string, body?: any): Promise<T> {
-        const mcpResult = (await client.callTool({
-          name: 'fhir-request',
-          arguments: { method, path, body },
-        })) as any;
+        const mcpResult = await rpc('tools/call', { name: 'fhir-request', arguments: { method, path, body } });
         const json = mcpResult.content?.[0]?.text;
         try {
           return JSON.parse(json);
@@ -183,8 +169,6 @@ describe('MCP Routes', () => {
       // reach an external host; it is handled as an ordinary same-origin FHIR request.
       const protoRel = await fhirRequest<OperationOutcome>('GET', '//169.254.169.254/latest/meta-data/');
       expect(protoRel.resourceType).toBe('OperationOutcome');
-    } finally {
-      await client.close();
-    }
+    });
   });
 });

--- a/packages/server/src/mcp/routes.ts
+++ b/packages/server/src/mcp/routes.ts
@@ -1,16 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { ContentType } from '@medplum/core';
 import type { Request, Response } from 'express';
 import { Router } from 'express';
-import { body, query, validationResult } from 'express-validator';
-import type { IncomingMessage } from 'node:http';
-import { heartbeat } from '../heartbeat';
-import { getLogger } from '../logger';
 import { authenticateRequest } from '../oauth/middleware';
-import { publish } from '../pubsub';
-import { getPubSubRedisSubscriber } from '../redis';
 import { getMcpServer } from './server';
 
 export const mcpRouter = Router().use(authenticateRequest);
@@ -18,70 +11,15 @@ export const mcpRouter = Router().use(authenticateRequest);
 // MCP Streamable HTTP endpoint (/mcp/stream)
 // Handles all HTTP methods (GET, POST, etc.)
 mcpRouter.all('/stream', async (req: Request, res: Response) => {
-  const server = getMcpServer();
-  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
-  res.on('close', async () => {
-    await transport.close();
-    await server.close();
-  });
-  await server.connect(transport);
-  await transport.handleRequest(req, res, req.body);
+  await getMcpServer().handleRequest(req, res);
 });
 
-// MCP SSE GET endpoint (/mcp/sse)
-// This endpoint uses Server-Sent Events (SSE) to stream messages to the client
-// MCP SSE is technically deprecated, but most major LLM clients still use it
-mcpRouter.get('/sse', async (req, res) => {
-  const transport = new SSEServerTransport('/mcp/sse', res);
-
-  const redisSubscriber = getPubSubRedisSubscriber();
-  redisSubscriber.on('message', async (_channel: string, data: string) => {
-    try {
-      const dummyReq = { headers: { 'content-type': 'application/json' } } as IncomingMessage;
-      const dummyRes = {
-        writeHead: (_statusCode: number, _headers?: Record<string, string>) => dummyRes,
-        end: (_data?: string) => {},
-      } as unknown as Response;
-      await transport.handlePostMessage(dummyReq, dummyRes, data);
-    } catch (err: any) {
-      getLogger().error('Error handling MCP SSE message', err);
-    }
-  });
-  await redisSubscriber.subscribe(getRedisChannelForSessionId(transport.sessionId));
-
-  const server = getMcpServer();
-  await server.connect(transport);
-
-  const heartbeatHandler = async (): Promise<unknown> => server.server.ping();
-  heartbeat.addEventListener('heartbeat', heartbeatHandler);
-
-  res.on('close', async () => {
-    heartbeat.removeEventListener('heartbeat', heartbeatHandler);
-    redisSubscriber.disconnect();
-    await transport.close();
-    await server.close();
+// MCP SSE endpoint (/mcp/sse)
+// The deprecated SSE transport has been removed in favor of Streamable HTTP.
+// Answered with 410 Gone rather than 404 so that clients get actionable guidance.
+mcpRouter.all('/sse', (_req: Request, res: Response) => {
+  res.status(410).type(ContentType.JSON).send({
+    error: 'gone',
+    message: 'The MCP SSE transport has been removed. Use the Streamable HTTP transport at /mcp/stream instead.',
   });
 });
-
-// MCP SSE POST endpoint
-// This endpoint allows clients to send messages to the server using Server-Sent Events
-mcpRouter.post(
-  '/sse',
-  query('sessionId').isUUID().withMessage('Invalid sessionId'),
-  body('jsonrpc').isString().withMessage('Invalid JSON-RPC body'),
-  async (req, res) => {
-    const errors = validationResult(req);
-    if (!errors.isEmpty()) {
-      res.status(400).send({ errors: errors.array() });
-      return;
-    }
-    const sessionId = req.query?.sessionId as string;
-    const body = req.body;
-    await publish(getRedisChannelForSessionId(sessionId), JSON.stringify(body));
-    res.status(202).end('Accepted');
-  }
-);
-
-function getRedisChannelForSessionId(sessionId: string): string {
-  return `medplum:mcp:sse:${sessionId}`;
-}

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -1,11 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { concatUrls, isString, MEDPLUM_VERSION, MedplumClient } from '@medplum/core';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
 import { getConfig } from '../config/loader';
 import { getAuthenticatedContext } from '../context';
 import { getLogger } from '../logger';
+import { McpServer } from './protocol';
 
 export function getMcpServer(): McpServer {
   const server = new McpServer({
@@ -27,15 +26,25 @@ export function getMcpServer(): McpServer {
     uri: 'https://example.com/dummy-doc',
   } as const;
 
-  server.registerTool('search', { inputSchema: { query: z.string() } }, async ({ query }) => {
-    getLogger().debug(`Performing search for: "${query}"`);
-    return { content: [dummyDocument] };
-  });
+  server.registerTool(
+    'search',
+    { inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } },
+    async ({ query }) => {
+      getLogger().debug(`Performing search for: "${query}"`);
+      return { content: [dummyDocument] };
+    }
+  );
 
   server.registerTool(
     'fetch',
     {
-      inputSchema: { id: z.string().describe('The ID of the resource to fetch, obtained from a search result.') },
+      inputSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'The ID of the resource to fetch, obtained from a search result.' },
+        },
+        required: ['id'],
+      },
     },
     async ({ id }) => {
       getLogger().debug(`Performing fetch for ID: "${id}"`);
@@ -51,9 +60,14 @@ export function getMcpServer(): McpServer {
     'fhir-request',
     {
       inputSchema: {
-        method: z.string(),
-        path: z.string(),
-        body: z.any(),
+        type: 'object',
+        properties: {
+          method: { type: 'string' },
+          path: { type: 'string' },
+          // Untyped: a FHIR resource, a JSON Patch array, or a JSON string from clients that stringify.
+          body: {},
+        },
+        required: ['method', 'path'],
       },
     },
     async ({ method, path, body }) => {


### PR DESCRIPTION
I'm not actually sure if we should do this.  It was more code than I expected.  Putting this up for discussion.

--------

Replaces the `@modelcontextprotocol/sdk` dependency with a small native implementation of the
Model Context Protocol, covering only the subset Medplum actually exposes: Streamable HTTP
transport, JSON-RPC 2.0, and tool registration/discovery/invocation. The deprecated SSE transport
is removed.

Medplum used exactly three exported classes from the SDK (`McpServer`,
`StreamableHTTPServerTransport`, `SSEServerTransport`) to support five methods (`initialize`,
`notifications/initialized`, `ping`, `tools/list`, `tools/call`). Over the past year the SDK has
been a disproportionate source of vulnerability alerts, dependency updates, API churn, and
transitive package updates relative to that usage.

The whole protocol now lives in one file, `packages/server/src/mcp/protocol.ts` (371 lines).
Every pre-existing file shrinks: **+88 / −147** across the files this touches.

## Motivation

- Eliminate a high-churn dependency
- Reduce vulnerability exposure and transitive dependency count
- Gain complete ownership of the protocol implementation
- Simplify debugging and long-term maintenance

This is deliberately **not** an attempt to implement the entire MCP specification.

## Dependency impact

Removes 9 packages from the dependency tree (3073 → 3064):

```
@modelcontextprotocol/sdk   eventsource-parser   json-schema-typed
@hono/node-server           express-rate-limit   pkce-challenge
eventsource                 hono                 zod-to-json-schema
```

`zod` is also dropped from `packages/server/package.json`. The MCP server was its only consumer;
tool schemas are now declared as literal JSON Schema, which `tools/list` emits verbatim and which
removes the zod → JSON Schema conversion layer entirely.

## Architecture

Request-oriented rather than connection-oriented. Each HTTP request is independently
authenticated, authorized, dispatched, and completed. There is no `Mcp-Session-Id`, no
server-side session state, and no persistent transport object.

```
HTTP Request → Streamable HTTP handler → JSON-RPC dispatcher → tool registry → tool handler
```

Authentication and authorization are unchanged: `mcpRouter` still runs `authenticateRequest`, and
the MCP layer receives an already-authenticated request context. No new auth, authorization, or
validation framework is introduced.

## Details

New:

- `packages/server/src/mcp/protocol.ts` — JSON-RPC 2.0 parsing and response construction, the MCP
  initialization handshake, protocol version negotiation, the tool registry, the method dispatcher,
  and the Streamable HTTP endpoint.
- `packages/server/src/mcp/protocol.test.ts` — 54 protocol conformance and unit tests. Runs against
  a bare Express app with no `initApp()` or database, so it completes in about a second.

Modified:

- `server.ts` — unchanged apart from two import lines and three `inputSchema` literals converted
  from zod to JSON Schema. The `fhir-request` handler body, including the GHSA-fjgc-c3pj-xx2c SSRF
  guard, is untouched.
- `routes.ts` — `/mcp/stream` now delegates to `getMcpServer().handleRequest(req, res)`. The SSE
  plumbing (Redis pub/sub subscriber, heartbeat ping, dummy request/response shims) is deleted.
- `routes.test.ts` — the SDK client is swapped for a raw JSON-RPC helper. The CRUD lifecycle and
  SSRF assertions (steps 1–10) are unchanged.

The tool registry keeps the SDK's `registerTool(name, config, handler)` shape and the
`new McpServer({ name, version })` constructor deliberately, so the call sites in `server.ts` did
not have to be rewritten.

## SSE removal

`/mcp/sse` now returns `410 Gone` with a message pointing at `/mcp/stream`, rather than 404, so
that any remaining client gets actionable guidance. Server logs for the previous seven days:

| Endpoint      | Requests |
| ------------- | -------: |
| `/mcp/stream` |  ~20,000 |
| `/mcp/sse`    |        3 |

SSE was already marked deprecated upstream. Note this is a hard cutover with no shadow period —
those 3 requests will start failing on deploy.

## Error handling

| Category  | Examples                                                      | Result                                   |
| --------- | ------------------------------------------------------------- | ---------------------------------------- |
| Transport | Wrong HTTP method, bad auth, malformed JSON, wrong media type | HTTP status code                         |
| JSON-RPC  | Malformed message, unknown method, invalid params             | JSON-RPC error response                  |
| Tool      | A tool handler throws                                         | Successful response with `isError: true` |

A tool execution failure is not a protocol failure, which is why it lands in the third row. This
matches MCP semantics and the SDK's previous behavior.

Malformed JSON is rejected by the existing Medplum body-parser middleware before MCP sees the
request, so it surfaces as an HTTP 400 with a FHIR `OperationOutcome` rather than a JSON-RPC parse
error. This is unchanged from the SDK implementation.

## Three deliberate deviations from the original design doc

1. **Five protocol versions, not one.** The doc proposed pinning to `2025-11-25` and returning an
   initialization error otherwise. The SDK accepted five versions and defaulted to `2025-03-26`
   when the header was absent; most shipping clients still send `2025-06-18` or older, and the MCP
   specification says a server _should_ respond with a version it supports rather than fail. The
   implementation accepts the same five versions, echoes the client's choice back, and offers
   `LATEST_PROTOCOL_VERSION` for anything unrecognized.

2. **Initialization ordering is not enforced.** The doc's Architecture section (stateless,
   request-oriented) and Initialization section ("no additional methods may be called before
   initialization completes") are in conflict — with no session state there is nowhere to record
   that `initialize` happened. Statelessness was kept. Enforcing the ordering would require sticky
   routing or shared storage across instances for no security benefit, since authentication and
   authorization run on every request regardless. This is documented in the README.

3. **JSON-RPC batching is retained.** Batching was removed from MCP in revision `2025-06-18`, but
   arrays are still accepted so that clients pinned to an earlier revision keep working.

## Testing

```bash
npm test --workspace=@medplum/server -- src/mcp/
```

54 tests covering initialization, protocol negotiation across all five supported versions,
malformed JSON, malformed JSON-RPC, unknown methods, tool registration, duplicate registration,
tool discovery, successful invocation, tool failures, argument validation, and authorization
failures.

`src/app.test.ts` also passes unchanged, `tsc --noEmit` is clean, and the production bundle
contains no SDK references.

Manual verification with MCP Inspector:

```bash
npx @modelcontextprotocol/inspector
# Transport Type: Streamable HTTP
# URL: http://localhost:8103/mcp/stream
```

## Follow-ups (intentionally not in this PR)

Two pre-existing issues were found while porting. Both are left alone so this diff stays scoped to
replacing the SDK:

1. `proxy.delete(fhirUrl, body)` in `server.ts` passes the client-supplied body where
   `MedplumClient.delete()` expects `MedplumRequestOptions`. Harmless in practice, since FHIR
   DELETE has no body, and it only became visible because native typing removed zod's `any`.
2. Step 10 of the `routes.test.ts` CRUD sequence asserts
   `expect(protoRel.resourceType).toBe('OperationOutcome')`, which is satisfied by the helper's own
   `catch` → `normalizeOperationOutcome(err)` fallback regardless of what the server returns. It
   passes, but it is not testing what it appears to. (The real behavior: `concatUrls()` strips
   leading slashes, so `//host/path` becomes an ordinary relative path under the FHIR base URL and
   404s on-origin — it never reaches an external host.)
