### PR TITLE
test(agent): stop waiting out the HL7 force-drain in the pool-persists test

### DIFF
--- a/packages/agent/src/app.test.ts
+++ b/packages/agent/src/app.test.ts
@@ -5000,19 +5000,19 @@ describe('App', () => {
     expect(app.hl7Clients.size).toBe(1);
     expect(app.hl7Clients.has('mllp://localhost:57110')).toBe(true);
 
-    // Stop the HL7 server — this closes connections from the server side
-    await hl7Server.stop();
-
-    // Wait for the close to propagate (client removed from pool, but pool stays)
-    await sleep(200);
+    // Stop the HL7 server — this closes connections from the server side. Force the
+    // drain: the agent holds a keepAlive connection open, so `close()` would otherwise
+    // block on the 10s default and leave the rest of the test a thin slice of its budget.
+    await hl7Server.stop({ forceDrainTimeoutMs: 0 });
 
     // Pool should STILL be in hl7Clients — it is never removed by client errors
     expect(app.hl7Clients.size).toBe(1);
     expect(app.hl7Clients.has('mllp://localhost:57110')).toBe(true);
 
-    // The pool should have no clients (they were removed when the connection closed)
+    // The pool sheds its clients as the closes land — waited on rather than slept off,
+    // so a shed that never happens names itself instead of failing a later assertion.
     const pool = app.hl7Clients.get('mllp://localhost:57110') as Hl7ClientPool;
-    expect(pool.size()).toBe(0);
+    await waitFor(() => pool.size() === 0, 2000, 'pool sheds its clients after the server closes');
 
     // Restart the HL7 server
     const hl7Server2 = new Hl7Server((conn) => {


### PR DESCRIPTION
`App > Pool persists in hl7Clients after client error — only cleared on keepAlive change` timed out at 15000ms on [run 32409467414 attempt 1](https://github.com/medplum/medplum/actions/runs/32409467414). The re-run went green — at **10441ms of its 15000ms budget**. That margin is the bug.

### Why it flakes

`Hl7Server.stop()` resolves when `net.Server.close()` calls back, and `close()` waits for every connection to go away. A lingering connection is only closed when the force-drain timer fires — `DEFAULT_FORCE_DRAIN_TIMEOUT_MS`, 10s.

This test's whole premise is that the agent keeps a `keepAlive` pooled connection open, so at `stop()` there is always exactly one connection lingering. It therefore always pays the full 10s, which leaves under 4.5s for the server restart, the second transmit, and the response wait. Ordinary CI variance eats that, and the test dies on the vitest timeout with no clue which wait stalled.

Reproduced locally at **10477ms**, variance under 5ms across runs — a fixed timer, not jitter.

### The fix

Force the drain, which is already the local convention (20 other `stop()` calls in this file pass `forceDrainTimeoutMs`), and wait on the pool actually shedding its clients instead of sleeping a fixed 200ms for it.

| | before | after |
| --- | --- | --- |
| this test | 10477ms | **254ms** |
| `app.test.ts` overall | ~28s | ~18s |

Budget headroom goes from 1.4x to ~59x. 60/60 tests in the file pass; `tsc`, `eslint`, `prettier` clean.

### Note for follow-up

The reason this cost so much to diagnose is that the failure said only `Test timed out in 15000ms` and pointed at the test's opening line. `app.test.ts` hand-rolls 131 `while (!cond) { await sleep(100) }` spin-waits whose only deadline is the vitest timeout, while the package already exports `waitFor(predicate, timeoutMs, label)` (`src/test-utils.ts`, 10ms poll, labeled timeout) — imported in this file but called once. `queue/integration.test.ts` uses it the intended way (`'leader detects the lost lease and steps down'`). Converting the spin-waits would turn future stalls into named failures and cut poll latency 10x; happy to do that as a separate sweep.

Closes #10269