### PR TITLE
refactor: unify modal layout and styling across the app

### DIFF
--- a/examples/medplum-provider/src/components/ChargeItem/ChargeItemList.tsx
+++ b/examples/medplum-provider/src/components/ChargeItem/ChargeItemList.tsx
@@ -5,7 +5,13 @@ import { useDisclosure } from '@mantine/hooks';
 import type { WithId } from '@medplum/core';
 import { createReference, HTTP_HL7_ORG } from '@medplum/core';
 import type { ChargeItem, ChargeItemDefinition, CodeableConcept, Encounter, Patient } from '@medplum/fhirtypes';
-import { AsyncAutocomplete, CodeableConceptInput, useMedplum } from '@medplum/react';
+import {
+  AsyncAutocomplete,
+  CodeableConceptInput,
+  ModalActionsFooter,
+  ModalContentLayout,
+  useMedplum,
+} from '@medplum/react';
 import { IconPlus } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useCallback, useEffect, useState } from 'react';
@@ -194,49 +200,53 @@ function AddChargeItemModal({ opened, onClose, onSubmit }: AddChargeItemModalPro
 
   return (
     <Modal opened={opened} onClose={handleClose} title="Add Charge Item" size="md">
-      <Stack gap="md">
-        <CodeableConceptInput
-          binding="http://www.ama-assn.org/go/cpt/vs"
-          label="CPT Code"
-          name="cptCode"
-          path="ChargeItem.code"
-          placeholder="Search for CPT code..."
-          required
-          onChange={setCptCode}
-        />
-
-        <Box>
-          <Text size="sm" fw={500} mb={5}>
-            Charge Item Definition{' '}
-            <Text span c="red">
-              *
-            </Text>
-          </Text>
-          <AsyncAutocomplete
-            placeholder="Search for charge item definition..."
-            onChange={handleSelectChargeItemDefinition}
-            toOption={(item: unknown) => {
-              const resource = item as ChargeItemDefinition;
-              return {
-                value: resource.id || '',
-                label: resource.title || resource.id || 'Untitled',
-                resource: resource,
-              };
-            }}
-            maxValues={1}
-            loadOptions={loadChargeItemDefinitions}
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <Button variant="filled" w="100%" onClick={handleSubmit} disabled={!cptCode || !chargeItemDefinition}>
+              Add Charge Item
+            </Button>
+            <Button variant="subtle" w="100%" onClick={handleClose}>
+              Cancel
+            </Button>
+          </ModalActionsFooter>
+        }
+      >
+        <Stack gap="md">
+          <CodeableConceptInput
+            binding="http://www.ama-assn.org/go/cpt/vs"
+            label="CPT Code"
+            name="cptCode"
+            path="ChargeItem.code"
+            placeholder="Search for CPT code..."
+            required
+            onChange={setCptCode}
           />
-        </Box>
 
-        <Flex justify="flex-end" gap="sm" mt="md">
-          <Button variant="subtle" onClick={handleClose}>
-            Cancel
-          </Button>
-          <Button onClick={handleSubmit} disabled={!cptCode || !chargeItemDefinition}>
-            Add Charge Item
-          </Button>
-        </Flex>
-      </Stack>
+          <Box>
+            <Text size="sm" fw={500} mb={5}>
+              Charge Item Definition{' '}
+              <Text span c="red">
+                *
+              </Text>
+            </Text>
+            <AsyncAutocomplete
+              placeholder="Search for charge item definition..."
+              onChange={handleSelectChargeItemDefinition}
+              toOption={(item: unknown) => {
+                const resource = item as ChargeItemDefinition;
+                return {
+                  value: resource.id || '',
+                  label: resource.title || resource.id || 'Untitled',
+                  resource: resource,
+                };
+              }}
+              maxValues={1}
+              loadOptions={loadChargeItemDefinitions}
+            />
+          </Box>
+        </Stack>
+      </ModalContentLayout>
     </Modal>
   );
 }

--- a/examples/medplum-provider/src/components/Conditions/ConditionModal.tsx
+++ b/examples/medplum-provider/src/components/Conditions/ConditionModal.tsx
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Group, Stack } from '@mantine/core';
+import { Stack } from '@mantine/core';
 import { addProfileToResource, createReference, HTTP_HL7_ORG, HTTP_TERMINOLOGY_HL7_ORG } from '@medplum/core';
 import type { CodeableConcept, Condition, Encounter, Patient } from '@medplum/fhirtypes';
-import { CodeableConceptInput, Form, SubmitButton } from '@medplum/react';
+import { CodeableConceptInput, Form, ModalActionsFooter, ModalContentLayout, SubmitButton } from '@medplum/react';
 import type { JSX } from 'react';
 import { useCallback, useState } from 'react';
 import { showErrorNotification } from '../../utils/notifications';
@@ -55,30 +55,35 @@ export default function ConditionModal(props: ConditionDialogProps): JSX.Element
 
   return (
     <Form onSubmit={handleSubmit}>
-      <Stack>
-        <CodeableConceptInput
-          binding="http://hl7.org/fhir/sid/icd-10-cm/vs/billable"
-          label="ICD-10 Code"
-          name="diagnosis"
-          path="Condition.code"
-          required
-          maxValues={1}
-          onChange={(diagnosis) => setDiagnosis(diagnosis)}
-        />
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <SubmitButton fullWidth>Save</SubmitButton>
+          </ModalActionsFooter>
+        }
+      >
+        <Stack gap="md">
+          <CodeableConceptInput
+            binding="http://hl7.org/fhir/sid/icd-10-cm/vs/billable"
+            label="ICD-10 Code"
+            name="diagnosis"
+            path="Condition.code"
+            required
+            maxValues={1}
+            onChange={(diagnosis) => setDiagnosis(diagnosis)}
+          />
 
-        <CodeableConceptInput
-          name="clinicalStatus"
-          label="Status"
-          path="Condition.clinicalStatus"
-          maxValues={1}
-          binding={HTTP_HL7_ORG + '/fhir/ValueSet/condition-clinical'}
-          onChange={(clinicalStatus) => setClinicalStatus(clinicalStatus)}
-          required
-        />
-        <Group justify="flex-end" gap={4} mt="md">
-          <SubmitButton>Save</SubmitButton>
-        </Group>
-      </Stack>
+          <CodeableConceptInput
+            name="clinicalStatus"
+            label="Status"
+            path="Condition.clinicalStatus"
+            maxValues={1}
+            binding={HTTP_HL7_ORG + '/fhir/ValueSet/condition-clinical'}
+            onChange={(clinicalStatus) => setClinicalStatus(clinicalStatus)}
+            required
+          />
+        </Stack>
+      </ModalContentLayout>
     </Form>
   );
 }

--- a/examples/medplum-provider/src/components/encounter/EncounterHeader.tsx
+++ b/examples/medplum-provider/src/components/encounter/EncounterHeader.tsx
@@ -4,6 +4,7 @@ import { ActionIcon, Box, Button, Flex, Group, Menu, Modal, Paper, SegmentedCont
 import { useDisclosure } from '@mantine/hooks';
 import { formatDate, formatHumanName } from '@medplum/core';
 import type { Encounter, Patient, Practitioner, Reference } from '@medplum/fhirtypes';
+import { ModalActionsFooter, ModalContentLayout } from '@medplum/react';
 import { IconChevronDown, IconLock, IconLockOpen, IconShieldCheck } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useState } from 'react';
@@ -210,20 +211,27 @@ export const EncounterHeader = (props: EncounterHeaderProps): JSX.Element => {
       </Paper>
 
       <Modal opened={confirmOpened} onClose={closeConfirm}>
-        <Text size="lg" fw={500}>
-          Are you sure you want to cancel this encounter?
-        </Text>
-        <Text size="sm" c="dimmed" mt="xs">
-          This action cannot be undone.
-        </Text>
-        <Group justify="flex-end" mt="xl" gap="xs">
-          <Button onClick={closeConfirm} color="red" variant="outline">
-            No, keep it
-          </Button>
-          <Button onClick={confirmStatusChange} color="red">
-            Yes, cancel it
-          </Button>
-        </Group>
+        <ModalContentLayout
+          footer={
+            <ModalActionsFooter>
+              <Button onClick={confirmStatusChange} color="red" w="100%">
+                Yes, cancel it
+              </Button>
+              <Button onClick={closeConfirm} color="red" variant="outline" w="100%">
+                No, keep it
+              </Button>
+            </ModalActionsFooter>
+          }
+        >
+          <Stack gap="md">
+            <Text size="lg" fw={500}>
+              Are you sure you want to cancel this encounter?
+            </Text>
+            <Text size="sm" c="dimmed">
+              This action cannot be undone.
+            </Text>
+          </Stack>
+        </ModalContentLayout>
       </Modal>
 
       <Modal opened={signOpened} onClose={closeSign} title="Signing As">

--- a/examples/medplum-provider/src/components/encounter/SignLockDialog.tsx
+++ b/examples/medplum-provider/src/components/encounter/SignLockDialog.tsx
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Button, Group, Paper, Stack, Text } from '@mantine/core';
+import { Button, Group, Paper, Text } from '@mantine/core';
 import { createReference } from '@medplum/core';
 import type { Practitioner, Reference } from '@medplum/fhirtypes';
-import { ResourceAvatar, useMedplumProfile } from '@medplum/react';
+import { ModalActionsFooter, ModalContentLayout, ResourceAvatar, useMedplumProfile } from '@medplum/react';
 import { IconLock, IconSignature } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { showErrorNotification } from '../../utils/notifications';
@@ -27,7 +27,23 @@ export const SignLockDialog = (props: SignLockDialogProps): JSX.Element => {
   };
 
   return (
-    <Stack gap="md">
+    <ModalContentLayout
+      footer={
+        <ModalActionsFooter>
+          <Button fullWidth leftSection={<IconLock size={18} />} onClick={() => handleSign(true)}>
+            Sign & Lock Note
+          </Button>
+          <Button
+            variant="outline"
+            fullWidth
+            leftSection={<IconSignature size={18} />}
+            onClick={() => handleSign(false)}
+          >
+            Just Sign
+          </Button>
+        </ModalActionsFooter>
+      }
+    >
       <Paper p="sm" withBorder radius="md">
         <Group gap="sm">
           <ResourceAvatar value={authorReference} radius="xl" size={36} />
@@ -36,22 +52,6 @@ export const SignLockDialog = (props: SignLockDialogProps): JSX.Element => {
           </Text>
         </Group>
       </Paper>
-
-      <Stack gap={0}>
-        <Button fullWidth leftSection={<IconLock size={18} />} onClick={() => handleSign(true)} mt="md">
-          Sign & Lock Note
-        </Button>
-
-        <Button
-          variant="outline"
-          fullWidth
-          leftSection={<IconSignature size={18} />}
-          onClick={() => handleSign(false)}
-          mt="md"
-        >
-          Just Sign
-        </Button>
-      </Stack>
-    </Stack>
+    </ModalContentLayout>
   );
 };

--- a/examples/medplum-provider/src/components/encounter/SubmitClaimModal.tsx
+++ b/examples/medplum-provider/src/components/encounter/SubmitClaimModal.tsx
@@ -4,6 +4,7 @@ import { Box, Button, Card, Checkbox, Divider, Grid, Group, Modal, Stack, Text }
 import type { WithId } from '@medplum/core';
 import { createReference, formatHumanName } from '@medplum/core';
 import type { Condition, Coverage, Patient, Practitioner, Reference } from '@medplum/fhirtypes';
+import { ModalActionsFooter, ModalContentLayout } from '@medplum/react';
 import { IconArrowUpRight } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useState } from 'react';
@@ -172,105 +173,111 @@ const ClaimReviewPanel = (props: ClaimReviewPanelProps): JSX.Element => {
   const canSubmit = billingType === 'self-pay' || selectedIds.size > 0;
 
   return (
-    <Stack gap="xl">
-      <Text size="sm" c="dimmed">
-        {patientName}
-      </Text>
-      <Box>
-        <Text size="xs" tt="uppercase" fw={600} c="dimmed" mb={8}>
-          Billing Type
-        </Text>
-        <Button.Group style={{ width: '100%' }}>
+    <ModalContentLayout
+      footer={
+        <ModalActionsFooter>
+          {onSubmitToStedi && (
+            <Button
+              size="md"
+              variant="outline"
+              rightSection={<IconArrowUpRight size={16} />}
+              disabled={!canSubmit}
+              w="100%"
+              onClick={() => handleSubmit(onSubmitToStedi)}
+            >
+              Submit to Stedi
+            </Button>
+          )}
           <Button
             size="md"
-            variant={billingType === 'insurance' ? 'filled' : 'default'}
-            onClick={() => setBillingType('insurance')}
-            style={{ flex: 1 }}
-            disabled={insuranceCoverages.length === 0}
-          >
-            Insurance pay
-          </Button>
-          <Button
-            size="md"
-            variant={billingType === 'self-pay' ? 'filled' : 'default'}
-            onClick={() => setBillingType('self-pay')}
-            style={{ flex: 1 }}
-          >
-            Self-pay
-          </Button>
-        </Button.Group>
-      </Box>
-
-      {billingType === 'insurance' && insuranceCoverages.length > 0 && (
-        <Box>
-          <Group justify="space-between" mb={8}>
-            <Text size="xs" tt="uppercase" fw={600} c="dimmed">
-              Coverage on file
-            </Text>
-            {insuranceCoverages.length > 1 && (
-              <Button variant="subtle" size="xs" onClick={toggleCoverageAll}>
-                {selectedIds.size === insuranceCoverages.length ? 'Deselect all' : 'Select all'}
-              </Button>
-            )}
-          </Group>
-          <Box style={{ maxHeight: 320, overflowY: 'auto' }}>
-            <Stack gap="sm" pr={6}>
-              {insuranceCoverages.map((coverage) => (
-                <CoverageCard
-                  key={coverage.id}
-                  coverage={coverage}
-                  selected={selectedIds.has(coverage.id)}
-                  onToggle={() => toggleCoverage(coverage.id)}
-                />
-              ))}
-            </Stack>
-          </Box>
-        </Box>
-      )}
-
-      <Divider />
-
-      <Grid gutter="lg">
-        <Grid.Col span={6}>
-          <Text size="xs" c="dimmed" mb={4}>
-            Diagnosis
-          </Text>
-          <Text size="sm" fw={600}>
-            {diagnosisText}
-          </Text>
-        </Grid.Col>
-        <Grid.Col span={6}>
-          <Text size="xs" c="dimmed" mb={4}>
-            Practitioner
-          </Text>
-          <Text size="sm" fw={600}>
-            {practitionerName}
-          </Text>
-        </Grid.Col>
-      </Grid>
-
-      <Group justify="flex-end">
-        {onSubmitToStedi && (
-          <Button
-            size="md"
-            variant="outline"
             rightSection={<IconArrowUpRight size={16} />}
             disabled={!canSubmit}
-            onClick={() => handleSubmit(onSubmitToStedi)}
+            w="100%"
+            onClick={() => handleSubmit(onSubmitClaim)}
           >
-            Submit to Stedi
+            Submit to Candid
           </Button>
+        </ModalActionsFooter>
+      }
+    >
+      <Stack gap="md">
+        <Text size="sm" c="dimmed">
+          {patientName}
+        </Text>
+        <Box>
+          <Text size="xs" tt="uppercase" fw={600} c="dimmed" mb={8}>
+            Billing Type
+          </Text>
+          <Button.Group style={{ width: '100%' }}>
+            <Button
+              size="md"
+              variant={billingType === 'insurance' ? 'filled' : 'default'}
+              onClick={() => setBillingType('insurance')}
+              style={{ flex: 1 }}
+              disabled={insuranceCoverages.length === 0}
+            >
+              Insurance pay
+            </Button>
+            <Button
+              size="md"
+              variant={billingType === 'self-pay' ? 'filled' : 'default'}
+              onClick={() => setBillingType('self-pay')}
+              style={{ flex: 1 }}
+            >
+              Self-pay
+            </Button>
+          </Button.Group>
+        </Box>
+
+        {billingType === 'insurance' && insuranceCoverages.length > 0 && (
+          <Box>
+            <Group justify="space-between" mb={8}>
+              <Text size="xs" tt="uppercase" fw={600} c="dimmed">
+                Coverage on file
+              </Text>
+              {insuranceCoverages.length > 1 && (
+                <Button variant="subtle" size="xs" onClick={toggleCoverageAll}>
+                  {selectedIds.size === insuranceCoverages.length ? 'Deselect all' : 'Select all'}
+                </Button>
+              )}
+            </Group>
+            <Box style={{ maxHeight: 320, overflowY: 'auto' }}>
+              <Stack gap="md" pr={6}>
+                {insuranceCoverages.map((coverage) => (
+                  <CoverageCard
+                    key={coverage.id}
+                    coverage={coverage}
+                    selected={selectedIds.has(coverage.id)}
+                    onToggle={() => toggleCoverage(coverage.id)}
+                  />
+                ))}
+              </Stack>
+            </Box>
+          </Box>
         )}
-        <Button
-          size="md"
-          rightSection={<IconArrowUpRight size={16} />}
-          disabled={!canSubmit}
-          onClick={() => handleSubmit(onSubmitClaim)}
-        >
-          Submit to Candid
-        </Button>
-      </Group>
-    </Stack>
+
+        <Divider />
+
+        <Grid gutter="lg">
+          <Grid.Col span={6}>
+            <Text size="xs" c="dimmed" mb={4}>
+              Diagnosis
+            </Text>
+            <Text size="sm" fw={600}>
+              {diagnosisText}
+            </Text>
+          </Grid.Col>
+          <Grid.Col span={6}>
+            <Text size="xs" c="dimmed" mb={4}>
+              Practitioner
+            </Text>
+            <Text size="sm" fw={600}>
+              {practitionerName}
+            </Text>
+          </Grid.Col>
+        </Grid>
+      </Stack>
+    </ModalContentLayout>
   );
 };
 
@@ -308,7 +315,7 @@ export const SubmitClaimModal = (props: SubmitClaimModalProps): JSX.Element => {
     !selectedIsSelfPay && insuranceCoverages.length > 0 ? 'insurance' : 'self-pay';
 
   return (
-    <Modal opened={opened} onClose={onClose} centered size="lg" padding="xl" title="Review before submitting claim">
+    <Modal opened={opened} onClose={onClose} centered size="lg" title="Review before submitting claim">
       {opened && (
         <ClaimReviewPanel
           patient={patient}

--- a/examples/medplum-provider/src/components/fax/AssignPatientModal.tsx
+++ b/examples/medplum-provider/src/components/fax/AssignPatientModal.tsx
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Button, Divider, Input, Modal, Stack } from '@mantine/core';
+import { Box, Button, Input, Modal, Stack } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { createReference, normalizeErrorString } from '@medplum/core';
 import type { Patient, Reference } from '@medplum/fhirtypes';
-import { ResourceInput, useMedplum } from '@medplum/react';
+import { ModalActionsFooter, ModalContentLayout, ResourceInput, useMedplum } from '@medplum/react';
 import { IconCircleOff } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useEffect, useState } from 'react';
@@ -102,49 +102,10 @@ export function AssignPatientModal({
   };
 
   return (
-    <Modal
-      opened={opened}
-      onClose={handleClose}
-      title="Assign Patient"
-      size="md"
-      centered
-      styles={{
-        body: { padding: 0 },
-        header: {
-          padding: 'var(--mantine-spacing-md) var(--mantine-spacing-lg)',
-          backgroundImage: `linear-gradient(var(--mantine-color-gray-2), var(--mantine-color-gray-2))`,
-          backgroundSize: 'calc(100% - 2 * var(--mantine-spacing-lg)) 1px',
-          backgroundPosition: 'center bottom',
-          backgroundRepeat: 'no-repeat',
-        },
-      }}
-    >
-      <Stack h="100%" justify="space-between" gap={0}>
-        <Box flex={1} miw={0}>
-          <Stack gap="lg" p="lg">
-            <Input.Wrapper
-              label="Select Patient"
-              description="This fax will be added to the Documents in their profile"
-            >
-              <Box mt="calc(var(--mantine-spacing-xs) / 2)">
-                <ResourceInput<Patient>
-                  key={resourceInputKey}
-                  resourceType="Patient"
-                  name="patient"
-                  placeholder="Type to search patients..."
-                  defaultValue={defaultPatient}
-                  onChange={(value: Patient | undefined) => setPatient(value ? createReference(value) : undefined)}
-                />
-              </Box>
-            </Input.Wrapper>
-            <Box pt="xs">
-              <Divider />
-            </Box>
-          </Stack>
-        </Box>
-
-        <Box px="lg" pb="lg">
-          <Stack gap="sm">
+    <Modal opened={opened} onClose={handleClose} title="Assign Patient" size="md" centered>
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
             <Button variant="filled" w="100%" onClick={handleAssign} loading={isSubmitting} disabled={!patient}>
               Assign Patient
             </Button>
@@ -153,9 +114,24 @@ export function AssignPatientModal({
                 Remove Assigned Patient
               </Button>
             )}
-          </Stack>
-        </Box>
-      </Stack>
+          </ModalActionsFooter>
+        }
+      >
+        <Stack gap="md">
+          <Input.Wrapper label="Select Patient" description="This fax will be added to the Documents in their profile">
+            <Box mt="calc(var(--mantine-spacing-xs) / 2)">
+              <ResourceInput<Patient>
+                key={resourceInputKey}
+                resourceType="Patient"
+                name="patient"
+                placeholder="Type to search patients..."
+                defaultValue={defaultPatient}
+                onChange={(value: Patient | undefined) => setPatient(value ? createReference(value) : undefined)}
+              />
+            </Box>
+          </Input.Wrapper>
+        </Stack>
+      </ModalContentLayout>
     </Modal>
   );
 }

--- a/examples/medplum-provider/src/components/fax/SendFaxModal.tsx
+++ b/examples/medplum-provider/src/components/fax/SendFaxModal.tsx
@@ -292,7 +292,11 @@ export function SendFaxModal({
                     }
                   }}
                   style={{
-                    border: `2px dashed ${isDragging ? 'var(--mantine-color-blue-5)' : 'var(--mantine-color-dark-4)'}`,
+                    border: `2px dashed ${
+                      isDragging
+                        ? 'var(--mantine-color-blue-5)'
+                        : 'light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4))'
+                    }`,
                     borderRadius: 'var(--mantine-radius-md)',
                     padding: 'var(--mantine-spacing-xl) var(--mantine-spacing-md)',
                     cursor: 'pointer',

--- a/examples/medplum-provider/src/components/fax/SendFaxModal.tsx
+++ b/examples/medplum-provider/src/components/fax/SendFaxModal.tsx
@@ -11,7 +11,7 @@ import type {
   Patient,
   Reference,
 } from '@medplum/fhirtypes';
-import { ResourceInput, useMedplum, useMedplumProfile } from '@medplum/react';
+import { ModalActionsFooter, ModalContentLayout, ResourceInput, useMedplum, useMedplumProfile } from '@medplum/react';
 import { IconCircleOff, IconUpload } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useEffect, useRef, useState } from 'react';
@@ -252,148 +252,129 @@ export function SendFaxModal({
   };
 
   return (
-    <Modal
-      opened={opened}
-      onClose={handleClose}
-      size="lg"
-      title="Send Fax"
-      centered
-      styles={{
-        body: { padding: 0 },
-        header: {
-          padding: 'var(--mantine-spacing-md) var(--mantine-spacing-lg)',
-          backgroundImage: `linear-gradient(var(--mantine-color-gray-2), var(--mantine-color-gray-2))`,
-          backgroundSize: 'calc(100% - 2 * var(--mantine-spacing-lg)) 1px',
-          backgroundPosition: 'center bottom',
-          backgroundRepeat: 'no-repeat',
-        },
-      }}
-    >
-      <Stack h="100%" justify="space-between" gap={0}>
-        <Box flex={1} miw={0}>
-          <Stack gap="lg" p="lg">
-            {!defaultAttachment && (
-              <>
-                <Stack gap={4}>
-                  <Text size="sm" fw={500}>
-                    Document <span style={{ color: 'var(--mantine-color-red-6)' }}>*</span>
-                  </Text>
-                  <input
-                    type="file"
-                    ref={fileInputRef}
-                    onChange={(e) => setFile(e.target.files?.[0] ?? null)}
-                    accept=".pdf,.png,.jpg,.jpeg,.tiff"
-                    style={{ display: 'none' }}
-                  />
-                  <Box
-                    onClick={() => fileInputRef.current?.click()}
-                    onDragOver={(e) => {
-                      e.preventDefault();
-                      setIsDragging(true);
-                    }}
-                    onDragLeave={() => setIsDragging(false)}
-                    onDrop={(e) => {
-                      e.preventDefault();
-                      setIsDragging(false);
-                      const dropped = e.dataTransfer.files?.[0];
-                      if (dropped) {
-                        setFile(dropped);
-                      }
-                    }}
-                    style={{
-                      border: `2px dashed ${isDragging ? 'var(--mantine-color-blue-5)' : 'var(--mantine-color-gray-3)'}`,
-                      borderRadius: 'var(--mantine-radius-md)',
-                      padding: 'var(--mantine-spacing-xl) var(--mantine-spacing-md)',
-                      cursor: 'pointer',
-                      textAlign: 'center',
-                      backgroundColor: isDragging ? 'var(--mantine-color-blue-0)' : undefined,
-                      transition: 'border-color 150ms ease, background-color 150ms ease',
-                    }}
-                  >
-                    <Stack align="center" gap={4}>
-                      <IconUpload
-                        size={24}
-                        color={file ? 'var(--mantine-color-blue-5)' : 'var(--mantine-color-gray-5)'}
-                      />
-                      <Text size="sm" c={file ? undefined : 'dimmed'}>
-                        {file ? file.name : 'Drag a file here or click to browse'}
+    <Modal opened={opened} onClose={handleClose} size="lg" title="Send Fax" centered>
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <Button variant="filled" w="100%" onClick={handleSend} loading={isSubmitting}>
+              Send Fax
+            </Button>
+          </ModalActionsFooter>
+        }
+      >
+        <Stack gap="md">
+          {!defaultAttachment && (
+            <>
+              <Stack gap={4}>
+                <Text size="sm" fw={500}>
+                  Document <span style={{ color: 'var(--mantine-color-red-6)' }}>*</span>
+                </Text>
+                <input
+                  type="file"
+                  ref={fileInputRef}
+                  onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+                  accept=".pdf,.png,.jpg,.jpeg,.tiff"
+                  style={{ display: 'none' }}
+                />
+                <Box
+                  onClick={() => fileInputRef.current?.click()}
+                  onDragOver={(e) => {
+                    e.preventDefault();
+                    setIsDragging(true);
+                  }}
+                  onDragLeave={() => setIsDragging(false)}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    setIsDragging(false);
+                    const dropped = e.dataTransfer.files?.[0];
+                    if (dropped) {
+                      setFile(dropped);
+                    }
+                  }}
+                  style={{
+                    border: `2px dashed ${isDragging ? 'var(--mantine-color-blue-5)' : 'var(--mantine-color-dark-4)'}`,
+                    borderRadius: 'var(--mantine-radius-md)',
+                    padding: 'var(--mantine-spacing-xl) var(--mantine-spacing-md)',
+                    cursor: 'pointer',
+                    textAlign: 'center',
+                    backgroundColor: isDragging ? 'var(--mantine-color-blue-0)' : undefined,
+                    transition: 'border-color 150ms ease, background-color 150ms ease',
+                  }}
+                >
+                  <Stack align="center" gap={4}>
+                    <IconUpload
+                      size={24}
+                      color={file ? 'var(--mantine-color-blue-5)' : 'var(--mantine-color-gray-5)'}
+                    />
+                    <Text size="sm" c={file ? undefined : 'dimmed'}>
+                      {file ? file.name : 'Drag a file here or click to browse'}
+                    </Text>
+                    {!file && (
+                      <Text size="xs" c="gray.5">
+                        PDF, PNG, JPG, TIFF
                       </Text>
-                      {!file && (
-                        <Text size="xs" c="gray.5">
-                          PDF, PNG, JPG, TIFF
-                        </Text>
-                      )}
-                    </Stack>
-                  </Box>
-                </Stack>
-                <Box py="xs">
-                  <Divider />
+                    )}
+                  </Stack>
                 </Box>
+              </Stack>
+              <Box py="xs">
+                <Divider />
+              </Box>
+            </>
+          )}
+          <TextInput
+            label="Subject (optional)"
+            placeholder="Enter subject"
+            value={subject}
+            onChange={(e) => setSubject(e.currentTarget.value)}
+          />
+          <Textarea
+            label="Cover Page Note (optional)"
+            placeholder="Enter cover page message..."
+            value={coverNote}
+            onChange={(e) => setCoverNote(e.currentTarget.value)}
+            minRows={3}
+            autosize
+            maxRows={6}
+          />
+          <Box py="xs">
+            <Divider />
+          </Box>
+
+          <ResourceInput<Organization>
+            resourceType="Organization"
+            name="recipientOrg"
+            label="Recipient Organization (optional)"
+            placeholder="Search for an organization..."
+            onChange={handleOrgChange}
+          />
+          <TextInput
+            label="Recipient Name (optional)"
+            placeholder="Enter recipient name"
+            value={recipientName}
+            onChange={(e) => setRecipientName(e.currentTarget.value)}
+          />
+
+          <TextInput
+            label={
+              <>
+                Fax Number <span style={{ color: 'var(--mantine-color-red-6)' }}>*</span>
               </>
-            )}
-            <TextInput
-              label="Subject (optional)"
-              placeholder="Enter subject"
-              value={subject}
-              onChange={(e) => setSubject(e.currentTarget.value)}
-            />
-            <Textarea
-              label="Cover Page Note (optional)"
-              placeholder="Enter cover page message..."
-              value={coverNote}
-              onChange={(e) => setCoverNote(e.currentTarget.value)}
-              minRows={3}
-              autosize
-              maxRows={6}
-            />
-            <Box py="xs">
-              <Divider />
-            </Box>
-
-            <ResourceInput<Organization>
-              resourceType="Organization"
-              name="recipientOrg"
-              label="Recipient Organization (optional)"
-              placeholder="Search for an organization..."
-              onChange={handleOrgChange}
-            />
-            <TextInput
-              label="Recipient Name (optional)"
-              placeholder="Enter recipient name"
-              value={recipientName}
-              onChange={(e) => setRecipientName(e.currentTarget.value)}
-            />
-
-            <TextInput
-              label={
-                <>
-                  Fax Number <span style={{ color: 'var(--mantine-color-red-6)' }}>*</span>
-                </>
-              }
-              placeholder="+1 (555) 123-4567"
-              value={faxNumber}
-              onChange={(e) => setFaxNumber(e.currentTarget.value)}
-            />
-            <ResourceInput<Patient>
-              resourceType="Patient"
-              name="patient"
-              label="Patient (optional)"
-              placeholder="Link to a patient..."
-              defaultValue={defaultPatient}
-              onChange={(value: Patient | undefined) => setPatient(value ? createReference(value) : undefined)}
-            />
-            <Box pt="xs">
-              <Divider />
-            </Box>
-          </Stack>
-        </Box>
-
-        <Box px="lg" pb="lg">
-          <Button variant="filled" w="100%" onClick={handleSend} loading={isSubmitting}>
-            Send Fax
-          </Button>
-        </Box>
-      </Stack>
+            }
+            placeholder="+1 (555) 123-4567"
+            value={faxNumber}
+            onChange={(e) => setFaxNumber(e.currentTarget.value)}
+          />
+          <ResourceInput<Patient>
+            resourceType="Patient"
+            name="patient"
+            label="Patient (optional)"
+            placeholder="Link to a patient..."
+            defaultValue={defaultPatient}
+            onChange={(value: Patient | undefined) => setPatient(value ? createReference(value) : undefined)}
+          />
+        </Stack>
+      </ModalContentLayout>
     </Modal>
   );
 }

--- a/examples/medplum-provider/src/components/meds/PrescriptionIFrameModal.tsx
+++ b/examples/medplum-provider/src/components/meds/PrescriptionIFrameModal.tsx
@@ -133,8 +133,8 @@ export function PrescriptionIFrameModal(props: PrescriptionIFrameModalProps): JS
   const hasReadErrors = errors.size > 0;
 
   return (
-    <Modal opened={opened} onClose={onClose} size="xl" centered title={title} styles={{ body: { padding: 0 } }}>
-      <Box p="md" style={{ maxWidth: 'min(100%, 560px)', margin: '0 auto' }}>
+    <Modal opened={opened} onClose={onClose} size="xl" centered title={title}>
+      <Box style={{ maxWidth: 'min(100%, 560px)', margin: '0 auto' }}>
         {timedOut && (
           <Alert
             mb="sm"

--- a/examples/medplum-provider/src/components/plandefinition/AddPlanDefinition.module.css
+++ b/examples/medplum-provider/src/components/plandefinition/AddPlanDefinition.module.css
@@ -6,13 +6,6 @@
   background-color: var(--mantine-color-blue-6) !important;
 }
 
-.footer {
-  display: flex;
-  justify-content: flex-end;
-  padding: var(--mantine-spacing-md);
-  height: 70px;
-}
-
 .preview {
   height: 100%;
   display: flex;
@@ -28,13 +21,11 @@
 }
 
 [data-mantine-color-scheme='dark'] .preview,
-[data-mantine-color-scheme='dark'] .planDefinition,
-[data-mantine-color-scheme='dark'] .footer {
+[data-mantine-color-scheme='dark'] .planDefinition {
   background-color: var(--mantine-color-dark-8);
 }
 
 [data-mantine-color-scheme='light'] .preview,
-[data-mantine-color-scheme='light'] .planDefinition,
-[data-mantine-color-scheme='light'] .footer {
+[data-mantine-color-scheme='light'] .planDefinition {
   background-color: var(--mantine-color-gray-1);
 }

--- a/examples/medplum-provider/src/components/plandefinition/AddPlanDefinition.tsx
+++ b/examples/medplum-provider/src/components/plandefinition/AddPlanDefinition.tsx
@@ -17,7 +17,7 @@ import {
 import { showNotification } from '@mantine/notifications';
 import { normalizeErrorString } from '@medplum/core';
 import type { PlanDefinition } from '@medplum/fhirtypes';
-import { useMedplum } from '@medplum/react';
+import { ModalActionsFooter, ModalContentLayout, useMedplum } from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
 import cx from 'clsx';
 import type { JSX } from 'react';
@@ -147,110 +147,110 @@ export const AddPlanDefinition = ({ encounterId, patientId, onApply }: AddPlanDe
         styles={{
           title: {
             fontSize: '1.2rem',
-            fontWeight: 600,
           },
           body: {
-            padding: '0',
             height: '80vh',
           },
         }}
       >
-        <Stack h="100%" justify="space-between" gap={0}>
-          <Box flex={1} miw={0}>
-            <Grid p="md">
-              <Grid.Col span={6} pr="md">
-                <Box>
-                  <Title order={5} mb="xs">
-                    Select care template
-                  </Title>
-                  <Text size="sm" c="dimmed" mb="md">
-                    Care templates are predefined sets of actions that can be applied to encounters.
-                  </Text>
+        <ModalContentLayout
+          footer={
+            <ModalActionsFooter>
+              <Button w="100%" onClick={handleApplyPlanDefinition}>
+                Add care template
+              </Button>
+            </ModalActionsFooter>
+          }
+        >
+          <Grid>
+            <Grid.Col span={6} pr="md">
+              <Box>
+                <Title order={5} mb="xs">
+                  Select care template
+                </Title>
+                <Text size="sm" c="dimmed" mb="md">
+                  Care templates are predefined sets of actions that can be applied to encounters.
+                </Text>
 
-                  <TextInput
-                    placeholder="Search by name"
-                    mb="md"
-                    value={searchQuery}
-                    onChange={(event) => setSearchQuery(event.currentTarget.value)}
-                    rightSection={isLoading ? <Loader size={16} /> : null}
-                    styles={{
-                      input: {
-                        '&:focus': {
-                          borderColor: '#228be6',
-                        },
+                <TextInput
+                  placeholder="Search by name"
+                  mb="md"
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.currentTarget.value)}
+                  rightSection={isLoading ? <Loader size={16} /> : null}
+                  styles={{
+                    input: {
+                      '&:focus': {
+                        borderColor: '#228be6',
                       },
-                    }}
-                  />
+                    },
+                  }}
+                />
 
-                  <ScrollArea style={{ height: 'calc(80vh - 250px)' }} type="scroll">
-                    {planDefinitions.length > 0 &&
-                      planDefinitions.map((plan) => (
-                        <Card
-                          key={plan.id}
-                          p="md"
-                          mb="xs"
-                          className={cx(classes.planDefinition, {
-                            [classes.selected]: selectedPlanDefinition?.id === plan.id,
-                          })}
-                          onClick={() => setSelectedPlanDefinition(plan)}
-                        >
-                          <Text fz="md" fw={500} c={selectedPlanDefinition?.id === plan.id ? 'white' : undefined}>
-                            {plan.name}
-                          </Text>
-                          <Text fw={500} c={selectedPlanDefinition?.id === plan.id ? 'white' : 'dimmed'}>
-                            {plan.subtitle}
-                          </Text>
-                        </Card>
-                      ))}
+                <ScrollArea style={{ height: 'calc(80vh - 250px)' }} type="scroll">
+                  {planDefinitions.length > 0 &&
+                    planDefinitions.map((plan) => (
+                      <Card
+                        key={plan.id}
+                        p="md"
+                        mb="xs"
+                        className={cx(classes.planDefinition, {
+                          [classes.selected]: selectedPlanDefinition?.id === plan.id,
+                        })}
+                        onClick={() => setSelectedPlanDefinition(plan)}
+                      >
+                        <Text fz="md" fw={500} c={selectedPlanDefinition?.id === plan.id ? 'white' : undefined}>
+                          {plan.name}
+                        </Text>
+                        <Text fw={500} c={selectedPlanDefinition?.id === plan.id ? 'white' : 'dimmed'}>
+                          {plan.subtitle}
+                        </Text>
+                      </Card>
+                    ))}
 
-                    {planDefinitions.length === 0 && !isLoading && (
-                      <Paper className={classes.notFound} h={40}>
-                        <Text>Nothing found! Try searching for another name of the care plan.</Text>
-                      </Paper>
+                  {planDefinitions.length === 0 && !isLoading && (
+                    <Paper className={classes.notFound} h={40}>
+                      <Text>Nothing found! Try searching for another name of the care plan.</Text>
+                    </Paper>
+                  )}
+                </ScrollArea>
+              </Box>
+            </Grid.Col>
+
+            <Grid.Col span={6}>
+              <Paper withBorder className={classes.preview}>
+                <ScrollArea style={{ height: 'calc(80vh - 110px)' }} type="scroll">
+                  <Stack gap="md" px="md" pt="md">
+                    <Title order={5}>Preview</Title>
+                    {selectedPlanDefinition ? (
+                      <>
+                        <Stack gap={0} p={0}>
+                          <Text fz="md" fw={500}>
+                            {selectedPlanDefinition.name}
+                          </Text>
+                          <Text fw={500} c="dimmed">
+                            {selectedPlanDefinition.subtitle}
+                          </Text>
+                        </Stack>
+
+                        <Stack gap="md" pb="md">
+                          {selectedPlanDefinition.action?.map((action, index) => (
+                            <Card key={`${action.id}-task-${index}`} withBorder shadow="sm">
+                              <Text fw={500}>{action.title}</Text>
+                              {action.description && <Text c="dimmed">{action.description}</Text>}
+                            </Card>
+                          ))}
+                        </Stack>
+                      </>
+                    ) : (
+                      <Text c="dimmed">Select a template to see preview.</Text>
                     )}
-                  </ScrollArea>
-                </Box>
-              </Grid.Col>
-
-              <Grid.Col span={6}>
-                <Paper withBorder className={classes.preview}>
-                  <ScrollArea style={{ height: 'calc(80vh - 110px)' }} type="scroll">
-                    <Stack gap="sm" px="md" pt="md">
-                      <Title order={5}>Preview</Title>
-                      {selectedPlanDefinition ? (
-                        <>
-                          <Stack gap={0} p={0}>
-                            <Text fz="md" fw={500}>
-                              {selectedPlanDefinition.name}
-                            </Text>
-                            <Text fw={500} c="dimmed">
-                              {selectedPlanDefinition.subtitle}
-                            </Text>
-                          </Stack>
-
-                          <Stack gap="xs" pb="md">
-                            {selectedPlanDefinition.action?.map((action, index) => (
-                              <Card key={`${action.id}-task-${index}`} withBorder shadow="sm">
-                                <Text fw={500}>{action.title}</Text>
-                                {action.description && <Text c="dimmed">{action.description}</Text>}
-                              </Card>
-                            ))}
-                          </Stack>
-                        </>
-                      ) : (
-                        <Text c="dimmed">Select a template to see preview.</Text>
-                      )}
-                    </Stack>
-                  </ScrollArea>
-                </Paper>
-              </Grid.Col>
-            </Grid>
-          </Box>
-
-          <Box className={classes.footer} h={70} p="md">
-            <Button onClick={handleApplyPlanDefinition}>Add care template</Button>
-          </Box>
-        </Stack>
+                  </Stack>
+                </ScrollArea>
+              </Paper>
+            </Grid.Col>
+          </Grid>
+        </ModalContentLayout>
       </Modal>
     </>
   );

--- a/examples/medplum-provider/src/components/tasks/NewTaskModal.tsx
+++ b/examples/medplum-provider/src/components/tasks/NewTaskModal.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Button, Divider, Grid, Modal, Stack, Text, Textarea, TextInput } from '@mantine/core';
+import { Box, Button, Grid, Modal, Stack, Text, Textarea, TextInput } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { createReference, normalizeErrorString } from '@medplum/core';
 import type { CodeableConcept, Patient, Practitioner, Reference, Task } from '@medplum/fhirtypes';
@@ -8,6 +8,8 @@ import {
   CodeableConceptInput,
   CodeInput,
   DateTimeInput,
+  ModalActionsFooter,
+  ModalContentLayout,
   ReferenceInput,
   ResourceInput,
   useMedplum,
@@ -125,118 +127,116 @@ export function NewTaskModal(props: NewTaskModalProps): JSX.Element {
       title="Create New Task"
       styles={{
         body: {
-          padding: 0,
           height: '70vh',
         },
       }}
     >
-      <Stack h="100%" justify="space-between" gap={0}>
-        <Box flex={1} miw={0}>
-          <Grid p="md" h="100%">
-            <Grid.Col span={6} pr="lg">
-              <Stack gap="md" h="100%">
-                <Box>
-                  <Stack gap="sm">
-                    <TextInput
-                      label="Title"
-                      placeholder="Enter task title"
-                      value={title}
-                      onChange={(event) => setTitle(event.currentTarget.value)}
-                      required
-                      size="md"
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <Button variant="filled" w="100%" onClick={handleSubmit} loading={isSubmitting}>
+              Create Task
+            </Button>
+          </ModalActionsFooter>
+        }
+      >
+        <Grid h="100%">
+          <Grid.Col span={6} pr="lg">
+            <Stack gap="md" h="100%">
+              <Box>
+                <Stack gap="md">
+                  <TextInput
+                    label="Title"
+                    placeholder="Enter task title"
+                    value={title}
+                    onChange={(event) => setTitle(event.currentTarget.value)}
+                    required
+                    size="md"
+                  />
+
+                  <Textarea
+                    label="Description"
+                    placeholder="Enter task description (optional)"
+                    value={description}
+                    onChange={(event) => setDescription(event.currentTarget.value)}
+                    minRows={4}
+                    autosize
+                    maxRows={8}
+                  />
+                </Stack>
+              </Box>
+            </Stack>
+          </Grid.Col>
+
+          <Grid.Col span={6} pl="lg">
+            <Stack gap="md" h="100%">
+              <Box>
+                <Stack gap="md">
+                  <CodeInput
+                    name="status"
+                    label="Status"
+                    binding="http://hl7.org/fhir/ValueSet/task-status"
+                    maxValues={1}
+                    defaultValue={status}
+                    onChange={(value) => setStatus((value as Task['status']) || 'draft')}
+                    required
+                  />
+
+                  <DateTimeInput
+                    name="dueDate"
+                    label="Due Date"
+                    placeholder="Select due date (optional)"
+                    defaultValue={dueDate}
+                    onChange={setDueDate}
+                  />
+
+                  <CodeInput
+                    name="priority"
+                    label="Priority"
+                    binding="http://hl7.org/fhir/ValueSet/request-priority"
+                    maxValues={1}
+                    defaultValue={priority}
+                    onChange={(value) => setPriority(value || 'routine')}
+                  />
+
+                  <ResourceInput<Patient>
+                    resourceType="Patient"
+                    name="patient"
+                    label="Patient"
+                    placeholder="Select patient"
+                    defaultValue={taskPatient}
+                    onChange={(value: Patient | undefined) =>
+                      setTaskPatient(value ? createReference(value) : undefined)
+                    }
+                  />
+
+                  <Box>
+                    <Text size="sm" fw={500} mb="xs">
+                      Assignee
+                    </Text>
+                    <ReferenceInput
+                      name="assignee"
+                      targetTypes={['Practitioner', 'Organization']}
+                      placeholder="Select assignee (optional)"
+                      onChange={(value) => setAssignee(value as Reference<Practitioner>)}
                     />
+                  </Box>
 
-                    <Textarea
-                      label="Description"
-                      placeholder="Enter task description (optional)"
-                      value={description}
-                      onChange={(event) => setDescription(event.currentTarget.value)}
-                      minRows={4}
-                      autosize
-                      maxRows={8}
-                    />
-                  </Stack>
-                </Box>
-              </Stack>
-            </Grid.Col>
-
-            <Grid.Col span={6} pl="lg">
-              <Stack gap="md" h="100%">
-                <Box>
-                  <Stack gap="sm">
-                    <CodeInput
-                      name="status"
-                      label="Status"
-                      binding="http://hl7.org/fhir/ValueSet/task-status"
-                      maxValues={1}
-                      defaultValue={status}
-                      onChange={(value) => setStatus((value as Task['status']) || 'draft')}
-                      required
-                    />
-
-                    <DateTimeInput
-                      name="dueDate"
-                      label="Due Date"
-                      placeholder="Select due date (optional)"
-                      defaultValue={dueDate}
-                      onChange={setDueDate}
-                    />
-
-                    <CodeInput
-                      name="priority"
-                      label="Priority"
-                      binding="http://hl7.org/fhir/ValueSet/request-priority"
-                      maxValues={1}
-                      defaultValue={priority}
-                      onChange={(value) => setPriority(value || 'routine')}
-                    />
-
-                    <ResourceInput<Patient>
-                      resourceType="Patient"
-                      name="patient"
-                      label="Patient"
-                      placeholder="Select patient"
-                      defaultValue={taskPatient}
-                      onChange={(value: Patient | undefined) =>
-                        setTaskPatient(value ? createReference(value) : undefined)
-                      }
-                    />
-
-                    <Box>
-                      <Text size="sm" fw={500} mb="xs">
-                        Assignee
-                      </Text>
-                      <ReferenceInput
-                        name="assignee"
-                        targetTypes={['Practitioner', 'Organization']}
-                        placeholder="Select assignee (optional)"
-                        onChange={(value) => setAssignee(value as Reference<Practitioner>)}
-                      />
-                    </Box>
-
-                    <CodeableConceptInput
-                      name="performerType"
-                      label="Performer Type"
-                      placeholder="Select performer type (optional)"
-                      binding="http://hl7.org/fhir/ValueSet/performer-role"
-                      maxValues={1}
-                      onChange={(value) => setPerformerType(value)}
-                      path={'Task.performerType'}
-                    />
-                  </Stack>
-                </Box>
-              </Stack>
-            </Grid.Col>
-          </Grid>
-        </Box>
-
-        <Stack p="md">
-          <Divider />
-          <Button variant="filled" w="100%" onClick={handleSubmit} loading={isSubmitting}>
-            Create Task
-          </Button>
-        </Stack>
-      </Stack>
+                  <CodeableConceptInput
+                    name="performerType"
+                    label="Performer Type"
+                    placeholder="Select performer type (optional)"
+                    binding="http://hl7.org/fhir/ValueSet/performer-role"
+                    maxValues={1}
+                    onChange={(value) => setPerformerType(value)}
+                    path={'Task.performerType'}
+                  />
+                </Stack>
+              </Box>
+            </Stack>
+          </Grid.Col>
+        </Grid>
+      </ModalContentLayout>
     </Modal>
   );
 }

--- a/examples/medplum-provider/src/components/tasks/TaskDetailsModal.module.css
+++ b/examples/medplum-provider/src/components/tasks/TaskDetailsModal.module.css
@@ -1,16 +1,7 @@
-.footer {
-  display: flex;
-  justify-content: flex-end;
-  padding: var(--mantine-spacing-md);
-  height: 70px;
-}
-
-[data-mantine-color-scheme='dark'] .taskDetails,
-[data-mantine-color-scheme='dark'] .footer {
+[data-mantine-color-scheme='dark'] .taskDetails {
   background-color: var(--mantine-color-dark-8);
 }
 
-[data-mantine-color-scheme='light'] .taskDetails,
-[data-mantine-color-scheme='light'] .footer {
+[data-mantine-color-scheme='light'] .taskDetails {
   background-color: var(--mantine-color-gray-1);
 }

--- a/examples/medplum-provider/src/components/tasks/TaskDetailsModal.test.tsx
+++ b/examples/medplum-provider/src/components/tasks/TaskDetailsModal.test.tsx
@@ -66,6 +66,15 @@ describe('TaskDetailsModal', () => {
     });
   });
 
+  test('renders the modal header title', async () => {
+    await medplum.createResource(mockTask);
+    setup();
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit Task')).toBeInTheDocument();
+    });
+  });
+
   test('displays patient information', async () => {
     await medplum.createResource(mockTask);
     await medplum.createResource(mockPatient);

--- a/examples/medplum-provider/src/components/tasks/TaskDetailsModal.tsx
+++ b/examples/medplum-provider/src/components/tasks/TaskDetailsModal.tsx
@@ -122,6 +122,7 @@ export const TaskDetailsModal = (): JSX.Element => {
         setIsOpened(false);
       }}
       size="xl"
+      title="Edit Task"
       styles={{
         body: {
           height: '60vh',

--- a/examples/medplum-provider/src/components/tasks/TaskDetailsModal.tsx
+++ b/examples/medplum-provider/src/components/tasks/TaskDetailsModal.tsx
@@ -1,10 +1,19 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Button, Card, Grid, Modal, Stack, Text, Textarea } from '@mantine/core';
+import { Button, Card, Grid, Modal, Stack, Text, Textarea } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { createReference, formatHumanName, normalizeErrorString } from '@medplum/core';
 import type { Practitioner, Task } from '@medplum/fhirtypes';
-import { CodeInput, DateTimeInput, Loading, ResourceInput, useMedplum, useMedplumProfile } from '@medplum/react';
+import {
+  CodeInput,
+  DateTimeInput,
+  Loading,
+  ModalActionsFooter,
+  ModalContentLayout,
+  ResourceInput,
+  useMedplum,
+  useMedplumProfile,
+} from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useEffect, useState } from 'react';
@@ -115,89 +124,88 @@ export const TaskDetailsModal = (): JSX.Element => {
       size="xl"
       styles={{
         body: {
-          padding: 0,
           height: '60vh',
         },
       }}
     >
-      <Stack h="100%" justify="space-between" gap={0}>
-        <Box flex={1} miw={0}>
-          <Grid p="md" h="100%">
-            <Grid.Col span={6} pr="lg">
-              <Stack gap="sm">
-                <Card p="md" radius="md" className={classes.taskDetails}>
-                  <Stack gap="sm">
-                    <Text fz="lg" fw={700}>
-                      {task?.code?.text}
-                    </Text>
-                    {task?.description && <Text>{task.description}</Text>}
-                    {patient?.name && (
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                        <Text>View Patient</Text>
-                        <Button variant="subtle" component={Link} to={`/Patient/${patient.id}`}>
-                          {formatHumanName(patient.name?.[0])}
-                        </Button>
-                      </div>
-                    )}
-                  </Stack>
-                </Card>
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <Button variant="filled" w="100%" onClick={handleOnSubmit}>
+              Save Changes
+            </Button>
+          </ModalActionsFooter>
+        }
+      >
+        <Grid h="100%">
+          <Grid.Col span={6} pr="lg">
+            <Stack gap="md">
+              <Card p="md" radius="md" className={classes.taskDetails}>
+                <Stack gap="md">
+                  <Text fz="lg" fw={700}>
+                    {task?.code?.text}
+                  </Text>
+                  {task?.description && <Text>{task.description}</Text>}
+                  {patient?.name && (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                      <Text>View Patient</Text>
+                      <Button variant="subtle" component={Link} to={`/Patient/${patient.id}`}>
+                        {formatHumanName(patient.name?.[0])}
+                      </Button>
+                    </div>
+                  )}
+                </Stack>
+              </Card>
 
-                <ResourceInput<Practitioner>
-                  name="practitioner"
-                  resourceType="Practitioner"
-                  label="Assigned to"
-                  defaultValue={task?.owner ? { reference: task.owner.reference } : undefined}
+              <ResourceInput<Practitioner>
+                name="practitioner"
+                resourceType="Practitioner"
+                label="Assigned to"
+                defaultValue={task?.owner ? { reference: task.owner.reference } : undefined}
+                onChange={(value) => {
+                  setPractitioner(value);
+                }}
+              />
+
+              <DateTimeInput
+                name="Due Date"
+                placeholder="End"
+                label="Due Date"
+                defaultValue={dueDate}
+                onChange={setDueDate}
+              />
+
+              {task?.status && (
+                <CodeInput
+                  name="status"
+                  label="Status"
+                  binding="http://hl7.org/fhir/ValueSet/task-status|4.0.1"
+                  maxValues={1}
+                  defaultValue={status}
                   onChange={(value) => {
-                    setPractitioner(value);
+                    if (value) {
+                      setStatus(value as typeof status);
+                    }
                   }}
                 />
+              )}
+            </Stack>
+          </Grid.Col>
 
-                <DateTimeInput
-                  name="Due Date"
-                  placeholder="End"
-                  label="Due Date"
-                  defaultValue={dueDate}
-                  onChange={setDueDate}
-                />
-
-                {task?.status && (
-                  <CodeInput
-                    name="status"
-                    label="Status"
-                    binding="http://hl7.org/fhir/ValueSet/task-status|4.0.1"
-                    maxValues={1}
-                    defaultValue={status}
-                    onChange={(value) => {
-                      if (value) {
-                        setStatus(value as typeof status);
-                      }
-                    }}
-                  />
-                )}
-              </Stack>
-            </Grid.Col>
-
-            <Grid.Col span={6} pr="md">
-              <Stack gap="sm">
-                <Text>Note</Text>
-                <Text c="dimmed">Optional free form details about this task</Text>
-                <Textarea
-                  placeholder="Add note to this task"
-                  minRows={3}
-                  value={note}
-                  onChange={(event) => setNote(event.currentTarget.value)}
-                />
-              </Stack>
-            </Grid.Col>
-          </Grid>
-        </Box>
-
-        <Box className={classes.footer} h={70} p="md">
-          <Button variant="filled" onClick={handleOnSubmit}>
-            Save Changes
-          </Button>
-        </Box>
-      </Stack>
+          <Grid.Col span={6} pr="md">
+            <Stack gap="md">
+              <Text>Note</Text>
+              <Text c="dimmed">Optional free form details about this task</Text>
+              <Textarea
+                placeholder="Add note to this task"
+                minRows={3}
+                value={note}
+                onChange={(event) => setNote(event.currentTarget.value)}
+              />
+            </Stack>
+          </Grid.Col>
+        </Grid>
+      </ModalContentLayout>
     </Modal>
   );
 };

--- a/examples/medplum-provider/src/components/tasks/TaskInputNote.tsx
+++ b/examples/medplum-provider/src/components/tasks/TaskInputNote.tsx
@@ -17,7 +17,14 @@ import {
 import { useDebouncedCallback } from '@mantine/hooks';
 import { createReference, formatDate, getDisplayString } from '@medplum/core';
 import type { Annotation, QuestionnaireResponse, Reference, Task } from '@medplum/fhirtypes';
-import { Loading, useMedplum, useMedplumProfile, useResource } from '@medplum/react';
+import {
+  Loading,
+  ModalActionsFooter,
+  ModalContentLayout,
+  useMedplum,
+  useMedplumProfile,
+  useResource,
+} from '@medplum/react';
 import { IconCheck, IconTrash } from '@tabler/icons-react';
 import React, { useState } from 'react';
 import { SAVE_TIMEOUT_MS } from '../../config/constants';
@@ -231,20 +238,25 @@ export function TaskInputNote(props: TaskInputNoteProps): React.JSX.Element {
           size="md"
           centered
         >
-          <Stack gap="md">
-            <Text>Are you sure you want to delete this task? This action cannot be undone.</Text>
-            <Text fw={500} c="dimmed">
-              Task: {getDisplayString(task)}
-            </Text>
-            <Flex justify="flex-end" gap="sm">
-              <Button variant="outline" onClick={() => setShowDeleteModal(false)}>
-                Cancel
-              </Button>
-              <Button color="red" onClick={confirmDeleteTask}>
-                Delete
-              </Button>
-            </Flex>
-          </Stack>
+          <ModalContentLayout
+            footer={
+              <ModalActionsFooter>
+                <Button color="red" w="100%" onClick={confirmDeleteTask}>
+                  Delete
+                </Button>
+                <Button variant="outline" w="100%" onClick={() => setShowDeleteModal(false)}>
+                  Cancel
+                </Button>
+              </ModalActionsFooter>
+            }
+          >
+            <Stack gap="md">
+              <Text>Are you sure you want to delete this task? This action cannot be undone.</Text>
+              <Text fw={500} c="dimmed">
+                Task: {getDisplayString(task)}
+              </Text>
+            </Stack>
+          </ModalContentLayout>
         </Modal>
       </Paper>
     </Flex>

--- a/examples/medplum-provider/src/main.tsx
+++ b/examples/medplum-provider/src/main.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { MantineProvider, createTheme } from '@mantine/core';
+import { MantineProvider, Modal, createTheme } from '@mantine/core';
 import '@mantine/core/styles.css';
 import { Notifications } from '@mantine/notifications';
 import '@mantine/notifications/styles.css';
@@ -8,6 +8,7 @@ import '@mantine/spotlight/styles.css';
 import { MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react';
 import '@medplum/react/styles.css';
+import { IconX } from '@tabler/icons-react';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider, createBrowserRouter } from 'react-router';
@@ -36,6 +37,44 @@ const theme = createTheme({
     md: '0.875rem',
     lg: '1.0rem',
     xl: '1.125rem',
+  },
+  components: {
+    Modal: Modal.extend({
+      defaultProps: {
+        padding: 'lg',
+        radius: 'md',
+        closeButtonProps: { icon: <IconX size={18} /> },
+      },
+      styles: {
+        content: {
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        },
+        header: {
+          minHeight: 0,
+          padding:
+            'var(--mantine-spacing-sm) var(--mantine-spacing-sm) var(--mantine-spacing-sm) var(--mantine-spacing-lg)',
+          borderBottom: '1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4))',
+          flexShrink: 0,
+          position: 'static',
+        },
+        close: {
+          width: '1.75rem',
+          height: '1.75rem',
+          borderRadius: '999px',
+        },
+        title: {
+          fontWeight: 800,
+        },
+        body: {
+          paddingTop: 'var(--mantine-spacing-lg)',
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+        },
+      },
+    }),
   },
 });
 

--- a/examples/medplum-provider/src/main.tsx
+++ b/examples/medplum-provider/src/main.tsx
@@ -1,14 +1,13 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { MantineProvider, Modal, createTheme } from '@mantine/core';
+import { MantineProvider, createTheme } from '@mantine/core';
 import '@mantine/core/styles.css';
 import { Notifications } from '@mantine/notifications';
 import '@mantine/notifications/styles.css';
 import '@mantine/spotlight/styles.css';
 import { MedplumClient } from '@medplum/core';
-import { MedplumProvider } from '@medplum/react';
+import { MedplumProvider, medplumModalTheme } from '@medplum/react';
 import '@medplum/react/styles.css';
-import { IconX } from '@tabler/icons-react';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider, createBrowserRouter } from 'react-router';
@@ -39,42 +38,7 @@ const theme = createTheme({
     xl: '1.125rem',
   },
   components: {
-    Modal: Modal.extend({
-      defaultProps: {
-        padding: 'lg',
-        radius: 'md',
-        closeButtonProps: { icon: <IconX size={18} /> },
-      },
-      styles: {
-        content: {
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
-        },
-        header: {
-          minHeight: 0,
-          padding:
-            'var(--mantine-spacing-sm) var(--mantine-spacing-sm) var(--mantine-spacing-sm) var(--mantine-spacing-lg)',
-          borderBottom: '1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4))',
-          flexShrink: 0,
-          position: 'static',
-        },
-        close: {
-          width: '1.75rem',
-          height: '1.75rem',
-          borderRadius: '999px',
-        },
-        title: {
-          fontWeight: 800,
-        },
-        body: {
-          paddingTop: 'var(--mantine-spacing-lg)',
-          flex: 1,
-          minHeight: 0,
-          overflowY: 'auto',
-        },
-      },
-    }),
+    Modal: medplumModalTheme,
   },
 });
 

--- a/examples/medplum-provider/src/pages/encounter/EncounterModal.module.css
+++ b/examples/medplum-provider/src/pages/encounter/EncounterModal.module.css
@@ -1,16 +1,7 @@
-.footer {
-  display: flex;
-  justify-content: flex-end;
-  padding: var(--mantine-spacing-md);
-  height: 70px;
-}
-
-[data-mantine-color-scheme='dark'] .planDefinition,
-[data-mantine-color-scheme='dark'] .footer {
+[data-mantine-color-scheme='dark'] .planDefinition {
   background-color: var(--mantine-color-dark-8);
 }
 
-[data-mantine-color-scheme='light'] .planDefinition,
-[data-mantine-color-scheme='light'] .footer {
+[data-mantine-color-scheme='light'] .planDefinition {
   background-color: var(--mantine-color-gray-1);
 }

--- a/examples/medplum-provider/src/pages/encounter/EncounterModal.test.tsx
+++ b/examples/medplum-provider/src/pages/encounter/EncounterModal.test.tsx
@@ -94,7 +94,7 @@ describe('EncounterModal', () => {
     setup();
 
     await waitFor(() => {
-      expect(screen.getByText('New encounter')).toBeInTheDocument();
+      expect(screen.getByText('New Visit')).toBeInTheDocument();
     });
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -189,7 +189,7 @@ describe('EncounterModal', () => {
 
     // The modal is open and can be closed via keyboard escape
     // This verifies the modal rendering behavior
-    expect(screen.getByText('New encounter')).toBeInTheDocument();
+    expect(screen.getByText('New Visit')).toBeInTheDocument();
   });
 
   test('Sets start date when DateTimeInput changes', async () => {

--- a/examples/medplum-provider/src/pages/encounter/EncounterModal.tsx
+++ b/examples/medplum-provider/src/pages/encounter/EncounterModal.tsx
@@ -1,10 +1,18 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Button, Card, Grid, Modal, Stack, Text } from '@mantine/core';
+import { Button, Card, Grid, Modal, Stack, Text } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { isResource, normalizeErrorString } from '@medplum/core';
 import type { Coding, Encounter, PlanDefinition, Practitioner } from '@medplum/fhirtypes';
-import { CodeInput, CodingInput, DateTimeInput, ResourceInput, useMedplum } from '@medplum/react';
+import {
+  CodeInput,
+  CodingInput,
+  DateTimeInput,
+  ModalActionsFooter,
+  ModalContentLayout,
+  ResourceInput,
+  useMedplum,
+} from '@medplum/react';
 import { IconAlertSquareRounded, IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useState } from 'react';
@@ -73,107 +81,107 @@ export const EncounterModal = (): JSX.Element => {
         setIsOpen(false);
       }}
       size="60%"
-      title="New encounter"
-      styles={{ title: { fontSize: '1.125rem', fontWeight: 600 }, body: { padding: 0, height: '60vh' } }}
+      title="New Visit"
+      styles={{ body: { height: '60vh' } }}
     >
-      <Stack h="100%" justify="space-between" gap={0}>
-        <Box flex={1} miw={0}>
-          <Grid p="md" h="100%">
-            <Grid.Col span={6} pr="md">
-              <Stack gap="md">
-                <ResourceInput
-                  label="Patient"
-                  resourceType="Patient"
-                  name="Patient-id"
-                  defaultValue={patient}
-                  disabled={true}
-                  required={true}
-                />
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <Button w="100%" onClick={handleCreateEncounter} loading={isLoading} disabled={isLoading}>
+              Create Encounter
+            </Button>
+          </ModalActionsFooter>
+        }
+      >
+        <Grid h="100%">
+          <Grid.Col span={6} pr="md">
+            <Stack gap="md">
+              <ResourceInput
+                label="Patient"
+                resourceType="Patient"
+                name="Patient-id"
+                defaultValue={patient}
+                disabled={true}
+                required={true}
+              />
 
-                <ResourceInput
-                  label="Practitioner"
-                  resourceType="Practitioner"
-                  name="Practitioner-id"
-                  defaultValue={practitioner}
-                  required={true}
-                  onChange={(value) => setPractitioner(value)}
-                />
+              <ResourceInput
+                label="Practitioner"
+                resourceType="Practitioner"
+                name="Practitioner-id"
+                defaultValue={practitioner}
+                required={true}
+                onChange={(value) => setPractitioner(value)}
+              />
 
-                <DateTimeInput
-                  name="start"
-                  label="Start Time"
-                  required={true}
-                  onChange={(value) => {
-                    setStart(new Date(value));
-                  }}
-                />
+              <DateTimeInput
+                name="start"
+                label="Start Time"
+                required={true}
+                onChange={(value) => {
+                  setStart(new Date(value));
+                }}
+              />
 
-                <DateTimeInput
-                  name="end"
-                  label="End Time"
-                  required={true}
-                  onChange={(value) => {
-                    setEnd(new Date(value));
-                  }}
-                />
+              <DateTimeInput
+                name="end"
+                label="End Time"
+                required={true}
+                onChange={(value) => {
+                  setEnd(new Date(value));
+                }}
+              />
 
-                <CodingInput
-                  name="class"
-                  label="Class"
-                  binding="http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
-                  required={true}
-                  onChange={setEncounterClass}
-                  path="Encounter.type"
-                />
+              <CodingInput
+                name="class"
+                label="Class"
+                binding="http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
+                required={true}
+                onChange={setEncounterClass}
+                path="Encounter.type"
+              />
 
-                <CodeInput
-                  name="status"
-                  label="Status"
-                  binding="http://hl7.org/fhir/ValueSet/encounter-status|4.0.1"
-                  maxValues={1}
-                  required={true}
-                  onChange={(value) => {
-                    if (value) {
-                      setStatus(value as typeof status);
-                    }
-                  }}
-                />
-              </Stack>
-            </Grid.Col>
+              <CodeInput
+                name="status"
+                label="Status"
+                binding="http://hl7.org/fhir/ValueSet/encounter-status|4.0.1"
+                maxValues={1}
+                required={true}
+                onChange={(value) => {
+                  if (value) {
+                    setStatus(value as typeof status);
+                  }
+                }}
+              />
+            </Stack>
+          </Grid.Col>
 
-            <Grid.Col span={6}>
-              <Card padding="lg" radius="md" className={classes.planDefinition}>
-                <Text size="md" fw={500} mb="xs">
-                  Apply care template
+          <Grid.Col span={6}>
+            <Card padding="lg" radius="md" className={classes.planDefinition}>
+              <Text size="md" fw={500} mb="xs">
+                Apply care template
+              </Text>
+              <Text size="sm" color="dimmed" mb="lg">
+                You can select template for new encounter. Tasks from the template will be automatically added to the
+                encounter. Administrators can create and edit templates in the{' '}
+                <Text component="a" href="#" variant="link">
+                  Medplum app
                 </Text>
-                <Text size="sm" color="dimmed" mb="lg">
-                  You can select template for new encounter. Tasks from the template will be automatically added to the
-                  encounter. Administrators can create and edit templates in the{' '}
-                  <Text component="a" href="#" variant="link">
-                    Medplum app
-                  </Text>
-                  .
-                </Text>
+                .
+              </Text>
 
-                <ResourceInput
-                  name="plandefinition"
-                  label="Care template"
-                  resourceType="PlanDefinition"
-                  onChange={(value) => setPlanDefinitionData(value as PlanDefinition)}
-                />
+              <ResourceInput
+                name="plandefinition"
+                label="Care template"
+                resourceType="PlanDefinition"
+                onChange={(value) => setPlanDefinitionData(value as PlanDefinition)}
+              />
 
-                <PlanDefinitionSummary planDefinition={planDefinitionData} />
-              </Card>
-            </Grid.Col>
-          </Grid>
-        </Box>
-
-        <Box className={classes.footer} h={70} p="md">
-          <Button fullWidth={false} onClick={handleCreateEncounter} loading={isLoading} disabled={isLoading}>
-            Create Encounter
-          </Button>
-        </Box>
-      </Stack>
+              <PlanDefinitionSummary planDefinition={planDefinitionData} />
+            </Card>
+          </Grid.Col>
+        </Grid>
+      </ModalContentLayout>
     </Modal>
   );
 };

--- a/examples/medplum-provider/src/pages/integrations/DoseSpotFavoritesPage.tsx
+++ b/examples/medplum-provider/src/pages/integrations/DoseSpotFavoritesPage.tsx
@@ -1,23 +1,11 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import {
-  Box,
-  Button,
-  Container,
-  Divider,
-  Group,
-  Group as MantineGroup,
-  Modal,
-  Paper,
-  Stack,
-  TextInput,
-  Title,
-} from '@mantine/core';
+import { Box, Button, Container, Divider, Group, Modal, Paper, Stack, TextInput, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { formatSearchQuery, generateId, isCodeableConcept, normalizeErrorString } from '@medplum/core';
 import { DOSESPOT_CLINIC_FAVORITE_ID_SYSTEM, useDoseSpotClinicFormulary } from '@medplum/dosespot-react';
 import type { CodeableConcept, MedicationKnowledge } from '@medplum/fhirtypes';
-import { AsyncAutocomplete, useMedplum } from '@medplum/react';
+import { AsyncAutocomplete, ModalActionsFooter, ModalContentLayout, useMedplum } from '@medplum/react';
 import { IconPlus } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
 import { showErrorNotification } from '../../utils/notifications';
@@ -129,49 +117,53 @@ export function DoseSpotFavoritesPage(): React.JSX.Element {
         size="lg"
         withCloseButton
       >
-        <Box>
-          <AsyncAutocomplete<CodeableConcept>
-            placeholder="Search medications..."
-            loadOptions={searchMedications}
-            toOption={toOption}
-            onChange={(medications) => {
-              if (medications.length > 0) {
-                setSelectedMedication(medications[0]);
-              } else {
-                setSelectedMedication(undefined);
-              }
-            }}
-            minInputLength={3} //DoseSpot requires at least 3 characters to search
-            clearable
-            maxValues={1} // Only allow single selection
-          />
+        <ModalContentLayout
+          footer={
+            <ModalActionsFooter>
+              <Button
+                w="100%"
+                onClick={() => handleAddFavoriteMedication()}
+                disabled={!state.directions || !state.selectedMedication || loading}
+                loading={loading}
+              >
+                Add Favorite
+              </Button>
+            </ModalActionsFooter>
+          }
+        >
+          <Box>
+            <AsyncAutocomplete<CodeableConcept>
+              placeholder="Search medications..."
+              loadOptions={searchMedications}
+              toOption={toOption}
+              onChange={(medications) => {
+                if (medications.length > 0) {
+                  setSelectedMedication(medications[0]);
+                } else {
+                  setSelectedMedication(undefined);
+                }
+              }}
+              minInputLength={3} //DoseSpot requires at least 3 characters to search
+              clearable
+              maxValues={1} // Only allow single selection
+            />
 
-          {/* After selecting a medication, show the medication info with followup input items */}
-          {state.selectedMedication && isCodeableConcept(state.selectedMedication) && (
-            <Stack gap="md" mt="lg">
-              <Divider />
-              {/* Prescription Form */}
-              <TextInput
-                label="Directions"
-                placeholder="e.g., Take 1 tablet by mouth daily"
-                value={state.directions}
-                onChange={(e) => setSelectedMedicationDirections(e.target.value)}
-                required
-              />
-            </Stack>
-          )}
-
-          {/* Action Buttons */}
-          <MantineGroup justify="flex-end" gap="md" mt="md">
-            <Button
-              onClick={() => handleAddFavoriteMedication()}
-              disabled={!state.directions || !state.selectedMedication || loading}
-              loading={loading}
-            >
-              Add Favorite
-            </Button>
-          </MantineGroup>
-        </Box>
+            {/* After selecting a medication, show the medication info with followup input items */}
+            {state.selectedMedication && isCodeableConcept(state.selectedMedication) && (
+              <Stack gap="md" mt="lg">
+                <Divider />
+                {/* Prescription Form */}
+                <TextInput
+                  label="Directions"
+                  placeholder="e.g., Take 1 tablet by mouth daily"
+                  value={state.directions}
+                  onChange={(e) => setSelectedMedicationDirections(e.target.value)}
+                  required
+                />
+              </Stack>
+            )}
+          </Box>
+        </ModalContentLayout>
       </Modal>
     </Container>
   );

--- a/examples/medplum-provider/src/pages/labs/OrderLabsPage.tsx
+++ b/examples/medplum-provider/src/pages/labs/OrderLabsPage.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Button, Container, Group, Input, Radio, Stack, TextInput } from '@mantine/core';
+import { Button, Group, Input, Radio, Stack, TextInput } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import type { MedplumClient } from '@medplum/core';
 import { ContentType, createReference } from '@medplum/core';
@@ -27,7 +27,8 @@ import type { AsyncAutocompleteOption } from '@medplum/react';
 import {
   AsyncAutocomplete,
   DateTimeInput,
-  Panel,
+  ModalActionsFooter,
+  ModalContentLayout,
   ResourceInput,
   useMedplum,
   useResource,
@@ -159,109 +160,110 @@ export function OrderLabsPage(props: OrderLabsPageProps): JSX.Element {
 
   return (
     <HealthGorillaLabOrderProvider {...labOrderReturn}>
-      <Container size="md">
-        <Panel>
-          <Stack gap="md">
-            <Input.Wrapper label="Requester" required error={createError?.validation?.requester?.message}>
-              <ResourceInput<Practitioner>
-                resourceType="Practitioner"
-                name="Requester"
-                onChange={setRequester}
-                defaultValue={requester}
-                searchCriteria={{ identifier: `${NPI_SYSTEM}|` }}
-              />
-            </Input.Wrapper>
-            <Input.Wrapper label="Patient" required error={createError?.validation?.patient?.message}>
-              <ResourceInput<Patient>
-                key={patient?.id ?? 'patient'}
-                resourceType="Patient"
-                name="patient"
-                defaultValue={patient}
-                onChange={setPatient}
-              />
-            </Input.Wrapper>
-            <PerformingLabInput
-              patient={patient}
-              performingLab={performingLab}
-              error={createError?.validation?.performingLab}
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <Button fullWidth onClick={submitOrder} loading={isSubmitting} disabled={isSubmitting}>
+              Submit Order
+            </Button>
+          </ModalActionsFooter>
+        }
+      >
+        <Stack gap="md">
+          <Input.Wrapper label="Requester" required error={createError?.validation?.requester?.message}>
+            <ResourceInput<Practitioner>
+              resourceType="Practitioner"
+              name="Requester"
+              onChange={setRequester}
+              defaultValue={requester}
+              searchCriteria={{ identifier: `${NPI_SYSTEM}|` }}
             />
-            <div>
-              <AsyncAutocomplete<TestCoding>
-                required
-                error={createError?.validation?.selectedTests?.message}
-                label="Selected tests"
-                disabled={!state.performingLab}
-                maxValues={10}
-                defaultValue={tests}
-                loadOptions={searchAvailableTests}
-                toOption={TestCodingToOption}
-                onChange={setTests}
-              />
-              {state.selectedTests.length > 0 && (
-                <Group mt="md" gap="md" align="flex-start" wrap="wrap">
-                  {state.selectedTests.map((test: TestCoding) => (
-                    <TestMetadataCardInput
-                      key={test.code}
-                      test={test}
-                      metadata={state.testMetadata[test.code]}
-                      error={createError?.validation?.testMetadata?.[test.code]}
-                    />
-                  ))}
-                </Group>
-              )}
-            </div>
-            <div>
-              <ValueSetAutocomplete
-                label="Diagnoses"
-                binding="http://hl7.org/fhir/sid/icd-10-cm/vs/billable"
-                name="diagnoses"
-                maxValues={10}
-                onChange={(items) => {
-                  const codeableConcepts = items.map((item) => ({
-                    coding: [valueSetElementToCoding(item)],
-                  })) as DiagnosisCodeableConcept[];
-                  setDiagnoses(codeableConcepts);
-                }}
-              />
-            </div>
-            <Group align="flex-start" gap={48}>
-              <div>
-                <Radio.Group
-                  value={state.billingInformation.billTo}
-                  error={createError?.validation?.billingInformation?.billTo?.message}
-                  onChange={(newBillTo) => {
-                    updateBillingInformation({ billTo: newBillTo as BillingInformation['billTo'] });
-                  }}
-                  label="Bill to"
-                  withAsterisk
-                >
-                  <Stack gap={4}>
-                    <Radio value="patient" label="Patient" />
-                    <Radio value="insurance" label="Insurance" />
-                    <Radio value="customer-account" label="Customer" />
-                  </Stack>
-                </Radio.Group>
-              </div>
-              {patient && (
-                <CoverageInput patient={patient} error={createError?.validation?.billingInformation?.patientCoverage} />
-              )}
-            </Group>
-            <TextInput label="Order notes" onChange={(e) => setOrderNotes(e.currentTarget.value)} />
-            <DateTimeInput
-              label="Specimen collection time"
-              name=""
-              onChange={(isoDateTimeString) => {
-                setSpecimenCollectedDateTime(isoDateTimeString ? new Date(isoDateTimeString) : undefined);
+          </Input.Wrapper>
+          <Input.Wrapper label="Patient" required error={createError?.validation?.patient?.message}>
+            <ResourceInput<Patient>
+              key={patient?.id ?? 'patient'}
+              resourceType="Patient"
+              name="patient"
+              defaultValue={patient}
+              onChange={setPatient}
+            />
+          </Input.Wrapper>
+          <PerformingLabInput
+            patient={patient}
+            performingLab={performingLab}
+            error={createError?.validation?.performingLab}
+          />
+          <div>
+            <AsyncAutocomplete<TestCoding>
+              required
+              error={createError?.validation?.selectedTests?.message}
+              label="Selected tests"
+              disabled={!state.performingLab}
+              maxValues={10}
+              defaultValue={tests}
+              loadOptions={searchAvailableTests}
+              toOption={TestCodingToOption}
+              onChange={setTests}
+            />
+            {state.selectedTests.length > 0 && (
+              <Group mt="md" gap="md" align="flex-start" wrap="wrap">
+                {state.selectedTests.map((test: TestCoding) => (
+                  <TestMetadataCardInput
+                    key={test.code}
+                    test={test}
+                    metadata={state.testMetadata[test.code]}
+                    error={createError?.validation?.testMetadata?.[test.code]}
+                  />
+                ))}
+              </Group>
+            )}
+          </div>
+          <div>
+            <ValueSetAutocomplete
+              label="Diagnoses"
+              binding="http://hl7.org/fhir/sid/icd-10-cm/vs/billable"
+              name="diagnoses"
+              maxValues={10}
+              onChange={(items) => {
+                const codeableConcepts = items.map((item) => ({
+                  coding: [valueSetElementToCoding(item)],
+                })) as DiagnosisCodeableConcept[];
+                setDiagnoses(codeableConcepts);
               }}
             />
-            <Group>
-              <Button onClick={submitOrder} loading={isSubmitting} disabled={isSubmitting}>
-                Submit Order
-              </Button>
-            </Group>
-          </Stack>
-        </Panel>
-      </Container>
+          </div>
+          <Group align="flex-start" gap={48}>
+            <div>
+              <Radio.Group
+                value={state.billingInformation.billTo}
+                error={createError?.validation?.billingInformation?.billTo?.message}
+                onChange={(newBillTo) => {
+                  updateBillingInformation({ billTo: newBillTo as BillingInformation['billTo'] });
+                }}
+                label="Bill to"
+                withAsterisk
+              >
+                <Stack gap={4}>
+                  <Radio value="patient" label="Patient" />
+                  <Radio value="insurance" label="Insurance" />
+                  <Radio value="customer-account" label="Customer" />
+                </Stack>
+              </Radio.Group>
+            </div>
+            {patient && (
+              <CoverageInput patient={patient} error={createError?.validation?.billingInformation?.patientCoverage} />
+            )}
+          </Group>
+          <TextInput label="Order notes" onChange={(e) => setOrderNotes(e.currentTarget.value)} />
+          <DateTimeInput
+            label="Specimen collection time"
+            name=""
+            onChange={(isoDateTimeString) => {
+              setSpecimenCollectedDateTime(isoDateTimeString ? new Date(isoDateTimeString) : undefined);
+            }}
+          />
+        </Stack>
+      </ModalContentLayout>
     </HealthGorillaLabOrderProvider>
   );
 }

--- a/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
@@ -44,7 +44,14 @@ import type {
   PractitionerRole,
 } from '@medplum/fhirtypes';
 import type { AsyncAutocompleteOption } from '@medplum/react';
-import { AsyncAutocomplete, Panel, ResourceInput, useMedplum } from '@medplum/react';
+import {
+  AsyncAutocomplete,
+  ModalActionsFooter,
+  ModalContentLayout,
+  Panel,
+  ResourceInput,
+  useMedplum,
+} from '@medplum/react';
 import { useSearchResources } from '@medplum/react-hooks';
 import {
   loadScriptSureQuantityQualifiers,
@@ -1141,305 +1148,326 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
           </Tabs.List>
 
           <Tabs.Panel value="single" pt="md">
-            <Stack gap="md">
-              <Input.Wrapper label="Patient" required>
-                <ResourceInput<Patient>
-                  key={patient?.id ?? 'patient-input'}
-                  resourceType="Patient"
-                  name="patient"
-                  defaultValue={patient}
-                  onChange={setPatient}
-                />
-              </Input.Wrapper>
+            <ModalContentLayout
+              footer={
+                <ModalActionsFooter>
+                  {onAddedToCart ? (
+                    <>
+                      <Button
+                        fullWidth
+                        onClick={() => {
+                          addToCart().catch(showErrorNotification);
+                        }}
+                        loading={isAddingToCart}
+                        disabled={submitting}
+                        leftSection={<IconShoppingCart size={16} />}
+                      >
+                        Add to cart
+                      </Button>
+                      <Button
+                        fullWidth
+                        variant="default"
+                        onClick={submitSingle}
+                        loading={submitting}
+                        disabled={isAddingToCart}
+                      >
+                        Prescribe this medication
+                      </Button>
+                    </>
+                  ) : (
+                    <Button onClick={submitSingle} loading={submitting} fullWidth>
+                      Prescribe now
+                    </Button>
+                  )}
+                </ModalActionsFooter>
+              }
+            >
+              <Stack gap="md">
+                <Input.Wrapper label="Patient" required>
+                  <ResourceInput<Patient>
+                    key={patient?.id ?? 'patient-input'}
+                    resourceType="Patient"
+                    name="patient"
+                    defaultValue={patient}
+                    onChange={setPatient}
+                  />
+                </Input.Wrapper>
 
-              <Input.Wrapper label="Requester" required>
-                <ResourceInput<Practitioner>
-                  key={requester?.id ?? 'requester-input'}
-                  resourceType="Practitioner"
-                  name="requester"
-                  defaultValue={requester}
-                  onChange={setRequester}
-                />
-              </Input.Wrapper>
+                <Input.Wrapper label="Requester" required>
+                  <ResourceInput<Practitioner>
+                    key={requester?.id ?? 'requester-input'}
+                    resourceType="Practitioner"
+                    name="requester"
+                    defaultValue={requester}
+                    onChange={setRequester}
+                  />
+                </Input.Wrapper>
 
-              <div>
-                <AsyncAutocomplete<Medication>
-                  required
-                  maxValues={1}
-                  minInputLength={2}
-                  label="Search medication"
-                  placeholder="Type drug name"
-                  loadOptions={loadMedicationOptions}
-                  toOption={medicationSearchToOption}
-                  itemComponent={MedicationSearchItem}
-                  onChange={(items) => {
-                    setTermMedication(items[0]);
-                    setFreeSig('');
-                  }}
-                />
-                {loadingFormats && <Text size="sm">Loading formulations…</Text>}
-              </div>
-
-              {formulationSigChoices.length > 0 && (
-                <Radio.Group
-                  label={`Formulation & directions (${formulationSigChoices.length})`}
-                  description="Pick the formulation and pre-built sig in one step"
-                  value={selectedChoiceKey}
-                  onChange={(v) => {
-                    const [fStr, sStr] = v.split(':');
-                    const fIdx = Number.parseInt(fStr, 10);
-                    const sIdx = Number.parseInt(sStr, 10);
-                    const fm = formatMedications[fIdx];
-                    if (fm) {
-                      setSelectedFormat(fm);
-                      setSigIndex(Math.max(sIdx, 0));
-                    }
-                  }}
-                >
-                  <ScrollArea.Autosize mah={320} mt="xs" type="auto" offsetScrollbars>
-                    <Stack gap="xs" pr="sm">
-                      {formulationSigChoices.map((choice) => (
-                        <Radio
-                          key={`${choice.formatIndex}:${choice.sigIndex}`}
-                          value={`${choice.formatIndex}:${choice.sigIndex}`}
-                          label={
-                            <Stack gap={0}>
-                              <Text size="sm" fw={500}>
-                                {choice.formatLabel}
-                              </Text>
-                              {choice.sigLine && (
-                                <Text size="xs" c="dimmed">
-                                  {choice.sigLine}
-                                  {choice.quantity > 0 ? ` · qty ${choice.quantity}` : ''}
-                                </Text>
-                              )}
-                            </Stack>
-                          }
-                        />
-                      ))}
-                    </Stack>
-                  </ScrollArea.Autosize>
-                </Radio.Group>
-              )}
-
-              {selectedFormat && sigOptions.length === 0 && (
-                <TextInput
-                  label="Sig (directions)"
-                  required
-                  value={freeSig}
-                  onChange={(e) => setFreeSig(e.currentTarget.value)}
-                />
-              )}
-
-              <Group grow>
-                <TextInput
-                  type="date"
-                  label="Written / start date"
-                  value={writtenDateYmd}
-                  onChange={(e) => setWrittenDateYmd(e.currentTarget.value)}
-                />
-                <TextInput
-                  type="date"
-                  label="Earliest fill (optional)"
-                  value={fillDateYmd}
-                  onChange={(e) => setFillDateYmd(e.currentTarget.value)}
-                />
-              </Group>
-
-              <Group grow align="flex-start">
-                <NumberInput
-                  label="Days supply"
-                  description="Auto-estimated from sig × quantity"
-                  value={daysSupply}
-                  onChange={(v) => {
-                    setDaysSupplyTouched(true);
-                    setDaysSupply(Number(v) || 0);
-                  }}
-                  min={1}
-                />
-                <NumberInput
-                  label="Quantity to dispense"
-                  description="Amount to send (e.g. tablets)"
-                  value={quantity}
-                  onChange={(v) => setQuantity(Number(v) || 0)}
-                  min={0}
-                />
-                <NumberInput
-                  label="Refills"
-                  description="Number of refills allowed"
-                  value={refill}
-                  onChange={(v) => setRefill(Number(v) || 0)}
-                  min={0}
-                />
-              </Group>
-
-              <Select
-                label="Quantity qualifier (dispense unit)"
-                description="How the dispensed amount is counted (NCI potency unit)"
-                data={qtyQualifierSelectData}
-                value={manualQtyQualifier}
-                onChange={(v) => setManualQtyQualifier(v ?? DEFAULT_QUANTITY_QUALIFIER)}
-                searchable
-              />
-
-              <Textarea
-                label="Notes to pharmacist"
-                placeholder="Shown on the ScriptSure pending order"
-                value={notesPharmacist}
-                onChange={(e) => setNotesPharmacist(e.currentTarget.value)}
-                minRows={2}
-              />
-              <Textarea
-                label="Patient instructions (additional)"
-                placeholder="Optional extra directions for the patient label"
-                value={patientInstruction}
-                onChange={(e) => setPatientInstruction(e.currentTarget.value)}
-                minRows={2}
-              />
-
-              <Checkbox
-                label="Allow substitution"
-                checked={useSubstitution}
-                onChange={(e) => setUseSubstitution(e.currentTarget.checked)}
-              />
-
-              <OptionalContextFields
-                medplum={medplum}
-                patient={patient}
-                primaryCondition={primaryCondition}
-                setPrimaryCondition={setPrimaryCondition}
-                coverage={coverage}
-                setCoverage={setCoverage}
-                pharmacyOrg={pharmacyOrg}
-                setPharmacyOrg={setPharmacyOrg}
-              />
-
-              {onAddedToCart && cartCount > 0 && (
-                <Group gap={6} justify="center">
-                  <IconShoppingCart size={16} />
-                  <Text size="sm" c="dimmed">
-                    {cartCount} in cart — review and check out on the Draft tab
-                  </Text>
-                </Group>
-              )}
-              {onAddedToCart ? (
-                <Group grow>
-                  <Button
-                    onClick={() => {
-                      addToCart().catch(showErrorNotification);
+                <div>
+                  <AsyncAutocomplete<Medication>
+                    required
+                    maxValues={1}
+                    minInputLength={2}
+                    label="Search medication"
+                    placeholder="Type drug name"
+                    loadOptions={loadMedicationOptions}
+                    toOption={medicationSearchToOption}
+                    itemComponent={MedicationSearchItem}
+                    onChange={(items) => {
+                      setTermMedication(items[0]);
+                      setFreeSig('');
                     }}
-                    loading={isAddingToCart}
-                    disabled={submitting}
-                    leftSection={<IconShoppingCart size={16} />}
+                  />
+                  {loadingFormats && <Text size="sm">Loading formulations…</Text>}
+                </div>
+
+                {formulationSigChoices.length > 0 && (
+                  <Radio.Group
+                    label={`Formulation & directions (${formulationSigChoices.length})`}
+                    description="Pick the formulation and pre-built sig in one step"
+                    value={selectedChoiceKey}
+                    onChange={(v) => {
+                      const [fStr, sStr] = v.split(':');
+                      const fIdx = Number.parseInt(fStr, 10);
+                      const sIdx = Number.parseInt(sStr, 10);
+                      const fm = formatMedications[fIdx];
+                      if (fm) {
+                        setSelectedFormat(fm);
+                        setSigIndex(Math.max(sIdx, 0));
+                      }
+                    }}
                   >
-                    Add to cart
-                  </Button>
-                  <Button variant="default" onClick={submitSingle} loading={submitting} disabled={isAddingToCart}>
-                    Prescribe this medication
-                  </Button>
+                    <ScrollArea.Autosize mah={320} mt="xs" type="auto" offsetScrollbars>
+                      <Stack gap="md" pr="sm">
+                        {formulationSigChoices.map((choice) => (
+                          <Radio
+                            key={`${choice.formatIndex}:${choice.sigIndex}`}
+                            value={`${choice.formatIndex}:${choice.sigIndex}`}
+                            label={
+                              <Stack gap={0}>
+                                <Text size="sm" fw={500}>
+                                  {choice.formatLabel}
+                                </Text>
+                                {choice.sigLine && (
+                                  <Text size="xs" c="dimmed">
+                                    {choice.sigLine}
+                                    {choice.quantity > 0 ? ` · qty ${choice.quantity}` : ''}
+                                  </Text>
+                                )}
+                              </Stack>
+                            }
+                          />
+                        ))}
+                      </Stack>
+                    </ScrollArea.Autosize>
+                  </Radio.Group>
+                )}
+
+                {selectedFormat && sigOptions.length === 0 && (
+                  <TextInput
+                    label="Sig (directions)"
+                    required
+                    value={freeSig}
+                    onChange={(e) => setFreeSig(e.currentTarget.value)}
+                  />
+                )}
+
+                <Group grow>
+                  <TextInput
+                    type="date"
+                    label="Written / start date"
+                    value={writtenDateYmd}
+                    onChange={(e) => setWrittenDateYmd(e.currentTarget.value)}
+                  />
+                  <TextInput
+                    type="date"
+                    label="Earliest fill (optional)"
+                    value={fillDateYmd}
+                    onChange={(e) => setFillDateYmd(e.currentTarget.value)}
+                  />
                 </Group>
-              ) : (
-                <Button onClick={submitSingle} loading={submitting} fullWidth>
-                  Prescribe now
-                </Button>
-              )}
-            </Stack>
+
+                <Group grow align="flex-start">
+                  <NumberInput
+                    label="Days supply"
+                    description="Auto-estimated from sig × quantity"
+                    value={daysSupply}
+                    onChange={(v) => {
+                      setDaysSupplyTouched(true);
+                      setDaysSupply(Number(v) || 0);
+                    }}
+                    min={1}
+                  />
+                  <NumberInput
+                    label="Quantity to dispense"
+                    description="Amount to send (e.g. tablets)"
+                    value={quantity}
+                    onChange={(v) => setQuantity(Number(v) || 0)}
+                    min={0}
+                  />
+                  <NumberInput
+                    label="Refills"
+                    description="Number of refills allowed"
+                    value={refill}
+                    onChange={(v) => setRefill(Number(v) || 0)}
+                    min={0}
+                  />
+                </Group>
+
+                <Select
+                  label="Quantity qualifier (dispense unit)"
+                  description="How the dispensed amount is counted (NCI potency unit)"
+                  data={qtyQualifierSelectData}
+                  value={manualQtyQualifier}
+                  onChange={(v) => setManualQtyQualifier(v ?? DEFAULT_QUANTITY_QUALIFIER)}
+                  searchable
+                />
+
+                <Textarea
+                  label="Notes to pharmacist"
+                  placeholder="Shown on the ScriptSure pending order"
+                  value={notesPharmacist}
+                  onChange={(e) => setNotesPharmacist(e.currentTarget.value)}
+                  minRows={2}
+                />
+                <Textarea
+                  label="Patient instructions (additional)"
+                  placeholder="Optional extra directions for the patient label"
+                  value={patientInstruction}
+                  onChange={(e) => setPatientInstruction(e.currentTarget.value)}
+                  minRows={2}
+                />
+
+                <Checkbox
+                  label="Allow substitution"
+                  checked={useSubstitution}
+                  onChange={(e) => setUseSubstitution(e.currentTarget.checked)}
+                />
+
+                <OptionalContextFields
+                  medplum={medplum}
+                  patient={patient}
+                  primaryCondition={primaryCondition}
+                  setPrimaryCondition={setPrimaryCondition}
+                  coverage={coverage}
+                  setCoverage={setCoverage}
+                  pharmacyOrg={pharmacyOrg}
+                  setPharmacyOrg={setPharmacyOrg}
+                />
+
+                {onAddedToCart && cartCount > 0 && (
+                  <Group gap={6} justify="center">
+                    <IconShoppingCart size={16} />
+                    <Text size="sm" c="dimmed">
+                      {cartCount} in cart — review and check out on the Draft tab
+                    </Text>
+                  </Group>
+                )}
+              </Stack>
+            </ModalContentLayout>
           </Tabs.Panel>
 
           <Tabs.Panel value="compound" pt="md">
-            <Stack gap="md">
-              <Input.Wrapper label="Patient" required>
-                <ResourceInput<Patient>
-                  key={patient?.id ?? 'patient-compound'}
-                  resourceType="Patient"
-                  name="patient-compound"
-                  defaultValue={patient}
-                  onChange={setPatient}
-                />
-              </Input.Wrapper>
+            <ModalContentLayout
+              footer={
+                <ModalActionsFooter>
+                  <Button fullWidth onClick={submitCompound} loading={submitting}>
+                    Prescribe
+                  </Button>
+                </ModalActionsFooter>
+              }
+            >
+              <Stack gap="md">
+                <Input.Wrapper label="Patient" required>
+                  <ResourceInput<Patient>
+                    key={patient?.id ?? 'patient-compound'}
+                    resourceType="Patient"
+                    name="patient-compound"
+                    defaultValue={patient}
+                    onChange={setPatient}
+                  />
+                </Input.Wrapper>
 
-              <ResourceInput<Practitioner>
-                resourceType="Practitioner"
-                name="requester-c"
-                label="Requester"
-                defaultValue={requester}
-                onChange={setRequester}
-              />
+                <ResourceInput<Practitioner>
+                  resourceType="Practitioner"
+                  name="requester-c"
+                  label="Requester"
+                  defaultValue={requester}
+                  onChange={setRequester}
+                />
 
-              <Group grow>
-                <TextInput
-                  type="date"
-                  label="Written / start date"
-                  value={compoundWrittenYmd}
-                  onChange={(e) => setCompoundWrittenYmd(e.currentTarget.value)}
+                <Group grow>
+                  <TextInput
+                    type="date"
+                    label="Written / start date"
+                    value={compoundWrittenYmd}
+                    onChange={(e) => setCompoundWrittenYmd(e.currentTarget.value)}
+                  />
+                  <TextInput
+                    type="date"
+                    label="Earliest fill (optional)"
+                    value={compoundFillYmd}
+                    onChange={(e) => setCompoundFillYmd(e.currentTarget.value)}
+                  />
+                </Group>
+                <NumberInput
+                  label="Days supply"
+                  description="Therapy length (days) for the compound order"
+                  value={compoundDaysSupply}
+                  onChange={(v) => setCompoundDaysSupply(Number(v) || 0)}
+                  min={1}
                 />
-                <TextInput
-                  type="date"
-                  label="Earliest fill (optional)"
-                  value={compoundFillYmd}
-                  onChange={(e) => setCompoundFillYmd(e.currentTarget.value)}
+                <Textarea
+                  label="Notes to pharmacist"
+                  value={compoundNotesPharmacist}
+                  onChange={(e) => setCompoundNotesPharmacist(e.currentTarget.value)}
+                  minRows={2}
                 />
-              </Group>
-              <NumberInput
-                label="Days supply"
-                description="Therapy length (days) for the compound order"
-                value={compoundDaysSupply}
-                onChange={(v) => setCompoundDaysSupply(Number(v) || 0)}
-                min={1}
-              />
-              <Textarea
-                label="Notes to pharmacist"
-                value={compoundNotesPharmacist}
-                onChange={(e) => setCompoundNotesPharmacist(e.currentTarget.value)}
-                minRows={2}
-              />
-              <Textarea
-                label="Patient instructions (additional)"
-                description="Appended to the first drug line sig sent to ScriptSure"
-                value={compoundPatientInstruction}
-                onChange={(e) => setCompoundPatientInstruction(e.currentTarget.value)}
-                minRows={2}
-              />
+                <Textarea
+                  label="Patient instructions (additional)"
+                  description="Appended to the first drug line sig sent to ScriptSure"
+                  value={compoundPatientInstruction}
+                  onChange={(e) => setCompoundPatientInstruction(e.currentTarget.value)}
+                  minRows={2}
+                />
 
-              {compoundLines.map((line, idx) => (
-                <CompoundLineEditor
-                  key={line.id}
-                  index={idx}
-                  line={line}
-                  searchMedications={searchMedications}
-                  onChange={(next) => updateCompoundLine(line.id, next)}
+                {compoundLines.map((line, idx) => (
+                  <CompoundLineEditor
+                    key={line.id}
+                    index={idx}
+                    line={line}
+                    searchMedications={searchMedications}
+                    onChange={(next) => updateCompoundLine(line.id, next)}
+                  />
+                ))}
+                <Button
+                  variant="light"
+                  onClick={() =>
+                    setCompoundLines((prev) => [
+                      ...prev,
+                      {
+                        id: `line-${Date.now()}-${prev.length}`,
+                        quantity: 30,
+                        refill: 0,
+                        useSubstitution: true,
+                      },
+                    ])
+                  }
+                >
+                  Add drug line
+                </Button>
+                <OptionalContextFields
+                  medplum={medplum}
+                  patient={patient}
+                  primaryCondition={primaryCondition}
+                  setPrimaryCondition={setPrimaryCondition}
+                  coverage={coverage}
+                  setCoverage={setCoverage}
+                  pharmacyOrg={pharmacyOrg}
+                  setPharmacyOrg={setPharmacyOrg}
                 />
-              ))}
-              <Button
-                variant="light"
-                onClick={() =>
-                  setCompoundLines((prev) => [
-                    ...prev,
-                    {
-                      id: `line-${Date.now()}-${prev.length}`,
-                      quantity: 30,
-                      refill: 0,
-                      useSubstitution: true,
-                    },
-                  ])
-                }
-              >
-                Add drug line
-              </Button>
-              <OptionalContextFields
-                medplum={medplum}
-                patient={patient}
-                primaryCondition={primaryCondition}
-                setPrimaryCondition={setPrimaryCondition}
-                coverage={coverage}
-                setCoverage={setCoverage}
-                pharmacyOrg={pharmacyOrg}
-                setPharmacyOrg={setPharmacyOrg}
-              />
-              <Button onClick={submitCompound} loading={submitting}>
-                Prescribe
-              </Button>
-            </Stack>
+              </Stack>
+            </ModalContentLayout>
           </Tabs.Panel>
 
           <Tabs.Panel value="order-set" pt="md">
@@ -1732,7 +1760,7 @@ function CompoundLineEditor(props: Readonly<CompoundLineEditorProps>): JSX.Eleme
 
   return (
     <PaperWithTitle title={`Drug line ${index + 1}`}>
-      <Stack gap="sm">
+      <Stack gap="md">
         <AsyncAutocomplete<Medication>
           label="Search"
           placeholder="Drug name"

--- a/examples/medplum-provider/src/pages/meds/OrderSetTabPanel.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderSetTabPanel.tsx
@@ -17,7 +17,7 @@ import {
 } from '@mantine/core';
 import { getReferenceString } from '@medplum/core';
 import type { Condition, Coverage, Organization, Patient, PlanDefinition, Practitioner } from '@medplum/fhirtypes';
-import { ResourceInput, useMedplum } from '@medplum/react';
+import { ModalActionsFooter, ModalContentLayout, ResourceInput, useMedplum } from '@medplum/react';
 import { SCRIPTSURE_ORDERSET_ID_SYSTEM, useScriptSureOrderSet } from '@medplum/scriptsure-react';
 import type { JSX } from 'react';
 import { useCallback, useState } from 'react';
@@ -231,109 +231,116 @@ export function OrderSetTabPanel(props: Readonly<OrderSetTabPanelProps>): JSX.El
   }, [submitDisabled, refresh, url, error, onOrderComplete]);
 
   return (
-    <Stack gap="md" data-testid="orderset-tab-panel">
-      <Input.Wrapper label="Patient" required>
-        <ResourceInput<Patient>
-          key={patient?.id ?? 'patient-orderset'}
-          resourceType="Patient"
-          name="patient-orderset"
-          defaultValue={patient}
-          onChange={onPatientChange}
-        />
-      </Input.Wrapper>
-
-      <Input.Wrapper label="Requester" required>
-        <ResourceInput<Practitioner>
-          key={requester?.id ?? 'requester-orderset'}
-          resourceType="Practitioner"
-          name="requester-orderset"
-          defaultValue={requester}
-          onChange={onRequesterChange}
-        />
-      </Input.Wrapper>
-
-      <Input.Wrapper
-        label="Order set"
-        description="Shared PlanDefinitions of type `order-set` (synced with ScriptSure)"
-        required
-      >
-        <ResourceInput<PlanDefinition>
-          key={planDefinition?.id ?? 'plan-definition-orderset'}
-          resourceType="PlanDefinition"
-          name="plan-definition-orderset"
-          defaultValue={planDefinition}
-          searchCriteria={{ type: 'order-set', status: 'active', context: 'shared' }}
-          itemComponent={renderPlanDefinitionOption}
-          onChange={(pd) => {
-            setPlanDefinition(pd);
-            // Picking a PD clears the manual escape hatch so the active
-            // selection always has exactly one source.
-            if (pd) {
-              setScriptSureIdEscape(undefined);
+    <ModalContentLayout
+      footer={
+        <ModalActionsFooter>
+          <Button
+            fullWidth
+            onClick={() => {
+              handleSubmit().catch(showErrorNotification);
+            }}
+            loading={loading || submitting}
+            disabled={submitDisabled}
+            title={
+              summaryWarnUnsynced
+                ? 'This order set hasn’t been synced to ScriptSure yet — pick a synced PlanDefinition or use the ScriptSure-id escape hatch.'
+                : undefined
             }
-          }}
-        />
-      </Input.Wrapper>
+          >
+            Open prescribing widget
+          </Button>
+        </ModalActionsFooter>
+      }
+    >
+      <Stack gap="md" data-testid="orderset-tab-panel">
+        <Input.Wrapper label="Patient" required>
+          <ResourceInput<Patient>
+            key={patient?.id ?? 'patient-orderset'}
+            resourceType="Patient"
+            name="patient-orderset"
+            defaultValue={patient}
+            onChange={onPatientChange}
+          />
+        </Input.Wrapper>
 
-      <Box>
-        <UnstyledButton onClick={() => setShowEscapeHatch((v) => !v)}>
-          <Text size="xs" c="dimmed">
-            {showEscapeHatch ? '▾' : '▸'} Use ScriptSure orderset id directly (escape hatch for un-synced sets)
-          </Text>
-        </UnstyledButton>
-        <Collapse in={showEscapeHatch} mt="xs">
-          <NumberInput
-            label="ScriptSure orderset id"
-            description="Use when the PlanDefinition picker can’t find your set. Disables PD selection while non-empty."
-            value={scriptSureIdEscape ?? ''}
-            onChange={(v) => {
-              const n = typeof v === 'number' ? v : Number.parseInt(String(v), 10);
-              const next = Number.isFinite(n) && n > 0 ? n : undefined;
-              setScriptSureIdEscape(next);
-              if (next !== undefined) {
-                setPlanDefinition(undefined);
+        <Input.Wrapper label="Requester" required>
+          <ResourceInput<Practitioner>
+            key={requester?.id ?? 'requester-orderset'}
+            resourceType="Practitioner"
+            name="requester-orderset"
+            defaultValue={requester}
+            onChange={onRequesterChange}
+          />
+        </Input.Wrapper>
+
+        <Input.Wrapper
+          label="Order set"
+          description="Shared PlanDefinitions of type `order-set` (synced with ScriptSure)"
+          required
+        >
+          <ResourceInput<PlanDefinition>
+            key={planDefinition?.id ?? 'plan-definition-orderset'}
+            resourceType="PlanDefinition"
+            name="plan-definition-orderset"
+            defaultValue={planDefinition}
+            searchCriteria={{ type: 'order-set', status: 'active', context: 'shared' }}
+            itemComponent={renderPlanDefinitionOption}
+            onChange={(pd) => {
+              setPlanDefinition(pd);
+              // Picking a PD clears the manual escape hatch so the active
+              // selection always has exactly one source.
+              if (pd) {
+                setScriptSureIdEscape(undefined);
               }
             }}
-            min={1}
-            allowNegative={false}
-            allowDecimal={false}
           />
-        </Collapse>
-      </Box>
+        </Input.Wrapper>
 
-      <OrderSetPreflightSummary pd={planDefinition} scriptSureIdEscape={scriptSureIdEscape} />
+        <Box>
+          <UnstyledButton onClick={() => setShowEscapeHatch((v) => !v)}>
+            <Text size="xs" c="dimmed">
+              {showEscapeHatch ? '▾' : '▸'} Use ScriptSure orderset id directly (escape hatch for un-synced sets)
+            </Text>
+          </UnstyledButton>
+          <Collapse in={showEscapeHatch} mt="xs">
+            <NumberInput
+              label="ScriptSure orderset id"
+              description="Use when the PlanDefinition picker can’t find your set. Disables PD selection while non-empty."
+              value={scriptSureIdEscape ?? ''}
+              onChange={(v) => {
+                const n = typeof v === 'number' ? v : Number.parseInt(String(v), 10);
+                const next = Number.isFinite(n) && n > 0 ? n : undefined;
+                setScriptSureIdEscape(next);
+                if (next !== undefined) {
+                  setPlanDefinition(undefined);
+                }
+              }}
+              min={1}
+              allowNegative={false}
+              allowDecimal={false}
+            />
+          </Collapse>
+        </Box>
 
-      <OptionalContextFields
-        medplum={medplum}
-        patient={patient}
-        primaryCondition={primaryCondition}
-        setPrimaryCondition={setPrimaryCondition}
-        coverage={coverage}
-        setCoverage={setCoverage}
-        pharmacyOrg={pharmacyOrg}
-        setPharmacyOrg={setPharmacyOrg}
-      />
+        <OrderSetPreflightSummary pd={planDefinition} scriptSureIdEscape={scriptSureIdEscape} />
 
-      {error ? (
-        <Alert color="red" variant="light" p="xs" radius="sm">
-          <Text size="xs">Failed to build widget URL — see browser console for details.</Text>
-        </Alert>
-      ) : null}
+        <OptionalContextFields
+          medplum={medplum}
+          patient={patient}
+          primaryCondition={primaryCondition}
+          setPrimaryCondition={setPrimaryCondition}
+          coverage={coverage}
+          setCoverage={setCoverage}
+          pharmacyOrg={pharmacyOrg}
+          setPharmacyOrg={setPharmacyOrg}
+        />
 
-      <Button
-        onClick={() => {
-          handleSubmit().catch(showErrorNotification);
-        }}
-        loading={loading || submitting}
-        disabled={submitDisabled}
-        title={
-          summaryWarnUnsynced
-            ? 'This order set hasn’t been synced to ScriptSure yet — pick a synced PlanDefinition or use the ScriptSure-id escape hatch.'
-            : undefined
-        }
-      >
-        Open prescribing widget
-      </Button>
-    </Stack>
+        {error ? (
+          <Alert color="red" variant="light" p="xs" radius="sm">
+            <Text size="xs">Failed to build widget URL — see browser console for details.</Text>
+          </Alert>
+        ) : null}
+      </Stack>
+    </ModalContentLayout>
   );
 }

--- a/examples/medplum-provider/src/pages/patient/DoseSpotAdvancedOptions.tsx
+++ b/examples/medplum-provider/src/pages/patient/DoseSpotAdvancedOptions.tsx
@@ -80,7 +80,6 @@ export function DoseSpotAdvancedOptions({ patientId }: { patientId: string }): J
         styles={{
           title: {
             fontSize: '1.5rem',
-            fontWeight: 600,
           },
         }}
       >

--- a/examples/medplum-provider/src/pages/patient/EditDocumentDetailsModal.tsx
+++ b/examples/medplum-provider/src/pages/patient/EditDocumentDetailsModal.tsx
@@ -1,9 +1,16 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Button, Divider, Group, Modal, Stack, Text, TextInput } from '@mantine/core';
+import { Box, Button, Modal, Stack, Text, TextInput } from '@mantine/core';
 import type { WithId } from '@medplum/core';
 import type { CodeableConcept, DocumentReference, Reference } from '@medplum/fhirtypes';
-import { CodeableConceptInput, ReferenceInput, useMedplum } from '@medplum/react';
+import {
+  CodeableConceptInput,
+  ModalActionsFooter,
+  ModalContentLayout,
+  ReferenceInput,
+  useMedplum,
+} from '@medplum/react';
+import { IconTrash } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useState } from 'react';
 import { showErrorNotification, showSuccessNotification } from '../../utils/notifications';
@@ -110,76 +117,84 @@ export function EditDocumentDetailsModal({
         <>
           {/* Edit form: kept mounted (only hidden) during delete confirmation so edits persist. */}
           <Box display={confirmingDelete ? 'none' : undefined}>
-            <Stack gap="md">
-              <Divider />
-
-              <TextInput
-                label="Description"
-                value={description}
-                onChange={(event) => setDescription(event.currentTarget.value)}
-              />
-
-              <CodeableConceptInput
-                name="type"
-                label="Type"
-                path={`${sourcePath}.type`}
-                binding="http://hl7.org/fhir/ValueSet/c80-doc-typecodes"
-                maxValues={1}
-                defaultValue={type}
-                onChange={(value) => setType(value)}
-              />
-
-              <CodeableConceptInput
-                name="category"
-                label="Category"
-                path={`${sourcePath}.category`}
-                binding="http://hl7.org/fhir/ValueSet/document-classcodes"
-                maxValues={1}
-                defaultValue={category}
-                onChange={(value) => setCategory(value)}
-              />
-
-              <Box>
-                <Text size="sm" fw={500} mb={4}>
-                  Author
-                </Text>
-                <ReferenceInput
-                  name="author"
-                  targetTypes={AUTHOR_TARGET_TYPES}
-                  defaultValue={authorRef}
-                  onChange={(value) => setAuthorRef(value)}
+            <ModalContentLayout
+              footer={
+                <ModalActionsFooter>
+                  <Button variant="filled" w="100%" onClick={() => handleSave().catch(console.error)} loading={saving}>
+                    Save Changes
+                  </Button>
+                  <Button
+                    variant="light"
+                    color="red"
+                    w="100%"
+                    leftSection={<IconTrash size={16} />}
+                    onClick={() => setConfirmingDelete(true)}
+                    disabled={saving}
+                  >
+                    Delete Document
+                  </Button>
+                </ModalActionsFooter>
+              }
+            >
+              <Stack gap="md">
+                <TextInput
+                  label="Description"
+                  value={description}
+                  onChange={(event) => setDescription(event.currentTarget.value)}
                 />
-              </Box>
 
-              <Divider />
+                <CodeableConceptInput
+                  name="type"
+                  label="Type"
+                  path={`${sourcePath}.type`}
+                  binding="http://hl7.org/fhir/ValueSet/c80-doc-typecodes"
+                  maxValues={1}
+                  defaultValue={type}
+                  onChange={(value) => setType(value)}
+                />
 
-              <Button variant="filled" w="100%" onClick={() => handleSave().catch(console.error)} loading={saving}>
-                Save Changes
-              </Button>
-              <Button
-                variant="outline"
-                color="red"
-                w="100%"
-                onClick={() => setConfirmingDelete(true)}
-                disabled={saving}
-              >
-                Delete Document
-              </Button>
-            </Stack>
+                <CodeableConceptInput
+                  name="category"
+                  label="Category"
+                  path={`${sourcePath}.category`}
+                  binding="http://hl7.org/fhir/ValueSet/document-classcodes"
+                  maxValues={1}
+                  defaultValue={category}
+                  onChange={(value) => setCategory(value)}
+                />
+
+                <Box>
+                  <Text size="sm" fw={500} mb={4}>
+                    Author
+                  </Text>
+                  <ReferenceInput
+                    name="author"
+                    targetTypes={AUTHOR_TARGET_TYPES}
+                    defaultValue={authorRef}
+                    onChange={(value) => setAuthorRef(value)}
+                  />
+                </Box>
+              </Stack>
+            </ModalContentLayout>
           </Box>
 
           {confirmingDelete && (
-            <Stack gap="md">
-              <Text>Are you sure you want to delete this document? This action cannot be undone.</Text>
-              <Group justify="flex-end" gap="sm">
-                <Button variant="outline" onClick={() => setConfirmingDelete(false)} disabled={deleting}>
-                  Cancel
-                </Button>
-                <Button color="red" onClick={() => handleDelete().catch(console.error)} loading={deleting}>
-                  Delete
-                </Button>
-              </Group>
-            </Stack>
+            <ModalContentLayout
+              footer={
+                <ModalActionsFooter>
+                  <Button color="red" w="100%" onClick={() => handleDelete().catch(console.error)} loading={deleting}>
+                    Delete
+                  </Button>
+                  <Button variant="outline" w="100%" onClick={() => setConfirmingDelete(false)} disabled={deleting}>
+                    Cancel
+                  </Button>
+                </ModalActionsFooter>
+              }
+            >
+              <Stack gap="md">
+                <Text>Are you sure you want to delete this document? This action cannot be undone.</Text>
+              </Stack>
+            </ModalContentLayout>
           )}
         </>
       )}

--- a/examples/medplum-provider/src/pages/patient/UploadDocumentModal.module.css
+++ b/examples/medplum-provider/src/pages/patient/UploadDocumentModal.module.css
@@ -10,7 +10,7 @@
 }
 
 .dropzone {
-  border: 2px dashed var(--mantine-color-gray-3);
+  border: 2px dashed var(--mantine-color-dark-4);
   border-radius: var(--mantine-radius-md);
   padding: var(--mantine-spacing-xl) var(--mantine-spacing-md);
   cursor: pointer;

--- a/examples/medplum-provider/src/pages/patient/UploadDocumentModal.module.css
+++ b/examples/medplum-provider/src/pages/patient/UploadDocumentModal.module.css
@@ -10,7 +10,7 @@
 }
 
 .dropzone {
-  border: 2px dashed var(--mantine-color-dark-4);
+  border: 2px dashed light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
   border-radius: var(--mantine-radius-md);
   padding: var(--mantine-spacing-xl) var(--mantine-spacing-md);
   cursor: pointer;

--- a/examples/medplum-provider/src/pages/patient/UploadDocumentModal.test.tsx
+++ b/examples/medplum-provider/src/pages/patient/UploadDocumentModal.test.tsx
@@ -42,7 +42,7 @@ describe('UploadDocumentModal', () => {
 
   test('renders the form when opened', () => {
     setup();
-    expect(screen.getByText('Upload document')).toBeInTheDocument();
+    expect(screen.getByText('Upload Document')).toBeInTheDocument();
     expect(screen.getByText('Drag a file here or click to browse')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Enter a description (optional)')).toBeInTheDocument();
     expect(screen.getByText('Type')).toBeInTheDocument();
@@ -51,7 +51,7 @@ describe('UploadDocumentModal', () => {
 
   test('renders nothing when closed', () => {
     setup({ opened: false });
-    expect(screen.queryByText('Upload document')).not.toBeInTheDocument();
+    expect(screen.queryByText('Upload Document')).not.toBeInTheDocument();
   });
 
   test('disables the Upload button until a file is selected', () => {

--- a/examples/medplum-provider/src/pages/patient/UploadDocumentModal.tsx
+++ b/examples/medplum-provider/src/pages/patient/UploadDocumentModal.tsx
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Button, Divider, Modal, Stack, Text, TextInput } from '@mantine/core';
+import { Box, Button, Modal, Stack, Text, TextInput } from '@mantine/core';
 import { createReference } from '@medplum/core';
 import type { CodeableConcept, DocumentReference, Patient, Reference } from '@medplum/fhirtypes';
-import { CodeableConceptInput, useMedplum, useResource } from '@medplum/react';
+import { CodeableConceptInput, ModalActionsFooter, ModalContentLayout, useMedplum, useResource } from '@medplum/react';
 import { IconUpload } from '@tabler/icons-react';
 import cx from 'clsx';
 import type { JSX } from 'react';
@@ -76,67 +76,71 @@ export function UploadDocumentModal({ opened, onClose, patient, onCreated }: Upl
   };
 
   return (
-    <Modal opened={opened} onClose={handleClose} title="Upload document" centered size="lg">
-      <Stack gap="md">
-        <Stack gap={4}>
-          <Text size="sm" fw={500}>
-            File <span className={classes.required}>*</span>
-          </Text>
-          <input
-            type="file"
-            ref={fileInputRef}
-            onChange={(e) => setFile(e.target.files?.[0] ?? null)}
-            className={classes.hiddenInput}
+    <Modal opened={opened} onClose={handleClose} title="Upload Document" centered size="lg">
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <Button variant="filled" w="100%" onClick={handleUpload} loading={isSubmitting} disabled={!file}>
+              Upload
+            </Button>
+          </ModalActionsFooter>
+        }
+      >
+        <Stack gap="md">
+          <Stack gap={4}>
+            <Text size="sm" fw={500}>
+              File <span className={classes.required}>*</span>
+            </Text>
+            <input
+              type="file"
+              ref={fileInputRef}
+              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+              className={classes.hiddenInput}
+            />
+            <Box
+              onClick={() => fileInputRef.current?.click()}
+              onDragOver={(e) => {
+                e.preventDefault();
+                setIsDragging(true);
+              }}
+              onDragLeave={() => setIsDragging(false)}
+              onDrop={(e) => {
+                e.preventDefault();
+                setIsDragging(false);
+                const dropped = e.dataTransfer.files?.[0];
+                if (dropped) {
+                  setFile(dropped);
+                }
+              }}
+              className={cx(classes.dropzone, isDragging && classes.dropzoneDragging)}
+            >
+              <Stack align="center" gap={4}>
+                <IconUpload size={24} color={file ? 'var(--mantine-color-blue-5)' : 'var(--mantine-color-gray-5)'} />
+                <Text size="sm" c={file ? undefined : 'dimmed'}>
+                  {file ? file.name : 'Drag a file here or click to browse'}
+                </Text>
+              </Stack>
+            </Box>
+          </Stack>
+
+          <TextInput
+            label="Description"
+            placeholder="Enter a description (optional)"
+            value={description}
+            onChange={(e) => setDescription(e.currentTarget.value)}
           />
-          <Box
-            onClick={() => fileInputRef.current?.click()}
-            onDragOver={(e) => {
-              e.preventDefault();
-              setIsDragging(true);
-            }}
-            onDragLeave={() => setIsDragging(false)}
-            onDrop={(e) => {
-              e.preventDefault();
-              setIsDragging(false);
-              const dropped = e.dataTransfer.files?.[0];
-              if (dropped) {
-                setFile(dropped);
-              }
-            }}
-            className={cx(classes.dropzone, isDragging && classes.dropzoneDragging)}
-          >
-            <Stack align="center" gap={4}>
-              <IconUpload size={24} color={file ? 'var(--mantine-color-blue-5)' : 'var(--mantine-color-gray-5)'} />
-              <Text size="sm" c={file ? undefined : 'dimmed'}>
-                {file ? file.name : 'Drag a file here or click to browse'}
-              </Text>
-            </Stack>
-          </Box>
+
+          <CodeableConceptInput
+            name="type"
+            path="DocumentReference.type"
+            label="Type"
+            placeholder="Select a document type (optional)"
+            binding="http://hl7.org/fhir/ValueSet/c80-doc-typecodes"
+            maxValues={1}
+            onChange={setType}
+          />
         </Stack>
-
-        <TextInput
-          label="Description"
-          placeholder="Enter a description (optional)"
-          value={description}
-          onChange={(e) => setDescription(e.currentTarget.value)}
-        />
-
-        <CodeableConceptInput
-          name="type"
-          path="DocumentReference.type"
-          label="Type"
-          placeholder="Select a document type (optional)"
-          binding="http://hl7.org/fhir/ValueSet/c80-doc-typecodes"
-          maxValues={1}
-          onChange={setType}
-        />
-
-        <Divider />
-
-        <Button variant="filled" onClick={handleUpload} loading={isSubmitting} disabled={!file}>
-          Upload
-        </Button>
-      </Stack>
+      </ModalContentLayout>
     </Modal>
   );
 }

--- a/examples/medplum-provider/vite.config.ts
+++ b/examples/medplum-provider/vite.config.ts
@@ -13,19 +13,32 @@ if (!existsSync(path.join(__dirname, '.env'))) {
   copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
 }
 
-// Resolve aliases to local packages when working within the monorepo
-const alias: NonNullable<UserConfig['resolve']>['alias'] = Object.fromEntries(
-  Object.entries({
+// Resolve aliases to local packages when working within the monorepo.
+// Use regex exact-matches for package entrypoints so Vite doesn't follow
+// package.json "exports" to dist, and so `@medplum/react/styles.css` still works.
+const alias: NonNullable<UserConfig['resolve']>['alias'] = [
+  {
+    find: '@medplum/react/styles.css',
+    replacement: path.resolve(__dirname, '../../packages/react/dist/esm/index.css'),
+  },
+  {
+    find: /^@medplum\/react$/,
+    replacement: path.resolve(__dirname, '../../packages/react/src/index.ts'),
+  },
+  {
+    find: /^@medplum\/react-hooks$/,
+    replacement: path.resolve(__dirname, '../../packages/react-hooks/src/index.ts'),
+  },
+  ...Object.entries({
     '@medplum/core': path.resolve(__dirname, '../../packages/core/src'),
     '@medplum/dosespot-react': path.resolve(__dirname, '../../packages/dosespot-react/src'),
     '@medplum/scriptsure-react': path.resolve(__dirname, '../../packages/scriptsure-react/src'),
-    '@medplum/react$': path.resolve(__dirname, '../../packages/react/src'),
-    '@medplum/react/styles.css': path.resolve(__dirname, '../../packages/react/dist/esm/index.css'),
-    '@medplum/react-hooks': path.resolve(__dirname, '../../packages/react-hooks/src'),
     '@medplum/health-gorilla-core': path.resolve(__dirname, '../../packages/health-gorilla-core/src'),
     '@medplum/health-gorilla-react': path.resolve(__dirname, '../../packages/health-gorilla-react/src'),
-  }).filter(([, relPath]) => existsSync(relPath))
-);
+  })
+    .filter(([, replacement]) => existsSync(replacement))
+    .map(([find, replacement]) => ({ find, replacement })),
+].filter((entry) => existsSync(entry.replacement));
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/packages/react/.storybook/themes.ts
+++ b/packages/react/.storybook/themes.ts
@@ -1,4 +1,7 @@
 import { createTheme, MantineThemeOverride } from '@mantine/core';
+// Imported from source, not '@medplum/react', so Storybook picks up local changes
+// rather than a stale dist build.
+import { medplumModalTheme } from '../src/theme/modalTheme';
 
 const medplumDefault = createTheme({
   headings: {
@@ -16,6 +19,11 @@ const medplumDefault = createTheme({
     md: '0.875rem',
     lg: '1.0rem',
     xl: '1.125rem',
+  },
+  // Only the Medplum preset gets our modal chrome; the other presets exist to show
+  // how these components look under a host app's own theme.
+  components: {
+    Modal: medplumModalTheme,
   },
 });
 

--- a/packages/react/src/BookmarkDialog/BookmarkDialog.tsx
+++ b/packages/react/src/BookmarkDialog/BookmarkDialog.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Group, Modal, NativeSelect, Stack, TextInput } from '@mantine/core';
+import { Modal, NativeSelect, Stack, TextInput } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import type { WithId } from '@medplum/core';
 import { deepClone, normalizeErrorString } from '@medplum/core';
@@ -9,6 +9,8 @@ import { useMedplum } from '@medplum/react-hooks';
 import type { JSX } from 'react';
 import { Form } from '../Form/Form';
 import { SubmitButton } from '../Form/SubmitButton';
+import { ModalActionsFooter } from '../ModalActionsFooter/ModalActionsFooter';
+import { ModalContentLayout } from '../ModalContentLayout/ModalContentLayout';
 
 interface BookmarkDialogProps {
   readonly pathname: string;
@@ -50,20 +52,25 @@ export function BookmarkDialog(props: BookmarkDialogProps): JSX.Element | null {
       onClose={props.onCancel}
     >
       <Form onSubmit={submitHandler}>
-        <Stack>
-          <SelectMenu config={config}></SelectMenu>
-          <TextInput
-            label="Bookmark Name"
-            type="text"
-            name="bookmarkname"
-            placeholder="Bookmark Name"
-            defaultValue={props.pathname.split('/')[1] || ''}
-            withAsterisk
-          />
-          <Group justify="flex-end">
-            <SubmitButton mt="sm">OK</SubmitButton>
-          </Group>
-        </Stack>
+        <ModalContentLayout
+          footer={
+            <ModalActionsFooter>
+              <SubmitButton fullWidth>OK</SubmitButton>
+            </ModalActionsFooter>
+          }
+        >
+          <Stack gap="md">
+            <SelectMenu config={config}></SelectMenu>
+            <TextInput
+              label="Bookmark Name"
+              type="text"
+              name="bookmarkname"
+              placeholder="Bookmark Name"
+              defaultValue={props.pathname.split('/')[1] || ''}
+              withAsterisk
+            />
+          </Stack>
+        </ModalContentLayout>
       </Form>
     </Modal>
   );

--- a/packages/react/src/ModalActionsFooter/ModalActionsFooter.test.tsx
+++ b/packages/react/src/ModalActionsFooter/ModalActionsFooter.test.tsx
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { render, screen } from '../test-utils/render';
+import { ModalActionsFooter } from './ModalActionsFooter';
+
+describe('ModalActionsFooter', () => {
+  test('Renders children', () => {
+    render(
+      <ModalActionsFooter>
+        <button type="button">Save</button>
+      </ModalActionsFooter>
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDefined();
+  });
+
+  test('Renders multiple actions', () => {
+    render(
+      <ModalActionsFooter>
+        <button type="button">Save</button>
+        <button type="button">Cancel</button>
+      </ModalActionsFooter>
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDefined();
+  });
+
+  test('Renders a divider by default', () => {
+    const { container } = render(
+      <ModalActionsFooter>
+        <button type="button">Save</button>
+      </ModalActionsFooter>
+    );
+    expect(container.querySelector('.mantine-Divider-root')).not.toBeNull();
+  });
+
+  test('Uses a full-bleed top border instead of a divider when sticky', () => {
+    const { container } = render(
+      <ModalActionsFooter sticky>
+        <button type="button">Save</button>
+      </ModalActionsFooter>
+    );
+    // Sticky mirrors the modal header with a border, so the Divider is not used.
+    expect(container.querySelector('.mantine-Divider-root')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDefined();
+  });
+});

--- a/packages/react/src/ModalActionsFooter/ModalActionsFooter.tsx
+++ b/packages/react/src/ModalActionsFooter/ModalActionsFooter.tsx
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Box, Divider, Stack } from '@mantine/core';
+import type { JSX, ReactNode } from 'react';
+
+const modalFooterBorder = '1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4))';
+
+export interface ModalActionsFooterProps {
+  readonly children: ReactNode;
+  /**
+   * Pin footer to modal bottom with a full-bleed top border (mirrors the modal header).
+   * Use with {@link ModalContentLayout} `insetContent` and a fixed-height modal body.
+   */
+  readonly sticky?: boolean;
+}
+
+/**
+ * Divider + full-width action buttons. Use as the footer slot in {@link ModalContentLayout}.
+ * @param props - The ModalActionsFooter React props.
+ * @returns The ModalActionsFooter React node.
+ */
+export function ModalActionsFooter(props: ModalActionsFooterProps): JSX.Element {
+  const { children, sticky } = props;
+
+  if (sticky) {
+    return (
+      <Box flex="0 0 auto" style={{ borderTop: modalFooterBorder }} px="lg" py="lg">
+        <Stack gap="sm">{children}</Stack>
+      </Box>
+    );
+  }
+
+  return (
+    <Stack gap="lg" pt="lg" style={{ flexShrink: 0 }}>
+      <Divider />
+      <Stack gap="sm">{children}</Stack>
+    </Stack>
+  );
+}

--- a/packages/react/src/ModalContentLayout/ModalContentLayout.test.tsx
+++ b/packages/react/src/ModalContentLayout/ModalContentLayout.test.tsx
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { render, screen } from '../test-utils/render';
+import { ModalContentLayout } from './ModalContentLayout';
+
+describe('ModalContentLayout', () => {
+  test('Renders children and footer', () => {
+    render(
+      <ModalContentLayout footer={<button type="button">Save</button>}>
+        <div>Body content</div>
+      </ModalContentLayout>
+    );
+    expect(screen.getByText('Body content')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDefined();
+  });
+
+  test('Renders children before footer in DOM order', () => {
+    render(
+      <ModalContentLayout footer={<span>Footer</span>}>
+        <span>Body</span>
+      </ModalContentLayout>
+    );
+    const body = screen.getByText('Body');
+    const footer = screen.getByText('Footer');
+    // Node.DOCUMENT_POSITION_FOLLOWING (4) means footer comes after body.
+    expect(body.compareDocumentPosition(footer) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  test('Renders both slots when insetContent is set', () => {
+    render(
+      <ModalContentLayout insetContent footer={<button type="button">Submit</button>}>
+        <div>Scrollable body</div>
+      </ModalContentLayout>
+    );
+    expect(screen.getByText('Scrollable body')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDefined();
+  });
+
+  test('insetContent scrolls the content rather than the layout', () => {
+    render(
+      <ModalContentLayout insetContent footer={<span>F</span>}>
+        <span>Inset body</span>
+      </ModalContentLayout>
+    );
+    // The content wrapper owns the overflow so the footer can stay pinned.
+    const contentWrapper = screen.getByText('Inset body').parentElement as HTMLElement;
+    expect(contentWrapper.style.overflowY).toBe('auto');
+  });
+});

--- a/packages/react/src/ModalContentLayout/ModalContentLayout.tsx
+++ b/packages/react/src/ModalContentLayout/ModalContentLayout.tsx
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Box, Stack } from '@mantine/core';
+import type { JSX, ReactNode } from 'react';
+
+export interface ModalContentLayoutProps {
+  readonly children: ReactNode;
+  readonly footer: ReactNode;
+  /** Scroll content in-place with standard modal horizontal/top padding (for sticky modal footers). */
+  readonly insetContent?: boolean;
+}
+
+/**
+ * Standard modal body layout: scrollable content above a pinned action footer.
+ * Pair with {@link ModalActionsFooter} for divider + full-width buttons.
+ * @param props - The ModalContentLayout React props.
+ * @returns The ModalContentLayout React node.
+ */
+export function ModalContentLayout(props: ModalContentLayoutProps): JSX.Element {
+  const { children, footer, insetContent } = props;
+
+  if (insetContent) {
+    return (
+      <Box
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          minHeight: 0,
+        }}
+      >
+        <Box miw={0} px="lg" pt="lg" style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
+          {children}
+        </Box>
+        {footer}
+      </Box>
+    );
+  }
+
+  return (
+    <Stack h="100%" justify="space-between" gap={0}>
+      <Box flex={1} miw={0}>
+        {children}
+      </Box>
+      {footer}
+    </Stack>
+  );
+}

--- a/packages/react/src/PatientSummary/Labs.tsx
+++ b/packages/react/src/PatientSummary/Labs.tsx
@@ -122,7 +122,7 @@ export function Labs(props: LabsProps): JSX.Element {
           {filteredServiceRequests.length === 0 && filteredDiagnosticReports.length === 0 && <Text>(none)</Text>}
         </Flex>
       </CollapsibleSection>
-      <Modal opened={reportDialogOpened} onClose={closeReportDialog} size="80%">
+      <Modal opened={reportDialogOpened} onClose={closeReportDialog} size="80%" title="Lab Results">
         {selectedReport && <DiagnosticReportDisplay value={selectedReport} hideSubject={true} />}
       </Modal>
     </>

--- a/packages/react/src/SearchFilterValueDialog/SearchFilterValueDialog.tsx
+++ b/packages/react/src/SearchFilterValueDialog/SearchFilterValueDialog.tsx
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Button, Grid, Modal } from '@mantine/core';
+import { Button, Modal } from '@mantine/core';
 import type { Filter } from '@medplum/core';
 import type { SearchParameter } from '@medplum/fhirtypes';
 import type { JSX } from 'react';
 import { useState } from 'react';
 import { Form } from '../Form/Form';
+import { ModalActionsFooter } from '../ModalActionsFooter/ModalActionsFooter';
+import { ModalContentLayout } from '../ModalContentLayout/ModalContentLayout';
 import { SearchFilterValueInput } from '../SearchFilterValueInput/SearchFilterValueInput';
 
 export interface SearchFilterValueDialogProps {
@@ -33,22 +35,23 @@ export function SearchFilterValueDialog(props: SearchFilterValueDialogProps): JS
   return (
     <Modal title={props.title} size="xl" opened={props.visible} onClose={props.onCancel}>
       <Form onSubmit={onOk}>
-        <Grid>
-          <Grid.Col span={10}>
-            <SearchFilterValueInput
-              resourceType={props.resourceType}
-              searchParam={props.searchParam}
-              defaultValue={value}
-              autoFocus={true}
-              onChange={setValue}
-            />
-          </Grid.Col>
-          <Grid.Col span={2}>
-            <Button onClick={onOk} fullWidth>
-              OK
-            </Button>
-          </Grid.Col>
-        </Grid>
+        <ModalContentLayout
+          footer={
+            <ModalActionsFooter>
+              <Button type="submit" fullWidth>
+                OK
+              </Button>
+            </ModalActionsFooter>
+          }
+        >
+          <SearchFilterValueInput
+            resourceType={props.resourceType}
+            searchParam={props.searchParam}
+            defaultValue={value}
+            autoFocus={true}
+            onChange={setValue}
+          />
+        </ModalContentLayout>
       </Form>
     </Modal>
   );

--- a/packages/react/src/chat/ThreadInbox/NewTopicDialog.tsx
+++ b/packages/react/src/chat/ThreadInbox/NewTopicDialog.tsx
@@ -14,6 +14,8 @@ import type {
 import { useMedplum, useMedplumProfile } from '@medplum/react-hooks';
 import type { JSX } from 'react';
 import { useMemo, useState } from 'react';
+import { ModalActionsFooter } from '../../ModalActionsFooter/ModalActionsFooter';
+import { ModalContentLayout } from '../../ModalContentLayout/ModalContentLayout';
 import { QuestionnaireForm } from '../../QuestionnaireForm/QuestionnaireForm';
 import { ResourceInput } from '../../ResourceInput/ResourceInput';
 
@@ -105,50 +107,58 @@ export const NewTopicDialog = (props: NewTopicDialogProps): JSX.Element => {
 
   return (
     <Modal opened={opened} onClose={onClose} title="New Message" size="md">
-      <Stack gap="xl">
-        <Stack gap={0}>
-          <Text fw={500}>Patient</Text>
-          {allowPatientSelection && <Text c="dimmed">Select a patient</Text>}
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <Button fullWidth onClick={handleSubmit}>
+              Next
+            </Button>
+          </ModalActionsFooter>
+        }
+      >
+        <Stack gap="md">
+          <Stack gap={0}>
+            <Text fw={500}>Patient</Text>
+            {allowPatientSelection && <Text c="dimmed">Select a patient</Text>}
 
-          <ResourceInput
-            resourceType="Patient"
-            name="patient"
-            required={true}
-            defaultValue={patient}
-            disabled={!allowPatientSelection && !!patient}
-            onChange={(value) => {
-              setPatient(value ? createReference(value) : undefined);
-            }}
-          />
+            <ResourceInput
+              resourceType="Patient"
+              name="patient"
+              required={true}
+              defaultValue={patient}
+              disabled={!allowPatientSelection && !!patient}
+              onChange={(value) => {
+                setPatient(value ? createReference(value) : undefined);
+              }}
+            />
+          </Stack>
+
+          <Stack gap={0}>
+            <Text fw={500}>Practitioner (optional)</Text>
+            <Text c="dimmed">Select one or more practitioners</Text>
+
+            <QuestionnaireForm
+              questionnaire={questionnaire}
+              questionnaireResponse={initialResponse}
+              excludeButtons={true}
+              onChange={(value: QuestionnaireResponse) => {
+                const references =
+                  value.item?.[0].answer
+                    ?.map((item) => item.valueReference)
+                    .filter((ref): ref is Reference<Practitioner> => ref !== undefined) ?? [];
+                setPractitioners(references);
+              }}
+            />
+          </Stack>
+
+          <Stack gap={0}>
+            <Text fw={500}>Topic (optional)</Text>
+            <Text c="dimmed">Enter a topic for the message</Text>
+
+            <TextInput placeholder="Enter your topic" value={topic} onChange={(e) => setTopic(e.target.value)} />
+          </Stack>
         </Stack>
-
-        <Stack gap={0}>
-          <Text fw={500}>Practitioner (optional)</Text>
-          <Text c="dimmed">Select one or more practitioners</Text>
-
-          <QuestionnaireForm
-            questionnaire={questionnaire}
-            questionnaireResponse={initialResponse}
-            excludeButtons={true}
-            onChange={(value: QuestionnaireResponse) => {
-              const references =
-                value.item?.[0].answer
-                  ?.map((item) => item.valueReference)
-                  .filter((ref): ref is Reference<Practitioner> => ref !== undefined) ?? [];
-              setPractitioners(references);
-            }}
-          />
-        </Stack>
-
-        <Stack gap={0}>
-          <Text fw={500}>Topic (optional)</Text>
-          <Text c="dimmed">Enter a topic for the message</Text>
-
-          <TextInput placeholder="Enter your topic" value={topic} onChange={(e) => setTopic(e.target.value)} />
-        </Stack>
-
-        <Button onClick={handleSubmit}>Next</Button>
-      </Stack>
+      </ModalContentLayout>
     </Modal>
   );
 };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -72,6 +72,8 @@ export * from './Loading/Loading';
 export * from './Logo/Logo';
 export * from './MeasureReportDisplay/MeasureReportDisplay';
 export * from './MedplumLink/MedplumLink';
+export * from './ModalActionsFooter/ModalActionsFooter';
+export * from './ModalContentLayout/ModalContentLayout';
 export * from './MoneyDisplay/MoneyDisplay';
 export * from './MoneyInput/MoneyInput';
 export * from './NoteDisplay/NoteDisplay';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -152,6 +152,7 @@ export * from './ServiceRequestTimeline/ServiceRequestTimeline';
 export * from './SignatureInput/SignatureInput';
 export * from './SmartAppLaunchLink/SmartAppLaunchLink';
 export * from './StatusBadge/StatusBadge';
+export * from './theme/modalTheme';
 export * from './Timeline/Timeline';
 export * from './TimingInput/TimingInput';
 export * from './UnavailableNote/UnavailableNote';

--- a/packages/react/src/theme/modalTheme.test.tsx
+++ b/packages/react/src/theme/modalTheme.test.tsx
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { MantineProvider, Modal, createTheme } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import { medplumModalTheme } from './modalTheme';
+
+function setup(): ReturnType<typeof render> {
+  return render(
+    <MantineProvider theme={createTheme({ components: { Modal: medplumModalTheme } })}>
+      <Modal opened onClose={() => undefined} title="Example">
+        <div>Body content</div>
+      </Modal>
+    </MantineProvider>
+  );
+}
+
+describe('medplumModalTheme', () => {
+  test('Renders a modal with the themed title', () => {
+    setup();
+    expect(screen.getByText('Example')).toBeDefined();
+    expect(screen.getByText('Body content')).toBeDefined();
+  });
+
+  test('Gives the header a bottom border and the title a bold weight', () => {
+    setup();
+    const header = document.querySelector('.mantine-Modal-header') as HTMLElement;
+    const title = document.querySelector('.mantine-Modal-title') as HTMLElement;
+    expect(header.style.borderBottom).toContain('light-dark(');
+    expect(header.style.flexShrink).toBe('0');
+    expect(title.style.fontWeight).toBe('800');
+  });
+
+  test('Makes the body the scrolling region so the header stays put', () => {
+    setup();
+    const content = document.querySelector('.mantine-Modal-content') as HTMLElement;
+    const body = document.querySelector('.mantine-Modal-body') as HTMLElement;
+    expect(content.style.display).toBe('flex');
+    expect(content.style.flexDirection).toBe('column');
+    expect(body.style.overflowY).toBe('auto');
+    expect(body.style.flexGrow).toBe('1');
+  });
+
+  test('Renders a round close button', () => {
+    setup();
+    const close = document.querySelector('.mantine-Modal-close') as HTMLElement;
+    expect(close).toBeDefined();
+    expect(close.style.borderRadius).toBe('999px');
+  });
+});

--- a/packages/react/src/theme/modalTheme.tsx
+++ b/packages/react/src/theme/modalTheme.tsx
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Modal } from '@mantine/core';
+import { IconX } from '@tabler/icons-react';
+
+/**
+ * Shared Mantine theme override for modals, giving every modal the same header
+ * (bottom border, bold title, round close button) and a content shell that lets
+ * `ModalContentLayout` scroll its body while `ModalActionsFooter` stays pinned.
+ *
+ * Lives here rather than in an individual app so the apps and Storybook render
+ * modals identically. Apply it via the theme's `components` map:
+ *
+ * ```tsx
+ * createTheme({ components: { Modal: medplumModalTheme } });
+ * ```
+ */
+export const medplumModalTheme = Modal.extend({
+  defaultProps: {
+    padding: 'lg',
+    radius: 'md',
+    closeButtonProps: { icon: <IconX size={18} /> },
+  },
+  styles: {
+    content: {
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
+    },
+    header: {
+      minHeight: 0,
+      padding:
+        'var(--mantine-spacing-sm) var(--mantine-spacing-sm) var(--mantine-spacing-sm) var(--mantine-spacing-lg)',
+      borderBottom: '1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4))',
+      flexShrink: 0,
+      position: 'static',
+    },
+    close: {
+      width: '1.75rem',
+      height: '1.75rem',
+      borderRadius: '999px',
+    },
+    title: {
+      fontWeight: 800,
+    },
+    body: {
+      paddingTop: 'var(--mantine-spacing-lg)',
+      flex: 1,
+      minHeight: 0,
+      overflowY: 'auto',
+    },
+  },
+});


### PR DESCRIPTION
This PR migrates ~20 Provider app modals and 3 @medplum/react modals onto the shared `ModalContentLayout` / `ModalActionsFooter` components (see #9963 for these foundation components). 

**Notable changes:**
- Action buttons become full-width and stack vertically with the primary action first, replacing the old right-aligned Group with cancel-on-the-left.
- Removes the now-redundant per-modal styling

**Small tangential changes:**
- Restyles the Upload Document and Send Fax dropzone borders from gray-3 to dark-4
- Capitalizes the Upload Document title
- Renames the "New encounter" modal title to "New Visit"

---

### Reference Images:

| Before      | After |
| ----------- | ----------- |
|   <img width="494" height="399" alt="Screenshot 2026-08-04 at 12 34 17 PM" src="https://github.com/user-attachments/assets/4f4e9fff-7b2c-4269-9aea-cefc2163ba4c" />   | <img width="514" height="443" alt="Screenshot 2026-08-04 at 12 33 51 PM" src="https://github.com/user-attachments/assets/1105387a-e2d7-4aa1-bd9a-2124de781a1b" /> |
|   <img width="679" height="985" alt="Screenshot 2026-08-04 at 12 34 29 PM" src="https://github.com/user-attachments/assets/2b889627-c080-45f6-bb41-f7b33a854c18" />   | <img width="663" height="939" alt="Screenshot 2026-08-04 at 12 34 03 PM" src="https://github.com/user-attachments/assets/5159c710-9fe0-49d9-b84e-764565c49c0a" /> |
|   <img width="519" height="538" alt="Screenshot 2026-08-04 at 12 34 39 PM" src="https://github.com/user-attachments/assets/ef08ef1b-4444-4f2f-922a-ee471a760a57" />   | <img width="503" height="527" alt="Screenshot 2026-08-04 at 12 32 23 PM" src="https://github.com/user-attachments/assets/09e6d313-7f84-47c1-a455-0cea23de3313" /> |