### PR TITLE
fix(server): tolerate a stored resource with no meta on update

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -50,6 +50,7 @@ import * as workersModule from '../workers';
 import { getRepoForLogin } from './accesspolicy';
 import { getGlobalSystemRepo, getProjectSystemRepo, getShardSystemRepo, Repository } from './repo';
 import { repoAccess } from './repository/access-tracker';
+import { deleteResourceCacheEntry } from './repository/resource-cache';
 import { SelectQuery } from './sql';
 import * as tokenColumnModule from './token-column';
 
@@ -579,6 +580,37 @@ describe('FHIR Repo', () => {
 
       expect(patient2.id).toStrictEqual(patient1.id);
       expect(patient2.meta?.versionId).toStrictEqual(patient1.meta?.versionId);
+    }));
+
+  test('Update resource stored without meta', () =>
+    withTestContext(async () => {
+      const patient1 = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['NoMeta'], family: 'NoMeta' }],
+      });
+
+      // Simulate a row seeded outside the normal write path, which leaves the
+      // stored content with no meta at all. Updating it used to throw a bare
+      // TypeError ("Cannot set properties of undefined") surfaced as a
+      // "Database error", rather than applying the update.
+      const { meta: _meta, ...withoutMeta } = patient1;
+      const client = systemRepo.getDatabaseClient(DatabaseMode.WRITER);
+      await client.query('UPDATE "Patient" SET content = $1 WHERE id = $2', [
+        JSON.stringify(withoutMeta),
+        patient1.id,
+      ]);
+      // Reads are served from the resource cache, which still holds the
+      // well-formed version written above.
+      await deleteResourceCacheEntry('Patient', patient1.id);
+
+      const patient2 = await systemRepo.updateResource<Patient>({
+        ...patient1,
+        name: [{ given: ['NoMeta'], family: 'Updated' }],
+      });
+
+      expect(patient2.id).toStrictEqual(patient1.id);
+      expect(patient2.name?.[0]?.family).toStrictEqual('Updated');
+      expect(patient2.meta?.versionId).toBeDefined();
     }));
 
   test('Update patient multiple names', () =>

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -972,7 +972,11 @@ export class Repository extends FhirRepository implements Disposable {
 
     const existing = create ? undefined : await this.checkExistingResource<T>(resourceType, id);
     if (existing) {
-      (existing.meta as Meta).compartment = this.getCompartments(existing); // Update compartments with latest rules
+      // A stored resource is normally written with meta, but a row seeded outside
+      // the normal write path may not have it. Without this the assignment below
+      // throws a bare TypeError that surfaces as an opaque "Database error".
+      existing.meta ??= {};
+      existing.meta.compartment = this.getCompartments(existing); // Update compartments with latest rules
       if (!this.canPerformInteraction(interaction, existing)) {
         // Check before the update
         throw new OperationOutcomeError(forbidden);


### PR DESCRIPTION
## Summary

A row seeded outside the normal write path can have content with no `meta` at all. `updateResourceImpl` cast `existing.meta` to `Meta` and wrote `compartment` onto it unguarded, so the update died with a bare `TypeError` ("Cannot set properties of undefined") that reached the caller as an opaque "Database error" rather than anything actionable.

Found while debugging a marketplace install against a project fixture in that state, but the fix is unrelated to the marketplace and stands on its own.

## Test plan

- [x] `packages/server` `repo.test.ts` — 97/97 passing
- [x] New regression test writes the malformed content with raw SQL and then drops the resource cache entry. Without that cache eviction the read is served from cache and the test passes with or without the fix, so the test would not be falsifiable.