### PR TITLE
feat(server): configurable default app name for user-facing content

### DIFF
--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -26,7 +26,7 @@ import { toDataURL } from 'qrcode';
 import { getConfig } from '../config/loader';
 import { EMAIL_MFA_CODE_EXPIRATION_MS, MAX_PASSWORD_LENGTH } from '../constants';
 import { sendEmail } from '../email/email';
-import { getProjectAppName } from '../email/utils';
+import { getAppName, getProjectAppName } from '../email/utils';
 import { sendOutcome } from '../fhir/outcomes';
 import type { SystemRepository } from '../fhir/repo';
 import { getGlobalSystemRepo, getShardSystemRepo } from '../fhir/repo';
@@ -36,9 +36,6 @@ import { getLogger } from '../logger';
 import { getClientApplication, getMembershipsForLogin } from '../oauth/utils';
 
 export type MfaMethod = 'totp' | 'email';
-
-/** App name used in MFA emails for projects that have not been white-labeled. */
-const DEFAULT_APP_NAME = 'Medplum';
 
 /** Authenticator app issuer used for projects that have not been white-labeled. */
 const DEFAULT_MFA_ISSUER = 'medplum.com';
@@ -149,7 +146,7 @@ export async function sendMfaEmailCode(
   const expiresAt = new Date(Date.now() + EMAIL_MFA_CODE_EXPIRATION_MS).toISOString();
   await systemRepo.updateResource<Login>({ ...login, emailMfa: { codeHash, expiresAt } });
   const expirationMinutes = Math.floor(EMAIL_MFA_CODE_EXPIRATION_MS / 60_000);
-  const appName = getProjectAppName(project) ?? DEFAULT_APP_NAME;
+  const appName = getAppName(project);
   await sendEmail(
     systemRepo,
     {

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -21,6 +21,11 @@ export interface MedplumServerConfig {
   signingKeyId?: string;
   signingKeyPassphrase?: string;
   supportEmail: string;
+  /**
+   * App name used in user-facing content (emails, MFA) for projects that have
+   * not set their own `appName` setting. Defaults to "Medplum".
+   */
+  appName?: string;
   approvedSenderEmails?: string;
   database: MedplumDatabaseConfig;
   /** @deprecated specify `database.host` and `database.ssl.require` as needed */

--- a/packages/server/src/email/utils.test.ts
+++ b/packages/server/src/email/utils.test.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Project } from '@medplum/fhirtypes';
-import { addressToString, applyFromDisplayName, getProjectAppName } from './utils';
+import { getConfig, loadTestConfig } from '../config/loader';
+import { addressToString, applyFromDisplayName, DEFAULT_APP_NAME, getAppName, getProjectAppName } from './utils';
 
 describe('Email utils', () => {
   function projectWithAppName(valueString: string | undefined): Project {
@@ -26,6 +27,43 @@ describe('Email utils', () => {
   test('getProjectAppName returns the trimmed app name', () => {
     expect(getProjectAppName(projectWithAppName('Acme Health'))).toBe('Acme Health');
     expect(getProjectAppName(projectWithAppName('  Acme Health  '))).toBe('Acme Health');
+  });
+
+  describe('getAppName', () => {
+    let originalAppName: string | undefined;
+
+    beforeAll(async () => {
+      await loadTestConfig();
+      originalAppName = getConfig().appName;
+    });
+
+    afterEach(() => {
+      getConfig().appName = originalAppName;
+    });
+
+    test('prefers the project setting over the server config', () => {
+      getConfig().appName = 'Server Brand';
+      expect(getAppName(projectWithAppName('Project Brand'))).toBe('Project Brand');
+    });
+
+    test('falls back to the server config when the project sets nothing', () => {
+      getConfig().appName = 'Server Brand';
+      expect(getAppName(projectWithAppName(undefined))).toBe('Server Brand');
+      // No project at all: server-scoped users, and the password reset flow
+      // that looks them up, take this path.
+      expect(getAppName()).toBe('Server Brand');
+    });
+
+    test('falls back to the default when neither names one', () => {
+      getConfig().appName = undefined;
+      expect(getAppName()).toBe(DEFAULT_APP_NAME);
+      expect(getAppName(projectWithAppName(undefined))).toBe(DEFAULT_APP_NAME);
+    });
+
+    test('treats a blank server config value as unset', () => {
+      getConfig().appName = '   ';
+      expect(getAppName()).toBe(DEFAULT_APP_NAME);
+    });
   });
 
   test('addressToString', () => {

--- a/packages/server/src/email/utils.ts
+++ b/packages/server/src/email/utils.ts
@@ -115,6 +115,28 @@ export function getProjectAppName(project: Project | undefined): string | undefi
   return project?.setting?.find((s) => s.name === 'appName')?.valueString?.trim() || undefined;
 }
 
+/** App name used when neither the project nor the server config names one. */
+export const DEFAULT_APP_NAME = 'Medplum';
+
+/**
+ * Returns the app name for user-facing content, most specific first: the
+ * project's `appName` setting, then the server's `appName` config setting,
+ * then the default.
+ *
+ * The server-level setting is what a self-hosted deployment needs. Content
+ * addressed to a user whose account is not scoped to a project has no project
+ * setting to read: server-scoped users (the default for Practitioner invites)
+ * and the password reset flow that looks them up. Without a server-level
+ * default, those messages name Medplum however the deployment is branded.
+ * @param project - The project the content belongs to, if any.
+ * @returns The app name to use.
+ */
+export function getAppName(project?: Project): string {
+  // `||` on the config value, not `??`: a blank setting means unset, and
+  // trimming one to an empty string would otherwise win over the default.
+  return getProjectAppName(project) ?? (getConfig().appName?.trim() || DEFAULT_APP_NAME);
+}
+
 /**
  * Adds a display name to a from address so recipients see the project's app name in
  * their inbox list rather than a bare address. Returns nodemailer's object form


### PR DESCRIPTION
## Problem

White-labeling reads the `appName` setting from the user's project. Content addressed to a user who has no project has nothing to read:

- Practitioner invites create **server-scoped** users by default (`User.project` is only set for Patients, externalId users, or an explicit `scope: 'project'`).
- `auth/resetpassword` looks the user up and passes `user.project`, which is undefined for exactly those users.

Those messages then name Medplum however the deployment is branded, and a self-hosted operator has no configuration that changes it. The From header is already configurable via `supportEmail`, so today a recipient can get an email from "Acme Health <no-reply@acme.com>" whose body says Medplum.

## Change

Adds an optional server config setting, `appName`, used when the project does not name one. Precedence: project setting, then server config, then the existing `'Medplum'` default, so behavior is unchanged for anyone who leaves it unset.

`getAppName(project)` in `email/utils` holds that precedence in one place; the MFA email switches to it. The authenticator issuer default (`DEFAULT_MFA_ISSUER`) is deliberately untouched, since it is a domain rather than a brand name.

## Notes

- Blank config values are treated as unset, matching how `getProjectAppName` treats a blank project setting.
- Unit tests cover all four cases: project wins over config, config used when the project has none, config used when there is no project at all, and the default when neither names one.
- Companion to #10069, which applies project white-labeling to the invite and password reset emails; that PR's call sites can move to `getAppName` once either lands. The two are independent and can merge in either order.