### PR TITLE
Fix API Extractor and TSDoc warnings in @medplum/core

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -934,8 +934,9 @@ export interface RequestProfileSchemaOptions extends MedplumRequestOptions {
  * Conditional methods (`createResourceIfNoneExist`, `upsertResource`) emit
  * even when the server made no change, except on HTTP 304 "Not Modified".
  *
- * @template T - The type of the modified resource. Defaults to `Resource`; narrow it (e.g. via
- * `useResourceModified('Slot', ...)`) to get a typed `resource` payload without extra guards.
+ * The generic type parameter `T` specifies the type of the modified resource.
+ * It defaults to `Resource`; narrow it (e.g. via `useResourceModified('Slot', ...)`)
+ * to get a typed `resource` payload without extra guards.
  */
 export interface ResourceModifiedEvent<T extends Resource = Resource> {
   /** The type of the modified resource. */

--- a/packages/core/src/medication-order-utils.ts
+++ b/packages/core/src/medication-order-utils.ts
@@ -86,20 +86,20 @@ export interface MedicationOrderDrugInput {
   readonly rxNorm?: string;
   readonly routedMedId?: number;
   /**
-   * Vendor formulation key, paired with {@link routedMedId} to order a drug that
+   * Vendor formulation key, paired with {@link MedicationOrderDrugInput.routedMedId} to order a drug that
    * has no dose-level product to resolve an NDC from — OTC / topical /
    * wide-multi-strength generics for which the vendor's dose-format lookup
-   * returns nothing. Supply {@link drugName} alongside it, since there is no
+   * returns nothing. Supply {@link MedicationOrderDrugInput.drugName} alongside it, since there is no
    * catalog row to derive a name from.
    */
   readonly gcnSeqno?: number;
-  /** Drug name, required for a {@link gcnSeqno}-keyed line (no catalog row to name it). */
+  /** Drug name, required for a {@link MedicationOrderDrugInput.gcnSeqno}-keyed line (no catalog row to name it). */
   readonly drugName?: string;
   /**
-   * Dose text for a {@link gcnSeqno}-keyed line, e.g. `"solution"`.
+   * Dose text for a {@link MedicationOrderDrugInput.gcnSeqno}-keyed line, e.g. `"solution"`.
    *
    * Optional, and only worth sending when the caller holds dose text *separate*
-   * from {@link drugName} — a hand-entered form, say. Passing a full product
+   * from {@link MedicationOrderDrugInput.drugName} — a hand-entered form, say. Passing a full product
    * label duplicates it in the description the vendor renders. When omitted, the
    * vendor derives the dose from the formulation key or falls back to the sig.
    */
@@ -205,7 +205,7 @@ export interface MedicationSearchParams {
   readonly rxNorm?: string;
   readonly routedMedId?: number;
   /**
-   * Vendor formulation keys under {@link routedMedId}, from the name-search hit.
+   * Vendor formulation keys under {@link MedicationSearchParams.routedMedId}, from the name-search hit.
    * Only used when the drug has no dose-level products: each key is resolved to
    * its marketed strength so the caller still gets selectable formulations
    * instead of an empty result. Ignored otherwise.


### PR DESCRIPTION
- Replace unsupported @template tag with inline type parameter documentation in ResourceModifiedEvent
- Fix unresolved @link references by qualifying them with interface names in medication-order-utils.ts

This resolves all api-extractor warnings:
- tsdoc-undefined-tag for @template
- ae-unresolved-link for routedMedId, drugName, and gcnSeqno references