### PR TITLE
React-scheduling cleanups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,7 @@ jobs:
           if changed '^packages/app/'; then deploy_app=true; fi
           if changed '^packages/docs/'; then deploy_docs=true; fi
           if changed '^examples/medplum-provider/'; then deploy_provider=true; fi
+          if changed '^examples/react-scheduling/'; then deploy_provider=true; fi
 
           deploy_any=false
           if [ "$deploy_app" = true ] || [ "$deploy_docs" = true ] || [ "$deploy_provider" = true ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
           if changed '^packages/app/'; then deploy_app=true; fi
           if changed '^packages/docs/'; then deploy_docs=true; fi
           if changed '^examples/medplum-provider/'; then deploy_provider=true; fi
-          if changed '^examples/react-scheduling/'; then deploy_provider=true; fi
+          if changed '^packages/react-scheduling/'; then deploy_provider=true; fi
 
           deploy_any=false
           if [ "$deploy_app" = true ] || [ "$deploy_docs" = true ] || [ "$deploy_provider" = true ]; then

--- a/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
@@ -119,12 +119,14 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
         const encounter = await medplum.searchOne('Encounter', { appointment: getReferenceString(appointment) });
         if (encounter) {
           await navigate(encounterUrl(encounter));
+        } else {
+          handleSelectAppointment(appointment);
         }
       } catch (error) {
         showErrorNotification(error);
       }
     },
-    [medplum, navigate]
+    [medplum, navigate, handleSelectAppointment]
   );
 
   const mergedSlots = useMemo(() => mergeOverlappingSlots(slots ?? []), [slots]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -45739,6 +45739,7 @@
         "@mantine/hooks": "8.3.18",
         "@medplum/core": "5.1.29",
         "@medplum/fhirtypes": "5.1.29",
+        "@medplum/mock": "5.1.29",
         "@medplum/react": "5.1.29",
         "@tabler/icons-react": "3.46.0",
         "@testing-library/dom": "10.4.1",

--- a/packages/react-scheduling/README.md
+++ b/packages/react-scheduling/README.md
@@ -29,13 +29,16 @@ Note the following peer dependencies:
 
 ## Basic Usage
 
-This is intended to be used inside an application built using [`@medplum/react`](https://www.npmjs.com/package/@medplum/react).
+These components are intended to be used inside an application built using [`@medplum/react`](https://www.npmjs.com/package/@medplum/react). Components expect to be mounted inside a `<MedplumProvider>` and a `<MantineProvider>`.
+
+Learn more about setting up your application at https://www.medplum.com/docs/react.
 
 ```tsx
 import { getReferenceString } from '@medplum/core';
 import type { Practitioner } from '@medplum/fhirtypes';
 import { useSearchResources } from '@medplum/react';
-import { Calendar } from '@medplum/react-scheduling'
+import { Calendar } from '@medplum/react-scheduling';
+import '@medplum/react-scheduling/styles.css';
 
 export function ScheduleView(props: { practitioner: Practitioner }) {
   const [appointments, loading] = useSearchResources(
@@ -47,7 +50,7 @@ export function ScheduleView(props: { practitioner: Practitioner }) {
   if (loading) {
     return <>Loading...</>;
   }
-  return <Calendar appointments={appointments} slots={[]} />
+  return <Calendar appointments={appointments} />;
 }
 ```
 

--- a/packages/react-scheduling/package.json
+++ b/packages/react-scheduling/package.json
@@ -71,6 +71,7 @@
     "@mantine/hooks": "8.3.18",
     "@medplum/core": "5.1.29",
     "@medplum/fhirtypes": "5.1.29",
+    "@medplum/mock": "5.1.29",
     "@medplum/react": "5.1.29",
     "@tabler/icons-react": "3.46.0",
     "@testing-library/dom": "10.4.1",

--- a/packages/react-scheduling/src/Calendar/Calendar.stories.tsx
+++ b/packages/react-scheduling/src/Calendar/Calendar.stories.tsx
@@ -1,5 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { createReference } from '@medplum/core';
+import type { Appointment, Slot } from '@medplum/fhirtypes';
+import { DrAliceSmith, DrAliceSmithSchedule, HomerSimpson } from '@medplum/mock';
 import type { Meta } from '@storybook/react';
 import type { JSX } from 'react';
 import { withMockedDate } from '../stories/decorators';
@@ -11,11 +14,67 @@ export default {
   decorators: [withMockedDate],
 } as Meta;
 
-export const Basic = (): JSX.Element => (
-  <div style={{ height: 600, padding: '1em' }}>
-    <Calendar slots={[]} appointments={[]} />
-  </div>
-);
+export const Basic = (): JSX.Element => {
+  const slots = [
+    // This slot should not be rendered, as it is shown via the matching Appointment resource
+    {
+      resourceType: 'Slot',
+      id: 'slot-1',
+      start: '2020-05-05T17:00:00Z',
+      end: '2020-05-05T18:00:00Z',
+      status: 'busy',
+      schedule: createReference(DrAliceSmithSchedule),
+    },
+
+    // This slot should be rendered as blocked time on the calendar
+    {
+      resourceType: 'Slot',
+      id: 'slot-2',
+      start: '2020-05-05T18:00:00Z',
+      end: '2020-05-05T18:15:00Z',
+      status: 'busy-unavailable',
+      schedule: createReference(DrAliceSmithSchedule),
+      comment: 'Blocked time after appointment',
+    },
+
+    // "Free" slots are used to create availability outside of common operating hours
+    {
+      resourceType: 'Slot',
+      id: 'slot-3',
+      start: '2020-05-06T14:00:00Z',
+      end: '2020-05-06T16:00:00Z',
+      status: 'free',
+      schedule: createReference(DrAliceSmithSchedule),
+      comment: 'Coming in early on wednesday morning',
+    },
+  ] satisfies Slot[];
+
+  const appointments: Appointment[] = [
+    {
+      resourceType: 'Appointment',
+      status: 'booked',
+      start: '2020-05-05T17:00:00Z',
+      end: '2020-05-05T18:00:00Z',
+      slot: [createReference(slots[0]), createReference(slots[1])],
+      participant: [
+        {
+          status: 'accepted',
+          actor: createReference(DrAliceSmith),
+        },
+        {
+          status: 'accepted',
+          actor: createReference(HomerSimpson),
+        },
+      ],
+    },
+  ];
+
+  return (
+    <div style={{ height: 600, padding: '1em' }}>
+      <Calendar slots={slots} appointments={appointments} />
+    </div>
+  );
+};
 
 export const WithAvailabilityOverlay = (): JSX.Element => (
   <div style={{ height: 600, padding: '1em' }}>

--- a/packages/react-scheduling/src/Calendar/Calendar.stories.tsx
+++ b/packages/react-scheduling/src/Calendar/Calendar.stories.tsx
@@ -52,6 +52,7 @@ export const Basic = (): JSX.Element => {
   const appointments: Appointment[] = [
     {
       resourceType: 'Appointment',
+      id: 'appt-1',
       status: 'booked',
       start: '2020-05-05T17:00:00Z',
       end: '2020-05-05T18:00:00Z',
@@ -71,7 +72,12 @@ export const Basic = (): JSX.Element => {
 
   return (
     <div style={{ height: 600, padding: '1em' }}>
-      <Calendar slots={slots} appointments={appointments} />
+      <Calendar
+        slots={slots}
+        appointments={appointments}
+        onSelectAppointment={(appointment) => alert(`Selected appointment ${appointment.id}`)}
+        onDoubleClickAppointment={(appointment) => alert(`Double-clicked appointment ${appointment.id}`)}
+      />
     </div>
   );
 };

--- a/packages/react-scheduling/src/Calendar/Calendar.test.tsx
+++ b/packages/react-scheduling/src/Calendar/Calendar.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { sleep } from '@medplum/core';
 import type { Appointment, HealthcareServiceAvailableTime, Slot } from '@medplum/fhirtypes';
 import { describe, expect, test, vi } from 'vitest';
 import { render, screen, userEvent } from '../test-utils/render';
@@ -337,6 +338,24 @@ describe('Calendar', () => {
 
       await userEvent.dblClick(screen.getByText(/John Doe/));
       await expect(onDoubleClickAppointment).toHaveBeenCalledWith(appointment);
+    });
+
+    test('double-clicking an appointment does not also fire onSelectAppointment', async () => {
+      const onSelectAppointment = vi.fn();
+      const onDoubleClickAppointment = vi.fn();
+      const appointment = createAppointment();
+      setup({ appointments: [appointment], onSelectAppointment, onDoubleClickAppointment });
+
+      await userEvent.dblClick(screen.getByText(/John Doe/));
+      expect(onDoubleClickAppointment).toHaveBeenCalledWith(appointment);
+      expect(onSelectAppointment).not.toHaveBeenCalled();
+
+      // With onDoubleClickAppointment set, the single-click select is
+      // debounced (100ms) so the double-click handler can cancel it before it
+      // fires. Wait past the debounce window to confirm the pending select
+      // was cancelled, not merely delayed.
+      await sleep(150);
+      expect(onSelectAppointment).not.toHaveBeenCalled();
     });
 
     test('filters out entered-in-error slots', async () => {

--- a/packages/react-scheduling/src/Calendar/Calendar.tsx
+++ b/packages/react-scheduling/src/Calendar/Calendar.tsx
@@ -107,12 +107,19 @@ export function Calendar(props: CalendarProps): JSX.Element {
     onDoubleClickRef.current = onDoubleClickAppointment;
   }, [onDoubleClickAppointment]);
 
-  const handleDblClick = useCallback((e: Event) => {
-    const ext = eventDataRef.current.get(e.currentTarget as Element);
-    if (ext?.type === 'appointment') {
-      onDoubleClickRef.current?.(ext.appointment);
-    }
-  }, []);
+  const handleDblClick = useCallback(
+    (e: Event) => {
+      const ext = eventDataRef.current.get(e.currentTarget as Element);
+      if (ext?.type === 'appointment') {
+        onDoubleClickRef.current?.(ext.appointment);
+
+        // The first click started a timer for `handleSelectEvent`; cancel that pending
+        // event since we are emitting the double-click instead.
+        handleSelectEventDebounced.cancel();
+      }
+    },
+    [handleSelectEventDebounced]
+  );
 
   const events = useMemo(() => {
     const appointments = props.appointments ?? [];

--- a/scripts/cicd-deploy.sh
+++ b/scripts/cicd-deploy.sh
@@ -114,6 +114,11 @@ if [[ "$FILES_CHANGED" =~ packages/react/ ]]; then
   DEPLOY_STORYBOOK=true
 fi
 
+if [[ "$FILES_CHANGED" =~ packages/react-hooks ]]; then
+  DEPLOY_APP=true
+  DEPLOY_STORYBOOK=true
+fi
+
 if [[ "$FILES_CHANGED" =~ packages/react-scheduling ]]; then
   DEPLOY_STORYBOOK=true
 fi

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -33,6 +33,7 @@ sonar.exclusions=**/node_modules/**,\
   packages/mock/src/test-resources/*.ts,\
   packages/react-scheduling/src/stories/*,\
   packages/react/src/stories/*,\
+  packages/react-scheduling/src/stories/*,\
   packages/server/src/migrations/migrate-main.ts,\
   packages/server/src/migrations/data/**/*.ts,\
   packages/server/src/migrations/schema/**/*.ts,\


### PR DESCRIPTION
Some fast follows after introducing @medplum/react-scheduling:
- Update Calendar storybook to be more representative
- Update preview url generation to trigger on react-scheduling changes
- Fix CICD-deploy script; restore triggering on `@medplum/react-hooks` (regression caused by changes in #10076)
- Tighten Calendar double-click handling