### PR TITLE
Add Storybook "@medplum/react-scheduling" banner

### DIFF
--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -9,6 +9,7 @@ import { FC, useEffect } from 'react';
 import { BrowserRouter } from 'react-router';
 import { useFakeTimers } from 'sinon';
 import { addons } from 'storybook/preview-api';
+import { withSchedulingHeader } from '../src/decorators';
 import { themePresetMap, themePresets } from './themes';
 
 export const parameters = {
@@ -63,6 +64,7 @@ function ColorSchemeWrapper({ children }: { children: React.ReactNode }) {
 }
 
 export const decorators = [
+  withSchedulingHeader,
   (Story: FC) => (
     <BrowserRouter>
       <MedplumProvider medplum={medplum}>

--- a/packages/storybook/src/decorators.tsx
+++ b/packages/storybook/src/decorators.tsx
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Alert } from '@mantine/core';
+import type { Decorator } from '@storybook/react';
+
+export const withSchedulingHeader: Decorator = (Story, Context) => {
+  const { fileName } = Context.parameters;
+
+  if (fileName.includes('react-scheduling')) {
+    return (
+      <>
+        <Alert mb="md">
+          This component is part of the <code>@medplum/react-scheduling</code> package.
+        </Alert>
+        <Story />
+      </>
+    );
+  }
+
+  return <Story />;
+};


### PR DESCRIPTION
We're introducing some new components in this separate package, and the storybook should make it clear when they need to be imported from a different place than the standard `@medplum/react`. Let's add a banner notification.

<img width="1758" height="1284" alt="Screenshot 2026-08-04 at 9 50 24 AM" src="https://github.com/user-attachments/assets/689bba8d-86e0-4190-959b-a97aba740f0d" />
