### PR TITLE
First pass at new community PR workflow

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,25 @@
+# Vouched (and denounced) contributors for this repository, used by the
+# "Vouch" GitHub Actions workflows (.github/workflows/vouch-*.yml) to decide
+# who can open issues/PRs without extra scrutiny.
+#
+# - Vouched users' PRs are never required to link to an "accepting-prs"
+#   labeled issue; everyone else's are (see vouch-check-pr.yml).
+# - Denounced users have their issues and PRs closed automatically,
+#   regardless of anything else (see vouch-check-issue.yml / vouch-check-pr.yml).
+#
+# This file is largely managed automatically: vouch-sync-codeowners.yml
+# (run manually via the Actions UI) expands the teams in .github/CODEOWNERS
+# into individual users and adds them here as vouched. It only ever adds
+# entries -- it won't remove someone just because they left a team, and it
+# will replace a denounced entry with a vouched one if that person is (or
+# becomes) a codeowner. Entries can also be added/edited by hand, e.g. to
+# vouch someone who isn't a codeowner, or to denounce someone.
+#
+# See https://github.com/mitchellh/vouch for the tool this file feeds.
+#
+# Syntax:
+#   - One handle per line (without @), sorted alphabetically.
+#   - Optional platform prefix: platform:username (e.g., github:user).
+#   - Denounce with a minus prefix: -username or -platform:username.
+#   - Optional free-text details after a space following the handle
+#     (e.g. a reason for denouncement).

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -2,7 +2,7 @@
 # "Vouch" GitHub Actions workflows (.github/workflows/vouch-*.yml) to decide
 # who can open issues/PRs without extra scrutiny.
 #
-# - Vouched users' PRs are never required to link to an "accepting-prs"
+# - Vouched users' PRs are never required to link to a correctly
 #   labeled issue; everyone else's are (see vouch-check-pr.yml).
 # - Denounced users have their issues and PRs closed automatically,
 #   regardless of anything else (see vouch-check-issue.yml / vouch-check-pr.yml).

--- a/.github/pr-unvouched-message
+++ b/.github/pr-unvouched-message
@@ -1,0 +1,9 @@
+Hi @{author}, thanks for the PR!
+
+Contributors who aren't yet vouched for need their PR linked to an issue labeled `{label}`, showing we've explicitly invited a community PR for that work (link it with "Fixes #..."/"Closes #..." in the description, or via the Development panel).
+
+This PR isn't linked to a qualifying issue, so it's being closed automatically. If there's already an issue for this work, ask a maintainer to add the `{label}` label to it, then link this PR to it and reopen. If there isn't one yet, open an issue describing the change -- a maintainer can add the `{label}` label if it's something we're open to a community PR for.
+
+You can browse [open issues labeled `{label}`](https://github.com/{repo}/issues?q=is%3Aissue+is%3Aopen+label%3A{label}) for existing work you could pick up instead.
+
+See our [contributing guide](https://www.medplum.com/docs/contributing) for more on how to get involved.

--- a/.github/pr-unvouched-message
+++ b/.github/pr-unvouched-message
@@ -2,7 +2,7 @@ Hi @{author}, thanks for the PR!
 
 Contributors who aren't yet vouched for need their PR linked to an issue labeled `{label}`, showing we've explicitly invited a community PR for that work (link it with "Fixes #..."/"Closes #..." in the description, or via the Development panel).
 
-This PR isn't linked to a qualifying issue, so it's being closed automatically. If there's already an issue for this work, ask a maintainer to add the `{label}` label to it, then link this PR to it and reopen. If there isn't one yet, open an issue describing the change -- a maintainer can add the `{label}` label if it's something we're open to a community PR for.
+This PR isn't linked to a qualifying issue, so it's being closed automatically. If there's already an issue for this work, comment there with your proposed approach. If there isn't one yet, open one describing the change. Either way, a maintainer will add the `{label}` label once there's enough discussion for us to be confident you have the context needed to land it -- at that point, link this PR to the issue and reopen it.
 
 You can browse [open issues labeled `{label}`](https://github.com/{repo}/issues?q=is%3Aissue+is%3Aopen+label%3A{label}) for existing work you could pick up instead.
 

--- a/.github/workflows/vouch-check-issue.yml
+++ b/.github/workflows/vouch-check-issue.yml
@@ -1,0 +1,26 @@
+on:
+  issues:
+    types: [opened, reopened]
+
+name: "Vouch - Check Issue"
+
+permissions:
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      # require-vouch is false: only explicitly denounced (blocked) users get
+      # closed here. Everyone else may file issues freely, per medplum's
+      # public contributing docs (medplum.com/docs/contributing). Note the
+      # action uses a fixed message for denounced users regardless of any
+      # template-file, so there's no template to configure here.
+      - uses: mitchellh/vouch/action/check-issue@d66fa29a64600490892131ad87597c30c91fcac4 # v1.5.0
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          require-vouch: false
+          auto-close: true
+          auto-lock: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-check-issue.yml
+++ b/.github/workflows/vouch-check-issue.yml
@@ -2,7 +2,7 @@ on:
   issues:
     types: [opened, reopened]
 
-name: "Vouch - Check Issue"
+name: 'Vouch - Check Issue'
 
 permissions:
   issues: write

--- a/.github/workflows/vouch-check-issue.yml
+++ b/.github/workflows/vouch-check-issue.yml
@@ -16,11 +16,16 @@ jobs:
       # public contributing docs (medplum.com/docs/contributing). Note the
       # action uses a fixed message for denounced users regardless of any
       # template-file, so there's no template to configure here.
+      # Defaults to dry-run (safe) until the VOUCH_DRY_RUN repo variable
+      # (Settings -> Secrets and variables -> Actions -> Variables) is
+      # explicitly set to "false" -- flip it there, no workflow edit needed,
+      # once you're ready to actually close/lock issues for real.
       - uses: mitchellh/vouch/action/check-issue@d66fa29a64600490892131ad87597c30c91fcac4 # v1.5.0
         with:
           issue-number: ${{ github.event.issue.number }}
           require-vouch: false
           auto-close: true
           auto-lock: true
+          dry-run: ${{ vars.VOUCH_DRY_RUN || 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -13,7 +13,7 @@ env:
   # Non-vouched (but not denounced) authors may still have their PR merged if
   # it's linked to an issue carrying this label, indicating we've explicitly
   # invited a community PR for that issue.
-  COMMUNITY_PR_LABEL: accepting-prs
+  COMMUNITY_PR_LABEL: open-to-community
 
 jobs:
   check:

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -2,7 +2,7 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
-name: "Vouch - Check PR"
+name: 'Vouch - Check PR'
 
 permissions:
   issues: write

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -24,12 +24,20 @@ jobs:
       # merely-unvouched (never vouched, never denounced) author comes back
       # as "allowed", and gets a second, narrower check below rather than
       # being closed outright.
+      #
+      # Defaults to dry-run (safe) until the VOUCH_DRY_RUN repo variable
+      # (Settings -> Secrets and variables -> Actions -> Variables) is
+      # explicitly set to "false" -- flip it there, no workflow edit needed,
+      # once you're ready to actually close PRs for real. The `status`
+      # output (and so the rest of this workflow's branching) is computed
+      # the same either way.
       - uses: mitchellh/vouch/action/check-pr@d66fa29a64600490892131ad87597c30c91fcac4 # v1.5.0
         id: vouch
         with:
           pr-number: ${{ github.event.pull_request.number }}
           require-vouch: false
           auto-close: true
+          dry-run: ${{ vars.VOUCH_DRY_RUN || 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -77,16 +85,25 @@ jobs:
         with:
           sparse-checkout: .github/pr-unvouched-message
 
+      # Not part of the vouch action, so it doesn't get dry-run for free --
+      # gated on the same VOUCH_DRY_RUN repo variable by hand, also
+      # defaulting to dry-run (safe) until explicitly set to "false".
       - name: Close PR (unvouched, no linked issue with the community-PR label)
         if: steps.vouch.outputs.status == 'allowed' && steps.label-check.outputs.has-label == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          DRY_RUN: ${{ vars.VOUCH_DRY_RUN || 'true' }}
         run: |
           MESSAGE=$(cat .github/pr-unvouched-message)
           MESSAGE="${MESSAGE//\{author\}/$PR_AUTHOR}"
           MESSAGE="${MESSAGE//\{label\}/$COMMUNITY_PR_LABEL}"
           MESSAGE="${MESSAGE//\{repo\}/${{ github.repository }}}"
 
-          gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --body "$MESSAGE"
-          gh pr close "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "(dry-run) Would post comment and close PR. Comment body:"
+            echo "$MESSAGE"
+          else
+            gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --body "$MESSAGE"
+            gh pr close "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"
+          fi

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -1,0 +1,92 @@
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+name: "Vouch - Check PR"
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+env:
+  # Non-vouched (but not denounced) authors may still have their PR merged if
+  # it's linked to an issue carrying this label, indicating we've explicitly
+  # invited a community PR for that issue.
+  COMMUNITY_PR_LABEL: accepting-prs
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      # require-vouch is false here so this step only ever auto-closes
+      # denounced users, which are always blocked with no exception. A
+      # merely-unvouched (never vouched, never denounced) author comes back
+      # as "allowed", and gets a second, narrower check below rather than
+      # being closed outright.
+      - uses: mitchellh/vouch/action/check-pr@d66fa29a64600490892131ad87597c30c91fcac4 # v1.5.0
+        id: vouch
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          require-vouch: false
+          auto-close: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # closingIssuesReferences reflects GitHub's own "linked issue" concept
+      # (a closing keyword like "Fixes #123" in the PR body, or a manual link
+      # via the Development panel) rather than just a mention of a number
+      # somewhere in the PR text. Note it isn't scoped to this repo: it also
+      # returns cross-repo closing references (e.g. "Fixes other/repo#123"),
+      # so a same-named label on an unrelated repo's issue would incorrectly
+      # satisfy this check. Not filtered here since we don't expect cross-repo
+      # linking in practice, but worth tightening if that changes.
+      - name: Check for a linked issue with the community-PR label
+        id: label-check
+        if: steps.vouch.outputs.status == 'allowed'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          HAS_LABEL=$(gh api graphql \
+            -f query='
+              query($owner: String!, $name: String!, $number: Int!) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 20) {
+                      nodes {
+                        labels(first: 50) {
+                          nodes { name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }' \
+            -f owner="${{ github.repository_owner }}" \
+            -f name="${{ github.event.repository.name }}" \
+            -F number="${{ github.event.pull_request.number }}" \
+            --jq "[.data.repository.pullRequest.closingIssuesReferences.nodes[].labels.nodes[].name] | any(. == \"$COMMUNITY_PR_LABEL\")")
+
+          echo "has-label=$HAS_LABEL" >> "$GITHUB_OUTPUT"
+
+      # Sparse-checkout of the base ref only (the default for pull_request_target),
+      # never the untrusted PR head, so this is just pulling a maintainer-controlled
+      # template file, not executing anything from the fork.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.vouch.outputs.status == 'allowed' && steps.label-check.outputs.has-label == 'false'
+        with:
+          sparse-checkout: .github/pr-unvouched-message
+
+      - name: Close PR (unvouched, no linked issue with the community-PR label)
+        if: steps.vouch.outputs.status == 'allowed' && steps.label-check.outputs.has-label == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          MESSAGE=$(cat .github/pr-unvouched-message)
+          MESSAGE="${MESSAGE//\{author\}/$PR_AUTHOR}"
+          MESSAGE="${MESSAGE//\{label\}/$COMMUNITY_PR_LABEL}"
+          MESSAGE="${MESSAGE//\{repo\}/${{ github.repository }}}"
+
+          gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --body "$MESSAGE"
+          gh pr close "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"

--- a/.github/workflows/vouch-sync-codeowners.yml
+++ b/.github/workflows/vouch-sync-codeowners.yml
@@ -1,12 +1,13 @@
 on:
+  # Does not run on a schedule since codeowners is very low velocity; manually triggering is sufficient for now.
   workflow_dispatch:
     inputs:
       lookback-days:
-        description: "How many days of merged PRs to scan for the unvouched-contributors report"
+        description: 'How many days of merged PRs to scan for the unvouched-contributors report'
         required: false
-        default: "90"
+        default: '90'
 
-name: "Vouch - Sync CODEOWNERS"
+name: 'Vouch - Sync CODEOWNERS'
 
 concurrency:
   group: vouch-manage
@@ -37,8 +38,8 @@ jobs:
       - uses: mitchellh/vouch/action/sync-codeowners@d66fa29a64600490892131ad87597c30c91fcac4 # v1.5.0
         with:
           repo: ${{ github.repository }}
-          pull-request: "true"
-          merge-immediately: "false"
+          pull-request: 'true'
+          merge-immediately: 'false'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
@@ -48,7 +49,7 @@ jobs:
       # re-reads VOUCHED.td via the Contents API rather than the local
       # checkout, since the sync step above may have just merged a PR
       # updating it. Read-only, so this uses the default GITHUB_TOKEN rather
-      # than VOUCH_SYNC_TOKEN.
+      # than the VOUCH_APP_ID/VOUCH_APP_PRIVATE_KEY App token.
       - name: Report merged-PR authors who aren't vouched
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-sync-codeowners.yml
+++ b/.github/workflows/vouch-sync-codeowners.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.VOUCH_APP_ID }}
+          app-id: ${{ vars.VOUCH_APP_ID }}
           private-key: ${{ secrets.VOUCH_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/vouch-sync-codeowners.yml
+++ b/.github/workflows/vouch-sync-codeowners.yml
@@ -1,0 +1,123 @@
+on:
+  workflow_dispatch:
+    inputs:
+      lookback-days:
+        description: "How many days of merged PRs to scan for the unvouched-contributors report"
+        required: false
+        default: "90"
+
+name: "Vouch - Sync CODEOWNERS"
+
+concurrency:
+  group: vouch-manage
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      # Every owner in our CODEOWNERS is a team (@medplum/core, @medplum/dev,
+      # etc.), so this always needs to resolve team membership via the org
+      # Teams API. The default GITHUB_TOKEN can't do that -- "members" isn't
+      # a grantable GITHUB_TOKEN permission scope at all, regardless of the
+      # `permissions:` block -- so this needs a PAT from a dedicated
+      # bot/service account instead: repo (or fine-grained: this repo's
+      # Contents + Pull requests, read/write) plus org Members: read-only.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ secrets.VOUCH_SYNC_TOKEN }}
+
+      - uses: mitchellh/vouch/action/sync-codeowners@d66fa29a64600490892131ad87597c30c91fcac4 # v1.5.0
+        with:
+          repo: ${{ github.repository }}
+          pull-request: "true"
+          merge-immediately: "true"
+        env:
+          GITHUB_TOKEN: ${{ secrets.VOUCH_SYNC_TOKEN }}
+
+      # Informational only: surfaces recent merged-PR authors who aren't
+      # vouched (via CODEOWNERS/team membership or otherwise), as candidates
+      # a maintainer might want to vouch by hand. Doesn't gate anything, and
+      # re-reads VOUCHED.td via the Contents API rather than the local
+      # checkout, since the sync step above may have just merged a PR
+      # updating it. Read-only, so this uses the default GITHUB_TOKEN rather
+      # than VOUCH_SYNC_TOKEN.
+      - name: Report merged-PR authors who aren't vouched
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          VOUCHED_JSON=$( { gh api "repos/${{ github.repository }}/contents/.github/VOUCHED.td" --jq '.content' 2>/dev/null \
+            | base64 -d \
+            | grep -v '^#' \
+            | grep -v '^-' \
+            | grep -vE '^\s*$' \
+            | awk '{print $1}' \
+            | sed -E 's/^[A-Za-z0-9_-]+://' \
+            | tr '[:upper:]' '[:lower:]' \
+            | sort -u || true; } \
+            | jq -R -s -c 'split("\n") | map(select(length > 0))')
+
+          SINCE=$(date -u -d "${{ github.event.inputs.lookback-days }} days ago" +%Y-%m-%d)
+          UNTIL=$(date -u +%Y-%m-%d)
+
+          # GitHub's search API hard-caps any single query at 1000 total
+          # results -- there's no cursor to page past that, since the cap is
+          # on the match count, not the pagination. Instead we adaptively
+          # bisect the merged-date range: a sub-range coming back with
+          # exactly 1000 results is a sign it may be truncated, so split it
+          # in half by date and re-query both halves, until every sub-range
+          # is safely under the cap.
+          RANGES=("$SINCE:$UNTIL")
+          PRS_JSON="[]"
+
+          while [ ${#RANGES[@]} -gt 0 ]; do
+            RANGE="${RANGES[0]}"
+            RANGES=("${RANGES[@]:1}")
+            START="${RANGE%%:*}"
+            END="${RANGE##*:}"
+
+            BATCH=$(gh search prs --repo "${{ github.repository }}" --merged \
+              --merged-at "${START}..${END}" --json number,author --limit 1000)
+            COUNT=$(echo "$BATCH" | jq 'length')
+
+            START_EPOCH=$(date -u -d "$START" +%s)
+            END_EPOCH=$(date -u -d "$END" +%s)
+            MID=$(date -u -d "@$(( (START_EPOCH + END_EPOCH) / 2 ))" +%Y-%m-%d)
+
+            if [ "$COUNT" -eq 1000 ] && [ "$MID" != "$START" ] && [ "$MID" != "$END" ]; then
+              RANGES+=("$START:$MID" "$MID:$END")
+            else
+              if [ "$COUNT" -eq 1000 ]; then
+                echo "::warning::merged-PR count hit the 1000 search cap for $START..$END and can't be split further (single day); results may be incomplete"
+              fi
+              PRS_JSON=$(jq -c -n --argjson a "$PRS_JSON" --argjson b "$BATCH" '$a + $b')
+            fi
+          done
+
+          # Group by (lowercased, non-bot) author login, count and list PR
+          # numbers per author, drop anyone already vouched, sort by
+          # descending merged-PR count.
+          REPORT=$(echo "$PRS_JSON" | jq -r --argjson vouched "$VOUCHED_JSON" '
+            map(select(.author.login | test("\\[bot\\]$") | not))
+            | map({login: (.author.login | ascii_downcase), number})
+            | group_by(.login)
+            | map({login: .[0].login, numbers: (map(.number) | sort | reverse)})
+            | map(select(.login as $l | $vouched | index($l) | not))
+            | sort_by(-(.numbers | length))
+            | map("| \(.login) | \(.numbers | length) | " + (.numbers | map("#\(.)") | join(", ")) + " |")
+            | .[]
+          ')
+
+          {
+            echo "### Merged-PR authors (last ${{ github.event.inputs.lookback-days }} days) who aren't vouched"
+            if [ -z "$REPORT" ]; then
+              echo "None -- everyone with a recently merged PR is vouched."
+            else
+              echo
+              echo "| Username | Merged PRs | PR Numbers |"
+              echo "|---|---|---|"
+              echo "$REPORT"
+            fi
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/vouch-sync-codeowners.yml
+++ b/.github/workflows/vouch-sync-codeowners.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           repo: ${{ github.repository }}
           pull-request: "true"
-          merge-immediately: "true"
+          merge-immediately: "false"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/vouch-sync-codeowners.yml
+++ b/.github/workflows/vouch-sync-codeowners.yml
@@ -20,12 +20,19 @@ jobs:
       # etc.), so this always needs to resolve team membership via the org
       # Teams API. The default GITHUB_TOKEN can't do that -- "members" isn't
       # a grantable GITHUB_TOKEN permission scope at all, regardless of the
-      # `permissions:` block -- so this needs a PAT from a dedicated
-      # bot/service account instead: repo (or fine-grained: this repo's
-      # Contents + Pull requests, read/write) plus org Members: read-only.
+      # `permissions:` block -- so this uses a dedicated GitHub App
+      # (VOUCH_APP_ID / VOUCH_APP_PRIVATE_KEY) installed on this repo with
+      # org Members: read-only plus repo Contents + Pull requests: read/write,
+      # rather than a PAT tied to a human or bot user account.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.VOUCH_APP_ID }}
+          private-key: ${{ secrets.VOUCH_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          token: ${{ secrets.VOUCH_SYNC_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: mitchellh/vouch/action/sync-codeowners@d66fa29a64600490892131ad87597c30c91fcac4 # v1.5.0
         with:
@@ -33,7 +40,7 @@ jobs:
           pull-request: "true"
           merge-immediately: "true"
         env:
-          GITHUB_TOKEN: ${{ secrets.VOUCH_SYNC_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # Informational only: surfaces recent merged-PR authors who aren't
       # vouched (via CODEOWNERS/team membership or otherwise), as candidates

--- a/packages/docs/docs/contributing/index.md
+++ b/packages/docs/docs/contributing/index.md
@@ -65,7 +65,7 @@ If you find a bug on Medplum and open a GitHub Pull Request that fixes it, we'll
 Before starting implementation of a new feature, open an issue first to discuss your plans and to ensure it fits into
 our roadmap and plans for the app.
 
-If you're not yet an established contributor, your pull request needs to be linked to an issue labeled `accepting-prs`
+If you're not yet an established contributor, your pull request needs to be linked to an issue labeled `open-to-community`
 (for example with a "Fixes #123" or "Closes #123" reference, or via the GitHub "Development" panel) -- this shows
 we've explicitly invited a community PR for that work. A maintainer can add this label to an existing issue, including
 one you just opened, on request. Pull requests that aren't linked to a qualifying issue are closed automatically;

--- a/packages/docs/docs/contributing/index.md
+++ b/packages/docs/docs/contributing/index.md
@@ -65,6 +65,13 @@ If you find a bug on Medplum and open a GitHub Pull Request that fixes it, we'll
 Before starting implementation of a new feature, open an issue first to discuss your plans and to ensure it fits into
 our roadmap and plans for the app.
 
+If you're not yet an established contributor, your pull request needs to be linked to an issue labeled `accepting-prs`
+(for example with a "Fixes #123" or "Closes #123" reference, or via the GitHub "Development" panel) -- this shows
+we've explicitly invited a community PR for that work. A maintainer can add this label to an existing issue, including
+one you just opened, on request. Pull requests that aren't linked to a qualifying issue are closed automatically;
+just reopen it once it's linked, or open the issue first if one doesn't exist yet. Medplum team members and
+established community contributors aren't subject to this requirement.
+
 **Ready to get started writing code?** First things first, you need to [clone the Medplum repository](./contributing/local-dev-setup).
 
 :::note[Legal Note]


### PR DESCRIPTION
The vouch system is currently configured in **dry run** mode; no automatic closing of PRs will occur until we flip `vars.VOUCH_DRY_RUN` to `false`

Created [the vouch app](https://github.com/organizations/medplum/settings/apps/medplum-vouch)
[Installed](https://github.com/organizations/medplum/settings/installations/149694730) the vouch app

Configured the necessary repo variables and secrets: 
**variables**
* VOUCH_DRY_RUN - `true`
* VOUCH_APP_ID - the numeric ID from the github app I created (

**secrets**
* VOUCH_APP_PRIVATE_KEY - PEM file generated from the app


The changes to our contributing workflow are very much a work in progress.  Please bear with us as we attempt to get a handle on this; Medplum loves being open source and thrives on community involvement. Like a lot of other open source projects, we have recently been struggling to triage and ingest the rapid rise of AI-driven contributions.