### PR TITLE
fix(test): remove/fix vitest ESM warnings

### DIFF
--- a/aliases.mjs
+++ b/aliases.mjs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { resolve } from 'node:path';
+
+const repoDir = import.meta.dirname;
+
+// resolve to the submodules for much easier testing
+export const medplumAliases = {
+  '@medplum/ccda': resolve(repoDir, 'packages/ccda/src'),
+  '@medplum/core': resolve(repoDir, 'packages/core/src'),
+  '@medplum/definitions': resolve(repoDir, 'packages/definitions/src'),
+  '@medplum/dosespot-core': resolve(repoDir, 'packages/dosespot-core/src'),
+  '@medplum/fhir-router': resolve(repoDir, 'packages/fhir-router/src'),
+  '@medplum/health-gorilla-core': resolve(repoDir, 'packages/health-gorilla-core/src'),
+  '@medplum/hl7': resolve(repoDir, 'packages/hl7/src'),
+  '@medplum/mock': resolve(repoDir, 'packages/mock/src'),
+  '@medplum/react': resolve(repoDir, 'packages/react/src'),
+  '@medplum/react-hooks': resolve(repoDir, 'packages/react-hooks/src'),
+};

--- a/examples/foomedical/vite.config.ts
+++ b/examples/foomedical/vite.config.ts
@@ -5,8 +5,8 @@ import { copyFileSync, existsSync } from 'fs';
 import path from 'path';
 import { defineConfig } from 'vitest/config';
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 // https://vitejs.dev/config/

--- a/examples/medplum-client-external-idp-demo/vite.config.ts
+++ b/examples/medplum-client-external-idp-demo/vite.config.ts
@@ -5,8 +5,11 @@ import { copyFileSync, existsSync } from 'fs';
 import path from 'path';
 import { defineConfig } from 'vite';
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(
+    path.join(import.meta.dirname, '.env.defaults'),
+    path.join(import.meta.dirname, '.env'),
+  );
 }
 
 export default defineConfig({

--- a/examples/medplum-client-external-idp-demo/vite.config.ts
+++ b/examples/medplum-client-external-idp-demo/vite.config.ts
@@ -6,7 +6,10 @@ import path from 'path';
 import { defineConfig } from 'vite';
 
 if (!existsSync(path.join(import.meta.dirname, '.env'))) {
-  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
+  copyFileSync(
+    path.join(import.meta.dirname, '.env.defaults'),
+    path.join(import.meta.dirname, '.env'),
+  );
 }
 
 export default defineConfig({

--- a/examples/medplum-client-external-idp-demo/vite.config.ts
+++ b/examples/medplum-client-external-idp-demo/vite.config.ts
@@ -5,8 +5,8 @@ import { copyFileSync, existsSync } from 'fs';
 import path from 'path';
 import { defineConfig } from 'vite';
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 export default defineConfig({

--- a/examples/medplum-efax-demo/vite.config.ts
+++ b/examples/medplum-efax-demo/vite.config.ts
@@ -8,8 +8,8 @@ import { defineConfig } from 'vite';
 
 dns.setDefaultResultOrder('verbatim');
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 // https://vitejs.dev/config/

--- a/examples/medplum-eligibility-demo/vite.config.ts
+++ b/examples/medplum-eligibility-demo/vite.config.ts
@@ -6,8 +6,8 @@ import { defineConfig } from 'vite';
 
 dns.setDefaultResultOrder('verbatim');
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 dns.setDefaultResultOrder('verbatim');

--- a/examples/medplum-fhircast-demo/vite.config.ts
+++ b/examples/medplum-fhircast-demo/vite.config.ts
@@ -5,8 +5,8 @@ import { copyFileSync, existsSync } from 'fs';
 import path from 'path';
 import { defineConfig } from 'vite';
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 // https://vitejs.dev/config/

--- a/examples/medplum-health-gorilla-demo/vite.config.ts
+++ b/examples/medplum-health-gorilla-demo/vite.config.ts
@@ -8,8 +8,8 @@ import { defineConfig } from 'vite';
 
 dns.setDefaultResultOrder('verbatim');
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 // https://vitejs.dev/config/

--- a/examples/medplum-hello-world/vite.config.ts
+++ b/examples/medplum-hello-world/vite.config.ts
@@ -8,8 +8,8 @@ import { defineConfig } from 'vite';
 
 dns.setDefaultResultOrder('verbatim');
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 dns.setDefaultResultOrder('verbatim');

--- a/examples/medplum-mso-demo/vite.config.ts
+++ b/examples/medplum-mso-demo/vite.config.ts
@@ -8,8 +8,8 @@ import { defineConfig } from 'vite';
 
 dns.setDefaultResultOrder('verbatim');
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 dns.setDefaultResultOrder('verbatim');

--- a/examples/medplum-multilingual-demo/vite.config.ts
+++ b/examples/medplum-multilingual-demo/vite.config.ts
@@ -8,8 +8,8 @@ import { defineConfig } from 'vite';
 
 dns.setDefaultResultOrder('verbatim');
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 export default defineConfig({

--- a/examples/medplum-patient-intake-demo/vite.config.ts
+++ b/examples/medplum-patient-intake-demo/vite.config.ts
@@ -6,8 +6,8 @@ import { defineConfig } from 'vite';
 
 dns.setDefaultResultOrder('verbatim');
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 dns.setDefaultResultOrder('verbatim');

--- a/examples/medplum-photon-integration/vite.config.ts
+++ b/examples/medplum-photon-integration/vite.config.ts
@@ -8,8 +8,8 @@ import { defineConfig } from 'vite';
 
 dns.setDefaultResultOrder('verbatim');
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 // https://vitejs.dev/config/

--- a/examples/medplum-provider/vite.config.ts
+++ b/examples/medplum-provider/vite.config.ts
@@ -9,21 +9,21 @@ import { defineConfig } from 'vitest/config';
 
 dns.setDefaultResultOrder('verbatim');
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 // Resolve aliases to local packages when working within the monorepo
 const alias: NonNullable<UserConfig['resolve']>['alias'] = Object.fromEntries(
   Object.entries({
-    '@medplum/core': path.resolve(__dirname, '../../packages/core/src'),
-    '@medplum/dosespot-react': path.resolve(__dirname, '../../packages/dosespot-react/src'),
-    '@medplum/scriptsure-react': path.resolve(__dirname, '../../packages/scriptsure-react/src'),
-    '@medplum/react': path.resolve(__dirname, '../../packages/react/src'),
-    '@medplum/react-scheduling': path.resolve(__dirname, '../../packages/react-scheduling/src'),
-    '@medplum/react-hooks': path.resolve(__dirname, '../../packages/react-hooks/src'),
-    '@medplum/health-gorilla-core': path.resolve(__dirname, '../../packages/health-gorilla-core/src'),
-    '@medplum/health-gorilla-react': path.resolve(__dirname, '../../packages/health-gorilla-react/src'),
+    '@medplum/core': path.resolve(import.meta.dirname, '../../packages/core/src'),
+    '@medplum/dosespot-react': path.resolve(import.meta.dirname, '../../packages/dosespot-react/src'),
+    '@medplum/scriptsure-react': path.resolve(import.meta.dirname, '../../packages/scriptsure-react/src'),
+    '@medplum/react': path.resolve(import.meta.dirname, '../../packages/react/src'),
+    '@medplum/react-scheduling': path.resolve(import.meta.dirname, '../../packages/react-scheduling/src'),
+    '@medplum/react-hooks': path.resolve(import.meta.dirname, '../../packages/react-hooks/src'),
+    '@medplum/health-gorilla-core': path.resolve(import.meta.dirname, '../../packages/health-gorilla-core/src'),
+    '@medplum/health-gorilla-react': path.resolve(import.meta.dirname, '../../packages/health-gorilla-react/src'),
   }).filter(([, relPath]) => existsSync(relPath))
 );
 

--- a/examples/medplum-questionnaire-hooks/vite.config.ts
+++ b/examples/medplum-questionnaire-hooks/vite.config.ts
@@ -5,8 +5,8 @@ import { copyFileSync, existsSync } from 'fs';
 import path from 'path';
 import { defineConfig } from 'vite';
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 export default defineConfig({

--- a/examples/medplum-smart-on-fhir-demo/vite.config.ts
+++ b/examples/medplum-smart-on-fhir-demo/vite.config.ts
@@ -8,8 +8,8 @@ import { defineConfig } from 'vite';
 
 dns.setDefaultResultOrder('verbatim');
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 // https://vitejs.dev/config/

--- a/examples/medplum-task-demo/vite.config.ts
+++ b/examples/medplum-task-demo/vite.config.ts
@@ -6,8 +6,8 @@ import { defineConfig } from 'vite';
 
 dns.setDefaultResultOrder('verbatim');
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 dns.setDefaultResultOrder('verbatim');

--- a/examples/medplum-valueset-selector/vite.config.ts
+++ b/examples/medplum-valueset-selector/vite.config.ts
@@ -8,8 +8,8 @@ import { defineConfig } from 'vite';
 
 dns.setDefaultResultOrder('verbatim');
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 dns.setDefaultResultOrder('verbatim');

--- a/examples/medplum-websocket-subscriptions-demo/vite.config.ts
+++ b/examples/medplum-websocket-subscriptions-demo/vite.config.ts
@@ -8,8 +8,8 @@ import { defineConfig } from 'vite';
 
 dns.setDefaultResultOrder('verbatim');
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 dns.setDefaultResultOrder('verbatim');

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -10,5 +10,5 @@
       "@medplum/react": ["../react/src"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts", "vitest.config.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -6,11 +6,11 @@ import { execSync } from 'child_process';
 import { copyFileSync, existsSync } from 'fs';
 import path from 'path';
 import { defineConfig } from 'vite';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 import packageJson from './package.json' with { type: 'json' };
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 let gitHash;
@@ -40,9 +40,9 @@ export default defineConfig({
   resolve: {
     alias: {
       ...medplumAliases,
-      '@medplum/core': path.resolve(__dirname, '../core/src'),
-      '@medplum/react': path.resolve(__dirname, '../react/src'),
-      '@medplum/react-hooks': path.resolve(__dirname, '../react-hooks/src'),
+      '@medplum/core': path.resolve(import.meta.dirname, '../core/src'),
+      '@medplum/react': path.resolve(import.meta.dirname, '../react/src'),
+      '@medplum/react-hooks': path.resolve(import.meta.dirname, '../react-hooks/src'),
     },
   },
 });

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react';
 import { copyFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 if (!existsSync(resolve(import.meta.dirname, '.env'))) {
   copyFileSync(resolve(import.meta.dirname, '.env.defaults'), resolve(import.meta.dirname, '.env'));

--- a/packages/ccda/vite.config.ts
+++ b/packages/ccda/vite.config.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   resolve: {

--- a/packages/cdk/vite.config.ts
+++ b/packages/cdk/vite.config.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   resolve: {

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   resolve: {

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   resolve: {

--- a/packages/create-medplum/vite.config.ts
+++ b/packages/create-medplum/vite.config.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   resolve: {

--- a/packages/definitions/vite.config.ts
+++ b/packages/definitions/vite.config.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   resolve: {

--- a/packages/dosespot-core/vite.config.ts
+++ b/packages/dosespot-core/vite.config.ts
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   resolve: {

--- a/packages/dosespot-react/vite.config.ts
+++ b/packages/dosespot-react/vite.config.ts
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   resolve: {

--- a/packages/fhir-router/vite.config.ts
+++ b/packages/fhir-router/vite.config.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   resolve: {

--- a/packages/generator/vite.config.ts
+++ b/packages/generator/vite.config.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   resolve: {

--- a/packages/graphiql/tsconfig.json
+++ b/packages/graphiql/tsconfig.json
@@ -5,5 +5,6 @@
     "moduleResolution": "bundler",
     "lib": ["esnext", "dom", "dom.iterable"],
     "types": ["vite/client"]
-  }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/graphiql/vite.config.ts
+++ b/packages/graphiql/vite.config.ts
@@ -8,17 +8,17 @@ import { defineConfig } from 'vite';
 // The docs recommend the `vite-plugin-monaco-editor` package, but its exports aren't cleanly
 // compatible with ESM. See https://github.com/vdesjs/vite-plugin-monaco-editor/issues/21
 import monacoEditorEsmPlugin from 'vite-plugin-monaco-editor-esm';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
-if (!existsSync(path.join(__dirname, '.env'))) {
-  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
+if (!existsSync(path.join(import.meta.dirname, '.env'))) {
+  copyFileSync(path.join(import.meta.dirname, '.env.defaults'), path.join(import.meta.dirname, '.env'));
 }
 
 export default defineConfig({
   resolve: {
     alias: {
       // necessary because styles.css is a side effect of the react package, so we can't use an alias
-      '@medplum/react/styles.css': path.resolve(__dirname, '../react/dist/esm/index.css'),
+      '@medplum/react/styles.css': path.resolve(import.meta.dirname, '../react/dist/esm/index.css'),
       ...medplumAliases,
     },
   },

--- a/packages/health-gorilla-core/vite.config.ts
+++ b/packages/health-gorilla-core/vite.config.ts
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   resolve: {

--- a/packages/health-gorilla-react/vite.config.ts
+++ b/packages/health-gorilla-react/vite.config.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { defineConfig as defineVitestConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 const vitestConfig = defineVitestConfig({
   resolve: {

--- a/packages/hl7/vite.config.ts
+++ b/packages/hl7/vite.config.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   resolve: {

--- a/packages/mock/vite.config.ts
+++ b/packages/mock/vite.config.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   resolve: {

--- a/packages/react-hooks/vite.config.ts
+++ b/packages/react-hooks/vite.config.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   resolve: {

--- a/packages/react-scheduling/vitest.config.ts
+++ b/packages/react-scheduling/vitest.config.ts
@@ -3,7 +3,7 @@
 import react from '@vitejs/plugin-react';
 import { resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   plugins: [

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -3,7 +3,7 @@
 import react from '@vitejs/plugin-react';
 import { resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   plugins: [

--- a/packages/scriptsure-react/vite.config.ts
+++ b/packages/scriptsure-react/vite.config.ts
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vitest/config';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 
 export default defineConfig({
   resolve: {

--- a/packages/server/vite.config.ts
+++ b/packages/server/vite.config.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 import type { TestSpecification } from 'vitest/node';
 import { BaseSequencer } from 'vitest/node';
-import { medplumAliases } from '../../vitest.config';
+import { medplumAliases } from '../../aliases.mjs';
 import packageJson from './package.json' with { type: 'json' };
 
 const serverDir = dirname(fileURLToPath(import.meta.url));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,25 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { resolve } from 'path';
 import { defineConfig } from 'vitest/config';
-
-const repoDir = dirname(fileURLToPath(import.meta.url));
-
-// resolve to the submodules for much easier testing
-export const medplumAliases = {
-  '@medplum/ccda': resolve(repoDir, 'packages/ccda/src'),
-  '@medplum/core': resolve(repoDir, 'packages/core/src'),
-  '@medplum/definitions': resolve(repoDir, 'packages/definitions/src'),
-  '@medplum/dosespot-core': resolve(repoDir, 'packages/dosespot-core/src'),
-  '@medplum/fhir-router': resolve(repoDir, 'packages/fhir-router/src'),
-  '@medplum/health-gorilla-core': resolve(repoDir, 'packages/health-gorilla-core/src'),
-  '@medplum/hl7': resolve(repoDir, 'packages/hl7/src'),
-  '@medplum/mock': resolve(repoDir, 'packages/mock/src'),
-  '@medplum/react': resolve(repoDir, 'packages/react/src'),
-  '@medplum/react-hooks': resolve(repoDir, 'packages/react-hooks/src'),
-};
+import { medplumAliases } from './aliases.mjs';
 
 export default defineConfig({
   resolve: {


### PR DESCRIPTION
```

(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - import "../../vitest.config" without a file extension (vite.config.ts:8:32). Add the file extension
  - ESM syntax in a file loaded as CommonJS (../../vitest.config.ts:3:1). Use a `.mjs` extension or set `"type": "module"` in the closest package.json
Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.
```

Signed-off-by: Karl Pietrzak <karl@medplum.com>
