### PR TITLE
docs: add Synthea as a sample-data source in seeding tutorial

### DIFF
--- a/packages/docs/docs/tutorials/importing-sample-data.md
+++ b/packages/docs/docs/tutorials/importing-sample-data.md
@@ -39,3 +39,9 @@ Log into Medplum and navigate to the [batch create](https://app.medplum.com/batc
 ![Batch create tool](/img/tutorials/batch-create.png)
 
 The batch upload tool is a lightweight wrapper around the [batch/transaction api](https://www.hl7.org/fhir/http.html#transaction) and here is the documentation on how to [upload a batch using the SDK](/docs/sdk/core.medplumclient.executebatch).
+
+## Generating More Sample Data with Synthea
+
+The two patients above are handy for a quick start, but when you need a larger, more varied population, [Synthea](https://github.com/synthetichealth/synthea) is a great source of synthetic FHIR data. Synthea generates realistic, statistically-modeled patient histories that you can load into Medplum the same way you loaded the files above.
+
+You can either download pre-generated [Synthea sample bundles](https://github.com/synthetichealth/synthea-sample-data/tree/master/downloads), or run Synthea yourself to generate a custom-sized population. For a step-by-step walkthrough of generating bundles and importing them with the [batch create](https://app.medplum.com/batch) tool, see the [Getting Started with Synthetic FHIR Data](/blog/2021/12/13/synthea) guide.


### PR DESCRIPTION
## Summary

Addresses the **"how to seed patients in test app"** question from #10082.

The [Import Sample Data](https://github.com/medplum/medplum/blob/main/packages/docs/docs/tutorials/importing-sample-data.md) tutorial already links the batch tool, but didn't mention that Synthea is a great source of synthetic data. Added a **Generating More Sample Data with Synthea** section pointing to the pre-generated [sample bundles](https://github.com/synthetichealth/synthea-sample-data/tree/master/downloads) and the existing [Getting Started with Synthetic FHIR Data](/blog/synthea) walkthrough.

## Files changed
- `packages/docs/docs/tutorials/importing-sample-data.md`

## Notes
- The "graph and charts" item from the issue was intentionally left out of this PR — the proposed docs change felt too weak to be worth shipping.

Refs #10082

🤖 Generated with [Claude Code](https://claude.com/claude-code)