### PR TITLE
feat(server): create Goal resources from PlanDefinition.goal in $apply

### DIFF
--- a/packages/server/src/fhir/operations/plandefinitionapply.test.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.test.ts
@@ -6,6 +6,7 @@ import type {
   ActivityDefinition,
   CarePlan,
   Encounter,
+  Goal,
   OperationOutcome,
   Organization,
   Patient,
@@ -1375,5 +1376,158 @@ describe('PlanDefinition apply', () => {
     expect(res5).toHaveStatus(200);
     const requestGroup = res5.body as RequestGroup;
     expect(requestGroup.instantiatesCanonical).toStrictEqual([planDefinition.url]);
+  });
+  test('Creates Goal resources from PlanDefinition.goal', async () => {
+    // 1. Create a PlanDefinition with goals
+    // 2. Create a Patient
+    // 3. Apply the PlanDefinition
+    // 4. Verify the CarePlan references the Goals
+    // 5. Verify the Goal contents
+
+    // 1. Create a PlanDefinition with goals
+    const res1 = await request(app)
+      .post(`/fhir/R4/PlanDefinition`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'PlanDefinition',
+        title: 'Example Plan Definition',
+        status: 'active',
+        goal: [
+          {
+            id: 'goal-1',
+            category: { text: 'Treatment' },
+            description: { text: 'Reduce hemoglobin A1c below 7.0%' },
+            priority: { text: 'high-priority' },
+            start: { text: 'When treatment starts' },
+            target: [
+              {
+                measure: { text: 'Hemoglobin A1c' },
+                detailQuantity: { value: 7, unit: '%' },
+                due: { value: 90, unit: 'days' },
+              },
+            ],
+          },
+          {
+            description: { text: 'Attend all scheduled follow up visits' },
+          },
+        ],
+        action: [
+          {
+            title: 'Follow up visit',
+          },
+        ],
+      });
+    expect(res1).toHaveStatus(201);
+
+    // 2. Create a Patient
+    const res2 = await request(app)
+      .post(`/fhir/R4/Patient`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Patient',
+        name: [{ given: ['Goal'], family: 'Demo' }],
+      });
+    expect(res2).toHaveStatus(201);
+    const patient = res2.body as WithId<Patient>;
+
+    // 3. Apply the PlanDefinition
+    const res3 = await request(app)
+      .post(`/fhir/R4/PlanDefinition/${res1.body.id}/$apply`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'subject',
+            valueString: getReferenceString(patient),
+          },
+        ],
+      });
+    expect(res3).toHaveStatus(200);
+
+    // 4. Verify the CarePlan references the Goals
+    const carePlan = res3.body as WithId<CarePlan>;
+    expect(carePlan.goal).toHaveLength(2);
+
+    // 5. Verify the Goal contents
+    const res4 = await request(app)
+      .get(`/fhir/R4/${carePlan.goal?.[0]?.reference}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res4).toHaveStatus(200);
+    const goal1 = res4.body as Goal;
+    expect(goal1.lifecycleStatus).toStrictEqual('proposed');
+    expect(goal1.subject).toMatchObject({ reference: getReferenceString(patient) });
+    expect(goal1.description).toMatchObject({ text: 'Reduce hemoglobin A1c below 7.0%' });
+    expect(goal1.category).toStrictEqual([{ text: 'Treatment' }]);
+    expect(goal1.priority).toMatchObject({ text: 'high-priority' });
+    expect(goal1.startCodeableConcept).toMatchObject({ text: 'When treatment starts' });
+    expect(goal1.target).toStrictEqual([
+      {
+        measure: { text: 'Hemoglobin A1c' },
+        detailQuantity: { value: 7, unit: '%' },
+        dueDuration: { value: 90, unit: 'days' },
+      },
+    ]);
+
+    const res5 = await request(app)
+      .get(`/fhir/R4/${carePlan.goal?.[1]?.reference}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res5).toHaveStatus(200);
+    const goal2 = res5.body as Goal;
+    expect(goal2.description).toMatchObject({ text: 'Attend all scheduled follow up visits' });
+    expect(goal2.category).toBeUndefined();
+    expect(goal2.priority).toBeUndefined();
+    expect(goal2.startCodeableConcept).toBeUndefined();
+    expect(goal2.target).toBeUndefined();
+  });
+
+  test('PlanDefinition without goals does not populate CarePlan.goal', async () => {
+    // 1. Create a PlanDefinition without goals
+    const res1 = await request(app)
+      .post(`/fhir/R4/PlanDefinition`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'PlanDefinition',
+        title: 'Example Plan Definition',
+        status: 'active',
+        action: [
+          {
+            title: 'Follow up visit',
+          },
+        ],
+      });
+    expect(res1).toHaveStatus(201);
+
+    // 2. Create a Patient
+    const res2 = await request(app)
+      .post(`/fhir/R4/Patient`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Patient',
+        name: [{ given: ['NoGoal'], family: 'Demo' }],
+      });
+    expect(res2).toHaveStatus(201);
+
+    // 3. Apply the PlanDefinition
+    const res3 = await request(app)
+      .post(`/fhir/R4/PlanDefinition/${res1.body.id}/$apply`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'subject',
+            valueString: getReferenceString(res2.body as Patient),
+          },
+        ],
+      });
+    expect(res3).toHaveStatus(200);
+    expect((res3.body as CarePlan).goal).toBeUndefined();
   });
 });

--- a/packages/server/src/fhir/operations/plandefinitionapply.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.ts
@@ -24,10 +24,13 @@ import type {
   ClientApplication,
   CodeableConcept,
   Encounter,
+  Goal,
+  GoalTarget,
   Organization,
   Patient,
   PlanDefinition,
   PlanDefinitionAction,
+  PlanDefinitionGoal,
   Practitioner,
   Questionnaire,
   Reference,
@@ -105,6 +108,11 @@ export async function planDefinitionApplyHandler(req: FhirRequest): Promise<Fhir
     );
   }
 
+  const goals: WithId<Goal>[] = [];
+  for (const goal of planDefinition.goal ?? EMPTY) {
+    goals.push(await createGoal(ctx.repo, subjectRef, goal));
+  }
+
   const requestGroup = await ctx.repo.createResource<RequestGroup>({
     resourceType: 'RequestGroup',
     instantiatesCanonical: planDefinition.url ? [planDefinition.url] : undefined,
@@ -128,9 +136,42 @@ export async function planDefinitionApplyHandler(req: FhirRequest): Promise<Fhir
       ? undefined
       : [concatUrls(getConfig().baseUrl, getReferenceString(planDefinition))],
     activity: [{ reference: createReference(requestGroup) }],
+    goal: goals.length > 0 ? goals.map(createReference) : undefined,
   });
 
   return [allOk, carePlan];
+}
+
+/**
+ * Creates a Goal for the given PlanDefinition goal.
+ *
+ * See: https://hl7.org/fhir/plandefinition-definitions.html#PlanDefinition.goal
+ * @param repo - The repository configured for the current user.
+ * @param subject - The subject of the plan definition.
+ * @param goal - The PlanDefinition goal.
+ * @returns The created Goal.
+ */
+async function createGoal(
+  repo: Repository,
+  subject: Reference<Patient>,
+  goal: PlanDefinitionGoal
+): Promise<WithId<Goal>> {
+  return repo.createResource<Goal>({
+    resourceType: 'Goal',
+    lifecycleStatus: 'proposed',
+    subject,
+    description: goal.description,
+    category: goal.category ? [goal.category] : undefined,
+    priority: goal.priority,
+    startCodeableConcept: goal.start,
+    target: goal.target?.map((target): GoalTarget => ({
+      measure: target.measure,
+      detailQuantity: target.detailQuantity,
+      detailRange: target.detailRange,
+      detailCodeableConcept: target.detailCodeableConcept,
+      dueDuration: target.due,
+    })),
+  });
 }
 
 /**


### PR DESCRIPTION
This PR proposes creating `Goal` resources from `PlanDefinition.goal` when `PlanDefinition/$apply` runs, and referencing them from the resulting `CarePlan` (Fixes #7268). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/403. You can sign in with your GitHub ID to claim ownership of the project.

## What changed and why

`planDefinitionApplyHandler` walks `PlanDefinition.action` to build a `RequestGroup` and its `Task`s, but never reads `PlanDefinition.goal`. Applying a plan that defines goals therefore returns a `CarePlan` with no `goal` element and creates no `Goal` resources for the subject, so goals authored on a `PlanDefinition` are silently dropped at apply time.

Reproduced on `main` at `76fa156` by applying a `PlanDefinition` that carries two goals (one with `category`, `priority`, `start` and a `target`; one with only the required `description`) to a `Patient`:

```
$ npx vitest run src/fhir/operations/plandefinitionapply.test.ts
 FAIL  src/fhir/operations/plandefinitionapply.test.ts > PlanDefinition apply > Creates Goal resources from PlanDefinition.goal
AssertionError: Target cannot be null or undefined.
 ❯ src/fhir/operations/plandefinitionapply.test.ts:1453:27
    1452|     const carePlan = res3.body as WithId<CarePlan>;
    1453|     expect(carePlan.goal).toHaveLength(2);
```

The change adds a `createGoal` helper that creates one `Goal` per `PlanDefinition.goal`, and sets `CarePlan.goal` to references of what it created. The mapping follows the element definitions: `description` (required on both sides) carries over directly, `category` becomes a single-entry `Goal.category` array, `priority` carries over, `start` becomes `startCodeableConcept`, and each `target` maps `measure`, `detailQuantity`, `detailRange` and `detailCodeableConcept` straight across with `due` (a `Duration`) becoming `dueDuration`. New goals get `lifecycleStatus: 'proposed'` and the applied subject. Two elements are deliberately not mapped because there is no lossless target for them: `PlanDefinition.goal.addresses` is a `CodeableConcept` describing a condition, whereas `Goal.addresses` is a `Reference` to an actual `Condition`/`Observation`, and `Goal` has no counterpart to `goal.documentation`.

The behaviour is additive. `CarePlan.goal` is left undefined when a `PlanDefinition` has no `goal` array, so existing plans apply exactly as before, and no existing element is rewritten.

Verification: two tests are added to `plandefinitionapply.test.ts`. The first fails on the unmodified tree (output above) and passes with the change, asserting every mapped field on both a fully populated goal and a description-only one. The second is a control asserting that a `PlanDefinition` without goals still produces a `CarePlan` with no `goal`. I ran the whole `src/fhir/operations` suite before and after against a seeded local Postgres and Redis: 79 files and 971 tests passing beforehand, 79 files and 973 tests passing afterwards, the two extra passes being the new tests, with no test moving from passing to failing. `npx tsc --noEmit` in `packages/server` is clean, as are `eslint` and `prettier --check` on both touched files. Commits are signed off per the DCO.

## How this was managed

This work was tracked as a story on a board imported from this repository's own issues and pull requests: [Add Goal resource to PlanDefinition$apply operation](https://eastagiletracker.com/projects/403/stories/360904) on the [Medplum board](https://eastagiletracker.com/projects/403), which holds 9,392 stories mapped from your issues, pull requests and milestones.

![board](https://raw.githubusercontent.com/eastagiletracker/medplum/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
