### PR TITLE
feat(fhircast): make heartbeat an event a subscriber has to ask for

### DIFF
--- a/packages/core/src/client-fhircast.test.ts
+++ b/packages/core/src/client-fhircast.test.ts
@@ -25,11 +25,12 @@ describe('FHIRcast', () => {
 
       const topic = 'abc123';
       const events = ['Patient-open'] as FhircastEventName[];
+      // The Hub only sends `heartbeat` to subscribers that name it, so it is requested by default
       const expectedSubRequest = {
         mode: 'subscribe',
         channelType: 'websocket',
         topic,
-        events,
+        events: ['Patient-open', 'heartbeat'],
       } satisfies PendingSubscriptionRequest;
       const serializedSubRequest = serializeFhircastSubscriptionRequest(expectedSubRequest);
 
@@ -45,6 +46,22 @@ describe('FHIRcast', () => {
       expect(subRequest).toStrictEqual(expect.objectContaining<PendingSubscriptionRequest>(expectedSubRequest));
       expect(subRequest.endpoint).toBeDefined();
       expect(subRequest.endpoint?.startsWith('ws')).toBeTruthy();
+      // The caller's array is not mutated; the heartbeat goes onto a copy
+      expect(events).toStrictEqual(['Patient-open']);
+    });
+
+    test('Opting out of the heartbeat', async () => {
+      const fetch = mockFetch(200, { 'hub.channel.endpoint': 'wss://api.medplum.com/ws/fhircast/def456' });
+      const client = new MedplumClient({ fetch });
+
+      const subRequest = await client.fhircastSubscribe('abc123', ['Patient-open'], { heartbeat: false });
+      expect(subRequest.events).toStrictEqual(['Patient-open']);
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.medplum.com/fhircast/STU3',
+        expect.objectContaining<RequestInit>({
+          body: 'hub.channel.type=websocket&hub.mode=subscribe&hub.topic=abc123&hub.events=Patient-open',
+        })
+      );
     });
 
     test('Invalid subscription request', async () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -52,10 +52,13 @@ import type {
   FhircastEventName,
   FhircastEventVersionOptional,
   FhircastEventVersionRequired,
+  FhircastSubscribableEventName,
+  FhircastSubscribeOptions,
   PendingSubscriptionRequest,
   SubscriptionRequest,
 } from './fhircast';
 import {
+  FHIRCAST_HEARTBEAT_EVENT,
   FhircastConnection,
   assertContextVersionOptional,
   createFhircastMessagePayload,
@@ -4453,12 +4456,21 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    *
    * Once you have the `SubscriptionRequest` returned from this method, you can call `fhircastConnect(subscriptionRequest)` to connect to the subscription stream.
    *
+   * The Hub delivers `heartbeat` only to subscribers that asked for it, so it is added to the
+   * request unless `options.heartbeat` is `false`. On a quiet topic it is the only traffic on the
+   * socket, which is what keeps an intermediary with an idle timeout from closing the connection.
+   *
    * @category FHIRcast
    * @param topic - The topic to publish to. Usually a UUID.
    * @param events - An array of event names to listen for.
+   * @param options - Options for the subscription.
    * @returns A `Promise` that resolves once the request completes, or rejects if it fails.
    */
-  async fhircastSubscribe(topic: string, events: FhircastEventName[]): Promise<SubscriptionRequest> {
+  async fhircastSubscribe(
+    topic: string,
+    events: FhircastEventName[],
+    options?: FhircastSubscribeOptions
+  ): Promise<SubscriptionRequest> {
     if (!(typeof topic === 'string' && topic !== '')) {
       throw new OperationOutcomeError(validationError('Invalid topic provided. Topic must be a valid string.'));
     }
@@ -4470,11 +4482,14 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       );
     }
 
+    const subscribedEvents: FhircastSubscribableEventName[] =
+      options?.heartbeat === false ? events : [...events, FHIRCAST_HEARTBEAT_EVENT];
+
     const subRequest = {
       channelType: 'websocket',
       mode: 'subscribe',
       topic,
-      events,
+      events: subscribedEvents,
     } as PendingSubscriptionRequest;
 
     const body = await this.post<{ 'hub.channel.endpoint': string }>(

--- a/packages/core/src/fhircast/index.test.ts
+++ b/packages/core/src/fhircast/index.test.ts
@@ -71,6 +71,16 @@ describe('validateFhircastSubscriptionRequest', () => {
         endpoint: 'wss://abc.com/hub',
       })
     ).toBe(true);
+
+    // `heartbeat` is not publishable, but a subscriber may ask the Hub for it
+    expect(
+      validateFhircastSubscriptionRequest({
+        topic: 'abc123',
+        mode: 'subscribe',
+        channelType: 'websocket',
+        events: ['Patient-open', 'heartbeat'],
+      })
+    ).toBe(true);
   });
 
   test('Invalid subscription requests', () => {
@@ -182,6 +192,19 @@ describe('serializeFhircastSubscriptionRequest', () => {
       })
     ).toStrictEqual(
       'hub.channel.type=websocket&hub.mode=subscribe&hub.topic=abc123&hub.events=Patient-open%2CPatient-close'
+    );
+  });
+
+  test('Valid subscription request with heartbeat', () => {
+    expect(
+      serializeFhircastSubscriptionRequest({
+        mode: 'subscribe',
+        channelType: 'websocket',
+        topic: 'abc123',
+        events: ['Patient-open', 'heartbeat'],
+      })
+    ).toStrictEqual(
+      'hub.channel.type=websocket&hub.mode=subscribe&hub.topic=abc123&hub.events=Patient-open%2Cheartbeat'
     );
   });
 

--- a/packages/core/src/fhircast/index.ts
+++ b/packages/core/src/fhircast/index.ts
@@ -54,6 +54,21 @@ export function assertContextVersionOptional(event: string): asserts event is Fh
 
 export type FhircastEventName = keyof typeof FHIRCAST_EVENT_NAMES;
 export type FhircastResourceEventName = Exclude<FhircastEventName, 'syncerror'>;
+
+/**
+ * The Hub's keepalive event.
+ *
+ * Deliberately not a member of `FHIRCAST_EVENT_NAMES`, which is the set of events a client can
+ * publish: the Hub generates `heartbeat` itself, and its payload carries a `period` rather than a
+ * context. A subscriber can still name it in `hub.events` to ask to receive it.
+ * Source: https://build.fhir.org/ig/HL7/fhircast-docs/3-3-1-heartbeat.html
+ */
+export const FHIRCAST_HEARTBEAT_EVENT = 'heartbeat';
+
+/**
+ * An event a subscriber can name in `hub.events`: everything publishable, plus the Hub's `heartbeat`.
+ */
+export type FhircastSubscribableEventName = FhircastEventName | typeof FHIRCAST_HEARTBEAT_EVENT;
 export type FhircastResourceType = (typeof FHIRCAST_RESOURCE_TYPES)[number];
 export type FhircastAnchorResourceType = 'Patient' | 'ImagingStudy' | 'Encounter' | 'DiagnosticReport';
 
@@ -144,9 +159,22 @@ export function isFhircastResourceType(resourceType: FhircastResourceType): bool
 export type SubscriptionRequest = {
   channelType: 'websocket';
   mode: 'subscribe' | 'unsubscribe';
-  events: FhircastEventName[];
+  events: FhircastSubscribableEventName[];
   topic: string;
   endpoint: string;
+};
+
+/**
+ * Options for `MedplumClient.fhircastSubscribe`.
+ */
+export type FhircastSubscribeOptions = {
+  /**
+   * Whether to subscribe to the Hub's `heartbeat`. Defaults to `true`.
+   *
+   * On an otherwise idle topic the heartbeat is the only traffic on the socket, so opting out leaves
+   * nothing to stop an intermediary with an idle timeout from closing the connection.
+   */
+  heartbeat?: boolean;
 };
 
 export type FhircastPatientContext = { key: 'patient'; resource: Patient };
@@ -337,7 +365,7 @@ export function validateFhircastSubscriptionRequest(
     return false;
   }
   for (const event of events) {
-    if (!FHIRCAST_EVENT_NAMES[event]) {
+    if (event !== FHIRCAST_HEARTBEAT_EVENT && !FHIRCAST_EVENT_NAMES[event]) {
       return false;
     }
   }
@@ -583,8 +611,11 @@ export class FhircastConnection extends TypedEventTarget<FhircastSubscriptionEve
         }
 
         const fhircastMessage = message as unknown as FhircastMessagePayload;
-        // Don't bubble up heartbeats, they are just noise
-        if (fhircastMessage.event['hub.event'] === ('heartbeat' as unknown as FhircastEventName)) {
+        // `heartbeat` keeps the socket alive rather than carrying context, so it stops here instead
+        // of reaching listeners. Read as a `string` because it is not one of the publishable event
+        // names `FhircastMessagePayload` is typed against.
+        const eventName: string = fhircastMessage.event['hub.event'];
+        if (eventName === FHIRCAST_HEARTBEAT_EVENT) {
           return;
         }
         this.dispatchEvent({ type: 'message', payload: fhircastMessage });

--- a/packages/server/src/ws/fhircast.test.ts
+++ b/packages/server/src/ws/fhircast.test.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { FhircastMessagePayload, WithId } from '@medplum/core';
+import type { FhircastMessagePayload, FhircastSubscribableEventName, WithId } from '@medplum/core';
 import {
   badRequest,
   ContentType,
@@ -173,6 +173,53 @@ describe('FHIRcast WebSocket', () => {
             expect(obj.event['hub.topic']).toBe(topic);
             expect(obj.event['hub.event']).toBe('syncerror');
             expect(obj.event.context[0].key).toBe('operationoutcome');
+          })
+          .sendJson({ id: generateId(), status: 200 })
+          .close()
+          .expectClosed();
+      }));
+
+    // A `syncerror` reports a context change the subscriber may itself have caused, so unlike every
+    // other event it reaches a subscriber that never named it
+    test('Send `syncerror` to a subscriber that did not subscribe to it', () =>
+      withTestContext(async () => {
+        const topic = randomUUID();
+
+        const res1 = await request(server)
+          .post('/fhircast/STU3')
+          .set('Content-Type', ContentType.FORM_URL_ENCODED)
+          .set('Authorization', 'Bearer ' + accessToken)
+          .send(
+            serializeFhircastSubscriptionRequest({
+              mode: 'subscribe',
+              channelType: 'websocket',
+              topic,
+              events: ['Patient-open'],
+            })
+          );
+
+        const pathname = new URL(res1.body['hub.channel.endpoint']).pathname;
+
+        await request(server)
+          .ws(pathname)
+          .expectJson((obj) => {
+            // Connection verification message
+            expect(obj['hub.topic']).toBe(topic);
+          })
+          .exec(async () => {
+            const res2 = await request(server)
+              .post(`/fhircast/STU3/${topic}`)
+              .set('Content-Type', ContentType.JSON)
+              .set('Authorization', 'Bearer ' + accessToken)
+              .send(
+                createFhircastMessagePayload(topic, 'syncerror', [
+                  { key: 'operationoutcome', resource: { ...badRequest('Something went wrong'), id: generateId() } },
+                ])
+              );
+            expect(res2).toHaveStatus(202);
+          })
+          .expectJson((obj: FhircastMessagePayload<'syncerror'>) => {
+            expect(obj.event['hub.event']).toBe('syncerror');
           })
           .sendJson({ id: generateId(), status: 200 })
           .close()
@@ -1162,7 +1209,7 @@ describe('FHIRcast WebSocket', () => {
               mode: 'subscribe',
               channelType: 'websocket',
               topic,
-              events: ['Patient-open'],
+              events: ['Patient-open', 'heartbeat'],
             })
           );
 
@@ -1205,7 +1252,7 @@ describe('FHIRcast WebSocket', () => {
               mode: 'subscribe',
               channelType: 'websocket',
               topic,
-              events: ['Patient-open'],
+              events: ['Patient-open', 'heartbeat'],
             })
           );
 
@@ -1265,6 +1312,66 @@ describe('FHIRcast WebSocket', () => {
               .expectClosed();
           })
           .sendJson({ ok: true })
+          .close()
+          .expectClosed();
+      }));
+
+    // The heartbeat is published to the whole topic, so the only thing keeping it from a subscriber
+    // that did not ask for it is the per-socket event filter
+    test('Only the subscriber that asked for a heartbeat gets one', () =>
+      withTestContext(async () => {
+        const topic = randomUUID();
+
+        const subscribe = async (events: FhircastSubscribableEventName[]): Promise<string> => {
+          const res = await request(server)
+            .post('/fhircast/STU3')
+            .set('Content-Type', ContentType.FORM_URL_ENCODED)
+            .set('Authorization', 'Bearer ' + accessToken)
+            .send(serializeFhircastSubscriptionRequest({ mode: 'subscribe', channelType: 'websocket', topic, events }));
+          return new URL(res.body['hub.channel.endpoint']).pathname;
+        };
+
+        const quietPathname = await subscribe(['Patient-open']);
+        const heartbeatPathname = await subscribe(['Patient-open', 'heartbeat']);
+
+        await request(server)
+          .ws(quietPathname)
+          .expectJson((obj) => {
+            // Connection verification message
+            expect(obj['hub.topic']).toBe(topic);
+          })
+          .exec(async () => {
+            await request(server)
+              .ws(heartbeatPathname)
+              .expectJson((obj) => {
+                expect(obj['hub.topic']).toBe(topic);
+              })
+              .expectJson((obj) => {
+                expect(obj.event['hub.event']).toBe('heartbeat');
+              })
+              .expectJson((obj) => {
+                expect(obj.event['hub.event']).toBe('heartbeat');
+              })
+              .close()
+              .expectClosed();
+
+            const res = await request(server)
+              .post(`/fhircast/STU3/${topic}`)
+              .set('Content-Type', ContentType.JSON)
+              .set('Authorization', 'Bearer ' + accessToken)
+              .send(
+                createFhircastMessagePayload(topic, 'Patient-open', [
+                  { key: 'patient', resource: { resourceType: 'Patient', id: randomUUID() } },
+                ])
+              );
+            expect(res).toHaveStatus(202);
+          })
+          // Several heartbeat ticks have gone by. This subscriber saw none of them, so the first
+          // message after the confirmation is the event it did subscribe to.
+          .expectJson((obj) => {
+            expect(obj.event['hub.event']).toBe('Patient-open');
+          })
+          .sendJson({ id: generateId(), status: 200 })
           .close()
           .expectClosed();
       }));

--- a/packages/server/src/ws/fhircast.ts
+++ b/packages/server/src/ws/fhircast.ts
@@ -52,6 +52,9 @@ export function initFhircastHeartbeat(): void {
         },
       };
 
+      // Published to every live topic; each socket then drops it unless that subscriber asked for
+      // `heartbeat`. Which subscribers those are is knowledge local to the instance holding their
+      // sockets, so it cannot be decided here.
       for (const projectAndTopic of topicRefCountMap.keys()) {
         publish(
           projectAndTopic,
@@ -82,11 +85,11 @@ export function stopFhircastHeartbeat(): void {
   }
 }
 
-// Events delivered to every subscriber regardless of the events they subscribed to: `heartbeat`
-// keeps the connection alive, and `syncerror` reports a context change the subscriber may have
-// caused, so a subscriber can't opt out of hearing about its own failures.
+// The one event delivered to every subscriber regardless of what it subscribed to: `syncerror`
+// reports a context change the subscriber may have caused, so a subscriber can't opt out of hearing
+// about its own failures. Every other event, `heartbeat` included, has to be asked for.
 // Source: https://build.fhir.org/ig/HL7/fhircast-docs/3-Events.html
-const UNCONDITIONAL_EVENTS = new Set(['heartbeat', 'syncerror']);
+const UNCONDITIONAL_EVENT = 'syncerror';
 
 /**
  * Decides what a subscriber should be sent from a message published to its topic.
@@ -122,7 +125,7 @@ function messageForSubscriber(
   const eventName = channelMessage.payload.event?.['hub.event'];
   if (typeof eventName === 'string') {
     const normalizedEventName = eventName.toLowerCase();
-    if (!UNCONDITIONAL_EVENTS.has(normalizedEventName) && !subscribedEvents.has(normalizedEventName)) {
+    if (normalizedEventName !== UNCONDITIONAL_EVENT && !subscribedEvents.has(normalizedEventName)) {
       return undefined;
     }
   }


### PR DESCRIPTION
The Hub sent `heartbeat` to every connected FHIRcast subscriber regardless of what its subscription named. This makes it an event a subscriber has to ask for, filtered per-socket exactly like every other event.

## Server

`packages/server/src/ws/fhircast.ts` no longer treats `heartbeat` as unconditional. `syncerror` stays unconditional and is now the only such event: a subscriber must not be able to opt out of hearing about a context change it may itself have caused.

`initFhircastHeartbeat` still publishes to every topic in `topicRefCountMap` on the timer. Which subscribers asked for a heartbeat is knowledge local to the instance holding their sockets, so the decision belongs at the socket, not at the publisher.

No change was needed in `packages/server/src/fhircast/routes.ts`: `parseFhircastEvents` splits and trims `hub.events` without validating names against a list, and `heartbeat` is already in the `eventsSupported` list the Hub advertises at `/.well-known/fhircast-configuration`. So the Hub already accepted `heartbeat` as a subscribed event name, and a client that sends it works against an older server too.

## Client

`MedplumClient.fhircastSubscribe(topic, events, options?)` now names `heartbeat` in the subscription request by default. `{ heartbeat: false }` opts out.

The opt-out is an optional third parameter (an options object rather than a bare boolean, so the next subscription-level knob does not need a fourth positional argument). The default is heartbeat-on for the reason under Compatibility below.

## The event-name typing decision

`heartbeat` is deliberately **not** added to `FHIRCAST_EVENT_NAMES`. That constant is the set of **publishable** context events: it drives `createFhircastMessagePayload`, `validateFhircastContexts`, `FHIRCAST_EVENT_VERSION_REQUIRED`, and the `FhircastEventContext` type machinery. Widening it would make `createFhircastMessagePayload(topic, 'heartbeat', ...)` typecheck, which is wrong — the Hub generates heartbeats and clients never publish them, and a heartbeat payload carries a `period` rather than a context.

Instead:

- `FHIRCAST_HEARTBEAT_EVENT = 'heartbeat'` — a named constant for the Hub's keepalive event.
- `FhircastSubscribableEventName = FhircastEventName | 'heartbeat'` — the superset of names a subscriber may put in `hub.events`.

`SubscriptionRequest.events` is typed against the subscribable set, so `heartbeat` is a **real member of `events`** on the request object rather than something appended at serialization time. That matters for two round trips: the `SubscriptionRequest` handed back to the caller now accurately states what the Hub was told, and `fhircastUnsubscribe` re-serializes and re-validates the same object (an unsubscribe omits `hub.events` entirely, so nothing has to be stripped). `validateFhircastSubscriptionRequest` accepts the heartbeat name accordingly.

The `events` parameter of `fhircastSubscribe` stays `FhircastEventName[]`, so there is exactly one way to ask for a heartbeat and no way to contradict the option.

This also deletes the `'heartbeat' as unknown as FhircastEventName` cast in `FhircastConnection` — that cast existed only because `heartbeat` was not a member of the union. The client still drops heartbeats before they reach `message` listeners.

## Compatibility

**This is the part worth reviewing.** At 10s intervals (`DEFAULT_HEARTBEAT_MS`), the heartbeat is the only server→client traffic on an idle FHIRcast socket — it is the de facto keepalive. After this change, a subscriber that does not ask for heartbeats gets nothing at all when its topic is quiet.

I checked whether anything else keeps those sockets alive. Nothing does:

- **`ws` does not ping on its own.** `WebSocketServer` is constructed in `packages/server/src/ws/routes.ts` with only `noServer` and `maxPayload` — no ping interval, and `ws` has no built-in one (there is no `setInterval` anywhere in the library; its docs tell you to implement a heartbeat yourself). `autoPong` defaults to true, but that only *answers* pings someone else sends.
- **The server never calls `socket.ping()`.** There is no `ping()` call on any WebSocket in `packages/server/src`.
- **The client cannot ping.** `FhircastConnection` runs on a browser `WebSocket` via `ReconnectingWebSocket`, and browser JS cannot send WebSocket ping frames. `ReconnectingWebSocket` has no application-level keepalive either. The connection only ever sends the per-message ack, i.e. nothing while idle. (The `subscriptions-r4` socket has an application-level `{type:'ping'}`/`{type:'pong'}`, but it is client-initiated and on a different path.)
- **No proxy-level keepalive is configured.** Nothing in the CDK sets an ALB `idle_timeout`, so the AWS default of 60s applies.

So the regression is real for **older Medplum clients and third-party subscribers that do not send `heartbeat`**: on upgrade, their sockets go quiet and an intermediary with a 60s idle timeout closes them. Combined with #10176, which just made the client reconnect automatically, that turns into a silent 60-second connect/drop/reconnect cycle rather than an obviously dead connection — quieter, and therefore easier to miss.

**Recommendation: add a server-side WebSocket ping, rather than a deprecation period or a config flag.** The keepalive job is the transport's, not the application protocol's; `heartbeat` was only doing it by accident. A `ws`-level ping on the FHIRcast socket (or on all sockets in `initWebSockets`) keeps every subscriber alive regardless of what it subscribed to, needs no client change, and does not depend on third parties updating. A deprecation period only delays the same cliff, and a config flag leaves operators to discover the failure mode themselves. Filed as a separate concern rather than expanding this PR's scope — happy to send it as a follow-up, and it would be reasonable to hold this PR until that lands.

## Tests

Server (`packages/server/src/ws/fhircast.test.ts`):

- The two existing heartbeat tests now subscribe to `heartbeat` explicitly.
- **New:** `Only the subscriber that asked for a heartbeat gets one` — two subscribers on one topic; the one that asked receives heartbeats, and the one that did not receives nothing across several ticks, proven by its first post-confirmation message being the `Patient-open` it did subscribe to. Verified to fail if `heartbeat` is put back in the unconditional set.
- **New:** `Send \`syncerror\` to a subscriber that did not subscribe to it` — pins that `syncerror` is still unconditional.

Core:

- `fhircastSubscribe` includes `heartbeat` in the serialized request by default and does not mutate the caller's array; `{ heartbeat: false }` omits it.
- `validateFhircastSubscriptionRequest` and `serializeFhircastSubscriptionRequest` accept `heartbeat` as a subscribed event.
- The existing test that heartbeats never reach `message` listeners still passes.

`packages/mock` needed no change — `MockClient` extends `MedplumClient` and does not stub `fhircastSubscribe`. The generated SDK docs under `packages/docs/docs/sdk` are gitignored.

**Results:** all `packages/core` FHIRcast/client tests and all `packages/server` FHIRcast tests pass (45 core, 100 server); `eslint`, `prettier --check`, and `tsc --noEmit` clean in both packages.

## Merge note

#10176 (`derrick-fhircast-reconnecting-websocket`) rewrites the `FhircastConnection` constructor in `packages/core/src/fhircast/index.ts`, including reindenting the message handler that holds the heartbeat filter changed here. Expect a conflict in that handler for whichever of the two merges second; the resolution is to keep the reindented handler from #10176 and apply this PR's three-line filter change inside it.
