### PR TITLE
[React-Scheduling] Style more calendar statuses

### DIFF
--- a/packages/react-scheduling/src/Calendar/Calendar.module.css
+++ b/packages/react-scheduling/src/Calendar/Calendar.module.css
@@ -13,6 +13,15 @@
     background-color: var(--cal-background-color);
   }
 
+  /**
+   * Appointment styles per-status
+   * - Happy-path statuses (pending, booked, arrived, fulfilled) do not get an
+   *   explicit status annotation after the title
+   * - Unusual or actionable statuses get color coding (pending, cancelled)
+   */
+  :global(.appointment.proposed) {
+    .eventTitle::after { content: ' (proposed)'; }
+  }
 
   :global(.appointment.pending) {
     --cal-color: light-dark(var(--mantine-color-blue-8), var(--mantine-color-blue-6));
@@ -22,11 +31,31 @@
     border: 1px solid var(--cal-color);
   }
 
+  :global(.appointment.waitlist) {
+    .eventTitle::after { content: ' (waitlist)'; }
+  }
+
+  :global(.appointment.checked-in) {
+    .eventTitle::after { content: ' (checked in)'; }
+  }
+
   :global(.appointment.cancelled) {
+    .eventTitle::after { content: ' (cancelled)'; }
     --cal-color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
     --cal-background-color: light-dark(var(--mantine-color-red-3), var(--mantine-color-red-8));
   }
 
+  :global(.appointment.noshow) {
+    .eventTitle::after { content: ' (no show)'; }
+  }
+
+  :global(.appointment.entered-in-error) {
+    .eventTitle::after { content: ' (entered in error)'; }
+  }
+
+  /**
+   * Slot styles per-status
+   */
   :global(.slot.free) {
     --cal-color: light-dark(var(--mantine-color-dark-7), var(--mantine-color-gray-1));
     --cal-background-color: light-dark(var(--mantine-color-green-1), var(--mantine-color-green-9));
@@ -50,25 +79,5 @@
 
   .eventTitle::after {
     opacity: .7;
-  }
-
-  /* No status annotation for "happy path" status in: pending, booked, arrived, fulfilled */
-  :global(.appointment.proposed) {
-    .eventTitle::after { content: ' (proposed)'; }
-  }
-  :global(.appointment.cancelled) {
-    .eventTitle::after { content: ' (cancelled)'; }
-  }
-  :global(.appointment.noshow) {
-    .eventTitle::after { content: ' (no show)'; }
-  }
-  :global(.appointment.entered-in-error) {
-    .eventTitle::after { content: ' (entered in error)'; }
-  }
-  :global(.appointment.checked-in) {
-    .eventTitle::after { content: ' (checked in)'; }
-  }
-  :global(.appointment.waitlist) {
-    .eventTitle::after { content: ' (waitlist)'; }
   }
 }

--- a/packages/react-scheduling/src/Calendar/Calendar.module.css
+++ b/packages/react-scheduling/src/Calendar/Calendar.module.css
@@ -22,9 +22,19 @@
     border: 1px solid var(--cal-color);
   }
 
+  :global(.appointment.cancelled) {
+    --cal-color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
+    --cal-background-color: light-dark(var(--mantine-color-red-3), var(--mantine-color-red-8));
+  }
+
   :global(.slot.free) {
     --cal-color: light-dark(var(--mantine-color-dark-7), var(--mantine-color-gray-1));
     --cal-background-color: light-dark(var(--mantine-color-green-1), var(--mantine-color-green-9));
+  }
+
+  :global(.slot.entered-in-error) {
+    --cal-color: light-dark(var(--mantine-color-dark-7), var(--mantine-color-black));
+    --cal-background-color: light-dark(var(--mantine-color-red-1), var(--mantine-color-red-3));
   }
 
   .event,

--- a/packages/react-scheduling/src/Calendar/Calendar.stories.tsx
+++ b/packages/react-scheduling/src/Calendar/Calendar.stories.tsx
@@ -47,6 +47,15 @@ export const Basic = (): JSX.Element => {
       schedule: createReference(DrAliceSmithSchedule),
       comment: 'Coming in early on wednesday morning',
     },
+
+    {
+      resourceType: 'Slot',
+      id: 'slot-4',
+      start: '2020-05-08T15:15:00Z',
+      end: '2020-05-08T16:15:00Z',
+      status: 'entered-in-error',
+      schedule: createReference(DrAliceSmithSchedule),
+    },
   ] satisfies Slot[];
 
   const appointments: Appointment[] = [
@@ -69,7 +78,6 @@ export const Basic = (): JSX.Element => {
         },
       ],
     },
-
     // A "pending" appointment is shown as an outlined block
     {
       resourceType: 'Appointment',
@@ -106,6 +114,42 @@ export const Basic = (): JSX.Element => {
         {
           status: 'accepted',
           actor: createReference(HomerSimpson),
+        },
+      ],
+    },
+
+    // A "cancelled" appointment gets some loud coloring and a status annotation
+    {
+      resourceType: 'Appointment',
+      id: 'appt-4',
+      status: 'cancelled',
+      start: '2020-05-05T16:00:00Z',
+      end: '2020-05-05T16:45:00Z',
+      slot: [],
+      participant: [
+        {
+          status: 'accepted',
+          actor: createReference(DrAliceSmith),
+        },
+        {
+          status: 'accepted',
+          actor: createReference(HomerSimpson),
+        },
+      ],
+    },
+
+    // An appointment with no Patient participent shows "No Patient" as the title
+    {
+      resourceType: 'Appointment',
+      id: 'appt-5',
+      status: 'booked',
+      start: '2020-05-06T15:30:00Z',
+      end: '2020-05-05T16:30:00Z',
+      slot: [],
+      participant: [
+        {
+          status: 'accepted',
+          actor: createReference(DrAliceSmith),
         },
       ],
     },


### PR DESCRIPTION
There may be scenarios where users of these components want to display slots/appointments in these statuses; let's be less opinionated in this component, and make these filters the responsibility of the caller.