### PR TITLE
feat(cdk): add opt-in ECS deployment circuit breaker

### DIFF
--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -549,6 +549,10 @@ export class BackEnd extends Construct {
       securityGroups: [this.fargateSecurityGroup],
       healthCheckGracePeriod: Duration.minutes(5),
       minHealthyPercent: 100, // 50% is the default
+      // Off unless configured, preserving the previous behaviour.
+      circuitBreaker: config.fargateDeploymentCircuitBreaker?.enable
+        ? { rollback: config.fargateDeploymentCircuitBreaker.rollback ?? false }
+        : undefined,
     });
 
     // Add autoscaling

--- a/packages/cdk/src/index.test.ts
+++ b/packages/cdk/src/index.test.ts
@@ -649,4 +649,63 @@ describe('Infra', () => {
       0
     );
   });
+
+  // Without the circuit breaker, a deployment whose tasks never become healthy
+  // retries forever: ECS replaces the failed task indefinitely and the
+  // deployment never concludes, so no failure is ever reported.
+  test('Deployment circuit breaker is off unless configured', async () => {
+    const sourceConfig = {
+      ...baseConfig,
+      stackName: 'MedplumNoCircuitBreakerStack',
+    } as unknown as MedplumSourceInfraConfig;
+    const config = await normalizeInfraConfig(sourceConfig);
+    const app = new App();
+    const stack = new MedplumStack(app, config);
+    const template = Template.fromStack(stack.primaryStack);
+
+    template.hasResourceProperties('AWS::ECS::Service', {
+      DeploymentConfiguration: Match.objectLike({
+        DeploymentCircuitBreaker: Match.absent(),
+      }),
+    });
+  });
+
+  test('fargateDeploymentCircuitBreaker enables the circuit breaker', async () => {
+    const sourceConfig = {
+      ...baseConfig,
+      stackName: 'MedplumCircuitBreakerStack',
+      fargateDeploymentCircuitBreaker: { enable: true, rollback: true },
+    } as unknown as MedplumSourceInfraConfig;
+    const config = await normalizeInfraConfig(sourceConfig);
+    const app = new App();
+    const stack = new MedplumStack(app, config);
+    const template = Template.fromStack(stack.primaryStack);
+
+    template.hasResourceProperties('AWS::ECS::Service', {
+      DeploymentConfiguration: Match.objectLike({
+        DeploymentCircuitBreaker: { Enable: true, Rollback: true },
+      }),
+    });
+  });
+
+  // `rollback` is the half that can surprise you — it restores the previous
+  // task definition, which is not always safe alongside a schema migration —
+  // so enabling the breaker must not opt you into it by accident.
+  test('rollback defaults to false when only enable is set', async () => {
+    const sourceConfig = {
+      ...baseConfig,
+      stackName: 'MedplumCircuitBreakerNoRollbackStack',
+      fargateDeploymentCircuitBreaker: { enable: true },
+    } as unknown as MedplumSourceInfraConfig;
+    const config = await normalizeInfraConfig(sourceConfig);
+    const app = new App();
+    const stack = new MedplumStack(app, config);
+    const template = Template.fromStack(stack.primaryStack);
+
+    template.hasResourceProperties('AWS::ECS::Service', {
+      DeploymentConfiguration: Match.objectLike({
+        DeploymentCircuitBreaker: { Enable: true, Rollback: false },
+      }),
+    });
+  });
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -131,6 +131,21 @@ export interface MedplumSourceInfraConfig {
     scaleInCooldown: ValueOrExternalSecret<number>;
     scaleOutCooldown: ValueOrExternalSecret<number>;
   };
+  /**
+   * Opt in to the ECS deployment circuit breaker.
+   *
+   * Without it a deployment whose tasks never reach a healthy state retries
+   * indefinitely: ECS keeps replacing the failed task and the deployment never
+   * concludes, so nothing reports a failure. Enabling it fails the deployment
+   * instead, and `rollback` additionally restores the last known-good task
+   * definition.
+   *
+   * Defaults to disabled, which is the current behaviour.
+   */
+  fargateDeploymentCircuitBreaker?: {
+    enable: ValueOrExternalSecret<boolean>;
+    rollback?: ValueOrExternalSecret<boolean>;
+  };
   environment?: StringMap;
   workers?: {
     enabled?: string[];
@@ -303,6 +318,10 @@ export interface MedplumInfraConfig {
     targetUtilizationPercent: number;
     scaleInCooldown: number;
     scaleOutCooldown: number;
+  };
+  fargateDeploymentCircuitBreaker?: {
+    enable: boolean;
+    rollback?: boolean;
   };
   environment?: StringMap;
   workers?: {


### PR DESCRIPTION
Without the deployment circuit breaker, a deployment whose tasks never reach a healthy state retries indefinitely — ECS keeps replacing the failed task and the deployment never concludes, so nothing ever surfaces a failure.

The service stays up on the previous tasks, which is what makes it easy to miss: the symptom is a deploy that appears to hang, not one that fails. We hit this on a stack whose new tasks crash-looped on a config problem; the deployment simply never finished and there was no failure signal to alert on.

## Change

Adds an optional `fargateDeploymentCircuitBreaker` to `MedplumInfraConfig`, mirroring the shape of the existing `fargateAutoScaling`:

```jsonc
{
  "fargateDeploymentCircuitBreaker": {
    "enable": true,
    "rollback": false
  }
}
```

It is absent by default, so existing stacks emit no `DeploymentCircuitBreaker` and behaviour is unchanged.

## Why `rollback` defaults to false

Restoring the previous task definition is not unconditionally safe alongside boot-time schema migrations: a version that migrates the schema and then crashes would roll back to an older server running against a newer schema. Opting into failing fast should not silently opt you into reverting too, so `rollback` is only set when asked for explicitly.

## Tests

Three cases in `packages/cdk/src/index.test.ts`:

- `DeploymentCircuitBreaker` is absent when the config is not set
- enabled with `Rollback: true` when configured
- `Rollback: false` when only `enable` is set

`packages/cdk` suite passes 43/43 locally, and `packages/core` typechecks clean.