### PR TITLE
Re-implement Binary reference extraction for performance

### DIFF
--- a/packages/server/src/fhir/operations/utils/binary.test.ts
+++ b/packages/server/src/fhir/operations/utils/binary.test.ts
@@ -13,4 +13,84 @@ describe('Binary utils', () => {
     expect(set2.size).toBe(1);
     expect(set2.has('123')).toBeTruthy();
   });
+
+  test('Nested and contained locations', () => {
+    const set = new Set<string>();
+    buildBinaryIds(
+      {
+        resourceType: 'DocumentReference',
+        content: [{ attachment: { url: 'Binary/abc' } }],
+        contained: [{ resourceType: 'Patient', photo: [{ url: 'Binary/def' }] }],
+      } as any,
+      set
+    );
+    expect(set.size).toBe(2);
+    expect(set.has('abc')).toBeTruthy();
+    expect(set.has('def')).toBeTruthy();
+  });
+
+  test('Multiple binaries are collected and deduped', () => {
+    const set = new Set<string>();
+    buildBinaryIds(
+      {
+        resourceType: 'Patient',
+        photo: [{ url: 'Binary/123' }, { url: 'Binary/456' }, { url: 'Binary/123' }],
+      },
+      set
+    );
+    expect(set.size).toBe(2);
+    expect(set.has('123')).toBeTruthy();
+    expect(set.has('456')).toBeTruthy();
+  });
+
+  test('Inline base64 data is ignored', () => {
+    const set = new Set<string>();
+    buildBinaryIds(
+      {
+        resourceType: 'Patient',
+        photo: [{ contentType: 'text/plain', data: Buffer.from('Binary/123').toString('base64').repeat(1000) }],
+      },
+      set
+    );
+    expect(set.size).toBe(0);
+  });
+
+  test('Non-binary urls are ignored', () => {
+    const set = new Set<string>();
+    buildBinaryIds(
+      {
+        resourceType: 'Patient',
+        photo: [{ url: 'http://example.com/x' }, { url: 'Patient/123' }],
+      },
+      set
+    );
+    expect(set.size).toBe(0);
+  });
+
+  test('Invalid binary ids are rejected', () => {
+    const set = new Set<string>();
+    buildBinaryIds(
+      {
+        resourceType: 'Patient',
+        photo: [{ url: 'Binary/' }, { url: 'Binary/ABC' }, { url: 'Binary/123?foo' }],
+      },
+      set
+    );
+    expect(set.size).toBe(0);
+  });
+
+  test('Non-url keys are ignored', () => {
+    const set = new Set<string>();
+    // The extension `url` is a definition URL, not an attachment, but we match it anyway
+    buildBinaryIds({ resourceType: 'Patient', extension: [{ url: 'Binary/123', valueString: 'x' }] } as any, set);
+    expect(set.has('123')).toBeTruthy();
+
+    const set2 = new Set<string>();
+    buildBinaryIds({ resourceType: 'Patient', identifier: [{ system: 'Binary/123' }] } as any, set2);
+    expect(set2.size).toBe(0);
+
+    const set3 = new Set<string>();
+    buildBinaryIds({ resourceType: 'Binary', id: '123', path: 'Binary/456' } as any, set3);
+    expect(set3.size).toBe(0);
+  });
 });

--- a/packages/server/src/fhir/operations/utils/binary.ts
+++ b/packages/server/src/fhir/operations/utils/binary.ts
@@ -2,14 +2,43 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Resource } from '@medplum/fhirtypes';
 
+const BINARY_PREFIX = 'Binary/';
+const BINARY_ID_REGEX = /^[a-f0-9-]+$/;
+
 /**
  * Builds a set of Binary IDs from a resource.
  * @param resource - The resource to search for Binary references.
  * @param output - The output set where Binary IDs will be added.
  */
 export function buildBinaryIds(resource: Resource, output: Set<string>): void {
-  const resourceObj = JSON.stringify(resource);
-  for (const match of resourceObj.matchAll(/"url":"Binary\/([a-f0-9-]+)"/g)) {
-    output.add(match[1]);
+  const stack: object[] = [resource];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (Array.isArray(current)) {
+      for (const item of current) {
+        if (typeof item === 'object' && item) {
+          stack.push(item);
+        }
+      }
+    } else {
+      for (const [key, value] of Object.entries(current as Record<string, unknown>)) {
+        const id = extractBinaryReference(key, value);
+        if (id) {
+          output.add(id);
+        } else if (typeof value === 'object' && value) {
+          stack.push(value);
+        }
+      }
+    }
   }
+}
+
+function extractBinaryReference(key: string, value: unknown): string | undefined {
+  if (key === 'url' && typeof value === 'string' && value.startsWith(BINARY_PREFIX)) {
+    const id = value.slice(BINARY_PREFIX.length);
+    if (BINARY_ID_REGEX.test(id)) {
+      return id;
+    }
+  }
+  return undefined;
 }

--- a/packages/server/src/fhir/operations/utils/binary.ts
+++ b/packages/server/src/fhir/operations/utils/binary.ts
@@ -11,9 +11,9 @@ const BINARY_ID_REGEX = /^[a-f0-9-]+$/;
  * @param output - The output set where Binary IDs will be added.
  */
 export function buildBinaryIds(resource: Resource, output: Set<string>): void {
-  const stack: object[] = [resource];
+  const stack: Record<string, any>[] = [resource];
   while (stack.length > 0) {
-    const current = stack.pop();
+    const current = stack.pop() as Record<string, any>; // Stack is guaranteed to contain something
     if (Array.isArray(current)) {
       for (const item of current) {
         if (typeof item === 'object' && item) {
@@ -21,7 +21,12 @@ export function buildBinaryIds(resource: Resource, output: Set<string>): void {
         }
       }
     } else {
-      for (const [key, value] of Object.entries(current as Record<string, unknown>)) {
+      for (const key in current) {
+        if (!Object.hasOwn(current, key)) {
+          continue;
+        }
+
+        const value = current[key];
         const id = extractBinaryReference(key, value);
         if (id) {
           output.add(id);


### PR DESCRIPTION
Local benchmarking indicates that the new direct traversal approach is a 120–150x speedup over `JSON.stringify()` + regex