### PR TITLE
feat(core): add $get-cart cart-contents operation support

### DIFF
--- a/packages/core/src/medication-order-utils.test.ts
+++ b/packages/core/src/medication-order-utils.test.ts
@@ -3,6 +3,7 @@
 
 import type { Medication, MedicationRequest, Parameters } from '@medplum/fhirtypes';
 import type {
+  MedicationCartContentsResponse,
   MedicationCartManageResponse,
   MedicationCheckoutRequest,
   MedicationCheckoutResponse,
@@ -13,6 +14,7 @@ import type {
   MedicationSearchParams,
 } from './medication-order-utils';
 import {
+  INVALID_MEDICATION_CART_CONTENTS_RESPONSE,
   INVALID_MEDICATION_CART_RESPONSE,
   INVALID_MEDICATION_CHECKOUT_RESPONSE,
   INVALID_MEDICATION_ORDER_RESPONSE,
@@ -24,16 +26,19 @@ import {
   getPendingMedicationOrderId,
   getPendingMedicationOrderStatus,
   isMedicationArray,
+  isMedicationCartContentsResponse,
   isMedicationCartManageResponse,
   isMedicationCheckoutResponse,
   isMedicationOrderResponse,
   isMedicationOrderSetResponse,
   medicationCartClearRequestToParameters,
+  medicationCartContentsRequestToParameters,
   medicationCartRemoveRequestToParameters,
   medicationCheckoutRequestToParameters,
   medicationOrderRequestToParameters,
   medicationOrderSetRequestToParameters,
   medicationSearchParamsToParameters,
+  parametersToMedicationCartContentsResponse,
   parametersToMedicationCartManageResponse,
   parametersToMedicationCheckoutResponse,
   parametersToMedicationOrderResponse,
@@ -724,6 +729,126 @@ describe('Custom FHIR operation Parameters helpers', () => {
         parameter: [{ name: 'removedCount', valueInteger: 0 }],
       };
       expect(() => parametersToMedicationCartManageResponse(params)).toThrow(INVALID_MEDICATION_CART_RESPONSE);
+    });
+  });
+
+  describe('cart contents', () => {
+    test('isMedicationCartContentsResponse validates required fields', () => {
+      expect(
+        isMedicationCartContentsResponse({
+          vendorPatientId: 1,
+          vendorTotal: 0,
+          draftCount: 0,
+          locked: false,
+          items: [],
+        })
+      ).toBe(true);
+      expect(isMedicationCartContentsResponse(null)).toBe(false);
+      expect(isMedicationCartContentsResponse({ vendorPatientId: 1, vendorTotal: 0, draftCount: 0, items: [] })).toBe(
+        false
+      );
+    });
+
+    test('medicationCartContentsRequestToParameters encodes the patient only', () => {
+      expect(medicationCartContentsRequestToParameters({ patientId: 'pat-1' }).parameter).toEqual([
+        { name: 'patientId', valueId: 'pat-1' },
+      ]);
+    });
+
+    test('parametersToMedicationCartContentsResponse round-trips reconciled lines', () => {
+      const expected: MedicationCartContentsResponse = {
+        vendorPatientId: 24057,
+        vendorTotal: 2,
+        draftCount: 1,
+        locked: false,
+        items: [
+          {
+            status: 'in-sync',
+            medicationRequestId: 'mr-1',
+            vendorLineId: 'rx-1',
+            drugName: 'Atorvastatin 10 MG',
+            ndc: '00093721410',
+            rxnorm: '859747',
+            quantity: 30,
+            validationState: 'Ready',
+            createdBy: 'Dr. Who',
+            createdAt: '2026-08-16T10:00:00.000Z',
+          },
+          {
+            status: 'vendor-only',
+            medicationRequestId: undefined,
+            vendorLineId: 'rx-2',
+            drugName: 'Melatonin 3 MG',
+            ndc: undefined,
+            rxnorm: undefined,
+            quantity: undefined,
+            validationState: undefined,
+            createdBy: undefined,
+            createdAt: undefined,
+          },
+        ],
+      };
+      const params: Parameters = {
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'vendorPatientId', valueInteger: 24057 },
+          { name: 'vendorTotal', valueInteger: 2 },
+          { name: 'draftCount', valueInteger: 1 },
+          { name: 'locked', valueBoolean: false },
+          {
+            name: 'items',
+            part: [
+              { name: 'status', valueCode: 'in-sync' },
+              { name: 'medicationRequestId', valueId: 'mr-1' },
+              { name: 'vendorLineId', valueString: 'rx-1' },
+              { name: 'drugName', valueString: 'Atorvastatin 10 MG' },
+              { name: 'ndc', valueString: '00093721410' },
+              { name: 'rxnorm', valueString: '859747' },
+              { name: 'quantity', valueDecimal: 30 },
+              { name: 'validationState', valueString: 'Ready' },
+              { name: 'createdBy', valueString: 'Dr. Who' },
+              { name: 'createdAt', valueDateTime: '2026-08-16T10:00:00.000Z' },
+            ],
+          },
+          {
+            name: 'items',
+            part: [
+              { name: 'status', valueCode: 'vendor-only' },
+              { name: 'vendorLineId', valueString: 'rx-2' },
+              { name: 'drugName', valueString: 'Melatonin 3 MG' },
+            ],
+          },
+        ],
+      };
+      expect(parametersToMedicationCartContentsResponse(params)).toEqual(expected);
+    });
+
+    test('parametersToMedicationCartContentsResponse drops lines with an unknown status', () => {
+      const params: Parameters = {
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'vendorPatientId', valueInteger: 7 },
+          { name: 'vendorTotal', valueInteger: 0 },
+          { name: 'draftCount', valueInteger: 0 },
+          { name: 'locked', valueBoolean: true },
+          { name: 'items', part: [{ name: 'status', valueCode: 'bogus' }] },
+        ],
+      };
+      expect(parametersToMedicationCartContentsResponse(params)).toMatchObject({ locked: true, items: [] });
+    });
+
+    test('parametersToMedicationCartContentsResponse rejects a missing vendorTotal', () => {
+      const params: Parameters = {
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'vendorPatientId', valueInteger: 7 },
+          { name: 'draftCount', valueInteger: 0 },
+          { name: 'locked', valueBoolean: false },
+        ],
+      };
+      expect(() => parametersToMedicationCartContentsResponse(params)).toThrow(
+        INVALID_MEDICATION_CART_CONTENTS_RESPONSE
+      );
     });
   });
 

--- a/packages/core/src/medication-order-utils.test.ts
+++ b/packages/core/src/medication-order-utils.test.ts
@@ -823,6 +823,72 @@ describe('Custom FHIR operation Parameters helpers', () => {
       expect(parametersToMedicationCartContentsResponse(params)).toEqual(expected);
     });
 
+    test('parametersToMedicationCartContentsResponse decodes not-staged and missing-from-vendor lines', () => {
+      const params: Parameters = {
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'vendorPatientId', valueInteger: 24057 },
+          { name: 'vendorTotal', valueInteger: 0 },
+          { name: 'draftCount', valueInteger: 2 },
+          { name: 'locked', valueBoolean: false },
+          {
+            name: 'items',
+            part: [
+              { name: 'status', valueCode: 'not-staged' },
+              { name: 'medicationRequestId', valueId: 'mr-1' },
+            ],
+          },
+          {
+            name: 'items',
+            part: [
+              { name: 'status', valueCode: 'missing-from-vendor' },
+              { name: 'medicationRequestId', valueId: 'mr-2' },
+              { name: 'vendorLineId', valueString: 'rx-2' },
+            ],
+          },
+        ],
+      };
+
+      const result = parametersToMedicationCartContentsResponse(params);
+
+      // A not-staged draft has no vendor line to describe; a missing-from-vendor
+      // one keeps the rxId it was stamped with, which is what makes the vendor's
+      // removal verifiable.
+      expect(result.items[0]).toEqual({
+        status: 'not-staged',
+        medicationRequestId: 'mr-1',
+        vendorLineId: undefined,
+        drugName: undefined,
+        ndc: undefined,
+        rxnorm: undefined,
+        quantity: undefined,
+        validationState: undefined,
+        createdBy: undefined,
+        createdAt: undefined,
+      });
+      expect(result.items[1]).toMatchObject({
+        status: 'missing-from-vendor',
+        medicationRequestId: 'mr-2',
+        vendorLineId: 'rx-2',
+      });
+    });
+
+    test('parametersToMedicationCartContentsResponse rejects a missing locked flag', () => {
+      const params: Parameters = {
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'vendorPatientId', valueInteger: 7 },
+          { name: 'vendorTotal', valueInteger: 0 },
+          { name: 'draftCount', valueInteger: 0 },
+        ],
+      };
+      // An absent lock state must not decode as `locked: false` — that reports a
+      // cart as safe to write on the strength of a field the bot never sent.
+      expect(() => parametersToMedicationCartContentsResponse(params)).toThrow(
+        INVALID_MEDICATION_CART_CONTENTS_RESPONSE
+      );
+    });
+
     test('parametersToMedicationCartContentsResponse drops lines with an unknown status', () => {
       const params: Parameters = {
         resourceType: 'Parameters',

--- a/packages/core/src/medication-order-utils.ts
+++ b/packages/core/src/medication-order-utils.ts
@@ -1026,6 +1026,189 @@ export function parametersToMedicationCartManageResponse(params: Parameters): Me
 }
 
 // ============================================================================
+// Cart contents ($get-cart)
+// ============================================================================
+
+/**
+ * Stable error when a cart-read bot response does not match
+ * {@link MedicationCartContentsResponse}.
+ */
+export const INVALID_MEDICATION_CART_CONTENTS_RESPONSE = 'Invalid response from get-cart bot';
+
+/**
+ * Reconciliation verdict for one cart line, comparing what the vendor holds
+ * against the local draft `MedicationRequest`s:
+ *
+ * - `in-sync`: the vendor line matches a draft. The normal case.
+ * - `vendor-only`: the vendor holds a line with no local draft — staged through
+ *   another UI or by a session whose draft is gone. The prescriber will still
+ *   see it in the approval widget, so a draft-derived cart count under-reports.
+ * - `not-staged`: a draft that has not been checked out yet, so the vendor
+ *   legitimately does not hold it. Benign, not drift.
+ * - `missing-from-vendor`: a draft the vendor no longer holds. Resolves the
+ *   ambiguity left by a failed `removeFromCart`: the line really is gone.
+ */
+export type MedicationCartLineStatus = 'in-sync' | 'vendor-only' | 'not-staged' | 'missing-from-vendor';
+
+/** One reconciled line in a {@link MedicationCartContentsResponse}. */
+export interface MedicationCartLine {
+  readonly status: MedicationCartLineStatus;
+  /** Local draft id; absent for `vendor-only` lines. */
+  readonly medicationRequestId?: string;
+  /** Vendor cart-item reference; absent for `not-staged` drafts. */
+  readonly vendorLineId?: string;
+  /** Display fields off the vendor line; absent for `not-staged` drafts (render those from the draft). */
+  readonly drugName?: string;
+  readonly ndc?: string;
+  readonly rxnorm?: string;
+  readonly quantity?: number;
+  /** Vendor readiness hint (e.g. `Ready`, `Incomplete`); not a guarantee the line will send. */
+  readonly validationState?: string;
+  /** Who staged the line, per the vendor. Identifies the source of an unexpected line. */
+  readonly createdBy?: string;
+  readonly createdAt?: string;
+}
+
+/** Vendor-neutral input to read the patient's vendor cart (`$get-cart`). */
+export interface MedicationCartContentsRequest {
+  readonly patientId: string;
+}
+
+/**
+ * Vendor-neutral view of the patient's cart as the vendor holds it, reconciled
+ * against local drafts.
+ *
+ * `vendorTotal` is what the prescriber will see in the approval widget;
+ * `draftCount` is what the local record says. They diverge whenever `items`
+ * contains a line that is not `in-sync` or `not-staged` — the drift a
+ * draft-derived cart badge cannot detect on its own.
+ */
+export interface MedicationCartContentsResponse {
+  /** Vendor-side patient id (numeric in ScriptSure today). */
+  readonly vendorPatientId: number;
+  readonly vendorTotal: number;
+  readonly draftCount: number;
+  /** True when the vendor reports the cart locked; a write may conflict. */
+  readonly locked: boolean;
+  readonly items: MedicationCartLine[];
+}
+
+/**
+ * Type guard: validates a cart-read bot response.
+ * @param value - Unknown bot JSON payload.
+ * @returns True when the value matches {@link MedicationCartContentsResponse}.
+ */
+export function isMedicationCartContentsResponse(value: unknown): value is MedicationCartContentsResponse {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.vendorPatientId === 'number' &&
+    Number.isFinite(obj.vendorPatientId) &&
+    typeof obj.vendorTotal === 'number' &&
+    Number.isFinite(obj.vendorTotal) &&
+    typeof obj.draftCount === 'number' &&
+    Number.isFinite(obj.draftCount) &&
+    typeof obj.locked === 'boolean' &&
+    Array.isArray(obj.items)
+  );
+}
+
+/**
+ * Encodes a {@link MedicationCartContentsRequest} as a FHIR `Parameters` body
+ * for the `$get-cart` custom operation. No `action` discriminator: unlike
+ * remove/clear, this operation has its own read-only bot.
+ *
+ * @param req - Cart-contents request (vendor-neutral).
+ * @returns A `Parameters` resource ready to POST.
+ */
+export function medicationCartContentsRequestToParameters(req: MedicationCartContentsRequest): Parameters {
+  return { resourceType: 'Parameters', parameter: [param('patientId', 'valueId', req.patientId)] };
+}
+
+/**
+ * Parses a single repeating `items` out-parameter (its nested `part:`) into a
+ * {@link MedicationCartLine}. Returns `undefined` when `status` is missing or
+ * not a known verdict.
+ *
+ * @param part - The `part` array of one `items` parameter entry.
+ * @returns The parsed cart line, or `undefined`.
+ */
+function cartLineFromPart(part: ParametersParameter[] | undefined): MedicationCartLine | undefined {
+  if (!part?.length) {
+    return undefined;
+  }
+  const map: Record<string, unknown> = {};
+  for (const p of part) {
+    if (p.name) {
+      map[p.name] = readParameterValue(p);
+    }
+  }
+  const status =
+    map.status === 'in-sync' ||
+    map.status === 'vendor-only' ||
+    map.status === 'not-staged' ||
+    map.status === 'missing-from-vendor'
+      ? map.status
+      : undefined;
+  if (!status) {
+    return undefined;
+  }
+  const str = (key: string): string | undefined => (typeof map[key] === 'string' ? map[key] : undefined);
+  return {
+    status,
+    medicationRequestId: str('medicationRequestId'),
+    vendorLineId: str('vendorLineId'),
+    drugName: str('drugName'),
+    ndc: str('ndc'),
+    rxnorm: str('rxnorm'),
+    quantity: typeof map.quantity === 'number' ? map.quantity : undefined,
+    validationState: str('validationState'),
+    createdBy: str('createdBy'),
+    createdAt: str('createdAt'),
+  };
+}
+
+/**
+ * Decodes the `Parameters` response from the `$get-cart` custom operation into
+ * a typed {@link MedicationCartContentsResponse}. Throws
+ * {@link INVALID_MEDICATION_CART_CONTENTS_RESPONSE} when required top-level
+ * fields are missing.
+ *
+ * @param params - The `Parameters` resource returned by the operation.
+ * @returns A vendor-neutral {@link MedicationCartContentsResponse}.
+ */
+export function parametersToMedicationCartContentsResponse(params: Parameters): MedicationCartContentsResponse {
+  const items: MedicationCartLine[] = [];
+  const map: Record<string, unknown> = {};
+  for (const p of params.parameter ?? []) {
+    if (!p.name) {
+      continue;
+    }
+    if (p.name === 'items') {
+      const item = cartLineFromPart(p.part);
+      if (item) {
+        items.push(item);
+      }
+    } else {
+      map[p.name] = readParameterValue(p);
+    }
+  }
+  const candidate: MedicationCartContentsResponse = {
+    vendorPatientId: typeof map.vendorPatientId === 'number' ? map.vendorPatientId : Number.NaN,
+    vendorTotal: typeof map.vendorTotal === 'number' ? map.vendorTotal : Number.NaN,
+    draftCount: typeof map.draftCount === 'number' ? map.draftCount : Number.NaN,
+    locked: map.locked === true,
+    items,
+  };
+  if (!isMedicationCartContentsResponse(candidate)) {
+    throw new Error(INVALID_MEDICATION_CART_CONTENTS_RESPONSE);
+  }
+  return candidate;
+}
+
+// ============================================================================
 // Order-set sync ($sync-orderset)
 // ============================================================================
 

--- a/packages/core/src/medication-order-utils.ts
+++ b/packages/core/src/medication-order-utils.ts
@@ -1199,7 +1199,11 @@ export function parametersToMedicationCartContentsResponse(params: Parameters): 
     vendorPatientId: typeof map.vendorPatientId === 'number' ? map.vendorPatientId : Number.NaN,
     vendorTotal: typeof map.vendorTotal === 'number' ? map.vendorTotal : Number.NaN,
     draftCount: typeof map.draftCount === 'number' ? map.draftCount : Number.NaN,
-    locked: map.locked === true,
+    // Passed through unchecked so the guard below can reject a missing lock
+    // state, exactly as `Number.NaN` does for the counts. `map.locked === true`
+    // would collapse "the bot never told us" into "not locked" — reporting a
+    // cart as safe to write on the strength of a field we never received.
+    locked: map.locked as boolean,
     items,
   };
   if (!isMedicationCartContentsResponse(candidate)) {

--- a/packages/docs/docs/integration/scriptsure/medication-cart.md
+++ b/packages/docs/docs/integration/scriptsure/medication-cart.md
@@ -144,3 +144,57 @@ Calls `POST /fhir/R4/MedicationRequest/$clear-cart`. Removes every item from the
 | `vendorPatientId` | `number` | Vendor-side patient id |
 | `removedCount` | `number` | Number of items successfully removed |
 | `items` | `MedicationCartItemResult[]` | Per-line result with `status: 'removed'` or `status: 'failed'` |
+
+## `getCart`
+
+Calls `POST /fhir/R4/MedicationRequest/$get-cart`. Reads the MedCart as ScriptSure holds it and reconciles it against the patient's draft `MedicationRequest`s. Read-only—it never writes to Medplum and never mutates the MedCart.
+
+Use this whenever a cart count or list is shown to a prescriber. Counting drafts alone gives a lower bound: it misses items staged through another UI, cannot confirm whether a failed `removeFromCart` actually left the vendor item behind, and gives no drift check before checkout—the mismatch otherwise surfaces only when the prescriber is already looking at the signing widget.
+
+**Request fields:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `patientId` | `string` | yes | Medplum `Patient` resource id |
+
+**Response fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `vendorPatientId` | `number` | Vendor-side patient id |
+| `vendorTotal` | `number` | Number of items ScriptSure holds—what the prescriber will see in the widget |
+| `draftCount` | `number` | Number of draft `MedicationRequest`s in Medplum |
+| `locked` | `boolean` | `true` when ScriptSure reports the cart locked; a write may conflict |
+| `items` | `MedicationCartLine[]` | One reconciled line per item either side holds (see below) |
+
+Each `items` entry:
+
+| Field | Type | Description |
+|---|---|---|
+| `status` | `MedicationCartLineStatus` | Reconciliation verdict (see below) |
+| `medicationRequestId` | `string` | Medplum draft id; absent for `vendor-only` lines |
+| `vendorLineId` | `string` | MedCart `rxId`; absent for `not-staged` drafts |
+| `drugName`, `ndc`, `rxnorm`, `quantity` | | Display fields off the vendor line; absent for `not-staged` drafts |
+| `validationState` | `string` | Vendor readiness hint (`Ready`, `Incomplete`)—echoed from what was submitted, not a guarantee the line will send |
+| `createdBy`, `createdAt` | `string` | Who staged the line and when, per the vendor |
+
+`status` values:
+
+| Value | Meaning |
+|---|---|
+| `in-sync` | Vendor line matched a draft. The normal case. |
+| `vendor-only` | ScriptSure holds a line with no Medplum draft—staged elsewhere. The prescriber will still see it in the widget. |
+| `not-staged` | Draft not checked out yet, so ScriptSure legitimately does not hold it. Benign, not drift. |
+| `missing-from-vendor` | Draft stamped with an `rxId` ScriptSure no longer returns—the line is gone and the draft is stale. |
+
+```tsx
+const { getCart } = useScriptSureCart();
+
+const cart = await getCart({ patientId });
+const badgeCount = cart.vendorTotal + cart.items.filter((i) => i.status === 'not-staged').length;
+const unexpected = cart.items.filter((i) => i.status === 'vendor-only');
+```
+
+:::note
+A failed vendor read throws rather than returning an empty cart—reporting "the cart is empty" when ScriptSure is merely unreachable is the failure this operation exists to prevent.
+:::

--- a/packages/react-hooks/src/useMedicationCart/useMedicationCart.test.tsx
+++ b/packages/react-hooks/src/useMedicationCart/useMedicationCart.test.tsx
@@ -1,8 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { WithId } from '@medplum/core';
-import { INVALID_MEDICATION_CART_RESPONSE, INVALID_MEDICATION_CHECKOUT_RESPONSE } from '@medplum/core';
+import type { MedicationCartContentsResponse, WithId } from '@medplum/core';
+import {
+  INVALID_MEDICATION_CART_CONTENTS_RESPONSE,
+  INVALID_MEDICATION_CART_RESPONSE,
+  INVALID_MEDICATION_CHECKOUT_RESPONSE,
+} from '@medplum/core';
 import type { MedicationRequest, Parameters } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { act, renderHook, waitFor } from '@testing-library/react';
@@ -24,6 +28,7 @@ function wrapper(medplum: MockClient) {
 const REMOVE_URL = 'fhir/R4/MedicationRequest/$remove-cart-medication';
 const CLEAR_URL = 'fhir/R4/MedicationRequest/$clear-cart';
 const CHECKOUT_URL = 'fhir/R4/MedicationRequest/$checkout-medications';
+const GET_CART_URL = 'fhir/R4/MedicationRequest/$get-cart';
 
 describe('useMedicationCart', () => {
   test('removeFromCart POSTs to $remove-cart-medication and decodes the Parameters response', async () => {
@@ -212,6 +217,65 @@ describe('useMedicationCart', () => {
 
     await expect(result.current.checkout({ patientId: 'p1', medicationRequestIds: ['mr-1'] })).rejects.toThrow(
       INVALID_MEDICATION_CHECKOUT_RESPONSE
+    );
+  });
+
+  test('getCart POSTs to $get-cart and decodes the reconciled lines', async () => {
+    const medplum = new MockClient();
+    const responseParams: Parameters = {
+      resourceType: 'Parameters',
+      parameter: [
+        { name: 'vendorPatientId', valueInteger: 24057 },
+        { name: 'vendorTotal', valueInteger: 2 },
+        { name: 'draftCount', valueInteger: 1 },
+        { name: 'locked', valueBoolean: false },
+        {
+          name: 'items',
+          part: [
+            { name: 'status', valueCode: 'in-sync' },
+            { name: 'medicationRequestId', valueId: 'mr-1' },
+            { name: 'vendorLineId', valueString: 'rx-1' },
+          ],
+        },
+        {
+          name: 'items',
+          part: [
+            { name: 'status', valueCode: 'vendor-only' },
+            { name: 'vendorLineId', valueString: 'rx-2' },
+            { name: 'drugName', valueString: 'Melatonin 3 MG' },
+          ],
+        },
+      ],
+    };
+    const postSpy = vi.spyOn(medplum, 'post').mockResolvedValueOnce(responseParams);
+
+    const { result } = renderHook(() => useMedicationCart(), { wrapper: wrapper(medplum) });
+
+    let out: MedicationCartContentsResponse | undefined;
+    await act(async () => {
+      out = await result.current.getCart({ patientId: 'p1' });
+    });
+
+    // The vendor holds a line we never staged, so a draft-derived badge (1)
+    // would under-report what the prescriber sees (2).
+    expect(out).toMatchObject({ vendorTotal: 2, draftCount: 1, locked: false });
+    expect(out?.items[1]).toMatchObject({ status: 'vendor-only', drugName: 'Melatonin 3 MG' });
+    const [calledUrl, body] = postSpy.mock.calls[0];
+    expect(calledUrl.toString()).toContain(GET_CART_URL);
+    expect(body).toMatchObject({
+      resourceType: 'Parameters',
+      parameter: [{ name: 'patientId', valueId: 'p1' }],
+    });
+  });
+
+  test('getCart throws when response is not a Parameters envelope', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'post').mockResolvedValueOnce({ vendorTotal: 0 });
+
+    const { result } = renderHook(() => useMedicationCart(), { wrapper: wrapper(medplum) });
+
+    await expect(result.current.getCart({ patientId: 'p1' })).rejects.toThrow(
+      INVALID_MEDICATION_CART_CONTENTS_RESPONSE
     );
   });
 

--- a/packages/react-hooks/src/useMedicationCart/useMedicationCart.ts
+++ b/packages/react-hooks/src/useMedicationCart/useMedicationCart.ts
@@ -3,18 +3,23 @@
 
 import type {
   MedicationCartClearRequest,
+  MedicationCartContentsRequest,
+  MedicationCartContentsResponse,
   MedicationCartManageResponse,
   MedicationCartRemoveRequest,
   MedicationCheckoutRequest,
   MedicationCheckoutResponse,
 } from '@medplum/core';
 import {
+  INVALID_MEDICATION_CART_CONTENTS_RESPONSE,
   INVALID_MEDICATION_CART_RESPONSE,
   INVALID_MEDICATION_CHECKOUT_RESPONSE,
   isResource,
   medicationCartClearRequestToParameters,
+  medicationCartContentsRequestToParameters,
   medicationCartRemoveRequestToParameters,
   medicationCheckoutRequestToParameters,
+  parametersToMedicationCartContentsResponse,
   parametersToMedicationCartManageResponse,
   parametersToMedicationCheckoutResponse,
 } from '@medplum/core';
@@ -43,13 +48,20 @@ export interface UseMedicationCartReturn {
   removeFromCart: (input: MedicationCartRemoveRequest) => Promise<MedicationCartManageResponse>;
   /** Remove every item from the patient's vendor cart. */
   clearCart: (input: MedicationCartClearRequest) => Promise<MedicationCartManageResponse>;
+  /**
+   * Read the patient's cart as the **vendor** holds it, reconciled against the
+   * local draft lines. Use this rather than counting drafts whenever the number
+   * is shown to a prescriber: drafts alone are a lower bound.
+   */
+  getCart: (input: MedicationCartContentsRequest) => Promise<MedicationCartContentsResponse>;
 }
 
 /**
  * Vendor-neutral hook for the full **medication cart** lifecycle: add a draft
  * line (`createResource`), check out a set of drafts into the vendor's batch
- * approval queue (`$checkout-medications`), and remove/clear cart lines
- * (`$remove-cart-medication` / `$clear-cart`).
+ * approval queue (`$checkout-medications`), remove/clear cart lines
+ * (`$remove-cart-medication` / `$clear-cart`), and read the vendor's own view of
+ * the cart (`$get-cart`).
  *
  * Cart checkout / remove / clear hit project-scoped **FHIR custom operations**
  * whose backing Bot is chosen at deploy time via an `OperationDefinition`
@@ -68,7 +80,7 @@ export interface UseMedicationCartReturn {
  * decoded by the matching `@medplum/core` helpers. Per-line outcomes arrive in
  * `response.items`.
  *
- * @returns Cart add / checkout / remove / clear callbacks plus `adding` state.
+ * @returns Cart add / checkout / remove / clear / read callbacks plus `adding` state.
  */
 export function useMedicationCart(): UseMedicationCartReturn {
   const medplum = useMedplum();
@@ -132,5 +144,17 @@ export function useMedicationCart(): UseMedicationCartReturn {
     [medplum]
   );
 
-  return { addToCart, adding, checkout, removeFromCart, clearCart };
+  const getCart = useCallback(
+    async (input: MedicationCartContentsRequest): Promise<MedicationCartContentsResponse> => {
+      const url = medplum.fhirUrl('MedicationRequest', '$get-cart');
+      const response = await medplum.post(url, medicationCartContentsRequestToParameters(input));
+      if (!isResource<Parameters>(response, 'Parameters')) {
+        throw new Error(INVALID_MEDICATION_CART_CONTENTS_RESPONSE);
+      }
+      return parametersToMedicationCartContentsResponse(response);
+    },
+    [medplum]
+  );
+
+  return { addToCart, adding, checkout, removeFromCart, clearCart, getCart };
 }

--- a/packages/scriptsure-react/src/useScriptSureCart.ts
+++ b/packages/scriptsure-react/src/useScriptSureCart.ts
@@ -10,8 +10,9 @@ export type UseScriptSureCartReturn = UseMedicationCartReturn;
  * React hook for the ScriptSure **medication cart** lifecycle: add a draft
  * `MedicationRequest` line (`createResource`), check out drafts into the
  * patient's ScriptSure MedCart (`$checkout-medications` →
- * `/widgets/medcart/{patientId}`), and remove/clear cart lines
- * (`$remove-cart-medication` / `$clear-cart`).
+ * `/widgets/medcart/{patientId}`), remove/clear cart lines
+ * (`$remove-cart-medication` / `$clear-cart`), and read the MedCart as
+ * ScriptSure holds it, reconciled against the local drafts (`$get-cart`).
  *
  * A near-empty re-export of `useMedicationCart` from `@medplum/react-hooks`: the
  * vendor binding for the custom operations lives entirely on the server, where
@@ -29,7 +30,7 @@ export type UseScriptSureCartReturn = UseMedicationCartReturn;
  * the MedCart widget).
  *
  * @returns The same API as `useMedicationCart` (`addToCart`, `adding`,
- * `checkout`, `removeFromCart`, `clearCart`).
+ * `checkout`, `removeFromCart`, `clearCart`, `getCart`).
  */
 export function useScriptSureCart(): UseScriptSureCartReturn {
   return useMedicationCart();


### PR DESCRIPTION
## Summary

Vendor-neutral client support for reading a patient's medication cart as the **vendor** holds it, reconciled against local draft `MedicationRequest`s.

Counting drafts alone gives a lower bound on what a prescriber will see in the signing widget: it misses lines staged through another UI, cannot confirm whether a failed `removeFromCart` left the vendor line behind, and offers no drift check before checkout. `getCart` closes that gap.

- **`@medplum/core`** — `MedicationCartContentsRequest` / `MedicationCartContentsResponse` / `MedicationCartLine` / `MedicationCartLineStatus`, a type guard, and `medicationCartContentsRequestToParameters` / `parametersToMedicationCartContentsResponse`, alongside the existing checkout and cart-manage converters.
- **`@medplum/react-hooks`** — `getCart` on `useMedicationCart`, POSTing to `$get-cart`.
- **`@medplum/scriptsure-react`** — flows through `useScriptSureCart` automatically (thin re-export); doc-only change.
- **Docs** — a `getCart` section on the Medication Cart page.

`status` on each line is `in-sync`, `vendor-only` (vendor holds a line with no local draft), `not-staged` (draft not checked out yet; benign), or `missing-from-vendor` (resolves the ambiguity a failed removal leaves behind). The response also carries `vendorTotal` against `draftCount` and a `locked` flag.

As with the other cart operations, the vendor binding lives entirely server-side: a project's `OperationDefinition` points `$get-cart` at whichever bot implements it. The ScriptSure implementation is in medplum-ee (medplum/medplum-ee#993, closing medplum/medplum-ee#984). Vendors without a batch cart simply never call it.

## Test plan

- [x] 60 core tests including round-trip, unknown-status rejection, and missing-field validation
- [x] 244 react-hooks tests including the new `getCart` encode/decode and non-`Parameters` guard
- [x] `medplum-provider` typechecks and its 17 `MedicationsPage` tests pass — the added interface member does not break existing cart-hook mocks
- [x] `tsc --noEmit` and eslint clean in core, react-hooks, and scriptsure-react