### PR TITLE
fix(fhircast): accept the legacy unsubscribe endpoint field

### DIFF
--- a/packages/server/src/fhircast/routes.test.ts
+++ b/packages/server/src/fhircast/routes.test.ts
@@ -474,6 +474,138 @@ describe('FHIRcast routes', () => {
     await expect(getEndpointSubscription(extractEndpoint(endpointUrl) as string)).resolves.toBeUndefined();
   });
 
+  // The body `@medplum/core` produced before 5.1.29: the endpoint under a bare `endpoint`, and the
+  // events repeated on an unsubscribe. Built here rather than with the client, which no longer
+  // names either that way.
+  function serializeLegacyUnsubscribeRequest(topic: string, endpointUrl: string): string {
+    return new URLSearchParams({
+      'hub.channel.type': 'websocket',
+      'hub.mode': 'unsubscribe',
+      'hub.topic': topic,
+      'hub.events': 'Patient-open',
+      endpoint: endpointUrl,
+    }).toString();
+  }
+
+  test('Unsubscribe with a request from a pre-5.1.29 client', async () => {
+    const topic = randomUUID();
+    const subRes = await request(server)
+      .post(STU3_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        'hub.channel.type': 'websocket',
+        'hub.mode': 'subscribe',
+        'hub.topic': topic,
+        'hub.events': 'Patient-open',
+      });
+    expect(subRes).toHaveStatus(202);
+    const endpointUrl = subRes.body['hub.channel.endpoint'];
+
+    await request(server)
+      .ws(new URL(endpointUrl).pathname)
+      .expectJson((obj) => {
+        expect(obj['hub.mode']).toBe('subscribe');
+      })
+      .exec(async () => {
+        const unsubRes = await request(server)
+          .post(STU3_BASE_ROUTE)
+          .set('Content-Type', ContentType.FORM_URL_ENCODED)
+          .set('Authorization', 'Bearer ' + accessToken)
+          .send(serializeLegacyUnsubscribeRequest(topic, endpointUrl));
+        expect(unsubRes).toHaveStatus(202);
+        expect(unsubRes.body['hub.channel.endpoint']).toStrictEqual(endpointUrl);
+      })
+      // The legacy name reaches the same subscriber with the same denial
+      .expectJson({
+        'hub.topic': topic,
+        'hub.mode': 'denied',
+        'hub.events': 'Patient-open',
+        'hub.reason': 'Subscriber unsubscribed from topic',
+      })
+      .expectClosed();
+
+    await expect(getEndpointSubscription(extractEndpoint(endpointUrl) as string)).resolves.toBeUndefined();
+  });
+
+  test('Unsubscribe naming an endpoint in both fields cancels the issued one', async () => {
+    const subscribe = async (): Promise<{ topic: string; endpointUrl: string }> => {
+      const topic = randomUUID();
+      const res = await request(server)
+        .post(STU3_BASE_ROUTE)
+        .set('Content-Type', ContentType.JSON)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .send({
+          'hub.channel.type': 'websocket',
+          'hub.mode': 'subscribe',
+          'hub.topic': topic,
+          'hub.events': 'Patient-open',
+        });
+      expect(res).toHaveStatus(202);
+      return { topic, endpointUrl: res.body['hub.channel.endpoint'] };
+    };
+
+    const toCancel = await subscribe();
+    const toKeep = await subscribe();
+
+    const unsubRes = await request(server)
+      .post(STU3_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        'hub.channel.type': 'websocket',
+        'hub.mode': 'unsubscribe',
+        'hub.topic': toCancel.topic,
+        'hub.channel.endpoint': toCancel.endpointUrl,
+        endpoint: toKeep.endpointUrl,
+      });
+    expect(unsubRes).toHaveStatus(202);
+    expect(unsubRes.body['hub.channel.endpoint']).toStrictEqual(toCancel.endpointUrl);
+
+    await expect(getEndpointSubscription(extractEndpoint(toCancel.endpointUrl) as string)).resolves.toBeUndefined();
+    await expect(getEndpointSubscription(extractEndpoint(toKeep.endpointUrl) as string)).resolves.toMatchObject({
+      topic: toKeep.topic,
+    });
+  });
+
+  test('Unsubscribe with the legacy endpoint field still has to name a subscription the caller holds', async () => {
+    const topic = randomUUID();
+    const subRes = await request(server)
+      .post(STU3_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        'hub.channel.type': 'websocket',
+        'hub.mode': 'subscribe',
+        'hub.topic': topic,
+        'hub.events': 'Patient-open',
+      });
+    expect(subRes).toHaveStatus(202);
+    const endpointUrl = subRes.body['hub.channel.endpoint'];
+
+    const fromAnotherProject = await request(server)
+      .post(STU3_BASE_ROUTE)
+      .set('Content-Type', ContentType.FORM_URL_ENCODED)
+      .set('Authorization', 'Bearer ' + tokenForAnotherProject)
+      .send(serializeLegacyUnsubscribeRequest(topic, endpointUrl));
+    expect(fromAnotherProject).toHaveStatus(400);
+    expect(fromAnotherProject.body.issue[0].details.text).toStrictEqual('Invalid endpoint');
+
+    const unknownEndpoint = await request(server)
+      .post(STU3_BASE_ROUTE)
+      .set('Content-Type', ContentType.FORM_URL_ENCODED)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send(serializeLegacyUnsubscribeRequest(topic, `ws://localhost:8103/ws/fhircast/${randomUUID()}`));
+    expect(unknownEndpoint).toHaveStatus(400);
+    expect(unknownEndpoint.body.issue[0].details.text).toStrictEqual('Invalid endpoint');
+
+    // Neither rejected request cancelled the subscription it named
+    await expect(getEndpointSubscription(extractEndpoint(endpointUrl) as string)).resolves.toMatchObject({
+      projectId: project.id,
+      topic,
+    });
+  });
+
   test('Unsubscribe without an endpoint is rejected', async () => {
     const topic = randomUUID();
     const subRes = await request(server)

--- a/packages/server/src/fhircast/routes.ts
+++ b/packages/server/src/fhircast/routes.ts
@@ -280,10 +280,21 @@ async function handleUnsubscribeRequest(req: Request, res: Response, topic: stri
   // Subscribers echo back the `hub.channel.endpoint` they were issued, which is what identifies the
   // subscription to cancel. Several subscribers can share a topic, so an unsubscribe the Hub cannot
   // address is not actionable: honoring it would mean denying every one of them.
-  const endpoint = extractEndpoint(req.body['hub.channel.endpoint']);
+  //
+  // `@medplum/core` before 5.1.29 sent it under a bare `endpoint` instead, so that name is honored
+  // when the issued one is absent. Such a client holds a valid endpoint and only names it
+  // differently; without this it could never cancel, and its subscription would sit until the lease
+  // ran out. The endpoint is still resolved to a subscription the caller owns either way.
+  const issuedEndpoint = extractEndpoint(req.body['hub.channel.endpoint']);
+  const endpoint = issuedEndpoint ?? extractEndpoint(req.body.endpoint);
   if (!endpoint) {
     sendOutcome(res, badRequest('Missing endpoint'));
     return;
+  }
+  if (!issuedEndpoint) {
+    // Debug rather than warn: the request is honored, and the line exists only to show whether any
+    // subscriber still depends on the legacy name before it is dropped.
+    getLogger().debug('[FHIRcast]: Unsubscribe request named its endpoint under the deprecated `endpoint` field');
   }
 
   const subscription = await getEndpointSubscription(endpoint);

--- a/packages/server/src/fhircast/routes.ts
+++ b/packages/server/src/fhircast/routes.ts
@@ -292,9 +292,9 @@ async function handleUnsubscribeRequest(req: Request, res: Response, topic: stri
     return;
   }
   if (!issuedEndpoint) {
-    // Debug rather than warn: the request is honored, and the line exists only to show whether any
+    // Info rather than warn: the request is honored, and the line exists only to show whether any
     // subscriber still depends on the legacy name before it is dropped.
-    getLogger().debug('[FHIRcast]: Unsubscribe request named its endpoint under the deprecated `endpoint` field');
+    getLogger().info('[FHIRcast]: Unsubscribe request named its endpoint under the deprecated `endpoint` field');
   }
 
   const subscription = await getEndpointSubscription(endpoint);


### PR DESCRIPTION
## The break

#10096 (first released in `v5.1.29`) renamed the field the client sends when cancelling a subscription. In `serializeFhircastSubscriptionRequest`, `endpoint` became `hub.channel.endpoint`, and the Hub's `handleUnsubscribeRequest` now reads only the latter.

A subscriber on `@medplum/core` <= 5.1.28 unsubscribing from a 5.1.29+ server gets `400 Missing endpoint`. Nothing is cancelled: the lease stays in Redis until `FHIRCAST_LEASE_SECONDS` expires, the socket is never denied and never closed, and the subscriber keeps receiving the topic's events. The subscribe side never changed -- the response has always carried `hub.channel.endpoint` -- so an old client holds a valid endpoint and only names it differently on the way back.

## The fix

`handleUnsubscribeRequest` falls back to `req.body.endpoint` when `hub.channel.endpoint` names no endpoint. `extractEndpoint` already strips a query string or fragment and takes the last path segment, so the full `wss://.../ws/fhircast/<id>` URL an old client echoes back resolves the same way the current form does. Server-side only -- no client change, and nothing else reads the legacy name.

**Precedence:** `hub.channel.endpoint` wins. It is the name the Hub issues and the only one a current client sends, so the legacy field is consulted solely when the issued one is absent -- a body carrying both cannot redirect a cancellation away from the endpoint it names.

**Logging:** debug, not warn. The request is honored, so it is not an anomaly worth a warn on every legacy unsubscribe; the line exists so an operator can see whether any subscriber still depends on the old name before the shim is dropped.

`hub.events`, which old clients also send on an unsubscribe, is already harmless: its check sits past the unsubscribe branch in `handleSubscriptionRequest`. The first test below sends a full legacy-shaped body, so that stays pinned rather than being taken on faith.

Nothing under `packages/docs/docs/fhircast/` specifies the unsubscribe request shape, so there was nothing to update.

## Test plan

Added to `packages/server/src/fhircast/routes.test.ts`:

- **`Unsubscribe with a request from a pre-5.1.29 client`** -- a full legacy body (form-encoded, bare `endpoint`, `hub.events` repeated) returns 202, publishes the targeted denial to that subscriber, closes its socket, and deletes the lease, exactly as the `hub.channel.endpoint` form does. Fails with `400 Missing endpoint` without this change.
- **`Unsubscribe naming an endpoint in both fields cancels the issued one`** -- pins the precedence: the `hub.channel.endpoint` subscription is cancelled, the one named under `endpoint` is left intact.
- **`Unsubscribe with the legacy endpoint field still has to name a subscription the caller holds`** -- the legacy name from another project, and one naming an unknown endpoint, are both rejected with `Invalid endpoint`, and the subscription survives. The fallback is not a way around the ownership check.

A request naming neither field is already covered by `Unsubscribe without an endpoint is rejected`, which still passes.

`npx vitest run src/fhircast/routes.test.ts` -- 56 passed. `eslint`, `prettier --check`, and `tsc --noEmit` clean for both files.