### PR TITLE
Fixed cli openBrowser on linux

### DIFF
--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -5,9 +5,12 @@ import { ContentType, getDisplayString, MEDPLUM_CLI_CLIENT_ID, normalizeErrorStr
 import { exec } from 'node:child_process';
 import { createServer } from 'node:http';
 import { platform } from 'node:os';
+import { promisify } from 'node:util';
 import { createMedplumClient } from './util/client';
 import type { Profile } from './utils';
 import { jwtAssertionLogin, jwtBearerLogin, MedplumCommand, saveProfile } from './utils';
+
+const execAsync = promisify(exec);
 
 const clientId = MEDPLUM_CLI_CLIENT_ID;
 const redirectUri = 'http://localhost:9615';
@@ -116,19 +119,7 @@ async function openBrowser(url: string): Promise<void> {
     default:
       throw new Error('Unsupported platform: ' + os);
   }
-  return new Promise((resolve, reject) => {
-    exec(cmd, (error, _, stderr) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      if (stderr) {
-        reject(new Error('Could not open browser: ' + stderr));
-        return;
-      }
-      resolve();
-    });
-  });
+  await execAsync(cmd);
 }
 
 /**


### PR DESCRIPTION
The CLI previously treated any output on `stderr` from the browser launcher as a failure, even when the browser was successfully opened.

In practice, some environments (such as WSL) emit warnings to `stderr` while still successfully launching the browser, causing `medplum login` to fail unnecessarily.

This change switches `openBrowser()` to use the promisified `exec()` API, which rejects only on actual execution failures (non-zero exit status or spawn errors) and ignores benign `stderr` output. This aligns with the behavior of `exec()` and makes browser launching more robust across platforms.

For example, under WSL `wslview` may emit warnings to `stderr` while successfully opening the Windows browser.
