### PR TITLE
Apply project appName white-labeling to invite and password reset emails

### DIFF
--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -5,10 +5,10 @@ import type { WithId } from '@medplum/core';
 import { allOk, ContentType, createReference, getReferenceString, normalizeErrorString } from '@medplum/core';
 import type {
   AccessPolicy,
-  Project,
   BundleEntry,
   Patient,
   Practitioner,
+  Project,
   ProjectMembership,
   Reference,
   RelatedPerson,
@@ -2205,5 +2205,4 @@ describe('Admin Invite', () => {
       expect(parsed.text).toContain(`Thank you,\n${appName}`);
     });
   });
-
 });

--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
+import type { WithId } from '@medplum/core';
 import { allOk, ContentType, createReference, getReferenceString, normalizeErrorString } from '@medplum/core';
 import type {
   AccessPolicy,
+  Project,
   BundleEntry,
   Patient,
   Practitioner,
@@ -25,7 +27,7 @@ import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config/loader';
 import { DatabaseMode, getDatabasePool } from '../database';
-import { getProjectSystemRepo } from '../fhir/repo';
+import { getGlobalSystemRepo, getProjectSystemRepo } from '../fhir/repo';
 import { SelectQuery } from '../fhir/sql';
 import { addTestUser, createTestProject, initTestAuth, setupRecaptchaMock, withTestContext } from '../test.setup';
 import { inviteUser } from './invite';
@@ -2115,4 +2117,93 @@ describe('Admin Invite', () => {
 
       expect(membership.accessPolicy).toBeUndefined();
     }));
+
+  describe('Project branding', () => {
+    const appName = 'Acme Health';
+
+    async function setProjectSetting(project: WithId<Project>, name: string, valueString: string): Promise<void> {
+      const systemRepo = getGlobalSystemRepo();
+      await withTestContext(async () => {
+        // Read the current project so successive calls compose rather than clobber.
+        const current = await systemRepo.readResource<Project>('Project', project.id);
+        await systemRepo.updateResource<Project>({
+          ...current,
+          setting: [...(current.setting?.filter((s) => s.name !== name) ?? []), { name, valueString }],
+        });
+      });
+    }
+
+    test('appName brands the new-user invite email', async () => {
+      const { project, accessToken } = await withTestContext(() =>
+        registerNew({
+          firstName: 'Alice',
+          lastName: 'Smith',
+          projectName: 'Alice Project',
+          email: `alice${randomUUID()}@example.com`,
+          password: 'password!@#',
+        })
+      );
+      await setProjectSetting(project, 'appName', appName);
+
+      const bobEmail = `bob${randomUUID()}@example.com`;
+      const res = await request(app)
+        .post('/admin/projects/' + project.id + '/invite')
+        .set('Authorization', 'Bearer ' + accessToken)
+        .send({
+          resourceType: 'Practitioner',
+          firstName: 'Bob',
+          lastName: 'Jones',
+          email: bobEmail,
+        });
+      expect(res).toHaveStatus(200);
+      expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
+
+      const inputArgs = mockSESv2Client.commandCalls(SendEmailCommand)[0].args[0].input;
+      const parsed = await simpleParser(Readable.from(inputArgs?.Content?.Raw?.Data ?? ''));
+      expect(parsed.subject).toBe(`Welcome to ${appName}`);
+      expect(parsed.text).toContain(`Thank you,\n${appName}`);
+    });
+
+    test('appName brands the existing-user invite email', async () => {
+      const aliceRegistration = await withTestContext(() =>
+        registerNew({
+          firstName: 'Alice',
+          lastName: 'Smith',
+          projectName: 'Alice Project',
+          email: `alice${randomUUID()}@example.com`,
+          password: 'password!@#',
+        })
+      );
+      await setProjectSetting(aliceRegistration.project, 'appName', appName);
+
+      const bobEmail = `bob${randomUUID()}@example.com`;
+      await withTestContext(() =>
+        registerNew({
+          firstName: 'Bob',
+          lastName: 'Jones',
+          projectName: 'Bob Project',
+          email: bobEmail,
+          password: 'password!@#',
+        })
+      );
+
+      const res = await request(app)
+        .post('/admin/projects/' + aliceRegistration.project.id + '/invite')
+        .set('Authorization', 'Bearer ' + aliceRegistration.accessToken)
+        .send({
+          resourceType: 'Practitioner',
+          firstName: 'Bob',
+          lastName: 'Jones',
+          email: bobEmail,
+        });
+      expect(res).toHaveStatus(200);
+      expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
+
+      const inputArgs = mockSESv2Client.commandCalls(SendEmailCommand)[0].args[0].input;
+      const parsed = await simpleParser(Readable.from(inputArgs?.Content?.Raw?.Data ?? ''));
+      expect(parsed.subject).toBe(`${appName}: Welcome to Alice Project`);
+      expect(parsed.text).toContain(`Thank you,\n${appName}`);
+    });
+  });
+
 });

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -34,6 +34,7 @@ import { getConfig } from '../config/loader';
 import { MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH } from '../constants';
 import { getAuthenticatedContext, tryGetRequestContext } from '../context';
 import { sendEmail } from '../email/email';
+import { DEFAULT_APP_NAME, getProjectAppName } from '../email/utils';
 import type { SystemRepository } from '../fhir/repo';
 import { getProjectSystemRepo } from '../fhir/repo';
 import { sendFhirResponse } from '../fhir/response';
@@ -520,9 +521,10 @@ async function sendInviteEmail(
   resetPasswordUrl: string | undefined
 ): Promise<void> {
   const options: Mail.Options = { to: user.email };
+  const appName = getProjectAppName(request.project) ?? DEFAULT_APP_NAME;
   if (existing) {
     // Existing user
-    options.subject = `Medplum: Welcome to ${request.project.name}`;
+    options.subject = `${appName}: Welcome to ${request.project.name}`;
     options.text = [
       `You were invited to ${request.project.name}`,
       '',
@@ -531,12 +533,12 @@ async function sendInviteEmail(
       `You can sign in here: ${getConfig().appBaseUrl}signin`,
       '',
       'Thank you,',
-      'Medplum',
+      appName,
       '',
     ].join('\n');
   } else {
     // New user
-    options.subject = 'Welcome to Medplum';
+    options.subject = `Welcome to ${appName}`;
     options.text = [
       `You were invited to ${request.project.name}`,
       '',
@@ -545,7 +547,7 @@ async function sendInviteEmail(
       resetPasswordUrl,
       '',
       'Thank you,',
-      'Medplum',
+      appName,
       '',
     ].join('\n');
   }

--- a/packages/server/src/auth/resetpassword.test.ts
+++ b/packages/server/src/auth/resetpassword.test.ts
@@ -11,11 +11,11 @@ import express from 'express';
 import { simpleParser } from 'mailparser';
 import request from 'supertest';
 import { vi } from 'vitest';
+import { inviteUser } from '../admin/invite';
 import { initApp, shutdownApp } from '../app';
 import { getConfig, loadTestConfig } from '../config/loader';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { setupRecaptchaMock, withTestContext } from '../test.setup';
-import { inviteUser } from '../admin/invite';
 import { registerNew } from './register';
 
 const { mockCreateTransport, mockSendMail } = vi.hoisted(() => {
@@ -564,5 +564,4 @@ describe('Reset Password', () => {
       expect(parsed.text).toContain(`Thank you,\n${appName}`);
     });
   });
-
 });

--- a/packages/server/src/auth/resetpassword.test.ts
+++ b/packages/server/src/auth/resetpassword.test.ts
@@ -553,6 +553,7 @@ describe('Reset Password', () => {
       const res = await request(app).post('/auth/resetpassword').type('json').send({
         email,
         projectId: project.id,
+        recaptchaToken: 'xyz',
       });
       expect(res).toHaveStatus(200);
       expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);

--- a/packages/server/src/auth/resetpassword.test.ts
+++ b/packages/server/src/auth/resetpassword.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
+import type { WithId } from '@medplum/core';
 import { createReference, getReferenceString, Operator, resolveId } from '@medplum/core';
 import type { DomainConfiguration, Project, User, UserSecurityRequest } from '@medplum/fhirtypes';
 import type { AwsClientStub } from 'aws-sdk-client-mock';
@@ -14,6 +15,7 @@ import { initApp, shutdownApp } from '../app';
 import { getConfig, loadTestConfig } from '../config/loader';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { setupRecaptchaMock, withTestContext } from '../test.setup';
+import { inviteUser } from '../admin/invite';
 import { registerNew } from './register';
 
 const { mockCreateTransport, mockSendMail } = vi.hoisted(() => {
@@ -506,4 +508,61 @@ describe('Reset Password', () => {
     const parsed = await simpleParser(args.Content?.Raw?.Data as Buffer);
     expect(parsed.subject).toBe('Medplum Password Reset');
   });
+
+  describe('Project branding', () => {
+    const appName = 'Acme Health';
+
+    async function setProjectSetting(project: WithId<Project>, name: string, valueString: string): Promise<void> {
+      const systemRepo = getGlobalSystemRepo();
+      await withTestContext(async () => {
+        // Read the current project so successive calls compose rather than clobber.
+        const current = await systemRepo.readResource<Project>('Project', project.id);
+        await systemRepo.updateResource<Project>({
+          ...current,
+          setting: [...(current.setting?.filter((s) => s.name !== name) ?? []), { name, valueString }],
+        });
+      });
+    }
+
+    test('appName brands the password reset email for a project-scoped user', async () => {
+      const { project } = await withTestContext(() =>
+        registerNew({
+          firstName: 'Admin',
+          lastName: 'Admin',
+          projectName: 'Branded Project',
+          email: `admin${randomUUID()}@example.com`,
+          password: 'password!@#',
+        })
+      );
+      await setProjectSetting(project, 'appName', appName);
+
+      // A project-scoped user, so the reset flow resolves the project.
+      const email = `member${randomUUID()}@example.com`;
+      await withTestContext(() =>
+        inviteUser({
+          project,
+          resourceType: 'Practitioner',
+          firstName: 'Member',
+          lastName: 'Member',
+          email,
+          scope: 'project',
+          sendEmail: false,
+        })
+      );
+
+      const res = await request(app).post('/auth/resetpassword').type('json').send({
+        email,
+        projectId: project.id,
+      });
+      expect(res).toHaveStatus(200);
+      expect(mockSESv2Client.commandCalls(SendEmailCommand)).toHaveLength(1);
+
+      const args = mockSESv2Client.commandCalls(SendEmailCommand)[0].args[0].input;
+      const parsed = await simpleParser(args.Content?.Raw?.Data as Buffer);
+      expect(parsed.subject).toBe(`${appName} Password Reset`);
+      expect(parsed.text).toContain(`Someone requested to reset your ${appName} password.`);
+      expect(parsed.text).toContain(`Thank you,\n${appName}`);
+    });
+  });
+
 });

--- a/packages/server/src/auth/resetpassword.ts
+++ b/packages/server/src/auth/resetpassword.ts
@@ -7,6 +7,7 @@ import type { Request, Response } from 'express';
 import { body } from 'express-validator';
 import { getConfig } from '../config/loader';
 import { sendEmail } from '../email/email';
+import { DEFAULT_APP_NAME, getProjectAppName } from '../email/utils';
 import { sendOutcome } from '../fhir/outcomes';
 import type { SystemRepository } from '../fhir/repo';
 import { getGlobalSystemRepo } from '../fhir/repo';
@@ -72,13 +73,14 @@ export async function resetPasswordHandler(req: Request, res: Response): Promise
 
   if (req.body.sendEmail !== false) {
     const project = user.project ? await systemRepo.readReference<Project>(user.project) : undefined;
+    const appName = getProjectAppName(project) ?? DEFAULT_APP_NAME;
     await sendEmail(
       systemRepo,
       {
         to: user.email,
-        subject: 'Medplum Password Reset',
+        subject: `${appName} Password Reset`,
         text: [
-          'Someone requested to reset your Medplum password.',
+          `Someone requested to reset your ${appName} password.`,
           '',
           'Please click on the following link:',
           '',
@@ -87,7 +89,7 @@ export async function resetPasswordHandler(req: Request, res: Response): Promise
           'If you received this in error, you can safely ignore it.',
           '',
           'Thank you,',
-          'Medplum',
+          appName,
           '',
         ].join('\n'),
       },

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -26,7 +26,7 @@ import { toDataURL } from 'qrcode';
 import { getConfig } from '../config/loader';
 import { EMAIL_MFA_CODE_EXPIRATION_MS, MAX_PASSWORD_LENGTH } from '../constants';
 import { sendEmail } from '../email/email';
-import { getProjectAppName } from '../email/utils';
+import { DEFAULT_APP_NAME, getProjectAppName } from '../email/utils';
 import { sendOutcome } from '../fhir/outcomes';
 import type { SystemRepository } from '../fhir/repo';
 import { getGlobalSystemRepo, getShardSystemRepo } from '../fhir/repo';
@@ -36,9 +36,6 @@ import { getLogger } from '../logger';
 import { getClientApplication, getMembershipsForLogin } from '../oauth/utils';
 
 export type MfaMethod = 'totp' | 'email';
-
-/** App name used in MFA emails for projects that have not been white-labeled. */
-const DEFAULT_APP_NAME = 'Medplum';
 
 /** Authenticator app issuer used for projects that have not been white-labeled. */
 const DEFAULT_MFA_ISSUER = 'medplum.com';

--- a/packages/server/src/email/utils.ts
+++ b/packages/server/src/email/utils.ts
@@ -103,11 +103,15 @@ export function getFromAddress(options: Mail.Options, projectSmtp?: ProjectSmtpC
   return defaultFrom;
 }
 
+/** App name used in user-facing content for projects that have not been white-labeled. */
+export const DEFAULT_APP_NAME = 'Medplum';
+
 /**
  * Returns the app name that a project has configured for user-facing content, or
  * undefined if the project has not been white-labeled. Controlled by the
- * `appName` project setting. Used for the email sender display name below, and
- * by MFA for email content and the authenticator app issuer.
+ * `appName` project setting. Used for the email sender display name below, for
+ * invite and password-reset email content, and by MFA for email content and the
+ * authenticator app issuer.
  * @param project - The project to read the setting from.
  * @returns The configured app name, or undefined if unset or blank.
  */


### PR DESCRIPTION
The `appName` project setting already white-labels the email sender display name, MFA email content, and the authenticator app issuer, but the invite emails (new user and existing user) and the password reset email still hardcode "Medplum" in their subjects and signatures.

This applies the same `getProjectAppName` lookup to those three templates, falling back to "Medplum" as before, so a white-labeled project brands every email it sends. `DEFAULT_APP_NAME` moves next to `getProjectAppName` in `email/utils` and the duplicate in `auth/utils` is removed.

No behavior change for projects without the setting: existing subject-line tests pass unchanged. New tests cover the branded variants of all three emails (new-user invite, existing-user invite, and password reset for a project-scoped user).