### PR TITLE
Guard against WebSocket subscription messages without a SubscriptionStatus

### DIFF
--- a/packages/core/src/subscriptions/index.test.ts
+++ b/packages/core/src/subscriptions/index.test.ts
@@ -975,6 +975,16 @@ describe('SubscriptionManager', () => {
 
       expect(receivedBundle).toStrictEqual(heartbeatBundle);
       expect(console.warn).toHaveBeenCalledTimes(2);
+      expect(console.warn).toHaveBeenNthCalledWith(
+        1,
+        'Received WebSocket message without a SubscriptionStatus resource; ignoring',
+        'invalid_json'
+      );
+      expect(console.warn).toHaveBeenNthCalledWith(
+        2,
+        'Received WebSocket message without a SubscriptionStatus resource; ignoring',
+        { resourceType: 'Bundle', type: 'history', entry: [] }
+      );
       expect(errorListener).not.toHaveBeenCalled();
       console.warn = originalWarn;
     });

--- a/packages/core/src/subscriptions/index.test.ts
+++ b/packages/core/src/subscriptions/index.test.ts
@@ -932,44 +932,51 @@ describe('SubscriptionManager', () => {
       expect(receivedBundle).toStrictEqual(sentBundle);
     });
 
-    test('should emit `error` event when invalid message comes in over WebSocket', async () => {
-      const originalError = console.error;
-      console.error = vi.fn();
+    test('should warn and ignore WebSocket messages without a SubscriptionStatus', async () => {
+      const originalWarn = console.warn;
+      console.warn = vi.fn();
 
       await wsServer.connected;
 
       const emitter = defaultManager.addCriteria('Communication');
-      const [receivedEvent1, receivedEvent2] = await new Promise<SubscriptionEventMap['error'][]>((resolve, reject) => {
-        const promises = [];
-        promises.push(
-          new Promise<SubscriptionEventMap['error']>((resolve) => {
-            defaultManager.getMasterEmitter().addEventListener('error', (event) => {
-              resolve(event);
-            });
-          })
-        );
-        promises.push(
-          new Promise<SubscriptionEventMap['error']>((resolve) => {
-            emitter.addEventListener('error', (event) => {
-              resolve(event);
-            });
-          })
-        );
+      const errorListener = vi.fn();
+      defaultManager.getMasterEmitter().addEventListener('error', errorListener);
+      emitter.addEventListener('error', errorListener);
 
-        wsServer.send('invalid_json');
-        Promise.all(promises).then(resolve).catch(reject);
+      // Parseable, but neither a `pong` nor a notification Bundle
+      wsServer.send('invalid_json');
+      // A Bundle with no SubscriptionStatus entry
+      wsServer.send({ resourceType: 'Bundle', type: 'history', entry: [] } as Bundle);
+
+      // The manager should still be alive and processing messages afterwards
+      const timestamp = new Date().toISOString();
+      const heartbeatBundle = {
+        resourceType: 'Bundle',
+        timestamp,
+        type: 'history',
+        entry: [
+          {
+            resource: {
+              resourceType: 'SubscriptionStatus',
+              status: 'active',
+              type: 'heartbeat',
+              subscription: { reference: `Subscription/${MOCK_SUBSCRIPTION_ID}` },
+            },
+          },
+        ],
+      } as Bundle;
+
+      const receivedBundle = await new Promise<Bundle>((resolve) => {
+        defaultManager.getMasterEmitter().addEventListener('heartbeat', (event) => {
+          resolve(event.payload);
+        });
+        wsServer.send(heartbeatBundle);
       });
 
-      expect(receivedEvent1?.type).toStrictEqual('error');
-      expect(receivedEvent1?.payload).toBeInstanceOf(TypeError);
-      expect(receivedEvent1?.payload?.message).toMatch(/^Cannot read properties of undefined*/);
-
-      expect(receivedEvent2?.type).toStrictEqual('error');
-      expect(receivedEvent2?.payload).toBeInstanceOf(TypeError);
-      expect(receivedEvent2?.payload?.message).toMatch(/^Cannot read properties of undefined*/);
-
-      expect(console.error).toHaveBeenCalledTimes(1);
-      console.error = originalError;
+      expect(receivedBundle).toStrictEqual(heartbeatBundle);
+      expect(console.warn).toHaveBeenCalledTimes(2);
+      expect(errorListener).not.toHaveBeenCalled();
+      console.warn = originalWarn;
     });
 
     test('should reconnect after WebSocket disconnects and receive messages', async () => {

--- a/packages/core/src/subscriptions/index.test.ts
+++ b/packages/core/src/subscriptions/index.test.ts
@@ -946,7 +946,7 @@ describe('SubscriptionManager', () => {
       // Parseable, but neither a `pong` nor a notification Bundle
       wsServer.send('invalid_json');
       // A Bundle with no SubscriptionStatus entry
-      wsServer.send({ resourceType: 'Bundle', type: 'history', entry: [] } as Bundle);
+      wsServer.send({ resourceType: 'Bundle', type: 'history', entry: [] });
 
       // The manager should still be alive and processing messages afterwards
       const timestamp = new Date().toISOString();

--- a/packages/core/src/subscriptions/index.ts
+++ b/packages/core/src/subscriptions/index.ts
@@ -167,7 +167,7 @@ export class SubscriptionManager {
         // Get criteria for event
         const status = bundle?.entry?.[0]?.resource as SubscriptionStatus | undefined;
         if (!status) {
-          console.warn('Received WebSocket message without a SubscriptionStatus resource; ignoring');
+          console.warn('Received WebSocket message without a SubscriptionStatus resource; ignoring', bundle);
           return;
         }
 

--- a/packages/core/src/subscriptions/index.ts
+++ b/packages/core/src/subscriptions/index.ts
@@ -165,7 +165,11 @@ export class SubscriptionManager {
         }
         const bundle = parsedData;
         // Get criteria for event
-        const status = bundle?.entry?.[0]?.resource as SubscriptionStatus;
+        const status = bundle?.entry?.[0]?.resource as SubscriptionStatus | undefined;
+        if (!status) {
+          console.warn('Received WebSocket message without a SubscriptionStatus resource; ignoring');
+          return;
+        }
 
         // Handle heartbeat
         if (status.type === 'heartbeat') {


### PR DESCRIPTION
## The bug

`SubscriptionManager`'s WebSocket message handler reads the notification bundle's status resource with optional chaining, then immediately dereferences it without a guard:

```ts
const status = bundle?.entry?.[0]?.resource as SubscriptionStatus;

// Handle heartbeat
if (status.type === 'heartbeat') {   // 💥 TypeError when entry[0].resource is absent
```

Any frame that parses as JSON but doesn't carry a `SubscriptionStatus` as `entry[0].resource` throws `Cannot read properties of undefined (reading 'type')`. The `catch` below then dispatches an `error` event to the master emitter **and every criteria emitter**, so an app with N active `useSubscription` hooks surfaces the error N+1 times.

I believe this is the crash reported in #6590 (closed unreproduced — the reporter was seeing it through Sentry with no repro). We hit it in production on our Medplum-based EHR: a bot wrote messages into a thread the user had open, and the chat page (two live subscriptions) popped two `Cannot read properties of undefined (reading 'type')` error toasts. The repro is deterministic once you know the shape: deliver any parseable frame without a status entry (see the updated test).

## The fix

Early-return with a `console.warn`, consistent with how the same handler already treats other anomalous-but-parseable frames ("Received notification for criteria the SubscriptionManager is not listening for"):

```ts
const status = bundle?.entry?.[0]?.resource as SubscriptionStatus | undefined;
if (!status) {
  console.warn('Received WebSocket message without a SubscriptionStatus resource; ignoring');
  return;
}
```

Genuinely unparseable frames are unaffected — `JSON.parse` failures still flow through the `catch` and surface as `error` events.

## Test changes

The existing test `should emit error event when invalid message comes in over WebSocket` was asserting the crash as the intended behavior — it sends `'invalid_json'` (which, via the mock's `jsonProtocol`, arrives as a perfectly parseable JSON string) and expects the resulting `TypeError: Cannot read properties of undefined...` to be emitted on both emitters. That accidental TypeError is exactly the noise from #6590.

Replaced it with `should warn and ignore WebSocket messages without a SubscriptionStatus`, which covers both malformed shapes (a non-Bundle JSON value, and a Bundle with no entries), asserts no `error` events fire and `console.warn` fires once per bad frame — and then delivers a valid heartbeat to prove the manager is still alive and processing afterwards.
