### PR TITLE
chore(skills): bias comment-compactor toward deleting comments

### DIFF
--- a/.claude/skills/comment-compactor/SKILL.md
+++ b/.claude/skills/comment-compactor/SKILL.md
@@ -1,29 +1,28 @@
 ---
 name: comment-compactor
-description: Review and rewrite every comment a diff adds so it is insightful, durable, and compact. Use as the final step before pushing, submitting, or finalizing a PR — after tests and lint pass, before `git push` / `gh pr create`. Also use when asked to "clean up the comments", "check the comments", or when a review flags a comment as stale, obvious, or conversation-bound.
+description: Delete the comments a diff adds unless they earn their place, and condense the few that do. Use as the final step before pushing, submitting, or finalizing a PR — after tests and lint pass, before `git push` / `gh pr create`. Also use when asked to "clean up the comments", "check the comments", or when a review flags a comment as stale, obvious, or conversation-bound.
 user_invocable: true
 ---
 
 # comment-compactor
 
-A dedicated pass over the comments a diff adds, run as its own step — not folded into writing
-the code, and not folded into a general code review.
+A dedicated pass over the comments a diff adds, run as its own step — not folded into writing the
+code, and not folded into a general code review.
 
-**Why this is a separate step:** comments are the only part of a diff that no tool checks. eslint,
-prettier, tsc, and the test suite all pass whether a comment is useful, bloated, or already false.
-They also have the longest half-life in the file: code gets refactored away, but a stale comment
-survives and actively misleads the next reader — human or agent.
+**The default is deletion.** Treat every comment an AI wrote while producing this diff as noise
+until it proves otherwise. The burden of proof is on keeping a comment, not on removing it. Most
+comments generated alongside code are narration of the work, written for the reviewer who is about
+to read the PR — an audience that stops existing the moment it merges.
 
-The dominant failure mode is comments that narrate _the session that produced them_ rather than the
-code that shipped: "the pre-rework shape", "the old recompute we removed", "unlike the previous
-approach", "as discussed". Those read fine during the PR and are meaningless a year later, because
-the reader has no access to the thing being contrasted against.
+**Why this is a separate step:** comments are the only part of a diff that no tool checks — eslint,
+prettier, tsc, and the tests all pass whether a comment is useful, bloated, or already false — and
+they have the longest half-life in the file.
 
 ## When to run
 
-Run this **immediately before pushing** a PR — after the mechanical gates (tests, eslint, prettier,
-`tsc --noEmit`) are green, and before `git push` or `gh pr create`. Re-run it after any round of
-review feedback that touches comments or restructures code.
+Run this **immediately before pushing** — after the mechanical gates (tests, eslint, prettier,
+`tsc --noEmit`) are green, and before `git push` or `gh pr create`. Re-run after any round of review
+feedback that touches comments or restructures code.
 
 ## Procedure
 
@@ -44,50 +43,96 @@ git diff --merge-base main -U0 -- '*.ts' '*.tsx' |
   '
 ```
 
-Widen the pathspec for other languages, and add their comment syntax to the regex (`#` for shell,
-Python, and YAML). Keep the pathspec narrow: without it, markdown headings and generated SVG paths
-bury the real hits.
+Widen the pathspec for other languages and add their comment syntax (`#` for shell, Python, YAML).
+Keep the pathspec narrow, or markdown headings and generated SVG paths bury the real hits.
 
-This is a candidate net, not a precise one — it still catches the odd string literal and misses
-comments whose opening line was unchanged. Treat the output as a worklist of locations to open, then
-read each one **in its surrounding context**, because the judgment below depends on the code the
-comment sits on.
+This is a candidate net, not a precise one. Treat it as a worklist of locations to open, and read
+each one **in its surrounding context**. Also check comments the diff did _not_ touch but whose code
+it changed — an untouched comment on rewritten code is the likeliest place for an outright false
+statement.
 
-Also check comments the diff did _not_ touch but whose code it changed: an untouched comment sitting
-on rewritten code is the most likely place for an outright false statement.
+### 2. Split every comment into sentences
 
-### 2. Judge each comment
+Do not judge a comment as a block. Split it into individual sentences (or clauses) and put each one
+on trial separately. This step is not optional and it is where most of the work happens: a
+four-sentence comment collapsing to a single clause is the normal, correct outcome. The
+non-obvious _why_ is typically one sentence buried inside setup, restatement, and hedging that all
+need to go.
 
-For every added or newly-adjacent comment, ask in order:
+### 3. Apply the audience test to each sentence
 
-- **Insightful?** Does it explain something the code cannot say itself — a _why_, an invariant, a
-  non-obvious constraint, a rejected alternative and the reason it was rejected? If it restates the
-  statement below it, delete it.
-- **Durable?** Would it still read correctly to someone who never saw this PR, this branch, or the
-  conversation that produced it? Strip references to prior iterations, removed code, review
-  feedback, and "we changed / we decided". State the invariant that holds now, not the history of
-  arriving at it.
-- **Compact?** Cut hedging, repetition, and anything a nearby comment already says. Long is fine
-  when the content earns it — a subtle concurrency invariant deserves a paragraph; a getter does
-  not. Prefer one dense paragraph to three loose ones.
-- **Correctly placed?** A rule that governs a whole module belongs once at the top of the module,
-  not repeated at each call site.
-- **Still true?** Verify the claim against the code as it now stands. A comment that was accurate
-  three commits ago is worse than no comment.
+The reader is a human opening this file months from now with no knowledge of the session, the PR, or
+the conversation that produced it. For each sentence, ask: **is this useful to that person?**
 
-### 3. Apply the edits
+Delete the sentence if it is any of:
 
-Edit in place. Deleting a comment is a normal outcome and usually the right one for restatement.
-Re-run prettier on touched files if the project formats comments.
+- **Narration of the change** — "we now batch these", "this replaces the old recompute", "as
+  requested", "note that the signature changed".
+- **Aimed at a reviewer** — justifying a decision, pre-empting an objection, explaining why the
+  approach was chosen over one the reader cannot see.
+- **Restatement** — says what the code plainly says. `// increment the counter` above `counter++`.
+- **Hedging or filler** — "this might possibly need", "for now", "basically", a lead-in sentence
+  whose only job is to introduce the next sentence.
+- **False** — verify each surviving claim against the code as it now stands.
 
-## The high-value case
+### 4. Keep only what survives, condensed
 
-Watch especially for comments explaining _why the code is not something else_. That is often the
-most valuable kind — it prevents a future regression — but only if it names the invariant rather
-than the diff:
+A sentence survives only if it is one of:
 
-- Durable: `MUST stay synchronous: an await here lets two workers dispatch the same partition out of order.`
-- Not durable: `this used to have an await before the rework.`
+- **Non-obvious _why_ the code cannot express**: a subtle invariant, a required ordering, a
+  concurrency hazard, a choice that looks wrong and is deliberate.
+- **An external requirement**: a spec or protocol rule, a workaround for a third-party bug (name it,
+  and link it if there is a URL).
+- **Public contract**: JSDoc/TSDoc on exported APIs — params, returns, thrown errors, usage.
+
+Then condense it to the shortest form that still carries the information. Surviving does not mean
+surviving verbatim. If a rule governs a whole module, state it once at the top rather than at each
+call site.
+
+### 5. Apply the edits
+
+Edit in place. Re-run prettier on touched files.
+
+## Examples
+
+**Multi-sentence comment collapsing to one clause.** Three of the four sentences fail: the first
+restates the line below it, the second justifies the change to a reviewer, the fourth contrasts
+against code the reader cannot see.
+
+```ts
+// Cache access policy results per (author, channel type) for this evaluation.
+// Without this we were calling satisfiesAccessPolicy() once per subscription, which showed up in profiling.
+// Channel type is part of the key because satisfiesAccessPolicy() is hardcoded to return true for rest-hook subs.
+// The previous version of this cache keyed on author alone.
+const accessPolicyCache = new Map<string, boolean>();
+```
+
+```ts
+// Channel type is in the key: satisfiesAccessPolicy() always returns true for rest-hook subs, so a
+// cached `true` would otherwise bypass the real check for a websocket sub with the same author.
+const accessPolicyCache = new Map<string, boolean>();
+```
+
+**Deleted outright.** The first sentence restates the expression; the second is an artifact of the
+session. Nothing is left.
+
+```ts
+// Compute the reconnect delay with exponential backoff, capped at the maximum.
+// This replaces the fixed 1s retry we had before.
+const delay = Math.min(baseDelay * 2 ** attempt, maxDelay);
+```
+
+```ts
+const delay = Math.min(baseDelay * 2 ** attempt, maxDelay);
+```
+
+## The one comment worth fighting for
+
+Comments explaining _why the code is not something else_ prevent future regressions — but only when
+they name the invariant instead of the diff:
+
+- Keep: `MUST stay synchronous: an await here lets two workers dispatch the same partition out of order.`
+- Delete: `this used to have an await before the rework.`
 
 Both point at the same hazard. Only the first survives the loss of the surrounding context.
 
@@ -96,14 +141,15 @@ Both point at the same hazard. Only the first survives the loss of the surroundi
 | Smell                       | Example                                                    | Fix                                            |
 | --------------------------- | ---------------------------------------------------------- | ---------------------------------------------- |
 | Restatement                 | `// increment the counter` above `counter++`               | Delete                                         |
-| Session-bound               | `// unlike the old approach, we now batch`                 | State the current invariant, or delete         |
+| Session-bound               | `// unlike the old approach, we now batch`                 | Delete; keep the invariant only if non-obvious |
+| Reviewer-facing             | `// as requested, this is now extracted into a helper`     | Delete                                         |
 | Hedged                      | `// this might possibly need to be checked here, probably` | Assert the constraint, or delete               |
 | Diffed against removed code | `// no longer calls refreshCache()`                        | Delete; the reader cannot see what was removed |
+| Preamble sentence           | Sentence whose only job is to introduce the next one       | Delete; keep the payload sentence              |
 | Scattered rule              | Same caveat repeated at five call sites                    | One module-level comment                       |
 | Stale                       | Comment names a parameter that was renamed                 | Update, or delete if now obvious               |
 
 ## Related conventions
 
 Pairs with the pre-commit gate (tests + eslint + prettier + `tsc --noEmit`), which is mechanical;
-this pass is the judgment one. It applies the same "cut it down" instinct that simplifying a large
-diff does, but to prose rather than code.
+this pass is the judgment one.


### PR DESCRIPTION
## Problem

The `comment-compactor` skill treated every comment a diff adds as something to improve. In practice most comments generated alongside code are narration of the work — written for the reviewer about to read the PR, an audience that stops existing the moment it merges. A skill whose default is "rewrite this well" keeps those comments; it just makes them shorter.

## Solution

Flips the default from compaction to deletion. A comment is noise until it proves otherwise, and the burden of proof is on keeping it.

- **Sentence-by-sentence evaluation.** Comments are split into sentences and each is tried separately rather than kept or dropped as a block. A four-sentence comment collapsing to a single clause is called out as the normal outcome — the non-obvious *why* is usually one sentence buried in setup, restatement, and hedging.
- **Audience test.** The reader is a human opening the file months later with no knowledge of the session, the PR, or the conversation. Narration-of-the-change and reviewer-facing justification are now their own delete categories.
- **A narrow survivor list:** non-obvious *why* the code cannot express, external requirements (spec rules, third-party bug workarounds), and public-contract JSDoc. Survivors are still condensed.
- Two before/after examples, and `Reviewer-facing` / `Preamble sentence` rows in the rewrite-patterns table.

The trigger phrases in the frontmatter `description` are unchanged, so the skill fires in exactly the same situations; only its stated purpose was updated to match the new posture.

## Testing

Docs-only change to a skill definition. `prettier --check` passes.
