### PR TITLE
build: override @medplum/core for @metriport/shared

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10987,24 +10987,6 @@
         "zod": "^3.22.1"
       }
     },
-    "node_modules/@metriport/shared/node_modules/@medplum/core": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/@medplum/core/-/core-2.2.10.tgz",
-      "integrity": "sha512-03JhETSAtOOlMOG6U9DkgqiSWGfY2b63MlYGWwR8sxft66hblY5tIxuLt2FmW8zRwlABC93xEzyoVpU8CHeYzw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "pdfmake": "^0.2.5"
-      },
-      "peerDependenciesMeta": {
-        "pdfmake": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@metriport/shared/node_modules/uuid": {
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "trailingComma": "es5"
   },
   "overrides": {
+    "@metriport/shared": {
+      "@medplum/core": "5.1.31"
+    },
     "@microsoft/api-documenter": {
       "js-yaml": "4.3.1"
     },

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -69,6 +69,10 @@ sed -i'' -E -e "s/\"version\": \"[^\"]+\"/\"version\": \"$NEW_VERSION\"/g" packa
 find examples -name 'package.json' -print0 | xargs -0 sed -i'' -E -e "s/(\"@medplum\/[^\"]+\"): \"[^\"]+\"/\1: \"$NEW_VERSION\"/g"
 find packages -name 'package.json' -print0 | xargs -0 sed -i'' -E -e "s/(\"@medplum\/[^\"]+\"): \"[^\"]+\"/\1: \"$NEW_VERSION\"/g"
 
+# The root's only @medplum/* pin is under "overrides"; if it drifts from the workspace
+# version, npm resolves a second copy from the registry instead of deduping
+sed -i'' -E -e "s/(\"@medplum\/[^\"]+\"): \"[^\"]+\"/\1: \"$NEW_VERSION\"/g" package.json
+
 # Set version in charts/Chart.yaml (Helm)
 sed -i'' -E -e "s/^appVersion: ['\"][^\'\"]+['\"]/appVersion: '$NEW_VERSION'/g" charts/Chart.yaml
 sed -i'' -E -e "s/^version: ['\"]?[^'\"]+['\"]?/version: '$NEW_VERSION'/g" charts/Chart.yaml


### PR DESCRIPTION
`@metriport/shared@0.37.0` declares `@medplum/core: ^2.2.10`, so npm was
resolving a nested registry copy of `@medplum/core@2.2.10` under it, alongside
the workspace build. This adds a nested override so that dependency dedupes
onto `packages/core`:

```json
"overrides": {
  "@metriport/shared": {
    "@medplum/core": "5.1.30"
  },
```

`package-lock.json` loses exactly one entry —
`node_modules/@metriport/shared/node_modules/@medplum/core` — and
`@metriport/shared` now resolves `@medplum/core` through the root
`node_modules/@medplum/core` link. `npm ci --dry-run` plans a single
`@medplum/core 5.1.30`.

### Risk

Low. `@metriport/shared`'s shipped `dist/` never imports `@medplum/core` — 26
references to `@medplum/fhirtypes`, zero to core — so the 2.x to 5.x jump has no
runtime surface in that package.

Unrelated and left alone: `@metriport/api-sdk` still pins a nested
`@medplum/fhirtypes@2.2.10`, which is the package metriport actually imports.
