### PR TITLE
Add project details to security sessions tab

### DIFF
--- a/packages/app/src/SecurityPage.tsx
+++ b/packages/app/src/SecurityPage.tsx
@@ -4,7 +4,7 @@ import { Anchor, Button, Table, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import type { ProfileResource } from '@medplum/core';
 import { formatDateTime, formatHumanName, getReferenceString, normalizeErrorString } from '@medplum/core';
-import type { UserConfiguration } from '@medplum/fhirtypes';
+import type { Reference, UserConfiguration } from '@medplum/fhirtypes';
 import { DescriptionList, DescriptionListEntry, Document, useMedplum } from '@medplum/react';
 import type { JSX } from 'react';
 import { useEffect, useState } from 'react';
@@ -17,6 +17,7 @@ interface UserSession {
   readonly remoteAddress: string;
   readonly browser?: string;
   readonly os?: string;
+  readonly project?: Reference;
 }
 
 interface SecurityDetails {
@@ -70,6 +71,7 @@ export function SecurityPage(): JSX.Element | null {
         <Table>
           <thead>
             <tr>
+              <th>Project</th>
               <th>OS</th>
               <th>Browser</th>
               <th>IP Address</th>
@@ -81,6 +83,7 @@ export function SecurityPage(): JSX.Element | null {
           <tbody>
             {details.security.sessions.map((session) => (
               <tr key={session.id}>
+                <td>{session.project?.display ?? 'Unknown'}</td>
                 <td>{session.os}</td>
                 <td>{session.browser}</td>
                 <td>{session.remoteAddress}</td>

--- a/packages/server/src/auth/me.ts
+++ b/packages/server/src/auth/me.ts
@@ -26,6 +26,7 @@ interface UserSession {
   remoteAddress: string;
   browser?: string;
   os?: string;
+  project?: Reference;
 }
 
 interface UserSecurity {
@@ -202,6 +203,7 @@ async function getSessions(systemRepo: SystemRepository, user: WithId<User>): Pr
       remoteAddress: login.remoteAddress as string,
       browser: browser?.getBrowser()?.name,
       os: browser?.getOS()?.name,
+      project: login.project,
     });
   }
   return result;


### PR DESCRIPTION
## Summary

This change adds a 'Project' column to the security sessions table on the Security page (`/security`). Each session now displays the project name that the login belongs to, making it clearer which token is being revoked.

## Changes

### Backend (`packages/server/src/auth/me.ts`)
- Added `project?: Reference` field to `UserSession` interface
- Pass `login.project` Reference directly to the session (O(1) per session, no extra database calls)

### Frontend (`packages/app/src/SecurityPage.tsx`)
- Added `project?: Reference` to `UserSession` interface
- Added 'Project' column as the first column in the sessions table
- Display uses `session.project?.display ?? 'Unknown'`

## Performance Note

The implementation uses the existing `Login.project` field which already contains the project reference with display name, avoiding any additional database lookups. This keeps the `/auth/me` endpoint efficient.

## Fixes

Fixes #1349

@codyebberson can click here to [continue refining the PR](https://app.all-hands.dev/conversations/57a8a42e-76e1-4ecb-9c66-649a71e860bb)