### PR TITLE
[Provider] Show Loader during ScriptSure iframe loading

### DIFF
--- a/examples/medplum-provider/src/pages/patient/ScriptSureTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/ScriptSureTab.tsx
@@ -5,7 +5,7 @@ import { showNotification } from '@mantine/notifications';
 import { normalizeErrorString } from '@medplum/core';
 import { useScriptSureIFrame } from '@medplum/scriptsure-react';
 import type { JSX } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useMemo, useRef } from 'react';
 import { useParams } from 'react-router';
 import { applyDarkmode } from '../../components/meds/applyDarkmode';
 import { useScriptSurePractice } from '../../scriptsure/ScriptSurePractice';
@@ -45,13 +45,14 @@ export function ScriptSureTab(): JSX.Element {
   // per iframe load so toggling the Mantine color scheme does not force the
   // chart iframe to reload (and lose any in-progress state).
   const colorScheme = useComputedColorScheme('light');
-  const [renderedUrl, setRenderedUrl] = useState<string | undefined>(undefined);
-  useEffect(() => {
-    setRenderedUrl(applyDarkmode(iframeUrl, colorScheme));
+
+  const renderedUrl = useMemo(
+    () => applyDarkmode(iframeUrl, colorScheme),
     // Intentionally not depending on `colorScheme` so the iframe is not
     // reloaded mid-session when the user toggles the theme.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [iframeUrl]);
+    [iframeUrl]
+  );
 
   return (
     <Box style={{ flex: 1, minHeight: 0 }}>

--- a/examples/medplum-provider/src/pages/patient/ScriptSureTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/ScriptSureTab.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Box, useComputedColorScheme } from '@mantine/core';
+import { Box, Center, Loader, useComputedColorScheme } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { normalizeErrorString } from '@medplum/core';
 import { useScriptSureIFrame } from '@medplum/scriptsure-react';
@@ -55,6 +55,11 @@ export function ScriptSureTab(): JSX.Element {
 
   return (
     <Box style={{ flex: 1, minHeight: 0 }}>
+      {!renderedUrl && (
+        <Center mt="xl">
+          <Loader />
+        </Center>
+      )}
       {renderedUrl && (
         <iframe
           id="scriptsure-iframe"


### PR DESCRIPTION
There's a step where the viewed Patient's information is sync'd from Medplum to ScriptSure before the iFrame is mounted that can take a few seconds. Let's show a loading spinner during that time to make it more clear that the work is happening.