### PR TITLE
Fix GraphiQL build+release

### DIFF
--- a/scripts/cicd-deploy.sh
+++ b/scripts/cicd-deploy.sh
@@ -168,6 +168,7 @@ fi
 
 if [[ "$DEPLOY_GRAPHIQL" = true ]]; then
   echo "Deploy GraphiQL"
+  npm run build -- --force --filter=@medplum/graphiql
   source ./scripts/deploy-graphiql.sh
 fi
 

--- a/scripts/cicd-deploy.sh
+++ b/scripts/cicd-deploy.sh
@@ -166,17 +166,17 @@ if [[ "$DEPLOY_APP" = true ]]; then
   source ./scripts/deploy-app.sh
 fi
 
-if [[ "$DEPLOY_GRAPHIQL" = true ]]; then
-  echo "Deploy GraphiQL"
-  npm run build -- --force --filter=@medplum/graphiql
-  source ./scripts/deploy-graphiql.sh
-fi
-
 if [[ "$DEPLOY_SERVER" = true ]]; then
   echo "Deploy server"
   npm run build -- --force --filter=@medplum/server
   source ./scripts/build-docker-server.sh --latest
   source ./scripts/deploy-server.sh
+fi
+
+if [[ "$DEPLOY_GRAPHIQL" = true ]]; then
+  echo "Deploy GraphiQL"
+  npm run build -- --force --filter=@medplum/graphiql
+  source ./scripts/deploy-graphiql.sh
 fi
 
 if [[ "$DEPLOY_STORYBOOK" = true ]]; then


### PR DESCRIPTION
This build step was dropped in commit 9d985e8b83f; let's restore it.

This was causing releases to fail with errors like this:
> ```
> + echo 'Deploy GraphiQL'
> + source ./scripts/deploy-graphiql.sh
> ++ [[ -z graphiql.***.com ]]
> ++ node scripts/s3deploy.mjs packages/graphiql/dist s3://graphiql.***.com/
> Starting deployment to s3://graphiql.***.com//
> Error: ENOENT: no such file or directory, scandir 'packages/graphiql/dist'
>     at async readdir (node:internal/fs/promises:956:18)
>     at async getFiles (file:///home/runner/work/***/***/scripts/s3deploy.mjs:126:17)
>     at async main (file:///home/runner/work/***/***/scripts/s3deploy.mjs:82:20) {
>   errno: -2,
>   code: 'ENOENT',
>   syscall: 'scandir',
>   path: 'packages/graphiql/dist'
> }
> ```