### PR TITLE
Fixes #9654 - Avoid subscription state update after unmount

### DIFF
--- a/packages/react-hooks/src/useSubscription/useSubscription.test.tsx
+++ b/packages/react-hooks/src/useSubscription/useSubscription.test.tsx
@@ -133,6 +133,23 @@ describe('useSubscription()', () => {
     expect(medplum.getSubscriptionManager().getCriteriaCount()).toEqual(0);
   });
 
+  test('Does not update React state after unmount', () => {
+    vi.useFakeTimers();
+    try {
+      const { unmount } = setup(<TestComponent criteria="Communication" />);
+      unmount();
+
+      // Reproduce the test environment teardown that exposed the delayed state update in #9654.
+      vi.stubGlobal('window', undefined);
+
+      expect(() => vi.advanceTimersByTime(3000)).not.toThrow();
+      expect(medplum.getSubscriptionManager().getCriteriaCount()).toEqual(0);
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
   test('Mount and remount before debounce timeout', async () => {
     expect(medplum.getSubscriptionManager().getCriteriaCount()).toEqual(0);
     const { rerender } = setup(<RenderToggleComponent render={true} />);

--- a/packages/react-hooks/src/useSubscription/useSubscription.ts
+++ b/packages/react-hooks/src/useSubscription/useSubscription.ts
@@ -116,7 +116,6 @@ export function useSubscription(
 
     return () => {
       unsubTimerRef.current = setTimeout(() => {
-        setEmitter(undefined);
         if (effectiveCriteria) {
           medplum.unsubscribeFromCriteria(effectiveCriteria, memoizedSubProps);
         }


### PR DESCRIPTION
## Summary

- Remove the delayed `setEmitter(undefined)` call from the `useSubscription` cleanup timer.
- Preserve the debounced `unsubscribeFromCriteria` behavior used for quick remounts and React Strict Mode.
- Add a regression test that reproduces JSDOM teardown before the delayed cleanup runs.

Although the failure surfaced while `BaseChat.test.tsx` was running, the stack trace pointed to the delayed cleanup callback in the shared `useSubscription` hook. After the component unmounted and JSDOM removed `window`, the timer attempted a React state update, causing React DOM to access the missing browser global.

The emitter state belongs to the unmounted component and no longer needs to be cleared. The external subscription still needs cleanup, so the delayed unsubscribe remains unchanged.

Fixes #9654

## Testing

- `npm test --workspace=packages/react-hooks -- src/useSubscription/useSubscription.test.tsx`
- `npm test --workspace=packages/react -- src/chat/BaseChat/BaseChat.test.tsx`
- `npm run build:fast`
- `npm run lint --workspace=packages/react-hooks`
