### PR TITLE
[React] Range selection on `CalendarDateInput`

### DIFF
--- a/packages/react/src/CalendarDateInput/CalendarDateInput.module.css
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.module.css
@@ -63,4 +63,22 @@
     color: var(--mantine-color-white);
     font-weight: 500;
   }
+
+  /* The days of a range, banded across the weeks they span so that the stretch
+     reads as one answer rather than as a fortnight of separate marks. Drawn on
+     the cell rather than the day, which leaves the circles to say which days of
+     it have times. */
+  & td.inRange {
+    background-color: var(--mantine-primary-color-light);
+  }
+
+  & td.rangeOpens {
+    border-top-left-radius: 999px;
+    border-bottom-left-radius: 999px;
+  }
+
+  & td.rangeCloses {
+    border-top-right-radius: 999px;
+    border-bottom-right-radius: 999px;
+  }
 }

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.module.css
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.module.css
@@ -24,7 +24,7 @@
     height: auto;
     aspect-ratio: 1;
     margin: 0 auto;
-    color: var(--mantine-color-gray-6);
+    color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-dark-2));
     font-size: 16px;
     font-weight: normal;
     text-align: center;
@@ -36,24 +36,24 @@
   }
 
   & td button:hover {
-    background-color: var(--mantine-color-gray-1);
+    background-color: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
   }
 
   & td button.available {
-    background-color: var(--mantine-color-gray-2);
+    background-color: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
     color: var(--mantine-color-text);
     font-weight: 500;
   }
 
   & td button.available:hover {
-    background-color: var(--mantine-color-gray-3);
+    background-color: light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-3));
   }
 
   & td button:disabled,
   & td button:disabled:hover {
     background-color: transparent;
     cursor: default;
-    color: var(--mantine-color-gray-4);
+    color: light-dark(var(--mantine-color-gray-4), var(--mantine-color-dark-4));
     font-weight: normal;
   }
 
@@ -77,4 +77,10 @@
     border-top-right-radius: 999px;
     border-bottom-right-radius: 999px;
   }
+}
+
+/* A finger dragging out a range must not scroll the page out from under it.
+   Only calendars that take ranges give up the scroll. */
+.table.selectsRanges td button {
+  touch-action: none;
 }

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.module.css
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.module.css
@@ -64,10 +64,6 @@
     font-weight: 500;
   }
 
-  /* The days of a range, banded across the weeks they span so that the stretch
-     reads as one answer rather than as a fortnight of separate marks. Drawn on
-     the cell rather than the day, which leaves the circles to say which days of
-     it have times. */
   & td.inRange {
     background-color: var(--mantine-primary-color-light);
   }

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.stories.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.stories.tsx
@@ -65,6 +65,24 @@ export const SparseAvailability = (): JSX.Element => {
   );
 };
 
+// A stretch of days, banded across the weeks it spans with both of its ends
+// marked. Drag across the days, or shift-click, to ask for another.
+export const Range = (): JSX.Element => {
+  const [range, setRange] = useState({ start: weekdaysOfMonth()[2], end: weekdaysOfMonth()[8] });
+  return (
+    <Document>
+      <CalendarDateInput
+        availableDates={weekdaysOfMonth()}
+        range={range}
+        allowUnavailableDates
+        onChangeMonth={(date: Date) => console.log(date)}
+        onClick={(date: Date) => setRange({ start: date, end: date })}
+        onSelectRange={(start: Date, end: Date) => setRange({ start, end })}
+      />
+    </Document>
+  );
+};
+
 /**
  * A calendar that can be asked about a day with nothing on it.
  * @returns The story.

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.stories.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.stories.tsx
@@ -65,8 +65,13 @@ export const SparseAvailability = (): JSX.Element => {
   );
 };
 
-// A stretch of days, banded across the weeks it spans with both of its ends
-// marked. Drag across the days, or shift-click, to ask for another.
+/**
+ * A stretch of days, banded across the weeks it spans with both of its ends marked. Drag across
+ * the days to ask for another, or shift-click to move one end — the range is measured from the day
+ * last clicked, or the day the last drag began on, so shift-clicking back where you started puts
+ * it back.
+ * @returns The story.
+ */
 export const Range = (): JSX.Element => {
   const [range, setRange] = useState({ start: weekdaysOfMonth()[2], end: weekdaysOfMonth()[8] });
   return (

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.stories.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.stories.tsx
@@ -67,9 +67,8 @@ export const SparseAvailability = (): JSX.Element => {
 
 /**
  * A stretch of days, banded across the weeks it spans with both of its ends marked. Drag across
- * the days to ask for another, or shift-click to move one end — the range is measured from the day
- * last clicked, or the day the last drag began on, so shift-clicking back where you started puts
- * it back.
+ * the days to ask for another, or shift-click to move the nearer end of this one — beyond either
+ * end to widen the range, within it to draw that end in.
  * @returns The story.
  */
 export const Range = (): JSX.Element => {

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
@@ -128,6 +128,75 @@ describe('CalendarDateInput', () => {
     expect(screen.getByRole('button', { name: '11' }).className).not.toContain('available');
   });
 
+  test('Bands a range across the days it covers, marking both ends as chosen', () => {
+    const month = getStartMonth();
+
+    render(
+      <CalendarDateInput
+        availableDates={[dayOf(month, 10)]}
+        month={month}
+        range={{ start: dayOf(month, 10), end: dayOf(month, 12) }}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: '10' }).className).toContain('selected');
+    expect(screen.getByRole('button', { name: '12' }).className).toContain('selected');
+    // The days between the ends are in the range without having been picked.
+    expect(screen.getByRole('button', { name: '11' }).className).not.toContain('selected');
+    expect(cellOf('11').className).toContain('inRange');
+    expect(cellOf('13').className).not.toContain('inRange');
+    // A day with times keeps saying so inside the band.
+    expect(screen.getByRole('button', { name: '10' }).className).toContain('available');
+  });
+
+  test('Rounds the band off where the range ends', () => {
+    // A month whose weekdays are known, so that the mid-range day is not also the
+    // end of its week: July 2026 opens on a Wednesday, putting the 13th to the
+    // 15th from Monday to Wednesday.
+    const month = new Date(2026, 6, 1);
+
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        range={{ start: dayOf(month, 13), end: dayOf(month, 15) }}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+      />
+    );
+
+    expect(cellOf('13').className).toContain('rangeOpens');
+    expect(cellOf('15').className).toContain('rangeCloses');
+    expect(cellOf('14').className).not.toContain('rangeOpens');
+    expect(cellOf('14').className).not.toContain('rangeCloses');
+  });
+
+  test('Squares the band off where a range carries on into the next week', () => {
+    const month = new Date(2026, 6, 1);
+
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        range={{ start: dayOf(month, 16), end: dayOf(month, 21) }}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+      />
+    );
+
+    // The 18th is a Saturday and the 19th the Sunday after it, so the band has to
+    // close at the end of one row and open again at the start of the next.
+    expect(cellOf('18').className).toContain('rangeCloses');
+    expect(cellOf('19').className).toContain('rangeOpens');
+    expect(cellOf('18').className).not.toContain('rangeOpens');
+    expect(cellOf('19').className).not.toContain('rangeCloses');
+  });
+
   test('Days before the earliest cannot be picked, even where empty days can', async () => {
     const month = new Date(2026, 6, 1);
     render(
@@ -200,6 +269,226 @@ describe('CalendarDateInput', () => {
     expect(onClick.mock.calls[0][0].getDate()).toBe(4);
   });
 
+  test('Dragging across days asks for the range they cover', async () => {
+    const onSelectRange = vi.fn();
+    const onClick = vi.fn();
+    const month = getStartMonth();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={onClick}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await drag(10, 11, 12);
+
+    // Drawn as the range it would ask for, so that what is being dragged out
+    // looks like what letting go will leave behind.
+    expect(cellOf('11').className).toContain('inRange');
+    expect(screen.getByRole('button', { name: '12' }).className).toContain('selected');
+
+    await release();
+
+    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 10), dayOf(month, 12));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('Dragging backwards asks for the same range', async () => {
+    const onSelectRange = vi.fn();
+    const month = getStartMonth();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await drag(12, 10);
+    await release();
+
+    // Someone working back from a deadline drags the other way round.
+    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 10), dayOf(month, 12));
+  });
+
+  test('A press and release on one day is a click, not a range', async () => {
+    const onSelectRange = vi.fn();
+    const onClick = vi.fn();
+    const month = getStartMonth();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={onClick}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await drag(10);
+    await release();
+    await click(10);
+
+    expect(onSelectRange).not.toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalledWith(dayOf(month, 10));
+  });
+
+  test('The click that ends a drag is not also a day being picked', async () => {
+    const onSelectRange = vi.fn();
+    const onClick = vi.fn();
+    const month = getStartMonth();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={onClick}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await drag(10, 12);
+    await release();
+    // A release reported as a click on the day it landed on would otherwise throw
+    // the range away and ask for that one day instead.
+    await click(12);
+
+    expect(onSelectRange).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('A day picked after a drag is still picked', async () => {
+    const onSelectRange = vi.fn();
+    const onClick = vi.fn();
+    const month = getStartMonth();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={onClick}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await drag(10, 12);
+    await release();
+
+    // A drag across days is released as a click on the row or table the two ends
+    // share rather than on either day, so nothing swallowed it on the way past.
+    // The next day pressed must not be swallowed in its place.
+    await pressDay(20);
+
+    expect(onSelectRange).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledWith(dayOf(month, 20));
+  });
+
+  test('Shift-clicking a second day asks for the range up to it', async () => {
+    const onSelectRange = vi.fn();
+    const onClick = vi.fn();
+    const month = getStartMonth();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        selected={dayOf(month, 10)}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={onClick}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    // Dragging needs a pointer that hovers, so shift is what leaves a range within
+    // reach of a touchscreen or a keyboard.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '12' }), { shiftKey: true });
+    });
+
+    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 10), dayOf(month, 12));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('Shift-clicking an earlier day asks for the range back to it', async () => {
+    const onSelectRange = vi.fn();
+    const month = getStartMonth();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        range={{ start: dayOf(month, 10), end: dayOf(month, 12) }}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '8' }), { shiftKey: true });
+    });
+
+    // Measured from where the range began, so widening it backwards works the same
+    // way as dragging backwards does.
+    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 8), dayOf(month, 10));
+  });
+
+  test('Shift-clicking with no day picked yet is just a click', async () => {
+    const onSelectRange = vi.fn();
+    const onClick = vi.fn();
+    const month = getStartMonth();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={onClick}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '12' }), { shiftKey: true });
+    });
+
+    // There is no other end for the range to run to.
+    expect(onSelectRange).not.toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalledWith(dayOf(month, 12));
+  });
+
+  test('Ignores dragging when the caller takes no ranges', async () => {
+    const onClick = vi.fn();
+    const month = getStartMonth();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={onClick}
+      />
+    );
+
+    await drag(10, 12);
+    expect(cellOf('11').className).not.toContain('inRange');
+    await release();
+    await click(12);
+
+    // Nothing is marked on the way, and the release is just a click.
+    expect(onClick).toHaveBeenCalledWith(dayOf(month, 12));
+  });
+
   test('Leaves days unpressed when nothing is selected', () => {
     const available = getStartMonth();
     available.setDate(10);
@@ -207,6 +496,28 @@ describe('CalendarDateInput', () => {
     render(<CalendarDateInput availableDates={[available]} onChangeMonth={vi.fn()} onClick={vi.fn()} />);
 
     expect(screen.getByRole('button', { name: '10' })).not.toHaveAttribute('aria-pressed');
+  });
+
+  test('Reports every day of a range as chosen', async () => {
+    const month = new Date(2026, 0, 1);
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        range={{ start: dayOf(month, 10), end: dayOf(month, 12) }}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+        onSelectRange={vi.fn()}
+      />
+    );
+
+    // Three days asked for are three days chosen. Reading the middle one back as
+    // unpressed would say the range has a hole in it.
+    for (const date of ['10', '11', '12']) {
+      expect(screen.getByRole('button', { name: date })).toHaveAttribute('aria-pressed', 'true');
+    }
+    expect(screen.getByRole('button', { name: '13' })).toHaveAttribute('aria-pressed', 'false');
   });
 
   test('Pages a month at a time from a month named by its last day', async () => {
@@ -270,4 +581,71 @@ describe('CalendarDateInput', () => {
  */
 function dayOf(month: Date, date: number): Date {
   return new Date(month.getFullYear(), month.getMonth(), date);
+}
+
+/**
+ * Returns the cell a day sits in, which is what carries the range band.
+ * @param date - The day of the shown month.
+ * @returns The day's table cell.
+ */
+function cellOf(date: string): HTMLElement {
+  const cell = screen.getByRole('button', { name: date }).closest('td');
+  if (!cell) {
+    throw new Error(`Day ${date} is not in a cell`);
+  }
+  return cell;
+}
+
+/**
+ * Presses the first day and travels over the rest.
+ *
+ * One gesture per act, because the days the drag has reached are read back out of
+ * state on the next render, and a whole drag inside one act would leave every
+ * step looking at where the pointer was when it started.
+ *
+ * @param dates - The days of the shown month the pointer passes over, in order.
+ */
+async function drag(...dates: number[]): Promise<void> {
+  for (const [index, date] of dates.entries()) {
+    const day = screen.getByRole('button', { name: String(date) });
+    await act(async () => {
+      if (index === 0) {
+        fireEvent.pointerDown(day);
+      }
+      fireEvent.pointerOver(day);
+    });
+  }
+}
+
+/**
+ * Lets go, wherever the pointer has ended up.
+ */
+async function release(): Promise<void> {
+  await act(async () => {
+    fireEvent.pointerUp(window);
+  });
+}
+
+/**
+ * Clicks a day of the shown month.
+ * @param date - The day to click.
+ */
+async function click(date: number): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: String(date) }));
+  });
+}
+
+/**
+ * Picks a day the way a mouse does: press, release, then the click that follows.
+ *
+ * The press matters, because it is what tells the calendar a fresh gesture has
+ * begun. `click` on its own is the keyboard's route in.
+ *
+ * @param date - The day to pick.
+ */
+async function pressDay(date: number): Promise<void> {
+  await drag(date);
+  await release();
+  await click(date);
 }

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
@@ -152,6 +152,33 @@ describe('CalendarDateInput', () => {
     expect(screen.getByRole('button', { name: '10' }).className).toContain('available');
   });
 
+  test('Bands a range whose ends carry a time of day', () => {
+    const month = getStartMonth();
+    const start = dayOf(month, 10);
+    start.setHours(9, 30);
+    const end = dayOf(month, 12);
+    end.setHours(17, 0);
+
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        range={{ start, end }}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+      />
+    );
+
+    // A caller handing over the ends of a booking gives instants, not days. The
+    // 10th would otherwise be drawn as an end of a band it did not belong to.
+    expect(cellOf('10').className).toContain('inRange');
+    expect(cellOf('11').className).toContain('inRange');
+    expect(cellOf('12').className).toContain('inRange');
+    expect(cellOf('13').className).not.toContain('inRange');
+    expect(screen.getByRole('button', { name: '11' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
   test('Rounds the band off where the range ends', () => {
     // A month whose weekdays are known, so that the mid-range day is not also the
     // end of its week: July 2026 opens on a Wednesday, putting the 13th to the
@@ -465,6 +492,57 @@ describe('CalendarDateInput', () => {
     // There is no other end for the range to run to.
     expect(onSelectRange).not.toHaveBeenCalled();
     expect(onClick).toHaveBeenCalledWith(dayOf(month, 12));
+  });
+
+  test('A drag begun by a finger takes the pointer back off the day it landed on', async () => {
+    const month = getStartMonth();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+        onSelectRange={vi.fn()}
+      />
+    );
+
+    const day = screen.getByRole('button', { name: '10' });
+    const releasePointerCapture = vi.fn();
+    Object.assign(day, { hasPointerCapture: () => true, releasePointerCapture });
+
+    await act(async () => {
+      fireEvent.pointerDown(day, { pointerId: 7 });
+    });
+
+    // A touchscreen captures the pointer to this day on its own. Kept, the
+    // capture would leave a finger dragging across the month stuck here.
+    expect(releasePointerCapture).toHaveBeenCalledWith(7);
+  });
+
+  test('A drag the browser takes over asks for nothing', async () => {
+    const onSelectRange = vi.fn();
+    const month = getStartMonth();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await drag(10, 12);
+    await act(async () => {
+      fireEvent.pointerCancel(window);
+    });
+
+    // A scroll or a second finger cancels the gesture, which is not the same as
+    // letting go on the 12th.
+    expect(onSelectRange).not.toHaveBeenCalled();
+    expect(cellOf('11').className).not.toContain('inRange');
   });
 
   test('Ignores dragging when the caller takes no ranges', async () => {

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { JSX } from 'react';
+import { useState } from 'react';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import { CalendarDateInput } from './CalendarDateInput';
 import { getMonthString, getStartMonth } from './CalendarDateInput.utils';
@@ -437,7 +439,8 @@ describe('CalendarDateInput', () => {
     );
 
     // Dragging needs a pointer that hovers, so shift is what leaves a range within
-    // reach of a touchscreen or a keyboard.
+    // reach of a touchscreen or a keyboard. With no gesture of its own to go on,
+    // the range is measured from the day the calendar was handed.
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: '12' }), { shiftKey: true });
     });
@@ -446,7 +449,7 @@ describe('CalendarDateInput', () => {
     expect(onClick).not.toHaveBeenCalled();
   });
 
-  test('Shift-clicking an earlier day asks for the range back to it', async () => {
+  test('A range handed in with no gesture is measured from its start', async () => {
     const onSelectRange = vi.fn();
     const month = getStartMonth();
     render(
@@ -465,8 +468,9 @@ describe('CalendarDateInput', () => {
       fireEvent.click(screen.getByRole('button', { name: '8' }), { shiftKey: true });
     });
 
-    // Measured from where the range began, so widening it backwards works the same
-    // way as dragging backwards does.
+    // Nothing here says which end the user anchored on, so the start is the only
+    // end there is to measure from. A range the calendar produced itself is
+    // measured from the day that gesture anchored on instead.
     expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 8), dayOf(month, 10));
   });
 
@@ -492,6 +496,145 @@ describe('CalendarDateInput', () => {
     // There is no other end for the range to run to.
     expect(onSelectRange).not.toHaveBeenCalled();
     expect(onClick).toHaveBeenCalledWith(dayOf(month, 12));
+  });
+
+  test('Shift-clicking again measures from the same day, so a range can be taken back', async () => {
+    const onSelectRange = vi.fn();
+    const month = getStartMonth();
+    render(<HeldRangeCalendar month={month} onSelectRange={onSelectRange} />);
+
+    await pressDay(10);
+    await shiftPressDay(20);
+
+    expect(onSelectRange).toHaveBeenLastCalledWith(dayOf(month, 10), dayOf(month, 20));
+
+    await shiftPressDay(5);
+
+    // The far end moves; the day picked stays put.
+    expect(onSelectRange).toHaveBeenLastCalledWith(dayOf(month, 5), dayOf(month, 10));
+
+    await shiftPressDay(20);
+
+    // So shift-clicking back where it started puts the range back.
+    expect(onSelectRange).toHaveBeenLastCalledWith(dayOf(month, 10), dayOf(month, 20));
+  });
+
+  test('A shift-click after a backwards drag measures from where the drag began', async () => {
+    const onSelectRange = vi.fn();
+    const month = getStartMonth();
+    render(<HeldRangeCalendar month={month} onSelectRange={onSelectRange} />);
+
+    await drag(20, 15, 10);
+    await release();
+
+    expect(onSelectRange).toHaveBeenLastCalledWith(dayOf(month, 10), dayOf(month, 20));
+
+    await shiftPressDay(25);
+
+    // Not from the 10th: the range grew out of the 20th, so that is the end it
+    // is still measured from.
+    expect(onSelectRange).toHaveBeenLastCalledWith(dayOf(month, 20), dayOf(month, 25));
+  });
+
+  test('A day picked with the keyboard is the day a shift-click measures from', async () => {
+    const onSelectRange = vi.fn();
+    const month = getStartMonth();
+    render(<HeldRangeCalendar month={month} onSelectRange={onSelectRange} />);
+
+    // No press at all, which is the route a keyboard takes.
+    await click(10);
+    await shiftPressDay(12);
+
+    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 10), dayOf(month, 12));
+  });
+
+  test('A day the caller did not keep is not measured from', async () => {
+    const onSelectRange = vi.fn();
+    const onClick = vi.fn();
+    const month = getStartMonth();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={onClick}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await pressDay(10);
+    await shiftPressDay(12);
+
+    // Nothing is on show to have anchored on, so there is no range to ask for.
+    expect(onSelectRange).not.toHaveBeenCalled();
+    expect(onClick).toHaveBeenLastCalledWith(dayOf(month, 12));
+  });
+
+  test('A range the caller replaces is measured from its own start', async () => {
+    const onSelectRange = vi.fn();
+    const month = getStartMonth();
+    const { rerender } = render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await pressDay(10);
+
+    rerender(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        range={{ start: dayOf(month, 20), end: dayOf(month, 22) }}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+        onSelectRange={onSelectRange}
+      />
+    );
+    await shiftPressDay(25);
+
+    // The caller has replaced what the click anchored on, so that day is spent.
+    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 20), dayOf(month, 25));
+  });
+
+  test('Shift-clicking carries a range into the next month', async () => {
+    const onSelectRange = vi.fn();
+    const month = getStartMonth();
+    const nextMonth = new Date(month.getFullYear(), month.getMonth() + 1, 1);
+    render(<HeldRangeCalendar onSelectRange={onSelectRange} />);
+
+    await pressDay(20);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Next month' }));
+    });
+    await shiftPressDay(3);
+
+    // Paging needs the pointer let go of, so a drag cannot cross a month. Shift
+    // is the only way to ask for a range that spans two of them.
+    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 20), dayOf(nextMonth, 3));
+  });
+
+  test('A drag the browser takes over leaves the day to measure from where it was', async () => {
+    const onSelectRange = vi.fn();
+    const month = getStartMonth();
+    render(<HeldRangeCalendar month={month} onSelectRange={onSelectRange} />);
+
+    await pressDay(10);
+    await drag(20, 22);
+    await act(async () => {
+      fireEvent.pointerCancel(window);
+    });
+    await shiftPressDay(15);
+
+    // A drag that asked for nothing anchored on nothing either.
+    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 10), dayOf(month, 15));
   });
 
   test('A drag begun by a finger takes the pointer back off the day it landed on', async () => {
@@ -726,4 +869,63 @@ async function pressDay(date: number): Promise<void> {
   await drag(date);
   await release();
   await click(date);
+}
+
+/**
+ * Shift-clicks a day the way a mouse does: press, release, then the click.
+ *
+ * The press is what a shift-click has to survive, since it is the same press
+ * that begins a drag.
+ *
+ * @param date - The day to shift-click.
+ */
+async function shiftPressDay(date: number): Promise<void> {
+  await act(async () => {
+    fireEvent.pointerDown(screen.getByRole('button', { name: String(date) }), { shiftKey: true });
+  });
+  await release();
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: String(date) }), { shiftKey: true });
+  });
+}
+
+interface HeldRangeCalendarProps {
+  readonly month?: Date;
+  readonly onClick?: (date: Date) => void;
+  readonly onSelectRange?: (start: Date, end: Date) => void;
+}
+
+/**
+ * A calendar whose caller keeps what it asks for, as a working one does.
+ *
+ * The day a shift-click measures from is only trusted while it is still on show,
+ * so what was asked for has to be handed back in for the next shift-click to
+ * build on it.
+ *
+ * @param props - The month to show, and spies on what is asked for.
+ * @returns The calendar, holding the day or the range it has been asked for.
+ */
+function HeldRangeCalendar(props: HeldRangeCalendarProps): JSX.Element {
+  const [selected, setSelected] = useState<Date>();
+  const [range, setRange] = useState<{ start: Date; end: Date }>();
+  return (
+    <CalendarDateInput
+      availableDates={[]}
+      month={props.month}
+      selected={selected}
+      range={range}
+      allowUnavailableDates
+      onChangeMonth={vi.fn()}
+      onClick={(date) => {
+        setRange(undefined);
+        setSelected(date);
+        props.onClick?.(date);
+      }}
+      onSelectRange={(start, end) => {
+        setSelected(undefined);
+        setRange({ start, end });
+        props.onSelectRange?.(start, end);
+      }}
+    />
+  );
 }

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
@@ -439,8 +439,7 @@ describe('CalendarDateInput', () => {
     );
 
     // Dragging needs a pointer that hovers, so shift is what leaves a range within
-    // reach of a touchscreen or a keyboard. With no gesture of its own to go on,
-    // the range is measured from the day the calendar was handed.
+    // reach of a touchscreen or a keyboard.
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: '12' }), { shiftKey: true });
     });
@@ -449,7 +448,7 @@ describe('CalendarDateInput', () => {
     expect(onClick).not.toHaveBeenCalled();
   });
 
-  test('A range handed in with no gesture is measured from its start', async () => {
+  test('Shift-clicking before a range widens it back to that day', async () => {
     const onSelectRange = vi.fn();
     const month = getStartMonth();
     render(
@@ -468,10 +467,253 @@ describe('CalendarDateInput', () => {
       fireEvent.click(screen.getByRole('button', { name: '8' }), { shiftKey: true });
     });
 
-    // Nothing here says which end the user anchored on, so the start is the only
-    // end there is to measure from. A range the calendar produced itself is
-    // measured from the day that gesture anchored on instead.
-    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 8), dayOf(month, 10));
+    // The start is the nearer end, so it is the one that moves; the end stays
+    // where it is rather than being thrown away.
+    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 8), dayOf(month, 12));
+  });
+
+  // July 2026, so that the day dead centre of the range is never the day a
+  // daylight-saving change makes 23 or 25 hours long.
+  test.each([
+    ['the 25th carries the end on', 25, 10, 25],
+    ['the 5th carries the start back', 5, 5, 20],
+    ['the 12th draws the start in', 12, 12, 20],
+    ['the 18th draws the end in', 18, 10, 18],
+    ['the 15th, dead centre, holds the start', 15, 10, 15],
+  ])('Shift-clicking %s', async (_why, clicked, start, end) => {
+    const onSelectRange = vi.fn();
+    const month = new Date(2026, 6, 1);
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        range={{ start: dayOf(month, 10), end: dayOf(month, 20) }}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await click(clicked, { shiftKey: true });
+
+    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, start), dayOf(month, end));
+  });
+
+  test('Shift-clicking an end of the range asks for nothing', async () => {
+    const onSelectRange = vi.fn();
+    const onClick = vi.fn();
+    const month = getStartMonth();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        range={{ start: dayOf(month, 10), end: dayOf(month, 20) }}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={onClick}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await click(10, { shiftKey: true });
+    await click(20, { shiftKey: true });
+
+    // That end is already where it would be moved to. Picking the day instead
+    // would throw the rest of the range away.
+    expect(onSelectRange).not.toHaveBeenCalled();
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('A range whose ends carry a time of day is measured and asked for by day', async () => {
+    const onSelectRange = vi.fn();
+    const month = getStartMonth();
+    const start = dayOf(month, 10);
+    const end = dayOf(month, 12);
+    end.setHours(23, 0);
+
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        range={{ start, end }}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await click(11, { shiftKey: true });
+
+    // Measured by the days the ends fall on, so the late hour on the 12th does
+    // not make the 11th look nearer to it than to the 10th.
+    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 10), dayOf(month, 11));
+  });
+
+  test('A day chosen at a time of day is asked for as the day it falls on', async () => {
+    const onSelectRange = vi.fn();
+    const month = getStartMonth();
+    const selected = dayOf(month, 10);
+    selected.setHours(14, 0);
+
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        selected={selected}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await click(12, { shiftKey: true });
+
+    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 10), dayOf(month, 12));
+  });
+
+  test('A range of one day behaves like a day picked', async () => {
+    const onSelectRange = vi.fn();
+    const onClick = vi.fn();
+    const month = getStartMonth();
+    const { rerender } = render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        range={{ start: dayOf(month, 10), end: dayOf(month, 10) }}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={onClick}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await click(14, { shiftKey: true });
+
+    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 10), dayOf(month, 14));
+
+    rerender(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        range={{ start: dayOf(month, 10), end: dayOf(month, 10) }}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={onClick}
+        onSelectRange={onSelectRange}
+      />
+    );
+    await click(10, { shiftKey: true });
+
+    // A range with nowhere to stretch to is just that day being picked again.
+    expect(onSelectRange).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledWith(dayOf(month, 10));
+  });
+
+  test('The way a range was dragged out makes no difference to a shift-click', async () => {
+    const onSelectRange = vi.fn();
+    const month = getStartMonth();
+    render(<HeldRangeCalendar month={month} onSelectRange={onSelectRange} />);
+
+    await drag(20, 15, 10);
+    await release();
+    await shiftPressDay(25);
+
+    // Dragged backwards, but the 20th is still the end nearer the 25th, so it is
+    // the end that moves.
+    expect(onSelectRange).toHaveBeenLastCalledWith(dayOf(month, 10), dayOf(month, 25));
+  });
+
+  test('Shift-clicking either side widens a range rather than replacing it', async () => {
+    const onSelectRange = vi.fn();
+    const month = getStartMonth();
+    render(<HeldRangeCalendar month={month} onSelectRange={onSelectRange} />);
+
+    await pressDay(10);
+    await shiftPressDay(20);
+
+    expect(onSelectRange).toHaveBeenLastCalledWith(dayOf(month, 10), dayOf(month, 20));
+
+    await shiftPressDay(5);
+
+    // The end is left alone rather than the range starting over from the 10th.
+    expect(onSelectRange).toHaveBeenLastCalledWith(dayOf(month, 5), dayOf(month, 20));
+
+    await shiftPressDay(25);
+
+    expect(onSelectRange).toHaveBeenLastCalledWith(dayOf(month, 5), dayOf(month, 25));
+  });
+
+  test('An end earlier than the earliest day is held rather than clamped', async () => {
+    const onSelectRange = vi.fn();
+    const month = getStartMonth();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        range={{ start: dayOf(month, 5), end: dayOf(month, 20) }}
+        earliestDate={dayOf(month, 10)}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await click(25, { shiftKey: true });
+
+    // The floor governs which days can be clicked, not what a caller may already
+    // be holding. Rewriting its start would lose data it did not ask us to touch.
+    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 5), dayOf(month, 25));
+  });
+
+  test('Shift-clicking in a later month draws in a range that began in an earlier one', async () => {
+    const onSelectRange = vi.fn();
+    const month = getStartMonth();
+    const nextMonth = new Date(month.getFullYear(), month.getMonth() + 1, 1);
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        range={{ start: dayOf(month, 20), end: dayOf(nextMonth, 5) }}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+        onSelectRange={onSelectRange}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Next month' }));
+    });
+    await click(3, { shiftKey: true });
+
+    // Nearness is measured on the range, not on the month in view, so the end two
+    // days away moves rather than the start that is off screen.
+    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 20), dayOf(nextMonth, 3));
+  });
+
+  test('A range on show survives a day being pressed', async () => {
+    const month = getStartMonth();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        range={{ start: dayOf(month, 10), end: dayOf(month, 20) }}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+        onSelectRange={vi.fn()}
+      />
+    );
+
+    await drag(15);
+
+    // A press that has not yet crossed a day would otherwise blink the band down
+    // to the day under the pointer on the way to every click.
+    expect(cellOf('12').className).toContain('inRange');
+    expect(cellOf('18').className).toContain('inRange');
   });
 
   test('Shift-clicking with no day picked yet is just a click', async () => {
@@ -498,112 +740,6 @@ describe('CalendarDateInput', () => {
     expect(onClick).toHaveBeenCalledWith(dayOf(month, 12));
   });
 
-  test('Shift-clicking again measures from the same day, so a range can be taken back', async () => {
-    const onSelectRange = vi.fn();
-    const month = getStartMonth();
-    render(<HeldRangeCalendar month={month} onSelectRange={onSelectRange} />);
-
-    await pressDay(10);
-    await shiftPressDay(20);
-
-    expect(onSelectRange).toHaveBeenLastCalledWith(dayOf(month, 10), dayOf(month, 20));
-
-    await shiftPressDay(5);
-
-    // The far end moves; the day picked stays put.
-    expect(onSelectRange).toHaveBeenLastCalledWith(dayOf(month, 5), dayOf(month, 10));
-
-    await shiftPressDay(20);
-
-    // So shift-clicking back where it started puts the range back.
-    expect(onSelectRange).toHaveBeenLastCalledWith(dayOf(month, 10), dayOf(month, 20));
-  });
-
-  test('A shift-click after a backwards drag measures from where the drag began', async () => {
-    const onSelectRange = vi.fn();
-    const month = getStartMonth();
-    render(<HeldRangeCalendar month={month} onSelectRange={onSelectRange} />);
-
-    await drag(20, 15, 10);
-    await release();
-
-    expect(onSelectRange).toHaveBeenLastCalledWith(dayOf(month, 10), dayOf(month, 20));
-
-    await shiftPressDay(25);
-
-    // Not from the 10th: the range grew out of the 20th, so that is the end it
-    // is still measured from.
-    expect(onSelectRange).toHaveBeenLastCalledWith(dayOf(month, 20), dayOf(month, 25));
-  });
-
-  test('A day picked with the keyboard is the day a shift-click measures from', async () => {
-    const onSelectRange = vi.fn();
-    const month = getStartMonth();
-    render(<HeldRangeCalendar month={month} onSelectRange={onSelectRange} />);
-
-    // No press at all, which is the route a keyboard takes.
-    await click(10);
-    await shiftPressDay(12);
-
-    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 10), dayOf(month, 12));
-  });
-
-  test('A day the caller did not keep is not measured from', async () => {
-    const onSelectRange = vi.fn();
-    const onClick = vi.fn();
-    const month = getStartMonth();
-    render(
-      <CalendarDateInput
-        availableDates={[]}
-        month={month}
-        allowUnavailableDates
-        onChangeMonth={vi.fn()}
-        onClick={onClick}
-        onSelectRange={onSelectRange}
-      />
-    );
-
-    await pressDay(10);
-    await shiftPressDay(12);
-
-    // Nothing is on show to have anchored on, so there is no range to ask for.
-    expect(onSelectRange).not.toHaveBeenCalled();
-    expect(onClick).toHaveBeenLastCalledWith(dayOf(month, 12));
-  });
-
-  test('A range the caller replaces is measured from its own start', async () => {
-    const onSelectRange = vi.fn();
-    const month = getStartMonth();
-    const { rerender } = render(
-      <CalendarDateInput
-        availableDates={[]}
-        month={month}
-        allowUnavailableDates
-        onChangeMonth={vi.fn()}
-        onClick={vi.fn()}
-        onSelectRange={onSelectRange}
-      />
-    );
-
-    await pressDay(10);
-
-    rerender(
-      <CalendarDateInput
-        availableDates={[]}
-        month={month}
-        range={{ start: dayOf(month, 20), end: dayOf(month, 22) }}
-        allowUnavailableDates
-        onChangeMonth={vi.fn()}
-        onClick={vi.fn()}
-        onSelectRange={onSelectRange}
-      />
-    );
-    await shiftPressDay(25);
-
-    // The caller has replaced what the click anchored on, so that day is spent.
-    expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 20), dayOf(month, 25));
-  });
-
   test('Shift-clicking carries a range into the next month', async () => {
     const onSelectRange = vi.fn();
     const month = getStartMonth();
@@ -621,7 +757,7 @@ describe('CalendarDateInput', () => {
     expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 20), dayOf(nextMonth, 3));
   });
 
-  test('A drag the browser takes over leaves the day to measure from where it was', async () => {
+  test('A drag the browser takes over leaves what is on show alone', async () => {
     const onSelectRange = vi.fn();
     const month = getStartMonth();
     render(<HeldRangeCalendar month={month} onSelectRange={onSelectRange} />);
@@ -633,7 +769,7 @@ describe('CalendarDateInput', () => {
     });
     await shiftPressDay(15);
 
-    // A drag that asked for nothing anchored on nothing either.
+    // A cancelled drag leaves the day already picked untouched.
     expect(onSelectRange).toHaveBeenCalledWith(dayOf(month, 10), dayOf(month, 15));
   });
 
@@ -850,10 +986,11 @@ async function release(): Promise<void> {
 /**
  * Clicks a day of the shown month.
  * @param date - The day to click.
+ * @param init - Anything the click carries, such as a held shift key.
  */
-async function click(date: number): Promise<void> {
+async function click(date: number, init?: MouseEventInit): Promise<void> {
   await act(async () => {
-    fireEvent.click(screen.getByRole('button', { name: String(date) }));
+    fireEvent.click(screen.getByRole('button', { name: String(date) }), init);
   });
 }
 
@@ -898,9 +1035,8 @@ interface HeldRangeCalendarProps {
 /**
  * A calendar whose caller keeps what it asks for, as a working one does.
  *
- * The day a shift-click measures from is only trusted while it is still on show,
- * so what was asked for has to be handed back in for the next shift-click to
- * build on it.
+ * A shift-click moves an end of the range on show, so what was asked for has to
+ * be handed back in for the next one to have anything to work from.
  *
  * @param props - The month to show, and spies on what is asked for.
  * @returns The calendar, holding the day or the range it has been asked for.

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
@@ -11,6 +11,7 @@ import {
   isBeforeDay,
   isSameDay,
   sortEnds,
+  startOfDay,
   startOfMonth,
 } from './CalendarDateInput.utils';
 import { useDayRangeDrag } from './useDayRangeDrag';
@@ -57,7 +58,9 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
     return (!day.available && !allowUnavailableDates) || (!!earliestDate && isBeforeDay(day.date, earliestDate));
   }
 
-  const range = drag.range ?? props.range;
+  // The grid holds local midnights, so a range whose ends carry a time of day
+  // would otherwise open a band its own start day sat outside of.
+  const range = toDays(drag.range ?? props.range);
   const selected = range ? undefined : props.selected;
 
   const grid = useMemo(() => buildGrid(month, props.availableDates), [month, props.availableDates]);
@@ -80,7 +83,7 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
           </Button>
         </Group>
       </Group>
-      <table className={classes.table}>
+      <table className={cx(classes.table, onSelectRange && classes.selectsRanges)}>
         <thead>
           <tr>
             <th>SUN</th>
@@ -121,7 +124,15 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
                       )}
                       aria-pressed={selected || range ? isChosen(day.date, range, selected) : undefined}
                       disabled={isDayDisabled(day)}
-                      onPointerDown={() => drag.begin(day.date)}
+                      onPointerDown={(event) => {
+                        // A touchscreen captures the pointer to the day the
+                        // finger landed on, leaving the days it crosses from
+                        // there never hearing about the drag.
+                        if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+                          event.currentTarget.releasePointerCapture(event.pointerId);
+                        }
+                        drag.begin(day.date);
+                      }}
                       onPointerOver={() => drag.extend(day.date)}
                       onClick={(event) => {
                         // A drag that crossed days has already asked for them, and
@@ -152,6 +163,15 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
 }
 
 type DayRange = CalendarDateInputProps['range'];
+
+/**
+ * Pulls the ends of a range back to the days they fall on.
+ * @param range - The stretch of days asked for, if there is one.
+ * @returns The same range at day granularity.
+ */
+function toDays(range: DayRange): DayRange {
+  return range && { start: startOfDay(range.start), end: startOfDay(range.end) };
+}
 
 /**
  * Returns whether a day is one of the two a range is anchored on.

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
@@ -19,8 +19,10 @@ import { useDayRangeDrag } from './useDayRangeDrag';
 export interface CalendarDateInputProps {
   readonly availableDates: Date[];
   readonly onChangeMonth: (date: Date) => void;
+  /** Called with the day picked, which is then the day a shift-click measures its range from. */
   readonly onClick: (date: Date) => void;
   readonly month?: Date;
+  /** The day chosen. Ignored while a range is given. */
   readonly selected?: Date;
   readonly allowUnavailableDates?: boolean;
   readonly earliestDate?: Date;
@@ -132,12 +134,15 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
                         if (drag.consumeClick()) {
                           return;
                         }
-                        const anchor = props.selected ?? props.range?.start;
-                        if (event.shiftKey && anchor && onSelectRange && !isSameDay(anchor, day.date)) {
-                          const ends = sortEnds(anchor, day.date);
-                          onSelectRange(ends.start, ends.end);
-                          return;
+                        if (event.shiftKey && onSelectRange) {
+                          const anchor = resolveAnchor(drag.anchor(), range, selected);
+                          if (anchor && !isSameDay(anchor, day.date)) {
+                            const ends = sortEnds(anchor, day.date);
+                            onSelectRange(ends.start, ends.end);
+                            return;
+                          }
                         }
+                        drag.anchorOn(day.date);
                         onClick(day.date);
                       }}
                     >
@@ -185,6 +190,30 @@ function isRangeEnd(date: Date, range: DayRange, selected: Date | undefined): bo
  */
 function isChosen(date: Date, range: DayRange, selected: Date | undefined): boolean {
   return isRangeEnd(date, range, selected) || (!!range && date > range.start && date < range.end);
+}
+
+/**
+ * Picks the day a shift-click measures its range from.
+ *
+ * The day a gesture anchored on only holds while it is still an end of what is on show: a caller
+ * that has set a range or a day of its own has replaced it. Failing that a range is widened from
+ * its start, the only end there is to measure from.
+ * @param anchored - The day the last gesture anchored on, if there was one.
+ * @param range - The stretch of days on show, if there is one.
+ * @param selected - The single day on show, if there is one.
+ * @returns The day to measure from, or undefined when nothing is on show.
+ */
+function resolveAnchor(anchored: Date | undefined, range: DayRange, selected: Date | undefined): Date | undefined {
+  const ends: Date[] = [];
+  if (range) {
+    ends.push(startOfDay(range.start), startOfDay(range.end));
+  } else if (selected) {
+    ends.push(startOfDay(selected));
+  }
+  if (anchored && ends.some((end) => isSameDay(anchored, end))) {
+    return anchored;
+  }
+  return ends[0];
 }
 
 function buildGrid(startDate: Date, availableDates: Date[]): OptionalCalendarCell[][] {

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
@@ -57,10 +57,7 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
     return (!day.available && !allowUnavailableDates) || (!!earliestDate && isBeforeDay(day.date, earliestDate));
   }
 
-  // A drag in progress is drawn as the range it would ask for, so that what is
-  // being dragged out looks like what releasing will leave behind.
   const range = drag.range ?? props.range;
-  // Both ends of a range are chosen days; a single day stands alone.
   const selected = range ? undefined : props.selected;
 
   const grid = useMemo(() => buildGrid(month, props.availableDates), [month, props.availableDates]);
@@ -125,8 +122,6 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
                       aria-pressed={selected || range ? isChosen(day.date, range, selected) : undefined}
                       disabled={isDayDisabled(day)}
                       onPointerDown={() => drag.begin(day.date)}
-                      // Over rather than enter, which React only reports by way of
-                      // this same event anyway.
                       onPointerOver={() => drag.extend(day.date)}
                       onClick={(event) => {
                         // A drag that crossed days has already asked for them, and
@@ -160,10 +155,6 @@ type DayRange = CalendarDateInputProps['range'];
 
 /**
  * Returns whether a day is one of the two a range is anchored on.
- *
- * The ends are drawn as chosen days and the days between them as a band, so
- * this is what tells one from the other.
- *
  * @param date - Local midnight of the day in question.
  * @param range - The stretch of days asked for, if there is one.
  * @param selected - The single day chosen, if there is one.
@@ -175,11 +166,6 @@ function isRangeEnd(date: Date, range: DayRange, selected: Date | undefined): bo
 
 /**
  * Returns whether a day is part of what has been chosen.
- *
- * Every day of a range counts, not just its ends: three days asked for are three
- * days chosen, and a reader told that the middle one is not selected would be
- * told something untrue.
- *
  * @param date - Local midnight of the day in question.
  * @param range - The stretch of days asked for, if there is one.
  * @param selected - The single day chosen, if there is one.

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
@@ -3,7 +3,7 @@
 import { Button, Group } from '@mantine/core';
 import cx from 'clsx';
 import type { JSX } from 'react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import classes from './CalendarDateInput.module.css';
 import { getMonthString, getStartMonth, isBeforeDay, isSameDay, startOfMonth } from './CalendarDateInput.utils';
 
@@ -15,6 +15,8 @@ export interface CalendarDateInputProps {
   readonly selected?: Date;
   readonly allowUnavailableDates?: boolean;
   readonly earliestDate?: Date;
+  readonly range?: { readonly start: Date; readonly end: Date };
+  readonly onSelectRange?: (start: Date, end: Date) => void;
 }
 
 interface CalendarCell {
@@ -25,13 +27,18 @@ interface CalendarCell {
 type OptionalCalendarCell = CalendarCell | undefined;
 
 export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
-  const { onChangeMonth, onClick, selected, allowUnavailableDates, earliestDate } = props;
+  const { onChangeMonth, onClick, onSelectRange, allowUnavailableDates, earliestDate } = props;
   const [uncontrolledMonth, setUncontrolledMonth] = useState<Date>(getStartMonth);
   const shownMonth = props.month ?? uncontrolledMonth;
   const year = shownMonth.getFullYear();
   const monthIndex = shownMonth.getMonth();
   const month = useMemo(() => new Date(year, monthIndex, 1), [year, monthIndex]);
   const atEarliestMonth = !!earliestDate && month <= startOfMonth(earliestDate);
+
+  const [dragFrom, setDragFrom] = useState<Date>();
+  const [dragTo, setDragTo] = useState<Date>();
+  // Set when a drag has just ended, to swallow the click that follows it.
+  const dragged = useRef(false);
 
   function moveMonth(delta: number): void {
     const newMonth = new Date(month.getFullYear(), month.getMonth() + delta, 1);
@@ -44,6 +51,32 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
   function isDayDisabled(day: CalendarCell): boolean {
     return (!day.available && !allowUnavailableDates) || (!!earliestDate && isBeforeDay(day.date, earliestDate));
   }
+
+  // Released anywhere, because a drag that ends off the calendar is still a drag
+  // the user finished, and one left hanging would follow the pointer around.
+  useEffect(() => {
+    if (!dragFrom) {
+      return undefined;
+    }
+    function finish(): void {
+      if (dragFrom && dragTo && !isSameDay(dragFrom, dragTo)) {
+        dragged.current = true;
+        const { start, end } = sortEnds(dragFrom, dragTo);
+        onSelectRange?.(start, end);
+      }
+      setDragFrom(undefined);
+      setDragTo(undefined);
+    }
+    window.addEventListener('pointerup', finish);
+    return () => window.removeEventListener('pointerup', finish);
+  }, [dragFrom, dragTo, onSelectRange]);
+
+  // A drag in progress is drawn as the range it would ask for, so that what is
+  // being dragged out looks like what releasing will leave behind.
+  const dragging = dragFrom && dragTo ? sortEnds(dragFrom, dragTo) : undefined;
+  const range = dragging ?? props.range;
+  // Both ends of a range are chosen days; a single day stands alone.
+  const selected = range ? undefined : props.selected;
 
   const grid = useMemo(() => buildGrid(month, props.availableDates), [month, props.availableDates]);
 
@@ -81,17 +114,65 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
           {grid.map((week, weekIndex) => (
             <tr key={'week-' + weekIndex}>
               {week.map((day, dayIndex) => (
-                <td key={'day-' + dayIndex}>
+                <td
+                  key={'day-' + dayIndex}
+                  className={cx(
+                    day &&
+                      range &&
+                      day.date >= range.start &&
+                      day.date <= range.end && [
+                        classes.inRange,
+                        // The band is drawn per row, so it is rounded off where the
+                        // range ends and squared where it carries on to the next
+                        // week.
+                        (isSameDay(day.date, range.start) || dayIndex === 0) && classes.rangeOpens,
+                        (isSameDay(day.date, range.end) || dayIndex === week.length - 1) && classes.rangeCloses,
+                      ]
+                  )}
+                >
                   {day && (
                     <Button
                       variant="light"
                       className={cx(
                         day.available && classes.available,
-                        isSameDay(day.date, selected) && classes.selected
+                        isRangeEnd(day.date, range, selected) && classes.selected
                       )}
-                      aria-pressed={selected ? isSameDay(day.date, selected) : undefined}
+                      aria-pressed={selected || range ? isChosen(day.date, range, selected) : undefined}
                       disabled={isDayDisabled(day)}
-                      onClick={() => onClick(day.date)}
+                      onPointerDown={() => {
+                        // A press begins a fresh gesture, so any drag still
+                        // waiting to have its click swallowed is spent. A drag
+                        // across days is released as a click on the row or table
+                        // its ends share, never on a day, so the handler below
+                        // cannot be relied on to clear this.
+                        dragged.current = false;
+                        if (onSelectRange) {
+                          setDragFrom(day.date);
+                          setDragTo(day.date);
+                        }
+                      }}
+                      // Over rather than enter, which React only reports by way of
+                      // this same event anyway.
+                      onPointerOver={() => {
+                        if (dragFrom) {
+                          setDragTo(day.date);
+                        }
+                      }}
+                      onClick={(event) => {
+                        // A drag that crossed days has already asked for them, and
+                        // the browser reports the release as a click as well.
+                        if (dragged.current) {
+                          dragged.current = false;
+                          return;
+                        }
+                        const anchor = props.selected ?? props.range?.start;
+                        if (event.shiftKey && anchor && onSelectRange && !isSameDay(anchor, day.date)) {
+                          const ends = sortEnds(anchor, day.date);
+                          onSelectRange(ends.start, ends.end);
+                          return;
+                        }
+                        onClick(day.date);
+                      }}
                     >
                       {day.date.getDate()}
                     </Button>
@@ -104,6 +185,54 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
       </table>
     </div>
   );
+}
+
+/**
+ * Puts the ends of a drag in order.
+ *
+ * Dragging backwards is as natural as forwards — a scheduler working back from a
+ * deadline starts at the far end — so the ends are sorted rather than the drag
+ * being refused.
+ *
+ * @param from - The day the drag began on.
+ * @param to - The day it has reached.
+ * @returns The earlier day as the start.
+ */
+function sortEnds(from: Date, to: Date): { start: Date; end: Date } {
+  return from <= to ? { start: from, end: to } : { start: to, end: from };
+}
+
+type DayRange = CalendarDateInputProps['range'];
+
+/**
+ * Returns whether a day is one of the two a range is anchored on.
+ *
+ * The ends are drawn as chosen days and the days between them as a band, so
+ * this is what tells one from the other.
+ *
+ * @param date - Local midnight of the day in question.
+ * @param range - The stretch of days asked for, if there is one.
+ * @param selected - The single day chosen, if there is one.
+ * @returns True when the day is an end of the range, or the day chosen.
+ */
+function isRangeEnd(date: Date, range: DayRange, selected: Date | undefined): boolean {
+  return isSameDay(date, selected) || (!!range && (isSameDay(date, range.start) || isSameDay(date, range.end)));
+}
+
+/**
+ * Returns whether a day is part of what has been chosen.
+ *
+ * Every day of a range counts, not just its ends: three days asked for are three
+ * days chosen, and a reader told that the middle one is not selected would be
+ * told something untrue.
+ *
+ * @param date - Local midnight of the day in question.
+ * @param range - The stretch of days asked for, if there is one.
+ * @param selected - The single day chosen, if there is one.
+ * @returns True when the day falls within what is chosen.
+ */
+function isChosen(date: Date, range: DayRange, selected: Date | undefined): boolean {
+  return isRangeEnd(date, range, selected) || (!!range && date > range.start && date < range.end);
 }
 
 function buildGrid(startDate: Date, availableDates: Date[]): OptionalCalendarCell[][] {

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
@@ -58,8 +58,6 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
     return (!day.available && !allowUnavailableDates) || (!!earliestDate && isBeforeDay(day.date, earliestDate));
   }
 
-  // The grid holds local midnights, so a range whose ends carry a time of day
-  // would otherwise open a band its own start day sat outside of.
   const range = toDays(drag.range ?? props.range);
   const selected = range ? undefined : props.selected;
 
@@ -107,9 +105,6 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
                       day.date >= range.start &&
                       day.date <= range.end && [
                         classes.inRange,
-                        // The band is drawn per row, so it is rounded off where the
-                        // range ends and squared where it carries on to the next
-                        // week.
                         (isSameDay(day.date, range.start) || dayIndex === 0) && classes.rangeOpens,
                         (isSameDay(day.date, range.end) || dayIndex === week.length - 1) && classes.rangeCloses,
                       ]
@@ -125,9 +120,6 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
                       aria-pressed={selected || range ? isChosen(day.date, range, selected) : undefined}
                       disabled={isDayDisabled(day)}
                       onPointerDown={(event) => {
-                        // A touchscreen captures the pointer to the day the
-                        // finger landed on, leaving the days it crosses from
-                        // there never hearing about the drag.
                         if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
                           event.currentTarget.releasePointerCapture(event.pointerId);
                         }

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
@@ -3,9 +3,17 @@
 import { Button, Group } from '@mantine/core';
 import cx from 'clsx';
 import type { JSX } from 'react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import classes from './CalendarDateInput.module.css';
-import { getMonthString, getStartMonth, isBeforeDay, isSameDay, startOfMonth } from './CalendarDateInput.utils';
+import {
+  getMonthString,
+  getStartMonth,
+  isBeforeDay,
+  isSameDay,
+  sortEnds,
+  startOfMonth,
+} from './CalendarDateInput.utils';
+import { useDayRangeDrag } from './useDayRangeDrag';
 
 export interface CalendarDateInputProps {
   readonly availableDates: Date[];
@@ -35,10 +43,7 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
   const month = useMemo(() => new Date(year, monthIndex, 1), [year, monthIndex]);
   const atEarliestMonth = !!earliestDate && month <= startOfMonth(earliestDate);
 
-  const [dragFrom, setDragFrom] = useState<Date>();
-  const [dragTo, setDragTo] = useState<Date>();
-  // Set when a drag has just ended, to swallow the click that follows it.
-  const dragged = useRef(false);
+  const drag = useDayRangeDrag(onSelectRange);
 
   function moveMonth(delta: number): void {
     const newMonth = new Date(month.getFullYear(), month.getMonth() + delta, 1);
@@ -52,29 +57,9 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
     return (!day.available && !allowUnavailableDates) || (!!earliestDate && isBeforeDay(day.date, earliestDate));
   }
 
-  // Released anywhere, because a drag that ends off the calendar is still a drag
-  // the user finished, and one left hanging would follow the pointer around.
-  useEffect(() => {
-    if (!dragFrom) {
-      return undefined;
-    }
-    function finish(): void {
-      if (dragFrom && dragTo && !isSameDay(dragFrom, dragTo)) {
-        dragged.current = true;
-        const { start, end } = sortEnds(dragFrom, dragTo);
-        onSelectRange?.(start, end);
-      }
-      setDragFrom(undefined);
-      setDragTo(undefined);
-    }
-    window.addEventListener('pointerup', finish);
-    return () => window.removeEventListener('pointerup', finish);
-  }, [dragFrom, dragTo, onSelectRange]);
-
   // A drag in progress is drawn as the range it would ask for, so that what is
   // being dragged out looks like what releasing will leave behind.
-  const dragging = dragFrom && dragTo ? sortEnds(dragFrom, dragTo) : undefined;
-  const range = dragging ?? props.range;
+  const range = drag.range ?? props.range;
   // Both ends of a range are chosen days; a single day stands alone.
   const selected = range ? undefined : props.selected;
 
@@ -139,30 +124,14 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
                       )}
                       aria-pressed={selected || range ? isChosen(day.date, range, selected) : undefined}
                       disabled={isDayDisabled(day)}
-                      onPointerDown={() => {
-                        // A press begins a fresh gesture, so any drag still
-                        // waiting to have its click swallowed is spent. A drag
-                        // across days is released as a click on the row or table
-                        // its ends share, never on a day, so the handler below
-                        // cannot be relied on to clear this.
-                        dragged.current = false;
-                        if (onSelectRange) {
-                          setDragFrom(day.date);
-                          setDragTo(day.date);
-                        }
-                      }}
+                      onPointerDown={() => drag.begin(day.date)}
                       // Over rather than enter, which React only reports by way of
                       // this same event anyway.
-                      onPointerOver={() => {
-                        if (dragFrom) {
-                          setDragTo(day.date);
-                        }
-                      }}
+                      onPointerOver={() => drag.extend(day.date)}
                       onClick={(event) => {
                         // A drag that crossed days has already asked for them, and
                         // the browser reports the release as a click as well.
-                        if (dragged.current) {
-                          dragged.current = false;
+                        if (drag.consumeClick()) {
                           return;
                         }
                         const anchor = props.selected ?? props.range?.start;
@@ -185,21 +154,6 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
       </table>
     </div>
   );
-}
-
-/**
- * Puts the ends of a drag in order.
- *
- * Dragging backwards is as natural as forwards — a scheduler working back from a
- * deadline starts at the far end — so the ends are sorted rather than the drag
- * being refused.
- *
- * @param from - The day the drag began on.
- * @param to - The day it has reached.
- * @returns The earlier day as the start.
- */
-function sortEnds(from: Date, to: Date): { start: Date; end: Date } {
-  return from <= to ? { start: from, end: to } : { start: to, end: from };
 }
 
 type DayRange = CalendarDateInputProps['range'];

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
@@ -6,6 +6,7 @@ import type { JSX } from 'react';
 import { useMemo, useState } from 'react';
 import classes from './CalendarDateInput.module.css';
 import {
+  dayNumber,
   getMonthString,
   getStartMonth,
   isBeforeDay,
@@ -19,14 +20,26 @@ import { useDayRangeDrag } from './useDayRangeDrag';
 export interface CalendarDateInputProps {
   readonly availableDates: Date[];
   readonly onChangeMonth: (date: Date) => void;
-  /** Called with the day picked, which is then the day a shift-click measures its range from. */
+  /** Called with the day picked. */
   readonly onClick: (date: Date) => void;
   readonly month?: Date;
   /** The day chosen. Ignored while a range is given. */
   readonly selected?: Date;
   readonly allowUnavailableDates?: boolean;
   readonly earliestDate?: Date;
+  /**
+   * The stretch of days on show, banded across the weeks it spans. The ends may carry a time of
+   * day; only the days they fall on are used.
+   */
   readonly range?: { readonly start: Date; readonly end: Date };
+  /**
+   * Called with the stretch of days a drag or a shift-click asked for, earlier end first.
+   *
+   * A shift-click moves the nearer end of the range to the day clicked and leaves the other where
+   * it is, so clicking beyond either end widens the range and clicking within it draws that end in.
+   * A day exactly between the two holds the start. The nearer end is measured on the range itself,
+   * which may begin in a month that has been paged away from.
+   */
   readonly onSelectRange?: (start: Date, end: Date) => void;
 }
 
@@ -60,7 +73,10 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
     return (!day.available && !allowUnavailableDates) || (!!earliestDate && isBeforeDay(day.date, earliestDate));
   }
 
-  const range = toDays(drag.range ?? props.range);
+  // A drag that has not yet crossed a day would otherwise blot out the range on show, so the band
+  // blinks down to the day pressed on the way to every click.
+  const dragging = drag.range && !isSameDay(drag.range.start, drag.range.end) ? drag.range : undefined;
+  const range = toDays(dragging ?? props.range);
   const selected = range ? undefined : props.selected;
 
   const grid = useMemo(() => buildGrid(month, props.availableDates), [month, props.availableDates]);
@@ -135,14 +151,19 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
                           return;
                         }
                         if (event.shiftKey && onSelectRange) {
-                          const anchor = resolveAnchor(drag.anchor(), range, selected);
-                          if (anchor && !isSameDay(anchor, day.date)) {
-                            const ends = sortEnds(anchor, day.date);
-                            onSelectRange(ends.start, ends.end);
+                          const reached = moveNearerEnd(day.date, range, selected);
+                          if (reached && !isSameDay(reached.start, reached.end)) {
+                            // Shift-clicking an end asks for the range already on show.
+                            if (
+                              !range ||
+                              !isSameDay(reached.start, range.start) ||
+                              !isSameDay(reached.end, range.end)
+                            ) {
+                              onSelectRange(reached.start, reached.end);
+                            }
                             return;
                           }
                         }
-                        drag.anchorOn(day.date);
                         onClick(day.date);
                       }}
                     >
@@ -193,27 +214,27 @@ function isChosen(date: Date, range: DayRange, selected: Date | undefined): bool
 }
 
 /**
- * Picks the day a shift-click measures its range from.
- *
- * The day a gesture anchored on only holds while it is still an end of what is on show: a caller
- * that has set a range or a day of its own has replaced it. Failing that a range is widened from
- * its start, the only end there is to measure from.
- * @param anchored - The day the last gesture anchored on, if there was one.
+ * Works out the range a shift-click asks for: the nearer end moves to the day clicked, and the
+ * other end is held where it is.
+ * @param date - Local midnight of the day shift-clicked.
  * @param range - The stretch of days on show, if there is one.
  * @param selected - The single day on show, if there is one.
- * @returns The day to measure from, or undefined when nothing is on show.
+ * @returns The range reached, or undefined when there is no end to hold.
  */
-function resolveAnchor(anchored: Date | undefined, range: DayRange, selected: Date | undefined): Date | undefined {
-  const ends: Date[] = [];
+function moveNearerEnd(date: Date, range: DayRange, selected: Date | undefined): DayRange {
   if (range) {
-    ends.push(startOfDay(range.start), startOfDay(range.end));
-  } else if (selected) {
-    ends.push(startOfDay(selected));
+    const start = startOfDay(range.start);
+    const end = startOfDay(range.end);
+    // Exactly one of these is negative unless the day falls within the range, so the nearer end
+    // comes out without measuring either distance. A day dead centre holds the start, leaving the
+    // end to come back to it.
+    const held = dayNumber(date) - dayNumber(start) < dayNumber(end) - dayNumber(date) ? end : start;
+    return sortEnds(held, date);
   }
-  if (anchored && ends.some((end) => isSameDay(anchored, end))) {
-    return anchored;
+  if (selected) {
+    return sortEnds(startOfDay(selected), date);
   }
-  return ends[0];
+  return undefined;
 }
 
 function buildGrid(startDate: Date, availableDates: Date[]): OptionalCalendarCell[][] {

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.utils.test.ts
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.utils.test.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { dayNumber } from './CalendarDateInput.utils';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+describe('dayNumber', () => {
+  test('Steps by exactly one day per day', () => {
+    // Whatever the machine's timezone, including one whose March has a 23-hour
+    // day. Measuring local midnights instead would be an hour out either side of
+    // a daylight-saving change, which is enough to decide a range's nearer end
+    // the wrong way.
+    const march = new Date(2026, 2, 7);
+    expect(dayNumber(new Date(2026, 2, 8)) - dayNumber(march)).toBe(DAY);
+    expect(dayNumber(new Date(2026, 2, 9)) - dayNumber(march)).toBe(2 * DAY);
+    expect(dayNumber(new Date(2026, 2, 11)) - dayNumber(new Date(2026, 2, 9))).toBe(2 * DAY);
+  });
+
+  test('Ignores the time of day', () => {
+    const morning = new Date(2026, 6, 14, 9, 30);
+    const night = new Date(2026, 6, 14, 23, 45);
+    expect(dayNumber(morning)).toBe(dayNumber(night));
+  });
+});

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.utils.ts
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.utils.ts
@@ -24,13 +24,22 @@ export function startOfMonth(date: Date): Date {
 }
 
 /**
+ * Returns local midnight of the day a date falls on.
+ * @param date - Any instant within the day.
+ * @returns The day it falls on, at midnight.
+ */
+export function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+/**
  * Returns whether a day falls before another, ignoring the time of day.
  * @param day - Local midnight of the day in question.
  * @param limit - The instant the day is measured against.
  * @returns True when the day ends before the limit.
  */
 export function isBeforeDay(day: Date, limit: Date): boolean {
-  return day.getTime() < new Date(limit.getFullYear(), limit.getMonth(), limit.getDate()).getTime();
+  return day.getTime() < startOfDay(limit).getTime();
 }
 
 /**

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.utils.ts
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.utils.ts
@@ -34,6 +34,16 @@ export function isBeforeDay(day: Date, limit: Date): boolean {
 }
 
 /**
+ * Puts the ends of a range in order.
+ * @param from - The day the range began on.
+ * @param to - The day it has reached.
+ * @returns The earlier day as the start.
+ */
+export function sortEnds(from: Date, to: Date): { start: Date; end: Date } {
+  return from <= to ? { start: from, end: to } : { start: to, end: from };
+}
+
+/**
  * Returns whether two dates fall on the same day in the local timezone.
  * @param left - The first date.
  * @param right - The second date, which may be absent.

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.utils.ts
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.utils.ts
@@ -33,6 +33,19 @@ export function startOfDay(date: Date): Date {
 }
 
 /**
+ * Numbers the day a date falls on, so two days can be counted apart.
+ *
+ * Local midnights are 23 or 25 hours apart across a daylight-saving change — enough to make a day
+ * exactly between two others look nearer to one of them — so the day is numbered rather than
+ * measured. Taking the local day as though it were UTC lands on an exact multiple of a day.
+ * @param date - Any instant within the day.
+ * @returns A number that steps by exactly one day per day.
+ */
+export function dayNumber(date: Date): number {
+  return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+/**
  * Returns whether a day falls before another, ignoring the time of day.
  * @param day - Local midnight of the day in question.
  * @param limit - The instant the day is measured against.

--- a/packages/react/src/CalendarDateInput/useDayRangeDrag.ts
+++ b/packages/react/src/CalendarDateInput/useDayRangeDrag.ts
@@ -39,8 +39,18 @@ export function useDayRangeDrag(onSelectRange?: (start: Date, end: Date) => void
       setFrom(undefined);
       setTo(undefined);
     }
+    // A drag the browser takes over, to scroll or to hand to another gesture,
+    // never reaches a day to ask for.
+    function abandon(): void {
+      setFrom(undefined);
+      setTo(undefined);
+    }
     window.addEventListener('pointerup', finish);
-    return () => window.removeEventListener('pointerup', finish);
+    window.addEventListener('pointercancel', abandon);
+    return () => {
+      window.removeEventListener('pointerup', finish);
+      window.removeEventListener('pointercancel', abandon);
+    };
   }, [from, to, onSelectRange]);
 
   return {

--- a/packages/react/src/CalendarDateInput/useDayRangeDrag.ts
+++ b/packages/react/src/CalendarDateInput/useDayRangeDrag.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { useEffect, useRef, useState } from 'react';
+import { isSameDay, sortEnds } from './CalendarDateInput.utils';
+
+export interface DayRangeDrag {
+  /** The range being dragged out, if a drag is under way. */
+  readonly range: { readonly start: Date; readonly end: Date } | undefined;
+  /** Begins a drag on a day. */
+  readonly begin: (date: Date) => void;
+  /** Carries the drag under way, if any, out to a day. */
+  readonly extend: (date: Date) => void;
+  /** Whether the click now arriving is the tail of a drag, and so is spent. */
+  readonly consumeClick: () => boolean;
+}
+
+/**
+ * Tracks a drag across calendar days, asking for the range it covers on release.
+ * @param onSelectRange - Called with the range a finished drag covered. A drag
+ * is only tracked when this is given.
+ * @returns The drag under way and the handlers that drive it.
+ */
+export function useDayRangeDrag(onSelectRange?: (start: Date, end: Date) => void): DayRangeDrag {
+  const [from, setFrom] = useState<Date>();
+  const [to, setTo] = useState<Date>();
+  // Set when a drag has just ended, to swallow the click that follows it.
+  const dragged = useRef(false);
+
+  useEffect(() => {
+    if (!from) {
+      return undefined;
+    }
+    function finish(): void {
+      if (from && to && !isSameDay(from, to)) {
+        dragged.current = true;
+        const { start, end } = sortEnds(from, to);
+        onSelectRange?.(start, end);
+      }
+      setFrom(undefined);
+      setTo(undefined);
+    }
+    window.addEventListener('pointerup', finish);
+    return () => window.removeEventListener('pointerup', finish);
+  }, [from, to, onSelectRange]);
+
+  return {
+    range: from && to ? sortEnds(from, to) : undefined,
+    begin(date: Date): void {
+      dragged.current = false;
+      if (onSelectRange) {
+        setFrom(date);
+        setTo(date);
+      }
+    },
+    extend(date: Date): void {
+      if (from) {
+        setTo(date);
+      }
+    },
+    consumeClick(): boolean {
+      const wasDrag = dragged.current;
+      dragged.current = false;
+      return wasDrag;
+    },
+  };
+}

--- a/packages/react/src/CalendarDateInput/useDayRangeDrag.ts
+++ b/packages/react/src/CalendarDateInput/useDayRangeDrag.ts
@@ -12,10 +12,16 @@ export interface DayRangeDrag {
   readonly extend: (date: Date) => void;
   /** Whether the click now arriving is the tail of a drag, and so is spent. */
   readonly consumeClick: () => boolean;
+  /** The day a shift-click measures its range from, as the last gesture left it. */
+  readonly anchor: () => Date | undefined;
+  /** Anchors on a day, so a shift-click measures its range from there. */
+  readonly anchorOn: (date: Date) => void;
 }
 
 /**
- * Tracks a drag across calendar days, asking for the range it covers on release.
+ * Tracks the gestures that leave a range behind: a drag across calendar days,
+ * which asks for the range it covers on release, and the day a shift-click
+ * measures its range from.
  * @param onSelectRange - Called with the range a finished drag covered. A drag
  * is only tracked when this is given.
  * @returns The drag under way and the handlers that drive it.
@@ -25,6 +31,9 @@ export function useDayRangeDrag(onSelectRange?: (start: Date, end: Date) => void
   const [to, setTo] = useState<Date>();
   // Set when a drag has just ended, to swallow the click that follows it.
   const dragged = useRef(false);
+  // The day a range grows from: a drag anchors on the day it began, a click on
+  // the day it picked, and a shift-click on neither.
+  const anchored = useRef<Date>(undefined);
 
   useEffect(() => {
     if (!from) {
@@ -33,6 +42,7 @@ export function useDayRangeDrag(onSelectRange?: (start: Date, end: Date) => void
     function finish(): void {
       if (from && to && !isSameDay(from, to)) {
         dragged.current = true;
+        anchored.current = from;
         const { start, end } = sortEnds(from, to);
         onSelectRange?.(start, end);
       }
@@ -71,6 +81,12 @@ export function useDayRangeDrag(onSelectRange?: (start: Date, end: Date) => void
       const wasDrag = dragged.current;
       dragged.current = false;
       return wasDrag;
+    },
+    anchor(): Date | undefined {
+      return anchored.current;
+    },
+    anchorOn(date: Date): void {
+      anchored.current = date;
     },
   };
 }

--- a/packages/react/src/CalendarDateInput/useDayRangeDrag.ts
+++ b/packages/react/src/CalendarDateInput/useDayRangeDrag.ts
@@ -12,16 +12,10 @@ export interface DayRangeDrag {
   readonly extend: (date: Date) => void;
   /** Whether the click now arriving is the tail of a drag, and so is spent. */
   readonly consumeClick: () => boolean;
-  /** The day a shift-click measures its range from, as the last gesture left it. */
-  readonly anchor: () => Date | undefined;
-  /** Anchors on a day, so a shift-click measures its range from there. */
-  readonly anchorOn: (date: Date) => void;
 }
 
 /**
- * Tracks the gestures that leave a range behind: a drag across calendar days,
- * which asks for the range it covers on release, and the day a shift-click
- * measures its range from.
+ * Tracks a drag across calendar days, asking for the range it covers on release.
  * @param onSelectRange - Called with the range a finished drag covered. A drag
  * is only tracked when this is given.
  * @returns The drag under way and the handlers that drive it.
@@ -31,9 +25,6 @@ export function useDayRangeDrag(onSelectRange?: (start: Date, end: Date) => void
   const [to, setTo] = useState<Date>();
   // Set when a drag has just ended, to swallow the click that follows it.
   const dragged = useRef(false);
-  // The day a range grows from: a drag anchors on the day it began, a click on
-  // the day it picked, and a shift-click on neither.
-  const anchored = useRef<Date>(undefined);
 
   useEffect(() => {
     if (!from) {
@@ -42,7 +33,6 @@ export function useDayRangeDrag(onSelectRange?: (start: Date, end: Date) => void
     function finish(): void {
       if (from && to && !isSameDay(from, to)) {
         dragged.current = true;
-        anchored.current = from;
         const { start, end } = sortEnds(from, to);
         onSelectRange?.(start, end);
       }
@@ -81,12 +71,6 @@ export function useDayRangeDrag(onSelectRange?: (start: Date, end: Date) => void
       const wasDrag = dragged.current;
       dragged.current = false;
       return wasDrag;
-    },
-    anchor(): Date | undefined {
-      return anchored.current;
-    },
-    anchorOn(date: Date): void {
-      anchored.current = date;
     },
   };
 }

--- a/packages/react/src/CalendarInput/CalendarInput.tsx
+++ b/packages/react/src/CalendarInput/CalendarInput.tsx
@@ -5,12 +5,20 @@ import type { JSX } from 'react';
 import { useMemo } from 'react';
 import { CalendarDateInput } from '../CalendarDateInput/CalendarDateInput';
 
+/** @deprecated Use CalendarDateInputProps instead. */
 export interface CalendarInputProps {
   readonly slots: Slot[];
   readonly onChangeMonth: (date: Date) => void;
   readonly onClick: (date: Date) => void;
 }
 
+/**
+ * A calendar that marks the days with slots as available.
+ * @deprecated Use CalendarDateInput instead, which takes the available dates directly
+ * and supports month navigation, a controlled selection, and date ranges.
+ * @param props - The Input props.
+ * @returns The JSX element to render.
+ */
 export function CalendarInput(props: CalendarInputProps): JSX.Element {
   const { slots, ...rest } = props;
   const availableDates = useMemo(() => slots.map((slot) => new Date(slot.start)), [slots]);


### PR DESCRIPTION
Follow-up to #10125 

## Range support on `<CalendarDateInput />`

This component now accepts user-entered date ranges: 

<img width="408" height="379" alt="image" src="https://github.com/user-attachments/assets/2a42c0e7-f2df-4f2e-ae76-d5014c2cbc57" />

| New Prop | Description | 
| --- | --- | 
| `range` | A stretch of days asked for, drawn as a band with both ends marked as chosen. A caller showing one day at a time wants `selected` instead. |
| `onSelectRange` | Takes the range asked for. Passing the callback is what turns the gesture on; without it a drag is just a click on the day it started from. |

A range is asked for by **dragging across the days**, or by **shift-clicking a second one**. A plain click is always a single day, whatever came before it.

## Deprecate `<CalendarInput />`

This is just a thin wrapper over `CalendarDateInput` that maps `Slot[]` to their start dates. Nothing in the repo uses it anymore (Scheduler moved to CalendarDateInput in #10125), so it's marked `@deprecated` here to point new consumers at the full component. 