### PR TITLE
feat(server): enforce lowercase `User.email` with a profile invariant

### DIFF
--- a/packages/core/src/typeschema/validation.test.ts
+++ b/packages/core/src/typeschema/validation.test.ts
@@ -32,6 +32,7 @@ import type {
   StructureDefinitionSnapshot,
   SubstanceProtein,
   Timing,
+  User,
   ValueSet,
 } from '@medplum/fhirtypes';
 import { readFileSync } from 'fs';
@@ -2030,6 +2031,33 @@ describe('FHIR resource validation', () => {
     };
 
     expect(() => validateResource(ra1)).not.toThrow();
+  });
+
+  test('User email constraint: user-1', () => {
+    const validUser: User = {
+      resourceType: 'User',
+      firstName: 'Alice',
+      lastName: 'Smith',
+      email: 'alice@example.com',
+    };
+    expect(() => validateResource(validUser)).not.toThrow();
+
+    const invalidUser: User = {
+      resourceType: 'User',
+      firstName: 'Alice',
+      lastName: 'Smith',
+      email: 'Alice@Example.com',
+    };
+    expect(() => validateResource(invalidUser)).toThrow(
+      new OperationOutcomeError(
+        validationError(
+          'Constraint user-1 not met: Email must be all lowercase',
+          ['User.email'],
+          'invariant',
+          '{"fhirpath":"$this = $this.lower()"}'
+        )
+      )
+    );
   });
 });
 

--- a/packages/definitions/src/fhir/r4/fhir.schema.json
+++ b/packages/definitions/src/fhir/r4/fhir.schema.json
@@ -62097,7 +62097,7 @@
           "$ref": "#/definitions/string"
         },
         "email": {
-          "description": "The email address that uniquely identifies the user.",
+          "description": "The email address that uniquely identifies the user. Must be all lowercase.",
           "$ref": "#/definitions/string"
         },
         "emailVerified": {

--- a/packages/definitions/src/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/src/fhir/r4/profiles-medplum.json
@@ -1406,11 +1406,17 @@
           {
             "id" : "User.email",
             "path" : "User.email",
-            "definition" : "The email address that uniquely identifies the user.",
+            "definition" : "The email address that uniquely identifies the user. Must be all lowercase.",
             "min" : 0,
             "max" : "1",
             "type" : [{
               "code" : "string"
+            }],
+            "constraint" : [{
+              "key" : "user-1",
+              "severity" : "error",
+              "human" : "Email must be all lowercase",
+              "expression" : "$this = $this.lower()"
             }],
             "base": {
               "path" : "User.email",

--- a/packages/docs/static/data/medplumDefinitions/user.json
+++ b/packages/docs/static/data/medplumDefinitions/user.json
@@ -236,7 +236,7 @@
       "min": 0,
       "max": "1",
       "short": "",
-      "definition": "The email address that uniquely identifies the user.",
+      "definition": "The email address that uniquely identifies the user. Must be all lowercase.",
       "comment": "",
       "inherited": false
     },
@@ -333,6 +333,22 @@
       "max": "1",
       "short": "",
       "definition": "Whether the user has completed MFA enrollment.",
+      "comment": "",
+      "inherited": false
+    },
+    {
+      "name": "mfaMethod",
+      "depth": 1,
+      "types": [
+        {
+          "datatype": "code"
+        }
+      ],
+      "path": "User.mfaMethod",
+      "min": 0,
+      "max": "*",
+      "short": "",
+      "definition": "The MFA methods the user has enrolled in. 'totp' uses an authenticator application; 'email' sends a magic link to the user's email address on login.",
       "comment": "",
       "inherited": false
     },

--- a/packages/fhirtypes/dist/User.d.ts
+++ b/packages/fhirtypes/dist/User.d.ts
@@ -117,7 +117,8 @@ export interface User {
   externalId?: string;
 
   /**
-   * The email address that uniquely identifies the user.
+   * The email address that uniquely identifies the user. Must be all
+   * lowercase.
    */
   email?: string;
 

--- a/packages/server/src/auth/google.ts
+++ b/packages/server/src/auth/google.ts
@@ -92,14 +92,15 @@ export async function googleHandler(req: Request, res: Response): Promise<void> 
   }
 
   const claims = result.payload as GoogleCredentialClaims;
+  const email = claims.email.toLowerCase();
 
-  const externalAuth = await isExternalAuth(claims.email);
+  const externalAuth = await isExternalAuth(email);
   if (externalAuth) {
     res.status(200).json(externalAuth);
     return;
   }
 
-  const existingUser = await getUserByEmail(claims.email, projectId);
+  const existingUser = await getUserByEmail(email, projectId);
   if (!existingUser) {
     if (!req.body.createUser) {
       sendOutcome(res, badRequest('User not found'));
@@ -115,14 +116,14 @@ export async function googleHandler(req: Request, res: Response): Promise<void> 
       resourceType: 'User',
       firstName: claims.given_name,
       lastName: claims.family_name,
-      email: claims.email,
+      email,
       project: projectId && projectId !== 'new' ? { reference: 'Project/' + projectId } : undefined,
     });
   }
 
   const login = await tryLogin({
     authMethod: 'google',
-    email: claims.email,
+    email,
     googleCredentials: claims,
     projectId,
     clientId,

--- a/packages/server/src/seed.ts
+++ b/packages/server/src/seed.ts
@@ -60,7 +60,7 @@ export async function seedDatabase(config: MedplumServerConfig): Promise<void> {
 }
 
 async function createSuperAdmin(systemRepo: SystemRepository, config: MedplumServerConfig): Promise<void> {
-  const email = config.defaultSuperAdminEmail ?? 'admin@example.com';
+  const email = (config.defaultSuperAdminEmail ?? 'admin@example.com').toLowerCase();
   const password = config.defaultSuperAdminPassword ?? 'medplum_admin';
   const [firstName, lastName] = ['Medplum', 'Admin'];
   const passwordHash = await bcryptHashPassword(password);


### PR DESCRIPTION
Fixes #10120

## What

- Adds a `user-1` FHIRPath invariant on `User.email` in `profiles-medplum.json` (`$this = $this.lower()`, severity `error`), enforced at runtime by the resource validator like the existing `clapp-1` / `axp-3` invariants. A mixed-case email is now rejected with `Constraint user-1 not met: Email must be all lowercase`.
- Documents the requirement in the element's `definition` text, with the downstream regenerated artifacts: `@medplum/fhirtypes` `User.d.ts` JSDoc, `fhir.schema.json`, and the docs data file `medplumDefinitions/user.json` (which also picked up the previously missing `mfaMethod` element from a stale generation).
- Normalizes the two remaining `User` creation paths that didn't lowercase: Google sign-up (`claims.email`) and `defaultSuperAdminEmail` in seeding. All other creation paths (`newuser`, `register`, `invite`, external auth) already normalized.

## Why

`User.email` was implicitly lowercase: every standard creation path normalizes it and `getUserByEmail` lowercases before searching, but nothing enforced it at the resource level. A `User` written with a mixed-case email (e.g. by a super admin via the FHIR API) is unreachable by login lookups. See #10120.

## Testing

- New `User email constraint: user-1` test in `packages/core/src/typeschema/validation.test.ts` covering accept/reject cases.
- Full local CI replication passes: build, lint, madge, server seed test, and the complete test suite (4,190+ server tests, 43 other packages).

## Migration note

Existing `User` rows with mixed-case emails (possible on older installs) will fail validation on their next update until corrected.
