### PR TITLE
fix(graphql): preserve OperationOutcome in GraphQL error extensions

### DIFF
--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -480,11 +480,13 @@ export function assertOk<T>(outcome: OperationOutcome, resource: T | undefined):
 
 export class OperationOutcomeError extends Error {
   readonly outcome: OperationOutcome;
+  readonly extensions: { outcome: OperationOutcome };
 
   constructor(outcome: OperationOutcome, options?: ErrorOptions) {
     super(operationOutcomeToString(outcome), options);
     this.name = 'OperationOutcomeError';
     this.outcome = outcome;
+    this.extensions = { outcome };
   }
 }
 

--- a/packages/fhir-router/src/graphql/graphql.test.ts
+++ b/packages/fhir-router/src/graphql/graphql.test.ts
@@ -1457,4 +1457,48 @@ describe('GraphQL', () => {
       /Expected value of type "PatchOperationInput" to be an object, found: "not-an-array"/
     );
   });
+  test('Mutation error preserves OperationOutcome in extensions', async () => {
+    const request = makeSimpleRequest('POST', '/fhir/R4/$graphql', {
+      query: `mutation {
+        ConditionCreate(
+          res: {
+            resourceType: "Condition"
+            subject: { reference: "Patient/${patient.id}" }
+            clinicalStatus: {
+              coding: [
+                {
+                  system: "http://terminology.hl7.org/CodeSystem/condition-clinical"
+                  code: "active"
+                  display: "Wrong Display Text"
+                }
+              ]
+            }
+          }
+        ) {
+          id
+        }
+      }`,
+    });
+
+    const fhirRouter = new FhirRouter();
+    const res = await graphqlHandler(request, repo, fhirRouter);
+
+    const errors = (res[1] as any).errors;
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
+
+    const error = errors[0];
+
+    // Backward-compatible: message string still there
+    expect(error.message).toContain('clinicalStatus');
+
+    // New: structured outcome preserved via extensions
+    expect(error.extensions).toBeDefined();
+    expect(error.extensions.outcome).toBeDefined();
+    expect(error.extensions.outcome.resourceType).toBe('OperationOutcome');
+
+    const issue = error.extensions.outcome.issue[0];
+    expect(issue.severity).toBe('error');
+    expect(issue.expression).toContain('Condition.clinicalStatus');
+  });
 });


### PR DESCRIPTION
## Summary

Preserve the structured `OperationOutcome` in GraphQL error responses by exposing it through `OperationOutcomeError.extensions`.

This keeps the existing `message` unchanged while allowing GraphQL clients to access the full `OperationOutcome` via `errors[].extensions.outcome`.

## Changes

- Added `extensions` to `OperationOutcomeError`.
- Preserved the `OperationOutcome` in GraphQL error responses.
- Added a GraphQL test to verify `extensions.outcome` is present.

Fixes #9981