### PR TITLE
Add PDex network-reference SearchParameter

### DIFF
--- a/packages/core/src/search/details.test.ts
+++ b/packages/core/src/search/details.test.ts
@@ -71,6 +71,17 @@ describe('SearchParameterDetails', () => {
     expect(details.type).toStrictEqual(SearchParameterType.REFERENCE);
   });
 
+  test('Get reference details for extension value', () => {
+    const networkReferenceParam = searchParams.find(
+      (e) => e.id === 'PractitionerRole-davinci-pdex-network-reference'
+    ) as SearchParameter;
+    const details = getSearchParameterDetails('PractitionerRole', networkReferenceParam);
+    expect(details).toBeDefined();
+    expect(details.type).toStrictEqual(SearchParameterType.REFERENCE);
+    expect(details.array).toStrictEqual(true);
+    expect(details.referenceTargetTypes).toStrictEqual(['Organization']);
+  });
+
   test('Missing expression for resource type', () => {
     const missingExpressionParam: SearchParameter = {
       resourceType: 'SearchParameter',

--- a/packages/definitions/src/fhir/r4/search-parameters-medplum.json
+++ b/packages/definitions/src/fhir/r4/search-parameters-medplum.json
@@ -1456,6 +1456,24 @@
       }
     },
     {
+      "fullUrl": "https://medplum.com/fhir/SearchParameter/PractitionerRole-davinci-pdex-network-reference",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "PractitionerRole-davinci-pdex-network-reference",
+        "url": "https://medplum.com/fhir/SearchParameter/PractitionerRole-davinci-pdex-network-reference",
+        "version": "4.0.1",
+        "name": "davinci-pdex-network-reference",
+        "status": "draft",
+        "publisher": "Medplum",
+        "description": "The healthcare provider insurance networks the practitioner participates in through their role",
+        "code": "network-reference",
+        "base": ["PractitionerRole"],
+        "type": "reference",
+        "expression": "PractitionerRole.extension.where(url='http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/network-reference').value.ofType(Reference)",
+        "target": ["Organization"]
+      }
+    },
+    {
       "fullUrl" : "http://hl7.org/fhir/SearchParameter/Immunization-encounter",
       "resource" : {
         "resourceType" : "SearchParameter",

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -333,8 +333,9 @@ export class Repository extends FhirRepository implements Disposable {
    *                Login.preAuthorizedCodeHash (https://github.com/medplum/medplum/pull/9231)
    *                Project.link (https://github.com/medplum/medplum/pull/9159)
    * 16. 06/30/26 - Added search param: Provenance-activity (https://github.com/medplum/medplum/pull/9709)
+   * 17. 08/15/26 - Added search param: PractitionerRole-network-reference
    */
-  static readonly VERSION: number = 16;
+  static readonly VERSION: number = 17;
 
   /**
    * Constructs a new Repository instance.

--- a/packages/server/src/fhir/search-params.test.ts
+++ b/packages/server/src/fhir/search-params.test.ts
@@ -1,7 +1,16 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { createReference, getReferenceString, Operator } from '@medplum/core';
-import type { Appointment, DiagnosticReport, Flag, Patient, Practitioner, Slot } from '@medplum/fhirtypes';
+import type {
+  Appointment,
+  DiagnosticReport,
+  Flag,
+  Organization,
+  Patient,
+  Practitioner,
+  PractitionerRole,
+  Slot,
+} from '@medplum/fhirtypes';
 import { randomUUID } from 'node:crypto';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
@@ -369,5 +378,43 @@ describe('Medplum Custom Search Parameters', () => {
 
       expect(result.entry).toHaveLength(1);
       expect(result.entry?.[0]?.resource).toMatchObject(practitioner1);
+    }));
+
+  test('Search for PractitionerRole by Da Vinci PDex network-reference', () =>
+    withTestContext(async () => {
+      const networkReferenceUrl =
+        'http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/network-reference';
+
+      const network1 = await repo.createResource<Organization>({
+        resourceType: 'Organization',
+        name: 'ACME Preferred Provider Network',
+      });
+      expect(network1).toBeDefined();
+
+      const network2 = await repo.createResource<Organization>({
+        resourceType: 'Organization',
+        name: 'ACME Premium Preferred Provider Network',
+      });
+      expect(network2).toBeDefined();
+
+      const role1 = await repo.createResource<PractitionerRole>({
+        resourceType: 'PractitionerRole',
+        extension: [{ url: networkReferenceUrl, valueReference: createReference(network1) }],
+      });
+      expect(role1).toBeDefined();
+
+      const role2 = await repo.createResource<PractitionerRole>({
+        resourceType: 'PractitionerRole',
+        extension: [{ url: networkReferenceUrl, valueReference: createReference(network2) }],
+      });
+      expect(role2).toBeDefined();
+
+      const result = await repo.search({
+        resourceType: 'PractitionerRole',
+        filters: [{ code: 'network-reference', operator: Operator.EQUALS, value: getReferenceString(network1) }],
+      });
+
+      expect(result.entry).toHaveLength(1);
+      expect(result.entry?.[0]?.resource).toMatchObject(role1);
     }));
 });

--- a/packages/server/src/migrations/data/data-version-manifest.json
+++ b/packages/server/src/migrations/data/data-version-manifest.json
@@ -153,5 +153,8 @@
   },
   "v41": {
     "serverVersion": "5.1.27"
+  },
+  "v42": {
+    "serverVersion": "5.1.28"
   }
 }

--- a/packages/server/src/migrations/data/index.ts
+++ b/packages/server/src/migrations/data/index.ts
@@ -50,3 +50,4 @@ export * as v38 from './v38';
 export * as v39 from './v39';
 export * as v40 from './v40';
 export * as v41 from './v41';
+export * as v42 from './v42';

--- a/packages/server/src/migrations/data/v42.ts
+++ b/packages/server/src/migrations/data/v42.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
+
+import type { PoolClient } from 'pg';
+import { prepareCustomMigrationJobData, runCustomMigration } from '../../workers/post-deploy-migration';
+import * as fns from '../migrate-functions';
+import type { MigrationActionResult } from '../types';
+import type { CustomPostDeployMigration } from './types';
+
+export const migration: CustomPostDeployMigration = {
+  type: 'custom',
+  prepareJobData: (asyncJob) => prepareCustomMigrationJobData(asyncJob),
+  run: async (repo, job, jobData) => runCustomMigration(repo, job, jobData, callback),
+};
+
+// prettier-ignore
+async function callback(client: PoolClient, results: MigrationActionResult[]): Promise<void> {
+  await fns.idempotentCreateIndex(client, results, 'PractitionerRole_networkReference_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "PractitionerRole_networkReference_idx" ON "PractitionerRole" USING gin ("networkReference")`);
+}

--- a/packages/server/src/migrations/schema/v112.ts
+++ b/packages/server/src/migrations/schema/v112.ts
@@ -12,4 +12,6 @@ import * as fns from '../migrate-functions';
 export async function run(client: PoolClient): Promise<void> {
   const results: { name: string; durationMs: number }[] = []
   await fns.query(client, results, `DROP INDEX CONCURRENTLY IF EXISTS "ConceptMapping_map_source_target_idx"`);
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "PractitionerRole" ADD COLUMN IF NOT EXISTS "networkReference" TEXT[]`);
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "PractitionerRole" ADD COLUMN IF NOT EXISTS "__networkReferenceIdentifierSort" TEXT`);
 }


### PR DESCRIPTION
## Summary

Adds built-in support for the Da Vinci PDex Plan-Net `network-reference` extension on `PractitionerRole`.

This enables searches such as:

`GET /PractitionerRole?network-reference=Organization/<network-id>`

## Changes

- Add `PractitionerRole-davinci-pdex-network-reference` SearchParameter
- Add schema/data migrations for indexed search support
- Bump repository index version for reindexing
- Add core SearchParameter detail coverage
- Add server search coverage for `PractitionerRole?network-reference=...`

## Tests

`npm test -- src/fhir/search-params.test.ts`

Result: 7 passed / 7

Closes #10010