### PR TITLE
fix(core): return empty collection from getReferenceKey/getResourceKey on empty input

### DIFF
--- a/packages/core/src/fhirpath/functions.test.ts
+++ b/packages/core/src/fhirpath/functions.test.ts
@@ -738,6 +738,27 @@ describe('FHIRPath functions', () => {
     ]);
   });
 
+  // SQL-on-FHIR utilities
+
+  test('getResourceKey', () => {
+    expect(functions.getResourceKey(context, [toTypedValue({ resourceType: 'Patient', id: '123' })])).toStrictEqual([
+      { type: PropertyType.id, value: '123' },
+    ]);
+    expect(functions.getResourceKey(context, [])).toStrictEqual([]);
+  });
+
+  test('getReferenceKey', () => {
+    const reference = toTypedValue({ reference: 'Patient/123' });
+    expect(functions.getReferenceKey(context, [reference], undefined as unknown as Atom)).toStrictEqual([
+      { type: PropertyType.id, value: '123' },
+    ]);
+    expect(functions.getReferenceKey(context, [reference], new SymbolAtom('Patient'))).toStrictEqual([
+      { type: PropertyType.id, value: '123' },
+    ]);
+    expect(functions.getReferenceKey(context, [reference], new SymbolAtom('Observation'))).toStrictEqual([]);
+    expect(functions.getReferenceKey(context, [], undefined as unknown as Atom)).toStrictEqual([]);
+  });
+
   // 12. Formal Specifications
 
   test('type', () => {

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -1869,7 +1869,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * @returns The resource key.
    */
   getResourceKey: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
-    const resource = input[0].value as Resource;
+    const resource = input[0]?.value as Resource;
     if (!resource?.id) {
       return [];
     }
@@ -1896,7 +1896,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * @returns The reference key.
    */
   getReferenceKey: (context: AtomContext, input: TypedValue[], typeAtom: Atom): TypedValue[] => {
-    const reference = input[0].value as Reference;
+    const reference = input[0]?.value as Reference;
     if (!reference?.reference) {
       return [];
     }

--- a/packages/core/src/sql-on-fhir/eval.test.ts
+++ b/packages/core/src/sql-on-fhir/eval.test.ts
@@ -81,4 +81,19 @@ describe('SQL on FHIR', () => {
     writeFileSync(__dirname + '/test_report.json', JSON.stringify(report, null, 2) + '\n', 'utf8');
     console.log(`Passed ${passedCount} of ${totalCount} tests`);
   });
+
+  test('column is null when its path resolves to nothing', () => {
+    const view: ViewDefinition = {
+      resource: 'MedicationRequest',
+      status: 'active',
+      select: [{ column: [{ name: 'med', path: 'medication.ofType(Reference).getReferenceKey(Medication)' }] }],
+    };
+    const resources = [
+      { resourceType: 'MedicationRequest', id: 'a', medicationReference: { reference: 'Medication/m1' } },
+      { resourceType: 'MedicationRequest', id: 'b', medicationCodeableConcept: { text: 'aspirin' } },
+      { resourceType: 'MedicationRequest', id: 'c', medicationReference: { reference: 'Medication/m3' } },
+    ] as Resource[];
+
+    expect(evalSqlOnFhir(view, resources)).toStrictEqual([{ med: 'm1' }, { med: null }, { med: 'm3' }]);
+  });
 });


### PR DESCRIPTION
## Why

`getReferenceKey()` and `getResourceKey()` read `input[0].value` without checking that `input` is non-empty. FHIRPath functions receive a collection, and that collection is legitimately empty whenever the path navigates to an absent element, so both throw:

```
FhirPathError on "<path>": TypeError: Cannot read properties of undefined (reading 'value')
```

Per SQL-on-FHIR v2 both should return the empty collection. The throw propagates out of `evalSqlOnFhir`, so a single row with an absent reference aborts the **entire** ViewDefinition instead of yielding `null` for that one column.

`medication` is a choice type, so `.ofType(Reference)` is empty for a request that uses `medicationCodeableConcept`:

```js
const view = {
  resource: 'MedicationRequest',
  status: 'active',
  select: [{ column: [{ name: 'med', path: 'medication.ofType(Reference).getReferenceKey(Medication)' }] }],
};

evalSqlOnFhir(view, [
  { resourceType: 'MedicationRequest', id: 'b', medicationCodeableConcept: { text: 'aspirin' } },
]);
// throws; expected [{ med: null }]
```

The same happens for any path that can navigate to nothing, e.g. `subject.getReferenceKey(Patient)` where `subject` is absent.

## What

- `input[0].value` → `input[0]?.value` in both functions. Each already null-checks on the next line (`!resource?.id` / `!reference?.reference`) and returns `[]`; optional chaining just lets `undefined` reach that guard. Behavior for non-empty input is unchanged.
- Adds unit tests for both functions, which had no coverage.
- Adds an end-to-end test that a ViewDefinition column whose path resolves to nothing yields `null`.
