### PR TITLE
perf(fhir): skip attachment rewrite when a resource has no attachments

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1075,9 +1075,13 @@ export class Repository extends FhirRepository implements Disposable {
       }
     }
 
-    let updated = await rewriteAttachments(RewriteMode.REFERENCE, this, {
-      ...this.restoreReadonlyFields(validatedResource, existing),
-    });
+    // replaceConditionalReferences rewrites nested references in place, so it needs a resource
+    // that shares no structure with validatedResource or the cached existing resource.
+    let updated = await rewriteAttachments(
+      RewriteMode.REFERENCE,
+      this,
+      deepClone(this.restoreReadonlyFields(validatedResource, existing))
+    );
     updated = await replaceConditionalReferences(this, updated);
 
     const resultMeta: Meta = {

--- a/packages/server/src/fhir/rewrite.test.ts
+++ b/packages/server/src/fhir/rewrite.test.ts
@@ -60,6 +60,50 @@ describe('URL rewrite', () => {
     expect(output).toMatchObject(input);
   });
 
+  test('Returns input unchanged when there are no attachments', async () => {
+    const patient: Patient = {
+      resourceType: 'Patient',
+      name: [{ given: ['Alice'], family: 'Smith' }],
+      extension: [{ url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex', valueCode: 'F' }],
+    };
+
+    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, patient);
+    expect(result).toBe(patient);
+  });
+
+  test('Does not mutate the input when rewriting', async () => {
+    const url = `Binary/${binary.id}`;
+    const practitioner: Practitioner = {
+      resourceType: 'Practitioner',
+      photo: [{ contentType: 'image/jpeg', url }],
+    };
+
+    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, practitioner);
+    expect(result).not.toBe(practitioner);
+    expect(result.photo?.[0].url).not.toBe(url);
+    expect(practitioner.photo?.[0].url).toBe(url);
+  });
+
+  test('Finds attachments nested below a non-binary url property', async () => {
+    const bundle: Bundle = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      entry: [
+        {
+          resource: {
+            resourceType: 'Practitioner',
+            extension: [{ url: 'http://example.com/not-a-binary' }],
+            photo: [{ contentType: 'image/jpeg', url: `Binary/${binary.id}` }],
+          },
+        },
+      ],
+    };
+
+    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, bundle);
+    const photo = (result.entry?.[0].resource as Practitioner).photo?.[0];
+    expect(photo?.url).toContain('Signature');
+  });
+
   test('Other URL', async () => {
     const practitioner: Practitioner = {
       resourceType: 'Practitioner',

--- a/packages/server/src/fhir/rewrite.ts
+++ b/packages/server/src/fhir/rewrite.ts
@@ -43,7 +43,49 @@ export type RewriteMode = (typeof RewriteMode)[keyof typeof RewriteMode];
  * @returns The rewritten value.
  */
 export async function rewriteAttachments<T>(mode: RewriteMode, repo: Repository, input: T): Promise<T> {
+  // Rewriting rebuilds the whole object graph and awaits once per property, which most resources
+  // do not need. The result may therefore be the input itself: callers that mutate it must copy.
+  if (!containsBinaryUrl(input)) {
+    return input;
+  }
   return new Rewriter(mode, repo).rewriteValue(input);
+}
+
+/**
+ * Determines whether a value contains any attachment URL that {@link Rewriter} would rewrite.
+ *
+ * Must mirror the property and `Binary` handling in `Rewriter.rewriteValue`: a false negative
+ * here silently skips a rewrite.
+ * @param input - The input value (object, array, or primitive).
+ * @returns True if the value contains at least one binary URL.
+ */
+function containsBinaryUrl(input: unknown): boolean {
+  if (input === null || typeof input !== 'object') {
+    return false;
+  }
+
+  if (Array.isArray(input)) {
+    return input.some(containsBinaryUrl);
+  }
+
+  if ((input as Resource).resourceType === 'Binary') {
+    return false;
+  }
+
+  for (const key of Object.keys(input)) {
+    const value = (input as Record<string, unknown>)[key];
+    if ((key === 'url' || key === 'path') && typeof value === 'string') {
+      // Extensions put a canonical URL on every element, so test for an actual binary
+      // rather than for the presence of a `url` property.
+      if (normalizeBinaryUrl(value).id) {
+        return true;
+      }
+    } else if (containsBinaryUrl(value)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #10202, which flagged this while tracing the search path. Independent of that PR — no file overlap, branched from `main`.

## Problem

`rewriteAttachments` runs on **every authenticated response** (`packages/server/src/fhir/response.ts`) and on **every WebSocket subscription notification** (`packages/server/src/ws/subscriptions.ts`). `Rewriter.rewriteValue` unconditionally rebuilds the entire object graph — `Object.fromEntries` for every object, a new array for every array — plus one `await` per property, even when the payload contains no attachments at all. Nothing short-circuits, and no attachments is the common case.

## Change

Scan for a binary URL first, and return the input untouched when there is nothing to rewrite. When there is, the existing rewrite path runs unchanged.

## Measurements

benchmark.js against the real `rewriteAttachments`, with app services initialized, over resources created in and read back from the database rather than object literals. Same machine for both columns.

### Search responses

400 real Patients (US Core extensions, identifiers, telecom, address) plus a real `Binary`, read back via `systemRepo.search()` — 254 KB and 272 KB bundles of 200 entries each.

| Case | `main` | this PR | change |
|---|---:|---:|---:|
| PRESIGNED_URL — no attachments | 309 ops/sec (3.24 ms) | **5,048 ops/sec (0.20 ms)** | **16.3x faster** |
| PRESIGNED_URL — with attachments | 179 ops/sec (5.59 ms) | 182 ops/sec (5.49 ms) | no regression |
| REFERENCE — with attachments | 288 ops/sec (3.47 ms) | 315 ops/sec (3.17 ms) | no regression |

### WebSocket subscription notifications

Bundles built by `createSubEventNotification` from a real Patient read back from the database.

| WS notification | `main` | this PR | change |
|---|---:|---:|---:|
| status only (`includeResource=false`, 533 B) | 204,165 ops/sec | **3,340,702 ops/sec** | **16.4x faster** |
| `includeResource`, no attachment (1683 B) | 54,548 ops/sec | **856,202 ops/sec** | **15.7x faster** |
| `includeResource`, with attachment (1774 B) | 304 ops/sec | 328 ops/sec | no regression |

±0.3–8.5% RSD, 42–91 samples per case.

## Why WebSockets benefit most

The multiplier is structural. In `sendSubscriptionEventNotifications` the rewrite sits inside a *nested* loop — once per subscription, then again per connected socket:

```ts
for (const [subscriptionId, options] of subEventArgsArr) {
  const bundle = createSubEventNotification(resource, subscriptionId, options);
  for (const socket of subToWsLookup.get(subscriptionId) ?? EMPTY) {
    ...
    rewrittenBundle = await rewriteAttachments(RewriteMode.PRESIGNED_URL, repo, bundle);
```

The bundle is constructed once per subscription but rebuilt once per **socket**. A single resource change fanning out to N subscriptions with M connected sockets each did N x M full object-graph rebuilds of a payload that, in the overwhelming majority of cases, had nothing to rewrite. That fan-out is precisely where a fixed per-call cost hurts most, and it is per notification rather than per request.

The default case is also the best case: `includeResource` defaults to `false`, so a typical notification is a 533-byte `SubscriptionStatus` carrying only a reference. It cannot contain an attachment, and now costs essentially nothing to pass through.

One consequence worth flagging for review: every socket now receives the *same* bundle object rather than its own deep copy. That is safe as the code stands, because nothing mutates `rewrittenBundle` between the rewrite and `socket.send(JSON.stringify(...))` — but it is the kind of sharing that would bite if per-socket mutation were added later. The attachment case still yields a distinct object per socket, since each socket's repo produces a different presigned URL.

The rest-hook / bot worker path (`workers/subscription.ts`) benefits less: it calls `rewriteAttachments(..., deepClone(versionedResource))`, so the clone cost remains regardless. It still skips the async per-property walk. I left that call site alone — the clone is what isolates the resource before it reaches `execBot` / `sendRestHook`, and removing it needs its own audit.

The benchmark files are not included here — they match `src/**/*.test.ts`, so committing them would add real time and resource creation to every CI test run, and would require adding `benchmark` as a devDependency. Happy to add them under an excluded glob if that is wanted.

## Two things that make this less obvious than it looks

**The predicate cannot be a `url` presence check.** Every FHIR extension carries a `url`, so "does any `url`/`path` property exist?" returns true for essentially any real resource and falls straight through to the slow path. On a US-Core Patient bundle with race/ethnicity extensions the naive check bails immediately. The predicate therefore tests for an actual binary via `normalizeBinaryUrl` — three `startsWith` checks, sync and cheap. There's a test covering an attachment nested below a non-binary `url` property.

**The result may now be the input itself, so callers that mutate it must copy first.** Exactly one did: `replaceConditionalReferences` (`references.ts`) rewrites nested references in place via `parent.value[key] = replacement`, and runs immediately after `rewriteAttachments` on the update path. It was relying on the rewrite having already detached the resource — note the call passed only a *shallow* spread, so without the deep rebuild its nested objects would still be shared with `validatedResource` and the cached `existing` resource. That copy is now explicit at the call site with `deepClone`, which preserves today's semantics exactly.

I audited the other callers: `response.ts`, `auth/me.ts`, `auth/clientinfo.ts`, `auth/utils.ts`, `bulkdata.ts`, and `ws/subscriptions.ts` all only serialize the result. `workers/subscription.ts` already `deepClone`s its input before calling, which corroborates that the copy was never universally relied upon.

`Object.keys` rather than `for...in` in the scan is deliberate: `for...in` benchmarked ~2x faster but trips `guard-for-in`, and 0.45 ms is not worth an eslint-disable.

## Tests

Three new cases in `rewrite.test.ts`: input returned by identity when there are no attachments, input not mutated when rewriting does happen, and an attachment found beneath a non-binary `url` property. Existing rewrite tests unchanged and passing.

Suites run: `rewrite`, `repo`, `batch`, `routes`, `references`, `bulkdata`, `auth/me`, `binary`, `workers/subscription`. `tsc --noEmit`, eslint, and prettier clean.

Note: `repo.test.ts` has 2 pre-existing failures around reader/writer pool routing, and `routes.test.ts` has 4 pre-existing environmental failures (`permission denied for table Patient` on the reader role). Both sets reproduce identically on a clean tree — I diffed the failing-test lists with and without these changes.