### PR TITLE
[Docs] Remove whitespace after docs videos when cookies not accepted

### DIFF
--- a/packages/docs/src/css/custom.css
+++ b/packages/docs/src/css/custom.css
@@ -351,7 +351,11 @@ li.theme-doc-sidebar-item-link:not(:first-child) strong {
   overflow: hidden;
 }
 
-.responsive-iframe-wrapper iframe {
+/* Applies to youtube iframe, cookieYes video placeholder (which is
+ * dropped in as a replacement when the viewer has not accepted
+ * cookies). */
+.responsive-iframe-wrapper iframe,
+.responsive-iframe-wrapper > .video-placeholder-youtube {
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
Until a viewer has accepted some cookies, the YouTube player is blocked and its iframe is replaced with a div placeholder. This means that our CSS targeting the iframe to remove it from the flow is not applied, and so the padding we apply to the wrapped div is excessive.

Let's treat the div the same way as the iframe and clear this up.

## Before
<img width="1840" height="1196" alt="Screenshot 2026-08-01 at 4 35 39 PM" src="https://github.com/user-attachments/assets/8435e61a-8470-4b8d-934e-badf6b9646eb" />

## After
(CSS applied via chrome devtools instead of trying to set up cookieyes in my local docs server)
<img width="1840" height="1196" alt="Screenshot 2026-08-01 at 4 37 22 PM" src="https://github.com/user-attachments/assets/c6162a07-023c-4c39-9af0-ccaf054ee8c8" />
