### PR TITLE
fix: prevent access token to external URLs in download()

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -3982,7 +3982,7 @@ describe('Client', () => {
       const client = new MedplumClient({ fetch, baseUrl, fhirUrlPath });
       client.setAccessToken(accessToken);
       await client.download(externalUrl);
-      
+
       // Verify the Authorization header was NOT sent to external URL
       expect(fetch).toHaveBeenCalledWith(
         externalUrl,
@@ -3993,11 +3993,11 @@ describe('Client', () => {
           },
         })
       );
-      
+
       // Verify Authorization header is NOT present
       const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(callArgs[1].headers.Authorization).toBeUndefined();
-      
+
       // Verify credentials are NOT included for external URLs
       expect(callArgs[1].credentials).toBeUndefined();
     });
@@ -4009,7 +4009,7 @@ describe('Client', () => {
       const client = new MedplumClient({ fetch, baseUrl, fhirUrlPath });
       client.setAccessToken(accessToken);
       await client.download(internalUrl);
-      
+
       // Verify the Authorization header WAS sent to internal URL
       const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(callArgs[1].headers.Authorization).toBe(`Bearer ${accessToken}`);
@@ -4022,7 +4022,7 @@ describe('Client', () => {
       const client = new MedplumClient({ fetch, baseUrl, fhirUrlPath });
       client.setAccessToken(accessToken);
       await client.download(externalUrl);
-      
+
       // Verify the Authorization header was NOT sent
       const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(callArgs[1].headers.Authorization).toBeUndefined();

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -3975,6 +3975,58 @@ describe('Client', () => {
       );
       expect(await blob.text()).toStrictEqual(`${baseUrl}${fhirUrlPath}Binary/fake-id`);
     });
+
+    test('Downloading external URLs should NOT include credentials', async () => {
+      const externalUrl = 'https://external-site.example.com/document.pdf';
+      const fetch = mockFetch(200, () => 'external content');
+      const client = new MedplumClient({ fetch, baseUrl, fhirUrlPath });
+      client.setAccessToken(accessToken);
+      await client.download(externalUrl);
+      
+      // Verify the Authorization header was NOT sent to external URL
+      expect(fetch).toHaveBeenCalledWith(
+        externalUrl,
+        expect.objectContaining({
+          headers: {
+            Accept: '*/*',
+            'X-Medplum': 'extended',
+          },
+        })
+      );
+      
+      // Verify Authorization header is NOT present
+      const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(callArgs[1].headers.Authorization).toBeUndefined();
+      
+      // Verify credentials are NOT included for external URLs
+      expect(callArgs[1].credentials).toBeUndefined();
+    });
+
+    test('Downloading from baseUrl path should include credentials', async () => {
+      // URLs under the baseUrl should still get credentials (legitimate Medplum endpoints)
+      const internalUrl = 'https://api.medplum.com/admin/projects/123';
+      const fetch = mockFetch(200, () => 'internal content');
+      const client = new MedplumClient({ fetch, baseUrl, fhirUrlPath });
+      client.setAccessToken(accessToken);
+      await client.download(internalUrl);
+      
+      // Verify the Authorization header WAS sent to internal URL
+      const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(callArgs[1].headers.Authorization).toBe(`Bearer ${accessToken}`);
+      expect(callArgs[1].credentials).toBe('include');
+    });
+
+    test('Downloading from subdomain should NOT include credentials', async () => {
+      const externalUrl = 'https://evil.api.medplum.com/malicious';
+      const fetch = mockFetch(200, () => 'external content');
+      const client = new MedplumClient({ fetch, baseUrl, fhirUrlPath });
+      client.setAccessToken(accessToken);
+      await client.download(externalUrl);
+      
+      // Verify the Authorization header was NOT sent
+      const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(callArgs[1].headers.Authorization).toBeUndefined();
+    });
   });
 
   describe('Media', () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3418,7 +3418,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       headers['Accept'] = '*/*';
     }
 
-    this.addFetchOptionsDefaults(options);
+    this.addFetchOptionsDefaults(options, url.toString());
     return this.fetchWithRetry(url.toString(), options);
   }
 
@@ -3567,7 +3567,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * @returns The response body.
    */
   async startAsyncRequest<T>(url: string, options: MedplumRequestOptions = {}): Promise<T> {
-    this.addFetchOptionsDefaults(options);
+    this.addFetchOptionsDefaults(options, url);
 
     const headers = options.headers as Record<string, string>;
     headers['Prefer'] = 'respond-async';
@@ -3585,7 +3585,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   async wrappedFetch(url: string, options: RequestInit): Promise<Response> {
     await this.refreshIfExpired();
 
-    this.addFetchOptionsDefaults(options);
+    this.addFetchOptionsDefaults(options, url);
 
     return this.fetchWithRetry(url, options);
   }
@@ -3996,7 +3996,30 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * Adds default options to the fetch options.
    * @param options - The options to add defaults to.
    */
-  private addFetchOptionsDefaults(options: MedplumRequestOptions): void {
+  /**
+   * Determines if a URL is internal and should receive authentication credentials.
+   * @param url - The URL to check
+   * @returns True if the URL should receive credentials
+   */
+  private isInternalUrl(url: string): boolean {
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      return true; // Relative URLs are internal
+    }
+
+    try {
+      const target = new URL(url);
+      return (
+        url.startsWith(this.baseUrl) ||
+        url.startsWith(this.fhirBaseUrl) ||
+        (target.origin === new URL(this.baseUrl).origin &&
+          ensureTrailingSlash(target.pathname).startsWith(ensureTrailingSlash(new URL(this.baseUrl).pathname)))
+      );
+    } catch {
+      return false; // Treat unparseable URLs as external
+    }
+  }
+
+  private addFetchOptionsDefaults(options: MedplumRequestOptions, url: string): void {
     // Apply default headers
     Object.entries(this.defaultHeaders).forEach(([name, value]) => {
       this.setRequestHeader(options, name, value);
@@ -4012,14 +4035,17 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       this.setRequestHeader(options, 'Content-Type', ContentType.FHIR_JSON, true);
     }
 
-    if (this.accessToken) {
-      this.setRequestHeader(options, 'Authorization', 'Bearer ' + this.accessToken);
-    } else if (this.basicAuth) {
-      this.setRequestHeader(options, 'Authorization', 'Basic ' + this.basicAuth);
-    }
+    // Only add authentication credentials for internal URLs
+    if (this.isInternalUrl(url)) {
+      if (this.accessToken) {
+        this.setRequestHeader(options, 'Authorization', 'Bearer ' + this.accessToken);
+      } else if (this.basicAuth) {
+        this.setRequestHeader(options, 'Authorization', 'Basic ' + this.basicAuth);
+      }
 
-    if (!options.credentials) {
-      options.credentials = 'include';
+      if (!options.credentials) {
+        options.credentials = 'include';
+      }
     }
   }
 


### PR DESCRIPTION
MedplumClient.download() and related methods were unconditionally sending the Authorization header with access tokens to all URLs, including attacker-controlled external domains.

This change adds URL validation to ensure credentials are only sent to internal Medplum server URLs (matching baseUrl or fhirBaseUrl origin and path).

Security impact:
- Prevents access token disclosure to external hosts
- Blocks subdomain attacks (evil.api.medplum.com)
- Validates path boundaries to prevent path traversal

Changes:
- Added isInternalUrl() method to validate URLs before adding credentials
- Modified addFetchOptionsDefaults() to accept URL parameter and check before adding Authorization header and credentials
- Updated call sites: downloadResponse(), startAsyncRequest(), wrappedFetch()
- Added comprehensive security test coverage