### PR TITLE
feat(react): support questionnaire-optionExclusive in QuestionnaireForm

### DIFF
--- a/packages/react-hooks/src/useQuestionnaireForm/useQuestionnaireForm.ts
+++ b/packages/react-hooks/src/useQuestionnaireForm/useQuestionnaireForm.ts
@@ -14,6 +14,7 @@ import type {
 import { useReducer, useRef } from 'react';
 import { useResource } from '../useResource/useResource';
 import {
+  applyOptionExclusive,
   buildInitialResponse,
   buildInitialResponseItem,
   evaluateCalculatedExpressionsInQuestionnaire,
@@ -219,7 +220,7 @@ export function useQuestionnaireForm(props: UseQuestionnaireFormProps): Readonly
   ): void {
     const currentItem = getResponseItemByContext(context, item);
     if (currentItem) {
-      currentItem.answer = answer;
+      currentItem.answer = applyOptionExclusive(item, currentItem.answer, answer);
       emitChange();
     }
   }

--- a/packages/react-hooks/src/useQuestionnaireForm/utils.test.ts
+++ b/packages/react-hooks/src/useQuestionnaireForm/utils.test.ts
@@ -10,6 +10,7 @@ import type {
   ResourceType,
 } from '@medplum/fhirtypes';
 import {
+  applyOptionExclusive,
   buildInitialResponse,
   evaluateCalculatedExpressionsInQuestionnaire,
   getNewMultiSelectValues,
@@ -17,6 +18,7 @@ import {
   getQuestionnaireItemReferenceTargetTypes,
   isChoiceQuestion,
   isQuestionEnabled,
+  QUESTIONNAIRE_OPTION_EXCLUSIVE_URL,
   setQuestionnaireItemReferenceTargetTypes,
   typedValueToResponseItem,
 } from './utils';
@@ -26,6 +28,94 @@ describe('Questionnaire Utils', () => {
     expect(isChoiceQuestion({ linkId: 'q3', type: 'string' })).toBe(false);
     expect(isChoiceQuestion({ linkId: 'q3', type: 'choice' })).toBe(true);
     expect(isChoiceQuestion({ linkId: 'q3', type: 'open-choice' })).toBe(true);
+  });
+});
+
+describe('applyOptionExclusive', () => {
+  const item: QuestionnaireItem = {
+    linkId: 'q1',
+    type: 'choice',
+    repeats: true,
+    answerOption: [
+      { valueString: 'Peanuts' },
+      { valueString: 'Shellfish' },
+      {
+        valueString: 'No known allergies',
+        extension: [{ url: QUESTIONNAIRE_OPTION_EXCLUSIVE_URL, valueBoolean: true }],
+      },
+    ],
+  };
+
+  test('returns answers unchanged when no options are exclusive', () => {
+    const plainItem: QuestionnaireItem = {
+      linkId: 'q1',
+      type: 'choice',
+      repeats: true,
+      answerOption: [{ valueString: 'Peanuts' }, { valueString: 'Shellfish' }],
+    };
+    const next = [{ valueString: 'Peanuts' }, { valueString: 'Shellfish' }];
+    expect(applyOptionExclusive(plainItem, [{ valueString: 'Peanuts' }], next)).toBe(next);
+  });
+
+  test('selecting an exclusive option clears other answers', () => {
+    const prev = [{ valueString: 'Peanuts' }, { valueString: 'Shellfish' }];
+    const next = [...prev, { valueString: 'No known allergies' }];
+    expect(applyOptionExclusive(item, prev, next)).toEqual([{ valueString: 'No known allergies' }]);
+  });
+
+  test('selecting a non-exclusive option clears the exclusive answer', () => {
+    const prev = [{ valueString: 'No known allergies' }];
+    const next = [...prev, { valueString: 'Peanuts' }];
+    expect(applyOptionExclusive(item, prev, next)).toEqual([{ valueString: 'Peanuts' }]);
+  });
+
+  test('removing an answer leaves the rest unchanged', () => {
+    const prev = [{ valueString: 'Peanuts' }, { valueString: 'Shellfish' }];
+    const next = [{ valueString: 'Peanuts' }];
+    expect(applyOptionExclusive(item, prev, next)).toBe(next);
+  });
+
+  test('first selection can be the exclusive option', () => {
+    expect(applyOptionExclusive(item, undefined, [{ valueString: 'No known allergies' }])).toEqual([
+      { valueString: 'No known allergies' },
+    ]);
+  });
+
+  test('extension with valueBoolean false is not exclusive', () => {
+    const nonExclusiveItem: QuestionnaireItem = {
+      linkId: 'q1',
+      type: 'choice',
+      repeats: true,
+      answerOption: [
+        { valueString: 'Peanuts' },
+        {
+          valueString: 'No known allergies',
+          extension: [{ url: QUESTIONNAIRE_OPTION_EXCLUSIVE_URL, valueBoolean: false }],
+        },
+      ],
+    };
+    const next = [{ valueString: 'Peanuts' }, { valueString: 'No known allergies' }];
+    expect(applyOptionExclusive(nonExclusiveItem, [{ valueString: 'Peanuts' }], next)).toBe(next);
+  });
+
+  test('supports valueCoding options', () => {
+    const codingItem: QuestionnaireItem = {
+      linkId: 'q1',
+      type: 'choice',
+      repeats: true,
+      answerOption: [
+        { valueCoding: { system: 'x', code: 'peanuts' } },
+        {
+          valueCoding: { system: 'x', code: 'no-known-allergies' },
+          extension: [{ url: QUESTIONNAIRE_OPTION_EXCLUSIVE_URL, valueBoolean: true }],
+        },
+      ],
+    };
+    const prev = [{ valueCoding: { system: 'x', code: 'peanuts' } }];
+    const next = [...prev, { valueCoding: { system: 'x', code: 'no-known-allergies' } }];
+    expect(applyOptionExclusive(codingItem, prev, next)).toEqual([
+      { valueCoding: { system: 'x', code: 'no-known-allergies' } },
+    ]);
   });
 });
 

--- a/packages/react-hooks/src/useQuestionnaireForm/utils.ts
+++ b/packages/react-hooks/src/useQuestionnaireForm/utils.ts
@@ -8,6 +8,7 @@ import {
   append,
   capitalize,
   deepClone,
+  deepEquals,
   evalFhirPathTyped,
   getExtension,
   getReferenceString,
@@ -62,6 +63,7 @@ export const QUESTIONNAIRE_CALCULATED_EXPRESSION_URL = `${HTTP_HL7_ORG}/fhir/uv/
 export const QUESTIONNAIRE_SIGNATURE_REQUIRED_URL = `${HTTP_HL7_ORG}/fhir/StructureDefinition/questionnaire-signatureRequired`;
 export const QUESTIONNAIRE_SIGNATURE_RESPONSE_URL = `${HTTP_HL7_ORG}/fhir/StructureDefinition/questionnaireresponse-signature`;
 export const QUESTIONNAIRE_HIDDEN_URL = `${HTTP_HL7_ORG}/fhir/StructureDefinition/questionnaire-hidden`;
+export const QUESTIONNAIRE_OPTION_EXCLUSIVE_URL = `${HTTP_HL7_ORG}/fhir/StructureDefinition/questionnaire-optionExclusive`;
 
 /**
  * Returns true if the item is a choice question.
@@ -348,6 +350,55 @@ export function getNewMultiSelectValues(
   }
 
   return result;
+}
+
+/**
+ * Applies the `questionnaire-optionExclusive` rule to an answer change.
+ *
+ * Given the previous and newly requested answers for an item, enforces that selecting an answer
+ * option marked exclusive clears every other answer, and selecting any other option clears a
+ * previously selected exclusive answer. Returns the new answers unchanged if the item has no
+ * exclusive options or the change only removed answers.
+ *
+ * See: https://hl7.org/fhir/extensions/StructureDefinition-questionnaire-optionExclusive.html
+ *
+ * @param item - The questionnaire item being answered.
+ * @param previousAnswers - The item's answers before the change.
+ * @param newAnswers - The answers requested by the change.
+ * @returns The reconciled answers.
+ */
+export function applyOptionExclusive(
+  item: QuestionnaireItem,
+  previousAnswers: QuestionnaireResponseItemAnswer[] | undefined,
+  newAnswers: QuestionnaireResponseItemAnswer[]
+): QuestionnaireResponseItemAnswer[] {
+  const exclusiveValues: TypedValue[] = [];
+  for (const option of item.answerOption ?? EMPTY) {
+    if (getExtension(option, QUESTIONNAIRE_OPTION_EXCLUSIVE_URL)?.valueBoolean === true) {
+      const optionValue = getItemAnswerOptionValue(option);
+      if (optionValue?.value !== undefined) {
+        exclusiveValues.push(optionValue);
+      }
+    }
+  }
+  if (exclusiveValues.length === 0) {
+    return newAnswers;
+  }
+
+  const isExclusive = (answer: QuestionnaireResponseItemAnswer): boolean => {
+    const answerValue = getResponseItemAnswerValue(answer);
+    return !!answerValue && exclusiveValues.some((exclusiveValue) => deepEquals(exclusiveValue, answerValue));
+  };
+
+  const added = newAnswers.filter((answer) => !previousAnswers?.some((prev) => deepEquals(prev, answer)));
+  const addedExclusive = added.find(isExclusive);
+  if (addedExclusive) {
+    return [addedExclusive];
+  }
+  if (added.some((answer) => !isExclusive(answer))) {
+    return newAnswers.filter((answer) => !isExclusive(answer));
+  }
+  return newAnswers;
 }
 
 function getByLinkId(

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
@@ -1085,6 +1085,105 @@ export const Choices = (): JSX.Element => (
   </Document>
 );
 
+export const OptionExclusive = (): JSX.Element => (
+  <Document>
+    <QuestionnaireForm
+      questionnaire={{
+        resourceType: 'Questionnaire',
+        id: 'option-exclusive',
+        title: 'Option Exclusive Example',
+        item: [
+          {
+            linkId: 'q1',
+            text: 'Question 1 - Checkbox (selecting "No known allergies" clears the others)',
+            type: 'choice',
+            repeats: true,
+            answerOption: [
+              {
+                valueString: 'Peanuts',
+              },
+              {
+                valueString: 'Shellfish',
+              },
+              {
+                valueString: 'Penicillin',
+              },
+              {
+                valueString: 'No known allergies',
+                extension: [
+                  {
+                    url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-optionExclusive',
+                    valueBoolean: true,
+                  },
+                ],
+              },
+            ],
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: 'http://hl7.org/fhir/questionnaire-item-control',
+                      code: 'check-box',
+                      display: 'Check box',
+                    },
+                  ],
+                  text: 'Check box',
+                },
+              },
+            ],
+          },
+          {
+            linkId: 'q2',
+            text: 'Question 2 - Multiselect Dropdown (selecting "None of the above" clears the others)',
+            type: 'choice',
+            repeats: true,
+            answerOption: [
+              {
+                valueString: 'Headache',
+              },
+              {
+                valueString: 'Fever',
+              },
+              {
+                valueString: 'Cough',
+              },
+              {
+                valueString: 'None of the above',
+                extension: [
+                  {
+                    url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-optionExclusive',
+                    valueBoolean: true,
+                  },
+                ],
+              },
+            ],
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: 'http://hl7.org/fhir/questionnaire-item-control',
+                      code: 'drop-down',
+                      display: 'Drop down',
+                    },
+                  ],
+                  text: 'Drop down',
+                },
+              },
+            ],
+          },
+        ],
+      }}
+      onSubmit={(formData: any) => {
+        console.log('submit', formData);
+      }}
+    />
+  </Document>
+);
+
 export const EnableWhen = (): JSX.Element => (
   <Document>
     <QuestionnaireForm

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -1714,7 +1714,7 @@ describe('QuestionnaireForm', () => {
       onSubmit,
     });
 
-    const checkboxes = screen.getAllByRole('checkbox');
+    const checkboxes = screen.getAllByRole<HTMLInputElement>('checkbox');
     expect(checkboxes.length).toBe(3);
     const [peanuts, shellfish, noAllergies] = checkboxes;
 

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -1666,6 +1666,193 @@ describe('QuestionnaireForm', () => {
     expect(response2.item[0].answer).toEqual(expect.arrayContaining([{}]));
   });
 
+  test('Checkbox optionExclusive', async () => {
+    const onSubmit = vi.fn();
+
+    await setup({
+      questionnaire: {
+        resourceType: 'Questionnaire',
+        status: 'active',
+        id: 'checkbox-option-exclusive',
+        title: 'Checkbox optionExclusive',
+        item: [
+          {
+            linkId: 'q1',
+            text: 'Select Allergies',
+            type: 'choice',
+            repeats: true,
+            answerOption: [
+              { valueString: 'Peanuts' },
+              { valueString: 'Shellfish' },
+              {
+                valueString: 'No known allergies',
+                extension: [
+                  {
+                    url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-optionExclusive',
+                    valueBoolean: true,
+                  },
+                ],
+              },
+            ],
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: 'http://hl7.org/fhir/questionnaire-item-control',
+                      code: 'check-box',
+                      display: 'Check Box',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+      onSubmit,
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes.length).toBe(3);
+    const [peanuts, shellfish, noAllergies] = checkboxes;
+
+    // Select two non-exclusive options
+    await act(async () => {
+      fireEvent.click(peanuts);
+    });
+    await act(async () => {
+      fireEvent.click(shellfish);
+    });
+    expect(peanuts.checked).toBe(true);
+    expect(shellfish.checked).toBe(true);
+
+    // Selecting the exclusive option clears the others
+    await act(async () => {
+      fireEvent.click(noAllergies);
+    });
+    expect(noAllergies.checked).toBe(true);
+    expect(peanuts.checked).toBe(false);
+    expect(shellfish.checked).toBe(false);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Submit'));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const response1 = onSubmit.mock.calls[0][0];
+    expect(response1.item[0].answer).toEqual([{ valueString: 'No known allergies' }]);
+
+    // Selecting a non-exclusive option clears the exclusive option
+    await act(async () => {
+      fireEvent.click(peanuts);
+    });
+    expect(peanuts.checked).toBe(true);
+    expect(noAllergies.checked).toBe(false);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Submit'));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+    const response2 = onSubmit.mock.calls[1][0];
+    expect(response2.item[0].answer).toEqual([{ valueString: 'Peanuts' }]);
+  });
+
+  test('Multi-Select Dropdown optionExclusive', async () => {
+    const onSubmit = vi.fn();
+
+    await setup({
+      questionnaire: {
+        resourceType: 'Questionnaire',
+        status: 'active',
+        id: 'dropdown-option-exclusive',
+        title: 'Multi-Select Dropdown optionExclusive',
+        item: [
+          {
+            linkId: 'q1',
+            text: 'Select Allergies',
+            type: 'choice',
+            repeats: true,
+            answerOption: [
+              { valueString: 'Peanuts' },
+              { valueString: 'Shellfish' },
+              {
+                valueString: 'No known allergies',
+                extension: [
+                  {
+                    url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-optionExclusive',
+                    valueBoolean: true,
+                  },
+                ],
+              },
+            ],
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: 'http://hl7.org/fhir/questionnaire-item-control',
+                      code: 'drop-down',
+                      display: 'Drop down',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+      onSubmit,
+    });
+
+    const input = screen.getByPlaceholderText('Select items');
+
+    const selectOption = async (label: string): Promise<void> => {
+      await act(async () => {
+        fireEvent.click(input);
+      });
+      await act(async () => {
+        fireEvent.change(input, { target: { value: label } });
+      });
+      // The options render into a portal that the a11y tree treats as hidden
+      await act(async () => {
+        fireEvent.click(screen.getByRole('option', { hidden: true, name: label }));
+      });
+    };
+
+    // Select two non-exclusive options
+    await selectOption('Peanuts');
+    await selectOption('Shellfish');
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Submit'));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const response1 = onSubmit.mock.calls[0][0];
+    expect(response1.item[0].answer).toEqual([{ valueString: 'Peanuts' }, { valueString: 'Shellfish' }]);
+
+    // Selecting the exclusive option clears the others
+    await selectOption('No known allergies');
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Submit'));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+    const response2 = onSubmit.mock.calls[1][0];
+    expect(response2.item[0].answer).toEqual([{ valueString: 'No known allergies' }]);
+
+    // Selecting a non-exclusive option clears the exclusive option
+    await selectOption('Peanuts');
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Submit'));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(3);
+    const response3 = onSubmit.mock.calls[2][0];
+    expect(response3.item[0].answer).toEqual([{ valueString: 'Peanuts' }]);
+  });
+
   test('Multi-Select Dropdown Value Set', async () => {
     const onSubmit = vi.fn();
 

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem.tsx
@@ -363,7 +363,7 @@ function QuestionnaireDropdownInput(props: QuestionnaireChoiceInputProps): JSX.E
         data={data}
         placeholder="Select items"
         searchable
-        defaultValue={currentAnswer || [typedValueToString(initialValue)]}
+        value={currentAnswer}
         required={required}
         onChange={(selected) => {
           if (selected.length === 0) {
@@ -592,12 +592,11 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
     available: isValueSetAvailable,
   } = useValueSetOptions(item.answerValueSet);
 
-  // Get initial values from response
-  const initialSelectedValues = item.answerValueSet
+  // Derive the selected values from the response rather than local state, so that answers
+  // rewritten by the form state (e.g. optionExclusive) are reflected in the checkboxes.
+  const selectedValues = item.answerValueSet
     ? (response?.answer?.map((a) => a.valueCoding) || []).filter((c): c is Coding => c !== undefined)
     : getCurrentMultiSelectAnswer(response);
-
-  const [selectedValues, setSelectedValues] = useState(initialSelectedValues);
 
   const options: [string, TypedValue][] = [];
 
@@ -641,7 +640,6 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
         newCodings = currentCodings.filter((c) => !deepEquals(c, optionValue.value));
       }
 
-      setSelectedValues(newCodings);
       if (newCodings.length === 0) {
         onChangeAnswer([{}]);
       } else {
@@ -658,7 +656,6 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
         newValues = currentValues.filter((v) => v !== optionValueStr);
       }
 
-      setSelectedValues(newValues);
       if (newValues.length === 0) {
         onChangeAnswer([{}]);
       } else {


### PR DESCRIPTION
Solves https://github.com/medplum/medplum/issues/8992

Implements the FHIR [`questionnaire-optionExclusive`](https://hl7.org/fhir/extensions/StructureDefinit
  ion-questionnaire-optionExclusive.html) extension for multi-answer choice items in
  `QuestionnaireForm`:

  - Selecting an option marked exclusive (e.g. "No known allergies") clears all other selections.
  - Selecting any non-exclusive option clears a previously selected exclusive one.
  
  
<img width="901" height="388" alt="Screenshot 2026-07-28 at 11 47 33 AM" src="https://github.com/user-attachments/assets/7d3a136a-a6d2-4dc4-805d-71bf670eaf4b" />
