### PR TITLE
fix(fhircast): return empty body for event notification HTTP 202

### DIFF
--- a/packages/server/src/fhircast/routes.ts
+++ b/packages/server/src/fhircast/routes.ts
@@ -491,7 +491,7 @@ async function finalizeContextChangeRequest(
   await publish(`${projectId}:${payload.event['hub.topic']}`, JSON.stringify(payload));
   // See: https://build.fhir.org/ig/HL7/fhircast-docs/2-6-RequestContextChange.html#response
   // Only HTTP status code is defined for response for RequestContextChange
-  res.status(202).json({ success: true, event: payload });
+  res.status(202).send();
 }
 
 async function closeCurrentContext(projectId: string, topic: string): Promise<void> {


### PR DESCRIPTION
## Summary

Per the [FHIRcast STU3 spec](https://build.fhir.org/ig/HL7/fhircast-docs/2-6-RequestContextChange.html#response), the Hub SHALL respond to the Subscriber's Context Change Request with an HTTP 202 (Accepted) response — the spec does not define a response body.

Currently `finalizeContextChangeRequest()` returns `res.status(202).json({ success: true, event: payload })`, which includes an undocumented response body.

## Change

```diff
-  res.status(202).json({ success: true, event: payload });
+  res.status(202).send();
```

## Verification

- Existing tests assert `expect(res).toHaveStatus(202)` — no test checks the response body, so this change is fully compatible.
- The context event is still published to the WebSocket via `publish()` before the response, so real-time subscribers are unaffected.

Closes #10033