### PR TITLE
build: dedupe js-yaml onto the latest 4.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9281,13 +9281,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -9304,29 +9297,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
@@ -28416,10 +28386,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "trailingComma": "es5"
   },
   "overrides": {
+    "@microsoft/api-documenter": {
+      "js-yaml": "4.3.1"
+    },
     "adm-zip": "0.6.0",
     "esbuild": "0.28.2",
     "typescript": "6.0.3",


### PR DESCRIPTION
Stacked on #10225 (nyc removal) — review/merge that first.

`js-yaml` is not a direct dependency of any package here and is not imported from any source file; it arrives transitively. Before this change it resolved three ways:

| copy | version |
| --- | --- |
| `node_modules/js-yaml` (docusaurus, cosmiconfig, fhirpath, api-documenter) | `4.1.1` |
| `@eslint/eslintrc/node_modules/js-yaml` | `4.3.1` |
| `@kubernetes/client-node/node_modules/js-yaml` | `5.3.0` |

The hoisted copy was held back at `4.1.1` by a single consumer: `@microsoft/api-documenter`, which asks for `~4.1.0`. Every other 4.x consumer allows `^4.1.0` / `^4.1.1` / `^4.3.0`, so overriding just that one lets the whole 4.x line dedupe onto the latest 4.x:

```json
"@microsoft/api-documenter": {
  "js-yaml": "4.3.1"
}
```

Result is two copies instead of three — one `4.3.1` for everything on the 4.x line, and `@kubernetes/client-node` left alone on `5.3.0`, since it genuinely depends on `^5.1.0` and shouldn't be forced across a major boundary.
