### PR TITLE
Align chained search filtering with direct searches

### DIFF
--- a/packages/server/src/fhir/chained-search.test.ts
+++ b/packages/server/src/fhir/chained-search.test.ts
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { parseSearchRequest } from '@medplum/core';
+import type { Encounter, Observation, Patient } from '@medplum/fhirtypes';
+import { randomUUID } from 'crypto';
+import { initAppServices, shutdownApp } from '../app';
+import { loadTestConfig } from '../config/loader';
+import { createTestProject, withTestContext } from '../test.setup';
+import { getGlobalSystemRepo, Repository } from './repo';
+
+/**
+ * Chained search builds an EXISTS() subquery over the reference lookup tables. Each link
+ * target in that subquery must be filtered by project and access policy just like the outer
+ * query filters its own resource type, so that a chain only ever traverses resources the
+ * caller can read. Reference values are indexed as plain strings, so a reference can point
+ * at a resource that is not visible to the repository holding it.
+ */
+describe('Chained search filters', () => {
+  let projectARepo: Repository;
+  let projectBRepo: Repository;
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initAppServices(config);
+
+    projectARepo = (await createTestProject({ withRepo: true })).repo;
+    projectBRepo = (await createTestProject({ withRepo: true })).repo;
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test('forward chain does not match a target in another project', () =>
+    withTestContext(async () => {
+      const family = randomUUID();
+      const patientA = await projectARepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ family, given: ['Victoria'] }],
+        birthDate: '1985-04-12',
+      });
+
+      const code = randomUUID();
+      const observationB = await projectBRepo.createResource<Observation>({
+        resourceType: 'Observation',
+        status: 'final',
+        code: { coding: [{ code }] },
+        subject: { reference: `Patient/${patientA.id}` },
+      });
+
+      // The Observation itself is visible within its own project...
+      const ownResult = await projectBRepo.search(parseSearchRequest(`Observation?code=${code}`));
+      expect(ownResult.entry?.map((e) => e.resource?.id)).toStrictEqual([observationB.id]);
+
+      // ...but no chained filter on the out-of-project target may match, for any field or
+      // partial value.
+      for (const query of [
+        `Observation?code=${code}&subject:Patient.name=${family}`,
+        `Observation?code=${code}&subject:Patient.name=${family.slice(0, 6)}`,
+        `Observation?code=${code}&subject:Patient.birthdate=1985-04-12`,
+        `Observation?code=${code}&subject:Patient.given=Victoria`,
+      ]) {
+        const result = await projectBRepo.search(parseSearchRequest(query));
+        expect(result.entry ?? []).toHaveLength(0);
+      }
+    }));
+
+  test('reverse chain does not match a referring resource in another project', () =>
+    withTestContext(async () => {
+      // Here the reference is written by the other project: project B owns the Patient and
+      // project A owns the Observation pointing at it.
+      const patientB = await projectBRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ family: randomUUID() }],
+      });
+      const codeA = randomUUID();
+      await projectARepo.createResource<Observation>({
+        resourceType: 'Observation',
+        status: 'final',
+        code: { coding: [{ code: codeA }] },
+        subject: { reference: `Patient/${patientB.id}` },
+      });
+
+      const result = await projectBRepo.search(
+        parseSearchRequest(`Patient?_id=${patientB.id}&_has:Observation:subject:code=${codeA}`)
+      );
+      expect(result.entry ?? []).toHaveLength(0);
+    }));
+
+  test('intermediate chain links are filtered, not just the terminal link', () =>
+    withTestContext(async () => {
+      // Chain: Patient <-(subject)- Observation -(encounter)-> Encounter
+      // Project B owns both ends; only the middle Observation belongs to project A.
+      const patientB = await projectBRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ family: randomUUID() }],
+      });
+      const encounterCode = randomUUID();
+      const encounterB = await projectBRepo.createResource<Encounter>({
+        resourceType: 'Encounter',
+        status: 'finished',
+        class: { code: encounterCode },
+      });
+      await projectARepo.createResource<Observation>({
+        resourceType: 'Observation',
+        status: 'final',
+        code: { coding: [{ code: randomUUID() }] },
+        subject: { reference: `Patient/${patientB.id}` },
+        encounter: { reference: `Encounter/${encounterB.id}` },
+      });
+
+      const result = await projectBRepo.search(
+        parseSearchRequest(
+          `Patient?_id=${patientB.id}&_has:Observation:subject:encounter:Encounter.class=${encounterCode}`
+        )
+      );
+      expect(result.entry ?? []).toHaveLength(0);
+    }));
+
+  test('chain respects access policy criteria on the chain target', () =>
+    withTestContext(async () => {
+      const family = randomUUID();
+      const { project, repo: limitedRepo } = await createTestProject({
+        withRepo: true,
+        accessPolicy: {
+          resource: [{ resourceType: 'Patient', criteria: 'Patient?active=true' }, { resourceType: 'Observation' }],
+        },
+      });
+
+      // Seed both Patients through the system repo so they land in the same project as
+      // limitedRepo without being subject to its access policy on write.
+      const systemRepo = getGlobalSystemRepo();
+      const excludedPatient = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        meta: { project: project.id },
+        name: [{ family }],
+        active: false,
+      });
+      const includedPatient = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        meta: { project: project.id },
+        name: [{ family }],
+        active: true,
+      });
+
+      const excludedCode = randomUUID();
+      await limitedRepo.createResource<Observation>({
+        resourceType: 'Observation',
+        status: 'final',
+        code: { coding: [{ code: excludedCode }] },
+        subject: { reference: `Patient/${excludedPatient.id}` },
+      });
+      const includedCode = randomUUID();
+      const includedObservation = await limitedRepo.createResource<Observation>({
+        resourceType: 'Observation',
+        status: 'final',
+        code: { coding: [{ code: includedCode }] },
+        subject: { reference: `Patient/${includedPatient.id}` },
+      });
+
+      // The criteria exclude the inactive Patient, so the chain must not match it.
+      const excludedResult = await limitedRepo.search(
+        parseSearchRequest(`Observation?code=${excludedCode}&subject:Patient.name=${family}`)
+      );
+      expect(excludedResult.entry ?? []).toHaveLength(0);
+
+      // The same chain still works for a Patient the criteria include.
+      const includedResult = await limitedRepo.search(
+        parseSearchRequest(`Observation?code=${includedCode}&subject:Patient.name=${family}`)
+      );
+      expect(includedResult.entry?.map((e) => e.resource?.id)).toStrictEqual([includedObservation.id]);
+    }));
+
+  test('access policy criteria that chain in a cycle are bounded', () =>
+    withTestContext(async () => {
+      // Filtering a chain link recurses when that link's own access policy criteria contain a
+      // chained search, so a cycle between two criteria would otherwise recurse until the
+      // stack overflows. Invariant axp-3 rejects such criteria on write, but rows stored
+      // before it existed are read back without revalidation.
+      const { project } = await createTestProject();
+      const repo = new Repository({
+        strictMode: true,
+        projects: [project],
+        author: { reference: 'User/' + randomUUID() },
+        accessPolicy: {
+          resourceType: 'AccessPolicy',
+          resource: [
+            { resourceType: 'Patient', criteria: 'Patient?_has:Observation:subject:status=final' },
+            { resourceType: 'Observation', criteria: 'Observation?subject:Patient.active=true' },
+          ],
+        },
+      });
+
+      await expect(repo.search(parseSearchRequest('Patient?name=nobody'))).rejects.toThrow(
+        'Access policy criteria are nested too deeply'
+      );
+    }));
+
+  test('chained search still matches within a single project', () =>
+    withTestContext(async () => {
+      const family = randomUUID();
+      const patient = await projectARepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ family }],
+        birthDate: '1990-06-07',
+      });
+      const code = randomUUID();
+      const observation = await projectARepo.createResource<Observation>({
+        resourceType: 'Observation',
+        status: 'final',
+        code: { coding: [{ code }] },
+        subject: { reference: `Patient/${patient.id}` },
+      });
+
+      const forward = await projectARepo.search(
+        parseSearchRequest(`Observation?code=${code}&subject:Patient.name=${family}`)
+      );
+      expect(forward.entry?.map((e) => e.resource?.id)).toStrictEqual([observation.id]);
+
+      const byBirthDate = await projectARepo.search(
+        parseSearchRequest(`Observation?code=${code}&subject:Patient.birthdate=1990-06-07`)
+      );
+      expect(byBirthDate.entry?.map((e) => e.resource?.id)).toStrictEqual([observation.id]);
+
+      const reverse = await projectARepo.search(parseSearchRequest(`Patient?_has:Observation:subject:code=${code}`));
+      expect(reverse.entry?.map((e) => e.resource?.id)).toStrictEqual([patient.id]);
+    }));
+});

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -131,7 +131,14 @@ import { buildSearchExpression, searchByReferenceImpl, searchImpl } from './sear
 import { lookupTables } from './searchparameter';
 import { GLOBAL_SHARD_ID } from './sharding';
 import type { Expression, PgQueryable } from './sql';
-import { Condition, DeleteQuery, Disjunction, InsertQuery, SelectQuery } from './sql';
+import { Column, Condition, DeleteQuery, Disjunction, InsertQuery, SelectQuery } from './sql';
+
+/**
+ * Maximum nesting depth for security filters. Depth only grows when an access policy
+ * criteria contains a chained search, whose target then has its own security filters
+ * applied. Legitimate policies nest at most one or two levels deep.
+ */
+const MAX_SECURITY_FILTER_DEPTH = 8;
 
 /**
  * The RepositoryContext interface defines standard metadata for repository actions.
@@ -276,6 +283,7 @@ export class Repository extends FhirRepository implements Disposable {
   private readonly connectionScope: ConnectionScope;
   private readonly ownsConnection: boolean;
   private closed = false;
+  private securityFilterDepth = 0;
 
   /**
    * The version to be set on resources when they are inserted/updated into the database.
@@ -1660,13 +1668,32 @@ export class Repository extends FhirRepository implements Disposable {
    * @param builder - The select query builder.
    * @param resourceType - The resource type for compartments.
    * @param interaction - The FHIR interaction being performed.
+   * @param table - Optional table name or alias holding `resourceType` rows. Defaults to
+   *   `resourceType`, which is correct when the resource table is the query's FROM table.
+   *   Chained search subqueries must pass the join alias of the chain link target instead.
    */
-  addSecurityFilters(builder: SelectQuery, resourceType: string, interaction: AccessPolicyInteraction): void {
-    // No compartment restrictions for admins.
-    if (!this.isSuperAdmin()) {
-      this.addProjectFilters(builder, resourceType);
+  addSecurityFilters(
+    builder: SelectQuery,
+    resourceType: string,
+    interaction: AccessPolicyInteraction,
+    table: string = resourceType
+  ): void {
+    // Access policy criteria may themselves contain chained searches, and each chain link
+    // recurses back into this method for its target type. A policy whose criteria chain
+    // between resource types in a cycle would otherwise recurse until the stack overflows.
+    if (this.securityFilterDepth >= MAX_SECURITY_FILTER_DEPTH) {
+      throw new OperationOutcomeError(badRequest('Access policy criteria are nested too deeply'));
     }
-    this.addAccessPolicyFilters(builder, resourceType, interaction);
+    this.securityFilterDepth++;
+    try {
+      // No compartment restrictions for admins.
+      if (!this.isSuperAdmin()) {
+        this.addProjectFilters(builder, resourceType, table);
+      }
+      this.addAccessPolicyFilters(builder, resourceType, interaction, table);
+    } finally {
+      this.securityFilterDepth--;
+    }
   }
 
   /**
@@ -1705,11 +1732,12 @@ export class Repository extends FhirRepository implements Disposable {
    * Adds the "project" filter to the select query.
    * @param builder - The select query builder.
    * @param resourceType - The resource type being searched.
+   * @param table - The table name or alias holding `resourceType` rows.
    */
-  private addProjectFilters(builder: SelectQuery, resourceType: string): void {
+  private addProjectFilters(builder: SelectQuery, resourceType: string, table: string): void {
     const projectIds = this.getPermittedProjectIds(resourceType);
     if (projectIds) {
-      builder.where('projectId', 'IN', projectIds);
+      builder.where(new Column(table, 'projectId'), 'IN', projectIds);
     }
   }
 
@@ -1718,11 +1746,13 @@ export class Repository extends FhirRepository implements Disposable {
    * @param builder - The select query builder.
    * @param resourceType - The resource type being read or searched.
    * @param interaction - The FHIR interaction being performed.
+   * @param table - The table name or alias holding `resourceType` rows.
    */
   private addAccessPolicyFilters(
     builder: SelectQuery,
     resourceType: string,
-    interaction: AccessPolicyInteraction
+    interaction: AccessPolicyInteraction,
+    table: string
   ): void {
     const accessPolicy = this.context.accessPolicy;
     if (!accessPolicy?.resource) {
@@ -1748,7 +1778,12 @@ export class Repository extends FhirRepository implements Disposable {
           // Deprecated - to be removed
           // Add compartment restriction for the access policy.
           expressions.push(
-            new Condition('compartments', 'ARRAY_OVERLAPS_AND_IS_NOT_NULL', policyCompartmentId, 'UUID[]')
+            new Condition(
+              new Column(table, 'compartments'),
+              'ARRAY_OVERLAPS_AND_IS_NOT_NULL',
+              policyCompartmentId,
+              'UUID[]'
+            )
           );
         } else if (policy.criteria) {
           if (!policy.criteria.startsWith(policy.resourceType + '?')) {
@@ -1771,7 +1806,9 @@ export class Repository extends FhirRepository implements Disposable {
             this,
             builder,
             searchRequest.resourceType,
-            searchRequest
+            searchRequest,
+            undefined,
+            table
           );
           if (accessPolicyExpression) {
             expressions.push(accessPolicyExpression);

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -1035,18 +1035,12 @@ export function buildSearchExpression(
   selectQuery: SelectQuery,
   resourceType: ResourceType,
   searchRequest: SearchRequest,
-  trackedResourceTypes?: TrackedResourceTypes
+  trackedResourceTypes?: TrackedResourceTypes,
+  table: string = resourceType
 ): Expression | undefined {
   const expressions: Expression[] = [];
   for (const filter of searchRequest.filters ?? EMPTY) {
-    const expr = buildSearchFilterExpression(
-      repo,
-      selectQuery,
-      resourceType,
-      resourceType,
-      filter,
-      trackedResourceTypes
-    );
+    const expr = buildSearchFilterExpression(repo, selectQuery, resourceType, table, filter, trackedResourceTypes);
     expressions.push(expr);
   }
   if (expressions.length === 0) {
@@ -1086,7 +1080,7 @@ function buildSearchFilterExpression(
 
   if (isChainedSearchFilter(filter)) {
     const chain = parseChainedParameter(resourceType, filter);
-    return buildChainedSearch(repo, selectQuery, resourceType, chain, trackedResourceTypes);
+    return buildChainedSearch(repo, selectQuery, resourceType, table, chain, trackedResourceTypes);
   }
 
   const specialParamExpression = trySpecialSearchParameter(
@@ -1788,6 +1782,7 @@ function buildChainedSearch(
   repo: Repository,
   selectQuery: SelectQuery,
   resourceType: string,
+  table: string,
   param: ChainedSearchParameter,
   trackedResourceTypes?: TrackedResourceTypes
 ): Expression {
@@ -1810,13 +1805,13 @@ function buildChainedSearch(
       repo,
       selectQuery,
       resourceType as ResourceType,
-      resourceType,
+      table,
       { code, operator: param.filter.operator, value: `${targetType}/${targetId}` },
       trackedResourceTypes
     );
   }
 
-  return buildChainedSearchUsingReferenceTable(repo, selectQuery, param, trackedResourceTypes);
+  return buildChainedSearchUsingReferenceTable(repo, table, param, trackedResourceTypes);
 }
 
 /**
@@ -1825,14 +1820,14 @@ function buildChainedSearch(
  * However, reference tables were only populated after Medplum version 2.2.0.
  * Self-hosted servers need to run a full re-index before this technique can be used.
  * @param repo - The repository.
- * @param selectQuery - The select query builder.
+ * @param table - The table name or alias holding the rows the chain starts from.
  * @param param - The chained search parameter.
  * @param trackedResourceTypes - Resource types involved in the logical query.
  * @returns The WHERE clause expression for the final chained filter.
  */
 function buildChainedSearchUsingReferenceTable(
   repo: Repository,
-  selectQuery: SelectQuery,
+  table: string,
   param: ChainedSearchParameter,
   trackedResourceTypes?: TrackedResourceTypes
 ): Expression {
@@ -1843,15 +1838,15 @@ function buildChainedSearchUsingReferenceTable(
   // Set up subquery for EXISTS(), starting on the first link of the chain
   let innerQuery: SelectQuery;
   if (link.implementation.type === SearchParameterType.CANONICAL) {
-    innerQuery = new SelectQuery(currentTable).whereExpr(
-      getCanonicalJoinCondition(selectQuery.effectiveTableName, link, currentTable)
-    );
+    innerQuery = new SelectQuery(currentTable).whereExpr(getCanonicalJoinCondition(table, link, currentTable));
   } else {
-    innerQuery = new SelectQuery(currentTable).whereExpr(
-      lookupTableJoinCondition(selectQuery.effectiveTableName, link, currentTable)
-    );
+    innerQuery = new SelectQuery(currentTable).whereExpr(lookupTableJoinCondition(table, link, currentTable));
     currentTable = linkLiteralReference(innerQuery, currentTable, link);
   }
+  // Filter each link target exactly as the outer query filters its own resource type, so the
+  // chain only traverses resources the caller can read. Without this the subquery can match
+  // rows from other projects, or rows excluded by the caller's access policy.
+  repo.addSecurityFilters(innerQuery, link.targetType, AccessPolicyInteraction.SEARCH, currentTable);
 
   // Add joins to inner query for all subsequent chain links
   for (let i = 1; i < param.chain.length; i++) {
@@ -1863,6 +1858,8 @@ function buildChainedSearchUsingReferenceTable(
       const lookupTable = linkReferenceLookupTable(innerQuery, currentTable, link);
       currentTable = linkLiteralReference(innerQuery, lookupTable, link);
     }
+    // Every hop is traversed, so every hop is filtered, not just the terminal one.
+    repo.addSecurityFilters(innerQuery, link.targetType, AccessPolicyInteraction.SEARCH, currentTable);
   }
 
   // Add terminal conditions on final target table, and return EXISTS() over subquery


### PR DESCRIPTION
Chained searches (`subject:Patient.name=...`) and reverse chained searches (`_has:Observation:subject:code=...`) evaluate predicates against linked resources using an `EXISTS` subquery. Those subqueries now apply the same project and access-policy filters as equivalent direct searches of the linked resource type.

This change keeps chained search behavior consistent with the rest of the search engine.

## Implementation

* Apply `addSecurityFilters(...)` to each chained search target using the appropriate table alias.
* Thread the SQL table alias through the search builder so security filters can be applied to joined tables.
* Update `addSecurityFilters`, `addProjectFilters`, and `addAccessPolicyFilters` to accept an optional table alias.
* Apply the same filtering to canonical chains.
* Add a recursion depth limit when evaluating access-policy criteria to guard against cyclic chained expressions in legacy configurations.
