### PR TITLE
Fix S3 docs deploy

### DIFF
--- a/scripts/cicd-deploy.sh
+++ b/scripts/cicd-deploy.sh
@@ -174,5 +174,6 @@ fi
 # Deploy docs last since it is the slowest
 if [[ "$DEPLOY_DOCS" = true ]]; then
   echo "Deploy docs"
+  npm run build:docs
   source ./scripts/deploy-docs.sh
 fi

--- a/scripts/s3deploy.mjs
+++ b/scripts/s3deploy.mjs
@@ -148,4 +148,7 @@ async function uploadAll(requests) {
   await Promise.all(uploads);
 }
 
-main().catch(console.error);
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
For now, `www.medplum.com` is still hosted by Vercel, so this has not been impactful, but in #7635 we introduced a "DEPLOY DOCS" chunk in `scripts/cicd-deploy.sh` with the intention of pushing a copy of the documentation into an S3 bucket.

That has not quite been working as intended; in the calling workflow (`.github/workflows/deploy`) we invoke `npm run build:fast`, which does not build the `docs` package (as it is slow).

This results in the cicd deploy script emitting output like this:
> ```
> Deploy docs
> + echo 'Deploy docs'
> + source ./scripts/deploy-docs.sh
> ++ [[ -z www.***.com ]]
> ++ set -e
> ++ set -x
> ++ node scripts/s3deploy.mjs packages/docs/build s3://www.***.com
> Starting deployment to s3://www.***.com/
> Error: ENOENT: no such file or directory, scandir 'packages/docs/build'
>     at async readdir (node:internal/fs/promises:956:18)
>     at async getFiles (file:///home/runner/work/***/***/scripts/s3deploy.mjs:126:17)
>     at async main (file:///home/runner/work/***/***/scripts/s3deploy.mjs:82:20) {
>   errno: -2,
>   code: 'ENOENT',
>   syscall: 'scandir',
>   path: 'packages/docs/build'
> }
> ```
(from https://github.com/medplum/medplum/actions/runs/30408761739/job/90440115038)

Let's fix this by actually invoking the build script in `packages/docs`, which generates the `packages/docs/build` directory that the script is expecting to read from.

To make such errors more apparent in the future, we also adjust the error handling case in `scripts/s3deploy.mjs` - if we catch an error, we set `process.exitCode = 1` so that when the node process terminates it exits with a non-zero exit code. That is called from `scripts/deploy-docs.sh`, which has the `-e` option set, so it will see that the command exited abnormally and itself exit with the same error code. That script is sourced from `scripts/cicd-deploy.sh`, which is invoked as a `run` command inside `.github/workflows/deploy.yml`. That will cause that workflow to error instead of swallowing the error at the tail end of a very long script output.