### PR TITLE
[Scheduling] Share the scheduling duration units in `@medplum/core`

### DIFF
--- a/packages/core/src/scheduling.test.ts
+++ b/packages/core/src/scheduling.test.ts
@@ -3,10 +3,10 @@
 import type { Extension, HealthcareService, Practitioner, Schedule } from '@medplum/fhirtypes';
 import {
   clearScheduleParameter,
-  durationToMinutes,
   extractServiceTypeReferences,
   getScheduleParameters,
   getSchedulingTimezone,
+  schedulingDurationToMinutes,
   SchedulingParametersURI,
   serviceTypeIncludesService,
   setScheduleParameter,
@@ -272,25 +272,25 @@ describe('serviceType CodeableConcepts', () => {
   });
 });
 
-describe('durationToMinutes', () => {
+describe('schedulingDurationToMinutes', () => {
   test('converts every unit scheduling accepts', () => {
-    expect(durationToMinutes({ value: 30, unit: 'min' })).toBe(30);
-    expect(durationToMinutes({ value: 1, unit: 'h' })).toBe(60);
-    expect(durationToMinutes({ value: 1, unit: 'd' })).toBe(1440);
-    expect(durationToMinutes({ value: 1, unit: 'wk' })).toBe(10080);
-    expect(durationToMinutes({ value: 0, unit: 'min' })).toBe(0);
+    expect(schedulingDurationToMinutes({ value: 30, unit: 'min' })).toBe(30);
+    expect(schedulingDurationToMinutes({ value: 1, unit: 'h' })).toBe(60);
+    expect(schedulingDurationToMinutes({ value: 1, unit: 'd' })).toBe(1440);
+    expect(schedulingDurationToMinutes({ value: 1, unit: 'wk' })).toBe(10080);
+    expect(schedulingDurationToMinutes({ value: 0, unit: 'min' })).toBe(0);
   });
 
   test('refuses a duration the scheduling operations would refuse', () => {
     // Rejected rather than read as minutes: a unit guessed wrong here and
     // validated there would have the two disagree by hours.
-    expect(durationToMinutes({ value: 30, unit: 's' })).toBeUndefined();
-    expect(durationToMinutes({ value: 1, unit: 'mo' })).toBeUndefined();
+    expect(schedulingDurationToMinutes({ value: 30, unit: 's' })).toBeUndefined();
+    expect(schedulingDurationToMinutes({ value: 1, unit: 'mo' })).toBeUndefined();
     // `unit` is what the operations validate; a UCUM code alone is not enough.
-    expect(durationToMinutes({ value: 1, code: 'h' })).toBeUndefined();
-    expect(durationToMinutes({ value: 1 })).toBeUndefined();
-    expect(durationToMinutes({ unit: 'min' })).toBeUndefined();
-    expect(durationToMinutes({ value: -30, unit: 'min' })).toBeUndefined();
-    expect(durationToMinutes(undefined)).toBeUndefined();
+    expect(schedulingDurationToMinutes({ value: 1, code: 'h' })).toBeUndefined();
+    expect(schedulingDurationToMinutes({ value: 1 })).toBeUndefined();
+    expect(schedulingDurationToMinutes({ unit: 'min' })).toBeUndefined();
+    expect(schedulingDurationToMinutes({ value: -30, unit: 'min' })).toBeUndefined();
+    expect(schedulingDurationToMinutes(undefined)).toBeUndefined();
   });
 });

--- a/packages/core/src/scheduling.test.ts
+++ b/packages/core/src/scheduling.test.ts
@@ -3,6 +3,7 @@
 import type { Extension, HealthcareService, Practitioner, Schedule } from '@medplum/fhirtypes';
 import {
   clearScheduleParameter,
+  durationToMinutes,
   extractServiceTypeReferences,
   getScheduleParameters,
   getSchedulingTimezone,
@@ -268,5 +269,28 @@ describe('serviceType CodeableConcepts', () => {
     const serviceType = toServiceTypeCodeableConcepts(service);
     expect(serviceTypeIncludesService(serviceType, { ...service, id: 'service-2' })).toBe(false);
     expect(serviceTypeIncludesService(undefined, service)).toBe(false);
+  });
+});
+
+describe('durationToMinutes', () => {
+  test('converts every unit scheduling accepts', () => {
+    expect(durationToMinutes({ value: 30, unit: 'min' })).toBe(30);
+    expect(durationToMinutes({ value: 1, unit: 'h' })).toBe(60);
+    expect(durationToMinutes({ value: 1, unit: 'd' })).toBe(1440);
+    expect(durationToMinutes({ value: 1, unit: 'wk' })).toBe(10080);
+    expect(durationToMinutes({ value: 0, unit: 'min' })).toBe(0);
+  });
+
+  test('refuses a duration the scheduling operations would refuse', () => {
+    // Rejected rather than read as minutes: a unit guessed wrong here and
+    // validated there would have the two disagree by hours.
+    expect(durationToMinutes({ value: 30, unit: 's' })).toBeUndefined();
+    expect(durationToMinutes({ value: 1, unit: 'mo' })).toBeUndefined();
+    // `unit` is what the operations validate; a UCUM code alone is not enough.
+    expect(durationToMinutes({ value: 1, code: 'h' })).toBeUndefined();
+    expect(durationToMinutes({ value: 1 })).toBeUndefined();
+    expect(durationToMinutes({ unit: 'min' })).toBeUndefined();
+    expect(durationToMinutes({ value: -30, unit: 'min' })).toBeUndefined();
+    expect(durationToMinutes(undefined)).toBeUndefined();
   });
 });

--- a/packages/core/src/scheduling.ts
+++ b/packages/core/src/scheduling.ts
@@ -299,7 +299,7 @@ const MINUTES_PER_UNIT: Record<string, number | undefined> = {
  * @returns The length in minutes, or undefined when the duration has no value, a
  * negative value, or a unit scheduling does not accept.
  */
-export function durationToMinutes(duration: Duration | undefined): number | undefined {
+export function schedulingDurationToMinutes(duration: Duration | undefined): number | undefined {
   const value = duration?.value;
   if (value === undefined || value < 0) {
     return undefined;

--- a/packages/core/src/scheduling.ts
+++ b/packages/core/src/scheduling.ts
@@ -1,6 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { CodeableConcept, Extension, HealthcareService, Reference, Resource, Schedule } from '@medplum/fhirtypes';
+import type {
+  CodeableConcept,
+  Duration,
+  Extension,
+  HealthcareService,
+  Reference,
+  Resource,
+  Schedule,
+} from '@medplum/fhirtypes';
 import type { WithId } from './utils';
 import {
   createReference,
@@ -271,4 +279,31 @@ export function extractServiceTypeReferences(
   return serviceType
     .map((concept) => getExtensionValue(concept, ServiceTypeReferenceURI) as Reference<HealthcareService> | undefined)
     .filter(isDefined);
+}
+
+/**
+ * The duration units SchedulingParameters accepts, and what each is worth in
+ * minutes.
+ */
+const MINUTES_PER_UNIT: Record<string, number | undefined> = {
+  wk: 60 * 24 * 7,
+  d: 60 * 24,
+  h: 60,
+  min: 1,
+};
+
+/**
+ * Converts a SchedulingParameters duration to minutes.
+ *
+ * @param duration - The duration to convert.
+ * @returns The length in minutes, or undefined when the duration has no value, a
+ * negative value, or a unit scheduling does not accept.
+ */
+export function durationToMinutes(duration: Duration | undefined): number | undefined {
+  const value = duration?.value;
+  if (value === undefined || value < 0) {
+    return undefined;
+  }
+  const perUnit = duration?.unit === undefined ? undefined : MINUTES_PER_UNIT[duration.unit];
+  return perUnit === undefined ? undefined : value * perUnit;
 }

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -4,10 +4,10 @@ import type { DayOfWeek, WithId } from '@medplum/core';
 import {
   badRequest,
   createReference,
-  durationToMinutes,
   isDayOfWeek,
   isDefined,
   OperationOutcomeError,
+  schedulingDurationToMinutes,
   SchedulingParametersURI,
 } from '@medplum/core';
 import type {
@@ -158,7 +158,7 @@ function extensionDurationToMinutes(extension: WithPath<Extension>): number {
     throw new OperationOutcomeError(badRequest('Got duration with negative value', getPath(extension)));
   }
 
-  const minutes = durationToMinutes(extension.valueDuration);
+  const minutes = schedulingDurationToMinutes(extension.valueDuration);
   if (minutes === undefined) {
     throw new OperationOutcomeError(badRequest(`Got unhandled duration unit "${unit}"`, getPath(extension)));
   }

--- a/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
+++ b/packages/server/src/fhir/operations/utils/scheduling-parameters.ts
@@ -4,6 +4,7 @@ import type { DayOfWeek, WithId } from '@medplum/core';
 import {
   badRequest,
   createReference,
+  durationToMinutes,
   isDayOfWeek,
   isDefined,
   OperationOutcomeError,
@@ -145,7 +146,7 @@ function isReferenceTo<T extends Resource>(reference: Reference<T> | undefined, 
   return refType === resource.resourceType && id === resource.id;
 }
 
-function durationToMinutes(extension: WithPath<Extension>): number {
+function extensionDurationToMinutes(extension: WithPath<Extension>): number {
   assertExtensionDuration(extension);
 
   const { value, unit } = extension.valueDuration;
@@ -157,18 +158,11 @@ function durationToMinutes(extension: WithPath<Extension>): number {
     throw new OperationOutcomeError(badRequest('Got duration with negative value', getPath(extension)));
   }
 
-  switch (unit) {
-    case 'wk':
-      return value * 60 * 24 * 7;
-    case 'd':
-      return value * 60 * 24;
-    case 'h':
-      return value * 60;
-    case 'min':
-      return value;
-    default:
-      throw new OperationOutcomeError(badRequest(`Got unhandled duration unit "${unit}"`, getPath(extension)));
+  const minutes = durationToMinutes(extension.valueDuration);
+  if (minutes === undefined) {
+    throw new OperationOutcomeError(badRequest(`Got unhandled duration unit "${unit}"`, getPath(extension)));
   }
+  return minutes;
 }
 
 function assertValidTimezone(ext: WithPath<Extension>): void {
@@ -346,7 +340,7 @@ function extractAvailability(
 // ("align to the hour") and rejects values > 1440 min (one day), since the
 // per-day grid anchoring in findAlignedSlotTimes makes longer intervals meaningless.
 function extractAlignmentInterval(ext: WithPath<Extension>): number {
-  const value = durationToMinutes(ext);
+  const value = extensionDurationToMinutes(ext);
   if (value === 0) {
     return 60;
   }
@@ -424,10 +418,10 @@ export function getHealthcareServiceSchedulingParameters(
   return result.patchLayer(
     withPath(
       {
-        ...(durationExt && { duration: durationToMinutes(durationExt) }),
-        ...(bufferBeforeExt && { bufferBefore: durationToMinutes(bufferBeforeExt) }),
-        ...(bufferAfterExt && { bufferAfter: durationToMinutes(bufferAfterExt) }),
-        ...(alignmentOffsetExt && { alignmentOffset: durationToMinutes(alignmentOffsetExt) }),
+        ...(durationExt && { duration: extensionDurationToMinutes(durationExt) }),
+        ...(bufferBeforeExt && { bufferBefore: extensionDurationToMinutes(bufferBeforeExt) }),
+        ...(bufferAfterExt && { bufferAfter: extensionDurationToMinutes(bufferAfterExt) }),
+        ...(alignmentOffsetExt && { alignmentOffset: extensionDurationToMinutes(alignmentOffsetExt) }),
         ...(alignmentIntervalExt && { alignmentInterval: extractAlignmentInterval(alignmentIntervalExt) }),
         ...(alignmentTimezoneExt && { alignmentTimezone: alignmentTimezoneExt.valueCode }),
         ...(timezoneExt && { timezone: timezoneExt.valueCode }),
@@ -501,10 +495,10 @@ export function getScheduleSchedulingParameters(
   const layer = withPath(
     {
       ...(availabilityExt.length && { availability: availabilityExt.flatMap(extractAvailabilityR4) }),
-      ...(durationExt && { duration: durationToMinutes(durationExt) }),
-      ...(bufferBeforeExt && { bufferBefore: durationToMinutes(bufferBeforeExt) }),
-      ...(bufferAfterExt && { bufferAfter: durationToMinutes(bufferAfterExt) }),
-      ...(alignmentOffsetExt && { alignmentOffset: durationToMinutes(alignmentOffsetExt) }),
+      ...(durationExt && { duration: extensionDurationToMinutes(durationExt) }),
+      ...(bufferBeforeExt && { bufferBefore: extensionDurationToMinutes(bufferBeforeExt) }),
+      ...(bufferAfterExt && { bufferAfter: extensionDurationToMinutes(bufferAfterExt) }),
+      ...(alignmentOffsetExt && { alignmentOffset: extensionDurationToMinutes(alignmentOffsetExt) }),
       ...(alignmentIntervalExt && { alignmentInterval: extractAlignmentInterval(alignmentIntervalExt) }),
       ...(alignmentTimezoneExt && { alignmentTimezone: alignmentTimezoneExt.valueCode }),
       ...(timezoneExt && { timezone: timezoneExt.valueCode }),


### PR DESCRIPTION
Split out of #10044.

The server converts `SchedulingParameters` durations to minutes when it places appointments. The scheduling components in #10044 need the same conversion on the client to show how long a visit is. Rather than add a second copy, it makes sense to move it into `@medplum/core` where both can reach it. 