### PR TITLE
Upload directories and glob patterns with dicomweb stow

### DIFF
--- a/packages/cli/src/dicomweb.test.ts
+++ b/packages/cli/src/dicomweb.test.ts
@@ -1,16 +1,41 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Readable } from 'node:stream';
 import { PassThrough } from 'node:stream';
 import type { Mock } from 'vitest';
 import { main } from '.';
-import { writeMultipartRelatedBody } from './dicomweb';
+import { resolveDicomFiles, writeMultipartRelatedBody } from './dicomweb';
 import { createMedplumClient } from './util/client';
 
 vi.mock('./util/client');
+
+/**
+ * Writes a file with a valid DICOM Part 10 preamble so that content sniffing detects it.
+ * @param filePath - The destination file path.
+ * @param contents - The file contents to write after the preamble.
+ */
+function writeDicomFile(filePath: string, contents: string): void {
+  writeFileSync(filePath, Buffer.concat([Buffer.alloc(128), Buffer.from('DICM'), Buffer.from(contents)]));
+}
+
+/**
+ * Mocks the Medplum client, collecting the request body of every `medplum.post` call as a string.
+ * @returns The mock `post` function.
+ */
+function mockPost(): Mock {
+  const post = vi.fn(async (_url: string, body: Readable, _contentType: string) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of body) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks).toString();
+  });
+  (createMedplumClient as unknown as Mock).mockResolvedValue({ post });
+  return post;
+}
 
 describe('CLI DICOMweb', () => {
   let testDir: string;
@@ -30,15 +55,7 @@ describe('CLI DICOMweb', () => {
     const fileName = join(testDir, 'instance.dcm');
     writeFileSync(fileName, Buffer.from('dicom bytes'));
 
-    const post = vi.fn(async (_url: string, body: Readable, _contentType: string) => {
-      const chunks: Buffer[] = [];
-      for await (const chunk of body) {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-      }
-      return Buffer.concat(chunks).toString();
-    });
-    (createMedplumClient as unknown as Mock).mockResolvedValue({ post });
-
+    const post = mockPost();
     await main(['node', 'index.js', 'dicomweb', 'stow', fileName]);
 
     expect(post).toHaveBeenCalledOnce();
@@ -52,6 +69,89 @@ describe('CLI DICOMweb', () => {
       [`--${boundary}`, 'Content-Type: application/dicom', '', 'dicom bytes', `--${boundary}--`, ''].join('\r\n')
     );
     expect(console.log).toHaveBeenCalledWith('STOW-RS response received', sentBody);
+  });
+
+  test('stow sends all DICOM files in a directory', async () => {
+    const seriesDir = join(testDir, 'series1');
+    mkdirSync(seriesDir);
+    writeDicomFile(join(testDir, 'a.dcm'), 'first');
+    writeDicomFile(join(seriesDir, 'IM000002'), 'second'); // No extension, detected by preamble
+    writeFileSync(join(testDir, 'README.txt'), 'not dicom');
+    writeFileSync(join(testDir, 'DICOMDIR'), Buffer.concat([Buffer.alloc(128), Buffer.from('DICM')]));
+
+    const post = mockPost();
+    await main(['node', 'index.js', 'dicomweb', 'stow', testDir]);
+
+    expect(post).toHaveBeenCalledOnce();
+    const sentBody = await post.mock.results[0].value;
+    expect(sentBody).toContain('first');
+    expect(sentBody).toContain('second');
+    expect(sentBody).not.toContain('not dicom');
+    expect(console.log).toHaveBeenCalledWith('Sending 2 DICOM file(s)');
+    expect(console.log).toHaveBeenCalledWith(`Skipped 2 non-DICOM file(s) in "${testDir}"`);
+  });
+
+  test('stow expands glob patterns', async () => {
+    writeDicomFile(join(testDir, 'a.dcm'), 'first');
+    writeDicomFile(join(testDir, 'b.dcm'), 'second');
+    writeDicomFile(join(testDir, 'c.other'), 'third');
+
+    const post = mockPost();
+    await main(['node', 'index.js', 'dicomweb', 'stow', `${testDir}/*.dcm`]);
+
+    expect(post).toHaveBeenCalledOnce();
+    const sentBody = await post.mock.results[0].value;
+    expect(sentBody).toContain('first');
+    expect(sentBody).toContain('second');
+    expect(sentBody).not.toContain('third');
+  });
+
+  test('stow accepts multiple arguments and de-duplicates', async () => {
+    const fileName = join(testDir, 'a.dcm');
+    writeDicomFile(fileName, 'first');
+    writeDicomFile(join(testDir, 'b.dcm'), 'second');
+
+    const post = mockPost();
+    await main(['node', 'index.js', 'dicomweb', 'stow', fileName, testDir]);
+
+    expect(post).toHaveBeenCalledOnce();
+    expect(console.log).toHaveBeenCalledWith('Sending 2 DICOM file(s)');
+  });
+
+  test('stow splits files into batches', async () => {
+    for (let i = 0; i < 5; i++) {
+      writeDicomFile(join(testDir, `${i}.dcm`), `instance${i}`);
+    }
+
+    const post = mockPost();
+    await main(['node', 'index.js', 'dicomweb', 'stow', '--batch-size', '2', testDir]);
+
+    expect(post).toHaveBeenCalledTimes(3);
+    const bodies = await Promise.all(post.mock.results.map((r) => r.value));
+    expect(bodies.map((body: string) => body.match(/instance\d/g)?.length)).toStrictEqual([2, 2, 1]);
+  });
+
+  test('resolveDicomFiles detects DICOM without a preamble', async () => {
+    // Part 10 with no preamble, starting directly with a (0002,0000) File Meta Information tag
+    const noPreamble = join(testDir, 'no-preamble');
+    writeFileSync(noPreamble, Buffer.from([0x02, 0x00, 0x00, 0x00, 0x55, 0x4c]));
+
+    // Raw dataset with no File Meta Information at all, recognized only by its extension
+    const rawDataset = join(testDir, 'raw.dcm');
+    writeFileSync(rawDataset, Buffer.from([0x08, 0x00, 0x00, 0x00, 0x55, 0x4c]));
+
+    // Same leading bytes as the raw dataset, but no DICOM extension to vouch for it
+    writeFileSync(join(testDir, 'notes.txt'), Buffer.from([0x08, 0x00, 0x00, 0x00, 0x55, 0x4c]));
+
+    await expect(resolveDicomFiles([testDir])).resolves.toStrictEqual([noPreamble, rawDataset]);
+  });
+
+  test('resolveDicomFiles throws on missing file', async () => {
+    await expect(resolveDicomFiles([join(testDir, 'missing.dcm')])).rejects.toThrow(/File not found/);
+  });
+
+  test('resolveDicomFiles returns empty array when nothing matches', async () => {
+    await expect(resolveDicomFiles([`${testDir}/*.dcm`])).resolves.toStrictEqual([]);
   });
 
   test('writeMultipartRelatedBody destroys stream on file read error', async () => {

--- a/packages/cli/src/dicomweb.test.ts
+++ b/packages/cli/src/dicomweb.test.ts
@@ -131,6 +131,18 @@ describe('CLI DICOMweb', () => {
     expect(bodies.map((body: string) => body.match(/instance\d/g)?.length)).toStrictEqual([2, 2, 1]);
   });
 
+  test('resolveDicomFiles matches nested directories and mismatched extension case', async () => {
+    const nestedDir = join(testDir, 'series1', 'sub');
+    mkdirSync(nestedDir, { recursive: true });
+    const topFile = join(testDir, 'a.DCM');
+    const nestedFile = join(nestedDir, 'b.DCM');
+    writeDicomFile(topFile, 'first');
+    writeDicomFile(nestedFile, 'second');
+
+    // `**` matches zero or more directories, so the top level file is included too
+    await expect(resolveDicomFiles([`${testDir}/**/*.dcm`])).resolves.toStrictEqual([topFile, nestedFile]);
+  });
+
   test('resolveDicomFiles detects DICOM without a preamble', async () => {
     // Part 10 with no preamble, starting directly with a (0002,0000) File Meta Information tag
     const noPreamble = join(testDir, 'no-preamble');

--- a/packages/cli/src/dicomweb.ts
+++ b/packages/cli/src/dicomweb.ts
@@ -81,7 +81,9 @@ export async function resolveDicomFiles(inputs: string[]): Promise<string[]> {
     if (stats?.isDirectory()) {
       matches = await fastGlob('**/*', { cwd: input, onlyFiles: true, absolute: true });
     } else if (fastGlob.isDynamicPattern(input)) {
-      matches = await fastGlob(input, { onlyFiles: true, absolute: true });
+      // Matched case-insensitively because DICOM extensions are inconsistently cased in the wild,
+      // and `*.dcm` silently matching none of a directory of `.DCM` files helps nobody
+      matches = await fastGlob(input, { onlyFiles: true, absolute: true, caseSensitiveMatch: false });
     } else {
       throw new Error(`File not found: ${input}`);
     }

--- a/packages/cli/src/dicomweb.ts
+++ b/packages/cli/src/dicomweb.ts
@@ -12,7 +12,7 @@ import { addSubcommand, MedplumCommand } from './utils';
 const DEFAULT_BATCH_SIZE = 25;
 
 /** Extensions unambiguously used for DICOM, to recognize raw datasets that carry no File Meta Information. */
-const DICOM_EXTENSIONS = ['.dcm', '.dicom', '.ima'];
+const DICOM_EXTENSIONS = new Set(['.dcm', '.dicom', '.ima']);
 
 /** A DICOM Part 10 file starts with a 128 byte preamble followed by the "DICM" prefix. */
 const DICOM_PREFIX = Buffer.from('DICM');
@@ -55,7 +55,7 @@ async function isDicomFile(filePath: string): Promise<boolean> {
     await handle.close();
   }
 
-  return DICOM_EXTENSIONS.includes(extname(filePath).toLowerCase());
+  return DICOM_EXTENSIONS.has(extname(filePath).toLowerCase());
 }
 
 /**
@@ -98,7 +98,7 @@ export async function resolveDicomFiles(inputs: string[]): Promise<string[]> {
       console.log(`Skipped ${skipped} non-DICOM file(s) in "${input}"`);
     }
   }
-  return Array.from(results).sort();
+  return Array.from(results).sort((a, b) => a.localeCompare(b));
 }
 
 async function writeBuffer(stream: PassThrough, buffer: Buffer): Promise<void> {

--- a/packages/cli/src/dicomweb.ts
+++ b/packages/cli/src/dicomweb.ts
@@ -1,10 +1,105 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import fastGlob from 'fast-glob';
 import { once } from 'node:events';
 import { createReadStream } from 'node:fs';
+import { open, stat } from 'node:fs/promises';
+import { basename, extname, resolve } from 'node:path';
 import { PassThrough } from 'node:stream';
 import { createMedplumClient } from './util/client';
 import { addSubcommand, MedplumCommand } from './utils';
+
+const DEFAULT_BATCH_SIZE = 25;
+
+/** Extensions unambiguously used for DICOM, to recognize raw datasets that carry no File Meta Information. */
+const DICOM_EXTENSIONS = ['.dcm', '.dicom', '.ima'];
+
+/** A DICOM Part 10 file starts with a 128 byte preamble followed by the "DICM" prefix. */
+const DICOM_PREFIX = Buffer.from('DICM');
+const DICOM_PREFIX_OFFSET = 128;
+const DICOM_HEADER_LENGTH = DICOM_PREFIX_OFFSET + DICOM_PREFIX.length;
+
+/** The File Meta Information group, which a Part 10 file without a preamble starts with. */
+const FILE_META_GROUP = 0x0002;
+
+/**
+ * Returns true if the file appears to be a storable DICOM instance.
+ *
+ * Only used when expanding directories and glob patterns, where the user did not name the file
+ * explicitly, so that stray files such as READMEs or JPEG previews do not get sent to the server.
+ *
+ * The two content checks mirror what the server's reader accepts, so that this does not reject
+ * files the server would have stored. It accepts a third encoding - a raw dataset with no File
+ * Meta Information - which has no distinguishing header to test for, hence the extension fallback.
+ * @param filePath - The candidate file path.
+ * @returns True if the file should be sent as a DICOM instance.
+ */
+async function isDicomFile(filePath: string): Promise<boolean> {
+  // DICOMDIR is a media directory record rather than a storable instance
+  if (basename(filePath).toUpperCase() === 'DICOMDIR') {
+    return false;
+  }
+
+  const handle = await open(filePath, 'r');
+  try {
+    const buffer = Buffer.alloc(DICOM_HEADER_LENGTH);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    if (bytesRead === buffer.length && buffer.subarray(DICOM_PREFIX_OFFSET).equals(DICOM_PREFIX)) {
+      return true;
+    }
+    // File Meta Information is always encoded little-endian, so the leading group number is too
+    if (bytesRead >= 2 && buffer.readUInt16LE(0) === FILE_META_GROUP) {
+      return true;
+    }
+  } finally {
+    await handle.close();
+  }
+
+  return DICOM_EXTENSIONS.includes(extname(filePath).toLowerCase());
+}
+
+/**
+ * Expands the command line file arguments into a sorted list of DICOM file paths.
+ *
+ * Each input can be a file, a directory (searched recursively), or a glob pattern. Note that
+ * POSIX shells expand unquoted patterns such as `*.dcm` before the CLI runs, so patterns only
+ * reach here when quoted by the user or when running on a shell that does not expand them.
+ * @param inputs - The file, directory, and glob pattern arguments.
+ * @returns The de-duplicated and sorted list of absolute DICOM file paths.
+ */
+export async function resolveDicomFiles(inputs: string[]): Promise<string[]> {
+  const results = new Set<string>();
+  for (const input of inputs) {
+    const stats = await stat(input).catch(() => undefined);
+    if (stats?.isFile()) {
+      // Explicitly named files are always sent, even if they do not look like DICOM
+      results.add(resolve(input));
+      continue;
+    }
+
+    let matches: string[];
+    if (stats?.isDirectory()) {
+      matches = await fastGlob('**/*', { cwd: input, onlyFiles: true, absolute: true });
+    } else if (fastGlob.isDynamicPattern(input)) {
+      matches = await fastGlob(input, { onlyFiles: true, absolute: true });
+    } else {
+      throw new Error(`File not found: ${input}`);
+    }
+
+    let skipped = 0;
+    for (const match of matches) {
+      if (await isDicomFile(match)) {
+        results.add(match);
+      } else {
+        skipped++;
+      }
+    }
+    if (skipped > 0) {
+      console.log(`Skipped ${skipped} non-DICOM file(s) in "${input}"`);
+    }
+  }
+  return Array.from(results).sort();
+}
 
 async function writeBuffer(stream: PassThrough, buffer: Buffer): Promise<void> {
   if (!stream.write(buffer)) {
@@ -47,19 +142,33 @@ export async function writeMultipartRelatedBody(
 }
 
 const stow = new MedplumCommand('stow')
-  .description('Send a DICOM instance via DICOMweb STOW-RS')
-  .argument('<file>', 'DICOM file to send')
-  .action(async (file, options) => {
+  .description('Send DICOM instances via DICOMweb STOW-RS')
+  .argument('<files...>', 'DICOM files, directories, or quoted glob patterns to send')
+  .option('--batch-size <count>', 'Maximum number of instances per STOW-RS request', String(DEFAULT_BATCH_SIZE))
+  .action(async (files: string[], options) => {
+    const batchSize = Number.parseInt(options.batchSize, 10);
+    if (!Number.isInteger(batchSize) || batchSize < 1) {
+      throw new Error(`Invalid batch size: ${options.batchSize}`);
+    }
+
+    const filePaths = await resolveDicomFiles(files);
+    if (filePaths.length === 0) {
+      throw new Error('No DICOM files found');
+    }
+    console.log(`Sending ${filePaths.length} DICOM file(s)`);
+
     const medplum = await createMedplumClient(options);
-    const boundary = `medplum-${Date.now()}`;
-    const contentType = `multipart/related; type=application/dicom; boundary=${boundary}`;
-    const stream = new PassThrough();
-    const writePromise = writeMultipartRelatedBody(stream, [file], boundary);
-    const requestPromise = medplum.post('/dicomweb/studies', stream, contentType);
-    await writePromise;
-    const text = await requestPromise;
-    console.log('STOW-RS response received', text);
-    return text;
+    for (let i = 0; i < filePaths.length; i += batchSize) {
+      const batch = filePaths.slice(i, i + batchSize);
+      const boundary = `medplum-${Date.now()}`;
+      const contentType = `multipart/related; type=application/dicom; boundary=${boundary}`;
+      const stream = new PassThrough();
+      const writePromise = writeMultipartRelatedBody(stream, batch, boundary);
+      const requestPromise = medplum.post('/dicomweb/studies', stream, contentType);
+      await writePromise;
+      const text = await requestPromise;
+      console.log('STOW-RS response received', text);
+    }
   });
 
 export const dicomweb = new MedplumCommand('dicomweb');

--- a/packages/docs/docs/dicom/cli.md
+++ b/packages/docs/docs/dicom/cli.md
@@ -16,30 +16,54 @@ medplum dicomweb stow MRBRAIN.DCM
 ## `medplum dicomweb stow`
 
 ```
-medplum dicomweb stow <file>
+medplum dicomweb stow <files...> [--batch-size <count>]
 ```
 
-Reads a DICOM Part 10 file, wraps it in a `multipart/related` body with
-`Content-Type: application/dicom`, and posts it to `/dicomweb/studies` on the configured server. The
-file is streamed from disk into the request rather than read into memory first.
+Reads DICOM Part 10 files, wraps them in a `multipart/related` body with
+`Content-Type: application/dicom`, and posts them to `/dicomweb/studies` on the configured server.
+Files are streamed from disk into the request rather than read into memory first.
 
-On success the STOW-RS response is printed — a DICOM JSON dataset containing a Referenced SOP
-Sequence naming the SOP Class UID and SOP Instance UID of each stored instance.
+On success the STOW-RS response of each request is printed — a DICOM JSON dataset containing a
+Referenced SOP Sequence naming the SOP Class UID and SOP Instance UID of each stored instance.
 
 The command accepts the CLI's standard [authentication](/docs/cli#authentication) and server
 options — stored credentials from `medplum login`, `MEDPLUM_CLIENT_ID` / `MEDPLUM_CLIENT_SECRET`
 environment variables, or `--client-id` / `--client-secret` flags. Set `MEDPLUM_BASE_URL` to target a
 self-hosted server.
 
-One file per invocation; there is no glob or directory form yet. To upload a directory of instances,
-loop in the shell:
+### Files, directories, and patterns
+
+Each argument can be a file, a directory, or a glob pattern, and you can mix them freely:
 
 ```bash
-for f in ./study/*.dcm; do medplum dicomweb stow "$f"; done
+medplum dicomweb stow MRBRAIN.DCM                 # One file
+medplum dicomweb stow ./study                     # Every DICOM file in the tree, recursively
+medplum dicomweb stow ./study/*.dcm               # Expanded by your shell
+medplum dicomweb stow './study/**/*.dcm'          # Quoted, so the CLI expands it
 ```
 
-Each file is a separate STOW-RS request, but because studies and series are created conditionally on
-their DICOM UIDs, the instances still collect under a single `DicomStudy` and its series.
+An unquoted pattern such as `*.dcm` is expanded by the shell before the CLI ever runs, so it arrives
+as an ordinary list of file names. Quote the pattern to have the CLI expand it instead — which is
+how to use `**` on shells that do not enable recursive globbing (bash without `globstar`), and how to
+pass patterns on Windows, where the shell does no expansion at all.
+
+Directories are searched recursively. When expanding a directory or a pattern, files that are not
+DICOM instances are skipped, so pointing at an export folder does not try to upload its README. A
+file counts as DICOM if it carries the `DICM` prefix at byte 128, or if it begins with a
+`(0002,xxxx)` File Meta Information tag — the two forms the server's reader recognizes structurally,
+including the extensionless file names common on modality exports and DICOM media. The server also
+accepts raw datasets carrying no File Meta Information, which have no header to test for, so those
+are recognized by a `.dcm`, `.dicom`, or `.ima` extension. `DICOMDIR` index files are always
+skipped, and the count of skipped files is printed. A file named explicitly on the command line is
+always sent, with no such filtering.
+
+### Batching
+
+Instances are sent in batches of 25 per STOW-RS request; use `--batch-size` to change that. Batching
+keeps a large upload from riding on one long-lived request, so a failure costs one batch rather than
+the whole study. Studies and series are created conditionally on their DICOM UIDs, so instances
+still collect under a single `DicomStudy` and its series no matter how they are split across
+requests.
 
 ## Verifying the upload
 

--- a/packages/docs/docs/dicom/cli.md
+++ b/packages/docs/docs/dicom/cli.md
@@ -44,11 +44,29 @@ medplum dicomweb stow './study/**/*.dcm'          # Quoted, so the CLI expands i
 
 An unquoted pattern such as `*.dcm` is expanded by the shell before the CLI ever runs, so it arrives
 as an ordinary list of file names. Quote the pattern to have the CLI expand it instead — which is
-how to use `**` on shells that do not enable recursive globbing (bash without `globstar`), and how to
-pass patterns on Windows, where the shell does no expansion at all.
+also how to pass patterns on Windows, where the shell does no expansion at all.
 
-Directories are searched recursively. When expanding a directory or a pattern, files that are not
-DICOM instances are skipped, so pointing at an export folder does not try to upload its README. A
+:::caution Quote `**` patterns
+
+**Always quote a pattern containing `**`.** bash only treats `**` as "any number of directories"
+when `globstar` is enabled, and it is off by default. Unquoted, `./study/**/*.dcm` expands to
+*exactly one* directory level, so a three-level study uploads only its middle level — and because
+the shell collapsed the pattern before the CLI started, nothing can detect this and warn you. Quoted,
+the CLI expands it and `**` recurses to any depth, including zero, so top level files match too.
+
+Passing the directory itself avoids the question entirely:
+
+```bash
+medplum dicomweb stow ./study
+```
+
+:::
+
+Patterns are matched case-insensitively, since `.dcm` and `.DCM` are both common. Directories are
+searched by content rather than by name, so their casing never matters.
+
+Directories are searched recursively, to any depth. When expanding a directory or a pattern, files
+that are not DICOM instances are skipped, so pointing at an export folder does not try to upload its README. A
 file counts as DICOM if it carries the `DICM` prefix at byte 128, or if it begins with a
 `(0002,xxxx)` File Meta Information tag — the two forms the server's reader recognizes structurally,
 including the extensionless file names common on modality exports and DICOM media. The server also

--- a/packages/docs/docs/dicom/index.md
+++ b/packages/docs/docs/dicom/index.md
@@ -74,8 +74,9 @@ update.
 
 ## Getting started
 
-1. **Store a file from your laptop.** `medplum dicomweb stow MRBRAIN.DCM` uploads a DICOM file
-   through STOW-RS with no infrastructure to set up. See the [CLI](./cli.md).
+1. **Store a file from your laptop.** `medplum dicomweb stow MRBRAIN.DCM` uploads a DICOM file — or
+   a whole directory of them — through STOW-RS with no infrastructure to set up. See the
+   [CLI](./cli.md).
 2. **Look at it.** Medplum's hosted cloud is preconfigured with an
    [OHIF Viewer](./ohif-viewer.md) at [viewer.medplum.com](https://viewer.medplum.com) — sign in and
    the study is there.

--- a/packages/server/src/dicom/routes.test.ts
+++ b/packages/server/src/dicom/routes.test.ts
@@ -355,6 +355,61 @@ describe('DICOM Routes', () => {
     expect((series.body as Record<string, { Value?: unknown[] }>[])[0]['00201209'].Value).toStrictEqual(['1']);
   });
 
+  test('Create study with multiple instances in one request', async () => {
+    // Every instance below shares a study and a series, so their conditional creates all resolve
+    // the same two resources. They must be written one at a time: `conditionalCreate` opens a
+    // serializable transaction on the connection they share, and overlapping them throws
+    // "Repository is in an active transaction".
+    const studyInstanceUid = '1.2.826.0.1.3680043.10.543.20';
+    const seriesInstanceUid = '1.2.826.0.1.3680043.10.543.21';
+    const sopInstanceUids = ['.22', '.23', '.24'].map((suffix) => `1.2.826.0.1.3680043.10.543${suffix}`);
+
+    const boundary = `medplum-${Date.now()}`;
+    const contentType = `multipart/related; type=application/dicom; boundary=${boundary}`;
+    const body = Buffer.concat([
+      ...sopInstanceUids.flatMap((sopInstanceUid, index) => [
+        Buffer.from(`--${boundary}\r\nContent-Type: application/dicom\r\n\r\n`),
+        createDicomBuffer({ sopInstanceUid, studyInstanceUid, seriesInstanceUid, instanceNumber: index + 1 }),
+        Buffer.from('\r\n'),
+      ]),
+      Buffer.from(`--${boundary}--\r\n`),
+    ]);
+
+    const res = await request(app)
+      .post(`/dicomweb/studies`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', contentType)
+      .send(body);
+    expect(res).toHaveStatus(200);
+
+    // Every instance is acknowledged, once each, in the order the request listed them
+    const referenced = (res.body as Record<string, { Value?: { '00081155': { Value: string[] } }[] }>)[
+      '00081199'
+    ].Value?.map((item) => item['00081155'].Value[0]);
+    expect(referenced).toStrictEqual(sopInstanceUids);
+
+    // A single study and series absorbed all three, rather than one being created per instance
+    const studies = await request(app)
+      .get(`/dicomweb/studies`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(studies).toHaveStatus(200);
+    const stored = (studies.body as Record<string, { Value?: unknown[] }>[]).filter(
+      (study) => study['0020000D']?.Value?.[0] === studyInstanceUid
+    );
+    expect(stored).toHaveLength(1);
+    // Counts have VR IS, which dcmjs denaturalizes to a string.
+    expect(stored[0]['00201206'].Value).toStrictEqual(['1']);
+    expect(stored[0]['00201208'].Value).toStrictEqual(['3']);
+
+    const series = await request(app)
+      .get(`/dicomweb/studies/${studyInstanceUid}/series`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(series).toHaveStatus(200);
+    const storedSeries = series.body as Record<string, { Value?: unknown[] }>[];
+    expect(storedSeries).toHaveLength(1);
+    expect(storedSeries[0]['00201209'].Value).toStrictEqual(['3']);
+  });
+
   test('Direct handler validation errors', async () => {
     await handleSearchSeries({ params: {} } as Request, createMockResponse(400, { error: 'Invalid study UID' }));
     await handleRetrieveSeriesMetadata(
@@ -384,20 +439,26 @@ describe('DICOM Routes', () => {
   });
 });
 
-function createDicomBuffer(): Buffer {
+function createDicomBuffer(overrides?: {
+  sopInstanceUid?: string;
+  studyInstanceUid?: string;
+  seriesInstanceUid?: string;
+  instanceNumber?: number;
+}): Buffer {
+  const sopInstanceUid = overrides?.sopInstanceUid ?? '1.2.826.0.1.3680043.10.543.1';
   const elements = {
     _meta: {
       FileMetaInformationVersion: new Uint8Array([0, 1]).buffer,
       MediaStorageSOPClassUID: '1.2.840.10008.5.1.4.1.1.7',
-      MediaStorageSOPInstanceUID: '1.2.826.0.1.3680043.10.543.1',
+      MediaStorageSOPInstanceUID: sopInstanceUid,
       TransferSyntaxUID: '1.2.840.10008.1.2.1',
       ImplementationClassUID: '1.2.826.0.1.3680043.10.543',
       ImplementationVersionName: 'MEDPLUM',
     },
     SOPClassUID: '1.2.840.10008.5.1.4.1.1.7',
-    SOPInstanceUID: '1.2.826.0.1.3680043.10.543.1',
-    StudyInstanceUID: '1.2.826.0.1.3680043.10.543.2',
-    SeriesInstanceUID: '1.2.826.0.1.3680043.10.543.3',
+    SOPInstanceUID: sopInstanceUid,
+    StudyInstanceUID: overrides?.studyInstanceUid ?? '1.2.826.0.1.3680043.10.543.2',
+    SeriesInstanceUID: overrides?.seriesInstanceUid ?? '1.2.826.0.1.3680043.10.543.3',
     StudyID: 'STOW',
     StudyDate: '20240102',
     StudyTime: '030405',
@@ -408,7 +469,7 @@ function createDicomBuffer(): Buffer {
     PatientBirthDate: '20000101',
     PatientSex: 'O',
     SeriesNumber: 1,
-    InstanceNumber: 1,
+    InstanceNumber: overrides?.instanceNumber ?? 1,
     Rows: 1,
     Columns: 1,
     BitsAllocated: 8,

--- a/packages/server/src/dicom/routes.test.ts
+++ b/packages/server/src/dicom/routes.test.ts
@@ -469,6 +469,10 @@ function createDicomBuffer(overrides?: {
     PatientBirthDate: '20000101',
     PatientSex: 'O',
     SeriesNumber: 1,
+    // Routinely sent by CT and MR scanners, and stored in elements typed as FHIR date and time,
+    // so a STOW request only succeeds if these are reformatted out of their DICOM DA and TM forms
+    PerformedProcedureStepStartDate: '20240102',
+    PerformedProcedureStepStartTime: '030405.000000',
     InstanceNumber: overrides?.instanceNumber ?? 1,
     Rows: 1,
     Columns: 1,

--- a/packages/server/src/dicom/stow-rs.ts
+++ b/packages/server/src/dicom/stow-rs.ts
@@ -41,7 +41,9 @@ export async function handleStoreInstances(req: Request, res: Response): Promise
 
   const ctx = getAuthenticatedContext();
   const repo = ctx.repo;
-  const promises: Promise<DicomInstance>[] = [];
+
+  /** One entry per instance, resolving once its bytes are stored and its metadata parsed. */
+  const parsedInstances: Promise<[Binary, DcmjsDicomDict]>[] = [];
 
   async function parseDicomMetadata(stream: PassThrough): Promise<DcmjsDicomDict> {
     const listener = new DicomMetadataListener({
@@ -102,6 +104,23 @@ export async function handleStoreInstances(req: Request, res: Response): Promise
   }
 
   /**
+   * Stores every instance in the request, one at a time.
+   *
+   * Sequential because these writes share one repository and each opens a transaction, so
+   * overlapping them throws "Repository is in an active transaction".
+   * @returns The stored instances, in the order the sender listed them.
+   */
+  async function storeInstances(): Promise<DicomInstance[]> {
+    const parsed = await Promise.all(parsedInstances);
+    const instances: DicomInstance[] = [];
+    for (const instance of parsed) {
+      instances.push(await processInstance(instance));
+    }
+    await updateAggregates(instances);
+    return instances;
+  }
+
+  /**
    * Recomputes Study and Series level aggregates once each, after every instance is stored.
    *
    * Doing this here rather than in `processInstance` keeps a large series to a single study update
@@ -110,9 +129,8 @@ export async function handleStoreInstances(req: Request, res: Response): Promise
    * and the next upload recomputes them again.
    *
    * @param instances - The instances stored by this request.
-   * @returns The same instances, for the STOW-RS response.
    */
-  async function updateAggregates(instances: DicomInstance[]): Promise<DicomInstance[]> {
+  async function updateAggregates(instances: DicomInstance[]): Promise<void> {
     const studyIds = new Set(instances.map((instance) => resolveId(instance.study)).filter(isString));
     for (const studyId of studyIds) {
       try {
@@ -130,8 +148,6 @@ export async function handleStoreInstances(req: Request, res: Response): Promise
         getLogger().error('Error updating DICOM series aggregates', { err, seriesId });
       }
     }
-
-    return instances;
   }
 
   function sendStowResponse(instances: DicomInstance[]): void {
@@ -167,10 +183,13 @@ export async function handleStoreInstances(req: Request, res: Response): Promise
     const uploadStream = new PassThrough();
     const parseStream = new PassThrough();
 
-    const uploadPromise = uploadBinaryData(repo, uploadStream, {
+    // Overlapping parts cannot share a repository, since creating the Binary opens a transaction.
+    // A clone is safe here, unlike in `processInstance`: each part inserts its own new row.
+    const binaryRepo = repo.clone();
+    const uploadPromise = uploadBinaryData(binaryRepo, uploadStream, {
       contentType: 'application/dicom',
       filename: 'instance.dcm',
-    });
+    }).finally(() => binaryRepo[Symbol.dispose]());
 
     const parsePromise = parseDicomMetadata(parseStream);
 
@@ -191,13 +210,13 @@ export async function handleStoreInstances(req: Request, res: Response): Promise
       parseStream.destroy(err);
     });
 
-    promises.push(Promise.all([uploadPromise, parsePromise]).then(processInstance));
+    parsedInstances.push(Promise.all([uploadPromise, parsePromise]));
   });
 
   dicomwebMultipartParser.on('error', handleError);
 
   dicomwebMultipartParser.on('finish', () => {
-    Promise.all(promises).then(updateAggregates).then(sendStowResponse).catch(handleError);
+    storeInstances().then(sendStowResponse).catch(handleError);
   });
 
   req.pipe(dicomwebMultipartParser);

--- a/packages/server/src/dicom/utils.test.ts
+++ b/packages/server/src/dicom/utils.test.ts
@@ -114,6 +114,9 @@ describe('DICOM utils', () => {
       modality: 'CT',
       seriesDescription: 'Head CT',
       numberOfSeriesRelatedInstances: 4,
+      // DICOM DA and TM, reformatted to the FHIR date and time the elements are typed as
+      performedProcedureStepStartDate: '2024-01-02',
+      performedProcedureStepStartTime: '03:04:05',
     });
 
     expect(
@@ -125,6 +128,8 @@ describe('DICOM utils', () => {
         modality: 'CT',
         seriesDescription: 'Head CT',
         numberOfSeriesRelatedInstances: 4,
+        performedProcedureStepStartDate: '2024-01-02',
+        performedProcedureStepStartTime: '03:04:05',
       })
     ).toMatchObject({
       StudyInstanceUID: 'study-uid',
@@ -132,6 +137,8 @@ describe('DICOM utils', () => {
       SeriesNumber: 7,
       Modality: 'CT',
       NumberOfSeriesRelatedInstances: 4,
+      PerformedProcedureStepStartDate: '20240102',
+      PerformedProcedureStepStartTime: '030405',
     });
   });
 
@@ -187,6 +194,28 @@ describe('DICOM utils', () => {
     expect(dicomTimeToFhirTime('0304')).toBeUndefined();
     expect(fhirTimeToDicomTime('03:04:05')).toBe('030405');
     expect(fhirTimeToDicomTime(undefined)).toBeUndefined();
+  });
+
+  test('drops unparseable dates and times rather than propagating them', () => {
+    // Each of these is the right length to be reformatted, so only validating the result rejects
+    // them. Propagating "asdf-as-df" instead would fail validation and reject the whole request.
+    expect(dicomDateToFhirDate('asdfasdf')).toBeUndefined();
+    expect(dicomDateToFhirDate('99999999')).toBeUndefined();
+    expect(dicomDateToFhirDate('20241301')).toBeUndefined(); // Month 13
+    expect(dicomDateToFhirDate('20240132')).toBeUndefined(); // Day 32
+    expect(dicomDateToFhirDate('2024-01-02')).toBeUndefined(); // Already FHIR formatted
+    expect(dicomDateToFhirDate(20240102)).toBeUndefined(); // Not a string
+
+    expect(dicomTimeToFhirTime('asdfas')).toBeUndefined();
+    expect(dicomTimeToFhirTime('999999')).toBeUndefined();
+    expect(dicomTimeToFhirTime('250405')).toBeUndefined(); // Hour 25
+    expect(dicomTimeToFhirTime('036005')).toBeUndefined(); // Minute 60
+    expect(dicomTimeToFhirTime('asdfasdfasdf')).toBeUndefined(); // Long enough to pass the length check
+    expect(dicomTimeToFhirTime(30405)).toBeUndefined(); // Not a string
+
+    // Leap seconds are valid in FHIR time, and midnight must survive the truthiness of no check
+    expect(dicomTimeToFhirTime('235960')).toBe('23:59:60');
+    expect(dicomTimeToFhirTime('000000')).toBe('00:00:00');
   });
 
   test('writes multipart related body', async () => {

--- a/packages/server/src/dicom/utils.ts
+++ b/packages/server/src/dicom/utils.ts
@@ -2,7 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { WithId } from '@medplum/core';
-import { deepEquals, getStatus, isObject, isString, normalizeOperationOutcome, Operator } from '@medplum/core';
+import {
+  deepEquals,
+  getStatus,
+  isObject,
+  isString,
+  normalizeOperationOutcome,
+  Operator,
+  validationRegexes,
+} from '@medplum/core';
 import type { DicomInstance, DicomSeries, DicomStudy, Reference, Resource } from '@medplum/fhirtypes';
 import type { DcmjsDicomDict, DcmjsDicomElement } from 'dcmjs';
 import { once } from 'node:events';
@@ -208,8 +216,8 @@ export function dcmjsSeriesToMedplumSeries(
     seriesDescription: naturalized.SeriesDescription as string,
     timezoneOffsetFromUtc: naturalized.TimezoneOffsetFromUTC as string,
     numberOfSeriesRelatedInstances: naturalized.NumberOfSeriesRelatedInstances as number,
-    performedProcedureStepStartDate: naturalized.PerformedProcedureStepStartDate as string,
-    performedProcedureStepStartTime: naturalized.PerformedProcedureStepStartTime as string,
+    performedProcedureStepStartDate: dicomDateToFhirDate(naturalized.PerformedProcedureStepStartDate),
+    performedProcedureStepStartTime: dicomTimeToFhirTime(naturalized.PerformedProcedureStepStartTime),
   };
 }
 
@@ -222,8 +230,8 @@ export function medplumSeriesToDcmjsSeries(study: DicomStudy, series: DicomSerie
     SeriesDescription: series.seriesDescription,
     TimezoneOffsetFromUTC: series.timezoneOffsetFromUtc,
     NumberOfSeriesRelatedInstances: series.numberOfSeriesRelatedInstances,
-    PerformedProcedureStepStartDate: series.performedProcedureStepStartDate,
-    PerformedProcedureStepStartTime: series.performedProcedureStepStartTime,
+    PerformedProcedureStepStartDate: fhirDateToDicomDate(series.performedProcedureStepStartDate),
+    PerformedProcedureStepStartTime: fhirTimeToDicomTime(series.performedProcedureStepStartTime),
   };
 }
 
@@ -330,7 +338,12 @@ export function stringToDicomPersonName(name: string | undefined): { Alphabetic:
 export function dicomDateToFhirDate(dicomDate: unknown): string | undefined {
   // DICOM date format is YYYYMMDD, while FHIR date format is YYYY-MM-DD
   if (isString(dicomDate) && dicomDate.length === 8) {
-    return `${dicomDate.substring(0, 4)}-${dicomDate.substring(4, 6)}-${dicomDate.substring(6, 8)}`;
+    const fhirDate = `${dicomDate.substring(0, 4)}-${dicomDate.substring(4, 6)}-${dicomDate.substring(6, 8)}`;
+    // Reformatting alone would turn "asdfasdf" into "asdf-as-df", which fails validation and would
+    // reject the whole request. Dropping an unparseable optional attribute keeps the study storable.
+    if (validationRegexes.date.test(fhirDate)) {
+      return fhirDate;
+    }
   }
   return undefined;
 }
@@ -341,9 +354,13 @@ export function fhirDateToDicomDate(fhirDate: string | undefined): string | unde
 }
 
 export function dicomTimeToFhirTime(dicomTime: unknown): string | undefined {
-  // DICOM time format is HHMMSS, while FHIR time format is HH:MM:SS
+  // DICOM time format is HHMMSS, optionally followed by fractional seconds, while FHIR time format is HH:MM:SS
   if (isString(dicomTime) && dicomTime.length >= 6) {
-    return `${dicomTime.substring(0, 2)}:${dicomTime.substring(2, 4)}:${dicomTime.substring(4, 6)}`;
+    const fhirTime = `${dicomTime.substring(0, 2)}:${dicomTime.substring(2, 4)}:${dicomTime.substring(4, 6)}`;
+    // Dropped rather than propagated when invalid, for the reason given in dicomDateToFhirDate
+    if (validationRegexes.time.test(fhirTime)) {
+      return fhirTime;
+    }
   }
   return undefined;
 }


### PR DESCRIPTION
`medplum dicomweb stow` took exactly one file per invocation. That is the wrong granularity for DICOM: a study is a directory of instances, and a single-slice upload is the exception rather than the rule. The docs acknowledged the gap by recommending a shell loop:

```bash
for f in ./study/*.dcm; do medplum dicomweb stow "$f"; done
```

That works, but it re-authenticates per file, and it makes the server do quadratic work. `updateAggregates` (`packages/server/src/dicom/stow-rs.ts`) runs once per *request*, and each pass recomputes a study's aggregates from every stored series and instance. One request per file turns a 100-instance study into 100 full study recomputes.

## What

```
medplum dicomweb stow <files...> [--batch-size <count>]
```

Each argument can be a file, a directory, or a glob pattern, and they can be mixed:

```bash
medplum dicomweb stow MRBRAIN.DCM                 # One file, as before
medplum dicomweb stow ./study                     # Every DICOM file in the tree, recursively
medplum dicomweb stow ./study/*.dcm               # Expanded by the shell
medplum dicomweb stow './study/**/*.dcm'          # Quoted, so the CLI expands it
```

`resolveDicomFiles` (`packages/cli/src/dicomweb.ts`) expands the arguments into a de-duplicated, sorted list of absolute paths: a file is taken as-is, a directory is walked recursively, anything `fastGlob.isDynamicPattern` recognizes is globbed, and a plain path that does not exist throws `File not found`. Instances are then sent in batches of 25 per STOW-RS request, configurable with `--batch-size`.

## Implementation notes

**Shell expansion does most of the work.** POSIX shells expand `*.dcm` before the CLI process starts, so the common case needs nothing but a variadic argument — the pattern arrives as an ordinary list of file names. Patterns reach the CLI literally in three situations: the user quoted them, the pattern matched nothing (bash passes it through), or the shell does no expansion at all (Windows `cmd`/PowerShell). `fast-glob` covers those, and it is what makes `**` usable on bash without `globstar`. It was already a dependency, used by `packages/cli/src/aws/update-app.ts`.

**Detection mirrors the server's reader.** Expanding a directory means deciding what in it is DICOM, and the cost of guessing wrong runs both directions: a false positive fails the whole batch server-side, and a false negative silently omits an instance from an upload the user believes succeeded. `isDicomFile` therefore tests exactly what the server accepts, rather than inventing its own rule. dcmjs's `AsyncDicomReader.readPreamble` handles three encodings, and `stow-rs.ts` sets `ignorePartsWithoutDicomPreamble: false` so preamble-less parts reach it:

1. Part 10 with a preamble — `DICM` at byte 128.
2. Part 10 without a preamble — the stream opens on a `(0002,xxxx)` File Meta Information tag. Checked as `readUInt16LE(0) === 0x0002`, since File Meta Information is always little-endian.
3. A raw dataset with no File Meta Information — nothing in the header distinguishes it from arbitrary binary, so this is the one case that falls back to a `.dcm` / `.dicom` / `.ima` extension.

Testing content rather than file names is what makes the extensionless names on modality exports and DICOM media (`IM000002`, `0012`) work. `.img` is deliberately *not* in the extension list — Analyze 7.5 and NIfTI use it for pixel data, and those would be false positives.

`DICOMDIR` is skipped by name: it carries a valid preamble but is a media directory record, not a storable instance.

**Filtering applies to expansion only.** A file named explicitly on the command line is always sent, whatever it looks like — naming it is the user's assertion that it is DICOM, and a client-side veto there would be unhelpful. The filter exists so that `stow ./study` does not try to upload the export folder's README. Skipped files are counted and reported rather than dropped silently.

**Batching is less server work, not more.** Aggregate recomputation is per-request and deduped by study and series ID, and each pass is O(study size) — it walks every series in the study and does an accurate count over every instance. So the total cost of an upload is roughly `(instances / batchSize) x studySize`, and larger batches are monotonically cheaper for the server than the shell loop this replaces.

Batches are sent sequentially, so a single invocation never races with itself against the `ifMatch` guard in `updateWithRetry`. That also gives the aggregates a self-healing property the one-file-per-request loop lacks: when a recompute exhausts `MAX_UPDATE_ATTEMPTS` it logs and leaves stale values, and because every recompute is a full recompute from stored resources, the next batch in the sequence corrects them.

The counterweight is blast radius. `handleError` fails an entire request on one bad part, so a larger batch means more work re-sent on failure. 25 is a conservative trade against that, not a tuned number.
