### PR TITLE
fix(cli): support custom config file for bot creation

### DIFF
--- a/packages/cli/src/bot.test.ts
+++ b/packages/cli/src/bot.test.ts
@@ -5,6 +5,7 @@ import type { Bot } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
+import { resolve } from 'node:path';
 import type { Mock, MockInstance } from 'vitest';
 import * as cli from '.';
 import { createMedplumClient } from './util/client';
@@ -320,6 +321,35 @@ describe('CLI Bots', () => {
     expect(console.log).toHaveBeenCalledWith(expect.stringMatching('Success! Bot created:'));
     expect(fs.existsSync).toHaveBeenCalled();
     expect(fs.readFileSync).not.toHaveBeenCalled();
+  });
+
+  test('Create bot command with custom config file', async () => {
+    const configFileName = 'medplum.staging.config.json';
+    medplum.router.router.add('POST', 'Bot/:id/$deploy', async () => [allOk]);
+
+    (fs.existsSync as unknown as Mock).mockReturnValue(true);
+    (fs.readFileSync as unknown as Mock).mockReturnValue(JSON.stringify({ bots: [] }));
+
+    await main([
+      'node',
+      'index.js',
+      'bot',
+      'create',
+      'test-bot',
+      '1',
+      'src/hello-world.ts',
+      'dist/src/hello-world.ts',
+      '--file',
+      configFileName,
+    ]);
+
+    expect(fs.existsSync).toHaveBeenCalledWith(resolve(configFileName));
+    expect(fs.readFileSync).toHaveBeenCalledWith(resolve(configFileName), 'utf8');
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      resolve(configFileName),
+      expect.stringContaining('"name": "test-bot"'),
+      'utf-8'
+    );
   });
 
   test('Create bot command with auth options', async () => {

--- a/packages/cli/src/bots.ts
+++ b/packages/cli/src/bots.ts
@@ -40,11 +40,21 @@ botCreateCommand
   .arguments('<botName> <projectId> <sourceFile> <distFile>')
   .description('Creating a bot')
   .option('--runtime-version <runtimeVersion>', 'Runtime version (awslambda, vmcontext)')
-  .option('--no-write-config', 'Do not write bot to config')
+  .option('--no-write-config', 'Do not write bot to config', true)
+  .option('--file <file>', 'Specifies the config file to write the bot to')
   .action(async (botName, projectId, sourceFile, distFile, options) => {
     const medplum = await createMedplumClient(options);
 
-    await createBot(medplum, botName, projectId, sourceFile, distFile, options.runtimeVersion, !!options.writeConfig);
+    await createBot(
+      medplum,
+      botName,
+      projectId,
+      sourceFile,
+      distFile,
+      options.runtimeVersion,
+      !!options.writeConfig,
+      options.file
+    );
   });
 
 export async function botWrapper(medplum: MedplumClient, botName: string, deploy = false): Promise<void> {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -97,7 +97,8 @@ export async function createBot(
   sourceFile: string,
   distFile: string,
   runtimeVersion?: string,
-  writeConfig?: boolean
+  writeConfig?: boolean,
+  configFileName?: string
 ): Promise<void> {
   const body = {
     name: botName,
@@ -119,7 +120,7 @@ export async function createBot(
   console.log(`Success! Bot created: ${bot.id}`);
 
   if (writeConfig) {
-    addBotToConfig(botConfig);
+    addBotToConfig(botConfig, configFileName);
   }
 }
 
@@ -188,13 +189,13 @@ function readFileContents(fileName: string): string {
   return readFileSync(path, 'utf8');
 }
 
-function addBotToConfig(botConfig: MedplumBotConfig): void {
-  const config = readConfig() ?? {};
+function addBotToConfig(botConfig: MedplumBotConfig, configFileName = getConfigFileName()): void {
+  const config = readConfig(undefined, { file: configFileName }) ?? {};
   if (!config.bots) {
     config.bots = [];
   }
   config.bots.push(botConfig);
-  writeFileSync('medplum.config.json', JSON.stringify(config, null, 2), 'utf8');
+  writeConfig(configFileName, config);
   console.log(`Bot added to config: ${botConfig.id}`);
 }
 


### PR DESCRIPTION

## Summary

- add a `--file` option to `medplum bot create`
- pass the selected config filename through the bot creation flow
- read and write the same config file
- preserve `medplum.config.json` as the default
- add regression coverage for custom config files

## Root cause

`addBotToConfig` always read and wrote `medplum.config.json`, so callers could not use environment-specific bot configuration files.

## Testing

- `npm test --workspace @medplum/cli -- --run src/bot.test.ts`
- `npm run lint --workspace @medplum/cli`
- `npm run build --workspace @medplum/cli`
