### PR TITLE
DICOM: de-dupe stored instances + search pagination

### DIFF
--- a/packages/server/src/dicom/qido-rs.ts
+++ b/packages/server/src/dicom/qido-rs.ts
@@ -5,7 +5,7 @@ import type { DicomSeries, DicomStudy } from '@medplum/fhirtypes';
 import dcmjs from 'dcmjs';
 import type { Request, Response } from 'express';
 import { getAuthenticatedContext } from '../context';
-import { medplumSeriesToDcmjsSeries, medplumStudyToDcmjsStudy } from './utils';
+import { medplumSeriesToDcmjsSeries, medplumStudyToDcmjsStudy, parseQueryInt } from './utils';
 
 // eslint-disable-next-line import/no-named-as-default-member
 const { data } = dcmjs;
@@ -75,21 +75,4 @@ export async function handleSearchSeries(req: Request, res: Response): Promise<v
     .json(
       seriesList.map((series) => DicomMetaDictionary.denaturalizeDataset(medplumSeriesToDcmjsSeries(study, series)))
     );
-}
-
-/**
- * Parses a QIDO-RS paging query parameter (`limit` or `offset`) into a non-negative integer.
- *
- * Returns undefined when the parameter is absent or invalid, so the caller falls back to the
- * server's default page size. The server clamps `count` to its own maximum (1000).
- *
- * @param value - The raw query parameter value from the request.
- * @returns The parsed non-negative integer, or undefined if absent/invalid.
- */
-function parseQueryInt(value: unknown): number | undefined {
-  if (!isString(value)) {
-    return undefined;
-  }
-  const parsed = Number.parseInt(value, 10);
-  return Number.isNaN(parsed) || parsed < 0 ? undefined : parsed;
 }

--- a/packages/server/src/dicom/qido-rs.ts
+++ b/packages/server/src/dicom/qido-rs.ts
@@ -23,7 +23,11 @@ const { DicomMetaDictionary } = data;
  */
 export async function handleSearchStudies(req: Request, res: Response): Promise<void> {
   const { repo } = getAuthenticatedContext();
-  const studies = await repo.searchResources<DicomStudy>({ resourceType: 'DicomStudy' });
+  const studies = await repo.searchResources<DicomStudy>({
+    resourceType: 'DicomStudy',
+    count: parseQueryInt(req.query.limit),
+    offset: parseQueryInt(req.query.offset),
+  });
   res
     .status(200)
     .type(ContentType.DICOM_JSON)
@@ -61,6 +65,8 @@ export async function handleSearchSeries(req: Request, res: Response): Promise<v
   const seriesList = await repo.searchResources<DicomSeries>({
     resourceType: 'DicomSeries',
     filters: [{ code: 'study', operator: Operator.EQUALS, value: `DicomStudy/${study.id}` }],
+    count: parseQueryInt(req.query.limit),
+    offset: parseQueryInt(req.query.offset),
   });
 
   res
@@ -69,4 +75,21 @@ export async function handleSearchSeries(req: Request, res: Response): Promise<v
     .json(
       seriesList.map((series) => DicomMetaDictionary.denaturalizeDataset(medplumSeriesToDcmjsSeries(study, series)))
     );
+}
+
+/**
+ * Parses a QIDO-RS paging query parameter (`limit` or `offset`) into a non-negative integer.
+ *
+ * Returns undefined when the parameter is absent or invalid, so the caller falls back to the
+ * server's default page size. The server clamps `count` to its own maximum (1000).
+ *
+ * @param value - The raw query parameter value from the request.
+ * @returns The parsed non-negative integer, or undefined if absent/invalid.
+ */
+function parseQueryInt(value: unknown): number | undefined {
+  if (!isString(value)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) || parsed < 0 ? undefined : parsed;
 }

--- a/packages/server/src/dicom/routes.test.ts
+++ b/packages/server/src/dicom/routes.test.ts
@@ -410,6 +410,53 @@ describe('DICOM Routes', () => {
     expect(storedSeries[0]['00201209'].Value).toStrictEqual(['3']);
   });
 
+  test('Re-uploading an instance does not create a duplicate', async () => {
+    const studyInstanceUid = '1.2.826.0.1.3680043.10.543.30';
+    const seriesInstanceUid = '1.2.826.0.1.3680043.10.543.31';
+    const sopInstanceUid = '1.2.826.0.1.3680043.10.543.32';
+
+    async function upload(): Promise<SuperAgentResponse> {
+      const boundary = `medplum-${Date.now()}`;
+      const contentType = `multipart/related; type=application/dicom; boundary=${boundary}`;
+      const body = Buffer.concat([
+        Buffer.from(`--${boundary}\r\nContent-Type: application/dicom\r\n\r\n`),
+        createDicomBuffer({ sopInstanceUid, studyInstanceUid, seriesInstanceUid }),
+        Buffer.from(`\r\n--${boundary}--\r\n`),
+      ]);
+      return request(app)
+        .post(`/dicomweb/studies`)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Content-Type', contentType)
+        .send(body);
+    }
+
+    // Store the same SOP instance twice, in two separate requests
+    expect(await upload()).toHaveStatus(200);
+    expect(await upload()).toHaveStatus(200);
+
+    // The conditional create resolved the existing instance the second time, so the study and series
+    // still count a single instance rather than two. NumberOfStudyRelatedInstances (0020,1208) and
+    // NumberOfSeriesRelatedInstances (0020,1209) are recomputed from the stored DicomInstance rows,
+    // so a duplicate would show here as '2'.
+    const studies = await request(app)
+      .get(`/dicomweb/studies`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(studies).toHaveStatus(200);
+    const stored = (studies.body as Record<string, { Value?: unknown[] }>[]).filter(
+      (study) => study['0020000D']?.Value?.[0] === studyInstanceUid
+    );
+    expect(stored).toHaveLength(1);
+    expect(stored[0]['00201208'].Value).toStrictEqual(['1']);
+
+    const series = await request(app)
+      .get(`/dicomweb/studies/${studyInstanceUid}/series`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(series).toHaveStatus(200);
+    const storedSeries = series.body as Record<string, { Value?: unknown[] }>[];
+    expect(storedSeries).toHaveLength(1);
+    expect(storedSeries[0]['00201209'].Value).toStrictEqual(['1']);
+  });
+
   test('Direct handler validation errors', async () => {
     await handleSearchSeries({ params: {} } as Request, createMockResponse(400, { error: 'Invalid study UID' }));
     await handleRetrieveSeriesMetadata(

--- a/packages/server/src/dicom/stow-rs.ts
+++ b/packages/server/src/dicom/stow-rs.ts
@@ -104,9 +104,7 @@ export async function handleStoreInstances(req: Request, res: Response): Promise
       },
       {
         resourceType: 'DicomInstance',
-        filters: [
-          { code: 'sop-instance-uid', operator: Operator.EXACT, value: naturalized.SOPInstanceUID as string },
-        ],
+        filters: [{ code: 'sop-instance-uid', operator: Operator.EXACT, value: naturalized.SOPInstanceUID as string }],
       }
     );
     return instanceResult.resource;

--- a/packages/server/src/dicom/stow-rs.ts
+++ b/packages/server/src/dicom/stow-rs.ts
@@ -85,22 +85,31 @@ export async function handleStoreInstances(req: Request, res: Response): Promise
       instanceNumber = '1'; // Default to "1" if InstanceNumber is missing or invalid, as it is a required field in DICOM
     }
 
-    return repo.createResource<DicomInstance>({
-      resourceType: 'DicomInstance',
-      study: createReference(studyResult.resource),
-      series: createReference(seriesResult.resource),
-      raw: createReference(binary),
-      metadata: JSON.stringify(dict),
-      sopClassUid: naturalized.SOPClassUID as string,
-      sopInstanceUid: naturalized.SOPInstanceUID as string,
-      instanceAvailability: naturalized.InstanceAvailability as string,
-      timezoneOffsetFromUtc: naturalized.TimezoneOffsetFromUTC as string,
-      instanceNumber: instanceNumber,
-      rows: naturalized.Rows as number,
-      columns: naturalized.Columns as number,
-      bitsAllocated: naturalized.BitsAllocated as number,
-      numberOfFrames: naturalized.NumberOfFrames as number,
-    });
+    const instanceResult = await repo.conditionalCreate<DicomInstance>(
+      {
+        resourceType: 'DicomInstance',
+        study: createReference(studyResult.resource),
+        series: createReference(seriesResult.resource),
+        raw: createReference(binary),
+        metadata: JSON.stringify(dict),
+        sopClassUid: naturalized.SOPClassUID as string,
+        sopInstanceUid: naturalized.SOPInstanceUID as string,
+        instanceAvailability: naturalized.InstanceAvailability as string,
+        timezoneOffsetFromUtc: naturalized.TimezoneOffsetFromUTC as string,
+        instanceNumber: instanceNumber,
+        rows: naturalized.Rows as number,
+        columns: naturalized.Columns as number,
+        bitsAllocated: naturalized.BitsAllocated as number,
+        numberOfFrames: naturalized.NumberOfFrames as number,
+      },
+      {
+        resourceType: 'DicomInstance',
+        filters: [
+          { code: 'sop-instance-uid', operator: Operator.EXACT, value: naturalized.SOPInstanceUID as string },
+        ],
+      }
+    );
+    return instanceResult.resource;
   }
 
   /**

--- a/packages/server/src/dicom/utils.test.ts
+++ b/packages/server/src/dicom/utils.test.ts
@@ -22,6 +22,7 @@ import {
   fhirTimeToDicomTime,
   medplumSeriesToDcmjsSeries,
   medplumStudyToDcmjsStudy,
+  parseQueryInt,
   stringToDicomPersonName,
   updateSeriesAggregates,
   updateStudyAggregates,
@@ -434,4 +435,17 @@ describe('DICOM study aggregates', () => {
       });
       updateResource.mockRestore();
     }));
+});
+
+describe('parseQueryInt', () => {
+  test('parses valid integers', () => {
+    expect(parseQueryInt('123')).toBe(123);
+  });
+
+  test('returns undefined for invalid integers', () => {
+    expect(parseQueryInt('abc')).toBeUndefined();
+    expect(parseQueryInt(undefined)).toBeUndefined();
+    expect(parseQueryInt(null)).toBeUndefined();
+    expect(parseQueryInt(['123', 'abc'])).toBeUndefined();
+  });
 });

--- a/packages/server/src/dicom/utils.ts
+++ b/packages/server/src/dicom/utils.ts
@@ -392,3 +392,20 @@ export async function writeBuffer(stream: PassThrough, buffer: Buffer): Promise<
     await once(stream, 'drain');
   }
 }
+
+/**
+ * Parses a QIDO-RS paging query parameter (`limit` or `offset`) into a non-negative integer.
+ *
+ * Returns undefined when the parameter is absent or invalid, so the caller falls back to the
+ * server's default page size. The server clamps `count` to its own maximum (1000).
+ *
+ * @param value - The raw query parameter value from the request.
+ * @returns The parsed non-negative integer, or undefined if absent/invalid.
+ */
+export function parseQueryInt(value: unknown): number | undefined {
+  if (!isString(value)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) || parsed < 0 ? undefined : parsed;
+}

--- a/packages/server/src/dicom/wado-rs.ts
+++ b/packages/server/src/dicom/wado-rs.ts
@@ -28,6 +28,9 @@ export async function handleRetrieveSeriesMetadata(req: Request, res: Response):
   const instances = await repo.searchResources<DicomInstance>({
     resourceType: 'DicomInstance',
     filters: [{ code: 'series', operator: Operator.EQUALS, value: `DicomSeries/${series.id}` }],
+    // Use the server max page size. A CT/MR series commonly has hundreds of instances;
+    // the default page size of 20 would silently truncate the series in the viewer.
+    count: 1000,
   });
   res
     .status(200)


### PR DESCRIPTION
Two independent DICOMweb fixes on this branch (kept together while DICOMweb is still early access).

## 1. STOW-RS: conditional create for DicomInstance

`handleStoreInstances` already used `conditionalCreate` for `DicomStudy` and `DicomSeries`, but wrote each `DicomInstance` with a plain `createResource`. Re-storing a SOP instance that was already stored — a normal, idempotent STOW-RS operation — therefore produced a duplicate `DicomInstance` row every time.

The instance write now uses `repo.conditionalCreate` filtered on the `sop-instance-uid` search parameter, matching the study/series pattern directly above it. Re-uploading the same SOP instance resolves the existing resource instead of creating a new one.

## 2. QIDO-RS / WADO-RS: search pagination

- **QIDO-RS study and series search** (`qido-rs.ts`) now honor `limit` and `offset` query parameters, parsed via a small `parseQueryInt` helper (ignores absent/invalid/negative values so the server default and its max-count clamp of 1000 still apply).
- **WADO-RS series metadata** (`wado-rs.ts`) now requests `count: 1000` (server max) instead of relying on the default page size of 20. A CT/MR series routinely has hundreds of instances, so the default would silently truncate the series returned to the viewer.
