### PR TITLE
[React] Month navigation and availability marking on `CalendarDateInput`

### DIFF
--- a/packages/react/src/CalendarDateInput/CalendarDateInput.module.css
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.module.css
@@ -57,8 +57,8 @@
     font-weight: normal;
   }
 
-  & td button.selected,
-  & td button.selected:hover {
+  & td button.selected:not(:disabled),
+  & td button.selected:not(:disabled):hover {
     background-color: var(--mantine-primary-color-filled);
     color: var(--mantine-color-white);
     font-weight: 500;

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.module.css
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.module.css
@@ -1,39 +1,66 @@
 .table {
-  width: 350px;
+  width: 100%;
+  min-width: 260px;
+  max-width: 350px;
+  table-layout: fixed;
+  border-collapse: collapse;
+  user-select: none;
 
   & th {
     font-weight: normal;
     font-size: 11px;
-    padding: 8px;
+    padding: 8px 2px;
     text-align: center;
   }
 
   & td {
-    padding: 2px 4px;
+    padding: 2px;
+    text-align: center;
   }
 
   & td button {
-    width: 44px;
-    height: 44px;
-    color: theme.colors[theme.primaryColor][5];
+    width: 100%;
+    max-width: 44px;
+    height: auto;
+    aspect-ratio: 1;
+    margin: 0 auto;
+    color: var(--mantine-color-gray-6);
     font-size: 16px;
-    font-weight: 500;
+    font-weight: normal;
     text-align: center;
     padding: 0;
-    background-color: theme.colors[theme.primaryColor][0];
+    background-color: transparent;
     border: 0;
-    border-radius: 50px;
+    border-radius: 50%;
     cursor: pointer;
   }
 
   & td button:hover {
-    background-color: theme.colors[theme.primaryColor][1];
+    background-color: var(--mantine-color-gray-1);
   }
 
-  & td button:disabled {
-    background-color: transparen;
-    cursor: defaul;
+  & td button.available {
+    background-color: var(--mantine-color-gray-2);
+    color: var(--mantine-color-text);
+    font-weight: 500;
+  }
+
+  & td button.available:hover {
+    background-color: var(--mantine-color-gray-3);
+  }
+
+  & td button:disabled,
+  & td button:disabled:hover {
+    background-color: transparent;
+    cursor: default;
     color: var(--mantine-color-gray-4);
     font-weight: normal;
+  }
+
+  & td button.selected,
+  & td button.selected:hover {
+    background-color: var(--mantine-primary-color-filled);
+    color: var(--mantine-color-white);
+    font-weight: 500;
   }
 }

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.stories.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.stories.tsx
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { Text } from '@mantine/core';
 import type { Meta } from '@storybook/react';
 import type { JSX } from 'react';
+import { useState } from 'react';
 import { Document } from '../Document/Document';
 import { withMockedDate } from '../stories/decorators';
 import { CalendarDateInput } from './CalendarDateInput';
@@ -12,14 +14,144 @@ export default {
   decorators: [withMockedDate],
 } as Meta;
 
-export const Basic = (): JSX.Element => {
+/**
+ * A month of open weekdays.
+ * @returns The story.
+ */
+export const Basic = (): JSX.Element => (
+  <Document>
+    <CalendarDateInput
+      availableDates={weekdaysOfMonth()}
+      onChangeMonth={(date: Date) => console.log(date)}
+      onClick={(date: Date) => console.log('Clicked ' + date)}
+    />
+  </Document>
+);
+
+/**
+ * The day chosen, marked out of the days on offer.
+ * @returns The story.
+ */
+export const SelectedDay = (): JSX.Element => {
+  const weekdays = weekdaysOfMonth();
   return (
     <Document>
       <CalendarDateInput
-        availableDates={[new Date()]}
+        availableDates={weekdays}
+        selected={weekdays[2]}
         onChangeMonth={(date: Date) => console.log(date)}
         onClick={(date: Date) => console.log('Clicked ' + date)}
       />
     </Document>
   );
 };
+
+/**
+ * A clinic with only a few days open, which is what most months actually look
+ * like once a schedule has been searched.
+ * @returns The story.
+ */
+export const SparseAvailability = (): JSX.Element => {
+  const [selected, setSelected] = useState<Date>();
+  return (
+    <Document>
+      <CalendarDateInput
+        availableDates={someDaysOfMonth([6, 7, 13, 20, 21, 27])}
+        selected={selected}
+        onChangeMonth={(date: Date) => console.log(date)}
+        onClick={setSelected}
+      />
+    </Document>
+  );
+};
+
+/**
+ * A calendar that can be asked about a day with nothing on it.
+ * @returns The story.
+ */
+export const EmptyDaysStillPickable = (): JSX.Element => {
+  const [selected, setSelected] = useState<Date>();
+  return (
+    <Document>
+      <CalendarDateInput
+        availableDates={someDaysOfMonth([6, 7, 13, 20, 21, 27])}
+        selected={selected}
+        allowUnavailableDates
+        onChangeMonth={(date: Date) => console.log(date)}
+        onClick={setSelected}
+      />
+    </Document>
+  );
+};
+
+/**
+ * A service that needs two days' notice.
+ * @returns The story.
+ */
+export const EarliestDay = (): JSX.Element => {
+  const [selected, setSelected] = useState<Date>();
+  const now = new Date();
+  const earliest = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 2);
+  return (
+    <Document>
+      <CalendarDateInput
+        availableDates={weekdaysOfMonth()}
+        selected={selected}
+        earliestDate={earliest}
+        allowUnavailableDates
+        onChangeMonth={(date: Date) => console.log(date)}
+        onClick={setSelected}
+      />
+    </Document>
+  );
+};
+
+/**
+ * The month held outside the calendar, as a host paging its own search would.
+ * @returns The story.
+ */
+export const CallerOwnedMonth = (): JSX.Element => {
+  const [month, setMonth] = useState(new Date());
+  return (
+    <Document>
+      <Text size="sm" c="dimmed" mb="md">
+        Showing {month.toLocaleDateString(undefined, { month: 'long', year: 'numeric' })}
+      </Text>
+      <CalendarDateInput
+        availableDates={weekdaysOfMonth(month)}
+        month={month}
+        onChangeMonth={setMonth}
+        onClick={(date: Date) => console.log('Clicked ' + date)}
+      />
+    </Document>
+  );
+};
+
+/**
+ * Returns every weekday of a month.
+ * @param month - Any day of the month to read. Defaults to the month on display.
+ * @returns Local midnight of each weekday.
+ */
+function weekdaysOfMonth(month?: Date): Date[] {
+  const now = month ?? new Date();
+  const days: Date[] = [];
+  for (let day = 1; day <= 31; day++) {
+    const date = new Date(now.getFullYear(), now.getMonth(), day);
+    if (date.getMonth() === now.getMonth() && date.getDay() !== 0 && date.getDay() !== 6) {
+      days.push(date);
+    }
+  }
+  return days;
+}
+
+/**
+ * Returns the named days of the month on display.
+ * @param days - Days of the month, as numbers.
+ * @returns Local midnight of each one that the month holds.
+ */
+function someDaysOfMonth(days: readonly number[]): Date[] {
+  const now = new Date();
+  return days
+    .map((day) => new Date(now.getFullYear(), now.getMonth(), day))
+    .filter((date) => date.getMonth() === now.getMonth());
+}

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
@@ -76,4 +76,198 @@ describe('CalendarDateInput', () => {
     expect(result.getMonth()).toBe(nextMonth.getMonth());
     expect(result.getDate()).toBe(15);
   });
+
+  test('Controlled month ignores internal navigation', async () => {
+    const month = getStartMonth();
+    const onChangeMonth = vi.fn();
+    render(<CalendarDateInput availableDates={[]} month={month} onChangeMonth={onChangeMonth} onClick={vi.fn()} />);
+
+    const nextMonth = new Date(month);
+    nextMonth.setMonth(month.getMonth() + 1);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Next month'));
+    });
+
+    // The caller is told which month was asked for, but the display stays put
+    // until the caller passes the new month back in.
+    expect(onChangeMonth).toHaveBeenCalledWith(nextMonth);
+    expect(screen.getByText(getMonthString(month))).toBeDefined();
+  });
+
+  test('Marks the selected day', () => {
+    const selected = getStartMonth();
+    selected.setDate(10);
+
+    const available = new Date(selected);
+    available.setHours(9, 0, 0, 0);
+
+    render(
+      <CalendarDateInput availableDates={[available]} selected={selected} onChangeMonth={vi.fn()} onClick={vi.fn()} />
+    );
+
+    expect(screen.getByRole('button', { name: '10' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('Marks the days that have times on them', () => {
+    const month = getStartMonth();
+
+    render(
+      <CalendarDateInput
+        availableDates={[dayOf(month, 10), dayOf(month, 12)]}
+        month={month}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+      />
+    );
+
+    // Which days are worth clicking is what the month view is read for.
+    expect(screen.getByRole('button', { name: '10' }).className).toContain('available');
+    expect(screen.getByRole('button', { name: '12' }).className).toContain('available');
+    expect(screen.getByRole('button', { name: '11' }).className).not.toContain('available');
+  });
+
+  test('Days before the earliest cannot be picked, even where empty days can', async () => {
+    const month = new Date(2026, 6, 1);
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        earliestDate={new Date(2026, 6, 15, 9, 30)}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+      />
+    );
+
+    // A day gone by is a different kind of empty from a day with nothing booked:
+    // there is no time on it left to ask for.
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: '14' }).disabled).toBe(true);
+    // The earliest day itself still has the rest of itself to offer.
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: '15' }).disabled).toBe(false);
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: '16' }).disabled).toBe(false);
+  });
+
+  test('Will not page back past the month the earliest day falls in', async () => {
+    const onChangeMonth = vi.fn();
+    const month = new Date(2026, 6, 1);
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        earliestDate={new Date(2026, 6, 15)}
+        allowUnavailableDates
+        onChangeMonth={onChangeMonth}
+        onClick={vi.fn()}
+      />
+    );
+
+    // June holds nothing bookable, so there is nothing to go back for.
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Previous month' }).disabled).toBe(true);
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Next month' }).disabled).toBe(false);
+  });
+
+  test('Pages back freely once past the earliest month', async () => {
+    const month = new Date(2026, 8, 1);
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        earliestDate={new Date(2026, 6, 15)}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Previous month' }).disabled).toBe(false);
+  });
+
+  test('Days with nothing on offer can be clicked when the caller allows it', async () => {
+    const onClick = vi.fn();
+    render(<CalendarDateInput availableDates={[]} allowUnavailableDates onChangeMonth={vi.fn()} onClick={onClick} />);
+
+    const day = screen.getByRole<HTMLButtonElement>('button', { name: '4' });
+    expect(day.disabled).toBe(false);
+    // Left unmarked, so it does not read as a day with times.
+    expect(day.className).not.toContain('available');
+
+    await act(async () => {
+      fireEvent.click(day);
+    });
+
+    expect(onClick.mock.calls[0][0].getDate()).toBe(4);
+  });
+
+  test('Leaves days unpressed when nothing is selected', () => {
+    const available = getStartMonth();
+    available.setDate(10);
+
+    render(<CalendarDateInput availableDates={[available]} onChangeMonth={vi.fn()} onClick={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: '10' })).not.toHaveAttribute('aria-pressed');
+  });
+
+  test('Pages a month at a time from a month named by its last day', async () => {
+    const onChangeMonth = vi.fn();
+    // January has 31 days and February does not, so counting a month on from the
+    // 31st lands on a day February does not have.
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={new Date(2026, 0, 31)}
+        onChangeMonth={onChangeMonth}
+        onClick={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('January 2026')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Next month' }));
+    });
+
+    // February, not the March a rolled-over 31st would have reached.
+    expect(onChangeMonth).toHaveBeenCalledWith(new Date(2026, 1, 1));
+  });
+
+  test('Stops paging back at the month the earliest day falls in', async () => {
+    const onChangeMonth = vi.fn();
+    const { rerender } = render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={new Date(2026, 0, 20)}
+        earliestDate={new Date(2026, 0, 15)}
+        onChangeMonth={onChangeMonth}
+        onClick={vi.fn()}
+      />
+    );
+
+    // Measured by month, so a day later in the same month is not a month further
+    // on: January is the earliest month and there is nothing to page back to.
+    expect(screen.getByRole('button', { name: 'Previous month' })).toBeDisabled();
+
+    rerender(
+      <CalendarDateInput
+        availableDates={[]}
+        month={new Date(2026, 1, 1)}
+        earliestDate={new Date(2026, 0, 15)}
+        onChangeMonth={onChangeMonth}
+        onClick={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Previous month' })).toBeEnabled();
+  });
 });
+
+/**
+ * A day of the shown month, as the calendar reports it.
+ * @param month - The month on screen.
+ * @param date - The day of that month.
+ * @returns Local midnight of that day.
+ */
+function dayOf(month: Date, date: number): Date {
+  return new Date(month.getFullYear(), month.getMonth(), date);
+}

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
@@ -27,12 +27,17 @@ type OptionalCalendarCell = CalendarCell | undefined;
 export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
   const { onChangeMonth, onClick, selected, allowUnavailableDates, earliestDate } = props;
   const [uncontrolledMonth, setUncontrolledMonth] = useState<Date>(getStartMonth);
-  const month = startOfMonth(props.month ?? uncontrolledMonth);
+  const shownMonth = props.month ?? uncontrolledMonth;
+  const year = shownMonth.getFullYear();
+  const monthIndex = shownMonth.getMonth();
+  const month = useMemo(() => new Date(year, monthIndex, 1), [year, monthIndex]);
   const atEarliestMonth = !!earliestDate && month <= startOfMonth(earliestDate);
 
   function moveMonth(delta: number): void {
     const newMonth = new Date(month.getFullYear(), month.getMonth() + delta, 1);
-    setUncontrolledMonth(newMonth);
+    if (props.month === undefined) {
+      setUncontrolledMonth(newMonth);
+    }
     onChangeMonth(newMonth);
   }
 

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
@@ -1,15 +1,20 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Button, Group } from '@mantine/core';
+import cx from 'clsx';
 import type { JSX } from 'react';
 import { useMemo, useState } from 'react';
 import classes from './CalendarDateInput.module.css';
-import { getMonthString, getStartMonth } from './CalendarDateInput.utils';
+import { getMonthString, getStartMonth, isBeforeDay, isSameDay, startOfMonth } from './CalendarDateInput.utils';
 
 export interface CalendarDateInputProps {
   readonly availableDates: Date[];
   readonly onChangeMonth: (date: Date) => void;
   readonly onClick: (date: Date) => void;
+  readonly month?: Date;
+  readonly selected?: Date;
+  readonly allowUnavailableDates?: boolean;
+  readonly earliestDate?: Date;
 }
 
 interface CalendarCell {
@@ -20,16 +25,19 @@ interface CalendarCell {
 type OptionalCalendarCell = CalendarCell | undefined;
 
 export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
-  const { onChangeMonth, onClick } = props;
-  const [month, setMonth] = useState<Date>(getStartMonth);
+  const { onChangeMonth, onClick, selected, allowUnavailableDates, earliestDate } = props;
+  const [uncontrolledMonth, setUncontrolledMonth] = useState<Date>(getStartMonth);
+  const month = startOfMonth(props.month ?? uncontrolledMonth);
+  const atEarliestMonth = !!earliestDate && month <= startOfMonth(earliestDate);
 
   function moveMonth(delta: number): void {
-    setMonth((currMonth) => {
-      const newMonth = new Date(currMonth);
-      newMonth.setMonth(currMonth.getMonth() + delta);
-      onChangeMonth(newMonth);
-      return newMonth;
-    });
+    const newMonth = new Date(month.getFullYear(), month.getMonth() + delta, 1);
+    setUncontrolledMonth(newMonth);
+    onChangeMonth(newMonth);
+  }
+
+  function isDayDisabled(day: CalendarCell): boolean {
+    return (!day.available && !allowUnavailableDates) || (!!earliestDate && isBeforeDay(day.date, earliestDate));
   }
 
   const grid = useMemo(() => buildGrid(month, props.availableDates), [month, props.availableDates]);
@@ -39,7 +47,12 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
       <Group justify="space-between" gap="xs" grow wrap="nowrap">
         <p style={{ flex: 1 }}>{getMonthString(month)}</p>
         <Group justify="flex-end" gap="xs">
-          <Button variant="outline" aria-label="Previous month" onClick={() => moveMonth(-1)}>
+          <Button
+            variant="outline"
+            aria-label="Previous month"
+            disabled={atEarliestMonth}
+            onClick={() => moveMonth(-1)}
+          >
             &lt;
           </Button>
           <Button variant="outline" aria-label="Next month" onClick={() => moveMonth(1)}>
@@ -65,7 +78,16 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
               {week.map((day, dayIndex) => (
                 <td key={'day-' + dayIndex}>
                   {day && (
-                    <Button variant="light" disabled={!day.available} onClick={() => onClick(day.date)}>
+                    <Button
+                      variant="light"
+                      className={cx(
+                        day.available && classes.available,
+                        isSameDay(day.date, selected) && classes.selected
+                      )}
+                      aria-pressed={selected ? isSameDay(day.date, selected) : undefined}
+                      disabled={isDayDisabled(day)}
+                      onClick={() => onClick(day.date)}
+                    >
                       {day.date.getDate()}
                     </Button>
                   )}
@@ -122,15 +144,5 @@ function buildGrid(startDate: Date, availableDates: Date[]): OptionalCalendarCel
  */
 function isDayAvailable(day: Date, availableDates: Date[]): boolean {
   // Note that slot start and end time may or may not be in UTC.
-  for (const availableDate of availableDates) {
-    if (
-      availableDate.getFullYear() === day.getFullYear() &&
-      availableDate.getMonth() === day.getMonth() &&
-      availableDate.getDate() === day.getDate()
-    ) {
-      return true;
-    }
-  }
-
-  return false;
+  return availableDates.some((availableDate) => isSameDay(availableDate, day));
 }

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.utils.ts
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.utils.ts
@@ -11,8 +11,39 @@ export function getMonthString(date: Date): string {
 }
 
 export function getStartMonth(): Date {
-  const result = new Date();
-  result.setDate(1);
-  result.setHours(0, 0, 0, 0);
-  return result;
+  return startOfMonth(new Date());
+}
+
+/**
+ * Returns local midnight on the first of a date's month.
+ * @param date - Any date within the month.
+ * @returns The first day of that month.
+ */
+export function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+/**
+ * Returns whether a day falls before another, ignoring the time of day.
+ * @param day - Local midnight of the day in question.
+ * @param limit - The instant the day is measured against.
+ * @returns True when the day ends before the limit.
+ */
+export function isBeforeDay(day: Date, limit: Date): boolean {
+  return day.getTime() < new Date(limit.getFullYear(), limit.getMonth(), limit.getDate()).getTime();
+}
+
+/**
+ * Returns whether two dates fall on the same day in the local timezone.
+ * @param left - The first date.
+ * @param right - The second date, which may be absent.
+ * @returns True when both dates are present and share a calendar day.
+ */
+export function isSameDay(left: Date, right: Date | undefined): boolean {
+  return (
+    !!right &&
+    left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate()
+  );
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,7 +30,6 @@ export * from './auth/SignInForm';
 export * from './BackboneElementDisplay/BackboneElementDisplay';
 export * from './BackboneElementInput/BackboneElementInput';
 export * from './CalendarDateInput/CalendarDateInput';
-export * from './CalendarDateInput/CalendarDateInput.utils';
 export * from './CalendarInput/CalendarInput';
 export * from './chat/BaseChat/BaseChat';
 export * from './chat/ChatModal/ChatModal';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,6 +30,7 @@ export * from './auth/SignInForm';
 export * from './BackboneElementDisplay/BackboneElementDisplay';
 export * from './BackboneElementInput/BackboneElementInput';
 export * from './CalendarDateInput/CalendarDateInput';
+export * from './CalendarDateInput/CalendarDateInput.utils';
 export * from './CalendarInput/CalendarInput';
 export * from './chat/BaseChat/BaseChat';
 export * from './chat/ChatModal/ChatModal';


### PR DESCRIPTION
Split out of #10044. 

# What 

`CalendarDateInput` lacks some functionality that we'll need in appointment-booking workflows, like: 
* Showing which days are worth clicking (e.g. has an available appointment slot)
* Selecting a day to mark as "chosen" 
* Ability for caller to page between months 

We'll add the following new props. They'll all be optional and default to their previous behavior, so existing callers will be unaffected (`CalendarInput` and `Scheduler`). 

| New prop |  |
| --- | --- |
| `month` | Makes the displayed month controlled, so a caller can keep it in step with its own search. Left out, the calendar still owns it. |
| `selected` | The day to mark as chosen. |
| `allowUnavailableDates` | Lets days that are marked as unavailable (aka not in the `availableDates` prop) to still be selectable. |
| `earliestDate` | A floor. Earlier days cannot be picked and the calendar will not page back past the month it falls in. A day that has passed is a different kind of empty from a day with nothing booked, so it stays closed even where `allowUnavailableDates` opens up the rest. |

# Screenshots 
## Selected day 

<img width="418" height="429" alt="image" src="https://github.com/user-attachments/assets/094579b9-e0c6-4428-a8e6-f34267e06c45" />

## Available days (preexisting)

<img width="432" height="423" alt="image" src="https://github.com/user-attachments/assets/ac3ac37e-2d1a-4c96-abb5-2e33ed61867b" />

## Allow unavailable days 

<img width="403" height="433" alt="image" src="https://github.com/user-attachments/assets/e90099d7-bf29-4fc7-b330-301168115102" />

## Earliest Date 

<img width="425" height="438" alt="image" src="https://github.com/user-attachments/assets/8415f3ad-4033-4013-966a-1bfaffaca485" />

## Month control (caller-owned)

<img width="954" height="433" alt="image" src="https://github.com/user-attachments/assets/656b91e3-ed7a-4cf8-935d-7964aa9aca57" />
