### PR TITLE
Rework cicd-deploy.sh to use turborepo dependency graph

### DIFF
--- a/packages/app/turbo.json
+++ b/packages/app/turbo.json
@@ -3,8 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "inputs": ["$TURBO_DEFAULT$", "../../scripts/cicd-deploy.sh"],
-      "outputs": ["storybook-static/**"]
+      "inputs": ["$TURBO_DEFAULT$", "../../scripts/cicd-deploy.sh"]
     }
   }
 }

--- a/packages/docs/turbo.json
+++ b/packages/docs/turbo.json
@@ -3,8 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "inputs": ["$TURBO_DEFAULT$", "../../scripts/cicd-deploy.sh"],
-      "outputs": ["storybook-static/**"]
+      "inputs": ["$TURBO_DEFAULT$", "../../scripts/cicd-deploy.sh"]
     }
   }
 }

--- a/packages/graphiql/turbo.json
+++ b/packages/graphiql/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "inputs": ["$TURBO_DEFAULT$", "../../scripts/cicd-deploy.sh", "../../scripts/deploy-introspection-schema.sh"]
+    }
+  }
+}

--- a/packages/server/turbo.json
+++ b/packages/server/turbo.json
@@ -13,6 +13,14 @@
       "outputs": ["coverage/**"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts"],
       "env": ["REDIS_PASSWORD_DISABLED_IN_TESTS", "POSTGRES_HOST", "POSTGRES_PORT", "SERVER_TEST_CACHE_KEY"]
+    },
+    "build": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../Dockerfile",
+        "../../.github/workflows/build.yml",
+        "../../scripts/cicd-deploy.sh"
+      ]
     }
   }
 }

--- a/scripts/cicd-deploy.sh
+++ b/scripts/cicd-deploy.sh
@@ -35,20 +35,22 @@ fi
 
 DEPLOYABLE_PACKAGES=("@medplum/app" "@medplum/server" "@medplum/graphiql" "@medplum/storybook" "@medplum/docs")
 
-# Turn the deployable package list into repeated `--filter=<pkg>` args
-DEPLOYABLE_FILTERS=()
-for pkg in "${DEPLOYABLE_PACKAGES[@]}"; do
-  DEPLOYABLE_FILTERS+=(--filter="$pkg")
-done
+# Determine which deployable packages have changed since $TURBO_SCM_BASE
+PACKAGES_CHANGED=$(npx turbo query affected --packages "${DEPLOYABLE_PACKAGES[@]}" \
+  | jq -r '.data.affectedPackages.items[].name')
 
-PACKAGES_CHANGED=$(npx turbo ls --affected "${DEPLOYABLE_FILTERS[@]}")
+# Build all affected packages
+if [[ -n "$PACKAGES_CHANGED" ]]; then
+  CHANGED_FILTERS=()
+  while IFS= read -r pkg; do
+    CHANGED_FILTERS+=(--filter="$pkg")
+  done <<< "$PACKAGES_CHANGED"
 
-# Build all packages with changes since $TURBO_SCM_BASE
-#
-# We use `--force` because the `build` task in `@medplum/core` has an implicit
-# build-time dependency on the git hash (used to bake it in to `MEDPLUM_VERSION`),
-# and we don't want to read an old version string from the turborepo build cache.
-npx turbo run build --affected --force "${DEPLOYABLE_FILTERS[@]}"
+  # We use `--force` because the `build` task in `@medplum/core` has an implicit
+  # build-time dependency on the git hash (used to bake it in to `MEDPLUM_VERSION`),
+  # and we don't want to read an old version string from the turborepo build cache.
+  npx turbo run build --force "${CHANGED_FILTERS[@]}"
+fi
 
 
 # Set DEPLOY_* based on whether each package appears in the turbo affected output.

--- a/scripts/cicd-deploy.sh
+++ b/scripts/cicd-deploy.sh
@@ -28,97 +28,43 @@ echo "$COMMIT_MESSAGE"
 # Fall back to HEAD~1 when GITHUB_BEFORE is absent (workflow_dispatch)
 # cat-file -e checks that we have the commit locally in order to diff successfully
 if [[ -n "$GITHUB_BEFORE" ]] && git cat-file -e "$GITHUB_BEFORE" 2>/dev/null; then
-  FILES_CHANGED=$(git diff --name-only HEAD "$GITHUB_BEFORE")
+  export TURBO_SCM_BASE=$GITHUB_BEFORE
 else
-  FILES_CHANGED=$(git diff --name-only HEAD HEAD~1)
+  export TURBO_SCM_BASE=HEAD~1
 fi
-echo "$FILES_CHANGED"
 
-DEPLOY_APP=false
-DEPLOY_DOCS=false
-DEPLOY_GRAPHIQL=false
-DEPLOY_SERVER=false
-DEPLOY_STORYBOOK=false
+DEPLOYABLE_PACKAGES=("@medplum/app" "@medplum/server" "@medplum/graphiql" "@medplum/storybook" "@medplum/docs")
 
+# Turn the deployable package list into repeated `--filter=<pkg>` args
+DEPLOYABLE_FILTERS=()
+for pkg in "${DEPLOYABLE_PACKAGES[@]}"; do
+  DEPLOYABLE_FILTERS+=(--filter="$pkg")
+done
+
+PACKAGES_CHANGED=$(npx turbo ls --affected "${DEPLOYABLE_FILTERS[@]}")
+
+# Build all packages with changes since $TURBO_SCM_BASE
 #
-# Inspect files changed
-#
+# We use `--force` because the `build` task in `@medplum/core` has an implicit
+# build-time dependency on the git hash (used to bake it in to `MEDPLUM_VERSION`),
+# and we don't want to read an old version string from the turborepo build cache.
+npx turbo run build --affected --force "${DEPLOYABLE_FILTERS[@]}"
 
-if [[ "$FILES_CHANGED" =~ build.yml ]]; then
-  DEPLOY_SERVER=true
-fi
 
-if [[ "$FILES_CHANGED" =~ Dockerfile ]]; then
-  DEPLOY_SERVER=true
-fi
+# Set DEPLOY_* based on whether each package appears in the turbo affected output.
+# -F: match the name literally (the `@` and `/` are not treated as regex)
+# -w: whole-word match, so `@medplum/app` won't match a hypothetical `@medplum/app-foo`
+# -q: quiet, we only care about the exit status
+package_changed() {
+  grep -Fqw -- "$1" <<< "$PACKAGES_CHANGED"
+}
 
-if [[ "$FILES_CHANGED" =~ cicd-deploy.sh ]]; then
-  DEPLOY_APP=true
-  DEPLOY_DOCS=true
-  DEPLOY_GRAPHIQL=true
-  DEPLOY_SERVER=true
-fi
-
-if [[ "$FILES_CHANGED" =~ deploy-introspection-schema.sh ]]; then
-  DEPLOY_GRAPHIQL=true
-fi
-
-if [[ "$FILES_CHANGED" =~ packages/app ]]; then
-  DEPLOY_APP=true
-fi
-
-if [[ "$FILES_CHANGED" =~ packages/ccda ]]; then
-  DEPLOY_SERVER=true
-fi
-
-if [[ "$FILES_CHANGED" =~ packages/core ]]; then
-  DEPLOY_APP=true
-  DEPLOY_DOCS=true
-  DEPLOY_SERVER=true
-fi
-
-if [[ "$FILES_CHANGED" =~ packages/definitions ]]; then
-  DEPLOY_APP=true
-  DEPLOY_SERVER=true
-fi
-
-if [[ "$FILES_CHANGED" =~ packages/docs ]]; then
-  DEPLOY_DOCS=true
-fi
-
-if [[ "$FILES_CHANGED" =~ packages/fhir-router ]]; then
-  DEPLOY_SERVER=true
-fi
-
-if [[ "$FILES_CHANGED" =~ packages/fhirtypes ]]; then
-  DEPLOY_APP=true
-  DEPLOY_SERVER=true
-fi
-
-if [[ "$FILES_CHANGED" =~ packages/graphiql ]]; then
-  DEPLOY_GRAPHIQL=true
-fi
-
-if [[ "$FILES_CHANGED" =~ packages/server ]]; then
-  DEPLOY_SERVER=true
-fi
-
-if [[ "$FILES_CHANGED" =~ packages/storybook ]]; then
-  DEPLOY_STORYBOOK=true
-fi
-
-if [[ "$FILES_CHANGED" =~ packages/react ]]; then
-  DEPLOY_APP=true
-  DEPLOY_STORYBOOK=true
-fi
-
-if [[ "$FORCE" = true ]]; then
-  DEPLOY_APP=true
-  DEPLOY_DOCS=true
-  DEPLOY_GRAPHIQL=true
-  DEPLOY_SERVER=true
-  DEPLOY_STORYBOOK=true
-fi
+# FORCE deploys everything; otherwise deploy only affected packages
+if [[ "$FORCE" = true ]] || package_changed "@medplum/app";       then DEPLOY_APP=true;       else DEPLOY_APP=false;       fi
+if [[ "$FORCE" = true ]] || package_changed "@medplum/docs";      then DEPLOY_DOCS=true;      else DEPLOY_DOCS=false;      fi
+if [[ "$FORCE" = true ]] || package_changed "@medplum/graphiql";  then DEPLOY_GRAPHIQL=true;  else DEPLOY_GRAPHIQL=false;  fi
+if [[ "$FORCE" = true ]] || package_changed "@medplum/server";    then DEPLOY_SERVER=true;    else DEPLOY_SERVER=false;    fi
+if [[ "$FORCE" = true ]] || package_changed "@medplum/storybook"; then DEPLOY_STORYBOOK=true; else DEPLOY_STORYBOOK=false; fi
 
 #
 # Send a slack message
@@ -168,26 +114,22 @@ fi
 
 if [[ "$DEPLOY_SERVER" = true ]]; then
   echo "Deploy server"
-  npm run build -- --force --filter=@medplum/server
   source ./scripts/build-docker-server.sh --latest
   source ./scripts/deploy-server.sh
 fi
 
 if [[ "$DEPLOY_GRAPHIQL" = true ]]; then
   echo "Deploy GraphiQL"
-  npm run build -- --force --filter=@medplum/graphiql
   source ./scripts/deploy-graphiql.sh
 fi
 
 if [[ "$DEPLOY_STORYBOOK" = true ]]; then
   echo "Deploy storybook"
-  npm run build -- --filter=@medplum/storybook
   source ./scripts/deploy-storybook.sh
 fi
 
 # Deploy docs last since it is the slowest
 if [[ "$DEPLOY_DOCS" = true ]]; then
   echo "Deploy docs"
-  npm run build:docs
   source ./scripts/deploy-docs.sh
 fi

--- a/scripts/deploy-storybook.sh
+++ b/scripts/deploy-storybook.sh
@@ -11,5 +11,5 @@ set -e
 # Echo commands
 set -x
 
-# Fast upload the docs to S3
+# Fast upload the storybook to S3
 node scripts/s3deploy.mjs packages/storybook/storybook-static "s3://${STORYBOOK_BUCKET}"

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "globalEnv": ["NODE_VERSION", "MEDPLUM_GIT_SHORTHASH"],
+  "futureFlags": {
+    "affectedUsingTaskInputs": true
+  },
   "tasks": {
     "clean": {
       "outputs": ["build/**", "dist/**", "coverage/**"]


### PR DESCRIPTION
Turborepo offers the `--affected` filter that lets us specify we should only apply a command to packages whose inputs have been touched in the diff since the `TURBO_SCM_BASE` git commit.

This has some benefits:

- The dependency graph defined by the `package.json` files across the workspace is fully respected without being reimplemented here as file checks.

- The `build` step can happen a single time (previously, when multiple apps were being deployed, each one would use a build step with `--force`, requiring rebuilding everything). All affected apps now can build in parallel, and share the common dependency builds.

There's some nuance as well:
- This turborepo feature seems to also detect changes in your working tree. This should not be impactful for this CI deploy script, but can make testing the script surprising if you have any local changes (including untracked files).

- When doing this CI build, we need to trigger the build with `--force` because the `@medplum/core` package has an implicit dependency on the current git hash (which it appends to its `MEDPLUM_VERSION` export; see https://github.com/medplum/medplum/blob/v5.1.27/packages/core/esbuild.mjs#L14).

- The `app` build still is doing some tricky ENV var work that I don't fully understand, so I've left its extra rebuild untouched.

- The deployable packages have had some extra metadata added to their `turbo.json` files to make them depend on some common files from the root (mainly the cicd-deploy script itself). This replaces some extra conditionals that used to be in the script. This requires enabling a "futureFlag" in turborepo to respect the "input" specifications when computing "affected" packages