### PR TITLE
fix(cdk): grant backend task role SES permissions on configuration-set resources

### DIFF
--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -348,6 +348,18 @@ export class BackEnd extends Construct {
           resources: [`arn:aws:ses:${region}:${accountNumber}:identity/*`],
         }),
 
+        // SES: Send emails via an identity that has a configuration set attached.
+        // AWS requires authorization on the configuration-set resource in addition to the
+        // identity resource whenever a configuration set is in play, or SendEmail/SendRawEmail
+        // fails at send time with an IAM authorization error even though the caller is
+        // authorized on the identity.
+        // https://docs.aws.amazon.com/ses/latest/dg/sending-authorization-policy-examples.html
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['ses:SendEmail', 'ses:SendRawEmail'],
+          resources: [`arn:aws:ses:${region}:${accountNumber}:configuration-set/*`],
+        }),
+
         // S3: List storage bucket
         // https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html
         new iam.PolicyStatement({


### PR DESCRIPTION
## Summary

The backend ECS task role's SES policy (`packages/cdk/src/backend.ts`) only grants `ses:SendEmail`/`ses:SendRawEmail` on `arn:aws:ses:<region>:<account>:identity/*`. AWS requires separate IAM authorization on the `configuration-set` resource whenever the sending SES identity has a configuration set attached — `identity/*` alone isn't sufficient in that case.

Without this, every transactional email (password reset, invites, etc.) sent through an identity with a configuration set attached fails at send time with an error like:

```
User `...assumed-role/.../TaskExecutionRole...' is not authorized to perform
`ses:SendRawEmail' on resource `arn:aws:ses:...:configuration-set/<name>'
```

This is easy to miss because it only surfaces once a configuration set is attached to the identity (a common and unremarkable SES setup — used for tracking sends, bounces, etc.), and application-level error handling around email sending can mask it (e.g. the caller may still return a generic success response upstream of this failure).

## Fix

Add a second `iam.PolicyStatement` granting the same two actions on `arn:aws:ses:<region>:<account>:configuration-set/*`, mirroring the existing identity statement.

## Test plan

- [x] Verified via `cdk diff` in a downstream project consuming this package that the added statement is the only IAM change produced
- [ ] No existing test coverage in this repo exercises the task role's IAM policy statements directly (nothing to update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)