### PR TITLE
feat(core): add defaultSearchParams to MedplumClient + compartment filter UI

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -25,6 +25,7 @@ import type { FunctionComponent, JSX } from 'react';
 import { Suspense } from 'react';
 import { Link, useLocation, useSearchParams } from 'react-router';
 import { AppRoutes } from './AppRoutes';
+import { CompartmentFilterControl } from './CompartmentFilterControl';
 
 import './App.css';
 
@@ -47,6 +48,7 @@ export function App(): JSX.Element {
       version={MEDPLUM_VERSION}
       menus={userConfigToMenu(config)}
       displayAddBookmark={!!config?.id}
+      notifications={<CompartmentFilterControl />}
       announcements={
         project?.superAdmin
           ? [

--- a/packages/app/src/CompartmentFilterControl.tsx
+++ b/packages/app/src/CompartmentFilterControl.tsx
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Button, Group, Pill, Popover, Stack, Text } from '@mantine/core';
+import { ReferenceInput, useMedplum } from '@medplum/react';
+import { IconFilter, IconFilterFilled } from '@tabler/icons-react';
+import type { JSX } from 'react';
+import { useState } from 'react';
+import { getCompartmentFilters, setCompartmentFilters } from './compartmentFilter';
+
+/**
+ * Header control that sets one or more compartment filters applied to all FHIR searches.
+ *
+ * Selected compartments are combined with OR semantics: a single `_compartment=A,B` default
+ * search param is set on the MedplumClient (see `compartmentFilter.ts`), scoping subsequent
+ * list/search queries to resources in ANY of the selected compartments. This is a client-side
+ * convenience only: the server still enforces the user's access policy, so it can only narrow
+ * results within what the user may already read.
+ *
+ * The popover lets the user build up the list without side effects; "Apply" commits the change
+ * and reloads the page so every query surface picks it up, matching the project switcher.
+ * @returns The compartment filter control element.
+ */
+export function CompartmentFilterControl(): JSX.Element {
+  const medplum = useMedplum();
+  const [opened, setOpened] = useState(false);
+  const active = getCompartmentFilters();
+
+  // Draft list edited within the popover; only committed on "Apply".
+  const [pending, setPending] = useState<string[]>(active);
+  // Bump to remount the ReferenceInput (clearing it) after each add.
+  const [inputKey, setInputKey] = useState(0);
+
+  function addReference(reference: string | undefined): void {
+    if (reference && !pending.includes(reference)) {
+      setPending([...pending, reference]);
+    }
+    setInputKey((k) => k + 1);
+  }
+
+  function removeReference(reference: string): void {
+    setPending(pending.filter((r) => r !== reference));
+  }
+
+  function apply(references: string[]): void {
+    setCompartmentFilters(medplum, references);
+    window.location.reload();
+  }
+
+  const dirty = pending.length !== active.length || pending.some((r, i) => r !== active[i]);
+
+  let label = 'Compartment';
+  if (active.length === 1) {
+    label = active[0];
+  } else if (active.length > 1) {
+    label = `${active.length} compartments`;
+  }
+
+  return (
+    <Popover opened={opened} onChange={setOpened} position="bottom-end" width={380} withArrow shadow="md">
+      <Popover.Target>
+        <Button
+          variant={active.length ? 'light' : 'subtle'}
+          color={active.length ? 'blue' : 'gray'}
+          size="compact-sm"
+          leftSection={active.length ? <IconFilterFilled size={16} /> : <IconFilter size={16} />}
+          onClick={() => setOpened((o) => !o)}
+          title="Filter all queries to one or more compartments"
+        >
+          {label}
+        </Button>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <Stack gap="sm">
+          <Text size="sm" fw={500}>
+            Compartment filter
+          </Text>
+          <Text size="xs" c="dimmed">
+            Scope all searches to one or more compartments (matches any). Pick any resource; the server still
+            enforces your access policy.
+          </Text>
+          {pending.length > 0 && (
+            <Pill.Group>
+              {pending.map((reference) => (
+                <Pill key={reference} withRemoveButton onRemove={() => removeReference(reference)}>
+                  {reference}
+                </Pill>
+              ))}
+            </Pill.Group>
+          )}
+          <ReferenceInput
+            key={inputKey}
+            name="compartment-filter"
+            placeholder="Add a resource"
+            onChange={(value) => addReference(value?.reference)}
+          />
+          <Group justify="space-between">
+            <Button
+              variant="subtle"
+              size="compact-sm"
+              color="gray"
+              disabled={pending.length === 0}
+              onClick={() => setPending([])}
+            >
+              Clear all
+            </Button>
+            <Button size="compact-sm" disabled={!dirty} onClick={() => apply(pending)}>
+              Apply
+            </Button>
+          </Group>
+        </Stack>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}

--- a/packages/app/src/CompartmentFilterControl.tsx
+++ b/packages/app/src/CompartmentFilterControl.tsx
@@ -75,8 +75,8 @@ export function CompartmentFilterControl(): JSX.Element {
             Compartment filter
           </Text>
           <Text size="xs" c="dimmed">
-            Scope all searches to one or more compartments (matches any). Pick any resource; the server still
-            enforces your access policy.
+            Scope all searches to one or more compartments (matches any). Pick any resource; the server still enforces
+            your access policy.
           </Text>
           {pending.length > 0 && (
             <Pill.Group>

--- a/packages/app/src/compartmentFilter.ts
+++ b/packages/app/src/compartmentFilter.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { MedplumClient } from '@medplum/core';
+
+/**
+ * localStorage key holding the active compartment filter references, as a JSON array of
+ * reference strings (e.g. ["Organization/abc", "Patient/123"]). Persisted so the filter
+ * survives reloads, mirroring the app's other localStorage-backed preferences.
+ */
+const STORAGE_KEY = 'compartmentFilter';
+
+/**
+ * Returns the active compartment filter references, or an empty array if no filter is set.
+ * Tolerates the legacy single-string format that earlier versions stored under the same key.
+ * @returns The compartment references (e.g. ["Organization/abc"]).
+ */
+export function getCompartmentFilters(): string[] {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((r): r is string => typeof r === 'string' && r.length > 0);
+    }
+  } catch {
+    // Legacy format: a bare reference string rather than a JSON array.
+    return [raw];
+  }
+  return [];
+}
+
+/**
+ * Builds the default search params for the active compartment filter.
+ * Used to seed `MedplumClient.defaultSearchParams` at construction and whenever the filter changes.
+ *
+ * Multiple compartments are combined with OR semantics via a single comma-separated
+ * `_compartment` value (e.g. `_compartment=Organization/abc,Patient/123`), matching a resource
+ * that belongs to ANY of the selected compartments.
+ * @returns URLSearchParams with `_compartment` set, or undefined if no filter is active.
+ */
+export function getCompartmentSearchParams(): URLSearchParams | undefined {
+  const references = getCompartmentFilters();
+  return references.length ? new URLSearchParams({ _compartment: references.join(',') }) : undefined;
+}
+
+/**
+ * Sets or clears the compartment filter and applies it to the client's default search params.
+ *
+ * This only narrows queries on the client; the server still enforces the user's access policy,
+ * so a user can never see resources they aren't already permitted to read.
+ * @param medplum - The Medplum client to apply the filter to.
+ * @param references - The compartment references (e.g. ["Organization/abc"]); empty to clear.
+ */
+export function setCompartmentFilters(medplum: MedplumClient, references: string[]): void {
+  if (references.length) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(references));
+  } else {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+  medplum.setDefaultSearchParams(getCompartmentSearchParams());
+}

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -11,6 +11,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider, createBrowserRouter } from 'react-router';
 import { App } from './App';
+import { getCompartmentSearchParams } from './compartmentFilter';
 import { getConfig } from './config';
 import './index.css';
 
@@ -23,6 +24,7 @@ export async function initApp(): Promise<void> {
     storagePrefix: '@medplum:',
     cacheTime: 60000,
     autoBatchTime: 100,
+    defaultSearchParams: getCompartmentSearchParams(),
     onUnauthenticated: () => {
       if (window.location.pathname !== '/signin' && window.location.pathname !== '/oauth') {
         window.location.href = '/signin?next=' + encodeURIComponent(window.location.pathname + window.location.search);

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -323,7 +323,9 @@ describe('Client', () => {
 
   test('defaultSearchParams', () => {
     // Applied from the constructor option
-    const client = new MedplumClient({ defaultSearchParams: new URLSearchParams({ _compartment: 'Organization/abc' }) });
+    const client = new MedplumClient({
+      defaultSearchParams: new URLSearchParams({ _compartment: 'Organization/abc' }),
+    });
     expect(client.fhirSearchUrl('Patient', undefined).searchParams.get('_compartment')).toBe('Organization/abc');
 
     // Merged alongside a caller's query

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -321,6 +321,46 @@ describe('Client', () => {
     expect(clientWithoutDefaultHeaders.getDefaultHeaders()).toStrictEqual({});
   });
 
+  test('defaultSearchParams', () => {
+    // Applied from the constructor option
+    const client = new MedplumClient({ defaultSearchParams: new URLSearchParams({ _compartment: 'Organization/abc' }) });
+    expect(client.fhirSearchUrl('Patient', undefined).searchParams.get('_compartment')).toBe('Organization/abc');
+
+    // Merged alongside a caller's query
+    const withQuery = client.fhirSearchUrl('Patient', 'name=Alice');
+    expect(withQuery.searchParams.get('name')).toBe('Alice');
+    expect(withQuery.searchParams.get('_compartment')).toBe('Organization/abc');
+
+    // An explicit param always wins over the default
+    const explicit = client.fhirSearchUrl('Patient', '_compartment=Organization/xyz');
+    expect(explicit.searchParams.getAll('_compartment')).toStrictEqual(['Organization/xyz']);
+
+    // Multiple default values for the same key are all applied (AND semantics via repeated param)
+    const multi = new MedplumClient({
+      defaultSearchParams: new URLSearchParams([
+        ['_compartment', 'Organization/abc'],
+        ['_compartment', 'Patient/123'],
+      ]),
+    });
+    expect(multi.fhirSearchUrl('Observation', undefined).searchParams.getAll('_compartment')).toStrictEqual([
+      'Organization/abc',
+      'Patient/123',
+    ]);
+
+    // Runtime setter updates the default and clears it
+    client.setDefaultSearchParams(new URLSearchParams({ _compartment: 'Patient/123' }));
+    expect(client.getDefaultSearchParams()?.get('_compartment')).toBe('Patient/123');
+    expect(client.fhirSearchUrl('Observation', undefined).searchParams.get('_compartment')).toBe('Patient/123');
+    client.setDefaultSearchParams(undefined);
+    expect(client.getDefaultSearchParams()).toBeUndefined();
+    expect(client.fhirSearchUrl('Observation', undefined).searchParams.has('_compartment')).toBe(false);
+
+    // Default: no params merged
+    const clientWithout = new MedplumClient();
+    expect(clientWithout.getDefaultSearchParams()).toBeUndefined();
+    expect(clientWithout.fhirSearchUrl('Patient', undefined).searchParams.has('_compartment')).toBe(false);
+  });
+
   test('storagePrefix option', () => {
     localStorage.clear();
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -404,6 +404,21 @@ export interface MedplumClientOptions {
   defaultHeaders?: Record<string, string>;
 
   /**
+   * Default search parameters merged into every FHIR search request.
+   *
+   * These are applied by {@link MedplumClient.fhirSearchUrl} to `search`, `searchOne`,
+   * `searchResources`, and `searchResourcePages`. They are *not* applied to reads by ID.
+   *
+   * A parameter is only added when the caller's own query does not already include it,
+   * so an explicit search param always takes precedence over the default.
+   *
+   * This is a client-side convenience for scoping queries (for example, a `_compartment`
+   * filter). It does not enforce access control; the server still applies the user's
+   * access policy. Use {@link MedplumClient.setDefaultSearchParams} to change these at runtime.
+   */
+  defaultSearchParams?: URLSearchParams;
+
+  /**
    * Prefix to add to all keys when using `localStorage` as the backing store for `ClientStorage` (the default option in the browser).
    *
    * Default is `''` (no prefix).
@@ -1032,6 +1047,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   private readonly fhircastHubUrl: string;
   private readonly cdsServicesUrl: string;
   private readonly defaultHeaders: Record<string, string>;
+  private defaultSearchParams?: URLSearchParams;
   private readonly onUnauthenticated?: () => void;
   private readonly autoBatchTime: number;
   private readonly autoBatchQueue: AutoBatchEntry[] | undefined;
@@ -1081,6 +1097,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     this.clientSecret = options?.clientSecret ?? '';
     this.credentialsInHeader = options?.authCredentialsMethod === 'header';
     this.defaultHeaders = options?.defaultHeaders ?? {};
+    this.defaultSearchParams = options?.defaultSearchParams;
     this.onUnauthenticated = options?.onUnauthenticated;
     this.refreshGracePeriod = options?.refreshGracePeriod ?? DEFAULT_REFRESH_GRACE_PERIOD;
     this.logLevel = this.initializeLogLevel(options);
@@ -1247,6 +1264,30 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    */
   getDefaultHeaders(): Record<string, string> {
     return this.defaultHeaders;
+  }
+
+  /**
+   * Returns the default search parameters merged into every FHIR search request.
+   * @category Search
+   * @returns The default search parameters, or undefined if none are set.
+   */
+  getDefaultSearchParams(): URLSearchParams | undefined {
+    return this.defaultSearchParams;
+  }
+
+  /**
+   * Sets the default search parameters merged into every FHIR search request.
+   *
+   * See {@link MedplumClientOptions.defaultSearchParams} for details on how these are applied.
+   * Passing `undefined` clears the defaults. Changing the defaults invalidates all cached
+   * search results and dispatches a "change" event so that subscribed views refresh.
+   * @category Search
+   * @param params - The default search parameters, or undefined to clear them.
+   */
+  setDefaultSearchParams(params: URLSearchParams | undefined): void {
+    this.defaultSearchParams = params;
+    this.invalidateAll();
+    this.dispatchEvent({ type: 'change' });
   }
 
   /**
@@ -1743,6 +1784,20 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     const url = this.fhirUrl(resourceType);
     if (query) {
       url.search = getQueryString(query);
+    }
+    if (this.defaultSearchParams) {
+      // Merge in default search parameters, but never override a param the caller set explicitly.
+      // Snapshot the caller's keys *before* appending so that:
+      //  - a default with repeated values (e.g. two `_compartment` entries) is applied in full,
+      //    rather than being truncated after the first append flips `has(key)` to true, and
+      //  - a param the caller already set (including on the re-entrant searchOne -> search path,
+      //    where the query already carries the merged default) always wins and is left untouched.
+      const explicitKeys = new Set(url.searchParams.keys());
+      for (const [key, value] of this.defaultSearchParams) {
+        if (!explicitKeys.has(key)) {
+          url.searchParams.append(key, value);
+        }
+      }
     }
     return url;
   }


### PR DESCRIPTION
## Summary

Adds a general-purpose way to apply default search params to every FHIR search, and a lightweight compartment-filter UI in the app built on top of it. Motivation: while logged in (e.g. as a super admin), being able to scope all queries to one or more compartments — useful for tenant/org-focused browsing.

### Core primitive — `MedplumClient.defaultSearchParams`
- New `defaultSearchParams?: URLSearchParams` option on `MedplumClientOptions`, plus runtime `getDefaultSearchParams()` / `setDefaultSearchParams()` (the setter invalidates the cache and fires the `change` event).
- Merged in the single search chokepoint `fhirSearchUrl`, so it applies to `search`, `searchOne`, `searchResources`, and `searchResourcePages` — but **not** reads-by-id.
- Explicit query params always win over defaults. The merge snapshots the caller's keys before appending, so a default with repeated values (e.g. two `_compartment` entries) is applied in full and the re-entrant `searchOne → search` path doesn't duplicate params.
- This is a **client-side convenience only** — it narrows queries but does not enforce access control. The server still applies the user's access policy, so it can never widen what a user may read.

### App — compartment filter control
- A header popover (via `AppShell`'s existing `notifications` slot, so no `@medplum/react` changes) where any user can pick one or more resources (`ReferenceInput`, any resource type) to scope all searches to those compartments.
- Multiple compartments combine with **OR** semantics via a single comma-joined `_compartment=A,B` value (matches a resource in any selected compartment).
- Selections show as removable pills; **Apply** commits and reloads once so every query surface (including `SearchControl`, which calls `medplum.search` directly) picks it up — mirroring the project switcher's reload-on-change.
- Persisted in `localStorage` (JSON array, with legacy single-string fallback) and seeded into the client at construction.

## Files
- `packages/core/src/client.ts` — `defaultSearchParams` option, getter/setter, merge in `fhirSearchUrl`
- `packages/core/src/client.test.ts` — unit tests (constructor, merge, explicit-wins, runtime set/clear, repeated-value multi-compartment)
- `packages/app/src/compartmentFilter.ts` — localStorage-backed state + params builder
- `packages/app/src/CompartmentFilterControl.tsx` — the header control
- `packages/app/src/App.tsx`, `packages/app/src/index.tsx` — wiring

## Testing
- New core unit test passing.
- Typecheck and eslint clean on all touched files.
- UI tests for the control still to be run.

## Notes / follow-ups
- Built with OR combine semantics. AND (`_compartment=A&_compartment=B`) is a small addition if wanted later — the core merge already handles repeated values correctly.
- No app-level test for the control yet; can add one with a `MockClient` passthrough for `get/setDefaultSearchParams`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)