### PR TITLE
fix(ci): restore the server coverage blob on a turbo cache hit

### DIFF
--- a/packages/server/turbo.json
+++ b/packages/server/turbo.json
@@ -4,13 +4,13 @@
   "tasks": {
     "test:seed": {
       "dependsOn": ["build"],
-      "outputs": ["coverage/**"],
+      "outputs": ["coverage/**", ".vitest-reports/**"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts"],
       "env": ["SHOULD_RUN_SEED_TEST", "POSTGRES_HOST", "POSTGRES_PORT"]
     },
     "test": {
       "dependsOn": ["test:seed"],
-      "outputs": ["coverage/**"],
+      "outputs": ["coverage/**", ".vitest-reports/**"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts"],
       "env": ["POSTGRES_HOST", "POSTGRES_PORT", "SERVER_TEST_CACHE_KEY"]
     }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,21 +14,25 @@ if [ -z "$NO_COVERAGE" ]; then
   # The blob reporter records each package's results and coverage for the merge step below.
   COVERAGE_FLAGS="--coverage --reporter=default --reporter=blob"
 
+  # The seed run shares a package with the main server run, so it writes to its own blob
+  # file. Sharing the default path lets a leftover seed blob stand in for the server blob.
+  SEED_COVERAGE_FLAGS="$COVERAGE_FLAGS --outputFile.blob=.vitest-reports/blob-seed.json"
+
   # Clear old code coverage data
-  rm -rf coverage .vitest-reports
+  rm -rf coverage .vitest-reports packages/*/.vitest-reports
   mkdir -p .vitest-reports
 else
   COVERAGE_FLAGS=""
+  SEED_COVERAGE_FLAGS=""
 fi
 
 # Seed the database
 # This is a special "test" which runs all of the seed logic, such as setting up structure definitions
 # On a normal developer machine, this is run only rarely when setting up a new database
 # This test must be run first, and cannot be run concurrently with other tests
-SHOULD_RUN_SEED_TEST=$(date) time npx turbo run test:seed --filter=./packages/server -- $COVERAGE_FLAGS
+SHOULD_RUN_SEED_TEST=$(date) time npx turbo run test:seed --filter=./packages/server -- $SEED_COVERAGE_FLAGS
 if [ -z "$NO_COVERAGE" ]; then
-  # Save the seed blob before the main server run overwrites it
-  cp "packages/server/.vitest-reports/blob.json" ".vitest-reports/blob-server-seed.json"
+  cp "packages/server/.vitest-reports/blob-seed.json" ".vitest-reports/blob-server-seed.json"
 fi
 
 # Test
@@ -37,6 +41,14 @@ fi
 npx turbo run test --concurrency=1 --filter='!@medplum/docs' --filter='!./examples/*' -- $COVERAGE_FLAGS
 
 if [ -z "$NO_COVERAGE" ]; then
+  # A package missing its blob drops out of the merged report entirely, which reads as a
+  # healthy percentage rather than a failure. The usual cause is a turbo cache hit for a
+  # task whose "outputs" omit .vitest-reports, so nothing gets restored.
+  if [ ! -f "packages/server/.vitest-reports/blob.json" ]; then
+    echo "error: packages/server produced no blob; check the test task 'outputs' in packages/server/turbo.json" >&2
+    exit 1
+  fi
+
   # Gather every package blob into one directory, which is all --merge-reports accepts.
   # Blobs are matched back to the root config's projects by name, hence the explicit
   # "test.name" in each package config.


### PR DESCRIPTION
## Problem

Coverage on `main` dropped from ~92% to **61.359%** on the first build after #10225, with no real change in test coverage.

`packages/server/turbo.json` overrides the root `test` task, and its `outputs` was never updated alongside the root `turbo.json`, so it still listed only `coverage/**`. On a cache hit turbo restores nothing under `.vitest-reports/`, and because the seed task always runs (`SHOULD_RUN_SEED_TEST=$(date)` forces a miss) its blob was still sitting at the default `packages/server/.vitest-reports/blob.json`. `scripts/test.sh` copied that in as the server blob, so the merged report counted the seed run twice and the server's real test coverage never made it into `lcov.info`.

Same tree (`83b8317fa`), two runs:

| run | `@medplum/server:test` | statements | lines | trailing `Per blob` timings |
| --- | --- | --- | --- | --- |
| [merge queue](https://github.com/medplum/medplum/actions/runs/32076021954) | cache miss, executed | 94.44% (43579/46142) | 94.54% | 73.41s, **488.03s** |
| [push to main](https://github.com/medplum/medplum/actions/runs/32077551278) | cache hit, FULL TURBO | 62.76% (28959/46142) | 62.82% | 68.62s, **68.62s** |

Identical denominators — the seed run loads every server source file — with ~14.6k covered statements missing, and the same blob timing twice. The 20 other packages restored correctly, since the root task config does list `.vitest-reports/**`.

## Changes

- Add `.vitest-reports/**` to the `test` and `test:seed` outputs in `packages/server/turbo.json`.
- Point the seed run at its own blob file (`--outputFile.blob`) so a leftover seed blob can never stand in for the server blob.
- Clear stale per-package `.vitest-reports` directories, and fail the run when the server blob is missing instead of publishing a report without it — a dropped package reads as a healthy percentage, not a failure.