### PR TITLE
feat(server): generate an MFA secret on demand at enrollment

### DIFF
--- a/packages/server/src/auth/mfa.test.ts
+++ b/packages/server/src/auth/mfa.test.ts
@@ -1597,7 +1597,7 @@ describe('MFA', () => {
     expect(res.body).toMatchObject(badRequest('Already enrolled'));
   });
 
-  test('login-enroll requires a secret for TOTP enrollment', async () => {
+  test('login-enroll generates a secret for a user who does not have one', async () => {
     const email = `login-enroll${randomUUID()}@example.com`;
     const password = 'password!@#';
 
@@ -1611,11 +1611,51 @@ describe('MFA', () => {
       })
     );
 
-    // Require MFA but clear the secret so TOTP enrollment cannot proceed
+    // Require MFA for a user who has no secret. Only users invited with
+    // `mfaRequired` get one up front, so enrollment must generate it.
     await setMfaRequired(user, { clearSecret: true });
 
     const loginRes = await request(app).post('/auth/login').type('json').send({ email, password, scope: 'openid' });
     expect(loginRes.body.mfaEnrollRequired).toBe(true);
+
+    // The offered QR code must carry a real secret, not an empty one
+    const secret = new URL(loginRes.body.enrollUri).searchParams.get('secret') as string;
+    expect(secret).toMatch(/^[A-Z2-7]+$/);
+
+    // ...and the user can enroll with a code derived from it
+    const res = await request(app)
+      .post('/auth/mfa/login-enroll')
+      .type('json')
+      .send({ login: loginRes.body.login, token: authenticator.generate(secret) });
+    expect(res).toHaveStatus(200);
+    expect(res.body.code).toBeDefined();
+
+    const updated = await getGlobalSystemRepo().readResource<User>('User', user.id);
+    expect(updated.mfaEnrolled).toBe(true);
+    expect(updated.mfaMethod).toEqual(['totp']);
+  });
+
+  test('login-enroll rejects TOTP enrollment if the secret is removed mid-flow', async () => {
+    const email = `login-enroll${randomUUID()}@example.com`;
+    const password = 'password!@#';
+
+    const { user } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Login',
+        lastName: 'SecretRemoved',
+        projectName: `Login Secret Removed Project ${randomUUID()}`,
+        email,
+        password,
+      })
+    );
+
+    await setMfaRequired(user);
+
+    const loginRes = await request(app).post('/auth/login').type('json').send({ email, password, scope: 'openid' });
+    expect(loginRes.body.mfaEnrollRequired).toBe(true);
+
+    // Clear the secret after the QR code was issued but before it is used
+    await setMfaRequired(user, { clearSecret: true });
 
     const res = await request(app).post('/auth/mfa/login-enroll').type('json').send({ login: loginRes.body.login });
     expect(res).toHaveStatus(400);

--- a/packages/server/src/auth/mfa.ts
+++ b/packages/server/src/auth/mfa.ts
@@ -7,7 +7,6 @@ import type { Request, Response } from 'express';
 import { Router } from 'express';
 import { body, validationResult } from 'express-validator';
 import { authenticator } from 'otplib';
-import { toDataURL } from 'qrcode';
 import { getConfig } from '../config/loader';
 import { getAuthenticatedContext } from '../context';
 import { invalidRequest, sendOutcome } from '../fhir/outcomes';
@@ -16,6 +15,7 @@ import { authenticateRequest } from '../oauth/middleware';
 import { verifyMfaToken } from '../oauth/utils';
 import type { MfaMethod } from './utils';
 import {
+  buildTotpEnrollment,
   getAllowedMfaMethods,
   getEnrolledMfaMethods,
   isMfaRequired,
@@ -84,23 +84,13 @@ export async function verifyConnectedFactor(user: User, login: Login, token: str
 
 mfaRouter.get('/status', authenticateRequest, async (_req: Request, res: Response) => {
   const ctx = getAuthenticatedContext();
-  let user = await ctx.systemRepo.readReference<User>(ctx.membership.user as Reference<User>);
+  const user = await ctx.systemRepo.readReference<User>(ctx.membership.user as Reference<User>);
   const allowedMethods = getAllowedMfaMethods(ctx.project);
 
-  // Ensure the user has an authenticator secret so the TOTP QR code can always
-  // be shown, whether for initial enrollment or for adding TOTP as a second
-  // method to an account already enrolled in email-based MFA.
-  if (!user.mfaSecret) {
-    user = await ctx.systemRepo.updateResource({
-      ...user,
-      mfaSecret: authenticator.generateSecret(),
-    });
-  }
-
-  const accountName = `Medplum - ${user.email}`;
-  const issuer = 'medplum.com';
-  const secret = user.mfaSecret as string;
-  const otp = authenticator.keyuri(accountName, issuer, secret);
+  // The TOTP QR code can always be shown, whether for initial enrollment or for
+  // adding TOTP as a second method to an account already enrolled in
+  // email-based MFA, because a secret is generated on demand if missing.
+  const { enrollUri, enrollQrCode } = await buildTotpEnrollment(ctx.systemRepo, user);
 
   res.json({
     enrolled: Boolean(user.mfaEnrolled),
@@ -110,8 +100,8 @@ mfaRouter.get('/status', authenticateRequest, async (_req: Request, res: Respons
     // it (the `/disable` endpoint enforces this server-side as well).
     mfaRequired: isMfaRequired(user, ctx.project),
     email: user.email,
-    enrollUri: otp,
-    enrollQrCode: await toDataURL(otp),
+    enrollUri,
+    enrollQrCode,
   });
 });
 

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -73,6 +73,32 @@ export function isMfaRequired(user: User, project: Project | undefined): boolean
 }
 
 /**
+ * Builds the authenticator (TOTP) enrollment payload for a user, generating and
+ * persisting an `mfaSecret` first if the user does not have one.
+ *
+ * A secret is only created up front when a user is invited with `mfaRequired`,
+ * so a user who comes under a requirement later — for example when the
+ * project-wide `mfaRequired` setting is enabled — reaches enrollment without
+ * one. Generating on demand keeps the QR code usable in that case. Users who
+ * already have a secret keep it, so the URI is stable across repeated calls.
+ * @param repo - The system repository used to persist a newly generated secret.
+ * @param user - The user enrolling in an authenticator app.
+ * @returns The enrollment URI and a QR code data URL for it.
+ */
+export async function buildTotpEnrollment(
+  repo: SystemRepository,
+  user: WithId<User>
+): Promise<{ enrollUri: string; enrollQrCode: string }> {
+  let mfaSecret = user.mfaSecret;
+  if (!mfaSecret) {
+    mfaSecret = authenticator.generateSecret();
+    await repo.updateResource<User>({ ...user, mfaSecret });
+  }
+  const enrollUri = authenticator.keyuri(`Medplum - ${user.email}`, 'medplum.com', mfaSecret);
+  return { enrollUri, enrollQrCode: await toDataURL(enrollUri) };
+}
+
+/**
  * Returns the MFA methods that a user has enrolled in.
  * Existing users enrolled before the introduction of `User.mfaMethod` are
  * treated as TOTP, which was the only method at the time.
@@ -215,15 +241,12 @@ export async function sendLoginResult(res: Response, login: Login): Promise<void
   const project = await getLoginProject(login);
 
   if (isMfaRequired(user, project) && !user.mfaEnrolled && login.authMethod === 'password' && !login.mfaVerified) {
-    const accountName = `Medplum - ${user.email}`;
-    const issuer = 'medplum.com';
-    const secret = user.mfaSecret as string;
-    const otp = authenticator.keyuri(accountName, issuer, secret);
+    const { enrollUri, enrollQrCode } = await buildTotpEnrollment(systemRepo, user);
     res.json({
       login: login.id,
       mfaEnrollRequired: true,
-      enrollUri: otp,
-      enrollQrCode: await toDataURL(otp),
+      enrollUri,
+      enrollQrCode,
       allowedMfaMethods: getAllowedMfaMethods(project),
     });
     return;


### PR DESCRIPTION
## Problem

A TOTP secret is only ever created for a `User` in two places: at invite time when `mfaRequired: true` is passed, and in `GET /auth/mfa/status`. Any user who comes under an MFA requirement *later* has no secret — most notably when the project-wide `mfaRequired` setting (#9678) is enabled, which applies to every existing member of the Project.

For those users, `sendLoginResult` read `user.mfaSecret as string` without generating one, so login returned an unusable enrollment URI and `login-enroll` rejected the code:

```
POST /auth/login
→ { "mfaEnrollRequired": true,
    "enrollUri": "otpauth://totp/...?secret=undefined&period=30&..." }

POST /auth/mfa/login-enroll  { method: "totp", token: "..." }
→ 400 { "details": { "text": "Secret not found" } }
```

Because the login could not complete, the member could not reach the Security page to have a secret generated either. The only way through was email-based MFA (`allowedMfaMethods: 'totp,email'`), which does work — so enabling project-wide `mfaRequired` on a Project whose members use authenticator apps locked them out.

## Fix

Generate and persist the secret when the enrollment payload is built. `GET /auth/mfa/status` already did exactly this, so both call sites now share a `buildTotpEnrollment` helper in `auth/utils.ts`. Users who already have a secret keep it, so enrollment URIs stay stable across repeated calls.

## Tests

`login-enroll requires a secret for TOTP enrollment` asserted the old behavior; it is replaced by:

- `login-enroll generates a secret for a user who does not have one` — a user with no secret is offered a real secret at login and completes authenticator enrollment end-to-end.
- `login-enroll rejects TOTP enrollment if the secret is removed mid-flow` — keeps coverage of the remaining `Secret not found` guard, which is now only reachable if the secret disappears between login and enrollment.

`src/auth` and `src/oauth` pass (512 tests). `src/auth/newproject.test.ts > GraphQL is restricted to project` fails identically on unmodified `main` in my local environment (`permission denied for table Patient`) and is unrelated.

## Docs

Documentation for the project-wide `mfaRequired` setting is in a separate PR. It currently carries a caution about this gap, which I will drop once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
