### PR TITLE
Preauthorize code: fix ClientApplication read

### DIFF
--- a/packages/server/src/auth/preauthorize.test.ts
+++ b/packages/server/src/auth/preauthorize.test.ts
@@ -120,4 +120,40 @@ describe('Pre-authorize', () => {
     expect(res.body.expiresAt).toBeDefined();
     expect(res.body.code).toBeUndefined();
   });
+
+  test('Succeeds when on-behalf-of user cannot read ClientApplication', async () => {
+    // AccessPolicy that allows Patient only — no ClientApplication.
+    // Minting must not depend on the target user's ability to read ClientApplication.
+    const restrictedAccount = await withTestContext(() =>
+      addTestUser(project, {
+        accessPolicy: {
+          resourceType: 'AccessPolicy',
+          resource: [{ resourceType: 'Patient' }],
+        },
+      })
+    );
+
+    const res = await request(app)
+      .post('/auth/preauthorize')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('X-Medplum-On-Behalf-Of', getReferenceString(restrictedAccount.profile))
+      .type('json')
+      .send({ clientId: client.id });
+    expect(res).toHaveStatus(200);
+    expect(res.body.preAuthorizedCode).toBeDefined();
+    expect(res.body.expiresAt).toBeDefined();
+  });
+
+  test('Rejects ClientApplication from another project', async () => {
+    const other = await withTestContext(() => createTestProject({ withClient: true }));
+
+    const res = await request(app)
+      .post('/auth/preauthorize')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount.profile))
+      .type('json')
+      .send({ clientId: other.client.id });
+    expect(res).toHaveStatus(404);
+    expect(res.body).toMatchObject(notFound);
+  });
 });

--- a/packages/server/src/auth/preauthorize.ts
+++ b/packages/server/src/auth/preauthorize.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { badRequest, createReference, forbidden, OperationOutcomeError } from '@medplum/core';
+import { badRequest, createReference, forbidden, notFound, OperationOutcomeError } from '@medplum/core';
 import type { ClientApplication, Login } from '@medplum/fhirtypes';
 import type { Request, Response } from 'express';
 import { body } from 'express-validator';
@@ -32,12 +32,20 @@ export async function preAuthorizeHandler(req: Request, res: Response): Promise<
     throw new OperationOutcomeError(badRequest('Pre-authorization requires onBehalfOfMembership'));
   }
 
+  // X-Medplum-On-Behalf-Of rebuilds the request repo as the target membership's AccessPolicy.
+  // Resolve ClientApplication with the admin/system repo so minting does not require the target
+  // user to be able to read ClientApplication (e.g. RelatedPerson magic-link flows).
+  const systemRepo = repo.getSystemRepo();
+  const client = await systemRepo.readResource<ClientApplication>('ClientApplication', req.body.clientId);
+  if (client.meta?.project !== project.id) {
+    throw new OperationOutcomeError(notFound);
+  }
+
   const preAuthorizedCode = generateSecret(128);
   const preAuthorizedCodeHash = createHash('sha256').update(preAuthorizedCode).digest('hex');
   const expiresIn = req.body.expiresIn ?? DEFAULT_PRE_AUTH_CODE_TTL;
   const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
-  const client = await repo.readResource<ClientApplication>('ClientApplication', req.body.clientId);
-  await repo.getSystemRepo().createResource<Login>({
+  await systemRepo.createResource<Login>({
     resourceType: 'Login',
     authMethod: 'pre-authorized',
     project: createReference(project),


### PR DESCRIPTION
Currently, if the user attempting to generate a preauthorize code does not have access to the ClientApplication, it will run into a forbidden error. 

This fix reads the ClientApplication via systemRepo, so that the user does not need to have access to the ClientApplication resource in order to properly generate the preauthorize code. 