### PR TITLE
Fixes #10108 - CLI login scope flag

### DIFF
--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -111,20 +111,14 @@ describe('CLI auth', () => {
   });
 
   test('Login with default scope includes offline_access', async () => {
-    let browserUrl: string | undefined;
-    (cp.exec as unknown as Mock).mockImplementation(
-      (cmd: string, callback: (error: Error | null, stdout: string, stderr: string) => void) => {
-        // Extract the URL from the browser open command
-        const urlMatch = cmd.match(/(https?:\/\/[^\s'"]+)/);
-        if (urlMatch) {
-          browserUrl = urlMatch[1];
-        }
-        if (callback) {
-          callback(null, '', '');
-        }
-        return true;
-      }
-    );
+    const execSpy = vi.spyOn(cp, 'exec').mockImplementation(((
+      cmd: string,
+      callback: (error: Error | null, stdout: string, stderr: string) => void
+    ) => {
+      callback(null, '', '');
+      return {} as any;
+    }) as any);
+
     (http.createServer as unknown as Mock).mockReturnValue({
       listen: () => ({
         close: () => undefined,
@@ -134,27 +128,26 @@ describe('CLI auth', () => {
     // Start the login without specifying scope
     await main(['node', 'index.js', 'login']);
 
-    // Verify the browser was opened with the default scope including offline_access
-    expect(browserUrl).toBeDefined();
-    const url = new URL(browserUrl as string);
+    // Verify exec was called with a browser open command
+    expect(execSpy).toHaveBeenCalled();
+    const execCall = execSpy.mock.calls[0][0] as string;
+    
+    // Extract and verify the URL from the command
+    const urlMatch = execCall.match(/(https?:\/\/[^\s'"]+)/);
+    expect(urlMatch).toBeDefined();
+    const url = new URL(urlMatch![1]);
     expect(url.searchParams.get('scope')).toBe('openid offline_access');
   });
 
   test('Login with custom scope', async () => {
-    let browserUrl: string | undefined;
-    (cp.exec as unknown as Mock).mockImplementation(
-      (cmd: string, callback: (error: Error | null, stdout: string, stderr: string) => void) => {
-        // Extract the URL from the browser open command
-        const urlMatch = cmd.match(/(https?:\/\/[^\s'"]+)/);
-        if (urlMatch) {
-          browserUrl = urlMatch[1];
-        }
-        if (callback) {
-          callback(null, '', '');
-        }
-        return true;
-      }
-    );
+    const execSpy = vi.spyOn(cp, 'exec').mockImplementation(((
+      cmd: string,
+      callback: (error: Error | null, stdout: string, stderr: string) => void
+    ) => {
+      callback(null, '', '');
+      return {} as any;
+    }) as any);
+
     (http.createServer as unknown as Mock).mockReturnValue({
       listen: () => ({
         close: () => undefined,
@@ -164,9 +157,14 @@ describe('CLI auth', () => {
     // Start the login with custom scope
     await main(['node', 'index.js', 'login', '--scope', 'openid profile']);
 
-    // Verify the browser was opened with the correct scope
-    expect(browserUrl).toBeDefined();
-    const url = new URL(browserUrl as string);
+    // Verify exec was called with a browser open command
+    expect(execSpy).toHaveBeenCalled();
+    const execCall = execSpy.mock.calls[0][0] as string;
+    
+    // Extract and verify the URL from the command
+    const urlMatch = execCall.match(/(https?:\/\/[^\s'"]+)/);
+    expect(urlMatch).toBeDefined();
+    const url = new URL(urlMatch![1]);
     expect(url.searchParams.get('scope')).toBe('openid profile');
   });
 

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -144,6 +144,9 @@ describe('CLI auth', () => {
     const urlMatch = capturedCommand.match(/(https?:\/\/[^\s'"]+)/);
     expect(urlMatch).toBeDefined();
     expect(urlMatch).not.toBeNull();
+    if (!urlMatch) {
+      throw new Error('URL not found in command');
+    }
     const url = new URL(urlMatch[1]);
     expect(url.searchParams.get('scope')).toBe('openid offline_access');
   });
@@ -174,6 +177,9 @@ describe('CLI auth', () => {
     const urlMatch = capturedCommand.match(/(https?:\/\/[^\s'"]+)/);
     expect(urlMatch).toBeDefined();
     expect(urlMatch).not.toBeNull();
+    if (!urlMatch) {
+      throw new Error('URL not found in command');
+    }
     const url = new URL(urlMatch[1]);
     expect(url.searchParams.get('scope')).toBe('openid profile');
   });

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -139,7 +139,7 @@ describe('CLI auth', () => {
     // Verify exec was called with a browser open command
     expect(cp.exec).toHaveBeenCalled();
     const capturedCommand = (cp.exec as unknown as Mock).mock.calls[0][0] as string;
-    
+
     // Extract and verify the URL from the command
     const urlMatch = capturedCommand.match(/(https?:\/\/[^\s'"]+)/);
     expect(urlMatch).toBeDefined();
@@ -172,7 +172,7 @@ describe('CLI auth', () => {
     // Verify exec was called with a browser open command
     expect(cp.exec).toHaveBeenCalled();
     const capturedCommand = (cp.exec as unknown as Mock).mock.calls[0][0] as string;
-    
+
     // Extract and verify the URL from the command
     const urlMatch = capturedCommand.match(/(https?:\/\/[^\s'"]+)/);
     expect(urlMatch).toBeDefined();

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -110,6 +110,36 @@ describe('CLI auth', () => {
     expect(medplum.getActiveLogin()).toBeDefined();
   });
 
+  test('Login with default scope includes offline_access', async () => {
+    let browserUrl: string | undefined;
+    (cp.exec as unknown as Mock).mockImplementation(
+      (cmd: string, callback: (error: Error | null, stdout: string, stderr: string) => void) => {
+        // Extract the URL from the browser open command
+        const urlMatch = cmd.match(/(?:xdg-open|open|start)\s+['"]?([^'"]+)['"]?/);
+        if (urlMatch) {
+          browserUrl = urlMatch[1];
+        }
+        if (callback) {
+          callback(null, '', '');
+        }
+        return true;
+      }
+    );
+    (http.createServer as unknown as Mock).mockReturnValue({
+      listen: () => ({
+        close: () => undefined,
+      }),
+    });
+
+    // Start the login without specifying scope
+    await main(['node', 'index.js', 'login']);
+
+    // Verify the browser was opened with the default scope including offline_access
+    expect(browserUrl).toBeDefined();
+    const url = new URL(browserUrl as string);
+    expect(url.searchParams.get('scope')).toBe('openid offline_access');
+  });
+
   test('Login with custom scope', async () => {
     let browserUrl: string | undefined;
     (cp.exec as unknown as Mock).mockImplementation(
@@ -132,12 +162,12 @@ describe('CLI auth', () => {
     });
 
     // Start the login with custom scope
-    await main(['node', 'index.js', 'login', '--scope', 'openid offline_access']);
+    await main(['node', 'index.js', 'login', '--scope', 'openid profile']);
 
     // Verify the browser was opened with the correct scope
     expect(browserUrl).toBeDefined();
     const url = new URL(browserUrl as string);
-    expect(url.searchParams.get('scope')).toBe('openid offline_access');
+    expect(url.searchParams.get('scope')).toBe('openid profile');
   });
 
   test('Login unsupported auth type', async () => {

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -110,6 +110,36 @@ describe('CLI auth', () => {
     expect(medplum.getActiveLogin()).toBeDefined();
   });
 
+  test('Login with custom scope', async () => {
+    let browserUrl: string | undefined;
+    (cp.exec as unknown as Mock).mockImplementation(
+      (cmd: string, callback: (error: Error | null, stdout: string, stderr: string) => void) => {
+        // Extract the URL from the browser open command
+        const urlMatch = cmd.match(/(?:xdg-open|open|start)\s+['"]?([^'"]+)['"]?/);
+        if (urlMatch) {
+          browserUrl = urlMatch[1];
+        }
+        if (callback) {
+          callback(null, '', '');
+        }
+        return true;
+      }
+    );
+    (http.createServer as unknown as Mock).mockReturnValue({
+      listen: () => ({
+        close: () => undefined,
+      }),
+    });
+
+    // Start the login with custom scope
+    await main(['node', 'index.js', 'login', '--scope', 'openid offline_access']);
+
+    // Verify the browser was opened with the correct scope
+    expect(browserUrl).toBeDefined();
+    const url = new URL(browserUrl as string);
+    expect(url.searchParams.get('scope')).toBe('openid offline_access');
+  });
+
   test('Login unsupported auth type', async () => {
     await expect(main(['node', 'index.js', 'login', '--auth-type', 'foo'])).rejects.toThrow(
       'Process exited with exit code 1'

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -11,7 +11,15 @@ import { main } from '.';
 import { FileSystemStorage } from './storage';
 import { createMedplumClient } from './util/client';
 
-vi.mock('node:child_process');
+vi.mock('node:child_process', () => {
+  const execMockFn = vi.fn();
+  return {
+    default: {
+      exec: execMockFn,
+    },
+    exec: execMockFn,
+  };
+});
 vi.mock('node:http');
 vi.mock('./util/client');
 vi.mock('node:fs', () => {
@@ -111,14 +119,14 @@ describe('CLI auth', () => {
   });
 
   test('Login with default scope includes offline_access', async () => {
-    const execSpy = vi.spyOn(cp, 'exec').mockImplementation(((
-      cmd: string,
-      callback: (error: Error | null, stdout: string, stderr: string) => void
-    ) => {
-      callback(null, '', '');
-      return {} as any;
-    }) as any);
-
+    (cp.exec as unknown as Mock).mockImplementation(
+      (cmd: string, callback: (error: Error | null, stdout: string, stderr: string) => void) => {
+        if (callback) {
+          callback(null, '', '');
+        }
+        return true;
+      }
+    );
     (http.createServer as unknown as Mock).mockReturnValue({
       listen: () => ({
         close: () => undefined,
@@ -129,25 +137,25 @@ describe('CLI auth', () => {
     await main(['node', 'index.js', 'login']);
 
     // Verify exec was called with a browser open command
-    expect(execSpy).toHaveBeenCalled();
-    const execCall = execSpy.mock.calls[0][0] as string;
+    expect(cp.exec).toHaveBeenCalled();
+    const capturedCommand = (cp.exec as unknown as Mock).mock.calls[0][0] as string;
     
     // Extract and verify the URL from the command
-    const urlMatch = execCall.match(/(https?:\/\/[^\s'"]+)/);
+    const urlMatch = capturedCommand.match(/(https?:\/\/[^\s'"]+)/);
     expect(urlMatch).toBeDefined();
     const url = new URL(urlMatch![1]);
     expect(url.searchParams.get('scope')).toBe('openid offline_access');
   });
 
   test('Login with custom scope', async () => {
-    const execSpy = vi.spyOn(cp, 'exec').mockImplementation(((
-      cmd: string,
-      callback: (error: Error | null, stdout: string, stderr: string) => void
-    ) => {
-      callback(null, '', '');
-      return {} as any;
-    }) as any);
-
+    (cp.exec as unknown as Mock).mockImplementation(
+      (cmd: string, callback: (error: Error | null, stdout: string, stderr: string) => void) => {
+        if (callback) {
+          callback(null, '', '');
+        }
+        return true;
+      }
+    );
     (http.createServer as unknown as Mock).mockReturnValue({
       listen: () => ({
         close: () => undefined,
@@ -158,11 +166,11 @@ describe('CLI auth', () => {
     await main(['node', 'index.js', 'login', '--scope', 'openid profile']);
 
     // Verify exec was called with a browser open command
-    expect(execSpy).toHaveBeenCalled();
-    const execCall = execSpy.mock.calls[0][0] as string;
+    expect(cp.exec).toHaveBeenCalled();
+    const capturedCommand = (cp.exec as unknown as Mock).mock.calls[0][0] as string;
     
     // Extract and verify the URL from the command
-    const urlMatch = execCall.match(/(https?:\/\/[^\s'"]+)/);
+    const urlMatch = capturedCommand.match(/(https?:\/\/[^\s'"]+)/);
     expect(urlMatch).toBeDefined();
     const url = new URL(urlMatch![1]);
     expect(url.searchParams.get('scope')).toBe('openid profile');

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -143,7 +143,8 @@ describe('CLI auth', () => {
     // Extract and verify the URL from the command
     const urlMatch = capturedCommand.match(/(https?:\/\/[^\s'"]+)/);
     expect(urlMatch).toBeDefined();
-    const url = new URL(urlMatch![1]);
+    expect(urlMatch).not.toBeNull();
+    const url = new URL(urlMatch[1]);
     expect(url.searchParams.get('scope')).toBe('openid offline_access');
   });
 
@@ -172,7 +173,8 @@ describe('CLI auth', () => {
     // Extract and verify the URL from the command
     const urlMatch = capturedCommand.match(/(https?:\/\/[^\s'"]+)/);
     expect(urlMatch).toBeDefined();
-    const url = new URL(urlMatch![1]);
+    expect(urlMatch).not.toBeNull();
+    const url = new URL(urlMatch[1]);
     expect(url.searchParams.get('scope')).toBe('openid profile');
   });
 

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -115,7 +115,7 @@ describe('CLI auth', () => {
     (cp.exec as unknown as Mock).mockImplementation(
       (cmd: string, callback: (error: Error | null, stdout: string, stderr: string) => void) => {
         // Extract the URL from the browser open command
-        const urlMatch = cmd.match(/(?:xdg-open|open|start)\s+['"]?([^'"]+)['"]?/);
+        const urlMatch = cmd.match(/(https?:\/\/[^\s'"]+)/);
         if (urlMatch) {
           browserUrl = urlMatch[1];
         }
@@ -145,7 +145,7 @@ describe('CLI auth', () => {
     (cp.exec as unknown as Mock).mockImplementation(
       (cmd: string, callback: (error: Error | null, stdout: string, stderr: string) => void) => {
         // Extract the URL from the browser open command
-        const urlMatch = cmd.match(/(?:xdg-open|open|start)\s+['"]?([^'"]+)['"]?/);
+        const urlMatch = cmd.match(/(https?:\/\/[^\s'"]+)/);
         if (urlMatch) {
           browserUrl = urlMatch[1];
         }

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -48,7 +48,7 @@ async function startLogin(medplum: MedplumClient, profile: Profile): Promise<voi
   const authType = profile?.authType ?? 'authorization-code';
   switch (authType) {
     case 'authorization-code':
-      await medplumAuthorizationCodeLogin(medplum);
+      await medplumAuthorizationCodeLogin(medplum, profile);
       break;
     case 'basic':
       medplum.setBasicAuth(profile.clientId as string, profile.clientSecret as string);
@@ -137,12 +137,12 @@ function printMe(medplum: MedplumClient): void {
   }
 }
 
-async function medplumAuthorizationCodeLogin(medplum: MedplumClient): Promise<void> {
+async function medplumAuthorizationCodeLogin(medplum: MedplumClient, profile: Profile): Promise<void> {
   await startWebServer(medplum);
   const loginUrl = new URL(medplum.getAuthorizeUrl());
   loginUrl.searchParams.set('client_id', clientId);
   loginUrl.searchParams.set('redirect_uri', redirectUri);
-  loginUrl.searchParams.set('scope', 'openid');
+  loginUrl.searchParams.set('scope', profile.scope ?? 'openid');
   loginUrl.searchParams.set('response_type', 'code');
   loginUrl.searchParams.set('prompt', 'login');
   await openBrowser(loginUrl.toString());

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -142,7 +142,7 @@ async function medplumAuthorizationCodeLogin(medplum: MedplumClient, profile: Pr
   const loginUrl = new URL(medplum.getAuthorizeUrl());
   loginUrl.searchParams.set('client_id', clientId);
   loginUrl.searchParams.set('redirect_uri', redirectUri);
-  loginUrl.searchParams.set('scope', profile.scope ?? 'openid');
+  loginUrl.searchParams.set('scope', profile.scope ?? 'openid offline_access');
   loginUrl.searchParams.set('response_type', 'code');
   loginUrl.searchParams.set('prompt', 'login');
   await openBrowser(loginUrl.toString());

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,7 +24,7 @@ export async function main(argv: string[]): Promise<void> {
     .option('--token-url <tokenUrl>', 'FHIR server token URL, absolute or relative to base URL')
     .option('--authorize-url <authorizeUrl>', 'FHIR server authorize URL, absolute or relative to base URL')
     .option('--fhir-url, --fhir-url-path <fhirUrlPath>', 'FHIR server URL, absolute or relative to base URL')
-    .option('--scope <scope>', 'JWT scope')
+    .option('--scope <scope>', 'OAuth scope (e.g., "openid offline_access")')
     .option('--access-token <accessToken>', 'Access token for token exchange authentication')
     .option('--callback-url <callbackUrl>', 'Callback URL for authorization code flow')
     .option('--subject <subject>', 'Subject for JWT authentication')


### PR DESCRIPTION
The `medplum login` command now:
1. ✅ Properly respects the `--scope` flag for authorization code flow
2. ✅ Defaults to `'openid offline_access'` to provide refresh tokens by default

## Problem

Previously, the scope was hardcoded to `'openid'` and the `--scope` flag was completely ignored during authorization code login. This meant users couldn't get refresh tokens even when explicitly requesting them.

## Solution

- Pass `profile` parameter to `medplumAuthorizationCodeLogin` to access the scope option
- **Changed default from `'openid'` to `'openid offline_access'`** - users now get refresh tokens by default
- Users can still override with `--scope` flag if needed
- Updated `--scope` option description with helpful example
- Added comprehensive test coverage

## Usage

**Default behavior (gets refresh token):**
```bash
medplum login  # Now defaults to 'openid offline_access'