### PR TITLE
feat(react): add shared modal layout components and unified modal theme

### DIFF
--- a/examples/medplum-provider/src/main.tsx
+++ b/examples/medplum-provider/src/main.tsx
@@ -1,15 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { MantineProvider, Modal, createTheme } from '@mantine/core';
+import { MantineProvider, createTheme } from '@mantine/core';
 import '@mantine/core/styles.css';
 import { Notifications } from '@mantine/notifications';
 import '@mantine/notifications/styles.css';
 import '@mantine/spotlight/styles.css';
 import { MedplumClient } from '@medplum/core';
-import { MedplumProvider } from '@medplum/react';
+import { MedplumProvider, medplumModalTheme } from '@medplum/react';
 import '@medplum/react-scheduling/styles.css';
 import '@medplum/react/styles.css';
-import { IconX } from '@tabler/icons-react';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider, createBrowserRouter } from 'react-router';
@@ -40,42 +39,7 @@ const theme = createTheme({
     xl: '1.125rem',
   },
   components: {
-    Modal: Modal.extend({
-      defaultProps: {
-        padding: 'lg',
-        radius: 'md',
-        closeButtonProps: { icon: <IconX size={18} /> },
-      },
-      styles: {
-        content: {
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
-        },
-        header: {
-          minHeight: 0,
-          padding:
-            'var(--mantine-spacing-sm) var(--mantine-spacing-sm) var(--mantine-spacing-sm) var(--mantine-spacing-lg)',
-          borderBottom: '1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4))',
-          flexShrink: 0,
-          position: 'static',
-        },
-        close: {
-          width: '1.75rem',
-          height: '1.75rem',
-          borderRadius: '999px',
-        },
-        title: {
-          fontWeight: 800,
-        },
-        body: {
-          paddingTop: 'var(--mantine-spacing-lg)',
-          flex: 1,
-          minHeight: 0,
-          overflowY: 'auto',
-        },
-      },
-    }),
+    Modal: medplumModalTheme,
   },
 });
 

--- a/examples/medplum-provider/src/main.tsx
+++ b/examples/medplum-provider/src/main.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { MantineProvider, createTheme } from '@mantine/core';
+import { MantineProvider, Modal, createTheme } from '@mantine/core';
 import '@mantine/core/styles.css';
 import { Notifications } from '@mantine/notifications';
 import '@mantine/notifications/styles.css';
@@ -9,6 +9,7 @@ import { MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react';
 import '@medplum/react-scheduling/styles.css';
 import '@medplum/react/styles.css';
+import { IconX } from '@tabler/icons-react';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider, createBrowserRouter } from 'react-router';
@@ -37,6 +38,44 @@ const theme = createTheme({
     md: '0.875rem',
     lg: '1.0rem',
     xl: '1.125rem',
+  },
+  components: {
+    Modal: Modal.extend({
+      defaultProps: {
+        padding: 'lg',
+        radius: 'md',
+        closeButtonProps: { icon: <IconX size={18} /> },
+      },
+      styles: {
+        content: {
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        },
+        header: {
+          minHeight: 0,
+          padding:
+            'var(--mantine-spacing-sm) var(--mantine-spacing-sm) var(--mantine-spacing-sm) var(--mantine-spacing-lg)',
+          borderBottom: '1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4))',
+          flexShrink: 0,
+          position: 'static',
+        },
+        close: {
+          width: '1.75rem',
+          height: '1.75rem',
+          borderRadius: '999px',
+        },
+        title: {
+          fontWeight: 800,
+        },
+        body: {
+          paddingTop: 'var(--mantine-spacing-lg)',
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+        },
+      },
+    }),
   },
 });
 

--- a/examples/medplum-provider/vite.config.ts
+++ b/examples/medplum-provider/vite.config.ts
@@ -13,19 +13,32 @@ if (!existsSync(path.join(__dirname, '.env'))) {
   copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
 }
 
-// Resolve aliases to local packages when working within the monorepo
-const alias: NonNullable<UserConfig['resolve']>['alias'] = Object.fromEntries(
-  Object.entries({
+// Resolve aliases to local packages when working within the monorepo.
+// Use regex exact-matches for package entrypoints so Vite doesn't follow
+// package.json "exports" to dist, and so `@medplum/react/styles.css` still works.
+const alias: NonNullable<UserConfig['resolve']>['alias'] = [
+  {
+    find: '@medplum/react/styles.css',
+    replacement: path.resolve(__dirname, '../../packages/react/dist/esm/index.css'),
+  },
+  {
+    find: /^@medplum\/react$/,
+    replacement: path.resolve(__dirname, '../../packages/react/src/index.ts'),
+  },
+  {
+    find: /^@medplum\/react-hooks$/,
+    replacement: path.resolve(__dirname, '../../packages/react-hooks/src/index.ts'),
+  },
+  ...Object.entries({
     '@medplum/core': path.resolve(__dirname, '../../packages/core/src'),
     '@medplum/dosespot-react': path.resolve(__dirname, '../../packages/dosespot-react/src'),
     '@medplum/scriptsure-react': path.resolve(__dirname, '../../packages/scriptsure-react/src'),
-    '@medplum/react$': path.resolve(__dirname, '../../packages/react/src'),
-    '@medplum/react/styles.css': path.resolve(__dirname, '../../packages/react/dist/esm/index.css'),
-    '@medplum/react-hooks': path.resolve(__dirname, '../../packages/react-hooks/src'),
     '@medplum/health-gorilla-core': path.resolve(__dirname, '../../packages/health-gorilla-core/src'),
     '@medplum/health-gorilla-react': path.resolve(__dirname, '../../packages/health-gorilla-react/src'),
-  }).filter(([, relPath]) => existsSync(relPath))
-);
+  })
+    .filter(([, replacement]) => existsSync(replacement))
+    .map(([find, replacement]) => ({ find, replacement })),
+].filter((entry) => existsSync(entry.replacement));
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/packages/react/src/ModalActionsFooter/ModalActionsFooter.test.tsx
+++ b/packages/react/src/ModalActionsFooter/ModalActionsFooter.test.tsx
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { render, screen } from '../test-utils/render';
+import { ModalActionsFooter } from './ModalActionsFooter';
+
+describe('ModalActionsFooter', () => {
+  test('Renders children', () => {
+    render(
+      <ModalActionsFooter>
+        <button type="button">Save</button>
+      </ModalActionsFooter>
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDefined();
+  });
+
+  test('Renders multiple actions', () => {
+    render(
+      <ModalActionsFooter>
+        <button type="button">Save</button>
+        <button type="button">Cancel</button>
+      </ModalActionsFooter>
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDefined();
+  });
+
+  test('Renders a divider by default', () => {
+    const { container } = render(
+      <ModalActionsFooter>
+        <button type="button">Save</button>
+      </ModalActionsFooter>
+    );
+    expect(container.querySelector('.mantine-Divider-root')).not.toBeNull();
+  });
+
+  test('Uses a full-bleed top border instead of a divider when sticky', () => {
+    const { container } = render(
+      <ModalActionsFooter sticky>
+        <button type="button">Save</button>
+      </ModalActionsFooter>
+    );
+    // Sticky mirrors the modal header with a border, so the Divider is not used.
+    expect(container.querySelector('.mantine-Divider-root')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDefined();
+  });
+});

--- a/packages/react/src/ModalActionsFooter/ModalActionsFooter.tsx
+++ b/packages/react/src/ModalActionsFooter/ModalActionsFooter.tsx
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Box, Divider, Stack } from '@mantine/core';
+import type { JSX, ReactNode } from 'react';
+
+const modalFooterBorder = '1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4))';
+
+export interface ModalActionsFooterProps {
+  readonly children: ReactNode;
+  /**
+   * Pin footer to modal bottom with a full-bleed top border (mirrors the modal header).
+   * Use with {@link ModalContentLayout} `insetContent` and a fixed-height modal body.
+   */
+  readonly sticky?: boolean;
+}
+
+/**
+ * Divider + full-width action buttons. Use as the footer slot in {@link ModalContentLayout}.
+ * @param props - The ModalActionsFooter React props.
+ * @returns The ModalActionsFooter React node.
+ */
+export function ModalActionsFooter(props: ModalActionsFooterProps): JSX.Element {
+  const { children, sticky } = props;
+
+  if (sticky) {
+    return (
+      <Box flex="0 0 auto" style={{ borderTop: modalFooterBorder }} px="lg" py="lg">
+        <Stack gap="sm">{children}</Stack>
+      </Box>
+    );
+  }
+
+  return (
+    <Stack gap="lg" pt="lg" style={{ flexShrink: 0 }}>
+      <Divider />
+      <Stack gap="sm">{children}</Stack>
+    </Stack>
+  );
+}

--- a/packages/react/src/ModalContentLayout/ModalContentLayout.test.tsx
+++ b/packages/react/src/ModalContentLayout/ModalContentLayout.test.tsx
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { render, screen } from '../test-utils/render';
+import { ModalContentLayout } from './ModalContentLayout';
+
+describe('ModalContentLayout', () => {
+  test('Renders children and footer', () => {
+    render(
+      <ModalContentLayout footer={<button type="button">Save</button>}>
+        <div>Body content</div>
+      </ModalContentLayout>
+    );
+    expect(screen.getByText('Body content')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDefined();
+  });
+
+  test('Renders children before footer in DOM order', () => {
+    render(
+      <ModalContentLayout footer={<span>Footer</span>}>
+        <span>Body</span>
+      </ModalContentLayout>
+    );
+    const body = screen.getByText('Body');
+    const footer = screen.getByText('Footer');
+    // Node.DOCUMENT_POSITION_FOLLOWING (4) means footer comes after body.
+    expect(body.compareDocumentPosition(footer) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  test('Renders both slots when insetContent is set', () => {
+    render(
+      <ModalContentLayout insetContent footer={<button type="button">Submit</button>}>
+        <div>Scrollable body</div>
+      </ModalContentLayout>
+    );
+    expect(screen.getByText('Scrollable body')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDefined();
+  });
+
+  test('insetContent scrolls the content rather than the layout', () => {
+    render(
+      <ModalContentLayout insetContent footer={<span>F</span>}>
+        <span>Inset body</span>
+      </ModalContentLayout>
+    );
+    // The content wrapper owns the overflow so the footer can stay pinned.
+    const contentWrapper = screen.getByText('Inset body').parentElement as HTMLElement;
+    expect(contentWrapper.style.overflowY).toBe('auto');
+  });
+});

--- a/packages/react/src/ModalContentLayout/ModalContentLayout.tsx
+++ b/packages/react/src/ModalContentLayout/ModalContentLayout.tsx
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Box, Stack } from '@mantine/core';
+import type { JSX, ReactNode } from 'react';
+
+export interface ModalContentLayoutProps {
+  readonly children: ReactNode;
+  readonly footer: ReactNode;
+  /** Scroll content in-place with standard modal horizontal/top padding (for sticky modal footers). */
+  readonly insetContent?: boolean;
+}
+
+/**
+ * Standard modal body layout: scrollable content above a pinned action footer.
+ * Pair with {@link ModalActionsFooter} for divider + full-width buttons.
+ * @param props - The ModalContentLayout React props.
+ * @returns The ModalContentLayout React node.
+ */
+export function ModalContentLayout(props: ModalContentLayoutProps): JSX.Element {
+  const { children, footer, insetContent } = props;
+
+  if (insetContent) {
+    return (
+      <Box
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          minHeight: 0,
+        }}
+      >
+        <Box miw={0} px="lg" pt="lg" style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
+          {children}
+        </Box>
+        {footer}
+      </Box>
+    );
+  }
+
+  return (
+    <Stack h="100%" justify="space-between" gap={0}>
+      <Box flex={1} miw={0}>
+        {children}
+      </Box>
+      {footer}
+    </Stack>
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -72,6 +72,8 @@ export * from './Loading/Loading';
 export * from './Logo/Logo';
 export * from './MeasureReportDisplay/MeasureReportDisplay';
 export * from './MedplumLink/MedplumLink';
+export * from './ModalActionsFooter/ModalActionsFooter';
+export * from './ModalContentLayout/ModalContentLayout';
 export * from './MoneyDisplay/MoneyDisplay';
 export * from './MoneyInput/MoneyInput';
 export * from './NoteDisplay/NoteDisplay';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -152,6 +152,7 @@ export * from './ServiceRequestTimeline/ServiceRequestTimeline';
 export * from './SignatureInput/SignatureInput';
 export * from './SmartAppLaunchLink/SmartAppLaunchLink';
 export * from './StatusBadge/StatusBadge';
+export * from './theme/modalTheme';
 export * from './Timeline/Timeline';
 export * from './TimingInput/TimingInput';
 export * from './UnavailableNote/UnavailableNote';

--- a/packages/react/src/theme/modalTheme.test.tsx
+++ b/packages/react/src/theme/modalTheme.test.tsx
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { MantineProvider, Modal, createTheme } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import { medplumModalTheme } from './modalTheme';
+
+function setup(): ReturnType<typeof render> {
+  return render(
+    <MantineProvider theme={createTheme({ components: { Modal: medplumModalTheme } })}>
+      <Modal opened onClose={() => undefined} title="Example">
+        <div>Body content</div>
+      </Modal>
+    </MantineProvider>
+  );
+}
+
+describe('medplumModalTheme', () => {
+  test('Renders a modal with the themed title', () => {
+    setup();
+    expect(screen.getByText('Example')).toBeDefined();
+    expect(screen.getByText('Body content')).toBeDefined();
+  });
+
+  test('Gives the header a bottom border and the title a bold weight', () => {
+    setup();
+    const header = document.querySelector('.mantine-Modal-header') as HTMLElement;
+    const title = document.querySelector('.mantine-Modal-title') as HTMLElement;
+    expect(header.style.borderBottom).toContain('light-dark(');
+    expect(header.style.flexShrink).toBe('0');
+    expect(title.style.fontWeight).toBe('800');
+  });
+
+  test('Makes the body the scrolling region so the header stays put', () => {
+    setup();
+    const content = document.querySelector('.mantine-Modal-content') as HTMLElement;
+    const body = document.querySelector('.mantine-Modal-body') as HTMLElement;
+    expect(content.style.display).toBe('flex');
+    expect(content.style.flexDirection).toBe('column');
+    expect(body.style.overflowY).toBe('auto');
+    expect(body.style.flexGrow).toBe('1');
+  });
+
+  test('Renders a round close button', () => {
+    setup();
+    const close = document.querySelector('.mantine-Modal-close') as HTMLElement;
+    expect(close).toBeDefined();
+    expect(close.style.borderRadius).toBe('999px');
+  });
+});

--- a/packages/react/src/theme/modalTheme.tsx
+++ b/packages/react/src/theme/modalTheme.tsx
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Modal } from '@mantine/core';
+import { IconX } from '@tabler/icons-react';
+
+/**
+ * Shared Mantine theme override for modals, giving every modal the same header
+ * (bottom border, bold title, round close button) and a content shell that lets
+ * `ModalContentLayout` scroll its body while `ModalActionsFooter` stays pinned.
+ *
+ * Lives here rather than in an individual app so the apps and Storybook render
+ * modals identically. Apply it via the theme's `components` map:
+ *
+ * ```tsx
+ * createTheme({ components: { Modal: medplumModalTheme } });
+ * ```
+ */
+export const medplumModalTheme = Modal.extend({
+  defaultProps: {
+    padding: 'lg',
+    radius: 'md',
+    closeButtonProps: { icon: <IconX size={18} /> },
+  },
+  styles: {
+    content: {
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
+    },
+    header: {
+      minHeight: 0,
+      padding:
+        'var(--mantine-spacing-sm) var(--mantine-spacing-sm) var(--mantine-spacing-sm) var(--mantine-spacing-lg)',
+      borderBottom: '1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4))',
+      flexShrink: 0,
+      position: 'static',
+    },
+    close: {
+      width: '1.75rem',
+      height: '1.75rem',
+      borderRadius: '999px',
+    },
+    title: {
+      fontWeight: 800,
+    },
+    body: {
+      paddingTop: 'var(--mantine-spacing-lg)',
+      flex: 1,
+      minHeight: 0,
+      overflowY: 'auto',
+    },
+  },
+});

--- a/packages/storybook/.storybook/themes.ts
+++ b/packages/storybook/.storybook/themes.ts
@@ -1,4 +1,5 @@
 import { createTheme, MantineThemeOverride } from '@mantine/core';
+import { medplumModalTheme } from '@medplum/react';
 
 const medplumDefault = createTheme({
   headings: {
@@ -16,6 +17,11 @@ const medplumDefault = createTheme({
     md: '0.875rem',
     lg: '1.0rem',
     xl: '1.125rem',
+  },
+  // Only the Medplum preset gets our modal chrome; the other presets exist to show
+  // how these components look under a host app's own theme.
+  components: {
+    Modal: medplumModalTheme,
   },
 });
 


### PR DESCRIPTION
This PR creates a standardized (and reusable) modal layout for use across all Medplum products (Admin and Provider apps). It adds `ModalContentLayout` and `ModalActionsFooter` to @medplum/react to create a consistent header, scrollable body section, and footer with divider and full-width buttons. This removes the need for per-modal styles and hacks at each call site.

NOTE: Please see #9964 for implementation across all existing modals. 

---

### **Reference Image**
<img width="910" height="643" alt="Screenshot 2026-08-04 at 12 23 15 PM" src="https://github.com/user-attachments/assets/36f44678-665e-4d36-89b2-73c15865188b" />