### PR TITLE
Fix CORS Access-Control-Max-Age

### DIFF
--- a/packages/core/src/client-fhircast.test.ts
+++ b/packages/core/src/client-fhircast.test.ts
@@ -40,7 +40,6 @@ describe('FHIRcast', () => {
           method: 'POST',
           body: serializedSubRequest,
           headers: expect.objectContaining({ 'Content-Type': ContentType.FORM_URL_ENCODED }),
-          cache: 'no-cache',
         })
       );
       expect(subRequest).toStrictEqual(expect.objectContaining<PendingSubscriptionRequest>(expectedSubRequest));

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -4017,10 +4017,6 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       this.setRequestHeader(options, 'Authorization', 'Basic ' + this.basicAuth);
     }
 
-    if (!options.cache) {
-      options.cache = 'no-cache';
-    }
-
     if (!options.credentials) {
       options.credentials = 'include';
     }


### PR DESCRIPTION
Remove the default `cache: 'no-cache'` option from MedplumClient requests.

Setting `cache: 'no-cache'` causes browsers to bypass the CORS preflight cache, resulting in an unnecessary `OPTIONS` request before every cross-origin API request. The browser's default fetch caching behavior is sufficient, and API response caching remains controlled by the server's `Cache-Control` headers.

This change leaves the `cache` option unset by default while continuing to respect it when explicitly provided by the caller.
