### PR TITLE
Share _include / _revinclude between the SQL and in-memory repositories

### DIFF
--- a/packages/fhir-router/src/index.ts
+++ b/packages/fhir-router/src/index.ts
@@ -4,4 +4,5 @@ export { BatchProcessor, buildBatchResponseBundle, processBatch } from './batch'
 export type { BatchEvent, BatchInitialState, BundlePreprocessInfo, LogEvent } from './batch';
 export * from './fhirrouter';
 export * from './repo';
+export * from './search-include';
 export * from './urlrouter';

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -21,7 +21,16 @@ import {
   preconditionFailed,
   stringify,
 } from '@medplum/core';
-import type { Bundle, OperationOutcome, Parameters, Reference, Resource, ResourceType } from '@medplum/fhirtypes';
+import type {
+  Bundle,
+  BundleEntry,
+  OperationOutcome,
+  Parameters,
+  Reference,
+  Resource,
+  ResourceType,
+} from '@medplum/fhirtypes';
+import { getExtraEntries } from './search-include';
 
 export type CreateResourceOptions = {
   assignedId?: boolean;
@@ -586,7 +595,15 @@ export class MemoryRepository extends FhirRepository {
   async readReferences<T extends Resource>(
     references: readonly Reference<T>[]
   ): Promise<(T | OperationOutcomeError)[]> {
-    return Promise.all(references.map((r) => this.readReference<T>(r)));
+    // Unresolvable references are returned as errors rather than rejecting the whole batch,
+    // matching the `(T | Error)[]` contract on FhirRepository.
+    return Promise.all(
+      references.map(async (r) =>
+        this.readReference<T>(r).catch((err) =>
+          err instanceof OperationOutcomeError ? err : new OperationOutcomeError(normalizeOperationOutcome(err))
+        )
+      )
+    );
   }
 
   async readHistory<T extends Resource>(resourceType: string, id: string): Promise<Bundle<T>> {
@@ -622,7 +639,10 @@ export class MemoryRepository extends FhirRepository {
         result.push(resource);
       }
     }
-    let entry = result.map((resource) => ({ resource: deepClone(resource) }));
+    let entry = result.map((resource): BundleEntry<WithId<T>> => ({
+      search: { mode: 'match' },
+      resource: deepClone(resource),
+    }));
     for (const sortRule of searchRequest.sortRules ?? EMPTY) {
       entry = entry.sort((a, b) => sortComparator(a.resource as T, b.resource as T, sortRule));
     }
@@ -641,7 +661,15 @@ export class MemoryRepository extends FhirRepository {
   }
 
   async search<T extends Resource>(searchRequest: SearchRequest<T>): Promise<Bundle<WithId<T>>> {
-    return this.searchSync(searchRequest);
+    const bundle = this.searchSync(searchRequest);
+    if ((searchRequest.include || searchRequest.revInclude) && bundle.entry?.length) {
+      // `total` intentionally continues to reflect only the matched resources.
+      const entries = bundle.entry as BundleEntry[];
+      const resources = entries.map((e) => e.resource as WithId<T>);
+      await getExtraEntries(this, searchRequest, resources, entries);
+      bundle.entry = entries as BundleEntry<WithId<T>>[];
+    }
+    return bundle;
   }
 
   async conditionalCreate<T extends Resource>(

--- a/packages/fhir-router/src/search-include.test.ts
+++ b/packages/fhir-router/src/search-include.test.ts
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import {
+  createReference,
+  getReferenceString,
+  indexSearchParameterBundle,
+  indexStructureDefinitionBundle,
+  OperationOutcomeError,
+  parseSearchRequest,
+} from '@medplum/core';
+import { readJson } from '@medplum/definitions';
+import type {
+  Bundle,
+  BundleEntry,
+  Encounter,
+  Observation,
+  Patient,
+  Questionnaire,
+  QuestionnaireResponse,
+  SearchParameter,
+  ServiceRequest,
+} from '@medplum/fhirtypes';
+import { MemoryRepository } from './repo';
+
+const repo = new MemoryRepository();
+
+function refs(bundle: Bundle, mode: 'match' | 'include'): string[] {
+  return (bundle.entry ?? [])
+    .filter((e: BundleEntry) => e.search?.mode === mode)
+    .map((e: BundleEntry) => getReferenceString(e.resource as any))
+    .sort();
+}
+
+describe('MemoryRepository _include/_revinclude', () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+    indexSearchParameterBundle(readJson('fhir/r4/search-parameters.json') as Bundle<SearchParameter>);
+  });
+
+  beforeEach(() => {
+    repo.clear();
+  });
+
+  test('Search entries are tagged with mode "match"', async () => {
+    await repo.createResource<Patient>({ resourceType: 'Patient' });
+    const bundle = await repo.search(parseSearchRequest('Patient'));
+    expect(bundle.entry).toHaveLength(1);
+    expect(bundle.entry?.[0].search).toStrictEqual({ mode: 'match' });
+  });
+
+  test('_include resolves a literal reference', async () => {
+    const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+    const observation = await repo.createResource<Observation>({
+      resourceType: 'Observation',
+      status: 'final',
+      code: { text: 'test' },
+      subject: createReference(patient),
+    });
+
+    const bundle = await repo.search(parseSearchRequest('Observation?_include=Observation:subject'));
+    expect(refs(bundle, 'match')).toStrictEqual([getReferenceString(observation)]);
+    expect(refs(bundle, 'include')).toStrictEqual([getReferenceString(patient)]);
+    // Included resources do not count toward `total`
+    expect(bundle.total).toBe(1);
+  });
+
+  test('_include does not throw on a dangling reference', async () => {
+    await repo.createResource<Observation>({
+      resourceType: 'Observation',
+      status: 'final',
+      code: { text: 'test' },
+      subject: { reference: 'Patient/00000000-0000-4000-8000-000000000000' },
+    });
+
+    const bundle = await repo.search(parseSearchRequest('Observation?_include=Observation:subject'));
+    expect(refs(bundle, 'match')).toHaveLength(1);
+    expect(refs(bundle, 'include')).toStrictEqual([]);
+  });
+
+  test('_include with a target type filters by that type', async () => {
+    const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+    const encounter = await repo.createResource<Encounter>({
+      resourceType: 'Encounter',
+      status: 'finished',
+      class: { code: 'AMB' },
+      subject: createReference(patient),
+    });
+    await repo.createResource<Observation>({
+      resourceType: 'Observation',
+      status: 'final',
+      code: { text: 'test' },
+      subject: createReference(patient),
+      encounter: createReference(encounter),
+    });
+
+    const included = await repo.search(parseSearchRequest('Observation?_include=Observation:subject:Patient'));
+    expect(refs(included, 'include')).toStrictEqual([getReferenceString(patient)]);
+
+    const excluded = await repo.search(parseSearchRequest('Observation?_include=Observation:subject:Group'));
+    expect(refs(excluded, 'include')).toStrictEqual([]);
+  });
+
+  test('_include deduplicates resources referenced more than once', async () => {
+    const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+    for (let i = 0; i < 3; i++) {
+      await repo.createResource<Observation>({
+        resourceType: 'Observation',
+        status: 'final',
+        code: { text: 'test' },
+        subject: createReference(patient),
+      });
+    }
+
+    const bundle = await repo.search(parseSearchRequest('Observation?_include=Observation:subject'));
+    expect(refs(bundle, 'match')).toHaveLength(3);
+    expect(refs(bundle, 'include')).toStrictEqual([getReferenceString(patient)]);
+  });
+
+  test('_include does not re-include a resource already in the match set', async () => {
+    const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+    await repo.createResource<ServiceRequest>({
+      resourceType: 'ServiceRequest',
+      status: 'active',
+      intent: 'order',
+      subject: createReference(patient),
+    });
+
+    const bundle = await repo.search(parseSearchRequest('Patient?_revinclude=ServiceRequest:subject'));
+    expect(refs(bundle, 'match')).toStrictEqual([getReferenceString(patient)]);
+    expect(refs(bundle, 'include')).toHaveLength(1);
+    // The patient appears exactly once, as a match
+    expect(bundle.entry).toHaveLength(2);
+  });
+
+  test('_revinclude resolves reverse references', async () => {
+    const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+    const observation = await repo.createResource<Observation>({
+      resourceType: 'Observation',
+      status: 'final',
+      code: { text: 'test' },
+      subject: createReference(patient),
+    });
+    // Unrelated observation that must not be pulled in
+    await repo.createResource<Observation>({
+      resourceType: 'Observation',
+      status: 'final',
+      code: { text: 'other' },
+      subject: { reference: 'Patient/00000000-0000-4000-8000-000000000000' },
+    });
+
+    const bundle = await repo.search(parseSearchRequest('Patient?_revinclude=Observation:subject'));
+    expect(refs(bundle, 'match')).toStrictEqual([getReferenceString(patient)]);
+    expect(refs(bundle, 'include')).toStrictEqual([getReferenceString(observation)]);
+  });
+
+  test('_revinclude with a target type filters the base resources', async () => {
+    const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+    await repo.createResource<Observation>({
+      resourceType: 'Observation',
+      status: 'final',
+      code: { text: 'test' },
+      subject: createReference(patient),
+    });
+
+    const bundle = await repo.search(parseSearchRequest('Patient?_revinclude=Observation:subject:Group'));
+    expect(refs(bundle, 'include')).toStrictEqual([]);
+  });
+
+  test('_include:iterate follows a chain of references', async () => {
+    const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+    const encounter = await repo.createResource<Encounter>({
+      resourceType: 'Encounter',
+      status: 'finished',
+      class: { code: 'AMB' },
+      subject: createReference(patient),
+    });
+    await repo.createResource<Observation>({
+      resourceType: 'Observation',
+      status: 'final',
+      code: { text: 'test' },
+      encounter: createReference(encounter),
+    });
+
+    const bundle = await repo.search(
+      parseSearchRequest('Observation?_include=Observation:encounter&_include:iterate=Encounter:subject')
+    );
+    expect(refs(bundle, 'include')).toStrictEqual([getReferenceString(encounter), getReferenceString(patient)].sort());
+  });
+
+  test('_include without :iterate does not recurse', async () => {
+    const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+    const encounter = await repo.createResource<Encounter>({
+      resourceType: 'Encounter',
+      status: 'finished',
+      class: { code: 'AMB' },
+      subject: createReference(patient),
+    });
+    await repo.createResource<Observation>({
+      resourceType: 'Observation',
+      status: 'final',
+      code: { text: 'test' },
+      encounter: createReference(encounter),
+    });
+
+    const bundle = await repo.search(
+      parseSearchRequest('Observation?_include=Observation:encounter&_include=Encounter:subject')
+    );
+    expect(refs(bundle, 'include')).toStrictEqual([getReferenceString(encounter)]);
+  });
+
+  test('_include resolves canonical references by exact URL', async () => {
+    const questionnaire = await repo.createResource<Questionnaire>({
+      resourceType: 'Questionnaire',
+      status: 'active',
+      url: 'http://example.com/q',
+    });
+    // Shares a URL prefix with the target; must not be included
+    await repo.createResource<Questionnaire>({
+      resourceType: 'Questionnaire',
+      status: 'active',
+      url: 'http://example.com/q-extra',
+    });
+    await repo.createResource<QuestionnaireResponse>({
+      resourceType: 'QuestionnaireResponse',
+      status: 'completed',
+      questionnaire: 'http://example.com/q',
+    });
+
+    const bundle = await repo.search(
+      parseSearchRequest('QuestionnaireResponse?_include=QuestionnaireResponse:questionnaire')
+    );
+    expect(refs(bundle, 'include')).toStrictEqual([getReferenceString(questionnaire)]);
+  });
+
+  test('_revinclude resolves canonical references', async () => {
+    const questionnaire = await repo.createResource<Questionnaire>({
+      resourceType: 'Questionnaire',
+      status: 'active',
+      url: 'http://example.com/q',
+    });
+    const response = await repo.createResource<QuestionnaireResponse>({
+      resourceType: 'QuestionnaireResponse',
+      status: 'completed',
+      questionnaire: 'http://example.com/q',
+    });
+
+    const bundle = await repo.search(
+      parseSearchRequest('Questionnaire?_revinclude=QuestionnaireResponse:questionnaire')
+    );
+    expect(refs(bundle, 'match')).toStrictEqual([getReferenceString(questionnaire)]);
+    expect(refs(bundle, 'include')).toStrictEqual([getReferenceString(response)]);
+  });
+
+  test('Invalid include parameter throws badRequest', async () => {
+    await repo.createResource<Patient>({ resourceType: 'Patient' });
+    await expect(repo.search(parseSearchRequest('Patient?_include=Patient:bogus'))).rejects.toThrow(
+      OperationOutcomeError
+    );
+  });
+
+  test('Empty match set skips include processing', async () => {
+    const bundle = await repo.search(parseSearchRequest('Observation?_include=Observation:subject'));
+    expect(bundle.entry).toBeUndefined();
+    expect(bundle.total).toBe(0);
+  });
+});

--- a/packages/fhir-router/src/search-include.ts
+++ b/packages/fhir-router/src/search-include.ts
@@ -1,0 +1,269 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { IncludeTarget, SearchRequest, WithId } from '@medplum/core';
+import {
+  DEFAULT_MAX_SEARCH_COUNT,
+  OperationOutcomeError,
+  Operator,
+  PropertyType,
+  SearchParameterType,
+  badRequest,
+  evalFhirPathTyped,
+  flatMapFilter,
+  getReferenceString,
+  getSearchParameter,
+  getSearchParameterDetails,
+  isResource,
+  toTypedValue,
+} from '@medplum/core';
+import type { BundleEntry, Reference, Resource, ResourceType } from '@medplum/fhirtypes';
+import type { FhirRepository } from './repo';
+
+/**
+ * The default maximum depth of `_include:iterate` / `_revinclude:iterate` recursion.
+ */
+const DEFAULT_MAX_INCLUDE_DEPTH = 5;
+
+/**
+ * FHIRPath result types that represent a canonical reference rather than a literal `Reference`.
+ */
+const canonicalReferenceTypes: string[] = [PropertyType.canonical, PropertyType.uri];
+
+/**
+ * Executes a search on behalf of the include logic.
+ *
+ * The default implementation uses {@link FhirRepository.searchResources}. The server overrides this
+ * to reuse its already-built query pipeline rather than re-entering the public `search()` entry point.
+ */
+export type IncludeSearchFn = (searchRequest: SearchRequest) => Promise<WithId<Resource>[]>;
+
+export interface IncludeOptions {
+  /**
+   * Builds the `Bundle.entry.fullUrl` for an included resource.
+   * When omitted, `fullUrl` is not set on the resulting entries.
+   */
+  readonly fullUrl?: (resourceType: string, id: string) => string;
+
+  /**
+   * The maximum number of `:iterate` rounds before the search is rejected. Defaults to 5.
+   */
+  readonly maxDepth?: number;
+
+  /**
+   * The maximum total number of bundle entries before the search is rejected.
+   * Defaults to `DEFAULT_MAX_SEARCH_COUNT`.
+   */
+  readonly maxResults?: number;
+
+  /**
+   * Executes the sub-searches needed for canonical `_include` and for all `_revinclude` targets.
+   * Defaults to `repo.searchResources()`.
+   */
+  readonly executeSearch?: IncludeSearchFn;
+}
+
+/**
+ * Gets the extra search entries for the _include and _revinclude parameters.
+ *
+ * The `entries` array is appended to in place.
+ *
+ * @param repo - The FHIR repository.
+ * @param searchRequest - The original search request.
+ * @param resources - The resources returned by the original search.
+ * @param entries - The output bundle entries.
+ * @param options - Optional repository-specific behavior.
+ */
+export async function getExtraEntries<T extends Resource>(
+  repo: FhirRepository,
+  searchRequest: SearchRequest<T>,
+  resources: T[],
+  entries: BundleEntry[],
+  options?: IncludeOptions
+): Promise<void> {
+  const maxDepth = options?.maxDepth ?? DEFAULT_MAX_INCLUDE_DEPTH;
+  const maxResults = options?.maxResults ?? DEFAULT_MAX_SEARCH_COUNT;
+
+  let base: Resource[] = resources;
+  let iterateOnly = false;
+  const seen = new Set<string>(resources.map((r) => `${r.resourceType}/${r.id}`));
+  let depth = 0;
+
+  while (base.length > 0) {
+    // Circuit breaker / load limit
+    if (depth >= maxDepth || entries.length > maxResults) {
+      throw new Error(`Search with _(rev)include reached query scope limit: depth=${depth}, results=${entries.length}`);
+    }
+
+    const includes = flatMapFilter(searchRequest.include, (p) =>
+      !iterateOnly || p.modifier === Operator.ITERATE ? getSearchIncludeEntries(repo, p, base, options) : undefined
+    );
+    const revincludes = flatMapFilter(searchRequest.revInclude, (p) =>
+      !iterateOnly || p.modifier === Operator.ITERATE ? getSearchRevIncludeEntries(repo, p, base, options) : undefined
+    );
+
+    const includedResources = (await Promise.all([...includes, ...revincludes])).flat();
+    base = [];
+    for (const entry of includedResources) {
+      const resource = entry.resource as Resource;
+      base.push(resource);
+
+      const ref = `${resource.resourceType}/${resource.id}`;
+      if (!seen.has(ref)) {
+        entries.push(entry);
+      }
+      seen.add(ref);
+    }
+
+    iterateOnly = true; // Only consider :iterate params on iterations after the first
+    depth++;
+  }
+}
+
+/**
+ * Returns bundle entries for the resources that are included in the search result.
+ *
+ * See documentation on _include: https://hl7.org/fhir/R4/search.html#include
+ * @param repo - The repository.
+ * @param include - The include parameter.
+ * @param resources - The base search result resources.
+ * @param options - Optional repository-specific behavior.
+ * @returns The bundle entries for the included resources.
+ */
+export async function getSearchIncludeEntries(
+  repo: FhirRepository,
+  include: IncludeTarget,
+  resources: Resource[],
+  options?: IncludeOptions
+): Promise<BundleEntry[]> {
+  const { resourceType, searchParam: code, targetType } = include;
+  const searchParam = getSearchParameter(resourceType, code);
+  if (!searchParam) {
+    throw new OperationOutcomeError(badRequest(`Invalid include parameter: ${resourceType}:${code}`));
+  }
+
+  const fhirPathResult = evalFhirPathTyped(searchParam.expression as string, resources.map(toTypedValue));
+  const references: Reference[] = [];
+  const canonicalReferences: string[] = [];
+  for (const result of fhirPathResult) {
+    if (result.type === PropertyType.Reference) {
+      references.push(result.value);
+    } else if (canonicalReferenceTypes.includes(result.type)) {
+      canonicalReferences.push(result.value);
+    }
+  }
+
+  // `_include=ResourceType:code:targetType` restricts the include to references of
+  // `targetType`; without the suffix every referenced resource type is returned.
+  const targetReferences = targetType
+    ? references.filter((reference) => reference.reference?.startsWith(targetType + '/'))
+    : references;
+
+  const includedResources = (await repo.readReferences(targetReferences)).filter((v) =>
+    isResource(v)
+  ) as WithId<Resource>[];
+
+  const canonicalTargets = targetType ? searchParam.target?.filter((t) => t === targetType) : searchParam.target;
+  if (canonicalTargets?.length && canonicalReferences.length > 0) {
+    const executeSearch = options?.executeSearch ?? ((s: SearchRequest) => repo.searchResources(s));
+    const canonicalSearches = canonicalTargets.map((canonicalTargetType) =>
+      executeSearch({
+        resourceType: canonicalTargetType,
+        filters: [
+          {
+            code: 'url',
+            operator: Operator.EQUALS,
+            value: canonicalReferences.join(','),
+          },
+        ],
+        count: DEFAULT_MAX_SEARCH_COUNT,
+        offset: 0,
+      })
+    );
+
+    // The `url` search is an exact match in the SQL implementation, but `matchesSearchRequest`
+    // treats `uri` parameters as a substring match, so filter the results to exact hits here.
+    // This is a no-op for repositories that already match exactly.
+    const wanted = new Set(canonicalReferences);
+    for (const searchResult of await Promise.all(canonicalSearches)) {
+      for (const resource of searchResult) {
+        const url = getCanonicalUrl(resource);
+        if (url && wanted.has(url)) {
+          includedResources.push(resource);
+        }
+      }
+    }
+  }
+
+  return includedResources.map((resource) => toIncludeEntry(resource, options));
+}
+
+/**
+ * Returns bundle entries for the resources that are reverse included in the search result.
+ *
+ * See documentation on _revinclude: https://hl7.org/fhir/R4/search.html#revinclude
+ * @param repo - The repository.
+ * @param revInclude - The revInclude parameter.
+ * @param resources - The base search result resources.
+ * @param options - Optional repository-specific behavior.
+ * @returns The bundle entries for the reverse included resources.
+ */
+export async function getSearchRevIncludeEntries(
+  repo: FhirRepository,
+  revInclude: IncludeTarget,
+  resources: Resource[],
+  options?: IncludeOptions
+): Promise<BundleEntry[]> {
+  const { resourceType, searchParam: code, targetType } = revInclude;
+  const searchParam = getSearchParameter(resourceType, code);
+  if (!searchParam) {
+    throw new OperationOutcomeError(badRequest(`Invalid include parameter: ${resourceType}:${code}`));
+  }
+
+  // `_revinclude=ResourceType:code:targetType` restricts the reverse include to
+  // base resources of `targetType`. Build the references in a single pass,
+  // filtering to the target type as we go.
+  const isCanonical = getSearchParameterDetails(resourceType, searchParam).type === SearchParameterType.CANONICAL;
+  const references: string[] = [];
+  for (const resource of resources) {
+    if (targetType && resource.resourceType !== targetType) {
+      continue;
+    }
+    if (isCanonical) {
+      const canonicalUrl = getCanonicalUrl(resource);
+      if (canonicalUrl) {
+        references.push(canonicalUrl);
+      }
+    } else {
+      const reference = getReferenceString(resource);
+      if (reference) {
+        references.push(reference);
+      }
+    }
+  }
+  if (references.length === 0) {
+    return [];
+  }
+
+  const executeSearch = options?.executeSearch ?? ((s: SearchRequest) => repo.searchResources(s));
+  const revIncluded = await executeSearch({
+    resourceType: resourceType as ResourceType,
+    filters: [{ code, operator: Operator.EQUALS, value: references.join(',') }],
+    count: DEFAULT_MAX_SEARCH_COUNT,
+    offset: 0,
+  });
+
+  return revIncluded.map((resource) => toIncludeEntry(resource, options));
+}
+
+function toIncludeEntry(resource: WithId<Resource>, options?: IncludeOptions): BundleEntry {
+  const fullUrl = options?.fullUrl?.(resource.resourceType, resource.id);
+  return {
+    ...(fullUrl ? { fullUrl } : undefined),
+    search: { mode: 'include' },
+    resource,
+  };
+}
+
+function getCanonicalUrl(resource: Resource): string | undefined {
+  return 'url' in resource ? resource.url : undefined;
+}

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { FhirFilterExpression, Filter, IncludeTarget, SearchRequest, SortRule, WithId } from '@medplum/core';
+import type { FhirFilterExpression, Filter, SearchRequest, SortRule, WithId } from '@medplum/core';
 import {
   AccessPolicyInteraction,
   badRequest,
@@ -8,7 +8,6 @@ import {
   DEFAULT_SEARCH_COUNT,
   deriveIdentifierSearchParameter,
   EMPTY,
-  evalFhirPathTyped,
   FhirFilterComparison,
   FhirFilterConnective,
   FhirFilterNegation,
@@ -16,35 +15,25 @@ import {
   forbidden,
   formatSearchQuery,
   getDataType,
-  getReferenceString,
   getSearchParameter,
   invalidSearchOperator,
-  isResource,
   isUUID,
   OperationOutcomeError,
   Operator,
   parseFhirPath,
   parseFilterParameter,
   parseParameter,
-  PropertyType,
   SearchParameterType,
   serverError,
   splitN,
   splitSearchOnComma,
   subsetResource,
   toPeriod,
-  toTypedValue,
   validateResourceType,
 } from '@medplum/core';
-import type {
-  Bundle,
-  BundleEntry,
-  BundleLink,
-  Reference,
-  Resource,
-  ResourceType,
-  SearchParameter,
-} from '@medplum/fhirtypes';
+import type { IncludeOptions } from '@medplum/fhir-router';
+import { getExtraEntries } from '@medplum/fhir-router';
+import type { Bundle, BundleEntry, BundleLink, Resource, ResourceType, SearchParameter } from '@medplum/fhirtypes';
 import { getConfig } from '../config/loader';
 import { systemResourceProjectId } from '../constants';
 import { clamp } from './operations/utils/parameters';
@@ -84,8 +73,6 @@ const maxSearchResults = DEFAULT_MAX_SEARCH_COUNT;
  * is relevant primarily to the deprecated v1 cursor format, but is enforced for v2 cursors as well.
  */
 export const minCursorBasedSearchPageSize = 20;
-
-const canonicalReferenceTypes: string[] = [PropertyType.canonical, PropertyType.uri];
 
 type SearchRequestWithCountAndOffset<T extends Resource = Resource> = SearchRequest<T> & {
   count: number;
@@ -391,7 +378,7 @@ async function getSearchEntries<T extends Resource>(
   }));
 
   if (searchRequest.include || searchRequest.revInclude) {
-    await getExtraEntries(repo, searchRequest, resources, entries);
+    await getExtraEntries(repo, searchRequest, resources, entries, getIncludeOptions(repo));
   }
 
   for (const entry of entries) {
@@ -498,188 +485,31 @@ function removeResourceFields(resource: Resource, repo: Repository, searchReques
 }
 
 /**
- * Gets the extra search entries for the _include and _revinclude parameters.
- * @param repo - The FHIR repository.
- * @param searchRequest - The original search request.
- * @param resources - The resources returned by the original search.
- * @param entries - The output bundle entries.
- */
-async function getExtraEntries<T extends Resource>(
-  repo: Repository,
-  searchRequest: SearchRequest<T>,
-  resources: T[],
-  entries: BundleEntry[]
-): Promise<void> {
-  let base: Resource[] = resources;
-  let iterateOnly = false;
-  const seen = new Set<string>(resources.map((r) => `${r.resourceType}/${r.id}`));
-  let depth = 0;
-
-  while (base.length > 0) {
-    // Circuit breaker / load limit
-    if (depth >= 5 || entries.length > maxSearchResults) {
-      throw new Error(`Search with _(rev)include reached query scope limit: depth=${depth}, results=${entries.length}`);
-    }
-
-    const includes = flatMapFilter(searchRequest.include, (p) =>
-      !iterateOnly || p.modifier === Operator.ITERATE ? getSearchIncludeEntries(repo, p, base) : undefined
-    );
-    const revincludes = flatMapFilter(searchRequest.revInclude, (p) =>
-      !iterateOnly || p.modifier === Operator.ITERATE ? getSearchRevIncludeEntries(repo, p, base) : undefined
-    );
-
-    const includedResources = (await Promise.all([...includes, ...revincludes])).flat();
-    base = [];
-    for (const entry of includedResources) {
-      const resource = entry.resource as Resource;
-      base.push(resource);
-
-      const ref = `${resource.resourceType}/${resource.id}`;
-      if (!seen.has(ref)) {
-        entries.push(entry);
-      }
-      seen.add(ref);
-    }
-
-    iterateOnly = true; // Only consider :iterate params on iterations after the first
-    depth++;
-  }
-}
-
-/**
- * Returns bundle entries for the resources that are included in the search result.
+ * Builds the server-specific behavior for the shared `_include` / `_revinclude` implementation.
  *
- * See documentation on _include: https://hl7.org/fhir/R4/search.html#include
- * @param repo - The repository.
- * @param include - The include parameter.
- * @param resources - The base search result resources.
- * @returns The bundle entries for the included resources.
+ * The include logic itself lives in `@medplum/fhir-router` so that it is shared with
+ * `MemoryRepository`. Only two things are server-specific: how a `fullUrl` is built, and how
+ * the sub-searches are executed.
+ * @param repo - The FHIR repository.
+ * @returns The include options for this repository.
  */
-async function getSearchIncludeEntries(
-  repo: Repository,
-  include: IncludeTarget,
-  resources: Resource[]
-): Promise<BundleEntry[]> {
-  const { resourceType, searchParam: code, targetType } = include;
-  const searchParam = getSearchParameter(resourceType, code);
-  if (!searchParam) {
-    throw new OperationOutcomeError(badRequest(`Invalid include parameter: ${resourceType}:${code}`));
-  }
-
-  const fhirPathResult = evalFhirPathTyped(searchParam.expression as string, resources.map(toTypedValue));
-  const references: Reference[] = [];
-  const canonicalReferences: string[] = [];
-  for (const result of fhirPathResult) {
-    if (result.type === PropertyType.Reference) {
-      references.push(result.value);
-    } else if (canonicalReferenceTypes.includes(result.type)) {
-      canonicalReferences.push(result.value);
-    }
-  }
-
-  // `_include=ResourceType:code:targetType` restricts the include to references of
-  // `targetType`; without the suffix every referenced resource type is returned.
-  const targetReferences = targetType
-    ? references.filter((reference) => reference.reference?.startsWith(targetType + '/'))
-    : references;
-
-  const includedResources = (await repo.readReferences(targetReferences)).filter((v) =>
-    isResource(v)
-  ) as WithId<Resource>[];
-  const canonicalTargets = targetType ? searchParam.target?.filter((t) => t === targetType) : searchParam.target;
-  if (canonicalTargets?.length && canonicalReferences.length > 0) {
-    const canonicalSearches = canonicalTargets.map((resourceType) => {
-      const searchRequest = {
-        resourceType: resourceType,
-        filters: [
-          {
-            code: 'url',
-            operator: Operator.EQUALS,
-            value: canonicalReferences.join(','),
-          },
-        ],
-        count: DEFAULT_MAX_SEARCH_COUNT,
-        offset: 0,
-      };
+function getIncludeOptions(repo: Repository): IncludeOptions {
+  return {
+    fullUrl: getFullUrl,
+    // Run sub-searches through the query pipeline directly rather than re-entering
+    // `Repository.search()`, which would additionally build bundle links for every sub-search.
+    executeSearch: async (searchRequest: SearchRequest): Promise<WithId<Resource>[]> => {
       const trackedResourceTypes = new Set<ResourceType>();
       const query = getSelectQueryForSearch(repo, searchRequest, { trackedResourceTypes });
-      return getSearchEntries(repo, searchRequest, query, trackedResourceTypes);
-    });
-
-    const searchResults = await Promise.all(canonicalSearches);
-    for (const result of searchResults) {
-      for (const entry of result.entry) {
-        includedResources.push(entry.resource as WithId<Resource>);
-      }
-    }
-  }
-
-  return includedResources.map((resource) => ({
-    fullUrl: getFullUrl(resource.resourceType, resource.id),
-    search: { mode: 'include' },
-    resource,
-  }));
-}
-
-/**
- * Returns bundle entries for the resources that are reverse included in the search result.
- *
- * See documentation on _revinclude: https://hl7.org/fhir/R4/search.html#revinclude
- * @param repo - The repository.
- * @param revInclude - The revInclude parameter.
- * @param resources - The base search result resources.
- * @returns The bundle entries for the reverse included resources.
- */
-async function getSearchRevIncludeEntries(
-  repo: Repository,
-  revInclude: IncludeTarget,
-  resources: Resource[]
-): Promise<BundleEntry[]> {
-  const { resourceType, searchParam: code, targetType } = revInclude;
-  const searchParam = getSearchParameter(resourceType, code);
-  if (!searchParam) {
-    throw new OperationOutcomeError(badRequest(`Invalid include parameter: ${resourceType}:${code}`));
-  }
-
-  // `_revinclude=ResourceType:code:targetType` restricts the reverse include to
-  // base resources of `targetType`. Build the references in a single pass,
-  // filtering to the target type as we go.
-  const isCanonical =
-    getSearchParameterImplementation(resourceType, searchParam).type === SearchParameterType.CANONICAL;
-  const references: string[] = [];
-  for (const resource of resources) {
-    if (targetType && resource.resourceType !== targetType) {
-      continue;
-    }
-    if (isCanonical) {
-      const canonicalUrl = getCanonicalUrl(resource);
-      if (canonicalUrl) {
-        references.push(canonicalUrl);
-      }
-    } else {
-      const reference = getReferenceString(resource);
-      if (reference) {
-        references.push(reference);
-      }
-    }
-  }
-  if (references.length === 0) {
-    return [];
-  }
-  const searchRequest = {
-    resourceType: resourceType as ResourceType,
-    filters: [{ code, operator: Operator.EQUALS, value: references.join(',') }],
-    count: DEFAULT_MAX_SEARCH_COUNT,
-    offset: 0,
+      const result = await getSearchEntries(
+        repo,
+        searchRequest as SearchRequestWithCountAndOffset,
+        query,
+        trackedResourceTypes
+      );
+      return result.entry.map((entry) => entry.resource as WithId<Resource>);
+    },
   };
-
-  const trackedResourceTypes = new Set<ResourceType>();
-  const query = getSelectQueryForSearch(repo, searchRequest, { trackedResourceTypes });
-  const entries = (await getSearchEntries(repo, searchRequest, query, trackedResourceTypes)).entry;
-  for (const entry of entries) {
-    entry.search = { mode: 'include' };
-  }
-  return entries;
 }
 
 /**
@@ -2083,8 +1913,4 @@ function splitChainedSearch(chain: string): string[] {
     }
   }
   return params;
-}
-
-function getCanonicalUrl(resource: Resource): string | undefined {
-  return 'url' in resource ? resource.url : undefined;
 }


### PR DESCRIPTION
`MemoryRepository` silently ignored `_include` and `_revinclude`. A search with those parameters returned only the matched resources, with no indication that the include directives had been dropped.

This adds support by moving the include logic out of `packages/server` and into `packages/fhir-router`, where both repositories can share it, rather than writing a second implementation.

## Background

The include implementation lived in three functions in `packages/server/src/fhir/search.ts` — `getExtraEntries`, `getSearchIncludeEntries`, and `getSearchRevIncludeEntries`. Duplicating them for `MemoryRepository` would have meant a second copy of the `:iterate` depth limiting, the seen-set deduplication, target-type filtering, and the canonical-versus-literal reference handling — all of it subtle, and all of it exactly the kind of thing that drifts between the two implementations.

Auditing their dependencies showed almost nothing was actually storage-specific:

| Dependency | Where it lived | Portable |
| --- | --- | --- |
| `flatMapFilter`, `Operator.ITERATE`, `getSearchParameter`, `evalFhirPathTyped`, `toTypedValue`, `PropertyType`, `isResource`, `getReferenceString`, `badRequest` | `@medplum/core` | yes |
| `maxSearchResults` | alias for core's `DEFAULT_MAX_SEARCH_COUNT` | yes |
| `canonicalReferenceTypes` | one-line local const over core's `PropertyType` | yes |
| `getCanonicalUrl` | `'url' in resource ? resource.url : undefined` | yes |
| `repo.readReferences(...)` | already abstract on `FhirRepository` | yes |
| `getSearchParameterImplementation(...).type` | server, but `SearchParameterImplementation extends SearchParameterDetails` and the impl is built by core's `getSearchParameterDetails` (`searchparameter.ts:121`) | yes, via substitution |
| `getSelectQueryForSearch` + `getSearchEntries` | server SQL | behind a seam |
| `getFullUrl` | server, needs `getConfig().baseUrl` | no |

So the whole body of logic reduced to two injection points.

## Changes

### New: `packages/fhir-router/src/search-include.ts`

The three functions, logic unchanged, rewritten against the `FhirRepository` abstract base. Repository-specific behavior is supplied through `IncludeOptions`:

```ts
export interface IncludeOptions {
  readonly fullUrl?: (resourceType: string, id: string) => string;
  readonly maxDepth?: number;
  readonly maxResults?: number;
  readonly executeSearch?: IncludeSearchFn;
}
```

- **`fullUrl`** — the only genuinely non-portable dependency. The server passes its config-aware `getFullUrl`; `MemoryRepository` omits it, and the field is left off the entry, matching that repository's existing behavior of not emitting `fullUrl`.
- **`executeSearch`** — runs the sub-searches needed for canonical `_include` and for every `_revinclude`. Defaults to `repo.searchResources()`. The server passes its existing `getSelectQueryForSearch` + `getSearchEntries` path, so its hot path is unchanged; `Repository.search()` is never re-entered, and no bundle links are built for sub-searches.

`getSearchParameterImplementation(...).type === SearchParameterType.CANONICAL` became `getSearchParameterDetails(...).type === SearchParameterType.CANONICAL`. These return the same value — the server's implementation registry is populated from core's `getSearchParameterDetails`.

`maxDepth` (5) and `maxResults` (`DEFAULT_MAX_SEARCH_COUNT`) default to the server's previous hardcoded limits, including the existing behavior of *throwing* rather than truncating when a chain exceeds them.

### `packages/server/src/fhir/search.ts`

The three functions, the local `getCanonicalUrl`, and the `canonicalReferenceTypes` const are removed. What remains is the options factory:

```ts
function getIncludeOptions(repo: Repository): IncludeOptions {
  return {
    fullUrl: getFullUrl,
    executeSearch: async (searchRequest: SearchRequest): Promise<WithId<Resource>[]> => {
      const trackedResourceTypes = new Set<ResourceType>();
      const query = getSelectQueryForSearch(repo, searchRequest, { trackedResourceTypes });
      const result = await getSearchEntries(
        repo,
        searchRequest as SearchRequestWithCountAndOffset,
        query,
        trackedResourceTypes
      );
      return result.entry.map((entry) => entry.resource as WithId<Resource>);
    },
  };
}
```

`removeResourceFields` is applied to included entries in exactly the same places and the same number of times as before.

### `packages/fhir-router/src/repo.ts`

- `MemoryRepository.search()` calls the shared `getExtraEntries` when `include` or `revInclude` is present and the page has at least one match.
- Match entries are now tagged `search: { mode: 'match' }`. Without this there is no way to tell a match from an include in the resulting bundle.
- `total` continues to reflect only the matched resources.
- `readReferences` no longer rejects the entire batch when a single reference is unresolvable. It was `Promise.all(refs.map(r => this.readReference(r)))` despite a declared return type of `(T | Error)[]`; unresolvable references now come back as errors, which is what the include code's `.filter(isResource)` expects. This was a live bug independent of `_include`.

## Behavior changes worth noting

**Canonical `_include` no longer over-matches in `MemoryRepository`.** The canonical branch searches `url` with `Operator.EQUALS`. `url` is a `uri` parameter, which `matchesSearchRequest` routes to `matchesStringValue` — a case-insensitive **substring** test. An `_include` targeting `http://example.com/q` would therefore also pull in `http://example.com/q-extra`.

This is fixed in the shared module by post-filtering canonical results against the exact requested URL set, rather than by changing `match.ts`. Fixing `uri` matching in core would also change subscription criteria evaluation, which is a larger blast radius and deserves its own change. The post-filter is a no-op on the server, where `url` already matches exactly.

**`MemoryRepository` bundles now carry `search.mode` on match entries.** This is the change with real blast radius, since `MockClient` is used throughout `react`, `app`, and the example apps. Every consuming suite passes unchanged.

## Not addressed

Two pre-existing `MemoryRepository` fidelity gaps, both outside the scope of `_include`:

- `matchesSearchRequest` treats `uri` parameters as substring matches everywhere other than the canonical path fixed here.
- `matchesSearchRequest` returns `false` for `number`, `quantity`, and composite search parameter types.

## Testing

New: `packages/fhir-router/src/search-include.test.ts` (14 tests) covering literal `_include`, dangling references, target-type filtering, deduplication, resources already present as matches, `_revinclude`, `_include:iterate` (with a companion test asserting non-`iterate` params do *not* recurse), canonical include and revinclude, exact-URL canonical matching, invalid include parameters, and the empty-match-set short circuit.

The canonical exact-match filter was verified to be load-bearing by neutering the condition and confirming the test fails with both questionnaires included.

```
npm test --workspace=@medplum/fhir-router          # 136 passed (14 new)
npm test --workspace=@medplum/server -- search.test.ts   # 487 passed (20 include-specific)
npm test --workspace=@medplum/mock                 # 90 passed
npm test --workspace=@medplum/react                # 1244 passed
npm test --workspace=@medplum/react-hooks          # 234 passed
npm test --workspace=@medplum/app                  # 458 passed
```

Also run green, as `@medplum/mock` consumers: `cli` (192), `agent` (544), `dosespot-core` (31), `dosespot-react` (63), `health-gorilla-core` (27), `health-gorilla-react` (23), `scriptsure-react` (30).

`tsc --noEmit` and `eslint` clean on `@medplum/fhir-router` and `@medplum/server`.
