### PR TITLE
feat(fhircast): alias FHIRcast STU3 routes at `/api/hub`

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -235,6 +235,9 @@ export async function initApp(app: Express, config: MedplumServerConfig): Promis
   apiRouter.use('/fhir/R4/', fhirRouter);
   apiRouter.use('/fhircast/STU2/', fhircastSTU2Router);
   apiRouter.use('/fhircast/STU3/', fhircastSTU3Router);
+  // Some subscribers (e.g. the OHIF DICOM viewer) hardcode `hub.url` to `/api/hub`.
+  // Alias it to the latest FHIRcast version we support.
+  apiRouter.use('/hub/', fhircastSTU3Router);
   apiRouter.use('/keyvalue/v1/', keyValueRouter);
   apiRouter.use('/oauth2/', oauthRouter);
   apiRouter.use('/scim/v2/', scimRouter);

--- a/packages/server/src/cors.test.ts
+++ b/packages/server/src/cors.test.ts
@@ -109,6 +109,21 @@ describe('CORS', () => {
     expect(callback).toHaveBeenCalledWith(null, { origin: false });
   });
 
+  test('Allow FHIRcast hub alias', () => {
+    for (const path of ['/hub', '/api/hub', '/api/hub/.well-known/fhircast-configuration']) {
+      const req = {
+        header: () => 'http://localhost:3000',
+        path,
+      } as unknown as Request;
+      const callback = vi.fn();
+      corsOptions(req, callback);
+      expect(callback).toHaveBeenCalledWith(
+        null,
+        expect.objectContaining({ credentials: true, origin: 'http://localhost:3000' })
+      );
+    }
+  });
+
   test('FHIR response includes RateLimit in Access-Control-Expose-Headers', async () => {
     const app = express();
     const config = await loadTestConfig();

--- a/packages/server/src/cors.ts
+++ b/packages/server/src/cors.ts
@@ -48,6 +48,10 @@ const prefixes = [
   '/email/',
   '/fhir/',
   '/fhircast/',
+  // The `/api` variant is spelled out because subscribers pointed at the FHIRcast alias
+  // send preflights to `/api/hub` rather than the root-mounted `/hub`.
+  '/hub',
+  '/api/hub',
   '/oauth2/',
   '/keyvalue/',
   '/shl/',

--- a/packages/server/src/fhircast/routes.test.ts
+++ b/packages/server/src/fhircast/routes.test.ts
@@ -20,6 +20,7 @@ import { setTopicCurrentContext } from './utils';
 
 const STU2_BASE_ROUTE = '/fhircast/STU2';
 const STU3_BASE_ROUTE = '/fhircast/STU3';
+const HUB_ALIAS_ROUTE = '/api/hub';
 
 type ExecResult = Awaited<ReturnType<ChainableCommander['exec']>>;
 
@@ -110,6 +111,51 @@ describe('FHIRcast routes', () => {
       expect(res).toHaveStatus(202);
       expect(res.body['hub.channel.endpoint']).toBeDefined();
     }
+  });
+
+  test('New subscription with url-encoded body', async () => {
+    for (const route of [STU2_BASE_ROUTE, STU3_BASE_ROUTE, HUB_ALIAS_ROUTE]) {
+      const res = await request(server)
+        .post(route)
+        .set('Content-Type', ContentType.FORM_URL_ENCODED)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .send(
+          new URLSearchParams({
+            'hub.channel.type': 'websocket',
+            'hub.mode': 'subscribe',
+            'hub.topic': 'topic',
+            'hub.events': 'Patient-open,Patient-close',
+          }).toString()
+        );
+      expect(res).toHaveStatus(202);
+      expect(res.body['hub.channel.endpoint']).toBeDefined();
+    }
+  });
+
+  test('Hub alias serves the STU3 router', async () => {
+    const wellKnown = await request(server).get(`${HUB_ALIAS_ROUTE}/.well-known/fhircast-configuration`);
+    expect(wellKnown).toHaveStatus(200);
+    expect(wellKnown.body.fhircastVersion).toBe('STU3');
+
+    const subscribe = await request(server)
+      .post(HUB_ALIAS_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        'hub.channel.type': 'websocket',
+        'hub.mode': 'subscribe',
+        'hub.topic': 'alias-topic',
+        'hub.events': 'Patient-open',
+      });
+    expect(subscribe).toHaveStatus(202);
+    expect(subscribe.body['hub.channel.endpoint']).toMatch(/ws:\/\/localhost:8103\/ws\/fhircast\/*/);
+
+    // STU3 shape for an empty current context, rather than the STU2 empty array
+    const currentContext = await request(server)
+      .get(`${HUB_ALIAS_ROUTE}/alias-topic`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(currentContext).toHaveStatus(200);
+    expect(currentContext.body).toStrictEqual({ 'context.type': '', context: [] });
   });
 
   test('New subscription no auth', async () => {


### PR DESCRIPTION
Fixes #10035

Adds the compatibility shims the OHIF DICOM viewer needs to talk to the Medplum FHIRcast hub.

## `/api/hub` alias

OHIF hardcodes `hub.url` to `/api/hub`, so the STU3 router is now mounted there in addition to `/fhircast/STU3/`. Since `apiRouter` is mounted at both `/api/` and `/`, this exposes `/api/hub` and `/hub`, consistent with every other route. The full STU3 surface comes along: subscribe/publish `POST /`, `POST /:topic`, `GET /:topic`, and `/.well-known/fhircast-configuration`.

## CORS

`/hub` and `/api/hub` added to the allowed prefixes so preflights succeed.

The `/api` variant needs its own entry because `isPathAllowed` inspects `req.path` before the `/api` mount strips the prefix. That is also why the list looks asymmetric now — see the note below.

## `application/x-www-form-urlencoded`

No code change required. The global `urlencoded({ extended: false })` parser in `initApp` already handles these requests, and because `extended: false` keeps dotted keys literal the body arrives as `{ 'hub.channel.type': 'websocket', ... }` — exactly the shape the existing `express-validator` chains and `handleSubscriptionRequest` expect. Locked in with a test across STU2, STU3, and the new alias instead.

## Tests

- `fhircast/routes.test.ts` — form-encoded subscription against all three routes; alias-serves-STU3 (asserts the STU3 empty-context object rather than STU2's `[]`, so it fails if the wrong router is mounted).
- `cors.test.ts` — `/hub`, `/api/hub`, and a nested path under the alias.

## Out of scope, but worth knowing

Because `isPathAllowed` runs against the pre-strip path, **CORS is currently denied for every `/api/*` path** — `/api/fhir/R4/Patient`, `/api/auth/login`, and so on. Only the root-mounted variants are allowed. A general fix is one line:

```ts
function isPathAllowed(path: string): boolean {
  const normalized = path.startsWith('/api/') ? path.slice(4) : path;
  return prefixes.some((prefix) => normalized.startsWith(prefix));
}
```

Left out here since it widens CORS across every route and deserves its own review. Happy to file it as a follow-up issue.