### PR TITLE
Follow JWT Best Practices for Audience Validation

### DIFF
--- a/packages/server/src/oauth/middleware.test.ts
+++ b/packages/server/src/oauth/middleware.test.ts
@@ -10,7 +10,7 @@ import { initApp, shutdownApp } from '../app';
 import { getConfig, loadTestConfig } from '../config/loader';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { createTestClient, createTestProject, withTestContext } from '../test.setup';
-import { generateAccessToken, generateSecret } from './keys';
+import { generateAccessToken, generateIdToken, generateRefreshToken, generateSecret } from './keys';
 import { PROMPT_BASIC_AUTH_PARAM } from './middleware';
 
 describe('Auth middleware', () => {
@@ -207,6 +207,45 @@ describe('Auth middleware', () => {
     const res = await request(app)
       .get('/fhir/R4/Patient')
       .set('Authorization', 'Basic ' + Buffer.from(client.id + ':' + client.secret).toString('base64'));
+    expect(res).toHaveStatus(401);
+  });
+
+  test('ID token rejected as access token', async () => {
+    const { client, login, accessToken } = await createTestProject({ withClient: true, withAccessToken: true });
+
+    // Control: the access token for this login works
+    const res1 = await request(app)
+      .get('/fhir/R4/Patient')
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res1).toHaveStatus(200);
+
+    // The ID token for the same login must not be accepted as an API credential
+    const idToken = await generateIdToken({
+      login_id: login.id,
+      client_id: client.id,
+      aud: client.id,
+      sub: client.id,
+      nonce: randomUUID(),
+    });
+
+    const res2 = await request(app)
+      .get('/fhir/R4/Patient')
+      .set('Authorization', 'Bearer ' + idToken);
+    expect(res2).toHaveStatus(401);
+  });
+
+  test('Refresh token rejected as access token', async () => {
+    const { client, login } = await createTestProject({ withClient: true, withAccessToken: true });
+
+    const refreshToken = await generateRefreshToken({
+      login_id: login.id,
+      client_id: client.id,
+      refresh_secret: generateSecret(32),
+    });
+
+    const res = await request(app)
+      .get('/fhir/R4/Patient')
+      .set('Authorization', 'Bearer ' + refreshToken);
     expect(res).toHaveStatus(401);
   });
 

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -1348,6 +1348,38 @@ describe('OAuth2 Token', () => {
     expect(res3.body.error_description).toBe('Incorrect client secret');
   });
 
+  test('Refresh token Basic auth failure incorrect secret', async () => {
+    const res = await request(app).post('/auth/login').type('json').send({
+      email,
+      password,
+      clientId: client.id,
+      codeChallenge: 'xyz',
+      codeChallengeMethod: 'plain',
+      scope: 'openid offline_access',
+    });
+    expect(res).toHaveStatus(200);
+
+    const res2 = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: 'authorization_code',
+      code: res.body.code,
+      code_verifier: 'xyz',
+    });
+    expect(res2).toHaveStatus(200);
+    expect(res2.body.refresh_token).toBeDefined();
+
+    const res3 = await request(app)
+      .post('/oauth2/token')
+      .set('Authorization', 'Basic ' + Buffer.from(client.id + ':' + randomUUID()).toString('base64'))
+      .type('form')
+      .send({
+        grant_type: 'refresh_token',
+        refresh_token: res2.body.refresh_token,
+      });
+    expect(res3).toHaveStatus(400);
+    expect(res3.body.error).toBe('invalid_request');
+    expect(res3.body.error_description).toBe('Invalid secret');
+  });
+
   test('Refresh token rotation', async () => {
     // 1) Authorize
     // 2) Get tokens with grant_type=authorization_code

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -323,6 +323,17 @@ async function handleRefreshToken(req: Request, res: Response): Promise<void> {
     return;
   }
 
+  let client: ClientApplication | undefined;
+  if (login.client) {
+    const clientId = resolveId(login.client) ?? '';
+    try {
+      client = await systemRepo.readResource<ClientApplication>('ClientApplication', clientId);
+    } catch {
+      sendTokenError(res, 'invalid_request', 'Invalid client');
+      return;
+    }
+  }
+
   const authHeader = req.headers.authorization;
   if (authHeader) {
     if (!authHeader.startsWith('Basic ')) {
@@ -340,15 +351,8 @@ async function handleRefreshToken(req: Request, res: Response): Promise<void> {
       sendTokenError(res, 'invalid_grant', 'Incorrect client secret');
       return;
     }
-  }
-
-  let client: ClientApplication | undefined;
-  if (login.client) {
-    const clientId = resolveId(login.client) ?? '';
-    try {
-      client = await systemRepo.readResource<ClientApplication>('ClientApplication', clientId);
-    } catch {
-      sendTokenError(res, 'invalid_request', 'Invalid client');
+    // The presented secret must match, and not merely be present
+    if (!(await validateClientIdAndSecret(res, client, clientSecret))) {
       return;
     }
   }

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -1015,6 +1015,13 @@ export async function getLoginForAccessToken(
 
   const claims = verifyResult.payload as MedplumAccessTokenClaims;
 
+  // A valid signature only proves that this server minted the token, not that it minted an access token.
+  // ID tokens are audienced to the client rather than to the issuer, and refresh tokens carry a refresh secret.
+  // Without these checks, either one is accepted as an access token. See RFC 8725 sections 3.9 and 3.12.
+  if (claims.aud !== getConfig().issuer || claims.refresh_secret !== undefined) {
+    return undefined;
+  }
+
   let login = undefined;
   try {
     login = await globalSystemRepo.readResource<Login>('Login', claims.login_id);


### PR DESCRIPTION
Applies two long-standing JWT and OAuth recommendations to the server's token verification paths:

- **RFC 8725 §3.9 (Use and Validate Audience)** and **§3.12 (Use Mutually Exclusive Validation Rules for Different Kinds of JWTs)** — the FHIR API path now validates the `aud` claim, and requires that a presented bearer token be an access token rather than any other server-signed JWT.
- **RFC 6749 §6** — the refresh grant now verifies a presented client secret rather than only checking that one was supplied.

No changes to the tokens the server issues. Existing access tokens continue to work unchanged.

## Background

The server signs ID tokens, access tokens, and refresh tokens with the same key and the same issuer, and all three carry a `login_id` claim. `verifyJwt` validates the issuer, algorithm, and expiry, so a valid signature establishes that the server minted the token but not which kind of token it minted. Per RFC 8725 §3.12, each kind of JWT should have validation rules that a JWT of another kind cannot satisfy.

The claims needed to distinguish them are already present:

- `aud` is the issuer on access tokens, and the client ID on ID tokens (as OpenID Connect requires).
- `refresh_secret` is present only on refresh tokens, which share the issuer audience with access tokens.

So the API path can require both, and no minted token has to change.

## Changes

### `packages/server/src/oauth/utils.ts`

`getLoginForAccessToken` now requires `aud` to equal the configured issuer and rejects any token carrying a `refresh_secret` claim. Seven lines, no new imports.

### `packages/server/src/oauth/token.ts`

The refresh grant now calls the existing `validateClientIdAndSecret` helper when a `Basic` authorization header is presented, which timing-safe compares against `client.secret` and supports `client.retiringSecret` for rotation. Previously the handler verified that the client ID matched the login and that a secret was non-empty, but did not compare the secret itself.

This is the same helper already used by the authorization_code and client_credentials grants, so all three grants now authenticate clients consistently.

The `ClientApplication` read moved above the authorization header block, unchanged, because the validation needs the client resource. Two minor consequences:

- If a request presents a `Basic` header whose client ID does not match the login *and* the login's `ClientApplication` cannot be read, the error changes from `invalid_grant` / `Incorrect client` to `invalid_request` / `Invalid client`. Both are 400s.
- A login whose client has no secret configured, presented with a non-empty secret, is now rejected. An empty secret continues to take the existing path.