### PR TITLE
refactor(fhircast): convert routing to dispatch pattern

### DIFF
--- a/packages/server/src/fhircast/routes.test.ts
+++ b/packages/server/src/fhircast/routes.test.ts
@@ -14,6 +14,8 @@ import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
 import { getCacheRedis } from '../redis';
 import { createTestProject, withTestContext } from '../test.setup';
+import type { EventCategory } from './routes';
+import { getEventCategory } from './routes';
 import { setTopicCurrentContext } from './utils';
 
 const STU2_BASE_ROUTE = '/fhircast/STU2';
@@ -897,5 +899,33 @@ describe('FHIRcast routes', () => {
       resourceType: 'OperationOutcome',
       issue: [{ severity: 'error', details: { text: 'No DiagnosticReport currently open for this topic' } }],
     });
+  });
+});
+
+describe('getEventCategory', () => {
+  test.each<[string, EventCategory]>([
+    ['DiagnosticReport-open', 'open'],
+    ['Patient-open', 'open'],
+    ['Encounter-open', 'open'],
+    ['ImagingStudy-open', 'open'],
+    ['DiagnosticReport-close', 'close'],
+    ['Patient-close', 'close'],
+    ['Encounter-close', 'close'],
+    ['ImagingStudy-close', 'close'],
+    ['DiagnosticReport-update', 'update'],
+    ['DiagnosticReport-select', 'select'],
+    ['Patient-select', 'select'],
+    // `Home-open` carries no anchor resource, so it must not be treated like the other `-open` events
+    ['Home-open', 'other'],
+    ['syncerror', 'other'],
+    ['userlogout', 'other'],
+    ['userhibernate', 'other'],
+    ['heartbeat', 'other'],
+    // Event names are matched case-insensitively
+    ['PATIENT-OPEN', 'open'],
+    ['home-OPEN', 'other'],
+    ['diagnosticreport-UPDATE', 'update'],
+  ])('%s -> %s', (eventName, expected) => {
+    expect(getEventCategory(eventName)).toStrictEqual(expected);
   });
 });

--- a/packages/server/src/fhircast/routes.ts
+++ b/packages/server/src/fhircast/routes.ts
@@ -46,12 +46,21 @@ export type EventCategory = 'open' | 'close' | 'update' | 'select' | 'other';
 
 export function getEventCategory(eventName: string): EventCategory {
   const lower = eventName.toLowerCase();
+  // `Home-open` represents the *lack* of a FHIR resource context, so it only borrows the
+  // `-open` suffix and has no anchor resource to establish a current context from.
+  // Source: https://build.fhir.org/ig/HL7/fhircast-docs/3-2-5-Home-open.html
+  if (lower === 'home-open') {
+    return 'other';
+  }
   if (lower.endsWith('-open')) {
     return 'open';
   }
   if (lower.endsWith('-close')) {
     return 'close';
   }
+  // `DiagnosticReport-update` is the only update event in the event catalog, so it's the only
+  // one we handle today.
+  // Source: https://build.fhir.org/ig/HL7/fhircast-docs/3-Events.html
   if (lower === 'diagnosticreport-update') {
     return 'update';
   }

--- a/packages/server/src/fhircast/routes.ts
+++ b/packages/server/src/fhircast/routes.ts
@@ -42,6 +42,33 @@ import {
   setTopicCurrentContext,
 } from './utils';
 
+export type EventCategory = 'open' | 'close' | 'update' | 'select' | 'other';
+
+export function getEventCategory(eventName: string): EventCategory {
+  const lower = eventName.toLowerCase();
+  if (lower.endsWith('-open')) {
+    return 'open';
+  }
+  if (lower.endsWith('-close')) {
+    return 'close';
+  }
+  if (lower === 'diagnosticreport-update') {
+    return 'update';
+  }
+  if (lower.endsWith('-select')) {
+    return 'select';
+  }
+  return 'other';
+}
+
+const EVENT_HANDLERS: Record<EventCategory, (req: Request, res: Response) => Promise<void>> = {
+  open: handleOpenContextChangeRequest,
+  close: handleCloseContextChangeRequest,
+  update: handleUpdateContextChangeRequest,
+  select: handleOtherContextChangeRequest,
+  other: handleOtherContextChangeRequest, // No-op for userlogout, heartbeat, etc.
+};
+
 export const fhircastSTU2Router = Router();
 export const fhircastSTU3Router = Router();
 
@@ -241,18 +268,8 @@ async function handleSubscriptionRequest(req: Request, res: Response): Promise<v
 
 async function handleContextChangeRequest(req: Request, res: Response): Promise<void> {
   const { event } = req.body as FhircastMessagePayload;
-  // Check if this an open event
-  if (event['hub.event'].endsWith('-open')) {
-    await handleOpenContextChangeRequest(req, res);
-  } else if (event['hub.event'].endsWith('-close')) {
-    await handleCloseContextChangeRequest(req, res);
-  } else if (event['hub.event'].toLowerCase() === 'diagnosticreport-update') {
-    await handleUpdateContextChangeRequest(req, res);
-  } else {
-    // Default handler just to publishes the message to all subscribers
-    const ctx = getAuthenticatedContext();
-    await finalizeContextChangeRequest(res, ctx.project.id, req.body);
-  }
+  const eventCategory = getEventCategory(event['hub.event']);
+  await EVENT_HANDLERS[eventCategory](req, res);
 }
 
 async function handleOpenContextChangeRequest(req: Request, res: Response): Promise<void> {
@@ -375,6 +392,11 @@ async function handleUpdateContextChangeRequest(req: Request, res: Response): Pr
   // See: https://build.fhir.org/ig/HL7/fhircast-docs/2-10-ContentSharing.html
   await setTopicCurrentContext(projectId, event['hub.topic'], currentContext);
   await finalizeContextChangeRequest(res, projectId, req.body);
+}
+
+async function handleOtherContextChangeRequest(req: Request, res: Response): Promise<void> {
+  const ctx = getAuthenticatedContext();
+  await finalizeContextChangeRequest(res, ctx.project.id, req.body);
 }
 
 function processUpdateBundle(updatesBundle: Bundle, currentContext: CurrentContext<'DiagnosticReport'>): void {

--- a/packages/server/src/ws/fhircast.test.ts
+++ b/packages/server/src/ws/fhircast.test.ts
@@ -4,6 +4,7 @@ import type { FhircastMessagePayload, WithId } from '@medplum/core';
 import {
   badRequest,
   ContentType,
+  createFhircastMessagePayload,
   createReference,
   generateId,
   getReferenceString,
@@ -108,6 +109,72 @@ describe('FHIRcast WebSocket', () => {
             expect(obj.event['hub.event']).toBe('Patient-open');
           })
           .sendJson({ ok: true })
+          .close()
+          .expectClosed();
+      }));
+
+    // `DiagnosticReport-select` and `syncerror` establish no context of their own, so the hub only relays them
+    test('Send `DiagnosticReport-select` and `syncerror` to subscriber', () =>
+      withTestContext(async () => {
+        const topic = randomUUID();
+
+        const res1 = await request(server)
+          .post('/fhircast/STU3')
+          .set('Content-Type', ContentType.FORM_URL_ENCODED)
+          .set('Authorization', 'Bearer ' + accessToken)
+          .send(
+            serializeFhircastSubscriptionRequest({
+              mode: 'subscribe',
+              channelType: 'websocket',
+              topic,
+              events: ['DiagnosticReport-select', 'syncerror'],
+            })
+          );
+
+        const pathname = new URL(res1.body['hub.channel.endpoint']).pathname;
+
+        const publishEvent = async (payload: FhircastMessagePayload): Promise<void> => {
+          const res = await request(server)
+            .post(`/fhircast/STU3/${topic}`)
+            .set('Content-Type', ContentType.JSON)
+            .set('Authorization', 'Bearer ' + accessToken)
+            .send(payload);
+          expect(res).toHaveStatus(202);
+        };
+
+        await request(server)
+          .ws(pathname)
+          .expectJson((obj) => {
+            // Connection verification message
+            expect(obj['hub.topic']).toBe(topic);
+          })
+          .exec(async () => {
+            await publishEvent(
+              createFhircastMessagePayload(topic, 'DiagnosticReport-select', [
+                { key: 'report', reference: { reference: `DiagnosticReport/${generateId()}` } },
+                { key: 'select', reference: { reference: `Observation/${generateId()}` } },
+              ])
+            );
+          })
+          .expectJson((obj: FhircastMessagePayload<'DiagnosticReport-select'>) => {
+            expect(obj.event['hub.topic']).toBe(topic);
+            expect(obj.event['hub.event']).toBe('DiagnosticReport-select');
+            expect(obj.event.context).toHaveLength(2);
+          })
+          .sendJson({ id: generateId(), status: 200 })
+          .exec(async () => {
+            await publishEvent(
+              createFhircastMessagePayload(topic, 'syncerror', [
+                { key: 'operationoutcome', resource: { ...badRequest('Something went wrong'), id: generateId() } },
+              ])
+            );
+          })
+          .expectJson((obj: FhircastMessagePayload<'syncerror'>) => {
+            expect(obj.event['hub.topic']).toBe(topic);
+            expect(obj.event['hub.event']).toBe('syncerror');
+            expect(obj.event.context[0].key).toBe('operationoutcome');
+          })
+          .sendJson({ id: generateId(), status: 200 })
           .close()
           .expectClosed();
       }));


### PR DESCRIPTION
Fixes #10037 

We single out `DiagnosticReport-update` since that's the only update event that will work as expected

Just realized we are not handling `Home-open` properly which is part of the released STU3 spec now...

Opened #10068 as a follow-up