### PR TITLE
TypedValue handles primitive extensions directly

### DIFF
--- a/packages/core/src/fhirpath/atoms.ts
+++ b/packages/core/src/fhirpath/atoms.ts
@@ -90,7 +90,12 @@ export class SymbolAtom implements Atom {
     if (this.name.startsWith('%')) {
       throw new Error(`Undefined variable ${this.name}`);
     }
-    return input.flatMap((e) => this.evalValue(e)).filter((e) => e?.value !== undefined) as TypedValue[];
+    return (
+      input
+        .flatMap((e) => this.evalValue(e))
+        // A primitive field with no value but a primitive extension is still a valid element
+        .filter((e) => e?.value !== undefined || e?.primitiveExtension !== undefined) as TypedValue[]
+    );
   }
 
   private getVariable(context: AtomContext): TypedValue | undefined {
@@ -108,7 +113,8 @@ export class SymbolAtom implements Atom {
 
   private evalValue(typedValue: TypedValue): TypedValue[] | TypedValue | undefined {
     const input = typedValue.value;
-    if (!input || typeof input !== 'object') {
+    // A primitive has no children of its own, but its primitive extension carries `id`/`extension`.
+    if ((!input || typeof input !== 'object') && typedValue.primitiveExtension === undefined) {
       return undefined;
     }
 

--- a/packages/core/src/fhirpath/fhirpath.test.ts
+++ b/packages/core/src/fhirpath/fhirpath.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { readJson } from '@medplum/definitions';
-import type { Bundle, Practitioner } from '@medplum/fhirtypes';
+import type { Bundle, Patient, Practitioner } from '@medplum/fhirtypes';
 import { HTTP_HL7_ORG, LOINC, SNOMED, UCUM } from '../constants';
 import type { TypedValue } from '../types';
 import { PropertyType } from '../types';
@@ -3580,6 +3580,105 @@ describe('FHIRPath Test Suite', () => {
           practitioner
         )
       ).toStrictEqual(['CA', 'MA', 'TX']);
+    });
+  });
+
+  describe('primitive extensions do not change evaluation', () => {
+    // A primitive that carries a `_property` sibling must evaluate exactly like one that does not.
+    const ext = { url: 'http://example.com/note', valueString: 'note' };
+    const withExt = {
+      resourceType: 'Patient',
+      id: '123',
+      birthDate: '1974-12-25',
+      _birthDate: { extension: [ext] },
+      active: false,
+      _active: { id: 'act1' },
+      multipleBirthInteger: 0,
+      _multipleBirthInteger: { id: 'mb1' },
+      name: [
+        {
+          given: ['Jane', 'Jayne'],
+          _given: [null, { id: 'giv1' }],
+          family: 'Smith',
+          _family: { id: 'fam1' },
+        },
+      ],
+    } as unknown as Patient;
+    const plain = {
+      resourceType: 'Patient',
+      id: '123',
+      birthDate: '1974-12-25',
+      active: false,
+      multipleBirthInteger: 0,
+      name: [{ given: ['Jane', 'Jayne'], family: 'Smith' }],
+    } as unknown as Patient;
+
+    test.each([
+      ['birthDate', ['1974-12-25']],
+      ["birthDate.startsWith('1974')", [true]],
+      ['birthDate.substring(0,4)', ['1974']],
+      ["birthDate.matches('^1974')", [true]],
+      ['birthDate.convertsToDate()', [true]],
+      ['birthDate.toDate()', ['1974-12-25']],
+      ["('1974-12-25' | 'x') contains birthDate", [true]],
+      ['name.family.length()', [5]],
+      ["name.family.indexOf('mi')", [1]],
+      ["name.family.replace('S','Z')", ['Zmith']],
+      ['name.family.upper()', ['SMITH']],
+      ['active.not()', [true]],
+      ['where(active).exists()', [false]],
+      ["iif(active, 'yes', 'no')", ['no']],
+      ['multipleBirth + 1', [1]],
+      ['multipleBirth > -1', [true]],
+      ['name.given[0] & name.given[1]', ['JaneJayne']],
+    ])('%s', (expr, expected) => {
+      // Sanity check: the expression means the same thing without the primitive extensions.
+      expect(evalFhirPath(expr, plain)).toStrictEqual(expected);
+      expect(evalFhirPath(expr, withExt)).toStrictEqual(expected);
+    });
+
+    test('extension() reads the primitive extension', () => {
+      expect(evalFhirPath("birthDate.extension('http://example.com/note').exists()", withExt)).toStrictEqual([true]);
+      expect(evalFhirPath("birthDate.extension('http://example.com/other').exists()", withExt)).toStrictEqual([false]);
+    });
+
+    test('evalFhirPathTyped exposes the primitive extension', () => {
+      expect(evalFhirPathTyped('birthDate', [toTypedValue(withExt)])).toStrictEqual([
+        { type: 'date', value: '1974-12-25', primitiveExtension: { extension: [ext] }, path: 'birthDate' },
+      ]);
+      expect(evalFhirPathTyped('birthDate', [toTypedValue(plain)])).toStrictEqual([
+        { type: 'date', value: '1974-12-25', path: 'birthDate' },
+      ]);
+    });
+
+    test('does not mutate the input resource', () => {
+      const input = JSON.parse(JSON.stringify(withExt));
+      const before = JSON.stringify(input);
+      evalFhirPath('birthDate | name.family | active | multipleBirth', input);
+      expect(JSON.stringify(input)).toStrictEqual(before);
+      expect(typeof input.birthDate).toStrictEqual('string');
+      expect(input.name[0].given.every((g: unknown) => typeof g === 'string')).toBe(true);
+    });
+
+    test('extension-only element is still present', () => {
+      const extensionOnly = {
+        resourceType: 'Patient',
+        _birthDate: { extension: [ext] },
+        name: [{ given: ['Alice', 'Brittany', null], _given: [null, { id: 'g1' }, { id: 'g2' }] }],
+      } as unknown as Patient;
+      expect(evalFhirPath('birthDate.exists()', extensionOnly)).toStrictEqual([true]);
+      expect(evalFhirPath('birthDate.empty()', extensionOnly)).toStrictEqual([false]);
+      expect(evalFhirPath("birthDate.extension('http://example.com/note').exists()", extensionOnly)).toStrictEqual([
+        true,
+      ]);
+      // No value, so a string function yields the empty collection rather than throwing.
+      expect(evalFhirPath("birthDate.startsWith('1974')", extensionOnly)).toStrictEqual([]);
+      // Array containing some extended elements and some extended nulls
+      expect(evalFhirPath('name.given.count() = 3', extensionOnly)).toStrictEqual([true]);
+      expect(evalFhirPath('name.given[0].id', extensionOnly)).toStrictEqual([]);
+      expect(evalFhirPath('name.given[1].id', extensionOnly)).toStrictEqual(['g1']);
+      expect(evalFhirPath('name.given[2]', extensionOnly)).toStrictEqual([]);
+      expect(evalFhirPath('name.given[2].id', extensionOnly)).toStrictEqual(['g2']);
     });
   });
 

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -4,13 +4,14 @@ import type { Reference, Resource } from '@medplum/fhirtypes';
 import type { Atom, AtomContext } from '../fhirlexer/parse';
 import type { TypedValue } from '../types';
 import { PropertyType, isResource } from '../types';
-import { calculateAge, getExtension, isEmpty, resolveId } from '../utils';
+import { calculateAge, getExtension, resolveId } from '../utils';
 import { DotAtom, SymbolAtom } from './atoms';
 import { parseDateString } from './date';
 import {
   booleanToTypedValue,
   fhirPathIs,
   isQuantity,
+  isTypedValueEmpty,
   removeDuplicates,
   singleton,
   toJsBoolean,
@@ -64,7 +65,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * @returns True if the input collection is empty ({ }) and false otherwise.
    */
   empty: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
-    return booleanToTypedValue(input.every((e) => isEmpty(e.value)));
+    return booleanToTypedValue(input.every(isTypedValueEmpty));
   },
 
   /**
@@ -97,7 +98,7 @@ export const functions: Record<string, FhirPathFunction> = {
     if (criteria) {
       return booleanToTypedValue(input.some((e) => toJsBoolean(criteria.eval(context, [e]))));
     } else {
-      return booleanToTypedValue(input.length > 0 && input.every((e) => !isEmpty(e.value)));
+      return booleanToTypedValue(input.length > 0 && !input.some(isTypedValueEmpty));
     }
   },
 
@@ -1914,7 +1915,8 @@ export const functions: Record<string, FhirPathFunction> = {
 
   extension: (context: AtomContext, input: TypedValue[], urlAtom: Atom): TypedValue[] => {
     const url = urlAtom.eval(context, input)[0].value as string;
-    const resource = input?.[0]?.value;
+    // For a primitive, extensions live on the `_property` sibling rather than on the value itself.
+    const resource = input?.[0]?.primitiveExtension ?? input?.[0]?.value;
     if (resource) {
       const extension = getExtension(resource, url);
       if (extension) {
@@ -1939,6 +1941,10 @@ function applyStringFunc<T>(
     return [];
   }
   const [{ value }] = validateInput(input, 1);
+  if (value === undefined) {
+    // A primitive that carries only an extension has no value to operate on.
+    return [];
+  }
   if (typeof value !== 'string') {
     throw new TypeError('String function cannot be called with non-string');
   }

--- a/packages/core/src/fhirpath/parse.ts
+++ b/packages/core/src/fhirpath/parse.ts
@@ -260,7 +260,10 @@ export function evalFhirPath(
       array[i] = toTypedValue(array[i]);
     }
   }
-  return evalFhirPathTyped(expression, array, variables, cache).map((e) => e.value);
+
+  return evalFhirPathTyped(expression, array, variables, cache)
+    .filter((e) => e.value !== undefined)
+    .map((e) => e.value);
 }
 
 /**
@@ -287,14 +290,5 @@ export function evalFhirPathTyped(
   } else {
     ast = expression;
   }
-  return ast.eval({ variables }, input).map((v) => {
-    const result: TypedValue & { path?: string } = {
-      type: v.type,
-      value: v.value?.valueOf(),
-    };
-    if ('path' in v) {
-      result.path = v.path as string;
-    }
-    return result;
-  });
+  return ast.eval({ variables }, input);
 }

--- a/packages/core/src/fhirpath/utils.test.ts
+++ b/packages/core/src/fhirpath/utils.test.ts
@@ -339,19 +339,18 @@ describe('FHIRPath utils', () => {
 
     expect(results).toHaveLength(2);
     const [simple, extended] = results as TypedValue[];
+    // The value stays a real primitive; the extension rides alongside it.
     expect(simple).toStrictEqual({ type: 'string', value: 'John' });
     expect(extended).toStrictEqual({
       type: 'string',
-      value: expect.objectContaining(Object.assign('', primitiveValue, { extension: [primitiveExtension] })),
+      value: primitiveValue,
+      primitiveExtension: { extension: [primitiveExtension] },
     });
+    expect(typeof extended.value).toBe('string');
 
-    // Check that values look correct when access "normally"
-    expect(extended.value.valueOf()).toBe('Johnny');
-    expect(extended.value.extension).toStrictEqual([primitiveExtension]);
-
-    // With primitive extensions, array values can be changed into a `String` wrapper type which has a typeof 'object';
-    // need to ensure the original input array values are not mutated as such
+    // The input must not be mutated, neither the array nor the `_given` sibling.
     expect(humanName.given.every((g) => typeof g === 'string')).toBe(true);
+    expect(humanName._given).toStrictEqual([null, { extension: [primitiveExtension] }]);
 
     // If extension only is specified, should still extract
     const results2 = getTypedPropertyValueWithSchema(
@@ -363,7 +362,8 @@ describe('FHIRPath utils', () => {
     const [extensionOnly] = results2 as TypedValue[];
     expect(extensionOnly).toStrictEqual({
       type: 'string',
-      value: expect.objectContaining(Object.assign('', { extension: [primitiveExtension] })),
+      value: undefined,
+      primitiveExtension: { extension: [primitiveExtension] },
     });
   });
 

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { Coding, Extension, Period, Quantity } from '@medplum/fhirtypes';
+import type { Coding, Element, Period, Quantity } from '@medplum/fhirtypes';
 import type { TypedValue } from '../types';
 import { PropertyType, getElementDefinition, isResource } from '../types';
 import type { InternalSchemaElement } from '../typeschema/types';
@@ -56,6 +56,18 @@ export function toJsBoolean(obj: TypedValue[]): boolean {
   return obj.length === 0 ? false : !!obj[0].value;
 }
 
+/**
+ * Determines whether a typed value carries nothing at all.
+ *
+ * A primitive whose value is absent is still present as an element when it has a primitive
+ * extension, so an extension alone is enough to make the value non-empty.
+ * @param typedValue - The typed value to check.
+ * @returns True if the value has neither content nor a primitive extension.
+ */
+export function isTypedValueEmpty(typedValue: TypedValue): boolean {
+  return isEmpty(typedValue.value) && typedValue.primitiveExtension === undefined;
+}
+
 export function singleton(collection: TypedValue[], type?: string): TypedValue | undefined {
   if (collection.length === 0) {
     return undefined;
@@ -88,6 +100,11 @@ export function getTypedPropertyValue(
   path: string,
   options?: GetTypedPropertyValueOptions
 ): TypedValue[] | TypedValue | undefined {
+  if (input.primitiveExtension !== undefined) {
+    // A primitive and its `_property` sibling are one node with e.g. `id` and `extension` as children
+    return getTypedPropertyValue({ type: 'Element', value: input.primitiveExtension }, path, options);
+  }
+
   if (!input.value) {
     return undefined;
   }
@@ -143,7 +160,7 @@ export function getTypedPropertyValueWithSchema(
   // So we need to use the element path to find the type.
   let resultValue: any = undefined;
   let resultType = 'undefined';
-  let primitiveExtension: Extension[] | undefined = undefined;
+  let primitiveExtension: Element | (Element | null)[] | undefined = undefined;
 
   const lastPathSegmentIndex = element.path.lastIndexOf('.');
   const lastPathSegment = element.path.substring(lastPathSegmentIndex + 1);
@@ -166,26 +183,8 @@ export function getTypedPropertyValueWithSchema(
     }
   }
 
-  // When checking for primitive extensions, we must use the "resolved" path.
-  // In the case of [x] choice-of-type, the type must be resolved to a single type.
-  if (primitiveExtension) {
-    if (Array.isArray(resultValue)) {
-      // Slice to avoid mutating the array in the input value
-      resultValue = resultValue.slice();
-      for (let i = 0; i < Math.max(resultValue.length, primitiveExtension.length); i++) {
-        resultValue[i] = assignPrimitiveExtension(resultValue[i], primitiveExtension[i]);
-      }
-    } else if (!resultValue && Array.isArray(primitiveExtension)) {
-      resultValue = primitiveExtension.slice();
-      for (let i = 0; i < primitiveExtension.length; i++) {
-        resultValue[i] = assignPrimitiveExtension(undefined, primitiveExtension[i]);
-      }
-    } else {
-      resultValue = assignPrimitiveExtension(resultValue, primitiveExtension);
-    }
-  }
-
-  if (isEmpty(resultValue)) {
+  // An element is present if it has a value, a primitive extension, or both
+  if (isEmpty(resultValue) && isEmpty(primitiveExtension)) {
     return undefined;
   }
 
@@ -193,18 +192,30 @@ export function getTypedPropertyValueWithSchema(
     resultType = element.type[0].code;
   }
 
-  if (Array.isArray(resultValue)) {
-    return resultValue.map((element) => toTypedValueWithType(element, resultType));
-  } else {
-    return toTypedValueWithType(resultValue, resultType);
+  // When checking for primitive extensions, we must use the "resolved" path.
+  // In the case of [x] choice-of-type, the type must be resolved to a single type.
+  // Either side may be the array: `_given` can have entries where `given` does not, and vice versa.
+  const values: any[] | undefined = Array.isArray(resultValue) ? resultValue : undefined;
+  const extensions: (Element | null)[] | undefined = Array.isArray(primitiveExtension) ? primitiveExtension : undefined;
+  if (values || extensions) {
+    const length = Math.max(values?.length ?? 0, extensions?.length ?? 0);
+    const results: TypedValue[] = [];
+    for (let i = 0; i < length; i++) {
+      // `null` on either side is a padding slot keeping the two arrays aligned, not a value.
+      results.push(toTypedValueWithType(values?.[i] ?? undefined, resultType, extensions?.[i] ?? undefined));
+    }
+    return results;
   }
+
+  return toTypedValueWithType(resultValue, resultType, primitiveExtension as Element | undefined);
 }
 
-function toTypedValueWithType(value: any, type: string): TypedValue {
+function toTypedValueWithType(value: any, type: string, primitiveExtension?: Element): TypedValue {
   if (type === 'Resource' && isResource(value)) {
     type = value.resourceType;
   }
-  return { type, value };
+  // Only set the property when there is one, so that the common case keeps its usual shape.
+  return primitiveExtension === undefined ? { type, value } : { type, value, primitiveExtension };
 }
 
 /**
@@ -336,8 +347,8 @@ export function fhirPathArrayNotEquals(x: TypedValue[], y: TypedValue[]): TypedV
  * @returns True if equal.
  */
 export function fhirPathEquals(x: TypedValue, y: TypedValue): TypedValue[] {
-  const xValue = x.value?.valueOf();
-  const yValue = y.value?.valueOf();
+  const xValue = x.value;
+  const yValue = y.value;
   if (typeof xValue === 'number' && typeof yValue === 'number') {
     return booleanToTypedValue(Math.abs(xValue - yValue) < 1e-8);
   }
@@ -375,10 +386,8 @@ export function fhirPathArrayEquivalent(x: TypedValue[], y: TypedValue[]): Typed
  * @returns True if equivalent.
  */
 export function fhirPathEquivalent(x: TypedValue, y: TypedValue): TypedValue[] {
-  const { type: xType, value: xValueRaw } = x;
-  const { type: yType, value: yValueRaw } = y;
-  const xValue = xValueRaw?.valueOf();
-  const yValue = yValueRaw?.valueOf();
+  const { type: xType, value: xValue } = x;
+  const { type: yType, value: yValue } = y;
 
   if (typeof xValue === 'number' && typeof yValue === 'number') {
     // Use more generous threshold than equality
@@ -424,8 +433,8 @@ export function fhirPathEquivalent(x: TypedValue, y: TypedValue): TypedValue[] {
  * @returns The sort order of the values.
  */
 function fhirPathEquivalentCompare(x: TypedValue, y: TypedValue): number {
-  const xValue = x.value?.valueOf();
-  const yValue = y.value?.valueOf();
+  const xValue = x.value;
+  const yValue = y.value;
   if (typeof xValue === 'number' && typeof yValue === 'number') {
     return xValue - yValue;
   }
@@ -595,27 +604,4 @@ function deepEquals<T1 extends object, T2 extends object>(object1: T1, object2: 
 
 function isObject(obj: unknown): obj is object {
   return obj !== null && typeof obj === 'object';
-}
-
-function assignPrimitiveExtension(target: any, primitiveExtension: any): any {
-  if (primitiveExtension) {
-    if (typeof primitiveExtension !== 'object') {
-      throw new Error('Primitive extension must be an object');
-    }
-    return safeAssign(target ?? {}, primitiveExtension);
-  }
-  return target;
-}
-
-/**
- * For primitive string, number, boolean, the return value will be the corresponding
- * `String`, `Number`, or `Boolean` version of the type.
- * @param target - The value to have `source` properties assigned to.
- * @param source - An object to be assigned to `target`.
- * @returns The `target` value with the properties of `source` assigned to it.
- */
-function safeAssign(target: any, source: any): any {
-  delete source.__proto__; //eslint-disable-line no-proto
-  delete source.constructor;
-  return Object.assign(target, source);
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -4,6 +4,7 @@ import type {
   Bundle,
   CodeableConcept,
   Coding,
+  Element,
   ElementDefinition,
   Reference,
   Resource,
@@ -30,6 +31,15 @@ export type TypeName<T> = T extends string
 export interface TypedValue {
   readonly type: string;
   readonly value: any;
+  /**
+   * The FHIR "primitive element" sibling of this value, i.e. the `_propertyName` object carrying
+   * `id` and `extension` for a primitive. Present only when the source JSON had one.
+   *
+   * The extension is kept alongside the value rather than attached to it, so that `value` remains
+   * a true primitive and `typeof` narrowing keeps working downstream.
+   * @see {@link https://hl7.org/fhir/R4/json.html#primitive}
+   */
+  readonly primitiveExtension?: Element;
 }
 
 /**

--- a/packages/core/src/typeschema/validation.test.ts
+++ b/packages/core/src/typeschema/validation.test.ts
@@ -8,6 +8,7 @@ import type {
   AppointmentParticipant,
   Binary,
   Bundle,
+  BundleEntry,
   CarePlan,
   CodeSystem,
   Condition,
@@ -26,6 +27,7 @@ import type {
   Patient,
   Questionnaire,
   QuestionnaireItem,
+  Reference,
   Resource,
   RiskAssessment,
   StructureDefinition,
@@ -700,8 +702,40 @@ describe('FHIR resource validation', () => {
         }
       }
     }`) as Patient;
-    expect(() => validateResource(patient)).not.toThrow();
+    // `__proto__` and `constructor` are not valid Element properties, so the resource is rejected.
+    expect(() => validateResource(patient)).toThrow('Invalid additional property');
+    // The important part: validating it never touches String.prototype.
     expect('hi'.trim()).toStrictEqual('hi');
+    expect(('1988-11-18' as any).valueOf()).toStrictEqual('1988-11-18');
+  });
+
+  test('Invariants using string functions with primitive extensions', () => {
+    // bdl-8 is `fullUrl.exists() implies fullUrl.contains('/_history/').not()`.
+    // A `_fullUrl` sibling must not make the invariant unevaluable.
+    const bundle: Bundle = {
+      resourceType: 'Bundle',
+      type: 'collection',
+      entry: [
+        {
+          fullUrl: 'http://example.com/Patient/1',
+          _fullUrl: { id: 'f1' },
+          resource: { resourceType: 'Patient', id: '1' },
+        } as unknown as BundleEntry,
+      ],
+    };
+    expect(() => validateResource(bundle)).not.toThrow();
+
+    // ref-1 is `reference.startsWith('#').not() or ...`
+    const observation: Observation = {
+      resourceType: 'Observation',
+      status: 'final',
+      code: { text: 'test' },
+      subject: {
+        // No actual primitive value
+        _reference: { extension: [{ url: 'http://example.com/note', valueString: 'note' }] },
+      } as unknown as Reference<Patient>,
+    };
+    expect(() => validateResource(observation)).not.toThrow();
   });
 
   test('Slice on value type', () => {
@@ -1050,7 +1084,8 @@ describe('FHIR resource validation', () => {
     const binary: Binary = { resourceType: 'Binary', contentType: ContentType.JSON };
     // Intentionally invalid: data should be base64 string, not object
     binary.data = { foo: 'bar' } as unknown as string;
-    expect(() => validateResource(binary)).toThrow('Invalid additional property "foo" (Binary.data.foo)');
+    // Rejected on the type of the value itself; the object is never walked into.
+    expect(() => validateResource(binary)).toThrow('Invalid JSON type: expected string, but got object (Binary.data)');
   });
 
   test('base64Binary exceeds configured byte cap fails', () => {

--- a/packages/core/src/typeschema/validation.ts
+++ b/packages/core/src/typeschema/validation.ts
@@ -257,7 +257,8 @@ class ResourceValidator implements CrawlerVisitor {
     field: InternalSchemaElement,
     path: string
   ): boolean {
-    if (!Array.isArray(value) && value.value === undefined) {
+    // A primitive extension with no value still satisfies the presence of the element.
+    if (!Array.isArray(value) && value.value === undefined && value.primitiveExtension === undefined) {
       if (field.min > 0) {
         this.issues.push(createStructureIssue(value.path, 'Missing required property'));
       }
@@ -360,7 +361,12 @@ class ResourceValidator implements CrawlerVisitor {
         choiceOfTypeElements[choiceOfTypeElementName] = key;
         continue;
       }
-      if (!(key in properties) && !(key.startsWith('_') && key.slice(1) in properties) && object[key] !== undefined) {
+
+      if (
+        !Object.hasOwn(properties, key) &&
+        !(key.startsWith('_') && Object.hasOwn(properties, key.slice(1))) &&
+        object[key] !== undefined
+      ) {
         this.issues.push(createStructureIssue(`${path}.${key}`, `Invalid additional property "${key}"`));
       }
     }
@@ -508,11 +514,11 @@ class ResourceValidator implements CrawlerVisitor {
   }
 
   private validatePrimitiveType(typedValue: TypedValueWithPath): void {
-    const [primitiveValue, extensionElement] = unpackPrimitiveElement(typedValue);
+    const { type, value, primitiveExtension } = typedValue;
     const path = typedValue.path;
 
-    if (primitiveValue) {
-      const { type, value } = primitiveValue;
+    // A primitive may carry only an extension, in which case there is no value to check
+    if (value !== undefined) {
       // First, make sure the value is the correct JS type
       if (!(type in fhirTypeToJsType)) {
         this.issues.push(createStructureIssue(path, `Invalid JSON type: ${type} is not a valid FHIR type`));
@@ -538,8 +544,17 @@ class ResourceValidator implements CrawlerVisitor {
         this.validateNumber(value as number, type, path);
       }
     }
-    if (extensionElement) {
-      crawlTypedValue(extensionElement, this, { schema: getDataType('Element'), initialPath: path });
+    if (primitiveExtension !== undefined) {
+      if (typeof primitiveExtension !== 'object') {
+        this.issues.push(
+          createStructureIssue(path, `Invalid JSON type: expected object, but got ${typeof primitiveExtension}`)
+        );
+        return;
+      }
+      crawlTypedValue({ type: 'Element', value: primitiveExtension }, this, {
+        schema: getDataType('Element'),
+        initialPath: path,
+      });
     }
   }
 
@@ -742,23 +757,6 @@ function checkSliceElement(value: TypedValue, slicingRules: SlicingRules | undef
     }
   }
   return undefined;
-}
-
-function unpackPrimitiveElement(v: TypedValue): [TypedValue | undefined, TypedValue | undefined] {
-  if (typeof v.value !== 'object' || !v.value) {
-    return [v, undefined];
-  }
-  const primitiveValue = v.value.valueOf();
-  if (primitiveValue === v.value) {
-    return [undefined, { type: 'Element', value: v.value }];
-  }
-  const primitiveKeys = new Set(Object.keys(primitiveValue));
-  const extensionEntries = Object.entries(v.value).filter(([k, _]) => !primitiveKeys.has(k));
-  const extensionElement = extensionEntries.length > 0 ? Object.fromEntries(extensionEntries) : undefined;
-  return [
-    { type: v.type, value: primitiveValue },
-    { type: 'Element', value: extensionElement },
-  ];
 }
 
 /**

--- a/packages/server/src/fhir/batch.test.ts
+++ b/packages/server/src/fhir/batch.test.ts
@@ -1795,9 +1795,9 @@ describe('Batch and Transaction processing', () => {
                   severity: 'error',
                   code: 'structure',
                   details: {
-                    text: 'Invalid additional property "failing"',
+                    text: 'Invalid JSON type: expected string, but got object',
                   },
-                  expression: ['Organization.name.failing'],
+                  expression: ['Organization.name'],
                 },
               ],
             },


### PR DESCRIPTION
Removing the footgun of boxed primitive types in the FHIRPath core, replaced with a first-class property in `TypedValue.primitiveExtension`