### PR TITLE
Complete  FHIR Profile validator

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,7 @@ export * from './typeschema/crawler';
 export * from './typeschema/slices';
 export * from './typeschema/types';
 export * from './typeschema/validation';
+export * from './typeschema/valuesets';
 export * from './utils';
 export * from './version-utils';
 export * from './websockets/reconnecting-websocket';

--- a/packages/core/src/typeschema/slices.ts
+++ b/packages/core/src/typeschema/slices.ts
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { TypedValue } from '../types';
-import { getNestedProperty } from './crawler';
 import type { InternalTypeSchema, SliceDefinition, SliceDiscriminator } from './types';
-import { matchDiscriminant } from './validation';
+import { matchDiscriminatorOnParent } from './validation';
 
 export type SliceDefinitionWithTypes = SliceDefinition & {
   type: NonNullable<SliceDefinition['type']>;
@@ -20,15 +19,13 @@ function isDiscriminatorComponentMatch(
   slice: SliceDefinitionWithTypes,
   profileUrl: string | undefined
 ): boolean {
-  const nestedProp = getNestedProperty(typedValue, discriminator.path, { profileUrl });
-
-  if (nestedProp) {
-    const elements = slice.typeSchema?.elements ?? slice.elements;
-    return nestedProp.some((v: any) => matchDiscriminant(v, discriminator, slice, elements)) ?? false;
-  }
-
-  console.assert(false, 'getNestedProperty[%s] in isDiscriminatorComponentMatch missed', discriminator.path);
-  return false;
+  return matchDiscriminatorOnParent(
+    typedValue,
+    discriminator,
+    slice,
+    slice.typeSchema?.elements ?? slice.elements,
+    profileUrl
+  );
 }
 
 export function getValueSliceName(

--- a/packages/core/src/typeschema/types.ts
+++ b/packages/core/src/typeschema/types.ts
@@ -383,11 +383,19 @@ class StructureDefinitionParser {
     }
     field.slicing = {
       discriminator: (element.slicing?.discriminator ?? []).map((d) => {
-        if (d.type !== 'value' && d.type !== 'pattern' && d.type !== 'type') {
+        // FHIR R4 DiscriminatorType: value | exists | pattern | type | profile
+        // See: https://hl7.org/fhir/R4/codesystem-discriminator-type.html
+        if (
+          d.type !== 'value' &&
+          d.type !== 'exists' &&
+          d.type !== 'pattern' &&
+          d.type !== 'type' &&
+          d.type !== 'profile'
+        ) {
           throw new Error(`Unsupported slicing discriminator type: ${d.type}`);
         }
         return {
-          path: d.path,
+          path: d.path as string,
           type: d.type,
         };
       }),

--- a/packages/core/src/typeschema/validation.test.ts
+++ b/packages/core/src/typeschema/validation.test.ts
@@ -43,7 +43,10 @@ import { generateId } from '../crypto';
 import { OperationOutcomeError, validationError } from '../outcomes';
 import { createReference, deepClone } from '../utils';
 import { indexStructureDefinitionBundle, loadDataType } from './types';
-import { validateResource, validateTypedValue } from './validation';
+import type { SliceDefinition } from './types';
+import { matchDiscriminant, validateResource, validateTypedValue } from './validation';
+import { clearValueSets, loadValueSet } from './valuesets';
+import { toTypedValue } from '../fhirpath/utils';
 
 const VALID_BP: Observation = {
   resourceType: 'Observation',
@@ -771,10 +774,28 @@ describe('FHIR resource validation', () => {
       expect(() => validateResource(conditionNoCategory, { profile: healthConcernsProfile })).toThrow();
     });
 
-    // Slicing by ValueSet not supported without async validation. Ideally validating this resource would fail,
-    // but it must pass for now to make it possible to save resources against profiles using ValueSet slicing
-    // like https://hl7.org/fhir/us/core/STU5.0.1/StructureDefinition-us-core-condition-problems-health-concerns.html
-    test.fails('Populated but missing required Condition.category', () => {
+    // Slicing by required ValueSet binding (FHIR R4 profiling §discriminator).
+    // With the ValueSet loaded, a category outside the bound set must not match
+    // the required `us-core` slice.
+    test('Populated but missing required Condition.category', () => {
+      loadValueSet({
+        resourceType: 'ValueSet',
+        url: 'http://hl7.org/fhir/us/core/ValueSet/us-core-problem-or-health-concern',
+        status: 'active',
+        compose: {
+          include: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/condition-category',
+              concept: [{ code: 'problem-list-item' }],
+            },
+            {
+              system: 'http://hl7.org/fhir/us/core/CodeSystem/condition-category',
+              concept: [{ code: 'health-concern' }],
+            },
+          ],
+        },
+      });
+
       const conditionWrongCategory = deepClone(baseCondition);
       conditionWrongCategory.category = [
         {
@@ -2058,6 +2079,201 @@ describe('FHIR resource validation', () => {
         )
       )
     );
+  });
+});
+
+describe('FHIR R4 discriminator types', () => {
+  afterEach(() => {
+    clearValueSets();
+  });
+
+  test('exists discriminator matches presence vs absence', () => {
+    const presentSlice: SliceDefinition = {
+      name: 'withPeriod',
+      path: 'Patient.identifier',
+      description: '',
+      min: 1,
+      max: 1,
+      type: [{ code: 'Identifier' }],
+      elements: {
+        period: {
+          description: '',
+          path: 'Patient.identifier.period',
+          min: 1,
+          max: 1,
+          type: [{ code: 'Period' }],
+        },
+      },
+    };
+    const absentSlice: SliceDefinition = {
+      name: 'withoutPeriod',
+      path: 'Patient.identifier',
+      description: '',
+      min: 0,
+      max: 1,
+      type: [{ code: 'Identifier' }],
+      elements: {
+        period: {
+          description: '',
+          path: 'Patient.identifier.period',
+          min: 0,
+          max: 0,
+          type: [{ code: 'Period' }],
+        },
+      },
+    };
+    const discriminator = { type: 'exists', path: 'period' };
+
+    expect(
+      matchDiscriminant(toTypedValue({ start: '2020-01-01' }), discriminator, presentSlice, presentSlice.elements)
+    ).toBe(true);
+    expect(matchDiscriminant(undefined, discriminator, presentSlice, presentSlice.elements)).toBe(false);
+
+    expect(matchDiscriminant(undefined, discriminator, absentSlice, absentSlice.elements)).toBe(true);
+    expect(
+      matchDiscriminant(toTypedValue({ start: '2020-01-01' }), discriminator, absentSlice, absentSlice.elements)
+    ).toBe(false);
+  });
+
+  test('profile discriminator matches loaded profile conformance', () => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+
+    const patientProfileA: StructureDefinition = {
+      resourceType: 'StructureDefinition',
+      url: 'http://example.org/StructureDefinition/patient-profile-a',
+      name: 'PatientProfileA',
+      status: 'active',
+      kind: 'resource',
+      abstract: false,
+      type: 'Patient',
+      baseDefinition: 'http://hl7.org/fhir/StructureDefinition/Patient',
+      derivation: 'constraint',
+      snapshot: {
+        element: [
+          { id: 'Patient', path: 'Patient', min: 0, max: '*' },
+          {
+            id: 'Patient.active',
+            path: 'Patient.active',
+            min: 1,
+            max: '1',
+            type: [{ code: 'boolean' }],
+          },
+        ],
+      },
+    };
+    loadDataType(patientProfileA);
+
+    const slice: SliceDefinition = {
+      name: 'profileA',
+      path: 'Bundle.entry',
+      description: '',
+      min: 1,
+      max: 1,
+      type: [{ code: 'BackboneElement' }],
+      elements: {
+        resource: {
+          description: '',
+          path: 'Bundle.entry.resource',
+          min: 1,
+          max: 1,
+          type: [
+            {
+              code: 'Patient',
+              profile: ['http://example.org/StructureDefinition/patient-profile-a'],
+            },
+          ],
+        },
+      },
+    };
+    const discriminator = { type: 'profile', path: 'resource' };
+
+    const conforming = toTypedValue({ resourceType: 'Patient', active: true });
+    conforming.type = 'Patient';
+    expect(matchDiscriminant(conforming, discriminator, slice, slice.elements)).toBe(true);
+
+    const nonConforming = toTypedValue({ resourceType: 'Patient', gender: 'male' });
+    nonConforming.type = 'Patient';
+    expect(matchDiscriminant(nonConforming, discriminator, slice, slice.elements)).toBe(false);
+  });
+
+  test('profile discriminator falls back to meta.profile when schema not loaded', () => {
+    const slice: SliceDefinition = {
+      name: 'asserted',
+      path: 'Bundle.entry',
+      description: '',
+      min: 0,
+      max: 1,
+      type: [{ code: 'BackboneElement' }],
+      elements: {
+        resource: {
+          description: '',
+          path: 'Bundle.entry.resource',
+          min: 1,
+          max: 1,
+          type: [
+            {
+              code: 'Patient',
+              profile: ['http://example.org/StructureDefinition/unloaded-profile'],
+            },
+          ],
+        },
+      },
+    };
+    const discriminator = { type: 'profile', path: 'resource' };
+
+    const asserted = toTypedValue({
+      resourceType: 'Patient',
+      meta: { profile: ['http://example.org/StructureDefinition/unloaded-profile'] },
+    });
+    asserted.type = 'Patient';
+    expect(matchDiscriminant(asserted, discriminator, slice, slice.elements)).toBe(true);
+
+    const notAsserted = toTypedValue({ resourceType: 'Patient' });
+    notAsserted.type = 'Patient';
+    expect(matchDiscriminant(notAsserted, discriminator, slice, slice.elements)).toBe(false);
+  });
+
+  test('value discriminator with required ValueSet binding matches extensional codes', () => {
+    loadValueSet({
+      resourceType: 'ValueSet',
+      url: 'http://example.org/ValueSet/telecom-systems',
+      status: 'active',
+      compose: {
+        include: [
+          {
+            system: 'http://hl7.org/fhir/contact-point-system',
+            concept: [{ code: 'phone' }, { code: 'email' }],
+          },
+        ],
+      },
+    });
+
+    const slice: SliceDefinition = {
+      name: 'allowed',
+      path: 'Patient.telecom',
+      description: '',
+      min: 1,
+      max: Number.POSITIVE_INFINITY,
+      type: [{ code: 'ContactPoint' }],
+      elements: {
+        system: {
+          description: '',
+          path: 'Patient.telecom.system',
+          min: 1,
+          max: 1,
+          type: [{ code: 'code' }],
+          binding: {
+            strength: 'required',
+            valueSet: 'http://example.org/ValueSet/telecom-systems',
+          },
+        },
+      },
+    };
+    const discriminator = { type: 'value', path: 'system' };
+
+    expect(matchDiscriminant(toTypedValue('email'), discriminator, slice, slice.elements)).toBe(true);
+    expect(matchDiscriminant(toTypedValue('fax'), discriminator, slice, slice.elements)).toBe(false);
   });
 });
 

--- a/packages/core/src/typeschema/validation.ts
+++ b/packages/core/src/typeschema/validation.ts
@@ -28,7 +28,8 @@ import type {
   SliceDiscriminator,
   SlicingRules,
 } from './types';
-import { getDataType, isResourceType, parseStructureDefinition } from './types';
+import { getDataType, isResourceType, parseStructureDefinition, tryGetProfile } from './types';
+import { typedValueInValueSet } from './valuesets';
 
 /*
  * This file provides schema validation utilities for FHIR JSON objects.
@@ -109,6 +110,12 @@ const skippedConstraintKeys: Record<string, boolean> = {
 
 export interface ValidatorOptions {
   profile?: StructureDefinition;
+  /**
+   * Canonical URL of a previously loaded profile (`loadDataType`).
+   * Used when validating against an indexed profile schema without re-parsing
+   * a StructureDefinition resource (e.g. profile discriminator matching).
+   */
+  profileUrl?: string;
   collect?: {
     tokens?: Record<string, TypedValueWithPath[]>;
   };
@@ -141,10 +148,12 @@ class ResourceValidator implements CrawlerVisitor {
     if (isResource(typedValue.value)) {
       this.resourceStack.push(typedValue.value);
     }
-    if (!options?.profile) {
-      this.schema = getDataType(typedValue.type);
-    } else {
+    if (options?.profile) {
       this.schema = parseStructureDefinition(options.profile);
+    } else if (options?.profileUrl) {
+      this.schema = getDataType(typedValue.type, options.profileUrl);
+    } else {
+      this.schema = getDataType(typedValue.type);
     }
     this.base64BinaryMaxBytes = options?.base64BinaryMaxBytes ?? 1 * 1024 * 1024;
     this.collect = options?.collect;
@@ -681,17 +690,47 @@ function matchesSpecifiedValue(value: TypedValue | TypedValue[], element: Intern
   return true;
 }
 
+/**
+ * Resolves a discriminator path on a parent value and tests slice membership.
+ * Shared by resource validation and schema-crawler slice matching.
+ * @param parent - The parent typed value (slice candidate).
+ * @param discriminator - The discriminator to apply.
+ * @param slice - The slice definition to test against.
+ * @param elements - Optional element map override (defaults to slice.elements).
+ * @param profileUrl - Optional profile URL for nested property resolution.
+ * @returns True if the parent matches this discriminator for the slice.
+ */
+export function matchDiscriminatorOnParent(
+  parent: TypedValue,
+  discriminator: SliceDiscriminator,
+  slice: SliceDefinition,
+  elements?: Record<string, InternalSchemaElement>,
+  profileUrl?: string
+): boolean {
+  const resolved = arrayify(getNestedProperty(parent, discriminator.path, { profileUrl }));
+  const elems = elements ?? slice.elements;
+
+  if (discriminator.type === 'exists') {
+    if (!resolved?.length) {
+      return matchDiscriminant(undefined, discriminator, slice, elems);
+    }
+    // A single resolved node may itself be an array-valued property; pass it
+    // through so presence means "non-empty". Multiple nodes: any match wins.
+    if (resolved.length === 1) {
+      return matchDiscriminant(resolved[0] as TypedValue | TypedValue[] | undefined, discriminator, slice, elems);
+    }
+    return resolved.some((v) => matchDiscriminant(v as TypedValue | undefined, discriminator, slice, elems));
+  }
+
+  return resolved?.some((v) => matchDiscriminant(v, discriminator, slice, elems)) ?? false;
+}
+
 export function matchDiscriminant(
   value: TypedValue | TypedValue[] | undefined,
   discriminator: SliceDiscriminator,
   slice: SliceDefinition,
   elements?: Record<string, InternalSchemaElement>
 ): boolean {
-  if (Array.isArray(value)) {
-    // Only single values can match
-    return false;
-  }
-
   let sliceElement: InternalSchemaElement | undefined;
   if (discriminator.path === '$this') {
     sliceElement = slice;
@@ -702,7 +741,11 @@ export function matchDiscriminant(
   const sliceType = slice.type;
   switch (discriminator.type) {
     case 'value':
-    case 'pattern':
+    case 'pattern': {
+      if (Array.isArray(value)) {
+        // Only single values can match value/pattern discriminators
+        return false;
+      }
       if (!value || !sliceElement) {
         return false;
       }
@@ -713,30 +756,127 @@ export function matchDiscriminant(
         return deepEquals(value, sliceElement.fixed);
       }
 
+      // FHIR R4: value/pattern discriminators may also distinguish slices via a
+      // required binding to an extensional ValueSet.
+      // See: https://hl7.org/fhir/R4/profiling.html#discriminator
       if (sliceElement.binding?.strength === 'required' && sliceElement.binding.valueSet) {
-        // This cannot be implemented correctly without asynchronous validation, so make it permissive for now.
-        // Ideally this should check something like value.value.coding.some((code) => isValidCode(sliceElement.binding.valueSet, code))
-        // where isValidCode is a function that checks if the code is included in the expansion of the ValueSet
+        const inSet = typedValueInValueSet(value, sliceElement.binding.valueSet);
+        if (inSet !== undefined) {
+          return inSet;
+        }
+        // ValueSet not loaded or not extensional — cannot distinguish; be
+        // permissive so profiles remain usable without a terminology server.
         return true;
       }
-      break;
-    case 'type':
-      if (!value || !sliceType?.length) {
+      return false;
+    }
+    case 'exists': {
+      // FHIR R4/R5: slices distinguished by presence vs absence. Typically one
+      // slice has min≥1 and the other max=0 on the nominated element.
+      // See: https://hl7.org/fhir/R4/profiling.html#discriminator
+      if (!sliceElement) {
+        return false;
+      }
+      const present = isDiscriminantValuePresent(value);
+      if (sliceElement.max === 0) {
+        return !present;
+      }
+      if (sliceElement.min >= 1) {
+        return present;
+      }
+      return false;
+    }
+    case 'type': {
+      if (Array.isArray(value) || !value || !sliceType?.length) {
         return false;
       }
       return sliceType.some((t) => t.code === value.type);
-    // Other discriminator types are not yet supported, see http://hl7.org/fhir/R4/profiling.html#discriminator
+    }
+    case 'profile': {
+      // FHIR R4: slices distinguished by conformance to a profile on the
+      // nominated element (or targetProfile when the path uses resolve()).
+      // See: https://hl7.org/fhir/R4/profiling.html#discriminator
+      if (Array.isArray(value) || !value) {
+        return false;
+      }
+      return matchesProfileDiscriminant(value, sliceElement, slice, discriminator.path);
+    }
   }
   // Default to no match
   return false;
 }
 
+/**
+ * Returns whether a discriminant path value is considered "present" for an
+ * `exists` discriminator.
+ * @param value - The resolved property value(s).
+ * @returns True if a non-empty value is present.
+ */
+function isDiscriminantValuePresent(value: TypedValue | TypedValue[] | undefined): boolean {
+  if (value === undefined) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some((v) => v !== undefined && !isEmpty(v.value));
+  }
+  return !isEmpty(value.value);
+}
+
+/**
+ * Matches a value against a `profile` discriminator using slice type profiles.
+ * @param value - The instance value at the discriminator path.
+ * @param sliceElement - The slice's element definition for the discriminator path.
+ * @param slice - The full slice definition.
+ * @param discriminatorPath - The discriminator path (may include `resolve()`).
+ * @returns True if the value conforms to a profile declared on the slice.
+ */
+function matchesProfileDiscriminant(
+  value: TypedValue,
+  sliceElement: InternalSchemaElement | undefined,
+  slice: SliceDefinition,
+  discriminatorPath: string
+): boolean {
+  const types = sliceElement?.type?.length ? sliceElement.type : slice.type;
+  if (!types?.length) {
+    return false;
+  }
+
+  const useTargetProfile = discriminatorPath.includes('resolve()');
+  const candidateProfiles = types.flatMap((t) => (useTargetProfile ? (t.targetProfile ?? []) : (t.profile ?? [])));
+  if (candidateProfiles.length === 0) {
+    return false;
+  }
+
+  return candidateProfiles.some((profileUrl) => conformsToProfile(value, profileUrl));
+}
+
+/**
+ * Checks whether a typed value conforms to a profile URL.
+ * Prefers full validation when the profile schema is loaded; falls back to a
+ * `meta.profile` assertion when the profile is not indexed.
+ * @param value - The value to check.
+ * @param profileUrl - Canonical profile URL.
+ * @returns True if conformance can be established.
+ */
+function conformsToProfile(value: TypedValue, profileUrl: string): boolean {
+  if (tryGetProfile(profileUrl)) {
+    try {
+      validateTypedValue(value, { profileUrl });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // Profile schema not loaded — accept explicit profile assertion on Resources
+  const metaProfiles = (value.value as { meta?: { profile?: string[] } } | undefined)?.meta?.profile;
+  return Array.isArray(metaProfiles) && metaProfiles.includes(profileUrl);
+}
+
 function checkSliceElement(value: TypedValue, slicingRules: SlicingRules | undefined): string | undefined {
   for (const slice of slicingRules?.slices ?? EMPTY) {
     if (
-      slicingRules?.discriminator?.every((discriminator) =>
-        arrayify(getNestedProperty(value, discriminator.path))?.some((v) => matchDiscriminant(v, discriminator, slice))
-      )
+      slicingRules?.discriminator?.every((discriminator) => matchDiscriminatorOnParent(value, discriminator, slice))
     ) {
       return slice.name;
     }

--- a/packages/core/src/typeschema/valuesets.test.ts
+++ b/packages/core/src/typeschema/valuesets.test.ts
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { toTypedValue } from '../fhirpath/utils';
+import {
+  clearValueSets,
+  indexValueSets,
+  isValueSetLoaded,
+  loadValueSet,
+  typedValueInValueSet,
+} from './valuesets';
+
+describe('ValueSet registry', () => {
+  afterEach(() => {
+    clearValueSets();
+  });
+
+  test('loadValueSet indexes extensional compose concepts', () => {
+    loadValueSet({
+      resourceType: 'ValueSet',
+      url: 'http://example.org/ValueSet/colors',
+      status: 'active',
+      compose: {
+        include: [
+          {
+            system: 'http://example.org/CodeSystem/colors',
+            concept: [{ code: 'red' }, { code: 'blue' }],
+          },
+        ],
+      },
+    });
+
+    expect(isValueSetLoaded('http://example.org/ValueSet/colors')).toBe(true);
+    expect(
+      typedValueInValueSet(
+        { type: 'Coding', value: { system: 'http://example.org/CodeSystem/colors', code: 'red' } },
+        'http://example.org/ValueSet/colors'
+      )
+    ).toBe(true);
+    expect(
+      typedValueInValueSet(
+        { type: 'Coding', value: { system: 'http://example.org/CodeSystem/colors', code: 'green' } },
+        'http://example.org/ValueSet/colors'
+      )
+    ).toBe(false);
+  });
+
+  test('CodeableConcept matches if any coding is in the set', () => {
+    loadValueSet({
+      resourceType: 'ValueSet',
+      url: 'http://example.org/ValueSet/colors',
+      status: 'active',
+      compose: {
+        include: [
+          {
+            system: 'http://example.org/CodeSystem/colors',
+            concept: [{ code: 'red' }],
+          },
+        ],
+      },
+    });
+
+    expect(
+      typedValueInValueSet(
+        {
+          type: 'CodeableConcept',
+          value: {
+            coding: [
+              { system: 'http://example.org/CodeSystem/other', code: 'x' },
+              { system: 'http://example.org/CodeSystem/colors', code: 'red' },
+            ],
+          },
+        },
+        'http://example.org/ValueSet/colors'
+      )
+    ).toBe(true);
+  });
+
+  test('returns undefined when ValueSet is not loaded', () => {
+    expect(typedValueInValueSet(toTypedValue('red'), 'http://example.org/ValueSet/missing')).toBeUndefined();
+  });
+
+  test('returns undefined for non-extensional includes', () => {
+    loadValueSet({
+      resourceType: 'ValueSet',
+      url: 'http://example.org/ValueSet/all-colors',
+      status: 'active',
+      compose: {
+        include: [{ system: 'http://example.org/CodeSystem/colors' }],
+      },
+    });
+    expect(isValueSetLoaded('http://example.org/ValueSet/all-colors')).toBe(true);
+    expect(typedValueInValueSet(toTypedValue('red'), 'http://example.org/ValueSet/all-colors')).toBeUndefined();
+  });
+
+  test('indexValueSets loads multiple', () => {
+    indexValueSets([
+      {
+        resourceType: 'ValueSet',
+        url: 'http://example.org/ValueSet/a',
+        status: 'active',
+        expansion: { timestamp: '2020-01-01', contains: [{ system: 's', code: 'a' }] },
+      },
+      {
+        resourceType: 'ValueSet',
+        url: 'http://example.org/ValueSet/b|1.0.0',
+        status: 'active',
+        expansion: { timestamp: '2020-01-01', contains: [{ system: 's', code: 'b' }] },
+      },
+    ]);
+    expect(isValueSetLoaded('http://example.org/ValueSet/a')).toBe(true);
+    expect(isValueSetLoaded('http://example.org/ValueSet/b')).toBe(true);
+    expect(isValueSetLoaded('http://example.org/ValueSet/b|1.0.0')).toBe(true);
+  });
+});

--- a/packages/core/src/typeschema/valuesets.ts
+++ b/packages/core/src/typeschema/valuesets.ts
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { Coding, ValueSet, ValueSetComposeInclude } from '@medplum/fhirtypes';
+import type { TypedValue } from '../types';
+import { isCodeableConcept, isCoding, splitN } from '../utils';
+
+/**
+ * In-memory ValueSet registry for synchronous terminology checks used by
+ * slicing discriminators (FHIR R4 profiling: value/pattern + required binding).
+ *
+ * Only extensional membership is supported: explicit `compose.include.concept`
+ * lists and/or `expansion.contains`. Includes that reference a full CodeSystem
+ * without enumerated concepts cannot be checked here.
+ */
+
+interface ValueSetCodeSet {
+  /** Keys are `system|code` when system is known, otherwise `|code`. */
+  codes: Set<string>;
+  /** True when at least one include enumerates concepts or expansion is present. */
+  extensional: boolean;
+}
+
+const VALUE_SETS: { [url: string]: ValueSetCodeSet } = Object.create(null);
+
+/**
+ * Indexes a ValueSet for synchronous membership checks.
+ * @param valueSet - The ValueSet resource to index.
+ */
+export function loadValueSet(valueSet: ValueSet): void {
+  if (!valueSet.url) {
+    return;
+  }
+  const codes = new Set<string>();
+  let extensional = false;
+
+  for (const include of valueSet.compose?.include ?? []) {
+    if (addIncludeConcepts(codes, include)) {
+      extensional = true;
+    }
+  }
+
+  for (const coding of valueSet.expansion?.contains ?? []) {
+    if (coding.code) {
+      codes.add(codeKey(coding.system, coding.code));
+      extensional = true;
+    }
+  }
+
+  const entry: ValueSetCodeSet = { codes, extensional };
+  VALUE_SETS[valueSet.url] = entry;
+  // Also index without version suffix for bindings like `...|4.0.1`
+  const bare = stripVersion(valueSet.url);
+  if (bare !== valueSet.url) {
+    VALUE_SETS[bare] = entry;
+  }
+}
+
+/**
+ * Indexes an array of ValueSet resources.
+ * @param valueSets - ValueSets to index.
+ */
+export function indexValueSets(valueSets: ValueSet[]): void {
+  for (const vs of valueSets) {
+    loadValueSet(vs);
+  }
+}
+
+/**
+ * Returns whether a ValueSet URL has been loaded into the registry.
+ * @param url - Canonical ValueSet URL (version suffix optional).
+ * @returns True if loaded.
+ */
+export function isValueSetLoaded(url: string): boolean {
+  return !!VALUE_SETS[url] || !!VALUE_SETS[stripVersion(url)];
+}
+
+/**
+ * Clears the ValueSet registry. Intended for tests.
+ */
+export function clearValueSets(): void {
+  for (const key of Object.keys(VALUE_SETS)) {
+    delete VALUE_SETS[key];
+  }
+}
+
+/**
+ * Checks whether a typed FHIR value is in a loaded extensional ValueSet.
+ *
+ * Per FHIR terminology rules for required bindings:
+ * - `code` / `uri` / `string`: the string value must appear in the set
+ * - `Coding`: the coding must appear in the set
+ * - `CodeableConcept`: at least one coding must appear in the set
+ * - `Quantity`: system+code must appear in the set
+ *
+ * @param typedValue - The instance value being tested.
+ * @param valueSetUrl - Canonical ValueSet URL from ElementDefinition.binding.
+ * @returns True if membership can be confirmed; false if not a member.
+ *   Returns `undefined` when the ValueSet is not loaded or is not extensional
+ *   (caller should decide fail-open vs fail-closed).
+ */
+export function typedValueInValueSet(typedValue: TypedValue, valueSetUrl: string): boolean | undefined {
+  const vs = VALUE_SETS[valueSetUrl] ?? VALUE_SETS[stripVersion(valueSetUrl)];
+  if (!vs?.extensional) {
+    return undefined;
+  }
+
+  switch (typedValue.type) {
+    case 'code':
+    case 'uri':
+    case 'string':
+    case 'canonical':
+      if (typeof typedValue.value !== 'string') {
+        return false;
+      }
+      return vs.codes.has(codeKey(undefined, typedValue.value)) || hasCodeIgnoreSystem(vs, typedValue.value);
+    case 'Coding':
+      return isCoding(typedValue.value) && codingInValueSet(vs, typedValue.value);
+    case 'CodeableConcept': {
+      if (!isCodeableConcept(typedValue.value)) {
+        return false;
+      }
+      return typedValue.value.coding.some((c) => codingInValueSet(vs, c));
+    }
+    case 'Quantity': {
+      const q = typedValue.value as { system?: string; code?: string } | undefined;
+      if (!q?.code) {
+        return false;
+      }
+      return vs.codes.has(codeKey(q.system, q.code));
+    }
+    default:
+      return false;
+  }
+}
+
+function addIncludeConcepts(codes: Set<string>, include: ValueSetComposeInclude): boolean {
+  if (!include.concept?.length) {
+    return false;
+  }
+  for (const concept of include.concept) {
+    if (concept.code) {
+      codes.add(codeKey(include.system, concept.code));
+    }
+  }
+  return true;
+}
+
+function codingInValueSet(vs: ValueSetCodeSet, coding: Coding): boolean {
+  return vs.codes.has(codeKey(coding.system, coding.code));
+}
+
+function hasCodeIgnoreSystem(vs: ValueSetCodeSet, code: string): boolean {
+  // Mirror FHIR token search "code only" matching (see codingMatchesToken):
+  // a bare code matches any system.
+  const suffix = '|' + code;
+  for (const key of vs.codes) {
+    if (key.endsWith(suffix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Same `system|code` key shape used elsewhere in core (e.g. stringifyCoding). */
+function codeKey(system: string | undefined, code: string): string {
+  return `${system ?? ''}|${code}`;
+}
+
+function stripVersion(url: string): string {
+  return splitN(url, '|', 2)[0];
+}


### PR DESCRIPTION
## Summary
- Completes Medplum's profile slicing discriminator support for the FHIR R4-defined types that were previously missing or stubbed: `exists`, `profile`, and required ValueSet bindings for `value`/`pattern`.
- Adds a sync extensional ValueSet registry (`loadValueSet` / `typedValueInValueSet`) so required-binding discriminators can distinguish slices without a terminology server.
- Shares discriminator path resolution via `matchDiscriminatorOnParent` (used by both resource validation and schema-crawler slice matching).

## Details
Per [FHIR R4 profiling §discriminator](https://hl7.org/fhir/R4/profiling.html#discriminator) and [DiscriminatorType](https://hl7.org/fhir/R4/codesystem-discriminator-type.html):

| Type | Before | After |
| --- | --- | --- |
| `value` / `pattern` | fixed/pattern only; required ValueSet binding always matched | Also matches against loaded extensional ValueSets |
| `exists` | Parser rejected / not matched | Presence (`min ≥ 1`) vs absence (`max = 0`) |
| `type` | Supported | Unchanged |
| `profile` | Parser rejected / not matched | Validates against loaded profile schemas (`profileUrl`); falls back to `meta.profile` if unloaded |

**Intentional limits (spec-aligned):**
- ValueSet membership is extensional only (`compose.include.concept` / `expansion.contains`); full CodeSystem includes still return “unknown” and stay permissive.
- Discriminator paths with `resolve()` are still not evaluated by `getNestedProperty`.
- R5-only `position` is not implemented.

## Test plan
- [x] `npx vitest run src/typeschema/valuesets.test.ts src/typeschema/validation.test.ts src/typeschema/types.test.ts src/typeschema/crawler.test.ts`
- [ ] Confirm US Core Condition problems-health-concerns slice fails when category is outside the bound ValueSet **and** that ValueSet is loaded
- [ ] Confirm profiles using only `value`/`pattern`/`type` discriminators still validate as before
- [ ] Spot-check a profile with `exists` (present vs absent child) and one with `profile` on `Bundle.entry.resource`