### PR TITLE
feat(react): spotlight quick actions and keyboard shortcut hints

### DIFF
--- a/examples/medplum-provider/src/App.tsx
+++ b/examples/medplum-provider/src/App.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { SpotlightActionData } from '@mantine/spotlight';
 import { getReferenceString } from '@medplum/core';
 import { useDoseSpotNotifications } from '@medplum/dosespot-react';
 import { AppShell, Loading, Logo, useMedplum, useMedplumProfile } from '@medplum/react';
@@ -18,7 +19,7 @@ import {
 } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { Suspense, useState } from 'react';
-import { Navigate, Route, Routes, useLocation, useSearchParams } from 'react-router';
+import { Navigate, Route, Routes, useLocation, useNavigate, useSearchParams } from 'react-router';
 import { TaskDetailsModal } from './components/tasks/TaskDetailsModal';
 import { hasScriptSureIdentifier } from './components/utils';
 import { useDoseSpotAccess } from './hooks/useDoseSpotAccess';
@@ -83,10 +84,39 @@ export function App(): JSX.Element | null {
   const membership = medplum.getProjectMembership();
   const hasScriptSure = hasScriptSureIdentifier(membership);
 
+  const navigate = useNavigate();
+
   const handleDismissSetup = (): void => {
     localStorage.setItem(SETUP_DISMISSED_KEY, 'true');
     setSetupDismissedByUser(true);
   };
+
+  const spotlightActions: SpotlightActionData[] = [
+    {
+      id: 'action-new-patient-intake',
+      label: 'New Patient Intake',
+      leftSection: <IconUserPlus size={16} color="var(--mantine-color-dimmed)" />,
+      onClick: () => navigate('/onboarding')?.catch(console.error),
+    },
+    {
+      id: 'action-new-message',
+      label: 'New Message',
+      leftSection: <IconMail size={16} color="var(--mantine-color-dimmed)" />,
+      onClick: () => navigate('/Communication', { state: { newMessage: Date.now() } })?.catch(console.error),
+    },
+    {
+      id: 'action-new-task',
+      label: 'New Task',
+      leftSection: <IconClipboardCheck size={16} color="var(--mantine-color-dimmed)" />,
+      onClick: () => navigate('/Task', { state: { newTask: Date.now() } })?.catch(console.error),
+    },
+    {
+      id: 'action-send-fax',
+      label: 'Send a Fax',
+      leftSection: <IconPrinter size={16} color="var(--mantine-color-dimmed)" />,
+      onClick: () => navigate('/Fax/Communication', { state: { sendFax: Date.now() } })?.catch(console.error),
+    },
+  ];
 
   if (medplum.isLoading()) {
     return null;
@@ -178,6 +208,7 @@ export function App(): JSX.Element | null {
       }
       resourceTypeSearchDisabled={true}
       spotlightPatientsOnly={true}
+      spotlightActions={spotlightActions}
     >
       <Suspense fallback={<Loading />}>
         <Routes>

--- a/examples/medplum-provider/src/components/fax/FaxBoard.tsx
+++ b/examples/medplum-provider/src/components/fax/FaxBoard.tsx
@@ -8,7 +8,7 @@ import { ResourceBoard, useMedplum } from '@medplum/react';
 import { IconSend } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { showErrorNotification } from '../../utils/notifications';
 import { FaxDetailPanel } from './FaxDetailPanel';
 import type { FaxTab } from './FaxListItem';
@@ -39,10 +39,19 @@ export function FaxBoard({
 }: FaxBoardProps): JSX.Element {
   const medplum = useMedplum();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const [sendModalOpened, setSendModalOpened] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
   const efaxPolledRef = useRef(false);
+
+  // Open the Send Fax modal when navigated here with that intent (e.g. from the global search).
+  const sendFaxSignal = (location.state as { sendFax?: number } | null)?.sendFax;
+  useEffect(() => {
+    if (sendFaxSignal) {
+      setSendModalOpened(true);
+    }
+  }, [sendFaxSignal]);
 
   const currentSearch = useMemo(() => parseSearchRequest(`Communication?${query}`), [query]);
 

--- a/examples/medplum-provider/src/components/tasks/TaskBoard.tsx
+++ b/examples/medplum-provider/src/components/tasks/TaskBoard.tsx
@@ -8,7 +8,7 @@ import { ListWithDetailPane, useMedplum } from '@medplum/react';
 import { IconPlus } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { showErrorNotification } from '../../utils/notifications';
 import { NewTaskModal } from './NewTaskModal';
 import { TaskDetailPanel } from './TaskDetailPanel';
@@ -57,11 +57,20 @@ export function TaskBoard({
 }: TaskBoardProps): JSX.Element {
   const medplum = useMedplum();
   const navigate = useNavigate();
+  const location = useLocation();
   const [tasks, setTasks] = useState<WithId<Task>[]>([]);
   const [selectedTask, setSelectedTask] = useState<WithId<Task> | undefined>(undefined);
   const [loading, setLoading] = useState(false);
   const [performerTypes, setPerformerTypes] = useState<CodeableConcept[]>([]);
   const [newTaskModalOpened, setNewTaskModalOpened] = useState(false);
+
+  // Open the New Task modal when navigated here with that intent (e.g. from the global search).
+  const newTaskSignal = (location.state as { newTask?: number } | null)?.newTask;
+  useEffect(() => {
+    if (newTaskSignal) {
+      setNewTaskModalOpened(true);
+    }
+  }, [newTaskSignal]);
   const [total, setTotal] = useState<number | undefined>(undefined);
   const requestIdRef = useRef(0);
   const fetchingRef = useRef(false);

--- a/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
+++ b/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
@@ -24,6 +24,7 @@ export function MessagesPage(): JSX.Element {
   const PharmacyDialogComponent = usePharmacyDialog();
   const [threadPatient, setThreadPatient] = useState<Reference<Patient>>();
   const { headerMenuItems, actionsModals, openEditModal } = usePatientActionsMenu(threadPatient);
+  const newMessageSignal = (location.state as { newMessage?: number } | null)?.newMessage;
 
   const currentSearch = useMemo(() => (location.search ? location.search.substring(1) : ''), [location.search]);
 
@@ -39,9 +40,10 @@ export function MessagesPage(): JSX.Element {
     const isDetailView = Boolean(messageId);
     if (!isDetailView && normalizedSearch !== currentSearch) {
       const prefix = normalizedSearch ? `?${normalizedSearch}` : '';
-      navigate(`/Communication${prefix}`, { replace: true })?.catch(console.error);
+      // Preserve navigation state (e.g. the "open New Message" intent) across the redirect.
+      navigate(`/Communication${prefix}`, { replace: true, state: location.state })?.catch(console.error);
     }
-  }, [currentSearch, navigate, normalizedSearch, messageId]);
+  }, [currentSearch, navigate, normalizedSearch, messageId, location.state]);
 
   const onChange = (search: SearchRequest): void => {
     navigate(`/Communication${formatSearchQuery(search)}`)?.catch(console.error);
@@ -96,6 +98,7 @@ export function MessagesPage(): JSX.Element {
         patientHeaderMenuItems={headerMenuItems}
         onEditPatient={openEditModal}
         onPatientChange={setThreadPatient}
+        openNewMessageSignal={newMessageSignal}
         allowPatientSelection={true}
         onNew={onNew}
         getThreadUri={getThreadUri}

--- a/examples/medplum-provider/src/pages/tasks/TasksPage.tsx
+++ b/examples/medplum-provider/src/pages/tasks/TasksPage.tsx
@@ -21,7 +21,8 @@ export function TasksPage(): JSX.Element {
   useEffect(() => {
     const { normalizedSearch, needsNavigation } = normalizeTaskSearch(location.pathname, location.search);
     if (needsNavigation) {
-      navigate(`/Task${formatSearchQuery(normalizedSearch)}`)?.catch(console.error);
+      // Preserve navigation state (e.g. the "open New Task" intent from global search) across the redirect.
+      navigate(`/Task${formatSearchQuery(normalizedSearch)}`, { state: location.state })?.catch(console.error);
     } else {
       setParsedSearch(normalizedSearch);
     }

--- a/packages/react/src/AppShell/AppShell.tsx
+++ b/packages/react/src/AppShell/AppShell.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { AppShellHeaderConfiguration, AppShellNavbarConfiguration } from '@mantine/core';
 import { AppShell as MantineAppShell } from '@mantine/core';
+import type { SpotlightActionData } from '@mantine/spotlight';
 import { useMedplum, useMedplumProfile } from '@medplum/react-hooks';
 import type { JSX, ReactNode } from 'react';
 import { Suspense, useState } from 'react';
@@ -36,6 +37,8 @@ export interface AppShellProps {
   readonly layoutVersion?: 'v1' | 'v2';
   readonly showLayoutVersionToggle?: boolean;
   readonly spotlightPatientsOnly?: boolean;
+  /** App-provided quick actions shown under an "Actions" group in the search modal's open state. */
+  readonly spotlightActions?: SpotlightActionData[];
 }
 
 export function AppShell(props: AppShellProps): JSX.Element {
@@ -124,6 +127,7 @@ export function AppShell(props: AppShellProps): JSX.Element {
         opened={navbarOpen}
         spotlightEnabled={true}
         patientsOnly={props.spotlightPatientsOnly}
+        spotlightActions={props.spotlightActions}
         userMenuEnabled={true}
         version={props.version}
         showLayoutVersionToggle={props.showLayoutVersionToggle}
@@ -165,6 +169,7 @@ export function AppShell(props: AppShellProps): JSX.Element {
           displayAddBookmark={props.displayAddBookmark}
           resourceTypeSearchDisabled={props.resourceTypeSearchDisabled}
           patientsOnly={props.spotlightPatientsOnly}
+          spotlightActions={props.spotlightActions}
         />
       ) : undefined;
   }

--- a/packages/react/src/AppShell/Navbar.tsx
+++ b/packages/react/src/AppShell/Navbar.tsx
@@ -11,6 +11,7 @@ import {
   Tooltip,
   UnstyledButton,
 } from '@mantine/core';
+import type { SpotlightActionData } from '@mantine/spotlight';
 import { spotlight } from '@mantine/spotlight';
 import { formatHumanName } from '@medplum/core';
 import type { ResourceType } from '@medplum/fhirtypes';
@@ -59,6 +60,7 @@ export interface NavbarProps {
   readonly closeNavbar: () => void;
   readonly spotlightEnabled?: boolean;
   readonly patientsOnly?: boolean;
+  readonly spotlightActions?: SpotlightActionData[];
   readonly userMenuEnabled?: boolean;
   readonly displayAddBookmark?: boolean;
   readonly resourceTypeSearchDisabled?: boolean;
@@ -123,7 +125,9 @@ export function Navbar(props: NavbarProps): JSX.Element {
                 </Tooltip>
               </Box>
             )}
-            {props.spotlightEnabled && <Spotlight patientsOnly={props.patientsOnly} />}
+            {props.spotlightEnabled && (
+              <Spotlight patientsOnly={props.patientsOnly} staticActions={props.spotlightActions} />
+            )}
             {!props.resourceTypeSearchDisabled && (
               <MantineAppShell.Section mb="sm">
                 <ResourceTypeInput

--- a/packages/react/src/AppShell/Spotlight.module.css
+++ b/packages/react/src/AppShell/Spotlight.module.css
@@ -43,12 +43,8 @@
 
 /* Add divider between action groups */
 .actionsGroup:not(:first-child) {
-  border-top: calc(0.0625rem * var(--mantine-scale)) solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
-}
-
-/* Group label spacing */
-.actionsGroup::before {
-  padding-bottom: 2px;
+  border-top: calc(0.0625rem * var(--mantine-scale)) solid
+    light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
 }
 
 /* Actions list container */
@@ -58,8 +54,64 @@
 
 /* Modal content wrapper */
 .content {
-  box-shadow: light-dark(
-    0 0.5rem 2rem rgba(0, 0, 0, 0.15),
-    0 0.5rem 2rem rgba(0, 0, 0, 0.5)
-  );
+  box-shadow: light-dark(0 0.5rem 2rem rgba(0, 0, 0, 0.15), 0 0.5rem 2rem rgba(0, 0, 0, 0.5));
+}
+
+/* Group label — match Menu.Label (title case, not Mantine's default uppercase). */
+.groupLabel,
+.actionsGroup::before {
+  font-size: var(--mantine-font-size-xs);
+  font-weight: 500;
+  color: var(--mantine-color-dimmed);
+  text-transform: none;
+}
+
+/* List titles / Searching: Searching's left padding */
+.actionsGroup::before,
+.emptyState .groupLabel {
+  padding-inline: var(--mantine-spacing-md);
+}
+
+.actionsGroup::before {
+  padding-bottom: 2px;
+}
+
+/* Searching / empty hint — same top as first Actions group */
+.emptyState {
+  padding-top: calc(var(--mantine-spacing-md) - 2px);
+  padding-inline: var(--mantine-spacing-md);
+  padding-bottom: var(--mantine-spacing-md);
+}
+
+/* Avoid double horizontal padding when emptyState wraps the Searching label */
+.emptyState:has(.groupLabel) {
+  padding-inline: 0;
+}
+
+/* Footer with keyboard shortcut hints — match Actions title inset */
+.footer {
+  border-top: calc(0.0625rem * var(--mantine-scale)) solid
+    light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+  padding: var(--mantine-spacing-md) calc(var(--mantine-spacing-md) + calc(0.25rem * var(--mantine-scale)));
+}
+
+.shortcutHints {
+  width: 100%;
+}
+
+.shortcutKey {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 5px;
+  border: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+  border-radius: var(--mantine-radius-sm);
+  background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-6));
+  color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-gray-5));
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
 }

--- a/packages/react/src/AppShell/Spotlight.tsx
+++ b/packages/react/src/AppShell/Spotlight.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Kbd, Stack, Text } from '@mantine/core';
+import { Group, Kbd, Stack, Text } from '@mantine/core';
 import { useDebouncedCallback } from '@mantine/hooks';
 import type { SpotlightActionData, SpotlightActionGroupData } from '@mantine/spotlight';
 import { Spotlight as MantineSpotlight } from '@mantine/spotlight';
@@ -9,7 +9,7 @@ import type { Patient, ServiceRequest, ValueSetExpansionContains } from '@medplu
 import type { MedplumNavigateFunction } from '@medplum/react-hooks';
 import { useMedplum, useMedplumNavigate } from '@medplum/react-hooks';
 import { IconSearch } from '@tabler/icons-react';
-import type { JSX } from 'react';
+import type { JSX, ReactNode } from 'react';
 import { useState } from 'react';
 import { ResourceAvatar } from '../ResourceAvatar/ResourceAvatar';
 import classes from './Spotlight.module.css';
@@ -20,6 +20,66 @@ export type HeaderSearchTypes = Patient | ServiceRequest;
 
 export interface SpotlightProps {
   readonly patientsOnly?: boolean;
+  /**
+   * Optional app-provided quick actions, shown under an "Actions" group in the empty (open) state.
+   * Each is keyboard-navigable like a search result.
+   */
+  readonly staticActions?: SpotlightActionData[];
+}
+
+function ShortcutKey({ children }: { readonly children: ReactNode }): JSX.Element {
+  return <span className={classes.shortcutKey}>{children}</span>;
+}
+
+function ShortcutHints(): JSX.Element {
+  return (
+    <Group gap="lg" justify="flex-start" align="center" wrap="wrap" className={classes.shortcutHints}>
+      <Group gap={6} align="center" wrap="nowrap">
+        <span className={classes.groupLabel}>Open search</span>
+        <ShortcutKey>⌘</ShortcutKey>
+        <ShortcutKey>K</ShortcutKey>
+      </Group>
+      <Group gap={6} align="center" wrap="nowrap">
+        <span className={classes.groupLabel}>Select</span>
+        <ShortcutKey>↑</ShortcutKey>
+        <ShortcutKey>↓</ShortcutKey>
+      </Group>
+      <Group gap={6} align="center" wrap="nowrap">
+        <span className={classes.groupLabel}>Open / Go</span>
+        <ShortcutKey>↵</ShortcutKey>
+      </Group>
+    </Group>
+  );
+}
+
+/**
+ * Filters action groups by query (matching label or description), dropping empty groups.
+ * Mirrors Mantine's built-in `defaultSpotlightFilter` behavior for the composable API.
+ * @param query - The search query.
+ * @param groups - The action groups to filter.
+ * @returns The filtered action groups.
+ */
+function filterActionGroups(query: string, groups: SpotlightActionGroupData[]): SpotlightActionGroupData[] {
+  const q = query.trim().toLowerCase();
+  if (!q) {
+    return groups;
+  }
+  const result: SpotlightActionGroupData[] = [];
+  for (const group of groups) {
+    const actions = group.actions.filter(
+      (a) =>
+        String(a.label ?? '')
+          .toLowerCase()
+          .includes(q) ||
+        String(a.description ?? '')
+          .toLowerCase()
+          .includes(q)
+    );
+    if (actions.length > 0) {
+      result.push({ group: group.group, actions });
+    }
+  }
+  return result;
 }
 
 interface SearchGraphQLResponse {
@@ -43,14 +103,15 @@ function KeyboardHint(): JSX.Element {
   );
 }
 
-export function Spotlight({ patientsOnly }: SpotlightProps): JSX.Element {
+export function Spotlight({ patientsOnly, staticActions }: SpotlightProps): JSX.Element {
   const medplum = useMedplum();
   const navigate = useMedplumNavigate();
-  const [nothingFoundMessage, setNothingFoundMessage] = useState<React.ReactNode>(<KeyboardHint />);
+  const [query, setQuery] = useState('');
+  const [searching, setSearching] = useState(false);
   const [actions, setActions] = useState<SpotlightActionGroupData[]>([]);
 
-  const debouncedSearch = useDebouncedCallback((query: string) => {
-    const graphqlQuery = buildGraphQLQuery(query);
+  const debouncedSearch = useDebouncedCallback((searchQuery: string) => {
+    const graphqlQuery = buildGraphQLQuery(searchQuery);
 
     if (patientsOnly) {
       // Only search patients
@@ -62,14 +123,14 @@ export function Spotlight({ patientsOnly }: SpotlightProps): JSX.Element {
           setActions(patientsToActions(patients, navigate));
         })
         .catch(console.error)
-        .finally(() => setNothingFoundMessage('No results found'));
+        .finally(() => setSearching(false));
     } else {
       // Search patients, service requests, and resource types
       Promise.all([
         medplum.graphql(graphqlQuery),
         medplum.valueSetExpand({
           url: 'https://medplum.com/fhir/ValueSet/resource-types',
-          filter: query,
+          filter: searchQuery,
           count: 5,
         }),
       ])
@@ -79,45 +140,42 @@ export function Spotlight({ patientsOnly }: SpotlightProps): JSX.Element {
           setActions(resourcesToActions(resources, resourceTypes, navigate));
         })
         .catch(console.error)
-        .finally(() => setNothingFoundMessage('No results found'));
+        .finally(() => setSearching(false));
     }
   }, DEBOUNCE_MS);
 
-  const handleQueryChange = (query: string): void => {
-    if (!query) {
+  const handleQueryChange = (newQuery: string): void => {
+    setQuery(newQuery);
+    if (!newQuery) {
       debouncedSearch.cancel();
-      setNothingFoundMessage(<KeyboardHint />);
+      setSearching(false);
       setActions([]);
       return;
     }
-
-    setNothingFoundMessage('Searching...');
-    debouncedSearch(query);
+    setSearching(true);
+    debouncedSearch(newQuery);
   };
 
+  const showStaticActions = !query && !!staticActions?.length;
+  const filteredActions = query ? filterActionGroups(query, actions) : [];
+
+  // Empty-state content, shown (via Spotlight.Empty) only when no actions are listed.
+  let emptyContent: React.ReactNode;
+  if (!showStaticActions && filteredActions.length === 0) {
+    if (searching) {
+      emptyContent = 'Searching...';
+    } else if (query) {
+      emptyContent = 'No results found';
+    } else {
+      emptyContent = <KeyboardHint />;
+    }
+  }
+
   return (
-    <MantineSpotlight
-      actions={actions}
-      nothingFound={nothingFoundMessage}
+    <MantineSpotlight.Root
+      query={query}
+      onQueryChange={handleQueryChange}
       radius="md"
-      highlightQuery
-      searchProps={
-        {
-          leftSection: <IconSearch size="1.2rem" stroke={2} color="var(--mantine-color-gray-5)" />,
-          placeholder: 'Start typing to search…',
-          type: 'search',
-          autoComplete: 'off',
-          autoCorrect: 'off',
-          spellCheck: false,
-          name: patientsOnly ? 'provider-spotlight-search' : 'spotlight-search',
-          // Tell common password managers to ignore this field
-          'data-1p-ignore': 'true',
-          'data-lpignore': 'true',
-          leftSectionProps: {
-            style: { marginLeft: 'calc(var(--mantine-spacing-md) - 12px)' },
-          },
-        } as any
-      }
       classNames={{
         body: classes.body,
         content: classes.content,
@@ -127,9 +185,63 @@ export function Spotlight({ patientsOnly }: SpotlightProps): JSX.Element {
         actionSection: classes.actionSection,
         actionDescription: classes.actionDescription,
         actionsGroup: classes.actionsGroup,
+        empty: classes.emptyState,
+        footer: classes.footer,
       }}
-      onQueryChange={handleQueryChange}
-    />
+    >
+      <MantineSpotlight.Search
+        leftSection={<IconSearch size="1.2rem" stroke={2} color="var(--mantine-color-gray-5)" />}
+        placeholder="Start typing to search…"
+        type="search"
+        autoComplete="off"
+        autoCorrect="off"
+        spellCheck={false}
+        name={patientsOnly ? 'provider-spotlight-search' : 'spotlight-search'}
+        // Tell common password managers to ignore this field
+        {...({ 'data-1p-ignore': 'true', 'data-lpignore': 'true' } as any)}
+        leftSectionProps={{ style: { marginLeft: 'calc(var(--mantine-spacing-md) - 12px)' } }}
+      />
+
+      <MantineSpotlight.ActionsList>
+        {showStaticActions && (
+          <MantineSpotlight.ActionsGroup label="Actions">
+            {staticActions?.map((action) => (
+              <MantineSpotlight.Action
+                key={action.id}
+                label={action.label}
+                description={action.description}
+                leftSection={action.leftSection}
+                onClick={action.onClick}
+              />
+            ))}
+          </MantineSpotlight.ActionsGroup>
+        )}
+
+        {!!query &&
+          filteredActions.map((group) => (
+            <MantineSpotlight.ActionsGroup key={group.group} label={group.group}>
+              {group.actions.map((action) => (
+                <MantineSpotlight.Action
+                  key={action.id}
+                  label={action.label}
+                  description={action.description}
+                  leftSection={action.leftSection}
+                  onClick={action.onClick}
+                  highlightQuery
+                  // `group` is forwarded to the action element for grouping/testing selectors.
+                  {...({ group: group.group } as Record<string, unknown>)}
+                />
+              ))}
+            </MantineSpotlight.ActionsGroup>
+          ))}
+
+        {emptyContent && <MantineSpotlight.Empty>{emptyContent}</MantineSpotlight.Empty>}
+      </MantineSpotlight.ActionsList>
+
+      <MantineSpotlight.Footer>
+        <ShortcutHints />
+      </MantineSpotlight.Footer>
+    </MantineSpotlight.Root>
   );
 }
 

--- a/packages/react/src/chat/ThreadInbox/ThreadInbox.tsx
+++ b/packages/react/src/chat/ThreadInbox/ThreadInbox.tsx
@@ -46,6 +46,8 @@ export interface ThreadInboxProps {
   readonly onEditPatient?: () => void;
   /** Fires with the selected thread's patient subject so the host can wire header actions/modals. */
   readonly onPatientChange?: (patient: Reference<Patient> | undefined) => void;
+  /** Change this to a new value (e.g. Date.now()) to programmatically open the New Message dialog. */
+  readonly openNewMessageSignal?: number;
   readonly onNew: (message: Communication) => void;
   readonly getThreadUri: (topic: Communication) => string;
   readonly onChange: (search: SearchRequest) => void;
@@ -66,6 +68,7 @@ export function ThreadInbox(props: ThreadInboxProps): JSX.Element {
     patientHeaderMenuItems,
     onEditPatient,
     onPatientChange,
+    openNewMessageSignal,
     onNew,
     getThreadUri,
     uploadEnabled,
@@ -118,6 +121,13 @@ export function ThreadInbox(props: ThreadInboxProps): JSX.Element {
   useEffect(() => {
     onPatientChange?.(subjectReference ? { reference: subjectReference } : undefined);
   }, [subjectReference, onPatientChange]);
+
+  // Allow the host to programmatically open the New Message dialog (e.g. from the global search).
+  useEffect(() => {
+    if (openNewMessageSignal !== undefined) {
+      openModal();
+    }
+  }, [openNewMessageSignal, openModal]);
 
   const handleParticipantsChange = useCallback(
     (participants: Reference<Patient | Practitioner>[]) => {


### PR DESCRIPTION
This PR refactors spotlight-based Search modal for Provider app to change the default state to include quick actions—simulating a globally-accessible command pallette. The exsting shortcuts from the default state and transformed into a single-row footer for easy reference. 

This is a global change that should allow for all apps built with Medplum to be able to populate their own quick actions. For Provider app, we are populating New Patient Intake, New Message, New Task and Send a Fax—with Import SMART Health Link action included in a subsequent PR (#9967)

---

### Reference Images:

| Before      | After |
| ----------- | ----------- |
|   <img width="748" height="259" alt="Screenshot 2026-08-04 at 1 02 54 PM" src="https://github.com/user-attachments/assets/6af22b07-91dd-46f5-a5ee-dd7926596284" />   | <img width="769" height="512" alt="631347072-e4f2f0b4-8e54-4c80-8929-41e5105fd77e" src="https://github.com/user-attachments/assets/3cd463d6-2d3f-4ff8-973c-954ce4559aa4" /> |
