### PR TITLE
fix(cli): respect scope in authorization-code login

### DIFF
--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -81,6 +81,10 @@ describe('CLI auth', () => {
     // Start the login
     await main(['node', 'index.js', 'login']);
 
+    const loginCommand = (cp.exec as unknown as Mock).mock.calls[0][0] as string;
+    const loginUrl = new URL(loginCommand.match(/https?:\/\/[^'"]+/)?.[0] as string);
+    expect(loginUrl.searchParams.get('scope')).toBe('openid');
+
     // Get the handler
     const handler = (http.createServer as unknown as Mock).mock.calls[0][0];
 
@@ -108,6 +112,26 @@ describe('CLI auth', () => {
     expect(res3.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': ContentType.TEXT });
     expect(res3.end).toHaveBeenCalledWith('Signed in as Alice Smith. You may close this window.');
     expect(medplum.getActiveLogin()).toBeDefined();
+  });
+
+  test('Login with custom scope', async () => {
+    (cp.exec as unknown as Mock).mockImplementation(
+      (_: unknown, callback: (error: Error | null, stdout: string, stderr: string) => void) => {
+        callback(null, '', '');
+        return true;
+      }
+    );
+    (http.createServer as unknown as Mock).mockReturnValue({
+      listen: () => ({
+        close: () => undefined,
+      }),
+    });
+
+    await main(['node', 'index.js', 'login', '--scope', 'openid offline_access']);
+
+    const loginCommand = (cp.exec as unknown as Mock).mock.calls[0][0] as string;
+    const loginUrl = new URL(loginCommand.match(/https?:\/\/[^'"]+/)?.[0] as string);
+    expect(loginUrl.searchParams.get('scope')).toBe('openid offline_access');
   });
 
   test('Login unsupported auth type', async () => {

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -48,7 +48,7 @@ async function startLogin(medplum: MedplumClient, profile: Profile): Promise<voi
   const authType = profile?.authType ?? 'authorization-code';
   switch (authType) {
     case 'authorization-code':
-      await medplumAuthorizationCodeLogin(medplum);
+      await medplumAuthorizationCodeLogin(medplum, profile);
       break;
     case 'basic':
       medplum.setBasicAuth(profile.clientId as string, profile.clientSecret as string);
@@ -137,12 +137,12 @@ function printMe(medplum: MedplumClient): void {
   }
 }
 
-async function medplumAuthorizationCodeLogin(medplum: MedplumClient): Promise<void> {
+async function medplumAuthorizationCodeLogin(medplum: MedplumClient, profile: Profile): Promise<void> {
   await startWebServer(medplum);
   const loginUrl = new URL(medplum.getAuthorizeUrl());
   loginUrl.searchParams.set('client_id', clientId);
   loginUrl.searchParams.set('redirect_uri', redirectUri);
-  loginUrl.searchParams.set('scope', 'openid');
+  loginUrl.searchParams.set('scope', profile.scope ?? 'openid');
   loginUrl.searchParams.set('response_type', 'code');
   loginUrl.searchParams.set('prompt', 'login');
   await openBrowser(loginUrl.toString());


### PR DESCRIPTION
## Summary

- pass the saved CLI profile into the authorization-code login flow
- use the configured `profile.scope` with `openid` as the default
- add regression tests for both the default and custom scope behavior

## Problem

The authorization-code flow used a hardcoded `scope=openid`, so the scope provided through the CLI was ignored. As a result, users could not request `offline_access` and receive a refresh token.

## Solution

The authorization-code login flow now reads the scope from the saved CLI profile:

```ts
profile.scope ?? 'openid'
```

Fixes #10108