### PR TITLE
Add project-scoped API routes

### DIFF
--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -12,6 +12,7 @@ import { getConfig, loadTestConfig } from './config/loader';
 import { DatabaseMode, getDatabasePool } from './database';
 import { getProjectSystemRepo } from './fhir/repo';
 import { globalLogger } from './logger';
+import { generateAccessToken } from './oauth/keys';
 import { getRateLimitRedis } from './redis';
 import type { TestRedisConfig } from './test.setup';
 import { createTestProject, deleteRedisKeys, initTestAuth } from './test.setup';
@@ -48,6 +49,52 @@ describe('App', () => {
     expect(res.headers['cache-control']).toBeDefined();
     expect(res.headers['content-security-policy']).toBeDefined();
     expect(res.headers['referrer-policy']).toBeDefined();
+    expect(await shutdownApp()).toBeUndefined();
+  });
+
+  test.each(['/projects/00000000-0000-0000-0000-000000000000/', '/api/projects/00000000-0000-0000-0000-000000000000/'])(
+    'Use project-scoped mount %s',
+    async (path) => {
+      const app = express();
+      const config = await loadTestConfig();
+      await initApp(app, config);
+      const res = await request(app).get(path);
+      expect(res).toHaveStatus(200);
+      expect(await shutdownApp()).toBeUndefined();
+    }
+  );
+
+  test('Enforce project scope on authenticated requests', async () => {
+    const app = express();
+    const config = await loadTestConfig();
+    await initApp(app, config);
+    const { client, login, project } = await createTestProject({ withAccessToken: true, withClient: true });
+    const getAccessToken = (issuer: string): Promise<string> =>
+      generateAccessToken(
+        {
+          login_id: login.id,
+          sub: client.id,
+          username: client.id,
+          client_id: client.id,
+          profile: `${client.resourceType}/${client.id}`,
+          scope: login.scope as string,
+        },
+        { issuer }
+      );
+
+    const accessToken = await getAccessToken(`${config.issuer}projects/${project.id}/`);
+
+    const matching = await request(app)
+      .get(`/projects/${project.id}/fhir/R4/Patient`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(matching).toHaveStatus(200);
+
+    const otherProjectId = '00000000-0000-0000-0000-000000000000';
+    const mismatchedAccessToken = await getAccessToken(`${config.issuer}projects/${otherProjectId}/`);
+    const mismatched = await request(app)
+      .get(`/projects/${otherProjectId}/fhir/R4/Patient`)
+      .set('Authorization', 'Bearer ' + mismatchedAccessToken);
+    expect(mismatched).toHaveStatus(403);
     expect(await shutdownApp()).toBeUndefined();
   });
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -207,10 +207,22 @@ export async function initApp(app: Express, config: MedplumServerConfig): Promis
 
   app.use(rateLimitHandler(config));
   app.use('/dicomweb/', dicomRouter);
-  app.use('/fhir/R4/Binary', binaryRouter);
+  app.use(
+    [
+      '/fhir/R4/Binary',
+      '/api/fhir/R4/Binary',
+      '/projects/:projectId/fhir/R4/Binary',
+      '/api/projects/:projectId/fhir/R4/Binary',
+    ],
+    binaryRouter
+  );
 
   // Handle async batch by enqueueing job
-  app.post('/fhir/R4', authenticateRequest, asyncBatchHandler(config));
+  app.post(
+    ['/fhir/R4', '/api/fhir/R4', '/projects/:projectId/fhir/R4', '/api/projects/:projectId/fhir/R4'],
+    authenticateRequest,
+    asyncBatchHandler(config)
+  );
 
   app.use(urlencoded({ extended: false }));
   app.use(text({ type: [ContentType.TEXT, ContentType.HL7_V2] }));
@@ -249,6 +261,8 @@ export async function initApp(app: Express, config: MedplumServerConfig): Promis
     apiRouter.use('/mcp', mcpRouter);
   }
 
+  app.use('/api/projects/:projectId/', apiRouter);
+  app.use('/projects/:projectId/', apiRouter);
   app.use('/api/', apiRouter);
   app.use('/', apiRouter);
   app.use(errorHandler);

--- a/packages/server/src/async-batch.ts
+++ b/packages/server/src/async-batch.ts
@@ -10,6 +10,7 @@ import type { MedplumServerConfig } from './config/types';
 import { getAuthenticatedContext } from './context';
 import { AsyncJobExecutor } from './fhir/operations/utils/asyncjobexecutor';
 import { sendOutcome } from './fhir/outcomes';
+import { getProjectScopedUrl } from './util/url';
 import { queueBatchProcessing, queueLegacyBatchProcessing } from './workers/batch';
 
 export function asyncBatchHandler(
@@ -49,7 +50,7 @@ export function asyncBatchHandler(
     });
 
     const { baseUrl } = getConfig();
-    sendOutcome(res, accepted(exec.getContentLocation(baseUrl)));
+    sendOutcome(res, accepted(exec.getContentLocation(getProjectScopedUrl(req.originalUrl, baseUrl))));
   };
 }
 

--- a/packages/server/src/cors.test.ts
+++ b/packages/server/src/cors.test.ts
@@ -124,6 +124,22 @@ describe('CORS', () => {
     }
   });
 
+  test.each(['/api/fhir/R4/Patient', '/projects/123/fhir/R4/Patient', '/api/projects/123/fhir/R4/Patient'])(
+    'Allow mounted FHIR path %s',
+    (path) => {
+      const req = {
+        header: () => 'http://localhost:3000',
+        path,
+      } as unknown as Request;
+      const callback = vi.fn();
+      corsOptions(req, callback);
+      expect(callback).toHaveBeenCalledWith(
+        null,
+        expect.objectContaining({ credentials: true, origin: 'http://localhost:3000' })
+      );
+    }
+  );
+
   test('FHIR response includes RateLimit in Access-Control-Expose-Headers', async () => {
     const app = express();
     const config = await loadTestConfig();

--- a/packages/server/src/cors.ts
+++ b/packages/server/src/cors.ts
@@ -3,6 +3,7 @@
 import type cors from 'cors';
 import type { Request } from 'express';
 import { getConfig } from './config/loader';
+import { getNormalizedPath } from './util/url';
 
 const exposedHeaders = ['Content-Location', 'ETag', 'Last-Modified', 'Location', 'RateLimit'];
 
@@ -13,7 +14,7 @@ const exposedHeaders = ['Content-Location', 'ETag', 'Last-Modified', 'Location',
  */
 export const corsOptions: cors.CorsOptionsDelegate<Request> = (req, callback) => {
   const origin = req.header('Origin');
-  const allow = isOriginAllowed(origin) && isPathAllowed(req.path);
+  const allow = isOriginAllowed(origin) && isPathAllowed(getNormalizedPath(req.path));
   if (allow) {
     callback(null, { origin, credentials: true, exposedHeaders, maxAge: 600 });
   } else {

--- a/packages/server/src/fhir/batch.test.ts
+++ b/packages/server/src/fhir/batch.test.ts
@@ -29,6 +29,7 @@ import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import { runInAuthenticatedContext } from '../context';
 import { DatabaseMode, getDatabasePool } from '../database';
+import { generateAccessToken } from '../oauth/keys';
 import { createTestProject, initTestAuth, waitForAsyncJob } from '../test.setup';
 import type { ReentrantBatchJobData } from '../workers/batch';
 import { execBatchJob, getBatchQueue } from '../workers/batch';
@@ -61,15 +62,21 @@ function mockBatchJob(data: ReentrantBatchJobData, overrides?: Record<string, un
 describe('Batch and Transaction processing', () => {
   const app = express();
   let accessToken: string;
+  let baseUrl: string;
+  let projectScopedAccessToken: string;
+  let projectId: string;
 
   beforeAll(async () => {
     const config = await loadTestConfig();
+    baseUrl = config.baseUrl;
     // Async batches throttle by sleeping `points * asyncDelayScaling` ms per DB op in the async
     // authenticated context (see Repository.recordFhirQuota). These tests exercise behavior, not
     // throttle timing, so zero the delay to avoid real sleeps that slow the suite down.
     config.asyncDelayScaling = 0;
     await initApp(app, config);
-    accessToken = await initTestAuth({
+    const testProject = await createTestProject({
+      withAccessToken: true,
+      withClient: true,
       project: {
         features: ['transaction-bundles', 'async-batch'],
         // Opt in to re-entrant async batch processing (see workers/batch.ts). The async batch tests
@@ -79,6 +86,19 @@ describe('Batch and Transaction processing', () => {
       },
       membership: { admin: true },
     });
+    accessToken = testProject.accessToken;
+    projectId = testProject.project.id;
+    projectScopedAccessToken = await generateAccessToken(
+      {
+        login_id: testProject.login.id,
+        sub: testProject.client.id,
+        username: testProject.client.id,
+        client_id: testProject.client.id,
+        profile: `${testProject.client.resourceType}/${testProject.client.id}`,
+        scope: testProject.login.scope as string,
+      },
+      { issuer: `${config.issuer}projects/${projectId}/` }
+    );
   });
 
   afterEach(() => {
@@ -245,8 +265,8 @@ describe('Batch and Transaction processing', () => {
     };
 
     const res = await request(app)
-      .post(`/fhir/R4/`)
-      .set('Authorization', 'Bearer ' + accessToken)
+      .post(`/projects/${projectId}/fhir/R4/`)
+      .set('Authorization', 'Bearer ' + projectScopedAccessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send(batch);
     expect(res).toHaveStatus(200);
@@ -1435,14 +1455,14 @@ describe('Batch and Transaction processing', () => {
     };
 
     const res = await request(app)
-      .post(`/fhir/R4/`)
-      .set('Authorization', 'Bearer ' + accessToken)
+      .post(`/projects/${projectId}/fhir/R4/`)
+      .set('Authorization', 'Bearer ' + projectScopedAccessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .set('Prefer', 'respond-async')
       .send(bundle);
     expect(res).toHaveStatus(202);
     const outcome = res.body as OperationOutcome;
-    expect(outcome.issue[0].diagnostics).toMatch('http://');
+    expect(outcome.issue[0].diagnostics).toMatch(`${baseUrl}projects/${projectId}/fhir/R4/job/`);
 
     // Manually push through BullMQ job. The bundle travels via object storage, not the job data (#9124).
     expect(queue.add).toHaveBeenCalledWith(
@@ -1458,7 +1478,7 @@ describe('Batch and Transaction processing', () => {
     await expect(execBatchJob(job)).resolves.toBe(undefined);
 
     const jobUrl = outcome.issue[0].diagnostics as string;
-    const asyncJob = await waitForAsyncJob(jobUrl, app, accessToken);
+    const asyncJob = await waitForAsyncJob(jobUrl, app, projectScopedAccessToken);
     expect(asyncJob.output).toMatchObject<Parameters>({
       resourceType: 'Parameters',
       parameter: [{ name: 'results', valueReference: { reference: expect.stringMatching(/^Binary\//) } }],

--- a/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
+++ b/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
@@ -12,6 +12,7 @@ import { DatabaseMode, getDatabasePool } from '../../../database';
 import { getLogger } from '../../../logger';
 import { markPostDeployMigrationCompleted } from '../../../migration-sql';
 import { maybeAutoRunPendingPostDeployMigration } from '../../../migrations/migration-utils';
+import { getProjectScopedUrl } from '../../../util/url';
 import { CancelledError } from '../../../workers/utils';
 import { sendOutcome } from '../../outcomes';
 import type { Repository } from '../../repo';
@@ -187,5 +188,5 @@ export async function sendAsyncResponse(
   const exec = new AsyncJobExecutor(ctx.repo);
   await exec.init(req.protocol + '://' + req.get('host') + req.originalUrl);
   exec.start(callback);
-  sendOutcome(res, accepted(exec.getContentLocation(baseUrl)));
+  sendOutcome(res, accepted(exec.getContentLocation(getProjectScopedUrl(req.originalUrl, baseUrl))));
 }

--- a/packages/server/src/fhir/smart.ts
+++ b/packages/server/src/fhir/smart.ts
@@ -21,6 +21,7 @@ import type { Request, Response } from 'express';
 import qs from 'node:querystring';
 import { getConfig } from '../config/loader';
 import type { AuthState } from '../oauth/middleware';
+import { getProjectScopedUrl } from '../util/url';
 import type { PopulatedAccessPolicy } from './accesspolicy';
 
 const smartScopeFormat = /^(patient|user|system)\/(\w+|\*)\.(read|write|c?r?u?d?s?|\*)$/;
@@ -36,25 +37,25 @@ export interface SmartScope {
  * Handles requests for the SMART configuration.
  * See: https://build.fhir.org/ig/HL7/smart-app-launch/conformance.html
  * See: https://build.fhir.org/ig/HL7/smart-app-launch/scopes-and-launch-context.html
- * @param _req - The HTTP request.
+ * @param req - The HTTP request.
  * @param res - The HTTP response.
  */
-export function smartConfigurationHandler(_req: Request, res: Response): void {
+export function smartConfigurationHandler(req: Request, res: Response): void {
   const config = getConfig();
   res
     .status(200)
     .contentType(ContentType.JSON)
     .json({
-      issuer: config.issuer,
-      jwks_uri: config.jwksUrl,
-      authorization_endpoint: config.authorizeUrl,
+      issuer: getProjectScopedUrl(req.originalUrl, config.issuer),
+      jwks_uri: getProjectScopedUrl(req.originalUrl, config.baseUrl, config.jwksUrl),
+      authorization_endpoint: getProjectScopedUrl(req.originalUrl, config.baseUrl, config.authorizeUrl),
       grant_types_supported: [
         OAuthGrantType.ClientCredentials,
         OAuthGrantType.AuthorizationCode,
         OAuthGrantType.RefreshToken,
         OAuthGrantType.TokenExchange,
       ],
-      token_endpoint: config.tokenUrl,
+      token_endpoint: getProjectScopedUrl(req.originalUrl, config.baseUrl, config.tokenUrl),
       token_endpoint_auth_methods_supported: [
         OAuthTokenAuthMethod.ClientSecretBasic,
         OAuthTokenAuthMethod.ClientSecretPost,
@@ -76,7 +77,7 @@ export function smartConfigurationHandler(_req: Request, res: Response): void {
         'online_access',
       ],
       response_types_supported: ['code'],
-      introspection_endpoint: config.introspectUrl,
+      introspection_endpoint: getProjectScopedUrl(req.originalUrl, config.baseUrl, config.introspectUrl),
       capabilities: [
         'authorize-post',
         'permission-v1',

--- a/packages/server/src/oauth/authorize.ts
+++ b/packages/server/src/oauth/authorize.ts
@@ -7,6 +7,7 @@ import { URL } from 'node:url';
 import { getConfig } from '../config/loader';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { getLogger } from '../logger';
+import { getProjectScopedUrl } from '../util/url';
 import { getClientRedirectUri } from './clients';
 import type { MedplumIdTokenClaims } from './keys';
 import { generateSecret, verifyJwt } from './keys';
@@ -223,7 +224,7 @@ async function getExistingLoginFromIdTokenHint(req: Request): Promise<Login | un
 
   let verifyResult;
   try {
-    verifyResult = await verifyJwt(idTokenHint);
+    verifyResult = await verifyJwt(idTokenHint, getProjectScopedUrl(req.originalUrl, getConfig().issuer));
   } catch (err: any) {
     getLogger().debug('Error verifying id_token_hint', err);
     return undefined;

--- a/packages/server/src/oauth/introspect.ts
+++ b/packages/server/src/oauth/introspect.ts
@@ -3,7 +3,9 @@
 import type { Login, SmartAppLaunch } from '@medplum/fhirtypes';
 import type { Request, RequestHandler, Response } from 'express';
 import type { JWTPayload } from 'jose';
+import { getConfig } from '../config/loader';
 import { getGlobalSystemRepo } from '../fhir/repo';
+import { getProjectScopedUrl } from '../util/url';
 import { verifyJwt } from './keys';
 
 /**
@@ -20,7 +22,7 @@ export const tokenIntrospectHandler: RequestHandler = async (req: Request, res: 
   }
 
   try {
-    const decodedToken = await verifyJwt(token);
+    const decodedToken = await verifyJwt(token, getProjectScopedUrl(req.originalUrl, getConfig().issuer));
 
     const systemRepo = getGlobalSystemRepo();
     const login = await systemRepo.readResource<Login>('Login', decodedToken.payload.login_id as string);

--- a/packages/server/src/oauth/keys.test.ts
+++ b/packages/server/src/oauth/keys.test.ts
@@ -155,6 +155,27 @@ describe('Keys', () => {
     expect(result.payload.login_id).toStrictEqual('123');
   });
 
+  test('Generate access token with project-scoped issuer', async () => {
+    const config = await loadTestConfig();
+    await initKeys(config);
+    const projectIssuer = `${config.issuer}projects/00000000-0000-0000-0000-000000000000/`;
+
+    const token = await generateAccessToken(
+      {
+        login_id: '123',
+        username: 'username',
+        scope: 'scope',
+        profile: 'profile',
+      },
+      { issuer: projectIssuer }
+    );
+
+    const result = await verifyJwt(token, projectIssuer);
+    expect(result.payload.iss).toBe(projectIssuer);
+    expect(result.payload.aud).toBe(projectIssuer);
+    await expect(verifyJwt(token)).rejects.toThrow();
+  });
+
   test('Generate refresh token', async () => {
     const config = await loadTestConfig();
     await initKeys(config);

--- a/packages/server/src/oauth/keys.ts
+++ b/packages/server/src/oauth/keys.ts
@@ -233,10 +233,11 @@ export function generateSecret(size: number): string {
 /**
  * Generates an ID token JWT.
  * @param claims - The ID token claims.
+ * @param tokenIssuer - Optional issuer override.
  * @returns A well-formed JWT that can be used as an ID token.
  */
-export function generateIdToken(claims: MedplumIdTokenClaims): Promise<string> {
-  return generateJwt('1h', claims);
+export function generateIdToken(claims: MedplumIdTokenClaims, tokenIssuer?: string): Promise<string> {
+  return generateJwt('1h', claims, tokenIssuer);
 }
 
 /**
@@ -245,35 +246,46 @@ export function generateIdToken(claims: MedplumIdTokenClaims): Promise<string> {
  * @param options - Optional parameters.
  * @param options.additionalClaims - Any additional custom claims.
  * @param options.lifetime - Access token duration.
+ * @param options.issuer - Optional issuer override.
  * @returns A well-formed JWT that can be used as an access token.
  */
 export function generateAccessToken(
   claims: MedplumAccessTokenClaims,
-  options?: { additionalClaims?: Record<string, string | number>; lifetime?: string }
+  options?: { additionalClaims?: Record<string, string | number>; lifetime?: string; issuer?: string }
 ): Promise<string> {
   const duration = options?.lifetime ?? DEFAULT_ACCESS_LIFETIME;
-  return generateJwt(duration, { aud: issuer, ...claims, ...options?.additionalClaims });
+  return generateJwt(
+    duration,
+    { aud: options?.issuer ?? issuer, ...claims, ...options?.additionalClaims },
+    options?.issuer
+  );
 }
 
 /**
  * Generates a refresh token JWT.
  * @param claims - The refresh token claims.
  * @param lifetime - The refresh token duration.
+ * @param tokenIssuer - Optional issuer override.
  * @returns A well-formed JWT that can be used as a refresh token.
  */
-export function generateRefreshToken(claims: MedplumRefreshTokenClaims, lifetime?: string): Promise<string> {
+export function generateRefreshToken(
+  claims: MedplumRefreshTokenClaims,
+  lifetime?: string,
+  tokenIssuer?: string
+): Promise<string> {
   const duration = lifetime ?? DEFAULT_REFRESH_LIFETIME;
-  return generateJwt(duration, { aud: issuer, ...claims });
+  return generateJwt(duration, { aud: tokenIssuer ?? issuer, ...claims }, tokenIssuer);
 }
 
 /**
  * Generates a JWT.
  * @param exp - Expiration time resolved to a time span.
  * @param claims - The key/value pairs to include in the payload section.
+ * @param tokenIssuer - Issuer for the generated token.
  * @returns Promise to generate and sign the JWT.
  */
-async function generateJwt(exp: string, claims: JWTPayload): Promise<string> {
-  if (!jsonWebKey || !defaultSigningKey || !issuer) {
+async function generateJwt(exp: string, claims: JWTPayload, tokenIssuer = issuer): Promise<string> {
+  if (!jsonWebKey || !defaultSigningKey || !tokenIssuer) {
     throw new Error('Signing key not initialized');
   }
 
@@ -291,7 +303,7 @@ async function generateJwt(exp: string, claims: JWTPayload): Promise<string> {
     .setJti(randomUUID())
     .setIssuedAt()
     .setNotBefore(new Date())
-    .setIssuer(issuer)
+    .setIssuer(tokenIssuer)
     .setAudience(claims.aud ?? (claims.client_id as string))
     .setExpirationTime(exp)
     .sign(defaultSigningKey);
@@ -300,15 +312,19 @@ async function generateJwt(exp: string, claims: JWTPayload): Promise<string> {
 /**
  * Decodes and verifies a JWT.
  * @param token - The jwt token / bearer token.
+ * @param expectedIssuer - Issuer expected in the token.
  * @returns Returns the decoded claims on success.
  */
-export async function verifyJwt(token: string): Promise<{ payload: JWTPayload; protectedHeader: JWSHeaderParameters }> {
-  if (!issuer) {
+export async function verifyJwt(
+  token: string,
+  expectedIssuer = issuer
+): Promise<{ payload: JWTPayload; protectedHeader: JWSHeaderParameters }> {
+  if (!expectedIssuer) {
     throw new Error('Signing key not initialized');
   }
 
   const verifyOptions: JWTVerifyOptions = {
-    issuer,
+    issuer: expectedIssuer,
     algorithms: [OAuthSigningAlgorithm.ES256, OAuthSigningAlgorithm.ES384, OAuthSigningAlgorithm.RS256],
   };
 

--- a/packages/server/src/oauth/middleware.ts
+++ b/packages/server/src/oauth/middleware.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { ProfileResource, WithId } from '@medplum/core';
-import { OperationOutcomeError, unauthorized } from '@medplum/core';
+import { forbidden, OperationOutcomeError, unauthorized } from '@medplum/core';
 import type {
   Bot,
   ClientApplication,
@@ -16,6 +16,7 @@ import type { IncomingMessage } from 'node:http';
 import { getConfig } from '../config/loader';
 import { AuthenticatedRequestContext, getRequestContext } from '../context';
 import type { Repository } from '../fhir/repo';
+import { getProjectIdFromUrl } from '../util/url';
 import { getLoginForAccessToken, getLoginForBasicAuth } from './utils';
 
 export type AuthState = {
@@ -41,6 +42,11 @@ export const PROMPT_BASIC_AUTH_PARAM = '_medplum-prompt-basic-auth';
 export function authenticateRequest(req: Request, res: Response, next: NextFunction): void {
   const ctx = getRequestContext();
   if (ctx instanceof AuthenticatedRequestContext) {
+    const projectId = getProjectIdFromUrl(req.originalUrl);
+    if (projectId && projectId !== ctx.project.id) {
+      next(new OperationOutcomeError(forbidden));
+      return;
+    }
     next();
   } else {
     const requestAuthScheme = req.headers.authorization?.split(' ')[0] ?? 'Bearer';

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -35,7 +35,7 @@ import { getConfig } from '../config/loader';
 import { getAccessPolicyForLogin } from '../fhir/accesspolicy';
 import { getGlobalSystemRepo } from '../fhir/repo';
 import { getTopicForUser } from '../fhircast/utils';
-import { safeFetch } from '../util/url';
+import { getProjectScopedUrl, safeFetch } from '../util/url';
 import { validateClientCert } from './cert';
 import type { MedplumRefreshTokenClaims } from './keys';
 import { generateSecret, verifyJwt } from './keys';
@@ -174,7 +174,7 @@ async function handleClientCredentials(req: Request, res: Response): Promise<voi
     return;
   }
 
-  await sendTokenResponse(res, login, client);
+  await sendTokenResponse(req, res, login, client);
 }
 
 /**
@@ -270,7 +270,7 @@ async function handleAuthorizationCode(req: Request, res: Response): Promise<voi
     }
   }
 
-  await sendTokenResponse(res, login, client);
+  await sendTokenResponse(req, res, login, client);
 }
 
 /**
@@ -288,7 +288,8 @@ async function handleRefreshToken(req: Request, res: Response): Promise<void> {
 
   let claims: MedplumRefreshTokenClaims;
   try {
-    claims = (await verifyJwt(refreshToken)).payload as MedplumRefreshTokenClaims;
+    claims = (await verifyJwt(refreshToken, getProjectScopedUrl(req.originalUrl, getConfig().issuer)))
+      .payload as MedplumRefreshTokenClaims;
   } catch {
     sendTokenError(res, 'invalid_request', 'Invalid refresh token');
     return;
@@ -363,7 +364,7 @@ async function handleRefreshToken(req: Request, res: Response): Promise<void> {
     userAgent: req.get('User-Agent'),
   });
 
-  await sendTokenResponse(res, updatedLogin, client);
+  await sendTokenResponse(req, res, updatedLogin, client);
 }
 
 /**
@@ -501,7 +502,7 @@ export async function exchangeExternalAuthToken(
     membershipId,
   });
 
-  await sendTokenResponse(res, login, client);
+  await sendTokenResponse(req, res, login, client);
 }
 
 function validateExternalAuthTokenExchangeRequest(
@@ -671,7 +672,7 @@ async function handlePreAuthorizedCode(req: Request, res: Response): Promise<voi
     return;
   }
 
-  await sendTokenResponse(res, login, client);
+  await sendTokenResponse(req, res, login, client);
 }
 
 /**
@@ -688,7 +689,7 @@ async function handlePreAuthorizedCode(req: Request, res: Response): Promise<voi
  */
 async function getClientIdAndSecret(req: Request): Promise<ClientIdAndSecret> {
   if (req.body.client_assertion_type) {
-    return parseClientAssertion(req.body.client_assertion_type, req.body.client_assertion);
+    return parseClientAssertion(req, req.body.client_assertion_type, req.body.client_assertion);
   }
 
   const authHeader = req.headers.authorization;
@@ -725,11 +726,13 @@ async function getClientIdAndSecret(req: Request): Promise<ClientIdAndSecret> {
  * 2. https://www.hl7.org/fhir/smart-app-launch/example-backend-services.html#step-2-discovery
  * 3. https://docs.oracle.com/en/cloud/get-started/subscriptions-cloud/csimg/obtaining-access-token-using-self-signed-client-assertion.html
  * 4. https://darutk.medium.com/oauth-2-0-client-authentication-4b5f929305d4
+ * @param req - The HTTP request.
  * @param clientAssertionType - The client assertion type.
  * @param clientAssertion - The client assertion JWT.
  * @returns The parsed client ID and secret on success, or an error message on failure.
  */
 async function parseClientAssertion(
+  req: Request,
   clientAssertionType: OAuthClientAssertionType,
   clientAssertion: string
 ): Promise<ClientIdAndSecret> {
@@ -741,7 +744,8 @@ async function parseClientAssertion(
     return { error: 'Invalid client assertion' };
   }
 
-  const { tokenUrl } = getConfig();
+  const config = getConfig();
+  const tokenUrl = getProjectScopedUrl(req.originalUrl, config.baseUrl, config.tokenUrl);
   const claims = parseJWTPayload(clientAssertion);
 
   if (claims.aud !== tokenUrl) {
@@ -882,11 +886,17 @@ async function validateClientIdAndSecret(
 
 /**
  * Sends a successful token response.
+ * @param req - The HTTP request.
  * @param res - The HTTP response.
  * @param login - The user login.
  * @param client - The client application. Optional.
  */
-async function sendTokenResponse(res: Response, login: WithId<Login>, client?: ClientApplication): Promise<void> {
+async function sendTokenResponse(
+  req: Request,
+  res: Response,
+  login: WithId<Login>,
+  client?: ClientApplication
+): Promise<void> {
   const config = getConfig();
 
   const systemRepo = getGlobalSystemRepo();
@@ -898,6 +908,7 @@ async function sendTokenResponse(res: Response, login: WithId<Login>, client?: C
   const tokens = await getAuthTokens(user, login, membership.profile as Reference<ProfileResource>, {
     accessLifetime: client?.accessTokenLifetime,
     refreshLifetime: client?.refreshTokenLifetime,
+    issuer: getProjectScopedUrl(req.originalUrl, config.issuer),
   });
   let patient = undefined;
   let encounter = undefined;

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -56,7 +56,7 @@ import {
   LoginEvent,
   UserAuthenticationEvent,
 } from '../util/auditevent';
-import { safeFetch } from '../util/url';
+import { getProjectScopedUrl, safeFetch } from '../util/url';
 import { getStandardClientById } from './clients';
 import type { MedplumAccessTokenClaims } from './keys';
 import { generateAccessToken, generateIdToken, generateRefreshToken, generateSecret, verifyJwt } from './keys';
@@ -608,6 +608,7 @@ export async function getAuthTokens(
   options?: {
     accessLifetime?: string;
     refreshLifetime?: string;
+    issuer?: string;
   }
 ): Promise<TokenResult> {
   assert.equal(getReferenceString(user), login.user?.reference);
@@ -626,16 +627,19 @@ export async function getAuthTokens(
     });
   }
 
-  const idToken = await generateIdToken({
-    client_id: clientId,
-    login_id: login.id,
-    fhirUser: profile.reference,
-    email: login.scope?.includes('email') && user.resourceType === 'User' ? user.email : undefined,
-    aud: clientId,
-    sub: user.id,
-    nonce: login.nonce as string,
-    auth_time: (getDateProperty(login.authTime) as Date).getTime() / 1000,
-  });
+  const idToken = await generateIdToken(
+    {
+      client_id: clientId,
+      login_id: login.id,
+      fhirUser: profile.reference,
+      email: login.scope?.includes('email') && user.resourceType === 'User' ? user.email : undefined,
+      aud: clientId,
+      sub: user.id,
+      nonce: login.nonce as string,
+      auth_time: (getDateProperty(login.authTime) as Date).getTime() / 1000,
+    },
+    options?.issuer
+  );
 
   const accessToken = await generateAccessToken(
     {
@@ -647,7 +651,7 @@ export async function getAuthTokens(
       profile: profile.reference as string,
       email: login.scope?.includes('email') && user.resourceType === 'User' ? user.email : undefined,
     },
-    { lifetime: options?.accessLifetime }
+    { lifetime: options?.accessLifetime, issuer: options?.issuer }
   );
 
   const refreshToken = login.refreshSecret
@@ -657,7 +661,8 @@ export async function getAuthTokens(
           login_id: login.id,
           refresh_secret: login.refreshSecret,
         },
-        options?.refreshLifetime
+        options?.refreshLifetime,
+        options?.issuer
       )
     : undefined;
 
@@ -1008,7 +1013,9 @@ export async function getLoginForAccessToken(
 
   let verifyResult: Awaited<ReturnType<typeof verifyJwt>>;
   try {
-    verifyResult = await verifyJwt(accessToken);
+    const config = getConfig();
+    const expectedIssuer = req ? getProjectScopedUrl(req.originalUrl, config.issuer) : config.issuer;
+    verifyResult = await verifyJwt(accessToken, expectedIssuer);
   } catch {
     return undefined;
   }
@@ -1018,7 +1025,9 @@ export async function getLoginForAccessToken(
   // A valid signature only proves that this server minted the token, not that it minted an access token.
   // ID tokens are audienced to the client rather than to the issuer, and refresh tokens carry a refresh secret.
   // Without these checks, either one is accepted as an access token. See RFC 8725 sections 3.9 and 3.12.
-  if (claims.aud !== getConfig().issuer || claims.refresh_secret !== undefined) {
+  const config = getConfig();
+  const expectedAudience = req ? getProjectScopedUrl(req.originalUrl, config.issuer) : config.issuer;
+  if (claims.aud !== expectedAudience || claims.refresh_secret !== undefined) {
     return undefined;
   }
 

--- a/packages/server/src/ratelimit.ts
+++ b/packages/server/src/ratelimit.ts
@@ -8,6 +8,7 @@ import { RateLimiterRedis } from 'rate-limiter-flexible';
 import type { MedplumServerConfig } from './config/types';
 import { AuthenticatedRequestContext, getRequestContext } from './context';
 import { getRateLimitRedis } from './redis';
+import { getNormalizedPath } from './util/url';
 
 // There are three separate rate limits:
 // 1. "Login" rate limit - applies only to `/auth/login` and `/auth/register` endpoints
@@ -149,7 +150,7 @@ function getRateLimitForRequest(req: Request, config?: MedplumServerConfig): num
 }
 
 function getRateLimitCategory(req: Request): RateLimitCategoryConfig {
-  const url = req.originalUrl;
+  const url = getNormalizedPath(req.originalUrl);
   for (let i = 0; i < categories.length - 1; i++) {
     const category = categories[i];
     if (category.matchesUrl(url)) {

--- a/packages/server/src/util/url.test.ts
+++ b/packages/server/src/util/url.test.ts
@@ -7,12 +7,56 @@ import { fetch } from 'undici';
 import { vi } from 'vitest';
 import {
   createSafeConnect,
+  getNormalizedPath,
+  getProjectIdFromUrl,
+  getProjectScopedUrl,
   isAllowedOutboundUrlForQueue,
   isUnsafeHostname,
   isUnsafeIpAddress,
   safeAgent,
   validateOutboundUrl,
 } from './url';
+
+describe('request URL helpers', () => {
+  test.each([
+    ['/fhir/R4/Patient', '/fhir/R4/Patient'],
+    ['/api/fhir/R4/Patient', '/fhir/R4/Patient'],
+    ['/projects/123/fhir/R4/Patient', '/fhir/R4/Patient'],
+    ['/api/projects/123/fhir/R4/Patient?active=true', '/fhir/R4/Patient'],
+    ['/apiary/fhir/R4/Patient', '/apiary/fhir/R4/Patient'],
+  ])('normalizes %s', (url, expected) => {
+    expect(getNormalizedPath(url)).toBe(expected);
+  });
+
+  test.each([
+    ['/projects/123/fhir/R4/Patient', '123'],
+    ['/api/projects/123/fhir/R4/Patient', '123'],
+    ['/fhir/R4/Patient', undefined],
+    ['/api/fhir/R4/Patient', undefined],
+  ])('gets the project ID from %s', (url, expected) => {
+    expect(getProjectIdFromUrl(url)).toBe(expected);
+  });
+
+  test('scopes an internal URL to the request project', () => {
+    expect(
+      getProjectScopedUrl(
+        '/projects/123/.well-known/openid-configuration',
+        'https://example.com/',
+        'https://example.com/oauth2/token'
+      )
+    ).toBe('https://example.com/projects/123/oauth2/token');
+  });
+
+  test('does not scope an external URL', () => {
+    expect(
+      getProjectScopedUrl(
+        '/projects/123/.well-known/openid-configuration',
+        'https://example.com/',
+        'https://identity.example.net/oauth2/token'
+      )
+    ).toBe('https://identity.example.net/oauth2/token');
+  });
+});
 
 describe('validateOutboundUrl', () => {
   test('parses HTTPS URLs', () => {

--- a/packages/server/src/util/url.test.ts
+++ b/packages/server/src/util/url.test.ts
@@ -47,6 +47,16 @@ describe('request URL helpers', () => {
     ).toBe('https://example.com/projects/123/oauth2/token');
   });
 
+  test('scopes an internal URL when the base URL has a path', () => {
+    expect(
+      getProjectScopedUrl(
+        '/api/projects/123/.well-known/openid-configuration',
+        'https://example.com/api/',
+        'https://example.com/api/oauth2/token'
+      )
+    ).toBe('https://example.com/api/projects/123/oauth2/token');
+  });
+
   test('does not scope an external URL', () => {
     expect(
       getProjectScopedUrl(

--- a/packages/server/src/util/url.ts
+++ b/packages/server/src/util/url.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { concatUrls } from '@medplum/core';
 import ipaddr from 'ipaddr.js';
 import dns from 'node:dns';
 import type { Dispatcher } from 'undici';
@@ -17,6 +18,54 @@ const connector = buildConnector({});
 // The DOM RequestInit type used by built-in fetch does not include Undici's
 // dispatcher option, even though Node's fetch accepts it.
 type FetchInitWithDispatcher = RequestInit & { dispatcher?: Dispatcher };
+
+/**
+ * Returns the project ID from a project-scoped API path.
+ * @param url - Request URL, optionally including a query string.
+ * @returns The project ID, or undefined if the URL is not project scoped.
+ */
+export function getProjectIdFromUrl(url: string): string | undefined {
+  const segments = url.split('?', 1)[0].split('/');
+  const index = segments[1] === 'api' ? 2 : 1;
+  return segments[index] === 'projects' ? segments[index + 1] : undefined;
+}
+
+/**
+ * Removes the optional `/api` and `/projects/{projectId}` mount prefixes from a request URL.
+ * @param url - Request URL, optionally including a query string.
+ * @returns The normalized request path.
+ */
+export function getNormalizedPath(url: string): string {
+  const path = url.split('?', 1)[0];
+  const segments = path.split('/');
+  let index = 1;
+
+  if (segments[index] === 'api') {
+    index++;
+  }
+  if (segments[index] === 'projects' && segments[index + 1]) {
+    index += 2;
+  }
+
+  return '/' + segments.slice(index).join('/');
+}
+
+/**
+ * Adds the request's project scope to an internal server URL.
+ * @param requestUrl - The incoming request URL.
+ * @param baseUrl - The configured base URL for the target URL.
+ * @param targetUrl - The URL to scope. Defaults to the base URL.
+ * @returns The target URL with the request's project scope, if present.
+ */
+export function getProjectScopedUrl(requestUrl: string, baseUrl: string, targetUrl = baseUrl): string {
+  const projectId = getProjectIdFromUrl(requestUrl);
+  if (!projectId || !targetUrl.startsWith(baseUrl)) {
+    return targetUrl;
+  }
+
+  const projectBaseUrl = concatUrls(baseUrl, `projects/${projectId}/`);
+  return projectBaseUrl + targetUrl.substring(baseUrl.length);
+}
 
 export function createSafeConnect(connect: buildConnector.connector = connector): buildConnector.connector {
   return (options, callback) => {

--- a/packages/server/src/util/url.ts
+++ b/packages/server/src/util/url.ts
@@ -64,7 +64,7 @@ export function getProjectScopedUrl(requestUrl: string, baseUrl: string, targetU
   }
 
   const projectBaseUrl = concatUrls(baseUrl, `projects/${projectId}/`);
-  return projectBaseUrl + targetUrl.substring(baseUrl.length);
+  return concatUrls(projectBaseUrl, targetUrl.substring(baseUrl.length));
 }
 
 export function createSafeConnect(connect: buildConnector.connector = connector): buildConnector.connector {

--- a/packages/server/src/wellknown.test.ts
+++ b/packages/server/src/wellknown.test.ts
@@ -4,7 +4,7 @@ import { isUUID } from '@medplum/core';
 import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from './app';
-import { loadTestConfig } from './config/loader';
+import { getConfig, loadTestConfig } from './config/loader';
 
 const app = express();
 
@@ -75,6 +75,36 @@ describe('Well Known', () => {
     expect(res.body.subject_types_supported).toBeDefined();
   });
 
+  test('Get project-scoped OpenID configuration', async () => {
+    const projectId = '00000000-0000-0000-0000-000000000000';
+    const projectBaseUrl = `${getConfig().baseUrl}projects/${projectId}/`;
+    const res = await request(app).get(`/projects/${projectId}/.well-known/openid-configuration`);
+    expect(res).toHaveStatus(200);
+    expect(res.body).toMatchObject({
+      issuer: projectBaseUrl,
+      authorization_endpoint: `${projectBaseUrl}oauth2/authorize`,
+      token_endpoint: `${projectBaseUrl}oauth2/token`,
+      userinfo_endpoint: `${projectBaseUrl}oauth2/userinfo`,
+      jwks_uri: `${projectBaseUrl}.well-known/jwks.json`,
+      introspection_endpoint: `${projectBaseUrl}oauth2/introspect`,
+      registration_endpoint: `${projectBaseUrl}oauth2/register`,
+    });
+  });
+
+  test('Get project-scoped SMART configuration', async () => {
+    const projectId = '00000000-0000-0000-0000-000000000000';
+    const projectBaseUrl = `${getConfig().baseUrl}projects/${projectId}/`;
+    const res = await request(app).get(`/projects/${projectId}/.well-known/smart-configuration`);
+    expect(res).toHaveStatus(200);
+    expect(res.body).toMatchObject({
+      issuer: projectBaseUrl,
+      authorization_endpoint: `${projectBaseUrl}oauth2/authorize`,
+      token_endpoint: `${projectBaseUrl}oauth2/token`,
+      jwks_uri: `${projectBaseUrl}.well-known/jwks.json`,
+      introspection_endpoint: `${projectBaseUrl}oauth2/introspect`,
+    });
+  });
+
   test('Get /.well-known/oauth-authorization-server', async () => {
     const res = await request(app).get('/.well-known/oauth-authorization-server');
     expect(res).toHaveStatus(200);
@@ -97,6 +127,19 @@ describe('Well Known', () => {
     expect(res.body.scopes_supported).toBeDefined();
     expect(res.body.bearer_methods_supported).toBeDefined();
     expect(res.body.introspection_endpoint).toBeDefined();
+  });
+
+  test('Get project-scoped protected resource configuration', async () => {
+    const projectId = '00000000-0000-0000-0000-000000000000';
+    const projectBaseUrl = `${getConfig().baseUrl}projects/${projectId}/`;
+    const res = await request(app).get(`/projects/${projectId}/.well-known/oauth-protected-resource`);
+    expect(res).toHaveStatus(200);
+    expect(res.body).toMatchObject({
+      resource: projectBaseUrl,
+      issuer: projectBaseUrl,
+      authorization_servers: [projectBaseUrl],
+      introspection_endpoint: `${projectBaseUrl}oauth2/introspect`,
+    });
   });
 
   test('Protected resource with custom request', async () => {

--- a/packages/server/src/wellknown.ts
+++ b/packages/server/src/wellknown.ts
@@ -6,6 +6,7 @@ import { Router } from 'express';
 import { getConfig } from './config/loader';
 import { smartConfigurationHandler, smartStylingHandler } from './fhir/smart';
 import { getJwks } from './oauth/keys';
+import { getProjectScopedUrl } from './util/url';
 
 export const wellKnownRouter = Router();
 
@@ -13,16 +14,16 @@ wellKnownRouter.get('/jwks.json', (_req: Request, res: Response) => {
   res.status(200).json(getJwks());
 });
 
-function handleOAuthConfig(_req: Request, res: Response): void {
+function handleOAuthConfig(req: Request, res: Response): void {
   const config = getConfig();
   res.status(200).json({
-    issuer: config.issuer,
-    authorization_endpoint: config.authorizeUrl,
-    token_endpoint: config.tokenUrl,
-    userinfo_endpoint: config.userInfoUrl,
-    jwks_uri: config.jwksUrl,
-    introspection_endpoint: config.introspectUrl,
-    registration_endpoint: config.registerUrl,
+    issuer: getProjectScopedUrl(req.originalUrl, config.issuer),
+    authorization_endpoint: getProjectScopedUrl(req.originalUrl, config.baseUrl, config.authorizeUrl),
+    token_endpoint: getProjectScopedUrl(req.originalUrl, config.baseUrl, config.tokenUrl),
+    userinfo_endpoint: getProjectScopedUrl(req.originalUrl, config.baseUrl, config.userInfoUrl),
+    jwks_uri: getProjectScopedUrl(req.originalUrl, config.baseUrl, config.jwksUrl),
+    introspection_endpoint: getProjectScopedUrl(req.originalUrl, config.baseUrl, config.introspectUrl),
+    registration_endpoint: getProjectScopedUrl(req.originalUrl, config.baseUrl, config.registerUrl),
     id_token_signing_alg_values_supported: [
       OAuthSigningAlgorithm.ES256,
       OAuthSigningAlgorithm.ES384,
@@ -50,11 +51,12 @@ function handleOAuthConfig(_req: Request, res: Response): void {
 
 function handleOauthProtectedResource(req: Request, res: Response): void {
   const config = getConfig();
-  let resource = config.baseUrl;
+  const baseUrl = getProjectScopedUrl(req.originalUrl, config.baseUrl);
+  let resource = baseUrl;
 
   const requestedResource = req.query.resource;
   if (requestedResource) {
-    if (typeof requestedResource !== 'string' || !requestedResource.startsWith(config.baseUrl)) {
+    if (typeof requestedResource !== 'string' || !requestedResource.startsWith(baseUrl)) {
       res.status(400).send('Invalid resource URL');
       return;
     }
@@ -63,11 +65,11 @@ function handleOauthProtectedResource(req: Request, res: Response): void {
 
   res.status(200).json({
     resource,
-    issuer: config.issuer,
-    authorization_servers: [config.issuer],
+    issuer: getProjectScopedUrl(req.originalUrl, config.issuer),
+    authorization_servers: [getProjectScopedUrl(req.originalUrl, config.issuer)],
     scopes_supported: ['openid', 'profile', 'email', 'phone', 'address'],
     bearer_methods_supported: ['header'],
-    introspection_endpoint: config.introspectUrl,
+    introspection_endpoint: getProjectScopedUrl(req.originalUrl, config.baseUrl, config.introspectUrl),
   });
 }
 


### PR DESCRIPTION
Adds project-scoped aliases for the Medplum API:

```text
/projects/{projectId}/...
/api/projects/{projectId}/...
```

The existing root and `/api` routes remain available and unchanged.

When an authenticated request uses a project-scoped route, the project ID in the URL must match the project resolved by the existing authentication flow. A mismatch returns `403 Forbidden`.

The URL is validation only: it does not select a membership, change repositories, or otherwise participate in resolving the authenticated identity. Authentication continues to resolve `Login -> ProjectMembership -> Project` as before.

## Motivation

Some integrations require a distinct API base URL for each tenant. In particular:

- ONC available-endpoint discovery expects a tenant-specific endpoint.
- CMS-0057-F CRD testing uses backend-service credentials that do not independently identify the Medplum project, making the endpoint URL the project-routing signal.

Project-scoped aliases provide that routing surface while preserving compatibility with existing clients.

## Changes

- Mount the API router at `/projects/:projectId/` and `/api/projects/:projectId/`.
- Validate the optional URL project ID in the existing `authenticateRequest` middleware.
- Add project-scoped routes for raw Binary requests and asynchronous batch requests, which are registered before the normal body parsers.
- Add the previously missing `/api` aliases for Binary and asynchronous batch routes.
- Normalize `/api` and `/projects/{projectId}` prefixes before CORS and rate-limit path classification.
- Add focused coverage for URL normalization, CORS, route mounting, and authenticated project mismatch behavior.
- Make OpenID, OAuth protected-resource, and SMART discovery URLs reflect the project-scoped request base.
- Mint and validate tokens using the issuer selected by the request URL.
- Validate private-key JWT assertions against the project-scoped token endpoint URL.

## Authoritative project behavior

For an authenticated request:

```text
URL project ID == authenticated ProjectMembership project ID
```

If no project scope is present in the URL, behavior is unchanged. If a project scope is present and does not match the authenticated project, the request is rejected.

Unauthenticated endpoints continue to use their existing authentication and project-resolution behavior. This change does not rewrite login, OAuth, membership, or repository selection logic.

## Compatibility

- Existing root routes continue to work.
- Existing `/api` routes continue to work.
- Project-scoped routes are additive.
- The same API router and handlers serve every mount.
- No resource schema, database, or configuration changes are required.

## Project-scoped discovery and issuer

Discovery remains within the URL pattern used to begin the session. A request to:

```text
/projects/{projectId}/.well-known/openid-configuration
```

advertises the corresponding project-scoped issuer, authorization endpoint, token endpoint, user-info endpoint, introspection endpoint, registration endpoint, and JWKS URI.

Token behavior follows the same request-relative scope:

- private-key JWT assertions accept the project-scoped token endpoint as `aud`;
- tokens issued through a project-scoped flow use the project-scoped issuer;
- subsequent token verification uses the issuer implied by the request URL.
