### PR TITLE
test(agent): deflake the park-backlog yield assertion

### DIFF
--- a/packages/agent/src/queue/worker.test.ts
+++ b/packages/agent/src/queue/worker.test.ts
@@ -1376,9 +1376,15 @@ describe('ChannelQueueWorker', () => {
       // rather than a wall-clock one.
       startSlot(app, worker, { loopYieldBudgetMs: 0 });
 
-      // One `await` drains the whole microtask queue. Without the yield the loop
-      // never leaves that drain, so all nine would already be parked here.
-      await sleep(0);
+      // Drain microtasks, and only microtasks. `sleep(0)` would not do: it is a timer,
+      // so the check-phase yields run during it and the assertion becomes a race
+      // between nine parks and one clamped 0ms timeout — about 110us per park is the
+      // tipping point. A microtask drain no park can cross removes the clock from the
+      // measurement, and still fails if the yield is dropped or downgraded to a
+      // microtask. 200 ticks is far more than the nine iterations need, and each is free.
+      for (let i = 0; i < 200; i++) {
+        await Promise.resolve();
+      }
       expect(queue.getChannelDepth('ch1').delayed).toBeLessThan(followers.length);
 
       // The budget only spreads the parks out — it must not lose any.


### PR DESCRIPTION
`packages/agent/src/queue/worker.test.ts` → "parks a blocked backlog across event-loop turns instead of draining it in one" is timing-marginal, and it has been failing in CI.

### Why it flakes

The test asserts that fewer than nine rows are parked after `await sleep(0)`. But `sleep(0)` is a timer, and the dispatcher yields on `setImmediate` (`dispatcher.ts`, `yieldToEventLoop` — deliberately the check phase, not a 0ms timeout). Check-phase callbacks run *during* a clamped timer, so the assertion is a race between nine parks and one `setTimeout(…, 0)`.

Measured how many `setImmediate` turns fit in one `setTimeout(0)`, varying the per-turn cost that stands in for `claimNext` + `markDelayed`:

| per-park cost | turns before the timer | result |
| --- | --- | --- |
| 200µs | 3–5 | passes |
| 120µs | 7–8 | passes, ~1.5x headroom |
| 60µs | 13–14 | **fails 15/15** |
| 20µs | ~30 | **fails 15/15** |

The assertion trips at 9 turns, so the tipping point is ~110µs per park. A faster runner, a warm SQLite cache, or a timer delayed under parallel-CI load crosses it. The existing comment ("one `await` drains the whole microtask queue") is what made it look safe — a timer drains macrotasks too.

### The fix

Drain microtasks, and only microtasks: no `setImmediate` callback can cross that, so the clock leaves the measurement entirely.

### Why this form and not a simpler one

Just dropping the `await` and asserting synchronously after `start()` is also deterministic, but it only proves *some* `await` exists in the loop body. Verified by patching the dispatcher three ways and re-running each candidate:

| test form | baseline | yield removed | yield downgraded to a microtask |
| --- | --- | --- | --- |
| `await sleep(0)` (current) | pass | fail | fail |
| synchronous assert after `start()` | pass | fail | **pass** ← blind spot |
| microtask drain (this PR) | pass | fail | fail |

Being a real event-loop turn — not a microtask — is the property `yieldToEventLoop` was chosen for, so the fix keeps covering it.

Test passes 5/5 filtered and with the full file (47/47); `tsc`, `eslint`, `prettier` clean.