### PR TITLE
[Server] Remove Slot.serviceType from $find/$book results

### DIFF
--- a/packages/server/src/fhir/operations/find.test.ts
+++ b/packages/server/src/fhir/operations/find.test.ts
@@ -1100,7 +1100,6 @@ describe('Appointment/$find', () => {
                 start: new Date('2026-03-17T13:00:00-04:00').toISOString(),
                 end: new Date('2026-03-17T13:30:00-04:00').toISOString(),
                 status: 'busy',
-                serviceType: [{ coding: [{ code: 'generic-visit' }] }],
               },
               // practitioner schedule: buffer before block
               {
@@ -1109,7 +1108,6 @@ describe('Appointment/$find', () => {
                 start: new Date('2026-03-17T12:40:00-04:00').toISOString(),
                 end: new Date('2026-03-17T13:00:00-04:00').toISOString(),
                 status: 'busy-unavailable',
-                serviceType: [{ coding: [{ code: 'generic-visit' }] }],
                 comment: 'buffer before appointment',
               },
               // practitioner schedule: buffer after block
@@ -1119,7 +1117,6 @@ describe('Appointment/$find', () => {
                 start: new Date('2026-03-17T13:30:00-04:00').toISOString(),
                 end: new Date('2026-03-17T13:45:00-04:00').toISOString(),
                 status: 'busy-unavailable',
-                serviceType: [{ coding: [{ code: 'generic-visit' }] }],
                 comment: 'buffer after appointment',
               },
               // location schedule: main appointment block
@@ -1129,7 +1126,6 @@ describe('Appointment/$find', () => {
                 start: new Date('2026-03-17T13:00:00-04:00').toISOString(),
                 end: new Date('2026-03-17T13:30:00-04:00').toISOString(),
                 status: 'busy',
-                serviceType: [{ coding: [{ code: 'generic-visit' }] }],
               },
             ],
           },

--- a/packages/server/src/fhir/operations/find.ts
+++ b/packages/server/src/fhir/operations/find.ts
@@ -204,7 +204,6 @@ async function handler(params: {
           end,
           schedule: createReference(schedule),
           status: 'busy',
-          serviceType,
         },
       ];
 
@@ -215,7 +214,6 @@ async function handler(params: {
           end: start,
           schedule: createReference(schedule),
           status: 'busy-unavailable',
-          serviceType,
           comment: 'buffer before appointment',
         });
       }
@@ -227,7 +225,6 @@ async function handler(params: {
           end: addMinutes(interval.end, parameters.get('bufferAfter')).toISOString(),
           schedule: createReference(schedule),
           status: 'busy-unavailable',
-          serviceType,
           comment: 'buffer after appointment',
         });
       }


### PR DESCRIPTION
In https://github.com/medplum/medplum/pull/9995 it was flagged that `Slot.serviceType` has some intended semantics for our availability computations that we are not currently respecting; a "busy" slot with a `serviceType` set should only block availability for matching services.

One challenge in merging that: the intent of `$find`/`$book` is that the Slots created should remove the scheduled time from availability for all service types. That means that these slots should be "wildcard", or applicable to all service types.

In early implementation we had started including `Slot.serviceType` on these results, which is in conflict with this intention.

As an immediate step, let's stop writing `Slot.serviceType` for new $find/$book results. We will follow up with a migration plan for existing Slot resources in this bad state.