### PR TITLE
feat(core): reconnect the FHIRcast client's WebSocket

### DIFF
--- a/examples/medplum-fhircast-demo/src/components/ConnectionHandler.tsx
+++ b/examples/medplum-fhircast-demo/src/components/ConnectionHandler.tsx
@@ -59,12 +59,9 @@ export default function ConnectionHandler(props: WebSocketHandlerProps): null {
 
     const connectHandler = (): void => setConnectionStatus('CONNECTED');
     const messageHandler = (event: FhircastMessageEvent): void => onMessageRef.current(event.payload);
-    const disconnectHandler = (): void => {
-      setConnectionStatus('DISCONNECTED');
-      connection.removeEventListener('connect', connectHandler);
-      connection.removeEventListener('message', messageHandler);
-      connection.removeEventListener('disconnect', disconnectHandler);
-    };
+    // The connection reconnects on its own, so a disconnect is a state to show rather than the end
+    // of the session: leave the listeners attached and let the next `connect` flip the status back.
+    const disconnectHandler = (): void => setConnectionStatus('DISCONNECTED');
 
     connection.addEventListener('connect', connectHandler);
     connection.addEventListener('message', messageHandler);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -48,6 +48,7 @@ import { isBrowserEnvironment, locationUtils } from './environment';
 import { TypedEventTarget } from './eventtarget';
 import type {
   CurrentContext,
+  FhircastConnectionOptions,
   FhircastEventContext,
   FhircastEventName,
   FhircastEventVersionOptional,
@@ -4527,10 +4528,11 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    *
    * @category FHIRcast
    * @param subRequest - The `SubscriptionRequest` to use for connecting.
+   * @param options - Options for the underlying `ReconnectingWebSocket`.
    * @returns A `FhircastConnection` which emits lifecycle events for the `FHIRcast` WebSocket connection.
    */
-  fhircastConnect(subRequest: SubscriptionRequest): FhircastConnection {
-    return new FhircastConnection(subRequest);
+  fhircastConnect(subRequest: SubscriptionRequest, options?: FhircastConnectionOptions): FhircastConnection {
+    return new FhircastConnection(subRequest, options);
   }
 
   /**

--- a/packages/core/src/fhircast/index.test.ts
+++ b/packages/core/src/fhircast/index.test.ts
@@ -3,6 +3,7 @@
 import { WS } from 'vitest-websocket-mock';
 import type {
   FhircastConnectEvent,
+  FhircastConnectionOptions,
   FhircastDiagnosticReportOpenContext,
   FhircastDiagnosticReportUpdateContext,
   FhircastDisconnectEvent,
@@ -23,6 +24,7 @@ import {
 } from '.';
 import { generateId } from '../crypto';
 import { OperationOutcomeError } from '../outcomes';
+import { sleep } from '../utils';
 
 describe('validateFhircastSubscriptionRequest', () => {
   test('Valid subscription requests', () => {
@@ -761,6 +763,89 @@ describe('FhircastConnection', () => {
 
     deniedServer.send({ 'hub.mode': 'denied', 'hub.topic': '', 'hub.events': '', 'hub.reason': 'invalid endpoint' });
     await expect(disconnected).resolves.toMatchObject({ type: 'disconnect' });
+  });
+
+  // Reconnects use their own Hub, since the mock server broadcasts to every client of a URL, and
+  // their own backoff, since the default first delay is seconds long.
+  const reconnectOptions: FhircastConnectionOptions = {
+    minReconnectionDelay: 10,
+    maxReconnectionDelay: 20,
+    connectionTimeout: 500,
+  };
+
+  function connectionAt(endpoint: string, options?: FhircastConnectionOptions): FhircastConnection {
+    return new FhircastConnection(
+      { topic: 'abc123', mode: 'subscribe', channelType: 'websocket', events: ['Patient-open'], endpoint },
+      options
+    );
+  }
+
+  function nthConnect(connection: FhircastConnection, n: number): Promise<void> {
+    let count = 0;
+    return new Promise<void>((resolve) => {
+      connection.addEventListener('connect', () => {
+        if (++count === n) {
+          resolve();
+        }
+      });
+    });
+  }
+
+  test('Reconnects after the Hub drops the socket', async () => {
+    const server = new WS('ws://localhost:1236', { jsonProtocol: true });
+    const connection = connectionAt('ws://localhost:1236', reconnectOptions);
+    try {
+      const reconnected = nthConnect(connection, 2);
+      const disconnected = new Promise<void>((resolve) => {
+        connection.addEventListener('disconnect', () => resolve());
+      });
+      await server.connected;
+
+      server.server.clients()[0].close();
+      await disconnected;
+      await reconnected;
+
+      // The message listener is bound to the `ReconnectingWebSocket` rather than to the socket that
+      // just went away, so the payload arrives exactly once over the new socket.
+      const messages: FhircastMessagePayload[] = [];
+      connection.addEventListener('message', (event) => messages.push(event.payload));
+      const message = createFhircastMessagePayload('abc123', 'Patient-open', {
+        key: 'patient',
+        resource: { id: '123', resourceType: 'Patient' },
+      });
+      server.send(message);
+
+      // The client acknowledges every message it dispatches, so the ack landing means the dispatch happened
+      await expect(server.nextMessage).resolves.toMatchObject({ id: message.id });
+      expect(messages).toStrictEqual([message]);
+    } finally {
+      connection.disconnect();
+    }
+  });
+
+  // A denied subscription is one the Hub has stopped honoring, so reconnecting to that endpoint
+  // would only be denied again.
+  test('.addEventListener("message") - Denial does not reconnect', async () => {
+    const server = new WS('ws://localhost:1237', { jsonProtocol: true });
+    const connection = connectionAt('ws://localhost:1237', reconnectOptions);
+    try {
+      let connects = 0;
+      connection.addEventListener('connect', () => connects++);
+      const disconnected = new Promise<void>((resolve) => {
+        connection.addEventListener('disconnect', () => resolve());
+      });
+      await server.connected;
+
+      server.send({ 'hub.mode': 'denied', 'hub.topic': '', 'hub.events': '', 'hub.reason': 'invalid endpoint' });
+      await disconnected;
+
+      // Long enough for several attempts at the backoff above, had the connection intended to make any
+      await sleep(200);
+      expect(connects).toStrictEqual(1);
+      expect(server.server.clients()).toHaveLength(0);
+    } finally {
+      connection.disconnect();
+    }
   });
 
   test('Invalid SubscriptionRequest in constructor', () => {

--- a/packages/core/src/fhircast/index.ts
+++ b/packages/core/src/fhircast/index.ts
@@ -14,6 +14,12 @@ import { generateId } from '../crypto';
 import { TypedEventTarget } from '../eventtarget';
 import { OperationOutcomeError, validationError } from '../outcomes';
 import { isReference } from '../types';
+import type {
+  IReconnectingWebSocket,
+  IReconnectingWebSocketCtor,
+  Options as ReconnectingWebSocketOptions,
+} from '../websockets/reconnecting-websocket';
+import { ReconnectingWebSocket } from '../websockets/reconnecting-websocket';
 
 // We currently try to satisfy both STU2 and STU3. Where STU3 removes a resource / key from STU2, we leave it in as a valid key but don't require it.
 
@@ -537,6 +543,11 @@ export type FhircastSubscriptionEventMap = {
   disconnect: FhircastDisconnectEvent;
 };
 
+export type FhircastConnectionOptions = ReconnectingWebSocketOptions & {
+  /** An alternate `ReconnectingWebSocket` implementation to open the connection with. */
+  ReconnectingWebSocket?: IReconnectingWebSocketCtor;
+};
+
 /**
  * A class representing a `FHIRcast` connection.
  *
@@ -545,17 +556,22 @@ export type FhircastSubscriptionEventMap = {
  * 2. `message` - Contains a `payload` field containing a `FHIRcast` message payload exactly as it comes in over WebSockets.
  * 3. `disconnect` - An event to signal when a WebSocket connection has been closed. Fired as soon as a WebSocket emits `close`.
  *
- * To close the connection, call `connection.disconnect()` and listen to the `disconnect` event to know when the connection has been disconnected.
+ * The underlying socket reconnects on its own, so `disconnect` followed by `connect` is the normal
+ * shape of a dropped connection rather than the end of the session. A subscription endpoint stays
+ * valid for the lease the Hub granted it, so reconnecting resubscribes without a new `hub.subscribe`
+ * request. Two things end a connection for good: calling `connection.disconnect()`, and the Hub
+ * denying the subscription — after either, `connect` will not fire again.
  */
 export class FhircastConnection extends TypedEventTarget<FhircastSubscriptionEventMap> {
   readonly subRequest: SubscriptionRequest;
-  private readonly websocket: WebSocket;
+  private readonly websocket: IReconnectingWebSocket;
 
   /**
    * Creates a new `FhircastConnection`.
    * @param subRequest - The subscription request to initialize the connection from.
+   * @param options - Options for the underlying `ReconnectingWebSocket`.
    */
-  constructor(subRequest: SubscriptionRequest) {
+  constructor(subRequest: SubscriptionRequest, options?: FhircastConnectionOptions) {
     super();
     this.subRequest = subRequest;
     if (!subRequest.endpoint) {
@@ -564,43 +580,50 @@ export class FhircastConnection extends TypedEventTarget<FhircastSubscriptionEve
     if (!validateFhircastSubscriptionRequest(subRequest)) {
       throw new OperationOutcomeError(validationError('Subscription request failed validation.'));
     }
-    const websocket = new WebSocket(subRequest.endpoint);
+
+    const { ReconnectingWebSocket: WebSocketCtor = ReconnectingWebSocket, ...websocketOptions } = options ?? {};
+    const websocket = new WebSocketCtor(subRequest.endpoint, undefined, websocketOptions);
+
+    // Listeners are bound to the `ReconnectingWebSocket` rather than to a particular socket, so they
+    // are attached once here and survive every reconnect. Binding them from within `open` would
+    // stack up a duplicate set of listeners each time the connection came back.
     websocket.addEventListener('open', () => {
       this.dispatchEvent({ type: 'connect' });
-
-      websocket.addEventListener('message', (event: MessageEvent) => {
-        const message = JSON.parse(event.data) as Record<string, string | object>;
-
-        // The Hub's control messages carry no `event`, so there is nothing for a listener to
-        // receive. A denial ends the subscription: close from this end too, rather than holding a
-        // socket the Hub has already stopped honoring. A denial the Hub could not resolve an
-        // endpoint for names no topic, so `hub.topic` alone does not identify one.
-        if (!message.event) {
-          if (message['hub.mode'] === 'denied') {
-            websocket.close();
-          }
-          return;
-        }
-
-        const fhircastMessage = message as unknown as FhircastMessagePayload;
-        // Don't bubble up heartbeats, they are just noise
-        if (fhircastMessage.event['hub.event'] === ('heartbeat' as unknown as FhircastEventName)) {
-          return;
-        }
-        this.dispatchEvent({ type: 'message', payload: fhircastMessage });
-
-        websocket.send(
-          JSON.stringify({
-            id: message?.id,
-            timestamp: new Date().toISOString(),
-          })
-        );
-      });
-
-      websocket.addEventListener('close', () => {
-        this.dispatchEvent({ type: 'disconnect' });
-      });
     });
+
+    websocket.addEventListener('message', (event: MessageEvent) => {
+      const message = JSON.parse(event.data) as Record<string, string | object>;
+
+      // The Hub's control messages carry no `event`, so there is nothing for a listener to
+      // receive. A denial ends the subscription, so disconnect for good rather than reconnecting to
+      // an endpoint the Hub just said it will not serve. A denial the Hub could not resolve an
+      // endpoint for names no topic, so `hub.topic` alone does not identify one.
+      if (!message.event) {
+        if (message['hub.mode'] === 'denied') {
+          this.disconnect();
+        }
+        return;
+      }
+
+      const fhircastMessage = message as unknown as FhircastMessagePayload;
+      // Don't bubble up heartbeats, they are just noise
+      if (fhircastMessage.event['hub.event'] === ('heartbeat' as unknown as FhircastEventName)) {
+        return;
+      }
+      this.dispatchEvent({ type: 'message', payload: fhircastMessage });
+
+      websocket.send(
+        JSON.stringify({
+          id: message?.id,
+          timestamp: new Date().toISOString(),
+        })
+      );
+    });
+
+    websocket.addEventListener('close', () => {
+      this.dispatchEvent({ type: 'disconnect' });
+    });
+
     this.websocket = websocket;
   }
 


### PR DESCRIPTION
## Summary

`FhircastConnection` opened a bare `WebSocket`, so any dropped connection — a hub restart, a proxy idle timeout, a laptop waking from sleep — ended the FHIRcast session silently, and callers had to resubscribe to recover. This swaps in the `ReconnectingWebSocket` already used by `SubscriptionManager`.

A subscription endpoint stays valid for the lease the hub granted it (`FHIRCAST_LEASE_SECONDS`, and the server only drops the endpoint on `hub.unsubscribe`, not on socket close), so reconnecting to the same endpoint resubscribes without a new `hub.subscribe` request.

Closes #10134

## Changes

- `FhircastConnection` uses `ReconnectingWebSocket` instead of a bare `WebSocket`.
- Listeners bind to the `ReconnectingWebSocket` rather than being registered from inside each `open` handler, which would have stacked a duplicate set of handlers per reconnect.
- A denied subscription still disconnects for good — reconnecting to an endpoint the hub refuses would only be refused again.
- `FhircastConnection` and `MedplumClient.fhircastConnect` accept an optional options bag forwarded to the socket, for backoff tuning and for supplying a `WebSocket` implementation outside the browser.
- The FHIRcast demo's `ConnectionHandler` no longer tears down its listeners on `disconnect`, so a reconnect flips the status back to `CONNECTED`.

## Behavior notes for reviewers

- `connect` and `disconnect` can now each fire more than once over the life of a connection. `disconnect` followed by `connect` is the normal shape of a dropped connection; only `connection.disconnect()` and a hub denial end it for good.
- A connection that never opens now dispatches `disconnect` (the `close` listener is attached upfront rather than from within `open`).

## Test plan

- New tests in `packages/core/src/fhircast/index.test.ts`: the connection recovers after the hub drops the socket and delivers a subsequent message exactly once; a denial does not reconnect.
- `npx vitest run src/fhircast src/client-fhircast.test.ts src/subscriptions/index.test.ts src/websockets` in `packages/core` — passing.
- `tsc --noEmit`, `eslint`, `prettier --check` on `packages/core` and the FHIRcast demo — clean.