### PR TITLE
[Provider] Fix Calendar styling

### DIFF
--- a/examples/medplum-provider/src/main.tsx
+++ b/examples/medplum-provider/src/main.tsx
@@ -7,6 +7,7 @@ import '@mantine/notifications/styles.css';
 import '@mantine/spotlight/styles.css';
 import { MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react';
+import '@medplum/react-scheduling/styles.css';
 import '@medplum/react/styles.css';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';


### PR DESCRIPTION
In #10076 we split the calendar component out into a new `@medplum/react-scheduling` component, and didn't pull the styles from that new package into this application. Let's correct that oversight and fix the large calendar UI.