### PR TITLE
fix(core): keep UUID values whole when parsing _filter expressions

### DIFF
--- a/packages/core/src/fhirlexer/tokenize.ts
+++ b/packages/core/src/fhirlexer/tokenize.ts
@@ -279,17 +279,16 @@ export class Tokenizer {
 
     const terminal = this.curr();
     if (terminal === '-' && this.dateTimeLiterals) {
-      // Rewind to one character before the start; both branches below skip that character.
-      this.pos.index = start - 1;
       if (DATE_TIME_LITERAL_REGEX.test(this.str.substring(start))) {
+        // Rewind to one character before the start, and then treat as dateTime literal.
+        this.pos.index = start - 1;
         return this.consumeDateTime();
       }
       // Digits followed by "-" that are not a date, such as the UUID
       // "12345678-1234-4123-8123-123456789abc". Consuming those as a dateTime literal would end the
       // token at the first letter ("12345678-1234-4"), silently changing the value and leaving the
-      // remainder to be parsed as separate tokens. Fall back to parsing as a string, same as the
-      // alphabetic terminal below.
-      return this.consumeString(' ');
+      // remainder to be parsed as separate tokens.
+      return this.consumeUnquotedString(start);
     } else if (terminal === ' ') {
       if (isUnitToken(this.peekToken())) {
         id = 'Quantity';
@@ -297,11 +296,30 @@ export class Tokenizer {
       }
     } else if (terminal && /[a-zA-Z_$]/.exec(terminal)) {
       // This cannot be a number, fall back to parsing as string
-      this.pos.index = start - 1;
-      return this.consumeString(' ');
+      return this.consumeUnquotedString(start);
     }
 
     return this.buildToken(id, this.str.substring(start, this.pos.index));
+  }
+
+  /**
+   * Consumes an unquoted string value that begins with digits, such as a UUID in a `_filter`
+   * expression, starting over from the beginning of the value.
+   *
+   * The value ends at the first character that cannot be part of a token, per `symbolRegex`. For the
+   * `_filter` tokenizer that is whitespace, ")", and "]", so a value at the end of a nested
+   * expression such as "(_id eq 12345678-1234-4123-8123-123456789abc)" does not swallow the closing
+   * parenthesis.
+   *
+   * @param start - The index of the first character of the value.
+   * @returns The string token.
+   */
+  private consumeUnquotedString(start: number): Token {
+    this.pos.index = start;
+    return this.buildToken(
+      'String',
+      this.consumeWhile(() => this.symbolRegex.exec(this.curr()))
+    );
   }
 
   private consumeSymbol(): Token {

--- a/packages/core/src/fhirlexer/tokenize.ts
+++ b/packages/core/src/fhirlexer/tokenize.ts
@@ -30,6 +30,15 @@ const STANDARD_UNITS = [
   'milliseconds',
 ];
 
+/**
+ * Matches an unquoted date or dateTime literal: a 4 digit year, a 2 digit month, and then only
+ * characters that can appear in a day or time part, up to the end of the token.
+ *
+ * Used to tell a date literal apart from other values that also start with digits followed by "-",
+ * such as a UUID: "2014-10-10" is a date, "12345678-1234-4123-8123-123456789abc" is not.
+ */
+const DATE_TIME_LITERAL_REGEX = /^\d{4}-\d{2}[\dT:.+\-Z]*(?=[\s)\]]|$)/;
+
 const ESCAPE_MAP: Record<string, string> = {
   "'": "'",
   '"': '"',
@@ -270,9 +279,17 @@ export class Tokenizer {
 
     const terminal = this.curr();
     if (terminal === '-' && this.dateTimeLiterals) {
-      // Rewind to one character before the start, and then treat as dateTime literal.
+      // Rewind to one character before the start; both branches below skip that character.
       this.pos.index = start - 1;
-      return this.consumeDateTime();
+      if (DATE_TIME_LITERAL_REGEX.test(this.str.substring(start))) {
+        return this.consumeDateTime();
+      }
+      // Digits followed by "-" that are not a date, such as the UUID
+      // "12345678-1234-4123-8123-123456789abc". Consuming those as a dateTime literal would end the
+      // token at the first letter ("12345678-1234-4"), silently changing the value and leaving the
+      // remainder to be parsed as separate tokens. Fall back to parsing as a string, same as the
+      // alphabetic terminal below.
+      return this.consumeString(' ');
     } else if (terminal === ' ') {
       if (isUnitToken(this.peekToken())) {
         id = 'Quantity';

--- a/packages/core/src/filter/parse.test.ts
+++ b/packages/core/src/filter/parse.test.ts
@@ -29,6 +29,23 @@ describe('_filter Parameter parser', () => {
       "_has:Observation:patient:_id ne ''",
       { path: '_has:Observation:patient:_id', operator: Operator.NOT_EQUALS, value: '' },
     ],
+    [
+      // A UUID whose first group is all digits looks like the start of a date literal.
+      // It must be kept whole rather than truncated at the first letter.
+      'UUID with all digits before the first hyphen',
+      '_id eq 12345678-1234-4123-8123-123456789abc',
+      { path: '_id', operator: Operator.EXACT, value: '12345678-1234-4123-8123-123456789abc' },
+    ],
+    [
+      'Date literal',
+      'birthdate ge 2014-10-10',
+      { path: 'birthdate', operator: Operator.GREATER_THAN_OR_EQUALS, value: '2014-10-10' },
+    ],
+    [
+      'DateTime literal',
+      '_lastUpdated gt 2014-10-10T12:30:45.123Z',
+      { path: '_lastUpdated', operator: Operator.GREATER_THAN, value: '2014-10-10T12:30:45.123Z' },
+    ],
   ])('%s', (_, filter, expected) => {
     const result = parseFilterParameter(filter);
     assert(result instanceof FhirFilterComparison);
@@ -86,6 +103,22 @@ describe('_filter Parameter parser', () => {
     expect(right.path).toBe('birthdate');
     expect(right.operator).toBe(Operator.GREATER_THAN_OR_EQUALS);
     expect(right.value).toBe('2014-10-10');
+  });
+
+  test('Or connective with UUID value', () => {
+    // Regression: the UUID was tokenized as a date literal and truncated, which dropped the "or"
+    // and everything after it, leaving a comparison against a value that matched nothing.
+    const result = parseFilterParameter('_project eq 12345678-1234-4123-8123-123456789abc or _project pr false');
+    expect(result).toBeInstanceOf(FhirFilterConnective);
+
+    const connective = result as FhirFilterConnective;
+    expect(connective.keyword).toBe('or');
+    expect(connective.left).toMatchObject({
+      path: '_project',
+      operator: Operator.EXACT,
+      value: '12345678-1234-4123-8123-123456789abc',
+    });
+    expect(connective.right).toMatchObject({ path: '_project', operator: Operator.PRESENT, value: 'false' });
   });
 
   test('Top level parentheses', () => {

--- a/packages/core/src/filter/parse.test.ts
+++ b/packages/core/src/filter/parse.test.ts
@@ -105,20 +105,108 @@ describe('_filter Parameter parser', () => {
     expect(right.value).toBe('2014-10-10');
   });
 
-  test('Or connective with UUID value', () => {
-    // Regression: the UUID was tokenized as a date literal and truncated, which dropped the "or"
-    // and everything after it, leaving a comparison against a value that matched nothing.
-    const result = parseFilterParameter('_project eq 12345678-1234-4123-8123-123456789abc or _project pr false');
-    expect(result).toBeInstanceOf(FhirFilterConnective);
+  // UUIDs are the values most likely to be mis-tokenized: they start with digits and contain
+  // hyphens, so they can look like the start of a date literal, and they are usually the last thing
+  // before a closing parenthesis. Both mistakes used to end the value token early, and the parser
+  // then silently discarded whatever was left -- returning a filter that searched for the wrong
+  // thing instead of reporting an error. NUMERIC_UUID has all digits before its first hyphen
+  // (about 2.3% of random UUIDs), HEX_UUID does not; they take different paths through the tokenizer.
+  const NUMERIC_UUID = '12345678-1234-4123-8123-123456789abc';
+  const HEX_UUID = '6783655a-6431-4baa-9243-914efcd984da';
 
-    const connective = result as FhirFilterConnective;
-    expect(connective.keyword).toBe('or');
-    expect(connective.left).toMatchObject({
-      path: '_project',
-      operator: Operator.EXACT,
-      value: '12345678-1234-4123-8123-123456789abc',
+  describe.each([
+    ['numeric', NUMERIC_UUID],
+    ['hex', HEX_UUID],
+  ])('Nested expressions with a %s UUID', (_, uuid) => {
+    test.each<[string, string, object]>([
+      ['parentheses', `(_id eq ${uuid})`, { path: '_id', operator: Operator.EXACT, value: uuid }],
+      ['negation', `not (_id eq ${uuid})`, { child: { path: '_id', operator: Operator.EXACT, value: uuid } }],
+      [
+        'or connective',
+        `_project eq ${uuid} or _project pr false`,
+        {
+          keyword: 'or',
+          left: { path: '_project', operator: Operator.EXACT, value: uuid },
+          right: { path: '_project', operator: Operator.PRESENT, value: 'false' },
+        },
+      ],
+      [
+        'two parenthesized comparisons',
+        `(_id eq ${uuid}) or (status eq active)`,
+        {
+          keyword: 'or',
+          left: { path: '_id', operator: Operator.EXACT, value: uuid },
+          right: { path: 'status', operator: Operator.EXACT, value: 'active' },
+        },
+      ],
+      [
+        'nested connective on the right',
+        `status eq active or (_id eq ${uuid} and birthdate ge 2014-10-10)`,
+        {
+          keyword: 'or',
+          left: { path: 'status', operator: Operator.EXACT, value: 'active' },
+          right: {
+            keyword: 'and',
+            left: { path: '_id', operator: Operator.EXACT, value: uuid },
+            right: { path: 'birthdate', operator: Operator.GREATER_THAN_OR_EQUALS, value: '2014-10-10' },
+          },
+        },
+      ],
+      [
+        'nested connective on the left',
+        `(_id eq ${uuid} or _id eq ${HEX_UUID}) and status eq active`,
+        {
+          keyword: 'and',
+          left: {
+            keyword: 'or',
+            left: { path: '_id', operator: Operator.EXACT, value: uuid },
+            right: { path: '_id', operator: Operator.EXACT, value: HEX_UUID },
+          },
+          right: { path: 'status', operator: Operator.EXACT, value: 'active' },
+        },
+      ],
+      [
+        'negated nested connectives',
+        `not ((_id eq ${uuid}) or (subject eq Patient/${uuid}))`,
+        {
+          child: {
+            keyword: 'or',
+            left: { path: '_id', operator: Operator.EXACT, value: uuid },
+            right: { path: 'subject', operator: Operator.EXACT, value: `Patient/${uuid}` },
+          },
+        },
+      ],
+      [
+        'reference value',
+        `(subject eq Patient/${uuid} and status eq final)`,
+        {
+          keyword: 'and',
+          left: { path: 'subject', operator: Operator.EXACT, value: `Patient/${uuid}` },
+          right: { path: 'status', operator: Operator.EXACT, value: 'final' },
+        },
+      ],
+      [
+        'alongside a dateTime literal',
+        `(_lastUpdated gt 2014-10-10T12:30:45.123Z and _id eq ${uuid})`,
+        {
+          keyword: 'and',
+          left: { path: '_lastUpdated', operator: Operator.GREATER_THAN, value: '2014-10-10T12:30:45.123Z' },
+          right: { path: '_id', operator: Operator.EXACT, value: uuid },
+        },
+      ],
+    ])('%s', (_name, filter, expected) => {
+      expect(parseFilterParameter(filter)).toMatchObject(expected);
     });
-    expect(connective.right).toMatchObject({ path: '_project', operator: Operator.PRESENT, value: 'false' });
+  });
+
+  test.each([
+    ['trailing token', `_id eq ${'12345678-1234-4123-8123-123456789abc'} extra`],
+    ['unclosed parenthesis', `(_id eq ${'12345678-1234-4123-8123-123456789abc'}`],
+    ['dangling connective', `_id eq ${'12345678-1234-4123-8123-123456789abc'} or`],
+  ])('Rejects an expression it cannot fully parse: %s', (_name, filter) => {
+    // Whatever the parser cannot account for must be an error. Returning the part that did parse
+    // would silently drop conditions from the search.
+    expect(() => parseFilterParameter(filter)).toThrow();
   });
 
   test('Top level parentheses', () => {

--- a/packages/core/src/filter/parse.ts
+++ b/packages/core/src/filter/parse.ts
@@ -108,5 +108,12 @@ const fhirPathParserBuilder = initFhirPathParserBuilder();
 export function parseFilterParameter(input: string): FhirFilterExpression {
   const parser = fhirPathParserBuilder.construct(tokenize(input));
   parser.removeComments();
-  return new FilterParameterParser(parser).parse();
+  const result = new FilterParameterParser(parser).parse();
+  const extra = parser.peek();
+  if (extra) {
+    // Anything left over means the expression was not fully understood. Returning the part that
+    // parsed would silently search for something other than what was asked for.
+    throw new OperationOutcomeError(badRequest('Unexpected token in _filter expression: ' + extra.value));
+  }
+  return result;
 }

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -3738,20 +3738,20 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
 
       // The first UUID has all digits before its first hyphen, which used to be tokenized as a date
       // literal and truncated. That silently dropped the rest of the expression -- including the
-      // "or" branch that matches the real resource.
-      const result = await repo.search({
-        resourceType: 'Patient',
-        filters: [
-          {
-            code: '_filter',
-            operator: Operator.EQUALS,
-            value: `_id eq 12345678-1234-4123-8123-123456789abc or _id eq ${patient.id}`,
-          },
-        ],
-      });
+      // "or" branch that matches the real resource. In the parenthesized form, the UUID also used to
+      // swallow the closing parenthesis.
+      for (const value of [
+        `_id eq 12345678-1234-4123-8123-123456789abc or _id eq ${patient.id}`,
+        `(_id eq 12345678-1234-4123-8123-123456789abc or _id eq ${patient.id})`,
+      ]) {
+        const result = await repo.search({
+          resourceType: 'Patient',
+          filters: [{ code: '_filter', operator: Operator.EQUALS, value }],
+        });
 
-      expect(result.entry).toHaveLength(1);
-      expect(result.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
+        expect(result.entry).toHaveLength(1);
+        expect(result.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
+      }
     }));
 
   test('_filter birthdate eq', () =>

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -3729,6 +3729,31 @@ describe.each<Project['features']>([undefined, ['range-search']])('project-scope
       expect(result2.entry).toHaveLength(1);
     }));
 
+  test('_filter with UUID value', () =>
+    withTestContext(async () => {
+      const patient = await repo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['Evelyn'] }],
+      });
+
+      // The first UUID has all digits before its first hyphen, which used to be tokenized as a date
+      // literal and truncated. That silently dropped the rest of the expression -- including the
+      // "or" branch that matches the real resource.
+      const result = await repo.search({
+        resourceType: 'Patient',
+        filters: [
+          {
+            code: '_filter',
+            operator: Operator.EQUALS,
+            value: `_id eq 12345678-1234-4123-8123-123456789abc or _id eq ${patient.id}`,
+          },
+        ],
+      });
+
+      expect(result.entry).toHaveLength(1);
+      expect(result.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
+    }));
+
   test('_filter birthdate eq', () =>
     withTestContext(async () => {
       const patient = await repo.createResource<Patient>({


### PR DESCRIPTION
## Problem

`src/workers/subscription.test.ts > Server-scoped subscription fires across projects when enabled` fails intermittently in CI ([example run](https://github.com/medplum/medplum/actions/runs/30189316049)) with `Job not found: no subscription job for Patient/... matching Subscription/...`, and no error in the logs.

It is a real bug, not a test problem. `getSubscriptions()` searches with:

```
_filter = "_project eq <projectId> or _project pr false"
```

`Tokenizer.consumeNumber` treats "digits followed by `-`" as a date literal, so when a project UUID's first group is **all digits** (`67836554-6431-4baa-…`), the value token ends at the first letter — `67836554-6431-4` — and `parseFilterParameter` then silently discarded the leftover tokens, including the entire `or _project pr false` branch. `buildIdSearchFilter` sees a non-UUID and substitutes the nil UUID, so the query becomes:

```sql
WHERE deleted = false AND ("projectId" = '00000000-0000-0000-0000-000000000000' AND status = 'active')
```

Nothing matches, so **no** subscription fires — not the server-scoped one, and not the project-scoped one either. 8 hex digits being all-numeric is (10/16)^8 ≈ **2.3%** of projects, which matches the observed flake rate. Any `_filter` query with such a UUID value is affected, not just this code path.

Two further problems turned up while covering nested expressions:

- The fallback for unquoted values that start with digits consumed up to the next **space**, so a UUID at the end of a nested expression swallowed the closing parenthesis. `(_id eq 6783655a-6431-4baa-9243-914efcd984da)` failed to parse at all — this one predates the change above and affects every UUID, not just all-numeric ones, so `_filter` + parentheses + a UUID never worked.
- `parseFilterParameter` returned whatever it managed to parse and dropped the rest of the token stream. That is what turned the tokenizer bug into silently-wrong search results instead of an error.

## Fix

- Take the dateTime path only when the token actually looks like `YYYY-MM[-DD][time]`.
- End an unquoted digit-led value at the first character that cannot be part of a token, per the tokenizer's own `symbolRegex` (whitespace, `)` and `]` for `_filter`), rather than at the next space.
- Reject a `_filter` expression that is not fully consumed, so a future mis-tokenization cannot silently drop conditions.

`dateTimeLiterals` is enabled only by the `_filter` tokenizer, so the date-literal change is scoped to `_filter` parsing.

## Tests

- `packages/core/src/filter/parse.test.ts`
  - Flat cases: the UUID value stays whole, and date/dateTime literals still parse as before.
  - `describe.each` over both UUID shapes — all digits before the first hyphen and not, which take different paths through the tokenizer — crossed with `test.each` of nine nesting shapes: parentheses, `not (…)`, `or` connective, two parenthesized comparisons, nested connective on either side, `not ((…) or (…))`, `Patient/<uuid>` reference values, and a UUID alongside a dateTime literal. Each asserts the full parsed expression, so a dropped branch or a truncated value fails.
  - Expressions that cannot be fully parsed (trailing token, unclosed parenthesis, dangling connective) now throw.
- `packages/server/src/fhir/search.test.ts` — end-to-end, in both the plain and parenthesized forms: `_filter=_id eq 12345678-1234-4123-8123-123456789abc or _id eq <real id>` returns the real resource.

13 of the new assertions fail with the second commit reverted, and 3 fail with the first reverted.

## Verification

- A stress harness driving the exact failing path reproduced the flake in **~2.5%** of iterations before the fix and **0 of 800** after.
- Full core suite (2525 tests, including the FHIRPath and FHIR Mapping tokenizers that share this code), fhir-router, and the full server suite; eslint, prettier and tsc clean. The server suite has 109 pre-existing local failures from a DB-grant problem between parallel test files — identical counts with and without these changes, and none in `_filter`, search, or subscription tests.

## Follow-up (not in this PR)

`getSubscriptions` could skip `_filter` entirely (`_project` accepts comma-OR, and `_project pr false` is `projectId = systemResourceProjectId`), which would be simpler and faster than building and parsing a filter expression.