### PR TITLE
feat(definitions): add MedicationDispense context search parameter

### DIFF
--- a/packages/definitions/src/fhir/r4/search-parameters-medplum.json
+++ b/packages/definitions/src/fhir/r4/search-parameters-medplum.json
@@ -1456,6 +1456,24 @@
       }
     },
     {
+      "fullUrl": "http://hl7.org/fhir/SearchParameter/MedicationDispense-context",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "MedicationDispense-context",
+        "url": "http://hl7.org/fhir/SearchParameter/MedicationDispense-context",
+        "version": "4.0.1",
+        "name": "context",
+        "status": "draft",
+        "publisher": "Health Level Seven International (Pharmacy)",
+        "description": "Returns dispenses with a specific context (episode or episode of care)",
+        "code": "context",
+        "base": ["MedicationDispense"],
+        "type": "reference",
+        "expression": "MedicationDispense.context",
+        "target": ["EpisodeOfCare", "Encounter"]
+      }
+    },
+    {
       "fullUrl" : "http://hl7.org/fhir/SearchParameter/Immunization-encounter",
       "resource" : {
         "resourceType" : "SearchParameter",

--- a/packages/definitions/src/index.test.ts
+++ b/packages/definitions/src/index.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { readJson } from '.';
+import type { SearchParameter } from '@medplum/fhirtypes';
+import { getDefinitionResource, readJson } from '.';
 
 describe('Definitions', () => {
   test('Read FHIR schema JSON', () => {
@@ -15,5 +16,21 @@ describe('Definitions', () => {
     // Call again to test caching
     const dataDir2 = readJson('fhir/r4/fhir.schema.json');
     expect(dataDir2).not.toBeNull();
+  });
+
+  test('MedicationDispense context search parameter', () => {
+    const searchParameter = getDefinitionResource<SearchParameter>(
+      'fhir/r4/search-parameters-medplum.json',
+      'SearchParameter',
+      'http://hl7.org/fhir/SearchParameter/MedicationDispense-context'
+    );
+
+    expect(searchParameter).toMatchObject({
+      code: 'context',
+      base: ['MedicationDispense'],
+      type: 'reference',
+      expression: 'MedicationDispense.context',
+      target: ['EpisodeOfCare', 'Encounter'],
+    });
   });
 });


### PR DESCRIPTION
## Summary

- add `MedicationDispense-context` to the always-loaded Medplum search-parameter bundle
- define it as a reference search parameter targeting `Encounter` and `EpisodeOfCare`
- add regression coverage for the definition

## Background

The standard R4 definitions contain this search parameter, but standard parameters can be restricted through `enabledSearchParameters`. Adding the definition to the Medplum bundle ensures it is loaded consistently alongside other Medplum-supported search parameters.

The definition searches the existing R4 field:

```text
MedicationDispense.context
```


`Fixes #10074` 