### PR TITLE
[Scheduling] Booking form: gather criteria and find a time

### DIFF
--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentActorSelect.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentActorSelect.tsx
@@ -71,7 +71,7 @@ export function AppointmentActorSelect(props: AppointmentActorSelectProps): JSX.
       name={role}
       label={label}
       required={required}
-      description={required ? undefined : `Optional. Leave empty to search without holding a ${noun}.`}
+      description={getFieldDescription(!service, required, noun)}
       placeholder={`Search ${noun}s`}
       error={error}
       disabled={disabled}
@@ -83,6 +83,25 @@ export function AppointmentActorSelect(props: AppointmentActorSelectProps): JSX.
       onChange={handleChange}
     />
   );
+}
+
+/**
+ * Says what the field is waiting for, or what leaving it empty means.
+ *
+ * The description rather than the placeholder, because a disabled field's
+ * placeholder does not render: without this the field waits on a visit type as a
+ * blank grey box, with nothing saying which answer is owed first.
+ *
+ * @param gated - Whether there is no visit type to search against yet.
+ * @param required - Whether a search can run without this role.
+ * @param noun - The role, lowercased, as it reads in a sentence.
+ * @returns The description, or undefined when the field has nothing to add.
+ */
+function getFieldDescription(gated: boolean, required: boolean, noun: string): string | undefined {
+  if (gated) {
+    return 'Choose a visit type first.';
+  }
+  return required ? undefined : `Optional. Leave empty to search without holding a ${noun}.`;
 }
 
 function toOption(candidate: ScheduleCandidate): AsyncAutocompleteOption<ScheduleCandidate> {

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentActorSelect.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentActorSelect.tsx
@@ -71,7 +71,7 @@ export function AppointmentActorSelect(props: AppointmentActorSelectProps): JSX.
       name={role}
       label={label}
       required={required}
-      description={getFieldDescription(!service, required, noun)}
+      description={required ? undefined : `Optional. Leave empty to search without holding a ${noun}.`}
       placeholder={`Search ${noun}s`}
       error={error}
       disabled={disabled}
@@ -83,25 +83,6 @@ export function AppointmentActorSelect(props: AppointmentActorSelectProps): JSX.
       onChange={handleChange}
     />
   );
-}
-
-/**
- * Says what the field is waiting for, or what leaving it empty means.
- *
- * The description rather than the placeholder, because a disabled field's
- * placeholder does not render: without this the field waits on a visit type as a
- * blank grey box, with nothing saying which answer is owed first.
- *
- * @param gated - Whether there is no visit type to search against yet.
- * @param required - Whether a search can run without this role.
- * @param noun - The role, lowercased, as it reads in a sentence.
- * @returns The description, or undefined when the field has nothing to add.
- */
-function getFieldDescription(gated: boolean, required: boolean, noun: string): string | undefined {
-  if (gated) {
-    return 'Choose a visit type first.';
-  }
-  return required ? undefined : `Optional. Leave empty to search without holding a ${noun}.`;
 }
 
 function toOption(candidate: ScheduleCandidate): AsyncAutocompleteOption<ScheduleCandidate> {

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
@@ -17,10 +17,9 @@ import { AppointmentBookingForm } from './AppointmentBookingForm';
 
 const STORY_FIXTURES = [...SchedulingFixtures, ...SurgicalFixtures, ...SubClinicProviderFixtures];
 
-// `withFindStub` is per story rather than shared: a story's own decorators are
-// added to these rather than replacing them, so a shared stub plus a story's own
-// would install two, and which of them answered would be an accident of effect
-// ordering. Everything here is safe to nest, so it stays.
+// Storybook adds a story's own decorators to these rather than replacing them, so
+// `$find` is stubbed per story: two stubs would both install, and which one
+// answered would be an accident of effect ordering.
 export default {
   title: 'Medplum/AppointmentBookingForm',
   component: AppointmentBookingForm,
@@ -81,8 +80,7 @@ NoAvailability.decorators = [withFindStub({ empty: true })];
  * counts. Open the provider field and Dr. Osei is not — a provider is sited only
  * by a role naming the clinic exactly, with no walk up the chain.
  *
- * Inherited from the schedule search rather than chosen here, and pinned as a
- * story so it stays a decision on the record.
+ * The rule lives in the schedule search, not in this component.
  * @returns The story.
  */
 export const SiteAsymmetryByRole = (): JSX.Element => (

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
@@ -33,8 +33,8 @@ export default {
  * held on practitioners, rooms and devices, and only the provider is required.
  *
  * Nothing is searched for times until "Find a time" is opened. There is no field
- * for a time: pick one and it appears as a summary under the action, saying how
- * long the visit runs and what it is held on, and the action offers to change it.
+ * for a time until one is picked: it then appears above the action, read-only, with
+ * how long the visit runs and what holds it, and the action offers to change it.
  * @returns The story.
  */
 export const Basic = (): JSX.Element => (

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
@@ -17,9 +17,9 @@ import { AppointmentBookingForm } from './AppointmentBookingForm';
 
 const STORY_FIXTURES = [...SchedulingFixtures, ...SurgicalFixtures, ...SubClinicProviderFixtures];
 
-// Storybook adds a story's own decorators to these rather than replacing them, so
-// `$find` is stubbed per story: two stubs would both install, and which one
-// answered would be an accident of effect ordering.
+// A story's own decorators add to these rather than replacing them, so `$find` is
+// stubbed per story: two stubs would both install, and which one answered would be
+// an accident of effect ordering.
 export default {
   title: 'Medplum/AppointmentBookingForm',
   component: AppointmentBookingForm,
@@ -30,16 +30,12 @@ export default {
  * The form from an empty state to a chosen time.
  *
  * Choose "Ultrasound Imaging" and the three role fields search against it: it is
- * held on practitioners, rooms and devices, and only the provider is required.
- *
- * "Find a time" stays unusable until a provider is named, and says so: a search
- * without one could only report that a provider is needed. There is no field for a
- * time until one is picked: it then appears above the action, read-only, with how
- * long the visit runs and what holds it, and the action offers to change it.
+ * held on practitioners, rooms and devices, and only the provider is required. So
+ * "Find a time" stays unusable until a provider is named, and says so.
  *
  * Change a resource with a time already picked and the time goes — it was found for
- * the resources that no longer stand — while the search stays open and re-runs, so
- * the replacement is one click away.
+ * resources that no longer stand — while the search stays open and re-runs, so the
+ * replacement is one click away.
  * @returns The story.
  */
 export const Basic = (): JSX.Element => (
@@ -67,8 +63,8 @@ SurgicalTeam.decorators = [withFindStub()];
 /**
  * A fully configured visit type with nothing free.
  *
- * The distinction matters: "no times for this selection" is a different dead end
- * from a role field that finds nobody, and the form says which.
+ * "No times for this selection" is a different dead end from a role field that finds
+ * nobody, and the form says which.
  * @returns The story.
  */
 export const NoAvailability = (): JSX.Element => (
@@ -79,14 +75,13 @@ export const NoAvailability = (): JSX.Element => (
 NoAvailability.decorators = [withFindStub({ empty: true })];
 
 /**
- * The site filter, which is asymmetric by role and reads as a bug until it is
- * seen deliberately.
+ * The site filter, which is asymmetric by role and reads as a bug until it is seen
+ * deliberately.
  *
- * The main clinic has a second floor, and on that floor are Exam Room B and Dr.
- * Ama Osei's only practitioner role. Open the room field and Exam Room B is
- * there — a room is sited by walking `partOf`, so anywhere inside the clinic
- * counts. Open the provider field and Dr. Osei is not — a provider is sited only
- * by a role naming the clinic exactly, with no walk up the chain.
+ * On the main clinic's second floor sit both Exam Room B and Dr. Ama Osei's only
+ * practitioner role. Booking at the clinic, the room field offers Exam Room B — a
+ * room is sited by walking `partOf` — while the provider field leaves Dr. Osei out,
+ * since a provider is sited only by a role naming the site exactly.
  *
  * The rule lives in the schedule search, not in this component.
  * @returns The story.

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
@@ -31,8 +31,6 @@ export default {
  *
  * Choose "Ultrasound Imaging" and the three role fields search against it: it is
  * held on practitioners, rooms and devices, and only the provider is required.
- * Until then each says so in its description rather than sitting blank, since a
- * disabled field's placeholder does not render.
  *
  * Nothing is searched for times until "Find a time" is opened. There is no field
  * for a time: pick one and it appears as a summary under the action, saying how

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
@@ -31,7 +31,12 @@ export default {
  *
  * Choose "Ultrasound Imaging" and the three role fields search against it: it is
  * held on practitioners, rooms and devices, and only the provider is required.
- * Nothing is searched for times until "Find a time" is opened.
+ * Until then each says so in its description rather than sitting blank, since a
+ * disabled field's placeholder does not render.
+ *
+ * Nothing is searched for times until "Find a time" is opened. There is no field
+ * for a time: pick one and it appears as a summary under the action, saying how
+ * long the visit runs and what it is held on, and the action offers to change it.
  * @returns The story.
  */
 export const Basic = (): JSX.Element => (

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
@@ -32,9 +32,14 @@ export default {
  * Choose "Ultrasound Imaging" and the three role fields search against it: it is
  * held on practitioners, rooms and devices, and only the provider is required.
  *
- * Nothing is searched for times until "Find a time" is opened. There is no field
- * for a time until one is picked: it then appears above the action, read-only, with
- * how long the visit runs and what holds it, and the action offers to change it.
+ * "Find a time" stays unusable until a provider is named, and says so: a search
+ * without one could only report that a provider is needed. There is no field for a
+ * time until one is picked: it then appears above the action, read-only, with how
+ * long the visit runs and what holds it, and the action offers to change it.
+ *
+ * Change a resource with a time already picked and the time goes — it was found for
+ * the resources that no longer stand — while the search stays open and re-runs, so
+ * the replacement is one click away.
  * @returns The story.
  */
 export const Basic = (): JSX.Element => (

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Alert, List, Stack, Text } from '@mantine/core';
+import { Document } from '@medplum/react';
+import type { Meta } from '@storybook/react';
+import type { JSX } from 'react';
+import { withChainedActorSearch, withFindStub, withFixtures, withMockedDate } from '../stories/decorators';
+import {
+  MainClinic,
+  SchedulingFixtures,
+  SubClinicProviderFixtures,
+  SurgeryService,
+  SurgicalFixtures,
+  UltrasoundImagingService,
+} from '../stories/scheduling';
+import { AppointmentBookingForm } from './AppointmentBookingForm';
+
+const STORY_FIXTURES = [...SchedulingFixtures, ...SurgicalFixtures, ...SubClinicProviderFixtures];
+
+// `withFindStub` is per story rather than shared: a story's own decorators are
+// added to these rather than replacing them, so a shared stub plus a story's own
+// would install two, and which of them answered would be an accident of effect
+// ordering. Everything here is safe to nest, so it stays.
+export default {
+  title: 'Medplum/AppointmentBookingForm',
+  component: AppointmentBookingForm,
+  decorators: [withChainedActorSearch(), withFixtures(STORY_FIXTURES), withMockedDate],
+} as Meta;
+
+/**
+ * The form from an empty state to a chosen time.
+ *
+ * Choose "Ultrasound Imaging" and the three role fields search against it: it is
+ * held on practitioners, rooms and devices, and only the provider is required.
+ * Nothing is searched for times until "Find a time" is opened.
+ * @returns The story.
+ */
+export const Basic = (): JSX.Element => (
+  <Document>
+    <AppointmentBookingForm />
+  </Document>
+);
+Basic.decorators = [withFindStub()];
+
+/**
+ * A visit that needs a whole team free at once: a surgeon, an anesthesiologist
+ * and an operating room.
+ *
+ * Everything named attends — `$find` intersects their schedules — so naming a
+ * second surgeon narrows the times rather than widening them.
+ * @returns The story.
+ */
+export const SurgicalTeam = (): JSX.Element => (
+  <Document>
+    <AppointmentBookingForm defaultService={SurgeryService} defaultLocation={MainClinic} />
+  </Document>
+);
+SurgicalTeam.decorators = [withFindStub()];
+
+/**
+ * A fully configured visit type with nothing free.
+ *
+ * The distinction matters: "no times for this selection" is a different dead end
+ * from a role field that finds nobody, and the form says which.
+ * @returns The story.
+ */
+export const NoAvailability = (): JSX.Element => (
+  <Document>
+    <AppointmentBookingForm />
+  </Document>
+);
+NoAvailability.decorators = [withFindStub({ empty: true })];
+
+/**
+ * The site filter, which is asymmetric by role and reads as a bug until it is
+ * seen deliberately.
+ *
+ * The main clinic has a second floor, and on that floor are Exam Room B and Dr.
+ * Ama Osei's only practitioner role. Open the room field and Exam Room B is
+ * there — a room is sited by walking `partOf`, so anywhere inside the clinic
+ * counts. Open the provider field and Dr. Osei is not — a provider is sited only
+ * by a role naming the clinic exactly, with no walk up the chain.
+ *
+ * Inherited from the schedule search rather than chosen here, and pinned as a
+ * story so it stays a decision on the record.
+ * @returns The story.
+ */
+export const SiteAsymmetryByRole = (): JSX.Element => (
+  <Document>
+    <Stack gap="md">
+      <Alert color="blue" title="Booking at Uro Associates - Main Clinic">
+        <Text size="sm">Both sit on the clinic's second floor, one floor inside the site being booked at:</Text>
+        <List size="sm" mt="xs">
+          <List.Item>
+            <b>Exam Room B</b> is offered in the Room field.
+          </List.Item>
+          <List.Item>
+            <b>Dr. Ama Osei</b> is left out of the Provider field, whose only role names the floor rather than the
+            clinic.
+          </List.Item>
+        </List>
+      </Alert>
+      <AppointmentBookingForm defaultLocation={MainClinic} defaultService={UltrasoundImagingService} />
+    </Stack>
+  </Document>
+);
+SiteAsymmetryByRole.decorators = [withFindStub()];

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -25,6 +25,7 @@ import { stubChainedActorSearch } from '../test-utils/chainedActorSearch';
 import { act, fireEvent, renderWithMedplum, screen, waitFor, within } from '../test-utils/render';
 import type { AppointmentBookingFormProps } from './AppointmentBookingForm';
 import { AppointmentBookingForm } from './AppointmentBookingForm';
+import { SCHEDULING_ROLES } from './AppointmentFinder.roles';
 
 /**
  * A Monday morning, so the stubbed `$find` has weekday hours ahead of it on the
@@ -211,11 +212,23 @@ function hasPill(name: string): boolean {
 }
 
 /**
- * The read-only field the chosen time is shown in.
- * @returns The field.
+ * The summary of the chosen time, or null while no time has been chosen.
+ *
+ * Nothing stands in for a time before one is picked, so its absence is an
+ * assertion in its own right rather than an empty value to read.
+ *
+ * @returns The summary region, or null.
  */
-function chosenTimeField(): HTMLInputElement {
-  return screen.getByRole<HTMLInputElement>('textbox', { name: /date & time/i });
+function chosenTimeSummary(): HTMLElement | null {
+  return screen.queryByTestId('chosen-time');
+}
+
+/**
+ * The action that finds a time, whatever it currently offers to do.
+ * @returns The button.
+ */
+function finderButton(): HTMLElement {
+  return screen.getByRole('button', { name: /find a time|change time|close time finder/i });
 }
 
 describe('AppointmentBookingForm', () => {
@@ -258,6 +271,22 @@ describe('AppointmentBookingForm', () => {
       await chooseImagingService();
 
       expect(field(/provider/i)).toBeInTheDocument();
+    });
+
+    test('Says what each gated field is waiting for', async () => {
+      setup(medplum);
+      await settleAutocomplete();
+
+      // In the description, not the placeholder: a disabled field's placeholder
+      // does not render, which is how three silent grey boxes reached review.
+      expect(screen.getAllByText('Choose a visit type first.')).toHaveLength(SCHEDULING_ROLES.length);
+
+      await chooseImagingService();
+
+      // Once there is something to search against, each field goes back to saying
+      // what leaving it empty means.
+      expect(screen.queryByText('Choose a visit type first.')).not.toBeInTheDocument();
+      expect(screen.getByText(/Optional. Leave empty to search without holding a room./)).toBeInTheDocument();
     });
 
     test('Searches no times until a provider is named', async () => {
@@ -525,39 +554,76 @@ describe('AppointmentBookingForm', () => {
 
       // The chosen time is the server's own proposal, so its instant is what a
       // booking would record.
-      expect(chosenTimeField().value).toContain(label);
+      expect(chosenTimeSummary()).toHaveTextContent(label);
     });
   });
 
   describe('Booking only a time that was offered', () => {
-    test('Shows the time that was picked', async () => {
+    test('Shows nothing standing in for a time before one is chosen', async () => {
+      setup(medplum);
+      await chooseImagingService();
+
+      // The action is offered, and nothing above or below it is an empty field
+      // waiting to be filled with a time. Matched by name rather than by there
+      // being no text field at all, since the form has other ones to grow.
+      expect(finderButton()).toHaveTextContent('Find a time');
+      expect(chosenTimeSummary()).not.toBeInTheDocument();
+      expect(screen.queryByRole('textbox', { name: /date|time/i })).not.toBeInTheDocument();
+    });
+
+    test('Shows the time that was picked, and what it commits to', async () => {
       setup(medplum);
       await chooseImagingService();
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await chooseActor(/room/i, 'exam', 'Exam Room A');
       await openTimeFinder();
 
-      expect(chosenTimeField().value).toBe('');
+      expect(chosenTimeSummary()).not.toBeInTheDocument();
       const label = await chooseFirstOfferedTime();
 
-      expect(chosenTimeField().value).toContain(label);
+      // Read off the proposal rather than off the answers above it, so the
+      // summary describes what `$book` would be handed: the time, how long the
+      // visit runs, and every resource it is held on.
+      const summary = chosenTimeSummary();
+      expect(summary).toHaveTextContent(label);
+      expect(summary).toHaveTextContent('30 min visit');
+      // Named with the role each fills, since the summary is read away from the
+      // fields they were chosen in.
+      expect(summary).toHaveTextContent('Provider: Dr. Maya Rivera');
+      expect(summary).toHaveTextContent('Room: Exam Room A');
     });
 
-    test('Refuses a time typed into the field', async () => {
+    test('Offers no way to type or amend the chosen time', async () => {
       setup(medplum);
       await chooseImagingService();
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
       await openTimeFinder();
       await chooseFirstOfferedTime();
-      const shown = chosenTimeField().value;
+
+      // Nothing can be booked onto time that was never checked against anybody's
+      // availability, so the time exists on screen only as text. Searching again
+      // is the only way to change it.
+      expect(within(chosenTimeSummary() as HTMLElement).queryByRole('textbox')).not.toBeInTheDocument();
+      expect(screen.queryByRole('textbox', { name: /date|time/i })).not.toBeInTheDocument();
+      expect(finderButton()).toBeInTheDocument();
+    });
+
+    test('Offers to change the time once one is chosen', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await chooseFirstOfferedTime();
 
       await act(async () => {
-        fireEvent.change(chosenTimeField(), { target: { value: 'Monday, August 17 at 11:59 PM' } });
+        fireEvent.click(finderButton());
       });
+      await settleAutocomplete();
 
-      // Nothing can be booked onto time that was never checked against
-      // anybody's availability, so the field only ever displays.
-      expect(chosenTimeField()).toHaveAttribute('readonly');
-      expect(chosenTimeField().value).toBe(shown);
+      // Repeating "Find a time" over a time that was found reads as though the
+      // search had come back with nothing.
+      expect(finderButton()).toHaveTextContent('Change time');
+      expect(screen.queryByRole('button', { name: /^find a time$/i })).not.toBeInTheDocument();
     });
 
     test('Clears the chosen time when the day changes', async () => {
@@ -569,7 +635,7 @@ describe('AppointmentBookingForm', () => {
 
       await chooseDay('18');
 
-      expect(chosenTimeField().value).toBe('');
+      expect(chosenTimeSummary()).not.toBeInTheDocument();
     });
   });
 
@@ -580,14 +646,14 @@ describe('AppointmentBookingForm', () => {
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
       await openTimeFinder();
       await chooseFirstOfferedTime();
-      expect(chosenTimeField().value).not.toBe('');
+      expect(chosenTimeSummary()).toBeInTheDocument();
 
       await clearVisitType('Ultrasound Imaging');
       await typeInAutocomplete(field(/service type/i), 'Bariatric');
       await clickAutocompleteOption('Bariatric Surgery');
       await settleAutocomplete();
 
-      expect(chosenTimeField().value).toBe('');
+      expect(chosenTimeSummary()).not.toBeInTheDocument();
       // Not just the state: the field keeps its own selection, so a surviving pill
       // would be handed back on the next pick and searched against a schedule the
       // new visit type cannot book.

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -430,7 +430,9 @@ describe('AppointmentBookingForm', () => {
 
       await typeInAutocomplete(field(/visit type/i), 'Ultrasound');
 
-      expect(screen.getByText('Showing visit types offered at Uro Associates - Satellite.')).toBeInTheDocument();
+      expect(
+        screen.getByText('Showing visit types offered at Uro Associates - Satellite, plus those not tied to a site.')
+      ).toBeInTheDocument();
       // Imaging names the main clinic, and only a visit type naming this site exactly
       // is offered at it.
       expect(await screen.findByText('Nothing found')).toBeInTheDocument();
@@ -748,16 +750,22 @@ describe('AppointmentBookingForm', () => {
       expect(hasPill('Ultrasound Imaging')).toBe(true);
     });
 
-    test('Keeps a visit type that names no location when the site changes', async () => {
+    test('Keeps a visit type that names no location when the site changes, and offers it there', async () => {
       setup(medplum, { defaultService: TelehealthService });
       await settleAutocomplete();
       expect(hasPill('Telehealth Consult')).toBe(true);
 
       await chooseSite('Main Clinic', 'Uro Associates - Main Clinic');
 
-      // Never tied to a site, so no site invalidates it — even though choosing one now
-      // keeps it from being offered again.
+      // Never tied to a site, so no site invalidates it.
       expect(hasPill('Telehealth Consult')).toBe(true);
+
+      // The predicate here and the pair of searches behind the field are one rule spelled
+      // twice, and only a test through both catches them drifting apart. The field hides
+      // its search box while it holds an answer, so asking costs the pill just asserted.
+      await removePill('Telehealth Consult');
+      const listbox = await searchField(/visit type/i, 'Telehealth');
+      expect(within(listbox).getByText('Telehealth Consult')).toBeInTheDocument();
     });
 
     test('Collapses the time search when the visit type is cleared, and says so', async () => {

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { MedplumClient } from '@medplum/core';
 import type { Device } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import type { JSX } from 'react';
+import type { MockInstance } from 'vitest';
 import { installFindStub } from '../stories/mockFind';
 import {
   MainClinic,
@@ -203,6 +205,19 @@ function chosenTimeField(): HTMLInputElement | null {
  */
 function isBefore(first: Element, second: Element): boolean {
   return Boolean(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING);
+}
+
+/**
+ * The `start` the most recent `$find` asked for.
+ * @param get - A spy on the client's `get`.
+ * @returns The `start` parameter, or undefined when nothing was asked.
+ */
+function lastFindStart(get: MockInstance<MedplumClient['get']>): string | undefined {
+  const urls = get.mock.calls
+    .map(([url]) => String(url))
+    .filter((url) => url.includes('Appointment/$find') || url.includes('Appointment/%24find'));
+  const last = urls.at(-1);
+  return last ? (new URL(last, 'https://example.com').searchParams.get('start') ?? undefined) : undefined;
 }
 
 /**
@@ -473,6 +488,24 @@ describe('AppointmentBookingForm', () => {
 
       await waitFor(() => expect(screen.getByText(/Tuesday, August 18/)).toBeInTheDocument());
       expect(screen.queryByText(/Monday, August 17/)).not.toBeInTheDocument();
+    });
+
+    test('Searches today from now rather than from midnight', async () => {
+      const get = vi.spyOn(medplum, 'get');
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      // The calendar hands back local midnight, so picking today must not walk the
+      // floor back: `$find` honours whatever `start` it is given, and would answer
+      // with times that have already passed.
+      await chooseDay('17');
+
+      const start = lastFindStart(get);
+      expect(start).toBeDefined();
+      // Local midnight would be 07:00Z on this clock; the floor must not go back there.
+      expect(new Date(start as string).getTime()).toBeGreaterThanOrEqual(MONDAY_MORNING.getTime());
     });
   });
 

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -26,10 +26,7 @@ import { act, fireEvent, renderWithMedplum, screen, waitFor, within } from '../t
 import type { AppointmentBookingFormProps } from './AppointmentBookingForm';
 import { AppointmentBookingForm } from './AppointmentBookingForm';
 
-/**
- * A Monday morning, so the stubbed `$find` has weekday hours ahead of it on the
- * day the form searches by default.
- */
+/** A Monday, so the stub has weekday hours ahead of it on the default search day. */
 const MONDAY_MORNING = new Date(2026, 7, 17, 8, 0, 0);
 
 /** The timezone the fixtures' visit type is held in, which is not the runner's. */
@@ -51,16 +48,10 @@ function setup(medplum: MockClient, props?: AppointmentBookingFormProps): void {
   renderWithMedplum(element, medplum);
 }
 
-/**
- * The search box for one of the form's fields.
- * @param label - Matches the label above the field.
- * @returns The field's search box.
- */
 function field(label: RegExp): HTMLElement {
   return screen.getByRole('searchbox', { name: label });
 }
 
-/** Chooses the imaging service, which is what the role fields search against. */
 async function chooseImagingService(): Promise<void> {
   await typeInAutocomplete(field(/visit type/i), 'Ultrasound');
   await clickAutocompleteOption('Ultrasound Imaging');
@@ -68,10 +59,8 @@ async function chooseImagingService(): Promise<void> {
 }
 
 /**
- * Opens one role's field on everything it has, without typing a name.
- *
- * `fireEvent.change` to the value already in the box is not a change, so the
- * unfiltered list is reached the way a user reaches it: by focusing.
+ * Opens one role's field on everything it has, by focusing: `fireEvent.change` to the
+ * value already in the box is not a change.
  *
  * @param role - The field to open.
  * @returns The field's search box.
@@ -88,9 +77,8 @@ async function openRoleField(role: RegExp): Promise<HTMLElement> {
 /**
  * Searches one field and returns the dropdown that field owns.
  *
- * Scoped per field: several autocompletes are on screen at once and a dropdown stays
- * in the document once opened, so an unscoped query could read — or click — an option
- * belonging to another field.
+ * Several autocompletes are on screen at once and a dropdown stays in the document
+ * once opened, so an unscoped query could read — or click — another field's option.
  *
  * @param label - Matches the label above the field.
  * @param query - What to type, which is what the search narrows on.
@@ -108,12 +96,6 @@ async function searchField(label: RegExp, query: string): Promise<HTMLElement> {
   return listbox;
 }
 
-/**
- * Names an actor for one role.
- * @param role - The field to choose in.
- * @param query - What to type, which is what the search narrows on.
- * @param name - The actor to choose out of what came back.
- */
 async function chooseActor(role: RegExp, query: string, name: string): Promise<void> {
   const listbox = await searchField(role, query);
   await act(async () => {
@@ -123,17 +105,14 @@ async function chooseActor(role: RegExp, query: string, name: string): Promise<v
 }
 
 /**
- * Takes one chosen value back out of the field holding it.
- *
- * The only way to change the visit type, which holds one value at most and so has
- * no search box while it is full. Also how a named resource is dropped.
+ * Takes one chosen value back out of the field holding it: the only way to change the
+ * visit type, which takes its search box away while full.
  *
  * @param name - The value currently chosen.
  */
 async function removePill(name: string): Promise<void> {
-  // Scoped to the pill, because a named resource is also on the slot card and in
-  // the chosen time's description. Mantine's remove button is `aria-hidden`, so it
-  // is reached through the pill it sits in rather than by its role.
+  // Scoped to the pill, since a named resource is also on the slot card and in the
+  // chosen time's description. Mantine's remove button is `aria-hidden`.
   const pill = screen.queryAllByText(name).find((node) => node.className.includes('Pill'));
   const remove = pill?.parentElement?.querySelector('button');
   if (!remove) {
@@ -146,18 +125,12 @@ async function removePill(name: string): Promise<void> {
 }
 
 /**
- * Chooses a site in the location field.
- *
- * Starts from an empty field: like the visit type, it holds one value and takes
- * its search box away while full.
- *
+ * Chooses a site in the location field, which holds one value at a time.
  * @param query - What to type.
  * @param name - The site to click out of what came back.
  */
 async function chooseSite(query: string, name: string): Promise<void> {
   const listbox = await searchField(/location/i, query);
-  // By name, not by position: a search narrow enough to return one site is a
-  // search narrow enough to pass while offering the wrong one.
   await act(async () => {
     fireEvent.click(within(listbox).getByText(name));
   });
@@ -174,7 +147,7 @@ async function openTimeFinder(): Promise<void> {
 
 /**
  * Clicks a day in the time search's calendar.
- * @param dayOfMonth - The day's number, which is what the cell is labelled with.
+ * @param dayOfMonth - The number the cell is labelled with.
  */
 async function chooseDay(dayOfMonth: string): Promise<void> {
   await act(async () => {
@@ -184,10 +157,8 @@ async function chooseDay(dayOfMonth: string): Promise<void> {
 }
 
 /**
- * Picks the first time on offer.
- *
- * Times are read at the site, whose timezone is not the runner's, so the time is
- * picked by position rather than by the clock face it shows.
+ * Picks the first time on offer, by position: times are read at the site, whose
+ * timezone is not the runner's.
  *
  * @returns The label of the time that was picked.
  */
@@ -202,10 +173,8 @@ async function chooseFirstOfferedTime(): Promise<string> {
 }
 
 /**
- * Whether a field is holding a value, read off the pill rather than the state.
- *
- * The pill is what went stale: the fields keep their own selection and ignore
- * `defaultValue` after mount, so a cleared form could still show one.
+ * Whether a field is holding a value, read off the pill rather than the state: the
+ * fields ignore `defaultValue` after mount, so a cleared form could still show one.
  *
  * @param name - The value's label.
  * @returns Whether a pill is showing it.
@@ -215,10 +184,8 @@ function hasPill(name: string): boolean {
 }
 
 /**
- * The field holding the chosen time, or null while no time has been chosen.
- *
- * There is no field at all before a time is picked, so its absence is an assertion
- * in its own right rather than an empty value to read.
+ * The field holding the chosen time, or null while no time has been chosen — there is
+ * no field at all before one is picked, so its absence is an assertion of its own.
  *
  * @returns The field, or null.
  */
@@ -227,11 +194,8 @@ function chosenTimeField(): HTMLInputElement | null {
 }
 
 /**
- * Whether one element comes before another in the document.
- *
- * Where the chosen time sits is part of the behaviour: the form is a column of
- * labelled fields and the answer belongs above the control that produced it, which
- * only document order carries.
+ * Whether one element comes before another in the document, which is the only thing
+ * carrying where the chosen time sits relative to the action.
  *
  * @param first - The element expected to come first.
  * @param second - The element expected to follow it.
@@ -242,7 +206,7 @@ function isBefore(first: Element, second: Element): boolean {
 }
 
 /**
- * The action that finds a time, whatever it currently offers to do.
+ * The action that finds a time, under whichever of its three labels.
  * @returns The button.
  */
 function finderButton(): HTMLElement {
@@ -268,8 +232,6 @@ describe('AppointmentBookingForm', () => {
       setup(medplum);
       await chooseImagingService();
 
-      // All three render whatever the visit type has configured, so the form's
-      // shape does not change with the data behind it.
       expect(field(/provider/i)).toBeInTheDocument();
       expect(field(/room/i)).toBeInTheDocument();
       expect(field(/device/i)).toBeInTheDocument();
@@ -279,7 +241,6 @@ describe('AppointmentBookingForm', () => {
       setup(medplum);
       await settleAutocomplete();
 
-      // Searching before a visit type is chosen could only find nothing.
       for (const role of [/^Provider$/, /^Room$/, /^Device$/]) {
         expect(screen.queryByRole('searchbox', { name: role })).not.toBeInTheDocument();
         expect(screen.getByText(role)).toBeInTheDocument();
@@ -294,10 +255,7 @@ describe('AppointmentBookingForm', () => {
       setup(medplum);
       await chooseImagingService();
 
-      // A room alone is not enough: it would hold the room while leaving the
-      // calendar it is booked against open. The action says so rather than opening
-      // a search that could only refuse to run — which would widen the host's
-      // panel to show a refusal.
+      // A room alone holds a room but no calendar to book it against.
       await chooseActor(/room/i, 'exam', 'Exam Room A');
 
       expect(finderButton()).toBeDisabled();
@@ -325,8 +283,6 @@ describe('AppointmentBookingForm', () => {
       setup(medplum);
       await chooseImagingService();
 
-      // A role with nothing configured is a search that finds nothing, not a
-      // missing field.
       const input = await openRoleField(/device/i);
       await typeInAutocomplete(input, 'nosuchdevice');
 
@@ -341,8 +297,7 @@ describe('AppointmentBookingForm', () => {
       await chooseActor(/provider/i, 'oka', 'Dr. Tunde Okafor');
       await openTimeFinder();
 
-      // One request over both schedules: `$find` intersects what it is given, so
-      // the times come back as a single set both are free for rather than two.
+      // One group, not two: `$find` intersects the schedules it is given.
       const groups = await screen.findAllByTestId(/^slot-group-/);
       expect(groups).toHaveLength(1);
       expect(within(groups[0]).getByText('Dr. Maya Rivera')).toBeInTheDocument();
@@ -375,8 +330,7 @@ describe('AppointmentBookingForm', () => {
     });
 
     test('Offers a provider whose role names the chosen site', async () => {
-      // Dr. Martinez's role names the main clinic itself, which is the only way a
-      // provider is sited.
+      // Dr. Martinez's role names the main clinic itself, the only way a provider is sited.
       setup(medplum, { defaultLocation: MainClinic, defaultService: SurgeryService });
       await settleAutocomplete();
 
@@ -417,8 +371,7 @@ describe('AppointmentBookingForm', () => {
 
       await openRoleField(/device/i);
 
-      // The devices record no location, and hiding something the caller may be
-      // entitled to book is worse than offering something at the wrong site.
+      // The devices record no location at all.
       expect(await screen.findByText('Ultrasound 1 (Main Campus)')).toBeInTheDocument();
     });
 
@@ -437,11 +390,9 @@ describe('AppointmentBookingForm', () => {
     test('Leaves a room and a bed out of the site field', async () => {
       setup(medplum);
 
-      // Unscoped: a search that came back with nothing leaves no dropdown to scope
-      // to, and only a field that has been searched shows an empty message at all.
+      // Unscoped: a search that came back with nothing leaves no dropdown to scope to.
       await typeInAutocomplete(field(/location/i), 'Exam Room A');
 
-      // Rooms and beds are Locations; nothing but their physical type keeps them out.
       expect(await screen.findByText('Nothing found')).toBeInTheDocument();
       expect(screen.queryByText('Exam Room A')).not.toBeInTheDocument();
       expect(screen.queryByText('Exam Room A Bed 1')).not.toBeInTheDocument();
@@ -452,8 +403,8 @@ describe('AppointmentBookingForm', () => {
 
       const listbox = await searchField(/location/i, 'Uro Associates');
 
-      // Neither clinic declares a physical type, and nothing requires one: the field
-      // excludes what says it is a room, rather than admitting only what says site.
+      // Neither clinic declares one, and nothing requires it: the field excludes what
+      // says it is a room rather than admitting only what says site.
       expect(within(listbox).getByText('Uro Associates - Main Clinic')).toBeInTheDocument();
       expect(within(listbox).getByText('Uro Associates - Satellite')).toBeInTheDocument();
     });
@@ -465,8 +416,8 @@ describe('AppointmentBookingForm', () => {
       await typeInAutocomplete(field(/visit type/i), 'Ultrasound');
 
       expect(screen.getByText('Showing visit types offered at Uro Associates - Satellite.')).toBeInTheDocument();
-      // Imaging names the main clinic, and only a visit type naming this site
-      // exactly is offered at it.
+      // Imaging names the main clinic, and only a visit type naming this site exactly
+      // is offered at it.
       expect(await screen.findByText('Nothing found')).toBeInTheDocument();
       expect(screen.queryByText('Ultrasound Imaging')).not.toBeInTheDocument();
     });
@@ -492,8 +443,6 @@ describe('AppointmentBookingForm', () => {
       await chooseImagingService();
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
 
-      // Everything the search needs has been answered, and still nothing is
-      // asked for: the times depend on every answer above them.
       expect(get.mock.calls.filter(([url]) => String(url).includes('find'))).toHaveLength(0);
       expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
 
@@ -536,8 +485,8 @@ describe('AppointmentBookingForm', () => {
 
       const [group] = await screen.findAllByTestId(/^slot-group-/);
       const [firstTime] = within(group).getAllByRole('button');
-      // The stub lays times on the clinic's open hours in the runner's timezone,
-      // so the label is that instant read at the site rather than 9:00 repeated.
+      // The stub lays times on the clinic's open hours in the runner's timezone, so the
+      // label is that instant read at the site rather than 9:00 repeated.
       const start = new Date(2026, 7, 17, 9, 0, 0);
 
       expect(firstTime).toHaveTextContent(
@@ -556,8 +505,6 @@ describe('AppointmentBookingForm', () => {
       await openTimeFinder();
       const label = await chooseFirstOfferedTime();
 
-      // The chosen time is the server's own proposal, so its instant is what a
-      // booking would record.
       expect(chosenTimeField()?.value).toContain(label);
     });
   });
@@ -567,8 +514,6 @@ describe('AppointmentBookingForm', () => {
       setup(medplum);
       await chooseImagingService();
 
-      // By name rather than by there being no text field at all, since the form has
-      // other ones to grow.
       expect(finderButton()).toHaveTextContent('Find a time');
       expect(chosenTimeField()).not.toBeInTheDocument();
       expect(screen.queryByRole('textbox', { name: /date|time/i })).not.toBeInTheDocument();
@@ -586,11 +531,8 @@ describe('AppointmentBookingForm', () => {
 
       const chosen = chosenTimeField() as HTMLInputElement;
       expect(chosen.value).toContain(label);
-      // Above the action, so the form stays one column of labelled answers rather
-      // than putting one below the control that produced it.
       expect(isBefore(chosen, finderButton())).toBe(true);
-      // Off the proposal, so what the field commits to is what `$book` would be
-      // handed. Roles named, since the field is read away from their own fields.
+      // Off the proposal, so what the field commits to is what `$book` would be handed.
       expect(chosen).toHaveAccessibleDescription('30 min visit · Provider: Dr. Maya Rivera · Room: Exam Room A');
     });
 
@@ -606,8 +548,6 @@ describe('AppointmentBookingForm', () => {
         fireEvent.change(chosenTimeField() as HTMLInputElement, { target: { value: 'Monday, August 17 at 11:59 PM' } });
       });
 
-      // Nothing can be booked onto time nobody checked availability for, so the
-      // field only ever displays.
       expect(chosenTimeField()).toHaveAttribute('readonly');
       expect(chosenTimeField()?.value).toBe(shown);
       expect(screen.getAllByRole('textbox', { name: /date|time/i })).toHaveLength(1);
@@ -626,8 +566,6 @@ describe('AppointmentBookingForm', () => {
       });
       await settleAutocomplete();
 
-      // Repeating "Find a time" over a time that was found reads as though the
-      // search had come back with nothing.
       expect(finderButton()).toHaveTextContent('Change time');
       expect(screen.queryByRole('button', { name: /^find a time$/i })).not.toBeInTheDocument();
     });
@@ -641,7 +579,6 @@ describe('AppointmentBookingForm', () => {
 
       await chooseDay('18');
 
-      // The field goes with the time rather than staying behind as an empty one.
       expect(chosenTimeField()).not.toBeInTheDocument();
     });
   });
@@ -659,13 +596,12 @@ describe('AppointmentBookingForm', () => {
       await chooseActor(/provider/i, 'oka', 'Dr. Tunde Okafor');
 
       // A chosen time is a proposal carrying its own participants and Slots. Kept
-      // through this, it would book Dr. Rivera while the form showed Dr. Okafor —
-      // and `$book` would accept it, because that time genuinely was hers.
+      // through this it would book Dr. Rivera while the form showed Dr. Okafor, and
+      // `$book` would accept it: that time genuinely was Dr. Rivera's.
       expect(chosenTimeField()).not.toBeInTheDocument();
 
       const label = await chooseFirstOfferedTime();
 
-      // The replacement is the new provider's, not a relabelled copy of the old.
       const chosen = chosenTimeField() as HTMLInputElement;
       expect(chosen.value).toContain(label);
       expect(chosen).toHaveAccessibleDescription(/Dr. Tunde Okafor/);
@@ -688,8 +624,8 @@ describe('AppointmentBookingForm', () => {
 
       await changeRoom();
 
-      // A time found without a room's availability is not a time that room is free
-      // for, and one found with it is not valid once it is no longer held.
+      // A time found without a room's availability is not a time that room is free for,
+      // and one found with it does not hold once the room is dropped.
       expect(chosenTimeField()).not.toBeInTheDocument();
     });
 
@@ -704,12 +640,10 @@ describe('AppointmentBookingForm', () => {
 
       await chooseActor(/room/i, 'exam', 'Exam Room A');
 
-      // The replacement stays one click away: closing here would take back the
-      // panel width the host just widened, mid-task.
+      // Closing here would take back the panel width the host just widened, mid-task.
       expect(finderButton()).toHaveTextContent('Close time finder');
       expect(onToggleTimeFinder).not.toHaveBeenCalled();
       const [group] = await screen.findAllByTestId(/^slot-group-/);
-      // Re-run for the new set, so the times on offer are the ones both share.
       expect(within(group).getByText('Dr. Maya Rivera')).toBeInTheDocument();
       expect(within(group).getByText('Exam Room A')).toBeInTheDocument();
     });
@@ -724,8 +658,6 @@ describe('AppointmentBookingForm', () => {
 
       await removePill('Dr. Maya Rivera');
 
-      // Not a rule about the provider field: there is simply nothing left to
-      // search, which is the one condition that closes the search at all.
       expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
       expect(onToggleTimeFinder).toHaveBeenLastCalledWith(false);
     });
@@ -744,8 +676,8 @@ describe('AppointmentBookingForm', () => {
       await settleAutocomplete();
 
       expect(chosenTimeField()).not.toBeInTheDocument();
-      // Not just the state: a surviving pill is handed back on the next pick, and
-      // searched against a schedule the new visit type cannot book.
+      // A surviving pill would be handed back on the next pick, and searched against a
+      // schedule the new visit type cannot book.
       expect(hasPill('Dr. Maya Rivera')).toBe(false);
     });
 
@@ -757,7 +689,6 @@ describe('AppointmentBookingForm', () => {
 
       await chooseSite('Main Clinic', 'Uro Associates - Main Clinic');
 
-      // The site decides which actors are offered at all.
       expect(hasPill('Dr. Maya Rivera')).toBe(false);
       // The imaging service is held there, so that answer stands.
       expect(hasPill('Ultrasound Imaging')).toBe(true);
@@ -791,8 +722,8 @@ describe('AppointmentBookingForm', () => {
 
       await chooseSite('Main Clinic', 'Uro Associates - Main Clinic');
 
-      // Never tied to a site, so no site can invalidate it — even though choosing one
-      // now keeps it from being offered again.
+      // Never tied to a site, so no site invalidates it — even though choosing one now
+      // keeps it from being offered again.
       expect(hasPill('Telehealth Consult')).toBe(true);
     });
 
@@ -806,9 +737,6 @@ describe('AppointmentBookingForm', () => {
 
       await removePill('Ultrasound Imaging');
 
-      // Through the derived condition rather than a close of its own: clearing the
-      // visit type clears the resources, which leaves no provider, which is what
-      // closes the search. The host is told so its panel narrows again.
       expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
       expect(screen.queryByRole('button', { name: /close time finder/i })).not.toBeInTheDocument();
       expect(onToggleTimeFinder).toHaveBeenLastCalledWith(false);
@@ -843,8 +771,8 @@ describe('AppointmentBookingForm', () => {
     });
 
     test('Opens the time search on the day the host named', async () => {
-      // A Wednesday in the following month, so neither today nor the month the
-      // calendar would otherwise open on could pass this by accident.
+      // In the following month, so the month the calendar would otherwise open on
+      // cannot pass this by accident.
       setup(medplum, { defaultService: UltrasoundImagingService, defaultStart: new Date(2026, 8, 2, 0, 0, 0) });
       await settleAutocomplete();
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -25,7 +25,6 @@ import { stubChainedActorSearch } from '../test-utils/chainedActorSearch';
 import { act, fireEvent, renderWithMedplum, screen, waitFor, within } from '../test-utils/render';
 import type { AppointmentBookingFormProps } from './AppointmentBookingForm';
 import { AppointmentBookingForm } from './AppointmentBookingForm';
-import { SCHEDULING_ROLES } from './AppointmentFinder.roles';
 
 /**
  * A Monday morning, so the stubbed `$find` has weekday hours ahead of it on the
@@ -63,7 +62,7 @@ function field(label: RegExp): HTMLElement {
 
 /** Chooses the imaging service, which is what the role fields search against. */
 async function chooseImagingService(): Promise<void> {
-  await typeInAutocomplete(field(/service type/i), 'Ultrasound');
+  await typeInAutocomplete(field(/visit type/i), 'Ultrasound');
   await clickAutocompleteOption('Ultrasound Imaging');
   await settleAutocomplete();
 }
@@ -273,22 +272,6 @@ describe('AppointmentBookingForm', () => {
       expect(field(/provider/i)).toBeInTheDocument();
     });
 
-    test('Says what each gated field is waiting for', async () => {
-      setup(medplum);
-      await settleAutocomplete();
-
-      // In the description, not the placeholder: a disabled field's placeholder
-      // does not render, which is how three silent grey boxes reached review.
-      expect(screen.getAllByText('Choose a visit type first.')).toHaveLength(SCHEDULING_ROLES.length);
-
-      await chooseImagingService();
-
-      // Once there is something to search against, each field goes back to saying
-      // what leaving it empty means.
-      expect(screen.queryByText('Choose a visit type first.')).not.toBeInTheDocument();
-      expect(screen.getByText(/Optional. Leave empty to search without holding a room./)).toBeInTheDocument();
-    });
-
     test('Searches no times until a provider is named', async () => {
       setup(medplum);
       await chooseImagingService();
@@ -458,7 +441,7 @@ describe('AppointmentBookingForm', () => {
       setup(medplum);
       await chooseSite('Satellite', 'Uro Associates - Satellite');
 
-      await typeInAutocomplete(field(/service type/i), 'Ultrasound');
+      await typeInAutocomplete(field(/visit type/i), 'Ultrasound');
 
       expect(screen.getByText('Showing visit types offered at Uro Associates - Satellite.')).toBeInTheDocument();
       // Imaging names the main clinic, and only a visit type naming this site
@@ -649,7 +632,7 @@ describe('AppointmentBookingForm', () => {
       expect(chosenTimeSummary()).toBeInTheDocument();
 
       await clearVisitType('Ultrasound Imaging');
-      await typeInAutocomplete(field(/service type/i), 'Bariatric');
+      await typeInAutocomplete(field(/visit type/i), 'Bariatric');
       await clickAutocompleteOption('Bariatric Surgery');
       await settleAutocomplete();
 

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -88,9 +88,9 @@ async function openRoleField(role: RegExp): Promise<HTMLElement> {
 /**
  * Searches one field and returns the dropdown that field owns.
  *
- * Scoped per field because five autocompletes are on screen at once and a
- * dropdown stays in the document once it has been opened, so an unscoped query
- * could read — or click — an option belonging to another field.
+ * Scoped per field: several autocompletes are on screen at once and a dropdown stays
+ * in the document once opened, so an unscoped query could read — or click — an option
+ * belonging to another field.
  *
  * @param label - Matches the label above the field.
  * @param query - What to type, which is what the search narrows on.
@@ -275,8 +275,7 @@ describe('AppointmentBookingForm', () => {
       setup(medplum);
       await settleAutocomplete();
 
-      // Asking before a visit type is chosen could only ever find nothing, which
-      // reads as a broken field rather than an answer still owed.
+      // Searching before a visit type is chosen could only find nothing.
       for (const role of [/^Provider$/, /^Room$/, /^Device$/]) {
         expect(screen.queryByRole('searchbox', { name: role })).not.toBeInTheDocument();
         expect(screen.getByText(role)).toBeInTheDocument();
@@ -427,14 +426,11 @@ describe('AppointmentBookingForm', () => {
     test('Leaves a room and a bed out of the site field', async () => {
       setup(medplum);
 
-      // Unscoped, because a field whose search came back with nothing has no
-      // dropdown to scope to. The empty message can only be this field's: it is
-      // the only one that has been searched, and a field nobody typed into shows
-      // none.
+      // Unscoped: a search that came back with nothing leaves no dropdown to scope
+      // to, and only a field that has been searched shows an empty message at all.
       await typeInAutocomplete(field(/location/i), 'Exam Room A');
 
-      // Rooms and beds are Locations, so nothing but their own physical type keeps
-      // them out of a field asking where the visit is held.
+      // Rooms and beds are Locations; nothing but their physical type keeps them out.
       expect(await screen.findByText('Nothing found')).toBeInTheDocument();
       expect(screen.queryByText('Exam Room A')).not.toBeInTheDocument();
       expect(screen.queryByText('Exam Room A Bed 1')).not.toBeInTheDocument();
@@ -445,9 +441,8 @@ describe('AppointmentBookingForm', () => {
 
       const listbox = await searchField(/location/i, 'Uro Associates');
 
-      // Neither clinic says what it physically is, and nothing requires it to. The
-      // field excludes what declares itself a room rather than admitting only what
-      // declares itself a site, so both are still offered.
+      // Neither clinic declares a physical type, and nothing requires one: the field
+      // excludes what says it is a room, rather than admitting only what says site.
       expect(within(listbox).getByText('Uro Associates - Main Clinic')).toBeInTheDocument();
       expect(within(listbox).getByText('Uro Associates - Satellite')).toBeInTheDocument();
     });
@@ -561,9 +556,8 @@ describe('AppointmentBookingForm', () => {
       setup(medplum);
       await chooseImagingService();
 
-      // The action is offered, and nothing above or below it is an empty field
-      // waiting to be filled with a time. Matched by name rather than by there
-      // being no text field at all, since the form has other ones to grow.
+      // By name rather than by there being no text field at all, since the form has
+      // other ones to grow.
       expect(finderButton()).toHaveTextContent('Find a time');
       expect(chosenTimeField()).not.toBeInTheDocument();
       expect(screen.queryByRole('textbox', { name: /date|time/i })).not.toBeInTheDocument();
@@ -584,10 +578,8 @@ describe('AppointmentBookingForm', () => {
       // Above the action, so the form stays one column of labelled answers rather
       // than putting one below the control that produced it.
       expect(isBefore(chosen, finderButton())).toBe(true);
-      // Read off the proposal rather than off the answers above it, so what the
-      // field says it commits to is what `$book` would be handed: how long the
-      // visit runs, and every resource it holds, each named with the role it
-      // fills — the field is read away from the ones they were chosen in.
+      // Off the proposal, so what the field commits to is what `$book` would be
+      // handed. Roles named, since the field is read away from their own fields.
       expect(chosen).toHaveAccessibleDescription('30 min visit · Provider: Dr. Maya Rivera · Room: Exam Room A');
     });
 
@@ -603,9 +595,8 @@ describe('AppointmentBookingForm', () => {
         fireEvent.change(chosenTimeField() as HTMLInputElement, { target: { value: 'Monday, August 17 at 11:59 PM' } });
       });
 
-      // Nothing can be booked onto time that was never checked against anybody's
-      // availability, so the field only ever displays and searching again is the
-      // only way in.
+      // Nothing can be booked onto time nobody checked availability for, so the
+      // field only ever displays.
       expect(chosenTimeField()).toHaveAttribute('readonly');
       expect(chosenTimeField()?.value).toBe(shown);
       expect(screen.getAllByRole('textbox', { name: /date|time/i })).toHaveLength(1);
@@ -659,9 +650,8 @@ describe('AppointmentBookingForm', () => {
       await settleAutocomplete();
 
       expect(chosenTimeField()).not.toBeInTheDocument();
-      // Not just the state: the field keeps its own selection, so a surviving pill
-      // would be handed back on the next pick and searched against a schedule the
-      // new visit type cannot book.
+      // Not just the state: a surviving pill is handed back on the next pick, and
+      // searched against a schedule the new visit type cannot book.
       expect(hasPill('Dr. Maya Rivera')).toBe(false);
     });
 
@@ -673,8 +663,7 @@ describe('AppointmentBookingForm', () => {
 
       await chooseSite('Main Clinic', 'Uro Associates - Main Clinic');
 
-      // Where a visit is held decides which actors are offered at all, so the one
-      // chosen before the site was known cannot be assumed to serve it.
+      // The site decides which actors are offered at all.
       expect(hasPill('Dr. Maya Rivera')).toBe(false);
       // The imaging service is held there, so that answer stands.
       expect(hasPill('Ultrasound Imaging')).toBe(true);
@@ -708,8 +697,8 @@ describe('AppointmentBookingForm', () => {
 
       await chooseSite('Main Clinic', 'Uro Associates - Main Clinic');
 
-      // Nothing about it was ever tied to a site, so no site can invalidate it —
-      // even though choosing one now keeps it from being offered again.
+      // Never tied to a site, so no site can invalidate it — even though choosing one
+      // now keeps it from being offered again.
       expect(hasPill('Telehealth Consult')).toBe(true);
     });
 

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -123,15 +123,19 @@ async function chooseActor(role: RegExp, query: string, name: string): Promise<v
 }
 
 /**
- * Empties the visit type field, which is the only way to change what it holds:
- * it takes one value at most, so its search box is gone while it is full.
+ * Takes one chosen value back out of the field holding it.
  *
- * @param name - The visit type currently chosen.
+ * The only way to change the visit type, which holds one value at most and so has
+ * no search box while it is full. Also how a named resource is dropped.
+ *
+ * @param name - The value currently chosen.
  */
-async function clearVisitType(name: string): Promise<void> {
-  // Mantine's remove button is `aria-hidden`, so it is reached through the pill
-  // it sits in rather than by its role.
-  const remove = screen.getByText(name).parentElement?.querySelector('button');
+async function removePill(name: string): Promise<void> {
+  // Scoped to the pill, because a named resource is also on the slot card and in
+  // the chosen time's description. Mantine's remove button is `aria-hidden`, so it
+  // is reached through the pill it sits in rather than by its role.
+  const pill = screen.queryAllByText(name).find((node) => node.className.includes('Pill'));
+  const remove = pill?.parentElement?.querySelector('button');
   if (!remove) {
     throw new Error(`No remove button on the ${name} pill`);
   }
@@ -286,17 +290,24 @@ describe('AppointmentBookingForm', () => {
       expect(field(/provider/i)).toBeInTheDocument();
     });
 
-    test('Searches no times until a provider is named', async () => {
+    test('Offers no search until a provider is named, and says so', async () => {
       setup(medplum);
       await chooseImagingService();
 
       // A room alone is not enough: it would hold the room while leaving the
-      // calendar it is booked against open.
+      // calendar it is booked against open. The action says so rather than opening
+      // a search that could only refuse to run — which would widen the host's
+      // panel to show a refusal.
       await chooseActor(/room/i, 'exam', 'Exam Room A');
-      await openTimeFinder();
 
-      expect(screen.getByText('Choose at least one provider')).toBeInTheDocument();
+      expect(finderButton()).toBeDisabled();
+      expect(screen.getByText('Choose at least one provider first.')).toBeInTheDocument();
       expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
+
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+
+      expect(finderButton()).toBeEnabled();
+      expect(screen.queryByText('Choose at least one provider first.')).not.toBeInTheDocument();
     });
 
     test('Searches against the provider alone when the room and device are left empty', async () => {
@@ -635,7 +646,90 @@ describe('AppointmentBookingForm', () => {
     });
   });
 
-  describe('Clearing answers that depended on the visit type', () => {
+  describe('Clearing answers that no longer hold', () => {
+    test('Replacing the provider clears the time, so no booking can hold the old one', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await chooseFirstOfferedTime();
+      expect(chosenTimeField()).toHaveAccessibleDescription(/Dr. Maya Rivera/);
+
+      await removePill('Dr. Maya Rivera');
+      await chooseActor(/provider/i, 'oka', 'Dr. Tunde Okafor');
+
+      // A chosen time is a proposal carrying its own participants and Slots. Kept
+      // through this, it would book Dr. Rivera while the form showed Dr. Okafor —
+      // and `$book` would accept it, because that time genuinely was hers.
+      expect(chosenTimeField()).not.toBeInTheDocument();
+
+      const label = await chooseFirstOfferedTime();
+
+      // The replacement is the new provider's, not a relabelled copy of the old.
+      const chosen = chosenTimeField() as HTMLInputElement;
+      expect(chosen.value).toContain(label);
+      expect(chosen).toHaveAccessibleDescription(/Dr. Tunde Okafor/);
+      expect(chosen).not.toHaveAccessibleDescription(/Dr. Maya Rivera/);
+    });
+
+    test.each([
+      ['added', async (): Promise<void> => chooseActor(/room/i, 'exam', 'Exam Room A')],
+      ['removed', async (): Promise<void> => removePill('Exam Room A')],
+    ])('A room %s after a time was chosen clears it', async (_change, changeRoom) => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      if (_change === 'removed') {
+        await chooseActor(/room/i, 'exam', 'Exam Room A');
+      }
+      await openTimeFinder();
+      await chooseFirstOfferedTime();
+      expect(chosenTimeField()).toBeInTheDocument();
+
+      await changeRoom();
+
+      // A time found without a room's availability is not a time that room is free
+      // for, and one found with it is not valid once it is no longer held.
+      expect(chosenTimeField()).not.toBeInTheDocument();
+    });
+
+    test('A resource change leaves the search open and re-runs it', async () => {
+      const onToggleTimeFinder = vi.fn();
+      setup(medplum, { onToggleTimeFinder });
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await chooseFirstOfferedTime();
+      onToggleTimeFinder.mockClear();
+
+      await chooseActor(/room/i, 'exam', 'Exam Room A');
+
+      // The replacement stays one click away: closing here would take back the
+      // panel width the host just widened, mid-task.
+      expect(finderButton()).toHaveTextContent('Close time finder');
+      expect(onToggleTimeFinder).not.toHaveBeenCalled();
+      const [group] = await screen.findAllByTestId(/^slot-group-/);
+      // Re-run for the new set, so the times on offer are the ones both share.
+      expect(within(group).getByText('Dr. Maya Rivera')).toBeInTheDocument();
+      expect(within(group).getByText('Exam Room A')).toBeInTheDocument();
+    });
+
+    test('Dropping the last provider closes the search, and says so', async () => {
+      const onToggleTimeFinder = vi.fn();
+      setup(medplum, { onToggleTimeFinder });
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await screen.findAllByTestId(/^slot-group-/);
+
+      await removePill('Dr. Maya Rivera');
+
+      // Not a rule about the provider field: there is simply nothing left to
+      // search, which is the one condition that closes the search at all.
+      expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
+      expect(onToggleTimeFinder).toHaveBeenLastCalledWith(false);
+    });
+
     test('Clears the chosen resources and time when the visit type changes', async () => {
       setup(medplum);
       await chooseImagingService();
@@ -644,7 +738,7 @@ describe('AppointmentBookingForm', () => {
       await chooseFirstOfferedTime();
       expect(chosenTimeField()).toBeInTheDocument();
 
-      await clearVisitType('Ultrasound Imaging');
+      await removePill('Ultrasound Imaging');
       await typeInAutocomplete(field(/visit type/i), 'Bariatric');
       await clickAutocompleteOption('Bariatric Surgery');
       await settleAutocomplete();
@@ -710,10 +804,11 @@ describe('AppointmentBookingForm', () => {
       await openTimeFinder();
       await screen.findAllByTestId(/^slot-group-/);
 
-      await clearVisitType('Ultrasound Imaging');
+      await removePill('Ultrasound Imaging');
 
-      // Nothing can be searched without a visit type, and the host has to be told
-      // so the panel it widened narrows again.
+      // Through the derived condition rather than a close of its own: clearing the
+      // visit type clears the resources, which leaves no provider, which is what
+      // closes the search. The host is told so its panel narrows again.
       expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
       expect(screen.queryByRole('button', { name: /close time finder/i })).not.toBeInTheDocument();
       expect(onToggleTimeFinder).toHaveBeenLastCalledWith(false);
@@ -734,6 +829,9 @@ describe('AppointmentBookingForm', () => {
       const onToggleTimeFinder = vi.fn();
       setup(medplum, { onToggleTimeFinder });
       await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      // Mounting is not an open or a close, so the host hears nothing until one.
+      expect(onToggleTimeFinder).not.toHaveBeenCalled();
 
       await openTimeFinder();
       expect(onToggleTimeFinder).toHaveBeenLastCalledWith(true);

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -211,15 +211,30 @@ function hasPill(name: string): boolean {
 }
 
 /**
- * The summary of the chosen time, or null while no time has been chosen.
+ * The field holding the chosen time, or null while no time has been chosen.
  *
- * Nothing stands in for a time before one is picked, so its absence is an
- * assertion in its own right rather than an empty value to read.
+ * There is no field at all before a time is picked, so its absence is an assertion
+ * in its own right rather than an empty value to read.
  *
- * @returns The summary region, or null.
+ * @returns The field, or null.
  */
-function chosenTimeSummary(): HTMLElement | null {
-  return screen.queryByTestId('chosen-time');
+function chosenTimeField(): HTMLInputElement | null {
+  return screen.queryByRole<HTMLInputElement>('textbox', { name: /date & time/i });
+}
+
+/**
+ * Whether one element comes before another in the document.
+ *
+ * Where the chosen time sits is part of the behaviour: the form is a column of
+ * labelled fields and the answer belongs above the control that produced it, which
+ * only document order carries.
+ *
+ * @param first - The element expected to come first.
+ * @param second - The element expected to follow it.
+ * @returns Whether they are in that order.
+ */
+function isBefore(first: Element, second: Element): boolean {
+  return Boolean(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING);
 }
 
 /**
@@ -537,7 +552,7 @@ describe('AppointmentBookingForm', () => {
 
       // The chosen time is the server's own proposal, so its instant is what a
       // booking would record.
-      expect(chosenTimeSummary()).toHaveTextContent(label);
+      expect(chosenTimeField()?.value).toContain(label);
     });
   });
 
@@ -550,30 +565,30 @@ describe('AppointmentBookingForm', () => {
       // waiting to be filled with a time. Matched by name rather than by there
       // being no text field at all, since the form has other ones to grow.
       expect(finderButton()).toHaveTextContent('Find a time');
-      expect(chosenTimeSummary()).not.toBeInTheDocument();
+      expect(chosenTimeField()).not.toBeInTheDocument();
       expect(screen.queryByRole('textbox', { name: /date|time/i })).not.toBeInTheDocument();
     });
 
-    test('Shows the time that was picked, and what it commits to', async () => {
+    test('Shows the time that was picked in a field above the action', async () => {
       setup(medplum);
       await chooseImagingService();
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
       await chooseActor(/room/i, 'exam', 'Exam Room A');
       await openTimeFinder();
 
-      expect(chosenTimeSummary()).not.toBeInTheDocument();
+      expect(chosenTimeField()).not.toBeInTheDocument();
       const label = await chooseFirstOfferedTime();
 
-      // Read off the proposal rather than off the answers above it, so the
-      // summary describes what `$book` would be handed: the time, how long the
-      // visit runs, and every resource it is held on.
-      const summary = chosenTimeSummary();
-      expect(summary).toHaveTextContent(label);
-      expect(summary).toHaveTextContent('30 min visit');
-      // Named with the role each fills, since the summary is read away from the
-      // fields they were chosen in.
-      expect(summary).toHaveTextContent('Provider: Dr. Maya Rivera');
-      expect(summary).toHaveTextContent('Room: Exam Room A');
+      const chosen = chosenTimeField() as HTMLInputElement;
+      expect(chosen.value).toContain(label);
+      // Above the action, so the form stays one column of labelled answers rather
+      // than putting one below the control that produced it.
+      expect(isBefore(chosen, finderButton())).toBe(true);
+      // Read off the proposal rather than off the answers above it, so what the
+      // field says it commits to is what `$book` would be handed: how long the
+      // visit runs, and every resource it holds, each named with the role it
+      // fills — the field is read away from the ones they were chosen in.
+      expect(chosen).toHaveAccessibleDescription('30 min visit · Provider: Dr. Maya Rivera · Room: Exam Room A');
     });
 
     test('Offers no way to type or amend the chosen time', async () => {
@@ -583,11 +598,17 @@ describe('AppointmentBookingForm', () => {
       await openTimeFinder();
       await chooseFirstOfferedTime();
 
+      const shown = (chosenTimeField() as HTMLInputElement).value;
+      await act(async () => {
+        fireEvent.change(chosenTimeField() as HTMLInputElement, { target: { value: 'Monday, August 17 at 11:59 PM' } });
+      });
+
       // Nothing can be booked onto time that was never checked against anybody's
-      // availability, so the time exists on screen only as text. Searching again
-      // is the only way to change it.
-      expect(within(chosenTimeSummary() as HTMLElement).queryByRole('textbox')).not.toBeInTheDocument();
-      expect(screen.queryByRole('textbox', { name: /date|time/i })).not.toBeInTheDocument();
+      // availability, so the field only ever displays and searching again is the
+      // only way in.
+      expect(chosenTimeField()).toHaveAttribute('readonly');
+      expect(chosenTimeField()?.value).toBe(shown);
+      expect(screen.getAllByRole('textbox', { name: /date|time/i })).toHaveLength(1);
       expect(finderButton()).toBeInTheDocument();
     });
 
@@ -618,7 +639,8 @@ describe('AppointmentBookingForm', () => {
 
       await chooseDay('18');
 
-      expect(chosenTimeSummary()).not.toBeInTheDocument();
+      // The field goes with the time rather than staying behind as an empty one.
+      expect(chosenTimeField()).not.toBeInTheDocument();
     });
   });
 
@@ -629,14 +651,14 @@ describe('AppointmentBookingForm', () => {
       await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
       await openTimeFinder();
       await chooseFirstOfferedTime();
-      expect(chosenTimeSummary()).toBeInTheDocument();
+      expect(chosenTimeField()).toBeInTheDocument();
 
       await clearVisitType('Ultrasound Imaging');
       await typeInAutocomplete(field(/visit type/i), 'Bariatric');
       await clickAutocompleteOption('Bariatric Surgery');
       await settleAutocomplete();
 
-      expect(chosenTimeSummary()).not.toBeInTheDocument();
+      expect(chosenTimeField()).not.toBeInTheDocument();
       // Not just the state: the field keeps its own selection, so a surviving pill
       // would be handed back on the next pick and searched against a schedule the
       // new visit type cannot book.

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -228,8 +228,8 @@ describe('AppointmentBookingForm', () => {
       setup(medplum);
       await chooseImagingService();
 
-      // A name the visit type has never heard of finds nothing, and the field
-      // says so rather than disappearing.
+      // A role with nothing configured is a search that finds nothing, not a
+      // missing field.
       const input = await openRoleField(/device/i);
       await typeInAutocomplete(input, 'nosuchdevice');
 
@@ -278,8 +278,8 @@ describe('AppointmentBookingForm', () => {
     });
 
     test('Offers a provider whose role names the chosen site', async () => {
-      // Dr. Martinez's practitioner role names the main clinic itself, which is
-      // the only way a provider is sited: there is no walk up the chain.
+      // Dr. Martinez's role names the main clinic itself, which is the only way a
+      // provider is sited.
       setup(medplum, { defaultLocation: MainClinic, defaultService: SurgeryService });
       await settleAutocomplete();
 
@@ -301,8 +301,8 @@ describe('AppointmentBookingForm', () => {
     });
 
     test('Leaves out a provider sited inside the chosen site rather than at it, while offering a room there', async () => {
-      // The asymmetry a reader is most likely to take for a bug: a room is sited
-      // by walking `partOf`, a provider only by a role naming the site exactly.
+      // A room is sited by walking `partOf`; a provider only by a role naming the
+      // site exactly.
       setup(medplum, { defaultLocation: MainClinic, defaultService: UltrasoundImagingService });
       await settleAutocomplete();
 
@@ -420,8 +420,8 @@ describe('AppointmentBookingForm', () => {
       await openTimeFinder();
       const label = await chooseFirstOfferedTime();
 
-      // The chosen time is the server's own proposal, so the instant it carries
-      // is what a booking would record, and the field reads it at the site.
+      // The chosen time is the server's own proposal, so its instant is what a
+      // booking would record.
       expect(chosenTimeField().value).toContain(label);
     });
   });
@@ -484,8 +484,6 @@ describe('AppointmentBookingForm', () => {
       await clickAutocompleteOption('Bariatric Surgery');
       await settleAutocomplete();
 
-      // The actors on offer come from the visit type, so what was chosen for the
-      // last one cannot mean anything for this one — nor can a time held on them.
       expect(chosenTimeField().value).toBe('');
       expect(screen.getByText('Choose at least one provider')).toBeInTheDocument();
     });

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -1,0 +1,529 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { Device } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import type { JSX } from 'react';
+import { installFindStub } from '../stories/mockFind';
+import {
+  MainClinic,
+  SatelliteClinic,
+  SchedulingFixtures,
+  SubClinicProviderFixtures,
+  SurgeryService,
+  SurgicalFixtures,
+  Ultrasound1Device,
+  UltrasoundImagingService,
+} from '../stories/scheduling';
+import {
+  clickAutocompleteOption,
+  installAutocompleteTimers,
+  settleAutocomplete,
+  typeInAutocomplete,
+} from '../test-utils/asyncAutocomplete';
+import { stubChainedActorSearch } from '../test-utils/chainedActorSearch';
+import { act, fireEvent, renderWithMedplum, screen, waitFor, within } from '../test-utils/render';
+import type { AppointmentBookingFormProps } from './AppointmentBookingForm';
+import { AppointmentBookingForm } from './AppointmentBookingForm';
+
+/**
+ * A Monday morning, so the stubbed `$find` has weekday hours ahead of it on the
+ * day the form searches by default.
+ */
+const MONDAY_MORNING = new Date(2026, 7, 17, 8, 0, 0);
+
+/** The timezone the fixtures' visit type is held in, which is not the runner's. */
+const SITE_TIMEZONE = 'America/New_York';
+
+installAutocompleteTimers();
+
+async function setupClient(): Promise<MockClient> {
+  const medplum = new MockClient();
+  for (const resource of [...SchedulingFixtures, ...SurgicalFixtures, ...SubClinicProviderFixtures]) {
+    await medplum.createResource(resource);
+  }
+  stubChainedActorSearch(medplum);
+  return medplum;
+}
+
+function setup(medplum: MockClient, props?: AppointmentBookingFormProps): void {
+  const element: JSX.Element = <AppointmentBookingForm {...props} />;
+  renderWithMedplum(element, medplum);
+}
+
+/**
+ * The search box for one of the form's fields.
+ * @param label - Matches the label above the field.
+ * @returns The field's search box.
+ */
+function field(label: RegExp): HTMLElement {
+  return screen.getByRole('searchbox', { name: label });
+}
+
+/** Chooses the imaging service, which is what the role fields search against. */
+async function chooseImagingService(): Promise<void> {
+  await typeInAutocomplete(field(/service type/i), 'Ultrasound');
+  await clickAutocompleteOption('Ultrasound Imaging');
+  await settleAutocomplete();
+}
+
+/**
+ * Opens one role's field on everything it has, without typing a name.
+ *
+ * `fireEvent.change` to the value already in the box is not a change, so the
+ * unfiltered list is reached the way a user reaches it: by focusing.
+ *
+ * @param role - The field to open.
+ * @returns The field's search box.
+ */
+async function openRoleField(role: RegExp): Promise<HTMLElement> {
+  const input = field(role);
+  await act(async () => {
+    fireEvent.focus(input);
+  });
+  await settleAutocomplete();
+  return input;
+}
+
+/**
+ * Names an actor for one role.
+ *
+ * The pick is scoped to the dropdown this field owns: three role fields are on
+ * screen at once and a dropdown stays in the document once it has been opened,
+ * so an unscoped search could click an option belonging to another field.
+ *
+ * @param role - The field to choose in.
+ * @param query - What to type, which is what the search narrows on.
+ * @param name - The actor to choose out of what came back.
+ */
+async function chooseActor(role: RegExp, query: string, name: string): Promise<void> {
+  const input = field(role);
+  await typeInAutocomplete(input, query);
+
+  const listboxId = input.getAttribute('aria-controls');
+  const listbox = listboxId && document.getElementById(listboxId);
+  if (!listbox) {
+    throw new Error(`No dropdown found for ${role.source}`);
+  }
+  await act(async () => {
+    fireEvent.click(within(listbox).getByText(name));
+  });
+  await settleAutocomplete();
+}
+
+/**
+ * Empties the visit type field, which is the only way to change what it holds:
+ * it takes one value at most, so its search box is gone while it is full.
+ *
+ * @param name - The visit type currently chosen.
+ */
+async function clearVisitType(name: string): Promise<void> {
+  // Mantine's remove button is `aria-hidden`, so it is reached through the pill
+  // it sits in rather than by its role.
+  const remove = screen.getByText(name).parentElement?.querySelector('button');
+  if (!remove) {
+    throw new Error(`No remove button on the ${name} pill`);
+  }
+  await act(async () => {
+    fireEvent.click(remove);
+  });
+  await settleAutocomplete();
+}
+
+/** Opens the time search, which is what sends the `$find` request. */
+async function openTimeFinder(): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /find a time/i }));
+  });
+  await settleAutocomplete();
+}
+
+/**
+ * Clicks a day in the time search's calendar.
+ * @param dayOfMonth - The day's number, which is what the cell is labelled with.
+ */
+async function chooseDay(dayOfMonth: string): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: dayOfMonth }));
+  });
+  await settleAutocomplete();
+}
+
+/**
+ * Picks the first time on offer.
+ *
+ * Times are read at the site, whose timezone is not the runner's, so the time is
+ * picked by position rather than by the clock face it shows.
+ *
+ * @returns The label of the time that was picked.
+ */
+async function chooseFirstOfferedTime(): Promise<string> {
+  const [firstGroup] = await screen.findAllByTestId(/^slot-group-/);
+  const [firstTime] = within(firstGroup).getAllByRole('button');
+  const label = firstTime.textContent ?? '';
+  await act(async () => {
+    fireEvent.click(firstTime);
+  });
+  return label;
+}
+
+/**
+ * The read-only field the chosen time is shown in.
+ * @returns The field.
+ */
+function chosenTimeField(): HTMLInputElement {
+  return screen.getByRole<HTMLInputElement>('textbox', { name: /date & time/i });
+}
+
+describe('AppointmentBookingForm', () => {
+  let medplum: MockClient;
+  let restoreFind: () => void;
+
+  beforeEach(async () => {
+    vi.setSystemTime(MONDAY_MORNING);
+    medplum = await setupClient();
+    restoreFind = installFindStub(medplum);
+  });
+
+  afterEach(() => {
+    restoreFind();
+  });
+
+  describe('Choosing the resources a visit is held on', () => {
+    test('Offers a field for all three roles', async () => {
+      setup(medplum);
+      await chooseImagingService();
+
+      // All three render whatever the visit type has configured, so the form's
+      // shape does not change with the data behind it.
+      expect(field(/provider/i)).toBeInTheDocument();
+      expect(field(/room/i)).toBeInTheDocument();
+      expect(field(/device/i)).toBeInTheDocument();
+    });
+
+    test('Searches no times until a provider is named', async () => {
+      setup(medplum);
+      await chooseImagingService();
+
+      // A room alone is not enough: it would hold the room while leaving the
+      // calendar it is booked against open.
+      await chooseActor(/room/i, 'exam', 'Exam Room A');
+      await openTimeFinder();
+
+      expect(screen.getByText('Choose at least one provider')).toBeInTheDocument();
+      expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
+    });
+
+    test('Searches against the provider alone when the room and device are left empty', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      const [group] = await screen.findAllByTestId(/^slot-group-/);
+      expect(within(group).getByText('Dr. Maya Rivera')).toBeInTheDocument();
+      expect(within(group).queryByText('Exam Room A')).not.toBeInTheDocument();
+    });
+
+    test('Still offers a role the visit type has nothing configured for', async () => {
+      setup(medplum);
+      await chooseImagingService();
+
+      // A name the visit type has never heard of finds nothing, and the field
+      // says so rather than disappearing.
+      const input = await openRoleField(/device/i);
+      await typeInAutocomplete(input, 'nosuchdevice');
+
+      expect(input).toBeEnabled();
+      expect(await screen.findByText('No devices found')).toBeInTheDocument();
+    });
+
+    test('Naming two providers narrows the times to the ones both are free for', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await chooseActor(/provider/i, 'oka', 'Dr. Tunde Okafor');
+      await openTimeFinder();
+
+      // One request over both schedules: `$find` intersects what it is given, so
+      // the times come back as a single set both are free for rather than two.
+      const groups = await screen.findAllByTestId(/^slot-group-/);
+      expect(groups).toHaveLength(1);
+      expect(within(groups[0]).getByText('Dr. Maya Rivera')).toBeInTheDocument();
+      expect(within(groups[0]).getByText('Dr. Tunde Okafor')).toBeInTheDocument();
+    });
+  });
+
+  describe('Narrowing resources to the chosen site', () => {
+    test('Offers a room that belongs to a place inside the chosen site', async () => {
+      setup(medplum, { defaultLocation: MainClinic, defaultService: UltrasoundImagingService });
+      await settleAutocomplete();
+
+      await openRoleField(/room/i);
+
+      // Exam Room B is `partOf` the second floor, which is `partOf` the clinic.
+      expect(await screen.findByText('Exam Room B')).toBeInTheDocument();
+      expect(screen.getByText('Exam Room A')).toBeInTheDocument();
+      expect(screen.queryByText('Satellite Exam Room')).not.toBeInTheDocument();
+    });
+
+    test('Offers a device kept inside the chosen site', async () => {
+      const sitedDevice: Device = { ...Ultrasound1Device, location: { reference: 'Location/second-floor' } };
+      await medplum.updateResource(sitedDevice);
+      setup(medplum, { defaultLocation: MainClinic, defaultService: UltrasoundImagingService });
+      await settleAutocomplete();
+
+      await openRoleField(/device/i);
+
+      expect(await screen.findByText('Ultrasound 1 (Main Campus)')).toBeInTheDocument();
+    });
+
+    test('Offers a provider whose role names the chosen site', async () => {
+      // Dr. Martinez's practitioner role names the main clinic itself, which is
+      // the only way a provider is sited: there is no walk up the chain.
+      setup(medplum, { defaultLocation: MainClinic, defaultService: SurgeryService });
+      await settleAutocomplete();
+
+      const input = await openRoleField(/provider/i);
+      await typeInAutocomplete(input, 'mart');
+
+      expect(await screen.findByText('Dr. Maria Martinez')).toBeInTheDocument();
+    });
+
+    test('Leaves out a provider whose roles name another site', async () => {
+      setup(medplum, { defaultLocation: SatelliteClinic, defaultService: SurgeryService });
+      await settleAutocomplete();
+
+      const input = await openRoleField(/provider/i);
+      await typeInAutocomplete(input, 'mart');
+
+      expect(await screen.findByText('No providers found')).toBeInTheDocument();
+      expect(screen.queryByText('Dr. Maria Martinez')).not.toBeInTheDocument();
+    });
+
+    test('Leaves out a provider sited inside the chosen site rather than at it, while offering a room there', async () => {
+      // The asymmetry a reader is most likely to take for a bug: a room is sited
+      // by walking `partOf`, a provider only by a role naming the site exactly.
+      setup(medplum, { defaultLocation: MainClinic, defaultService: UltrasoundImagingService });
+      await settleAutocomplete();
+
+      await openRoleField(/provider/i);
+      expect(await screen.findByText('Dr. Maya Rivera')).toBeInTheDocument();
+      expect(screen.queryByText('Dr. Ama Osei')).not.toBeInTheDocument();
+
+      await openRoleField(/room/i);
+      expect(await screen.findByText('Exam Room B')).toBeInTheDocument();
+    });
+
+    test('Keeps a resource that records nothing about where it is', async () => {
+      setup(medplum, { defaultLocation: SatelliteClinic, defaultService: UltrasoundImagingService });
+      await settleAutocomplete();
+
+      await openRoleField(/device/i);
+
+      // The devices record no location, and hiding something the caller may be
+      // entitled to book is worse than offering something at the wrong site.
+      expect(await screen.findByText('Ultrasound 1 (Main Campus)')).toBeInTheDocument();
+    });
+
+    test('Narrows nothing by location when no site is chosen', async () => {
+      setup(medplum, { defaultService: UltrasoundImagingService });
+      await settleAutocomplete();
+
+      await openRoleField(/room/i);
+
+      expect(await screen.findByText('Exam Room A')).toBeInTheDocument();
+      expect(screen.getByText('Satellite Exam Room')).toBeInTheDocument();
+    });
+  });
+
+  describe('Offering only times every named resource is free', () => {
+    test('Offers the times the named resources share', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await chooseActor(/room/i, 'exam', 'Exam Room A');
+      await openTimeFinder();
+
+      const groups = await screen.findAllByTestId(/^slot-group-/);
+      expect(groups).toHaveLength(1);
+      expect(within(groups[0]).getByText('Dr. Maya Rivera')).toBeInTheDocument();
+      expect(within(groups[0]).getByText('Exam Room A')).toBeInTheDocument();
+    });
+
+    test('Issues no request until the time search is opened', async () => {
+      const get = vi.spyOn(medplum, 'get');
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+
+      // Everything the search needs has been answered, and still nothing is
+      // asked for: the times depend on every answer above them.
+      expect(get.mock.calls.filter(([url]) => String(url).includes('find'))).toHaveLength(0);
+      expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
+
+      await openTimeFinder();
+
+      expect((await screen.findAllByTestId(/^slot-group-/)).length).toBeGreaterThan(0);
+    });
+
+    test('Says so when the search offers nothing', async () => {
+      restoreFind();
+      restoreFind = installFindStub(medplum, { empty: true });
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      expect(await screen.findByText('No times are available for this selection.')).toBeInTheDocument();
+    });
+
+    test('Replaces the times when another day is chosen', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      expect(await screen.findByText(/Monday, August 17/)).toBeInTheDocument();
+
+      await chooseDay('18');
+
+      await waitFor(() => expect(screen.getByText(/Tuesday, August 18/)).toBeInTheDocument());
+      expect(screen.queryByText(/Monday, August 17/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Reading times in the site’s timezone', () => {
+    test('Shows an offered time as the time at the site', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      const [group] = await screen.findAllByTestId(/^slot-group-/);
+      const [firstTime] = within(group).getAllByRole('button');
+      // The stub lays times on the clinic's open hours in the runner's timezone,
+      // so the label is that instant read at the site rather than 9:00 repeated.
+      const start = new Date(2026, 7, 17, 9, 0, 0);
+
+      expect(firstTime).toHaveTextContent(
+        new Intl.DateTimeFormat(undefined, {
+          timeZone: SITE_TIMEZONE,
+          hour: 'numeric',
+          minute: '2-digit',
+        }).format(start)
+      );
+    });
+
+    test('Records the instant the site-local time stands for', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      const label = await chooseFirstOfferedTime();
+
+      // The chosen time is the server's own proposal, so the instant it carries
+      // is what a booking would record, and the field reads it at the site.
+      expect(chosenTimeField().value).toContain(label);
+    });
+  });
+
+  describe('Booking only a time that was offered', () => {
+    test('Shows the time that was picked', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      expect(chosenTimeField().value).toBe('');
+      const label = await chooseFirstOfferedTime();
+
+      expect(chosenTimeField().value).toContain(label);
+    });
+
+    test('Refuses a time typed into the field', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await chooseFirstOfferedTime();
+      const shown = chosenTimeField().value;
+
+      await act(async () => {
+        fireEvent.change(chosenTimeField(), { target: { value: 'Monday, August 17 at 11:59 PM' } });
+      });
+
+      // Nothing can be booked onto time that was never checked against
+      // anybody's availability, so the field only ever displays.
+      expect(chosenTimeField()).toHaveAttribute('readonly');
+      expect(chosenTimeField().value).toBe(shown);
+    });
+
+    test('Clears the chosen time when the day changes', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await chooseFirstOfferedTime();
+
+      await chooseDay('18');
+
+      expect(chosenTimeField().value).toBe('');
+    });
+  });
+
+  describe('Clearing answers that depended on the visit type', () => {
+    test('Clears the chosen resources and time when the visit type changes', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await chooseFirstOfferedTime();
+      expect(chosenTimeField().value).not.toBe('');
+
+      await clearVisitType('Ultrasound Imaging');
+      await typeInAutocomplete(field(/service type/i), 'Bariatric');
+      await clickAutocompleteOption('Bariatric Surgery');
+      await settleAutocomplete();
+
+      // The actors on offer come from the visit type, so what was chosen for the
+      // last one cannot mean anything for this one — nor can a time held on them.
+      expect(chosenTimeField().value).toBe('');
+      expect(screen.getByText('Choose at least one provider')).toBeInTheDocument();
+    });
+
+    test('Reports the visit type as it changes', async () => {
+      const onChangeService = vi.fn();
+      setup(medplum, { onChangeService });
+
+      await chooseImagingService();
+
+      expect(onChangeService).toHaveBeenCalledWith(expect.objectContaining({ id: 'ultrasound-imaging' }));
+    });
+  });
+
+  describe('Mounting the form', () => {
+    test('Reports the time search opening and closing', async () => {
+      const onToggleTimeFinder = vi.fn();
+      setup(medplum, { onToggleTimeFinder });
+      await chooseImagingService();
+
+      await openTimeFinder();
+      expect(onToggleTimeFinder).toHaveBeenLastCalledWith(true);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /close time finder/i }));
+      });
+      expect(onToggleTimeFinder).toHaveBeenLastCalledWith(false);
+    });
+
+    test('Opens the time search on the day the host named', async () => {
+      // A Wednesday in the following month, so neither today nor the month the
+      // calendar would otherwise open on could pass this by accident.
+      setup(medplum, { defaultService: UltrasoundImagingService, defaultStart: new Date(2026, 8, 2, 0, 0, 0) });
+      await settleAutocomplete();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      expect(await screen.findByText(/Wednesday, September 2/)).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -11,6 +11,7 @@ import {
   SubClinicProviderFixtures,
   SurgeryService,
   SurgicalFixtures,
+  TelehealthService,
   Ultrasound1Device,
   UltrasoundImagingService,
 } from '../stories/scheduling';
@@ -85,25 +86,36 @@ async function openRoleField(role: RegExp): Promise<HTMLElement> {
 }
 
 /**
- * Names an actor for one role.
+ * Searches one field and returns the dropdown that field owns.
  *
- * The pick is scoped to the dropdown this field owns: three role fields are on
- * screen at once and a dropdown stays in the document once it has been opened,
- * so an unscoped search could click an option belonging to another field.
+ * Scoped per field because five autocompletes are on screen at once and a
+ * dropdown stays in the document once it has been opened, so an unscoped query
+ * could read — or click — an option belonging to another field.
  *
- * @param role - The field to choose in.
+ * @param label - Matches the label above the field.
  * @param query - What to type, which is what the search narrows on.
- * @param name - The actor to choose out of what came back.
+ * @returns The field's dropdown.
  */
-async function chooseActor(role: RegExp, query: string, name: string): Promise<void> {
-  const input = field(role);
+async function searchField(label: RegExp, query: string): Promise<HTMLElement> {
+  const input = field(label);
   await typeInAutocomplete(input, query);
 
   const listboxId = input.getAttribute('aria-controls');
   const listbox = listboxId && document.getElementById(listboxId);
   if (!listbox) {
-    throw new Error(`No dropdown found for ${role.source}`);
+    throw new Error(`No dropdown found for ${label.source}`);
   }
+  return listbox;
+}
+
+/**
+ * Names an actor for one role.
+ * @param role - The field to choose in.
+ * @param query - What to type, which is what the search narrows on.
+ * @param name - The actor to choose out of what came back.
+ */
+async function chooseActor(role: RegExp, query: string, name: string): Promise<void> {
+  const listbox = await searchField(role, query);
   await act(async () => {
     fireEvent.click(within(listbox).getByText(name));
   });
@@ -125,6 +137,25 @@ async function clearVisitType(name: string): Promise<void> {
   }
   await act(async () => {
     fireEvent.click(remove);
+  });
+  await settleAutocomplete();
+}
+
+/**
+ * Chooses a site in the location field.
+ *
+ * Starts from an empty field: like the visit type, it holds one value and takes
+ * its search box away while full.
+ *
+ * @param query - What to type.
+ * @param name - The site to click out of what came back.
+ */
+async function chooseSite(query: string, name: string): Promise<void> {
+  const listbox = await searchField(/location/i, query);
+  // By name, not by position: a search narrow enough to return one site is a
+  // search narrow enough to pass while offering the wrong one.
+  await act(async () => {
+    fireEvent.click(within(listbox).getByText(name));
   });
   await settleAutocomplete();
 }
@@ -167,6 +198,19 @@ async function chooseFirstOfferedTime(): Promise<string> {
 }
 
 /**
+ * Whether a field is holding a value, read off the pill rather than the state.
+ *
+ * The pill is what went stale: the fields keep their own selection and ignore
+ * `defaultValue` after mount, so a cleared form could still show one.
+ *
+ * @param name - The value's label.
+ * @returns Whether a pill is showing it.
+ */
+function hasPill(name: string): boolean {
+  return screen.queryAllByText(name).some((node) => node.className.includes('Pill'));
+}
+
+/**
  * The read-only field the chosen time is shown in.
  * @returns The field.
  */
@@ -198,6 +242,22 @@ describe('AppointmentBookingForm', () => {
       expect(field(/provider/i)).toBeInTheDocument();
       expect(field(/room/i)).toBeInTheDocument();
       expect(field(/device/i)).toBeInTheDocument();
+    });
+
+    test('Offers nothing to type into until a visit type is chosen', async () => {
+      setup(medplum);
+      await settleAutocomplete();
+
+      // Asking before a visit type is chosen could only ever find nothing, which
+      // reads as a broken field rather than an answer still owed.
+      for (const role of [/^Provider$/, /^Room$/, /^Device$/]) {
+        expect(screen.queryByRole('searchbox', { name: role })).not.toBeInTheDocument();
+        expect(screen.getByText(role)).toBeInTheDocument();
+      }
+
+      await chooseImagingService();
+
+      expect(field(/provider/i)).toBeInTheDocument();
     });
 
     test('Searches no times until a provider is named', async () => {
@@ -333,6 +393,49 @@ describe('AppointmentBookingForm', () => {
 
       expect(await screen.findByText('Exam Room A')).toBeInTheDocument();
       expect(screen.getByText('Satellite Exam Room')).toBeInTheDocument();
+    });
+  });
+
+  describe('Choosing where the visit is held', () => {
+    test('Leaves a room and a bed out of the site field', async () => {
+      setup(medplum);
+
+      // Unscoped, because a field whose search came back with nothing has no
+      // dropdown to scope to. The empty message can only be this field's: it is
+      // the only one that has been searched, and a field nobody typed into shows
+      // none.
+      await typeInAutocomplete(field(/location/i), 'Exam Room A');
+
+      // Rooms and beds are Locations, so nothing but their own physical type keeps
+      // them out of a field asking where the visit is held.
+      expect(await screen.findByText('Nothing found')).toBeInTheDocument();
+      expect(screen.queryByText('Exam Room A')).not.toBeInTheDocument();
+      expect(screen.queryByText('Exam Room A Bed 1')).not.toBeInTheDocument();
+    });
+
+    test('Offers a Location that records no physical type', async () => {
+      setup(medplum);
+
+      const listbox = await searchField(/location/i, 'Uro Associates');
+
+      // Neither clinic says what it physically is, and nothing requires it to. The
+      // field excludes what declares itself a room rather than admitting only what
+      // declares itself a site, so both are still offered.
+      expect(within(listbox).getByText('Uro Associates - Main Clinic')).toBeInTheDocument();
+      expect(within(listbox).getByText('Uro Associates - Satellite')).toBeInTheDocument();
+    });
+
+    test('Narrows the visit types to the chosen site, and says which site', async () => {
+      setup(medplum);
+      await chooseSite('Satellite', 'Uro Associates - Satellite');
+
+      await typeInAutocomplete(field(/service type/i), 'Ultrasound');
+
+      expect(screen.getByText('Showing visit types offered at Uro Associates - Satellite.')).toBeInTheDocument();
+      // Imaging names the main clinic, and only a visit type naming this site
+      // exactly is offered at it.
+      expect(await screen.findByText('Nothing found')).toBeInTheDocument();
+      expect(screen.queryByText('Ultrasound Imaging')).not.toBeInTheDocument();
     });
   });
 
@@ -485,7 +588,75 @@ describe('AppointmentBookingForm', () => {
       await settleAutocomplete();
 
       expect(chosenTimeField().value).toBe('');
-      expect(screen.getByText('Choose at least one provider')).toBeInTheDocument();
+      // Not just the state: the field keeps its own selection, so a surviving pill
+      // would be handed back on the next pick and searched against a schedule the
+      // new visit type cannot book.
+      expect(hasPill('Dr. Maya Rivera')).toBe(false);
+    });
+
+    test('Clears the chosen resources when the site changes', async () => {
+      setup(medplum, { defaultService: UltrasoundImagingService });
+      await settleAutocomplete();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      expect(hasPill('Dr. Maya Rivera')).toBe(true);
+
+      await chooseSite('Main Clinic', 'Uro Associates - Main Clinic');
+
+      // Where a visit is held decides which actors are offered at all, so the one
+      // chosen before the site was known cannot be assumed to serve it.
+      expect(hasPill('Dr. Maya Rivera')).toBe(false);
+      // The imaging service is held there, so that answer stands.
+      expect(hasPill('Ultrasound Imaging')).toBe(true);
+    });
+
+    test('Clears the visit type when the new site does not hold it', async () => {
+      setup(medplum, { defaultService: SurgeryService });
+      await settleAutocomplete();
+      expect(hasPill('Bariatric Surgery')).toBe(true);
+
+      // Surgery is held at the main clinic only.
+      await chooseSite('Satellite', 'Uro Associates - Satellite');
+
+      expect(hasPill('Bariatric Surgery')).toBe(false);
+    });
+
+    test('Keeps a visit type the new site does hold', async () => {
+      setup(medplum, { defaultService: UltrasoundImagingService });
+      await settleAutocomplete();
+
+      await chooseSite('Main Clinic', 'Uro Associates - Main Clinic');
+
+      // The imaging service names the main clinic, so the answer still stands.
+      expect(hasPill('Ultrasound Imaging')).toBe(true);
+    });
+
+    test('Keeps a visit type that names no location when the site changes', async () => {
+      setup(medplum, { defaultService: TelehealthService });
+      await settleAutocomplete();
+      expect(hasPill('Telehealth Consult')).toBe(true);
+
+      await chooseSite('Main Clinic', 'Uro Associates - Main Clinic');
+
+      // Nothing about it was ever tied to a site, so no site can invalidate it —
+      // even though choosing one now keeps it from being offered again.
+      expect(hasPill('Telehealth Consult')).toBe(true);
+    });
+
+    test('Collapses the time search when the visit type is cleared, and says so', async () => {
+      const onToggleTimeFinder = vi.fn();
+      setup(medplum, { onToggleTimeFinder });
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await screen.findAllByTestId(/^slot-group-/);
+
+      await clearVisitType('Ultrasound Imaging');
+
+      // Nothing can be searched without a visit type, and the host has to be told
+      // so the panel it widened narrows again.
+      expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
+      expect(screen.queryByRole('button', { name: /close time finder/i })).not.toBeInTheDocument();
+      expect(onToggleTimeFinder).toHaveBeenLastCalledWith(false);
     });
 
     test('Reports the visit type as it changes', async () => {

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Alert, Button, Loader, Stack, Text, TextInput } from '@mantine/core';
+import { Alert, Button, Group, Loader, Paper, Stack, Text } from '@mantine/core';
 import type { WithId } from '@medplum/core';
-import { getSchedulingTimezone, normalizeErrorString } from '@medplum/core';
+import { getReferenceString, getSchedulingTimezone, isDefined, normalizeErrorString } from '@medplum/core';
 import type { Appointment, HealthcareService, Location } from '@medplum/fhirtypes';
-import { CalendarDateInput, ResourceInput } from '@medplum/react';
+import { CalendarDateInput, ReferenceDisplay, ResourceInput } from '@medplum/react';
 import { IconCalendarSearch } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useCallback, useMemo, useState } from 'react';
@@ -12,11 +12,11 @@ import { AppointmentActorSelect } from './AppointmentActorSelect';
 import { AppointmentDayTimes } from './AppointmentDayTimes';
 import classes from './AppointmentFinder.module.css';
 import type { SchedulingRole } from './AppointmentFinder.roles';
-import { SCHEDULING_ROLES } from './AppointmentFinder.roles';
+import { getActorRoleLabel, SCHEDULING_ROLES } from './AppointmentFinder.roles';
 import type { ActorSelections, ScheduleCandidate } from './AppointmentFinder.schedules';
 import { getActorCombinations, getSelectedCandidates, getSelectionError } from './AppointmentFinder.schedules';
 import type { DateRange } from './AppointmentFinder.times';
-import { endOfDay, getFindWindowError, groupAppointmentsByDay } from './AppointmentFinder.times';
+import { endOfDay, getDurationMinutes, getFindWindowError, groupAppointmentsByDay } from './AppointmentFinder.times';
 import { AppointmentServiceSelect } from './AppointmentServiceSelect';
 import { isServiceKeptAtLocation } from './AppointmentServiceSelect.utils';
 import { useProposedAppointments } from './useProposedAppointments';
@@ -71,8 +71,9 @@ export interface AppointmentBookingFormProps {
  * Choosing a time is deliberately a separate step behind "Find a time". The
  * times depend on every answer above them, so offering them earlier would only
  * show times that are about to change. Only a time the search offered can be
- * chosen: the field displaying it is read-only, so nothing can be booked onto
- * time that was never checked against anybody's availability.
+ * chosen: what it produced is summarised beneath the action, and there is no
+ * field to type into, so nothing can be booked onto time that was never checked
+ * against anybody's availability.
  *
  * @param props - The React props.
  * @returns The form.
@@ -205,23 +206,13 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
           />
         ))}
 
-        <TextInput
-          label="Date & time"
-          placeholder="Find a time to choose one"
-          // A field rather than plain text, because the chosen time belongs among
-          // the answers — but read-only, so there is nothing to type into.
-          readOnly
-          value={chosen?.start ? formatZonedDateTime(new Date(chosen.start), timezone) : ''}
-        />
-        <Button
-          variant="outline"
-          fullWidth
-          leftSection={<IconCalendarSearch size={16} stroke={1.8} />}
+        <ChosenTime
+          appointment={chosen}
+          timezone={timezone}
+          finding={finding}
           disabled={!service}
-          onClick={toggleFinder}
-        >
-          {finding ? 'Close time finder' : 'Find a time'}
-        </Button>
+          onToggleFinder={toggleFinder}
+        />
 
         {finding && (
           <Stack gap={4}>
@@ -269,6 +260,97 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
       )}
     </div>
   );
+}
+
+interface ChosenTimeProps {
+  /** The proposal the user picked, or undefined while none has been. */
+  readonly appointment: Appointment | undefined;
+  /** IANA timezone the visit is held in. */
+  readonly timezone: string | undefined;
+  readonly finding: boolean;
+  readonly disabled?: boolean;
+  readonly onToggleFinder: () => void;
+}
+
+/**
+ * The action that finds a time, and beneath it what the chosen one commits to.
+ *
+ * One region: the action sits directly under the resource fields it depends on,
+ * the summary sits directly under the action that produced it, and both read from
+ * the chosen proposal. Nothing stands in for a time before one is chosen — an
+ * empty white input among greyed-out ones reads as the one thing still fillable,
+ * and the field this replaces sat above the button that filled it.
+ *
+ * The summary is deliberately the only thing that varies here: entering a time
+ * nobody offered arrives by swapping it for a time input and an override warning
+ * in place, which stays a control change only while the region around it is not
+ * arranged for the read-only case.
+ *
+ * @param props - The React props.
+ * @returns The action, and the summary once there is one.
+ */
+function ChosenTime(props: ChosenTimeProps): JSX.Element {
+  const { appointment, timezone, finding, disabled, onToggleFinder } = props;
+
+  // Read off the proposal rather than off the answers above: it is what `$book`
+  // is handed, so the summary describes what would actually be booked.
+  const actors = (appointment?.participant ?? []).map((participant) => participant.actor).filter(isDefined);
+  const durationMinutes = getDurationMinutes(appointment);
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        fullWidth
+        leftSection={<IconCalendarSearch size={16} stroke={1.8} />}
+        disabled={disabled}
+        onClick={onToggleFinder}
+      >
+        {getFinderLabel(finding, !!appointment)}
+      </Button>
+
+      {appointment?.start && (
+        <Paper withBorder p="sm" data-testid="chosen-time">
+          <Group justify="space-between" align="flex-start" wrap="nowrap">
+            <Text size="sm" fw={500}>
+              {formatZonedDateTime(new Date(appointment.start), timezone)}
+            </Text>
+            {durationMinutes > 0 && (
+              <Text size="xs" c="dimmed" style={{ whiteSpace: 'nowrap' }}>
+                {durationMinutes} min visit
+              </Text>
+            )}
+          </Group>
+          <Group gap="md" mt={4} wrap="wrap">
+            {actors.map((actor) => {
+              const roleLabel = getActorRoleLabel(actor);
+              return (
+                <Text key={getReferenceString(actor) ?? actor.display} size="sm" c="dimmed">
+                  {roleLabel && `${roleLabel}: `}
+                  <ReferenceDisplay value={actor} link={false} />
+                </Text>
+              );
+            })}
+          </Group>
+        </Paper>
+      )}
+    </>
+  );
+}
+
+/**
+ * Names what the action does next.
+ * @param finding - Whether the time search is open.
+ * @param chosen - Whether a time has been picked.
+ * @returns The button's label.
+ */
+function getFinderLabel(finding: boolean, chosen: boolean): string {
+  if (finding) {
+    return 'Close time finder';
+  }
+  // Repeating the invitation once a time is chosen reads as though the search had
+  // come back with nothing.
+  return chosen ? 'Change time' : 'Find a time';
 }
 
 interface RoleFieldProps {
@@ -320,7 +402,7 @@ function oneDay(date: Date): DateRange {
 /**
  * Writes an instant as the day and time it falls on at the site.
  *
- * Read in the timezone the visit is held in, so the field shows the time the
+ * Read in the timezone the visit is held in, so the summary shows the time the
  * clinic will keep rather than the time on the booker's own clock.
  *
  * @param value - The chosen start time.

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
@@ -18,9 +18,14 @@ import { getActorCombinations, getSelectedCandidates, getSelectionError } from '
 import type { DateRange } from './AppointmentFinder.times';
 import { endOfDay, getFindWindowError, groupAppointmentsByDay } from './AppointmentFinder.times';
 import { AppointmentServiceSelect } from './AppointmentServiceSelect';
+import { isServiceKeptAtLocation } from './AppointmentServiceSelect.utils';
 import { useProposedAppointments } from './useProposedAppointments';
 
-const LOCATION_SEARCH_CRITERIA = { _count: '25', _sort: 'name' };
+// Rooms are Locations too, so the site field is kept off them by what they are
+// not: `physical-type` is a Medplum search parameter, so the exclusion is the
+// server's and paging survives it. Naming what a site *is* would be more precise
+// and would silently hide a Location whose type nobody populated.
+const LOCATION_SEARCH_CRITERIA = { _count: '25', _sort: 'name', 'physical-type:not': 'ro,bd' };
 
 // Nothing has scanned a month for the days that have times on them, so every day
 // is offered and the search is what answers.
@@ -82,6 +87,12 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
   const [month, setMonth] = useState<Date | undefined>(defaultStart);
   const [finding, setFinding] = useState(false);
   const [chosen, setChosen] = useState<Appointment | undefined>(undefined);
+  // The fields below hold their own selections and ignore `defaultValue` after
+  // mount, so clearing the state above is not enough to clear what is on screen.
+  // Remounting is, and these are what force it — counters rather than the chosen
+  // values, so a field is never remounted out from under the user's own pick.
+  const [roleFieldsKey, setRoleFieldsKey] = useState(0);
+  const [serviceFieldKey, setServiceFieldKey] = useState(0);
 
   const selectionError = getSelectionError(selections);
   const windowError = getFindWindowError(range);
@@ -116,8 +127,40 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
     onChangeService?.(next);
     // The actors on offer come from the visit type, so what was chosen for the
     // last one cannot mean anything for this one — nor can a time held on them.
+    clearResources();
+    // Nothing can be searched without a visit type, and the field holds one at a
+    // time, so every change passes through none. Collapsing keeps the times from
+    // outliving what produced them, and the host is told so its panel narrows
+    // with them.
+    closeFinder();
+  }
+
+  function chooseLocation(next: WithId<Location> | undefined): void {
+    setLocation(next);
+    // Where a visit is held decides which actors are offered at all, so the ones
+    // chosen for the last site cannot be assumed to serve this one.
+    clearResources();
+    // The visit type is narrowed by site too. It only has to go when the new site
+    // does not hold it; otherwise the answer still stands.
+    if (service && !isServiceKeptAtLocation(service, next)) {
+      setService(undefined);
+      onChangeService?.(undefined);
+      setServiceFieldKey((key) => key + 1);
+      closeFinder();
+    }
+  }
+
+  function clearResources(): void {
     setSelections({});
     setChosen(undefined);
+    setRoleFieldsKey((key) => key + 1);
+  }
+
+  function closeFinder(): void {
+    if (finding) {
+      setFinding(false);
+      onToggleTimeFinder?.(false);
+    }
   }
 
   function chooseDay(date: Date): void {
@@ -136,12 +179,30 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
           placeholder="Any location"
           searchCriteria={LOCATION_SEARCH_CRITERIA}
           defaultValue={defaultLocation}
-          onChange={setLocation}
+          onChange={chooseLocation}
         />
-        <AppointmentServiceSelect location={location} defaultValue={defaultService} onChange={chooseService} />
+        <AppointmentServiceSelect
+          key={serviceFieldKey}
+          location={location}
+          // Seeded from state, not from the prop: a remount is how the field is
+          // cleared, and re-seeding from `defaultService` would put back the visit
+          // type that was just cleared.
+          defaultValue={service}
+          onChange={chooseService}
+        />
 
         {SCHEDULING_ROLES.map((role) => (
-          <RoleField key={role} role={role} service={service} location={location} onChange={setSelections} />
+          <RoleField
+            key={`${role}-${roleFieldsKey}`}
+            role={role}
+            service={service}
+            location={location}
+            // The actors on offer come from the visit type, so asking before one
+            // is chosen could only ever find nothing, which reads as a fault in
+            // the field rather than an answer still owed.
+            disabled={!service}
+            onChange={setSelections}
+          />
         ))}
 
         <TextInput
@@ -199,7 +260,7 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
                 onSelectAppointment={setChosen}
               />
             ))}
-          {!search.loading && !search.error && !selectionError && days.length === 0 && (
+          {!search.loading && !search.error && !selectionError && !windowError && days.length === 0 && (
             <Text c="dimmed" ta="center">
               No times are available for this selection.
             </Text>
@@ -214,6 +275,7 @@ interface RoleFieldProps {
   readonly role: SchedulingRole;
   readonly service: WithId<HealthcareService> | undefined;
   readonly location: WithId<Location> | undefined;
+  readonly disabled?: boolean;
   readonly onChange: (update: (selections: ActorSelections) => ActorSelections) => void;
 }
 
@@ -228,14 +290,22 @@ interface RoleFieldProps {
  * @returns The field for that role.
  */
 function RoleField(props: RoleFieldProps): JSX.Element {
-  const { role, service, location, onChange } = props;
+  const { role, service, location, disabled, onChange } = props;
 
   const handleChange = useCallback(
     (candidates: readonly ScheduleCandidate[]) => onChange((selections) => ({ ...selections, [role]: candidates })),
     [onChange, role]
   );
 
-  return <AppointmentActorSelect role={role} service={service} location={location} onChange={handleChange} />;
+  return (
+    <AppointmentActorSelect
+      role={role}
+      service={service}
+      location={location}
+      disabled={disabled}
+      onChange={handleChange}
+    />
+  );
 }
 
 /**

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Alert, Button, Loader, Stack, Text, TextInput } from '@mantine/core';
+import type { WithId } from '@medplum/core';
+import { getSchedulingTimezone, normalizeErrorString } from '@medplum/core';
+import type { Appointment, HealthcareService, Location } from '@medplum/fhirtypes';
+import { CalendarDateInput, ResourceInput } from '@medplum/react';
+import { IconCalendarSearch } from '@tabler/icons-react';
+import type { JSX } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { AppointmentActorSelect } from './AppointmentActorSelect';
+import { AppointmentDayTimes } from './AppointmentDayTimes';
+import classes from './AppointmentFinder.module.css';
+import type { SchedulingRole } from './AppointmentFinder.roles';
+import { SCHEDULING_ROLES } from './AppointmentFinder.roles';
+import type { ActorSelections, ScheduleCandidate } from './AppointmentFinder.schedules';
+import { getActorCombinations, getSelectedCandidates, getSelectionError } from './AppointmentFinder.schedules';
+import type { DateRange } from './AppointmentFinder.times';
+import { endOfDay, getFindWindowError, groupAppointmentsByDay } from './AppointmentFinder.times';
+import { AppointmentServiceSelect } from './AppointmentServiceSelect';
+import { useProposedAppointments } from './useProposedAppointments';
+
+/** How many places the site field offers, and the order they come back in. */
+const LOCATION_SEARCH_CRITERIA = { _count: '25', _sort: 'name' };
+
+/**
+ * The calendar marks the days it knows have times on them. Nothing has scanned a
+ * whole month for that, so every day is offered instead and the search answers.
+ */
+const NO_MARKED_DATES: Date[] = [];
+
+export interface AppointmentBookingFormProps {
+  /** Pre-fills where the visit is, for a host that already knows. */
+  readonly defaultLocation?: WithId<Location>;
+  /** Pre-fills the visit type, for a deep link or a reschedule. */
+  readonly defaultService?: WithId<HealthcareService>;
+  /**
+   * The day the time search opens on. Defaults to today.
+   *
+   * Seeds the day rather than the time: only a time `$find` offered can be
+   * chosen, so a pre-filled time could not survive its own validation.
+   */
+  readonly defaultStart?: Date;
+  /**
+   * Called when the time search opens or closes.
+   *
+   * The times sit beside the form rather than under it, so a host that puts this
+   * in a side panel has to widen the panel to fit them. That is the host's
+   * layout to change, which is why this reports rather than decides.
+   */
+  readonly onToggleTimeFinder?: (open: boolean) => void;
+  /**
+   * Called with the visit type as it changes.
+   *
+   * The type decides more than the search — it carries the availability a host
+   * may want to shade its own calendar with, and the configuration that says
+   * what else a booking implies.
+   */
+  readonly onChangeService?: (service: WithId<HealthcareService> | undefined) => void;
+}
+
+/**
+ * Gathers what a visit is held on, and finds a time every one of them is free.
+ *
+ * Narrow by site and visit type, then name the actors: one field per scheduling
+ * role, each searching the schedules bookable for that type. Everything named
+ * attends, because `$find` intersects their schedules — so naming a second room
+ * narrows the times rather than widening them.
+ *
+ * Choosing a time is deliberately a separate step behind "Find a time". The
+ * times depend on every answer above them, so offering them earlier would only
+ * show times that are about to change. Only a time the search offered can be
+ * chosen: the field displaying it is read-only, so nothing can be booked onto
+ * time that was never checked against anybody's availability.
+ *
+ * @param props - The React props.
+ * @returns The form.
+ */
+export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.Element {
+  const { defaultLocation, defaultService, defaultStart, onToggleTimeFinder, onChangeService } = props;
+
+  const [location, setLocation] = useState<WithId<Location> | undefined>(defaultLocation);
+  const [service, setService] = useState<WithId<HealthcareService> | undefined>(defaultService);
+  const [selections, setSelections] = useState<ActorSelections>({});
+  const [range, setRange] = useState<DateRange>(() => oneDay(defaultStart ?? new Date()));
+  const [month, setMonth] = useState<Date | undefined>(defaultStart);
+  const [finding, setFinding] = useState(false);
+  const [chosen, setChosen] = useState<Appointment | undefined>(undefined);
+
+  const selectionError = getSelectionError(selections);
+  const windowError = getFindWindowError(range);
+
+  // Nothing is searched until the time search is open, so the answers above can
+  // be changed without a request per keystroke.
+  const combinations = useMemo(
+    () => (finding && !selectionError && !windowError ? getActorCombinations(selections) : []),
+    [finding, selectionError, windowError, selections]
+  );
+
+  const search = useProposedAppointments({ service, combinations, range });
+
+  // The schedule is what carries the timezone for a service, so the first chosen
+  // actor's schedule answers it. Every actor in one search shares the scheduling
+  // parameters — `$find` rejects the request otherwise.
+  const timezone = useMemo(() => {
+    const [first] = getSelectedCandidates(selections);
+    return service ? getSchedulingTimezone(service, first?.schedule, first?.actorResource) : undefined;
+  }, [service, selections]);
+
+  const days = useMemo(() => groupAppointmentsByDay(search.appointments, timezone), [search.appointments, timezone]);
+
+  function toggleFinder(): void {
+    const next = !finding;
+    setFinding(next);
+    onToggleTimeFinder?.(next);
+  }
+
+  function chooseService(next: WithId<HealthcareService> | undefined): void {
+    setService(next);
+    onChangeService?.(next);
+    // The actors on offer come from the visit type, so what was chosen for the
+    // last one cannot mean anything for this one — nor can a time held on them.
+    setSelections({});
+    setChosen(undefined);
+  }
+
+  function chooseDay(date: Date): void {
+    setRange(oneDay(date));
+    // A time on one day is not a time on another.
+    setChosen(undefined);
+  }
+
+  return (
+    <div className={classes.layout}>
+      <Stack className={classes.form} gap="sm">
+        <ResourceInput<WithId<Location>>
+          resourceType="Location"
+          name="location"
+          label="Location"
+          placeholder="Any location"
+          searchCriteria={LOCATION_SEARCH_CRITERIA}
+          defaultValue={defaultLocation}
+          onChange={setLocation}
+        />
+        <AppointmentServiceSelect location={location} defaultValue={defaultService} onChange={chooseService} />
+
+        {SCHEDULING_ROLES.map((role) => (
+          <RoleField key={role} role={role} service={service} location={location} onChange={setSelections} />
+        ))}
+
+        <TextInput
+          label="Date & time"
+          placeholder="Find a time to choose one"
+          // Read-only rather than absent: the chosen time belongs among the
+          // answers, but only a time the search offered may be booked, so there
+          // is nothing here to type into.
+          readOnly
+          value={chosen?.start ? formatZonedDateTime(new Date(chosen.start), timezone) : ''}
+        />
+        <Button
+          variant="outline"
+          fullWidth
+          leftSection={<IconCalendarSearch size={16} stroke={1.8} />}
+          disabled={!service}
+          onClick={toggleFinder}
+        >
+          {finding ? 'Close time finder' : 'Find a time'}
+        </Button>
+
+        {finding && (
+          <Stack gap={4}>
+            <CalendarDateInput
+              availableDates={NO_MARKED_DATES}
+              allowUnavailableDates
+              earliestDate={new Date()}
+              month={month}
+              selected={range.start}
+              onChangeMonth={setMonth}
+              onClick={chooseDay}
+            />
+            {windowError && <Alert color="yellow">{windowError}</Alert>}
+            {selectionError && (
+              <Text size="sm" c="dimmed">
+                {selectionError}
+              </Text>
+            )}
+          </Stack>
+        )}
+      </Stack>
+
+      {finding && (
+        <Stack className={classes.results} gap="lg">
+          {search.loading && <Loader size="sm" />}
+          {search.error && <Alert color="red">{normalizeErrorString(search.error)}</Alert>}
+          {!search.loading &&
+            !search.error &&
+            days.map((day) => (
+              <AppointmentDayTimes
+                key={day.key}
+                date={day.date}
+                groups={day.groups}
+                timezone={timezone}
+                selected={chosen}
+                onSelectAppointment={setChosen}
+              />
+            ))}
+          {!search.loading && !search.error && !selectionError && days.length === 0 && (
+            <Text c="dimmed" ta="center">
+              No times are available for this selection.
+            </Text>
+          )}
+        </Stack>
+      )}
+    </div>
+  );
+}
+
+interface RoleFieldProps {
+  readonly role: SchedulingRole;
+  readonly service: WithId<HealthcareService> | undefined;
+  readonly location: WithId<Location> | undefined;
+  readonly onChange: (update: (selections: ActorSelections) => ActorSelections) => void;
+}
+
+/**
+ * One role's field, writing its own key of the selections.
+ *
+ * A component of its own so the callback it hands down is stable per role: the
+ * field searches on a changed callback, and one built inline would be new on
+ * every keystroke anywhere in the form.
+ *
+ * @param props - The React props.
+ * @returns The field for that role.
+ */
+function RoleField(props: RoleFieldProps): JSX.Element {
+  const { role, service, location, onChange } = props;
+
+  const handleChange = useCallback(
+    (candidates: readonly ScheduleCandidate[]) => onChange((selections) => ({ ...selections, [role]: candidates })),
+    [onChange, role]
+  );
+
+  return <AppointmentActorSelect role={role} service={service} location={location} onChange={handleChange} />;
+}
+
+/**
+ * Returns the range covering one whole day.
+ * @param date - Any instant during the day.
+ * @returns The day, both ends closed, as `$find` requires.
+ */
+function oneDay(date: Date): DateRange {
+  return { start: date, end: endOfDay(date) };
+}
+
+/**
+ * Writes an instant as the day and time it falls on at the site.
+ *
+ * Read in the timezone the visit is held in, so the field shows the time the
+ * clinic will keep rather than the time on the booker's own clock.
+ *
+ * @param value - The chosen start time.
+ * @param timezone - IANA timezone the visit is scheduled in.
+ * @returns The time to display.
+ */
+function formatZonedDateTime(value: Date, timezone: string | undefined): string {
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone: timezone,
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(value);
+}

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
@@ -20,13 +20,10 @@ import { endOfDay, getFindWindowError, groupAppointmentsByDay } from './Appointm
 import { AppointmentServiceSelect } from './AppointmentServiceSelect';
 import { useProposedAppointments } from './useProposedAppointments';
 
-/** How many places the site field offers, and the order they come back in. */
 const LOCATION_SEARCH_CRITERIA = { _count: '25', _sort: 'name' };
 
-/**
- * The calendar marks the days it knows have times on them. Nothing has scanned a
- * whole month for that, so every day is offered instead and the search answers.
- */
+// Nothing has scanned a month for the days that have times on them, so every day
+// is offered and the search is what answers.
 const NO_MARKED_DATES: Date[] = [];
 
 export interface AppointmentBookingFormProps {
@@ -45,16 +42,15 @@ export interface AppointmentBookingFormProps {
    * Called when the time search opens or closes.
    *
    * The times sit beside the form rather than under it, so a host that puts this
-   * in a side panel has to widen the panel to fit them. That is the host's
-   * layout to change, which is why this reports rather than decides.
+   * in a side panel has to widen the panel to fit them. Reports rather than
+   * decides, because that is the host's layout to change.
    */
   readonly onToggleTimeFinder?: (open: boolean) => void;
   /**
    * Called with the visit type as it changes.
    *
-   * The type decides more than the search — it carries the availability a host
-   * may want to shade its own calendar with, and the configuration that says
-   * what else a booking implies.
+   * The type decides more than the search: it carries the availability a host may
+   * want to shade its own calendar with.
    */
   readonly onChangeService?: (service: WithId<HealthcareService> | undefined) => void;
 }
@@ -151,9 +147,8 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
         <TextInput
           label="Date & time"
           placeholder="Find a time to choose one"
-          // Read-only rather than absent: the chosen time belongs among the
-          // answers, but only a time the search offered may be booked, so there
-          // is nothing here to type into.
+          // A field rather than plain text, because the chosen time belongs among
+          // the answers — but read-only, so there is nothing to type into.
           readOnly
           value={chosen?.start ? formatZonedDateTime(new Date(chosen.start), timezone) : ''}
         />

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
@@ -21,10 +21,9 @@ import { AppointmentServiceSelect } from './AppointmentServiceSelect';
 import { isServiceKeptAtLocation } from './AppointmentServiceSelect.utils';
 import { useProposedAppointments } from './useProposedAppointments';
 
-// Rooms are Locations too, so the site field is kept off them by what they are
-// not: `physical-type` is a Medplum search parameter, so the exclusion is the
-// server's and paging survives it. Naming what a site *is* would be more precise
-// and would silently hide a Location whose type nobody populated.
+// Excluded by what a room is, never by what a site is: `physicalType` is optional,
+// so `physical-type=si,bu` would silently hide a Location nobody typed. Server-side,
+// because it is a Medplum search parameter, so paging survives it.
 const LOCATION_SEARCH_CRITERIA = { _count: '25', _sort: 'name', 'physical-type:not': 'ro,bd' };
 
 // Nothing has scanned a month for the days that have times on them, so every day
@@ -71,9 +70,8 @@ export interface AppointmentBookingFormProps {
  * Choosing a time is deliberately a separate step behind "Find a time". The
  * times depend on every answer above them, so offering them earlier would only
  * show times that are about to change. Only a time the search offered can be
- * chosen: the field that holds it accepts no input, and there is none at all until
- * a time exists, so nothing can be booked onto time that was never checked against
- * anybody's availability.
+ * chosen: the field holding it accepts no input, so nothing can be booked onto time
+ * that was never checked against anybody's availability.
  *
  * @param props - The React props.
  * @returns The form.
@@ -88,10 +86,9 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
   const [month, setMonth] = useState<Date | undefined>(defaultStart);
   const [finding, setFinding] = useState(false);
   const [chosen, setChosen] = useState<Appointment | undefined>(undefined);
-  // The fields below hold their own selections and ignore `defaultValue` after
-  // mount, so clearing the state above is not enough to clear what is on screen.
-  // Remounting is, and these are what force it — counters rather than the chosen
-  // values, so a field is never remounted out from under the user's own pick.
+  // The fields below ignore `defaultValue` after mount, so clearing the state above
+  // leaves their pills on screen; remounting is what clears them. Counters rather
+  // than the chosen values, so a field is never remounted out from under a pick.
   const [roleFieldsKey, setRoleFieldsKey] = useState(0);
   const [serviceFieldKey, setServiceFieldKey] = useState(0);
 
@@ -129,20 +126,16 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
     // The actors on offer come from the visit type, so what was chosen for the
     // last one cannot mean anything for this one — nor can a time held on them.
     clearResources();
-    // Nothing can be searched without a visit type, and the field holds one at a
-    // time, so every change passes through none. Collapsing keeps the times from
-    // outliving what produced them, and the host is told so its panel narrows
-    // with them.
+    // Times must not outlive the visit type that produced them, and every change
+    // passes through none, since the field holds one at a time.
     closeFinder();
   }
 
   function chooseLocation(next: WithId<Location> | undefined): void {
     setLocation(next);
-    // Where a visit is held decides which actors are offered at all, so the ones
-    // chosen for the last site cannot be assumed to serve this one.
+    // The site decides which actors are offered at all, so the ones chosen for the
+    // last one cannot be assumed to serve this.
     clearResources();
-    // The visit type is narrowed by site too. It only has to go when the new site
-    // does not hold it; otherwise the answer still stands.
     if (service && !isServiceKeptAtLocation(service, next)) {
       setService(undefined);
       onChangeService?.(undefined);
@@ -185,9 +178,8 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
         <AppointmentServiceSelect
           key={serviceFieldKey}
           location={location}
-          // Seeded from state, not from the prop: a remount is how the field is
-          // cleared, and re-seeding from `defaultService` would put back the visit
-          // type that was just cleared.
+          // From state, not the prop: re-seeding from `defaultService` on a remount
+          // would put back the visit type that remount was clearing.
           defaultValue={service}
           onChange={chooseService}
         />
@@ -198,9 +190,8 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
             role={role}
             service={service}
             location={location}
-            // The actors on offer come from the visit type, so asking before one
-            // is chosen could only ever find nothing, which reads as a fault in
-            // the field rather than an answer still owed.
+            // Searching before a visit type is chosen could only find nothing,
+            // which reads as a broken field rather than an answer still owed.
             disabled={!service}
             onChange={setSelections}
           />
@@ -263,7 +254,6 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
 }
 
 interface ChosenTimeProps {
-  /** The proposal the user picked, or undefined while none has been. */
   readonly appointment: Appointment | undefined;
   /** IANA timezone the visit is held in. */
   readonly timezone: string | undefined;
@@ -275,17 +265,12 @@ interface ChosenTimeProps {
 /**
  * The chosen time, and under it the action that found it.
  *
- * The form is a column of labelled fields and the chosen time is one of its
- * answers, so it sits in that column, above the control that produced it. What it
- * must not be is a field before there is anything to put in it: an empty white
- * input among greyed-out ones reads as the one thing still fillable, and its
- * placeholder repeated the button's own invitation. So there is no field until
- * there is a time.
+ * Above the action, because the form is a column of labelled answers. But no field
+ * at all until there is a time: an empty white input among greyed-out ones reads as
+ * the one thing still fillable.
  *
- * Read-only, and deliberately an input rather than plain text: for a user
- * permitted to override, this same field in this same place becomes editable and
- * gains a warning. Keeping the region isolated and reading from the chosen
- * proposal is what makes that a control change rather than a layout change.
+ * An input rather than plain text, deliberately: for a user permitted to override,
+ * this same field in this same place becomes editable and gains a warning.
  *
  * @param props - The React props.
  * @returns The chosen time, once there is one, and the action.
@@ -300,8 +285,7 @@ function ChosenTime(props: ChosenTimeProps): JSX.Element {
           label="Date & time"
           readOnly
           value={formatZonedDateTime(new Date(appointment.start), timezone)}
-          // Under the value rather than over it: the time is the answer, and what
-          // it commits to only qualifies it.
+          // Below the value, which is the answer; the description only qualifies it.
           inputWrapperOrder={['label', 'input', 'description']}
           description={<ChosenTimeCommitment appointment={appointment} />}
         />
@@ -327,10 +311,9 @@ interface ChosenTimeCommitmentProps {
 /**
  * What the chosen time commits to: how long the visit runs, and what holds it.
  *
- * Read off the proposal rather than off the answers above, because the proposal is
- * what `$book` is handed — so this describes what would actually be booked. Inline
- * elements only: it renders as the field's description, which is a paragraph, and
- * being the field's own description is what ties it to the value it qualifies.
+ * Read off the proposal rather than off the answers above, since the proposal is what
+ * `$book` is handed. Inline elements only — it renders inside the field's
+ * description, which is a paragraph.
  *
  * @param props - The React props.
  * @returns The detail beneath the time.
@@ -367,8 +350,8 @@ function getFinderLabel(finding: boolean, chosen: boolean): string {
   if (finding) {
     return 'Close time finder';
   }
-  // Repeating the invitation once a time is chosen reads as though the search had
-  // come back with nothing.
+  // Repeating the invitation over a time already found reads as a search that
+  // came back with nothing.
   return chosen ? 'Change time' : 'Find a time';
 }
 
@@ -421,8 +404,8 @@ function oneDay(date: Date): DateRange {
 /**
  * Writes an instant as the day and time it falls on at the site.
  *
- * Read in the timezone the visit is held in, so the summary shows the time the
- * clinic will keep rather than the time on the booker's own clock.
+ * Read in the timezone the visit is held in, so the field shows the time the clinic
+ * will keep rather than the time on the booker's own clock.
  *
  * @param value - The chosen start time.
  * @param timezone - IANA timezone the visit is scheduled in.

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
@@ -21,13 +21,11 @@ import { AppointmentServiceSelect } from './AppointmentServiceSelect';
 import { isServiceKeptAtLocation } from './AppointmentServiceSelect.utils';
 import { useProposedAppointments } from './useProposedAppointments';
 
-// Excluded by what a room is, never by what a site is: `physicalType` is optional,
-// so `physical-type=si,bu` would silently hide a Location nobody typed. Server-side,
-// because it is a Medplum search parameter, so paging survives it.
+// Excludes what a room is rather than admitting what a site is: `physicalType` is
+// optional, so `physical-type=si,bu` would hide a Location that never declared one.
 const LOCATION_SEARCH_CRITERIA = { _count: '25', _sort: 'name', 'physical-type:not': 'ro,bd' };
 
-// Nothing has scanned a month for the days that have times on them, so every day
-// is offered and the search is what answers.
+// No month-wide scan exists, so every day is offered and the search answers.
 const NO_MARKED_DATES: Date[] = [];
 
 export interface AppointmentBookingFormProps {
@@ -38,40 +36,29 @@ export interface AppointmentBookingFormProps {
   /**
    * The day the time search opens on. Defaults to today.
    *
-   * Seeds the day rather than the time: only a time `$find` offered can be
-   * chosen, so a pre-filled time could not survive its own validation.
+   * A day, not a time: only a time `$find` offered can be chosen.
    */
   readonly defaultStart?: Date;
   /**
    * Called when the time search opens or closes.
    *
-   * The times sit beside the form rather than under it, so a host that puts this
-   * in a side panel has to widen the panel to fit them. Reports rather than
-   * decides, because that is the host's layout to change.
+   * The times render beside the form, not under it, so a host in a side panel has
+   * to widen it to fit them.
    */
   readonly onToggleTimeFinder?: (open: boolean) => void;
-  /**
-   * Called with the visit type as it changes.
-   *
-   * The type decides more than the search: it carries the availability a host may
-   * want to shade its own calendar with.
-   */
+  /** Called with the visit type as it changes. */
   readonly onChangeService?: (service: WithId<HealthcareService> | undefined) => void;
 }
 
 /**
  * Gathers what a visit is held on, and finds a time every one of them is free.
  *
- * Narrow by site and visit type, then name the actors: one field per scheduling
- * role, each searching the schedules bookable for that type. Everything named
- * attends, because `$find` intersects their schedules — so naming a second room
- * narrows the times rather than widening them.
+ * One field per scheduling role, each searching the schedules bookable for the
+ * chosen visit type. Everything named attends, because `$find` intersects their
+ * schedules — so naming a second room narrows the times rather than widening them.
  *
- * Choosing a time is deliberately a separate step behind "Find a time". The
- * times depend on every answer above them, so offering them earlier would only
- * show times that are about to change. Only a time the search offered can be
- * chosen: the field holding it accepts no input, so nothing can be booked onto time
- * that was never checked against anybody's availability.
+ * Only a time the search offered can be chosen: the field holding it accepts no
+ * input, so nothing can be booked onto time nobody checked availability for.
  *
  * @param props - The React props.
  * @returns The form.
@@ -86,22 +73,20 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
   const [month, setMonth] = useState<Date | undefined>(defaultStart);
   const [finding, setFinding] = useState(false);
   const [chosen, setChosen] = useState<Appointment | undefined>(undefined);
-  // The fields below ignore `defaultValue` after mount, so clearing the state above
-  // leaves their pills on screen; remounting is what clears them. Counters rather
-  // than the chosen values, so a field is never remounted out from under a pick.
+  // The fields ignore `defaultValue` after mount, so remounting is the only way to
+  // clear their pills. Counters, so a field is never remounted out from under a pick.
   const [roleFieldsKey, setRoleFieldsKey] = useState(0);
   const [serviceFieldKey, setServiceFieldKey] = useState(0);
 
   const selectionError = getSelectionError(selections);
   const windowError = getFindWindowError(range);
 
-  // The one condition for the search being open. Closing is never its own rule:
-  // there is nothing to search without a provider, so clearing the last one closes
-  // it — however it was cleared, and without any caller having to remember to.
+  // Derived, not a flag: closing is never its own rule, so losing the last provider
+  // closes the search however it was lost.
   const searching = finding && !selectionError;
 
-  // Nothing is searched until the time search is open, so the answers above can
-  // be changed without a request per keystroke.
+  // Nothing is searched until the time search is open, so the answers above cost no
+  // request per keystroke.
   const combinations = useMemo(
     () => (searching && !windowError ? getActorCombinations(selections) : []),
     [searching, windowError, selections]
@@ -109,9 +94,8 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
 
   const search = useProposedAppointments({ service, combinations, range });
 
-  // The schedule is what carries the timezone for a service, so the first chosen
-  // actor's schedule answers it. Every actor in one search shares the scheduling
-  // parameters — `$find` rejects the request otherwise.
+  // The first actor's schedule answers for all of them: every actor in one search
+  // shares the scheduling parameters, or `$find` rejects the request.
   const timezone = useMemo(() => {
     const [first] = getSelectedCandidates(selections);
     return service ? getSchedulingTimezone(service, first?.schedule, first?.actorResource) : undefined;
@@ -119,9 +103,8 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
 
   const days = useMemo(() => groupAppointmentsByDay(search.appointments, timezone), [search.appointments, timezone]);
 
-  // Reported from the derived value rather than from the click, so a search that
-  // closed because its last provider went is reported the same as one closed by
-  // hand. The ref holds what the host was last told, so mounting reports nothing.
+  // The ref holds what the host was last told, so mounting reports nothing and a
+  // search that closed on its own is reported like one closed by hand.
   const reported = useRef(false);
   useEffect(() => {
     if (reported.current !== searching) {
@@ -136,27 +119,20 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
 
   const chooseResources = useCallback((update: (selections: ActorSelections) => ActorSelections): void => {
     setSelections(update);
-    // A chosen time is a proposal held on the resources it was found for, carrying
-    // their Slots. Booking it after one changes would hold the resources inside the
-    // proposal rather than the ones on screen — and `$book` cannot catch that,
-    // because the proposal is internally consistent and that time genuinely was
-    // free for whoever is named in it.
+    // A chosen time is a proposal carrying the Slots it was found for. Booked after
+    // a resource changes it would hold whoever is named inside the proposal, and
+    // `$book` cannot catch that: the proposal is internally consistent.
     setChosen(undefined);
   }, []);
 
   function chooseService(next: WithId<HealthcareService> | undefined): void {
     setService(next);
     onChangeService?.(next);
-    // The actors on offer come from the visit type, so what was chosen for the
-    // last one cannot mean anything for this one — nor can a time held on them.
-    // That leaves no provider, which is what closes the search.
     clearResources();
   }
 
   function chooseLocation(next: WithId<Location> | undefined): void {
     setLocation(next);
-    // The site decides which actors are offered at all, so the ones chosen for the
-    // last one cannot be assumed to serve this.
     clearResources();
     if (service && !isServiceKeptAtLocation(service, next)) {
       setService(undefined);
@@ -165,6 +141,7 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
     }
   }
 
+  /** Both the site and the visit type decide which actors are offered at all. */
   function clearResources(): void {
     setSelections({});
     setChosen(undefined);
@@ -173,7 +150,6 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
 
   function chooseDay(date: Date): void {
     setRange(oneDay(date));
-    // A time on one day is not a time on another.
     setChosen(undefined);
   }
 
@@ -192,8 +168,8 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
         <AppointmentServiceSelect
           key={serviceFieldKey}
           location={location}
-          // From state, not the prop: re-seeding from `defaultService` on a remount
-          // would put back the visit type that remount was clearing.
+          // From state, not the prop: `defaultService` on a remount would put back
+          // the visit type the remount was clearing.
           defaultValue={service}
           onChange={chooseService}
         />
@@ -204,8 +180,6 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
             role={role}
             service={service}
             location={location}
-            // Searching before a visit type is chosen could only find nothing,
-            // which reads as a broken field rather than an answer still owed.
             disabled={!service}
             onChange={chooseResources}
           />
@@ -215,8 +189,6 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
           appointment={chosen}
           timezone={timezone}
           searching={searching}
-          // Before a visit type there is no provider to ask for yet, so the answer
-          // owed is the one the fields above are already waiting on.
           blockedBy={service ? selectionError : 'Choose a visit type'}
           onToggleFinder={toggleFinder}
         />
@@ -277,12 +249,8 @@ interface ChosenTimeProps {
 /**
  * The chosen time, and under it the action that found it.
  *
- * Above the action, because the form is a column of labelled answers. But no field
- * at all until there is a time: an empty white input among greyed-out ones reads as
- * the one thing still fillable.
- *
- * An input rather than plain text, deliberately: for a user permitted to override,
- * this same field in this same place becomes editable and gains a warning.
+ * An input rather than plain text: for a user permitted to override, this same field
+ * in this same place becomes editable and gains a warning.
  *
  * @param props - The React props.
  * @returns The chosen time, once there is one, and the action.
@@ -297,7 +265,7 @@ function ChosenTime(props: ChosenTimeProps): JSX.Element {
           label="Date & time"
           readOnly
           value={formatZonedDateTime(new Date(appointment.start), timezone)}
-          // Below the value, which is the answer; the description only qualifies it.
+          // Mantine puts the description above the input by default.
           inputWrapperOrder={['label', 'input', 'description']}
           description={<ChosenTimeCommitment appointment={appointment} />}
         />
@@ -313,8 +281,6 @@ function ChosenTime(props: ChosenTimeProps): JSX.Element {
         >
           {getFinderLabel(searching, !!appointment)}
         </Button>
-        {/* On the action rather than inside the search: a disabled action cannot
-            open the region that used to carry this, so it would never be read. */}
         {blockedBy && (
           <Text size="xs" c="dimmed">
             {blockedBy} first.
@@ -332,9 +298,9 @@ interface ChosenTimeCommitmentProps {
 /**
  * What the chosen time commits to: how long the visit runs, and what holds it.
  *
- * Read off the proposal rather than off the answers above, since the proposal is what
- * `$book` is handed. Inline elements only — it renders inside the field's
- * description, which is a paragraph.
+ * Read off the proposal rather than the answers above, since the proposal is what
+ * `$book` is handed. Inline elements only: it renders inside a `description`, which
+ * is a paragraph.
  *
  * @param props - The React props.
  * @returns The detail beneath the time.
@@ -371,8 +337,6 @@ function getFinderLabel(searching: boolean, chosen: boolean): string {
   if (searching) {
     return 'Close time finder';
   }
-  // Repeating the invitation over a time already found reads as a search that
-  // came back with nothing.
   return chosen ? 'Change time' : 'Find a time';
 }
 
@@ -388,8 +352,8 @@ interface RoleFieldProps {
  * One role's field, writing its own key of the selections.
  *
  * A component of its own so the callback it hands down is stable per role: the
- * field searches on a changed callback, and one built inline would be new on
- * every keystroke anywhere in the form.
+ * field searches on a changed callback, and an inline one would be new on every
+ * keystroke anywhere in the form.
  *
  * @param props - The React props.
  * @returns The field for that role.
@@ -423,10 +387,8 @@ function oneDay(date: Date): DateRange {
 }
 
 /**
- * Writes an instant as the day and time it falls on at the site.
- *
- * Read in the timezone the visit is held in, so the field shows the time the clinic
- * will keep rather than the time on the booker's own clock.
+ * Writes an instant as the day and time it falls on at the site, not on the
+ * booker's own clock.
  *
  * @param value - The chosen start time.
  * @param timezone - IANA timezone the visit is scheduled in.

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Alert, Button, Group, Loader, Paper, Stack, Text } from '@mantine/core';
+import { Alert, Button, Loader, Stack, Text, TextInput } from '@mantine/core';
 import type { WithId } from '@medplum/core';
 import { getReferenceString, getSchedulingTimezone, isDefined, normalizeErrorString } from '@medplum/core';
 import type { Appointment, HealthcareService, Location } from '@medplum/fhirtypes';
 import { CalendarDateInput, ReferenceDisplay, ResourceInput } from '@medplum/react';
 import { IconCalendarSearch } from '@tabler/icons-react';
 import type { JSX } from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { Fragment, useCallback, useMemo, useState } from 'react';
 import { AppointmentActorSelect } from './AppointmentActorSelect';
 import { AppointmentDayTimes } from './AppointmentDayTimes';
 import classes from './AppointmentFinder.module.css';
@@ -71,9 +71,9 @@ export interface AppointmentBookingFormProps {
  * Choosing a time is deliberately a separate step behind "Find a time". The
  * times depend on every answer above them, so offering them earlier would only
  * show times that are about to change. Only a time the search offered can be
- * chosen: what it produced is summarised beneath the action, and there is no
- * field to type into, so nothing can be booked onto time that was never checked
- * against anybody's availability.
+ * chosen: the field that holds it accepts no input, and there is none at all until
+ * a time exists, so nothing can be booked onto time that was never checked against
+ * anybody's availability.
  *
  * @param props - The React props.
  * @returns The form.
@@ -273,32 +273,40 @@ interface ChosenTimeProps {
 }
 
 /**
- * The action that finds a time, and beneath it what the chosen one commits to.
+ * The chosen time, and under it the action that found it.
  *
- * One region: the action sits directly under the resource fields it depends on,
- * the summary sits directly under the action that produced it, and both read from
- * the chosen proposal. Nothing stands in for a time before one is chosen — an
- * empty white input among greyed-out ones reads as the one thing still fillable,
- * and the field this replaces sat above the button that filled it.
+ * The form is a column of labelled fields and the chosen time is one of its
+ * answers, so it sits in that column, above the control that produced it. What it
+ * must not be is a field before there is anything to put in it: an empty white
+ * input among greyed-out ones reads as the one thing still fillable, and its
+ * placeholder repeated the button's own invitation. So there is no field until
+ * there is a time.
  *
- * The summary is deliberately the only thing that varies here: entering a time
- * nobody offered arrives by swapping it for a time input and an override warning
- * in place, which stays a control change only while the region around it is not
- * arranged for the read-only case.
+ * Read-only, and deliberately an input rather than plain text: for a user
+ * permitted to override, this same field in this same place becomes editable and
+ * gains a warning. Keeping the region isolated and reading from the chosen
+ * proposal is what makes that a control change rather than a layout change.
  *
  * @param props - The React props.
- * @returns The action, and the summary once there is one.
+ * @returns The chosen time, once there is one, and the action.
  */
 function ChosenTime(props: ChosenTimeProps): JSX.Element {
   const { appointment, timezone, finding, disabled, onToggleFinder } = props;
 
-  // Read off the proposal rather than off the answers above: it is what `$book`
-  // is handed, so the summary describes what would actually be booked.
-  const actors = (appointment?.participant ?? []).map((participant) => participant.actor).filter(isDefined);
-  const durationMinutes = getDurationMinutes(appointment);
-
   return (
     <>
+      {appointment?.start && (
+        <TextInput
+          label="Date & time"
+          readOnly
+          value={formatZonedDateTime(new Date(appointment.start), timezone)}
+          // Under the value rather than over it: the time is the answer, and what
+          // it commits to only qualifies it.
+          inputWrapperOrder={['label', 'input', 'description']}
+          description={<ChosenTimeCommitment appointment={appointment} />}
+        />
+      )}
+
       <Button
         variant="outline"
         fullWidth
@@ -308,32 +316,43 @@ function ChosenTime(props: ChosenTimeProps): JSX.Element {
       >
         {getFinderLabel(finding, !!appointment)}
       </Button>
+    </>
+  );
+}
 
-      {appointment?.start && (
-        <Paper withBorder p="sm" data-testid="chosen-time">
-          <Group justify="space-between" align="flex-start" wrap="nowrap">
-            <Text size="sm" fw={500}>
-              {formatZonedDateTime(new Date(appointment.start), timezone)}
-            </Text>
-            {durationMinutes > 0 && (
-              <Text size="xs" c="dimmed" style={{ whiteSpace: 'nowrap' }}>
-                {durationMinutes} min visit
-              </Text>
-            )}
-          </Group>
-          <Group gap="md" mt={4} wrap="wrap">
-            {actors.map((actor) => {
-              const roleLabel = getActorRoleLabel(actor);
-              return (
-                <Text key={getReferenceString(actor) ?? actor.display} size="sm" c="dimmed">
-                  {roleLabel && `${roleLabel}: `}
-                  <ReferenceDisplay value={actor} link={false} />
-                </Text>
-              );
-            })}
-          </Group>
-        </Paper>
-      )}
+interface ChosenTimeCommitmentProps {
+  readonly appointment: Appointment;
+}
+
+/**
+ * What the chosen time commits to: how long the visit runs, and what holds it.
+ *
+ * Read off the proposal rather than off the answers above, because the proposal is
+ * what `$book` is handed — so this describes what would actually be booked. Inline
+ * elements only: it renders as the field's description, which is a paragraph, and
+ * being the field's own description is what ties it to the value it qualifies.
+ *
+ * @param props - The React props.
+ * @returns The detail beneath the time.
+ */
+function ChosenTimeCommitment(props: ChosenTimeCommitmentProps): JSX.Element {
+  const { appointment } = props;
+  const actors = (appointment.participant ?? []).map((participant) => participant.actor).filter(isDefined);
+  const durationMinutes = getDurationMinutes(appointment);
+
+  return (
+    <>
+      {durationMinutes > 0 && `${durationMinutes} min visit`}
+      {actors.map((actor, index) => {
+        const roleLabel = getActorRoleLabel(actor);
+        return (
+          <Fragment key={getReferenceString(actor) ?? actor.display}>
+            {(index > 0 || durationMinutes > 0) && ' · '}
+            {roleLabel && `${roleLabel}: `}
+            <ReferenceDisplay value={actor} link={false} />
+          </Fragment>
+        );
+      })}
     </>
   );
 }

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
@@ -7,7 +7,7 @@ import type { Appointment, HealthcareService, Location } from '@medplum/fhirtype
 import { CalendarDateInput, ReferenceDisplay, ResourceInput } from '@medplum/react';
 import { IconCalendarSearch } from '@tabler/icons-react';
 import type { JSX } from 'react';
-import { Fragment, useCallback, useMemo, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AppointmentActorSelect } from './AppointmentActorSelect';
 import { AppointmentDayTimes } from './AppointmentDayTimes';
 import classes from './AppointmentFinder.module.css';
@@ -95,11 +95,16 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
   const selectionError = getSelectionError(selections);
   const windowError = getFindWindowError(range);
 
+  // The one condition for the search being open. Closing is never its own rule:
+  // there is nothing to search without a provider, so clearing the last one closes
+  // it — however it was cleared, and without any caller having to remember to.
+  const searching = finding && !selectionError;
+
   // Nothing is searched until the time search is open, so the answers above can
   // be changed without a request per keystroke.
   const combinations = useMemo(
-    () => (finding && !selectionError && !windowError ? getActorCombinations(selections) : []),
-    [finding, selectionError, windowError, selections]
+    () => (searching && !windowError ? getActorCombinations(selections) : []),
+    [searching, windowError, selections]
   );
 
   const search = useProposedAppointments({ service, combinations, range });
@@ -114,21 +119,38 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
 
   const days = useMemo(() => groupAppointmentsByDay(search.appointments, timezone), [search.appointments, timezone]);
 
+  // Reported from the derived value rather than from the click, so a search that
+  // closed because its last provider went is reported the same as one closed by
+  // hand. The ref holds what the host was last told, so mounting reports nothing.
+  const reported = useRef(false);
+  useEffect(() => {
+    if (reported.current !== searching) {
+      reported.current = searching;
+      onToggleTimeFinder?.(searching);
+    }
+  }, [searching, onToggleTimeFinder]);
+
   function toggleFinder(): void {
-    const next = !finding;
-    setFinding(next);
-    onToggleTimeFinder?.(next);
+    setFinding(!finding);
   }
+
+  const chooseResources = useCallback((update: (selections: ActorSelections) => ActorSelections): void => {
+    setSelections(update);
+    // A chosen time is a proposal held on the resources it was found for, carrying
+    // their Slots. Booking it after one changes would hold the resources inside the
+    // proposal rather than the ones on screen — and `$book` cannot catch that,
+    // because the proposal is internally consistent and that time genuinely was
+    // free for whoever is named in it.
+    setChosen(undefined);
+  }, []);
 
   function chooseService(next: WithId<HealthcareService> | undefined): void {
     setService(next);
     onChangeService?.(next);
     // The actors on offer come from the visit type, so what was chosen for the
     // last one cannot mean anything for this one — nor can a time held on them.
+    // That leaves no provider, which is what closes the search.
     clearResources();
-    // Times must not outlive the visit type that produced them, and every change
-    // passes through none, since the field holds one at a time.
-    closeFinder();
   }
 
   function chooseLocation(next: WithId<Location> | undefined): void {
@@ -140,7 +162,6 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
       setService(undefined);
       onChangeService?.(undefined);
       setServiceFieldKey((key) => key + 1);
-      closeFinder();
     }
   }
 
@@ -148,13 +169,6 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
     setSelections({});
     setChosen(undefined);
     setRoleFieldsKey((key) => key + 1);
-  }
-
-  function closeFinder(): void {
-    if (finding) {
-      setFinding(false);
-      onToggleTimeFinder?.(false);
-    }
   }
 
   function chooseDay(date: Date): void {
@@ -193,19 +207,21 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
             // Searching before a visit type is chosen could only find nothing,
             // which reads as a broken field rather than an answer still owed.
             disabled={!service}
-            onChange={setSelections}
+            onChange={chooseResources}
           />
         ))}
 
         <ChosenTime
           appointment={chosen}
           timezone={timezone}
-          finding={finding}
-          disabled={!service}
+          searching={searching}
+          // Before a visit type there is no provider to ask for yet, so the answer
+          // owed is the one the fields above are already waiting on.
+          blockedBy={service ? selectionError : 'Choose a visit type'}
           onToggleFinder={toggleFinder}
         />
 
-        {finding && (
+        {searching && (
           <Stack gap={4}>
             <CalendarDateInput
               availableDates={NO_MARKED_DATES}
@@ -217,16 +233,11 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
               onClick={chooseDay}
             />
             {windowError && <Alert color="yellow">{windowError}</Alert>}
-            {selectionError && (
-              <Text size="sm" c="dimmed">
-                {selectionError}
-              </Text>
-            )}
           </Stack>
         )}
       </Stack>
 
-      {finding && (
+      {searching && (
         <Stack className={classes.results} gap="lg">
           {search.loading && <Loader size="sm" />}
           {search.error && <Alert color="red">{normalizeErrorString(search.error)}</Alert>}
@@ -242,7 +253,7 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
                 onSelectAppointment={setChosen}
               />
             ))}
-          {!search.loading && !search.error && !selectionError && !windowError && days.length === 0 && (
+          {!search.loading && !search.error && !windowError && days.length === 0 && (
             <Text c="dimmed" ta="center">
               No times are available for this selection.
             </Text>
@@ -257,8 +268,9 @@ interface ChosenTimeProps {
   readonly appointment: Appointment | undefined;
   /** IANA timezone the visit is held in. */
   readonly timezone: string | undefined;
-  readonly finding: boolean;
-  readonly disabled?: boolean;
+  readonly searching: boolean;
+  /** What is still owed before a time can be searched for, if anything. */
+  readonly blockedBy: string | undefined;
   readonly onToggleFinder: () => void;
 }
 
@@ -276,7 +288,7 @@ interface ChosenTimeProps {
  * @returns The chosen time, once there is one, and the action.
  */
 function ChosenTime(props: ChosenTimeProps): JSX.Element {
-  const { appointment, timezone, finding, disabled, onToggleFinder } = props;
+  const { appointment, timezone, searching, blockedBy, onToggleFinder } = props;
 
   return (
     <>
@@ -291,15 +303,24 @@ function ChosenTime(props: ChosenTimeProps): JSX.Element {
         />
       )}
 
-      <Button
-        variant="outline"
-        fullWidth
-        leftSection={<IconCalendarSearch size={16} stroke={1.8} />}
-        disabled={disabled}
-        onClick={onToggleFinder}
-      >
-        {getFinderLabel(finding, !!appointment)}
-      </Button>
+      <Stack gap={4}>
+        <Button
+          variant="outline"
+          fullWidth
+          leftSection={<IconCalendarSearch size={16} stroke={1.8} />}
+          disabled={!!blockedBy}
+          onClick={onToggleFinder}
+        >
+          {getFinderLabel(searching, !!appointment)}
+        </Button>
+        {/* On the action rather than inside the search: a disabled action cannot
+            open the region that used to carry this, so it would never be read. */}
+        {blockedBy && (
+          <Text size="xs" c="dimmed">
+            {blockedBy} first.
+          </Text>
+        )}
+      </Stack>
     </>
   );
 }
@@ -342,12 +363,12 @@ function ChosenTimeCommitment(props: ChosenTimeCommitmentProps): JSX.Element {
 
 /**
  * Names what the action does next.
- * @param finding - Whether the time search is open.
+ * @param searching - Whether the time search is open.
  * @param chosen - Whether a time has been picked.
  * @returns The button's label.
  */
-function getFinderLabel(finding: boolean, chosen: boolean): string {
-  if (finding) {
+function getFinderLabel(searching: boolean, chosen: boolean): string {
+  if (searching) {
     return 'Close time finder';
   }
   // Repeating the invitation over a time already found reads as a search that

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
@@ -141,7 +141,12 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
     }
   }
 
-  /** Both the site and the visit type decide which actors are offered at all. */
+  /**
+   * Clears every named resource, deliberately: a resource can be schedulable for more
+   * than one visit type, so some would survive a narrower check. Both the site and the
+   * visit type change which actors are offered, and re-asking is easier to explain than
+   * a partial clear.
+   */
   function clearResources(): void {
     setSelections({});
     setChosen(undefined);
@@ -249,8 +254,8 @@ interface ChosenTimeProps {
 /**
  * The chosen time, and under it the action that found it.
  *
- * An input rather than plain text: for a user permitted to override, this same field
- * in this same place becomes editable and gains a warning.
+ * An input rather than plain text: overrides are not implemented, but when they are, a
+ * permitted user gets this same field in this same place, editable and with a warning.
  *
  * @param props - The React props.
  * @returns The chosen time, once there is one, and the action.
@@ -378,12 +383,19 @@ function RoleField(props: RoleFieldProps): JSX.Element {
 }
 
 /**
- * Returns the range covering one whole day.
+ * Returns the range covering the bookable part of one day.
+ *
+ * `$find` treats `start` as a hard floor, so a day already under way starts from now
+ * rather than midnight: the calendar hands back local midnight, and asking from there
+ * would offer times that have already passed.
+ *
  * @param date - Any instant during the day.
- * @returns The day, both ends closed, as `$find` requires.
+ * @returns The day from now at the earliest, both ends closed, as `$find` requires.
  */
 function oneDay(date: Date): DateRange {
-  return { start: date, end: endOfDay(date) };
+  const now = new Date();
+  const start = date > now ? date : now;
+  return { start, end: endOfDay(start) };
 }
 
 /**

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.module.css
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.module.css
@@ -3,3 +3,24 @@
 .timeGrid {
   row-gap: var(--mantine-spacing-xs);
 }
+
+/* The form, and beside it the times once the search is open. Wraps rather than
+   scrolling sideways, so a narrow host stacks the two instead of clipping one. */
+.layout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--mantine-spacing-lg);
+  align-items: flex-start;
+}
+
+.form {
+  flex: 1 1 300px;
+  min-width: 0;
+  max-width: 420px;
+}
+
+/* Only present while the time search is open, which is what widens the panel. */
+.results {
+  flex: 1 1 380px;
+  min-width: 0;
+}

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.test.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { buildProposedAppointment } from '../stories/scheduling';
 import {
+  MAX_FIND_WINDOW_DAYS,
   endOfMonth,
   enumerateDateRange,
   filterByTimeOfDay,
@@ -10,6 +11,7 @@ import {
   getActorGroupKey,
   getAppointmentKey,
   getDurationMinutes,
+  getFindWindowError,
   groupAppointmentsByDay,
   parseDayKey,
   parseZonedTime,
@@ -219,5 +221,26 @@ describe('formatDateRange', () => {
 
   test('Says nothing when neither end was asked for', () => {
     expect(formatDateRange({})).toBeUndefined();
+  });
+});
+
+describe('getFindWindowError', () => {
+  test('A range inside the window can be searched', () => {
+    expect(getFindWindowError({ start: new Date(2026, 6, 27), end: new Date(2026, 6, 27, 23, 59) })).toBeUndefined();
+    const lastAllowed = new Date(2026, 6, 27);
+    lastAllowed.setDate(lastAllowed.getDate() + MAX_FIND_WINDOW_DAYS);
+    expect(getFindWindowError({ start: new Date(2026, 6, 27), end: lastAllowed })).toBeUndefined();
+  });
+
+  test('A wider range is refused before a request is made for it', () => {
+    const tooFar = new Date(2026, 6, 27);
+    tooFar.setDate(tooFar.getDate() + MAX_FIND_WINDOW_DAYS + 1);
+    expect(getFindWindowError({ start: new Date(2026, 6, 27), end: tooFar })).toBe('Choose at most 31 days at a time.');
+  });
+
+  test('An open range says nothing, because there is no width to judge', () => {
+    expect(getFindWindowError({})).toBeUndefined();
+    expect(getFindWindowError({ start: new Date(2026, 6, 27) })).toBeUndefined();
+    expect(getFindWindowError({ end: new Date(2026, 6, 27) })).toBeUndefined();
   });
 });

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
@@ -357,9 +357,8 @@ export function enumerateDateRange(range: DateRange, limit = MAX_FIND_WINDOW_DAY
 /**
  * Reports a window `$find` will not answer, before a request is made for it.
  *
- * The server refuses a range wider than `MAX_FIND_WINDOW_DAYS`, so asking for
- * one only produces a server error where a message about the range is what the
- * user needs.
+ * The server refuses a range wider than `MAX_FIND_WINDOW_DAYS`, and answers with
+ * an error rather than anything a user could act on.
  *
  * @param range - The days asked for.
  * @returns The message to show, or undefined when the range can be searched.

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
@@ -357,9 +357,6 @@ export function enumerateDateRange(range: DateRange, limit = MAX_FIND_WINDOW_DAY
 /**
  * Reports a window `$find` will not answer, before a request is made for it.
  *
- * The server refuses a range wider than `MAX_FIND_WINDOW_DAYS`, and answers with
- * an error rather than anything a user could act on.
- *
  * @param range - The days asked for.
  * @returns The message to show, or undefined when the range can be searched.
  */

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentFinder.times.ts
@@ -10,6 +10,8 @@ import type { SchedulingActor } from './AppointmentFinder.roles';
  */
 export const MAX_FIND_WINDOW_DAYS = 31;
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
 export type TimeOfDay = 'any' | 'morning' | 'afternoon';
 
 /** A calendar day's worth of available times, split by the actors offering them. */
@@ -350,6 +352,25 @@ export function enumerateDateRange(range: DateRange, limit = MAX_FIND_WINDOW_DAY
     days.push(day);
   }
   return days;
+}
+
+/**
+ * Reports a window `$find` will not answer, before a request is made for it.
+ *
+ * The server refuses a range wider than `MAX_FIND_WINDOW_DAYS`, so asking for
+ * one only produces a server error where a message about the range is what the
+ * user needs.
+ *
+ * @param range - The days asked for.
+ * @returns The message to show, or undefined when the range can be searched.
+ */
+export function getFindWindowError(range: DateRange): string | undefined {
+  const { start, end } = range;
+  if (!start || !end) {
+    return undefined;
+  }
+  const days = Math.ceil((end.getTime() - start.getTime()) / MS_PER_DAY);
+  return days > MAX_FIND_WINDOW_DAYS ? `Choose at most ${MAX_FIND_WINDOW_DAYS} days at a time.` : undefined;
 }
 
 /**

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.stories.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.stories.tsx
@@ -14,7 +14,8 @@ import { AppointmentServiceSelect } from './AppointmentServiceSelect';
 /**
  * Enough visit types to read as a list, chosen for what each one shows: two share a
  * category and differ only in length, and the third is held at the satellite site
- * alone, so narrowing to the main clinic drops it.
+ * alone, so narrowing to the main clinic drops it. The location-less "Telehealth
+ * Consult" comes with the shared fixtures, and is what a site cannot exclude.
  */
 const STORY_FIXTURES = [
   ...SchedulingFixtures,
@@ -73,8 +74,14 @@ export const Basic = (): JSX.Element => {
 };
 
 /**
- * A site chosen earlier narrows what is on offer, and the field says so. The
- * satellite-only "Urodynamics Study" drops off the list.
+ * A site chosen earlier narrows what is on offer, and the field says so.
+ *
+ * A site holds what it is named on, plus everything named on no location at all: the
+ * practice-wide "Telehealth Consult" is offered here and at every other site, while the
+ * satellite-only "Urodynamics Study" drops off. Open the field to read them — the two
+ * come from separate searches and arrive as one list in name order, "Telehealth Consult"
+ * between the sited visit types rather than grouped at either end.
+ *
  * @returns The story.
  */
 export const NarrowedToASite = (): JSX.Element => (

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.test.tsx
@@ -4,10 +4,18 @@ import type { WithId } from '@medplum/core';
 import type { HealthcareService } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import type { RenderResult } from '@testing-library/react';
-import { MainClinic, SatelliteClinic, SchedulingFixtures, UltrasoundImagingService } from '../stories/scheduling';
+import type { MockInstance } from 'vitest';
+import {
+  buildSchedulableService,
+  MainClinic,
+  SatelliteClinic,
+  SchedulingFixtures,
+  UltrasoundImagingService,
+} from '../stories/scheduling';
 import {
   clickAutocompleteOption,
   installAutocompleteTimers,
+  openAutocomplete,
   settleAutocomplete,
   typeInAutocomplete,
 } from '../test-utils/asyncAutocomplete';
@@ -17,12 +25,42 @@ import { AppointmentServiceSelect } from './AppointmentServiceSelect';
 
 const medplum = new MockClient();
 
-/** A second schedulable visit type, for reassigning the field to. */
+/**
+ * A second schedulable visit type at the main clinic, for reassigning the field to.
+ * Named to sort before the location-less one, so the merged list can interleave.
+ */
 const BARIATRIC_SURGERY: WithId<HealthcareService> = {
   ...UltrasoundImagingService,
   id: 'bariatric-surgery',
   name: 'Bariatric Surgery',
 };
+
+/** Held at the other site only. */
+const SATELLITE_ULTRASOUND = buildSchedulableService({
+  id: 'satellite-ultrasound',
+  name: 'Satellite Ultrasound',
+  category: 'Imaging',
+  durationMinutes: 45,
+  alignmentMinutes: 15,
+  locationIds: ['satellite-clinic'],
+});
+
+/** Named on no location and configured for nothing, so neither route may offer it. */
+const TELEHEALTH_CHAT: WithId<HealthcareService> = {
+  resourceType: 'HealthcareService',
+  id: 'telehealth-chat',
+  name: 'Telehealth Chat',
+};
+
+/** Held at a room inside the main clinic, rather than at the clinic itself. */
+const EXAM_ROOM_ULTRASOUND = buildSchedulableService({
+  id: 'exam-room-ultrasound',
+  name: 'Exam Room Ultrasound',
+  category: 'Imaging',
+  durationMinutes: 60,
+  alignmentMinutes: 15,
+  locationIds: ['exam-room-a'],
+});
 
 function setup(props: Partial<AppointmentServiceSelectProps> = {}, key?: string): RenderResult {
   return renderWithMedplum(<AppointmentServiceSelect key={key} onChange={vi.fn()} {...props} />, medplum);
@@ -32,9 +70,27 @@ function searchBox(): HTMLElement {
   return screen.getByPlaceholderText('Search visit types');
 }
 
+/**
+ * The criteria each `HealthcareService` request carried, in the order issued.
+ * @param searchResources - The spy on the client's search.
+ * @returns One entry per request issued.
+ */
+function serviceSearches(searchResources: MockInstance): URLSearchParams[] {
+  return searchResources.mock.calls
+    .filter((call) => call[0] === 'HealthcareService')
+    .map((call) => call[1] as URLSearchParams);
+}
+
 describe('AppointmentServiceSelect', () => {
   beforeAll(async () => {
-    for (const resource of SchedulingFixtures) {
+    const fixtures = [
+      ...SchedulingFixtures,
+      BARIATRIC_SURGERY,
+      SATELLITE_ULTRASOUND,
+      EXAM_ROOM_ULTRASOUND,
+      TELEHEALTH_CHAT,
+    ];
+    for (const resource of fixtures) {
       await medplum.createResource(resource);
     }
   });
@@ -76,25 +132,20 @@ describe('AppointmentServiceSelect', () => {
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ id: 'ultrasound-imaging' }));
   });
 
-  test('Leaves the ordering to the server, so the filter never reshuffles the list', async () => {
-    const searchResources = vi.spyOn(medplum, 'searchResources');
-    setup();
-
-    await typeInAutocomplete(searchBox(), 'Ultrasound');
-
-    const serviceSearch = searchResources.mock.calls.find((call) => call[0] === 'HealthcareService');
-    expect((serviceSearch?.[1] as URLSearchParams).get('_sort')).toBe('name');
-    searchResources.mockRestore();
-  });
-
   test('Narrows the services to a chosen location', async () => {
     const searchResources = vi.spyOn(medplum, 'searchResources');
     setup({ location: MainClinic });
 
     await typeInAutocomplete(searchBox(), 'Ultrasound');
 
-    const serviceSearch = searchResources.mock.calls.find((call) => call[0] === 'HealthcareService');
-    expect((serviceSearch?.[1] as URLSearchParams).get('location')).toBe('Location/main-clinic');
+    const searches = serviceSearches(searchResources);
+    expect(searches).toHaveLength(2);
+    expect(searches[0].get('location')).toBe('Location/main-clinic');
+    expect(searches[1].get('location:missing')).toBe('true');
+    expect(searches.map((params) => [params.get('name'), params.get('_count'), params.get('_sort')])).toEqual([
+      ['Ultrasound', '25', 'name'],
+      ['Ultrasound', '25', 'name'],
+    ]);
     expect(screen.getByText(/Showing visit types offered at/)).toBeInTheDocument();
     searchResources.mockRestore();
   });
@@ -107,10 +158,102 @@ describe('AppointmentServiceSelect', () => {
 
     await typeInAutocomplete(searchBox(), 'Ultrasound');
 
-    const serviceSearch = searchResources.mock.calls.find((call) => call[0] === 'HealthcareService');
-    expect((serviceSearch?.[1] as URLSearchParams).get('location')).toBe('Location/main-clinic');
-    expect(await screen.findByText(`Showing visit types offered at ${MainClinic.name}.`)).toBeInTheDocument();
+    expect(serviceSearches(searchResources)[0].get('location')).toBe('Location/main-clinic');
+    expect(
+      await screen.findByText(`Showing visit types offered at ${MainClinic.name}, plus those not tied to a site.`)
+    ).toBeInTheDocument();
     searchResources.mockRestore();
+  });
+
+  describe('Offering the visit types a chosen site can hold', () => {
+    test('Offers a visit type that names the chosen site', async () => {
+      setup({ location: MainClinic });
+
+      await typeInAutocomplete(searchBox(), 'Ultrasound');
+
+      expect(await screen.findByText('Ultrasound Imaging')).toBeInTheDocument();
+    });
+
+    test('Offers a visit type that names no location, at every site in turn', async () => {
+      const { rerender } = setup({ location: MainClinic }, 'main');
+      await typeInAutocomplete(searchBox(), 'Telehealth');
+      expect(await screen.findByText('Telehealth Consult')).toBeInTheDocument();
+
+      rerender(<AppointmentServiceSelect key="satellite" onChange={vi.fn()} location={SatelliteClinic} />);
+      await typeInAutocomplete(searchBox(), 'Telehealth');
+
+      expect(await screen.findByText('Telehealth Consult')).toBeInTheDocument();
+    });
+
+    test('Leaves out a visit type held only somewhere else', async () => {
+      setup({ location: MainClinic });
+
+      await typeInAutocomplete(searchBox(), 'Ultrasound');
+
+      await screen.findByText('Ultrasound Imaging');
+      expect(screen.queryByText('Satellite Ultrasound')).not.toBeInTheDocument();
+    });
+
+    test('Leaves out a visit type held at a place inside the chosen site', async () => {
+      setup({ location: MainClinic });
+
+      await typeInAutocomplete(searchBox(), 'Ultrasound');
+
+      // No `partOf` walk: a visit type is tested against the site it names and nothing
+      // below it.
+      await screen.findByText('Ultrasound Imaging');
+      expect(screen.queryByText('Exam Room Ultrasound')).not.toBeInTheDocument();
+    });
+
+    test('Narrows nothing, and asks once, when no site is chosen', async () => {
+      const searchResources = vi.spyOn(medplum, 'searchResources');
+      setup();
+
+      await typeInAutocomplete(searchBox(), 'Ultrasound');
+
+      const searches = serviceSearches(searchResources);
+      expect(searches).toHaveLength(1);
+      expect(searches[0].get('location')).toBeNull();
+      expect(searches[0].get('location:missing')).toBeNull();
+      expect(await screen.findByText('Satellite Ultrasound')).toBeInTheDocument();
+      expect(screen.getByText('Ultrasound Imaging')).toBeInTheDocument();
+      searchResources.mockRestore();
+    });
+
+    test('Finds nothing rather than falling back when a site can hold nothing', async () => {
+      setup({ location: SatelliteClinic });
+
+      await typeInAutocomplete(searchBox(), 'Imaging');
+
+      // Every visit type matching "Imaging" is held elsewhere, and the location-less one
+      // is named something else, so there is nothing left to offer.
+      await settleAutocomplete();
+      expect(screen.queryByRole('option')).not.toBeInTheDocument();
+      expect(screen.queryByText('Ultrasound Imaging')).not.toBeInTheDocument();
+    });
+
+    test('Reads as one list in name order, not two lists end to end', async () => {
+      setup({ location: MainClinic });
+
+      await openAutocomplete(searchBox());
+
+      // The location-less visit type lands between the two sited ones, which appending
+      // one search to the other could not produce.
+      expect(screen.getAllByRole('option').map((option) => option.textContent)).toEqual([
+        expect.stringMatching(/^Bariatric Surgery/),
+        expect.stringMatching(/^Telehealth Consult/),
+        expect.stringMatching(/^Ultrasound Imaging/),
+      ]);
+    });
+
+    test('Does not smuggle in an unschedulable visit type by the location-less route', async () => {
+      setup({ location: MainClinic });
+
+      await typeInAutocomplete(searchBox(), 'Telehealth');
+
+      expect(await screen.findByText('Telehealth Consult')).toBeInTheDocument();
+      expect(screen.queryByText('Telehealth Chat')).not.toBeInTheDocument();
+    });
   });
 
   test('Starts on the visit type it was given', async () => {

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.tsx
@@ -37,7 +37,7 @@ export interface AppointmentServiceSelectProps {
  * @returns The service field.
  */
 export function AppointmentServiceSelect(props: AppointmentServiceSelectProps): JSX.Element {
-  const { location, defaultValue, onChange, label = 'Service type', error, disabled } = props;
+  const { location, defaultValue, onChange, label = 'Visit type', error, disabled } = props;
   const medplum = useMedplum();
 
   const locationReference = location && getReferenceString(location);

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.tsx
@@ -11,10 +11,14 @@ import { useCallback } from 'react';
 import { AppointmentOptionRow } from './AppointmentOptionRow';
 import { getServiceDurationMinutes } from './AppointmentServiceSelect.utils';
 
+const SERVICE_PAGE_SIZE = 25;
+
 /**
- * How many visit types one search offers, and the order they come back in.
+ * `_sort=name` stays on both requests even though the field orders the merge itself:
+ * it makes each response its own first page by name, and the true first page is
+ * contained in the union of the two.
  */
-const SERVICE_SEARCH_CRITERIA = { _count: '25', _sort: 'name' };
+const SERVICE_SEARCH_CRITERIA = { _count: String(SERVICE_PAGE_SIZE), _sort: 'name' };
 
 export interface AppointmentServiceSelectProps {
   readonly defaultValue?: WithId<HealthcareService>;
@@ -33,6 +37,9 @@ export interface AppointmentServiceSelectProps {
  * without a `SchedulingParameters` extension has no duration or alignment for
  * `$find` to work from, so booking against it cannot succeed.
  *
+ * A chosen site narrows the list to the visit types it can hold: the ones naming
+ * that site, and the ones naming no location at all.
+ *
  * @param props - The React props.
  * @returns The service field.
  */
@@ -45,17 +52,27 @@ export function AppointmentServiceSelect(props: AppointmentServiceSelectProps): 
 
   const loadOptions = useCallback(
     async (input: string, signal: AbortSignal): Promise<WithId<HealthcareService>[]> => {
-      const searchParams = new URLSearchParams(SERVICE_SEARCH_CRITERIA);
+      const criteria = new URLSearchParams(SERVICE_SEARCH_CRITERIA);
       if (input) {
-        searchParams.set('name', input);
+        criteria.set('name', input);
       }
-      if (locationReference) {
-        searchParams.set('location', locationReference);
-      }
-      const services = await medplum.searchResources('HealthcareService', searchParams, { signal });
+      // A reference search needs the element present, so what names no location cannot
+      // ride on the site's own search and the field asks twice, together. With no site
+      // it asks once: `location:missing=true` alone would hide every sited visit type.
+      const searches = locationReference
+        ? [withParam(criteria, 'location', locationReference), withParam(criteria, 'location:missing', 'true')]
+        : [criteria];
+      const pages = await Promise.all(
+        searches.map(async (params) => medplum.searchResources('HealthcareService', params, { signal }))
+      );
       // The scheduling filter is applied here rather than in the search because it
       // reads an extension, which no search parameter covers.
-      return services.filter(hasSchedulingParameters);
+      const services = pages.flatMap((page) => page.filter(hasSchedulingParameters));
+      // Disjoint by construction — one needs `location` present, the other needs it
+      // absent — so the merge is a sort with nothing to deduplicate, and where a visit
+      // type was found never shows in the order.
+      services.sort((left, right) => (left.name ?? '').localeCompare(right.name ?? ''));
+      return services.slice(0, SERVICE_PAGE_SIZE);
     },
     [medplum, locationReference]
   );
@@ -68,7 +85,9 @@ export function AppointmentServiceSelect(props: AppointmentServiceSelectProps): 
       label={label}
       placeholder="Search visit types"
       description={
-        locationResource ? `Showing visit types offered at ${getDisplayString(locationResource)}.` : undefined
+        locationResource
+          ? `Showing visit types offered at ${getDisplayString(locationResource)}, plus those not tied to a site.`
+          : undefined
       }
       required
       maxValues={1}
@@ -81,6 +100,12 @@ export function AppointmentServiceSelect(props: AppointmentServiceSelectProps): 
       onChange={handleChange}
     />
   );
+}
+
+function withParam(criteria: URLSearchParams, name: string, value: string): URLSearchParams {
+  const params = new URLSearchParams(criteria);
+  params.set(name, value);
+  return params;
 }
 
 function toOption(service: WithId<HealthcareService>): AsyncAutocompleteOption<WithId<HealthcareService>> {

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.utils.test.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.utils.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { SchedulingParametersURI } from '@medplum/core';
 import type { Duration, HealthcareService } from '@medplum/fhirtypes';
-import { getServiceDurationMinutes } from './AppointmentServiceSelect.utils';
+import { getServiceDurationMinutes, isServiceKeptAtLocation } from './AppointmentServiceSelect.utils';
 
 function serviceWithDuration(valueDuration: Duration): HealthcareService {
   return {
@@ -45,5 +45,41 @@ describe('getServiceDurationMinutes', () => {
         extension: [{ url: SchedulingParametersURI, extension: [{ url: 'timezone', valueCode: 'America/New_York' }] }],
       })
     ).toBeUndefined();
+  });
+});
+
+describe('isServiceKeptAtLocation', () => {
+  const service: HealthcareService = {
+    resourceType: 'HealthcareService',
+    name: 'Ultrasound Imaging',
+    location: [{ reference: 'Location/main-clinic' }, { reference: 'Location/satellite-clinic' }],
+  };
+
+  test('a site the service names', () => {
+    expect(isServiceKeptAtLocation(service, { reference: 'Location/main-clinic' })).toBe(true);
+    expect(isServiceKeptAtLocation(service, { reference: 'Location/satellite-clinic' })).toBe(true);
+  });
+
+  test('a site the service does not name', () => {
+    expect(isServiceKeptAtLocation(service, { reference: 'Location/other-clinic' })).toBe(false);
+  });
+
+  test('a room inside a site the service names does not count', () => {
+    // The `location` search parameter matches by exact reference and does not walk
+    // `partOf`, so neither does this.
+    expect(isServiceKeptAtLocation(service, { reference: 'Location/exam-room-a' })).toBe(false);
+  });
+
+  test('a service naming no site is kept whatever the site', () => {
+    // Nothing about it was ever tied to a site, so no site can invalidate it — even
+    // though the search would not offer it once a site is chosen.
+    const unsited: HealthcareService = { resourceType: 'HealthcareService', name: 'Walk-in' };
+    expect(isServiceKeptAtLocation(unsited, { reference: 'Location/main-clinic' })).toBe(true);
+    expect(isServiceKeptAtLocation({ ...unsited, location: [] }, { reference: 'Location/main-clinic' })).toBe(true);
+    expect(isServiceKeptAtLocation(unsited, undefined)).toBe(true);
+  });
+
+  test('no site narrows nothing', () => {
+    expect(isServiceKeptAtLocation(service, undefined)).toBe(true);
   });
 });

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.utils.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.utils.ts
@@ -1,7 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { getExtensions, isDefined, schedulingDurationToMinutes, SchedulingParametersURI } from '@medplum/core';
-import type { HealthcareService } from '@medplum/fhirtypes';
+import type { WithId } from '@medplum/core';
+import {
+  getExtensions,
+  getReferenceString,
+  isDefined,
+  schedulingDurationToMinutes,
+  SchedulingParametersURI,
+} from '@medplum/core';
+import type { HealthcareService, Location, Reference } from '@medplum/fhirtypes';
 
 /**
  * Reads the visit length a service configures for itself, in minutes.
@@ -13,4 +20,34 @@ export function getServiceDurationMinutes(service: HealthcareService): number | 
   return getExtensions(service, [SchedulingParametersURI, 'duration'])
     .map((subextension) => schedulingDurationToMinutes(subextension.valueDuration))
     .find(isDefined);
+}
+
+/**
+ * Reports whether a chosen service survives a move to a site.
+ *
+ * A named site is matched the way the pick list matches it: `AppointmentServiceSelect`
+ * narrows on the `location` parameter, which reads `HealthcareService.location` by
+ * exact reference and does not walk `partOf`, so a room inside a site does not
+ * stand for the site.
+ *
+ * A service naming no location at all is kept, because nothing about it was ever
+ * tied to a site and so no site can invalidate it. That is deliberately not what
+ * the search does — a reference search needs the element present, so such a
+ * service matches no site and is not *offered* once one is chosen even though it
+ * is *kept* when it was chosen first.
+ *
+ * @param service - The service being checked.
+ * @param location - The site being booked at, or undefined for no site at all.
+ * @returns Whether the service still stands at that site.
+ */
+export function isServiceKeptAtLocation(
+  service: HealthcareService,
+  location: Reference<Location> | WithId<Location> | undefined
+): boolean {
+  const reference = location && getReferenceString(location);
+  const held = service.location ?? [];
+  if (!reference || held.length === 0) {
+    return true;
+  }
+  return held.some((site) => site.reference === reference);
 }

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.utils.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.utils.ts
@@ -25,13 +25,12 @@ export function getServiceDurationMinutes(service: HealthcareService): number | 
 /**
  * Reports whether a chosen service survives a move to a site.
  *
- * Matched the way the pick list matches it: `HealthcareService.location` by exact
- * reference, with no `partOf` walk, so a room inside a site does not stand for the
- * site.
+ * Matches `HealthcareService.location` by exact reference, with no `partOf` walk, so
+ * a room inside a site does not stand for the site.
  *
- * A service naming no location is kept, since nothing about it was ever tied to a
- * site. That deliberately diverges from the search, which needs the element present
- * — so such a service is kept when chosen first but is not offered once a site is.
+ * A service naming no location is kept, which diverges from the search: the search
+ * needs the element present, so such a service survives being chosen first but is
+ * not offered once a site is.
  *
  * @param service - The service being checked.
  * @param location - The site being booked at, or undefined for no site at all.

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.utils.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.utils.ts
@@ -28,9 +28,9 @@ export function getServiceDurationMinutes(service: HealthcareService): number | 
  * Matches `HealthcareService.location` by exact reference, with no `partOf` walk, so
  * a room inside a site does not stand for the site.
  *
- * A service naming no location is kept, which diverges from the search: the search
- * needs the element present, so such a service survives being chosen first but is
- * not offered once a site is.
+ * A service naming no location is kept: nothing about it was ever tied to a site. This
+ * is the client-side mirror of the field's pair of searches — `location=<site>` and
+ * `location:missing=true` — held to them by nothing but the test that runs both.
  *
  * @param service - The service being checked.
  * @param location - The site being booked at, or undefined for no site at all.

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.utils.ts
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentServiceSelect.utils.ts
@@ -25,16 +25,13 @@ export function getServiceDurationMinutes(service: HealthcareService): number | 
 /**
  * Reports whether a chosen service survives a move to a site.
  *
- * A named site is matched the way the pick list matches it: `AppointmentServiceSelect`
- * narrows on the `location` parameter, which reads `HealthcareService.location` by
- * exact reference and does not walk `partOf`, so a room inside a site does not
- * stand for the site.
+ * Matched the way the pick list matches it: `HealthcareService.location` by exact
+ * reference, with no `partOf` walk, so a room inside a site does not stand for the
+ * site.
  *
- * A service naming no location at all is kept, because nothing about it was ever
- * tied to a site and so no site can invalidate it. That is deliberately not what
- * the search does — a reference search needs the element present, so such a
- * service matches no site and is not *offered* once one is chosen even though it
- * is *kept* when it was chosen first.
+ * A service naming no location is kept, since nothing about it was ever tied to a
+ * site. That deliberately diverges from the search, which needs the element present
+ * — so such a service is kept when chosen first but is not offered once a site is.
  *
  * @param service - The service being checked.
  * @param location - The site being booked at, or undefined for no site at all.

--- a/packages/react-scheduling/src/stories/WithChainedActorSearch.tsx
+++ b/packages/react-scheduling/src/stories/WithChainedActorSearch.tsx
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { MockClient } from '@medplum/mock';
+import { useMedplum } from '@medplum/react-hooks';
+import type { JSX, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+import { stubChainedActorSearch } from '../test-utils/chainedActorSearch';
+
+export interface WithChainedActorSearchProps {
+  readonly children: ReactNode;
+}
+
+/**
+ * Teaches the ambient Storybook client to answer the chained `actor:` filters.
+ *
+ * The role fields find their schedules through `actor:Practitioner.name` and its
+ * siblings. `MemoryRepository` looks a filter's code up in the flat search
+ * parameter table, so a chained one matches nothing — and returns an empty
+ * bundle rather than an error, which reads as a visit type with nothing
+ * configured. Installed before the children render, so the first search cannot
+ * reach the unpatched client and come back empty.
+ *
+ * @param props - The React props.
+ * @returns The children, once the stub is in place.
+ */
+export function WithChainedActorSearch(props: WithChainedActorSearchProps): JSX.Element | null {
+  const medplum = useMedplum();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    // The preview's ambient client is a MockClient, which is what the stub patches.
+    const restore = stubChainedActorSearch(medplum as MockClient);
+    setReady(true);
+    return () => {
+      setReady(false);
+      restore();
+    };
+  }, [medplum]);
+
+  return ready ? <>{props.children}</> : null;
+}

--- a/packages/react-scheduling/src/stories/WithChainedActorSearch.tsx
+++ b/packages/react-scheduling/src/stories/WithChainedActorSearch.tsx
@@ -13,10 +13,9 @@ export interface WithChainedActorSearchProps {
 /**
  * Teaches the ambient Storybook client to answer the chained `actor:` filters.
  *
- * The role fields search through chained `actor:` filters, which the in-memory
- * repository answers with an empty bundle rather than an error — see
- * `stubChainedActorSearch`. Installed before the children render, so the first
- * search cannot reach the unpatched client and come back empty.
+ * The in-memory repository answers them with an empty bundle rather than an error,
+ * so the stub goes in before the children render: a search that beats it looks like
+ * a story with no fixtures.
  *
  * @param props - The React props.
  * @returns The children, once the stub is in place.

--- a/packages/react-scheduling/src/stories/WithChainedActorSearch.tsx
+++ b/packages/react-scheduling/src/stories/WithChainedActorSearch.tsx
@@ -13,12 +13,10 @@ export interface WithChainedActorSearchProps {
 /**
  * Teaches the ambient Storybook client to answer the chained `actor:` filters.
  *
- * The role fields find their schedules through `actor:Practitioner.name` and its
- * siblings. `MemoryRepository` looks a filter's code up in the flat search
- * parameter table, so a chained one matches nothing — and returns an empty
- * bundle rather than an error, which reads as a visit type with nothing
- * configured. Installed before the children render, so the first search cannot
- * reach the unpatched client and come back empty.
+ * The role fields search through chained `actor:` filters, which the in-memory
+ * repository answers with an empty bundle rather than an error — see
+ * `stubChainedActorSearch`. Installed before the children render, so the first
+ * search cannot reach the unpatched client and come back empty.
  *
  * @param props - The React props.
  * @returns The children, once the stub is in place.

--- a/packages/react-scheduling/src/stories/WithFindStub.tsx
+++ b/packages/react-scheduling/src/stories/WithFindStub.tsx
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { useMedplum } from '@medplum/react-hooks';
+import type { JSX, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+import type { FindStubOptions } from './mockFind';
+import { installFindStub } from './mockFind';
+
+export interface WithFindStubProps extends FindStubOptions {
+  readonly children: ReactNode;
+}
+
+/**
+ * Teaches the ambient Storybook client to answer `Appointment/$find`.
+ *
+ * Installed before the children render, so the first search cannot reach the
+ * unpatched client and come back empty.
+ *
+ * @param props - The React props.
+ * @returns The children, once the stub is in place.
+ */
+export function WithFindStub(props: WithFindStubProps): JSX.Element | null {
+  const medplum = useMedplum();
+  const { empty } = props;
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const restore = installFindStub(medplum, { empty });
+    setReady(true);
+    return () => {
+      setReady(false);
+      restore();
+    };
+  }, [medplum, empty]);
+
+  return ready ? <>{props.children}</> : null;
+}

--- a/packages/react-scheduling/src/stories/WithFixtures.tsx
+++ b/packages/react-scheduling/src/stories/WithFixtures.tsx
@@ -4,6 +4,7 @@ import type { Resource } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import type { JSX, ReactNode } from 'react';
 import { useEffect, useState } from 'react';
+import { indexSchedulingSearchParameters } from './searchParameters';
 
 export interface WithFixturesProps {
   readonly resources: readonly Resource[];
@@ -26,6 +27,9 @@ export function WithFixtures(props: WithFixturesProps): JSX.Element | null {
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
+    // Storing the resources is only half of it: MockClient still needs the
+    // search parameters registered before it can find any of them again.
+    indexSchedulingSearchParameters();
     Promise.all(props.resources.map((resource) => medplum.updateResource(resource)))
       .then(() => setReady(true))
       .catch(console.error);

--- a/packages/react-scheduling/src/stories/WithFixtures.tsx
+++ b/packages/react-scheduling/src/stories/WithFixtures.tsx
@@ -27,8 +27,8 @@ export function WithFixtures(props: WithFixturesProps): JSX.Element | null {
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
-    // Storing the resources is only half of it: MockClient still needs the
-    // search parameters registered before it can find any of them again.
+    // MockClient cannot find a stored resource until the search parameters are
+    // registered too.
     indexSchedulingSearchParameters();
     Promise.all(props.resources.map((resource) => medplum.updateResource(resource)))
       .then(() => setReady(true))

--- a/packages/react-scheduling/src/stories/decorators.tsx
+++ b/packages/react-scheduling/src/stories/decorators.tsx
@@ -16,9 +16,6 @@ export const withMockedDate: Decorator = (Story) => (
 
 /**
  * Stores resources on the ambient client before the story renders.
- *
- * For fields that search the server, which have nothing to offer unless the
- * fixtures are already stored.
  * @param resources - What to store first. Must be a stable reference; a module
  * constant rather than an array built inside a story.
  * @returns The decorator.

--- a/packages/react-scheduling/src/stories/decorators.tsx
+++ b/packages/react-scheduling/src/stories/decorators.tsx
@@ -3,6 +3,8 @@
 import type { Resource } from '@medplum/fhirtypes';
 import type { Decorator } from '@storybook/react';
 import { MockDateWrapper } from './MockDateWrapper';
+import { WithChainedActorSearch } from './WithChainedActorSearch';
+import { WithFindStub } from './WithFindStub';
 import { WithFixtures } from './WithFixtures';
 
 // Freezes the system clock so date/time-dependent stories are deterministic.
@@ -28,3 +30,28 @@ export const withFixtures =
       <Story />
     </WithFixtures>
   );
+
+/**
+ * Answers `Appointment/$find` from the stored fixtures, which MockClient cannot.
+ * @param options - How the stub should answer.
+ * @param options.empty - Offer no times at all, for the empty state.
+ * @returns The decorator.
+ */
+export const withFindStub =
+  (options: { empty?: boolean } = {}): Decorator =>
+  (Story) => (
+    <WithFindStub empty={options.empty}>
+      <Story />
+    </WithFindStub>
+  );
+
+/**
+ * Answers the chained `actor:` filters the role fields search with, which the
+ * in-memory repository cannot.
+ * @returns The decorator.
+ */
+export const withChainedActorSearch = (): Decorator => (Story) => (
+  <WithChainedActorSearch>
+    <Story />
+  </WithChainedActorSearch>
+);

--- a/packages/react-scheduling/src/stories/mockFind.ts
+++ b/packages/react-scheduling/src/stories/mockFind.ts
@@ -20,11 +20,9 @@ export interface FindStubOptions {
 /**
  * Answers `Appointment/$find` against the resources a MockClient already holds.
  *
- * `MockClient` has no scheduling operations, so a story showing times has to
- * stand in for the server. This intersects nothing and checks no availability —
- * it lays times on the alignment grid through the range asked for, on the
- * schedules asked for, which is enough for the flow around it to behave the way
- * it will against a real server.
+ * `MockClient` has no scheduling operations. This intersects nothing and checks no
+ * availability: it lays times on the alignment grid through the range asked for, on
+ * the schedules asked for.
  *
  * @param medplum - The client to patch. Other requests are passed through.
  * @param options - Whether to offer anything.
@@ -63,8 +61,8 @@ async function findTimes(medplum: MedplumClient, url: URL, options: FindStubOpti
   const service = await medplum.readReference<HealthcareService>({ reference: serviceReference });
   const durationMinutes = getServiceDurationMinutes(service) ?? DEFAULT_DURATION_MINUTES;
 
-  // Every actor named attends, mirroring what `$find` returns for an intersected
-  // set of schedules: one appointment carrying all of them.
+  // `$find` answers an intersected set of schedules with one appointment carrying
+  // every actor, so the stub does the same.
   const actorReferences = schedules.map((schedule) => schedule.actor[0]);
 
   const appointments: Appointment[] = [];

--- a/packages/react-scheduling/src/stories/mockFind.ts
+++ b/packages/react-scheduling/src/stories/mockFind.ts
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { MedplumClient } from '@medplum/core';
+import type { Appointment, Bundle, HealthcareService, Schedule } from '@medplum/fhirtypes';
+import { getServiceDurationMinutes } from '../AppointmentFinder/AppointmentServiceSelect.utils';
+import { buildFindBundle, buildProposedAppointment } from './scheduling';
+
+/** Clinic hours the stub offers times within, as local hours of the day. */
+const OPENS_AT = 9;
+const CLOSES_AT = 17;
+
+/** Fallback visit length for a service that configures none. */
+const DEFAULT_DURATION_MINUTES = 30;
+
+export interface FindStubOptions {
+  /** Offer nothing at all, for the empty state. Defaults to false. */
+  readonly empty?: boolean;
+}
+
+/**
+ * Answers `Appointment/$find` against the resources a MockClient already holds.
+ *
+ * `MockClient` has no scheduling operations, so a story showing times has to
+ * stand in for the server. This intersects nothing and checks no availability —
+ * it lays times on the alignment grid through the range asked for, on the
+ * schedules asked for, which is enough for the flow around it to behave the way
+ * it will against a real server.
+ *
+ * @param medplum - The client to patch. Other requests are passed through.
+ * @param options - Whether to offer anything.
+ * @returns A function restoring the client's own `get`.
+ */
+export function installFindStub(medplum: MedplumClient, options: FindStubOptions = {}): () => void {
+  const original = medplum.get.bind(medplum);
+
+  medplum.get = async function stubbedGet<T>(url: string | URL, requestOptions?: RequestInit): Promise<T> {
+    const asString = url.toString();
+    if (!asString.includes('Appointment/%24find') && !asString.includes('Appointment/$find')) {
+      return original(url, requestOptions);
+    }
+    return findTimes(medplum, new URL(asString), options) as Promise<T>;
+  } as MedplumClient['get'];
+
+  return () => {
+    medplum.get = original;
+  };
+}
+
+async function findTimes(medplum: MedplumClient, url: URL, options: FindStubOptions): Promise<Bundle<Appointment>> {
+  const start = new Date(url.searchParams.get('start') ?? '');
+  const end = new Date(url.searchParams.get('end') ?? '');
+  const scheduleReferences = url.searchParams.getAll('schedule');
+  const serviceReference = url.searchParams.get('service-type-reference') ?? '';
+  const count = Number(url.searchParams.get('_count') ?? '20');
+
+  if (options.empty || scheduleReferences.length === 0 || Number.isNaN(start.getTime())) {
+    return buildFindBundle([]);
+  }
+
+  const schedules = await Promise.all(
+    scheduleReferences.map(async (reference) => medplum.readReference<Schedule>({ reference }))
+  );
+  const service = await medplum.readReference<HealthcareService>({ reference: serviceReference });
+  const durationMinutes = getServiceDurationMinutes(service) ?? DEFAULT_DURATION_MINUTES;
+
+  // Every actor named attends, mirroring what `$find` returns for an intersected
+  // set of schedules: one appointment carrying all of them.
+  const actorReferences = schedules.map((schedule) => schedule.actor[0]);
+
+  const appointments: Appointment[] = [];
+  for (const slotStart of enumerateSlots(start, end, durationMinutes)) {
+    if (appointments.length >= count) {
+      break;
+    }
+    appointments.push(
+      buildProposedAppointment({
+        start: slotStart.toISOString(),
+        durationMinutes,
+        scheduleReferences,
+        actorReferences,
+        serviceId: serviceReference.split('/')[1],
+      })
+    );
+  }
+
+  return buildFindBundle(appointments);
+}
+
+/**
+ * Walks the clinic's open hours through a range, a visit's length at a time.
+ * @param start - First instant the search covers.
+ * @param end - Last instant the search covers.
+ * @param durationMinutes - How long one visit runs.
+ * @yields Each time a visit could start at.
+ */
+function* enumerateSlots(start: Date, end: Date, durationMinutes: number): Generator<Date> {
+  const first = new Date(start);
+  first.setHours(0, 0, 0, 0);
+
+  for (let offset = 0; ; offset++) {
+    const day = new Date(first);
+    day.setDate(day.getDate() + offset);
+    if (day > end) {
+      return;
+    }
+    const weekday = day.getDay();
+    if (weekday === 0 || weekday === 6) {
+      continue;
+    }
+    for (let minute = OPENS_AT * 60; minute + durationMinutes <= CLOSES_AT * 60; minute += durationMinutes) {
+      const slot = new Date(day);
+      slot.setHours(0, minute, 0, 0);
+      if (slot >= start && slot <= end) {
+        yield slot;
+      }
+    }
+  }
+}

--- a/packages/react-scheduling/src/stories/scheduling.ts
+++ b/packages/react-scheduling/src/stories/scheduling.ts
@@ -147,7 +147,11 @@ export const UltrasoundImagingService = buildSchedulableService({
   locationIds: ['main-clinic'],
 });
 
-/** A visit type naming no location, for the kept-but-not-offered asymmetry. */
+/**
+ * A visit type naming no location: offered at every site, kept across every site change.
+ * Its name has to sort between the sited ones — that is what makes the merged list's
+ * order evidence of a sort rather than one search appended to the other.
+ */
 export const TelehealthService = buildSchedulableService({
   id: 'telehealth-consult',
   name: 'Telehealth Consult',

--- a/packages/react-scheduling/src/stories/scheduling.ts
+++ b/packages/react-scheduling/src/stories/scheduling.ts
@@ -32,8 +32,8 @@ export const APPOINTMENT_TYPE_SYSTEM = 'http://example.org/appointment-types';
 /**
  * Declares a fixture a room or a bed.
  *
- * The clinics deliberately declare nothing: the element is optional, and a Location
- * omitting it must still be offered as a site. Do not complete them.
+ * Leave the clinics without one: the element is optional, and a Location omitting it
+ * must still be offered as a site.
  *
  * @param code - The `location-physical-type` code the Location declares.
  * @returns The concept to record it as.
@@ -422,12 +422,12 @@ export function buildFindBundle(appointments: readonly Appointment[]): Bundle<Ap
 }
 
 /**
- * A provider whose only role names the clinic's second floor rather than the
- * clinic, which is what leaves her out of a provider field booking at the clinic
- * while Exam Room B, on that same floor, is offered.
+ * A provider whose only role names the clinic's second floor rather than the clinic,
+ * so a provider field booking at the clinic leaves them out while Exam Room B, on
+ * that same floor, is offered.
  *
- * Exported separately from `SchedulingFixtures` so that adding her does not change
- * the option counts the actor and schedule tests assert on.
+ * Kept out of `SchedulingFixtures` so it does not change the option counts the actor
+ * and schedule tests assert on.
  */
 export const DrOseiPractitioner: WithId<Practitioner> = {
   resourceType: 'Practitioner',

--- a/packages/react-scheduling/src/stories/scheduling.ts
+++ b/packages/react-scheduling/src/stories/scheduling.ts
@@ -30,9 +30,10 @@ type ParticipantActor = NonNullable<AppointmentParticipant['actor']>;
 export const APPOINTMENT_TYPE_SYSTEM = 'http://example.org/appointment-types';
 
 /**
- * What a Location says it physically is, which is how the site field tells a site
- * from a room. The clinics below deliberately say nothing: nothing requires the
- * element, and a Location that omits it is still offered as a site.
+ * Declares a fixture a room or a bed.
+ *
+ * The clinics deliberately declare nothing: the element is optional, and a Location
+ * omitting it must still be offered as a site. Do not complete them.
  *
  * @param code - The `location-physical-type` code the Location declares.
  * @returns The concept to record it as.
@@ -146,13 +147,7 @@ export const UltrasoundImagingService = buildSchedulableService({
   locationIds: ['main-clinic'],
 });
 
-/**
- * A visit type held nowhere in particular.
- *
- * It names no location, so a reference search on `location` matches it against no
- * site — which is why choosing a site stops it being offered, while a site change
- * cannot invalidate an answer that was never tied to one.
- */
+/** A visit type naming no location, for the kept-but-not-offered asymmetry. */
 export const TelehealthService = buildSchedulableService({
   id: 'telehealth-consult',
   name: 'Telehealth Consult',

--- a/packages/react-scheduling/src/stories/scheduling.ts
+++ b/packages/react-scheduling/src/stories/scheduling.ts
@@ -6,6 +6,7 @@ import type {
   Appointment,
   AppointmentParticipant,
   Bundle,
+  CodeableConcept,
   Device,
   HealthcareService,
   Location,
@@ -28,6 +29,18 @@ type ParticipantActor = NonNullable<AppointmentParticipant['actor']>;
 
 export const APPOINTMENT_TYPE_SYSTEM = 'http://example.org/appointment-types';
 
+/**
+ * What a Location says it physically is, which is how the site field tells a site
+ * from a room. The clinics below deliberately say nothing: nothing requires the
+ * element, and a Location that omits it is still offered as a site.
+ *
+ * @param code - The `location-physical-type` code the Location declares.
+ * @returns The concept to record it as.
+ */
+function physicalType(code: 'ro' | 'bd'): CodeableConcept {
+  return { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/location-physical-type', code }] };
+}
+
 export const MainClinic: WithId<Location> = {
   resourceType: 'Location',
   id: 'main-clinic',
@@ -40,7 +53,17 @@ export const ExamRoomA: WithId<Location> = {
   resourceType: 'Location',
   id: 'exam-room-a',
   name: 'Exam Room A',
+  physicalType: physicalType('ro'),
   partOf: { reference: 'Location/main-clinic' },
+};
+
+/** A bed in that room: the other thing a site is never one of. */
+export const ExamRoomABed: WithId<Location> = {
+  resourceType: 'Location',
+  id: 'exam-room-a-bed-1',
+  name: 'Exam Room A Bed 1',
+  physicalType: physicalType('bd'),
+  partOf: { reference: 'Location/exam-room-a' },
 };
 
 export const SecondFloor: WithId<Location> = {
@@ -55,6 +78,7 @@ export const ExamRoomB: WithId<Location> = {
   resourceType: 'Location',
   id: 'exam-room-b',
   name: 'Exam Room B',
+  physicalType: physicalType('ro'),
   partOf: { reference: 'Location/second-floor' },
 };
 
@@ -69,6 +93,7 @@ export const SatelliteRoom: WithId<Location> = {
   resourceType: 'Location',
   id: 'satellite-room',
   name: 'Satellite Exam Room',
+  physicalType: physicalType('ro'),
   partOf: { reference: 'Location/satellite-clinic' },
 };
 
@@ -79,22 +104,25 @@ export interface SchedulableServiceOptions {
   readonly category: string;
   readonly durationMinutes: number;
   readonly alignmentMinutes: number;
-  /** The sites holding it. */
-  readonly locationIds: readonly string[];
+  /** The sites holding it, omitted entirely by a visit type held nowhere in particular. */
+  readonly locationIds?: readonly string[];
 }
 
 /**
- * Builds a service `$find` can produce times for: typed, sited, and carrying the
- * `SchedulingParameters` a booking needs.
+ * Builds a service `$find` can produce times for: typed, optionally sited, and
+ * carrying the `SchedulingParameters` a booking needs.
  * @param options - What the visit is, how long it runs, and where it is held.
  * @returns The service.
  */
 export function buildSchedulableService(options: SchedulableServiceOptions): WithId<HealthcareService> {
+  const locationIds = options.locationIds ?? [];
   return {
     resourceType: 'HealthcareService',
     id: options.id,
     name: options.name,
-    location: options.locationIds.map((locationId) => ({ reference: `Location/${locationId}` })),
+    ...(locationIds.length > 0 && {
+      location: locationIds.map((locationId) => ({ reference: `Location/${locationId}` })),
+    }),
     type: [{ coding: [{ system: APPOINTMENT_TYPE_SYSTEM, code: options.id }], text: options.category }],
     extension: [
       {
@@ -116,6 +144,21 @@ export const UltrasoundImagingService = buildSchedulableService({
   durationMinutes: 30,
   alignmentMinutes: 15,
   locationIds: ['main-clinic'],
+});
+
+/**
+ * A visit type held nowhere in particular.
+ *
+ * It names no location, so a reference search on `location` matches it against no
+ * site — which is why choosing a site stops it being offered, while a site change
+ * cannot invalidate an answer that was never tied to one.
+ */
+export const TelehealthService = buildSchedulableService({
+  id: 'telehealth-consult',
+  name: 'Telehealth Consult',
+  category: 'Telehealth',
+  durationMinutes: 20,
+  alignmentMinutes: 20,
 });
 
 /** A service with no SchedulingParameters, which must never be offered. */
@@ -289,11 +332,13 @@ export const SurgicalFixtures = [
 export const SchedulingFixtures = [
   MainClinic,
   ExamRoomA,
+  ExamRoomABed,
   SecondFloor,
   ExamRoomB,
   SatelliteClinic,
   SatelliteRoom,
   UltrasoundImagingService,
+  TelehealthService,
   WalkInService,
   DrRiveraPractitioner,
   DrOkaforPractitioner,

--- a/packages/react-scheduling/src/stories/scheduling.ts
+++ b/packages/react-scheduling/src/stories/scheduling.ts
@@ -380,3 +380,31 @@ export function buildFindBundle(appointments: readonly Appointment[]): Bundle<Ap
     entry: appointments.map((resource) => ({ resource })),
   };
 }
+
+/**
+ * A provider whose only role sits inside the main clinic rather than at it.
+ *
+ * The site filter is asymmetric by role: a room is sited by walking `partOf`, so
+ * anywhere inside the clinic counts, while a provider is sited by a
+ * `PractitionerRole` naming the clinic exactly. Dr. Osei practises on the second
+ * floor, so booking at the main clinic leaves her out while offering Exam Room B,
+ * which is on that same floor. Kept apart from `SchedulingFixtures` so it is the
+ * asymmetry story's own case rather than something every other story inherits.
+ */
+export const DrOseiPractitioner: WithId<Practitioner> = {
+  resourceType: 'Practitioner',
+  id: 'dr-osei',
+  name: [{ given: ['Ama'], family: 'Osei', prefix: ['Dr.'] }],
+};
+
+export const DrOseiRole: WithId<PractitionerRole> = {
+  resourceType: 'PractitionerRole',
+  id: 'role-dr-osei',
+  practitioner: { reference: 'Practitioner/dr-osei' },
+  healthcareService: [{ reference: 'HealthcareService/ultrasound-imaging' }],
+  location: [{ reference: 'Location/second-floor' }],
+};
+
+export const DrOseiSchedule = buildSchedule('schedule-dr-osei', 'Practitioner/dr-osei', 'Dr. Ama Osei');
+
+export const SubClinicProviderFixtures = [DrOseiPractitioner, DrOseiRole, DrOseiSchedule];

--- a/packages/react-scheduling/src/stories/scheduling.ts
+++ b/packages/react-scheduling/src/stories/scheduling.ts
@@ -382,14 +382,12 @@ export function buildFindBundle(appointments: readonly Appointment[]): Bundle<Ap
 }
 
 /**
- * A provider whose only role sits inside the main clinic rather than at it.
+ * A provider whose only role names the clinic's second floor rather than the
+ * clinic, which is what leaves her out of a provider field booking at the clinic
+ * while Exam Room B, on that same floor, is offered.
  *
- * The site filter is asymmetric by role: a room is sited by walking `partOf`, so
- * anywhere inside the clinic counts, while a provider is sited by a
- * `PractitionerRole` naming the clinic exactly. Dr. Osei practises on the second
- * floor, so booking at the main clinic leaves her out while offering Exam Room B,
- * which is on that same floor. Kept apart from `SchedulingFixtures` so it is the
- * asymmetry story's own case rather than something every other story inherits.
+ * Exported separately from `SchedulingFixtures` so that adding her does not change
+ * the option counts the actor and schedule tests assert on.
  */
 export const DrOseiPractitioner: WithId<Practitioner> = {
   resourceType: 'Practitioner',

--- a/packages/react-scheduling/src/stories/searchParameters.ts
+++ b/packages/react-scheduling/src/stories/searchParameters.ts
@@ -6,14 +6,11 @@ import type { Bundle, SearchParameter } from '@medplum/fhirtypes';
 /**
  * The search parameters the scheduling fields issue their searches against.
  *
- * `MockClient` answers a search by evaluating each parameter against what it
- * holds, so a parameter nobody registered matches nothing — silently, with an
- * empty bundle rather than an error. Without `Schedule.service-type` a story
- * reads as "this visit type has nothing configured".
+ * A parameter nobody registered matches nothing, silently, with an empty bundle
+ * rather than an error — so a story reads as a visit type with nothing configured.
  *
- * The tests index every bundle `@medplum/definitions` ships. A story cannot:
- * `readJson` reads from disk, and there is no disk in a browser. These are the
- * ones the form actually issues, written out rather than loaded.
+ * Written out rather than loaded from `@medplum/definitions` the way the tests do:
+ * `readJson` reads from disk, and there is no disk in a browser.
  */
 const SCHEDULING_SEARCH_PARAMETERS: Bundle<SearchParameter> = {
   resourceType: 'Bundle',
@@ -151,10 +148,8 @@ const SCHEDULING_SEARCH_PARAMETERS: Bundle<SearchParameter> = {
 let indexed = false;
 
 /**
- * Registers those parameters, once per page.
- *
- * The registry is global to `@medplum/core`, so indexing the same bundle for
- * every story would only rewrite what is already there.
+ * Registers those parameters once per page; the registry is global to
+ * `@medplum/core`.
  */
 export function indexSchedulingSearchParameters(): void {
   if (!indexed) {

--- a/packages/react-scheduling/src/stories/searchParameters.ts
+++ b/packages/react-scheduling/src/stories/searchParameters.ts
@@ -132,9 +132,6 @@ const SCHEDULING_SEARCH_PARAMETERS: Bundle<SearchParameter> = {
       },
     },
     {
-      // Medplum's own parameter rather than one of FHIR's, and the one the site
-      // field excludes rooms with. Unregistered it would match nothing, so the
-      // field would offer no site at all.
       resource: {
         resourceType: 'SearchParameter',
         id: 'Location-physical-type',

--- a/packages/react-scheduling/src/stories/searchParameters.ts
+++ b/packages/react-scheduling/src/stories/searchParameters.ts
@@ -131,6 +131,23 @@ const SCHEDULING_SEARCH_PARAMETERS: Bundle<SearchParameter> = {
         expression: 'Location.name | Location.alias',
       },
     },
+    {
+      // Medplum's own parameter rather than one of FHIR's, and the one the site
+      // field excludes rooms with. Unregistered it would match nothing, so the
+      // field would offer no site at all.
+      resource: {
+        resourceType: 'SearchParameter',
+        id: 'Location-physical-type',
+        url: 'https://medplum.com/fhir/SearchParameter/Location-physical-type',
+        name: 'physical-type',
+        status: 'draft',
+        description: 'The physical type of the Location resource',
+        code: 'physical-type',
+        base: ['Location'],
+        type: 'token',
+        expression: 'Location.physicalType',
+      },
+    },
   ],
 };
 

--- a/packages/react-scheduling/src/stories/searchParameters.ts
+++ b/packages/react-scheduling/src/stories/searchParameters.ts
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { indexSearchParameterBundle } from '@medplum/core';
+import type { Bundle, SearchParameter } from '@medplum/fhirtypes';
+
+/**
+ * The search parameters the scheduling fields issue their searches against.
+ *
+ * `MockClient` answers a search by evaluating each parameter against what it
+ * holds, so a parameter nobody registered matches nothing — silently, with an
+ * empty bundle rather than an error. Without `Schedule.service-type` a story
+ * reads as "this visit type has nothing configured".
+ *
+ * The tests index every bundle `@medplum/definitions` ships. A story cannot:
+ * `readJson` reads from disk, and there is no disk in a browser. These are the
+ * ones the form actually issues, written out rather than loaded.
+ */
+const SCHEDULING_SEARCH_PARAMETERS: Bundle<SearchParameter> = {
+  resourceType: 'Bundle',
+  type: 'collection',
+  entry: [
+    {
+      resource: {
+        resourceType: 'SearchParameter',
+        id: 'Schedule-service-type',
+        url: 'http://hl7.org/fhir/SearchParameter/Schedule-service-type',
+        name: 'service-type',
+        status: 'active',
+        description: 'The type of appointments that can be booked into associated slot(s)',
+        code: 'service-type',
+        base: ['Schedule'],
+        type: 'token',
+        expression: 'Schedule.serviceType',
+      },
+    },
+    {
+      resource: {
+        resourceType: 'SearchParameter',
+        id: 'Schedule-active',
+        url: 'http://hl7.org/fhir/SearchParameter/Schedule-active',
+        name: 'active',
+        status: 'active',
+        description: 'Is the schedule in active use',
+        code: 'active',
+        base: ['Schedule'],
+        type: 'token',
+        expression: 'Schedule.active',
+      },
+    },
+    {
+      resource: {
+        resourceType: 'SearchParameter',
+        id: 'Schedule-actor',
+        url: 'http://hl7.org/fhir/SearchParameter/Schedule-actor',
+        name: 'actor',
+        status: 'active',
+        description: 'The individual (HealthcareService, Practitioner, Location, ...) to find a Schedule for',
+        code: 'actor',
+        base: ['Schedule'],
+        type: 'reference',
+        expression: 'Schedule.actor',
+      },
+    },
+    {
+      resource: {
+        resourceType: 'SearchParameter',
+        id: 'PractitionerRole-practitioner',
+        url: 'http://hl7.org/fhir/SearchParameter/PractitionerRole-practitioner',
+        name: 'practitioner',
+        status: 'active',
+        description: 'Practitioner that is able to provide the defined services for the organization',
+        code: 'practitioner',
+        base: ['PractitionerRole'],
+        type: 'reference',
+        expression: 'PractitionerRole.practitioner',
+      },
+    },
+    {
+      resource: {
+        resourceType: 'SearchParameter',
+        id: 'PractitionerRole-active',
+        url: 'http://hl7.org/fhir/SearchParameter/PractitionerRole-active',
+        name: 'active',
+        status: 'active',
+        description: 'Whether this practitioner role record is in active use',
+        code: 'active',
+        base: ['PractitionerRole'],
+        type: 'token',
+        expression: 'PractitionerRole.active',
+      },
+    },
+    {
+      resource: {
+        resourceType: 'SearchParameter',
+        id: 'HealthcareService-name',
+        url: 'http://hl7.org/fhir/SearchParameter/HealthcareService-name',
+        name: 'name',
+        status: 'active',
+        description: 'A portion of the Healthcare service name',
+        code: 'name',
+        base: ['HealthcareService'],
+        type: 'string',
+        expression: 'HealthcareService.name',
+      },
+    },
+    {
+      resource: {
+        resourceType: 'SearchParameter',
+        id: 'HealthcareService-location',
+        url: 'http://hl7.org/fhir/SearchParameter/HealthcareService-location',
+        name: 'location',
+        status: 'active',
+        description: 'The location of the Healthcare Service',
+        code: 'location',
+        base: ['HealthcareService'],
+        type: 'reference',
+        expression: 'HealthcareService.location',
+      },
+    },
+    {
+      resource: {
+        resourceType: 'SearchParameter',
+        id: 'Location-name',
+        url: 'http://hl7.org/fhir/SearchParameter/Location-name',
+        name: 'name',
+        status: 'active',
+        description: 'A portion of the location name or alias',
+        code: 'name',
+        base: ['Location'],
+        type: 'string',
+        expression: 'Location.name | Location.alias',
+      },
+    },
+  ],
+};
+
+let indexed = false;
+
+/**
+ * Registers those parameters, once per page.
+ *
+ * The registry is global to `@medplum/core`, so indexing the same bundle for
+ * every story would only rewrite what is already there.
+ */
+export function indexSchedulingSearchParameters(): void {
+  if (!indexed) {
+    indexSearchParameterBundle(SCHEDULING_SEARCH_PARAMETERS);
+    indexed = true;
+  }
+}

--- a/packages/react-scheduling/src/test-utils/asyncAutocomplete.ts
+++ b/packages/react-scheduling/src/test-utils/asyncAutocomplete.ts
@@ -19,6 +19,19 @@ export async function typeInAutocomplete(input: HTMLElement, text: string): Prom
 }
 
 /**
+ * Opens an autocomplete without typing, which searches on an empty query — the list a
+ * user sees on clicking the field.
+ * @param input - The autocomplete input element.
+ */
+export async function openAutocomplete(input: HTMLElement): Promise<void> {
+  await act(async () => {
+    fireEvent.focus(input);
+  });
+
+  await settleAutocomplete();
+}
+
+/**
  * Registers the fake timers an autocomplete needs, and drains them afterwards so a
  * pending debounce cannot fire into the next test.
  */

--- a/packages/react-scheduling/src/test-utils/chainedActorSearch.ts
+++ b/packages/react-scheduling/src/test-utils/chainedActorSearch.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import type { QueryTypes } from '@medplum/core';
 import { getDisplayString } from '@medplum/core';
 import type { Bundle, Resource, Schedule } from '@medplum/fhirtypes';
 import type { MockClient } from '@medplum/mock';
@@ -25,18 +26,19 @@ const ACTOR_CHAIN_PREFIX = 'actor:';
 export function stubChainedActorSearch(medplum: MockClient): () => void {
   const original = medplum.search;
   const search = medplum.search.bind(medplum);
-  medplum.search = (async (
-    resourceType: 'Schedule',
-    query: Record<string, string>,
-    options?: object
-  ): Promise<Bundle> => {
-    const criteria: Record<string, string> = {};
+  medplum.search = (async (resourceType: 'Schedule', query: QueryTypes, options?: object): Promise<Bundle> => {
+    // Through the constructor rather than by reading keys off the query: callers
+    // hand `search` a record, a query string or a `URLSearchParams`, and
+    // `Object.entries` of the last of those is empty — which would drop every
+    // filter and answer a narrowed search with everything.
+    const params = new URLSearchParams(query as never);
+    const criteria = new URLSearchParams();
     const chained: [string, string][] = [];
-    for (const [code, value] of Object.entries(query ?? {})) {
+    for (const [code, value] of params) {
       if (code.startsWith(ACTOR_CHAIN_PREFIX)) {
         chained.push([code.slice(ACTOR_CHAIN_PREFIX.length), value]);
       } else {
-        criteria[code] = value;
+        criteria.append(code, value);
       }
     }
 

--- a/packages/react-scheduling/src/test-utils/chainedActorSearch.ts
+++ b/packages/react-scheduling/src/test-utils/chainedActorSearch.ts
@@ -27,10 +27,9 @@ export function stubChainedActorSearch(medplum: MockClient): () => void {
   const original = medplum.search;
   const search = medplum.search.bind(medplum);
   medplum.search = (async (resourceType: 'Schedule', query: QueryTypes, options?: object): Promise<Bundle> => {
-    // Through the constructor rather than by reading keys off the query: callers
-    // hand `search` a record, a query string or a `URLSearchParams`, and
-    // `Object.entries` of the last of those is empty — which would drop every
-    // filter and answer a narrowed search with everything.
+    // `Object.entries` of a `URLSearchParams` is empty, and `searchResources` hands
+    // `search` exactly that — reading keys off the query would drop every filter and
+    // answer a narrowed search with everything.
     const params = new URLSearchParams(query as never);
     const criteria = new URLSearchParams();
     const chained: [string, string][] = [];

--- a/packages/react-scheduling/src/test-utils/chainedActorSearch.ts
+++ b/packages/react-scheduling/src/test-utils/chainedActorSearch.ts
@@ -19,8 +19,11 @@ const ACTOR_CHAIN_PREFIX = 'actor:';
  * sends, not chained search in general.
  *
  * @param medplum - The client to stub.
+ * @returns A function restoring the client's own `search`, for a caller sharing
+ *   one client across renders.
  */
-export function stubChainedActorSearch(medplum: MockClient): void {
+export function stubChainedActorSearch(medplum: MockClient): () => void {
+  const original = medplum.search;
   const search = medplum.search.bind(medplum);
   medplum.search = (async (
     resourceType: 'Schedule',
@@ -59,6 +62,10 @@ export function stubChainedActorSearch(medplum: MockClient): void {
 
     return { ...bundle, entry: kept };
   }) as never;
+
+  return () => {
+    medplum.search = original;
+  };
 }
 
 /**

--- a/packages/react-scheduling/src/test-utils/chainedActorSearch.ts
+++ b/packages/react-scheduling/src/test-utils/chainedActorSearch.ts
@@ -11,13 +11,12 @@ const ACTOR_CHAIN_PREFIX = 'actor:';
 /**
  * Answers the chained actor filters out of the in-memory repository.
  *
- * `MemoryRepository` matches a filter by looking its code up in the flat search
- * parameter table, so `actor:Practitioner.name` matches nothing — and returns an
- * empty bundle rather than an error, which would make every test below pass for
- * the wrong reason. The stub lifts the chained filters off the query, lets the
- * repository answer the rest, and applies them to what came back, so these tests
- * still run against the fixtures. It understands only the two filters the search
- * sends, not chained search in general.
+ * `MemoryRepository` looks a filter's code up in the flat search parameter table, so
+ * `actor:Practitioner.name` matches nothing — and answers with an empty bundle rather
+ * than an error, which a caller cannot tell from a search that found nobody. The stub
+ * lifts the chained filters off the query, lets the repository answer the rest, and
+ * applies them to what came back. It understands only the two filters
+ * `searchScheduleCandidates` sends, not chained search in general.
  *
  * @param medplum - The client to stub.
  * @returns A function restoring the client's own `search`, for a caller sharing
@@ -27,9 +26,8 @@ export function stubChainedActorSearch(medplum: MockClient): () => void {
   const original = medplum.search;
   const search = medplum.search.bind(medplum);
   medplum.search = (async (resourceType: 'Schedule', query: QueryTypes, options?: object): Promise<Bundle> => {
-    // `Object.entries` of a `URLSearchParams` is empty, and `searchResources` hands
-    // `search` exactly that — reading keys off the query would drop every filter and
-    // answer a narrowed search with everything.
+    // `searchResources` hands `search` a `URLSearchParams`, whose `Object.entries` is
+    // empty — reading keys off the query drops every filter.
     const params = new URLSearchParams(query as never);
     const criteria = new URLSearchParams();
     const chained: [string, string][] = [];


### PR DESCRIPTION
Addresses #10003 

The pieces from #10144 and #10164 are all merged, but there's still nothing a host application can actually mount. This assembles them into `AppointmentBookingForm`: pick the site and the visit type, name the provider, room and device the visit is held on, and pick a time from `Appointment/$find`.

This is the first of three PRs and it is not usable on its own yet. The next one adds the patient field and the `$book` call itself, and exports the component from `index.ts`. A third reduces the two integrations in `examples/medplum-provider` to an `onBooked` handler each, since the form will own the `$book` block both of them currently duplicate. Then we publish, and the host can embed it.

The form deliberately has no drawer, modal, page, or navigation of its own — the host supplies the surface it sits in, so it can decide where booking happens and how wide it gets. `onToggleTimeFinder` exists for exactly that: the times sit beside the form rather than under it, so a host that puts this in a side panel needs to know when to widen the panel. Every prop is optional, and a host launching from its own calendar can pre-fill the answers it already knows:

```tsx
// The host owns the surface; the form just fills it.
<Drawer opened={opened} onClose={close} size={timesOpen ? 'xl' : 'md'}>
  <AppointmentBookingForm
    defaultLocation={clinic}
    defaultService={visitType}
    defaultStart={dayTheUserClicked}
    onToggleTimeFinder={setTimesOpen}
    onChangeService={shadeCalendarFor}
  />
</Drawer>
```

`defaultStart` seeds the day the time search opens on rather than a chosen time, because only a time `$find` offered can be held — a pre-filled time couldn't survive its own validation. Searching today starts from now rather than local midnight: `$find` treats `start` as a hard floor, and `CalendarDateInput` hands back midnight for the day you click, so picking today would otherwise be answered with times that have already gone.

The site field excludes what declares itself a room or a bed (`physical-type:not=ro,bd`) rather than admitting only what declares itself a site, since the element is optional and a Location whose physical type nobody populated still has to be offered.

The visit type field narrows to the chosen site by asking twice, together: `location=<site>`, plus `location:missing=true` for the visit types tied to no site, which no site can hold exclusively and none can exclude. A reference search needs the element present, so one query cannot ask for both. `_filter=location eq <site> or location pr false` can, and the server implements it, but `matchesSearchRequest` has no `_filter` path at all, and that is what `MemoryRepository` searches with, so against `MockClient` every test and every story would match nothing. Dropping `location` and filtering the results client-side is the other one-request option, and it breaks at any practice with more visit types than a page: the server returns the first 25 by name across every site and the filter empties them. The two responses are disjoint by construction, so merging them is a sort by name, and which of the two searches found a visit type never reaches the list.

All three role fields always render, and each takes its `role` rather than a list of candidates derived from the visit type's schedules. Showing only the roles a visit type configures needs a cheap per-role count, which is a follow-up — deriving the fields from a fetched candidate list instead would reintroduce the `_count=100` ceiling that #10164 was written to remove.

One invariant governs what the form throws away: an answer goes as soon as the thing it depended on changes. A new visit type or site clears the named resources and the chosen time. Changing any resource clears the time alone, because a chosen time is a `$find` proposal carrying its own participants and its resources' Slots, so booking it after swapping the provider would book whoever is named inside the proposal rather than whoever is on screen. `$book` cannot catch that: the proposal is internally consistent, and that time genuinely was free for whoever is in it. The search stays open through a resource change and re-runs for the new set, so the replacement time is one click away rather than behind a reopen that also costs the host the panel width it just widened.

The time is a read-only display rather than an editable field. An earlier draft let you type any time and booked it even when `$find` never offered it, which is booking over occupied time — that's an admin-only capability we haven't built yet, so it's cut rather than gated.

Two things worth calling out for review. `getFindWindowError` refuses a range wider than `$find` will answer, but nothing can reach it through the UI yet: range selection isn't in the date input until #10127, so the range is always one day. It's wired up and unit tested so the rule is already right when the gesture arrives.

And the Storybook stories needed the server stubbed to show anything at all. The role fields search through chained `actor:Practitioner.name` filters, which `MemoryRepository` answers with an empty bundle rather than an error, and `MockClient` has no `$find`. Both are now decorators, so a story reads as "nothing configured" only when that's actually true.

<img width="952" height="546" alt="image" src="https://github.com/user-attachments/assets/99067259-9d89-4d23-9a2b-9f0dacaad177" />

<img width="953" height="954" alt="image" src="https://github.com/user-attachments/assets/ffada5fe-c022-4d66-bff2-e137cee7fb82" />

The `SiteAsymmetryByRole` story below is worth a look: the Room field offers Exam Room B while the Provider field leaves out Dr. Ama Osei, though both sit on the clinic's second floor. That asymmetry is inherited from #10164 rather than decided here — a room is sited by walking `partOf`, a provider only by a `PractitionerRole` naming the site exactly. It reads as a bug, which is why it now has a story.

<img width="953" height="954" alt="image" src="https://github.com/user-attachments/assets/87cd255f-200c-47b6-8b63-fa41e85650c8" />
