### PR TITLE
Align CodeSystem and ConceptMap import permission model

### DIFF
--- a/packages/server/src/fhir/operations/codesystemimport.test.ts
+++ b/packages/server/src/fhir/operations/codesystemimport.test.ts
@@ -293,6 +293,113 @@ describe('CodeSystem $import', () => {
     expect(res2).toHaveStatus(400);
   });
 
+  test('Allows Super Admin to import into base CodeSystem by ID', async () => {
+    // `accessToken` is a Super Admin; base terminology maintenance must remain possible
+    const res = await request(app)
+      .get('/fhir/R4/CodeSystem?url=http://terminology.hl7.org/CodeSystem/v3-RoleCode')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send();
+    expect(res).toHaveStatus(200);
+    const baseCodeSystem = res.body.entry?.[0]?.resource as CodeSystem;
+    expect(baseCodeSystem?.id).toBeDefined();
+
+    const code = 'ZZ' + randomUUID();
+    const res2 = await request(app)
+      .post(`/fhir/R4/CodeSystem/${baseCodeSystem.id}/$import`)
+      .set('X-Medplum', 'extended')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'concept', valueCoding: { code, display: 'Super Admin concept' } }],
+      });
+    expect(res2).toHaveStatus(200);
+    await assertCodeExists(baseCodeSystem.id, code);
+  });
+
+  test('Prevents writes by Project admin to base CodeSystem by ID', async () => {
+    // Base R4 CodeSystems are readable from every Project, but the Coding table they write into is
+    // shared server-wide; importing into one by ID must not bypass the `ownProjectOnly` check.
+    const { accessToken } = await createTestProject({
+      project: { superAdmin: false },
+      membership: { admin: true },
+      withAccessToken: true,
+    });
+
+    const res = await request(app)
+      .get('/fhir/R4/CodeSystem?url=http://terminology.hl7.org/CodeSystem/v3-RoleCode')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send();
+    expect(res).toHaveStatus(200);
+    const baseCodeSystem = res.body.entry?.[0]?.resource as CodeSystem;
+    expect(baseCodeSystem?.id).toBeDefined();
+
+    const code = 'ZZ' + randomUUID();
+    const res2 = await request(app)
+      .post(`/fhir/R4/CodeSystem/${baseCodeSystem.id}/$import`)
+      .set('X-Medplum', 'extended')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'concept', valueCoding: { code, display: 'Injected concept' } }],
+      });
+    expect(res2).toHaveStatus(403);
+    await assertCodeMissing(baseCodeSystem.id, code);
+  });
+
+  test('Imports into own Project CodeSystem by ID', async () => {
+    const { accessToken, repo } = await createTestProject({
+      withAccessToken: true,
+      withRepo: true,
+      membership: { admin: true },
+    });
+    const codeSystem = await repo.createResource<CodeSystem>({
+      ...snomedJSON,
+      url: 'http://example.com/CodeSystem/' + randomUUID(),
+    });
+
+    const code = 'ZZ' + randomUUID();
+    const res = await request(app)
+      .post(`/fhir/R4/CodeSystem/${codeSystem.id}/$import`)
+      .set('X-Medplum', 'extended')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'concept', valueCoding: { code, display: 'Own project concept' } }],
+      });
+    expect(res).toHaveStatus(200);
+    await assertCodeExists(codeSystem.id, code);
+  });
+
+  test('Requires update permission on own Project CodeSystem', async () => {
+    // Writing a CodeSystem's contents requires permission to update the CodeSystem itself
+    const { accessToken, repo } = await createTestProject({
+      withAccessToken: true,
+      withRepo: true,
+      membership: { admin: true },
+      accessPolicy: { resource: [{ resourceType: 'CodeSystem', interaction: ['create', 'read'] }] },
+    });
+    const codeSystem = await repo.createResource<CodeSystem>({
+      ...snomedJSON,
+      url: 'http://example.com/CodeSystem/' + randomUUID(),
+    });
+
+    const code = 'ZZ' + randomUUID();
+    const res = await request(app)
+      .post(`/fhir/R4/CodeSystem/${codeSystem.id}/$import`)
+      .set('X-Medplum', 'extended')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'concept', valueCoding: { code, display: 'Read-only policy' } }],
+      });
+    expect(res).toHaveStatus(403);
+    await assertCodeMissing(codeSystem.id, code);
+  });
+
   test('Imports concepts and synonym designations', async () => {
     const res = await request(app)
       .post(`/fhir/R4/CodeSystem/$import`)
@@ -423,6 +530,12 @@ async function assertCodeExists(system: string | undefined, code: string): Promi
     .execute(db);
   expect(coding).toHaveLength(1);
   return coding[0];
+}
+
+async function assertCodeMissing(system: string | undefined, code: string): Promise<void> {
+  const db = getDatabasePool(DatabaseMode.READER);
+  const coding = await selectCoding(system as string, code).execute(db);
+  expect(coding).toHaveLength(0);
 }
 
 async function assertPropertyExists(

--- a/packages/server/src/fhir/operations/codesystemimport.ts
+++ b/packages/server/src/fhir/operations/codesystemimport.ts
@@ -1,7 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { OperationOutcomeError, allOk, badRequest, forbidden, normalizeOperationOutcome } from '@medplum/core';
+import {
+  AccessPolicyInteraction,
+  OperationOutcomeError,
+  allOk,
+  badRequest,
+  forbidden,
+  normalizeOperationOutcome,
+} from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { CodeSystem, CodeSystemProperty, Coding, OperationDefinitionParameter } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
@@ -96,6 +103,9 @@ export async function codeSystemImportHandler(req: FhirRequest): Promise<FhirRes
   let codeSystem: WithId<CodeSystem>;
   if (req.params.id) {
     codeSystem = await repo.readResource<CodeSystem>('CodeSystem', req.params.id);
+    if (!repo.canPerformInteraction(AccessPolicyInteraction.UPDATE, codeSystem)) {
+      return [forbidden];
+    }
   } else if (params.system) {
     codeSystem = await findTerminologyResource<CodeSystem>(repo, 'CodeSystem', params.system, {
       ownProjectOnly: !isSuperAdmin,

--- a/packages/server/src/fhir/operations/codesystemlookup.test.ts
+++ b/packages/server/src/fhir/operations/codesystemlookup.test.ts
@@ -496,6 +496,7 @@ describe('CodeSystem lookup', () => {
   test('Correctly renders imported properties of different types', async () => {
     const res = await request(app)
       .post(`/fhir/R4/CodeSystem/${codeSystem.id}/$import`)
+      .set('X-Medplum', 'extended')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/fhir+json')
       .send({

--- a/packages/server/src/fhir/operations/conceptmapimport.test.ts
+++ b/packages/server/src/fhir/operations/conceptmapimport.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { ContentType, SNOMED } from '@medplum/core';
+import { ContentType, createReference, SNOMED } from '@medplum/core';
 import type { ConceptMap, OperationOutcome, Parameters } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
@@ -214,6 +214,7 @@ describe('ConceptMap/$import', () => {
 
     const res = await request(app)
       .post(`/fhir/R4/ConceptMap/${conceptMap.id}/$import`)
+      .set('X-Medplum', 'extended')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({
@@ -289,6 +290,7 @@ describe('ConceptMap/$import', () => {
 
     const res = await request(app)
       .post(`/fhir/R4/ConceptMap/${conceptMap.id}/$import`)
+      .set('X-Medplum', 'extended')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({
@@ -304,6 +306,48 @@ describe('ConceptMap/$import', () => {
         ],
       } satisfies Parameters);
     expect(res).toHaveStatus(403);
+  });
+
+  test('Prevents writes by Project admin to linked Project ConceptMap', async () => {
+    // ConceptMaps in linked Projects are readable, but their mappings are shared server-wide;
+    // importing into one by ID must not bypass the `ownProjectOnly` check.
+    const { project: linkedProject, repo: linkedRepo } = await createTestProject({
+      withRepo: true,
+      project: { exportedResourceType: ['ConceptMap'] },
+    });
+    const conceptMap = await linkedRepo.createResource<ConceptMap>({
+      resourceType: 'ConceptMap',
+      status: 'draft',
+      name: 'Linked Project ConceptMap',
+    });
+
+    const { accessToken: linkedAccessToken } = await createTestProject({
+      withAccessToken: true,
+      membership: { admin: true },
+      project: { link: [{ project: createReference(linkedProject) }] },
+    });
+
+    const res = await request(app)
+      .post(`/fhir/R4/ConceptMap/${conceptMap.id}/$import`)
+      .set('X-Medplum', 'extended')
+      .set('Authorization', 'Bearer ' + linkedAccessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'mapping',
+            part: [
+              { name: 'source', valueCoding: { system: SNOMED, code: '10347006' } },
+              { name: 'target', valueCoding: { system: 'http://hl7.org/fhir/sid/icd-10-cm', code: 'T50.905' } },
+            ],
+          },
+        ],
+      } satisfies Parameters);
+    expect(res).toHaveStatus(403);
+
+    const results = await getMappingRows(getDatabasePool(DatabaseMode.READER), conceptMap);
+    expect(results).toHaveLength(0);
   });
 
   test('Allows selecting ConceptMap by URL', async () => {
@@ -366,6 +410,7 @@ describe('ConceptMap/$import', () => {
 
     const res = await request(app)
       .post(`/fhir/R4/ConceptMap/${conceptMap.id}/$import`)
+      .set('X-Medplum', 'extended')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({
@@ -399,6 +444,7 @@ describe('ConceptMap/$import', () => {
 
     const res = await request(app)
       .post(`/fhir/R4/ConceptMap/${conceptMap.id}/$import`)
+      .set('X-Medplum', 'extended')
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({

--- a/packages/server/src/fhir/operations/conceptmapimport.ts
+++ b/packages/server/src/fhir/operations/conceptmapimport.ts
@@ -1,7 +1,16 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { TypedValue, WithId } from '@medplum/core';
-import { allOk, append, badRequest, EMPTY, flatMapFilter, forbidden, OperationOutcomeError } from '@medplum/core';
+import {
+  AccessPolicyInteraction,
+  allOk,
+  append,
+  badRequest,
+  EMPTY,
+  flatMapFilter,
+  forbidden,
+  OperationOutcomeError,
+} from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Coding, ConceptMap, ConceptMapGroupElementTargetDependsOn } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
@@ -113,6 +122,9 @@ export async function conceptMapImportHandler(req: FhirRequest): Promise<FhirRes
     return [badRequest('Parameter `url` not permitted for instance operation', 'Parameters.parameter')];
   } else if (req.params.id) {
     conceptMap = await repo.readResource('ConceptMap', req.params.id);
+    if (!repo.canPerformInteraction(AccessPolicyInteraction.UPDATE, conceptMap)) {
+      return [forbidden];
+    }
   } else if (params.url) {
     conceptMap = await findTerminologyResource(repo, 'ConceptMap', params.url, { ownProjectOnly: !isSuperAdmin });
   } else {


### PR DESCRIPTION
`CodeSystem/$import` and `ConceptMap/$import` can each address their target in two ways: by `url`/`system` parameter, or by resource ID on the instance endpoint. The parameter path already required the target to belong to the caller's own project. The instance path did not apply an equivalent check.

This change applies the same rule to the instance path, so both routes resolve to the same permission model.

## Background

Terminology content imported by these operations is written to the `Coding`, `Coding_Property`, and `CodeSystem_Property` tables, keyed by the target resource's ID. These tables are not partitioned by project, so their contents are visible to every project that can resolve the owning `CodeSystem` or `ConceptMap`.

Project-scoped repositories can read terminology resources beyond their own project:

- The synthetic base FHIR R4 project is appended to every project-scoped repository (`repo.ts:259-266`) and exports `CodeSystem` (`constants.ts:15-20`), so base R4 CodeSystems are readable from any project.
- Linked projects are similarly readable, subject to their `exportedResourceType`.

The parameter path accounts for this by passing `ownProjectOnly` to `findTerminologyResource`, with existing coverage in `codesystemimport.test.ts` ("Prevents writes by Project admin to linked Project systems"). The instance path resolved its target with `repo.readResource` alone, which establishes read access but not write access. As a result, a project administrator could import into a readable resource owned by another project.

## Changes

### `packages/server/src/fhir/operations/codesystemimport.ts`, `conceptmapimport.ts`

Both handlers gain the same check on the instance branch:

```ts
// Requires extended mode: `meta.project` is stripped otherwise, so this check fails closed
codeSystem = await repo.readResource<CodeSystem>('CodeSystem', req.params.id);
if (!repo.canPerformInteraction(AccessPolicyInteraction.UPDATE, codeSystem)) {
  return [forbidden];
}
```

`canPerformInteraction` performs the same project comparison the parameter path relies on (`repo.ts:2130`), and additionally evaluates the caller's access policy. Writing a terminology resource's contents now requires permission to update the resource itself.

No new helpers, exports, or reads. The remainder of the source diff is Prettier reflowing two import statements.

## Behavior changes

Three consequences worth noting in release notes:

1. **Instance-path imports into another project's resource are rejected.** This matches what the parameter path has always done, and is the intended model rather than a new restriction.

2. **The caller's access policy is now consulted.** A project administrator whose policy grants read-only access to `CodeSystem` or `ConceptMap` can no longer import into one. Callers with no access policy are unaffected. Super administrators are subject to their own access policy if one is configured; with no policy configured, behavior is unchanged.

3. **The instance path requires extended mode.** `Repository.readResource()` clears `meta.project` unless the request carries `X-Medplum: extended` (`repo.ts:2197-2205`), so without it the check has no project to compare and denies the request. `MedplumClient` sends this header by default (`client.ts:4010`), so SDK and CLI callers are unaffected; direct HTTP callers using the instance endpoint need to add it. The parameter path is unaffected.

Requests rejected by any of the above receive `403 Forbidden`.