### PR TITLE
feat(server): CoverageEligibilityRequest submit operation

### DIFF
--- a/packages/server/src/fhir/operations/claimsubmit.ts
+++ b/packages/server/src/fhir/operations/claimsubmit.ts
@@ -4,9 +4,9 @@ import { badRequest, isResource } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import type { Bundle, Claim } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
-import { tryCustomOperation } from './custom';
 import { getOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
+import { dispatchSubmitOperation } from './utils/submit';
 
 const CLAIM_SUBMIT_OPERATION_SETTING = 'CLAIM_SUBMIT_OPERATION';
 const PRIOR_AUTH_SUBMIT_OPERATION_SETTING = 'PRIOR_AUTH_SUBMIT_OPERATION';
@@ -21,17 +21,13 @@ interface ClaimSubmitParameters {
  * Common function to handle claim submit operations.
  *
  * Dispatches to the custom OperationDefinition named by the relevant project setting,
- * passing the Claim or Bundle resource as the request body. The core server stays
- * vendor-neutral: any claim processor registers a custom OperationDefinition whose
- * implementation is a Bot, and $submit forwards to it via tryCustomOperation.
+ * passing the Claim or Bundle resource as the request body.
  *
  * @param req - The FHIR request.
  * @param resource - The FHIR Claim or Bundle resource to submit.
  * @returns The FHIR response from the underlying custom operation.
  */
 async function handleClaimSubmit(req: FhirRequest, resource: Bundle | Claim): Promise<FhirResponse> {
-  const { project, repo } = getAuthenticatedContext();
-
   let claim: Claim | undefined = undefined;
   if (isResource<Claim>(resource, 'Claim')) {
     claim = resource;
@@ -46,28 +42,7 @@ async function handleClaimSubmit(req: FhirRequest, resource: Bundle | Claim): Pr
   const operationSetting =
     claim.use === 'preauthorization' ? PRIOR_AUTH_SUBMIT_OPERATION_SETTING : CLAIM_SUBMIT_OPERATION_SETTING;
 
-  const customOperationCode = project.setting?.find((s) => s.name === operationSetting)?.valueString;
-  if (!customOperationCode) {
-    return [badRequest(`Claim submit is not configured: set the ${operationSetting} project setting.`)];
-  }
-
-  // Normalize to a type-level POST so tryCustomOperation forwards the Claim or Bundle as the body,
-  // regardless of whether the original request was instance-level or type-level.
-  const subRequest: FhirRequest = {
-    ...req,
-    method: 'POST',
-    url: `/Claim/$${customOperationCode}`,
-    body: resource,
-  };
-  const result = await tryCustomOperation(subRequest, repo);
-  if (!result) {
-    return [
-      badRequest(
-        'Claim submit operation is not available. No claim processor is configured to handle claim submission.'
-      ),
-    ];
-  }
-  return result;
+  return dispatchSubmitOperation(req, resource, 'Claim', operationSetting);
 }
 
 /**

--- a/packages/server/src/fhir/operations/coverageeligibilityrequestsubmit.test.ts
+++ b/packages/server/src/fhir/operations/coverageeligibilityrequestsubmit.test.ts
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import { ContentType, createReference } from '@medplum/core';
+import type { Bot, Bundle, CoverageEligibilityRequest, Project } from '@medplum/fhirtypes';
+import express from 'express';
+import request from 'supertest';
+import { initApp, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config/loader';
+import { createTestProject, initTestAuth, withTestContext } from '../../test.setup';
+import type { Repository } from '../repo';
+
+const app = express();
+const SUB_OPERATION_CODE = 'test-submit-eligibility';
+
+const minimalEligibilityRequest: CoverageEligibilityRequest = {
+  resourceType: 'CoverageEligibilityRequest',
+  status: 'active',
+  purpose: ['benefits'],
+  patient: { reference: 'Patient/example' },
+  created: '2026-01-01T00:00:00.000Z',
+  insurer: { reference: 'Organization/example' },
+  insurance: [
+    {
+      focal: true,
+      coverage: { reference: 'Coverage/example' },
+    },
+  ],
+};
+
+// Bot handler that echoes the submitted CoverageEligibilityRequest back as a minimal CoverageEligibilityResponse.
+function getEligibilityResponseBotCode(insurerDisplay: string): string {
+  return `
+  exports.handler = async function (medplum, event) {
+    const eligibilityRequest = event.input;
+    return {
+      resourceType: 'CoverageEligibilityResponse',
+      status: 'active',
+      purpose: eligibilityRequest.purpose,
+      patient: eligibilityRequest.patient,
+      created: '2026-01-01T00:00:00.000Z',
+      request: { reference: 'CoverageEligibilityRequest/example' },
+      insurer: { display: '${insurerDisplay}' },
+      outcome: 'complete',
+    };
+  };
+`;
+}
+
+// Sets the eligibility submit project setting to the given operation code.
+async function setEligibilitySubmitOperation(
+  repo: Repository,
+  project: WithId<Project>,
+  code: string,
+  name = 'ELIGIBILITY_SUBMIT_OPERATION'
+): Promise<void> {
+  const systemRepo = repo.getSystemRepo();
+  await withTestContext(async () => {
+    const latest = await systemRepo.readResource<Project>('Project', project.id);
+    await systemRepo.updateResource({
+      ...latest,
+      setting: [...(latest.setting?.filter((s) => s.name !== name) ?? []), { name, valueString: code }],
+    });
+  });
+}
+
+// Creates a custom eligibility-submit OperationDefinition backed by a deployed Bot.
+async function deployEligibilityOperation(
+  accessToken: string,
+  code = SUB_OPERATION_CODE,
+  insurerDisplay = 'Test Payer'
+): Promise<void> {
+  const res1 = await request(app)
+    .post('/fhir/R4/Bot')
+    .set('Content-Type', ContentType.FHIR_JSON)
+    .set('Authorization', 'Bearer ' + accessToken)
+    .send({ resourceType: 'Bot', name: 'Eligibility Submit Bot', runtimeVersion: 'vmcontext' });
+  expect(res1).toHaveStatus(201);
+  const bot = res1.body as WithId<Bot>;
+
+  const res2 = await request(app)
+    .post(`/fhir/R4/Bot/${bot.id}/$deploy`)
+    .set('Content-Type', ContentType.FHIR_JSON)
+    .set('Authorization', 'Bearer ' + accessToken)
+    .send({ code: getEligibilityResponseBotCode(insurerDisplay) });
+  expect(res2).toHaveStatus(200);
+
+  const res3 = await request(app)
+    .post('/fhir/R4/OperationDefinition')
+    .set('Content-Type', ContentType.FHIR_JSON)
+    .set('Authorization', 'Bearer ' + accessToken)
+    .send({
+      resourceType: 'OperationDefinition',
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/operationDefinition-implementation',
+          valueReference: createReference(bot),
+        },
+      ],
+      name: code,
+      status: 'active',
+      kind: 'operation',
+      code,
+      system: false,
+      type: true,
+      instance: false,
+      resource: ['CoverageEligibilityRequest'],
+      parameter: [{ use: 'out', name: 'return', type: 'CoverageEligibilityResponse', min: 1, max: '1' }],
+    });
+  expect(res3).toHaveStatus(201);
+}
+
+function bodyWith(resource?: Bundle | CoverageEligibilityRequest): object {
+  const parameter: { name: string; resource?: Bundle | CoverageEligibilityRequest }[] = [];
+  if (resource !== undefined) {
+    parameter.push({ name: 'resource', resource });
+  }
+  return { resourceType: 'Parameters', parameter };
+}
+
+describe('CoverageEligibilityRequest $submit', () => {
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    config.vmContextBotsEnabled = true;
+    await initApp(app, config);
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test('Returns 400 when ELIGIBILITY_SUBMIT_OPERATION is not configured', async () => {
+    const accessToken = await initTestAuth();
+    const res = await request(app)
+      .post('/fhir/R4/CoverageEligibilityRequest/$submit')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send(bodyWith(minimalEligibilityRequest));
+    expect(res).toHaveStatus(400);
+    expect(JSON.stringify(res.body)).toMatch(/ELIGIBILITY_SUBMIT_OPERATION/);
+  });
+
+  test('Returns 400 when the configured operation has no matching OperationDefinition', async () => {
+    const { project, accessToken, repo } = await createTestProject({ withAccessToken: true, withRepo: true });
+    await setEligibilitySubmitOperation(repo, project, 'no-such-operation');
+
+    const res = await request(app)
+      .post('/fhir/R4/CoverageEligibilityRequest/$submit')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send(bodyWith(minimalEligibilityRequest));
+    expect(res).toHaveStatus(400);
+    expect(JSON.stringify(res.body)).toMatch(/not available/i);
+  });
+
+  test('Dispatches to the operation named by the ELIGIBILITY_SUBMIT_OPERATION project setting', async () => {
+    const { project, accessToken, repo } = await createTestProject({ withAccessToken: true, withRepo: true });
+    await deployEligibilityOperation(accessToken);
+    await setEligibilitySubmitOperation(repo, project, SUB_OPERATION_CODE);
+
+    const res = await request(app)
+      .post('/fhir/R4/CoverageEligibilityRequest/$submit')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send(bodyWith(minimalEligibilityRequest));
+    expect(res).toHaveStatus(200);
+    // A single 'return' output of a resource type is sent as the bare resource, not wrapped in Parameters.
+    expect(res.body.resourceType).toBe('CoverageEligibilityResponse');
+    expect(res.body.outcome).toBe('complete');
+  });
+
+  test('Dispatches a raw CoverageEligibilityRequest body to the configured operation', async () => {
+    const { project, accessToken, repo } = await createTestProject({ withAccessToken: true, withRepo: true });
+    await deployEligibilityOperation(accessToken);
+    await setEligibilitySubmitOperation(repo, project, SUB_OPERATION_CODE);
+
+    const res = await request(app)
+      .post('/fhir/R4/CoverageEligibilityRequest/$submit')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send(minimalEligibilityRequest);
+    expect(res).toHaveStatus(200);
+    expect(res.body.resourceType).toBe('CoverageEligibilityResponse');
+    expect(res.body.outcome).toBe('complete');
+  });
+
+  test('Dispatches Bundles containing a CoverageEligibilityRequest to the configured operation', async () => {
+    const { project, accessToken, repo } = await createTestProject({ withAccessToken: true, withRepo: true });
+    await deployEligibilityOperation(accessToken);
+    await setEligibilitySubmitOperation(repo, project, SUB_OPERATION_CODE);
+
+    const bundle: Bundle = {
+      resourceType: 'Bundle',
+      type: 'collection',
+      entry: [{ resource: minimalEligibilityRequest }, { resource: { resourceType: 'Patient', id: 'example' } }],
+    };
+
+    const res = await request(app)
+      .post('/fhir/R4/CoverageEligibilityRequest/$submit')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send(bundle);
+    expect(res).toHaveStatus(200);
+    expect(res.body.resourceType).toBe('CoverageEligibilityResponse');
+    expect(res.body.outcome).toBe('complete');
+  });
+
+  test('Returns 400 when a Bundle does not contain a CoverageEligibilityRequest', async () => {
+    const { project, accessToken, repo } = await createTestProject({ withAccessToken: true, withRepo: true });
+    await deployEligibilityOperation(accessToken);
+    await setEligibilitySubmitOperation(repo, project, SUB_OPERATION_CODE);
+
+    const res = await request(app)
+      .post('/fhir/R4/CoverageEligibilityRequest/$submit')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send(
+        bodyWith({
+          resourceType: 'Bundle',
+          type: 'collection',
+          entry: [{ resource: { resourceType: 'Patient', id: 'example' } }],
+        })
+      );
+    expect(res).toHaveStatus(400);
+    expect(JSON.stringify(res.body)).toMatch(
+      /Eligibility submit must contain at least one CoverageEligibilityRequest resource/i
+    );
+  });
+
+  test('Reads the CoverageEligibilityRequest from the URL on the instance route', async () => {
+    const { project, accessToken, repo } = await createTestProject({ withAccessToken: true, withRepo: true });
+    await deployEligibilityOperation(accessToken);
+    await setEligibilitySubmitOperation(repo, project, SUB_OPERATION_CODE);
+
+    const createRes = await request(app)
+      .post('/fhir/R4/CoverageEligibilityRequest')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send(minimalEligibilityRequest);
+    expect(createRes).toHaveStatus(201);
+    const eligibilityRequestId = createRes.body.id;
+
+    const res = await request(app)
+      .post(`/fhir/R4/CoverageEligibilityRequest/${eligibilityRequestId}/$submit`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Accept', 'application/fhir+json');
+    expect(res).toHaveStatus(200);
+    expect(res.body.resourceType).toBe('CoverageEligibilityResponse');
+    // Confirms the CoverageEligibilityRequest read from the URL was forwarded to the bot as the body.
+    expect(res.body.patient?.reference).toBe('Patient/example');
+  });
+
+  test('Returns 400 when no CoverageEligibilityRequest payload is provided', async () => {
+    const { project, accessToken, repo } = await createTestProject({ withAccessToken: true, withRepo: true });
+    await deployEligibilityOperation(accessToken);
+    await setEligibilitySubmitOperation(repo, project, SUB_OPERATION_CODE);
+
+    const res = await request(app)
+      .post('/fhir/R4/CoverageEligibilityRequest/$submit')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send(bodyWith());
+    expect(res).toHaveStatus(400);
+    expect(res.body.resourceType).toBe('OperationOutcome');
+    expect(res.body.issue[0].severity).toBe('error');
+  });
+});

--- a/packages/server/src/fhir/operations/coverageeligibilityrequestsubmit.ts
+++ b/packages/server/src/fhir/operations/coverageeligibilityrequestsubmit.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { badRequest, isResource } from '@medplum/core';
+import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
+import type { Bundle, CoverageEligibilityRequest } from '@medplum/fhirtypes';
+import { getAuthenticatedContext } from '../../context';
+import { getOperationDefinition } from './definitions';
+import { parseInputParameters } from './utils/parameters';
+import { dispatchSubmitOperation } from './utils/submit';
+
+const ELIGIBILITY_SUBMIT_OPERATION_SETTING = 'ELIGIBILITY_SUBMIT_OPERATION';
+
+export const operation = getOperationDefinition('CoverageEligibilityRequest', 'submit');
+
+interface CoverageEligibilitySubmitParameters {
+  readonly resource: Bundle | CoverageEligibilityRequest;
+}
+
+/**
+ * Common function to handle coverage eligibility submit operations.
+ *
+ * Dispatches to the custom OperationDefinition named by the ELIGIBILITY_SUBMIT_OPERATION
+ * project setting, passing the CoverageEligibilityRequest or Bundle resource as the request body.
+ *
+ * @param req - The FHIR request.
+ * @param resource - The FHIR CoverageEligibilityRequest or Bundle resource to submit.
+ * @returns The FHIR response from the underlying custom operation.
+ */
+async function handleCoverageEligibilitySubmit(
+  req: FhirRequest,
+  resource: Bundle | CoverageEligibilityRequest
+): Promise<FhirResponse> {
+  let eligibilityRequest: CoverageEligibilityRequest | undefined = undefined;
+  if (isResource<CoverageEligibilityRequest>(resource, 'CoverageEligibilityRequest')) {
+    eligibilityRequest = resource;
+  } else if (isResource<Bundle>(resource, 'Bundle')) {
+    eligibilityRequest = resource.entry?.find((e) => isResource(e.resource, 'CoverageEligibilityRequest'))
+      ?.resource as CoverageEligibilityRequest | undefined;
+  }
+
+  if (!eligibilityRequest) {
+    return [badRequest('Eligibility submit must contain at least one CoverageEligibilityRequest resource.')];
+  }
+
+  return dispatchSubmitOperation(req, resource, 'CoverageEligibilityRequest', ELIGIBILITY_SUBMIT_OPERATION_SETTING);
+}
+
+/**
+ * Handles HTTP POST requests for the instance-level CoverageEligibilityRequest $submit operation.
+ *
+ * Reads the coverage eligibility request from the database and dispatches it to the configured processor.
+ *
+ * Endpoint:
+ *   [fhir base]/CoverageEligibilityRequest/{id}/$submit
+ *
+ * @param req - The FHIR request.
+ * @returns The FHIR response from the underlying custom operation.
+ */
+export async function coverageEligibilitySubmitPostByIdHandler(req: FhirRequest): Promise<FhirResponse> {
+  const { repo } = getAuthenticatedContext();
+  const eligibilityRequestId = req.params.id;
+
+  if (!eligibilityRequestId) {
+    return [badRequest('CoverageEligibilityRequest ID is required')];
+  }
+
+  const eligibilityRequest = await repo.readResource<CoverageEligibilityRequest>(
+    'CoverageEligibilityRequest',
+    eligibilityRequestId
+  );
+  return handleCoverageEligibilitySubmit(req, eligibilityRequest);
+}
+
+/**
+ * Handles HTTP POST requests for the type-level CoverageEligibilityRequest $submit operation.
+ *
+ * Dispatches the CoverageEligibilityRequest passed via the 'resource' input parameter to the
+ * configured processor.
+ *
+ * Endpoint:
+ *   [fhir base]/CoverageEligibilityRequest/$submit
+ *
+ * @param req - The FHIR request.
+ * @returns The FHIR response from the underlying custom operation.
+ */
+export async function coverageEligibilitySubmitPostHandler(req: FhirRequest): Promise<FhirResponse> {
+  const params = parseInputParameters<CoverageEligibilitySubmitParameters>(operation, req);
+  const eligibilityRequest = params.resource;
+  return handleCoverageEligibilitySubmit(req, eligibilityRequest);
+}

--- a/packages/server/src/fhir/operations/coverageeligibilityrequestsubmit.ts
+++ b/packages/server/src/fhir/operations/coverageeligibilityrequestsubmit.ts
@@ -34,8 +34,8 @@ async function handleCoverageEligibilitySubmit(
   if (isResource<CoverageEligibilityRequest>(resource, 'CoverageEligibilityRequest')) {
     eligibilityRequest = resource;
   } else if (isResource<Bundle>(resource, 'Bundle')) {
-    eligibilityRequest = resource.entry?.find((e) => isResource(e.resource, 'CoverageEligibilityRequest'))
-      ?.resource as CoverageEligibilityRequest | undefined;
+    eligibilityRequest = resource.entry?.find((e) => isResource(e.resource, 'CoverageEligibilityRequest'))?.resource as
+      CoverageEligibilityRequest | undefined;
   }
 
   if (!eligibilityRequest) {

--- a/packages/server/src/fhir/operations/utils/submit.ts
+++ b/packages/server/src/fhir/operations/utils/submit.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { badRequest } from '@medplum/core';
+import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
+import type { Resource, ResourceType } from '@medplum/fhirtypes';
+import { getAuthenticatedContext } from '../../../context';
+import { tryCustomOperation } from '../custom';
+
+/**
+ * Dispatches a submit-style operation to the custom OperationDefinition named by a project setting,
+ * passing the given resource as the request body. The core server stays vendor-neutral: any
+ * processor registers a custom OperationDefinition whose implementation is a Bot, and $submit
+ * forwards to it via tryCustomOperation.
+ *
+ * @param req - The FHIR request.
+ * @param resource - The FHIR resource (or Bundle) to forward as the sub-request body.
+ * @param resourceType - The resource type used in the sub-request URL.
+ * @param settingName - The project setting holding the custom operation code.
+ * @returns The FHIR response from the underlying custom operation.
+ */
+export async function dispatchSubmitOperation(
+  req: FhirRequest,
+  resource: Resource,
+  resourceType: ResourceType,
+  settingName: string
+): Promise<FhirResponse> {
+  const { project, repo } = getAuthenticatedContext();
+
+  const customOperationCode = project.setting?.find((s) => s.name === settingName)?.valueString;
+  if (!customOperationCode) {
+    return [badRequest(`${resourceType} submit is not configured: set the ${settingName} project setting.`)];
+  }
+
+  // Normalize to a type-level POST so tryCustomOperation forwards the resource as the body,
+  // regardless of whether the original request was instance-level or type-level.
+  const subRequest: FhirRequest = {
+    ...req,
+    method: 'POST',
+    url: `/${resourceType}/$${customOperationCode}`,
+    body: resource,
+  };
+  const result = await tryCustomOperation(subRequest, repo);
+  if (!result) {
+    return [
+      badRequest(
+        `${resourceType} submit operation is not available. No processor is configured to handle the submission.`
+      ),
+    ];
+  }
+  return result;
+}

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -38,6 +38,10 @@ import { codeSystemValidateCodeHandler } from './operations/codesystemvalidateco
 import { conceptMapImportHandler } from './operations/conceptmapimport';
 import { conceptMapTranslateHandler } from './operations/conceptmaptranslate';
 import { appointmentConfirmHandler } from './operations/confirm';
+import {
+  coverageEligibilitySubmitPostByIdHandler,
+  coverageEligibilitySubmitPostHandler,
+} from './operations/coverageeligibilityrequestsubmit';
 import { csvHandler } from './operations/csv';
 import { tryCustomOperation } from './operations/custom';
 import { getColumnStatisticsHandler } from './operations/db-column-statistics';
@@ -336,6 +340,10 @@ function initInternalFhirRouter(): FhirRouter {
   // Claim $submit operation (dispatches to the configured claim or prior auth custom operation).
   router.add('POST', '/Claim/$submit', claimSubmitPostHandler);
   router.add('POST', '/Claim/:id/$submit', claimSubmitPostByIdHandler);
+
+  // CoverageEligibilityRequest $submit operation (dispatches to the configured eligibility custom operation).
+  router.add('POST', '/CoverageEligibilityRequest/$submit', coverageEligibilitySubmitPostHandler);
+  router.add('POST', '/CoverageEligibilityRequest/:id/$submit', coverageEligibilitySubmitPostByIdHandler);
 
   // Group $export operation
   router.add('GET', '/Group/:id/$export', groupExportHandler);


### PR DESCRIPTION
Adds CoverageEligibilityRequest/$submit
This operation is agnostic to which service it is being used to check eligibility (Stedi or Candid). 
Relies on ELIGIBILITY_SUBMIT_OPERATION_SETTING to know what custom operation to execute.