### PR TITLE
Align Basic Auth with the Client Credentials Flow

### DIFF
--- a/packages/server/src/oauth/middleware.test.ts
+++ b/packages/server/src/oauth/middleware.test.ts
@@ -249,6 +249,48 @@ describe('Auth middleware', () => {
     expect(res).toHaveStatus(401);
   });
 
+  test('Basic auth with inactive client status', async () => {
+    for (const status of ['off', 'error'] as const) {
+      const client = await createTestClient();
+      const authHeader = 'Basic ' + Buffer.from(client.id + ':' + client.secret).toString('base64');
+
+      // Control: the client works before it is disabled
+      const res1 = await request(app).get('/fhir/R4/Patient').set('Authorization', authHeader);
+      expect(res1).toHaveStatus(200);
+
+      await withTestContext(() => systemRepo.updateResource<ClientApplication>({ ...client, status }));
+
+      const res2 = await request(app).get('/fhir/R4/Patient').set('Authorization', authHeader);
+      expect(res2).toHaveStatus(401);
+    }
+  });
+
+  test('Basic auth with IP access rules', async () => {
+    const client = await createTestClient({
+      accessPolicy: {
+        resourceType: 'AccessPolicy',
+        resource: [{ resourceType: '*' }],
+        ipAccessRule: [
+          { name: 'Block test', value: '6.6.6.6', action: 'block' },
+          { name: 'Allow by default', value: '*', action: 'allow' },
+        ],
+      },
+    });
+    const authHeader = 'Basic ' + Buffer.from(client.id + ':' + client.secret).toString('base64');
+
+    const res1 = await request(app)
+      .get('/fhir/R4/Patient')
+      .set('X-Forwarded-For', '6.6.6.6')
+      .set('Authorization', authHeader);
+    expect(res1).toHaveStatus(401);
+
+    const res2 = await request(app)
+      .get('/fhir/R4/Patient')
+      .set('X-Forwarded-For', '5.5.5.5')
+      .set('Authorization', authHeader);
+    expect(res2).toHaveStatus(200);
+  });
+
   test('Basic auth with super admin client', async () => {
     const { client, project } = await createTestProject({ superAdmin: true, withClient: true });
     const { project: otherProject } = await createTestProject({ withClient: false });

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -1049,10 +1049,7 @@ export async function getLoginForAccessToken(
  * @param token - The basic auth token as provided by the client.
  * @returns On success, returns the login, membership, and project. On failure, throws an error.
  */
-export async function getLoginForBasicAuth(
-  req: IncomingMessage,
-  token: string
-): Promise<AuthenticationResult | undefined> {
+export async function getLoginForBasicAuth(req: Request, token: string): Promise<AuthenticationResult | undefined> {
   const credentials = Buffer.from(token, 'base64').toString('ascii');
   const [username, password] = credentials.split(':');
   if (!username || !password) {
@@ -1071,6 +1068,10 @@ export async function getLoginForBasicAuth(
     return undefined;
   }
 
+  if (client.status && client.status !== 'active') {
+    return undefined;
+  }
+
   const membership = await getClientApplicationMembership(systemRepo, client);
   if (!membership || membership.active === false) {
     return undefined;
@@ -1082,7 +1083,18 @@ export async function getLoginForBasicAuth(
     user: createReference(client),
     authMethod: 'client',
     authTime: new Date().toISOString(),
+    remoteAddress: req.ip,
   };
+
+  // Basic auth has no login step, so the checks that the token endpoint performs once
+  // when issuing a token must be performed here on every request instead.
+  const userConfig = await getUserConfiguration(systemRepo, project, membership);
+  const accessPolicy = await getAccessPolicyForLogin({ login, project, membership, userConfig });
+  try {
+    await checkIpAccessRules(login, accessPolicy);
+  } catch {
+    return undefined;
+  }
 
   return makeAuthResult(systemRepo, req, login, project, membership, { profile: client });
 }


### PR DESCRIPTION
HTTP Basic auth and the `client_credentials` grant authenticate the same thing in the same way: a `ClientApplication`, by ID and secret. The token endpoint applies two checks that the Basic auth path did not, so the two flows accepted slightly different sets of clients. This brings them into line.

`getLoginForBasicAuth` now applies both:

- **`ClientApplication.status`** — a client whose status is not `active` is rejected, matching `handleClientCredentials` (`token.ts:135`).
- **IP access rules** — `checkIpAccessRules` is evaluated against the request's remote address, matching `handleClientCredentials` (`token.ts:171`).

Scoped to one function. No new imports.

## Background

The `client_credentials` grant performs these checks once, when it issues a token. Basic auth has no issuance step — it is stateless, so each request is its own authentication event — which is why the equivalent checks belong on the per-request path.

`checkIpAccessRules` returns early unless `login.remoteAddress` is set, and the synthetic `Login` that Basic auth constructs did not set it. Calling the function without also populating that field would have had no effect, so the fix requires both halves.

## Changes

`packages/server/src/oauth/utils.ts`, all within `getLoginForBasicAuth`:

- Reject a `ClientApplication` whose `status` is set to anything other than `active`. An unset status continues to mean active.
- Populate `login.remoteAddress` from `req.ip`, which is the same source the token endpoint uses and honors the Express `trust proxy` setting, so the real client address is used rather than an intermediary's.
- Resolve the access policy for the membership and evaluate `checkIpAccessRules`.
- Signature changed from `IncomingMessage` to `Request`. `req.ip` is Express-specific; `IncomingMessage` exposes only `socket.remoteAddress`, which behind a load balancer is the balancer's address. The sole caller (`middleware.ts:69`) already passes an Express `Request`.

## Notes

**IP rule failures return `undefined` rather than propagating.** `checkIpAccessRules` throws `badRequest('IP address not allowed')`. If that propagated out of the auth path, `attachRequestContext` (`context.ts:156`) would catch it, log it at `ERROR` level as `'Authentication error'`, and return 400 with the message in diagnostics — presenting a deliberate policy decision as a server fault and emitting an error-log line per request from a blocked address. Returning `undefined` yields a clean 401 and matches how every other failure in this function behaves.

The tradeoff is that a client blocked by an IP rule receives a bare 401 with no reason. Surfacing the reason properly would mean a 403 path through the auth middleware, which is a larger change than this PR.

**`getUserConfiguration` is called twice per Basic auth request** — once here to resolve the access policy, once inside `makeAuthResult`. It performs no read when `membership.userConfiguration` is unset, which is the normal case for a `ClientApplication`. Threading the value into `makeAuthResult` would remove the duplication, but that function is shared with the bearer token path, so it was left unchanged.