### PR TITLE
Fix S3 storybook iframe embedding

### DIFF
--- a/scripts/s3deploy.mjs
+++ b/scripts/s3deploy.mjs
@@ -91,6 +91,9 @@ async function main() {
     if (relativePath === 'index.html') {
       // Special case for root index.html
       s3Key += 'index.html';
+    } else if (relativePath === 'iframe.html') {
+      // Special case for root iframe.html (Storybook nested page)
+      s3Key += 'iframe.html';
     } else if (relativePath.endsWith('/index.html')) {
       // Special case for directories with index.html
       s3Key += relativePath.slice(0, -'index.html'.length);


### PR DESCRIPTION
Storybook expects its inner page to be available at `/iframe.html`, but `scripts/s3deploy.mjs` removed the suffix.

For now this is just a single file with a fairly unique name that needs this special case, so I've chosen to inline it instead of adding something like a `--no-strip-html-extension` flag or similar to the s3 deploy script.