### PR TITLE
feat(claims): Candid claim status

### DIFF
--- a/examples/medplum-provider/src/components/encounter/BillingTab.test.tsx
+++ b/examples/medplum-provider/src/components/encounter/BillingTab.test.tsx
@@ -1014,7 +1014,11 @@ describe('BillingTab', () => {
     // and ClaimSubmittedPanel executes the URL bot to resolve the portal URL, so stub executeBot per bot.
     const mockSearchOneWithClaimResponse = (
       claimResponse: WithId<ClaimResponse>,
-      options?: { claim?: WithId<Claim>; getEncounterDeployed?: boolean; refreshedClaimResponse?: WithId<ClaimResponse> }
+      options?: {
+        claim?: WithId<Claim>;
+        getEncounterDeployed?: boolean;
+        refreshedClaimResponse?: WithId<ClaimResponse>;
+      }
     ): void => {
       let currentClaimResponse = claimResponse;
       vi.spyOn(medplum, 'searchOne').mockImplementation(((resourceType: string, query?: Record<string, string>) => {

--- a/examples/medplum-provider/src/components/encounter/BillingTab.test.tsx
+++ b/examples/medplum-provider/src/components/encounter/BillingTab.test.tsx
@@ -1001,18 +1001,25 @@ describe('BillingTab', () => {
 
     const candidClaimUrl = 'https://app-staging.joincandidhealth.com/claims/candid-encounter-123';
 
+    // A claim that has been submitted to Candid: the submit operation writes the Candid encounter
+    // id back onto the Claim, which is what triggers the refresh on load.
+    const candidClaim: WithId<Claim> = {
+      ...mockClaim,
+      identifier: [{ system: 'https://candidhealth.com/encounter-id', value: 'candid-encounter-123' }],
+    };
+
     // The Candid card requires BillingTab to find an existing Claim (searchOne), its ClaimResponse
     // (searchOne), and the deployed bots (searchOne on Bot, dispatched by identifier). BillingTab
-    // executes get-encounter to refresh a Candid ClaimResponse on load, and ClaimSubmittedPanel
-    // executes the URL bot to resolve the portal URL, so stub executeBot per bot.
+    // executes get-encounter with the Claim's Candid encounter id before fetching the ClaimResponse,
+    // and ClaimSubmittedPanel executes the URL bot to resolve the portal URL, so stub executeBot per bot.
     const mockSearchOneWithClaimResponse = (
       claimResponse: WithId<ClaimResponse>,
-      options?: { getEncountersDeployed?: boolean; refreshedClaimResponse?: WithId<ClaimResponse> }
+      options?: { claim?: WithId<Claim>; getEncounterDeployed?: boolean; refreshedClaimResponse?: WithId<ClaimResponse> }
     ): void => {
       let currentClaimResponse = claimResponse;
       vi.spyOn(medplum, 'searchOne').mockImplementation(((resourceType: string, query?: Record<string, string>) => {
         if (resourceType === 'Claim') {
-          return Promise.resolve(mockClaim);
+          return Promise.resolve(options?.claim ?? mockClaim);
         }
         if (resourceType === 'Bot') {
           const identifier = String(query?.identifier ?? '');
@@ -1020,7 +1027,7 @@ describe('BillingTab', () => {
             return Promise.resolve(candidUrlBot);
           }
           if (identifier.endsWith('get-encounter')) {
-            return Promise.resolve(options?.getEncountersDeployed ? getEncountersBot : undefined);
+            return Promise.resolve(options?.getEncounterDeployed ? getEncountersBot : undefined);
           }
           return Promise.resolve(undefined);
         }
@@ -1048,12 +1055,22 @@ describe('BillingTab', () => {
     });
 
     test('displays status badge and submission date from ClaimResponse', async () => {
-      mockSearchOneWithClaimResponse(candidClaimResponse);
+      mockSearchOneWithClaimResponse({
+        ...candidClaimResponse,
+        extension: [
+          {
+            url: 'https://medplum.com/fhir/StructureDefinition/source-claim-status',
+            valueCodeableConcept: {
+              coding: [{ system: 'https://candidhealth.com/claim-status', code: 'waiting_for_provider' }],
+            },
+          },
+        ],
+      });
 
       await setup();
 
       await waitFor(() => {
-        expect(screen.getByText('Submitted')).toBeInTheDocument();
+        expect(screen.getByText('Waiting For Provider')).toBeInTheDocument();
         expect(screen.getByText(/Submitted on/)).toBeInTheDocument();
       });
     });
@@ -1076,11 +1093,16 @@ describe('BillingTab', () => {
       };
 
       mockSearchResources({ Coverage: [mockCoverage] });
-      mockSearchOneWithClaimResponse(candidClaimResponse, { getEncountersDeployed: true, refreshedClaimResponse });
+      mockSearchOneWithClaimResponse(candidClaimResponse, {
+        claim: candidClaim,
+        getEncounterDeployed: true,
+        refreshedClaimResponse,
+      });
 
       await setup();
 
-      // The bot ran with the Candid encounter ID as input, and the refetched (refreshed) total is shown.
+      // The bot ran with the claim's Candid encounter ID as input, and the (already refreshed)
+      // ClaimResponse was fetched once.
       await waitFor(() => {
         expect(medplum.executeBot).toHaveBeenCalledWith(
           'get-encounter-bot',
@@ -1089,13 +1111,16 @@ describe('BillingTab', () => {
         );
         expect(screen.getByText('$150')).toBeInTheDocument();
       });
+      const claimResponseSearches = vi.mocked(medplum.searchOne).mock.calls.filter((c) => c[0] === 'ClaimResponse');
+      expect(claimResponseSearches).toHaveLength(1);
     });
 
-    test('does not run get-encounter when the ClaimResponse is not from Candid', async () => {
+    test('does not run get-encounter when the claim was not submitted to Candid', async () => {
       const nonCandidClaimResponse: WithId<ClaimResponse> = { ...candidClaimResponse, identifier: [] };
 
       mockSearchResources({ Coverage: [mockCoverage] });
-      mockSearchOneWithClaimResponse(nonCandidClaimResponse, { getEncountersDeployed: true });
+      // The claim (default mockClaim) has no Candid encounter id, so there is nothing to refresh.
+      mockSearchOneWithClaimResponse(nonCandidClaimResponse, { getEncounterDeployed: true });
 
       await setup();
 
@@ -1108,7 +1133,7 @@ describe('BillingTab', () => {
 
     test('skips the refresh when the get-encounter bot is not deployed', async () => {
       mockSearchResources({ Coverage: [mockCoverage] });
-      mockSearchOneWithClaimResponse(candidClaimResponse);
+      mockSearchOneWithClaimResponse(candidClaimResponse, { claim: candidClaim });
 
       await setup();
 

--- a/examples/medplum-provider/src/components/encounter/BillingTab.test.tsx
+++ b/examples/medplum-provider/src/components/encounter/BillingTab.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
-import type { ReadablePromise, WithId } from '@medplum/core';
+import type { WithId } from '@medplum/core';
 import type {
   Bot,
   ChargeItem,
@@ -993,22 +993,46 @@ describe('BillingTab', () => {
       identifier: [{ system: 'https://medplum.com/integrations/candid-health', value: 'get-candid-claim-portal-url' }],
     };
 
+    const getEncountersBot: WithId<Bot> = {
+      resourceType: 'Bot',
+      id: 'get-encounter-bot',
+      identifier: [{ system: 'https://medplum.com/integrations/candid-health', value: 'get-encounter' }],
+    };
+
     const candidClaimUrl = 'https://app-staging.joincandidhealth.com/claims/candid-encounter-123';
 
     // The Candid card requires BillingTab to find an existing Claim (searchOne), its ClaimResponse
-    // (searchOne), and the deployed URL bot (searchOne on Bot). ClaimSubmittedPanel then executes that
-    // bot to resolve the portal URL, so stub executeBot to return it.
-    const mockSearchOneWithClaimResponse = (claimResponse: WithId<ClaimResponse>): void => {
-      vi.spyOn(medplum, 'searchOne').mockImplementation(((resourceType: string) =>
-        Promise.resolve(
-          (resourceType === 'Claim' && mockClaim) || (resourceType === 'Bot' && candidUrlBot) || claimResponse
-        )) as (
-        resourceType: string
-      ) => ReadablePromise<WithId<Claim> | WithId<ClaimResponse> | WithId<Bot> | undefined>);
-      vi.spyOn(medplum, 'executeBot').mockResolvedValue({
-        encounterId: 'candid-encounter-123',
-        url: candidClaimUrl,
-      });
+    // (searchOne), and the deployed bots (searchOne on Bot, dispatched by identifier). BillingTab
+    // executes get-encounter to refresh a Candid ClaimResponse on load, and ClaimSubmittedPanel
+    // executes the URL bot to resolve the portal URL, so stub executeBot per bot.
+    const mockSearchOneWithClaimResponse = (
+      claimResponse: WithId<ClaimResponse>,
+      options?: { getEncountersDeployed?: boolean; refreshedClaimResponse?: WithId<ClaimResponse> }
+    ): void => {
+      let currentClaimResponse = claimResponse;
+      vi.spyOn(medplum, 'searchOne').mockImplementation(((resourceType: string, query?: Record<string, string>) => {
+        if (resourceType === 'Claim') {
+          return Promise.resolve(mockClaim);
+        }
+        if (resourceType === 'Bot') {
+          const identifier = String(query?.identifier ?? '');
+          if (identifier.endsWith('get-candid-claim-portal-url')) {
+            return Promise.resolve(candidUrlBot);
+          }
+          if (identifier.endsWith('get-encounter')) {
+            return Promise.resolve(options?.getEncountersDeployed ? getEncountersBot : undefined);
+          }
+          return Promise.resolve(undefined);
+        }
+        return Promise.resolve(currentClaimResponse);
+      }) as any);
+      vi.spyOn(medplum, 'executeBot').mockImplementation((async (botId: string) => {
+        if (botId === getEncountersBot.id) {
+          currentClaimResponse = options?.refreshedClaimResponse ?? currentClaimResponse;
+          return {};
+        }
+        return { encounterId: 'candid-encounter-123', url: candidClaimUrl };
+      }) as typeof medplum.executeBot);
     };
 
     test('shows Candid claim card when a ClaimResponse exists', async () => {
@@ -1043,6 +1067,55 @@ describe('BillingTab', () => {
         expect(screen.getByText('Claim Status:')).toBeInTheDocument();
       });
       expect(screen.queryByText(/Submitted on/)).not.toBeInTheDocument();
+    });
+
+    test('executes the get-encounter bot to refresh a Candid ClaimResponse on load', async () => {
+      const refreshedClaimResponse: WithId<ClaimResponse> = {
+        ...candidClaimResponse,
+        total: [{ category: { coding: [{ code: 'submitted' }] }, amount: { value: 150 } }],
+      };
+
+      mockSearchResources({ Coverage: [mockCoverage] });
+      mockSearchOneWithClaimResponse(candidClaimResponse, { getEncountersDeployed: true, refreshedClaimResponse });
+
+      await setup();
+
+      // The bot ran with the Candid encounter ID as input, and the refetched (refreshed) total is shown.
+      await waitFor(() => {
+        expect(medplum.executeBot).toHaveBeenCalledWith(
+          'get-encounter-bot',
+          { encounterId: 'candid-encounter-123' },
+          'application/json'
+        );
+        expect(screen.getByText('$150')).toBeInTheDocument();
+      });
+    });
+
+    test('does not run get-encounter when the ClaimResponse is not from Candid', async () => {
+      const nonCandidClaimResponse: WithId<ClaimResponse> = { ...candidClaimResponse, identifier: [] };
+
+      mockSearchResources({ Coverage: [mockCoverage] });
+      mockSearchOneWithClaimResponse(nonCandidClaimResponse, { getEncountersDeployed: true });
+
+      await setup();
+
+      await waitFor(() => {
+        expect(screen.getByText('Claim Status:')).toBeInTheDocument();
+      });
+      // Neither the refresh bot nor the Candid URL bot runs for a non-Candid claim.
+      expect(medplum.executeBot).not.toHaveBeenCalled();
+    });
+
+    test('skips the refresh when the get-encounter bot is not deployed', async () => {
+      mockSearchResources({ Coverage: [mockCoverage] });
+      mockSearchOneWithClaimResponse(candidClaimResponse);
+
+      await setup();
+
+      await waitFor(() => {
+        expect(screen.getByText('Claim Status:')).toBeInTheDocument();
+      });
+      expect(medplum.executeBot).not.toHaveBeenCalledWith('get-encounter-bot', expect.anything(), expect.anything());
     });
 
     test('View Claim on Candid button opens the correct Candid URL', async () => {

--- a/examples/medplum-provider/src/components/encounter/BillingTab.tsx
+++ b/examples/medplum-provider/src/components/encounter/BillingTab.tsx
@@ -128,7 +128,6 @@ export const BillingTab = (props: BillingTabProps): JSX.Element => {
           showErrorNotification(err);
         }
       }
-      console.log('ClaimResponse', result);
       setClaimResponse(result ?? null);
     } finally {
       setClaimResponseLoading(false);

--- a/examples/medplum-provider/src/components/encounter/BillingTab.tsx
+++ b/examples/medplum-provider/src/components/encounter/BillingTab.tsx
@@ -25,6 +25,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { SAVE_TIMEOUT_MS } from '../../config/constants';
 import { useDebouncedUpdateResource } from '../../hooks/useDebouncedUpdateResource';
 import { ChartNoteStatus } from '../../types/encounter';
+import { isCandidClaimResponse, refreshCandidClaimResponse } from '../../utils/candid';
 import { getChargeItemsForEncounter } from '../../utils/chargeitems';
 import { buildClaimFromEncounter } from '../../utils/claims';
 import { createSelfPayCoverage, isSelfPayCoverage } from '../../utils/coverage';
@@ -113,11 +114,21 @@ export const BillingTab = (props: BillingTabProps): JSX.Element => {
     }
     setClaimResponseLoading(true);
     try {
-      const result = await medplum.searchOne(
-        'ClaimResponse',
-        { request: getReferenceString(claim) },
-        { cache: 'no-cache' }
-      );
+      const searchClaimResponse = (): Promise<WithId<ClaimResponse> | undefined> =>
+        medplum.searchOne('ClaimResponse', { request: getReferenceString(claim) }, { cache: 'no-cache' });
+      let result = await searchClaimResponse();
+      if (result && isCandidClaimResponse(result)) {
+        // Candid claims are refreshed on load: the get-encounter bot pulls the latest claim state
+        // from Candid onto the ClaimResponse. If the refresh fails, fall back to the stale response.
+        try {
+          if (await refreshCandidClaimResponse(medplum, result)) {
+            result = (await searchClaimResponse()) ?? result;
+          }
+        } catch (err) {
+          showErrorNotification(err);
+        }
+      }
+      console.log('ClaimResponse', result);
       setClaimResponse(result ?? null);
     } finally {
       setClaimResponseLoading(false);

--- a/examples/medplum-provider/src/components/encounter/BillingTab.tsx
+++ b/examples/medplum-provider/src/components/encounter/BillingTab.tsx
@@ -25,7 +25,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { SAVE_TIMEOUT_MS } from '../../config/constants';
 import { useDebouncedUpdateResource } from '../../hooks/useDebouncedUpdateResource';
 import { ChartNoteStatus } from '../../types/encounter';
-import { isCandidClaimResponse, refreshCandidClaimResponse } from '../../utils/candid';
+import { refreshCandidClaimResponse } from '../../utils/candid';
 import { getChargeItemsForEncounter } from '../../utils/chargeitems';
 import { buildClaimFromEncounter } from '../../utils/claims';
 import { createSelfPayCoverage, isSelfPayCoverage } from '../../utils/coverage';
@@ -114,20 +114,18 @@ export const BillingTab = (props: BillingTabProps): JSX.Element => {
     }
     setClaimResponseLoading(true);
     try {
-      const searchClaimResponse = (): Promise<WithId<ClaimResponse> | undefined> =>
-        medplum.searchOne('ClaimResponse', { request: getReferenceString(claim) }, { cache: 'no-cache' });
-      let result = await searchClaimResponse();
-      if (result && isCandidClaimResponse(result)) {
-        // Candid claims are refreshed on load: the get-encounter bot pulls the latest claim state
-        // from Candid onto the ClaimResponse. If the refresh fails, fall back to the stale response.
-        try {
-          if (await refreshCandidClaimResponse(medplum, result)) {
-            result = (await searchClaimResponse()) ?? result;
-          }
-        } catch (err) {
-          showErrorNotification(err);
-        }
+      // Candid claims are refreshed on load: the claim carries the Candid encounter id, so the
+      // get-encounter bot can pull the latest state onto the stored ClaimResponse
+      try {
+        await refreshCandidClaimResponse(medplum, claim);
+      } catch (err) {
+        showErrorNotification(err);
       }
+      const result = await medplum.searchOne(
+        'ClaimResponse',
+        { request: getReferenceString(claim) },
+        { cache: 'no-cache' }
+      );
       setClaimResponse(result ?? null);
     } finally {
       setClaimResponseLoading(false);

--- a/examples/medplum-provider/src/components/encounter/ClaimSubmittedPanel.test.tsx
+++ b/examples/medplum-provider/src/components/encounter/ClaimSubmittedPanel.test.tsx
@@ -109,6 +109,48 @@ describe('ClaimSubmittedPanel', () => {
     expect(screen.queryByText('Submitted')).not.toBeInTheDocument();
   });
 
+  test('shows a short label derived from the X12 status category for a Stedi claim', () => {
+    setup({
+      ...baseClaimResponse,
+      identifier: [{ system: 'https://www.stedi.com/claims', value: '01M00V1PM9V1WXN77YRMD00MZ2' }],
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/source-claim-status',
+          valueCodeableConcept: {
+            coding: [
+              {
+                system: 'https://codesystem.x12.org/external/507',
+                code: 'A1',
+                display: 'Acknowledgement/Receipt - The claim/encounter has been received.',
+              },
+              { system: 'https://codesystem.x12.org/external/508', code: '16' },
+            ],
+          },
+        },
+      ],
+    });
+    expect(screen.getByText('Received')).toBeInTheDocument();
+  });
+
+  test('prefers the Candid status when both status codings are present', () => {
+    setup({
+      ...baseClaimResponse,
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/source-claim-status',
+          valueCodeableConcept: {
+            coding: [
+              { system: 'https://candidhealth.com/claim-status', code: 'paid' },
+              { system: 'https://codesystem.x12.org/external/507', code: 'A1' },
+            ],
+          },
+        },
+      ],
+    });
+    expect(screen.getByText('Paid')).toBeInTheDocument();
+    expect(screen.queryByText('Received')).not.toBeInTheDocument();
+  });
+
   test('shows submission date when created is provided', () => {
     setup({ ...baseClaimResponse, created: '2026-03-02T21:32:57.748Z' });
     expect(screen.getByText(/Submitted on/)).toBeInTheDocument();

--- a/examples/medplum-provider/src/components/encounter/ClaimSubmittedPanel.test.tsx
+++ b/examples/medplum-provider/src/components/encounter/ClaimSubmittedPanel.test.tsx
@@ -87,9 +87,25 @@ describe('ClaimSubmittedPanel', () => {
     expect(screen.getByText('Export')).toBeInTheDocument();
   });
 
-  test('shows Submitted status badge', () => {
+  test('shows Submitted status badge when the ClaimResponse has no source claim status', () => {
     setup();
     expect(screen.getByText('Submitted')).toBeInTheDocument();
+  });
+
+  test('shows the Candid status from the source-claim-status extension when present', () => {
+    setup({
+      ...baseClaimResponse,
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/source-claim-status',
+          valueCodeableConcept: {
+            coding: [{ system: 'https://candidhealth.com/claim-status', code: 'waiting_for_provider' }],
+          },
+        },
+      ],
+    });
+    expect(screen.getByText('Waiting For Provider')).toBeInTheDocument();
+    expect(screen.queryByText('Submitted')).not.toBeInTheDocument();
   });
 
   test('shows submission date when created is provided', () => {

--- a/examples/medplum-provider/src/components/encounter/ClaimSubmittedPanel.test.tsx
+++ b/examples/medplum-provider/src/components/encounter/ClaimSubmittedPanel.test.tsx
@@ -87,9 +87,10 @@ describe('ClaimSubmittedPanel', () => {
     expect(screen.getByText('Export')).toBeInTheDocument();
   });
 
-  test('shows Submitted status badge when the ClaimResponse has no source claim status', () => {
+  test('shows no status badge when the ClaimResponse has no source claim status', () => {
     setup();
-    expect(screen.getByText('Submitted')).toBeInTheDocument();
+    expect(screen.getByText('Claim Status:')).toBeInTheDocument();
+    expect(screen.queryByText('Submitted')).not.toBeInTheDocument();
   });
 
   test('shows the Candid status from the source-claim-status extension when present', () => {
@@ -133,7 +134,7 @@ describe('ClaimSubmittedPanel', () => {
     await deployCandidBot();
     const { identifier: _identifier, ...nonCandid } = baseClaimResponse;
     setup(nonCandid);
-    await waitFor(() => expect(screen.getByText('Submitted')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Claim Status:')).toBeInTheDocument());
     expect(medplum.executeBot).not.toHaveBeenCalled();
     expect(screen.queryByText('View Claim on Candid')).not.toBeInTheDocument();
   });
@@ -142,7 +143,7 @@ describe('ClaimSubmittedPanel', () => {
     await deployCandidBot(undefined);
     setup();
     // Give the bot lookup/execution a chance to resolve before asserting absence.
-    await waitFor(() => expect(screen.getByText('Submitted')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Claim Status:')).toBeInTheDocument());
     expect(screen.queryByText('View Claim on Candid')).not.toBeInTheDocument();
   });
 

--- a/examples/medplum-provider/src/components/encounter/ClaimSubmittedPanel.tsx
+++ b/examples/medplum-provider/src/components/encounter/ClaimSubmittedPanel.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Badge, Box, Button, Card, Divider, Flex, Group, Loader, Stack, Text } from '@mantine/core';
+import { Badge, Box, Button, Card, Divider, Flex, Group, Loader, Stack, Text, Tooltip } from '@mantine/core';
 import { formatDateTime } from '@medplum/core';
 import type { ClaimResponse, Reference } from '@medplum/fhirtypes';
 import { useMedplum, useResource, useSearchOne } from '@medplum/react';
@@ -9,6 +9,7 @@ import type { JSX, ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import { CANDID_CLAIM_URL_BOT_IDENTIFIER, getCandidClaimStatus, isCandidClaimResponse } from '../../utils/candid';
 import { showErrorNotification } from '../../utils/notifications';
+import { formatStediClaimStatus, getStediClaimStatus } from '../../utils/stedi';
 
 interface GetCandidClaimUrlOutput {
   encounterId: string;
@@ -80,7 +81,8 @@ export const ClaimSubmittedPanel = (props: ClaimSubmittedPanelProps): JSX.Elemen
     return null;
   }
 
-  const status: string | undefined = getCandidClaimStatus(claimResponseResource);
+  const candidStatus = getCandidClaimStatus(claimResponseResource);
+  const stediStatus = candidStatus ? undefined : getStediClaimStatus(claimResponseResource);
   const createdAt = claimResponseResource.created;
   const claimAmount = claimResponseResource.total?.reduce((sum, total) => sum + (total.amount?.value ?? 0), 0) ?? 0;
 
@@ -92,10 +94,17 @@ export const ClaimSubmittedPanel = (props: ClaimSubmittedPanelProps): JSX.Elemen
             <Text size="xs" c="dimmed">
               Claim Status:
             </Text>
-            {status && (
-              <Badge color={getStatusColor(status)} radius="xl" variant="filled">
-                {formatCandidStatus(status)}
+            {candidStatus && (
+              <Badge color={getStatusColor(candidStatus)} radius="xl" variant="filled">
+                {formatCandidStatus(candidStatus)}
               </Badge>
+            )}
+            {stediStatus && (
+              <Tooltip label={stediStatus.display} disabled={!stediStatus.display} multiline maw={360}>
+                <Badge color={getStediStatusColor(stediStatus.code)} radius="xl" variant="filled">
+                  {formatStediClaimStatus(stediStatus)}
+                </Badge>
+              </Tooltip>
             )}
           </Stack>
           <Box style={{ flex: 1 }}>
@@ -131,6 +140,20 @@ export const ClaimSubmittedPanel = (props: ClaimSubmittedPanelProps): JSX.Elemen
       </Stack>
     </Card>
   );
+};
+
+// X12 507 category codes group by first letter; see formatStediClaimStatus.
+const getStediStatusColor = (code: string | undefined): string => {
+  switch (code?.charAt(0)) {
+    case 'F':
+      return 'green';
+    case 'P':
+      return 'yellow';
+    case 'E':
+      return 'red';
+    default:
+      return 'violet';
+  }
 };
 
 const getStatusColor = (status: string): string => {

--- a/examples/medplum-provider/src/components/encounter/ClaimSubmittedPanel.tsx
+++ b/examples/medplum-provider/src/components/encounter/ClaimSubmittedPanel.tsx
@@ -80,10 +80,7 @@ export const ClaimSubmittedPanel = (props: ClaimSubmittedPanelProps): JSX.Elemen
     return null;
   }
 
-  // The get-encounter bot writes the latest Candid claim status (e.g. `waiting_for_provider`) into
-  // the source-claim-status extension; until the first refresh lands the response only reflects
-  // the submission.
-  const status = getCandidClaimStatus(claimResponseResource) ?? 'Submitted';
+  const status: string | undefined = getCandidClaimStatus(claimResponseResource);
   const createdAt = claimResponseResource.created;
   const claimAmount = claimResponseResource.total?.reduce((sum, total) => sum + (total.amount?.value ?? 0), 0) ?? 0;
 

--- a/examples/medplum-provider/src/components/encounter/ClaimSubmittedPanel.tsx
+++ b/examples/medplum-provider/src/components/encounter/ClaimSubmittedPanel.tsx
@@ -7,18 +7,8 @@ import { useMedplum, useResource, useSearchOne } from '@medplum/react';
 import { IconExternalLink } from '@tabler/icons-react';
 import type { JSX, ReactNode } from 'react';
 import { useEffect, useState } from 'react';
+import { CANDID_CLAIM_URL_BOT_IDENTIFIER, getCandidClaimStatus, isCandidClaimResponse } from '../../utils/candid';
 import { showErrorNotification } from '../../utils/notifications';
-
-// Identifier of the deployed bot that resolves a Candid Health claim portal URL.
-// The URL itself lives in the bot's secrets, so it is never hardcoded here.
-const CANDID_CLAIM_URL_BOT_IDENTIFIER = {
-  system: 'https://medplum.com/integrations/candid-health',
-  value: 'get-candid-claim-portal-url',
-};
-
-// Identifier the send-to-candid bot writes onto the ClaimResponse; its presence marks the
-// claim as a Candid claim and is what the URL bot reads to build the portal link.
-const CANDID_ENCOUNTER_ID_SYSTEM = 'https://candidhealth.com/encounter-id';
 
 interface GetCandidClaimUrlOutput {
   encounterId: string;
@@ -42,14 +32,12 @@ export const ClaimSubmittedPanel = (props: ClaimSubmittedPanelProps): JSX.Elemen
   const [candidUrlLoading, setCandidUrlLoading] = useState(false);
 
   const botId = candidUrlBot?.id;
-  const isCandidClaimResponse = claimResponseResource?.identifier?.some(
-    (id) => id.system === CANDID_ENCOUNTER_ID_SYSTEM
-  );
+  const isCandidClaim = claimResponseResource && isCandidClaimResponse(claimResponseResource);
 
   useEffect(() => {
     let active = true;
 
-    if (!botId || !claimResponseResource || !isCandidClaimResponse) {
+    if (!botId || !claimResponseResource || !isCandidClaim) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setCandidClaimUrl(undefined);
       setCandidUrlLoading(false);
@@ -86,13 +74,16 @@ export const ClaimSubmittedPanel = (props: ClaimSubmittedPanelProps): JSX.Elemen
     return () => {
       active = false;
     };
-  }, [botId, claimResponseResource, isCandidClaimResponse, medplum]);
+  }, [botId, claimResponseResource, isCandidClaim, medplum]);
 
   if (!claimResponseResource) {
     return null;
   }
 
-  const status = 'Submitted';
+  // The get-encounter bot writes the latest Candid claim status (e.g. `waiting_for_provider`) into
+  // the source-claim-status extension; until the first refresh lands the response only reflects
+  // the submission.
+  const status = getCandidClaimStatus(claimResponseResource) ?? 'Submitted';
   const createdAt = claimResponseResource.created;
   const claimAmount = claimResponseResource.total?.reduce((sum, total) => sum + (total.amount?.value ?? 0), 0) ?? 0;
 

--- a/examples/medplum-provider/src/utils/candid.ts
+++ b/examples/medplum-provider/src/utils/candid.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { MedplumClient } from '@medplum/core';
-import type { ClaimResponse } from '@medplum/fhirtypes';
+import type { Claim, ClaimResponse } from '@medplum/fhirtypes';
 
 // Identifier system shared by the deployed Candid Health integration bots. The bots are looked up
 // by identifier so nothing renders (or runs) in projects where they are not deployed.
@@ -34,8 +34,9 @@ export const SOURCE_CLAIM_STATUS_EXTENSION_URL = 'https://medplum.com/fhir/Struc
 // System of the Candid claim status codes (e.g. `waiting_for_provider`, `finalized_paid`).
 export const CANDID_CLAIM_STATUS_SYSTEM = 'https://candidhealth.com/claim-status';
 
-export function getCandidEncounterId(claimResponse: ClaimResponse): string | undefined {
-  return claimResponse.identifier?.find((id) => id.system === CANDID_ENCOUNTER_ID_SYSTEM)?.value;
+// The submit operation writes the Candid encounter id onto both the Claim and its ClaimResponse.
+export function getCandidEncounterId(resource: Claim | ClaimResponse): string | undefined {
+  return resource.identifier?.find((id) => id.system === CANDID_ENCOUNTER_ID_SYSTEM)?.value;
 }
 
 export function getCandidClaimStatus(claimResponse: ClaimResponse): string | undefined {
@@ -45,19 +46,20 @@ export function getCandidClaimStatus(claimResponse: ClaimResponse): string | und
 }
 
 /**
- * Executes the Candid `get-encounter` bot, which refreshes the given ClaimResponse with the
- * latest claim state from Candid Health. The bot takes the Candid encounter ID as input.
- * No-op when the bot is not deployed in the project or the ClaimResponse has no encounter ID.
+ * Executes the Candid `get-encounter` bot, which refreshes the stored ClaimResponse with the
+ * latest claim state from Candid Health. The bot takes the Candid encounter ID as input, which
+ * can come from either the Claim or its ClaimResponse (the submit operation writes it onto both).
+ * No-op when the resource has no Candid encounter ID or the bot is not deployed in the project.
  *
  * @param medplum - The Medplum client.
- * @param claimResponse - The Candid ClaimResponse to refresh.
- * @returns True when the bot ran (the caller should refetch the ClaimResponse), false otherwise.
+ * @param resource - The Claim or ClaimResponse carrying the Candid encounter-id identifier.
+ * @returns True when the bot ran, false otherwise.
  */
 export async function refreshCandidClaimResponse(
   medplum: MedplumClient,
-  claimResponse: ClaimResponse
+  resource: Claim | ClaimResponse
 ): Promise<boolean> {
-  const encounterId = getCandidEncounterId(claimResponse);
+  const encounterId = getCandidEncounterId(resource);
   if (!encounterId) {
     return false;
   }

--- a/examples/medplum-provider/src/utils/candid.ts
+++ b/examples/medplum-provider/src/utils/candid.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { MedplumClient } from '@medplum/core';
+import type { ClaimResponse } from '@medplum/fhirtypes';
+
+// Identifier system shared by the deployed Candid Health integration bots. The bots are looked up
+// by identifier so nothing renders (or runs) in projects where they are not deployed.
+export const CANDID_INTEGRATION_SYSTEM = 'https://medplum.com/integrations/candid-health';
+
+// Bot that resolves a Candid Health claim portal URL. The URL itself lives in the bot's secrets,
+// so it is never hardcoded here.
+export const CANDID_CLAIM_URL_BOT_IDENTIFIER = {
+  system: CANDID_INTEGRATION_SYSTEM,
+  value: 'get-candid-claim-portal-url',
+};
+
+// Bot that pulls the latest encounter state from Candid and refreshes the ClaimResponse.
+export const CANDID_GET_ENCOUNTER_BOT_IDENTIFIER = {
+  system: CANDID_INTEGRATION_SYSTEM,
+  value: 'get-encounter',
+};
+
+// Identifier the send-to-candid bot writes onto the ClaimResponse; its presence marks the
+// claim as a Candid claim.
+export const CANDID_ENCOUNTER_ID_SYSTEM = 'https://candidhealth.com/encounter-id';
+
+export function isCandidClaimResponse(claimResponse: ClaimResponse): boolean {
+  return claimResponse.identifier?.some((id) => id.system === CANDID_ENCOUNTER_ID_SYSTEM) ?? false;
+}
+
+// Extension the get-encounter bot writes the source (Candid) claim status into.
+export const SOURCE_CLAIM_STATUS_EXTENSION_URL = 'https://medplum.com/fhir/StructureDefinition/source-claim-status';
+
+// System of the Candid claim status codes (e.g. `waiting_for_provider`, `finalized_paid`).
+export const CANDID_CLAIM_STATUS_SYSTEM = 'https://candidhealth.com/claim-status';
+
+export function getCandidEncounterId(claimResponse: ClaimResponse): string | undefined {
+  return claimResponse.identifier?.find((id) => id.system === CANDID_ENCOUNTER_ID_SYSTEM)?.value;
+}
+
+export function getCandidClaimStatus(claimResponse: ClaimResponse): string | undefined {
+  return claimResponse.extension
+    ?.find((e) => e.url === SOURCE_CLAIM_STATUS_EXTENSION_URL)
+    ?.valueCodeableConcept?.coding?.find((c) => c.system === CANDID_CLAIM_STATUS_SYSTEM)?.code;
+}
+
+/**
+ * Executes the Candid `get-encounter` bot, which refreshes the given ClaimResponse with the
+ * latest claim state from Candid Health. The bot takes the Candid encounter ID as input.
+ * No-op when the bot is not deployed in the project or the ClaimResponse has no encounter ID.
+ *
+ * @param medplum - The Medplum client.
+ * @param claimResponse - The Candid ClaimResponse to refresh.
+ * @returns True when the bot ran (the caller should refetch the ClaimResponse), false otherwise.
+ */
+export async function refreshCandidClaimResponse(
+  medplum: MedplumClient,
+  claimResponse: ClaimResponse
+): Promise<boolean> {
+  const encounterId = getCandidEncounterId(claimResponse);
+  if (!encounterId) {
+    return false;
+  }
+  const bot = await medplum.searchOne('Bot', {
+    identifier: `${CANDID_GET_ENCOUNTER_BOT_IDENTIFIER.system}|${CANDID_GET_ENCOUNTER_BOT_IDENTIFIER.value}`,
+  });
+  if (!bot?.id) {
+    return false;
+  }
+  await medplum.executeBot(bot.id, { encounterId }, 'application/json');
+  return true;
+}

--- a/examples/medplum-provider/src/utils/stedi.ts
+++ b/examples/medplum-provider/src/utils/stedi.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { ClaimResponse, Coding } from '@medplum/fhirtypes';
+import { SOURCE_CLAIM_STATUS_EXTENSION_URL } from './candid';
+
+// Identifier the Stedi webhook handler writes onto the ClaimResponse; its presence marks the
+// claim as a Stedi claim.
+export const STEDI_CLAIM_IDENTIFIER_SYSTEM = 'https://www.stedi.com/claims';
+
+// System of the X12 claim status category codes (external code list 507, e.g. `A1`, `P1`, `F1`)
+// that the Stedi webhook handler writes into the source-claim-status extension.
+export const X12_CLAIM_STATUS_CATEGORY_SYSTEM = 'https://codesystem.x12.org/external/507';
+
+export function isStediClaimResponse(claimResponse: ClaimResponse): boolean {
+  return claimResponse.identifier?.some((id) => id.system === STEDI_CLAIM_IDENTIFIER_SYSTEM) ?? false;
+}
+
+export function getStediClaimStatus(claimResponse: ClaimResponse): Coding | undefined {
+  return claimResponse.extension
+    ?.find((e) => e.url === SOURCE_CLAIM_STATUS_EXTENSION_URL)
+    ?.valueCodeableConcept?.coding?.find((c) => c.system === X12_CLAIM_STATUS_CATEGORY_SYSTEM);
+}
+
+// X12 507 category codes group by first letter: A* acknowledgements, P* pending,
+// F* finalized, E* errors. Unknown prefixes fall back to the raw code.
+export function formatStediClaimStatus(coding: Coding): string {
+  switch (coding.code?.charAt(0)) {
+    case 'A':
+      return 'Received';
+    case 'P':
+      return 'Pending';
+    case 'F':
+      return 'Finalized';
+    case 'E':
+      return 'Error';
+    default:
+      return coding.code ?? 'Unknown';
+  }
+}


### PR DESCRIPTION
When we pull from Candid to refresh the encounter/claims, the status is also refreshed in the ClaimResponse.
https://github.com/medplum/medplum-ee/pull/977

This PR triggers the refresh and displays the status from Candid.
<img width="667" height="151" alt="Screenshot 2026-08-13 at 12 50 09 PM" src="https://github.com/user-attachments/assets/a794e9ec-7a2d-49fd-b264-2526ed0a320c" />
