### PR TITLE
Fixes #10132 - reduce serialization conflicts in invite

### DIFF
--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -105,55 +105,49 @@ export async function inviteUser(request: ServerInviteRequest): Promise<ServerIn
   const userResource = await makeUserResource(request);
   let user: WithId<User>;
   if (email) {
-    const { resource: result, outcome } = await systemRepo.withTransaction(
-      async (txRepo) => {
-        // If inviting with an email address, check for existing memberships
-        // tied to this project/email combination that are at a different scope
-        // than the one we would create. This avoids confusion of someone
-        // having separate server-scoped and project-scoped user records.
-        //
-        // This check is bypassed if the caller explicitly passes `forceNewMembership: true`
-        if (!request.forceNewMembership) {
-          const projectFilter = userResource.project
-            ? { code: 'user:User.project', operator: Operator.MISSING, value: 'true' }
-            : { code: 'user:User.project', operator: Operator.EXACT, value: `Project/${project.id}` };
+    // If inviting with an email address, check for existing memberships
+    // tied to this project/email combination that are at a different scope
+    // than the one we would create. This avoids confusion of someone
+    // having separate server-scoped and project-scoped user records.
+    //
+    // This check is bypassed if the caller explicitly passes `forceNewMembership: true`.
+    // It is intentionally separate from the conditional create: the ProjectMembership
+    // is created later in the invite flow, so wrapping only this check and User creation
+    // in a larger transaction does not make the cross-resource invariant atomic.
+    if (!request.forceNewMembership) {
+      const projectFilter = userResource.project
+        ? { code: 'user:User.project', operator: Operator.MISSING, value: 'true' }
+        : { code: 'user:User.project', operator: Operator.EXACT, value: `Project/${project.id}` };
 
-          const existingMemberships = await txRepo.searchResources<ProjectMembership>({
-            resourceType: 'ProjectMembership',
-            filters: [
-              { code: 'user:User.email', operator: Operator.EXACT, value: email },
-              { code: 'project', operator: Operator.EXACT, value: `Project/${project.id}` },
-              projectFilter,
-            ],
-          });
+      const existingMemberships = await systemRepo.searchResources<ProjectMembership>({
+        resourceType: 'ProjectMembership',
+        filters: [
+          { code: 'user:User.email', operator: Operator.EXACT, value: email },
+          { code: 'project', operator: Operator.EXACT, value: `Project/${project.id}` },
+          projectFilter,
+        ],
+      });
 
-          if (existingMemberships.length > 0) {
-            throw new OperationOutcomeError(conflict('User is already a member of this project'));
-          }
-        }
-
-        const searchRequest: SearchRequest<User> = {
-          resourceType: 'User',
-          filters: [
-            {
-              code: 'email',
-              operator: Operator.EXACT,
-              value: email,
-            },
-            userResource.project
-              ? { code: 'project', operator: Operator.EQUALS, value: `Project/${project.id}` }
-              : { code: 'project', operator: Operator.MISSING, value: 'true' },
-          ],
-        };
-
-        return txRepo.conditionalCreate(userResource, searchRequest);
-      },
-      {
-        resourceTypes: ['ProjectMembership', 'User'],
-        source: 'inviteUser.upsertUser',
-        serializable: true,
+      if (existingMemberships.length > 0) {
+        throw new OperationOutcomeError(conflict('User is already a member of this project'));
       }
-    );
+    }
+
+    const searchRequest: SearchRequest<User> = {
+      resourceType: 'User',
+      filters: [
+        {
+          code: 'email',
+          operator: Operator.EXACT,
+          value: email,
+        },
+        userResource.project
+          ? { code: 'project', operator: Operator.EQUALS, value: `Project/${project.id}` }
+          : { code: 'project', operator: Operator.MISSING, value: 'true' },
+      ],
+    };
+
+    const { resource: result, outcome } = await systemRepo.conditionalCreate(userResource, searchRequest);
     user = result;
     existingUser = !isCreated(outcome);
   } else {
@@ -450,15 +444,36 @@ async function upsertProjectMembership(
     return createProjectMembership(systemRepo, user, project, profile, partialMembership);
   }
 
+  const membershipSearch: SearchRequest<ProjectMembership> = {
+    resourceType: 'ProjectMembership',
+    filters: [
+      { code: 'user', operator: Operator.EQUALS, value: getReferenceString(user) },
+      { code: 'project', operator: Operator.EQUALS, value: getReferenceString(project) },
+    ],
+  };
+
+  if (!request.upsert) {
+    const { resource: membership, outcome } = await systemRepo.conditionalCreate<ProjectMembership>(
+      {
+        ...partialMembership,
+        resourceType: 'ProjectMembership',
+        project: createReference(project),
+        user: createReference(user),
+        profile: createReference(profile),
+      },
+      membershipSearch
+    );
+    if (!isCreated(outcome)) {
+      throw new OperationOutcomeError(conflict('User is already a member of this project'));
+    }
+    return membership;
+  }
+
   // Upsert ProjectMembership resource to connect User to profile resource in the given Project
   const membership = await systemRepo.withTransaction(
     async (txRepo) => {
       const existingMembership = await searchForExistingMembership(txRepo, user, project);
       if (existingMembership) {
-        if (!request.upsert) {
-          throw new OperationOutcomeError(conflict('User is already a member of this project'));
-        }
-
         if (existingMembership.profile?.reference !== getReferenceString(profile)) {
           throw new OperationOutcomeError(
             conflict('User is already a member of this project with a different profile')

--- a/packages/server/src/fhir/repository/repository-connection.ts
+++ b/packages/server/src/fhir/repository/repository-connection.ts
@@ -23,7 +23,7 @@ import { RepositoryAccessTracker } from './access-tracker';
 import type { TransactionIdleStatus, TransactionIdleTrackerOptions } from './transaction-idle-tracker';
 import { TransactionIdleTracker } from './transaction-idle-tracker';
 
-const defaultTransactionAttempts = 2;
+const defaultTransactionAttempts = 3;
 const defaultExpBackoffBaseDelayMs = 50;
 const transactionIsolationLevelPriority: Record<TransactionIsolationLevel, number> = {
   'REPEATABLE READ': 1,

--- a/packages/server/src/fhir/repository/transaction-idle-tracker.test.ts
+++ b/packages/server/src/fhir/repository/transaction-idle-tracker.test.ts
@@ -256,7 +256,7 @@ describe('TransactionIdleTracker', () => {
           serializable: false,
           status: 'committed',
           thresholdMs: 50,
-          transactionAttempts: 2,
+          transactionAttempts: 3,
           transactionDurationMs: 100,
         })
       );

--- a/packages/server/src/fhir/repository/transaction.test.ts
+++ b/packages/server/src/fhir/repository/transaction.test.ts
@@ -864,7 +864,7 @@ describe('FHIR Repo Transactions', () => {
       createError: () =>
         new OperationOutcomeError(conflict('transaction conflict', PostgresError.SerializationFailure)),
       succeedsOnRetry: false,
-      expectedCalls: 2,
+      expectedCalls: 3,
       expectedError: 'transaction conflict',
     },
   ])('$name', ({ createError, succeedsOnRetry, expectedCalls, expectedError, expectedResult }) =>
@@ -905,8 +905,8 @@ describe('FHIR Repo Transactions', () => {
       succeedsOnRetry: false,
       catchNestedError: false,
       expectedError: 'transaction conflict',
-      expectedTxCalls: 2,
-      expectedOuterCalls: 2,
+      expectedTxCalls: 3,
+      expectedOuterCalls: 3,
     },
     {
       name: 'Nested transaction does not retry independently',


### PR DESCRIPTION
Reduce serialization conflicts in the `/invite` flow by using smaller atomic repository primitives, and increase the default number of transaction attempts from two to three.

## Changes

- Move the opposite-scope `ProjectMembership` validation outside of the transaction used to conditionally create a `User`.
- Continue using `conditionalCreate` to atomically find or create the invited `User`.
- Use `conditionalCreate` to atomically create a `ProjectMembership` for the normal, non-upsert invite path.
- Retain the focused transaction for membership upserts, where the existing membership must be read, validated, merged, and updated together.
- Increase `defaultTransactionAttempts` from `2` to `3`, matching the current production configuration.

## Rationale

The previous user transaction combined a chained `ProjectMembership`/`User` search with the conditional creation of a `User`. This increased the serializable transaction's predicate-lock footprint and made it more likely to conflict with unrelated user and membership writes under CI and production concurrency.

That larger transaction did not make the complete cross-resource invite invariant atomic because the corresponding `ProjectMembership` is created later in the flow. Separating the validation from `conditionalCreate` preserves existing endpoint behavior while allowing serialization retries to cover only the actual conditional user creation.

The normal membership creation path is itself a conditional create: create the membership if none exists, otherwise return the existing membership and translate that result into the endpoint's expected business conflict. Using the repository primitive makes that atomic boundary explicit and keeps it small.

Increasing the default transaction attempts to three provides one additional opportunity to recover from a transient PostgreSQL serialization failure while keeping retry amplification bounded. This is intentionally incremental rather than increasing directly to five attempts.
