### PR TITLE
fix(core): stop retrying POST/PATCH on 5xx to avoid duplicate writes …

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2938,6 +2938,57 @@ describe('Client', () => {
       );
       expect(fetch).toHaveBeenCalledTimes(2);
     });
+
+    test('should not retry POST on server error', async () => {
+      const fetch = mockFetch(500, serverError(new Error('Something is broken')));
+      const client = new MedplumClient({ fetch });
+
+      await expect(client.post(client.fhirUrl('Patient'), { resourceType: 'Patient' })).rejects.toThrow(
+        'Internal server error (Error: Something is broken)'
+      );
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('should not retry PATCH on server error', async () => {
+      const fetch = mockFetch(500, serverError(new Error('Something is broken')));
+      const client = new MedplumClient({ fetch });
+
+      await expect(
+        client.patch(client.fhirUrl('Patient', '123'), [{ op: 'replace', path: '/active', value: true }])
+      ).rejects.toThrow('Internal server error (Error: Something is broken)');
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('should retry PUT on server error', async () => {
+      const fetch = mockFetch(500, serverError(new Error('Something is broken')));
+      const client = new MedplumClient({ fetch });
+
+      await expect(
+        client.put(client.fhirUrl('Patient', '123'), { resourceType: 'Patient', id: '123' })
+      ).rejects.toThrow('Internal server error (Error: Something is broken)');
+      expect(fetch).toHaveBeenCalledTimes(3);
+    });
+
+    test('should not retry POST on fetch error', async () => {
+      const fetch = vi.fn().mockImplementation(async (_url: string, _options?: RequestInit) => {
+        throw new Error('Some kind of fetch error occurred');
+      });
+      const client = new MedplumClient({ fetch });
+
+      await expect(client.post(client.fhirUrl('Patient'), { resourceType: 'Patient' })).rejects.toThrow(
+        'Some kind of fetch error occurred'
+      );
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('should retry POST on rate limit', async () => {
+      // A rate limited request was never processed, so retrying it is safe for any method
+      const fetch = mockFetch(429, tooManyRequests);
+      const client = new MedplumClient({ fetch, maxRetries: 1 });
+
+      await expect(client.post(client.fhirUrl('Patient'), { resourceType: 'Patient' })).rejects.toThrow();
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('Paginated Search ', () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3803,6 +3803,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     // Previously default for maxRetries was 3, but we will interpret maxRetries literally and not count first attempt
     // Default of 2 matches old behavior with the new semantics
     const maxRetries = options?.maxRetries ?? this.maxRetries;
+    const idempotent = isIdempotentMethod(options.method);
 
     // We use <= since we want to retry maxRetries times and first retry is when attemptNum === 1
     for (let attemptNum = 0; attemptNum <= maxRetries; attemptNum++) {
@@ -3820,7 +3821,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
 
         // Handle non-500 response and max retries exceeded
         // We return immediately for non-500 or 500 that has exceeded max retries
-        if (attemptNum >= maxRetries || !isRetryable(response)) {
+        if (attemptNum >= maxRetries || !isRetryable(response, idempotent)) {
           return response;
         }
 
@@ -3837,8 +3838,9 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
           this.dispatchEvent({ type: 'offline' });
         }
 
-        // If we got an abort error or exceeded retries, then throw immediately
-        if ((err as Error).name === 'AbortError' || attemptNum === maxRetries) {
+        // If we got an abort error, the request is not safe to retry, or we exceeded retries,
+        // then throw immediately
+        if ((err as Error).name === 'AbortError' || !idempotent || attemptNum === maxRetries) {
           throw err;
         }
       }
@@ -4967,6 +4969,14 @@ export function normalizeCreatePdfOptions(
   };
 }
 
-function isRetryable(response: Response): boolean {
-  return response.status === 429 || response.status >= 500;
+// POST and PATCH are not idempotent: after a timeout or 5xx the write may already have been
+// applied, so retrying risks duplicating it.
+function isIdempotentMethod(method: string | undefined): boolean {
+  const normalized = method?.toUpperCase();
+  return normalized !== 'POST' && normalized !== 'PATCH';
+}
+
+function isRetryable(response: Response, idempotent: boolean): boolean {
+  // 429 is always safe to retry: the request was rejected before being processed.
+  return response.status === 429 || (response.status >= 500 && idempotent);
 }


### PR DESCRIPTION
Fixes #9009

After a timeout or 5xx, a `POST`/`PATCH` may already have been applied server-side. Auto-retrying it can silently duplicate the write (e.g. a batch executed twice).

The client now only auto-retries idempotent methods (`GET`/`PUT`/`DELETE`) on server error. `POST` and `PATCH` are no longer retried on 5xx or network errors. `429` stays retryable for every method, since a rate-limited request was rejected before being processed.

As noted on the issue, only `POST` and `PATCH` are unsafe; `PUT`/`DELETE` are already idempotent. The `429` handling isn't in the thread happy to drop it if you'd rather keep it out of scope.

- [x] Added test cases
- [x] Lint passing