### PR TITLE
Compute DICOM Study level aggregates

### DIFF
--- a/packages/server/src/dicom/routes.test.ts
+++ b/packages/server/src/dicom/routes.test.ts
@@ -332,6 +332,20 @@ describe('DICOM Routes', () => {
     expect(res).toHaveStatus(200);
     expect(JSON.stringify(res.body)).toContain('1.2.840.10008.5.1.4.1.1.7');
     expect(JSON.stringify(res.body)).toContain('1.2.826.0.1.3680043.10.543.1');
+
+    // The uploaded instance carries no ModalitiesInStudy (0008,0061), so the value below can only
+    // come from reconciling the study against its stored series.
+    const studies = await request(app)
+      .get(`/dicomweb/studies`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(studies).toHaveStatus(200);
+    const stored = (studies.body as Record<string, { Value?: unknown[] }>[]).find(
+      (study) => study['0020000D']?.Value?.[0] === '1.2.826.0.1.3680043.10.543.2'
+    );
+    expect(stored?.['00080061'].Value).toStrictEqual(['OT']);
+    // Both counts have VR IS, which dcmjs denaturalizes to a string.
+    expect(stored?.['00201206'].Value).toStrictEqual(['1']);
+    expect(stored?.['00201208'].Value).toStrictEqual(['1']);
   });
 
   test('Direct handler validation errors', async () => {
@@ -382,7 +396,6 @@ function createDicomBuffer(): Buffer {
     StudyTime: '030405',
     AccessionNumber: 'A123',
     Modality: 'OT',
-    ModalitiesInStudy: ['OT'],
     PatientName: [{ Alphabetic: 'STOW^TEST' }],
     PatientID: 'P-STOW',
     PatientBirthDate: '20000101',

--- a/packages/server/src/dicom/routes.test.ts
+++ b/packages/server/src/dicom/routes.test.ts
@@ -346,6 +346,13 @@ describe('DICOM Routes', () => {
     // Both counts have VR IS, which dcmjs denaturalizes to a string.
     expect(stored?.['00201206'].Value).toStrictEqual(['1']);
     expect(stored?.['00201208'].Value).toStrictEqual(['1']);
+
+    const series = await request(app)
+      .get(`/dicomweb/studies/1.2.826.0.1.3680043.10.543.2/series`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(series).toHaveStatus(200);
+    // NumberOfSeriesRelatedInstances (0020,1209), also computed rather than sent.
+    expect((series.body as Record<string, { Value?: unknown[] }>[])[0]['00201209'].Value).toStrictEqual(['1']);
   });
 
   test('Direct handler validation errors', async () => {

--- a/packages/server/src/dicom/stow-rs.ts
+++ b/packages/server/src/dicom/stow-rs.ts
@@ -14,6 +14,7 @@ import {
   cleanDicomJsonDict,
   dcmjsSeriesToMedplumSeries,
   dcmjsStudyToMedplumStudy,
+  updateSeriesAggregates,
   updateStudyAggregates,
 } from './utils';
 
@@ -101,16 +102,17 @@ export async function handleStoreInstances(req: Request, res: Response): Promise
   }
 
   /**
-   * Recomputes Study level aggregates once per study, after every instance in the request is stored.
+   * Recomputes Study and Series level aggregates once each, after every instance is stored.
    *
    * Doing this here rather than in `processInstance` keeps a large series to a single study update
-   * instead of one per instance. Failure is logged but not fatal: the instances are already stored,
-   * and the next upload to the study recomputes them again.
+   * instead of one per instance. Only the series this request touched are updated, since the rest of
+   * the study cannot have changed. Failure is logged but not fatal: the instances are already stored,
+   * and the next upload recomputes them again.
    *
    * @param instances - The instances stored by this request.
    * @returns The same instances, for the STOW-RS response.
    */
-  async function updateStudies(instances: DicomInstance[]): Promise<DicomInstance[]> {
+  async function updateAggregates(instances: DicomInstance[]): Promise<DicomInstance[]> {
     const studyIds = new Set(instances.map((instance) => resolveId(instance.study)).filter(isString));
     for (const studyId of studyIds) {
       try {
@@ -119,6 +121,16 @@ export async function handleStoreInstances(req: Request, res: Response): Promise
         getLogger().error('Error updating DICOM study aggregates', { err, studyId });
       }
     }
+
+    const seriesIds = new Set(instances.map((instance) => resolveId(instance.series)).filter(isString));
+    for (const seriesId of seriesIds) {
+      try {
+        await updateSeriesAggregates(repo, seriesId);
+      } catch (err) {
+        getLogger().error('Error updating DICOM series aggregates', { err, seriesId });
+      }
+    }
+
     return instances;
   }
 
@@ -185,7 +197,7 @@ export async function handleStoreInstances(req: Request, res: Response): Promise
   dicomwebMultipartParser.on('error', handleError);
 
   dicomwebMultipartParser.on('finish', () => {
-    Promise.all(promises).then(updateStudies).then(sendStowResponse).catch(handleError);
+    Promise.all(promises).then(updateAggregates).then(sendStowResponse).catch(handleError);
   });
 
   req.pipe(dicomwebMultipartParser);

--- a/packages/server/src/dicom/stow-rs.ts
+++ b/packages/server/src/dicom/stow-rs.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { createReference, isString, Operator } from '@medplum/core';
+import { createReference, isString, Operator, resolveId } from '@medplum/core';
 import type { Binary, DicomInstance, DicomSeries, DicomStudy } from '@medplum/fhirtypes';
 import type { DcmjsDicomDict } from 'dcmjs';
 import dcmjs from 'dcmjs';
@@ -10,7 +10,12 @@ import { PassThrough } from 'node:stream';
 import { getAuthenticatedContext } from '../context';
 import { uploadBinaryData } from '../fhir/binary';
 import { getLogger } from '../logger';
-import { cleanDicomJsonDict, dcmjsSeriesToMedplumSeries, dcmjsStudyToMedplumStudy } from './utils';
+import {
+  cleanDicomJsonDict,
+  dcmjsSeriesToMedplumSeries,
+  dcmjsStudyToMedplumStudy,
+  updateStudyAggregates,
+} from './utils';
 
 // eslint-disable-next-line import/no-named-as-default-member
 const { async, data, utilities } = dcmjs;
@@ -95,6 +100,28 @@ export async function handleStoreInstances(req: Request, res: Response): Promise
     });
   }
 
+  /**
+   * Recomputes Study level aggregates once per study, after every instance in the request is stored.
+   *
+   * Doing this here rather than in `processInstance` keeps a large series to a single study update
+   * instead of one per instance. Failure is logged but not fatal: the instances are already stored,
+   * and the next upload to the study recomputes them again.
+   *
+   * @param instances - The instances stored by this request.
+   * @returns The same instances, for the STOW-RS response.
+   */
+  async function updateStudies(instances: DicomInstance[]): Promise<DicomInstance[]> {
+    const studyIds = new Set(instances.map((instance) => resolveId(instance.study)).filter(isString));
+    for (const studyId of studyIds) {
+      try {
+        await updateStudyAggregates(repo, studyId);
+      } catch (err) {
+        getLogger().error('Error updating DICOM study aggregates', { err, studyId });
+      }
+    }
+    return instances;
+  }
+
   function sendStowResponse(instances: DicomInstance[]): void {
     res.status(200).json(
       DicomMetaDictionary.denaturalizeDataset({
@@ -158,7 +185,7 @@ export async function handleStoreInstances(req: Request, res: Response): Promise
   dicomwebMultipartParser.on('error', handleError);
 
   dicomwebMultipartParser.on('finish', () => {
-    Promise.all(promises).then(sendStowResponse).catch(handleError);
+    Promise.all(promises).then(updateStudies).then(sendStowResponse).catch(handleError);
   });
 
   req.pipe(dicomwebMultipartParser);

--- a/packages/server/src/dicom/utils.test.ts
+++ b/packages/server/src/dicom/utils.test.ts
@@ -1,8 +1,16 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { createReference, OperationOutcomeError, preconditionFailed } from '@medplum/core';
+import type { DicomInstance, DicomSeries, DicomStudy } from '@medplum/fhirtypes';
 import type { DcmjsDicomDict } from 'dcmjs';
+import express from 'express';
+import { randomUUID } from 'node:crypto';
 import { PassThrough } from 'node:stream';
+import { initApp, shutdownApp } from '../app';
+import { loadTestConfig } from '../config/loader';
+import type { Repository } from '../fhir/repo';
+import { createTestProject, withTestContext } from '../test.setup';
 import {
   cleanDicomJsonDict,
   dcmjsSeriesToMedplumSeries,
@@ -15,6 +23,7 @@ import {
   medplumSeriesToDcmjsSeries,
   medplumStudyToDcmjsStudy,
   stringToDicomPersonName,
+  updateStudyAggregates,
   writeMultipartRelatedBody,
 } from './utils';
 
@@ -63,6 +72,9 @@ describe('DICOM utils', () => {
         accessionNumber: 'A123',
         patientName: 'TEST^PATIENT',
         patientBirthDate: '2000-01-01',
+        modalitiesInStudy: ['CT', 'PT'],
+        numberOfStudyRelatedSeries: 2,
+        numberOfStudyRelatedInstances: 3,
       })
     ).toMatchObject({
       StudyInstanceUID: 'study-uid',
@@ -70,11 +82,11 @@ describe('DICOM utils', () => {
       StudyDate: '20240102',
       StudyTime: '030405',
       AccessionNumber: 'A123',
-      ModalitiesInStudy: ['DX'],
+      ModalitiesInStudy: ['CT', 'PT'],
       PatientName: [{ Alphabetic: 'TEST^PATIENT' }],
       PatientBirthDate: '20000101',
-      NumberOfStudyRelatedSeries: 1,
-      NumberOfStudyRelatedInstances: 1,
+      NumberOfStudyRelatedSeries: 2,
+      NumberOfStudyRelatedInstances: 3,
     });
   });
 
@@ -209,4 +221,132 @@ describe('DICOM utils', () => {
     await expect(writeMultipartRelatedBody(stream, [Buffer.from('one')], 'boundary')).rejects.toThrow('write failed');
     expect(stream.destroyed).toBe(true);
   });
+});
+
+describe('DICOM study aggregates', () => {
+  const app = express();
+  let repo: Repository;
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initApp(app, config);
+    repo = (await createTestProject({ withRepo: true })).repo;
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  async function createStudy(): Promise<DicomStudy & { id: string }> {
+    return repo.createResource<DicomStudy>({ resourceType: 'DicomStudy', studyInstanceUid: randomUUID() });
+  }
+
+  async function addSeries(study: DicomStudy, modality: string | undefined, instances: number): Promise<void> {
+    const series = await repo.createResource<DicomSeries>({
+      resourceType: 'DicomSeries',
+      study: createReference(study),
+      seriesInstanceUid: randomUUID(),
+      modality,
+    });
+    for (let i = 0; i < instances; i++) {
+      await repo.createResource<DicomInstance>({
+        resourceType: 'DicomInstance',
+        study: createReference(study),
+        series: createReference(series),
+        sopInstanceUid: randomUUID(),
+        sopClassUid: '1.2.3',
+        raw: { reference: 'Binary/123' },
+        metadata: '{}',
+      });
+    }
+  }
+
+  test('Unions modalities across a mixed modality study', () =>
+    withTestContext(async () => {
+      const study = await createStudy();
+      await addSeries(study, 'PT', 2);
+      await addSeries(study, 'ct', 3); // Normalized to match the CS value below
+      await addSeries(study, 'CT', 1); // Duplicate modality, counted once
+      await addSeries(study, undefined, 1); // Missing modality is skipped, but the series still counts
+
+      await updateStudyAggregates(repo, study.id);
+
+      expect(await repo.readResource<DicomStudy>('DicomStudy', study.id)).toMatchObject({
+        modalitiesInStudy: ['CT', 'PT'],
+        numberOfStudyRelatedSeries: 4,
+        numberOfStudyRelatedInstances: 7,
+      });
+    }));
+
+  test('Leaves modalities absent when no series has one', () =>
+    withTestContext(async () => {
+      const study = await createStudy();
+      await addSeries(study, undefined, 1);
+
+      await updateStudyAggregates(repo, study.id);
+
+      const result = await repo.readResource<DicomStudy>('DicomStudy', study.id);
+      expect(result.modalitiesInStudy).toBeUndefined();
+      expect(result.numberOfStudyRelatedSeries).toBe(1);
+    }));
+
+  test('Does not create a new version when the study is already correct', () =>
+    withTestContext(async () => {
+      const study = await createStudy();
+      await addSeries(study, 'CT', 1);
+
+      await updateStudyAggregates(repo, study.id);
+      const first = await repo.readResource<DicomStudy>('DicomStudy', study.id);
+
+      await updateStudyAggregates(repo, study.id);
+      const second = await repo.readResource<DicomStudy>('DicomStudy', study.id);
+
+      expect(second.meta?.versionId).toBe(first.meta?.versionId);
+    }));
+
+  test('Retries when another writer updates the study first', () =>
+    withTestContext(async () => {
+      const study = await createStudy();
+      await addSeries(study, 'CT', 1);
+
+      const updateResource = vi
+        .spyOn(repo, 'updateResource')
+        .mockRejectedValueOnce(new OperationOutcomeError(preconditionFailed));
+
+      await updateStudyAggregates(repo, study.id);
+
+      expect(updateResource).toHaveBeenCalledTimes(2);
+      expect(await repo.readResource<DicomStudy>('DicomStudy', study.id)).toMatchObject({
+        modalitiesInStudy: ['CT'],
+      });
+      updateResource.mockRestore();
+    }));
+
+  test('Gives up after repeated conflicts', () =>
+    withTestContext(async () => {
+      const study = await createStudy();
+      await addSeries(study, 'CT', 1);
+
+      const updateResource = vi
+        .spyOn(repo, 'updateResource')
+        .mockRejectedValue(new OperationOutcomeError(preconditionFailed));
+
+      await expect(updateStudyAggregates(repo, study.id)).resolves.toBeUndefined();
+
+      expect(updateResource).toHaveBeenCalledTimes(3);
+      updateResource.mockRestore();
+    }));
+
+  test('Rethrows errors that are not conflicts', () =>
+    withTestContext(async () => {
+      const study = await createStudy();
+      await addSeries(study, 'CT', 1);
+
+      const updateResource = vi.spyOn(repo, 'updateResource').mockRejectedValue(new Error('boom'));
+
+      await expect(updateStudyAggregates(repo, study.id)).rejects.toThrow('boom');
+
+      expect(updateResource).toHaveBeenCalledTimes(1);
+      updateResource.mockRestore();
+    }));
 });

--- a/packages/server/src/dicom/utils.test.ts
+++ b/packages/server/src/dicom/utils.test.ts
@@ -23,6 +23,7 @@ import {
   medplumSeriesToDcmjsSeries,
   medplumStudyToDcmjsStudy,
   stringToDicomPersonName,
+  updateSeriesAggregates,
   updateStudyAggregates,
   writeMultipartRelatedBody,
 } from './utils';
@@ -123,13 +124,14 @@ describe('DICOM utils', () => {
         seriesNumber: '7',
         modality: 'CT',
         seriesDescription: 'Head CT',
+        numberOfSeriesRelatedInstances: 4,
       })
     ).toMatchObject({
       StudyInstanceUID: 'study-uid',
       SeriesInstanceUID: 'series-uid',
       SeriesNumber: 7,
       Modality: 'CT',
-      NumberOfSeriesRelatedInstances: 1,
+      NumberOfSeriesRelatedInstances: 4,
     });
   });
 
@@ -241,7 +243,11 @@ describe('DICOM study aggregates', () => {
     return repo.createResource<DicomStudy>({ resourceType: 'DicomStudy', studyInstanceUid: randomUUID() });
   }
 
-  async function addSeries(study: DicomStudy, modality: string | undefined, instances: number): Promise<void> {
+  async function addSeries(
+    study: DicomStudy,
+    modality: string | undefined,
+    instances: number
+  ): Promise<DicomSeries & { id: string }> {
     const series = await repo.createResource<DicomSeries>({
       resourceType: 'DicomSeries',
       study: createReference(study),
@@ -259,6 +265,7 @@ describe('DICOM study aggregates', () => {
         metadata: '{}',
       });
     }
+    return series;
   }
 
   test('Unions modalities across a mixed modality study', () =>
@@ -347,6 +354,55 @@ describe('DICOM study aggregates', () => {
       await expect(updateStudyAggregates(repo, study.id)).rejects.toThrow('boom');
 
       expect(updateResource).toHaveBeenCalledTimes(1);
+      updateResource.mockRestore();
+    }));
+
+  test('Counts instances per series', () =>
+    withTestContext(async () => {
+      const study = await createStudy();
+      const ct = await addSeries(study, 'CT', 3);
+      const pt = await addSeries(study, 'PT', 2);
+
+      await updateSeriesAggregates(repo, ct.id);
+      await updateSeriesAggregates(repo, pt.id);
+
+      expect(await repo.readResource<DicomSeries>('DicomSeries', ct.id)).toMatchObject({
+        numberOfSeriesRelatedInstances: 3,
+      });
+      expect(await repo.readResource<DicomSeries>('DicomSeries', pt.id)).toMatchObject({
+        numberOfSeriesRelatedInstances: 2,
+      });
+    }));
+
+  test('Does not create a new version when the series is already correct', () =>
+    withTestContext(async () => {
+      const study = await createStudy();
+      const series = await addSeries(study, 'CT', 2);
+
+      await updateSeriesAggregates(repo, series.id);
+      const first = await repo.readResource<DicomSeries>('DicomSeries', series.id);
+
+      await updateSeriesAggregates(repo, series.id);
+      const second = await repo.readResource<DicomSeries>('DicomSeries', series.id);
+
+      expect(second.meta?.versionId).toBe(first.meta?.versionId);
+    }));
+
+  test('Retries the series update when another writer gets there first', () =>
+    withTestContext(async () => {
+      const study = await createStudy();
+      const series = await addSeries(study, 'CT', 2);
+
+      const updateResource = vi
+        .spyOn(repo, 'updateResource')
+        .mockRejectedValueOnce(new OperationOutcomeError(preconditionFailed));
+
+      await updateSeriesAggregates(repo, series.id);
+
+      expect(updateResource).toHaveBeenCalledTimes(2);
+      expect(await repo.readResource<DicomSeries>('DicomSeries', series.id)).toMatchObject({
+        numberOfSeriesRelatedInstances: 2,
+      });
       updateResource.mockRestore();
     }));
 });

--- a/packages/server/src/dicom/utils.ts
+++ b/packages/server/src/dicom/utils.ts
@@ -148,7 +148,8 @@ export async function updateStudyAggregates(repo: Repository, studyId: string): 
     });
 
     // Sorted so that an unchanged study compares equal below, rather than churning a new version.
-    const modalitiesInStudy = modalities.size > 0 ? Array.from(modalities).sort() : undefined;
+    const modalitiesInStudy =
+      modalities.size > 0 ? Array.from(modalities).sort((a, b) => a.localeCompare(b)) : undefined;
 
     if (
       deepEquals(study.modalitiesInStudy, modalitiesInStudy) &&

--- a/packages/server/src/dicom/utils.ts
+++ b/packages/server/src/dicom/utils.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { WithId } from '@medplum/core';
 import { deepEquals, getStatus, isObject, isString, normalizeOperationOutcome, Operator } from '@medplum/core';
 import type { DicomInstance, DicomSeries, DicomStudy, Reference, Resource } from '@medplum/fhirtypes';
-import type { WithId } from '@medplum/core';
 import type { DcmjsDicomDict, DcmjsDicomElement } from 'dcmjs';
 import { once } from 'node:events';
 import type { PassThrough } from 'node:stream';

--- a/packages/server/src/dicom/utils.ts
+++ b/packages/server/src/dicom/utils.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { deepEquals, getStatus, isObject, isString, normalizeOperationOutcome, Operator } from '@medplum/core';
-import type { DicomInstance, DicomSeries, DicomStudy, Reference } from '@medplum/fhirtypes';
+import type { DicomInstance, DicomSeries, DicomStudy, Reference, Resource } from '@medplum/fhirtypes';
+import type { WithId } from '@medplum/core';
 import type { DcmjsDicomDict, DcmjsDicomElement } from 'dcmjs';
 import { once } from 'node:events';
 import type { PassThrough } from 'node:stream';
@@ -61,7 +62,47 @@ export function medplumStudyToDcmjsStudy(study: DicomStudy): Record<string, unkn
 }
 
 /** Attempts at the read-modify-write cycle before giving up, to bound retries against a busy study. */
-const MAX_STUDY_UPDATE_ATTEMPTS = 3;
+const MAX_UPDATE_ATTEMPTS = 3;
+
+/**
+ * Applies a recomputed version of a resource, retrying when a concurrent writer gets there first.
+ *
+ * Instances in a single STOW request are stored concurrently, and separate requests can target the
+ * same study, so the aggregates below are a genuine read-modify-write race. The write is guarded by
+ * `ifMatch`; the loser of a race re-reads after the winner committed, so it always recomputes from
+ * strictly fresher data. Two concurrent writers therefore converge after one retry.
+ *
+ * @param repo - The repository to read and write with.
+ * @param resourceType - The resource type to update.
+ * @param id - The ID of the resource to update.
+ * @param recompute - Returns the updated resource, or undefined when it already holds the right values.
+ */
+async function updateWithRetry<T extends Resource>(
+  repo: Repository,
+  resourceType: T['resourceType'],
+  id: string,
+  recompute: (existing: WithId<T>) => Promise<T | undefined>
+): Promise<void> {
+  for (let attempt = 0; attempt < MAX_UPDATE_ATTEMPTS; attempt++) {
+    const existing = await repo.readResource<T>(resourceType, id);
+    const updated = await recompute(existing);
+    if (!updated) {
+      return;
+    }
+
+    try {
+      await repo.updateResource<T>(updated, { ifMatch: existing.meta?.versionId });
+      return;
+    } catch (err) {
+      if (getStatus(normalizeOperationOutcome(err)) !== 412) {
+        throw err;
+      }
+      // Another writer won. Read it back and recompute.
+    }
+  }
+
+  getLogger().warn('Unable to update DICOM aggregates', { resourceType, id });
+}
 
 /**
  * Recomputes the Study level aggregate attributes of a `DicomStudy` from its series and instances.
@@ -73,8 +114,7 @@ const MAX_STUDY_UPDATE_ATTEMPTS = 3;
  *
  * Computing from the stored series - rather than appending the modality of whatever instance just
  * arrived - keeps this idempotent, so a retry, a re-upload, or an upload following a partial failure
- * all converge on the same answer. Instances within a single request are stored concurrently, so the
- * write uses optimistic locking; a loser re-reads the series and writes the full union.
+ * all converge on the same answer.
  *
  * @param repo - The repository to read and write with.
  * @param studyId - The ID of the `DicomStudy` to update.
@@ -82,9 +122,7 @@ const MAX_STUDY_UPDATE_ATTEMPTS = 3;
 export async function updateStudyAggregates(repo: Repository, studyId: string): Promise<void> {
   const studyReference = `DicomStudy/${studyId}`;
 
-  for (let attempt = 0; attempt < MAX_STUDY_UPDATE_ATTEMPTS; attempt++) {
-    const study = await repo.readResource<DicomStudy>('DicomStudy', studyId);
-
+  await updateWithRetry<DicomStudy>(repo, 'DicomStudy', studyId, async (study) => {
     const modalities = new Set<string>();
     let seriesCount = 0;
     await repo.processAllResources<DicomSeries>(
@@ -109,34 +147,51 @@ export async function updateStudyAggregates(repo: Repository, studyId: string): 
       total: 'accurate',
     });
 
-    const updated: DicomStudy = {
+    // Sorted so that an unchanged study compares equal below, rather than churning a new version.
+    const modalitiesInStudy = modalities.size > 0 ? Array.from(modalities).sort() : undefined;
+
+    if (
+      deepEquals(study.modalitiesInStudy, modalitiesInStudy) &&
+      study.numberOfStudyRelatedSeries === seriesCount &&
+      study.numberOfStudyRelatedInstances === instanceBundle.total
+    ) {
+      return undefined;
+    }
+
+    return {
       ...study,
-      // Sorted so that an unchanged study compares equal below, rather than churning a new version.
-      modalitiesInStudy: modalities.size > 0 ? Array.from(modalities).sort() : undefined,
+      modalitiesInStudy,
       numberOfStudyRelatedSeries: seriesCount,
       numberOfStudyRelatedInstances: instanceBundle.total,
     };
+  });
+}
 
-    if (
-      deepEquals(study.modalitiesInStudy, updated.modalitiesInStudy) &&
-      study.numberOfStudyRelatedSeries === updated.numberOfStudyRelatedSeries &&
-      study.numberOfStudyRelatedInstances === updated.numberOfStudyRelatedInstances
-    ) {
-      return;
+/**
+ * Recomputes NumberOfSeriesRelatedInstances (0020,1209) for a `DicomSeries`.
+ *
+ * Another Q/R query key absent from the composite IOD, for the same reasons described on
+ * {@link updateStudyAggregates}. Only series that actually received instances need this, so STOW
+ * calls it for the series it touched rather than every series in the study.
+ *
+ * @param repo - The repository to read and write with.
+ * @param seriesId - The ID of the `DicomSeries` to update.
+ */
+export async function updateSeriesAggregates(repo: Repository, seriesId: string): Promise<void> {
+  await updateWithRetry<DicomSeries>(repo, 'DicomSeries', seriesId, async (series) => {
+    const instanceBundle = await repo.search<DicomInstance>({
+      resourceType: 'DicomInstance',
+      filters: [{ code: 'series', operator: Operator.EQUALS, value: `DicomSeries/${seriesId}` }],
+      count: 0,
+      total: 'accurate',
+    });
+
+    if (series.numberOfSeriesRelatedInstances === instanceBundle.total) {
+      return undefined;
     }
 
-    try {
-      await repo.updateResource<DicomStudy>(updated, { ifMatch: study.meta?.versionId });
-      return;
-    } catch (err) {
-      if (getStatus(normalizeOperationOutcome(err)) !== 412) {
-        throw err;
-      }
-      // Another instance in this study won the write. Read it back and recompute.
-    }
-  }
-
-  getLogger().warn('Unable to update DICOM study aggregates', { studyId });
+    return { ...series, numberOfSeriesRelatedInstances: instanceBundle.total };
+  });
 }
 
 export function dcmjsSeriesToMedplumSeries(
@@ -165,7 +220,7 @@ export function medplumSeriesToDcmjsSeries(study: DicomStudy, series: DicomSerie
     Modality: series.modality,
     SeriesDescription: series.seriesDescription,
     TimezoneOffsetFromUTC: series.timezoneOffsetFromUtc,
-    NumberOfSeriesRelatedInstances: 1,
+    NumberOfSeriesRelatedInstances: series.numberOfSeriesRelatedInstances,
     PerformedProcedureStepStartDate: series.performedProcedureStepStartDate,
     PerformedProcedureStepStartTime: series.performedProcedureStepStartTime,
   };

--- a/packages/server/src/dicom/utils.ts
+++ b/packages/server/src/dicom/utils.ts
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { isObject, isString } from '@medplum/core';
-import type { DicomSeries, DicomStudy, Reference } from '@medplum/fhirtypes';
+import { deepEquals, getStatus, isObject, isString, normalizeOperationOutcome, Operator } from '@medplum/core';
+import type { DicomInstance, DicomSeries, DicomStudy, Reference } from '@medplum/fhirtypes';
 import type { DcmjsDicomDict, DcmjsDicomElement } from 'dcmjs';
 import { once } from 'node:events';
 import type { PassThrough } from 'node:stream';
+import type { Repository } from '../fhir/repo';
+import { getLogger } from '../logger';
 
 export function dcmjsStudyToMedplumStudy(naturalized: Record<string, unknown>): DicomStudy {
   return {
@@ -46,17 +48,95 @@ export function medplumStudyToDcmjsStudy(study: DicomStudy): Record<string, unkn
     StudyTime: fhirTimeToDicomTime(study.studyTime),
     AccessionNumber: study.accessionNumber,
     InstanceAvailability: study.instanceAvailability,
-    // ModalitiesInStudy: study.modalitiesInStudy,
-    ModalitiesInStudy: ['DX'], // TODO: Add support for multiple modalities.
+    ModalitiesInStudy: study.modalitiesInStudy,
     ReferringPhysicianName: study.referringPhysiciansName,
     TimezoneOffsetFromUTC: study.timezoneOffsetFromUtc,
     PatientName: stringToDicomPersonName(study.patientName),
     PatientID: study.patientId,
     PatientBirthDate: fhirDateToDicomDate(study.patientBirthDate),
     PatientSex: study.patientSex,
-    NumberOfStudyRelatedSeries: 1,
-    NumberOfStudyRelatedInstances: 1,
+    NumberOfStudyRelatedSeries: study.numberOfStudyRelatedSeries,
+    NumberOfStudyRelatedInstances: study.numberOfStudyRelatedInstances,
   };
+}
+
+/** Attempts at the read-modify-write cycle before giving up, to bound retries against a busy study. */
+const MAX_STUDY_UPDATE_ATTEMPTS = 3;
+
+/**
+ * Recomputes the Study level aggregate attributes of a `DicomStudy` from its series and instances.
+ *
+ * ModalitiesInStudy (0008,0061), NumberOfStudyRelatedSeries (0020,1206), and
+ * NumberOfStudyRelatedInstances (0020,1208) are Study level query keys that the archive computes
+ * (PS3.4 C.6.2.1.2). They belong to no composite IOD, so stored instances almost never carry them,
+ * and a sender that does include them is describing its own view of the study rather than ours.
+ *
+ * Computing from the stored series - rather than appending the modality of whatever instance just
+ * arrived - keeps this idempotent, so a retry, a re-upload, or an upload following a partial failure
+ * all converge on the same answer. Instances within a single request are stored concurrently, so the
+ * write uses optimistic locking; a loser re-reads the series and writes the full union.
+ *
+ * @param repo - The repository to read and write with.
+ * @param studyId - The ID of the `DicomStudy` to update.
+ */
+export async function updateStudyAggregates(repo: Repository, studyId: string): Promise<void> {
+  const studyReference = `DicomStudy/${studyId}`;
+
+  for (let attempt = 0; attempt < MAX_STUDY_UPDATE_ATTEMPTS; attempt++) {
+    const study = await repo.readResource<DicomStudy>('DicomStudy', studyId);
+
+    const modalities = new Set<string>();
+    let seriesCount = 0;
+    await repo.processAllResources<DicomSeries>(
+      {
+        resourceType: 'DicomSeries',
+        filters: [{ code: 'study', operator: Operator.EQUALS, value: studyReference }],
+        count: 1000,
+      },
+      async (series) => {
+        seriesCount++;
+        const modality = series.modality?.trim().toUpperCase();
+        if (modality) {
+          modalities.add(modality);
+        }
+      }
+    );
+
+    const instanceBundle = await repo.search<DicomInstance>({
+      resourceType: 'DicomInstance',
+      filters: [{ code: 'study', operator: Operator.EQUALS, value: studyReference }],
+      count: 0,
+      total: 'accurate',
+    });
+
+    const updated: DicomStudy = {
+      ...study,
+      // Sorted so that an unchanged study compares equal below, rather than churning a new version.
+      modalitiesInStudy: modalities.size > 0 ? Array.from(modalities).sort() : undefined,
+      numberOfStudyRelatedSeries: seriesCount,
+      numberOfStudyRelatedInstances: instanceBundle.total,
+    };
+
+    if (
+      deepEquals(study.modalitiesInStudy, updated.modalitiesInStudy) &&
+      study.numberOfStudyRelatedSeries === updated.numberOfStudyRelatedSeries &&
+      study.numberOfStudyRelatedInstances === updated.numberOfStudyRelatedInstances
+    ) {
+      return;
+    }
+
+    try {
+      await repo.updateResource<DicomStudy>(updated, { ifMatch: study.meta?.versionId });
+      return;
+    } catch (err) {
+      if (getStatus(normalizeOperationOutcome(err)) !== 412) {
+        throw err;
+      }
+      // Another instance in this study won the write. Read it back and recompute.
+    }
+  }
+
+  getLogger().warn('Unable to update DICOM study aggregates', { studyId });
 }
 
 export function dcmjsSeriesToMedplumSeries(


### PR DESCRIPTION
The initial DICOMweb PR hardcoded four aggregate attributes in the QIDO-RS response:

```ts
ModalitiesInStudy: ['DX'], // TODO: Add support for multiple modalities.
NumberOfStudyRelatedSeries: 1,
NumberOfStudyRelatedInstances: 1,
NumberOfSeriesRelatedInstances: 1,
```

The obvious fix — read `ModalitiesInStudy` (0008,0061) from the incoming instance — does not work. That attribute belongs to no composite IOD. It is a Study level query key that the archive is expected to compute (PS3.4 C.6.2.1.2), so conformant stored instances do not carry it, and a sender that does include it is describing its own view of the study rather than ours. The same is true of `NumberOfStudyRelatedSeries` (0020,1206), `NumberOfStudyRelatedInstances` (0020,1208), and `NumberOfSeriesRelatedInstances` (0020,1209).

Medplum is the archive here, so computing these is our job.

## What

Two functions in `packages/server/src/dicom/utils.ts`, both recomputing from stored resources rather than from the incoming instance.

`updateStudyAggregates(repo, studyId)`:

- `modalitiesInStudy` — the sorted, deduped, upper-cased union of `DicomSeries.modality` (0008,0060), which *is* Type 1 in the General Series module and therefore reliable. Mixed modality studies (PET/CT, CT + SR, DX + PR) are the normal case, and the union is the spec definition rather than a workaround.
- `numberOfStudyRelatedSeries` — falls out of the same paginated series scan at no extra cost.
- `numberOfStudyRelatedInstances` — an accurate count of the study's instances.

`updateSeriesAggregates(repo, seriesId)` sets `numberOfSeriesRelatedInstances` from an accurate count of that series' instances.

STOW-RS calls both after every instance in the request has been stored: once per distinct study, and once per distinct series *the request actually touched*. A 500-slice single-series CT produces one study update and one series update, not 1000.

`medplumStudyToDcmjsStudy` and `medplumSeriesToDcmjsSeries` now emit the stored values.

## Implementation notes

**Recompute, don't append.** Adding the incoming instance's modality to the existing list would be cheaper, but recomputing from the stored series makes the operation idempotent. A retry, a re-upload, or an upload following a partial failure all converge on the same answer, and studies that predate this change repair themselves on the next upload without a separate backfill.

**Optimistic locking.** Concurrent STOW requests to the same study are a genuine read-modify-write race, and losing it silently drops a modality — which would then drop the study out of any modality-filtered QIDO search. Both paths share `updateWithRetry`, which guards the write with `ifMatch` on the resource's `versionId` and retries up to three times on `412`.

The retry is what makes this correct rather than best-effort: the loser of a race re-reads *after* the winner committed, so it always recomputes from strictly fresher data. With two concurrent writers one retry converges deterministically; three attempts covers three-way contention. Errors are also one-directional — because each write is a complete snapshot and instances are only ever added during ingest, a stale write can only ever omit data, never invent it.

**Only touched series are updated.** The study pass scans every series, because a new series changes the study's modality union. The series pass deliberately does not: a series that received no instances in this request cannot have changed its own count. This keeps the common single-series STOW at two extra queries and one extra write rather than scaling with the size of the study.

The asymmetry is worth noting explicitly — a `DicomStudy` recomputes from everything stored and therefore self-heals, while a `DicomSeries` only recomputes when touched. Nothing in this PR repairs pre-existing drift at either level, and there is no launched data to repair.

**No version churn.** Updates are skipped entirely when the recomputed values match what is already stored, so steady-state uploads do not create new versions.

**Failure is non-fatal.** The instances are already stored by the time this runs. A failed update is logged and the STOW response still succeeds; the next upload recomputes.
