### PR TITLE
perf(subscriptions): drop redundant deepClone in the subscription worker

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -1149,6 +1149,26 @@ describe('FHIR Repo', () => {
       expect(entries[2].resource).toBeDefined();
     }));
 
+  test('readVersion returns an unshared resource', () =>
+    withTestContext(async () => {
+      const patient = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['Alice'], family: 'Smith' }],
+      });
+      const versionId = patient.meta?.versionId as string;
+
+      // Callers mutate the result of readVersion in place rather than cloning it first,
+      // so each read must return structure that is not shared with any cache or other reader.
+      const first = await systemRepo.readVersion<Patient>('Patient', patient.id, versionId);
+      const second = await systemRepo.readVersion<Patient>('Patient', patient.id, versionId);
+      expect(first).not.toBe(second);
+      expect(first.name).not.toBe(second.name);
+      expect(first.name?.[0]).not.toBe(second.name?.[0]);
+
+      (first.name as object[])[0] = { family: 'Mutated' };
+      expect(second.name?.[0]?.family).toStrictEqual('Smith');
+    }));
+
   test('Restore deleted resource', () =>
     withTestContext(async () => {
       const patient = await systemRepo.createResource<Patient>({

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -7,7 +7,6 @@ import {
   EMPTY,
   Operator,
   createReference,
-  deepClone,
   getExtension,
   getExtensionValue,
   getReferenceString,
@@ -655,7 +654,7 @@ export async function execSubscriptionJob(job: Job<SubscriptionJobData>): Promis
     const versionedResource = await systemRepo.readVersion(resourceType, id, versionId);
     // We use the resource with rewritten attachments here since we want subscribers to get the resource with the same attachment URLs
     // They would get if they did a search
-    rewrittenResource = await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, deepClone(versionedResource));
+    rewrittenResource = await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, versionedResource);
   } catch (err) {
     if (job.attemptsMade < MAX_PREAMBLE_ATTEMPTS) {
       throw err;


### PR DESCRIPTION
**Stacked on #10204** — base is `derrick-rewrite-attachments-perf`, so review that one first. The diff shown here is only this change once GitHub retargets after #10204 merges.

## What

`workers/subscription.ts` cloned the resource before rewriting attachments:

```ts
rewrittenResource = await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, deepClone(versionedResource));
```

The clone copies an object nothing else can observe. Removed.

## Why it is safe

`versionedResource` comes from `systemRepo.readVersion`, which is already a private parse:

- `readVersion` builds its result via `parseHistoryContent(rows[0].content)`, and that is literally `JSON.parse(content)` (`repository/row-builder.ts`).
- `removeHiddenFields` then mutates and returns that same object rather than copying it.
- The cache read inside `readVersion` is only used for the `VREAD` access check; its result is discarded.

So the resource handed to `rewriteAttachments` is freshly parsed per call and referenced by nothing else in the process. Its only consumers are `execBot` and `sendRestHook`, and it is not read after that point — so even if they mutate it, there is no observer.

Worth noting the clone was redundant **before** the fast path in #10204 as well, since `rewriteAttachments` rebuilt the entire object graph on every call regardless. #10204 simply made it the dominant remaining cost on this path, which is what surfaced it.

This is the rest-hook / bot path. The WebSocket notification path is unaffected — it has no clone, and needs none, because the resource reaches it through `JSON.parse` of the Redis pub/sub message in `ws/subscriptions.ts`.

## Guarding the invariant

The removal depends on `readVersion` never handing out shared structure, which is currently an emergent property of "it parses a row" rather than a stated contract. Added a test that pins it:

```ts
const first = await systemRepo.readVersion<Patient>('Patient', patient.id, versionId);
const second = await systemRepo.readVersion<Patient>('Patient', patient.id, versionId);
expect(first).not.toBe(second);
expect(first.name?.[0]).not.toBe(second.name?.[0]);
```

plus a mutation check that writing through one result does not affect the other. If an in-process cache is ever added in front of `readVersion`, this fails and flags every caller that mutates its result in place — which, given `removeHiddenFields` and `restoreReadonlyFields` both mutate, is several.

## Tests

`src/workers/subscription.test.ts` (75 passed, 2 skipped), `src/fhir/repo.test.ts`, `src/ws/subscriptions.test.ts` (34 passed), `src/fhir/operations/execute.test.ts`, `src/bots/utils.test.ts`. `tsc --noEmit`, eslint, prettier clean.

Note: `repo.test.ts` has 2 pre-existing failures around reader/writer pool routing, unrelated to this change and reproducible on a clean tree. `ws/subscriptions.test.ts` failed once for me in a multi-file run and passed 34/34 when run alone — known cross-file pollution in that suite, not this change.