### PR TITLE
feat(react): shift-click day ranges on `CalendarDateInput`

### DIFF
--- a/packages/react/src/CalendarDateInput/CalendarDateInput.module.css
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.module.css
@@ -57,6 +57,13 @@
     font-weight: normal;
   }
 
+  & td button.withinRange:not(:disabled),
+  & td button.withinRange:not(:disabled):hover {
+    background-color: var(--mantine-primary-color-light);
+    color: var(--mantine-primary-color-filled);
+    font-weight: 500;
+  }
+
   & td button.selected:not(:disabled),
   & td button.selected:not(:disabled):hover {
     background-color: var(--mantine-primary-color-filled);

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.stories.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.stories.tsx
@@ -6,6 +6,7 @@ import type { JSX } from 'react';
 import { useState } from 'react';
 import { Document } from '../Document/Document';
 import { withMockedDate } from '../stories/decorators';
+import type { DateRange } from './CalendarDateInput';
 import { CalendarDateInput } from './CalendarDateInput';
 
 export default {
@@ -126,6 +127,46 @@ export const CallerOwnedMonth = (): JSX.Element => {
     </Document>
   );
 };
+
+/**
+ * A span of days, swept out by holding shift. Click a day to start again from
+ * it, then shift-click a second day to reach across to it.
+ * @returns The story.
+ */
+export const DayRange = (): JSX.Element => {
+  const [selected, setSelected] = useState<Date | DateRange>();
+  return (
+    <Document>
+      <Text size="sm" c="dimmed" mb="md">
+        {describeSelection(selected)}
+      </Text>
+      <CalendarDateInput
+        availableDates={weekdaysOfMonth()}
+        selected={selected}
+        allowDateRange
+        allowUnavailableDates
+        onChangeMonth={(date: Date) => console.log(date)}
+        onChangeSelected={setSelected}
+        onClick={(date: Date) => console.log('Clicked ' + date)}
+      />
+    </Document>
+  );
+};
+
+/**
+ * Names the current selection for the story's caption.
+ * @param selected - The current selection, which may be absent.
+ * @returns A sentence naming the day or the span.
+ */
+function describeSelection(selected: Date | DateRange | undefined): string {
+  if (!selected) {
+    return 'Shift-click a second day to reach across to it.';
+  }
+  if (selected instanceof Date) {
+    return selected.toLocaleDateString();
+  }
+  return `${selected.start.toLocaleDateString()} — ${selected.end.toLocaleDateString()}`;
+}
 
 /**
  * Returns every weekday of a month.

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.test.tsx
@@ -260,6 +260,180 @@ describe('CalendarDateInput', () => {
 
     expect(screen.getByRole('button', { name: 'Previous month' })).toBeEnabled();
   });
+
+  test('Shift-click sweeps a range out from the selected day', () => {
+    const month = new Date(2026, 6, 1);
+    const onChangeSelected = vi.fn();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        selected={dayOf(month, 10)}
+        allowDateRange
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onChangeSelected={onChangeSelected}
+        onClick={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '14' }), { shiftKey: true });
+
+    expect(onChangeSelected).toHaveBeenCalledWith({ start: dayOf(month, 10), end: dayOf(month, 14) });
+  });
+
+  test('Shift-click back past the anchor still reads earliest day first', () => {
+    const month = new Date(2026, 6, 1);
+    const onChangeSelected = vi.fn();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        selected={dayOf(month, 10)}
+        allowDateRange
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onChangeSelected={onChangeSelected}
+        onClick={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '3' }), { shiftKey: true });
+
+    // A range is a span of days, not a record of which end was clicked first.
+    expect(onChangeSelected).toHaveBeenCalledWith({ start: dayOf(month, 3), end: dayOf(month, 10) });
+  });
+
+  test('Sweeping again measures from where the range began', () => {
+    const month = new Date(2026, 6, 1);
+    const onChangeSelected = vi.fn();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        selected={{ start: dayOf(month, 10), end: dayOf(month, 14) }}
+        allowDateRange
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onChangeSelected={onChangeSelected}
+        onClick={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '20' }), { shiftKey: true });
+
+    expect(onChangeSelected).toHaveBeenCalledWith({ start: dayOf(month, 10), end: dayOf(month, 20) });
+  });
+
+  test('A plain click drops the range and starts again from one day', () => {
+    const month = new Date(2026, 6, 1);
+    const onChangeSelected = vi.fn();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        selected={{ start: dayOf(month, 10), end: dayOf(month, 14) }}
+        allowDateRange
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onChangeSelected={onChangeSelected}
+        onClick={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '20' }));
+
+    expect(onChangeSelected).toHaveBeenCalledWith(dayOf(month, 20));
+  });
+
+  test('Shift-click picks a single day when ranges are not allowed', () => {
+    const month = new Date(2026, 6, 1);
+    const onChangeSelected = vi.fn();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        selected={dayOf(month, 10)}
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onChangeSelected={onChangeSelected}
+        onClick={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '14' }), { shiftKey: true });
+
+    expect(onChangeSelected).toHaveBeenCalledWith(dayOf(month, 14));
+  });
+
+  test('Shift-click with nothing selected yet has no day to measure from', () => {
+    const month = new Date(2026, 6, 1);
+    const onChangeSelected = vi.fn();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        allowDateRange
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onChangeSelected={onChangeSelected}
+        onClick={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '14' }), { shiftKey: true });
+
+    expect(onChangeSelected).toHaveBeenCalledWith(dayOf(month, 14));
+  });
+
+  test('Marks both ends of a range and the days it spans', () => {
+    const month = new Date(2026, 6, 1);
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        selected={{ start: dayOf(month, 10), end: dayOf(month, 13) }}
+        allowDateRange
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onClick={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: '10' }).className).toContain('selected');
+    expect(screen.getByRole('button', { name: '13' }).className).toContain('selected');
+    expect(screen.getByRole('button', { name: '11' }).className).toContain('withinRange');
+    expect(screen.getByRole('button', { name: '11' }).className).not.toContain('selected');
+    expect(screen.getByRole('button', { name: '9' }).className).not.toContain('withinRange');
+    expect(screen.getByRole('button', { name: '14' }).className).not.toContain('withinRange');
+
+    // The days between count as pressed too, not just the two ends.
+    expect(screen.getByRole('button', { name: '10' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: '11' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: '13' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: '14' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('A range reported to onClick is the day clicked, not the span', () => {
+    const month = new Date(2026, 6, 1);
+    const onClick = vi.fn();
+    render(
+      <CalendarDateInput
+        availableDates={[]}
+        month={month}
+        selected={dayOf(month, 10)}
+        allowDateRange
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onChangeSelected={vi.fn()}
+        onClick={onClick}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '14' }), { shiftKey: true });
+
+    expect(onClick).toHaveBeenCalledWith(dayOf(month, 14));
+  });
 });
 
 /**

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.tsx
@@ -2,17 +2,38 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Button, Group } from '@mantine/core';
 import cx from 'clsx';
-import type { JSX } from 'react';
+import type { JSX, MouseEvent } from 'react';
 import { useMemo, useState } from 'react';
 import classes from './CalendarDateInput.module.css';
-import { getMonthString, getStartMonth, isBeforeDay, isSameDay, startOfMonth } from './CalendarDateInput.utils';
+import type { DateRange } from './CalendarDateInput.utils';
+import {
+  getMonthString,
+  getRangeAnchor,
+  getStartMonth,
+  isBeforeDay,
+  isSameDay,
+  isSelectedDay,
+  isWithinDateRange,
+  startOfMonth,
+  toDateRange,
+} from './CalendarDateInput.utils';
+
+export type { DateRange } from './CalendarDateInput.utils';
 
 export interface CalendarDateInputProps {
   readonly availableDates: Date[];
   readonly onChangeMonth: (date: Date) => void;
   readonly onClick: (date: Date) => void;
+  /**
+   * Called with the selection a click leaves behind, for callers holding
+   * `selected`. A plain click reports the day on its own; a shift-click reports
+   * the range swept from the current selection when `allowDateRange` is set.
+   */
+  readonly onChangeSelected?: (selected: Date | DateRange) => void;
   readonly month?: Date;
-  readonly selected?: Date;
+  readonly selected?: Date | DateRange;
+  /** Lets shift-click sweep a range of days out from the selected one. */
+  readonly allowDateRange?: boolean;
   readonly allowUnavailableDates?: boolean;
   readonly earliestDate?: Date;
 }
@@ -25,7 +46,8 @@ interface CalendarCell {
 type OptionalCalendarCell = CalendarCell | undefined;
 
 export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
-  const { onChangeMonth, onClick, selected, allowUnavailableDates, earliestDate } = props;
+  const { onChangeMonth, onClick, onChangeSelected, selected, allowDateRange, allowUnavailableDates, earliestDate } =
+    props;
   const [uncontrolledMonth, setUncontrolledMonth] = useState<Date>(getStartMonth);
   const shownMonth = props.month ?? uncontrolledMonth;
   const year = shownMonth.getFullYear();
@@ -43,6 +65,15 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
 
   function isDayDisabled(day: CalendarCell): boolean {
     return (!day.available && !allowUnavailableDates) || (!!earliestDate && isBeforeDay(day.date, earliestDate));
+  }
+
+  function handleDayClick(date: Date, event: MouseEvent<HTMLButtonElement>): void {
+    onClick(date);
+    if (!onChangeSelected) {
+      return;
+    }
+    const anchor = allowDateRange && event.shiftKey ? getRangeAnchor(selected) : undefined;
+    onChangeSelected(anchor ? toDateRange(anchor, date) : date);
   }
 
   const grid = useMemo(() => buildGrid(month, props.availableDates), [month, props.availableDates]);
@@ -80,24 +111,29 @@ export function CalendarDateInput(props: CalendarDateInputProps): JSX.Element {
         <tbody>
           {grid.map((week, weekIndex) => (
             <tr key={'week-' + weekIndex}>
-              {week.map((day, dayIndex) => (
-                <td key={'day-' + dayIndex}>
-                  {day && (
-                    <Button
-                      variant="light"
-                      className={cx(
-                        day.available && classes.available,
-                        isSameDay(day.date, selected) && classes.selected
-                      )}
-                      aria-pressed={selected ? isSameDay(day.date, selected) : undefined}
-                      disabled={isDayDisabled(day)}
-                      onClick={() => onClick(day.date)}
-                    >
-                      {day.date.getDate()}
-                    </Button>
-                  )}
-                </td>
-              ))}
+              {week.map((day, dayIndex) => {
+                const picked = !!day && isSelectedDay(day.date, selected);
+                const spanned = !!day && isWithinDateRange(day.date, selected);
+                return (
+                  <td key={'day-' + dayIndex}>
+                    {day && (
+                      <Button
+                        variant="light"
+                        className={cx(
+                          day.available && classes.available,
+                          spanned && classes.withinRange,
+                          picked && classes.selected
+                        )}
+                        aria-pressed={selected ? picked || spanned : undefined}
+                        disabled={isDayDisabled(day)}
+                        onClick={(event) => handleDayClick(day.date, event)}
+                      >
+                        {day.date.getDate()}
+                      </Button>
+                    )}
+                  </td>
+                );
+              })}
             </tr>
           ))}
         </tbody>

--- a/packages/react/src/CalendarDateInput/CalendarDateInput.utils.ts
+++ b/packages/react/src/CalendarDateInput/CalendarDateInput.utils.ts
@@ -2,6 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
+ * A span of days, inclusive of both ends.
+ */
+export interface DateRange {
+  readonly start: Date;
+  readonly end: Date;
+}
+
+/**
  * Returns a month display string (e.g. "January 2020").
  * @param date - Any date within the month.
  * @returns The month display string (e.g. "January 2020")
@@ -24,13 +32,22 @@ export function startOfMonth(date: Date): Date {
 }
 
 /**
+ * Returns local midnight on a date's own day.
+ * @param date - Any instant within the day.
+ * @returns The start of that day.
+ */
+export function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+/**
  * Returns whether a day falls before another, ignoring the time of day.
  * @param day - Local midnight of the day in question.
  * @param limit - The instant the day is measured against.
  * @returns True when the day ends before the limit.
  */
 export function isBeforeDay(day: Date, limit: Date): boolean {
-  return day.getTime() < new Date(limit.getFullYear(), limit.getMonth(), limit.getDate()).getTime();
+  return day.getTime() < startOfDay(limit).getTime();
 }
 
 /**
@@ -46,4 +63,65 @@ export function isSameDay(left: Date, right: Date | undefined): boolean {
     left.getMonth() === right.getMonth() &&
     left.getDate() === right.getDate()
   );
+}
+
+/**
+ * Returns whether a selection covers a span of days rather than a single day.
+ * @param selected - The current selection, which may be absent.
+ * @returns True when the selection is a range.
+ */
+export function isDateRange(selected: Date | DateRange | undefined): selected is DateRange {
+  return !!selected && !(selected instanceof Date);
+}
+
+/**
+ * Returns the day a shift-click measures its range from.
+ *
+ * A range keeps its start as the anchor, so repeated shift-clicks move only the
+ * far end instead of the span walking away from where it began.
+ * @param selected - The current selection, which may be absent.
+ * @returns The anchor day, or undefined when nothing is selected yet.
+ */
+export function getRangeAnchor(selected: Date | DateRange | undefined): Date | undefined {
+  if (!selected) {
+    return undefined;
+  }
+  return isDateRange(selected) ? selected.start : selected;
+}
+
+/**
+ * Returns the two days as a range, in the order a calendar reads them.
+ * @param anchor - The day the range is measured from.
+ * @param date - The day the range was swept to, on either side of the anchor.
+ * @returns The range, earliest day first.
+ */
+export function toDateRange(anchor: Date, date: Date): DateRange {
+  return isBeforeDay(startOfDay(date), anchor) ? { start: date, end: anchor } : { start: anchor, end: date };
+}
+
+/**
+ * Returns whether a day is one the selection names outright.
+ * @param day - Local midnight of the day in question.
+ * @param selected - The current selection, which may be absent.
+ * @returns True for the selected day, or for either end of a selected range.
+ */
+export function isSelectedDay(day: Date, selected: Date | DateRange | undefined): boolean {
+  if (isDateRange(selected)) {
+    return isSameDay(day, selected.start) || isSameDay(day, selected.end);
+  }
+  return isSameDay(day, selected);
+}
+
+/**
+ * Returns whether a day falls inside a selected range, between its two ends.
+ * @param day - Local midnight of the day in question.
+ * @param selected - The current selection, which may be absent.
+ * @returns True only for the days a range spans over, never for its ends.
+ */
+export function isWithinDateRange(day: Date, selected: Date | DateRange | undefined): boolean {
+  if (!isDateRange(selected)) {
+    return false;
+  }
+  const time = startOfDay(day).getTime();
+  return time > startOfDay(selected.start).getTime() && time < startOfDay(selected.end).getTime();
 }

--- a/packages/react/src/CalendarInput/CalendarInput.test.tsx
+++ b/packages/react/src/CalendarInput/CalendarInput.test.tsx
@@ -80,4 +80,25 @@ describe('CalendarInput', () => {
     const result = onClick.mock.calls[0][0];
     expect(result.getDate()).toBe(15);
   });
+
+  test('Hands the calendar props through to it', () => {
+    const month = new Date(2026, 6, 1);
+    const onChangeSelected = vi.fn();
+    render(
+      <CalendarInput
+        slots={[]}
+        month={month}
+        selected={new Date(2026, 6, 10)}
+        allowDateRange
+        allowUnavailableDates
+        onChangeMonth={vi.fn()}
+        onChangeSelected={onChangeSelected}
+        onClick={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '14' }), { shiftKey: true });
+
+    expect(onChangeSelected).toHaveBeenCalledWith({ start: new Date(2026, 6, 10), end: new Date(2026, 6, 14) });
+  });
 });

--- a/packages/react/src/CalendarInput/CalendarInput.tsx
+++ b/packages/react/src/CalendarInput/CalendarInput.tsx
@@ -3,14 +3,21 @@
 import type { Slot } from '@medplum/fhirtypes';
 import type { JSX } from 'react';
 import { useMemo } from 'react';
+import type { CalendarDateInputProps } from '../CalendarDateInput/CalendarDateInput';
 import { CalendarDateInput } from '../CalendarDateInput/CalendarDateInput';
 
-export interface CalendarInputProps {
+export interface CalendarInputProps extends Omit<CalendarDateInputProps, 'availableDates'> {
   readonly slots: Slot[];
-  readonly onChangeMonth: (date: Date) => void;
-  readonly onClick: (date: Date) => void;
 }
 
+/**
+ * A calendar of the days a set of Slot resources fall on.
+ * @param props - The calendar props, which are CalendarDateInput's with the
+ * available dates read off Slot resources instead.
+ * @returns The calendar.
+ * @deprecated Use CalendarDateInput instead, mapping slots to their start dates.
+ * This wrapper will be removed in a future major version.
+ */
 export function CalendarInput(props: CalendarInputProps): JSX.Element {
   const { slots, ...rest } = props;
   const availableDates = useMemo(() => slots.map((slot) => new Date(slot.start)), [slots]);


### PR DESCRIPTION
## Summary

Adds range selection to `CalendarDateInput`, and tidies up the relationship between it and `CalendarInput`.

`selected` widens from `Date` to `Date | DateRange`, and a new optional `onChangeSelected` callback reports the selection a click leaves behind:

- a plain click picks the day on its own
- a shift-click sweeps a range out from the current selection, when `allowDateRange` is set

```tsx
const [selected, setSelected] = useState<Date | DateRange>();

<CalendarDateInput
  availableDates={dates}
  selected={selected}
  allowDateRange
  onChangeSelected={setSelected}
  onChangeMonth={setMonth}
  onClick={handleClick}
/>
```

## Notes

**Selection stays fully controlled.** The anchor a shift-click measures from is derived from `selected` rather than held in component state, so a range keeps measuring from its `start` — repeated shift-clicks move only the far end instead of the span walking away from where it began. A range is always returned earliest day first, whichever end was clicked first.

**`onClick` is unchanged.** It still fires with the day clicked, on every click. Callers that do not pass `onChangeSelected` behave exactly as before, so this is additive.

**Styling.** Days a range spans get a new `withinRange` class; the two ends keep the existing `selected` class, so a range end reads the same as a lone selected day.

## `CalendarInput`

`CalendarInputProps` only declared `slots`, `onChangeMonth`, and `onClick`, so it could not pass through `selected`, `month`, `earliestDate`, or `allowUnavailableDates` — it was strictly less capable than the component it wraps. It now extends `CalendarDateInputProps` and forwards everything.

It is also now `@deprecated`. It is a five-line wrapper whose whole job is mapping `Slot.start` to a `Date`; `Scheduler` uses `CalendarDateInput` directly, and there are no other callers in the repo. Deprecating rather than deleting since it has been a public export of `@medplum/react` since 2022 — it can go at the next major.

## Test plan

- [x] `vitest run` — 43 passing across `CalendarDateInput`, `CalendarInput`, `Scheduler`
- [x] New tests cover: sweeping a range, sweeping backwards past the anchor, re-sweeping from an existing range, a plain click collapsing a range, shift-click with `allowDateRange` off, shift-click with nothing selected yet, the rendered classes and `aria-pressed`, and prop forwarding through `CalendarInput`
- [x] `tsc --noEmit`, `eslint`, `prettier`, and a full `npm run build` (api-extractor) all clean
- [ ] New `DayRange` story — worth a look in Storybook

## Follow-up

Keyboard parity is not in this PR. Reaching a range without a mouse wants Shift+Arrow and a roving tabindex, and the current per-day `aria-pressed` boolean is a rough fit for a span. Happy to do it as a follow-up if it is worth the lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)