### PR TITLE
Fix storybook release build

### DIFF
--- a/scripts/cicd-deploy.sh
+++ b/scripts/cicd-deploy.sh
@@ -181,7 +181,7 @@ fi
 
 if [[ "$DEPLOY_STORYBOOK" = true ]]; then
   echo "Deploy storybook"
-  npm run build -- --filter=@medplum/storybook
+  npm run build:all -- --filter=@medplum/storybook
   source ./scripts/deploy-storybook.sh
 fi
 


### PR DESCRIPTION
The `build` script in the root includes filters to avoid some slower builds during usual operations (`--filter=!@medplum/docs --filter=!@medplum/storybook`). When presented with conflicting filters (`--filter=!@medplum/storybook --filter=@medplum/storybook`), it seems that the negation wins and the package is not built.

Let's adjust this to start from the `build:all` script, which does not add the default filters excluding storybook+docs.