### PR TITLE
[React] Remove deprecation notice from `<ResourceInput>`

### DIFF
--- a/packages/react/src/ResourceInput/ResourceInput.tsx
+++ b/packages/react/src/ResourceInput/ResourceInput.tsx
@@ -6,9 +6,6 @@ import { useCallback } from 'react';
 import type { AsyncAutocompleteOption, AsyncAutocompleteProps } from '../AsyncAutocomplete/AsyncAutocomplete';
 import { MultiResourceInput } from './MultiResourceInput';
 
-/**
- * @deprecated Use MultiResourceInput instead, which supports multiple default and selected values.
- */
 export interface ResourceInputProps<T extends Resource = Resource> {
   readonly resourceType: T['resourceType'];
   readonly name: string;


### PR DESCRIPTION
In #8949 we considered deprecating this component in favor of `MultiResourceInput`, but we decided that keeping this thin wrapper to make using the single-resource case easy was worthwhile.

We removed the deprecation notice on the component itself, but accidentally left behind the one on the Props type.

This has made some coding agents less likely to use this component and re-author very similar code wrapping the MultiResourceInput. Oops!