### PR TITLE
Add vouch backlog summary step

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -24,19 +24,24 @@
 #   - Optional free-text details after a space following the handle
 #     (e.g. a reason for denouncement).
 alexanderxlin
+amcgivern prior contributions
 andystoneman
 codyebberson
 deam65
+dillonstreator prior contributions
 everett-williams
 filupnot
 finnbergquist
 ianplunkett
+jdjkelly prior contributions
+kevinwadeshaw
 maddyli
 mattlong
 mattwiller
 medplumbot
 noahsilas
 oleg-mp
+rahul1 prior contributions
 reshmakh
 techdavidy
 thatonebro

--- a/.github/workflows/vouch-check-pr-backlog.yml
+++ b/.github/workflows/vouch-check-pr-backlog.yml
@@ -9,32 +9,114 @@ on:
         description: "Comma-separated PR numbers to check (empty = all open PRs)"
         required: false
         default: ""
+      include-vouched-authors:
+        description: "Also check PRs whose author is vouched in .github/VOUCHED.td (normally skipped)"
+        required: false
+        default: false
+        type: boolean
 
 name: "Vouch - Check PR Backlog"
+
+env:
+  # Matrix jobs cap out at 256. Anything past that is deferred to a later run
+  # rather than failing the whole sweep up front, and is listed in the summary
+  # so it's clear what still needs a pass.
+  MATRIX_MAX: 256
 
 jobs:
   list-prs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       pr-numbers: ${{ steps.list.outputs.numbers }}
+      considered: ${{ steps.list.outputs.considered }}
+      skipped: ${{ steps.list.outputs.skipped }}
+      deferred: ${{ steps.list.outputs.deferred }}
     steps:
+      # Sparse-checkout of the base ref only, just to read the vouched list.
+      # Path matches the vouch action's own `vouched-file` default, which the
+      # check jobs rely on, so the two can't disagree about who's vouched.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github/VOUCHED.td
+
+      # Most of the open-PR backlog belongs to maintainers and other vouched
+      # contributors, whose PRs the check can only ever leave alone. Dropping
+      # them here keeps the matrix (and the summary) down to the PRs where the
+      # answer isn't known in advance. Denounced entries (leading "-") are
+      # deliberately *not* dropped: those are the ones that do get closed.
       - name: List target PRs
         id: list
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBERS_INPUT: ${{ github.event.inputs.pr-numbers }}
+          INCLUDE_VOUCHED: ${{ github.event.inputs.include-vouched-authors }}
+          REPO: ${{ github.repository }}
         run: |
-          if [ -n "$PR_NUMBERS_INPUT" ]; then
-            NUMBERS=$(echo "$PR_NUMBERS_INPUT" | tr ',' '\n' | jq -R 'select(length > 0) | tonumber' | jq -s -c '.')
-          else
-            NUMBERS=$(gh pr list --repo "${{ github.repository }}" --state open --limit 1000 --json number --jq '[.[].number]')
-          fi
-          echo "Targeting PR numbers: $NUMBERS"
-          echo "numbers=$NUMBERS" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
 
-  # Matrix jobs cap out at 256 -- if the open-PR backlog ever exceeds that,
-  # batch it manually across a few runs using the pr-numbers input instead
-  # of trying to sweep everything in one go.
+          # Same normalization the vouch tool applies to this file: strip
+          # comments and any platform prefix (github:user), lowercase, and
+          # ignore denounced entries.
+          VOUCHED=$(awk '!/^[[:space:]]*#/ && NF && $1 !~ /^-/ {
+              sub(/^[A-Za-z0-9_-]+:/, "", $1); print tolower($1)
+            }' .github/VOUCHED.td | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "Vouched authors: $VOUCHED"
+
+          # An explicit list may name closed PRs, which `gh pr list` won't
+          # return, so those are looked up one at a time. tonumber doubles as
+          # input validation before anything reaches a command line; the trim
+          # is what makes "1, 2, 3" work as well as "1,2,3".
+          if [ -n "$PR_NUMBERS_INPUT" ]; then
+            CANDIDATES="[]"
+            for NUMBER in $(echo "$PR_NUMBERS_INPUT" | tr ',' '\n' \
+              | jq -R -r 'gsub("^\\s+|\\s+$"; "") | select(length > 0) | tonumber'); do
+              PR=$(gh pr view "$NUMBER" --repo "$REPO" --json number,author)
+              CANDIDATES=$(jq -c -s 'add' <(echo "$CANDIDATES") <(echo "[$PR]"))
+            done
+          else
+            CANDIDATES=$(gh pr list --repo "$REPO" --state open --limit 1000 --json number,author)
+          fi
+
+          # Partition into what the matrix will check and what got filtered
+          # out, keeping the latter so the summary can account for every PR
+          # the sweep looked at. "app/" is how the gh CLI renders bot logins.
+          PARTITION=$(jq -c \
+            --argjson vouched "$VOUCHED" \
+            --arg include "$INCLUDE_VOUCHED" \
+            --argjson max "$MATRIX_MAX" '
+            ($vouched | INDEX(.)) as $set
+            | [.[] | {number, author: .author.login}]
+            | map(. + {
+                skip: ($include != "true"
+                  and $set[(.author | ascii_downcase | sub("^app/"; ""))] != null)
+              })
+            | (map(select(.skip | not)) | sort_by(.number)) as $check
+            | {
+                considered: length,
+                check: ($check[0:$max] | map(del(.skip))),
+                deferred: ($check[$max:] | map(.number)),
+                skipped: (map(select(.skip)) | sort_by(.author | ascii_downcase) | map(del(.skip)))
+              }' <<<"$CANDIDATES")
+
+          NUMBERS=$(jq -c '[.check[].number]' <<<"$PARTITION")
+          DEFERRED=$(jq -c '.deferred' <<<"$PARTITION")
+
+          {
+            echo "numbers=$NUMBERS"
+            echo "considered=$(jq -r '.considered' <<<"$PARTITION")"
+            echo "skipped=$(jq -c '.skipped' <<<"$PARTITION")"
+            echo "deferred=$DEFERRED"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Targeting PR numbers: $NUMBERS"
+
+          if [ "$(jq 'length' <<<"$DEFERRED")" -gt 0 ]; then
+            echo "::warning::More than $MATRIX_MAX PRs to check; deferred $(jq -c '.' <<<"$DEFERRED") to a later run (pass them via the pr-numbers input)."
+          fi
+
   check:
     needs: list-prs
     if: needs.list-prs.outputs.pr-numbers != '[]'
@@ -50,4 +132,115 @@ jobs:
     uses: ./.github/workflows/vouch-check-pr-shared.yml
     with:
       pr-number: ${{ matrix.pr-number }}
+      report-artifact: true
     secrets: inherit
+
+  # Rolls the per-PR result artifacts up into one table, so a 100-job sweep
+  # can be read (and, in dry-run mode, acted on) without opening every job.
+  summary:
+    needs: [list-prs, check]
+    if: ${{ !cancelled() && needs.list-prs.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      # download-artifact errors out when nothing matches the pattern, which
+      # is a legitimate state here (every PR got filtered out, or every check
+      # job died before uploading). Let it fail and have the renderer below
+      # account for the missing results instead.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        id: download
+        continue-on-error: true
+        with:
+          path: results
+          pattern: vouch-result-*
+
+      - name: Render summary
+        env:
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ vars.VOUCH_DRY_RUN || 'true' }}
+          TARGETED: ${{ needs.list-prs.outputs.pr-numbers }}
+          CONSIDERED: ${{ needs.list-prs.outputs.considered }}
+          SKIPPED: ${{ needs.list-prs.outputs.skipped }}
+          DEFERRED: ${{ needs.list-prs.outputs.deferred }}
+        run: |
+          set -euo pipefail
+
+          RESULTS="[]"
+          if [ -d results ]; then
+            RESULTS=$(find results -name '*.json' -print0 | xargs -0 -r cat | jq -s -c '.')
+          fi
+
+          jq -n -r \
+            --argjson results "$RESULTS" \
+            --argjson targeted "$TARGETED" \
+            --argjson skipped "$SKIPPED" \
+            --argjson deferred "$DEFERRED" \
+            --argjson considered "$CONSIDERED" \
+            --arg repo "$REPO" \
+            --arg dry_run "$DRY_RUN" '
+            ($dry_run == "true") as $dry
+
+            # PR titles are arbitrary text; keep them from breaking out of a
+            # table cell.
+            | def cell: (. // "") | gsub("\r?\n"; " ") | gsub("\\|"; "\\|")
+              | if length > 80 then .[0:77] + "..." else . end;
+            def link: "[#\(.)](https://github.com/\($repo)/pull/\(.))";
+            def table($cols; $rows):
+              "| " + ($cols | join(" | ")) + " |",
+              "| " + ($cols | map("---") | join(" | ")) + " |",
+              ($rows | map("| " + join(" | ") + " |") | .[]);
+            def section($title; $rows):
+              if ($rows | length) == 0 then empty
+              else "", "### \($title) (\($rows | length))", "",
+                table(["PR", "Author", "Title"];
+                  $rows | map([(.number | link), .author, (.title | cell)]))
+              end;
+            def details($title; $body):
+              if ($body | length) == 0 then empty
+              else "", "<details><summary>\($title)</summary>", "", $body, "", "</details>"
+              end;
+
+            # Every outcome the shared workflow can record, in the order a
+            # reviewer cares about: what got closed first, then failures,
+            # then the PRs it deliberately left alone.
+            [ {key: "close-denounced", label: "Closed: denounced author"},
+              {key: "would-close-denounced", label: "Would close: denounced author"},
+              {key: "close-unvouched", label: "Closed: unvouched author, no linked `open-to-community` issue"},
+              {key: "would-close-unvouched", label: "Would close: unvouched author, no linked `open-to-community` issue"},
+              {key: "error", label: "Errored (check the job logs)"},
+              {key: "linked-issue", label: "Left open: linked issue has the `open-to-community` label"},
+              {key: "vouched", label: "Left open: the action vouched the author itself (repo write access)"},
+              {key: "bot", label: "Left open: author is a bot"}
+            ] as $outcomes
+            | ($results | group_by(.outcome) | map({key: .[0].outcome, rows: sort_by(.number)})
+               | INDEX(.key)) as $byOutcome
+            | ($targeted - ($results | map(.number))) as $missing
+            | ($byOutcome | keys - ($outcomes | map(.key))) as $unknown
+
+            | [ "## Vouch backlog sweep",
+                "",
+                if $dry then
+                  "**Dry run** (`VOUCH_DRY_RUN` is not `false`): nothing was commented on or closed. Flip the repo variable to act for real."
+                else
+                  "**Live run**: unvouched and denounced PRs listed below were commented on and closed."
+                end,
+                "",
+                "- Considered: **\($considered)** PR(s)",
+                "- Skipped as vouched authors: **\($skipped | length)**",
+                "- Checked: **\($targeted | length)**",
+                if ($deferred | length) > 0 then
+                  "- Deferred past the 256-job matrix cap: **\($deferred | length)** (\($deferred | map(link) | join(", ")))"
+                else empty end,
+                if ($missing | length) > 0 then
+                  "- No result reported (job failed or was cancelled): **\($missing | length)** (\($missing | map(link) | join(", ")))"
+                else empty end,
+
+                ($outcomes[] | section(.label; $byOutcome[.key].rows // [])),
+                ($unknown[] | section("Unrecognized outcome `\(.)`"; $byOutcome[.].rows)),
+
+                details("Skipped: \($skipped | length) PR(s) from vouched authors";
+                  [table(["PR", "Author"]; $skipped | map([(.number | link), .author]))] | join("\n"))
+              ]
+            | join("\n")
+          ' | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/vouch-check-pr-backlog.yml
+++ b/.github/workflows/vouch-check-pr-backlog.yml
@@ -23,17 +23,21 @@ jobs:
       considered: ${{ steps.list.outputs.considered }}
       skipped-count: ${{ steps.list.outputs.skipped-count }}
     steps:
-      # Sparse-checkout of the base ref only, just to read the vouched list.
-      # Path matches the vouch action's own `vouched-file` default, which the
-      # check jobs rely on, so the two can't disagree about who's vouched.
+      # Sparse-checkout of the base ref only, so `vouch check` below has a
+      # vouched list to read. Path matches the vouch action's own
+      # `vouched-file` default, which the check jobs rely on.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github/VOUCHED.td
 
+      # Puts the `vouch` CLI on PATH (installing Nushell if needed), so the
+      # prefilter can ask the tool who's vouched instead of parsing
+      # VOUCHED.td here and drifting from how the check jobs read it.
+      - uses: mitchellh/vouch/action/setup-vouch@d66fa29a64600490892131ad87597c30c91fcac4 # v1.5.0
+
       # Most of the open-PR backlog belongs to maintainers and other vouched
       # contributors, whose PRs the check can only ever leave alone. Dropping
-      # them here roughly halves the matrix. Denounced entries (leading "-")
-      # are deliberately *not* dropped: those are the ones that do get closed.
+      # them here roughly halves the matrix.
       - name: List target PRs
         id: list
         env:
@@ -53,23 +57,32 @@ jobs:
               | jq -s -c '.')
             SKIPPED="[]"
           else
-            # Same normalization the vouch tool applies to this file: strip
-            # comments and any platform prefix (github:user), lowercase, and
-            # ignore denounced entries.
-            VOUCHED=$(awk '!/^[[:space:]]*#/ && NF && $1 !~ /^-/ {
-                sub(/^[A-Za-z0-9_-]+:/, "", $1); print tolower($1)
-              }' .github/VOUCHED.td | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
-            echo "Vouched authors: $VOUCHED"
+            # `vouch check` resolves .github/VOUCHED.td from the repo root on
+            # its own, the same default the check jobs use. Assert it landed
+            # rather than quietly prefiltering nothing if checkout missed it.
+            test -f .github/VOUCHED.td
 
-            # "app/" is how the gh CLI renders bot logins.
-            PARTITION=$(gh pr list --repo "$REPO" --state open --limit 1000 --json number,author \
-              | jq -c --argjson vouched "$VOUCHED" '
-                ($vouched | INDEX(.)) as $set
-                | [.[] | {number, login: (.author.login | ascii_downcase | sub("^app/"; ""))}]
-                | {
-                    numbers: (map(select($set[.login] == null) | .number) | sort),
-                    skipped: (map(select($set[.login] != null) | .number) | sort)
-                  }')
+            CANDIDATES=$(gh pr list --repo "$REPO" --state open --limit 1000 --json number,author)
+
+            # One `vouch check` per distinct author, not per PR. It exits 0
+            # for vouched, 1 for denounced and 2 for unknown -- only the
+            # first is safe to skip, since denounced PRs are precisely the
+            # ones that get closed. Its own output is the audit trail for
+            # what this filter decided.
+            VOUCHED="[]"
+            for LOGIN in $(jq -r '[.[].author.login] | unique | .[]' <<<"$CANDIDATES"); do
+              if vouch check "$LOGIN"; then
+                VOUCHED=$(jq -c --arg login "$LOGIN" '. + [$login]' <<<"$VOUCHED")
+              fi
+            done
+
+            PARTITION=$(jq -c --argjson vouched "$VOUCHED" '
+              ($vouched | INDEX(.)) as $set
+              | [.[] | {number, login: .author.login}]
+              | {
+                  numbers: (map(select($set[.login] == null) | .number) | sort),
+                  skipped: (map(select($set[.login] != null) | .number) | sort)
+                }' <<<"$CANDIDATES")
             NUMBERS=$(jq -c '.numbers' <<<"$PARTITION")
             SKIPPED=$(jq -c '.skipped' <<<"$PARTITION")
           fi

--- a/.github/workflows/vouch-check-pr-backlog.yml
+++ b/.github/workflows/vouch-check-pr-backlog.yml
@@ -9,19 +9,8 @@ on:
         description: "Comma-separated PR numbers to check (empty = all open PRs)"
         required: false
         default: ""
-      include-vouched-authors:
-        description: "Also check PRs whose author is vouched in .github/VOUCHED.td (normally skipped)"
-        required: false
-        default: false
-        type: boolean
 
 name: "Vouch - Check PR Backlog"
-
-env:
-  # Matrix jobs cap out at 256. Anything past that is deferred to a later run
-  # rather than failing the whole sweep up front, and is listed in the summary
-  # so it's clear what still needs a pass.
-  MATRIX_MAX: 256
 
 jobs:
   list-prs:
@@ -32,8 +21,7 @@ jobs:
     outputs:
       pr-numbers: ${{ steps.list.outputs.numbers }}
       considered: ${{ steps.list.outputs.considered }}
-      skipped: ${{ steps.list.outputs.skipped }}
-      deferred: ${{ steps.list.outputs.deferred }}
+      skipped-count: ${{ steps.list.outputs.skipped-count }}
     steps:
       # Sparse-checkout of the base ref only, just to read the vouched list.
       # Path matches the vouch action's own `vouched-file` default, which the
@@ -44,79 +32,62 @@ jobs:
 
       # Most of the open-PR backlog belongs to maintainers and other vouched
       # contributors, whose PRs the check can only ever leave alone. Dropping
-      # them here keeps the matrix (and the summary) down to the PRs where the
-      # answer isn't known in advance. Denounced entries (leading "-") are
-      # deliberately *not* dropped: those are the ones that do get closed.
+      # them here roughly halves the matrix. Denounced entries (leading "-")
+      # are deliberately *not* dropped: those are the ones that do get closed.
       - name: List target PRs
         id: list
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBERS_INPUT: ${{ github.event.inputs.pr-numbers }}
-          INCLUDE_VOUCHED: ${{ github.event.inputs.include-vouched-authors }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          # Same normalization the vouch tool applies to this file: strip
-          # comments and any platform prefix (github:user), lowercase, and
-          # ignore denounced entries.
-          VOUCHED=$(awk '!/^[[:space:]]*#/ && NF && $1 !~ /^-/ {
-              sub(/^[A-Za-z0-9_-]+:/, "", $1); print tolower($1)
-            }' .github/VOUCHED.td | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          echo "Vouched authors: $VOUCHED"
-
-          # An explicit list may name closed PRs, which `gh pr list` won't
-          # return, so those are looked up one at a time. tonumber doubles as
-          # input validation before anything reaches a command line; the trim
-          # is what makes "1, 2, 3" work as well as "1,2,3".
+          # An explicitly named list is taken as given -- no filtering -- which
+          # doubles as the way to force a re-check of a PR whose author is
+          # vouched. tonumber doubles as input validation before anything
+          # reaches a command line; the trim makes "1, 2, 3" work too.
           if [ -n "$PR_NUMBERS_INPUT" ]; then
-            CANDIDATES="[]"
-            for NUMBER in $(echo "$PR_NUMBERS_INPUT" | tr ',' '\n' \
-              | jq -R -r 'gsub("^\\s+|\\s+$"; "") | select(length > 0) | tonumber'); do
-              PR=$(gh pr view "$NUMBER" --repo "$REPO" --json number,author)
-              CANDIDATES=$(jq -c -s 'add' <(echo "$CANDIDATES") <(echo "[$PR]"))
-            done
+            NUMBERS=$(echo "$PR_NUMBERS_INPUT" | tr ',' '\n' \
+              | jq -R -r 'gsub("^\\s+|\\s+$"; "") | select(length > 0) | tonumber' \
+              | jq -s -c '.')
+            SKIPPED="[]"
           else
-            CANDIDATES=$(gh pr list --repo "$REPO" --state open --limit 1000 --json number,author)
+            # Same normalization the vouch tool applies to this file: strip
+            # comments and any platform prefix (github:user), lowercase, and
+            # ignore denounced entries.
+            VOUCHED=$(awk '!/^[[:space:]]*#/ && NF && $1 !~ /^-/ {
+                sub(/^[A-Za-z0-9_-]+:/, "", $1); print tolower($1)
+              }' .github/VOUCHED.td | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            echo "Vouched authors: $VOUCHED"
+
+            # "app/" is how the gh CLI renders bot logins.
+            PARTITION=$(gh pr list --repo "$REPO" --state open --limit 1000 --json number,author \
+              | jq -c --argjson vouched "$VOUCHED" '
+                ($vouched | INDEX(.)) as $set
+                | [.[] | {number, login: (.author.login | ascii_downcase | sub("^app/"; ""))}]
+                | {
+                    numbers: (map(select($set[.login] == null) | .number) | sort),
+                    skipped: (map(select($set[.login] != null) | .number) | sort)
+                  }')
+            NUMBERS=$(jq -c '.numbers' <<<"$PARTITION")
+            SKIPPED=$(jq -c '.skipped' <<<"$PARTITION")
           fi
 
-          # Partition into what the matrix will check and what got filtered
-          # out, keeping the latter so the summary can account for every PR
-          # the sweep looked at. "app/" is how the gh CLI renders bot logins.
-          PARTITION=$(jq -c \
-            --argjson vouched "$VOUCHED" \
-            --arg include "$INCLUDE_VOUCHED" \
-            --argjson max "$MATRIX_MAX" '
-            ($vouched | INDEX(.)) as $set
-            | [.[] | {number, author: .author.login}]
-            | map(. + {
-                skip: ($include != "true"
-                  and $set[(.author | ascii_downcase | sub("^app/"; ""))] != null)
-              })
-            | (map(select(.skip | not)) | sort_by(.number)) as $check
-            | {
-                considered: length,
-                check: ($check[0:$max] | map(del(.skip))),
-                deferred: ($check[$max:] | map(.number)),
-                skipped: (map(select(.skip)) | sort_by(.author | ascii_downcase) | map(del(.skip)))
-              }' <<<"$CANDIDATES")
-
-          NUMBERS=$(jq -c '[.check[].number]' <<<"$PARTITION")
-          DEFERRED=$(jq -c '.deferred' <<<"$PARTITION")
-
+          # The skipped count carries into the summary so it can account for
+          # every PR the sweep looked at, not just the ones it checked.
           {
             echo "numbers=$NUMBERS"
-            echo "considered=$(jq -r '.considered' <<<"$PARTITION")"
-            echo "skipped=$(jq -c '.skipped' <<<"$PARTITION")"
-            echo "deferred=$DEFERRED"
+            echo "considered=$(( $(jq 'length' <<<"$NUMBERS") + $(jq 'length' <<<"$SKIPPED") ))"
+            echo "skipped-count=$(jq 'length' <<<"$SKIPPED")"
           } >> "$GITHUB_OUTPUT"
 
+          echo "Skipping vouched authors' PRs: $SKIPPED"
           echo "Targeting PR numbers: $NUMBERS"
 
-          if [ "$(jq 'length' <<<"$DEFERRED")" -gt 0 ]; then
-            echo "::warning::More than $MATRIX_MAX PRs to check; deferred $(jq -c '.' <<<"$DEFERRED") to a later run (pass them via the pr-numbers input)."
-          fi
-
+  # Matrix jobs cap out at 256 -- if the unvouched backlog ever exceeds that,
+  # batch it manually across a few runs using the pr-numbers input instead
+  # of trying to sweep everything in one go.
   check:
     needs: list-prs
     if: needs.list-prs.outputs.pr-numbers != '[]'
@@ -135,7 +106,7 @@ jobs:
       report-artifact: true
     secrets: inherit
 
-  # Rolls the per-PR result artifacts up into one table, so a 100-job sweep
+  # Rolls the per-PR result artifacts up into one table, so a 50-job sweep
   # can be read (and, in dry-run mode, acted on) without opening every job.
   summary:
     needs: [list-prs, check]
@@ -161,8 +132,7 @@ jobs:
           DRY_RUN: ${{ vars.VOUCH_DRY_RUN || 'true' }}
           TARGETED: ${{ needs.list-prs.outputs.pr-numbers }}
           CONSIDERED: ${{ needs.list-prs.outputs.considered }}
-          SKIPPED: ${{ needs.list-prs.outputs.skipped }}
-          DEFERRED: ${{ needs.list-prs.outputs.deferred }}
+          SKIPPED_COUNT: ${{ needs.list-prs.outputs.skipped-count }}
         run: |
           set -euo pipefail
 
@@ -174,9 +144,8 @@ jobs:
           jq -n -r \
             --argjson results "$RESULTS" \
             --argjson targeted "$TARGETED" \
-            --argjson skipped "$SKIPPED" \
-            --argjson deferred "$DEFERRED" \
             --argjson considered "$CONSIDERED" \
+            --argjson skipped_count "$SKIPPED_COUNT" \
             --arg repo "$REPO" \
             --arg dry_run "$DRY_RUN" '
             ($dry_run == "true") as $dry
@@ -186,19 +155,11 @@ jobs:
             | def cell: (. // "") | gsub("\r?\n"; " ") | gsub("\\|"; "\\|")
               | if length > 80 then .[0:77] + "..." else . end;
             def link: "[#\(.)](https://github.com/\($repo)/pull/\(.))";
-            def table($cols; $rows):
-              "| " + ($cols | join(" | ")) + " |",
-              "| " + ($cols | map("---") | join(" | ")) + " |",
-              ($rows | map("| " + join(" | ") + " |") | .[]);
             def section($title; $rows):
               if ($rows | length) == 0 then empty
               else "", "### \($title) (\($rows | length))", "",
-                table(["PR", "Author", "Title"];
-                  $rows | map([(.number | link), .author, (.title | cell)]))
-              end;
-            def details($title; $body):
-              if ($body | length) == 0 then empty
-              else "", "<details><summary>\($title)</summary>", "", $body, "", "</details>"
+                "| PR | Author | Title |", "| --- | --- | --- |",
+                ($rows | map("| \(.number | link) | \(.author) | \(.title | cell) |") | .[])
               end;
 
             # Every outcome the shared workflow can record, in the order a
@@ -227,20 +188,14 @@ jobs:
                 end,
                 "",
                 "- Considered: **\($considered)** PR(s)",
-                "- Skipped as vouched authors: **\($skipped | length)**",
+                "- Skipped without checking, author is vouched in `.github/VOUCHED.td`: **\($skipped_count)**",
                 "- Checked: **\($targeted | length)**",
-                if ($deferred | length) > 0 then
-                  "- Deferred past the 256-job matrix cap: **\($deferred | length)** (\($deferred | map(link) | join(", ")))"
-                else empty end,
                 if ($missing | length) > 0 then
                   "- No result reported (job failed or was cancelled): **\($missing | length)** (\($missing | map(link) | join(", ")))"
                 else empty end,
 
                 ($outcomes[] | section(.label; $byOutcome[.key].rows // [])),
-                ($unknown[] | section("Unrecognized outcome `\(.)`"; $byOutcome[.].rows)),
-
-                details("Skipped: \($skipped | length) PR(s) from vouched authors";
-                  [table(["PR", "Author"]; $skipped | map([(.number | link), .author]))] | join("\n"))
+                ($unknown[] | section("Unrecognized outcome `\(.)`"; $byOutcome[.].rows))
               ]
             | join("\n")
           ' | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/vouch-check-pr-shared.yml
+++ b/.github/workflows/vouch-check-pr-shared.yml
@@ -9,6 +9,16 @@ on:
         description: "PR number to check"
         required: true
         type: number
+      # A matrix of workflow_call jobs can't return per-job outputs (they all
+      # write to the same `needs.<job>.outputs`, last writer wins), so the
+      # backlog sweep collects one small artifact per PR instead and renders
+      # them in a single summary job. Off for the event-triggered path, where
+      # a one-row report would just be noise.
+      report-artifact:
+        description: "Upload a one-PR JSON result artifact for a caller to aggregate"
+        required: false
+        default: false
+        type: boolean
 
 name: "Vouch - Check PR (shared)"
 
@@ -23,6 +33,23 @@ jobs:
       pull-requests: write
       contents: read
     steps:
+      # Read once up front so both the close message and the result artifact
+      # share one lookup. There's no event payload to read the author from
+      # here (this runs the same way whether called from an event or a
+      # backlog matrix), so it has to come from the API either way. Kept in a
+      # file rather than step outputs so the untrusted PR title is never
+      # interpolated into a shell script.
+      - name: Look up PR metadata
+        id: pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr-number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh pr view "$PR_NUMBER" --repo "$REPO" --json number,author,title > "$RUNNER_TEMP/pr.json"
+          jq -r '"author=" + .author.login' "$RUNNER_TEMP/pr.json" >> "$GITHUB_OUTPUT"
+
       # require-vouch is false so this step only ever auto-closes denounced
       # users, which are always blocked with no exception. A merely-unvouched
       # (never vouched, never denounced) author comes back as "allowed", and
@@ -92,18 +119,15 @@ jobs:
           sparse-checkout: .github/pr-unvouched-message
 
       # Not part of the vouch action, so it doesn't get dry-run for free --
-      # gated on the same VOUCH_DRY_RUN repo variable by hand. No event
-      # payload to read the author from here (this runs the same way
-      # whether called from an event or a backlog matrix), so it's looked
-      # up explicitly via the API.
+      # gated on the same VOUCH_DRY_RUN repo variable by hand.
       - name: Close PR (unvouched, no linked issue with the community-PR label)
+        id: close
         if: steps.vouch.outputs.status == 'allowed' && steps.label-check.outputs.has-label == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: ${{ vars.VOUCH_DRY_RUN || 'true' }}
+          PR_AUTHOR: ${{ steps.pr.outputs.author }}
         run: |
-          PR_AUTHOR=$(gh pr view "${{ inputs.pr-number }}" --repo "${{ github.repository }}" --json author --jq '.author.login')
-
           MESSAGE=$(cat .github/pr-unvouched-message)
           MESSAGE="${MESSAGE//\{author\}/$PR_AUTHOR}"
           MESSAGE="${MESSAGE//\{label\}/$COMMUNITY_PR_LABEL}"
@@ -116,3 +140,78 @@ jobs:
             gh pr comment "${{ inputs.pr-number }}" --repo "${{ github.repository }}" --body "$MESSAGE"
             gh pr close "${{ inputs.pr-number }}" --repo "${{ github.repository }}"
           fi
+
+      # Collapses the two independent gates (the vouch action's own verdict,
+      # then the linked-issue check) into a single outcome describing what this
+      # job actually did -- or, under dry-run, would have done. Runs even when
+      # an earlier step failed, so a broken PR shows up in the summary as an
+      # error rather than silently vanishing from it.
+      - name: Record result
+        if: ${{ !cancelled() && inputs.report-artifact }}
+        env:
+          PR_NUMBER: ${{ inputs.pr-number }}
+          VOUCH_RESULT: ${{ steps.vouch.outcome }}
+          VOUCH_STATUS: ${{ steps.vouch.outputs.status }}
+          HAS_LABEL: ${{ steps.label-check.outputs.has-label }}
+          CLOSE_RESULT: ${{ steps.close.outcome }}
+          DRY_RUN: ${{ vars.VOUCH_DRY_RUN || 'true' }}
+        run: |
+          set -euo pipefail
+
+          if [ "$DRY_RUN" = "true" ]; then WOULD="would-"; else WOULD=""; fi
+
+          if [ "$VOUCH_RESULT" != "success" ]; then
+            OUTCOME="error"
+          else
+            case "$VOUCH_STATUS" in
+              skipped) OUTCOME="bot" ;;
+              vouched) OUTCOME="vouched" ;;
+              closed) OUTCOME="${WOULD}close-denounced" ;;
+              allowed)
+                case "$HAS_LABEL" in
+                  true) OUTCOME="linked-issue" ;;
+                  false)
+                    if [ "$CLOSE_RESULT" = "success" ]; then
+                      OUTCOME="${WOULD}close-unvouched"
+                    else
+                      OUTCOME="error"
+                    fi
+                    ;;
+                  *) OUTCOME="error" ;;
+                esac
+                ;;
+              *) OUTCOME="error" ;;
+            esac
+          fi
+
+          # The metadata step failing is itself an error worth reporting, so
+          # fall back to a number-only record rather than failing this step.
+          if [ ! -f "$RUNNER_TEMP/pr.json" ]; then
+            echo "{\"number\": $PR_NUMBER, \"author\": {\"login\": \"unknown\"}, \"title\": \"(lookup failed)\"}" \
+              > "$RUNNER_TEMP/pr.json"
+            OUTCOME="error"
+          fi
+
+          mkdir -p "$RUNNER_TEMP/vouch-result"
+          jq -c \
+            --arg outcome "$OUTCOME" \
+            --arg vouch_status "$VOUCH_STATUS" \
+            --arg has_label "$HAS_LABEL" \
+            --arg dry_run "$DRY_RUN" \
+            '{
+              number,
+              author: .author.login,
+              title,
+              outcome: $outcome,
+              vouch_status: $vouch_status,
+              has_label: $has_label,
+              dry_run: ($dry_run == "true")
+            }' "$RUNNER_TEMP/pr.json" | tee "$RUNNER_TEMP/vouch-result/$PR_NUMBER.json"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ !cancelled() && inputs.report-artifact }}
+        with:
+          name: vouch-result-${{ inputs.pr-number }}
+          path: ${{ runner.temp }}/vouch-result/${{ inputs.pr-number }}.json
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
Previously without the rollup, each of many GH actions had to be opened individually to see the verdict of each PR.