### PR TITLE
Order meds by GCN and ROUTED MED ID (without RxNorm or NDC number present)

### DIFF
--- a/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
@@ -120,6 +120,40 @@ function getRoutedMedIdFromMedication(m: Medication): number | undefined {
   return Number.isFinite(n) ? n : undefined;
 }
 
+/**
+ * The single GCN_SEQNO on a Medication, or undefined when it carries none — or
+ * **several**.
+ *
+ * A dose-level formulation has exactly one GCN. A drug-name search hit for a
+ * multi-strength product carries one identifier per available GCN, and nothing
+ * on the resource says which strength the prescriber meant. Since GCN is what
+ * the vendor resolves the dose from when there is no NDC, picking the first of
+ * several would silently prescribe an arbitrary strength — so an ambiguous
+ * Medication yields nothing and the caller falls back to requiring a
+ * formulation.
+ *
+ * @param m - Medication from drug search.
+ * @returns The GCN_SEQNO as a number, or undefined when absent or ambiguous.
+ */
+function getUnambiguousGcnSeqnoFromMedication(m: Medication): number | undefined {
+  const values = new Set<string>();
+  for (const id of m.identifier ?? []) {
+    if (id.system === SCRIPTSURE_GCN_SEQNO_SYSTEM && id.value) {
+      values.add(id.value);
+    }
+  }
+  for (const coding of m.code?.coding ?? []) {
+    if (coding.system === SCRIPTSURE_GCN_SEQNO_SYSTEM && coding.code) {
+      values.add(coding.code);
+    }
+  }
+  if (values.size !== 1) {
+    return undefined;
+  }
+  const n = Number.parseInt([...values][0], 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
 function normalizeNdcDigits(ndc: string | undefined): string | undefined {
   if (!ndc) {
     return undefined;
@@ -443,10 +477,17 @@ function medicationToOrderDrugInput(
   const ndc = (m.code && getCodeBySystem(m.code, NDC)) ?? getIdentifier(m, NDC);
   const rxNorm = (m.code && getCodeBySystem(m.code, RXNORM)) ?? getIdentifier(m, RXNORM);
   const routedMedId = getRoutedMedIdFromMedication(m);
+  // A drug whose formulation lookup came back empty (OTC / topical products) has
+  // no NDC or RxNorm; it is ordered on routedMedId + GCN, with the name carried
+  // explicitly because there is no dose-level record to derive it from.
+  const gcnSeqno = ndc || rxNorm ? undefined : getUnambiguousGcnSeqnoFromMedication(m);
+  const drugName = m.code?.text?.trim();
   return {
     ...(ndc ? { ndc } : {}),
     ...(rxNorm ? { rxNorm } : {}),
     ...(routedMedId === undefined ? {} : { routedMedId }),
+    ...(gcnSeqno === undefined ? {} : { gcnSeqno }),
+    ...(gcnSeqno !== undefined && drugName ? { drugName } : {}),
     quantity: opts.quantity,
     quantityQualifier: opts.quantityQualifier ?? DEFAULT_QUANTITY_QUALIFIER,
     refill: opts.refill,
@@ -498,10 +539,13 @@ function medicationToCodeableConcept(
   // (not a code.coding). Promote it to a coding so the draft MR carries the
   // FDB clinical-formulation key: the ScriptSure prescription webhook reconciles
   // draft→sent by GCN when the NDC drifts (#9300) or a generic is substituted
-  // (brand/generic share a GCN). See scriptsure-react SCRIPTSURE_GCN_SEQNO_SYSTEM.
-  const gcn = getIdentifier(format, SCRIPTSURE_GCN_SEQNO_SYSTEM);
-  if (gcn && !coding.some((c) => c.system === SCRIPTSURE_GCN_SEQNO_SYSTEM)) {
-    coding.push({ system: SCRIPTSURE_GCN_SEQNO_SYSTEM, code: gcn });
+  // (brand/generic share a GCN). It also makes a draft orderable when the drug
+  // has no formulations at all (`format` falls back to the name-search hit, so
+  // there is no NDC) — the order is then keyed on routedMedId + GCN. Skipped
+  // when several GCNs are present, since none of them is "the" strength.
+  const gcn = getUnambiguousGcnSeqnoFromMedication(format);
+  if (gcn !== undefined && !coding.some((c) => c.system === SCRIPTSURE_GCN_SEQNO_SYSTEM)) {
+    coding.push({ system: SCRIPTSURE_GCN_SEQNO_SYSTEM, code: String(gcn) });
   }
   return {
     coding,

--- a/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
@@ -136,6 +136,22 @@ function getRoutedMedIdFromMedication(m: Medication): number | undefined {
  * @returns The GCN_SEQNO as a number, or undefined when absent or ambiguous.
  */
 function getUnambiguousGcnSeqnoFromMedication(m: Medication): number | undefined {
+  const values = getGcnSeqnosFromMedication(m);
+  return values.length === 1 ? values[0] : undefined;
+}
+
+/**
+ * Every GCN_SEQNO on a Medication, deduplicated.
+ *
+ * A name-search hit for a multi-strength product carries one per available
+ * strength. Passing them to the formulation lookup is what lets the prescriber
+ * pick a strength for drugs the vendor has no dose-format rows for — each key
+ * resolves to a named, dispensable product.
+ *
+ * @param m - Medication from drug search.
+ * @returns GCN_SEQNOs as numbers, in the order encountered.
+ */
+function getGcnSeqnosFromMedication(m: Medication): number[] {
   const values = new Set<string>();
   for (const id of m.identifier ?? []) {
     if (id.system === SCRIPTSURE_GCN_SEQNO_SYSTEM && id.value) {
@@ -147,11 +163,7 @@ function getUnambiguousGcnSeqnoFromMedication(m: Medication): number | undefined
       values.add(coding.code);
     }
   }
-  if (values.size !== 1) {
-    return undefined;
-  }
-  const n = Number.parseInt([...values][0], 10);
-  return Number.isFinite(n) ? n : undefined;
+  return [...values].map((v) => Number.parseInt(v, 10)).filter((n) => Number.isFinite(n));
 }
 
 function normalizeNdcDigits(ndc: string | undefined): string | undefined {
@@ -863,7 +875,10 @@ export function OrderMedicationPage(props: Readonly<OrderMedicationPageProps>): 
     }
     let cancelled = false;
     setLoadingFormats(true);
-    searchMedications({ routedMedId: rid })
+    // The GCNs come along so a drug with no dose formats still yields selectable
+    // strengths (each GCN resolves to a named product) instead of dropping the
+    // prescriber onto the strength-less name-search hit.
+    searchMedications({ routedMedId: rid, gcnSeqnos: getGcnSeqnosFromMedication(termMedication) })
       .then((list) => {
         if (!cancelled) {
           const deduped = dedupeMedications(list);
@@ -1726,7 +1741,7 @@ interface CompoundLineState {
 interface CompoundLineEditorProps {
   index: number;
   line: CompoundLineState;
-  searchMedications: (p: { term?: string; routedMedId?: number }) => Promise<Medication[]>;
+  searchMedications: (p: { term?: string; routedMedId?: number; gcnSeqnos?: number[] }) => Promise<Medication[]>;
   onChange: (line: CompoundLineState) => void;
 }
 
@@ -1764,7 +1779,9 @@ function CompoundLineEditor(props: Readonly<CompoundLineEditorProps>): JSX.Eleme
     }
     setLoading(true);
     try {
-      const list = dedupeMedications(await searchMedications({ routedMedId: rid }));
+      const list = dedupeMedications(
+        await searchMedications({ routedMedId: rid, gcnSeqnos: getGcnSeqnosFromMedication(m) })
+      );
       setFormats(list);
       onChange({ ...line, termMed: m, formatMed: list[0] ?? m });
     } catch (e) {

--- a/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
+++ b/examples/medplum-provider/src/pages/meds/OrderMedicationPage.tsx
@@ -70,6 +70,12 @@ import {
   STATIC_QUALIFIER_MATCHER,
 } from '../../components/meds/quantity-qualifiers';
 import { ScriptSurePracticeSwitcher, useScriptSurePractice } from '../../scriptsure/ScriptSurePractice';
+import {
+  getDisplayNameFromMedication,
+  getGcnSeqnosFromMedication,
+  getUnambiguousGcnSeqnoFromMedication,
+  getVendorKeyFromMedication,
+} from '../../utils/medication-gcn';
 import { showErrorNotification } from '../../utils/notifications';
 import { OrderSetTabPanel } from './OrderSetTabPanel';
 
@@ -110,60 +116,7 @@ export interface OrderMedicationPageProps {
 }
 
 function getRoutedMedIdFromMedication(m: Medication): number | undefined {
-  const v =
-    getIdentifier(m, SCRIPTSURE_ROUTED_MED_ID_SYSTEM) ??
-    (m.code && getCodeBySystem(m.code, SCRIPTSURE_ROUTED_MED_ID_SYSTEM));
-  if (!v) {
-    return undefined;
-  }
-  const n = Number.parseInt(v, 10);
-  return Number.isFinite(n) ? n : undefined;
-}
-
-/**
- * The single GCN_SEQNO on a Medication, or undefined when it carries none — or
- * **several**.
- *
- * A dose-level formulation has exactly one GCN. A drug-name search hit for a
- * multi-strength product carries one identifier per available GCN, and nothing
- * on the resource says which strength the prescriber meant. Since GCN is what
- * the vendor resolves the dose from when there is no NDC, picking the first of
- * several would silently prescribe an arbitrary strength — so an ambiguous
- * Medication yields nothing and the caller falls back to requiring a
- * formulation.
- *
- * @param m - Medication from drug search.
- * @returns The GCN_SEQNO as a number, or undefined when absent or ambiguous.
- */
-function getUnambiguousGcnSeqnoFromMedication(m: Medication): number | undefined {
-  const values = getGcnSeqnosFromMedication(m);
-  return values.length === 1 ? values[0] : undefined;
-}
-
-/**
- * Every GCN_SEQNO on a Medication, deduplicated.
- *
- * A name-search hit for a multi-strength product carries one per available
- * strength. Passing them to the formulation lookup is what lets the prescriber
- * pick a strength for drugs the vendor has no dose-format rows for — each key
- * resolves to a named, dispensable product.
- *
- * @param m - Medication from drug search.
- * @returns GCN_SEQNOs as numbers, in the order encountered.
- */
-function getGcnSeqnosFromMedication(m: Medication): number[] {
-  const values = new Set<string>();
-  for (const id of m.identifier ?? []) {
-    if (id.system === SCRIPTSURE_GCN_SEQNO_SYSTEM && id.value) {
-      values.add(id.value);
-    }
-  }
-  for (const coding of m.code?.coding ?? []) {
-    if (coding.system === SCRIPTSURE_GCN_SEQNO_SYSTEM && coding.code) {
-      values.add(coding.code);
-    }
-  }
-  return [...values].map((v) => Number.parseInt(v, 10)).filter((n) => Number.isFinite(n));
+  return getVendorKeyFromMedication(m, SCRIPTSURE_ROUTED_MED_ID_SYSTEM);
 }
 
 function normalizeNdcDigits(ndc: string | undefined): string | undefined {
@@ -492,14 +445,18 @@ function medicationToOrderDrugInput(
   // A drug whose formulation lookup came back empty (OTC / topical products) has
   // no NDC or RxNorm; it is ordered on routedMedId + GCN, with the name carried
   // explicitly because there is no dose-level record to derive it from.
-  const gcnSeqno = ndc || rxNorm ? undefined : getUnambiguousGcnSeqnoFromMedication(m);
-  const drugName = m.code?.text?.trim();
+  //
+  // The name is what makes such a line legible to the pharmacy, so a GCN-keyed
+  // line is only emitted when one is available — otherwise this falls back to
+  // routedMedId alone and the vendor requires a resolvable formulation, which
+  // fails with a clearer error than a nameless order would.
+  const drugName = getDisplayNameFromMedication(m, SCRIPTSURE_ROUTED_MED_ID_SYSTEM);
+  const gcnSeqno = ndc || rxNorm || !drugName ? undefined : getUnambiguousGcnSeqnoFromMedication(m);
   return {
     ...(ndc ? { ndc } : {}),
     ...(rxNorm ? { rxNorm } : {}),
     ...(routedMedId === undefined ? {} : { routedMedId }),
-    ...(gcnSeqno === undefined ? {} : { gcnSeqno }),
-    ...(gcnSeqno !== undefined && drugName ? { drugName } : {}),
+    ...(gcnSeqno === undefined ? {} : { gcnSeqno, drugName }),
     quantity: opts.quantity,
     quantityQualifier: opts.quantityQualifier ?? DEFAULT_QUANTITY_QUALIFIER,
     refill: opts.refill,

--- a/examples/medplum-provider/src/utils/medication-gcn.test.ts
+++ b/examples/medplum-provider/src/utils/medication-gcn.test.ts
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { Medication } from '@medplum/fhirtypes';
+import { SCRIPTSURE_GCN_SEQNO_SYSTEM, SCRIPTSURE_ROUTED_MED_ID_SYSTEM } from '@medplum/scriptsure-react';
+import { describe, expect, test } from 'vitest';
+import {
+  getDisplayNameFromMedication,
+  getGcnSeqnosFromMedication,
+  getUnambiguousGcnSeqnoFromMedication,
+  getVendorKeyFromMedication,
+} from './medication-gcn';
+
+function medicationWithGcnIdentifiers(...values: string[]): Medication {
+  return {
+    resourceType: 'Medication',
+    identifier: values.map((value) => ({ system: SCRIPTSURE_GCN_SEQNO_SYSTEM, value })),
+  };
+}
+
+describe('getGcnSeqnosFromMedication', () => {
+  test('returns nothing for a Medication with no formulation keys', () => {
+    expect(getGcnSeqnosFromMedication({ resourceType: 'Medication' })).toStrictEqual([]);
+    expect(
+      getGcnSeqnosFromMedication({
+        resourceType: 'Medication',
+        identifier: [{ system: 'http://hl7.org/fhir/sid/ndc', value: '00310075190' }],
+      })
+    ).toStrictEqual([]);
+  });
+
+  test('reads a single key off an identifier', () => {
+    expect(getGcnSeqnosFromMedication(medicationWithGcnIdentifiers('51784'))).toStrictEqual([51784]);
+  });
+
+  test('reads every key for a multi-strength search hit', () => {
+    expect(getGcnSeqnosFromMedication(medicationWithGcnIdentifiers('8346', '22528', '22530'))).toStrictEqual([
+      8346, 22528, 22530,
+    ]);
+  });
+
+  test('collects keys from code.coding as well as identifier', () => {
+    const m: Medication = {
+      resourceType: 'Medication',
+      identifier: [{ system: SCRIPTSURE_GCN_SEQNO_SYSTEM, value: '8346' }],
+      code: { coding: [{ system: SCRIPTSURE_GCN_SEQNO_SYSTEM, code: '22528' }] },
+    };
+    expect(getGcnSeqnosFromMedication(m)).toStrictEqual([8346, 22528]);
+  });
+
+  test('deduplicates the same key repeated across identifier and coding', () => {
+    const m: Medication = {
+      resourceType: 'Medication',
+      identifier: [{ system: SCRIPTSURE_GCN_SEQNO_SYSTEM, value: '7341' }],
+      code: { coding: [{ system: SCRIPTSURE_GCN_SEQNO_SYSTEM, code: '7341' }] },
+    };
+    expect(getGcnSeqnosFromMedication(m)).toStrictEqual([7341]);
+  });
+
+  test('treats a zero-padded key as the same strength, not a second one', () => {
+    // Deduping raw strings would yield [8346, 8346] and make one logical
+    // strength look ambiguous.
+    expect(getGcnSeqnosFromMedication(medicationWithGcnIdentifiers('8346', '08346'))).toStrictEqual([8346]);
+  });
+
+  test('drops values that are not purely numeric rather than half-parsing them', () => {
+    expect(getGcnSeqnosFromMedication(medicationWithGcnIdentifiers('12abc', '', '  ', 'abc'))).toStrictEqual([]);
+    expect(getGcnSeqnosFromMedication(medicationWithGcnIdentifiers(' 8346 ', '9x'))).toStrictEqual([8346]);
+  });
+});
+
+describe('getUnambiguousGcnSeqnoFromMedication', () => {
+  test('returns the key when exactly one is present', () => {
+    expect(getUnambiguousGcnSeqnoFromMedication(medicationWithGcnIdentifiers('51784'))).toBe(51784);
+  });
+
+  test('returns nothing when none is present', () => {
+    expect(getUnambiguousGcnSeqnoFromMedication({ resourceType: 'Medication' })).toBeUndefined();
+  });
+
+  test('returns nothing when several are present, rather than picking a strength', () => {
+    expect(getUnambiguousGcnSeqnoFromMedication(medicationWithGcnIdentifiers('8346', '22528'))).toBeUndefined();
+  });
+
+  test('still resolves when duplicates collapse to one key', () => {
+    expect(getUnambiguousGcnSeqnoFromMedication(medicationWithGcnIdentifiers('7341', '07341'))).toBe(7341);
+  });
+});
+
+describe('getDisplayNameFromMedication', () => {
+  test('prefers code.text', () => {
+    const m: Medication = {
+      resourceType: 'Medication',
+      code: {
+        text: 'Tolcylen topical',
+        coding: [{ system: SCRIPTSURE_ROUTED_MED_ID_SYSTEM, code: '177770', display: 'Tolcylen' }],
+      },
+    };
+    expect(getDisplayNameFromMedication(m, SCRIPTSURE_ROUTED_MED_ID_SYSTEM)).toBe('Tolcylen topical');
+  });
+
+  test('falls back to the routed-med coding display when there is no text', () => {
+    const m: Medication = {
+      resourceType: 'Medication',
+      code: {
+        coding: [
+          { system: 'http://hl7.org/fhir/sid/ndc', code: '00310075190', display: 'NDC display' },
+          { system: SCRIPTSURE_ROUTED_MED_ID_SYSTEM, code: '76704', display: 'Crestor oral' },
+        ],
+      },
+    };
+    expect(getDisplayNameFromMedication(m, SCRIPTSURE_ROUTED_MED_ID_SYSTEM)).toBe('Crestor oral');
+  });
+
+  test('falls back to any coding display as a last resort', () => {
+    const m: Medication = {
+      resourceType: 'Medication',
+      code: { coding: [{ system: 'http://hl7.org/fhir/sid/ndc', code: '1', display: 'Some product' }] },
+    };
+    expect(getDisplayNameFromMedication(m, SCRIPTSURE_ROUTED_MED_ID_SYSTEM)).toBe('Some product');
+  });
+
+  test('returns nothing when every candidate is blank, so callers can refuse to send a nameless line', () => {
+    const m: Medication = {
+      resourceType: 'Medication',
+      code: { text: '   ', coding: [{ system: SCRIPTSURE_ROUTED_MED_ID_SYSTEM, code: '1', display: '  ' }] },
+    };
+    expect(getDisplayNameFromMedication(m, SCRIPTSURE_ROUTED_MED_ID_SYSTEM)).toBeUndefined();
+  });
+});
+
+describe('getVendorKeyFromMedication', () => {
+  test('reads the key from an identifier', () => {
+    const m: Medication = {
+      resourceType: 'Medication',
+      identifier: [{ system: SCRIPTSURE_ROUTED_MED_ID_SYSTEM, value: '177770' }],
+    };
+    expect(getVendorKeyFromMedication(m, SCRIPTSURE_ROUTED_MED_ID_SYSTEM)).toBe(177770);
+  });
+
+  test('falls back to code.coding', () => {
+    const m: Medication = {
+      resourceType: 'Medication',
+      code: { coding: [{ system: SCRIPTSURE_ROUTED_MED_ID_SYSTEM, code: '6143' }] },
+    };
+    expect(getVendorKeyFromMedication(m, SCRIPTSURE_ROUTED_MED_ID_SYSTEM)).toBe(6143);
+  });
+
+  test('returns nothing when absent or non-numeric', () => {
+    expect(getVendorKeyFromMedication({ resourceType: 'Medication' }, SCRIPTSURE_ROUTED_MED_ID_SYSTEM)).toBeUndefined();
+    const m: Medication = {
+      resourceType: 'Medication',
+      identifier: [{ system: SCRIPTSURE_ROUTED_MED_ID_SYSTEM, value: '17abc' }],
+    };
+    expect(getVendorKeyFromMedication(m, SCRIPTSURE_ROUTED_MED_ID_SYSTEM)).toBeUndefined();
+  });
+});

--- a/examples/medplum-provider/src/utils/medication-gcn.ts
+++ b/examples/medplum-provider/src/utils/medication-gcn.ts
@@ -22,9 +22,7 @@ import { SCRIPTSURE_GCN_SEQNO_SYSTEM } from '@medplum/scriptsure-react';
  */
 export function getGcnSeqnosFromMedication(m: Medication): number[] {
   const raw: (string | undefined)[] = [
-    ...(m.identifier ?? [])
-      .filter((id) => id.system === SCRIPTSURE_GCN_SEQNO_SYSTEM)
-      .map((id) => id.value),
+    ...(m.identifier ?? []).filter((id) => id.system === SCRIPTSURE_GCN_SEQNO_SYSTEM).map((id) => id.value),
     ...(m.code?.coding ?? [])
       .filter((coding) => coding.system === SCRIPTSURE_GCN_SEQNO_SYSTEM)
       .map((coding) => coding.code),

--- a/examples/medplum-provider/src/utils/medication-gcn.ts
+++ b/examples/medplum-provider/src/utils/medication-gcn.ts
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { getCodeBySystem, getIdentifier } from '@medplum/core';
+import type { Medication } from '@medplum/fhirtypes';
+import { SCRIPTSURE_GCN_SEQNO_SYSTEM } from '@medplum/scriptsure-react';
+
+/**
+ * Every vendor formulation key (GCN_SEQNO) on a Medication, deduplicated.
+ *
+ * A name-search hit for a multi-strength product carries one per available
+ * strength, on `identifier` or on `code.coding` depending on which lookup
+ * produced it. Passing them to the formulation lookup is what lets a prescriber
+ * pick a strength for drugs the vendor has no dose-format rows for — each key
+ * resolves to a named, dispensable product.
+ *
+ * Deduplication is on the parsed number, not the raw string, so `"8346"` and
+ * `"08346"` cannot present one logical strength as two — which would also make
+ * {@link getUnambiguousGcnSeqnoFromMedication} call it ambiguous.
+ *
+ * @param m - Medication from drug search.
+ * @returns Formulation keys as numbers, in the order encountered.
+ */
+export function getGcnSeqnosFromMedication(m: Medication): number[] {
+  const raw: (string | undefined)[] = [
+    ...(m.identifier ?? [])
+      .filter((id) => id.system === SCRIPTSURE_GCN_SEQNO_SYSTEM)
+      .map((id) => id.value),
+    ...(m.code?.coding ?? [])
+      .filter((coding) => coding.system === SCRIPTSURE_GCN_SEQNO_SYSTEM)
+      .map((coding) => coding.code),
+  ];
+
+  const seen = new Set<number>();
+  for (const value of raw) {
+    const parsed = parseVendorKey(value);
+    if (parsed !== undefined) {
+      seen.add(parsed);
+    }
+  }
+  return [...seen];
+}
+
+/**
+ * The single formulation key on a Medication, or undefined when it carries none
+ * — or **several**.
+ *
+ * A dose-level formulation has exactly one. A drug-name search hit for a
+ * multi-strength product carries one per available strength, and nothing on the
+ * resource says which the prescriber meant. Since that key is what the vendor
+ * resolves the dose from when there is no NDC, picking the first of several
+ * would silently prescribe an arbitrary strength — so an ambiguous Medication
+ * yields nothing and the caller falls back to requiring a formulation.
+ *
+ * @param m - Medication from drug search.
+ * @returns The formulation key, or undefined when absent or ambiguous.
+ */
+export function getUnambiguousGcnSeqnoFromMedication(m: Medication): number | undefined {
+  const values = getGcnSeqnosFromMedication(m);
+  return values.length === 1 ? values[0] : undefined;
+}
+
+/**
+ * A human-readable name for a Medication, for the order lines that must carry
+ * one explicitly — a formulation-key line has no catalog row to derive it from.
+ *
+ * Mirrors the fallback chain the MedicationRequest-driven order path uses,
+ * because a search hit does not always populate `code.text`; a coding `display`
+ * is the next best thing, and either beats sending a line the pharmacy cannot
+ * read.
+ *
+ * @param m - Medication from drug search.
+ * @param routedMedIdSystem - Coding system whose `display` to prefer as a fallback.
+ * @returns The name, or undefined when the resource carries no usable text.
+ */
+export function getDisplayNameFromMedication(m: Medication, routedMedIdSystem: string): string | undefined {
+  const candidates = [
+    m.code?.text,
+    m.code?.coding?.find((c) => c.system === routedMedIdSystem)?.display,
+    m.code?.coding?.find((c) => c.display)?.display,
+  ];
+  return candidates.map((c) => c?.trim()).find((c) => Boolean(c));
+}
+
+/**
+ * Reads a vendor routed medication id off a Medication.
+ *
+ * @param m - Medication from drug search.
+ * @param system - Identifier/coding system carrying the id.
+ * @returns The id as a number, or undefined when absent or non-numeric.
+ */
+export function getVendorKeyFromMedication(m: Medication, system: string): number | undefined {
+  return parseVendorKey(getIdentifier(m, system) ?? (m.code && getCodeBySystem(m.code, system)) ?? undefined);
+}
+
+/**
+ * Parses a vendor key, accepting only digits.
+ *
+ * `Number.parseInt` alone would take `"12abc"` as `12`; these keys are integer
+ * ids, so anything else is bad data and better dropped than half-read.
+ *
+ * @param value - Raw identifier/coding value.
+ * @returns The parsed number, or undefined when absent or not all digits.
+ */
+function parseVendorKey(value: string | undefined): number | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || !/^\d+$/.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}

--- a/packages/core/src/medication-order-utils.test.ts
+++ b/packages/core/src/medication-order-utils.test.ts
@@ -242,6 +242,15 @@ describe('Custom FHIR operation Parameters helpers', () => {
     ]);
   });
 
+  test('medicationSearchParamsToParameters repeats gcnSeqnos, one parameter per key', () => {
+    const result = medicationSearchParamsToParameters({ routedMedId: 6143, gcnSeqnos: [8346, 22528] });
+    expect(result.parameter).toEqual([
+      { name: 'routedMedId', valueInteger: 6143 },
+      { name: 'gcnSeqnos', valueInteger: 8346 },
+      { name: 'gcnSeqnos', valueInteger: 22528 },
+    ]);
+  });
+
   test('medicationOrderRequestToParameters emits one drugs entry per line', () => {
     const req: MedicationOrderRequest = {
       patientId: 'pat-1',

--- a/packages/core/src/medication-order-utils.test.ts
+++ b/packages/core/src/medication-order-utils.test.ts
@@ -330,6 +330,29 @@ describe('Custom FHIR operation Parameters helpers', () => {
     expect(compoundSig?.part).toContainEqual({ name: 'drugId', valueInteger: 42 });
   });
 
+  test('medicationOrderRequestToParameters encodes a GCN-keyed drug line (no NDC or RxNorm)', () => {
+    const result = medicationOrderRequestToParameters({
+      patientId: 'pat-1',
+      drugs: [
+        {
+          routedMedId: 177770,
+          gcnSeqno: 7341,
+          drugName: 'Tolcylen topical',
+          line1: 'solution',
+          quantity: 30,
+          quantityQualifier: 'C28254',
+        },
+      ],
+    });
+
+    const drugs = result.parameter?.find((p) => p.name === 'drugs');
+    expect(drugs?.part).toContainEqual({ name: 'routedMedId', valueInteger: 177770 });
+    expect(drugs?.part).toContainEqual({ name: 'gcnSeqno', valueInteger: 7341 });
+    expect(drugs?.part).toContainEqual({ name: 'drugName', valueString: 'Tolcylen topical' });
+    expect(drugs?.part).toContainEqual({ name: 'line1', valueString: 'solution' });
+    expect(drugs?.part?.some((p) => p.name === 'ndc' || p.name === 'rxNorm')).toBe(false);
+  });
+
   test('parametersToMedicationOrderResponse round-trips the order response shape', () => {
     const expected: MedicationOrderResponse = {
       orderId: 1822,

--- a/packages/core/src/medication-order-utils.ts
+++ b/packages/core/src/medication-order-utils.ts
@@ -85,6 +85,18 @@ export interface MedicationOrderDrugInput {
   readonly ndc?: string;
   readonly rxNorm?: string;
   readonly routedMedId?: number;
+  /**
+   * Vendor formulation key, paired with {@link routedMedId} to order a drug that
+   * has no dose-level product to resolve an NDC from — OTC / topical /
+   * wide-multi-strength generics for which the vendor's dose-format lookup
+   * returns nothing. Supply {@link drugName} and {@link line1} alongside it,
+   * since there is no catalog row to derive them from.
+   */
+  readonly gcnSeqno?: number;
+  /** Drug name, required for a {@link gcnSeqno}-keyed line (no catalog row to name it). */
+  readonly drugName?: string;
+  /** Dose text for a {@link gcnSeqno}-keyed line, e.g. `"solution"`. */
+  readonly line1?: string;
   readonly quantity: number;
   readonly quantityQualifier?: string;
   readonly refill?: number;
@@ -417,6 +429,15 @@ function drugLineToParameter(name: string, drug: MedicationOrderDrugInput): Para
   }
   if (drug.routedMedId !== undefined) {
     part.push(param('routedMedId', 'valueInteger', drug.routedMedId));
+  }
+  if (drug.gcnSeqno !== undefined) {
+    part.push(param('gcnSeqno', 'valueInteger', drug.gcnSeqno));
+  }
+  if (drug.drugName !== undefined) {
+    part.push(param('drugName', 'valueString', drug.drugName));
+  }
+  if (drug.line1 !== undefined) {
+    part.push(param('line1', 'valueString', drug.line1));
   }
   part.push(param('quantity', 'valueDecimal', drug.quantity));
   if (drug.quantityQualifier !== undefined) {

--- a/packages/core/src/medication-order-utils.ts
+++ b/packages/core/src/medication-order-utils.ts
@@ -197,6 +197,13 @@ export interface MedicationSearchParams {
   readonly ndc?: string;
   readonly rxNorm?: string;
   readonly routedMedId?: number;
+  /**
+   * Vendor formulation keys under {@link routedMedId}, from the name-search hit.
+   * Only used when the drug has no dose-level products: each key is resolved to
+   * its marketed strength so the caller still gets selectable formulations
+   * instead of an empty result. Ignored otherwise.
+   */
+  readonly gcnSeqnos?: number[];
   readonly searchOtc?: boolean;
   readonly searchSupply?: boolean;
   readonly searchBrand?: boolean;
@@ -386,6 +393,9 @@ export function medicationSearchParamsToParameters(params: MedicationSearchParam
   }
   if (params.routedMedId !== undefined) {
     parameter.push(param('routedMedId', 'valueInteger', params.routedMedId));
+  }
+  for (const gcnSeqno of params.gcnSeqnos ?? []) {
+    parameter.push(param('gcnSeqnos', 'valueInteger', gcnSeqno));
   }
   if (params.searchOtc !== undefined) {
     parameter.push(param('searchOtc', 'valueBoolean', params.searchOtc));

--- a/packages/core/src/medication-order-utils.ts
+++ b/packages/core/src/medication-order-utils.ts
@@ -89,13 +89,20 @@ export interface MedicationOrderDrugInput {
    * Vendor formulation key, paired with {@link routedMedId} to order a drug that
    * has no dose-level product to resolve an NDC from — OTC / topical /
    * wide-multi-strength generics for which the vendor's dose-format lookup
-   * returns nothing. Supply {@link drugName} and {@link line1} alongside it,
-   * since there is no catalog row to derive them from.
+   * returns nothing. Supply {@link drugName} alongside it, since there is no
+   * catalog row to derive a name from.
    */
   readonly gcnSeqno?: number;
   /** Drug name, required for a {@link gcnSeqno}-keyed line (no catalog row to name it). */
   readonly drugName?: string;
-  /** Dose text for a {@link gcnSeqno}-keyed line, e.g. `"solution"`. */
+  /**
+   * Dose text for a {@link gcnSeqno}-keyed line, e.g. `"solution"`.
+   *
+   * Optional, and only worth sending when the caller holds dose text *separate*
+   * from {@link drugName} — a hand-entered form, say. Passing a full product
+   * label duplicates it in the description the vendor renders. When omitted, the
+   * vendor derives the dose from the formulation key or falls back to the sig.
+   */
   readonly line1?: string;
   readonly quantity: number;
   readonly quantityQualifier?: string;

--- a/packages/docs/docs/integration/scriptsure/order-medication.md
+++ b/packages/docs/docs/integration/scriptsure/order-medication.md
@@ -60,13 +60,30 @@ Calls `POST /fhir/R4/Medication/$drug-search`. Returns `Medication[]`.
 | `term` | `string` | Free-text drug search term |
 | `ndc` | `string` | National Drug Code |
 | `rxNorm` | `string` | RxNorm code |
-| `routedMedId` | `number` | Vendor routed medication id |
+| `routedMedId` | `number` | Vendor routed medication id — returns the drug's formulations |
+| `gcnSeqnos` | `number[]` | Vendor formulation keys under `routedMedId`, taken from the name-search hit. Used only when the drug has no formulations; see below |
 | `searchOtc` | `boolean` | Include over-the-counter drugs |
 | `searchSupply` | `boolean` | Include supplies |
 | `searchBrand` | `boolean` | Include brand-name drugs |
 | `searchGeneric` | `boolean` | Include generic drugs |
 | `includeCode` | `boolean` | Include coding in returned `Medication` resources |
 | `quantityQualifiers` | `boolean` | Return quantity qualifiers instead of `Medication[]` |
+
+### Drugs with no formulations
+
+Some products — over-the-counter, topical, and multi-strength generics — have no rows in the
+vendor's dose-format table, so a `routedMedId` search alone returns nothing even though the drug
+exists and is prescribable. Each of the drug's formulation keys is a strength, so passing them
+resolves the strengths individually:
+
+```ts
+const strengths = await searchMedications({ routedMedId: 6143, gcnSeqnos: [8346, 22528, 22530] });
+```
+
+A name-search `Medication` carries one `https://scriptsure.com/gcn-seqno` identifier per key, so
+the caller can read them straight off the search hit. Expect fewer results than keys passed —
+discontinued formulations resolve to nothing and are omitted. These results carry a dispensable
+NDC but no pre-built sig lines, so the caller supplies the quantity and directions.
 
 ## `orderMedication`
 
@@ -106,7 +123,7 @@ Calls `POST /fhir/R4/MedicationRequest/$order-medication`. Creates or updates a 
 | `ndc` | `string` | | National Drug Code — preferred drug identifier |
 | `rxNorm` | `string` | | RxNorm code |
 | `routedMedId` | `number` | | Vendor routed medication id |
-| `gcnSeqno` | `number` | | Vendor formulation key. Pair with `routedMedId` to order a drug that has no dose-level formulation to resolve an NDC from (OTC / topical / multi-strength generics whose formulation lookup returns nothing) |
+| `gcnSeqno` | `number` | | Vendor formulation key. Pair with `routedMedId` to order a drug that has no dose-level formulation to resolve an NDC from. Usually resolves to a real NDC anyway — see [Drugs with no formulations](#drugs-with-no-formulations) — so this is a fallback for the rare product with no marketed package |
 | `drugName` | `string` | | Drug name. Required with `gcnSeqno`, since there is no dose-level record to derive it from |
 | `line1` | `string` | | Dose text for a `gcnSeqno`-keyed line, e.g. `"solution"` |
 | `quantityQualifier` | `string` | | NCI unit code for the quantity (e.g. `C48542` tablet) |
@@ -116,6 +133,13 @@ Calls `POST /fhir/R4/MedicationRequest/$order-medication`. Creates or updates a 
 | `useSubstitution` | `boolean` | | Whether generic substitution is allowed |
 
 Supply exactly one drug identity per line: `ndc`, `rxNorm`, or `routedMedId` (+ `gcnSeqno` when the drug has no formulations).
+
+:::note
+A line keyed on `gcnSeqno` with no NDC is only prescribable through this operation: cart checkout
+(`$checkout-medications`) accepts one, but the vendor's cart UI leaves it incomplete and the
+prescriber cannot send it. This applies only when no NDC could be resolved at all — see
+[Drugs with no formulations](#drugs-with-no-formulations).
+:::
 
 **Response fields:**
 

--- a/packages/docs/docs/integration/scriptsure/order-medication.md
+++ b/packages/docs/docs/integration/scriptsure/order-medication.md
@@ -98,6 +98,25 @@ Calls `POST /fhir/R4/MedicationRequest/$order-medication`. Creates or updates a 
 | `patientInstruction` | `string` | | Free-text patient instructions |
 | `appId` | `string` | | Vendor application id |
 
+**`MedicationOrderDrugInput` (one per `drugs[]` entry):**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `quantity` | `number` | yes | Quantity to dispense |
+| `ndc` | `string` | | National Drug Code — preferred drug identifier |
+| `rxNorm` | `string` | | RxNorm code |
+| `routedMedId` | `number` | | Vendor routed medication id |
+| `gcnSeqno` | `number` | | Vendor formulation key. Pair with `routedMedId` to order a drug that has no dose-level formulation to resolve an NDC from (OTC / topical / multi-strength generics whose formulation lookup returns nothing) |
+| `drugName` | `string` | | Drug name. Required with `gcnSeqno`, since there is no dose-level record to derive it from |
+| `line1` | `string` | | Dose text for a `gcnSeqno`-keyed line, e.g. `"solution"` |
+| `quantityQualifier` | `string` | | NCI unit code for the quantity (e.g. `C48542` tablet) |
+| `refill` | `number` | | Number of refills |
+| `drugOrder` | `number` | | 1-based position within the order |
+| `sigLine3` | `string` | | Patient directions (sig) |
+| `useSubstitution` | `boolean` | | Whether generic substitution is allowed |
+
+Supply exactly one drug identity per line: `ndc`, `rxNorm`, or `routedMedId` (+ `gcnSeqno` when the drug has no formulations).
+
 **Response fields:**
 
 | Field | Type | Description |

--- a/packages/docs/docs/integration/scriptsure/order-medication.md
+++ b/packages/docs/docs/integration/scriptsure/order-medication.md
@@ -125,7 +125,7 @@ Calls `POST /fhir/R4/MedicationRequest/$order-medication`. Creates or updates a 
 | `routedMedId` | `number` | | Vendor routed medication id |
 | `gcnSeqno` | `number` | | Vendor formulation key. Pair with `routedMedId` to order a drug that has no dose-level formulation to resolve an NDC from. Usually resolves to a real NDC anyway — see [Drugs with no formulations](#drugs-with-no-formulations) — so this is a fallback for the rare product with no marketed package |
 | `drugName` | `string` | | Drug name. Required with `gcnSeqno`, since there is no dose-level record to derive it from |
-| `line1` | `string` | | Dose text for a `gcnSeqno`-keyed line, e.g. `"solution"` |
+| `line1` | `string` | | Dose text for a `gcnSeqno`-keyed line, e.g. `"solution"`. Only send it when you hold dose text separate from `drugName`, such as a hand-entered form; a full product label duplicates itself in the rendered description. Omitted by both built-in order paths |
 | `quantityQualifier` | `string` | | NCI unit code for the quantity (e.g. `C48542` tablet) |
 | `refill` | `number` | | Number of refills |
 | `drugOrder` | `number` | | 1-based position within the order |


### PR DESCRIPTION
This enables rare use cases when some niche medications may lack RxNorm or resolving of an NDC number might not be available via eRx vendor API