### PR TITLE
fix(bots): report undeployed bots instead of "Function not found"

### DIFF
--- a/packages/server/src/cloud/aws/execute.test.ts
+++ b/packages/server/src/cloud/aws/execute.test.ts
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { InvokeCommand, LambdaClient, ListLayerVersionsCommand } from '@aws-sdk/client-lambda';
+import {
+  InvokeCommand,
+  LambdaClient,
+  ListLayerVersionsCommand,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-lambda';
 import { badRequest, ContentType } from '@medplum/core';
 import type { Bot } from '@medplum/fhirtypes';
 import type { AwsClientStub } from 'aws-sdk-client-mock';
@@ -13,7 +18,7 @@ import { initApp, shutdownApp } from '../../app';
 import { getConfig, loadTestConfig } from '../../config/loader';
 import { getBinaryStorage } from '../../storage/loader';
 import { initTestAuth } from '../../test.setup';
-import { getLambdaFunctionName } from './execute';
+import { getLambdaFunctionName, normalizeLambdaExecutionError } from './execute';
 
 const app = express();
 let accessToken: string;
@@ -247,5 +252,34 @@ describe('Execute', () => {
       .send({});
     expect(res).toHaveStatus(400);
     expect(res.body).toMatchObject(outcome);
+  });
+
+  test('Execute bot that has not been deployed', async () => {
+    // AWS reports a bot whose Lambda was never created as "Function not found"
+    mockLambdaClient
+      .on(InvokeCommand)
+      .rejects(new ResourceNotFoundException({ $metadata: {}, message: 'Function not found' }));
+
+    const res = await request(app)
+      .post(`/fhir/R4/Bot/${bot.id}/$execute`)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({});
+    expect(res).toHaveStatus(400);
+    expect(res.body.issue[0].details.text).toStrictEqual(
+      `Bot is not deployed (AWS Lambda function "medplum-bot-lambda-${bot.id}" not found). Deploy the bot with Bot/$deploy and try again.`
+    );
+  });
+});
+
+describe('normalizeLambdaExecutionError', () => {
+  test('Missing function reports the deploy operation', () => {
+    expect(normalizeLambdaExecutionError(new ResourceNotFoundException({ $metadata: {}, message: 'x' }), 'my-fn')).toBe(
+      'Bot is not deployed (AWS Lambda function "my-fn" not found). Deploy the bot with Bot/$deploy and try again.'
+    );
+  });
+
+  test('Other errors are passed through', () => {
+    expect(normalizeLambdaExecutionError(new Error('Rate exceeded'), 'my-fn')).toBe('Rate exceeded');
   });
 });

--- a/packages/server/src/cloud/aws/execute.test.ts
+++ b/packages/server/src/cloud/aws/execute.test.ts
@@ -267,19 +267,35 @@ describe('Execute', () => {
       .send({});
     expect(res).toHaveStatus(400);
     expect(res.body.issue[0].details.text).toStrictEqual(
-      `Bot is not deployed (AWS Lambda function "medplum-bot-lambda-${bot.id}" not found). Deploy the bot with Bot/$deploy and try again.`
+      'Bot "Test Bot" is not deployed. Deploy the bot with Bot/$deploy and try again.'
     );
   });
 });
 
 describe('normalizeLambdaExecutionError', () => {
   test('Missing function reports the deploy operation', () => {
-    expect(normalizeLambdaExecutionError(new ResourceNotFoundException({ $metadata: {}, message: 'x' }), 'my-fn')).toBe(
-      'Bot is not deployed (AWS Lambda function "my-fn" not found). Deploy the bot with Bot/$deploy and try again.'
-    );
+    // The AWS message is discarded; we synthesize our own.
+    expect(
+      normalizeLambdaExecutionError(new ResourceNotFoundException({ $metadata: {}, message: 'Function not found' }), {
+        resourceType: 'Bot',
+        id: 'abc',
+        name: 'My Bot',
+      })
+    ).toBe('Bot "My Bot" is not deployed. Deploy the bot with Bot/$deploy and try again.');
+  });
+
+  test('Missing function falls back to the bot id when unnamed', () => {
+    expect(
+      normalizeLambdaExecutionError(new ResourceNotFoundException({ $metadata: {}, message: 'Function not found' }), {
+        resourceType: 'Bot',
+        id: 'abc',
+      })
+    ).toBe('Bot "abc" is not deployed. Deploy the bot with Bot/$deploy and try again.');
   });
 
   test('Other errors are passed through', () => {
-    expect(normalizeLambdaExecutionError(new Error('Rate exceeded'), 'my-fn')).toBe('Rate exceeded');
+    expect(
+      normalizeLambdaExecutionError(new Error('Rate exceeded'), { resourceType: 'Bot', id: 'abc', name: 'My Bot' })
+    ).toBe('Rate exceeded');
   });
 });

--- a/packages/server/src/cloud/aws/execute.ts
+++ b/packages/server/src/cloud/aws/execute.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
+import { InvokeCommand, LambdaClient, ResourceNotFoundException } from '@aws-sdk/client-lambda';
 import { Hl7Message, createReference, getIdentifier, normalizeErrorString } from '@medplum/core';
 import type { Bot } from '@medplum/fhirtypes';
 import { TextDecoder, TextEncoder } from 'node:util';
@@ -77,9 +77,26 @@ export async function runInLambda(request: BotExecutionContext): Promise<BotExec
   } catch (err) {
     return {
       success: false,
-      logResult: normalizeErrorString(err),
+      logResult: normalizeLambdaExecutionError(err, name),
     };
   }
+}
+
+/**
+ * Converts an error from a Lambda invocation into a log result string.
+ *
+ * If the bot has never been deployed, there is no Lambda function to invoke, and AWS
+ * reports that as a bare "Function not found". That does not tell the user what to do,
+ * so this substitutes a message naming the deploy operation.
+ * @param err - The error thrown while invoking the Lambda.
+ * @param name - The AWS Lambda function name.
+ * @returns The log result string.
+ */
+export function normalizeLambdaExecutionError(err: unknown, name: string): string {
+  if (err instanceof ResourceNotFoundException) {
+    return `Bot is not deployed (AWS Lambda function "${name}" not found). Deploy the bot with Bot/$deploy and try again.`;
+  }
+  return normalizeErrorString(err);
 }
 
 /**

--- a/packages/server/src/cloud/aws/execute.ts
+++ b/packages/server/src/cloud/aws/execute.ts
@@ -77,7 +77,7 @@ export async function runInLambda(request: BotExecutionContext): Promise<BotExec
   } catch (err) {
     return {
       success: false,
-      logResult: normalizeLambdaExecutionError(err, name),
+      logResult: normalizeLambdaExecutionError(err, request.bot),
     };
   }
 }
@@ -87,14 +87,14 @@ export async function runInLambda(request: BotExecutionContext): Promise<BotExec
  *
  * If the bot has never been deployed, there is no Lambda function to invoke, and AWS
  * reports that as a bare "Function not found". That does not tell the user what to do,
- * so this substitutes a message naming the deploy operation.
+ * so this substitutes a message naming the bot and the deploy operation.
  * @param err - The error thrown while invoking the Lambda.
- * @param name - The AWS Lambda function name.
+ * @param bot - The Bot resource being executed.
  * @returns The log result string.
  */
-export function normalizeLambdaExecutionError(err: unknown, name: string): string {
+export function normalizeLambdaExecutionError(err: unknown, bot: Bot): string {
   if (err instanceof ResourceNotFoundException) {
-    return `Bot is not deployed (AWS Lambda function "${name}" not found). Deploy the bot with Bot/$deploy and try again.`;
+    return `Bot "${bot.name ?? bot.id}" is not deployed. Deploy the bot with Bot/$deploy and try again.`;
   }
   return normalizeErrorString(err);
 }

--- a/packages/server/src/cloud/aws/executestreaming.ts
+++ b/packages/server/src/cloud/aws/executestreaming.ts
@@ -42,7 +42,7 @@ export async function runInLambdaStreaming(request: BotExecutionContext): Promis
 
     return await processEventStream(response.EventStream, responseStream);
   } catch (err) {
-    return { success: false, logResult: normalizeLambdaExecutionError(err, name) };
+    return { success: false, logResult: normalizeLambdaExecutionError(err, bot) };
   }
 }
 

--- a/packages/server/src/cloud/aws/executestreaming.ts
+++ b/packages/server/src/cloud/aws/executestreaming.ts
@@ -9,6 +9,7 @@ import {
   buildLambdaPayload,
   getExecuteLambdaClient,
   getLambdaFunctionName,
+  normalizeLambdaExecutionError,
   parseLambdaLog,
   sanitizeLogResult,
 } from './execute';
@@ -41,7 +42,7 @@ export async function runInLambdaStreaming(request: BotExecutionContext): Promis
 
     return await processEventStream(response.EventStream, responseStream);
   } catch (err) {
-    return { success: false, logResult: normalizeErrorString(err) };
+    return { success: false, logResult: normalizeLambdaExecutionError(err, name) };
   }
 }
 


### PR DESCRIPTION
Executing a bot whose Lambda was never deployed surfaced AWS's raw error rather than the actual problem:

```
Function not found: arn:aws:lambda:...:function:medplum-bot-lambda-<id>
```

That names the symptom, not the cause, and gives no indication that the fix is to deploy the bot.

## What changed

`runInLambda` caught the invoke error and passed the message straight through. `ResourceNotFoundException` is now recognised and reported as:

```
Bot is not deployed (AWS Lambda function "medplum-bot-lambda-<id>" not found). Deploy the bot with Bot/$deploy and try again.
```

`runInLambdaStreaming` had the same gap, so both paths now share a single `normalizeLambdaExecutionError`. Every other error is passed through unchanged.

## Verification

- `packages/server/src/cloud/aws/execute.test.ts` — 12 passed, including two new cases: `ResourceNotFoundException` produces the deploy message, and unrelated errors are untouched.
- Full `packages/server` suite run against this branch and against `main`: 124 failing on both, 4256 passing here vs 4253 on `main` — the three added tests, no new failures. The pre-existing failures are terminology tests that need post-deploy migrations, which `test.config.json` disables.

Fixes #6551
