### PR TITLE
refactor(fhircast): replace suffix routing with event dispatch

### DIFF
--- a/packages/server/src/fhircast/routes.ts
+++ b/packages/server/src/fhircast/routes.ts
@@ -33,10 +33,12 @@ import { getLogger } from '../logger';
 import { authenticateRequest } from '../oauth/middleware';
 import { publish } from '../pubsub';
 import { getCacheRedis } from '../redis';
+import type { EventCategory } from './utils';
 import {
   cleanupContextForResource,
   extractAnchorResourceType,
   getCurrentContext,
+  getEventCategory,
   getTopicContextStorageKey,
   getTopicCurrentContextKey,
   setTopicCurrentContext,
@@ -77,6 +79,16 @@ const eventsSupported = [
   'DiagnosticReport-select',
   'DiagnosticReport-update',
 ];
+
+type ContextChangeHandler = (req: Request, res: Response) => Promise<void>;
+
+const EVENT_HANDLERS: Record<EventCategory, ContextChangeHandler> = {
+  open: handleOpenContextChangeRequest,
+  close: handleCloseContextChangeRequest,
+  update: handleUpdateContextChangeRequest,
+  select: publishContextChangeRequest,
+  other: publishContextChangeRequest,
+};
 
 publicSTU2Routes.get('/.well-known/fhircast-configuration', (_req: Request, res: Response) => {
   res.status(200).json({
@@ -241,18 +253,13 @@ async function handleSubscriptionRequest(req: Request, res: Response): Promise<v
 
 async function handleContextChangeRequest(req: Request, res: Response): Promise<void> {
   const { event } = req.body as FhircastMessagePayload;
-  // Check if this an open event
-  if (event['hub.event'].endsWith('-open')) {
-    await handleOpenContextChangeRequest(req, res);
-  } else if (event['hub.event'].endsWith('-close')) {
-    await handleCloseContextChangeRequest(req, res);
-  } else if (event['hub.event'].toLowerCase() === 'diagnosticreport-update') {
-    await handleUpdateContextChangeRequest(req, res);
-  } else {
-    // Default handler just to publishes the message to all subscribers
-    const ctx = getAuthenticatedContext();
-    await finalizeContextChangeRequest(res, ctx.project.id, req.body);
-  }
+  const category = getEventCategory(event['hub.event']);
+  await EVENT_HANDLERS[category](req, res);
+}
+
+async function publishContextChangeRequest(req: Request, res: Response): Promise<void> {
+  const ctx = getAuthenticatedContext();
+  await finalizeContextChangeRequest(res, ctx.project.id, req.body);
 }
 
 async function handleOpenContextChangeRequest(req: Request, res: Response): Promise<void> {

--- a/packages/server/src/fhircast/utils.test.ts
+++ b/packages/server/src/fhircast/utils.test.ts
@@ -5,7 +5,7 @@ import type { OperationOutcome } from '@medplum/fhirtypes';
 import { vi } from 'vitest';
 import { loadTestConfig } from '../config/loader';
 import { closeRedis, getCacheRedis, initRedis } from '../redis';
-import { getTopicForUser } from './utils';
+import { getEventCategory, getTopicForUser } from './utils';
 
 describe('FHIRcast Utils', () => {
   beforeAll(async () => {
@@ -15,6 +15,40 @@ describe('FHIRcast Utils', () => {
 
   afterAll(async () => {
     await closeRedis();
+  });
+
+  describe('getEventCategory', () => {
+    test('Open events', () => {
+      expect(getEventCategory('Patient-open')).toBe('open');
+      expect(getEventCategory('Encounter-open')).toBe('open');
+      expect(getEventCategory('ImagingStudy-open')).toBe('open');
+      expect(getEventCategory('DiagnosticReport-open')).toBe('open');
+    });
+
+    test('Close events', () => {
+      expect(getEventCategory('Patient-close')).toBe('close');
+      expect(getEventCategory('Encounter-close')).toBe('close');
+      expect(getEventCategory('ImagingStudy-close')).toBe('close');
+      expect(getEventCategory('DiagnosticReport-close')).toBe('close');
+    });
+
+    test('Update events', () => {
+      expect(getEventCategory('DiagnosticReport-update')).toBe('update');
+    });
+
+    test('Select events', () => {
+      expect(getEventCategory('DiagnosticReport-select')).toBe('select');
+    });
+
+    test('Other events', () => {
+      expect(getEventCategory('syncerror')).toBe('other');
+      expect(getEventCategory('Observation-create')).toBe('other');
+    });
+
+    test('Event name matching is case-insensitive', () => {
+      expect(getEventCategory('patient-OPEN')).toBe('open');
+      expect(getEventCategory('diagnosticreport-SELECT')).toBe('select');
+    });
   });
 
   describe('getTopicForUser', () => {

--- a/packages/server/src/fhircast/utils.ts
+++ b/packages/server/src/fhircast/utils.ts
@@ -12,6 +12,25 @@ const RESOURCE_TYPE_LOWER_TO_VALID_RESOURCE_TYPE = {
   diagnosticreport: 'DiagnosticReport',
 } as Record<string, FhircastAnchorResourceType>;
 
+export type EventCategory = 'open' | 'close' | 'update' | 'select' | 'other';
+
+export function getEventCategory(eventName: string): EventCategory {
+  const lower = eventName.toLowerCase();
+  if (lower.endsWith('-open')) {
+    return 'open';
+  }
+  if (lower.endsWith('-close')) {
+    return 'close';
+  }
+  if (lower.endsWith('-update')) {
+    return 'update';
+  }
+  if (lower.endsWith('-select')) {
+    return 'select';
+  }
+  return 'other';
+}
+
 export function getTopicCurrentContextKey(projectId: string, topic: string): string {
   return `medplum:fhircast:project:${projectId}:topic:${topic}:latest`;
 }


### PR DESCRIPTION
Implements #10037.

This refactors FHIRcast context change routing to classify events into categories (`open`, `close`, `update`, `select`, `other`) and dispatch requests through a lookup table.

Runtime behavior is preserved:

- Reuses the existing handlers for `open`, `close`, and `update` events.
- Preserves the existing publish behavior for `select` and `other` events.

Also adds unit tests for `getEventCategory()`.