### PR TITLE
fix(server): apply a FHIRcast context update only to the version it was built on

### DIFF
--- a/packages/server/src/fhircast/routes.test.ts
+++ b/packages/server/src/fhircast/routes.test.ts
@@ -28,7 +28,13 @@ import { getCacheRedis } from '../redis';
 import { createTestProject, withTestContext } from '../test.setup';
 import type { EventCategory } from './routes';
 import { getEventCategory } from './routes';
-import { extractEndpoint, getEndpointSubscription, setTopicCurrentContext } from './utils';
+import {
+  extractEndpoint,
+  getCurrentContext,
+  getEndpointSubscription,
+  getTopicCurrentContextKey,
+  setTopicCurrentContext,
+} from './utils';
 
 const STU2_BASE_ROUTE = '/fhircast/STU2';
 const STU3_BASE_ROUTE = '/fhircast/STU3';
@@ -1176,6 +1182,74 @@ describe('FHIRcast routes', () => {
     expect(
       (publishRes.body.event.event as FhircastEventPayload<'DiagnosticReport-update'>)['context.priorVersionId']
     ).toStrictEqual(versionId);
+  });
+
+  test('`DiagnosticReport-update` is rejected when another update lands while it is applied', async () => {
+    const topic = randomUUID();
+    const versionId = generateId();
+    const reportId = generateId();
+    const openContext = (contextVersionId: string): CurrentContext<'DiagnosticReport'> => ({
+      'context.type': 'DiagnosticReport',
+      'context.versionId': contextVersionId,
+      context: [
+        {
+          key: 'report',
+          resource: {
+            id: reportId,
+            resourceType: 'DiagnosticReport',
+            status: 'preliminary',
+            code: { text: 'Radiology Imaging study' },
+          },
+        },
+        { key: 'content', resource: { id: generateId(), resourceType: 'Bundle', type: 'collection' } },
+      ],
+    });
+
+    await setTopicCurrentContext(project.id, topic, openContext(versionId));
+
+    // Stand in for a second update that commits between this one's read and its write. Both are
+    // validated against `versionId`, so only a conditional write can tell them apart.
+    const winningVersionId = generateId();
+    const redis = getCacheRedis();
+    const contextKey = getTopicCurrentContextKey(project.id, topic);
+    const originalGet = redis.get.bind(redis);
+    const getSpy = vi.spyOn(redis, 'get').mockImplementation((async (key: string): Promise<string | null> => {
+      const value = await originalGet(key);
+      if (key === contextKey) {
+        await setTopicCurrentContext(project.id, topic, openContext(winningVersionId));
+      }
+      return value;
+    }) as typeof redis.get);
+
+    try {
+      const payload = createFhircastMessagePayload(
+        topic,
+        'DiagnosticReport-update',
+        [
+          { key: 'report', reference: { reference: `DiagnosticReport/${reportId}` } },
+          { key: 'updates', resource: { id: generateId(), resourceType: 'Bundle', type: 'transaction' } },
+        ] satisfies FhircastEventContext<'DiagnosticReport-update'>[],
+        versionId
+      );
+
+      const res = await request(server)
+        .post(STU3_BASE_ROUTE)
+        .set('Content-Type', ContentType.JSON)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .send(payload);
+      expect(res).toHaveStatus(409);
+      expect(res.body).toMatchObject({
+        resourceType: 'OperationOutcome',
+        issue: [{ severity: 'error', code: 'conflict' }],
+      });
+    } finally {
+      getSpy.mockRestore();
+    }
+
+    // The update that lost the race left the one that won it untouched
+    await expect(getCurrentContext(project.id, topic)).resolves.toMatchObject({
+      'context.versionId': winningVersionId,
+    });
   });
 
   test('`DiagnosticReport-update` returns 400 when current context is not a DiagnosticReport', async () => {

--- a/packages/server/src/fhircast/routes.ts
+++ b/packages/server/src/fhircast/routes.ts
@@ -11,6 +11,7 @@ import type {
 import {
   append,
   badRequest,
+  conflict,
   EMPTY,
   generateId,
   getWebSocketUrl,
@@ -34,6 +35,7 @@ import { publish } from '../pubsub';
 import { getCacheRedis } from '../redis';
 import {
   cleanupContextForResource,
+  compareAndSetTopicCurrentContext,
   deleteEndpointSubscription,
   extractAnchorResourceType,
   extractEndpoint,
@@ -444,7 +446,19 @@ async function handleUpdateContextChangeRequest(req: Request, res: Response): Pr
   event['context.priorVersionId'] = priorVersionId;
   currentContext['context.versionId'] = event['context.versionId'] = generateId();
   // See: https://build.fhir.org/ig/HL7/fhircast-docs/2-10-ContentSharing.html
-  await setTopicCurrentContext(projectId, event['hub.topic'], currentContext);
+  // The version was checked above, but only a conditional write keeps it true: another update to
+  // this topic may have landed while this one was being applied, and it would be the version this
+  // event names as its prior.
+  const applied = await compareAndSetTopicCurrentContext(projectId, event['hub.topic'], priorVersionId, currentContext);
+  if (!applied) {
+    sendOutcome(
+      res,
+      conflict(
+        `Context for this topic changed while the update was being applied, it is no longer at version '${priorVersionId}'`
+      )
+    );
+    return;
+  }
   await finalizeContextChangeRequest(res, projectId, req.body);
 }
 

--- a/packages/server/src/fhircast/utils.test.ts
+++ b/packages/server/src/fhircast/utils.test.ts
@@ -247,5 +247,44 @@ describe('FHIRcast Utils', () => {
       await expect(compareAndSetTopicCurrentContext(projectId, topic, generateId(), context)).resolves.toBe(false);
       await expect(getCurrentContext(projectId, topic)).resolves.toBeUndefined();
     });
+
+    test('Replaces the context when the script is no longer cached by Redis', async () => {
+      const projectId = generateId();
+      const topic = generateId();
+      const versionId = generateId();
+      await setTopicCurrentContext(projectId, topic, contextAtVersion(versionId));
+      await getCacheRedis().script('FLUSH');
+
+      const next = contextAtVersion(generateId());
+      await expect(compareAndSetTopicCurrentContext(projectId, topic, versionId, next)).resolves.toBe(true);
+      await expect(getCurrentContext(projectId, topic)).resolves.toStrictEqual(next);
+    });
+
+    test('Sends only the script digest once Redis has the script cached', async () => {
+      const projectId = generateId();
+      const topic = generateId();
+      const versionId = generateId();
+      await setTopicCurrentContext(projectId, topic, contextAtVersion(versionId));
+
+      // Caches the script, so the call being measured has no reason to send the body again.
+      const nextVersionId = generateId();
+      await expect(
+        compareAndSetTopicCurrentContext(projectId, topic, versionId, contextAtVersion(nextVersionId))
+      ).resolves.toBe(true);
+
+      const redis = getCacheRedis();
+      const evalshaSpy = vi.spyOn(redis, 'evalsha');
+      const evalSpy = vi.spyOn(redis, 'eval');
+      try {
+        const next = contextAtVersion(generateId());
+        await expect(compareAndSetTopicCurrentContext(projectId, topic, nextVersionId, next)).resolves.toBe(true);
+        expect(evalshaSpy).toHaveBeenCalledTimes(1);
+        expect(evalSpy).not.toHaveBeenCalled();
+        await expect(getCurrentContext(projectId, topic)).resolves.toStrictEqual(next);
+      } finally {
+        evalshaSpy.mockRestore();
+        evalSpy.mockRestore();
+      }
+    });
   });
 });

--- a/packages/server/src/fhircast/utils.test.ts
+++ b/packages/server/src/fhircast/utils.test.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { CurrentContext } from '@medplum/core';
 import { generateId, OperationOutcomeError } from '@medplum/core';
 import type { OperationOutcome } from '@medplum/fhirtypes';
 import { vi } from 'vitest';
@@ -7,14 +8,17 @@ import { loadTestConfig } from '../config/loader';
 import { closeRedis, getCacheRedis, initRedis } from '../redis';
 import type { FhircastSubscription } from './utils';
 import {
+  compareAndSetTopicCurrentContext,
   deleteEndpointSubscription,
   extractEndpoint,
   FHIRCAST_LEASE_SECONDS,
+  getCurrentContext,
   getEndpointSubscription,
   getEndpointSubscriptionKey,
   getTopicForUser,
   parseFhircastEvents,
   setEndpointSubscription,
+  setTopicCurrentContext,
 } from './utils';
 
 describe('FHIRcast Utils', () => {
@@ -192,6 +196,56 @@ describe('FHIRcast Utils', () => {
       const endpoint = generateId();
       await getCacheRedis().set(getEndpointSubscriptionKey(endpoint), cached);
       await expect(getEndpointSubscription(endpoint)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('compareAndSetTopicCurrentContext', () => {
+    const contextAtVersion = (versionId: string): CurrentContext<'DiagnosticReport'> => ({
+      'context.type': 'DiagnosticReport',
+      'context.versionId': versionId,
+      context: [
+        {
+          key: 'report',
+          resource: {
+            id: generateId(),
+            resourceType: 'DiagnosticReport',
+            status: 'preliminary',
+            code: { text: 'Radiology Imaging study' },
+          },
+        },
+        { key: 'content', resource: { id: generateId(), resourceType: 'Bundle', type: 'collection' } },
+      ],
+    });
+
+    test('Replaces the context when it is still at the expected version', async () => {
+      const projectId = generateId();
+      const topic = generateId();
+      const versionId = generateId();
+      await setTopicCurrentContext(projectId, topic, contextAtVersion(versionId));
+
+      const next = contextAtVersion(generateId());
+      await expect(compareAndSetTopicCurrentContext(projectId, topic, versionId, next)).resolves.toBe(true);
+      await expect(getCurrentContext(projectId, topic)).resolves.toStrictEqual(next);
+    });
+
+    test('Leaves a context that has already moved on', async () => {
+      const projectId = generateId();
+      const topic = generateId();
+      const winner = contextAtVersion(generateId());
+      await setTopicCurrentContext(projectId, topic, winner);
+
+      const loser = contextAtVersion(generateId());
+      await expect(compareAndSetTopicCurrentContext(projectId, topic, generateId(), loser)).resolves.toBe(false);
+      await expect(getCurrentContext(projectId, topic)).resolves.toStrictEqual(winner);
+    });
+
+    test('Establishes no context for a topic that has none', async () => {
+      const projectId = generateId();
+      const topic = generateId();
+
+      const context = contextAtVersion(generateId());
+      await expect(compareAndSetTopicCurrentContext(projectId, topic, generateId(), context)).resolves.toBe(false);
+      await expect(getCurrentContext(projectId, topic)).resolves.toBeUndefined();
     });
   });
 });

--- a/packages/server/src/fhircast/utils.ts
+++ b/packages/server/src/fhircast/utils.ts
@@ -177,8 +177,66 @@ export async function getCurrentContext<ResourceType extends FhircastAnchorResou
 export async function setTopicCurrentContext<
   ResourceType extends FhircastAnchorResourceType = FhircastAnchorResourceType,
 >(projectId: string, topic: string, currentContext: CurrentContext<ResourceType>): Promise<void> {
-  const topicCurrentContextKey = `medplum:fhircast:project:${projectId}:topic:${topic}:latest`;
+  const topicCurrentContextKey = getTopicCurrentContextKey(projectId, topic);
   await getCacheRedis().set(topicCurrentContextKey, JSON.stringify(currentContext));
+}
+
+/**
+ * Replaces a topic's current context, but only if it is still at the version the caller read it at.
+ *
+ * Redis runs a script to completion before serving another command, so the version is compared and
+ * the context replaced without another update landing in between.
+ * Source: https://redis.io/docs/latest/develop/programmability/eval-intro/
+ *
+ * `KEYS[1]` is the context key, `ARGV[1]` the version the caller expects to still be stored, and
+ * `ARGV[2]` the serialized context to store. Returns 1 when the context was replaced, 0 when it was
+ * missing or had already moved on.
+ */
+const COMPARE_AND_SET_CURRENT_CONTEXT = `
+local stored = redis.call('GET', KEYS[1])
+if not stored then
+  return 0
+end
+local ok, context = pcall(cjson.decode, stored)
+if not ok or context['context.versionId'] ~= ARGV[1] then
+  return 0
+end
+redis.call('SET', KEYS[1], ARGV[2])
+return 1
+`;
+
+/**
+ * Replaces a topic's current context, unless it has changed since the caller read it.
+ *
+ * Applying a context update is a read-modify-write: the Hub reads the current context, applies the
+ * subscriber's update bundle to it, and stores the result under a new version. Two updates racing on
+ * one topic would both pass the version check they are each validated against, and the write that
+ * landed second would drop the other's changes while announcing a `context.priorVersionId` that was
+ * never the version it was actually applied to. Making the write conditional keeps the version chain
+ * honest: whichever update loses the race is rejected and its subscriber can retry against the
+ * context that won.
+ * @param projectId - The project the topic belongs to.
+ * @param topic - The topic whose current context is being replaced.
+ * @param expectedVersionId - The `context.versionId` the caller read and applied its update to.
+ * @param currentContext - The context to store, carrying its new `context.versionId`.
+ * @returns `true` if the context was replaced, `false` if it had already moved on.
+ */
+export async function compareAndSetTopicCurrentContext<
+  ResourceType extends FhircastAnchorResourceType = FhircastAnchorResourceType,
+>(
+  projectId: string,
+  topic: string,
+  expectedVersionId: string,
+  currentContext: CurrentContext<ResourceType>
+): Promise<boolean> {
+  const replaced = await getCacheRedis().eval(
+    COMPARE_AND_SET_CURRENT_CONTEXT,
+    1,
+    getTopicCurrentContextKey(projectId, topic),
+    expectedVersionId,
+    JSON.stringify(currentContext)
+  );
+  return replaced === 1;
 }
 
 export async function cleanupContextForResource(

--- a/packages/server/src/fhircast/utils.ts
+++ b/packages/server/src/fhircast/utils.ts
@@ -3,6 +3,7 @@
 import type { CurrentContext, FhircastAnchorResourceType } from '@medplum/core';
 import { OperationOutcomeError, badRequest, generateId, serverError } from '@medplum/core';
 import type { Resource } from '@medplum/fhirtypes';
+import { createHash } from 'node:crypto';
 import { globalLogger } from '../logger';
 import { getCacheRedis } from '../redis';
 
@@ -206,6 +207,12 @@ return 1
 `;
 
 /**
+ * Redis keys its script cache by the SHA-1 of the script body, so the digest the cache is addressed
+ * by can be derived here instead of being learned from a `SCRIPT LOAD` round trip at startup.
+ */
+const COMPARE_AND_SET_CURRENT_CONTEXT_SHA = createHash('sha1').update(COMPARE_AND_SET_CURRENT_CONTEXT).digest('hex');
+
+/**
  * Replaces a topic's current context, unless it has changed since the caller read it.
  *
  * Applying a context update is a read-modify-write: the Hub reads the current context, applies the
@@ -229,13 +236,32 @@ export async function compareAndSetTopicCurrentContext<
   expectedVersionId: string,
   currentContext: CurrentContext<ResourceType>
 ): Promise<boolean> {
-  const replaced = await getCacheRedis().eval(
-    COMPARE_AND_SET_CURRENT_CONTEXT,
-    1,
-    getTopicCurrentContextKey(projectId, topic),
-    expectedVersionId,
-    JSON.stringify(currentContext)
-  );
+  const key = getTopicCurrentContextKey(projectId, topic);
+  const serializedContext = JSON.stringify(currentContext);
+  let replaced: unknown;
+  try {
+    replaced = await getCacheRedis().evalsha(
+      COMPARE_AND_SET_CURRENT_CONTEXT_SHA,
+      1,
+      key,
+      expectedVersionId,
+      serializedContext
+    );
+  } catch (err: unknown) {
+    // A `NOSCRIPT` reply means the cache no longer holds the script, which a flush, a restart, or a
+    // failover to a replica can each leave behind. `EVAL` runs the script and caches it under the
+    // same digest, putting later calls back on `EVALSHA`.
+    if (!(err instanceof Error && err.message.includes('NOSCRIPT'))) {
+      throw err;
+    }
+    replaced = await getCacheRedis().eval(
+      COMPARE_AND_SET_CURRENT_CONTEXT,
+      1,
+      key,
+      expectedVersionId,
+      serializedContext
+    );
+  }
   return replaced === 1;
 }
 


### PR DESCRIPTION
Stacked on #10096 — review that one first; this diff is only the last commit.

## The problem

Applying a `DiagnosticReport-update` is a read-modify-write:

1. read the topic's current context
2. reject unless `event['context.versionId']` matches its `context.versionId`
3. apply the subscriber's update bundle to the content bundle
4. write the result back under a freshly generated version

Step 2 validated against a value that had already been read, so two updates racing on one topic both passed it. The write that landed second stored a context built from the version it read, dropping the first update's changes, and published a `context.priorVersionId` naming a version that was never the one it was actually applied to. Subscribers reconstructing the content from the event stream see a version chain that never happened.

The window is small but not theoretical: it is exactly the multi-subscriber case #10096 exists to support — two apps sharing a topic, both driving updates.

## The change

The write is now conditional on the context still being at the version the update was built on. `compareAndSetTopicCurrentContext` compares and replaces inside a Lua script, which Redis runs to completion before serving another command, so nothing can land in between:

```lua
local stored = redis.call('GET', KEYS[1])
if not stored then
  return 0
end
local ok, context = pcall(cjson.decode, stored)
if not ok or context['context.versionId'] ~= ARGV[1] then
  return 0
end
redis.call('SET', KEYS[1], ARGV[2])
return 1
```

The up-front version check stays — it gives a stale client a precise 400 without doing the work. The conditional write is what catches a racing update, and the loser gets a **409** so a client can tell a conflict it should retry from a request it should not resend. Nothing is published when the write is refused.

The bundle merge stays in TypeScript. Porting `processUpdateBundle` to Lua would move FHIR reference resolution and validation into an unreviewable script for no additional safety — compare-and-set gives the same guarantee.

## Scope

Only the update path. `-open` and `-close` also read-modify-write, but they establish a context rather than extend a version chain, and a racing `-open` or `-close` now correctly fails an in-flight update's conditional write.

## Tests

- `compareAndSetTopicCurrentContext` unit tests: replaces at the expected version, leaves a context that moved on, establishes nothing for a topic with no context.
- A route-level test that drives the race deterministically — a second update commits between this one's read and its write — asserting 409 and that the winner's context is left untouched. Verified load-bearing: reverting to the unconditional write fails it.

93 tests pass across `fhircast/routes`, `fhircast/utils` and `ws/fhircast`; `tsc --noEmit`, eslint and prettier clean.