### PR TITLE
Align SCIM user updates with normal project auth permissions

### DIFF
--- a/packages/server/src/scim/routes.test.ts
+++ b/packages/server/src/scim/routes.test.ts
@@ -1,21 +1,24 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
 import { ContentType, createReference } from '@medplum/core';
-import type { AccessPolicy } from '@medplum/fhirtypes';
+import type { AccessPolicy, Project, User } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
+import { inviteUser } from '../admin/invite';
 import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config/loader';
 import type { SystemRepository } from '../fhir/repo';
-import { getProjectSystemRepo } from '../fhir/repo';
+import { getGlobalSystemRepo, getProjectSystemRepo } from '../fhir/repo';
 import { addTestUser, withTestContext } from '../test.setup';
 
 describe('SCIM Routes', () => {
   const app = express();
   let accessToken: string;
   let systemRepo: SystemRepository;
+  let project: WithId<Project>;
 
   beforeAll(async () => {
     const config = await loadTestConfig();
@@ -30,6 +33,7 @@ describe('SCIM Routes', () => {
       password: 'password!@#',
     });
     accessToken = registration.accessToken;
+    project = registration.project;
     systemRepo = await getProjectSystemRepo(registration.project);
 
     // Create default access policy
@@ -180,6 +184,146 @@ describe('SCIM Routes', () => {
       });
     expect(res).toHaveStatus(201);
     expect(res.body.userType).toBe('Practitioner');
+  });
+
+  test('Reject update of server-scoped user', async () => {
+    // Bob registers his own project, which creates a server-scoped (global) User
+    const bobEmail = `bob${randomUUID()}@example.com`;
+    const bob = await withTestContext(() =>
+      registerNew({
+        firstName: 'Bob',
+        lastName: 'Jones',
+        projectName: 'Bob Project',
+        email: bobEmail,
+        password: 'password!@#',
+      })
+    );
+    expect(bob.user.project).toBeUndefined();
+
+    // Alice invites Bob by email, which reuses Bob's existing global User
+    const { membership, user } = await withTestContext(() =>
+      inviteUser({
+        project,
+        email: bobEmail,
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        sendEmail: false,
+      })
+    );
+    expect(user.id).toBe(bob.user.id);
+    expect(user.project).toBeUndefined();
+    expect(membership.project?.reference).toBe(`Project/${project.id}`);
+
+    // The membership is in Alice's project, but the User is not, so Alice cannot write to it
+    const newEmail = `attacker${randomUUID()}@example.com`;
+    const updateResponse = await request(app)
+      .put(`/scim/v2/Users/${membership.id}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        id: membership.id,
+        userType: 'Practitioner',
+        name: { givenName: 'Bob', familyName: 'Jones' },
+        emails: [{ value: newEmail }],
+      });
+    expect(updateResponse).toHaveStatus(403);
+
+    const patchResponse = await request(app)
+      .patch(`/scim/v2/Users/${membership.id}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+        Operations: [{ op: 'replace', value: { emails: [{ value: newEmail }] } }],
+      });
+    expect(patchResponse).toHaveStatus(403);
+
+    // Bob's login email is unchanged
+    const bobUser = await getGlobalSystemRepo().readResource<User>('User', bob.user.id);
+    expect(bobUser.email).toBe(bobEmail);
+  });
+
+  test('Reject update of user from another project', async () => {
+    // Bob is a project-scoped user in his own project
+    const bob = await withTestContext(() =>
+      registerNew({
+        firstName: 'Bob',
+        lastName: 'Jones',
+        projectName: 'Bob Project',
+        email: `bob${randomUUID()}@example.com`,
+        password: 'password!@#',
+      })
+    );
+    const bobPatient = await withTestContext(() =>
+      addTestUser(bob.project, { resourceType: 'Patient', accessPolicy: { resourceType: 'AccessPolicy' } })
+    );
+    expect(bobPatient.user.project?.reference).toBe(`Project/${bob.project.id}`);
+
+    // Alice references Bob's project membership, which is not in her project
+    const updateResponse = await request(app)
+      .put(`/scim/v2/Users/${bobPatient.membership.id}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        id: bobPatient.membership.id,
+        userType: 'Patient',
+        name: { givenName: 'Bob', familyName: 'Jones' },
+        emails: [{ value: `attacker${randomUUID()}@example.com` }],
+      });
+    expect(updateResponse).toHaveStatus(403);
+
+    const bobUser = await getGlobalSystemRepo().readResource<User>('User', bobPatient.user.id);
+    expect(bobUser.email).toBe(bobPatient.user.email);
+  });
+
+  test('Deactivate server-scoped user', async () => {
+    // Bob registers his own project, which creates a server-scoped (global) User
+    const bobEmail = `bob${randomUUID()}@example.com`;
+    const bob = await withTestContext(() =>
+      registerNew({
+        firstName: 'Bob',
+        lastName: 'Jones',
+        projectName: 'Bob Project',
+        email: bobEmail,
+        password: 'password!@#',
+      })
+    );
+
+    // Alice invites Bob by email, which reuses Bob's existing global User
+    const { membership, user } = await withTestContext(() =>
+      inviteUser({
+        project,
+        email: bobEmail,
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        sendEmail: false,
+      })
+    );
+    expect(user.id).toBe(bob.user.id);
+    expect(user.project).toBeUndefined();
+
+    const before = await getGlobalSystemRepo().readResource<User>('User', user.id);
+
+    // Alice owns the membership, so she can still deactivate Bob within her own project
+    const patchResponse = await request(app)
+      .patch(`/scim/v2/Users/${membership.id}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.SCIM_JSON)
+      .send({
+        schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+        Operations: [{ op: 'replace', value: { active: false } }],
+      });
+    expect(patchResponse).toHaveStatus(200);
+    expect(patchResponse.body.active).toBe(false);
+
+    // Bob's global User was not written at all
+    const after = await getGlobalSystemRepo().readResource<User>('User', user.id);
+    expect(after.email).toBe(bobEmail);
+    expect(after.meta?.versionId).toBe(before.meta?.versionId);
   });
 
   test('Search users as super admin', async () => {

--- a/packages/server/src/scim/utils.ts
+++ b/packages/server/src/scim/utils.ts
@@ -127,6 +127,36 @@ export async function readScimUser(systemRepo: SystemRepository, project: Projec
 }
 
 /**
+ * Reads the ProjectMembership and User for a SCIM write operation.
+ *
+ * The membership check alone is not sufficient. A User is a global record that can be a member of
+ * many projects, so a membership in the caller's project does not establish that the caller owns
+ * the User it points at. Membership fields are always writable, but User fields are only writable
+ * by the project that owns the User. Server-scoped Users belong to no project and are therefore
+ * never owned by a SCIM caller.
+ *
+ * @param systemRepo - The system repository.
+ * @param project - The project.
+ * @param id - The ProjectMembership ID.
+ * @returns The membership, the User it references, and whether the User is writable.
+ */
+async function readMembershipAndUserForWrite(
+  systemRepo: SystemRepository,
+  project: Project,
+  id: string
+): Promise<{ membership: WithId<ProjectMembership>; user: WithId<User>; userWritable: boolean }> {
+  const projectReference = getReferenceString(project);
+
+  const membership = await systemRepo.readResource<ProjectMembership>('ProjectMembership', id);
+  if (membership.project?.reference !== projectReference) {
+    throw new OperationOutcomeError(forbidden);
+  }
+
+  const user = await systemRepo.readReference<User>(membership.user as Reference<User>);
+  return { membership, user, userWritable: user.project?.reference === projectReference };
+}
+
+/**
  * Updates an existing user.
  *
  * See SCIM 3.5.1 - Replace a Resource
@@ -141,21 +171,20 @@ export async function updateScimUser(
   project: Project,
   scimUser: ScimUser
 ): Promise<ScimUser> {
-  let membership = await systemRepo.readResource<ProjectMembership>('ProjectMembership', scimUser.id as string);
-  if (membership.project?.reference !== getReferenceString(project)) {
-    throw new OperationOutcomeError(forbidden);
-  }
-
-  let user = await systemRepo.readReference<User>(membership.user as Reference<User>);
+  const { membership, user, userWritable } = await readMembershipAndUserForWrite(
+    systemRepo,
+    project,
+    scimUser.id as string
+  );
 
   // Copy the updated properties from the SCIM user to the Medplum user and membership
-  scimUserToUserAndMembership(scimUser, user, membership);
+  scimUserToUserAndMembership(scimUser, user, membership, userWritable);
 
   // Save the updated user and membership
-  user = await systemRepo.updateResource(user);
-  membership = await systemRepo.updateResource(membership);
+  const updatedUser = userWritable ? await systemRepo.updateResource(user) : user;
+  const updatedMembership = await systemRepo.updateResource(membership);
 
-  return convertToScimUser(user, membership);
+  return convertToScimUser(updatedUser, updatedMembership);
 }
 
 /**
@@ -176,12 +205,7 @@ export async function patchScimUser(
   id: string,
   request: ScimPatchRequest
 ): Promise<ScimUser> {
-  let membership = await systemRepo.readResource<ProjectMembership>('ProjectMembership', id);
-  if (membership.project?.reference !== getReferenceString(project)) {
-    throw new OperationOutcomeError(forbidden);
-  }
-
-  let user = await systemRepo.readReference<User>(membership.user as Reference<User>);
+  const { membership, user, userWritable } = await readMembershipAndUserForWrite(systemRepo, project, id);
 
   // Convert the user and membership to a SCIM user
   const scimUser = convertToScimUser(user, membership);
@@ -190,13 +214,13 @@ export async function patchScimUser(
   patchObject(scimUser, convertScimToJsonPatch(request));
 
   // Copy the updated properties from the SCIM user to the Medplum user and membership
-  scimUserToUserAndMembership(scimUser, user, membership);
+  scimUserToUserAndMembership(scimUser, user, membership, userWritable);
 
   // Save the updated user and membership
-  user = await systemRepo.updateResource(user);
-  membership = await systemRepo.updateResource(membership);
+  const updatedUser = userWritable ? await systemRepo.updateResource(user) : user;
+  const updatedMembership = await systemRepo.updateResource(membership);
 
-  return convertToScimUser(user, membership);
+  return convertToScimUser(updatedUser, updatedMembership);
 }
 
 /**
@@ -271,14 +295,26 @@ export function convertToScimUser(user: User, membership: ProjectMembership): Sc
  * @param scimUser - The input SCIM user.
  * @param user - The output Medplum user.
  * @param membership - The output Medplum project membership.
+ * @param userWritable - Whether the caller's project owns the User.
  */
-function scimUserToUserAndMembership(scimUser: ScimUser, user: User, membership: ProjectMembership): void {
-  user.firstName = scimUser.name?.givenName as string;
-  user.lastName = scimUser.name?.familyName as string;
-  user.externalId = scimUser.externalId;
+function scimUserToUserAndMembership(
+  scimUser: ScimUser,
+  user: User,
+  membership: ProjectMembership,
+  userWritable: boolean
+): void {
+  if (userWritable) {
+    user.firstName = scimUser.name?.givenName as string;
+    user.lastName = scimUser.name?.familyName as string;
+    user.externalId = scimUser.externalId;
 
-  if (scimUser.emails?.[0]?.value) {
-    user.email = scimUser.emails[0]?.value;
+    if (scimUser.emails?.[0]?.value) {
+      user.email = scimUser.emails[0]?.value;
+    }
+  } else if (scimUser.emails?.[0]?.value && scimUser.emails[0].value !== user.email) {
+    // The login email of a User owned by another project is not the caller's to change.
+    // The other User fields are treated as read-only and ignored.
+    throw new OperationOutcomeError(forbidden);
   }
 
   if (scimUser.active !== undefined) {


### PR DESCRIPTION
A SCIM `User` maps onto two Medplum resources: a `ProjectMembership`, which is owned by a single project, and the `User` it references, which is a global record that can be a member of many projects. `PUT` and `PATCH` on `/scim/v2/Users/{id}` verified that the membership belongs to the caller's project, then wrote fields on both resources.

Elsewhere in the server, writes to a `User` require that the `User` itself belong to the caller's project. This change applies that same rule to the SCIM write path, so SCIM resolves to the same permission model as the rest of the server.