### PR TITLE
feat(app): open Super Admin docs in new tab

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -54,7 +54,11 @@ export function App(): JSX.Element {
                 message: (
                   <>
                     Warning: logged in as{' '}
-                    <Link to="https://www.medplum.com/docs/self-hosting/super-admin-guide" target="_blank" rel="noopener noreferrer">
+                    <Link
+                      to="https://www.medplum.com/docs/self-hosting/super-admin-guide"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
                       Medplum Super Admin
                     </Link>
                     .

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -54,7 +54,10 @@ export function App(): JSX.Element {
                 message: (
                   <>
                     Warning: logged in as{' '}
-                    <Link to="https://www.medplum.com/docs/self-hosting/super-admin-guide">Medplum Super Admin</Link>.
+                    <Link to="https://www.medplum.com/docs/self-hosting/super-admin-guide" target="_blank" rel="noopener noreferrer">
+                      Medplum Super Admin
+                    </Link>
+                    .
                   </>
                 ),
                 color: 'red',


### PR DESCRIPTION
Hello, good afternoon!

This is my first time contributing to this project, so apologies in advance if I'm missing something.

This is a simple proposal to improve the UX of the Super Admin user.

<img width="340" height="61" alt="Screenshot From 2026-08-10 17-32-37" src="https://github.com/user-attachments/assets/2743fb4e-f9e7-4f5c-abd1-49d1088ac6e1" />

**Current behaviour:** When clicking the link in the Super Admin user warning, we navigate away from the app and into the docs page.

**Proposed change:** Instead of navigating away from the app, open the docs in a new tab.