### PR TITLE
fix(ci): require Redis password to match local config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,8 +371,9 @@ jobs:
           - 5432:5432
       redis:
         image: redis:${{ matrix.redis-version }}
+        command: redis-server --requirepass medplum
         options: >-
-          --health-cmd "redis-cli ping"
+          --health-cmd "redis-cli --no-auth-warning -a medplum ping"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -429,7 +430,6 @@ jobs:
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
-          REDIS_PASSWORD_DISABLED_IN_TESTS: 1
           SERVER_TEST_CACHE_KEY: NODE${{ matrix.node-version }}-PG${{ matrix.pg-version }}-REDIS${{ matrix.redis-version }}
           NO_COVERAGE: ${{ case(matrix.node-version == 22 && matrix.pg-version == 14 && matrix.redis-version == 7, '', '1') }}
 
@@ -533,8 +533,9 @@ jobs:
           - 5432:5432
       redis:
         image: redis:${{ matrix.redis-version }}
+        command: redis-server --requirepass medplum
         options: >-
-          --health-cmd "redis-cli ping"
+          --health-cmd "redis-cli --no-auth-warning -a medplum ping"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -591,8 +592,6 @@ jobs:
       - name: Build Medplum
         run: npm run build:fast
       - name: Smoke test npm run dev
-        env:
-          REDIS_PASSWORD_DISABLED_IN_TESTS: 1
         run: |
           pushd packages/server
           setsid npm run dev > server-dev.log 2>&1 &
@@ -628,8 +627,6 @@ jobs:
           # last resort if something is still listening
           kill -9 -- "-$SERVER_PID" 2>/dev/null || true
       - name: Start server and app
-        env:
-          REDIS_PASSWORD_DISABLED_IN_TESTS: 1
         run: |
           pushd packages/server
           npm start > server.log 2>&1 &

--- a/packages/server/src/config/loader.ts
+++ b/packages/server/src/config/loader.ts
@@ -139,7 +139,6 @@ export async function loadTestConfig(): Promise<MedplumServerConfig> {
     password: 'medplum_test_readonly',
   };
   config.redis.db = 7; // Select logical DB `7` so we don't collide with existing dev Redis cache.
-  config.redis.password = process.env['REDIS_PASSWORD_DISABLED_IN_TESTS'] ? undefined : config.redis.password;
   // leave cacheRedis on the default DB
   config.rateLimitRedis = {
     ...config.redis,

--- a/packages/server/turbo.json
+++ b/packages/server/turbo.json
@@ -12,7 +12,7 @@
       "dependsOn": ["test:seed"],
       "outputs": ["coverage/**"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts"],
-      "env": ["REDIS_PASSWORD_DISABLED_IN_TESTS", "POSTGRES_HOST", "POSTGRES_PORT", "SERVER_TEST_CACHE_KEY"]
+      "env": ["POSTGRES_HOST", "POSTGRES_PORT", "SERVER_TEST_CACHE_KEY"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- CI Redis now uses `--requirepass medplum`, matching docker-compose and `medplum.config.json`, so unit tests and e2e `npm run dev` AUTH the same way.
- Removes `REDIS_PASSWORD_DISABLED_IN_TESTS`, which only stripped the password in `loadTestConfig()` and left e2e smoke tests sending a password to an open Redis (the `Unhandled Redis error` AUTH warning).
- 