### PR TITLE
Widen flatMapFilter to accept Iterable

### DIFF
--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -1822,6 +1822,18 @@ describe('flatMapFilter', () => {
     const input = [1, 2, 3];
     expect(flatMapFilter(input, (x) => (x % 2 !== 1 ? [x, x] : x))).toStrictEqual([1, 2, 2, 3]);
   });
+
+  test('undefined input returns empty array', () => {
+    expect(flatMapFilter(undefined, (x) => x)).toStrictEqual([]);
+  });
+
+  test('accepts non-array iterables', () => {
+    expect(flatMapFilter(new Set([1, 2, 3]), (x) => (x >= 2 ? x * x : undefined))).toStrictEqual([4, 9]);
+  });
+
+  test('passes sequential indexes', () => {
+    expect(flatMapFilter(new Set(['a', 'b']), (_x, idx) => idx)).toStrictEqual([0, 1]);
+  });
 });
 
 describe('singularize', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1561,14 +1561,18 @@ export function removeProfileFromResource<T extends Resource = Resource>(resourc
   return resource;
 }
 
-export function flatMapFilter<T, U>(arr: T[] | undefined, fn: (value: T, idx: number) => U | U[] | undefined): U[] {
+export function flatMapFilter<T, U>(
+  items: Iterable<T> | undefined,
+  fn: (value: T, idx: number) => U | U[] | undefined
+): U[] {
   const result: U[] = [];
-  if (!arr) {
+  if (!items) {
     return result;
   }
 
-  for (let i = 0; i < arr.length; i++) {
-    const resultValue = fn(arr[i], i);
+  let i = 0;
+  for (const value of items) {
+    const resultValue = fn(value, i++);
     if (Array.isArray(resultValue)) {
       result.push(...resultValue);
     } else if (resultValue !== undefined) {


### PR DESCRIPTION
- Widen `flatMapFilter` from `T[] | undefined` to `Iterable<T> | undefined`, iterating with `for...of` while preserving sequential indexes.
- Add coverage for `undefined`, non-array iterables (`Set`), and index ordering.
