### PR TITLE
feat(react): patient summary header menu, Goals + Immunizations, and polish

### DIFF
--- a/examples/medplum-provider/src/components/spaces/ResourcePanel.tsx
+++ b/examples/medplum-provider/src/components/spaces/ResourcePanel.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Box, Text } from '@mantine/core';
-import type { Reference, Resource } from '@medplum/fhirtypes';
+import type { Patient, Reference, Resource } from '@medplum/fhirtypes';
 import {
   createPharmaciesSection,
   getDefaultSections,
@@ -10,6 +10,7 @@ import {
   useResource,
 } from '@medplum/react';
 import type { JSX } from 'react';
+import { usePatientActionsMenu } from '../../pages/patient/usePatientActionsMenu';
 import { EncounterChart } from '../encounter/EncounterChart';
 import { LabOrderDetails } from '../labs/LabOrderDetails';
 import { LabResultDetails } from '../labs/LabResultDetails';
@@ -24,6 +25,8 @@ export function ResourcePanel<T extends Resource = Resource>(props: ResourcePane
   const { resource } = props;
   const displayResource = useResource(resource);
   const PharmacyDialogComponent = usePharmacyDialog();
+  const patientForActions = displayResource?.resourceType === 'Patient' ? (displayResource as Patient) : undefined;
+  const { headerMenuItems, actionsModals, openEditModal } = usePatientActionsMenu(patientForActions);
 
   const sections = getDefaultSections().map((s) =>
     s.key === 'pharmacies' ? createPharmaciesSection(PharmacyDialogComponent) : s
@@ -36,7 +39,17 @@ export function ResourcePanel<T extends Resource = Resource>(props: ResourcePane
 
     switch (displayResource.resourceType) {
       case 'Patient':
-        return <PatientSummary patient={displayResource} sections={sections} />;
+        return (
+          <>
+            <PatientSummary
+              patient={displayResource}
+              sections={sections}
+              headerMenuItems={headerMenuItems}
+              onEditPatient={openEditModal}
+            />
+            {actionsModals}
+          </>
+        );
       case 'Task':
         return <TaskDetailPanel task={displayResource} />;
       case 'DiagnosticReport':

--- a/examples/medplum-provider/src/components/tasks/TaskDetailPanel.tsx
+++ b/examples/medplum-provider/src/components/tasks/TaskDetailPanel.tsx
@@ -13,6 +13,7 @@ import {
 } from '@medplum/react';
 import type { JSX } from 'react';
 import { useEffect, useState } from 'react';
+import { usePatientActionsMenu } from '../../pages/patient/usePatientActionsMenu';
 import { showErrorNotification } from '../../utils/notifications';
 import { usePharmacyDialog } from '../pharmacy/usePharmacyDialog';
 import classes from './TaskBoard.module.css';
@@ -41,6 +42,7 @@ export function TaskDetailPanel(props: TaskDetailPanelProps): JSX.Element | null
 
   const patientRef = task?.for as Reference<Patient>;
   const selectedPatient = useResource<Patient>(patientRef);
+  const { headerMenuItems, actionsModals, openEditModal } = usePatientActionsMenu(selectedPatient);
 
   if (!task) {
     return (
@@ -84,6 +86,7 @@ export function TaskDetailPanel(props: TaskDetailPanelProps): JSX.Element | null
 
   return (
     <>
+      {actionsModals}
       <Box
         h="100%"
         style={{
@@ -138,6 +141,8 @@ export function TaskDetailPanel(props: TaskDetailPanelProps): JSX.Element | null
                   sections={getDefaultSections().map((s) =>
                     s.key === 'pharmacies' ? createPharmaciesSection(PharmacyDialogComponent) : s
                   )}
+                  headerMenuItems={headerMenuItems}
+                  onEditPatient={openEditModal}
                 />
               </ScrollArea>
             )}

--- a/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
+++ b/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { SearchRequest } from '@medplum/core';
 import { formatSearchQuery, getReferenceString, Operator } from '@medplum/core';
-import type { Communication, DocumentReference, Reference } from '@medplum/fhirtypes';
+import type { Communication, DocumentReference, Patient, Reference } from '@medplum/fhirtypes';
 import { createPharmaciesSection, getDefaultSections, ThreadInbox } from '@medplum/react';
 import { useMedplum } from '@medplum/react-hooks';
 import type { JSX } from 'react';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { usePharmacyDialog } from '../../components/pharmacy/usePharmacyDialog';
 import { normalizeCommunicationSearch } from '../../utils/communication-search';
+import { usePatientActionsMenu } from '../patient/usePatientActionsMenu';
 import classes from './MessagesPage.module.css';
 /**
  * Fetches
@@ -21,6 +22,8 @@ export function MessagesPage(): JSX.Element {
   const location = useLocation();
   const medplum = useMedplum();
   const PharmacyDialogComponent = usePharmacyDialog();
+  const [threadPatient, setThreadPatient] = useState<Reference<Patient>>();
+  const { headerMenuItems, actionsModals, openEditModal } = usePatientActionsMenu(threadPatient);
 
   const currentSearch = useMemo(() => (location.search ? location.search.substring(1) : ''), [location.search]);
 
@@ -84,11 +87,15 @@ export function MessagesPage(): JSX.Element {
 
   return (
     <div className={classes.container}>
+      {actionsModals}
       <ThreadInbox
         threadId={messageId}
         query={formatSearchQuery(parsedSearch).substring(1)}
         showPatientSummary={true}
         sections={sections}
+        patientHeaderMenuItems={headerMenuItems}
+        onEditPatient={openEditModal}
+        onPatientChange={setThreadPatient}
         allowPatientSelection={true}
         onNew={onNew}
         getThreadUri={getThreadUri}

--- a/examples/medplum-provider/src/pages/patient/PatientEditModal.tsx
+++ b/examples/medplum-provider/src/pages/patient/PatientEditModal.tsx
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Anchor, Modal } from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
+import { deepClone, normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
+import type { OperationOutcome, Patient, Resource } from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react';
+import type { JSX } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { ResourceFormWithRequiredProfile } from '../../components/ResourceFormWithRequiredProfile';
+import { RESOURCE_PROFILE_URLS } from '../resource/utils';
+
+const missingProfileMessage = RESOURCE_PROFILE_URLS.Patient ? (
+  <>
+    Could not find the{' '}
+    <Anchor href={RESOURCE_PROFILE_URLS.Patient} target="_blank">
+      US Core Patient Profile
+    </Anchor>
+  </>
+) : undefined;
+
+export interface PatientEditModalProps {
+  readonly patient: Patient;
+  readonly opened: boolean;
+  readonly onClose: () => void;
+}
+
+/**
+ * State-driven modal for editing a patient's profile details. Reuses the same form flow as
+ * the full-page {@link EditTab} (`/Patient/:id/edit`), but opens in place over whatever page
+ * currently shows the Patient Summary — so it works on the patient chart and on top-level
+ * pages like /Communication and /Task alike.
+ * @param props - The modal props.
+ * @returns The patient profile edit modal.
+ */
+export function PatientEditModal(props: PatientEditModalProps): JSX.Element {
+  const { patient, opened, onClose } = props;
+  const medplum = useMedplum();
+  const [value, setValue] = useState<Resource | undefined>();
+  const [outcome, setOutcome] = useState<OperationOutcome | undefined>();
+
+  useEffect(() => {
+    if (!opened || !patient.id) {
+      return;
+    }
+    medplum
+      .readResource('Patient', patient.id)
+      .then((resource) => setValue(deepClone(resource)))
+      .catch((err) => {
+        setOutcome(normalizeOperationOutcome(err));
+        showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false });
+      });
+  }, [opened, patient.id, medplum]);
+
+  const handleSubmit = useCallback(
+    (newResource: Resource): void => {
+      setOutcome(undefined);
+      medplum
+        .updateResource(newResource)
+        .then(() => {
+          showNotification({ color: 'green', message: 'Success' });
+          onClose();
+        })
+        .catch((err) => {
+          setOutcome(normalizeOperationOutcome(err));
+          showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false });
+        });
+    },
+    [medplum, onClose]
+  );
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      size="xl"
+      title="Edit Patient Profile Details"
+      styles={{
+        body: {
+          padding: 0,
+          overflow: 'hidden',
+          height: '70vh',
+          flex: 'none',
+          display: 'flex',
+          flexDirection: 'column',
+        },
+      }}
+    >
+      {value ? (
+        <ResourceFormWithRequiredProfile
+          missingProfileMessage={missingProfileMessage}
+          defaultValue={value}
+          onSubmit={handleSubmit}
+          outcome={outcome}
+          profileUrl={RESOURCE_PROFILE_URLS.Patient}
+          stackedSubmit
+          stickyModalFooter
+        />
+      ) : null}
+    </Modal>
+  );
+}

--- a/examples/medplum-provider/src/pages/patient/PatientPage.module.css
+++ b/examples/medplum-provider/src/pages/patient/PatientPage.module.css
@@ -10,10 +10,12 @@
   flex: 1;
   width: 350px;
   height: 100%;
+  background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-8));
 }
 
 .scrollArea {
   height: 100%;
+  background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-8));
 }
 
 .content {

--- a/examples/medplum-provider/src/pages/patient/PatientPage.test.tsx
+++ b/examples/medplum-provider/src/pages/patient/PatientPage.test.tsx
@@ -68,19 +68,28 @@ describe('PatientPage', () => {
     });
 
     // Check for some key tabs
-    expect(screen.getByText('Edit')).toBeInTheDocument();
     expect(screen.getByText('Visits')).toBeInTheDocument();
     expect(screen.getByText('Tasks')).toBeInTheDocument();
     expect(screen.getByText('Meds')).toBeInTheDocument();
   });
 
-  test('sets initial tab from URL path', async () => {
-    setup(`/Patient/${HomerSimpson.id}/edit`);
+  test('does not render an Edit tab (profile editing moved to the summary header menu)', async () => {
+    setup(`/Patient/${HomerSimpson.id}`);
 
     await waitFor(() => {
-      const editTab = screen.getByText('Edit');
-      expect(editTab).toBeInTheDocument();
-      expect(editTab.closest('[role="tab"]')).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByText('Timeline')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+  });
+
+  test('sets initial tab from URL path', async () => {
+    setup(`/Patient/${HomerSimpson.id}/DocumentReference`);
+
+    await waitFor(() => {
+      const documentsTab = screen.getByText('Documents');
+      expect(documentsTab).toBeInTheDocument();
+      expect(documentsTab.closest('[role="tab"]')).toHaveAttribute('aria-selected', 'true');
     });
   });
 
@@ -92,13 +101,12 @@ describe('PatientPage', () => {
       expect(screen.getByText('Timeline')).toBeInTheDocument();
     });
 
-    const editTab = screen.getByText('Edit');
-    await user.click(editTab);
+    await user.click(screen.getByText('Documents'));
 
     await waitFor(() => {
-      const editTab = screen.getByText('Edit');
-      expect(editTab).toBeInTheDocument();
-      expect(editTab.closest('[role="tab"]')).toHaveAttribute('aria-selected', 'true');
+      const documentsTab = screen.getByText('Documents');
+      expect(documentsTab).toBeInTheDocument();
+      expect(documentsTab.closest('[role="tab"]')).toHaveAttribute('aria-selected', 'true');
     });
   });
 
@@ -150,13 +158,13 @@ describe('PatientPage', () => {
     });
   });
 
-  test('highlights the Edit tab in a case-insensitive way even when /EDIT is used', async () => {
-    setup(`/Patient/${HomerSimpson.id}/EDIT`);
+  test('highlights the matching tab in a case-insensitive way even when the path case differs', async () => {
+    setup(`/Patient/${HomerSimpson.id}/DOCUMENTREFERENCE`);
 
     await waitFor(() => {
-      const editTab = screen.getByText('Edit');
-      expect(editTab).toBeInTheDocument();
-      expect(editTab.closest('[role="tab"]')).toHaveAttribute('aria-selected', 'true');
+      const documentsTab = screen.getByText('Documents');
+      expect(documentsTab).toBeInTheDocument();
+      expect(documentsTab.closest('[role="tab"]')).toHaveAttribute('aria-selected', 'true');
     });
   });
 });

--- a/examples/medplum-provider/src/pages/patient/PatientPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/PatientPage.tsx
@@ -21,6 +21,7 @@ import { usePatient } from '../../hooks/usePatient';
 import { OrderLabsPage } from '../labs/OrderLabsPage';
 import classes from './PatientPage.module.css';
 import { getPatientPageTabs, patientPathPrefix } from './PatientPage.utils';
+import { usePatientActionsMenu } from './usePatientActionsMenu';
 
 export function PatientPage(): JSX.Element {
   const navigate = useNavigate();
@@ -29,6 +30,7 @@ export function PatientPage(): JSX.Element {
   const [outcome, setOutcome] = useState<OperationOutcome>();
   const patient = usePatient({ setOutcome });
   const [isLabsModalOpen, setIsLabsModalOpen] = useState(false);
+  const { headerMenuItems, actionsModals, openEditModal } = usePatientActionsMenu(patient);
   const PharmacyDialogComponent = usePharmacyDialog();
   const { hasAccess: hasDoseSpotAccess } = useDoseSpotAccess();
   const tabs = getPatientPageTabs(membership, { hasDoseSpotAccess });
@@ -81,6 +83,9 @@ export function PatientPage(): JSX.Element {
                 navigate(`/Patient/${patientId}/${resource.resourceType}/${resource.id}`)?.catch(console.error)
               }
               sections={sections}
+              headerMenuItems={headerMenuItems}
+              linkToPatient={false}
+              onEditPatient={openEditModal}
             />
           </ScrollArea>
         </div>
@@ -105,6 +110,7 @@ export function PatientPage(): JSX.Element {
       <Modal opened={isLabsModalOpen} onClose={handleCloseLabsModal} size="xl" centered title="Order Labs">
         <OrderLabsPage onSubmitLabOrder={handleCloseLabsModal} />
       </Modal>
+      {actionsModals}
     </>
   );
 }

--- a/examples/medplum-provider/src/pages/patient/PatientPage.utils.test.ts
+++ b/examples/medplum-provider/src/pages/patient/PatientPage.utils.test.ts
@@ -124,10 +124,10 @@ describe('PatientPage.utils', () => {
       expect(timelineTab.url).toBe('');
       expect(timelineTab.label).toBe('Timeline');
 
-      const editTab = getPatientPageTabOrThrow('edit');
-      expect(editTab.id).toBe('edit');
-      expect(editTab.url).toBe('edit');
-      expect(editTab.label).toBe('Edit');
+      const documentsTab = getPatientPageTabOrThrow('documentreference');
+      expect(documentsTab.id).toBe('documentreference');
+      expect(documentsTab.url).toBe('DocumentReference');
+      expect(documentsTab.label).toBe('Documents');
 
       const medsTab = getPatientPageTabOrThrow('meds');
       expect(medsTab.id).toBe('meds');
@@ -146,7 +146,6 @@ describe('PatientPage.utils', () => {
     test('finds all defined tabs', () => {
       const tabIds = [
         'timeline',
-        'edit',
         'encounter',
         'tasks',
         'meds',
@@ -177,7 +176,6 @@ describe('PatientPage.utils', () => {
     test('contains expected tabs', () => {
       const tabIds = PatientPageTabs.map((tab) => tab.id);
       expect(tabIds).toContain('timeline');
-      expect(tabIds).toContain('edit');
       expect(tabIds).toContain('encounter');
       expect(tabIds).toContain('tasks');
       expect(tabIds).toContain('meds');

--- a/examples/medplum-provider/src/pages/patient/PatientPage.utils.ts
+++ b/examples/medplum-provider/src/pages/patient/PatientPage.utils.ts
@@ -64,7 +64,9 @@ export function getPatientPageTabs(
 
 export const PatientPageTabs: PatientPageTabInfo[] = [
   { id: 'timeline', url: '', label: 'Timeline' },
-  { id: 'edit', url: 'edit', label: 'Edit' },
+  // Note: patient profile editing moved to the "…" menu in the Patient Summary header
+  // (opens the /Patient/:id/edit-details modal). The full-page /Patient/:id/edit route
+  // still works by direct URL; it is intentionally unlinked from this tab bar.
   {
     id: 'encounter',
     url: 'Encounter?_count=20&_fields=_lastUpdated,period,status,serviceType&_sort=-_lastUpdated&patient=%patient.id',

--- a/examples/medplum-provider/src/pages/patient/usePatientActionsMenu.tsx
+++ b/examples/medplum-provider/src/pages/patient/usePatientActionsMenu.tsx
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Menu, Text } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import type { Patient, Reference } from '@medplum/fhirtypes';
+import { useResource } from '@medplum/react';
+import { IconEdit } from '@tabler/icons-react';
+import type { ReactNode } from 'react';
+import { PatientEditModal } from './PatientEditModal';
+
+export interface PatientActionsMenu {
+  /** `<Menu.Item>` nodes to pass to `PatientSummary`'s `headerMenuItems` prop. */
+  readonly headerMenuItems: ReactNode;
+  /** The action modals to render alongside the summary. */
+  readonly actionsModals: ReactNode;
+  /** Opens the patient edit modal — pass to `PatientSummary`'s `onEditPatient` prop. */
+  readonly openEditModal: () => void;
+}
+
+/**
+ * Shared "…" header-menu actions for the Patient Summary. The actions open state-driven
+ * modals hosted here, so the menu works wherever the summary appears (patient chart,
+ * /Communication, /Task, …).
+ * @param patientArg - The patient (or a reference to it) the actions apply to; undefined while loading.
+ * @returns The menu items and the modals to render.
+ */
+export function usePatientActionsMenu(patientArg: Patient | Reference<Patient> | undefined): PatientActionsMenu {
+  const patient = useResource(patientArg);
+  const [editOpened, editHandlers] = useDisclosure(false);
+
+  const headerMenuItems = (
+    <Menu.Item leftSection={<IconEdit size={16} color="var(--mantine-color-dimmed)" />} onClick={editHandlers.open}>
+      <Text size="sm">Edit Patient Profile Details</Text>
+    </Menu.Item>
+  );
+
+  const actionsModals = patient ? (
+    <PatientEditModal patient={patient} opened={editOpened} onClose={editHandlers.close} />
+  ) : null;
+
+  return { headerMenuItems, actionsModals, openEditModal: editHandlers.open };
+}

--- a/packages/react/src/PatientSummary/AllergyDialog.tsx
+++ b/packages/react/src/PatientSummary/AllergyDialog.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Group, Stack, TextInput } from '@mantine/core';
+import { Stack, TextInput } from '@mantine/core';
 import { HTTP_HL7_ORG, addProfileToResource, createReference } from '@medplum/core';
 import type { AllergyIntolerance, Encounter, Patient } from '@medplum/fhirtypes';
 import type { JSX } from 'react';
@@ -9,6 +9,8 @@ import { CodeableConceptInput } from '../CodeableConceptInput/CodeableConceptInp
 import { DateTimeInput } from '../DateTimeInput/DateTimeInput';
 import { Form } from '../Form/Form';
 import { SubmitButton } from '../Form/SubmitButton';
+import { ModalActionsFooter } from '../ModalActionsFooter/ModalActionsFooter';
+import { ModalContentLayout } from '../ModalContentLayout/ModalContentLayout';
 
 export interface AllergyDialogProps {
   readonly patient: Patient;
@@ -49,34 +51,39 @@ export function AllergyDialog(props: AllergyDialogProps): JSX.Element {
 
   return (
     <Form key={allergy?.id} onSubmit={handleSubmit}>
-      <Stack>
-        <CodeableConceptInput
-          name="allergy"
-          label="Code"
-          path="AllergyIntolerance.code"
-          data-autofocus={true}
-          binding={HTTP + 'cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1186.8'}
-          maxValues={1}
-          defaultValue={allergy?.code}
-          onChange={(code) => setCode(code)}
-          outcome={undefined}
-        />
-        <TextInput name="reaction" label="Reaction" defaultValue={allergy?.reaction?.[0]?.manifestation?.[0]?.text} />
-        <CodeableConceptInput
-          name="clinicalStatus"
-          label="Clinical Status"
-          path="AllergyIntolerance.clinicalStatus"
-          binding={HTTP_HL7_ORG + '/fhir/ValueSet/allergyintolerance-clinical'}
-          maxValues={1}
-          defaultValue={allergy?.clinicalStatus}
-          onChange={(clinicalStatus) => setClinicalStatus(clinicalStatus)}
-          outcome={undefined}
-        />
-        <DateTimeInput name="onsetDateTime" label="Onset" defaultValue={allergy?.recordedDate} />
-        <Group justify="flex-end" gap={4} mt="md">
-          <SubmitButton>Save</SubmitButton>
-        </Group>
-      </Stack>
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <SubmitButton fullWidth>Save</SubmitButton>
+          </ModalActionsFooter>
+        }
+      >
+        <Stack gap="md">
+          <CodeableConceptInput
+            name="allergy"
+            label="Code"
+            path="AllergyIntolerance.code"
+            data-autofocus={true}
+            binding={HTTP + 'cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1186.8'}
+            maxValues={1}
+            defaultValue={allergy?.code}
+            onChange={(code) => setCode(code)}
+            outcome={undefined}
+          />
+          <TextInput name="reaction" label="Reaction" defaultValue={allergy?.reaction?.[0]?.manifestation?.[0]?.text} />
+          <CodeableConceptInput
+            name="clinicalStatus"
+            label="Clinical Status"
+            path="AllergyIntolerance.clinicalStatus"
+            binding={HTTP_HL7_ORG + '/fhir/ValueSet/allergyintolerance-clinical'}
+            maxValues={1}
+            defaultValue={allergy?.clinicalStatus}
+            onChange={(clinicalStatus) => setClinicalStatus(clinicalStatus)}
+            outcome={undefined}
+          />
+          <DateTimeInput name="onsetDateTime" label="Onset" defaultValue={allergy?.recordedDate} />
+        </Stack>
+      </ModalContentLayout>
     </Form>
   );
 }

--- a/packages/react/src/PatientSummary/CollapsibleSection.module.css
+++ b/packages/react/src/PatientSummary/CollapsibleSection.module.css
@@ -12,10 +12,17 @@
 .chevron {
   transition: transform 0.2s ease;
   cursor: pointer;
+  color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-dark-1)) !important;
 }
 
 .chevron[data-collapsed] {
   transform: rotate(-90deg);
+}
+
+@media (hover: hover) {
+  .chevron:hover {
+    background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6)) !important;
+  }
 }
 
 .title {
@@ -23,8 +30,6 @@
 }
 
 .addButton {
-  position: absolute;
-  right: 0;
-  top: 0;
+  flex-shrink: 0;
   stroke-width: 1;
 }

--- a/packages/react/src/PatientSummary/CollapsibleSection.tsx
+++ b/packages/react/src/PatientSummary/CollapsibleSection.tsx
@@ -18,11 +18,13 @@ export function CollapsibleSection(props: CollapsibleSectionProps): JSX.Element 
   const [collapsed, setCollapsed] = useState(false);
 
   return (
-    <Box className={classes.root}>
-      <Group justify="space-between" className={classes.header}>
-        <Group gap={8}>
+    <Box className={classes.root} py="xs">
+      <Group justify="space-between" align="center" wrap="nowrap" className={classes.header}>
+        <Group gap={8} wrap="nowrap">
           <ActionIcon
             variant="subtle"
+            color="gray"
+            radius="xl"
             onClick={() => setCollapsed((c) => !c)}
             aria-label={collapsed ? `Show ${title.toLowerCase()}` : `Hide ${title.toLowerCase()}`}
             className={classes.chevron}
@@ -42,6 +44,7 @@ export function CollapsibleSection(props: CollapsibleSectionProps): JSX.Element 
             aria-label="Add item"
             className={classes.addButton}
             variant="subtle"
+            radius="xl"
             onClick={(e) => {
               killEvent(e);
               onAdd();

--- a/packages/react/src/PatientSummary/ConditionDialog.tsx
+++ b/packages/react/src/PatientSummary/ConditionDialog.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Group, Stack } from '@mantine/core';
+import { Stack } from '@mantine/core';
 import { HTTP_HL7_ORG, HTTP_TERMINOLOGY_HL7_ORG, addProfileToResource, createReference } from '@medplum/core';
 import type { Condition, Encounter, Patient } from '@medplum/fhirtypes';
 import type { JSX } from 'react';
@@ -10,6 +10,8 @@ import { DateTimeInput } from '../DateTimeInput/DateTimeInput';
 import { convertLocalToIso } from '../DateTimeInput/DateTimeInput.utils';
 import { Form } from '../Form/Form';
 import { SubmitButton } from '../Form/SubmitButton';
+import { ModalActionsFooter } from '../ModalActionsFooter/ModalActionsFooter';
+import { ModalContentLayout } from '../ModalContentLayout/ModalContentLayout';
 
 export interface ConditionDialogProps {
   readonly patient: Patient;
@@ -56,31 +58,36 @@ export function ConditionDialog(props: ConditionDialogProps): JSX.Element {
 
   return (
     <Form key={condition?.id} onSubmit={handleSubmit}>
-      <Stack>
-        <CodeableConceptInput
-          name="code"
-          label="Problem"
-          path="Condition.code"
-          data-autofocus={true}
-          binding={HTTP_HL7_ORG + '/fhir/us/core/ValueSet/us-core-condition-code'}
-          defaultValue={condition?.code}
-          onChange={(code) => setCode(code)}
-          outcome={undefined}
-        />
-        <CodeableConceptInput
-          name="clinicalStatus"
-          label="Status"
-          path="Condition.clinicalStatus"
-          binding={HTTP_HL7_ORG + '/fhir/ValueSet/condition-clinical'}
-          defaultValue={condition?.clinicalStatus}
-          onChange={(clinicalStatus) => setClinicalStatus(clinicalStatus)}
-          outcome={undefined}
-        />
-        <DateTimeInput name="onsetDateTime" label="Dx Date" defaultValue={condition?.onsetDateTime} required />
-        <Group justify="flex-end" gap={4} mt="md">
-          <SubmitButton>Save</SubmitButton>
-        </Group>
-      </Stack>
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <SubmitButton fullWidth>Save</SubmitButton>
+          </ModalActionsFooter>
+        }
+      >
+        <Stack gap="md">
+          <CodeableConceptInput
+            name="code"
+            label="Problem"
+            path="Condition.code"
+            data-autofocus={true}
+            binding={HTTP_HL7_ORG + '/fhir/us/core/ValueSet/us-core-condition-code'}
+            defaultValue={condition?.code}
+            onChange={(code) => setCode(code)}
+            outcome={undefined}
+          />
+          <CodeableConceptInput
+            name="clinicalStatus"
+            label="Status"
+            path="Condition.clinicalStatus"
+            binding={HTTP_HL7_ORG + '/fhir/ValueSet/condition-clinical'}
+            defaultValue={condition?.clinicalStatus}
+            onChange={(clinicalStatus) => setClinicalStatus(clinicalStatus)}
+            outcome={undefined}
+          />
+          <DateTimeInput name="onsetDateTime" label="Dx Date" defaultValue={condition?.onsetDateTime} required />
+        </Stack>
+      </ModalContentLayout>
     </Form>
   );
 }

--- a/packages/react/src/PatientSummary/GoalDialog.tsx
+++ b/packages/react/src/PatientSummary/GoalDialog.tsx
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Button, Stack, TextInput } from '@mantine/core';
+import { createReference } from '@medplum/core';
+import type { Goal, Patient } from '@medplum/fhirtypes';
+import { IconTrash } from '@tabler/icons-react';
+import type { JSX } from 'react';
+import { useCallback, useState } from 'react';
+import { CodeInput } from '../CodeInput/CodeInput';
+import { Form } from '../Form/Form';
+import { SubmitButton } from '../Form/SubmitButton';
+import { ModalActionsFooter } from '../ModalActionsFooter/ModalActionsFooter';
+import { ModalContentLayout } from '../ModalContentLayout/ModalContentLayout';
+
+export interface GoalDialogProps {
+  readonly patient: Patient;
+  readonly goal?: Goal;
+  readonly onSubmit: (goal: Goal) => void;
+  /** When editing an existing goal, called to delete it. */
+  readonly onDelete?: () => void;
+}
+
+const GOAL_STATUS_VALUESET = 'http://hl7.org/fhir/ValueSet/goal-status';
+
+export function GoalDialog(props: GoalDialogProps): JSX.Element {
+  const { patient, goal, onSubmit, onDelete } = props;
+  const [lifecycleStatus, setLifecycleStatus] = useState<Goal['lifecycleStatus']>(goal?.lifecycleStatus ?? 'active');
+
+  const handleSubmit = useCallback(
+    (formData: Record<string, string>) => {
+      onSubmit({
+        ...goal,
+        resourceType: 'Goal',
+        lifecycleStatus: lifecycleStatus ?? 'active',
+        description: { text: formData.description ?? goal?.description?.text ?? '' },
+        subject: createReference(patient),
+        startDate: formData.startDate || undefined,
+        target: formData.dueDate ? [{ ...goal?.target?.[0], dueDate: formData.dueDate }] : goal?.target,
+      });
+    },
+    [patient, goal, lifecycleStatus, onSubmit]
+  );
+
+  return (
+    <Form key={goal?.id} onSubmit={handleSubmit}>
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <SubmitButton fullWidth>Save</SubmitButton>
+            {goal?.id && onDelete && (
+              <Button fullWidth variant="light" color="red" leftSection={<IconTrash size={16} />} onClick={onDelete}>
+                Delete
+              </Button>
+            )}
+          </ModalActionsFooter>
+        }
+      >
+        <Stack gap="md">
+          <TextInput
+            name="description"
+            label="Goal"
+            data-autofocus={true}
+            required
+            defaultValue={goal?.description?.text}
+          />
+          <CodeInput
+            name="lifecycleStatus"
+            label="Status"
+            binding={GOAL_STATUS_VALUESET}
+            maxValues={1}
+            defaultValue={goal?.lifecycleStatus ?? 'active'}
+            onChange={(value) => setLifecycleStatus((value as Goal['lifecycleStatus']) ?? undefined)}
+          />
+          <TextInput type="date" name="startDate" label="Start Date" defaultValue={goal?.startDate} />
+          <TextInput type="date" name="dueDate" label="Target Date" defaultValue={goal?.target?.[0]?.dueDate} />
+        </Stack>
+      </ModalContentLayout>
+    </Form>
+  );
+}

--- a/packages/react/src/PatientSummary/Goals.test.tsx
+++ b/packages/react/src/PatientSummary/Goals.test.tsx
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { createReference } from '@medplum/core';
+import type { Goal } from '@medplum/fhirtypes';
+import { HomerSimpson, MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react-hooks';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
+import { act, fireEvent, render, screen } from '../test-utils/render';
+import { Goals } from './Goals';
+
+const medplum = new MockClient();
+
+describe('PatientSummary - Goals', () => {
+  async function setup(children: ReactNode): Promise<void> {
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
+        </MemoryRouter>
+      );
+    });
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      vi.runOnlyPendingTimers();
+    });
+    vi.useRealTimers();
+  });
+
+  test('Renders empty', async () => {
+    await setup(<Goals patient={HomerSimpson} goals={[]} />);
+    expect(screen.getByText('Goals')).toBeInTheDocument();
+    expect(screen.getByText('(none)')).toBeInTheDocument();
+  });
+
+  test('Renders existing with description, status, and target date', async () => {
+    await setup(
+      <Goals
+        patient={HomerSimpson}
+        goals={[
+          {
+            resourceType: 'Goal',
+            id: 'bp',
+            lifecycleStatus: 'active',
+            description: { text: 'Lower blood pressure' },
+            subject: createReference(HomerSimpson),
+            target: [{ dueDate: '2026-12-31' }],
+          },
+        ]}
+      />
+    );
+    expect(screen.getByText('Lower blood pressure')).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+    expect(screen.getByText(/Target/)).toBeInTheDocument();
+  });
+
+  test('Falls back to start date when no target due date', async () => {
+    await setup(
+      <Goals
+        patient={HomerSimpson}
+        goals={[
+          {
+            resourceType: 'Goal',
+            id: 'walk',
+            lifecycleStatus: 'active',
+            description: { text: 'Walk daily' },
+            subject: createReference(HomerSimpson),
+            startDate: '2026-02-01',
+          },
+        ]}
+      />
+    );
+    expect(screen.getByText(/Started/)).toBeInTheDocument();
+  });
+
+  test('Add goal', async () => {
+    await setup(<Goals patient={HomerSimpson} goals={[]} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Add item'));
+    });
+
+    const descriptionInput = await screen.findByRole('textbox', { name: /Goal/i });
+    await act(async () => {
+      fireEvent.change(descriptionInput, { target: { value: 'Lose weight' } });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+    });
+
+    expect(await screen.findByText('Lose weight')).toBeInTheDocument();
+  });
+
+  test('Edit goal', async () => {
+    const goal: Goal = {
+      resourceType: 'Goal',
+      id: 'bp',
+      lifecycleStatus: 'active',
+      description: { text: 'Lower blood pressure' },
+      subject: createReference(HomerSimpson),
+    };
+
+    await setup(<Goals patient={HomerSimpson} goals={[goal]} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Lower blood pressure'));
+    });
+
+    expect(await screen.findByText('Edit Goal')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+    });
+  });
+
+  test('Add modal omits Delete button and shows a Status field', async () => {
+    await setup(<Goals patient={HomerSimpson} goals={[]} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Add item'));
+    });
+
+    expect(await screen.findByText('Add Goal')).toBeInTheDocument();
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+    // Status is a ValueSet-bound (HL7) autocomplete, not the native menu.
+    expect(screen.getByText('Status')).toBeInTheDocument();
+  });
+
+  test('Delete goal', async () => {
+    const created = await medplum.createResource<Goal>({
+      resourceType: 'Goal',
+      lifecycleStatus: 'active',
+      description: { text: 'Lower blood pressure' },
+      subject: createReference(HomerSimpson),
+    });
+
+    await setup(<Goals patient={HomerSimpson} goals={[created]} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Lower blood pressure'));
+    });
+
+    const deleteButton = await screen.findByText('Delete');
+    await act(async () => {
+      fireEvent.click(deleteButton);
+    });
+
+    expect(screen.queryByText('Lower blood pressure')).not.toBeInTheDocument();
+  });
+
+  test('Hides entered-in-error goals', async () => {
+    await setup(
+      <Goals
+        patient={HomerSimpson}
+        goals={[
+          {
+            resourceType: 'Goal',
+            id: 'shown',
+            lifecycleStatus: 'active',
+            description: { text: 'Shown Goal' },
+            subject: createReference(HomerSimpson),
+          },
+          {
+            resourceType: 'Goal',
+            id: 'hidden',
+            lifecycleStatus: 'entered-in-error',
+            description: { text: 'Hidden Goal' },
+            subject: createReference(HomerSimpson),
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Shown Goal')).toBeInTheDocument();
+    expect(screen.queryByText('Hidden Goal')).not.toBeInTheDocument();
+  });
+
+  test('Goal status colors', async () => {
+    await setup(
+      <Goals
+        patient={HomerSimpson}
+        goals={[
+          {
+            resourceType: 'Goal',
+            id: 'active',
+            lifecycleStatus: 'active',
+            description: { text: 'Active Goal' },
+            subject: createReference(HomerSimpson),
+          },
+          {
+            resourceType: 'Goal',
+            id: 'on-hold',
+            lifecycleStatus: 'on-hold',
+            description: { text: 'On Hold Goal' },
+            subject: createReference(HomerSimpson),
+          },
+          {
+            resourceType: 'Goal',
+            id: 'cancelled',
+            lifecycleStatus: 'cancelled',
+            description: { text: 'Cancelled Goal' },
+            subject: createReference(HomerSimpson),
+          },
+        ]}
+      />
+    );
+
+    const activeBadge = screen.getByText('active').closest('[class*="mantine-Badge-root"]');
+    expect(activeBadge).toHaveStyle({ '--badge-color': 'var(--mantine-color-green-light-color)' });
+
+    const onHoldBadge = screen.getByText('on hold').closest('[class*="mantine-Badge-root"]');
+    expect(onHoldBadge).toHaveStyle({ '--badge-color': 'var(--mantine-color-yellow-light-color)' });
+
+    const cancelledBadge = screen.getByText('cancelled').closest('[class*="mantine-Badge-root"]');
+    expect(cancelledBadge).toHaveStyle({ '--badge-color': 'var(--mantine-color-red-light-color)' });
+  });
+});

--- a/packages/react/src/PatientSummary/Goals.tsx
+++ b/packages/react/src/PatientSummary/Goals.tsx
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Box, Flex, Group, Modal, Text } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { formatCodeableConcept, formatDate } from '@medplum/core';
+import type { Goal, Patient } from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react-hooks';
+import type { JSX } from 'react';
+import { useCallback, useState } from 'react';
+import { StatusBadge } from '../StatusBadge/StatusBadge';
+import { CollapsibleSection } from './CollapsibleSection';
+import { GoalDialog } from './GoalDialog';
+import { isEnteredInError } from './PatientSummary.utils';
+import SummaryItem from './SummaryItem';
+import styles from './SummaryItem.module.css';
+
+export interface GoalsProps {
+  readonly patient: Patient;
+  readonly goals: Goal[];
+  readonly onClickResource?: (resource: Goal) => void;
+}
+
+export function Goals(props: GoalsProps): JSX.Element {
+  const medplum = useMedplum();
+  const { patient } = props;
+  const [goals, setGoals] = useState(props.goals);
+  const [opened, { open, close }] = useDisclosure(false);
+  const [editGoal, setEditGoal] = useState<Goal>();
+
+  const handleSubmit = useCallback(
+    async (goal: Goal) => {
+      if (goal.id) {
+        const updated = await medplum.updateResource(goal);
+        setGoals(goals.map((g) => (g.id === updated.id ? updated : g)));
+      } else {
+        const created = await medplum.createResource(goal);
+        setGoals([created, ...goals]);
+      }
+      setEditGoal(undefined);
+      close();
+    },
+    [medplum, goals, close]
+  );
+
+  // Hide entered-in-error goals (still reachable by direct URL).
+  const visibleGoals = goals.filter((goal) => !isEnteredInError(goal));
+
+  const handleDelete = useCallback(async () => {
+    if (!editGoal?.id) {
+      return;
+    }
+    await medplum.deleteResource('Goal', editGoal.id);
+    setGoals(goals.filter((g) => g.id !== editGoal.id));
+    setEditGoal(undefined);
+    close();
+  }, [medplum, goals, editGoal, close]);
+
+  return (
+    <>
+      <CollapsibleSection
+        title="Goals"
+        onAdd={() => {
+          setEditGoal(undefined);
+          open();
+        }}
+      >
+        {visibleGoals.length > 0 ? (
+          <Flex direction="column" gap={8}>
+            {visibleGoals.map((goal) => (
+              <SummaryItem
+                key={goal.id}
+                onClick={() => {
+                  setEditGoal(goal);
+                  open();
+                }}
+              >
+                <Box>
+                  <Text fw={500} className={styles.itemText}>
+                    {getGoalDisplay(goal)}
+                  </Text>
+                  <Group mt={2} gap={4}>
+                    {goal.lifecycleStatus && (
+                      <StatusBadge
+                        color={getGoalStatusColor(goal.lifecycleStatus)}
+                        variant="light"
+                        status={goal.lifecycleStatus}
+                      />
+                    )}
+                    {getGoalDateText(goal) && (
+                      <Text size="xs" fw={500} c="dimmed">
+                        {getGoalDateText(goal)}
+                      </Text>
+                    )}
+                  </Group>
+                </Box>
+              </SummaryItem>
+            ))}
+          </Flex>
+        ) : (
+          <Text>(none)</Text>
+        )}
+      </CollapsibleSection>
+      <Modal opened={opened} onClose={close} title={editGoal ? 'Edit Goal' : 'Add Goal'}>
+        <GoalDialog patient={patient} goal={editGoal} onSubmit={handleSubmit} onDelete={handleDelete} />
+      </Modal>
+    </>
+  );
+}
+
+function getGoalDisplay(goal: Goal): string {
+  return (goal.description && formatCodeableConcept(goal.description)) || 'Goal';
+}
+
+function getGoalDateText(goal: Goal): string | undefined {
+  const dueDate = goal.target?.find((target) => target.dueDate)?.dueDate;
+  if (dueDate) {
+    return `Target ${formatDate(dueDate)}`;
+  }
+  return goal.startDate ? `Started ${formatDate(goal.startDate)}` : undefined;
+}
+
+function getGoalStatusColor(status: string): string {
+  switch (status) {
+    case 'active':
+    case 'accepted':
+    case 'completed':
+      return 'green';
+    case 'on-hold':
+    case 'planned':
+    case 'proposed':
+      return 'yellow';
+    case 'cancelled':
+    case 'rejected':
+    case 'entered-in-error':
+      return 'red';
+    default:
+      return 'gray';
+  }
+}

--- a/packages/react/src/PatientSummary/Goals.tsx
+++ b/packages/react/src/PatientSummary/Goals.tsx
@@ -17,7 +17,6 @@ import styles from './SummaryItem.module.css';
 export interface GoalsProps {
   readonly patient: Patient;
   readonly goals: Goal[];
-  readonly onClickResource?: (resource: Goal) => void;
 }
 
 export function Goals(props: GoalsProps): JSX.Element {

--- a/packages/react/src/PatientSummary/ImmunizationDialog.tsx
+++ b/packages/react/src/PatientSummary/ImmunizationDialog.tsx
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Button, Radio, Stack } from '@mantine/core';
+import { createReference } from '@medplum/core';
+import type { Encounter, Immunization, Patient } from '@medplum/fhirtypes';
+import { IconTrash } from '@tabler/icons-react';
+import type { JSX } from 'react';
+import { useCallback, useState } from 'react';
+import { CodeableConceptInput } from '../CodeableConceptInput/CodeableConceptInput';
+import { DateTimeInput } from '../DateTimeInput/DateTimeInput';
+import { convertLocalToIso } from '../DateTimeInput/DateTimeInput.utils';
+import { Form } from '../Form/Form';
+import { SubmitButton } from '../Form/SubmitButton';
+import { ModalActionsFooter } from '../ModalActionsFooter/ModalActionsFooter';
+import { ModalContentLayout } from '../ModalContentLayout/ModalContentLayout';
+import { formatStatusLabel } from './PatientSummary.utils';
+
+export interface ImmunizationDialogProps {
+  readonly patient: Patient;
+  readonly encounter?: Encounter;
+  readonly immunization?: Immunization;
+  readonly onSubmit: (immunization: Immunization) => void;
+  /** When editing an existing immunization, called to delete it. */
+  readonly onDelete?: () => void;
+}
+
+const statusValues: Immunization['status'][] = ['completed', 'not-done'];
+
+export function ImmunizationDialog(props: ImmunizationDialogProps): JSX.Element {
+  const { patient, encounter, immunization, onSubmit, onDelete } = props;
+  const [vaccineCode, setVaccineCode] = useState(immunization?.vaccineCode);
+
+  const handleSubmit = useCallback(
+    (formData: Record<string, string>) => {
+      onSubmit({
+        ...immunization,
+        resourceType: 'Immunization',
+        status: (formData.status as Immunization['status']) ?? 'completed',
+        patient: createReference(patient),
+        encounter: immunization?.encounter ?? (encounter && createReference(encounter)),
+        vaccineCode: vaccineCode ?? { text: '' },
+        occurrenceDateTime: formData.occurrenceDateTime
+          ? convertLocalToIso(formData.occurrenceDateTime)
+          : (immunization?.occurrenceDateTime ?? ''),
+      });
+    },
+    [patient, encounter, immunization, vaccineCode, onSubmit]
+  );
+
+  return (
+    <Form key={immunization?.id} onSubmit={handleSubmit}>
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <SubmitButton fullWidth>Save</SubmitButton>
+            {immunization?.id && onDelete && (
+              <Button fullWidth variant="light" color="red" leftSection={<IconTrash size={16} />} onClick={onDelete}>
+                Delete
+              </Button>
+            )}
+          </ModalActionsFooter>
+        }
+      >
+        <Stack gap="md">
+          <CodeableConceptInput
+            name="vaccineCode"
+            label="Vaccine"
+            path="Immunization.vaccineCode"
+            data-autofocus={true}
+            binding="http://hl7.org/fhir/ValueSet/vaccine-code"
+            maxValues={1}
+            defaultValue={immunization?.vaccineCode}
+            onChange={(value) => setVaccineCode(value)}
+            outcome={undefined}
+          />
+          <DateTimeInput
+            name="occurrenceDateTime"
+            label="Date Given"
+            defaultValue={immunization?.occurrenceDateTime}
+            required
+          />
+          <Radio.Group name="status" label="Status" required defaultValue={immunization?.status ?? 'completed'}>
+            {statusValues.map((sv) => (
+              <Radio key={sv} value={sv} label={formatStatusLabel(sv as string)} my="xs" required />
+            ))}
+          </Radio.Group>
+        </Stack>
+      </ModalContentLayout>
+    </Form>
+  );
+}

--- a/packages/react/src/PatientSummary/Immunizations.test.tsx
+++ b/packages/react/src/PatientSummary/Immunizations.test.tsx
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { createReference } from '@medplum/core';
+import type { Immunization } from '@medplum/fhirtypes';
+import { HomerSimpson, MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react-hooks';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
+import { act, fireEvent, render, screen, selectAutocompleteOption } from '../test-utils/render';
+import { Immunizations } from './Immunizations';
+
+const medplum = new MockClient();
+
+describe('PatientSummary - Immunizations', () => {
+  async function setup(children: ReactNode): Promise<void> {
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
+        </MemoryRouter>
+      );
+    });
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      vi.runOnlyPendingTimers();
+    });
+    vi.useRealTimers();
+  });
+
+  test('Renders empty', async () => {
+    await setup(<Immunizations patient={HomerSimpson} immunizations={[]} />);
+    expect(screen.getByText('Immunizations')).toBeInTheDocument();
+    expect(screen.getByText('(none)')).toBeInTheDocument();
+  });
+
+  test('Renders existing with vaccine, status, and date', async () => {
+    await setup(
+      <Immunizations
+        patient={HomerSimpson}
+        immunizations={[
+          {
+            resourceType: 'Immunization',
+            id: 'flu',
+            status: 'completed',
+            patient: createReference(HomerSimpson),
+            vaccineCode: { text: 'Influenza vaccine' },
+            occurrenceDateTime: '2026-01-15T00:00:00Z',
+          },
+        ]}
+      />
+    );
+    expect(screen.getByText('Influenza vaccine')).toBeInTheDocument();
+    expect(screen.getByText('completed')).toBeInTheDocument();
+    expect(screen.getByText(/Given/)).toBeInTheDocument();
+  });
+
+  test('Add immunization', async () => {
+    await setup(<Immunizations patient={HomerSimpson} immunizations={[]} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Add item'));
+    });
+
+    const input = await screen.findByRole('searchbox');
+    await selectAutocompleteOption(input, 'Test', 'Test Display');
+    expect(screen.getByText('Test Display')).toBeDefined();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+    });
+  });
+
+  test('Edit immunization', async () => {
+    const immunization: Immunization = {
+      resourceType: 'Immunization',
+      id: 'flu',
+      status: 'completed',
+      patient: createReference(HomerSimpson),
+      vaccineCode: { text: 'Influenza vaccine' },
+      occurrenceDateTime: '2026-01-15T00:00:00Z',
+    };
+
+    await setup(<Immunizations patient={HomerSimpson} immunizations={[immunization]} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Influenza vaccine'));
+    });
+
+    expect(await screen.findByText('Edit Immunization')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+    });
+  });
+
+  test('Add modal omits Delete button and entered-in-error status', async () => {
+    await setup(<Immunizations patient={HomerSimpson} immunizations={[]} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Add item'));
+    });
+
+    expect(await screen.findByText('Add Immunization')).toBeInTheDocument();
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+    expect(screen.queryByText('entered-in-error')).not.toBeInTheDocument();
+    // Status radio labels are capitalized with hyphens removed.
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.getByText('Not Done')).toBeInTheDocument();
+    expect(screen.queryByText('not-done')).not.toBeInTheDocument();
+  });
+
+  test('Delete immunization', async () => {
+    const created = await medplum.createResource<Immunization>({
+      resourceType: 'Immunization',
+      status: 'completed',
+      patient: createReference(HomerSimpson),
+      vaccineCode: { text: 'Influenza vaccine' },
+      occurrenceDateTime: '2026-01-15T00:00:00Z',
+    });
+
+    await setup(<Immunizations patient={HomerSimpson} immunizations={[created]} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Influenza vaccine'));
+    });
+
+    const deleteButton = await screen.findByText('Delete');
+    await act(async () => {
+      fireEvent.click(deleteButton);
+    });
+
+    expect(screen.queryByText('Influenza vaccine')).not.toBeInTheDocument();
+  });
+
+  test('Immunization status colors', async () => {
+    await setup(
+      <Immunizations
+        patient={HomerSimpson}
+        immunizations={[
+          {
+            resourceType: 'Immunization',
+            id: 'completed',
+            status: 'completed',
+            patient: createReference(HomerSimpson),
+            vaccineCode: { text: 'Completed Vaccine' },
+          },
+          {
+            resourceType: 'Immunization',
+            id: 'not-done',
+            status: 'not-done',
+            patient: createReference(HomerSimpson),
+            vaccineCode: { text: 'Not Done Vaccine' },
+          },
+        ]}
+      />
+    );
+
+    const completedBadge = screen.getByText('completed').closest('[class*="mantine-Badge-root"]');
+    expect(completedBadge).toHaveStyle({ '--badge-color': 'var(--mantine-color-green-light-color)' });
+
+    const notDoneBadge = screen.getByText('not done').closest('[class*="mantine-Badge-root"]');
+    expect(notDoneBadge).toHaveStyle({ '--badge-color': 'var(--mantine-color-gray-light-color)' });
+  });
+
+  test('Hides entered-in-error immunizations', async () => {
+    await setup(
+      <Immunizations
+        patient={HomerSimpson}
+        immunizations={[
+          {
+            resourceType: 'Immunization',
+            id: 'shown',
+            status: 'completed',
+            patient: createReference(HomerSimpson),
+            vaccineCode: { text: 'Shown Vaccine' },
+          },
+          {
+            resourceType: 'Immunization',
+            id: 'hidden',
+            status: 'entered-in-error',
+            patient: createReference(HomerSimpson),
+            vaccineCode: { text: 'Hidden Vaccine' },
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Shown Vaccine')).toBeInTheDocument();
+    expect(screen.queryByText('Hidden Vaccine')).not.toBeInTheDocument();
+  });
+});

--- a/packages/react/src/PatientSummary/Immunizations.tsx
+++ b/packages/react/src/PatientSummary/Immunizations.tsx
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Box, Flex, Group, Modal, Text } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { formatCodeableConcept, formatDate } from '@medplum/core';
+import type { Encounter, Immunization, Patient } from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react-hooks';
+import type { JSX } from 'react';
+import { useCallback, useState } from 'react';
+import { StatusBadge } from '../StatusBadge/StatusBadge';
+import { CollapsibleSection } from './CollapsibleSection';
+import { ImmunizationDialog } from './ImmunizationDialog';
+import { isEnteredInError } from './PatientSummary.utils';
+import SummaryItem from './SummaryItem';
+import styles from './SummaryItem.module.css';
+
+export interface ImmunizationsProps {
+  readonly patient: Patient;
+  readonly encounter?: Encounter;
+  readonly immunizations: Immunization[];
+  readonly onClickResource?: (resource: Immunization) => void;
+}
+
+export function Immunizations(props: ImmunizationsProps): JSX.Element {
+  const medplum = useMedplum();
+  const { patient, encounter } = props;
+  const [immunizations, setImmunizations] = useState(props.immunizations);
+  const [opened, { open, close }] = useDisclosure(false);
+  const [editImmunization, setEditImmunization] = useState<Immunization>();
+
+  // Hide entered-in-error immunizations (still reachable by direct URL); most recent first.
+  const sortedImmunizations = [...immunizations]
+    .filter((immunization) => !isEnteredInError(immunization))
+    .sort((a, b) => (b.occurrenceDateTime ?? '').localeCompare(a.occurrenceDateTime ?? ''));
+
+  const handleSubmit = useCallback(
+    async (immunization: Immunization) => {
+      if (immunization.id) {
+        const updated = await medplum.updateResource(immunization);
+        setImmunizations(immunizations.map((i) => (i.id === updated.id ? updated : i)));
+      } else {
+        const created = await medplum.createResource(immunization);
+        setImmunizations([created, ...immunizations]);
+      }
+      setEditImmunization(undefined);
+      close();
+    },
+    [medplum, immunizations, close]
+  );
+
+  const handleDelete = useCallback(async () => {
+    if (!editImmunization?.id) {
+      return;
+    }
+    await medplum.deleteResource('Immunization', editImmunization.id);
+    setImmunizations(immunizations.filter((i) => i.id !== editImmunization.id));
+    setEditImmunization(undefined);
+    close();
+  }, [medplum, immunizations, editImmunization, close]);
+
+  return (
+    <>
+      <CollapsibleSection
+        title="Immunizations"
+        onAdd={() => {
+          setEditImmunization(undefined);
+          open();
+        }}
+      >
+        {sortedImmunizations.length > 0 ? (
+          <Flex direction="column" gap={8}>
+            {sortedImmunizations.map((immunization) => (
+              <SummaryItem
+                key={immunization.id}
+                onClick={() => {
+                  setEditImmunization(immunization);
+                  open();
+                }}
+              >
+                <Box>
+                  <Text fw={500} className={styles.itemText}>
+                    {getImmunizationDisplay(immunization)}
+                  </Text>
+                  <Group mt={2} gap={4}>
+                    {immunization.status && (
+                      <StatusBadge
+                        color={getImmunizationStatusColor(immunization.status)}
+                        variant="light"
+                        status={immunization.status}
+                      />
+                    )}
+                    {immunization.occurrenceDateTime && (
+                      <Text size="xs" fw={500} c="dimmed">
+                        Given {formatDate(immunization.occurrenceDateTime)}
+                      </Text>
+                    )}
+                  </Group>
+                </Box>
+              </SummaryItem>
+            ))}
+          </Flex>
+        ) : (
+          <Text>(none)</Text>
+        )}
+      </CollapsibleSection>
+      <Modal opened={opened} onClose={close} title={editImmunization ? 'Edit Immunization' : 'Add Immunization'}>
+        <ImmunizationDialog
+          patient={patient}
+          encounter={encounter}
+          immunization={editImmunization}
+          onSubmit={handleSubmit}
+          onDelete={handleDelete}
+        />
+      </Modal>
+    </>
+  );
+}
+
+function getImmunizationDisplay(immunization: Immunization): string {
+  return (immunization.vaccineCode && formatCodeableConcept(immunization.vaccineCode)) || 'Immunization';
+}
+
+function getImmunizationStatusColor(status: string): string {
+  switch (status) {
+    case 'completed':
+      return 'green';
+    case 'not-done':
+      return 'gray';
+    case 'entered-in-error':
+      return 'red';
+    default:
+      return 'gray';
+  }
+}

--- a/packages/react/src/PatientSummary/Immunizations.tsx
+++ b/packages/react/src/PatientSummary/Immunizations.tsx
@@ -18,7 +18,6 @@ export interface ImmunizationsProps {
   readonly patient: Patient;
   readonly encounter?: Encounter;
   readonly immunizations: Immunization[];
-  readonly onClickResource?: (resource: Immunization) => void;
 }
 
 export function Immunizations(props: ImmunizationsProps): JSX.Element {

--- a/packages/react/src/PatientSummary/MedicationDialog.tsx
+++ b/packages/react/src/PatientSummary/MedicationDialog.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Alert, Group, Radio, Stack } from '@mantine/core';
+import { Alert, Radio, Stack } from '@mantine/core';
 import { HTTP_HL7_ORG, addProfileToResource, createReference } from '@medplum/core';
 import type { Encounter, MedicationRequest, Patient } from '@medplum/fhirtypes';
 import { useMedplumProfile } from '@medplum/react-hooks';
@@ -9,6 +9,8 @@ import { useCallback, useState } from 'react';
 import { CodeableConceptInput } from '../CodeableConceptInput/CodeableConceptInput';
 import { Form } from '../Form/Form';
 import { SubmitButton } from '../Form/SubmitButton';
+import { ModalActionsFooter } from '../ModalActionsFooter/ModalActionsFooter';
+import { ModalContentLayout } from '../ModalContentLayout/ModalContentLayout';
 
 export interface MedicationDialogProps {
   readonly patient: Patient;
@@ -66,26 +68,31 @@ export function MedicationDialog(props: MedicationDialogProps): JSX.Element {
 
   return (
     <Form onSubmit={handleSubmit}>
-      <Stack>
-        <CodeableConceptInput
-          name="request"
-          path="MedicationRequest.medication[x]"
-          data-autofocus={true}
-          binding={HTTP + 'cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4'}
-          maxValues={1}
-          defaultValue={medication?.medicationCodeableConcept}
-          onChange={(request) => setCode(request)}
-          outcome={undefined}
-        />
-        <Radio.Group name="status" label="Request Status" required defaultValue={medication?.status}>
-          {statusValues.map((sv) => (
-            <Radio key={sv} value={sv} label={sv} my="xs" required />
-          ))}
-        </Radio.Group>
-        <Group justify="flex-end" gap={4}>
-          <SubmitButton>Save</SubmitButton>
-        </Group>
-      </Stack>
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <SubmitButton fullWidth>Save</SubmitButton>
+          </ModalActionsFooter>
+        }
+      >
+        <Stack gap="md">
+          <CodeableConceptInput
+            name="request"
+            path="MedicationRequest.medication[x]"
+            data-autofocus={true}
+            binding={HTTP + 'cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4'}
+            maxValues={1}
+            defaultValue={medication?.medicationCodeableConcept}
+            onChange={(request) => setCode(request)}
+            outcome={undefined}
+          />
+          <Radio.Group name="status" label="Request Status" required defaultValue={medication?.status}>
+            {statusValues.map((sv) => (
+              <Radio key={sv} value={sv} label={sv} my="xs" required />
+            ))}
+          </Radio.Group>
+        </Stack>
+      </ModalContentLayout>
     </Form>
   );
 }

--- a/packages/react/src/PatientSummary/PatientInfoItem.tsx
+++ b/packages/react/src/PatientSummary/PatientInfoItem.tsx
@@ -13,16 +13,22 @@ export interface PatientInfoItemProps {
   placeholder: string;
   label: string;
   onClickResource?: (patient: Patient) => void;
+  /** When provided, takes precedence over `onClickResource` (e.g. to open a patient edit modal). */
+  onClick?: () => void;
 }
 
 export const PatientInfoItem = (props: PatientInfoItemProps): JSX.Element => {
-  const { patient, value, icon, placeholder, label, onClickResource } = props;
+  const { patient, value, icon, placeholder, label, onClickResource, onClick } = props;
   const displayText = value || placeholder;
 
   return (
     <SummaryItem
       onClick={() => {
-        onClickResource?.(patient);
+        if (onClick) {
+          onClick();
+        } else {
+          onClickResource?.(patient);
+        }
       }}
     >
       <Box className={styles.patientSummaryListItem}>

--- a/packages/react/src/PatientSummary/PatientSummary.module.css
+++ b/packages/react/src/PatientSummary/PatientSummary.module.css
@@ -11,16 +11,20 @@
   background-color: var(--mantine-color-white);
 }
 
-.headerRow {
-  position: relative;
-}
-
 .avatar {
   border: 1px solid var(--mantine-color-gray-3);
 }
 
 [data-mantine-color-scheme='dark'] .avatar {
   border-color: var(--mantine-color-dark-4);
+}
+
+/* Both the link wrapper and the content it wraps take the row's free space and allow
+   shrinking, so the name truncates instead of pushing the actions menu around. */
+.headerLink,
+.headerContent {
+  flex: 1;
+  min-width: 0;
 }
 
 .headerLink {
@@ -33,65 +37,13 @@
   text-decoration: none;
 }
 
-/* Same hover treatment as SummaryItem: opaque solid behind the icon, with a white fade
-   to its left so truncated name text never shows through. Confined to the content row
-   (Divider is a sibling) and inset from the right to avoid the panel scrollbar. */
-.gradient {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  right: calc(var(--mantine-spacing-xs) + 28px);
-  width: 48px;
-  z-index: 1;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.2s;
+.actionsButton {
+  flex-shrink: 0;
 }
 
-[data-mantine-color-scheme='light'] .gradient {
-  background: linear-gradient(to right, transparent, var(--mantine-color-white));
-}
-
-[data-mantine-color-scheme='dark'] .gradient {
-  background: linear-gradient(to right, transparent, var(--mantine-color-body));
-}
-
-.headerMenu {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  right: var(--mantine-spacing-xs);
-  width: 28px;
-  z-index: 2;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.2s;
-}
-
-[data-mantine-color-scheme='light'] .headerMenu {
-  background: var(--mantine-color-white);
-}
-
-[data-mantine-color-scheme='dark'] .headerMenu {
-  background: var(--mantine-color-body);
-}
-
-.headerRow:hover .gradient,
-.headerRow:hover .headerMenu,
-.headerRow:focus-within .gradient,
-.headerRow:focus-within .headerMenu,
-/* Keep the overlay + trigger visible while the menu is open (dropdown is portaled). */
-.headerRow:has(:global([data-expanded])) .gradient,
-.headerRow:has(:global([data-expanded])) .headerMenu {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-/* Match ActionIcon subtle hover while the menu stays open. */
-.headerMenu :global(.mantine-ActionIcon-root[data-expanded]) {
+/* Match ActionIcon subtle hover while the menu stays open (the dropdown is portaled,
+   so the trigger loses :hover as soon as the pointer moves into it). */
+.actionsButton[data-expanded] {
   background-color: var(--mantine-primary-color-light);
   color: var(--mantine-primary-color-light-color);
 }

--- a/packages/react/src/PatientSummary/PatientSummary.module.css
+++ b/packages/react/src/PatientSummary/PatientSummary.module.css
@@ -1,13 +1,99 @@
 .panel {
+  min-height: 100%;
   height: 100%;
 }
 
 [data-mantine-color-scheme='dark'] .panel {
-  background-color: var(--mantine-color-dark-8);
+  background-color: var(--mantine-color-body);
 }
 
 [data-mantine-color-scheme='light'] .panel {
   background-color: var(--mantine-color-white);
+}
+
+.headerRow {
+  position: relative;
+}
+
+.avatar {
+  border: 1px solid var(--mantine-color-gray-3);
+}
+
+[data-mantine-color-scheme='dark'] .avatar {
+  border-color: var(--mantine-color-dark-4);
+}
+
+.headerLink {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+
+.headerLink:hover {
+  text-decoration: none;
+}
+
+/* Same hover treatment as SummaryItem: opaque solid behind the icon, with a white fade
+   to its left so truncated name text never shows through. Confined to the content row
+   (Divider is a sibling) and inset from the right to avoid the panel scrollbar. */
+.gradient {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: calc(var(--mantine-spacing-xs) + 28px);
+  width: 48px;
+  z-index: 1;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+
+[data-mantine-color-scheme='light'] .gradient {
+  background: linear-gradient(to right, transparent, var(--mantine-color-white));
+}
+
+[data-mantine-color-scheme='dark'] .gradient {
+  background: linear-gradient(to right, transparent, var(--mantine-color-body));
+}
+
+.headerMenu {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: var(--mantine-spacing-xs);
+  width: 28px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+
+[data-mantine-color-scheme='light'] .headerMenu {
+  background: var(--mantine-color-white);
+}
+
+[data-mantine-color-scheme='dark'] .headerMenu {
+  background: var(--mantine-color-body);
+}
+
+.headerRow:hover .gradient,
+.headerRow:hover .headerMenu,
+.headerRow:focus-within .gradient,
+.headerRow:focus-within .headerMenu,
+/* Keep the overlay + trigger visible while the menu is open (dropdown is portaled). */
+.headerRow:has(:global([data-expanded])) .gradient,
+.headerRow:has(:global([data-expanded])) .headerMenu {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Match ActionIcon subtle hover while the menu stays open. */
+.headerMenu :global(.mantine-ActionIcon-root[data-expanded]) {
+  background-color: var(--mantine-primary-color-light);
+  color: var(--mantine-primary-color-light-color);
 }
 
 .patientSummaryBadge {

--- a/packages/react/src/PatientSummary/PatientSummary.stories.tsx
+++ b/packages/react/src/PatientSummary/PatientSummary.stories.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Box } from '@mantine/core';
+import { Box, Menu } from '@mantine/core';
 import { HomerSimpson } from '@medplum/mock';
 import type { Meta } from '@storybook/react';
 import type { JSX } from 'react';
@@ -14,5 +14,33 @@ export default {
 export const Patient = (): JSX.Element => (
   <Box w={350}>
     <PatientSummary patient={HomerSimpson} />
+  </Box>
+);
+
+const headerMenuItems = (
+  <>
+    <Menu.Item>Edit Patient Profile</Menu.Item>
+    <Menu.Item>Import Patient Records</Menu.Item>
+  </>
+);
+
+// The "…" actions menu only renders when headerMenuItems is provided.
+export const WithHeaderMenu = (): JSX.Element => (
+  <Box w={350}>
+    <PatientSummary patient={HomerSimpson} headerMenuItems={headerMenuItems} />
+  </Box>
+);
+
+// A name long enough to truncate, so the gap the header row reserves between the
+// name and the always-visible "…" trigger is visible at a narrow width.
+export const WithHeaderMenuTruncatedName = (): JSX.Element => (
+  <Box w={260}>
+    <PatientSummary
+      patient={{
+        ...HomerSimpson,
+        name: [{ given: ['Bartholomew', 'Jonathan'], family: 'Simpson-Vandermeerschen' }],
+      }}
+      headerMenuItems={headerMenuItems}
+    />
   </Box>
 );

--- a/packages/react/src/PatientSummary/PatientSummary.test.tsx
+++ b/packages/react/src/PatientSummary/PatientSummary.test.tsx
@@ -12,6 +12,8 @@ import {
   createLabsSection,
   DemographicsSection,
   getDefaultSections,
+  GoalsSection,
+  ImmunizationsSection,
   InsuranceSection,
   LabsSection,
   MedicationsSection,
@@ -228,6 +230,37 @@ describe('PatientSummary', () => {
     expect(screen.getByText('Active Only')).toBeInTheDocument();
   });
 
+  test('Hides entered-in-error resources from all sections', async () => {
+    const patientRef = createReference(HomerSimpson);
+    await medplum.createResource({
+      resourceType: 'Condition',
+      subject: patientRef,
+      code: { text: 'Visible Condition' },
+      verificationStatus: {
+        coding: [{ system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status', code: 'confirmed' }],
+      },
+    });
+    await medplum.createResource({
+      resourceType: 'Condition',
+      subject: patientRef,
+      code: { text: 'Errored Condition' },
+      verificationStatus: {
+        coding: [{ system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status', code: 'entered-in-error' }],
+      },
+    });
+
+    const section = summaryResourceListSection({
+      key: 'ver-status-conditions',
+      title: 'Conditions',
+      search: { resourceType: 'Condition', patientParam: 'subject' },
+    });
+
+    await setup({ patient: HomerSimpson, sections: [section] });
+
+    expect(screen.getByText('Visible Condition')).toBeInTheDocument();
+    expect(screen.queryByText('Errored Condition')).not.toBeInTheDocument();
+  });
+
   test('Renders summaryResourceListSection with getDisplayString, getStatus, and getSecondaryText', async () => {
     const patientRef = createReference(HomerSimpson);
     await medplum.createResource({
@@ -312,13 +345,15 @@ describe('PatientSummary', () => {
 
   test('getDefaultSections returns all built-in sections', () => {
     const sections = getDefaultSections();
-    expect(sections).toHaveLength(10);
+    expect(sections).toHaveLength(12);
     expect(sections.map((s) => s.key)).toEqual([
       'demographics',
+      'goals',
       'insurance',
       'allergies',
       'problemList',
       'medications',
+      'immunizations',
       'labs',
       'sexualOrientation',
       'smokingStatus',
@@ -501,6 +536,52 @@ describe('PatientSummary', () => {
 
     expect(VitalsSection.key).toBe('vitals');
     expect(VitalsSection.searches?.[0].query).toEqual({ category: 'vital-signs' });
+
+    expect(ImmunizationsSection.key).toBe('immunizations');
+    expect(ImmunizationsSection.title).toBe('Immunizations');
+    expect(ImmunizationsSection.searches?.[0].resourceType).toBe('Immunization');
+    expect(ImmunizationsSection.searches?.[0].patientParam).toBe('patient');
+
+    expect(GoalsSection.key).toBe('goals');
+    expect(GoalsSection.title).toBe('Goals');
+    expect(GoalsSection.searches?.[0].resourceType).toBe('Goal');
+    expect(GoalsSection.searches?.[0].patientParam).toBe('patient');
+  });
+
+  test('Renders Immunizations section with vaccine, status, and date', async () => {
+    const patientRef = createReference(HomerSimpson);
+    await medplum.createResource({
+      resourceType: 'Immunization',
+      status: 'completed',
+      patient: patientRef,
+      vaccineCode: { text: 'Influenza vaccine' },
+      occurrenceDateTime: '2026-01-15T00:00:00Z',
+    });
+
+    await setup({ patient: HomerSimpson, sections: [ImmunizationsSection] });
+
+    expect(screen.getByText('Immunizations')).toBeInTheDocument();
+    expect(screen.getByText('Influenza vaccine')).toBeInTheDocument();
+    expect(screen.getByText('completed')).toBeInTheDocument();
+    expect(screen.getByText(/Given/)).toBeInTheDocument();
+  });
+
+  test('Renders Goals section with description, lifecycle status, and target date', async () => {
+    const patientRef = createReference(HomerSimpson);
+    await medplum.createResource({
+      resourceType: 'Goal',
+      lifecycleStatus: 'active',
+      description: { text: 'Lower blood pressure' },
+      subject: patientRef,
+      target: [{ dueDate: '2026-12-31' }],
+    });
+
+    await setup({ patient: HomerSimpson, sections: [GoalsSection] });
+
+    expect(screen.getByText('Goals')).toBeInTheDocument();
+    expect(screen.getByText('Lower blood pressure')).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+    expect(screen.getByText(/Target/)).toBeInTheDocument();
   });
 
   test('Renders with empty sections array', async () => {

--- a/packages/react/src/PatientSummary/PatientSummary.tsx
+++ b/packages/react/src/PatientSummary/PatientSummary.tsx
@@ -101,7 +101,7 @@ export function PatientSummary(props: PatientSummaryProps): JSX.Element | null {
   }
 
   const headerContent = (
-    <Group align="center" gap="sm" py="md" pl="sm" pr="xl">
+    <Group align="center" gap="sm" wrap="nowrap" className={styles.headerContent}>
       <ResourceAvatar value={patient} size={48} radius={48} className={styles.avatar} />
       <Stack gap={0} style={{ flex: 1, minWidth: 0 }}>
         <Tooltip
@@ -133,7 +133,11 @@ export function PatientSummary(props: PatientSummaryProps): JSX.Element | null {
   return (
     <Flex direction="column" gap={0} w="100%" h="100%" className={styles.panel}>
       <Box>
-        <Box className={styles.headerRow}>
+        {/* The actions menu is a real flex sibling of the name rather than an overlay, so the
+            row's `gap` reserves the space itself: the name truncates that far short of the
+            icon at any panel width, and the icon stays pinned to the same right inset as the
+            sections' "+" buttons. Without the menu, keep the old right padding. */}
+        <Group align="center" gap="sm" wrap="nowrap" py="md" pl="sm" pr={headerMenuItems ? 'xs' : 'xl'}>
           {linkToPatient ? (
             <MedplumLink to={patient} className={styles.headerLink} underline="never">
               {headerContent}
@@ -142,21 +146,22 @@ export function PatientSummary(props: PatientSummaryProps): JSX.Element | null {
             headerContent
           )}
           {headerMenuItems && (
-            <>
-              <div className={styles.gradient} aria-hidden="true" />
-              <div className={styles.headerMenu}>
-                <Menu shadow="md" radius="md" width={240} position="bottom-end">
-                  <Menu.Target>
-                    <ActionIcon variant="subtle" size="md" radius="xl" aria-label="Patient actions">
-                      <IconDots size={18} />
-                    </ActionIcon>
-                  </Menu.Target>
-                  <Menu.Dropdown>{headerMenuItems}</Menu.Dropdown>
-                </Menu>
-              </div>
-            </>
+            <Menu shadow="md" radius="md" width={240} position="bottom-end">
+              <Menu.Target>
+                <ActionIcon
+                  variant="subtle"
+                  size="md"
+                  radius="xl"
+                  aria-label="Patient actions"
+                  className={styles.actionsButton}
+                >
+                  <IconDots size={18} />
+                </ActionIcon>
+              </Menu.Target>
+              <Menu.Dropdown>{headerMenuItems}</Menu.Dropdown>
+            </Menu>
           )}
-        </Box>
+        </Group>
         <Divider />
       </Box>
 

--- a/packages/react/src/PatientSummary/PatientSummary.tsx
+++ b/packages/react/src/PatientSummary/PatientSummary.tsx
@@ -1,29 +1,69 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Divider, Flex, Group, Stack, Text, Tooltip } from '@mantine/core';
+import { ActionIcon, Box, Divider, Flex, Group, Menu, Stack, Text, Tooltip } from '@mantine/core';
 import { formatHumanName, resolveId } from '@medplum/core';
 import type { Patient, Reference, Resource } from '@medplum/fhirtypes';
 import { useMedplum, usePatientSummaryData, useResource } from '@medplum/react-hooks';
-import type { JSX } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { IconDots } from '@tabler/icons-react';
+import type { JSX, ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { MedplumLink } from '../MedplumLink/MedplumLink';
 import { ResourceAvatar } from '../ResourceAvatar/ResourceAvatar';
 import styles from './PatientSummary.module.css';
 import type { PatientSummarySectionConfig } from './PatientSummary.types';
+import { isEnteredInError } from './PatientSummary.utils';
 import { getDefaultSections } from './sectionConfigs';
-import SummaryItem from './SummaryItem';
+
+/**
+ * Drops `entered-in-error` resources from a section's search results so they don't appear in the
+ * summary. The underlying resources are untouched and remain accessible by direct URL.
+ * @param results - The section's search results, keyed by search key.
+ * @returns The results with entered-in-error resources removed.
+ */
+function filterEnteredInError(results: Record<string, Resource[]>): Record<string, Resource[]> {
+  const filtered: Record<string, Resource[]> = {};
+  for (const [key, resources] of Object.entries(results)) {
+    filtered[key] = Array.isArray(resources) ? resources.filter((resource) => !isEnteredInError(resource)) : resources;
+  }
+  return filtered;
+}
 
 export interface PatientSummaryProps {
   readonly patient: Patient | Reference<Patient>;
   readonly onClickResource?: (resource: Resource) => void;
   readonly onRequestLabs?: () => void;
   readonly sections?: PatientSummarySectionConfig[];
+  /**
+   * Optional `<Menu.Item>` nodes rendered inside a "…" actions menu in the header.
+   * When provided, a hover-revealed menu button appears in the header's top-right.
+   */
+  readonly headerMenuItems?: ReactNode;
+  /**
+   * When true (default), the header links to the patient profile root (`/Patient/:id`).
+   * Set false when the summary is already shown on that patient's profile page.
+   */
+  readonly linkToPatient?: boolean;
+  /**
+   * When provided, clicking a Demographics row opens this callback (the patient edit modal)
+   * instead of navigating via `onClickResource`.
+   */
+  readonly onEditPatient?: () => void;
 }
 
 export function PatientSummary(props: PatientSummaryProps): JSX.Element | null {
   const medplum = useMedplum();
-  const { patient: propsPatient, onClickResource, onRequestLabs } = props;
+  const {
+    patient: propsPatient,
+    onClickResource,
+    onRequestLabs,
+    headerMenuItems,
+    linkToPatient = true,
+    onEditPatient,
+  } = props;
   const patient = useResource(propsPatient);
   const [createdDate, setCreatedDate] = useState<string | undefined>();
+  const nameRef = useRef<HTMLParagraphElement>(null);
+  const [isNameTruncated, setIsNameTruncated] = useState(false);
 
   // Determine sections: custom or default
   const defaultSections = useMemo(() => getDefaultSections(onRequestLabs), [onRequestLabs]);
@@ -46,43 +86,81 @@ export function PatientSummary(props: PatientSummaryProps): JSX.Element | null {
     }
   }, [propsPatient, medplum]);
 
+  useEffect(() => {
+    const checkTruncation = (): void => {
+      const el = nameRef.current;
+      setIsNameTruncated(!!el && el.scrollWidth > el.clientWidth);
+    };
+    checkTruncation();
+    window.addEventListener('resize', checkTruncation);
+    return () => window.removeEventListener('resize', checkTruncation);
+  }, [patient]);
+
   if (!patient) {
     return null;
   }
 
-  return (
-    <Flex direction="column" gap="xs" w="100%" h="100%" className={styles.panel}>
-      <SummaryItem
-        onClick={() => {
-          onClickResource?.(patient);
-        }}
-      >
-        <Group align="center" gap="sm" p={16}>
-          <ResourceAvatar value={patient} size={48} radius={48} style={{ border: '2px solid white' }} />
-          <Stack gap={0} style={{ flex: 1, minWidth: 0 }}>
-            <Tooltip label={formatHumanName(patient.name?.[0])} position="top-start" openDelay={650}>
-              <Text fz="h4" fw={800} truncate style={{ minWidth: 0 }}>
-                {formatHumanName(patient.name?.[0])}
-              </Text>
-            </Tooltip>
-            {(() => {
-              const dateString = typeof createdDate === 'string' && createdDate.length > 0 ? createdDate : undefined;
-              if (!dateString) {
-                return null;
-              }
-              const d = new Date(dateString);
-              return (
-                <Text fz="xs" mt={-2} fw={500} c="gray.6" truncate style={{ minWidth: 0 }}>
-                  Patient since {d.getMonth() + 1}/{d.getDate()}/{d.getFullYear()}
-                </Text>
-              );
-            })()}
-          </Stack>
-        </Group>
-        <Divider />
-      </SummaryItem>
+  const headerContent = (
+    <Group align="center" gap="sm" py="md" pl="sm" pr="xl">
+      <ResourceAvatar value={patient} size={48} radius={48} className={styles.avatar} />
+      <Stack gap={0} style={{ flex: 1, minWidth: 0 }}>
+        <Tooltip
+          label={formatHumanName(patient.name?.[0])}
+          position="top-start"
+          openDelay={650}
+          disabled={!isNameTruncated}
+        >
+          <Text ref={nameRef} fz="h4" fw={800} truncate style={{ minWidth: 0 }}>
+            {formatHumanName(patient.name?.[0])}
+          </Text>
+        </Tooltip>
+        {(() => {
+          const dateString = typeof createdDate === 'string' && createdDate.length > 0 ? createdDate : undefined;
+          if (!dateString) {
+            return null;
+          }
+          const d = new Date(dateString);
+          return (
+            <Text fz="xs" mt={-2} fw={500} c="gray.6" truncate style={{ minWidth: 0 }}>
+              Patient since {d.getMonth() + 1}/{d.getDate()}/{d.getFullYear()}
+            </Text>
+          );
+        })()}
+      </Stack>
+    </Group>
+  );
 
-      <Stack gap="xs" px={16} pt={12} pb={16} style={{ flex: 2, overflowY: 'auto', minHeight: 0 }}>
+  return (
+    <Flex direction="column" gap={0} w="100%" h="100%" className={styles.panel}>
+      <Box>
+        <Box className={styles.headerRow}>
+          {linkToPatient ? (
+            <MedplumLink to={patient} className={styles.headerLink} underline="never">
+              {headerContent}
+            </MedplumLink>
+          ) : (
+            headerContent
+          )}
+          {headerMenuItems && (
+            <>
+              <div className={styles.gradient} aria-hidden="true" />
+              <div className={styles.headerMenu}>
+                <Menu shadow="md" radius="md" width={240} position="bottom-end">
+                  <Menu.Target>
+                    <ActionIcon variant="subtle" size="md" radius="xl" aria-label="Patient actions">
+                      <IconDots size={18} />
+                    </ActionIcon>
+                  </Menu.Target>
+                  <Menu.Dropdown>{headerMenuItems}</Menu.Dropdown>
+                </Menu>
+              </div>
+            </>
+          )}
+        </Box>
+        <Divider />
+      </Box>
+
+      <Stack gap={0} px="xs" pb={16} style={{ flex: 2, overflowY: 'auto', minHeight: 0 }}>
         {error && (
           <Text c="red" fz="sm">
             Error loading patient summary: {error.message}
@@ -97,7 +175,8 @@ export function PatientSummary(props: PatientSummaryProps): JSX.Element | null {
                   <SectionComponent
                     patient={patient}
                     onClickResource={onClickResource}
-                    results={sectionData[index] ?? {}}
+                    onEditPatient={onEditPatient}
+                    results={filterEnteredInError(sectionData[index] ?? {})}
                   />
                   <Divider />
                 </div>

--- a/packages/react/src/PatientSummary/PatientSummary.types.ts
+++ b/packages/react/src/PatientSummary/PatientSummary.types.ts
@@ -10,6 +10,8 @@ export type { FhirSearchDescriptor, SectionResults };
 export interface SectionRenderContext {
   readonly patient: Patient;
   readonly onClickResource?: (resource: Resource) => void;
+  /** When provided, the Demographics rows open this (the patient edit modal) instead of navigating. */
+  readonly onEditPatient?: () => void;
   /** Named results for each search in the section's `searches` array, keyed by `FhirSearchDescriptor.key`. */
   readonly results: SectionResults;
 }

--- a/packages/react/src/PatientSummary/PatientSummary.utils.test.ts
+++ b/packages/react/src/PatientSummary/PatientSummary.utils.test.ts
@@ -1,21 +1,59 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { HTTP_HL7_ORG } from '@medplum/core';
-import type { Patient } from '@medplum/fhirtypes';
+import type { Patient, Resource } from '@medplum/fhirtypes';
 import {
   formatPatientGenderDisplay,
   formatPatientRaceEthnicityDisplay,
+  formatStatusLabel,
   getBirthSex,
   getEthnicity,
   getGenderIdentity,
   getGeneralPractitioner,
   getPreferredLanguage,
   getRace,
+  isEnteredInError,
 } from './PatientSummary.utils';
 
 describe('Patient Utilities', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('formatStatusLabel', () => {
+    it('capitalizes and removes hyphens', () => {
+      expect(formatStatusLabel('active')).toBe('Active');
+      expect(formatStatusLabel('on-hold')).toBe('On Hold');
+      expect(formatStatusLabel('not-done')).toBe('Not Done');
+      expect(formatStatusLabel('entered-in-error')).toBe('Entered In Error');
+    });
+  });
+
+  describe('isEnteredInError', () => {
+    it('detects entered-in-error via status', () => {
+      expect(isEnteredInError({ resourceType: 'Immunization', status: 'entered-in-error' } as Resource)).toBe(true);
+      expect(isEnteredInError({ resourceType: 'Immunization', status: 'completed' } as Resource)).toBe(false);
+    });
+
+    it('detects entered-in-error via lifecycleStatus (Goal)', () => {
+      expect(isEnteredInError({ resourceType: 'Goal', lifecycleStatus: 'entered-in-error' } as Resource)).toBe(true);
+      expect(isEnteredInError({ resourceType: 'Goal', lifecycleStatus: 'active' } as Resource)).toBe(false);
+    });
+
+    it('detects entered-in-error via verificationStatus (Condition/Allergy)', () => {
+      expect(
+        isEnteredInError({
+          resourceType: 'Condition',
+          verificationStatus: { coding: [{ code: 'entered-in-error' }] },
+        } as Resource)
+      ).toBe(true);
+      expect(
+        isEnteredInError({
+          resourceType: 'Condition',
+          verificationStatus: { coding: [{ code: 'confirmed' }] },
+        } as Resource)
+      ).toBe(false);
+    });
   });
 
   describe('getGenderIdentity', () => {

--- a/packages/react/src/PatientSummary/PatientSummary.utils.ts
+++ b/packages/react/src/PatientSummary/PatientSummary.utils.ts
@@ -1,7 +1,27 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { capitalize, getExtension, HTTP_HL7_ORG } from '@medplum/core';
-import type { Patient } from '@medplum/fhirtypes';
+import type { CodeableConcept, Patient, Resource } from '@medplum/fhirtypes';
+
+/**
+ * Returns true when a resource has been marked `entered-in-error`. Such resources are hidden from
+ * list/summary views (they remain accessible by direct URL). The error state lives in different
+ * fields depending on resource type: `.status` (most), `.lifecycleStatus` (Goal), and
+ * `.verificationStatus` (AllergyIntolerance, Condition).
+ * @param resource - The resource to check.
+ * @returns True if the resource is entered-in-error.
+ */
+export function isEnteredInError(resource: Resource): boolean {
+  const candidate = resource as Resource & {
+    status?: string;
+    lifecycleStatus?: string;
+    verificationStatus?: CodeableConcept;
+  };
+  if (candidate.status === 'entered-in-error' || candidate.lifecycleStatus === 'entered-in-error') {
+    return true;
+  }
+  return !!candidate.verificationStatus?.coding?.some((coding) => coding.code === 'entered-in-error');
+}
 
 export function getGenderIdentity(patient: Patient): string | undefined {
   const genderIdentityExt = getExtension(
@@ -66,6 +86,19 @@ export function formatPatientRaceEthnicityDisplay(patient: Patient): string {
   }
 
   return parts.join(' · ');
+}
+
+/**
+ * Formats a FHIR status/lifecycleStatus code for display: removes hyphens and capitalizes each word.
+ * e.g. 'on-hold' → 'On Hold', 'not-done' → 'Not Done', 'active' → 'Active'.
+ * @param status - The raw status code.
+ * @returns The human-friendly, capitalized, hyphen-free label.
+ */
+export function formatStatusLabel(status: string): string {
+  return status
+    .split('-')
+    .map((word) => capitalize(word))
+    .join(' ');
 }
 
 export const getPreferredLanguage = (patient: Patient): string | undefined => {

--- a/packages/react/src/PatientSummary/PharmacyDialog.tsx
+++ b/packages/react/src/PatientSummary/PharmacyDialog.tsx
@@ -7,6 +7,8 @@ import { formatAddress, normalizeErrorString } from '@medplum/core';
 import type { Organization, Patient } from '@medplum/fhirtypes';
 import type { JSX, ReactNode } from 'react';
 import { useCallback, useMemo, useState } from 'react';
+import { ModalActionsFooter } from '../ModalActionsFooter/ModalActionsFooter';
+import { ModalContentLayout } from '../ModalContentLayout/ModalContentLayout';
 import styles from './PharmacyDialog.module.css';
 
 /**
@@ -81,25 +83,31 @@ function SearchForm({ onSearch, searching, renderBeforeSearchButton, placeholder
         onSearch(formData);
       }}
     >
-      <Stack gap="md">
-        <TextInput name="name" label="Pharmacy Name" placeholder={placeholders.name} />
-        <Group grow>
-          <TextInput name="city" label="City" placeholder={placeholders.city} />
-          <TextInput name="state" label="State" placeholder={placeholders.state} />
-        </Group>
-        <Group grow>
-          <TextInput name="zip" label="Zip Code" placeholder={placeholders.zip} />
-          <TextInput name="phoneOrFax" label="Phone or Fax" placeholder={placeholders.phoneOrFax} />
-        </Group>
-        <TextInput name="address" label="Address" placeholder={placeholders.address} />
-        <TextInput name="ncpdpID" label="NCPDP ID" placeholder={placeholders.ncpdpID} />
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <Button type="submit" fullWidth loading={searching}>
+              Search
+            </Button>
+          </ModalActionsFooter>
+        }
+      >
+        <Stack gap="md">
+          <TextInput name="name" label="Pharmacy Name" placeholder={placeholders.name} />
+          <Group grow>
+            <TextInput name="city" label="City" placeholder={placeholders.city} />
+            <TextInput name="state" label="State" placeholder={placeholders.state} />
+          </Group>
+          <Group grow>
+            <TextInput name="zip" label="Zip Code" placeholder={placeholders.zip} />
+            <TextInput name="phoneOrFax" label="Phone or Fax" placeholder={placeholders.phoneOrFax} />
+          </Group>
+          <TextInput name="address" label="Address" placeholder={placeholders.address} />
+          <TextInput name="ncpdpID" label="NCPDP ID" placeholder={placeholders.ncpdpID} />
 
-        {renderBeforeSearchButton}
-
-        <Button type="submit" loading={searching}>
-          Search
-        </Button>
-      </Stack>
+          {renderBeforeSearchButton}
+        </Stack>
+      </ModalContentLayout>
     </form>
   );
 }
@@ -177,53 +185,56 @@ function SearchResults({
 }: SearchResultsProps): JSX.Element {
   return (
     <Box mt="xl">
-      <Text fw={600} mb="md">
-        Search Results ({searchResults.length})
-      </Text>
-      <Radio.Group
-        value={selectedPharmacy ? getPharmacyKey(selectedPharmacy, searchResults.indexOf(selectedPharmacy)) : ''}
-        onChange={(value) => {
-          const selected = searchResults.find((p, i) => getPharmacyKey(p, i) === value);
-          if (selected) {
-            onSelectPharmacy(selected);
-          }
-        }}
+      <ModalContentLayout
+        footer={
+          <ModalActionsFooter>
+            <Button fullWidth onClick={onAddFavorite} disabled={!selectedPharmacy} loading={adding}>
+              Add to Favorites
+            </Button>
+            <Button fullWidth variant="subtle" onClick={onClose}>
+              Cancel
+            </Button>
+          </ModalActionsFooter>
+        }
       >
-        <Stack gap="sm">
-          {searchResults.map((pharmacy, index) => {
-            const pharmacyKey = getPharmacyKey(pharmacy, index);
-            const isSelected = selectedPharmacy
-              ? getPharmacyKey(selectedPharmacy, searchResults.indexOf(selectedPharmacy)) === pharmacyKey
-              : false;
+        <Text fw={600} mb="md">
+          Search Results ({searchResults.length})
+        </Text>
+        <Radio.Group
+          value={selectedPharmacy ? getPharmacyKey(selectedPharmacy, searchResults.indexOf(selectedPharmacy)) : ''}
+          onChange={(value) => {
+            const selected = searchResults.find((p, i) => getPharmacyKey(p, i) === value);
+            if (selected) {
+              onSelectPharmacy(selected);
+            }
+          }}
+        >
+          <Stack gap="md">
+            {searchResults.map((pharmacy, index) => {
+              const pharmacyKey = getPharmacyKey(pharmacy, index);
+              const isSelected = selectedPharmacy
+                ? getPharmacyKey(selectedPharmacy, searchResults.indexOf(selectedPharmacy)) === pharmacyKey
+                : false;
 
-            return (
-              <PharmacyItem
-                key={pharmacyKey}
-                pharmacy={pharmacy}
-                pharmacyKey={pharmacyKey}
-                isSelected={isSelected}
-                onSelect={() => onSelectPharmacy(pharmacy)}
-              />
-            );
-          })}
-        </Stack>
-      </Radio.Group>
+              return (
+                <PharmacyItem
+                  key={pharmacyKey}
+                  pharmacy={pharmacy}
+                  pharmacyKey={pharmacyKey}
+                  isSelected={isSelected}
+                  onSelect={() => onSelectPharmacy(pharmacy)}
+                />
+              );
+            })}
+          </Stack>
+        </Radio.Group>
 
-      <Flex mt="lg" gap="md" align="center" justify="space-between">
         <Checkbox
           label="Set as primary pharmacy"
           checked={setAsPrimary}
           onChange={(e) => onSetAsPrimary(e.currentTarget.checked)}
         />
-        <Group>
-          <Button variant="subtle" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button onClick={onAddFavorite} disabled={!selectedPharmacy} loading={adding}>
-            Add to Favorites
-          </Button>
-        </Group>
-      </Flex>
+      </ModalContentLayout>
     </Box>
   );
 }

--- a/packages/react/src/PatientSummary/SexualOrientation.tsx
+++ b/packages/react/src/PatientSummary/SexualOrientation.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Flex, Group, Modal, Radio, Stack, Text, UnstyledButton } from '@mantine/core';
+import { Box, Flex, Modal, Radio, Text, UnstyledButton } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { createReference, HTTP_HL7_ORG, HTTP_TERMINOLOGY_HL7_ORG, LOINC, SNOMED } from '@medplum/core';
 import type { Encounter, Observation, Patient } from '@medplum/fhirtypes';
@@ -9,6 +9,8 @@ import type { JSX } from 'react';
 import { useCallback, useState } from 'react';
 import { Form } from '../Form/Form';
 import { SubmitButton } from '../Form/SubmitButton';
+import { ModalActionsFooter } from '../ModalActionsFooter/ModalActionsFooter';
+import { ModalContentLayout } from '../ModalContentLayout/ModalContentLayout';
 import { killEvent } from '../utils/dom';
 import { CollapsibleSection } from './CollapsibleSection';
 
@@ -137,16 +139,19 @@ export function SexualOrientation(props: SexualOrientationProps): JSX.Element {
       </CollapsibleSection>
       <Modal opened={opened} onClose={close} title="Set Sexual Orientation">
         <Form onSubmit={handleSubmit}>
-          <Stack>
+          <ModalContentLayout
+            footer={
+              <ModalActionsFooter>
+                <SubmitButton fullWidth>Save</SubmitButton>
+              </ModalActionsFooter>
+            }
+          >
             <Radio.Group name="sexualOrientation" label="Sexual Orientation" required>
               {Object.entries(CodesToText).map(([code, text]) => (
                 <Radio key={code} value={code} label={text} my="xs" />
               ))}
             </Radio.Group>
-            <Group justify="flex-end" gap={4} mt="md">
-              <SubmitButton>Save</SubmitButton>
-            </Group>
-          </Stack>
+          </ModalContentLayout>
         </Form>
       </Modal>
     </>

--- a/packages/react/src/PatientSummary/SmokingStatus.tsx
+++ b/packages/react/src/PatientSummary/SmokingStatus.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Group, Modal, Radio, Stack, Text, UnstyledButton } from '@mantine/core';
+import { Modal, Radio, Text, UnstyledButton } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { HTTP_HL7_ORG, LOINC, SNOMED, createReference, formatCodeableConcept } from '@medplum/core';
 import type { Encounter, Observation, Patient } from '@medplum/fhirtypes';
@@ -9,6 +9,8 @@ import type { JSX } from 'react';
 import { useCallback, useState } from 'react';
 import { Form } from '../Form/Form';
 import { SubmitButton } from '../Form/SubmitButton';
+import { ModalActionsFooter } from '../ModalActionsFooter/ModalActionsFooter';
+import { ModalContentLayout } from '../ModalContentLayout/ModalContentLayout';
 import { CollapsibleSection } from './CollapsibleSection';
 
 // Smoking Status widget
@@ -109,16 +111,19 @@ export function SmokingStatus(props: SmokingStatusProps): JSX.Element {
       </CollapsibleSection>
       <Modal opened={opened} onClose={close} title="Set Smoking Status">
         <Form onSubmit={handleSubmit}>
-          <Stack>
+          <ModalContentLayout
+            footer={
+              <ModalActionsFooter>
+                <SubmitButton fullWidth>Save</SubmitButton>
+              </ModalActionsFooter>
+            }
+          >
             <Radio.Group name="smokingStatus" label="Smoking Status" required>
               {Object.entries(smokingStatusOptions).map(([code, text]) => (
                 <Radio key={code} value={code} label={text} my="xs" />
               ))}
             </Radio.Group>
-            <Group justify="flex-end" gap={4} mt="md">
-              <SubmitButton>Save</SubmitButton>
-            </Group>
-          </Stack>
+          </ModalContentLayout>
         </Form>
       </Modal>
     </>

--- a/packages/react/src/PatientSummary/SummaryItem.module.css
+++ b/packages/react/src/PatientSummary/SummaryItem.module.css
@@ -12,7 +12,7 @@
 }
 
 [data-mantine-color-scheme='dark'] .gradient {
-  background: linear-gradient(to right, transparent, var(--mantine-color-dark-8));
+  background: linear-gradient(to right, transparent, var(--mantine-color-body));
 }
 
 [data-mantine-color-scheme='light'] .gradient {
@@ -35,7 +35,7 @@
 }
 
 [data-mantine-color-scheme='dark'] .container {
-  background: var(--mantine-color-dark-8);
+  background: var(--mantine-color-body);
 }
 
 [data-mantine-color-scheme='light'] .container {

--- a/packages/react/src/PatientSummary/Vitals.tsx
+++ b/packages/react/src/PatientSummary/Vitals.tsx
@@ -9,6 +9,8 @@ import type { JSX } from 'react';
 import { useCallback, useState } from 'react';
 import { Form } from '../Form/Form';
 import { SubmitButton } from '../Form/SubmitButton';
+import { ModalActionsFooter } from '../ModalActionsFooter/ModalActionsFooter';
+import { ModalContentLayout } from '../ModalContentLayout/ModalContentLayout';
 import { CollapsibleSection } from './CollapsibleSection';
 import {
   createCompoundObservation,
@@ -184,22 +186,29 @@ export function Vitals(props: VitalsProps): JSX.Element {
 
       <Modal opened={opened} onClose={close} title="Add Vitals">
         <Form onSubmit={handleSubmit}>
-          <SimpleGrid cols={2}>
-            {LOINC_CODES.map((meta, index) => (
-              <TextInput
-                key={meta.name}
-                name={meta.name}
-                label={meta.short}
-                description={`${meta.title} (${meta.unit})`}
-                data-autofocus={index === 0}
-                autoFocus={index === 0}
-              />
-            ))}
-          </SimpleGrid>
-          <Textarea name="notes" label="Notes" />
-          <Group justify="flex-end" gap={4} mt="md">
-            <SubmitButton>Save</SubmitButton>
-          </Group>
+          <ModalContentLayout
+            footer={
+              <ModalActionsFooter>
+                <SubmitButton fullWidth>Save</SubmitButton>
+              </ModalActionsFooter>
+            }
+          >
+            <Stack gap="md">
+              <SimpleGrid cols={2}>
+                {LOINC_CODES.map((meta, index) => (
+                  <TextInput
+                    key={meta.name}
+                    name={meta.name}
+                    label={meta.short}
+                    description={`${meta.title} (${meta.unit})`}
+                    data-autofocus={index === 0}
+                    autoFocus={index === 0}
+                  />
+                ))}
+              </SimpleGrid>
+              <Textarea name="notes" label="Notes" />
+            </Stack>
+          </ModalContentLayout>
         </Form>
       </Modal>
     </>

--- a/packages/react/src/PatientSummary/sectionConfigs.tsx
+++ b/packages/react/src/PatientSummary/sectionConfigs.tsx
@@ -175,12 +175,8 @@ export const ImmunizationsSection: PatientSummarySectionConfig = {
   key: 'immunizations',
   title: 'Immunizations',
   searches: [{ key: 'immunizations', resourceType: 'Immunization', patientParam: 'patient' }],
-  component: ({ results, patient, onClickResource }: SectionRenderContext) => (
-    <Immunizations
-      patient={patient}
-      immunizations={(results['immunizations'] as Immunization[]) || []}
-      onClickResource={onClickResource}
-    />
+  component: ({ results, patient }: SectionRenderContext) => (
+    <Immunizations patient={patient} immunizations={(results['immunizations'] as Immunization[]) || []} />
   ),
 };
 
@@ -189,8 +185,8 @@ export const GoalsSection: PatientSummarySectionConfig = {
   key: 'goals',
   title: 'Goals',
   searches: [{ key: 'goals', resourceType: 'Goal', patientParam: 'patient' }],
-  component: ({ results, patient, onClickResource }: SectionRenderContext) => (
-    <Goals patient={patient} goals={(results['goals'] as Goal[]) || []} onClickResource={onClickResource} />
+  component: ({ results, patient }: SectionRenderContext) => (
+    <Goals patient={patient} goals={(results['goals'] as Goal[]) || []} />
   ),
 };
 

--- a/packages/react/src/PatientSummary/sectionConfigs.tsx
+++ b/packages/react/src/PatientSummary/sectionConfigs.tsx
@@ -8,6 +8,8 @@ import type {
   Condition,
   Coverage,
   DiagnosticReport,
+  Goal,
+  Immunization,
   MedicationRequest,
   MedicationStatement,
   Observation,
@@ -23,6 +25,8 @@ import {
 } from '@tabler/icons-react';
 import type { ComponentType } from 'react';
 import { Allergies } from './Allergies';
+import { Goals } from './Goals';
+import { Immunizations } from './Immunizations';
 import { Insurance } from './Insurance';
 import { Labs } from './Labs';
 import { Medications } from './Medications';
@@ -47,10 +51,10 @@ import { Vitals } from './Vitals';
 export const DemographicsSection: PatientSummarySectionConfig = {
   key: 'demographics',
   title: 'Demographics',
-  component: ({ patient, onClickResource }: SectionRenderContext) => {
+  component: ({ patient, onClickResource, onEditPatient }: SectionRenderContext) => {
     const languageDisplay = getPreferredLanguage(patient);
     return (
-      <Stack gap="xs" py={8}>
+      <Stack gap="xs" py="md">
         <PatientInfoItem
           patient={patient}
           value={patient.birthDate ? `${patient.birthDate} (${calculateAgeString(patient.birthDate)})` : undefined}
@@ -58,6 +62,7 @@ export const DemographicsSection: PatientSummarySectionConfig = {
           placeholder="Add Birthdate"
           label="Birthdate & Age"
           onClickResource={onClickResource}
+          onClick={onEditPatient}
         />
         <PatientInfoItem
           patient={patient}
@@ -66,6 +71,7 @@ export const DemographicsSection: PatientSummarySectionConfig = {
           placeholder="Add Gender & Identity"
           label="Gender & Identity"
           onClickResource={onClickResource}
+          onClick={onEditPatient}
         />
         <PatientInfoItem
           patient={patient}
@@ -74,6 +80,7 @@ export const DemographicsSection: PatientSummarySectionConfig = {
           placeholder="Add Race & Ethnicity"
           label="Race & Ethnicity"
           onClickResource={onClickResource}
+          onClick={onEditPatient}
         />
         <PatientInfoItem
           patient={patient}
@@ -82,6 +89,7 @@ export const DemographicsSection: PatientSummarySectionConfig = {
           placeholder="Add Location"
           label="Location"
           onClickResource={onClickResource}
+          onClick={onEditPatient}
         />
         <PatientInfoItem
           patient={patient}
@@ -90,6 +98,7 @@ export const DemographicsSection: PatientSummarySectionConfig = {
           placeholder="Add Language"
           label="Language"
           onClickResource={onClickResource}
+          onClick={onEditPatient}
         />
         <PatientInfoItem
           patient={patient}
@@ -98,6 +107,7 @@ export const DemographicsSection: PatientSummarySectionConfig = {
           placeholder="Add General Practitioner"
           label="General Practitioner"
           onClickResource={onClickResource}
+          onClick={onEditPatient}
         />
       </Stack>
     );
@@ -157,6 +167,30 @@ export const MedicationsSection: PatientSummarySectionConfig = {
       medicationStatements={(results['medicationStatements'] as MedicationStatement[]) || []}
       onClickResource={onClickResource}
     />
+  ),
+};
+
+/** Immunizations section — searches for Immunization resources. */
+export const ImmunizationsSection: PatientSummarySectionConfig = {
+  key: 'immunizations',
+  title: 'Immunizations',
+  searches: [{ key: 'immunizations', resourceType: 'Immunization', patientParam: 'patient' }],
+  component: ({ results, patient, onClickResource }: SectionRenderContext) => (
+    <Immunizations
+      patient={patient}
+      immunizations={(results['immunizations'] as Immunization[]) || []}
+      onClickResource={onClickResource}
+    />
+  ),
+};
+
+/** Goals section — searches for Goal resources. */
+export const GoalsSection: PatientSummarySectionConfig = {
+  key: 'goals',
+  title: 'Goals',
+  searches: [{ key: 'goals', resourceType: 'Goal', patientParam: 'patient' }],
+  component: ({ results, patient, onClickResource }: SectionRenderContext) => (
+    <Goals patient={patient} goals={(results['goals'] as Goal[]) || []} onClickResource={onClickResource} />
   ),
 };
 
@@ -261,10 +295,12 @@ export const PharmaciesSection: PatientSummarySectionConfig = createPharmaciesSe
 export function getDefaultSections(onRequestLabs?: () => void): PatientSummarySectionConfig[] {
   return [
     DemographicsSection,
+    GoalsSection,
     InsuranceSection,
     AllergiesSection,
     ProblemListSection,
     MedicationsSection,
+    ImmunizationsSection,
     createLabsSection(onRequestLabs),
     SexualOrientationSection,
     SmokingStatusSection,

--- a/packages/react/src/ResourceForm/ResourceForm.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.tsx
@@ -17,6 +17,8 @@ import type { FormEvent, JSX } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { BackboneElementInput } from '../BackboneElementInput/BackboneElementInput';
 import { FormSection } from '../FormSection/FormSection';
+import { ModalActionsFooter } from '../ModalActionsFooter/ModalActionsFooter';
+import { ModalContentLayout } from '../ModalContentLayout/ModalContentLayout';
 import classes from './ResourceForm.module.css';
 
 export interface ResourceFormProps {
@@ -27,6 +29,10 @@ export interface ResourceFormProps {
   readonly onDelete?: (resource: Resource) => void;
   /** (optional) URL of the resource profile used to display the form. Takes priority over schemaName. */
   readonly profileUrl?: string;
+  /** When true, renders a divider and full-width submit button for modal footers. */
+  readonly stackedSubmit?: boolean;
+  /** When true with stackedSubmit, pins the footer to the modal bottom with a full-bleed divider. */
+  readonly stickyModalFooter?: boolean;
 }
 
 export function ResourceForm(props: ResourceFormProps): JSX.Element {
@@ -102,17 +108,9 @@ export function ResourceForm(props: ResourceFormProps): JSX.Element {
     );
   }
 
-  return (
-    <form
-      noValidate
-      autoComplete="off"
-      onSubmit={(e: FormEvent) => {
-        e.preventDefault();
-        if (props.onSubmit) {
-          props.onSubmit(value);
-        }
-      }}
-    >
+  // Shared between the plain and modal-footer layouts below.
+  const formBody = (
+    <>
       <Stack mb="xl">
         <FormSection title="Resource Type" htmlFor="resourceType" outcome={outcome}>
           <TextInput name="resourceType" defaultValue={value.resourceType} disabled={true} />
@@ -131,49 +129,86 @@ export function ResourceForm(props: ResourceFormProps): JSX.Element {
         profileUrl={props.profileUrl}
         accessPolicyResource={accessPolicyResource}
       />
-      <Group justify="flex-end" mt="xl" wrap="nowrap" gap={0}>
-        <Button type="submit" className={cx((props.onPatch || props.onDelete) && classes.splitButton)}>
-          {defaultValue?.id ? 'Update' : 'Create'}
-        </Button>
-        {(props.onPatch || props.onDelete) && (
-          <Menu transitionProps={{ transition: 'pop' }} position="bottom-end" withinPortal>
-            <Menu.Target>
-              <ActionIcon
-                variant="filled"
-                color={theme.primaryColor}
-                size={36}
-                className={classes.menuControl}
-                aria-label="More actions"
-              >
-                <IconChevronDown size={14} stroke={1.5} />
-              </ActionIcon>
-            </Menu.Target>
-            <Menu.Dropdown>
-              {props.onPatch && (
-                <Menu.Item
-                  leftSection={<IconEdit size={14} stroke={1.5} />}
-                  onClick={() => {
-                    (props.onPatch as (resource: Resource) => void)(value);
-                  }}
-                >
-                  Patch
-                </Menu.Item>
-              )}
-              {props.onDelete && (
-                <Menu.Item
-                  color="red"
-                  leftSection={<IconTrash size={14} stroke={1.5} color="red" />}
-                  onClick={() => {
-                    (props.onDelete as (resource: Resource) => void)(value);
-                  }}
-                >
-                  Delete
-                </Menu.Item>
-              )}
-            </Menu.Dropdown>
-          </Menu>
-        )}
-      </Group>
+    </>
+  );
+
+  return (
+    <form
+      noValidate
+      autoComplete="off"
+      style={
+        props.stickyModalFooter && props.stackedSubmit
+          ? { display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0, width: '100%' }
+          : undefined
+      }
+      onSubmit={(e: FormEvent) => {
+        e.preventDefault();
+        if (props.onSubmit) {
+          props.onSubmit(value);
+        }
+      }}
+    >
+      {props.stackedSubmit && !props.onPatch && !props.onDelete ? (
+        <ModalContentLayout
+          insetContent={props.stickyModalFooter}
+          footer={
+            <ModalActionsFooter sticky={props.stickyModalFooter}>
+              <Button type="submit" fullWidth>
+                {defaultValue?.id ? 'Update' : 'Create'}
+              </Button>
+            </ModalActionsFooter>
+          }
+        >
+          {formBody}
+        </ModalContentLayout>
+      ) : (
+        <>
+          {formBody}
+          <Group justify="flex-end" mt="xl" wrap="nowrap" gap={0}>
+            <Button type="submit" className={cx((props.onPatch || props.onDelete) && classes.splitButton)}>
+              {defaultValue?.id ? 'Update' : 'Create'}
+            </Button>
+            {(props.onPatch || props.onDelete) && (
+              <Menu transitionProps={{ transition: 'pop' }} position="bottom-end" withinPortal>
+                <Menu.Target>
+                  <ActionIcon
+                    variant="filled"
+                    color={theme.primaryColor}
+                    size={36}
+                    className={classes.menuControl}
+                    aria-label="More actions"
+                  >
+                    <IconChevronDown size={14} stroke={1.5} />
+                  </ActionIcon>
+                </Menu.Target>
+                <Menu.Dropdown>
+                  {props.onPatch && (
+                    <Menu.Item
+                      leftSection={<IconEdit size={14} stroke={1.5} />}
+                      onClick={() => {
+                        (props.onPatch as (resource: Resource) => void)(value);
+                      }}
+                    >
+                      Patch
+                    </Menu.Item>
+                  )}
+                  {props.onDelete && (
+                    <Menu.Item
+                      color="red"
+                      leftSection={<IconTrash size={14} stroke={1.5} color="red" />}
+                      onClick={() => {
+                        (props.onDelete as (resource: Resource) => void)(value);
+                      }}
+                    >
+                      Delete
+                    </Menu.Item>
+                  )}
+                </Menu.Dropdown>
+              </Menu>
+            )}
+          </Group>
+        </>
+      )}
     </form>
   );
 }

--- a/packages/react/src/chat/ThreadInbox/ThreadDetail.tsx
+++ b/packages/react/src/chat/ThreadInbox/ThreadDetail.tsx
@@ -4,7 +4,7 @@ import { Box, Button, Divider, Flex, Menu, Paper, ScrollArea, Stack, Text } from
 import { getReferenceString } from '@medplum/core';
 import type { Communication, DocumentReference, Patient, Reference } from '@medplum/fhirtypes';
 import { IconChevronDown } from '@tabler/icons-react';
-import type { JSX } from 'react';
+import type { JSX, ReactNode } from 'react';
 import { PatientSummary } from '../../PatientSummary/PatientSummary';
 import type { PatientSummarySectionConfig } from '../../PatientSummary/PatientSummary.types';
 import { ThreadChat } from '../ThreadChat/ThreadChat';
@@ -17,6 +17,10 @@ export interface ThreadDetailProps {
   readonly showPatientSummary?: boolean;
   /** Optional sections configuration for the patient summary. */
   readonly sections?: PatientSummarySectionConfig[];
+  /** `<Menu.Item>` nodes for the patient summary header's "…" actions menu. */
+  readonly patientHeaderMenuItems?: ReactNode;
+  /** When provided, Demographics rows open this (the patient edit modal) instead of navigating. */
+  readonly onEditPatient?: () => void;
   readonly uploadEnabled?: boolean;
   readonly onViewInDocuments?: (reference: Reference<DocumentReference>) => void;
   /** Fired when the user changes the thread status from the header menu. */
@@ -30,7 +34,16 @@ export interface ThreadDetailProps {
  * @returns The ThreadDetail React node.
  */
 export function ThreadDetail(props: ThreadDetailProps): JSX.Element {
-  const { thread, showPatientSummary = false, sections, uploadEnabled, onViewInDocuments, onStatusChange } = props;
+  const {
+    thread,
+    showPatientSummary = false,
+    sections,
+    patientHeaderMenuItems,
+    onEditPatient,
+    uploadEnabled,
+    onViewInDocuments,
+    onStatusChange,
+  } = props;
 
   return (
     <>
@@ -85,7 +98,13 @@ export function ThreadDetail(props: ThreadDetailProps): JSX.Element {
       {thread.subject && showPatientSummary && (
         <Box w={300} h="100%">
           <ScrollArea p={0} h="100%" scrollbarSize={10} type="hover" scrollHideDelay={250}>
-            <PatientSummary key={thread.id} patient={thread.subject as Reference<Patient>} sections={sections} />
+            <PatientSummary
+              key={thread.id}
+              patient={thread.subject as Reference<Patient>}
+              sections={sections}
+              headerMenuItems={patientHeaderMenuItems}
+              onEditPatient={onEditPatient}
+            />
           </ScrollArea>
         </Box>
       )}

--- a/packages/react/src/chat/ThreadInbox/ThreadInbox.tsx
+++ b/packages/react/src/chat/ThreadInbox/ThreadInbox.tsx
@@ -9,7 +9,7 @@ import { normalizeErrorString, Operator, parseSearchRequest } from '@medplum/cor
 import type { Communication, DocumentReference, Patient, Practitioner, Reference } from '@medplum/fhirtypes';
 import { useMedplumNavigate, useThreadInbox } from '@medplum/react-hooks';
 import { IconMessageCircle, IconPlus } from '@tabler/icons-react';
-import type { JSX } from 'react';
+import type { JSX, ReactNode } from 'react';
 import { useCallback, useEffect, useMemo } from 'react';
 import type { ListWithDetailPaneTab } from '../../ListWithDetailPane/ListWithDetailPane';
 import { ListWithDetailPane } from '../../ListWithDetailPane/ListWithDetailPane';
@@ -40,6 +40,12 @@ export interface ThreadInboxProps {
   readonly subject?: Reference<Patient> | Patient;
   readonly showPatientSummary?: boolean;
   readonly sections?: PatientSummarySectionConfig[];
+  /** `<Menu.Item>` nodes for the patient summary header's "…" actions menu. */
+  readonly patientHeaderMenuItems?: ReactNode;
+  /** When provided, Demographics rows open this (the patient edit modal) instead of navigating. */
+  readonly onEditPatient?: () => void;
+  /** Fires with the selected thread's patient subject so the host can wire header actions/modals. */
+  readonly onPatientChange?: (patient: Reference<Patient> | undefined) => void;
   readonly onNew: (message: Communication) => void;
   readonly getThreadUri: (topic: Communication) => string;
   readonly onChange: (search: SearchRequest) => void;
@@ -57,6 +63,9 @@ export function ThreadInbox(props: ThreadInboxProps): JSX.Element {
     subject,
     showPatientSummary = false,
     sections,
+    patientHeaderMenuItems,
+    onEditPatient,
+    onPatientChange,
     onNew,
     getThreadUri,
     uploadEnabled,
@@ -103,6 +112,12 @@ export function ThreadInbox(props: ThreadInboxProps): JSX.Element {
     query,
     threadId,
   });
+
+  // Surface the selected thread's patient subject so the host can wire header actions/modals.
+  const subjectReference = (selectedThread?.subject as Reference<Patient> | undefined)?.reference;
+  useEffect(() => {
+    onPatientChange?.(subjectReference ? { reference: subjectReference } : undefined);
+  }, [subjectReference, onPatientChange]);
 
   const handleParticipantsChange = useCallback(
     (participants: Reference<Patient | Practitioner>[]) => {
@@ -219,6 +234,8 @@ export function ThreadInbox(props: ThreadInboxProps): JSX.Element {
               thread={thread}
               showPatientSummary={showPatientSummary}
               sections={sections}
+              patientHeaderMenuItems={patientHeaderMenuItems}
+              onEditPatient={onEditPatient}
               uploadEnabled={uploadEnabled}
               onViewInDocuments={onViewInDocuments}
               onStatusChange={handleTopicStatusChangeWithErrorHandling}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -92,6 +92,8 @@ export * from './PatientSummary/PharmacyDialog';
 export {
   AllergiesSection,
   DemographicsSection,
+  GoalsSection,
+  ImmunizationsSection,
   InsuranceSection,
   LabsSection,
   MedicationsSection,


### PR DESCRIPTION
This PR makes several updates to our Patient Summary component for Provider app, as detailed below:

**Header, Demographics, and Edit**
- Changes the header from showing a chevron/arrow on hover to having a static "…" action button which opens a context menu.
- The "…" context menu includes a single item (for now!) for editing a patient's basic details (previously the entire header was this link, with chevron as indicator).
- Adds `usePatientActionsMenu` + `PatientEditModal` so the edit option in the context menu opens an modal for editing patient details.
  - The Demographics rows just below the header also open this modal for editing.
  - `ResourceForm` gains `stackedSubmit` and `stickyModalFooter` to render that form inside a modal.
- Removes the patient "Edit" tab from the broader profile tabs section, though the /edit route is still accessible by direct URL.
- Patient name tooltip in the header now only appears when the name is actually truncated.
- For all contexts where patient summary is visible outside of a profile page (e.g. global Tasks, Messages), the patient summary header is now linked to the profile page for direct navigation.

**New Sections**
- Adds Goals and Immunizations sections with add/edit/delete modals (to fully match C-CDA standards)

**Data Display Cleanup**
- filterEnteredInError now hides entered-in-error resources from *every* section, not just the new ones. The resources are preserved in the database and remain accessible via direct URL.

**Visual Polish**
- Dark mode: panel and hover overlays use --mantine-color-body so they match the app shell instead of sitting on a mismatched dark-8.
- Avatar border changes to 1px, replacing a hardcoded 2px white ring and matching the global divider color.
- Tightened spacing across the full Patient Summary.
- Restyled secondary action icon buttons for section-collapsing chevrons and add buttons.

---

### **Reference Images**

<img width="451" height="1037" alt="Screenshot 2026-08-04 at 11 55 20 AM" src="https://github.com/user-attachments/assets/477f70d7-2e85-4894-acb3-2d427dc4c684" />

<img width="451" height="1037" alt="Screenshot 2026-08-04 at 11 55 26 AM" src="https://github.com/user-attachments/assets/2d4789a9-3da8-421f-a8c6-1f0bbcce13d1" />

<img width="451" height="1037" alt="Screenshot 2026-08-04 at 11 56 38 AM" src="https://github.com/user-attachments/assets/5c73fbbe-bb45-4de5-97f0-6b2ec44d8726" />

<img width="1488" height="1037" alt="Screenshot 2026-08-04 at 11 57 00 AM" src="https://github.com/user-attachments/assets/a9875fc8-5e50-4c3a-a97e-085eb5356cd8" />


