### PR TITLE
feat(server): allow project admins to read catalog packages via link + export

### DIFF
--- a/packages/core/src/access.ts
+++ b/packages/core/src/access.ts
@@ -29,6 +29,20 @@ export const projectAdminResourceTypes = [
 ];
 
 /**
+ * Marketplace catalog resource types.
+ *
+ * These are project admin resources, but unlike the rest of
+ * {@link projectAdminResourceTypes} they describe a deployment-wide,
+ * read-only package catalog rather than per-project identity/configuration.
+ * They may therefore be read **cross-project** via `Project.link` +
+ * `Project.exportedResourceType`, so a project admin whose project links to the
+ * catalog project can browse and install published packages. `PackageInstallation`
+ * is intentionally excluded — installations are per-customer-project state and
+ * must stay scoped to the owning project.
+ */
+export const catalogResourceTypes = ['Package', 'PackageRelease'];
+
+/**
  * Interactions with a resource that can be controlled via an access policy.
  *
  * Codes taken from http://hl7.org/fhir/codesystem-restful-interaction.html

--- a/packages/server/src/fhir/operations/packageinstall.test.ts
+++ b/packages/server/src/fhir/operations/packageinstall.test.ts
@@ -280,6 +280,94 @@ describe('PackageRelease $install', () => {
     expect(after.body.entry[0].resource.id).toBe(firstId);
   });
 
+  test('Project admin can browse and install a release from a linked catalog project', async () => {
+    const systemRepo = getGlobalSystemRepo();
+
+    // Catalog project publishes the package and exports the catalog types (option 1: link + export).
+    const { project: catalogProject } = await createTestProject({
+      project: { exportedResourceType: ['Package', 'PackageRelease'] },
+    });
+
+    // Customer project links to the catalog and authenticates as a project admin.
+    const customer = await createTestProject({
+      withAccessToken: true,
+      membership: { admin: true },
+      project: { link: [{ project: createReference(catalogProject) }] },
+    });
+
+    const bundle: Bundle = {
+      resourceType: 'Bundle',
+      meta: { project: customer.project.id },
+      type: 'transaction',
+      entry: [
+        {
+          resource: { resourceType: 'Patient', name: [{ given: ['Catalog'], family: 'Install' }] },
+          request: { method: 'POST', url: 'Patient' },
+        },
+      ],
+    };
+
+    // Package, Binary, and PackageRelease all live in the catalog project.
+    const pkg = await withTestContext(() =>
+      systemRepo.createResource<Package>({
+        resourceType: 'Package',
+        meta: { project: catalogProject.id },
+        status: 'active',
+        name: 'Linked Catalog Package',
+        author: { reference: 'Organization/' + randomUUID() },
+      })
+    );
+    const binary = await withTestContext(() =>
+      systemRepo.createResource<Binary>({
+        resourceType: 'Binary',
+        meta: { project: catalogProject.id },
+        contentType: ContentType.FHIR_JSON,
+      })
+    );
+    const packageRelease = await withTestContext(() =>
+      systemRepo.createResource<PackageRelease>({
+        resourceType: 'PackageRelease',
+        meta: { project: catalogProject.id },
+        package: createReference(pkg),
+        version: '1.0.0',
+        content: { contentType: ContentType.FHIR_JSON, url: `Binary/${binary.id}` },
+      })
+    );
+
+    const mockBinaryStorage = new MockBinaryStorage(JSON.stringify(bundle));
+    vi.spyOn(storage, 'getBinaryStorage').mockImplementation(() => mockBinaryStorage as unknown as BinaryStorage);
+
+    // Browse: the customer admin can read the catalog release cross-link.
+    const browse = await request(app)
+      .get(`/fhir/R4/PackageRelease/${packageRelease.id}`)
+      .set('Authorization', 'Bearer ' + customer.accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send();
+    expect(browse.status).toBe(200);
+
+    // Install: $install succeeds even though the release + Binary live in the catalog project.
+    const res = await request(app)
+      .post(`/fhir/R4/PackageRelease/${packageRelease.id}/$install`)
+      .set('Authorization', 'Bearer ' + customer.accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({});
+    expect(res.status).toBe(200);
+
+    const res2 = await request(app)
+      .get(`/fhir/R4/PackageInstallation?version=1.0.0`)
+      .set('Authorization', 'Bearer ' + customer.accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send();
+    expect(res2.status).toBe(200);
+    const installations = res2.body.entry?.map((e: any) => e.resource) as PackageInstallation[];
+    expect(installations?.length).toBe(1);
+    expect(installations[0].status).toBe('installed');
+    // PackageInstallation is not a catalog type, so it stays scoped to the caller's
+    // project. Finding it via the customer's own admin token proves the install record
+    // landed in the customer project, not the catalog.
+    expect(installations[0].packageRelease?.reference).toBe(`PackageRelease/${packageRelease.id}`);
+  });
+
   test('Error handling when bundle processing fails', async () => {
     const systemRepo = getGlobalSystemRepo();
 

--- a/packages/server/src/fhir/operations/packageinstall.ts
+++ b/packages/server/src/fhir/operations/packageinstall.ts
@@ -140,11 +140,16 @@ export async function packageInstallHandler(
   }
 
   const { id } = req.params;
+  // Caller-scoped read is the authorization gate: a project admin can only reach a
+  // PackageRelease in their own project or in a linked catalog project that exports
+  // it (see catalogResourceTypes / Project.exportedResourceType).
   const packageRelease = await repo.readResource<PackageRelease>('PackageRelease', id);
 
   // Load the install Bundle (Stage 1 content) and validate the optional settings
   // body against the bundled config Questionnaire *before* mutating any state.
-  const bundle = await readPackageBundle(repo, packageRelease);
+  // The Bundle is stored as a Binary, which cannot be exported cross-project, so it
+  // is read via systemRepo now that the caller has proven access to the release.
+  const bundle = await readPackageBundle(systemRepo, packageRelease);
   const settings = parseSettings(req.body);
   const questionnaire = findQuestionnaire(bundle);
   if (questionnaire) {

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -23,6 +23,9 @@ import type {
   Login,
   OperationOutcome,
   Organization,
+  Package,
+  PackageInstallation,
+  PackageRelease,
   Patient,
   Practitioner,
   Project,
@@ -2066,6 +2069,96 @@ describe('FHIR Repo', () => {
       await expect(repo.readResource<Patient>('Patient', linkedPatient.id)).rejects.toThrow(
         new OperationOutcomeError(notFound)
       );
+    }));
+
+  test('Catalog resource types are readable from a linked project', () =>
+    withTestContext(async () => {
+      // A catalog project publishes Package/PackageRelease and exports them so
+      // linked customer projects can browse and install (option 1: link + export).
+      const { project: catalogProject } = await createTestProject({
+        project: { exportedResourceType: ['Package', 'PackageRelease'] },
+      });
+      const catalogRepo = await getProjectSystemRepo(catalogProject);
+
+      const pkg = await catalogRepo.createResource<Package>({
+        resourceType: 'Package',
+        meta: { project: catalogProject.id },
+        status: 'active',
+        name: 'Catalog Package',
+        author: { reference: 'Organization/' + randomUUID() },
+      });
+      const release = await catalogRepo.createResource<PackageRelease>({
+        resourceType: 'PackageRelease',
+        meta: { project: catalogProject.id },
+        package: createReference(pkg),
+        version: '1.0.0',
+        content: { contentType: 'application/fhir+json', url: `Binary/${randomUUID()}` },
+      });
+      // An installation lives in the catalog project but must NOT leak cross-project.
+      const catalogInstall = await catalogRepo.createResource<PackageInstallation>({
+        resourceType: 'PackageInstallation',
+        meta: { project: catalogProject.id },
+        package: createReference(pkg),
+        packageRelease: createReference(release),
+        version: '1.0.0',
+        status: 'installed',
+        installedBy: { reference: 'ClientApplication/' + randomUUID() },
+      });
+
+      // Customer project links to the catalog project; the membership is a project admin.
+      const { repo: customerRepo } = await createTestProject({
+        project: { link: [{ project: createReference(catalogProject) }] },
+        membership: { admin: true },
+        withRepo: true,
+      });
+
+      // Catalog Package/PackageRelease are readable and searchable cross-project.
+      const readPkg = await customerRepo.readResource<Package>('Package', pkg.id);
+      expect(readPkg.id).toStrictEqual(pkg.id);
+      const readRelease = await customerRepo.readResource<PackageRelease>('PackageRelease', release.id);
+      expect(readRelease.id).toStrictEqual(release.id);
+
+      const packages = await customerRepo.searchResources<Package>({ resourceType: 'Package' });
+      expect(packages.map((p) => p.id)).toContain(pkg.id);
+      const releases = await customerRepo.searchResources<PackageRelease>({ resourceType: 'PackageRelease' });
+      expect(releases.map((r) => r.id)).toContain(release.id);
+
+      // PackageInstallation is a project-admin resource that is NOT a catalog type, so it
+      // stays scoped to the owning project even across a link.
+      await expect(
+        customerRepo.readResource<PackageInstallation>('PackageInstallation', catalogInstall.id)
+      ).rejects.toThrow(new OperationOutcomeError(notFound));
+      const installs = await customerRepo.searchResources<PackageInstallation>({ resourceType: 'PackageInstallation' });
+      expect(installs.map((i) => i.id)).not.toContain(catalogInstall.id);
+    }));
+
+  test('Catalog resource types are not readable cross-project without export', () =>
+    withTestContext(async () => {
+      // Without exportedResourceType (and without listing the catalog types), a linked
+      // project must not expose its Packages — link alone is insufficient.
+      const { project: catalogProject } = await createTestProject({
+        project: { exportedResourceType: ['Organization'] },
+      });
+      const catalogRepo = await getProjectSystemRepo(catalogProject);
+      const pkg = await catalogRepo.createResource<Package>({
+        resourceType: 'Package',
+        meta: { project: catalogProject.id },
+        status: 'active',
+        name: 'Unexported Catalog Package',
+        author: { reference: 'Organization/' + randomUUID() },
+      });
+
+      const { repo: customerRepo } = await createTestProject({
+        project: { link: [{ project: createReference(catalogProject) }] },
+        membership: { admin: true },
+        withRepo: true,
+      });
+
+      await expect(customerRepo.readResource<Package>('Package', pkg.id)).rejects.toThrow(
+        new OperationOutcomeError(notFound)
+      );
+      const packages = await customerRepo.searchResources<Package>({ resourceType: 'Package' });
+      expect(packages.map((p) => p.id)).not.toContain(pkg.id);
     }));
 
   test('Project.exportedResourceType allows resources in primary project', () =>

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -7,6 +7,7 @@ import {
   allOk,
   append,
   badRequest,
+  catalogResourceTypes,
   deepClone,
   deepEquals,
   DEFAULT_MAX_SEARCH_COUNT,
@@ -1682,8 +1683,15 @@ export class Repository extends FhirRepository implements Disposable {
 
     const projectIds = [this.context.projects[0].id]; // Always include the first project
 
-    if (resourceType !== 'Project' && projectAdminResourceTypes.includes(resourceType)) {
-      // If the resource type is a project admin resource, only include the current project (the first project)
+    if (
+      resourceType !== 'Project' &&
+      projectAdminResourceTypes.includes(resourceType) &&
+      !catalogResourceTypes.includes(resourceType)
+    ) {
+      // If the resource type is a project admin resource, only include the current project (the first project).
+      // Catalog resource types (Package, PackageRelease) are exempt: they describe a deployment-wide,
+      // read-only package catalog and fall through to the link + exportedResourceType logic below so that
+      // a project admin can browse/install packages published in a linked catalog project.
       return projectIds;
     }
 


### PR DESCRIPTION
> **This is an access-control change.** It relaxes how `getPermittedProjectIds` scopes two project-admin resource types. Please review it as such rather than as marketplace plumbing — it was previously buried inside #9490 and is split out for exactly this reason.

## Summary

`Package` and `PackageRelease` are `projectAdminResourceTypes`, and `getPermittedProjectIds` scoped all admin resource types to the caller's own project. A published marketplace catalog lives in a separate publisher project, so a customer-project admin could not see it: `GET /Package` returned an empty searchset even with admin rights.

This introduces `catalogResourceTypes` (`Package`, `PackageRelease`) and exempts them from the admin current-project-only scoping, so they flow through the existing `Project.link` + `exportedResourceType` logic rather than through a new mechanism.

What deliberately does **not** change:

- `PackageInstallation` stays scoped to the owning project, so an install record never leaks across the link.
- `$install` keeps the caller-scoped `PackageRelease` read as its authorization gate. Only after that access is proven does it read the install Bundle `Binary` via `systemRepo`, because `Binary` is never cross-project exportable.
- Visibility still requires **both** link and export. A link alone grants nothing.

## Stacked on

#9490. Review that first; this PR's diff is scoped to the access change on top of it.

## Test plan

- [x] `repo.test.ts` and `packageinstall.test.ts` — 110/110 passing
- [x] Cross-link read covered both with and without `exportedResourceType`, so the export half of the gate is exercised, not just the link half
- [x] `PackageInstallation` scoping asserted via the customer's own admin token, proving the install record landed in the customer project rather than the catalog
- [x] End-to-end project-admin browse + install from a linked catalog project