### PR TITLE
perf(fhir-router): optimize conditional operations to reduce 40001 conflicts

### DIFF
--- a/packages/fhir-router/src/repo.test.ts
+++ b/packages/fhir-router/src/repo.test.ts
@@ -319,5 +319,46 @@ describe('MemoryRepository', () => {
       const results = await Promise.all([p1, p2]);
       expect(results.map((r) => r.outcome.id)).toEqual(['created', 'ok']);
     });
+
+    test('conditionalUpdate', async () => {
+      const patient: Patient = {
+        resourceType: 'Patient',
+        id: 'update-test',
+        active: true,
+      };
+
+      const c1 = await repo.conditionalUpdate(patient, parseSearchRequest('Patient?_id=update-test'), { assignedId: true });
+      expect(c1.outcome.id).toBe('created');
+
+      patient.active = false;
+      const u1 = await repo.conditionalUpdate(patient, parseSearchRequest('Patient?_id=update-test'), { assignedId: true });
+      expect(u1.outcome.id).toBe('ok');
+      expect(u1.resource.active).toBe(false);
+    });
+
+    test('conditionalDelete', async () => {
+      const patient: Patient = {
+        resourceType: 'Patient',
+        id: 'delete-test',
+      };
+      await repo.createResource(patient);
+
+      await expect(repo.conditionalDelete(parseSearchRequest('Patient?_id=delete-test'))).resolves.toBeUndefined();
+      await expect(repo.conditionalDelete(parseSearchRequest('Patient?_id=delete-test'))).resolves.toBeUndefined(); // second delete is no-op
+    });
+
+    test('conditionalPatch', async () => {
+      const patient: Patient = {
+        resourceType: 'Patient',
+        id: 'patch-test',
+        active: true,
+      };
+      await repo.createResource(patient);
+
+      const patched = (await repo.conditionalPatch(parseSearchRequest('Patient?_id=patch-test'), [
+        { op: 'replace', path: '/active', value: false },
+      ])) as Patient;
+      expect(patched.active).toBe(false);
+    });
   });
 });

--- a/packages/fhir-router/src/repo.test.ts
+++ b/packages/fhir-router/src/repo.test.ts
@@ -327,11 +327,15 @@ describe('MemoryRepository', () => {
         active: true,
       };
 
-      const c1 = await repo.conditionalUpdate(patient, parseSearchRequest('Patient?_id=update-test'), { assignedId: true });
+      const c1 = await repo.conditionalUpdate(patient, parseSearchRequest('Patient?_id=update-test'), {
+        assignedId: true,
+      });
       expect(c1.outcome.id).toBe('created');
 
       patient.active = false;
-      const u1 = await repo.conditionalUpdate(patient, parseSearchRequest('Patient?_id=update-test'), { assignedId: true });
+      const u1 = await repo.conditionalUpdate(patient, parseSearchRequest('Patient?_id=update-test'), {
+        assignedId: true,
+      });
       expect(u1.outcome.id).toBe('ok');
       expect(u1.resource.active).toBe(false);
     });

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -8,6 +8,7 @@ import {
   allOk,
   applyPatch,
   badRequest,
+  conflict,
   created,
   deepClone,
   evalFhirPath,
@@ -285,18 +286,33 @@ export abstract class FhirRepository {
     search.count = 2;
     search.sortRules = undefined;
 
+    // 1. Optimistic Search
+    const matches = await this.searchResources(search);
+    if (matches.length === 1) {
+      const existing = matches[0];
+      if (!options?.assignedId && resource.id && resource.id !== existing.id) {
+        throw new OperationOutcomeError(
+          badRequest('Resource ID did not match resolved ID', resource.resourceType + '.id')
+        );
+      }
+      return { resource: existing, outcome: allOk };
+    } else if (matches.length > 1) {
+      throw new OperationOutcomeError(multipleMatches);
+    }
+
+    // 2. Fallback to SERIALIZABLE transaction only if no match found
     return this.withTransaction(
       async (txRepo) => {
-        const matches = await txRepo.searchResources(search);
-        if (matches.length === 1) {
-          const existing = matches[0];
+        const txMatches = await txRepo.searchResources(search);
+        if (txMatches.length === 1) {
+          const existing = txMatches[0];
           if (!options?.assignedId && resource.id && resource.id !== existing.id) {
             throw new OperationOutcomeError(
               badRequest('Resource ID did not match resolved ID', resource.resourceType + '.id')
             );
           }
-          return { resource: matches[0], outcome: allOk };
-        } else if (matches.length > 1) {
+          return { resource: txMatches[0], outcome: allOk };
+        } else if (txMatches.length > 1) {
           throw new OperationOutcomeError(multipleMatches);
         }
 
@@ -341,10 +357,40 @@ export abstract class FhirRepository {
     search.count = 2;
     search.sortRules = undefined;
 
+    // 1. Optimistic Search
+    const matches = await this.searchResources(search);
+    if (matches.length === 1) {
+      const existing = matches[0];
+      if (resource.id && resource.id !== existing.id) {
+        throw new OperationOutcomeError(
+          badRequest('Resource ID did not match resolved ID', resource.resourceType + '.id')
+        );
+      }
+
+      // Perform the update in a standard (non-serializable) transaction
+      return this.withTransaction(
+        async (txRepo) => {
+          const txMatches = await txRepo.searchResources(search);
+          if (txMatches.length === 1) {
+            const updated = await txRepo.updateResource({ ...resource, id: txMatches[0].id }, options);
+            return { resource: updated, outcome: allOk };
+          }
+          throw new OperationOutcomeError(conflict('Resource state changed during update'));
+        },
+        {
+          resourceTypes: getSearchResourceTypes(search),
+          serializable: false,
+        }
+      );
+    } else if (matches.length > 1) {
+      throw new OperationOutcomeError(multipleMatches);
+    }
+
+    // 2. Fallback to SERIALIZABLE transaction only if no match found
     return this.withTransaction(
       async (txRepo) => {
-        const matches = await txRepo.searchResources(search);
-        if (matches.length === 0) {
+        const txMatches = await txRepo.searchResources(search);
+        if (txMatches.length === 0) {
           if (resource.id && !options?.assignedId) {
             throw new OperationOutcomeError(
               badRequest('Cannot perform create as update with client-assigned ID', resource.resourceType + '.id')
@@ -352,11 +398,11 @@ export abstract class FhirRepository {
           }
           const createdResource = await txRepo.createResource(resource, options);
           return { resource: createdResource, outcome: created };
-        } else if (matches.length > 1) {
+        } else if (txMatches.length > 1) {
           throw new OperationOutcomeError(multipleMatches);
         }
 
-        const existing = matches[0];
+        const existing = txMatches[0];
         if (resource.id && resource.id !== existing.id) {
           throw new OperationOutcomeError(
             badRequest('Resource ID did not match resolved ID', resource.resourceType + '.id')
@@ -366,7 +412,10 @@ export abstract class FhirRepository {
         const updated = await txRepo.updateResource({ ...resource, id: existing.id }, options);
         return { resource: updated, outcome: allOk };
       },
-      { serializable: true, resourceTypes: getSearchResourceTypes(search) }
+      {
+        resourceTypes: getSearchResourceTypes(search),
+        serializable: true,
+      }
     );
   }
 
@@ -388,19 +437,31 @@ export abstract class FhirRepository {
     search.count = 2;
     search.sortRules = undefined;
 
+    // 1. Optimistic Search
+    const matches = await this.searchResources(search);
+    if (matches.length > 1) {
+      throw new OperationOutcomeError(multipleMatches);
+    } else if (!matches.length) {
+      return;
+    }
+
+    // 2. Perform the delete in a standard (non-serializable) transaction
     await this.withTransaction(
       async (txRepo) => {
-        const matches = await txRepo.searchResources(search);
-        if (matches.length > 1) {
+        const txMatches = await txRepo.searchResources(search);
+        if (txMatches.length > 1) {
           throw new OperationOutcomeError(multipleMatches);
-        } else if (!matches.length) {
+        } else if (!txMatches.length) {
           return;
         }
 
-        const resource = matches[0];
+        const resource = txMatches[0];
         await txRepo.deleteResource(resource.resourceType, resource.id);
       },
-      { serializable: true, resourceTypes: getSearchResourceTypes(search) }
+      {
+        resourceTypes: getSearchResourceTypes(search),
+        serializable: false,
+      }
     );
   }
 
@@ -413,19 +474,31 @@ export abstract class FhirRepository {
     search.count = 2;
     search.sortRules = undefined;
 
+    // 1. Optimistic Search
+    const matches = await this.searchResources(search);
+    if (matches.length > 1) {
+      throw new OperationOutcomeError(multipleMatches);
+    } else if (!matches.length) {
+      throw new OperationOutcomeError(notFound);
+    }
+
+    // 2. Perform the patch in a standard (non-serializable) transaction
     return this.withTransaction(
       async (txRepo) => {
-        const matches = await txRepo.searchResources(search);
-        if (matches.length > 1) {
+        const txMatches = await txRepo.searchResources(search);
+        if (txMatches.length > 1) {
           throw new OperationOutcomeError(multipleMatches);
-        } else if (!matches.length) {
+        } else if (!txMatches.length) {
           throw new OperationOutcomeError(notFound);
         }
 
-        const resource = matches[0];
+        const resource = txMatches[0];
         return txRepo.patchResource(resource.resourceType, resource.id, patch, options);
       },
-      { serializable: true, resourceTypes: getSearchResourceTypes(search) }
+      {
+        resourceTypes: getSearchResourceTypes(search),
+        serializable: false,
+      }
     );
   }
 }


### PR DESCRIPTION
Carrying over from https://github.com/medplum/medplum/pull/9916

Bringing into `medplum` organization for access to all static analysis tools

@lsub-ai's original description:

--------

Redesigns conditionalCreate, conditionalUpdate, conditionalDelete, and
conditionalPatch in FhirRepository to use an Optimistic Search pattern
(Double-Checked Locking).

Rather than forcing the entire operation (search + write) into a
SERIALIZABLE transaction, we perform an optimistic search first. If exactly
one match is found (representing the vast majority of load under updates/deletes/patches
on existing resources), we execute the write within a normal REPEATABLE READ
(serializable: false) transaction. This completely avoids coarse GIN
index page-level predicate locks and false-positive 40001 serialization
errors on the happy path.
