### PR TITLE
docs: expand custom integrations section on /docs/integration

### DIFF
--- a/packages/docs/docs/integration/index.md
+++ b/packages/docs/docs/integration/index.md
@@ -270,7 +270,7 @@ Medplum provides templates and playbooks for common medical integrations.
 
 ## Custom built integrations
 
-Medplum provides building blocks for custom integrations. **Any system that exposes an API (REST/FHIR), HL7, or SFTP interface can be connected to Medplum** - you are not limited to a fixed catalog of vendors. Because the integration logic is built with [Bots](/docs/bots) that run on your own project, you own and control it. This makes integrations **portable**: if you switch vendors - for example, moving from one e-signature provider to another - you can re-point the same integration code at the new system.
+Medplum provides building blocks for custom integrations. **Any system that exposes an API (REST/FHIR), HL7, or SFTP interface can be connected to Medplum** - you are not limited to a fixed catalog of vendors. Because the integration logic is built with [Bots](/docs/bots) that run on your own project, you own and control it. This makes custom built integrations both flexible and portable. 
 
 <table>
   <thead>

--- a/packages/docs/docs/integration/index.md
+++ b/packages/docs/docs/integration/index.md
@@ -270,7 +270,9 @@ Medplum provides templates and playbooks for common medical integrations.
 
 ## Custom built integrations
 
-Medplum provides building blocks for custom integrations. Some examples are below.
+Medplum provides building blocks for custom integrations. **Any system that exposes an API (REST/FHIR), HL7, or SFTP interface can be connected to Medplum** - you are not limited to a fixed catalog of vendors. Because the integration logic is built with [Bots](/docs/bots) that run on your own project, you own and control it. This makes integrations **portable**: if you switch vendors - for example, moving from one e-signature provider to another - you can re-point the same integration code at the new system.
+
+Common examples of custom-built integrations include e-signature (e.g. [DocuSign](https://www.docusign.com/), [Dropbox Sign](https://sign.dropbox.com/)), payments, scheduling, and CRM systems - most of which expose a REST API with webhooks. See [common patterns for building integrations](/docs/bots) for guidance on how to structure these. Some examples are below.
 
 <table>
   <thead>
@@ -332,6 +334,21 @@ Medplum provides building blocks for custom integrations. Some examples are belo
       <td>Bot PDF</td>
       <td>Create PDF for Superbill</td>
       <td><a href="https://github.com/medplum/medplum/blob/main/examples/medplum-demo-bots/src/create-pdf.ts">PDF Bot</a></td>
+    </tr>
+    <tr style={{backgroundColor: '#f6f8fa'}}>
+      <td colspan="4"><strong>Consent and E-signature (Bot Webhooks)</strong></td>
+    </tr>
+    <tr>
+      <td><a href="https://www.docusign.com/">DocuSign</a></td>
+      <td>Bot Webhooks</td>
+      <td>Send documents for signature and store completed agreements</td>
+      <td><a href="/docs/bots/consuming-webhooks">Consuming webhooks</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://sign.dropbox.com/">Dropbox Sign</a></td>
+      <td>Bot Webhooks</td>
+      <td>Send documents for signature and store completed agreements</td>
+      <td><a href="/docs/bots/consuming-webhooks">Consuming webhooks</a></td>
     </tr>
   </tbody>
 </table>

--- a/packages/docs/docs/integration/index.md
+++ b/packages/docs/docs/integration/index.md
@@ -272,8 +272,6 @@ Medplum provides templates and playbooks for common medical integrations.
 
 Medplum provides building blocks for custom integrations. **Any system that exposes an API (REST/FHIR), HL7, or SFTP interface can be connected to Medplum** - you are not limited to a fixed catalog of vendors. Because the integration logic is built with [Bots](/docs/bots) that run on your own project, you own and control it. This makes integrations **portable**: if you switch vendors - for example, moving from one e-signature provider to another - you can re-point the same integration code at the new system.
 
-Common examples of custom-built integrations include e-signature (e.g. [DocuSign](https://www.docusign.com/), [Dropbox Sign](https://sign.dropbox.com/)), payments, scheduling, and CRM systems - most of which expose a REST API with webhooks. See [common patterns for building integrations](/docs/bots) for guidance on how to structure these. Some examples are below.
-
 <table>
   <thead>
     <tr>

--- a/packages/docs/src/pages/products/integration.md
+++ b/packages/docs/src/pages/products/integration.md
@@ -39,6 +39,20 @@ Before starting an integration, we recommend filling out the following checklist
 - [ ] How can you request credentials/access to a test environment?
 - [ ] What process is required to gain access to production?
 
+## Custom Integrations
+
+Beyond the pre-built integrations, **any system that exposes an API (REST/FHIR), HL7, or SFTP interface can be connected to Medplum**. Because integrations are built as [Bots](/docs/bots) - code that runs on your Medplum project - you are not limited to a fixed catalog of vendors. If a service can send or receive data over one of these interfaces, an integration to it can be built.
+
+Common examples of custom integrations include:
+
+- **E-signature** - services like DocuSign or Dropbox Sign expose REST APIs and webhooks, so consent forms and agreements can be sent, tracked, and stored back to FHIR resources
+- **Payments and billing** - REST APIs from processors and billing clearinghouses
+- **Scheduling, CRM, and messaging** - most modern digital health tools expose a REST API with webhooks
+
+This approach is **portable**. Because the integration logic lives in Bots that you own and control, you are not locked into a single vendor. If you switch e-signature providers - or want to move an existing vendor's workflow onto Medplum itself - you own the integration code and can re-point it at a new system.
+
+We plan to publish a companion guide on common patterns for building these custom integrations. In the meantime, if you have a specific integration in mind, please contact us at hello@medplum.com or in our [Discord](https://discord.gg/medplum).
+
 ## Examples: Integrations by Interface Type
 
 To get started integrating services into Medplum, it can be useful to think about **which type of medical applications have which type of interfaces**. Medplum provides the infrastructure that helps connect systems like these together.

--- a/packages/docs/src/pages/products/integration.md
+++ b/packages/docs/src/pages/products/integration.md
@@ -39,20 +39,6 @@ Before starting an integration, we recommend filling out the following checklist
 - [ ] How can you request credentials/access to a test environment?
 - [ ] What process is required to gain access to production?
 
-## Custom Integrations
-
-Beyond the pre-built integrations, **any system that exposes an API (REST/FHIR), HL7, or SFTP interface can be connected to Medplum**. Because integrations are built as [Bots](/docs/bots) - code that runs on your Medplum project - you are not limited to a fixed catalog of vendors. If a service can send or receive data over one of these interfaces, an integration to it can be built.
-
-Common examples of custom integrations include:
-
-- **E-signature** - services like DocuSign or Dropbox Sign expose REST APIs and webhooks, so consent forms and agreements can be sent, tracked, and stored back to FHIR resources
-- **Payments and billing** - REST APIs from processors and billing clearinghouses
-- **Scheduling, CRM, and messaging** - most modern digital health tools expose a REST API with webhooks
-
-This approach is **portable**. Because the integration logic lives in Bots that you own and control, you are not locked into a single vendor. If you switch e-signature providers - or want to move an existing vendor's workflow onto Medplum itself - you own the integration code and can re-point it at a new system.
-
-We plan to publish a companion guide on common patterns for building these custom integrations. In the meantime, if you have a specific integration in mind, please contact us at hello@medplum.com or in our [Discord](https://discord.gg/medplum).
-
 ## Examples: Integrations by Interface Type
 
 To get started integrating services into Medplum, it can be useful to think about **which type of medical applications have which type of interfaces**. Medplum provides the infrastructure that helps connect systems like these together.


### PR DESCRIPTION
## Summary

Expands the **Custom built integrations** section on the [Integration docs page](https://www.medplum.com/docs/integration) (`packages/docs/docs/integration/index.md`), addressing a question raised in #10080 about what can be built through custom integrations, which vendors are used, and how portable that setup is.

Changes:
- Clarifies that **any system exposing an API (REST/FHIR), HL7, or SFTP interface can be connected to Medplum** — integrations aren't limited to a fixed vendor catalog.
- Notes that Bot-based integrations are **portable**: because the integration logic lives in Bots you own, you can re-point it at a new vendor (e.g. switching e-signature providers).
- Adds **e-signature** (DocuSign, Dropbox Sign) as concrete examples, both in the section text and as rows in the examples table under a new "Consent and E-signature (Bot Webhooks)" category.

## Test plan

- [x] Markdown-only change; all internal links (`/docs/bots`, `/docs/bots/consuming-webhooks`) verified to exist
- [ ] Verify rendering in the docs site preview

Closes #10080

🤖 Generated with [Claude Code](https://claude.com/claude-code)