### PR TITLE
[Scheduling] Booking form: attach the details and book

### DIFF
--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.stories.tsx
@@ -4,18 +4,35 @@ import { Alert, List, Stack, Text } from '@mantine/core';
 import { Document } from '@medplum/react';
 import type { Meta } from '@storybook/react';
 import type { JSX } from 'react';
-import { withChainedActorSearch, withFindStub, withFixtures, withMockedDate } from '../stories/decorators';
+import {
+  withBookStub,
+  withChainedActorSearch,
+  withFindStub,
+  withFixtures,
+  withMockedDate,
+} from '../stories/decorators';
 import {
   MainClinic,
+  MRN_SYSTEM,
+  PatientFixtures,
   SchedulingFixtures,
   SubClinicProviderFixtures,
   SurgeryService,
   SurgicalFixtures,
   UltrasoundImagingService,
 } from '../stories/scheduling';
+import type { AppointmentBooking } from './AppointmentBookingForm';
 import { AppointmentBookingForm } from './AppointmentBookingForm';
 
-const STORY_FIXTURES = [...SchedulingFixtures, ...SurgicalFixtures, ...SubClinicProviderFixtures];
+const STORY_FIXTURES = [...SchedulingFixtures, ...SurgicalFixtures, ...SubClinicProviderFixtures, ...PatientFixtures];
+
+/**
+ * Stands in for the host, which is the only thing a story has to supply.
+ * @param booking - What the form wrote.
+ */
+function reportBooking(booking: AppointmentBooking): void {
+  console.info('Booked', booking.appointment.id, `over ${booking.slots.length} slot(s)`);
+}
 
 // A story's own decorators add to these rather than replacing them, so `$find` is
 // stubbed per story: two stubs would both install, and which one answered would be
@@ -23,11 +40,12 @@ const STORY_FIXTURES = [...SchedulingFixtures, ...SurgicalFixtures, ...SubClinic
 export default {
   title: 'Medplum/AppointmentBookingForm',
   component: AppointmentBookingForm,
-  decorators: [withChainedActorSearch(), withFixtures(STORY_FIXTURES), withMockedDate],
+  decorators: [withChainedActorSearch(), withBookStub(), withFixtures(STORY_FIXTURES), withMockedDate],
 } as Meta;
 
 /**
- * The form from an empty state to a chosen time.
+ * The whole form, mounted the way a host with no configuration mounts it:
+ * `onBooked` and nothing else.
  *
  * Choose "Ultrasound Imaging" and the three role fields search against it: it is
  * held on practitioners, rooms and devices, and only the provider is required. So
@@ -36,14 +54,33 @@ export default {
  * Change a resource with a time already picked and the time goes — it was found for
  * resources that no longer stand — while the search stays open and re-runs, so the
  * replacement is one click away.
+ *
+ * Name a patient and "Book appointment" writes the visit. Two patients here are
+ * called Jordan Reyes, which is what the birth date and medical record number under
+ * each name are for.
  * @returns The story.
  */
 export const Basic = (): JSX.Element => (
   <Document>
-    <AppointmentBookingForm />
+    <AppointmentBookingForm onBooked={reportBooking} />
   </Document>
 );
 Basic.decorators = [withFindStub()];
+
+/**
+ * A project whose identifiers carry no `type`, so nothing on an identifier says
+ * which one is the medical record number.
+ *
+ * `mrnSystem` is what names it. Search "Sam" and the number appears under the
+ * name; drop the prop and the same patient lists by name and birth date alone.
+ * @returns The story.
+ */
+export const UntypedMedicalRecordNumbers = (): JSX.Element => (
+  <Document>
+    <AppointmentBookingForm mrnSystem={MRN_SYSTEM} onBooked={reportBooking} />
+  </Document>
+);
+UntypedMedicalRecordNumbers.decorators = [withFindStub()];
 
 /**
  * A visit that needs a whole team free at once: a surgeon, an anesthesiologist
@@ -55,7 +92,7 @@ Basic.decorators = [withFindStub()];
  */
 export const SurgicalTeam = (): JSX.Element => (
   <Document>
-    <AppointmentBookingForm defaultService={SurgeryService} defaultLocation={MainClinic} />
+    <AppointmentBookingForm defaultService={SurgeryService} defaultLocation={MainClinic} onBooked={reportBooking} />
   </Document>
 );
 SurgicalTeam.decorators = [withFindStub()];
@@ -69,7 +106,7 @@ SurgicalTeam.decorators = [withFindStub()];
  */
 export const NoAvailability = (): JSX.Element => (
   <Document>
-    <AppointmentBookingForm />
+    <AppointmentBookingForm onBooked={reportBooking} />
   </Document>
 );
 NoAvailability.decorators = [withFindStub({ empty: true })];
@@ -101,7 +138,11 @@ export const SiteAsymmetryByRole = (): JSX.Element => (
           </List.Item>
         </List>
       </Alert>
-      <AppointmentBookingForm defaultLocation={MainClinic} defaultService={UltrasoundImagingService} />
+      <AppointmentBookingForm
+        defaultLocation={MainClinic}
+        defaultService={UltrasoundImagingService}
+        onBooked={reportBooking}
+      />
     </Stack>
   </Document>
 );

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -1,61 +1,27 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { MedplumClient } from '@medplum/core';
-import { formatDate } from '@medplum/core';
-import type { Appointment, Device, Parameters, Patient, Slot } from '@medplum/fhirtypes';
-import { MockClient } from '@medplum/mock';
+import type { Appointment, Slot } from '@medplum/fhirtypes';
+import type { MockClient } from '@medplum/mock';
 import type { JSX } from 'react';
 import type { MockInstance } from 'vitest';
 import { installBookStub } from '../stories/mockBook';
 import { installFindStub } from '../stories/mockFind';
+import { installAutocompleteTimers } from '../test-utils/asyncAutocomplete';
 import {
-  ElderJordanPatient,
-  MainClinic,
-  MRN_SYSTEM,
-  PatientFixtures,
-  SatelliteClinic,
-  SchedulingFixtures,
-  SubClinicProviderFixtures,
-  SurgeryService,
-  SurgicalFixtures,
-  TelehealthService,
-  Ultrasound1Device,
-  UltrasoundImagingService,
-  UntypedMrnPatient,
-  YoungerJordanPatient,
-} from '../stories/scheduling';
-import {
-  clickAutocompleteOption,
-  installAutocompleteTimers,
-  settleAutocomplete,
-  typeInAutocomplete,
-} from '../test-utils/asyncAutocomplete';
-import { stubChainedActorSearch } from '../test-utils/chainedActorSearch';
-import { act, fireEvent, renderWithMedplum, screen, waitFor, within } from '../test-utils/render';
+  bookButton,
+  chosenTimeField,
+  clickBook,
+  field,
+  fillBooking,
+  MONDAY_MORNING,
+  setupBookingClient,
+} from '../test-utils/bookingForm';
+import { renderWithMedplum, screen } from '../test-utils/render';
 import type { AppointmentBookingFormProps } from './AppointmentBookingForm';
 import { AppointmentBookingForm } from './AppointmentBookingForm';
 
-/** A Monday, so the stub has weekday hours ahead of it on the default search day. */
-const MONDAY_MORNING = new Date(2026, 7, 17, 8, 0, 0);
-
-/** The timezone the fixtures' visit type is held in, which is not the runner's. */
-const SITE_TIMEZONE = 'America/New_York';
-
 installAutocompleteTimers();
-
-async function setupClient(): Promise<MockClient> {
-  const medplum = new MockClient();
-  for (const resource of [
-    ...SchedulingFixtures,
-    ...SurgicalFixtures,
-    ...SubClinicProviderFixtures,
-    ...PatientFixtures,
-  ]) {
-    await medplum.createResource(resource);
-  }
-  stubChainedActorSearch(medplum);
-  return medplum;
-}
 
 /** Every mount needs one, and it is the only prop a host must supply. */
 const onBooked = vi.fn();
@@ -65,253 +31,13 @@ function setup(medplum: MockClient, props?: Partial<AppointmentBookingFormProps>
   renderWithMedplum(element, medplum);
 }
 
-function field(label: RegExp): HTMLElement {
-  return screen.getByRole('searchbox', { name: label });
-}
-
-async function chooseImagingService(): Promise<void> {
-  await typeInAutocomplete(field(/visit type/i), 'Ultrasound');
-  await clickAutocompleteOption('Ultrasound Imaging');
-  await settleAutocomplete();
-}
-
 /**
- * Opens one role's field on everything it has, by focusing: `fireEvent.change` to the
- * value already in the box is not a change.
- *
- * @param role - The field to open.
- * @returns The field's search box.
+ * What the booking reported writing.
+ * @returns The booking `onBooked` was handed.
  */
-async function openRoleField(role: RegExp): Promise<HTMLElement> {
-  const input = field(role);
-  await act(async () => {
-    fireEvent.focus(input);
-  });
-  await settleAutocomplete();
-  return input;
-}
-
-/**
- * Searches one field and returns the dropdown that field owns.
- *
- * Several autocompletes are on screen at once and a dropdown stays in the document
- * once opened, so an unscoped query could read — or click — another field's option.
- *
- * @param label - Matches the label above the field.
- * @param query - What to type, which is what the search narrows on.
- * @returns The field's dropdown.
- */
-async function searchField(label: RegExp, query: string): Promise<HTMLElement> {
-  const input = field(label);
-  await typeInAutocomplete(input, query);
-
-  const listboxId = input.getAttribute('aria-controls');
-  const listbox = listboxId && document.getElementById(listboxId);
-  if (!listbox) {
-    throw new Error(`No dropdown found for ${label.source}`);
-  }
-  return listbox;
-}
-
-async function chooseActor(role: RegExp, query: string, name: string): Promise<void> {
-  const listbox = await searchField(role, query);
-  await act(async () => {
-    fireEvent.click(within(listbox).getByText(name));
-  });
-  await settleAutocomplete();
-}
-
-/**
- * Takes one chosen value back out of the field holding it: the only way to change the
- * visit type, which takes its search box away while full.
- *
- * @param name - The value currently chosen.
- */
-async function removePill(name: string): Promise<void> {
-  // Scoped to the pill, since a named resource is also on the slot card and in the
-  // chosen time's description. Mantine's remove button is `aria-hidden`.
-  const pill = screen.queryAllByText(name).find((node) => node.className.includes('Pill'));
-  const remove = pill?.parentElement?.querySelector('button');
-  if (!remove) {
-    throw new Error(`No remove button on the ${name} pill`);
-  }
-  await act(async () => {
-    fireEvent.click(remove);
-  });
-  await settleAutocomplete();
-}
-
-/**
- * Chooses a site in the location field, which holds one value at a time.
- * @param query - What to type.
- * @param name - The site to click out of what came back.
- */
-async function chooseSite(query: string, name: string): Promise<void> {
-  const listbox = await searchField(/location/i, query);
-  await act(async () => {
-    fireEvent.click(within(listbox).getByText(name));
-  });
-  await settleAutocomplete();
-}
-
-/** Opens the time search, which is what sends the `$find` request. */
-async function openTimeFinder(): Promise<void> {
-  await act(async () => {
-    fireEvent.click(screen.getByRole('button', { name: /find a time/i }));
-  });
-  await settleAutocomplete();
-}
-
-/**
- * Clicks a day in the time search's calendar.
- * @param dayOfMonth - The number the cell is labelled with.
- */
-async function chooseDay(dayOfMonth: string): Promise<void> {
-  await act(async () => {
-    fireEvent.click(screen.getByRole('button', { name: dayOfMonth }));
-  });
-  await settleAutocomplete();
-}
-
-/**
- * Picks the first time on offer, by position: times are read at the site, whose
- * timezone is not the runner's.
- *
- * @returns The label of the time that was picked.
- */
-async function chooseFirstOfferedTime(): Promise<string> {
-  const [firstGroup] = await screen.findAllByTestId(/^slot-group-/);
-  const [firstTime] = within(firstGroup).getAllByRole('button');
-  const label = firstTime.textContent ?? '';
-  await act(async () => {
-    fireEvent.click(firstTime);
-  });
-  return label;
-}
-
-/** Picks the next time along, for a change of mind about the first. */
-async function chooseSecondOfferedTime(): Promise<void> {
-  const [firstGroup] = await screen.findAllByTestId(/^slot-group-/);
-  const [, secondTime] = within(firstGroup).getAllByRole('button');
-  await act(async () => {
-    fireEvent.click(secondTime);
-  });
-}
-
-/**
- * Whether a field is holding a value, read off the pill rather than the state: the
- * fields ignore `defaultValue` after mount, so a cleared form could still show one.
- *
- * @param name - The value's label.
- * @returns Whether a pill is showing it.
- */
-function hasPill(name: string): boolean {
-  return screen.queryAllByText(name).some((node) => node.className.includes('Pill'));
-}
-
-/**
- * The field holding the chosen time, or null while no time has been chosen — there is
- * no field at all before one is picked, so its absence is an assertion of its own.
- *
- * @returns The field, or null.
- */
-function chosenTimeField(): HTMLInputElement | null {
-  return screen.queryByRole<HTMLInputElement>('textbox', { name: /date & time/i });
-}
-
-/**
- * Whether one element comes before another in the document.
- *
- * Where a field sits is part of the behaviour: the form asks the criteria, finds the
- * time, then takes the details, and the chosen time belongs above the control that
- * produced it. Only document order carries either.
- *
- * @param first - The element expected to come first.
- * @param second - The element expected to follow it.
- * @returns Whether they are in that order.
- */
-function isBefore(first: Element, second: Element): boolean {
-  return Boolean(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING);
-}
-
-/**
- * The `start` the most recent `$find` asked for.
- * @param get - A spy on the client's `get`.
- * @returns The `start` parameter, or undefined when nothing was asked.
- */
-function lastFindStart(get: MockInstance<MedplumClient['get']>): string | undefined {
-  const urls = get.mock.calls
-    .map(([url]) => String(url))
-    .filter((url) => url.includes('Appointment/$find') || url.includes('Appointment/%24find'));
-  const last = urls.at(-1);
-  return last ? (new URL(last, 'https://example.com').searchParams.get('start') ?? undefined) : undefined;
-}
-
-/**
- * The action that finds a time, under whichever of its three labels.
- * @returns The button.
- */
-function finderButton(): HTMLElement {
-  return screen.getByRole('button', { name: /find a time|change time|close time finder/i });
-}
-
-/**
- * The action that writes the booking.
- * @returns The button.
- */
-function bookButton(): HTMLElement {
-  return screen.getByRole('button', { name: /book appointment/i });
-}
-
-/**
- * What one patient's option row reads under their name.
- * @param patient - The patient on offer.
- * @param mrn - Their medical record number, for a patient with one on file.
- * @returns The line that tells them apart from a namesake.
- */
-function patientDetail(patient: Patient, mrn?: string): string {
-  return [formatDate(patient.birthDate), mrn && `MRN ${mrn}`].filter(Boolean).join(' · ');
-}
-
-/**
- * Names the patient the visit is for.
- *
- * Chosen by the line under the name rather than the name itself, because two of
- * the fixtures share one — which is the reason that line is there.
- *
- * @param query - What to type, which is what the search narrows on.
- * @param detail - The birth date and medical record number of the one to pick.
- */
-async function choosePatient(query: string, detail: string): Promise<void> {
-  const input = field(/patient/i);
-  await typeInAutocomplete(input, query);
-
-  const listboxId = input.getAttribute('aria-controls');
-  const listbox = listboxId && document.getElementById(listboxId);
-  if (!listbox) {
-    throw new Error('No dropdown found for the patient field');
-  }
-  await act(async () => {
-    fireEvent.click(within(listbox).getByText(detail));
-  });
-  await settleAutocomplete();
-}
-
-/** Answers everything a booking needs: a visit type, a provider, a time, a patient. */
-async function fillBooking(): Promise<void> {
-  await chooseImagingService();
-  await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-  await openTimeFinder();
-  await chooseFirstOfferedTime();
-  await choosePatient('Jordan', patientDetail(ElderJordanPatient, 'MRN-0041'));
-}
-
-/** Confirms the booking. */
-async function clickBook(): Promise<void> {
-  await act(async () => {
-    fireEvent.click(screen.getByRole('button', { name: /book appointment/i }));
-  });
-  await settleAutocomplete();
+function reportedBooking(): { appointment: Appointment; slots: Slot[] } {
+  const [booking] = onBooked.mock.calls[0] as [{ appointment: Appointment; slots: Slot[] }];
+  return booking;
 }
 
 /**
@@ -327,16 +53,6 @@ function bookCount(post: MockInstance<MedplumClient['post']>): number {
   return post.mock.calls.filter(([url]) => String(url).includes('$book')).length;
 }
 
-/**
- * The appointment handed to `$book`, as the form assembled it.
- * @param post - The spy standing in front of the client's `post`.
- * @returns The proposal that was posted.
- */
-function postedAppointment(post: MockInstance<MedplumClient['post']>): Appointment {
-  const [, body] = post.mock.calls[0];
-  return (body as Parameters).parameter?.find((parameter) => parameter.name === 'appointment')?.resource as Appointment;
-}
-
 describe('AppointmentBookingForm', () => {
   let medplum: MockClient;
   let restoreFind: () => void;
@@ -345,7 +61,8 @@ describe('AppointmentBookingForm', () => {
   beforeEach(async () => {
     vi.setSystemTime(MONDAY_MORNING);
     onBooked.mockClear();
-    medplum = await setupClient();
+    onBooked.mockResolvedValue(undefined);
+    medplum = await setupBookingClient();
     restoreFind = installFindStub(medplum);
     restoreBook = installBookStub(medplum);
   });
@@ -355,693 +72,21 @@ describe('AppointmentBookingForm', () => {
     restoreFind();
   });
 
-  describe('Choosing the resources a visit is held on', () => {
-    test('Offers a field for all three roles', async () => {
-      setup(medplum);
-      await chooseImagingService();
-
-      expect(field(/provider/i)).toBeInTheDocument();
-      expect(field(/room/i)).toBeInTheDocument();
-      expect(field(/device/i)).toBeInTheDocument();
-    });
-
-    test('Offers nothing to type into until a visit type is chosen', async () => {
-      setup(medplum);
-      await settleAutocomplete();
-
-      for (const role of [/^Provider$/, /^Room$/, /^Device$/]) {
-        expect(screen.queryByRole('searchbox', { name: role })).not.toBeInTheDocument();
-        expect(screen.getByText(role)).toBeInTheDocument();
-      }
-
-      await chooseImagingService();
-
-      expect(field(/provider/i)).toBeInTheDocument();
-    });
-
-    test('Offers no search until a provider is named, and says so', async () => {
-      setup(medplum);
-      await chooseImagingService();
-
-      // A room alone holds a room but no calendar to book it against.
-      await chooseActor(/room/i, 'exam', 'Exam Room A');
-
-      expect(finderButton()).toBeDisabled();
-      expect(screen.getByText('Choose at least one provider first.')).toBeInTheDocument();
-      expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
-
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-
-      expect(finderButton()).toBeEnabled();
-      expect(screen.queryByText('Choose at least one provider first.')).not.toBeInTheDocument();
-    });
-
-    test('Searches against the provider alone when the room and device are left empty', async () => {
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-
-      const [group] = await screen.findAllByTestId(/^slot-group-/);
-      expect(within(group).getByText('Dr. Maya Rivera')).toBeInTheDocument();
-      expect(within(group).queryByText('Exam Room A')).not.toBeInTheDocument();
-    });
-
-    test('Still offers a role the visit type has nothing configured for', async () => {
-      setup(medplum);
-      await chooseImagingService();
-
-      const input = await openRoleField(/device/i);
-      await typeInAutocomplete(input, 'nosuchdevice');
-
-      expect(input).toBeEnabled();
-      expect(await screen.findByText('No devices found')).toBeInTheDocument();
-    });
-
-    test('Naming two providers narrows the times to the ones both are free for', async () => {
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await chooseActor(/provider/i, 'oka', 'Dr. Tunde Okafor');
-      await openTimeFinder();
-
-      // One group, not two: `$find` intersects the schedules it is given.
-      const groups = await screen.findAllByTestId(/^slot-group-/);
-      expect(groups).toHaveLength(1);
-      expect(within(groups[0]).getByText('Dr. Maya Rivera')).toBeInTheDocument();
-      expect(within(groups[0]).getByText('Dr. Tunde Okafor')).toBeInTheDocument();
-    });
-  });
-
-  describe('Narrowing resources to the chosen site', () => {
-    test('Offers a room that belongs to a place inside the chosen site', async () => {
-      setup(medplum, { defaultLocation: MainClinic, defaultService: UltrasoundImagingService });
-      await settleAutocomplete();
-
-      await openRoleField(/room/i);
-
-      // Exam Room B is `partOf` the second floor, which is `partOf` the clinic.
-      expect(await screen.findByText('Exam Room B')).toBeInTheDocument();
-      expect(screen.getByText('Exam Room A')).toBeInTheDocument();
-      expect(screen.queryByText('Satellite Exam Room')).not.toBeInTheDocument();
-    });
-
-    test('Offers a device kept inside the chosen site', async () => {
-      const sitedDevice: Device = { ...Ultrasound1Device, location: { reference: 'Location/second-floor' } };
-      await medplum.updateResource(sitedDevice);
-      setup(medplum, { defaultLocation: MainClinic, defaultService: UltrasoundImagingService });
-      await settleAutocomplete();
-
-      await openRoleField(/device/i);
-
-      expect(await screen.findByText('Ultrasound 1 (Main Campus)')).toBeInTheDocument();
-    });
-
-    test('Offers a provider whose role names the chosen site', async () => {
-      // Dr. Martinez's role names the main clinic itself, the only way a provider is sited.
-      setup(medplum, { defaultLocation: MainClinic, defaultService: SurgeryService });
-      await settleAutocomplete();
-
-      const input = await openRoleField(/provider/i);
-      await typeInAutocomplete(input, 'mart');
-
-      expect(await screen.findByText('Dr. Maria Martinez')).toBeInTheDocument();
-    });
-
-    test('Leaves out a provider whose roles name another site', async () => {
-      setup(medplum, { defaultLocation: SatelliteClinic, defaultService: SurgeryService });
-      await settleAutocomplete();
-
-      const input = await openRoleField(/provider/i);
-      await typeInAutocomplete(input, 'mart');
-
-      expect(await screen.findByText('No providers found')).toBeInTheDocument();
-      expect(screen.queryByText('Dr. Maria Martinez')).not.toBeInTheDocument();
-    });
-
-    test('Leaves out a provider sited inside the chosen site rather than at it, while offering a room there', async () => {
-      // A room is sited by walking `partOf`; a provider only by a role naming the
-      // site exactly.
-      setup(medplum, { defaultLocation: MainClinic, defaultService: UltrasoundImagingService });
-      await settleAutocomplete();
-
-      await openRoleField(/provider/i);
-      expect(await screen.findByText('Dr. Maya Rivera')).toBeInTheDocument();
-      expect(screen.queryByText('Dr. Ama Osei')).not.toBeInTheDocument();
-
-      await openRoleField(/room/i);
-      expect(await screen.findByText('Exam Room B')).toBeInTheDocument();
-    });
-
-    test('Keeps a resource that records nothing about where it is', async () => {
-      setup(medplum, { defaultLocation: SatelliteClinic, defaultService: UltrasoundImagingService });
-      await settleAutocomplete();
-
-      await openRoleField(/device/i);
-
-      // The devices record no location at all.
-      expect(await screen.findByText('Ultrasound 1 (Main Campus)')).toBeInTheDocument();
-    });
-
-    test('Narrows nothing by location when no site is chosen', async () => {
-      setup(medplum, { defaultService: UltrasoundImagingService });
-      await settleAutocomplete();
-
-      await openRoleField(/room/i);
-
-      expect(await screen.findByText('Exam Room A')).toBeInTheDocument();
-      expect(screen.getByText('Satellite Exam Room')).toBeInTheDocument();
-    });
-  });
-
-  describe('Choosing where the visit is held', () => {
-    test('Leaves a room and a bed out of the site field', async () => {
-      setup(medplum);
-
-      // Unscoped: a search that came back with nothing leaves no dropdown to scope to.
-      await typeInAutocomplete(field(/location/i), 'Exam Room A');
-
-      expect(await screen.findByText('Nothing found')).toBeInTheDocument();
-      expect(screen.queryByText('Exam Room A')).not.toBeInTheDocument();
-      expect(screen.queryByText('Exam Room A Bed 1')).not.toBeInTheDocument();
-    });
-
-    test('Offers a Location that records no physical type', async () => {
-      setup(medplum);
-
-      const listbox = await searchField(/location/i, 'Uro Associates');
-
-      // Neither clinic declares one, and nothing requires it: the field excludes what
-      // says it is a room rather than admitting only what says site.
-      expect(within(listbox).getByText('Uro Associates - Main Clinic')).toBeInTheDocument();
-      expect(within(listbox).getByText('Uro Associates - Satellite')).toBeInTheDocument();
-    });
-
-    test('Narrows the visit types to the chosen site, and says which site', async () => {
-      setup(medplum);
-      await chooseSite('Satellite', 'Uro Associates - Satellite');
-
-      await typeInAutocomplete(field(/visit type/i), 'Ultrasound');
-
-      expect(
-        screen.getByText('Showing visit types offered at Uro Associates - Satellite, plus those not tied to a site.')
-      ).toBeInTheDocument();
-      // Imaging names the main clinic, and only a visit type naming this site exactly
-      // is offered at it.
-      expect(await screen.findByText('Nothing found')).toBeInTheDocument();
-      expect(screen.queryByText('Ultrasound Imaging')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Offering only times every named resource is free', () => {
-    test('Offers the times the named resources share', async () => {
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await chooseActor(/room/i, 'exam', 'Exam Room A');
-      await openTimeFinder();
-
-      const groups = await screen.findAllByTestId(/^slot-group-/);
-      expect(groups).toHaveLength(1);
-      expect(within(groups[0]).getByText('Dr. Maya Rivera')).toBeInTheDocument();
-      expect(within(groups[0]).getByText('Exam Room A')).toBeInTheDocument();
-    });
-
-    test('Issues no request until the time search is opened', async () => {
-      const get = vi.spyOn(medplum, 'get');
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-
-      expect(get.mock.calls.filter(([url]) => String(url).includes('find'))).toHaveLength(0);
-      expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
-
-      await openTimeFinder();
-
-      expect((await screen.findAllByTestId(/^slot-group-/)).length).toBeGreaterThan(0);
-    });
-
-    test('Says so when the search offers nothing', async () => {
-      restoreFind();
-      restoreFind = installFindStub(medplum, { empty: true });
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-
-      expect(await screen.findByText('No times are available for this selection.')).toBeInTheDocument();
-    });
-
-    test('Replaces the times when another day is chosen', async () => {
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-      expect(await screen.findByText(/Monday, August 17/)).toBeInTheDocument();
-
-      await chooseDay('18');
-
-      await waitFor(() => expect(screen.getByText(/Tuesday, August 18/)).toBeInTheDocument());
-      expect(screen.queryByText(/Monday, August 17/)).not.toBeInTheDocument();
-    });
-
-    test('Searches today from now rather than from midnight', async () => {
-      const get = vi.spyOn(medplum, 'get');
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-
-      // The calendar hands back local midnight, so picking today must not walk the
-      // floor back: `$find` honours whatever `start` it is given, and would answer
-      // with times that have already passed.
-      await chooseDay('17');
-
-      const start = lastFindStart(get);
-      expect(start).toBeDefined();
-      // Local midnight would be 07:00Z on this clock; the floor must not go back there.
-      expect(new Date(start as string).getTime()).toBeGreaterThanOrEqual(MONDAY_MORNING.getTime());
-    });
-  });
-
-  describe('Reading times in the site’s timezone', () => {
-    test('Shows an offered time as the time at the site', async () => {
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-
-      const [group] = await screen.findAllByTestId(/^slot-group-/);
-      const [firstTime] = within(group).getAllByRole('button');
-      // The stub lays times on the clinic's open hours in the runner's timezone, so the
-      // label is that instant read at the site rather than 9:00 repeated.
-      const start = new Date(2026, 7, 17, 9, 0, 0);
-
-      expect(firstTime).toHaveTextContent(
-        new Intl.DateTimeFormat(undefined, {
-          timeZone: SITE_TIMEZONE,
-          hour: 'numeric',
-          minute: '2-digit',
-        }).format(start)
-      );
-    });
-
-    test('Records the instant the site-local time stands for', async () => {
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-      const label = await chooseFirstOfferedTime();
-
-      expect(chosenTimeField()?.value).toContain(label);
-    });
-  });
-
-  describe('Booking only a time that was offered', () => {
-    test('Shows nothing standing in for a time before one is chosen', async () => {
-      setup(medplum);
-      await chooseImagingService();
-
-      expect(finderButton()).toHaveTextContent('Find a time');
-      expect(chosenTimeField()).not.toBeInTheDocument();
-      expect(screen.queryByRole('textbox', { name: /date|time/i })).not.toBeInTheDocument();
-    });
-
-    test('Shows the time that was picked in a field above the action', async () => {
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await chooseActor(/room/i, 'exam', 'Exam Room A');
-      await openTimeFinder();
-
-      expect(chosenTimeField()).not.toBeInTheDocument();
-      const label = await chooseFirstOfferedTime();
-
-      const chosen = chosenTimeField() as HTMLInputElement;
-      expect(chosen.value).toContain(label);
-      expect(isBefore(chosen, finderButton())).toBe(true);
-      // Off the proposal, so what the field commits to is what `$book` would be handed.
-      expect(chosen).toHaveAccessibleDescription('30 min visit · Provider: Dr. Maya Rivera · Room: Exam Room A');
-    });
-
-    test('Offers no way to type or amend the chosen time', async () => {
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-      await chooseFirstOfferedTime();
-
-      const shown = (chosenTimeField() as HTMLInputElement).value;
-      await act(async () => {
-        fireEvent.change(chosenTimeField() as HTMLInputElement, { target: { value: 'Monday, August 17 at 11:59 PM' } });
-      });
-
-      expect(chosenTimeField()).toHaveAttribute('readonly');
-      expect(chosenTimeField()?.value).toBe(shown);
-      expect(screen.getAllByRole('textbox', { name: /date|time/i })).toHaveLength(1);
-      expect(finderButton()).toBeInTheDocument();
-    });
-
-    test('Offers to change the time once one is chosen', async () => {
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-      await chooseFirstOfferedTime();
-
-      await act(async () => {
-        fireEvent.click(finderButton());
-      });
-      await settleAutocomplete();
-
-      expect(finderButton()).toHaveTextContent('Change time');
-      expect(screen.queryByRole('button', { name: /^find a time$/i })).not.toBeInTheDocument();
-    });
-
-    test('Clears the chosen time when the day changes', async () => {
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-      await chooseFirstOfferedTime();
-
-      await chooseDay('18');
-
-      expect(chosenTimeField()).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Clearing answers that no longer hold', () => {
-    test('Replacing the provider clears the time, so no booking can hold the old one', async () => {
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-      await chooseFirstOfferedTime();
-      expect(chosenTimeField()).toHaveAccessibleDescription(/Dr. Maya Rivera/);
-
-      await removePill('Dr. Maya Rivera');
-      await chooseActor(/provider/i, 'oka', 'Dr. Tunde Okafor');
-
-      // A chosen time is a proposal carrying its own participants and Slots. Kept
-      // through this it would book Dr. Rivera while the form showed Dr. Okafor, and
-      // `$book` would accept it: that time genuinely was Dr. Rivera's.
-      expect(chosenTimeField()).not.toBeInTheDocument();
-
-      const label = await chooseFirstOfferedTime();
-
-      const chosen = chosenTimeField() as HTMLInputElement;
-      expect(chosen.value).toContain(label);
-      expect(chosen).toHaveAccessibleDescription(/Dr. Tunde Okafor/);
-      expect(chosen).not.toHaveAccessibleDescription(/Dr. Maya Rivera/);
-    });
-
-    test.each([
-      ['added', async (): Promise<void> => chooseActor(/room/i, 'exam', 'Exam Room A')],
-      ['removed', async (): Promise<void> => removePill('Exam Room A')],
-    ])('A room %s after a time was chosen clears it', async (_change, changeRoom) => {
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      if (_change === 'removed') {
-        await chooseActor(/room/i, 'exam', 'Exam Room A');
-      }
-      await openTimeFinder();
-      await chooseFirstOfferedTime();
-      expect(chosenTimeField()).toBeInTheDocument();
-
-      await changeRoom();
-
-      // A time found without a room's availability is not a time that room is free for,
-      // and one found with it does not hold once the room is dropped.
-      expect(chosenTimeField()).not.toBeInTheDocument();
-    });
-
-    test('A resource change leaves the search open and re-runs it', async () => {
-      const onToggleTimeFinder = vi.fn();
-      setup(medplum, { onToggleTimeFinder });
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-      await chooseFirstOfferedTime();
-      onToggleTimeFinder.mockClear();
-
-      await chooseActor(/room/i, 'exam', 'Exam Room A');
-
-      // Closing here would take back the panel width the host just widened, mid-task.
-      expect(finderButton()).toHaveTextContent('Close time finder');
-      expect(onToggleTimeFinder).not.toHaveBeenCalled();
-      const [group] = await screen.findAllByTestId(/^slot-group-/);
-      expect(within(group).getByText('Dr. Maya Rivera')).toBeInTheDocument();
-      expect(within(group).getByText('Exam Room A')).toBeInTheDocument();
-    });
-
-    test('Dropping the last provider closes the search, and says so', async () => {
-      const onToggleTimeFinder = vi.fn();
-      setup(medplum, { onToggleTimeFinder });
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-      await screen.findAllByTestId(/^slot-group-/);
-
-      await removePill('Dr. Maya Rivera');
-
-      expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
-      expect(onToggleTimeFinder).toHaveBeenLastCalledWith(false);
-    });
-
-    test('Clears the chosen resources and time when the visit type changes', async () => {
-      setup(medplum);
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-      await chooseFirstOfferedTime();
-      expect(chosenTimeField()).toBeInTheDocument();
-
-      await removePill('Ultrasound Imaging');
-      await typeInAutocomplete(field(/visit type/i), 'Bariatric');
-      await clickAutocompleteOption('Bariatric Surgery');
-      await settleAutocomplete();
-
-      expect(chosenTimeField()).not.toBeInTheDocument();
-      // A surviving pill would be handed back on the next pick, and searched against a
-      // schedule the new visit type cannot book.
-      expect(hasPill('Dr. Maya Rivera')).toBe(false);
-    });
-
-    test('Clears the chosen resources when the site changes', async () => {
-      setup(medplum, { defaultService: UltrasoundImagingService });
-      await settleAutocomplete();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      expect(hasPill('Dr. Maya Rivera')).toBe(true);
-
-      await chooseSite('Main Clinic', 'Uro Associates - Main Clinic');
-
-      expect(hasPill('Dr. Maya Rivera')).toBe(false);
-      // The imaging service is held there, so that answer stands.
-      expect(hasPill('Ultrasound Imaging')).toBe(true);
-    });
-
-    test('Clears the visit type when the new site does not hold it', async () => {
-      setup(medplum, { defaultService: SurgeryService });
-      await settleAutocomplete();
-      expect(hasPill('Bariatric Surgery')).toBe(true);
-
-      // Surgery is held at the main clinic only.
-      await chooseSite('Satellite', 'Uro Associates - Satellite');
-
-      expect(hasPill('Bariatric Surgery')).toBe(false);
-    });
-
-    test('Keeps a visit type the new site does hold', async () => {
-      setup(medplum, { defaultService: UltrasoundImagingService });
-      await settleAutocomplete();
-
-      await chooseSite('Main Clinic', 'Uro Associates - Main Clinic');
-
-      // The imaging service names the main clinic, so the answer still stands.
-      expect(hasPill('Ultrasound Imaging')).toBe(true);
-    });
-
-    test('Keeps a visit type that names no location when the site changes, and offers it there', async () => {
-      setup(medplum, { defaultService: TelehealthService });
-      await settleAutocomplete();
-      expect(hasPill('Telehealth Consult')).toBe(true);
-
-      await chooseSite('Main Clinic', 'Uro Associates - Main Clinic');
-
-      // Never tied to a site, so no site invalidates it.
-      expect(hasPill('Telehealth Consult')).toBe(true);
-
-      // The predicate here and the pair of searches behind the field are one rule spelled
-      // twice, and only a test through both catches them drifting apart. The field hides
-      // its search box while it holds an answer, so asking costs the pill just asserted.
-      await removePill('Telehealth Consult');
-      const listbox = await searchField(/visit type/i, 'Telehealth');
-      expect(within(listbox).getByText('Telehealth Consult')).toBeInTheDocument();
-    });
-
-    test('Collapses the time search when the visit type is cleared, and says so', async () => {
-      const onToggleTimeFinder = vi.fn();
-      setup(medplum, { onToggleTimeFinder });
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-      await screen.findAllByTestId(/^slot-group-/);
-
-      await removePill('Ultrasound Imaging');
-
-      expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
-      expect(screen.queryByRole('button', { name: /close time finder/i })).not.toBeInTheDocument();
-      expect(onToggleTimeFinder).toHaveBeenLastCalledWith(false);
-    });
-
-    test('Reports the visit type as it changes', async () => {
-      const onChangeService = vi.fn();
-      setup(medplum, { onChangeService });
-
-      await chooseImagingService();
-
-      expect(onChangeService).toHaveBeenCalledWith(expect.objectContaining({ id: 'ultrasound-imaging' }));
-    });
-  });
-
   describe('Mounting the booking form', () => {
     test('Books with nothing supplied but the booking callback', async () => {
-      // The zero-configuration case: one prop, every field offered, and a
-      // booking written without the host issuing a request of its own.
+      // The zero-configuration case: one prop, every field offered, and a booking
+      // written without the host issuing a request of its own.
       setup(medplum);
+      expect(field(/patient/i)).toBeInTheDocument();
+
       await fillBooking();
       await clickBook();
 
       expect(onBooked).toHaveBeenCalledTimes(1);
-      const [booking] = onBooked.mock.calls[0] as [{ appointment: Appointment; slots: Slot[] }];
+      const booking = reportedBooking();
       expect(booking.appointment.id).toBeDefined();
       expect(booking.appointment.status).toBe('booked');
       expect(booking.slots.length).toBeGreaterThan(0);
-    });
-
-    test('Starts with the answers the host pre-filled', async () => {
-      setup(medplum, {
-        defaultLocation: MainClinic,
-        defaultService: UltrasoundImagingService,
-        defaultPatient: ElderJordanPatient,
-      });
-      await settleAutocomplete();
-
-      expect(screen.getByText(MainClinic.name as string)).toBeInTheDocument();
-      expect(screen.getByText('Ultrasound Imaging')).toBeInTheDocument();
-      expect(screen.getByText('Jordan Reyes')).toBeInTheDocument();
-    });
-
-    test('Reports the time search opening and closing', async () => {
-      const onToggleTimeFinder = vi.fn();
-      setup(medplum, { onToggleTimeFinder });
-      await chooseImagingService();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      // Mounting is not an open or a close, so the host hears nothing until one.
-      expect(onToggleTimeFinder).not.toHaveBeenCalled();
-
-      await openTimeFinder();
-      expect(onToggleTimeFinder).toHaveBeenLastCalledWith(true);
-
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: /close time finder/i }));
-      });
-      expect(onToggleTimeFinder).toHaveBeenLastCalledWith(false);
-    });
-
-    test('Opens the time search on the day the host named', async () => {
-      // In the following month, so the month the calendar would otherwise open on
-      // cannot pass this by accident.
-      setup(medplum, { defaultService: UltrasoundImagingService, defaultStart: new Date(2026, 8, 2, 0, 0, 0) });
-      await settleAutocomplete();
-      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
-      await openTimeFinder();
-
-      expect(await screen.findByText(/Wednesday, September 2/)).toBeInTheDocument();
-    });
-  });
-
-  describe('Identifying the patient', () => {
-    test('Asks for the patient below the action that finds a time', async () => {
-      setup(medplum);
-
-      // Naming a patient cannot change which times are offered, so asking for one
-      // ahead of the search puts work that cannot affect the result in front of the
-      // one control that can.
-      expect(isBefore(finderButton(), field(/patient/i))).toBe(true);
-    });
-
-    test('Offers patients matching the name typed', async () => {
-      setup(medplum);
-      await typeInAutocomplete(field(/patient/i), 'Whitfield');
-
-      expect(await screen.findByText('Sam Whitfield')).toBeInTheDocument();
-      expect(screen.queryByText('Jordan Reyes')).not.toBeInTheDocument();
-    });
-
-    test('Tells apart two patients who share a name', async () => {
-      setup(medplum);
-      await typeInAutocomplete(field(/patient/i), 'Jordan');
-
-      // The name is on both rows, so the birth date and the medical record
-      // number under it are the only things separating them.
-      expect(await screen.findByText(patientDetail(ElderJordanPatient, 'MRN-0041'))).toBeInTheDocument();
-      expect(screen.getByText(patientDetail(YoungerJordanPatient))).toBeInTheDocument();
-      expect(screen.getAllByText('Jordan Reyes')).toHaveLength(2);
-    });
-
-    test('Lists a patient with no medical record number by name and birth date', async () => {
-      setup(medplum);
-      await typeInAutocomplete(field(/patient/i), 'Jordan');
-
-      // Hiding somebody because a number is missing would lose the patient, not
-      // the ambiguity.
-      expect(await screen.findByText(patientDetail(YoungerJordanPatient))).toBeInTheDocument();
-    });
-
-    test('Reads the medical record number from the system the host named', async () => {
-      // Sam's identifier carries no type, so nothing but its system says what it
-      // is. Without `mrnSystem` the same patient lists by birth date alone.
-      setup(medplum, { mrnSystem: MRN_SYSTEM });
-      await typeInAutocomplete(field(/patient/i), 'Whitfield');
-
-      expect(await screen.findByText(patientDetail(UntypedMrnPatient, 'MRN-0099'))).toBeInTheDocument();
-    });
-
-    test('Leaves the patient out of the search for times', async () => {
-      const get = vi.spyOn(medplum, 'get');
-      setup(medplum);
-      await fillBooking();
-
-      // `$find` proposes times on calendars and knows nothing about who the
-      // visit is for; the patient is attached on the way to `$book`.
-      const searched = get.mock.calls.map(([url]) => String(url)).filter((url) => url.includes('find'));
-      expect(searched.length).toBeGreaterThan(0);
-      expect(searched.some((url) => url.includes('Patient'))).toBe(false);
-    });
-
-    test('Asks nothing else below the action that finds a time', async () => {
-      setup(medplum);
-
-      // The free text about the visit that used to sit here is one of the fields a
-      // practice configures, so the patient is the form's last question.
-      const inputs = [...screen.getAllByRole('searchbox'), ...screen.queryAllByRole('textbox')];
-      expect(inputs.filter((input) => isBefore(finderButton(), input))).toEqual([field(/patient/i)]);
-    });
-
-    test('Names the patient as a required participant, once', async () => {
-      const post = vi.spyOn(medplum, 'post');
-      setup(medplum);
-      await fillBooking();
-      await clickBook();
-
-      const participants = postedAppointment(post).participant.filter(
-        (participant) => participant.actor?.reference === `Patient/${ElderJordanPatient.id}`
-      );
-      expect(participants).toHaveLength(1);
-      expect(participants[0].required).toBe('required');
     });
   });
 
@@ -1053,7 +98,7 @@ describe('AppointmentBookingForm', () => {
       await clickBook();
 
       expect(String(post.mock.calls[0][0])).toContain('Appointment/$book');
-      const [booking] = onBooked.mock.calls[0] as [{ appointment: Appointment; slots: Slot[] }];
+      const booking = reportedBooking();
       expect(booking.appointment.resourceType).toBe('Appointment');
       expect(booking.slots.every((slot) => slot.resourceType === 'Slot')).toBe(true);
     });
@@ -1071,23 +116,6 @@ describe('AppointmentBookingForm', () => {
       expect(announced).toContain('Slot');
     });
 
-    test('Hands the proposal over to a host supplying onBook', async () => {
-      const onBook = vi.fn();
-      const post = vi.spyOn(medplum, 'post');
-      const notify = vi.spyOn(medplum, 'notifyResourceModified');
-      setup(medplum, { onBook });
-      await fillBooking();
-      await clickBook();
-
-      expect(onBook).toHaveBeenCalledTimes(1);
-      const [proposal] = onBook.mock.calls[0] as [Appointment];
-      expect(proposal.participant.some((p) => p.actor?.reference === `Patient/${ElderJordanPatient.id}`)).toBe(true);
-      // The host owns the write, so it owns invalidating its own caches too.
-      expect(post).not.toHaveBeenCalled();
-      expect(notify).not.toHaveBeenCalled();
-      expect(onBooked).not.toHaveBeenCalled();
-    });
-
     test('Reports a booking the host callback threw over as written', async () => {
       onBooked.mockRejectedValueOnce(new Error('Calendar refresh failed'));
       const post = vi.spyOn(medplum, 'post');
@@ -1100,6 +128,7 @@ describe('AppointmentBookingForm', () => {
       // would show an error over a time that was taken, and invite a second click.
       expect(bookCount(post)).toBe(1);
       expect(screen.queryByText('Calendar refresh failed')).not.toBeInTheDocument();
+      expect(bookButton()).toBeDisabled();
     });
 
     test('Writes a booking once, however many times the button is clicked', async () => {
@@ -1115,30 +144,6 @@ describe('AppointmentBookingForm', () => {
       expect(bookCount(post)).toBe(1);
     });
 
-    test('Offers to book again once the patient changes', async () => {
-      setup(medplum);
-      await fillBooking();
-      await clickBook();
-      expect(bookButton()).toBeDisabled();
-
-      await removePill('Jordan Reyes');
-      await choosePatient('Jordan', patientDetail(YoungerJordanPatient));
-
-      // The other Jordan is a different visit, not the one already written.
-      expect(bookButton()).toBeEnabled();
-    });
-
-    test('Offers to book again once the time changes', async () => {
-      setup(medplum);
-      await fillBooking();
-      await clickBook();
-      expect(bookButton()).toBeDisabled();
-
-      await chooseSecondOfferedTime();
-
-      expect(bookButton()).toBeEnabled();
-    });
-
     test('Shows a refused booking and keeps every answer', async () => {
       vi.spyOn(medplum, 'post').mockRejectedValue(new Error('Slot is no longer available'));
       setup(medplum);
@@ -1151,6 +156,7 @@ describe('AppointmentBookingForm', () => {
       // is one field away.
       expect(chosenTimeField()?.value).toBe(time);
       expect(screen.getByText('Jordan Reyes')).toBeInTheDocument();
+      expect(onBooked).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -280,17 +280,6 @@ async function choosePatient(query: string, detail: string): Promise<void> {
   await settleAutocomplete();
 }
 
-/**
- * Types into one of the free-text fields.
- * @param label - Matches the label above the field.
- * @param text - What to type.
- */
-async function typeInto(label: RegExp, text: string): Promise<void> {
-  await act(async () => {
-    fireEvent.change(screen.getByRole('textbox', { name: label }), { target: { value: text } });
-  });
-}
-
 /** Answers everything a booking needs: a visit type, a provider, a time, a patient. */
 async function fillBooking(): Promise<void> {
   await chooseImagingService();
@@ -1002,17 +991,14 @@ describe('AppointmentBookingForm', () => {
       expect(searched.length).toBeGreaterThan(0);
       expect(searched.some((url) => url.includes('Patient'))).toBe(false);
     });
-  });
 
-  describe('Recording what the visit is for', () => {
-    test('Asks for all three free-text fields below the action that finds a time', async () => {
+    test('Asks nothing else below the action that finds a time', async () => {
       setup(medplum);
 
-      // Together rather than split across the action: none of the three is an answer
-      // the search depends on, so none of them belongs above it.
-      for (const label of [/reason for visit/i, /notes or comments/i, /patient instructions/i]) {
-        expect(isBefore(finderButton(), screen.getByRole('textbox', { name: label }))).toBe(true);
-      }
+      // The free text about the visit that used to sit here is one of the fields a
+      // practice configures, so the patient is the form's last question.
+      const inputs = [...screen.getAllByRole('searchbox'), ...screen.queryAllByRole('textbox')];
+      expect(inputs.filter((input) => isBefore(finderButton(), input))).toEqual([field(/patient/i)]);
     });
 
     test('Names the patient as a required participant, once', async () => {
@@ -1026,35 +1012,6 @@ describe('AppointmentBookingForm', () => {
       );
       expect(participants).toHaveLength(1);
       expect(participants[0].required).toBe('required');
-    });
-
-    test('Writes each free-text field onto its own element', async () => {
-      const post = vi.spyOn(medplum, 'post');
-      setup(medplum);
-      await fillBooking();
-      await typeInto(/reason for visit/i, 'Follow-up scan');
-      await typeInto(/notes or comments/i, 'Bring prior imaging');
-      await typeInto(/patient instructions/i, 'Arrive 15 minutes early');
-      await clickBook();
-
-      const booked = postedAppointment(post);
-      expect(booked.description).toBe('Follow-up scan');
-      expect(booked.comment).toBe('Bring prior imaging');
-      expect(booked.patientInstruction).toBe('Arrive 15 minutes early');
-    });
-
-    test('Leaves off an element whose field holds nothing', async () => {
-      const post = vi.spyOn(medplum, 'post');
-      setup(medplum);
-      await fillBooking();
-      // Whitespace is nothing typed, not a note saying nothing.
-      await typeInto(/notes or comments/i, '   ');
-      await clickBook();
-
-      const booked = postedAppointment(post);
-      expect(booked).not.toHaveProperty('description');
-      expect(booked).not.toHaveProperty('comment');
-      expect(booked).not.toHaveProperty('patientInstruction');
     });
   });
 
@@ -1106,7 +1063,6 @@ describe('AppointmentBookingForm', () => {
       setup(medplum);
       await fillBooking();
       const time = (chosenTimeField() as HTMLInputElement).value;
-      await typeInto(/reason for visit/i, 'Follow-up scan');
       await clickBook();
 
       expect(await screen.findByText('Slot is no longer available')).toBeInTheDocument();
@@ -1114,7 +1070,6 @@ describe('AppointmentBookingForm', () => {
       // is one field away.
       expect(chosenTimeField()?.value).toBe(time);
       expect(screen.getByText('Jordan Reyes')).toBeInTheDocument();
-      expect(screen.getByRole('textbox', { name: /reason for visit/i })).toHaveValue('Follow-up scan');
     });
   });
 });

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -211,8 +211,11 @@ function chosenTimeField(): HTMLInputElement | null {
 }
 
 /**
- * Whether one element comes before another in the document, which is the only thing
- * carrying where the chosen time sits relative to the action.
+ * Whether one element comes before another in the document.
+ *
+ * Where a field sits is part of the behaviour: the form asks the criteria, finds the
+ * time, then takes the details, and the chosen time belongs above the control that
+ * produced it. Only document order carries either.
  *
  * @param first - The element expected to come first.
  * @param second - The element expected to follow it.
@@ -942,6 +945,15 @@ describe('AppointmentBookingForm', () => {
   });
 
   describe('Identifying the patient', () => {
+    test('Asks for the patient below the action that finds a time', async () => {
+      setup(medplum);
+
+      // Naming a patient cannot change which times are offered, so asking for one
+      // ahead of the search puts work that cannot affect the result in front of the
+      // one control that can.
+      expect(isBefore(finderButton(), field(/patient/i))).toBe(true);
+    });
+
     test('Offers patients matching the name typed', async () => {
       setup(medplum);
       await typeInAutocomplete(field(/patient/i), 'Whitfield');
@@ -993,6 +1005,16 @@ describe('AppointmentBookingForm', () => {
   });
 
   describe('Recording what the visit is for', () => {
+    test('Asks for all three free-text fields below the action that finds a time', async () => {
+      setup(medplum);
+
+      // Together rather than split across the action: none of the three is an answer
+      // the search depends on, so none of them belongs above it.
+      for (const label of [/reason for visit/i, /notes or comments/i, /patient instructions/i]) {
+        expect(isBefore(finderButton(), screen.getByRole('textbox', { name: label }))).toBe(true);
+      }
+    });
+
     test('Names the patient as a required participant, once', async () => {
       const post = vi.spyOn(medplum, 'post');
       setup(medplum);

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -1,13 +1,18 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { MedplumClient } from '@medplum/core';
-import type { Device } from '@medplum/fhirtypes';
+import { formatDate } from '@medplum/core';
+import type { Appointment, Device, Parameters, Patient, Slot } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import type { JSX } from 'react';
 import type { MockInstance } from 'vitest';
+import { installBookStub } from '../stories/mockBook';
 import { installFindStub } from '../stories/mockFind';
 import {
+  ElderJordanPatient,
   MainClinic,
+  MRN_SYSTEM,
+  PatientFixtures,
   SatelliteClinic,
   SchedulingFixtures,
   SubClinicProviderFixtures,
@@ -16,6 +21,8 @@ import {
   TelehealthService,
   Ultrasound1Device,
   UltrasoundImagingService,
+  UntypedMrnPatient,
+  YoungerJordanPatient,
 } from '../stories/scheduling';
 import {
   clickAutocompleteOption,
@@ -38,15 +45,23 @@ installAutocompleteTimers();
 
 async function setupClient(): Promise<MockClient> {
   const medplum = new MockClient();
-  for (const resource of [...SchedulingFixtures, ...SurgicalFixtures, ...SubClinicProviderFixtures]) {
+  for (const resource of [
+    ...SchedulingFixtures,
+    ...SurgicalFixtures,
+    ...SubClinicProviderFixtures,
+    ...PatientFixtures,
+  ]) {
     await medplum.createResource(resource);
   }
   stubChainedActorSearch(medplum);
   return medplum;
 }
 
-function setup(medplum: MockClient, props?: AppointmentBookingFormProps): void {
-  const element: JSX.Element = <AppointmentBookingForm {...props} />;
+/** Every mount needs one, and it is the only prop a host must supply. */
+const onBooked = vi.fn();
+
+function setup(medplum: MockClient, props?: Partial<AppointmentBookingFormProps>): void {
+  const element: JSX.Element = <AppointmentBookingForm onBooked={onBooked} {...props} />;
   renderWithMedplum(element, medplum);
 }
 
@@ -228,17 +243,93 @@ function finderButton(): HTMLElement {
   return screen.getByRole('button', { name: /find a time|change time|close time finder/i });
 }
 
+/**
+ * What one patient's option row reads under their name.
+ * @param patient - The patient on offer.
+ * @param mrn - Their medical record number, for a patient with one on file.
+ * @returns The line that tells them apart from a namesake.
+ */
+function patientDetail(patient: Patient, mrn?: string): string {
+  return [formatDate(patient.birthDate), mrn && `MRN ${mrn}`].filter(Boolean).join(' · ');
+}
+
+/**
+ * Names the patient the visit is for.
+ *
+ * Chosen by the line under the name rather than the name itself, because two of
+ * the fixtures share one — which is the reason that line is there.
+ *
+ * @param query - What to type, which is what the search narrows on.
+ * @param detail - The birth date and medical record number of the one to pick.
+ */
+async function choosePatient(query: string, detail: string): Promise<void> {
+  const input = field(/patient/i);
+  await typeInAutocomplete(input, query);
+
+  const listboxId = input.getAttribute('aria-controls');
+  const listbox = listboxId && document.getElementById(listboxId);
+  if (!listbox) {
+    throw new Error('No dropdown found for the patient field');
+  }
+  await act(async () => {
+    fireEvent.click(within(listbox).getByText(detail));
+  });
+  await settleAutocomplete();
+}
+
+/**
+ * Types into one of the free-text fields.
+ * @param label - Matches the label above the field.
+ * @param text - What to type.
+ */
+async function typeInto(label: RegExp, text: string): Promise<void> {
+  await act(async () => {
+    fireEvent.change(screen.getByRole('textbox', { name: label }), { target: { value: text } });
+  });
+}
+
+/** Answers everything a booking needs: a visit type, a provider, a time, a patient. */
+async function fillBooking(): Promise<void> {
+  await chooseImagingService();
+  await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+  await openTimeFinder();
+  await chooseFirstOfferedTime();
+  await choosePatient('Jordan', patientDetail(ElderJordanPatient, 'MRN-0041'));
+}
+
+/** Confirms the booking. */
+async function clickBook(): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /book appointment/i }));
+  });
+  await settleAutocomplete();
+}
+
+/**
+ * The appointment handed to `$book`, as the form assembled it.
+ * @param post - The spy standing in front of the client's `post`.
+ * @returns The proposal that was posted.
+ */
+function postedAppointment(post: MockInstance<MedplumClient['post']>): Appointment {
+  const [, body] = post.mock.calls[0];
+  return (body as Parameters).parameter?.find((parameter) => parameter.name === 'appointment')?.resource as Appointment;
+}
+
 describe('AppointmentBookingForm', () => {
   let medplum: MockClient;
   let restoreFind: () => void;
+  let restoreBook: () => void;
 
   beforeEach(async () => {
     vi.setSystemTime(MONDAY_MORNING);
+    onBooked.mockClear();
     medplum = await setupClient();
     restoreFind = installFindStub(medplum);
+    restoreBook = installBookStub(medplum);
   });
 
   afterEach(() => {
+    restoreBook();
     restoreFind();
   });
 
@@ -793,7 +884,34 @@ describe('AppointmentBookingForm', () => {
     });
   });
 
-  describe('Mounting the form', () => {
+  describe('Mounting the booking form', () => {
+    test('Books with nothing supplied but the booking callback', async () => {
+      // The zero-configuration case: one prop, every field offered, and a
+      // booking written without the host issuing a request of its own.
+      setup(medplum);
+      await fillBooking();
+      await clickBook();
+
+      expect(onBooked).toHaveBeenCalledTimes(1);
+      const [booking] = onBooked.mock.calls[0] as [{ appointment: Appointment; slots: Slot[] }];
+      expect(booking.appointment.id).toBeDefined();
+      expect(booking.appointment.status).toBe('booked');
+      expect(booking.slots.length).toBeGreaterThan(0);
+    });
+
+    test('Starts with the answers the host pre-filled', async () => {
+      setup(medplum, {
+        defaultLocation: MainClinic,
+        defaultService: UltrasoundImagingService,
+        defaultPatient: ElderJordanPatient,
+      });
+      await settleAutocomplete();
+
+      expect(screen.getByText(MainClinic.name as string)).toBeInTheDocument();
+      expect(screen.getByText('Ultrasound Imaging')).toBeInTheDocument();
+      expect(screen.getByText('Jordan Reyes')).toBeInTheDocument();
+    });
+
     test('Reports the time search opening and closing', async () => {
       const onToggleTimeFinder = vi.fn();
       setup(medplum, { onToggleTimeFinder });
@@ -820,6 +938,161 @@ describe('AppointmentBookingForm', () => {
       await openTimeFinder();
 
       expect(await screen.findByText(/Wednesday, September 2/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Identifying the patient', () => {
+    test('Offers patients matching the name typed', async () => {
+      setup(medplum);
+      await typeInAutocomplete(field(/patient/i), 'Whitfield');
+
+      expect(await screen.findByText('Sam Whitfield')).toBeInTheDocument();
+      expect(screen.queryByText('Jordan Reyes')).not.toBeInTheDocument();
+    });
+
+    test('Tells apart two patients who share a name', async () => {
+      setup(medplum);
+      await typeInAutocomplete(field(/patient/i), 'Jordan');
+
+      // The name is on both rows, so the birth date and the medical record
+      // number under it are the only things separating them.
+      expect(await screen.findByText(patientDetail(ElderJordanPatient, 'MRN-0041'))).toBeInTheDocument();
+      expect(screen.getByText(patientDetail(YoungerJordanPatient))).toBeInTheDocument();
+      expect(screen.getAllByText('Jordan Reyes')).toHaveLength(2);
+    });
+
+    test('Lists a patient with no medical record number by name and birth date', async () => {
+      setup(medplum);
+      await typeInAutocomplete(field(/patient/i), 'Jordan');
+
+      // Hiding somebody because a number is missing would lose the patient, not
+      // the ambiguity.
+      expect(await screen.findByText(patientDetail(YoungerJordanPatient))).toBeInTheDocument();
+    });
+
+    test('Reads the medical record number from the system the host named', async () => {
+      // Sam's identifier carries no type, so nothing but its system says what it
+      // is. Without `mrnSystem` the same patient lists by birth date alone.
+      setup(medplum, { mrnSystem: MRN_SYSTEM });
+      await typeInAutocomplete(field(/patient/i), 'Whitfield');
+
+      expect(await screen.findByText(patientDetail(UntypedMrnPatient, 'MRN-0099'))).toBeInTheDocument();
+    });
+
+    test('Leaves the patient out of the search for times', async () => {
+      const get = vi.spyOn(medplum, 'get');
+      setup(medplum);
+      await fillBooking();
+
+      // `$find` proposes times on calendars and knows nothing about who the
+      // visit is for; the patient is attached on the way to `$book`.
+      const searched = get.mock.calls.map(([url]) => String(url)).filter((url) => url.includes('find'));
+      expect(searched.length).toBeGreaterThan(0);
+      expect(searched.some((url) => url.includes('Patient'))).toBe(false);
+    });
+  });
+
+  describe('Recording what the visit is for', () => {
+    test('Names the patient as a required participant, once', async () => {
+      const post = vi.spyOn(medplum, 'post');
+      setup(medplum);
+      await fillBooking();
+      await clickBook();
+
+      const participants = postedAppointment(post).participant.filter(
+        (participant) => participant.actor?.reference === `Patient/${ElderJordanPatient.id}`
+      );
+      expect(participants).toHaveLength(1);
+      expect(participants[0].required).toBe('required');
+    });
+
+    test('Writes each free-text field onto its own element', async () => {
+      const post = vi.spyOn(medplum, 'post');
+      setup(medplum);
+      await fillBooking();
+      await typeInto(/reason for visit/i, 'Follow-up scan');
+      await typeInto(/notes or comments/i, 'Bring prior imaging');
+      await typeInto(/patient instructions/i, 'Arrive 15 minutes early');
+      await clickBook();
+
+      const booked = postedAppointment(post);
+      expect(booked.description).toBe('Follow-up scan');
+      expect(booked.comment).toBe('Bring prior imaging');
+      expect(booked.patientInstruction).toBe('Arrive 15 minutes early');
+    });
+
+    test('Leaves off an element whose field holds nothing', async () => {
+      const post = vi.spyOn(medplum, 'post');
+      setup(medplum);
+      await fillBooking();
+      // Whitespace is nothing typed, not a note saying nothing.
+      await typeInto(/notes or comments/i, '   ');
+      await clickBook();
+
+      const booked = postedAppointment(post);
+      expect(booked).not.toHaveProperty('description');
+      expect(booked).not.toHaveProperty('comment');
+      expect(booked).not.toHaveProperty('patientInstruction');
+    });
+  });
+
+  describe('Booking the appointment', () => {
+    test('Persists the booking and reports what was written', async () => {
+      const post = vi.spyOn(medplum, 'post');
+      setup(medplum);
+      await fillBooking();
+      await clickBook();
+
+      expect(String(post.mock.calls[0][0])).toContain('Appointment/$book');
+      const [booking] = onBooked.mock.calls[0] as [{ appointment: Appointment; slots: Slot[] }];
+      expect(booking.appointment.resourceType).toBe('Appointment');
+      expect(booking.slots.every((slot) => slot.resourceType === 'Slot')).toBe(true);
+    });
+
+    test('Announces the appointment and every slot it reserved', async () => {
+      const notify = vi.spyOn(medplum, 'notifyResourceModified');
+      setup(medplum);
+      await fillBooking();
+      await clickBook();
+
+      // `$book` is a custom operation, so nothing else invalidates the caches a
+      // host's own calendar reads from.
+      const announced = notify.mock.calls.map(([event]) => event.resourceType);
+      expect(announced).toContain('Appointment');
+      expect(announced).toContain('Slot');
+    });
+
+    test('Hands the proposal over to a host supplying onBook', async () => {
+      const onBook = vi.fn();
+      const post = vi.spyOn(medplum, 'post');
+      const notify = vi.spyOn(medplum, 'notifyResourceModified');
+      setup(medplum, { onBook });
+      await fillBooking();
+      await clickBook();
+
+      expect(onBook).toHaveBeenCalledTimes(1);
+      const [proposal] = onBook.mock.calls[0] as [Appointment];
+      expect(proposal.participant.some((p) => p.actor?.reference === `Patient/${ElderJordanPatient.id}`)).toBe(true);
+      // The host owns the write, so it owns invalidating its own caches too.
+      expect(post).not.toHaveBeenCalled();
+      expect(notify).not.toHaveBeenCalled();
+      expect(onBooked).not.toHaveBeenCalled();
+    });
+
+    test('Shows a refused booking and keeps every answer', async () => {
+      vi.spyOn(medplum, 'post').mockRejectedValue(new Error('Slot is no longer available'));
+      setup(medplum);
+      await fillBooking();
+      const time = (chosenTimeField() as HTMLInputElement).value;
+      await typeInto(/reason for visit/i, 'Follow-up scan');
+      await clickBook();
+
+      expect(await screen.findByText('Slot is no longer available')).toBeInTheDocument();
+      // A refusal is usually somebody else taking the time, and the next attempt
+      // is one field away.
+      expect(chosenTimeField()?.value).toBe(time);
+      expect(screen.getByText('Jordan Reyes')).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: /reason for visit/i })).toHaveValue('Follow-up scan');
     });
   });
 });

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.test.tsx
@@ -189,6 +189,15 @@ async function chooseFirstOfferedTime(): Promise<string> {
   return label;
 }
 
+/** Picks the next time along, for a change of mind about the first. */
+async function chooseSecondOfferedTime(): Promise<void> {
+  const [firstGroup] = await screen.findAllByTestId(/^slot-group-/);
+  const [, secondTime] = within(firstGroup).getAllByRole('button');
+  await act(async () => {
+    fireEvent.click(secondTime);
+  });
+}
+
 /**
  * Whether a field is holding a value, read off the pill rather than the state: the
  * fields ignore `defaultValue` after mount, so a cleared form could still show one.
@@ -247,6 +256,14 @@ function finderButton(): HTMLElement {
 }
 
 /**
+ * The action that writes the booking.
+ * @returns The button.
+ */
+function bookButton(): HTMLElement {
+  return screen.getByRole('button', { name: /book appointment/i });
+}
+
+/**
  * What one patient's option row reads under their name.
  * @param patient - The patient on offer.
  * @param mrn - Their medical record number, for a patient with one on file.
@@ -295,6 +312,19 @@ async function clickBook(): Promise<void> {
     fireEvent.click(screen.getByRole('button', { name: /book appointment/i }));
   });
   await settleAutocomplete();
+}
+
+/**
+ * How many times `$book` was posted.
+ *
+ * Counted off the URL rather than off the spy: the stub standing in for the
+ * server writes the appointment and its slots through the same `post`.
+ *
+ * @param post - The spy standing in front of the client's `post`.
+ * @returns The number of bookings written.
+ */
+function bookCount(post: MockInstance<MedplumClient['post']>): number {
+  return post.mock.calls.filter(([url]) => String(url).includes('$book')).length;
 }
 
 /**
@@ -1056,6 +1086,57 @@ describe('AppointmentBookingForm', () => {
       expect(post).not.toHaveBeenCalled();
       expect(notify).not.toHaveBeenCalled();
       expect(onBooked).not.toHaveBeenCalled();
+    });
+
+    test('Reports a booking the host callback threw over as written', async () => {
+      onBooked.mockRejectedValueOnce(new Error('Calendar refresh failed'));
+      const post = vi.spyOn(medplum, 'post');
+      setup(medplum);
+      await fillBooking();
+      await clickBook();
+
+      // The appointment exists by the time `onBooked` runs, so what the host does
+      // with it afterwards is not the booking failing. Painting the refusal here
+      // would show an error over a time that was taken, and invite a second click.
+      expect(bookCount(post)).toBe(1);
+      expect(screen.queryByText('Calendar refresh failed')).not.toBeInTheDocument();
+    });
+
+    test('Writes a booking once, however many times the button is clicked', async () => {
+      const post = vi.spyOn(medplum, 'post');
+      setup(medplum);
+      await fillBooking();
+      await clickBook();
+
+      // Every answer stays on screen, because a refusal needs them; the button is
+      // what keeps that from booking the same time a second time.
+      expect(bookButton()).toBeDisabled();
+      await clickBook();
+      expect(bookCount(post)).toBe(1);
+    });
+
+    test('Offers to book again once the patient changes', async () => {
+      setup(medplum);
+      await fillBooking();
+      await clickBook();
+      expect(bookButton()).toBeDisabled();
+
+      await removePill('Jordan Reyes');
+      await choosePatient('Jordan', patientDetail(YoungerJordanPatient));
+
+      // The other Jordan is a different visit, not the one already written.
+      expect(bookButton()).toBeEnabled();
+    });
+
+    test('Offers to book again once the time changes', async () => {
+      setup(medplum);
+      await fillBooking();
+      await clickBook();
+      expect(bookButton()).toBeDisabled();
+
+      await chooseSecondOfferedTime();
+
+      expect(bookButton()).toBeEnabled();
     });
 
     test('Shows a refused booking and keeps every answer', async () => {

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
@@ -1,50 +1,13 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Alert, Button, Loader, Stack, Text, TextInput } from '@mantine/core';
 import type { WithId } from '@medplum/core';
-import {
-  createReference,
-  formatDate,
-  getIdentifier,
-  getIdentifierByType,
-  getReferenceString,
-  getSchedulingTimezone,
-  isDefined,
-  MRN_IDENTIFIER_TYPE,
-  normalizeErrorString,
-} from '@medplum/core';
-import type { Appointment, Bundle, HealthcareService, Location, Patient, Slot } from '@medplum/fhirtypes';
-import type { AsyncAutocompleteOption } from '@medplum/react';
-import { CalendarDateInput, ReferenceDisplay, ResourceInput } from '@medplum/react';
+import { isDefined } from '@medplum/core';
+import type { Appointment, Bundle, Slot } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
-import { IconCalendarSearch } from '@tabler/icons-react';
 import type { JSX } from 'react';
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { AppointmentActorSelect } from './AppointmentActorSelect';
-import { AppointmentDayTimes } from './AppointmentDayTimes';
-import classes from './AppointmentFinder.module.css';
-import type { SchedulingRole } from './AppointmentFinder.roles';
-import { getActorRoleLabel, SCHEDULING_ROLES } from './AppointmentFinder.roles';
-import type { ActorSelections, ScheduleCandidate } from './AppointmentFinder.schedules';
-import { getActorCombinations, getSelectedCandidates, getSelectionError } from './AppointmentFinder.schedules';
-import type { DateRange } from './AppointmentFinder.times';
-import { endOfDay, getDurationMinutes, getFindWindowError, groupAppointmentsByDay } from './AppointmentFinder.times';
-import { AppointmentOptionRow } from './AppointmentOptionRow';
-import { AppointmentServiceSelect } from './AppointmentServiceSelect';
-import { isServiceKeptAtLocation } from './AppointmentServiceSelect.utils';
-import { useProposedAppointments } from './useProposedAppointments';
-
-// Excludes what a room is rather than admitting what a site is: `physicalType` is
-// optional, so `physical-type=si,bu` would hide a Location that never declared one.
-const LOCATION_SEARCH_CRITERIA = { _count: '25', _sort: 'name', 'physical-type:not': 'ro,bd' };
-
-// Alphabetical, then by birth date: a short prefix — or the first click, before
-// anything is typed — leaves a list only a name orders usefully, and the birth
-// date is what tells the people sharing one apart.
-const PATIENT_SEARCH_CRITERIA = { _count: '25', _sort: 'name,birthdate' };
-
-// No month-wide scan exists, so every day is offered and the search answers.
-const NO_MARKED_DATES: Date[] = [];
+import { useCallback } from 'react';
+import type { AppointmentProposalFormProps } from './AppointmentProposalForm';
+import { AppointmentProposalForm } from './AppointmentProposalForm';
 
 /** What a booking wrote, as `Appointment/$book` returned it. */
 export interface AppointmentBooking {
@@ -53,534 +16,66 @@ export interface AppointmentBooking {
   readonly slots: readonly WithId<Slot>[];
 }
 
-export interface AppointmentBookingFormProps {
-  /** Pre-fills where the visit is, for a host that already knows. */
-  readonly defaultLocation?: WithId<Location>;
-  /** Pre-fills the visit type, for a deep link or a reschedule. */
-  readonly defaultService?: WithId<HealthcareService>;
-  /** Pre-fills who the visit is for, for a host launching from a patient's chart. */
-  readonly defaultPatient?: WithId<Patient>;
+export interface AppointmentBookingFormProps extends Omit<AppointmentProposalFormProps, 'onBook'> {
   /**
-   * The day the time search opens on. Defaults to today.
+   * Called with what the booking wrote.
    *
-   * A day, not a time: only a time `$find` offered can be chosen.
-   */
-  readonly defaultStart?: Date;
-  /**
-   * The `Identifier.system` a project issues medical record numbers under.
-   *
-   * Only needed where identifiers carry no `type`. Which identifier is the
-   * medical record number is a project's own convention, and there is nothing on
-   * an untyped one to recognise it by.
-   */
-  readonly mrnSystem?: string;
-  /**
-   * Called when the time search opens or closes.
-   *
-   * The times render beside the form, not under it, so a host in a side panel has
-   * to widen it to fit them.
-   */
-  readonly onToggleTimeFinder?: (open: boolean) => void;
-  /** Called with the visit type as it changes. */
-  readonly onChangeService?: (service: WithId<HealthcareService> | undefined) => void;
-  /**
-   * Takes the booking over, instead of the form writing it.
-   *
-   * For a host doing something other than `$book` with the proposal — holding it
-   * through `$hold`, or writing it inside a transaction of its own. The form
-   * writes nothing and announces nothing in that case, so a host taking this over
-   * owns invalidating its own caches.
-   */
-  readonly onBook?: (proposal: Appointment) => void | Promise<void>;
-  /**
-   * Called with what the booking wrote. Not called when `onBook` took it over.
-   *
-   * The answers stay on screen and the form stops offering to book, until one of
-   * them changes: a host is free to keep this mounted without it writing twice.
+   * The answers stay on screen and the form stops offering to book until one of
+   * them changes, so a host can keep this mounted without it writing twice. A
+   * failure here is logged rather than shown as a refusal: the appointment exists
+   * by the time it runs.
    */
   readonly onBooked: (booking: AppointmentBooking) => void | Promise<void>;
 }
 
 /**
- * Gathers what a visit is held on, finds a time every one of them is free, and
- * books it.
+ * The booking form, writing the booking itself.
  *
- * One field per scheduling role, each searching the schedules bookable for the
- * chosen visit type. Everything named attends, because `$find` intersects their
- * schedules — so naming a second room narrows the times rather than widening them.
+ * Wraps {@link AppointmentProposalForm}: posts `Appointment/$book`, announces the
+ * appointment and every time it reserved so views reading them refresh, then
+ * reports what was written through `onBooked` — the only required prop.
  *
- * Only a time the search offered can be chosen: the field holding it accepts no
- * input, so nothing can be booked onto time nobody checked availability for.
- *
- * The booking itself is the form's, not the host's: it posts `Appointment/$book`
- * and announces what came back, so a host embedding this needs no scheduling API
- * code of its own. `onBook` is there for the host that wants it anyway.
+ * A host doing something else with the proposal mounts the proposal form instead.
  *
  * @param props - The React props.
  * @returns The form.
  */
 export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.Element {
-  const {
-    defaultLocation,
-    defaultService,
-    defaultPatient,
-    defaultStart,
-    mrnSystem,
-    onToggleTimeFinder,
-    onChangeService,
-    onBook,
-    onBooked,
-  } = props;
-
+  const { onBooked, ...formProps } = props;
   const medplum = useMedplum();
 
-  const [location, setLocation] = useState<WithId<Location> | undefined>(defaultLocation);
-  const [service, setService] = useState<WithId<HealthcareService> | undefined>(defaultService);
-  const [selections, setSelections] = useState<ActorSelections>({});
-  const [range, setRange] = useState<DateRange>(() => oneDay(defaultStart ?? new Date()));
-  const [month, setMonth] = useState<Date | undefined>(defaultStart);
-  const [finding, setFinding] = useState(false);
-  const [chosen, setChosen] = useState<Appointment | undefined>(undefined);
-  // The fields ignore `defaultValue` after mount, so remounting is the only way to
-  // clear their pills. Counters, so a field is never remounted out from under a pick.
-  const [roleFieldsKey, setRoleFieldsKey] = useState(0);
-  const [serviceFieldKey, setServiceFieldKey] = useState(0);
-  const [patient, setPatient] = useState<WithId<Patient> | undefined>(defaultPatient);
-  const [booking, setBooking] = useState(false);
-  const [booked, setBooked] = useState(false);
-  const [bookError, setBookError] = useState<unknown>(undefined);
-
-  const selectionError = getSelectionError(selections);
-  const windowError = getFindWindowError(range);
-
-  // Derived, not a flag: closing is never its own rule, so losing the last provider
-  // closes the search however it was lost.
-  const searching = finding && !selectionError;
-
-  // Nothing is searched until the time search is open, so the answers above cost no
-  // request per keystroke.
-  const combinations = useMemo(
-    () => (searching && !windowError ? getActorCombinations(selections) : []),
-    [searching, windowError, selections]
-  );
-
-  const search = useProposedAppointments({ service, combinations, range });
-
-  // The first actor's schedule answers for all of them: every actor in one search
-  // shares the scheduling parameters, or `$find` rejects the request.
-  const timezone = useMemo(() => {
-    const [first] = getSelectedCandidates(selections);
-    return service ? getSchedulingTimezone(service, first?.schedule, first?.actorResource) : undefined;
-  }, [service, selections]);
-
-  const days = useMemo(() => groupAppointmentsByDay(search.appointments, timezone), [search.appointments, timezone]);
-
-  // The ref holds what the host was last told, so mounting reports nothing and a
-  // search that closed on its own is reported like one closed by hand.
-  const reported = useRef(false);
-  useEffect(() => {
-    if (reported.current !== searching) {
-      reported.current = searching;
-      onToggleTimeFinder?.(searching);
-    }
-  }, [searching, onToggleTimeFinder]);
-
-  const patientItem = useCallback(
-    (option: AsyncAutocompleteOption<WithId<Patient>>) => (
-      <AppointmentOptionRow label={option.label} detail={formatPatientDetail(option.resource, mrnSystem)} />
-    ),
-    [mrnSystem]
-  );
-
-  function toggleFinder(): void {
-    setFinding(!finding);
-  }
-
-  const chooseResources = useCallback((update: (selections: ActorSelections) => ActorSelections): void => {
-    setSelections(update);
-    // A chosen time is a proposal carrying the Slots it was found for. Booked after
-    // a resource changes it would hold whoever is named inside the proposal, and
-    // `$book` cannot catch that: the proposal is internally consistent.
-    setChosen(undefined);
-  }, []);
-
-  function chooseService(next: WithId<HealthcareService> | undefined): void {
-    setService(next);
-    onChangeService?.(next);
-    clearResources();
-  }
-
-  function chooseLocation(next: WithId<Location> | undefined): void {
-    setLocation(next);
-    clearResources();
-    if (service && !isServiceKeptAtLocation(service, next)) {
-      setService(undefined);
-      onChangeService?.(undefined);
-      setServiceFieldKey((key) => key + 1);
-    }
-  }
-
-  /**
-   * Clears every named resource, deliberately: a resource can be schedulable for more
-   * than one visit type, so some would survive a narrower check. Both the site and the
-   * visit type change which actors are offered, and re-asking is easier to explain than
-   * a partial clear.
-   */
-  function clearResources(): void {
-    setSelections({});
-    setChosen(undefined);
-    setRoleFieldsKey((key) => key + 1);
-  }
-
-  function chooseDay(date: Date): void {
-    setRange(oneDay(date));
-    setChosen(undefined);
-  }
-
-  // The two answers a written booking can still be changed by. Everything else
-  // above clears the chosen time, which disables the button on its own; these
-  // are what re-enable it, because changing either makes it a different visit.
-  function chooseTime(next: Appointment): void {
-    setChosen(next);
-    setBooked(false);
-  }
-
-  function choosePatient(next: WithId<Patient> | undefined): void {
-    setPatient(next);
-    setBooked(false);
-  }
-
-  async function bookAppointment(): Promise<void> {
-    if (!chosen || !patient) {
-      return;
-    }
-
-    setBooking(true);
-    setBookError(undefined);
-    try {
-      const proposal = buildBooking(chosen, patient);
-
-      if (onBook) {
-        // The host owns the write here, so a refusal from it is the booking's.
-        await onBook(proposal);
-        return;
-      }
-
-      let result: AppointmentBooking;
-      try {
-        const written = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(
-          medplum.fhirUrl('Appointment', '$book'),
-          { resourceType: 'Parameters', parameter: [{ name: 'appointment', resource: proposal }] }
-        );
-        result = readBooking(written);
-      } catch (error) {
-        // Left on screen with every answer still filled in: a refusal is usually
-        // somebody else taking the time, and the next attempt is one field away.
-        setBookError(error);
-        return;
-      }
-
-      // Only the write is reported as a booking that failed. Past it the
-      // appointment exists, and a red refusal over one that was written would
-      // invite a second click that books the time twice.
-      setBooked(true);
+  const book = useCallback(
+    async (proposal: Appointment): Promise<void> => {
+      const written = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(
+        medplum.fhirUrl('Appointment', '$book'),
+        { resourceType: 'Parameters', parameter: [{ name: 'appointment', resource: proposal }] }
+      );
+      const booking = readBooking(written);
 
       // `$book` is a custom operation, so the client cannot tell what it changed.
       // Announcing it is what refreshes a host's calendar beside this form.
       medplum.notifyResourceModified({
         resourceType: 'Appointment',
         operation: 'create',
-        id: result.appointment.id,
-        resource: result.appointment,
+        id: booking.appointment.id,
+        resource: booking.appointment,
       });
-      for (const slot of result.slots) {
+      for (const slot of booking.slots) {
         medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'create', id: slot.id, resource: slot });
       }
 
       try {
-        await onBooked(result);
+        await onBooked(booking);
       } catch (error) {
-        // Reported where a host's own failures are, never as the booking's: the
-        // appointment exists by now, and a red refusal over one that was written
-        // reads as a time still free.
+        // Not rethrown: the form would paint it as the booking's refusal, and a red
+        // refusal over an appointment that exists reads as a time still free.
         console.error(error);
       }
-    } catch (error) {
-      setBookError(error);
-    } finally {
-      setBooking(false);
-    }
-  }
-
-  return (
-    <div className={classes.layout}>
-      {/* Not a `form` element: this mounts inside a host's own surface, which may
-          already be one, and a form cannot be nested in a form. */}
-      <Stack className={classes.form} gap="sm">
-        <ResourceInput<WithId<Location>>
-          resourceType="Location"
-          name="location"
-          label="Location"
-          placeholder="Any location"
-          searchCriteria={LOCATION_SEARCH_CRITERIA}
-          defaultValue={defaultLocation}
-          onChange={chooseLocation}
-        />
-        <AppointmentServiceSelect
-          key={serviceFieldKey}
-          location={location}
-          // From state, not the prop: `defaultService` on a remount would put back
-          // the visit type the remount was clearing.
-          defaultValue={service}
-          onChange={chooseService}
-        />
-
-        {SCHEDULING_ROLES.map((role) => (
-          <RoleField
-            key={`${role}-${roleFieldsKey}`}
-            role={role}
-            service={service}
-            location={location}
-            disabled={!service}
-            onChange={chooseResources}
-          />
-        ))}
-
-        <ChosenTime
-          appointment={chosen}
-          timezone={timezone}
-          searching={searching}
-          blockedBy={service ? selectionError : 'Choose a visit type'}
-          onToggleFinder={toggleFinder}
-        />
-
-        {searching && (
-          <Stack gap={4}>
-            <CalendarDateInput
-              availableDates={NO_MARKED_DATES}
-              allowUnavailableDates
-              earliestDate={new Date()}
-              month={month}
-              selected={range.start}
-              onChangeMonth={setMonth}
-              onClick={chooseDay}
-            />
-            {windowError && <Alert color="yellow">{windowError}</Alert>}
-          </Stack>
-        )}
-
-        <ResourceInput<WithId<Patient>>
-          resourceType="Patient"
-          name="patient"
-          label="Patient"
-          placeholder="Search patients by name"
-          required
-          searchCriteria={PATIENT_SEARCH_CRITERIA}
-          defaultValue={defaultPatient}
-          itemComponent={patientItem}
-          onChange={choosePatient}
-        />
-
-        {bookError !== undefined && <Alert color="red">{normalizeErrorString(bookError)}</Alert>}
-        <Button
-          fullWidth
-          // A booking that was written is not written again: every answer is
-          // still on screen, and clicking through a second time would book the
-          // same time twice. Changing one of them makes it a new request.
-          disabled={!chosen || !patient || booked}
-          loading={booking}
-          onClick={bookAppointment}
-        >
-          Book appointment
-        </Button>
-      </Stack>
-
-      {searching && (
-        <Stack className={classes.results} gap="lg">
-          {search.loading && <Loader size="sm" />}
-          {search.error && <Alert color="red">{normalizeErrorString(search.error)}</Alert>}
-          {!search.loading &&
-            !search.error &&
-            days.map((day) => (
-              <AppointmentDayTimes
-                key={day.key}
-                date={day.date}
-                groups={day.groups}
-                timezone={timezone}
-                selected={chosen}
-                onSelectAppointment={chooseTime}
-              />
-            ))}
-          {!search.loading && !search.error && !windowError && days.length === 0 && (
-            <Text c="dimmed" ta="center">
-              No times are available for this selection.
-            </Text>
-          )}
-        </Stack>
-      )}
-    </div>
-  );
-}
-
-interface ChosenTimeProps {
-  readonly appointment: Appointment | undefined;
-  /** IANA timezone the visit is held in. */
-  readonly timezone: string | undefined;
-  readonly searching: boolean;
-  /** What is still owed before a time can be searched for, if anything. */
-  readonly blockedBy: string | undefined;
-  readonly onToggleFinder: () => void;
-}
-
-/**
- * The chosen time, and under it the action that found it.
- *
- * An input rather than plain text: overrides are not implemented, but when they are, a
- * permitted user gets this same field in this same place, editable and with a warning.
- *
- * @param props - The React props.
- * @returns The chosen time, once there is one, and the action.
- */
-function ChosenTime(props: ChosenTimeProps): JSX.Element {
-  const { appointment, timezone, searching, blockedBy, onToggleFinder } = props;
-
-  return (
-    <>
-      {appointment?.start && (
-        <TextInput
-          label="Date & time"
-          readOnly
-          value={formatZonedDateTime(new Date(appointment.start), timezone)}
-          // Mantine puts the description above the input by default.
-          inputWrapperOrder={['label', 'input', 'description']}
-          description={<ChosenTimeCommitment appointment={appointment} />}
-        />
-      )}
-
-      <Stack gap={4}>
-        <Button
-          variant="outline"
-          fullWidth
-          leftSection={<IconCalendarSearch size={16} stroke={1.8} />}
-          disabled={!!blockedBy}
-          onClick={onToggleFinder}
-        >
-          {getFinderLabel(searching, !!appointment)}
-        </Button>
-        {blockedBy && (
-          <Text size="xs" c="dimmed">
-            {blockedBy} first.
-          </Text>
-        )}
-      </Stack>
-    </>
-  );
-}
-
-interface ChosenTimeCommitmentProps {
-  readonly appointment: Appointment;
-}
-
-/**
- * What the chosen time commits to: how long the visit runs, and what holds it.
- *
- * Read off the proposal rather than the answers above, since the proposal is what
- * `$book` is handed. Inline elements only: it renders inside a `description`, which
- * is a paragraph.
- *
- * @param props - The React props.
- * @returns The detail beneath the time.
- */
-function ChosenTimeCommitment(props: ChosenTimeCommitmentProps): JSX.Element {
-  const { appointment } = props;
-  const actors = (appointment.participant ?? []).map((participant) => participant.actor).filter(isDefined);
-  const durationMinutes = getDurationMinutes(appointment);
-
-  return (
-    <>
-      {durationMinutes > 0 && `${durationMinutes} min visit`}
-      {actors.map((actor, index) => {
-        const roleLabel = getActorRoleLabel(actor);
-        return (
-          <Fragment key={getReferenceString(actor) ?? actor.display}>
-            {(index > 0 || durationMinutes > 0) && ' · '}
-            {roleLabel && `${roleLabel}: `}
-            <ReferenceDisplay value={actor} link={false} />
-          </Fragment>
-        );
-      })}
-    </>
-  );
-}
-
-/**
- * Names what the action does next.
- * @param searching - Whether the time search is open.
- * @param chosen - Whether a time has been picked.
- * @returns The button's label.
- */
-function getFinderLabel(searching: boolean, chosen: boolean): string {
-  if (searching) {
-    return 'Close time finder';
-  }
-  return chosen ? 'Change time' : 'Find a time';
-}
-
-interface RoleFieldProps {
-  readonly role: SchedulingRole;
-  readonly service: WithId<HealthcareService> | undefined;
-  readonly location: WithId<Location> | undefined;
-  readonly disabled?: boolean;
-  readonly onChange: (update: (selections: ActorSelections) => ActorSelections) => void;
-}
-
-/**
- * One role's field, writing its own key of the selections.
- *
- * A component of its own so the callback it hands down is stable per role: the
- * field searches on a changed callback, and an inline one would be new on every
- * keystroke anywhere in the form.
- *
- * @param props - The React props.
- * @returns The field for that role.
- */
-function RoleField(props: RoleFieldProps): JSX.Element {
-  const { role, service, location, disabled, onChange } = props;
-
-  const handleChange = useCallback(
-    (candidates: readonly ScheduleCandidate[]) => onChange((selections) => ({ ...selections, [role]: candidates })),
-    [onChange, role]
+    },
+    [medplum, onBooked]
   );
 
-  return (
-    <AppointmentActorSelect
-      role={role}
-      service={service}
-      location={location}
-      disabled={disabled}
-      onChange={handleChange}
-    />
-  );
-}
-
-/**
- * Puts the patient onto the proposal that will be booked.
- *
- * @param proposal - The time that was chosen, as `$find` offered it.
- * @param patient - Who the visit is for.
- * @returns The appointment to book.
- */
-function buildBooking(proposal: Appointment, patient: WithId<Patient>): Appointment {
-  const patientReference = getReferenceString(patient);
-  return {
-    ...proposal,
-    participant: [
-      // A proposal knows nothing about patients, but a host may have put one on
-      // the appointment it handed over, and naming them twice books them twice.
-      ...proposal.participant.filter((participant) => participant.actor?.reference !== patientReference),
-      { actor: createReference(patient), required: 'required', status: 'needs-action' },
-    ],
-  };
+  return <AppointmentProposalForm {...formProps} onBook={book} />;
 }
 
 /**
@@ -597,67 +92,4 @@ function readBooking(written: Bundle<WithId<Appointment> | WithId<Slot>>): Appoi
     throw new Error('$book returned no appointment');
   }
   return { appointment, slots: resources.filter((resource) => resource.resourceType === 'Slot') };
-}
-
-/**
- * What tells one patient apart from another of the same name.
- * @param patient - The patient on offer.
- * @param mrnSystem - The system a project issues medical record numbers under.
- * @returns The line under their name, or undefined when nothing is on file.
- */
-function formatPatientDetail(patient: WithId<Patient>, mrnSystem: string | undefined): string | undefined {
-  const mrn = getMedicalRecordNumber(patient, mrnSystem);
-  return [formatDate(patient.birthDate), mrn && `MRN ${mrn}`].filter(Boolean).join(' · ') || undefined;
-}
-
-/**
- * Reads a patient's medical record number.
- *
- * A typed identifier answers it whoever issued it, which is the case that needs
- * no configuration. `mrnSystem` is for the project whose identifiers carry no
- * type, where nothing but the system says which one this is.
- *
- * @param patient - The patient to read.
- * @param mrnSystem - The system a project issues medical record numbers under.
- * @returns The medical record number, or undefined for a patient with none.
- */
-function getMedicalRecordNumber(patient: WithId<Patient>, mrnSystem: string | undefined): string | undefined {
-  return (
-    getIdentifierByType(patient, MRN_IDENTIFIER_TYPE) ?? (mrnSystem ? getIdentifier(patient, mrnSystem) : undefined)
-  );
-}
-
-/**
- * Returns the range covering the bookable part of one day.
- *
- * `$find` treats `start` as a hard floor, so a day already under way starts from now
- * rather than midnight: the calendar hands back local midnight, and asking from there
- * would offer times that have already passed.
- *
- * @param date - Any instant during the day.
- * @returns The day from now at the earliest, both ends closed, as `$find` requires.
- */
-function oneDay(date: Date): DateRange {
-  const now = new Date();
-  const start = date > now ? date : now;
-  return { start, end: endOfDay(start) };
-}
-
-/**
- * Writes an instant as the day and time it falls on at the site, not on the
- * booker's own clock.
- *
- * @param value - The chosen start time.
- * @param timezone - IANA timezone the visit is scheduled in.
- * @returns The time to display.
- */
-function formatZonedDateTime(value: Date, timezone: string | undefined): string {
-  return new Intl.DateTimeFormat(undefined, {
-    timeZone: timezone,
-    weekday: 'long',
-    month: 'long',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  }).format(value);
 }

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
@@ -91,7 +91,12 @@ export interface AppointmentBookingFormProps {
    * owns invalidating its own caches.
    */
   readonly onBook?: (proposal: Appointment) => void | Promise<void>;
-  /** Called with what the booking wrote. Not called when `onBook` took it over. */
+  /**
+   * Called with what the booking wrote. Not called when `onBook` took it over.
+   *
+   * The answers stay on screen and the form stops offering to book, until one of
+   * them changes: a host is free to keep this mounted without it writing twice.
+   */
   readonly onBooked: (booking: AppointmentBooking) => void | Promise<void>;
 }
 
@@ -141,6 +146,7 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
   const [serviceFieldKey, setServiceFieldKey] = useState(0);
   const [patient, setPatient] = useState<WithId<Patient> | undefined>(defaultPatient);
   const [booking, setBooking] = useState(false);
+  const [booked, setBooked] = useState(false);
   const [bookError, setBookError] = useState<unknown>(undefined);
 
   const selectionError = getSelectionError(selections);
@@ -230,6 +236,19 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
     setChosen(undefined);
   }
 
+  // The two answers a written booking can still be changed by. Everything else
+  // above clears the chosen time, which disables the button on its own; these
+  // are what re-enable it, because changing either makes it a different visit.
+  function chooseTime(next: Appointment): void {
+    setChosen(next);
+    setBooked(false);
+  }
+
+  function choosePatient(next: WithId<Patient> | undefined): void {
+    setPatient(next);
+    setBooked(false);
+  }
+
   async function bookAppointment(): Promise<void> {
     if (!chosen || !patient) {
       return;
@@ -241,32 +260,51 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
       const proposal = buildBooking(chosen, patient);
 
       if (onBook) {
+        // The host owns the write here, so a refusal from it is the booking's.
         await onBook(proposal);
         return;
       }
 
-      const written = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(
-        medplum.fhirUrl('Appointment', '$book'),
-        { resourceType: 'Parameters', parameter: [{ name: 'appointment', resource: proposal }] }
-      );
-      const booked = readBooking(written);
+      let result: AppointmentBooking;
+      try {
+        const written = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(
+          medplum.fhirUrl('Appointment', '$book'),
+          { resourceType: 'Parameters', parameter: [{ name: 'appointment', resource: proposal }] }
+        );
+        result = readBooking(written);
+      } catch (error) {
+        // Left on screen with every answer still filled in: a refusal is usually
+        // somebody else taking the time, and the next attempt is one field away.
+        setBookError(error);
+        return;
+      }
+
+      // Only the write is reported as a booking that failed. Past it the
+      // appointment exists, and a red refusal over one that was written would
+      // invite a second click that books the time twice.
+      setBooked(true);
 
       // `$book` is a custom operation, so the client cannot tell what it changed.
       // Announcing it is what refreshes a host's calendar beside this form.
       medplum.notifyResourceModified({
         resourceType: 'Appointment',
         operation: 'create',
-        id: booked.appointment.id,
-        resource: booked.appointment,
+        id: result.appointment.id,
+        resource: result.appointment,
       });
-      for (const slot of booked.slots) {
+      for (const slot of result.slots) {
         medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'create', id: slot.id, resource: slot });
       }
 
-      await onBooked(booked);
+      try {
+        await onBooked(result);
+      } catch (error) {
+        // Reported where a host's own failures are, never as the booking's: the
+        // appointment exists by now, and a red refusal over one that was written
+        // reads as a time still free.
+        console.error(error);
+      }
     } catch (error) {
-      // Left on screen with every answer still filled in: a refusal is usually
-      // somebody else taking the time, and the next attempt is one field away.
       setBookError(error);
     } finally {
       setBooking(false);
@@ -339,11 +377,19 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
           searchCriteria={PATIENT_SEARCH_CRITERIA}
           defaultValue={defaultPatient}
           itemComponent={patientItem}
-          onChange={setPatient}
+          onChange={choosePatient}
         />
 
         {bookError !== undefined && <Alert color="red">{normalizeErrorString(bookError)}</Alert>}
-        <Button fullWidth disabled={!chosen || !patient} loading={booking} onClick={bookAppointment}>
+        <Button
+          fullWidth
+          // A booking that was written is not written again: every answer is
+          // still on screen, and clicking through a second time would book the
+          // same time twice. Changing one of them makes it a new request.
+          disabled={!chosen || !patient || booked}
+          loading={booking}
+          onClick={bookAppointment}
+        >
           Book appointment
         </Button>
       </Stack>
@@ -361,7 +407,7 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
                 groups={day.groups}
                 timezone={timezone}
                 selected={chosen}
-                onSelectAppointment={setChosen}
+                onSelectAppointment={chooseTime}
               />
             ))}
           {!search.loading && !search.error && !windowError && days.length === 0 && (

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
@@ -310,24 +310,6 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
           />
         ))}
 
-        <ResourceInput<WithId<Patient>>
-          resourceType="Patient"
-          name="patient"
-          label="Patient"
-          placeholder="Search patients by name"
-          required
-          searchCriteria={PATIENT_SEARCH_CRITERIA}
-          defaultValue={defaultPatient}
-          itemComponent={patientItem}
-          onChange={setPatient}
-        />
-        <TextInput
-          label="Reason for visit"
-          placeholder="What the visit is for"
-          value={reason}
-          onChange={(event) => setReason(event.currentTarget.value)}
-        />
-
         <ChosenTime
           appointment={chosen}
           timezone={timezone}
@@ -351,8 +333,23 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
           </Stack>
         )}
 
-        {/* Below the booking decision: they are the longest fields on the form and
-            the least likely to change what can be booked. */}
+        <ResourceInput<WithId<Patient>>
+          resourceType="Patient"
+          name="patient"
+          label="Patient"
+          placeholder="Search patients by name"
+          required
+          searchCriteria={PATIENT_SEARCH_CRITERIA}
+          defaultValue={defaultPatient}
+          itemComponent={patientItem}
+          onChange={setPatient}
+        />
+        <TextInput
+          label="Reason for visit"
+          placeholder="What the visit is for"
+          value={reason}
+          onChange={(event) => setReason(event.currentTarget.value)}
+        />
         <Textarea
           label="Notes or comments"
           description="Kept internally, for the practice."

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
@@ -38,9 +38,10 @@ import { useProposedAppointments } from './useProposedAppointments';
 // optional, so `physical-type=si,bu` would hide a Location that never declared one.
 const LOCATION_SEARCH_CRITERIA = { _count: '25', _sort: 'name', 'physical-type:not': 'ro,bd' };
 
-// Birth date rather than name: the list is already narrowed by the name that was
-// typed, so what orders it usefully is the thing that tells those people apart.
-const PATIENT_SEARCH_CRITERIA = { _count: '25', _sort: 'birthdate' };
+// Alphabetical, then by birth date: a short prefix — or the first click, before
+// anything is typed — leaves a list only a name orders usefully, and the birth
+// date is what tells the people sharing one apart.
+const PATIENT_SEARCH_CRITERIA = { _count: '25', _sort: 'name,birthdate' };
 
 // No month-wide scan exists, so every day is offered and the search answers.
 const NO_MARKED_DATES: Date[] = [];

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Alert, Button, Loader, Stack, Text, Textarea, TextInput } from '@mantine/core';
+import { Alert, Button, Loader, Stack, Text, TextInput } from '@mantine/core';
 import type { WithId } from '@medplum/core';
 import {
   createReference,
@@ -140,9 +140,6 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
   const [roleFieldsKey, setRoleFieldsKey] = useState(0);
   const [serviceFieldKey, setServiceFieldKey] = useState(0);
   const [patient, setPatient] = useState<WithId<Patient> | undefined>(defaultPatient);
-  const [reason, setReason] = useState('');
-  const [comment, setComment] = useState('');
-  const [patientInstruction, setPatientInstruction] = useState('');
   const [booking, setBooking] = useState(false);
   const [bookError, setBookError] = useState<unknown>(undefined);
 
@@ -241,7 +238,7 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
     setBooking(true);
     setBookError(undefined);
     try {
-      const proposal = buildBooking(chosen, patient, { reason, comment, patientInstruction });
+      const proposal = buildBooking(chosen, patient);
 
       if (onBook) {
         await onBook(proposal);
@@ -343,28 +340,6 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
           defaultValue={defaultPatient}
           itemComponent={patientItem}
           onChange={setPatient}
-        />
-        <TextInput
-          label="Reason for visit"
-          placeholder="What the visit is for"
-          value={reason}
-          onChange={(event) => setReason(event.currentTarget.value)}
-        />
-        <Textarea
-          label="Notes or comments"
-          description="Kept internally, for the practice."
-          autosize
-          minRows={2}
-          value={comment}
-          onChange={(event) => setComment(event.currentTarget.value)}
-        />
-        <Textarea
-          label="Patient instructions"
-          description="Shown to the patient."
-          autosize
-          minRows={2}
-          value={patientInstruction}
-          onChange={(event) => setPatientInstruction(event.currentTarget.value)}
         />
 
         {bookError !== undefined && <Alert color="red">{normalizeErrorString(bookError)}</Alert>}
@@ -541,24 +516,16 @@ function RoleField(props: RoleFieldProps): JSX.Element {
   );
 }
 
-/** The free text written onto a booking, as typed. */
-interface AppointmentNotes {
-  readonly reason: string;
-  readonly comment: string;
-  readonly patientInstruction: string;
-}
-
 /**
- * Puts the patient and the free text onto the proposal that will be booked.
+ * Puts the patient onto the proposal that will be booked.
  *
  * @param proposal - The time that was chosen, as `$find` offered it.
  * @param patient - Who the visit is for.
- * @param notes - What was typed about it.
  * @returns The appointment to book.
  */
-function buildBooking(proposal: Appointment, patient: WithId<Patient>, notes: AppointmentNotes): Appointment {
+function buildBooking(proposal: Appointment, patient: WithId<Patient>): Appointment {
   const patientReference = getReferenceString(patient);
-  const booking: Appointment = {
+  return {
     ...proposal,
     participant: [
       // A proposal knows nothing about patients, but a host may have put one on
@@ -567,23 +534,6 @@ function buildBooking(proposal: Appointment, patient: WithId<Patient>, notes: Ap
       { actor: createReference(patient), required: 'required', status: 'needs-action' },
     ],
   };
-
-  // A field nobody filled in is left off rather than written empty: an empty
-  // string is a note saying nothing, which reads as a note on the chart.
-  const description = notes.reason.trim();
-  if (description) {
-    booking.description = description;
-  }
-  const comment = notes.comment.trim();
-  if (comment) {
-    booking.comment = comment;
-  }
-  const patientInstruction = notes.patientInstruction.trim();
-  if (patientInstruction) {
-    booking.patientInstruction = patientInstruction;
-  }
-
-  return booking;
 }
 
 /**

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentBookingForm.tsx
@@ -1,10 +1,22 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Alert, Button, Loader, Stack, Text, TextInput } from '@mantine/core';
+import { Alert, Button, Loader, Stack, Text, Textarea, TextInput } from '@mantine/core';
 import type { WithId } from '@medplum/core';
-import { getReferenceString, getSchedulingTimezone, isDefined, normalizeErrorString } from '@medplum/core';
-import type { Appointment, HealthcareService, Location } from '@medplum/fhirtypes';
+import {
+  createReference,
+  formatDate,
+  getIdentifier,
+  getIdentifierByType,
+  getReferenceString,
+  getSchedulingTimezone,
+  isDefined,
+  MRN_IDENTIFIER_TYPE,
+  normalizeErrorString,
+} from '@medplum/core';
+import type { Appointment, Bundle, HealthcareService, Location, Patient, Slot } from '@medplum/fhirtypes';
+import type { AsyncAutocompleteOption } from '@medplum/react';
 import { CalendarDateInput, ReferenceDisplay, ResourceInput } from '@medplum/react';
+import { useMedplum } from '@medplum/react-hooks';
 import { IconCalendarSearch } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -17,6 +29,7 @@ import type { ActorSelections, ScheduleCandidate } from './AppointmentFinder.sch
 import { getActorCombinations, getSelectedCandidates, getSelectionError } from './AppointmentFinder.schedules';
 import type { DateRange } from './AppointmentFinder.times';
 import { endOfDay, getDurationMinutes, getFindWindowError, groupAppointmentsByDay } from './AppointmentFinder.times';
+import { AppointmentOptionRow } from './AppointmentOptionRow';
 import { AppointmentServiceSelect } from './AppointmentServiceSelect';
 import { isServiceKeptAtLocation } from './AppointmentServiceSelect.utils';
 import { useProposedAppointments } from './useProposedAppointments';
@@ -25,20 +38,41 @@ import { useProposedAppointments } from './useProposedAppointments';
 // optional, so `physical-type=si,bu` would hide a Location that never declared one.
 const LOCATION_SEARCH_CRITERIA = { _count: '25', _sort: 'name', 'physical-type:not': 'ro,bd' };
 
+// Birth date rather than name: the list is already narrowed by the name that was
+// typed, so what orders it usefully is the thing that tells those people apart.
+const PATIENT_SEARCH_CRITERIA = { _count: '25', _sort: 'birthdate' };
+
 // No month-wide scan exists, so every day is offered and the search answers.
 const NO_MARKED_DATES: Date[] = [];
+
+/** What a booking wrote, as `Appointment/$book` returned it. */
+export interface AppointmentBooking {
+  readonly appointment: WithId<Appointment>;
+  /** The times reserved for it, one per schedule it is held on. */
+  readonly slots: readonly WithId<Slot>[];
+}
 
 export interface AppointmentBookingFormProps {
   /** Pre-fills where the visit is, for a host that already knows. */
   readonly defaultLocation?: WithId<Location>;
   /** Pre-fills the visit type, for a deep link or a reschedule. */
   readonly defaultService?: WithId<HealthcareService>;
+  /** Pre-fills who the visit is for, for a host launching from a patient's chart. */
+  readonly defaultPatient?: WithId<Patient>;
   /**
    * The day the time search opens on. Defaults to today.
    *
    * A day, not a time: only a time `$find` offered can be chosen.
    */
   readonly defaultStart?: Date;
+  /**
+   * The `Identifier.system` a project issues medical record numbers under.
+   *
+   * Only needed where identifiers carry no `type`. Which identifier is the
+   * medical record number is a project's own convention, and there is nothing on
+   * an untyped one to recognise it by.
+   */
+  readonly mrnSystem?: string;
   /**
    * Called when the time search opens or closes.
    *
@@ -48,10 +82,22 @@ export interface AppointmentBookingFormProps {
   readonly onToggleTimeFinder?: (open: boolean) => void;
   /** Called with the visit type as it changes. */
   readonly onChangeService?: (service: WithId<HealthcareService> | undefined) => void;
+  /**
+   * Takes the booking over, instead of the form writing it.
+   *
+   * For a host doing something other than `$book` with the proposal — holding it
+   * through `$hold`, or writing it inside a transaction of its own. The form
+   * writes nothing and announces nothing in that case, so a host taking this over
+   * owns invalidating its own caches.
+   */
+  readonly onBook?: (proposal: Appointment) => void | Promise<void>;
+  /** Called with what the booking wrote. Not called when `onBook` took it over. */
+  readonly onBooked: (booking: AppointmentBooking) => void | Promise<void>;
 }
 
 /**
- * Gathers what a visit is held on, and finds a time every one of them is free.
+ * Gathers what a visit is held on, finds a time every one of them is free, and
+ * books it.
  *
  * One field per scheduling role, each searching the schedules bookable for the
  * chosen visit type. Everything named attends, because `$find` intersects their
@@ -60,11 +106,27 @@ export interface AppointmentBookingFormProps {
  * Only a time the search offered can be chosen: the field holding it accepts no
  * input, so nothing can be booked onto time nobody checked availability for.
  *
+ * The booking itself is the form's, not the host's: it posts `Appointment/$book`
+ * and announces what came back, so a host embedding this needs no scheduling API
+ * code of its own. `onBook` is there for the host that wants it anyway.
+ *
  * @param props - The React props.
  * @returns The form.
  */
 export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.Element {
-  const { defaultLocation, defaultService, defaultStart, onToggleTimeFinder, onChangeService } = props;
+  const {
+    defaultLocation,
+    defaultService,
+    defaultPatient,
+    defaultStart,
+    mrnSystem,
+    onToggleTimeFinder,
+    onChangeService,
+    onBook,
+    onBooked,
+  } = props;
+
+  const medplum = useMedplum();
 
   const [location, setLocation] = useState<WithId<Location> | undefined>(defaultLocation);
   const [service, setService] = useState<WithId<HealthcareService> | undefined>(defaultService);
@@ -77,6 +139,12 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
   // clear their pills. Counters, so a field is never remounted out from under a pick.
   const [roleFieldsKey, setRoleFieldsKey] = useState(0);
   const [serviceFieldKey, setServiceFieldKey] = useState(0);
+  const [patient, setPatient] = useState<WithId<Patient> | undefined>(defaultPatient);
+  const [reason, setReason] = useState('');
+  const [comment, setComment] = useState('');
+  const [patientInstruction, setPatientInstruction] = useState('');
+  const [booking, setBooking] = useState(false);
+  const [bookError, setBookError] = useState<unknown>(undefined);
 
   const selectionError = getSelectionError(selections);
   const windowError = getFindWindowError(range);
@@ -112,6 +180,13 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
       onToggleTimeFinder?.(searching);
     }
   }, [searching, onToggleTimeFinder]);
+
+  const patientItem = useCallback(
+    (option: AsyncAutocompleteOption<WithId<Patient>>) => (
+      <AppointmentOptionRow label={option.label} detail={formatPatientDetail(option.resource, mrnSystem)} />
+    ),
+    [mrnSystem]
+  );
 
   function toggleFinder(): void {
     setFinding(!finding);
@@ -158,8 +233,53 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
     setChosen(undefined);
   }
 
+  async function bookAppointment(): Promise<void> {
+    if (!chosen || !patient) {
+      return;
+    }
+
+    setBooking(true);
+    setBookError(undefined);
+    try {
+      const proposal = buildBooking(chosen, patient, { reason, comment, patientInstruction });
+
+      if (onBook) {
+        await onBook(proposal);
+        return;
+      }
+
+      const written = await medplum.post<Bundle<WithId<Appointment> | WithId<Slot>>>(
+        medplum.fhirUrl('Appointment', '$book'),
+        { resourceType: 'Parameters', parameter: [{ name: 'appointment', resource: proposal }] }
+      );
+      const booked = readBooking(written);
+
+      // `$book` is a custom operation, so the client cannot tell what it changed.
+      // Announcing it is what refreshes a host's calendar beside this form.
+      medplum.notifyResourceModified({
+        resourceType: 'Appointment',
+        operation: 'create',
+        id: booked.appointment.id,
+        resource: booked.appointment,
+      });
+      for (const slot of booked.slots) {
+        medplum.notifyResourceModified({ resourceType: 'Slot', operation: 'create', id: slot.id, resource: slot });
+      }
+
+      await onBooked(booked);
+    } catch (error) {
+      // Left on screen with every answer still filled in: a refusal is usually
+      // somebody else taking the time, and the next attempt is one field away.
+      setBookError(error);
+    } finally {
+      setBooking(false);
+    }
+  }
+
   return (
     <div className={classes.layout}>
+      {/* Not a `form` element: this mounts inside a host's own surface, which may
+          already be one, and a form cannot be nested in a form. */}
       <Stack className={classes.form} gap="sm">
         <ResourceInput<WithId<Location>>
           resourceType="Location"
@@ -190,6 +310,24 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
           />
         ))}
 
+        <ResourceInput<WithId<Patient>>
+          resourceType="Patient"
+          name="patient"
+          label="Patient"
+          placeholder="Search patients by name"
+          required
+          searchCriteria={PATIENT_SEARCH_CRITERIA}
+          defaultValue={defaultPatient}
+          itemComponent={patientItem}
+          onChange={setPatient}
+        />
+        <TextInput
+          label="Reason for visit"
+          placeholder="What the visit is for"
+          value={reason}
+          onChange={(event) => setReason(event.currentTarget.value)}
+        />
+
         <ChosenTime
           appointment={chosen}
           timezone={timezone}
@@ -212,6 +350,30 @@ export function AppointmentBookingForm(props: AppointmentBookingFormProps): JSX.
             {windowError && <Alert color="yellow">{windowError}</Alert>}
           </Stack>
         )}
+
+        {/* Below the booking decision: they are the longest fields on the form and
+            the least likely to change what can be booked. */}
+        <Textarea
+          label="Notes or comments"
+          description="Kept internally, for the practice."
+          autosize
+          minRows={2}
+          value={comment}
+          onChange={(event) => setComment(event.currentTarget.value)}
+        />
+        <Textarea
+          label="Patient instructions"
+          description="Shown to the patient."
+          autosize
+          minRows={2}
+          value={patientInstruction}
+          onChange={(event) => setPatientInstruction(event.currentTarget.value)}
+        />
+
+        {bookError !== undefined && <Alert color="red">{normalizeErrorString(bookError)}</Alert>}
+        <Button fullWidth disabled={!chosen || !patient} loading={booking} onClick={bookAppointment}>
+          Book appointment
+        </Button>
       </Stack>
 
       {searching && (
@@ -379,6 +541,95 @@ function RoleField(props: RoleFieldProps): JSX.Element {
       disabled={disabled}
       onChange={handleChange}
     />
+  );
+}
+
+/** The free text written onto a booking, as typed. */
+interface AppointmentNotes {
+  readonly reason: string;
+  readonly comment: string;
+  readonly patientInstruction: string;
+}
+
+/**
+ * Puts the patient and the free text onto the proposal that will be booked.
+ *
+ * @param proposal - The time that was chosen, as `$find` offered it.
+ * @param patient - Who the visit is for.
+ * @param notes - What was typed about it.
+ * @returns The appointment to book.
+ */
+function buildBooking(proposal: Appointment, patient: WithId<Patient>, notes: AppointmentNotes): Appointment {
+  const patientReference = getReferenceString(patient);
+  const booking: Appointment = {
+    ...proposal,
+    participant: [
+      // A proposal knows nothing about patients, but a host may have put one on
+      // the appointment it handed over, and naming them twice books them twice.
+      ...proposal.participant.filter((participant) => participant.actor?.reference !== patientReference),
+      { actor: createReference(patient), required: 'required', status: 'needs-action' },
+    ],
+  };
+
+  // A field nobody filled in is left off rather than written empty: an empty
+  // string is a note saying nothing, which reads as a note on the chart.
+  const description = notes.reason.trim();
+  if (description) {
+    booking.description = description;
+  }
+  const comment = notes.comment.trim();
+  if (comment) {
+    booking.comment = comment;
+  }
+  const patientInstruction = notes.patientInstruction.trim();
+  if (patientInstruction) {
+    booking.patientInstruction = patientInstruction;
+  }
+
+  return booking;
+}
+
+/**
+ * Reads what `$book` wrote out of the bundle it answers with.
+ * @param written - The bundle `$book` returned.
+ * @returns The appointment and the times reserved for it.
+ */
+function readBooking(written: Bundle<WithId<Appointment> | WithId<Slot>>): AppointmentBooking {
+  const resources = (written.entry ?? []).map((entry) => entry.resource).filter(isDefined);
+  const appointment = resources.find((resource) => resource.resourceType === 'Appointment');
+  if (!appointment) {
+    // Cannot happen against a server that honoured the request, and the host is
+    // owed an appointment rather than a silent success.
+    throw new Error('$book returned no appointment');
+  }
+  return { appointment, slots: resources.filter((resource) => resource.resourceType === 'Slot') };
+}
+
+/**
+ * What tells one patient apart from another of the same name.
+ * @param patient - The patient on offer.
+ * @param mrnSystem - The system a project issues medical record numbers under.
+ * @returns The line under their name, or undefined when nothing is on file.
+ */
+function formatPatientDetail(patient: WithId<Patient>, mrnSystem: string | undefined): string | undefined {
+  const mrn = getMedicalRecordNumber(patient, mrnSystem);
+  return [formatDate(patient.birthDate), mrn && `MRN ${mrn}`].filter(Boolean).join(' · ') || undefined;
+}
+
+/**
+ * Reads a patient's medical record number.
+ *
+ * A typed identifier answers it whoever issued it, which is the case that needs
+ * no configuration. `mrnSystem` is for the project whose identifiers carry no
+ * type, where nothing but the system says which one this is.
+ *
+ * @param patient - The patient to read.
+ * @param mrnSystem - The system a project issues medical record numbers under.
+ * @returns The medical record number, or undefined for a patient with none.
+ */
+function getMedicalRecordNumber(patient: WithId<Patient>, mrnSystem: string | undefined): string | undefined {
+  return (
+    getIdentifierByType(patient, MRN_IDENTIFIER_TYPE) ?? (mrnSystem ? getIdentifier(patient, mrnSystem) : undefined)
   );
 }
 

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.test.tsx
@@ -1,0 +1,836 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { Appointment, Device } from '@medplum/fhirtypes';
+import type { MockClient } from '@medplum/mock';
+import type { JSX } from 'react';
+import { installFindStub } from '../stories/mockFind';
+import {
+  ElderJordanPatient,
+  MainClinic,
+  MRN_SYSTEM,
+  SatelliteClinic,
+  SurgeryService,
+  TelehealthService,
+  Ultrasound1Device,
+  UltrasoundImagingService,
+  UntypedMrnPatient,
+  YoungerJordanPatient,
+} from '../stories/scheduling';
+import {
+  clickAutocompleteOption,
+  installAutocompleteTimers,
+  settleAutocomplete,
+  typeInAutocomplete,
+} from '../test-utils/asyncAutocomplete';
+import {
+  bookButton,
+  chooseActor,
+  chooseDay,
+  chooseFirstOfferedTime,
+  chooseImagingService,
+  choosePatient,
+  chooseSecondOfferedTime,
+  chooseSite,
+  chosenTimeField,
+  clickBook,
+  field,
+  fillBooking,
+  finderButton,
+  hasPill,
+  isBefore,
+  lastFindStart,
+  MONDAY_MORNING,
+  openRoleField,
+  openTimeFinder,
+  patientDetail,
+  removePill,
+  searchField,
+  setupBookingClient,
+} from '../test-utils/bookingForm';
+import { act, fireEvent, renderWithMedplum, screen, waitFor, within } from '../test-utils/render';
+import type { AppointmentProposalFormProps } from './AppointmentProposalForm';
+import { AppointmentProposalForm } from './AppointmentProposalForm';
+
+/** The timezone the fixtures' visit type is held in, which is not the runner's. */
+const SITE_TIMEZONE = 'America/New_York';
+
+installAutocompleteTimers();
+
+/** Stands in for whoever writes the booking. */
+const onBook = vi.fn();
+
+function setup(medplum: MockClient, props?: Partial<AppointmentProposalFormProps>): void {
+  const element: JSX.Element = <AppointmentProposalForm onBook={onBook} {...props} />;
+  renderWithMedplum(element, medplum);
+}
+
+/**
+ * The proposal the form handed over, as it assembled it.
+ * @returns The appointment `onBook` was called with.
+ */
+function proposedAppointment(): Appointment {
+  const [proposal] = onBook.mock.calls[0] as [Appointment];
+  return proposal;
+}
+
+describe('AppointmentProposalForm', () => {
+  let medplum: MockClient;
+  let restoreFind: () => void;
+
+  beforeEach(async () => {
+    vi.setSystemTime(MONDAY_MORNING);
+    onBook.mockClear();
+    onBook.mockResolvedValue(undefined);
+    medplum = await setupBookingClient();
+    restoreFind = installFindStub(medplum);
+  });
+
+  afterEach(() => {
+    restoreFind();
+  });
+
+  describe('Choosing the resources a visit is held on', () => {
+    test('Offers a field for all three roles', async () => {
+      setup(medplum);
+      await chooseImagingService();
+
+      expect(field(/provider/i)).toBeInTheDocument();
+      expect(field(/room/i)).toBeInTheDocument();
+      expect(field(/device/i)).toBeInTheDocument();
+    });
+
+    test('Offers nothing to type into until a visit type is chosen', async () => {
+      setup(medplum);
+      await settleAutocomplete();
+
+      for (const role of [/^Provider$/, /^Room$/, /^Device$/]) {
+        expect(screen.queryByRole('searchbox', { name: role })).not.toBeInTheDocument();
+        expect(screen.getByText(role)).toBeInTheDocument();
+      }
+
+      await chooseImagingService();
+
+      expect(field(/provider/i)).toBeInTheDocument();
+    });
+
+    test('Offers no search until a provider is named, and says so', async () => {
+      setup(medplum);
+      await chooseImagingService();
+
+      // A room alone holds a room but no calendar to book it against.
+      await chooseActor(/room/i, 'exam', 'Exam Room A');
+
+      expect(finderButton()).toBeDisabled();
+      expect(screen.getByText('Choose at least one provider first.')).toBeInTheDocument();
+      expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
+
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+
+      expect(finderButton()).toBeEnabled();
+      expect(screen.queryByText('Choose at least one provider first.')).not.toBeInTheDocument();
+    });
+
+    test('Searches against the provider alone when the room and device are left empty', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      const [group] = await screen.findAllByTestId(/^slot-group-/);
+      expect(within(group).getByText('Dr. Maya Rivera')).toBeInTheDocument();
+      expect(within(group).queryByText('Exam Room A')).not.toBeInTheDocument();
+    });
+
+    test('Still offers a role the visit type has nothing configured for', async () => {
+      setup(medplum);
+      await chooseImagingService();
+
+      const input = await openRoleField(/device/i);
+      await typeInAutocomplete(input, 'nosuchdevice');
+
+      expect(input).toBeEnabled();
+      expect(await screen.findByText('No devices found')).toBeInTheDocument();
+    });
+
+    test('Naming two providers narrows the times to the ones both are free for', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await chooseActor(/provider/i, 'oka', 'Dr. Tunde Okafor');
+      await openTimeFinder();
+
+      // One group, not two: `$find` intersects the schedules it is given.
+      const groups = await screen.findAllByTestId(/^slot-group-/);
+      expect(groups).toHaveLength(1);
+      expect(within(groups[0]).getByText('Dr. Maya Rivera')).toBeInTheDocument();
+      expect(within(groups[0]).getByText('Dr. Tunde Okafor')).toBeInTheDocument();
+    });
+  });
+
+  describe('Narrowing resources to the chosen site', () => {
+    test('Offers a room that belongs to a place inside the chosen site', async () => {
+      setup(medplum, { defaultLocation: MainClinic, defaultService: UltrasoundImagingService });
+      await settleAutocomplete();
+
+      await openRoleField(/room/i);
+
+      // Exam Room B is `partOf` the second floor, which is `partOf` the clinic.
+      expect(await screen.findByText('Exam Room B')).toBeInTheDocument();
+      expect(screen.getByText('Exam Room A')).toBeInTheDocument();
+      expect(screen.queryByText('Satellite Exam Room')).not.toBeInTheDocument();
+    });
+
+    test('Offers a device kept inside the chosen site', async () => {
+      const sitedDevice: Device = { ...Ultrasound1Device, location: { reference: 'Location/second-floor' } };
+      await medplum.updateResource(sitedDevice);
+      setup(medplum, { defaultLocation: MainClinic, defaultService: UltrasoundImagingService });
+      await settleAutocomplete();
+
+      await openRoleField(/device/i);
+
+      expect(await screen.findByText('Ultrasound 1 (Main Campus)')).toBeInTheDocument();
+    });
+
+    test('Offers a provider whose role names the chosen site', async () => {
+      // Dr. Martinez's role names the main clinic itself, the only way a provider is sited.
+      setup(medplum, { defaultLocation: MainClinic, defaultService: SurgeryService });
+      await settleAutocomplete();
+
+      const input = await openRoleField(/provider/i);
+      await typeInAutocomplete(input, 'mart');
+
+      expect(await screen.findByText('Dr. Maria Martinez')).toBeInTheDocument();
+    });
+
+    test('Leaves out a provider whose roles name another site', async () => {
+      setup(medplum, { defaultLocation: SatelliteClinic, defaultService: SurgeryService });
+      await settleAutocomplete();
+
+      const input = await openRoleField(/provider/i);
+      await typeInAutocomplete(input, 'mart');
+
+      expect(await screen.findByText('No providers found')).toBeInTheDocument();
+      expect(screen.queryByText('Dr. Maria Martinez')).not.toBeInTheDocument();
+    });
+
+    test('Leaves out a provider sited inside the chosen site rather than at it, while offering a room there', async () => {
+      // A room is sited by walking `partOf`; a provider only by a role naming the
+      // site exactly.
+      setup(medplum, { defaultLocation: MainClinic, defaultService: UltrasoundImagingService });
+      await settleAutocomplete();
+
+      await openRoleField(/provider/i);
+      expect(await screen.findByText('Dr. Maya Rivera')).toBeInTheDocument();
+      expect(screen.queryByText('Dr. Ama Osei')).not.toBeInTheDocument();
+
+      await openRoleField(/room/i);
+      expect(await screen.findByText('Exam Room B')).toBeInTheDocument();
+    });
+
+    test('Keeps a resource that records nothing about where it is', async () => {
+      setup(medplum, { defaultLocation: SatelliteClinic, defaultService: UltrasoundImagingService });
+      await settleAutocomplete();
+
+      await openRoleField(/device/i);
+
+      // The devices record no location at all.
+      expect(await screen.findByText('Ultrasound 1 (Main Campus)')).toBeInTheDocument();
+    });
+
+    test('Narrows nothing by location when no site is chosen', async () => {
+      setup(medplum, { defaultService: UltrasoundImagingService });
+      await settleAutocomplete();
+
+      await openRoleField(/room/i);
+
+      expect(await screen.findByText('Exam Room A')).toBeInTheDocument();
+      expect(screen.getByText('Satellite Exam Room')).toBeInTheDocument();
+    });
+  });
+
+  describe('Choosing where the visit is held', () => {
+    test('Leaves a room and a bed out of the site field', async () => {
+      setup(medplum);
+
+      // Unscoped: a search that came back with nothing leaves no dropdown to scope to.
+      await typeInAutocomplete(field(/location/i), 'Exam Room A');
+
+      expect(await screen.findByText('Nothing found')).toBeInTheDocument();
+      expect(screen.queryByText('Exam Room A')).not.toBeInTheDocument();
+      expect(screen.queryByText('Exam Room A Bed 1')).not.toBeInTheDocument();
+    });
+
+    test('Offers a Location that records no physical type', async () => {
+      setup(medplum);
+
+      const listbox = await searchField(/location/i, 'Uro Associates');
+
+      // Neither clinic declares one, and nothing requires it: the field excludes what
+      // says it is a room rather than admitting only what says site.
+      expect(within(listbox).getByText('Uro Associates - Main Clinic')).toBeInTheDocument();
+      expect(within(listbox).getByText('Uro Associates - Satellite')).toBeInTheDocument();
+    });
+
+    test('Narrows the visit types to the chosen site, and says which site', async () => {
+      setup(medplum);
+      await chooseSite('Satellite', 'Uro Associates - Satellite');
+
+      await typeInAutocomplete(field(/visit type/i), 'Ultrasound');
+
+      expect(
+        screen.getByText('Showing visit types offered at Uro Associates - Satellite, plus those not tied to a site.')
+      ).toBeInTheDocument();
+      // Imaging names the main clinic, and only a visit type naming this site exactly
+      // is offered at it.
+      expect(await screen.findByText('Nothing found')).toBeInTheDocument();
+      expect(screen.queryByText('Ultrasound Imaging')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Offering only times every named resource is free', () => {
+    test('Offers the times the named resources share', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await chooseActor(/room/i, 'exam', 'Exam Room A');
+      await openTimeFinder();
+
+      const groups = await screen.findAllByTestId(/^slot-group-/);
+      expect(groups).toHaveLength(1);
+      expect(within(groups[0]).getByText('Dr. Maya Rivera')).toBeInTheDocument();
+      expect(within(groups[0]).getByText('Exam Room A')).toBeInTheDocument();
+    });
+
+    test('Issues no request until the time search is opened', async () => {
+      const get = vi.spyOn(medplum, 'get');
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+
+      expect(get.mock.calls.filter(([url]) => String(url).includes('find'))).toHaveLength(0);
+      expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
+
+      await openTimeFinder();
+
+      expect((await screen.findAllByTestId(/^slot-group-/)).length).toBeGreaterThan(0);
+    });
+
+    test('Says so when the search offers nothing', async () => {
+      restoreFind();
+      restoreFind = installFindStub(medplum, { empty: true });
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      expect(await screen.findByText('No times are available for this selection.')).toBeInTheDocument();
+    });
+
+    test('Replaces the times when another day is chosen', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      expect(await screen.findByText(/Monday, August 17/)).toBeInTheDocument();
+
+      await chooseDay('18');
+
+      await waitFor(() => expect(screen.getByText(/Tuesday, August 18/)).toBeInTheDocument());
+      expect(screen.queryByText(/Monday, August 17/)).not.toBeInTheDocument();
+    });
+
+    test('Searches today from now rather than from midnight', async () => {
+      const get = vi.spyOn(medplum, 'get');
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      // The calendar hands back local midnight, so picking today must not walk the
+      // floor back: `$find` honours whatever `start` it is given, and would answer
+      // with times that have already passed.
+      await chooseDay('17');
+
+      const start = lastFindStart(get);
+      expect(start).toBeDefined();
+      // Local midnight would be 07:00Z on this clock; the floor must not go back there.
+      expect(new Date(start as string).getTime()).toBeGreaterThanOrEqual(MONDAY_MORNING.getTime());
+    });
+  });
+
+  describe('Reading times in the site’s timezone', () => {
+    test('Shows an offered time as the time at the site', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      const [group] = await screen.findAllByTestId(/^slot-group-/);
+      const [firstTime] = within(group).getAllByRole('button');
+      // The stub lays times on the clinic's open hours in the runner's timezone, so the
+      // label is that instant read at the site rather than 9:00 repeated.
+      const start = new Date(2026, 7, 17, 9, 0, 0);
+
+      expect(firstTime).toHaveTextContent(
+        new Intl.DateTimeFormat(undefined, {
+          timeZone: SITE_TIMEZONE,
+          hour: 'numeric',
+          minute: '2-digit',
+        }).format(start)
+      );
+    });
+
+    test('Records the instant the site-local time stands for', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      const label = await chooseFirstOfferedTime();
+
+      expect(chosenTimeField()?.value).toContain(label);
+    });
+  });
+
+  describe('Booking only a time that was offered', () => {
+    test('Shows nothing standing in for a time before one is chosen', async () => {
+      setup(medplum);
+      await chooseImagingService();
+
+      expect(finderButton()).toHaveTextContent('Find a time');
+      expect(chosenTimeField()).not.toBeInTheDocument();
+      expect(screen.queryByRole('textbox', { name: /date|time/i })).not.toBeInTheDocument();
+    });
+
+    test('Shows the time that was picked in a field above the action', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await chooseActor(/room/i, 'exam', 'Exam Room A');
+      await openTimeFinder();
+
+      expect(chosenTimeField()).not.toBeInTheDocument();
+      const label = await chooseFirstOfferedTime();
+
+      const chosen = chosenTimeField() as HTMLInputElement;
+      expect(chosen.value).toContain(label);
+      expect(isBefore(chosen, finderButton())).toBe(true);
+      // Off the proposal, so what the field commits to is what `$book` would be handed.
+      expect(chosen).toHaveAccessibleDescription('30 min visit · Provider: Dr. Maya Rivera · Room: Exam Room A');
+    });
+
+    test('Offers no way to type or amend the chosen time', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await chooseFirstOfferedTime();
+
+      const shown = (chosenTimeField() as HTMLInputElement).value;
+      await act(async () => {
+        fireEvent.change(chosenTimeField() as HTMLInputElement, { target: { value: 'Monday, August 17 at 11:59 PM' } });
+      });
+
+      expect(chosenTimeField()).toHaveAttribute('readonly');
+      expect(chosenTimeField()?.value).toBe(shown);
+      expect(screen.getAllByRole('textbox', { name: /date|time/i })).toHaveLength(1);
+      expect(finderButton()).toBeInTheDocument();
+    });
+
+    test('Offers to change the time once one is chosen', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await chooseFirstOfferedTime();
+
+      await act(async () => {
+        fireEvent.click(finderButton());
+      });
+      await settleAutocomplete();
+
+      expect(finderButton()).toHaveTextContent('Change time');
+      expect(screen.queryByRole('button', { name: /^find a time$/i })).not.toBeInTheDocument();
+    });
+
+    test('Clears the chosen time when the day changes', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await chooseFirstOfferedTime();
+
+      await chooseDay('18');
+
+      expect(chosenTimeField()).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Clearing answers that no longer hold', () => {
+    test('Replacing the provider clears the time, so no booking can hold the old one', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await chooseFirstOfferedTime();
+      expect(chosenTimeField()).toHaveAccessibleDescription(/Dr. Maya Rivera/);
+
+      await removePill('Dr. Maya Rivera');
+      await chooseActor(/provider/i, 'oka', 'Dr. Tunde Okafor');
+
+      // A chosen time is a proposal carrying its own participants and Slots. Kept
+      // through this it would book Dr. Rivera while the form showed Dr. Okafor, and
+      // `$book` would accept it: that time genuinely was Dr. Rivera's.
+      expect(chosenTimeField()).not.toBeInTheDocument();
+
+      const label = await chooseFirstOfferedTime();
+
+      const chosen = chosenTimeField() as HTMLInputElement;
+      expect(chosen.value).toContain(label);
+      expect(chosen).toHaveAccessibleDescription(/Dr. Tunde Okafor/);
+      expect(chosen).not.toHaveAccessibleDescription(/Dr. Maya Rivera/);
+    });
+
+    test.each([
+      ['added', async (): Promise<void> => chooseActor(/room/i, 'exam', 'Exam Room A')],
+      ['removed', async (): Promise<void> => removePill('Exam Room A')],
+    ])('A room %s after a time was chosen clears it', async (_change, changeRoom) => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      if (_change === 'removed') {
+        await chooseActor(/room/i, 'exam', 'Exam Room A');
+      }
+      await openTimeFinder();
+      await chooseFirstOfferedTime();
+      expect(chosenTimeField()).toBeInTheDocument();
+
+      await changeRoom();
+
+      // A time found without a room's availability is not a time that room is free for,
+      // and one found with it does not hold once the room is dropped.
+      expect(chosenTimeField()).not.toBeInTheDocument();
+    });
+
+    test('A resource change leaves the search open and re-runs it', async () => {
+      const onToggleTimeFinder = vi.fn();
+      setup(medplum, { onToggleTimeFinder });
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await chooseFirstOfferedTime();
+      onToggleTimeFinder.mockClear();
+
+      await chooseActor(/room/i, 'exam', 'Exam Room A');
+
+      // Closing here would take back the panel width the host just widened, mid-task.
+      expect(finderButton()).toHaveTextContent('Close time finder');
+      expect(onToggleTimeFinder).not.toHaveBeenCalled();
+      const [group] = await screen.findAllByTestId(/^slot-group-/);
+      expect(within(group).getByText('Dr. Maya Rivera')).toBeInTheDocument();
+      expect(within(group).getByText('Exam Room A')).toBeInTheDocument();
+    });
+
+    test('Dropping the last provider closes the search, and says so', async () => {
+      const onToggleTimeFinder = vi.fn();
+      setup(medplum, { onToggleTimeFinder });
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await screen.findAllByTestId(/^slot-group-/);
+
+      await removePill('Dr. Maya Rivera');
+
+      expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
+      expect(onToggleTimeFinder).toHaveBeenLastCalledWith(false);
+    });
+
+    test('Clears the chosen resources and time when the visit type changes', async () => {
+      setup(medplum);
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await chooseFirstOfferedTime();
+      expect(chosenTimeField()).toBeInTheDocument();
+
+      await removePill('Ultrasound Imaging');
+      await typeInAutocomplete(field(/visit type/i), 'Bariatric');
+      await clickAutocompleteOption('Bariatric Surgery');
+      await settleAutocomplete();
+
+      expect(chosenTimeField()).not.toBeInTheDocument();
+      // A surviving pill would be handed back on the next pick, and searched against a
+      // schedule the new visit type cannot book.
+      expect(hasPill('Dr. Maya Rivera')).toBe(false);
+    });
+
+    test('Clears the chosen resources when the site changes', async () => {
+      setup(medplum, { defaultService: UltrasoundImagingService });
+      await settleAutocomplete();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      expect(hasPill('Dr. Maya Rivera')).toBe(true);
+
+      await chooseSite('Main Clinic', 'Uro Associates - Main Clinic');
+
+      expect(hasPill('Dr. Maya Rivera')).toBe(false);
+      // The imaging service is held there, so that answer stands.
+      expect(hasPill('Ultrasound Imaging')).toBe(true);
+    });
+
+    test('Clears the visit type when the new site does not hold it', async () => {
+      setup(medplum, { defaultService: SurgeryService });
+      await settleAutocomplete();
+      expect(hasPill('Bariatric Surgery')).toBe(true);
+
+      // Surgery is held at the main clinic only.
+      await chooseSite('Satellite', 'Uro Associates - Satellite');
+
+      expect(hasPill('Bariatric Surgery')).toBe(false);
+    });
+
+    test('Keeps a visit type the new site does hold', async () => {
+      setup(medplum, { defaultService: UltrasoundImagingService });
+      await settleAutocomplete();
+
+      await chooseSite('Main Clinic', 'Uro Associates - Main Clinic');
+
+      // The imaging service names the main clinic, so the answer still stands.
+      expect(hasPill('Ultrasound Imaging')).toBe(true);
+    });
+
+    test('Keeps a visit type that names no location when the site changes, and offers it there', async () => {
+      setup(medplum, { defaultService: TelehealthService });
+      await settleAutocomplete();
+      expect(hasPill('Telehealth Consult')).toBe(true);
+
+      await chooseSite('Main Clinic', 'Uro Associates - Main Clinic');
+
+      // Never tied to a site, so no site invalidates it.
+      expect(hasPill('Telehealth Consult')).toBe(true);
+
+      // The predicate here and the pair of searches behind the field are one rule spelled
+      // twice, and only a test through both catches them drifting apart. The field hides
+      // its search box while it holds an answer, so asking costs the pill just asserted.
+      await removePill('Telehealth Consult');
+      const listbox = await searchField(/visit type/i, 'Telehealth');
+      expect(within(listbox).getByText('Telehealth Consult')).toBeInTheDocument();
+    });
+
+    test('Collapses the time search when the visit type is cleared, and says so', async () => {
+      const onToggleTimeFinder = vi.fn();
+      setup(medplum, { onToggleTimeFinder });
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+      await screen.findAllByTestId(/^slot-group-/);
+
+      await removePill('Ultrasound Imaging');
+
+      expect(screen.queryAllByTestId(/^slot-group-/)).toHaveLength(0);
+      expect(screen.queryByRole('button', { name: /close time finder/i })).not.toBeInTheDocument();
+      expect(onToggleTimeFinder).toHaveBeenLastCalledWith(false);
+    });
+
+    test('Reports the visit type as it changes', async () => {
+      const onChangeService = vi.fn();
+      setup(medplum, { onChangeService });
+
+      await chooseImagingService();
+
+      expect(onChangeService).toHaveBeenCalledWith(expect.objectContaining({ id: 'ultrasound-imaging' }));
+    });
+  });
+
+  describe('Mounting the form', () => {
+    test('Starts with the answers the host pre-filled', async () => {
+      setup(medplum, {
+        defaultLocation: MainClinic,
+        defaultService: UltrasoundImagingService,
+        defaultPatient: ElderJordanPatient,
+      });
+      await settleAutocomplete();
+
+      expect(screen.getByText(MainClinic.name as string)).toBeInTheDocument();
+      expect(screen.getByText('Ultrasound Imaging')).toBeInTheDocument();
+      expect(screen.getByText('Jordan Reyes')).toBeInTheDocument();
+    });
+
+    test('Reports the time search opening and closing', async () => {
+      const onToggleTimeFinder = vi.fn();
+      setup(medplum, { onToggleTimeFinder });
+      await chooseImagingService();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      // Mounting is not an open or a close, so the host hears nothing until one.
+      expect(onToggleTimeFinder).not.toHaveBeenCalled();
+
+      await openTimeFinder();
+      expect(onToggleTimeFinder).toHaveBeenLastCalledWith(true);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /close time finder/i }));
+      });
+      expect(onToggleTimeFinder).toHaveBeenLastCalledWith(false);
+    });
+
+    test('Opens the time search on the day the host named', async () => {
+      // In the following month, so the month the calendar would otherwise open on
+      // cannot pass this by accident.
+      setup(medplum, { defaultService: UltrasoundImagingService, defaultStart: new Date(2026, 8, 2, 0, 0, 0) });
+      await settleAutocomplete();
+      await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+      await openTimeFinder();
+
+      expect(await screen.findByText(/Wednesday, September 2/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Identifying the patient', () => {
+    test('Asks for the patient below the action that finds a time', async () => {
+      setup(medplum);
+
+      // Naming a patient cannot change which times are offered, so asking for one
+      // ahead of the search puts work that cannot affect the result in front of the
+      // one control that can.
+      expect(isBefore(finderButton(), field(/patient/i))).toBe(true);
+    });
+
+    test('Offers patients matching the name typed', async () => {
+      setup(medplum);
+      await typeInAutocomplete(field(/patient/i), 'Whitfield');
+
+      expect(await screen.findByText('Sam Whitfield')).toBeInTheDocument();
+      expect(screen.queryByText('Jordan Reyes')).not.toBeInTheDocument();
+    });
+
+    test('Tells apart two patients who share a name', async () => {
+      setup(medplum);
+      await typeInAutocomplete(field(/patient/i), 'Jordan');
+
+      // The name is on both rows, so the birth date and the medical record
+      // number under it are the only things separating them.
+      expect(await screen.findByText(patientDetail(ElderJordanPatient, 'MRN-0041'))).toBeInTheDocument();
+      expect(screen.getByText(patientDetail(YoungerJordanPatient))).toBeInTheDocument();
+      expect(screen.getAllByText('Jordan Reyes')).toHaveLength(2);
+    });
+
+    test('Lists a patient with no medical record number by name and birth date', async () => {
+      setup(medplum);
+      await typeInAutocomplete(field(/patient/i), 'Jordan');
+
+      // Hiding somebody because a number is missing would lose the patient, not
+      // the ambiguity.
+      expect(await screen.findByText(patientDetail(YoungerJordanPatient))).toBeInTheDocument();
+    });
+
+    test('Reads the medical record number from the system the host named', async () => {
+      // Sam's identifier carries no type, so nothing but its system says what it
+      // is. Without `mrnSystem` the same patient lists by birth date alone.
+      setup(medplum, { mrnSystem: MRN_SYSTEM });
+      await typeInAutocomplete(field(/patient/i), 'Whitfield');
+
+      expect(await screen.findByText(patientDetail(UntypedMrnPatient, 'MRN-0099'))).toBeInTheDocument();
+    });
+
+    test('Leaves the patient out of the search for times', async () => {
+      const get = vi.spyOn(medplum, 'get');
+      setup(medplum);
+      await fillBooking();
+
+      // `$find` proposes times on calendars and knows nothing about who the
+      // visit is for; the patient is attached on the way to `$book`.
+      const searched = get.mock.calls.map(([url]) => String(url)).filter((url) => url.includes('find'));
+      expect(searched.length).toBeGreaterThan(0);
+      expect(searched.some((url) => url.includes('Patient'))).toBe(false);
+    });
+
+    test('Asks nothing else below the action that finds a time', async () => {
+      setup(medplum);
+
+      // The free text about the visit that used to sit here is one of the fields a
+      // practice configures, so the patient is the form's last question.
+      const inputs = [...screen.getAllByRole('searchbox'), ...screen.queryAllByRole('textbox')];
+      expect(inputs.filter((input) => isBefore(finderButton(), input))).toEqual([field(/patient/i)]);
+    });
+
+    test('Names the patient as a required participant, once', async () => {
+      setup(medplum);
+      await fillBooking();
+      await clickBook();
+
+      const participants = proposedAppointment().participant.filter(
+        (participant) => participant.actor?.reference === `Patient/${ElderJordanPatient.id}`
+      );
+      expect(participants).toHaveLength(1);
+      expect(participants[0].required).toBe('required');
+    });
+  });
+
+  describe('Booking the appointment', () => {
+    test('Hands the proposal it built over, writing and announcing nothing', async () => {
+      const post = vi.spyOn(medplum, 'post');
+      const notify = vi.spyOn(medplum, 'notifyResourceModified');
+      setup(medplum);
+      await fillBooking();
+      await clickBook();
+
+      expect(onBook).toHaveBeenCalledTimes(1);
+      const proposal = proposedAppointment();
+      expect(proposal.start).toBeDefined();
+      expect(proposal.participant.some((p) => p.actor?.reference === `Patient/${ElderJordanPatient.id}`)).toBe(true);
+      // Whoever owns the write owns invalidating its own caches too.
+      expect(post).not.toHaveBeenCalled();
+      expect(notify).not.toHaveBeenCalled();
+    });
+
+    test('Hands the proposal over once, however many times the button is clicked', async () => {
+      setup(medplum);
+      await fillBooking();
+      await clickBook();
+
+      // Every answer stays on screen, because a refusal needs them; the button is
+      // what keeps that from booking the same time a second time.
+      expect(bookButton()).toBeDisabled();
+      await clickBook();
+      expect(onBook).toHaveBeenCalledTimes(1);
+    });
+
+    test('Offers to book again once the patient changes', async () => {
+      setup(medplum);
+      await fillBooking();
+      await clickBook();
+      expect(bookButton()).toBeDisabled();
+
+      await removePill('Jordan Reyes');
+      await choosePatient('Jordan', patientDetail(YoungerJordanPatient));
+
+      // The other Jordan is a different visit, not the one already written.
+      expect(bookButton()).toBeEnabled();
+    });
+
+    test('Offers to book again once the time changes', async () => {
+      setup(medplum);
+      await fillBooking();
+      await clickBook();
+      expect(bookButton()).toBeDisabled();
+
+      await chooseSecondOfferedTime();
+
+      expect(bookButton()).toBeEnabled();
+    });
+
+    test('Shows a refused booking and keeps every answer', async () => {
+      // A rejection is the refusal, wherever the write was attempted.
+      onBook.mockRejectedValue(new Error('Slot is no longer available'));
+      setup(medplum);
+      await fillBooking();
+      const time = (chosenTimeField() as HTMLInputElement).value;
+      await clickBook();
+
+      expect(await screen.findByText('Slot is no longer available')).toBeInTheDocument();
+      // A refusal is usually somebody else taking the time, and the next attempt
+      // is one field away.
+      expect(chosenTimeField()?.value).toBe(time);
+      expect(screen.getByText('Jordan Reyes')).toBeInTheDocument();
+      expect(bookButton()).toBeEnabled();
+    });
+  });
+});

--- a/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
+++ b/packages/react-scheduling/src/AppointmentFinder/AppointmentProposalForm.tsx
@@ -1,0 +1,585 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Alert, Button, Loader, Stack, Text, TextInput } from '@mantine/core';
+import type { WithId } from '@medplum/core';
+import {
+  createReference,
+  formatDate,
+  getIdentifier,
+  getIdentifierByType,
+  getReferenceString,
+  getSchedulingTimezone,
+  isDefined,
+  MRN_IDENTIFIER_TYPE,
+  normalizeErrorString,
+} from '@medplum/core';
+import type { Appointment, HealthcareService, Location, Patient } from '@medplum/fhirtypes';
+import type { AsyncAutocompleteOption } from '@medplum/react';
+import { CalendarDateInput, ReferenceDisplay, ResourceInput } from '@medplum/react';
+import { IconCalendarSearch } from '@tabler/icons-react';
+import type { JSX } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AppointmentActorSelect } from './AppointmentActorSelect';
+import { AppointmentDayTimes } from './AppointmentDayTimes';
+import classes from './AppointmentFinder.module.css';
+import type { SchedulingRole } from './AppointmentFinder.roles';
+import { getActorRoleLabel, SCHEDULING_ROLES } from './AppointmentFinder.roles';
+import type { ActorSelections, ScheduleCandidate } from './AppointmentFinder.schedules';
+import { getActorCombinations, getSelectedCandidates, getSelectionError } from './AppointmentFinder.schedules';
+import type { DateRange } from './AppointmentFinder.times';
+import { endOfDay, getDurationMinutes, getFindWindowError, groupAppointmentsByDay } from './AppointmentFinder.times';
+import { AppointmentOptionRow } from './AppointmentOptionRow';
+import { AppointmentServiceSelect } from './AppointmentServiceSelect';
+import { isServiceKeptAtLocation } from './AppointmentServiceSelect.utils';
+import { useProposedAppointments } from './useProposedAppointments';
+
+// Excludes what a room is rather than admitting what a site is: `physicalType` is
+// optional, so `physical-type=si,bu` would hide a Location that never declared one.
+const LOCATION_SEARCH_CRITERIA = { _count: '25', _sort: 'name', 'physical-type:not': 'ro,bd' };
+
+// Alphabetical, then by birth date: a short prefix — or the first click, before
+// anything is typed — leaves a list only a name orders usefully, and the birth
+// date is what tells the people sharing one apart.
+const PATIENT_SEARCH_CRITERIA = { _count: '25', _sort: 'name,birthdate' };
+
+// No month-wide scan exists, so every day is offered and the search answers.
+const NO_MARKED_DATES: Date[] = [];
+
+export interface AppointmentProposalFormProps {
+  /** Pre-fills where the visit is, for a host that already knows. */
+  readonly defaultLocation?: WithId<Location>;
+  /** Pre-fills the visit type, for a deep link or a reschedule. */
+  readonly defaultService?: WithId<HealthcareService>;
+  /** Pre-fills who the visit is for, for a host launching from a patient's chart. */
+  readonly defaultPatient?: WithId<Patient>;
+  /**
+   * The day the time search opens on. Defaults to today.
+   *
+   * A day, not a time: only a time `$find` offered can be chosen.
+   */
+  readonly defaultStart?: Date;
+  /**
+   * The `Identifier.system` a project issues medical record numbers under.
+   *
+   * Only needed where identifiers carry no `type`. Which identifier is the
+   * medical record number is a project's own convention, and there is nothing on
+   * an untyped one to recognise it by.
+   */
+  readonly mrnSystem?: string;
+  /**
+   * Called when the time search opens or closes.
+   *
+   * The times render beside the form, not under it, so a host in a side panel has
+   * to widen it to fit them.
+   */
+  readonly onToggleTimeFinder?: (open: boolean) => void;
+  /** Called with the visit type as it changes. */
+  readonly onChangeService?: (service: WithId<HealthcareService> | undefined) => void;
+  /**
+   * Performs the booking with the proposal the form assembled.
+   *
+   * Resolving marks the form booked, so it stops offering to book until an answer
+   * changes; rejecting shows the reason as the booking's refusal, every answer kept.
+   */
+  readonly onBook: (proposal: Appointment) => void | Promise<void>;
+}
+
+/**
+ * Gathers what a visit is held on, finds a time every one of them is free, and
+ * hands the proposal out to be booked.
+ *
+ * One field per scheduling role, each searching the schedules bookable for the
+ * chosen visit type. Everything named attends, because `$find` intersects their
+ * schedules — so naming a second room narrows the times rather than widening them.
+ *
+ * Only a time the search offered can be chosen: the field holding it accepts no
+ * input, so nothing can be booked onto time nobody checked availability for.
+ *
+ * Writes nothing and announces nothing: `onBook` owns that. Mount this to do
+ * something other than `$book` with the proposal — hold it through `$hold`, or
+ * write it inside a transaction of your own. {@link AppointmentBookingForm} is the
+ * one that books.
+ *
+ * @param props - The React props.
+ * @returns The form.
+ */
+export function AppointmentProposalForm(props: AppointmentProposalFormProps): JSX.Element {
+  const {
+    defaultLocation,
+    defaultService,
+    defaultPatient,
+    defaultStart,
+    mrnSystem,
+    onToggleTimeFinder,
+    onChangeService,
+    onBook,
+  } = props;
+
+  const [location, setLocation] = useState<WithId<Location> | undefined>(defaultLocation);
+  const [service, setService] = useState<WithId<HealthcareService> | undefined>(defaultService);
+  const [selections, setSelections] = useState<ActorSelections>({});
+  const [range, setRange] = useState<DateRange>(() => oneDay(defaultStart ?? new Date()));
+  const [month, setMonth] = useState<Date | undefined>(defaultStart);
+  const [finding, setFinding] = useState(false);
+  const [chosen, setChosen] = useState<Appointment | undefined>(undefined);
+  // The fields ignore `defaultValue` after mount, so remounting is the only way to
+  // clear their pills. Counters, so a field is never remounted out from under a pick.
+  const [roleFieldsKey, setRoleFieldsKey] = useState(0);
+  const [serviceFieldKey, setServiceFieldKey] = useState(0);
+  const [patient, setPatient] = useState<WithId<Patient> | undefined>(defaultPatient);
+  const [booking, setBooking] = useState(false);
+  const [booked, setBooked] = useState(false);
+  const [bookError, setBookError] = useState<unknown>(undefined);
+
+  const selectionError = getSelectionError(selections);
+  const windowError = getFindWindowError(range);
+
+  // Derived, not a flag: closing is never its own rule, so losing the last provider
+  // closes the search however it was lost.
+  const searching = finding && !selectionError;
+
+  // Nothing is searched until the time search is open, so the answers above cost no
+  // request per keystroke.
+  const combinations = useMemo(
+    () => (searching && !windowError ? getActorCombinations(selections) : []),
+    [searching, windowError, selections]
+  );
+
+  const search = useProposedAppointments({ service, combinations, range });
+
+  // The first actor's schedule answers for all of them: every actor in one search
+  // shares the scheduling parameters, or `$find` rejects the request.
+  const timezone = useMemo(() => {
+    const [first] = getSelectedCandidates(selections);
+    return service ? getSchedulingTimezone(service, first?.schedule, first?.actorResource) : undefined;
+  }, [service, selections]);
+
+  const days = useMemo(() => groupAppointmentsByDay(search.appointments, timezone), [search.appointments, timezone]);
+
+  // The ref holds what the host was last told, so mounting reports nothing and a
+  // search that closed on its own is reported like one closed by hand.
+  const reported = useRef(false);
+  useEffect(() => {
+    if (reported.current !== searching) {
+      reported.current = searching;
+      onToggleTimeFinder?.(searching);
+    }
+  }, [searching, onToggleTimeFinder]);
+
+  const patientItem = useCallback(
+    (option: AsyncAutocompleteOption<WithId<Patient>>) => (
+      <AppointmentOptionRow label={option.label} detail={formatPatientDetail(option.resource, mrnSystem)} />
+    ),
+    [mrnSystem]
+  );
+
+  function toggleFinder(): void {
+    setFinding(!finding);
+  }
+
+  const chooseResources = useCallback((update: (selections: ActorSelections) => ActorSelections): void => {
+    setSelections(update);
+    // A chosen time is a proposal carrying the Slots it was found for. Booked after
+    // a resource changes it would hold whoever is named inside the proposal, and
+    // `$book` cannot catch that: the proposal is internally consistent.
+    setChosen(undefined);
+  }, []);
+
+  function chooseService(next: WithId<HealthcareService> | undefined): void {
+    setService(next);
+    onChangeService?.(next);
+    clearResources();
+  }
+
+  function chooseLocation(next: WithId<Location> | undefined): void {
+    setLocation(next);
+    clearResources();
+    if (service && !isServiceKeptAtLocation(service, next)) {
+      setService(undefined);
+      onChangeService?.(undefined);
+      setServiceFieldKey((key) => key + 1);
+    }
+  }
+
+  /**
+   * Clears every named resource, deliberately: a resource can be schedulable for more
+   * than one visit type, so some would survive a narrower check. Both the site and the
+   * visit type change which actors are offered, and re-asking is easier to explain than
+   * a partial clear.
+   */
+  function clearResources(): void {
+    setSelections({});
+    setChosen(undefined);
+    setRoleFieldsKey((key) => key + 1);
+  }
+
+  function chooseDay(date: Date): void {
+    setRange(oneDay(date));
+    setChosen(undefined);
+  }
+
+  // The two answers a written booking can still be changed by. Everything else
+  // above clears the chosen time, which disables the button on its own; these
+  // are what re-enable it, because changing either makes it a different visit.
+  function chooseTime(next: Appointment): void {
+    setChosen(next);
+    setBooked(false);
+  }
+
+  function choosePatient(next: WithId<Patient> | undefined): void {
+    setPatient(next);
+    setBooked(false);
+  }
+
+  async function bookAppointment(): Promise<void> {
+    if (!chosen || !patient) {
+      return;
+    }
+
+    setBooking(true);
+    setBookError(undefined);
+    try {
+      await onBook(buildBooking(chosen, patient));
+      setBooked(true);
+    } catch (error) {
+      // Left on screen with every answer still filled in: a refusal is usually
+      // somebody else taking the time, and the next attempt is one field away.
+      setBookError(error);
+    } finally {
+      setBooking(false);
+    }
+  }
+
+  return (
+    <div className={classes.layout}>
+      {/* Not a `form` element: this mounts inside a host's own surface, which may
+          already be one, and a form cannot be nested in a form. */}
+      <Stack className={classes.form} gap="sm">
+        <ResourceInput<WithId<Location>>
+          resourceType="Location"
+          name="location"
+          label="Location"
+          placeholder="Any location"
+          searchCriteria={LOCATION_SEARCH_CRITERIA}
+          defaultValue={defaultLocation}
+          onChange={chooseLocation}
+        />
+        <AppointmentServiceSelect
+          key={serviceFieldKey}
+          location={location}
+          // From state, not the prop: `defaultService` on a remount would put back
+          // the visit type the remount was clearing.
+          defaultValue={service}
+          onChange={chooseService}
+        />
+
+        {SCHEDULING_ROLES.map((role) => (
+          <RoleField
+            key={`${role}-${roleFieldsKey}`}
+            role={role}
+            service={service}
+            location={location}
+            disabled={!service}
+            onChange={chooseResources}
+          />
+        ))}
+
+        <ChosenTime
+          appointment={chosen}
+          timezone={timezone}
+          searching={searching}
+          blockedBy={service ? selectionError : 'Choose a visit type'}
+          onToggleFinder={toggleFinder}
+        />
+
+        {searching && (
+          <Stack gap={4}>
+            <CalendarDateInput
+              availableDates={NO_MARKED_DATES}
+              allowUnavailableDates
+              earliestDate={new Date()}
+              month={month}
+              selected={range.start}
+              onChangeMonth={setMonth}
+              onClick={chooseDay}
+            />
+            {windowError && <Alert color="yellow">{windowError}</Alert>}
+          </Stack>
+        )}
+
+        <ResourceInput<WithId<Patient>>
+          resourceType="Patient"
+          name="patient"
+          label="Patient"
+          placeholder="Search patients by name"
+          required
+          searchCriteria={PATIENT_SEARCH_CRITERIA}
+          defaultValue={defaultPatient}
+          itemComponent={patientItem}
+          onChange={choosePatient}
+        />
+
+        {bookError !== undefined && <Alert color="red">{normalizeErrorString(bookError)}</Alert>}
+        <Button
+          fullWidth
+          // A booking that was written is not written again: every answer is
+          // still on screen, and clicking through a second time would book the
+          // same time twice. Changing one of them makes it a new request.
+          disabled={!chosen || !patient || booked}
+          loading={booking}
+          onClick={bookAppointment}
+        >
+          Book appointment
+        </Button>
+      </Stack>
+
+      {searching && (
+        <Stack className={classes.results} gap="lg">
+          {search.loading && <Loader size="sm" />}
+          {search.error && <Alert color="red">{normalizeErrorString(search.error)}</Alert>}
+          {!search.loading &&
+            !search.error &&
+            days.map((day) => (
+              <AppointmentDayTimes
+                key={day.key}
+                date={day.date}
+                groups={day.groups}
+                timezone={timezone}
+                selected={chosen}
+                onSelectAppointment={chooseTime}
+              />
+            ))}
+          {!search.loading && !search.error && !windowError && days.length === 0 && (
+            <Text c="dimmed" ta="center">
+              No times are available for this selection.
+            </Text>
+          )}
+        </Stack>
+      )}
+    </div>
+  );
+}
+
+interface ChosenTimeProps {
+  readonly appointment: Appointment | undefined;
+  /** IANA timezone the visit is held in. */
+  readonly timezone: string | undefined;
+  readonly searching: boolean;
+  /** What is still owed before a time can be searched for, if anything. */
+  readonly blockedBy: string | undefined;
+  readonly onToggleFinder: () => void;
+}
+
+/**
+ * The chosen time, and under it the action that found it.
+ *
+ * An input rather than plain text: overrides are not implemented, but when they are, a
+ * permitted user gets this same field in this same place, editable and with a warning.
+ *
+ * @param props - The React props.
+ * @returns The chosen time, once there is one, and the action.
+ */
+function ChosenTime(props: ChosenTimeProps): JSX.Element {
+  const { appointment, timezone, searching, blockedBy, onToggleFinder } = props;
+
+  return (
+    <>
+      {appointment?.start && (
+        <TextInput
+          label="Date & time"
+          readOnly
+          value={formatZonedDateTime(new Date(appointment.start), timezone)}
+          // Mantine puts the description above the input by default.
+          inputWrapperOrder={['label', 'input', 'description']}
+          description={<ChosenTimeCommitment appointment={appointment} />}
+        />
+      )}
+
+      <Stack gap={4}>
+        <Button
+          variant="outline"
+          fullWidth
+          leftSection={<IconCalendarSearch size={16} stroke={1.8} />}
+          disabled={!!blockedBy}
+          onClick={onToggleFinder}
+        >
+          {getFinderLabel(searching, !!appointment)}
+        </Button>
+        {blockedBy && (
+          <Text size="xs" c="dimmed">
+            {blockedBy} first.
+          </Text>
+        )}
+      </Stack>
+    </>
+  );
+}
+
+interface ChosenTimeCommitmentProps {
+  readonly appointment: Appointment;
+}
+
+/**
+ * What the chosen time commits to: how long the visit runs, and what holds it.
+ *
+ * Read off the proposal rather than the answers above, since the proposal is what
+ * gets booked. Inline elements only: it renders inside a `description`, which is a
+ * paragraph.
+ *
+ * @param props - The React props.
+ * @returns The detail beneath the time.
+ */
+function ChosenTimeCommitment(props: ChosenTimeCommitmentProps): JSX.Element {
+  const { appointment } = props;
+  const actors = (appointment.participant ?? []).map((participant) => participant.actor).filter(isDefined);
+  const durationMinutes = getDurationMinutes(appointment);
+
+  return (
+    <>
+      {durationMinutes > 0 && `${durationMinutes} min visit`}
+      {actors.map((actor, index) => {
+        const roleLabel = getActorRoleLabel(actor);
+        return (
+          <Fragment key={getReferenceString(actor) ?? actor.display}>
+            {(index > 0 || durationMinutes > 0) && ' · '}
+            {roleLabel && `${roleLabel}: `}
+            <ReferenceDisplay value={actor} link={false} />
+          </Fragment>
+        );
+      })}
+    </>
+  );
+}
+
+/**
+ * Names what the action does next.
+ * @param searching - Whether the time search is open.
+ * @param chosen - Whether a time has been picked.
+ * @returns The button's label.
+ */
+function getFinderLabel(searching: boolean, chosen: boolean): string {
+  if (searching) {
+    return 'Close time finder';
+  }
+  return chosen ? 'Change time' : 'Find a time';
+}
+
+interface RoleFieldProps {
+  readonly role: SchedulingRole;
+  readonly service: WithId<HealthcareService> | undefined;
+  readonly location: WithId<Location> | undefined;
+  readonly disabled?: boolean;
+  readonly onChange: (update: (selections: ActorSelections) => ActorSelections) => void;
+}
+
+/**
+ * One role's field, writing its own key of the selections.
+ *
+ * A component of its own so the callback it hands down is stable per role: the
+ * field searches on a changed callback, and an inline one would be new on every
+ * keystroke anywhere in the form.
+ *
+ * @param props - The React props.
+ * @returns The field for that role.
+ */
+function RoleField(props: RoleFieldProps): JSX.Element {
+  const { role, service, location, disabled, onChange } = props;
+
+  const handleChange = useCallback(
+    (candidates: readonly ScheduleCandidate[]) => onChange((selections) => ({ ...selections, [role]: candidates })),
+    [onChange, role]
+  );
+
+  return (
+    <AppointmentActorSelect
+      role={role}
+      service={service}
+      location={location}
+      disabled={disabled}
+      onChange={handleChange}
+    />
+  );
+}
+
+/**
+ * Puts the patient onto the proposal that will be booked.
+ *
+ * @param proposal - The time that was chosen, as `$find` offered it.
+ * @param patient - Who the visit is for.
+ * @returns The appointment to book.
+ */
+function buildBooking(proposal: Appointment, patient: WithId<Patient>): Appointment {
+  const patientReference = getReferenceString(patient);
+  return {
+    ...proposal,
+    participant: [
+      // A proposal knows nothing about patients, but a host may have put one on
+      // the appointment it handed over, and naming them twice books them twice.
+      ...proposal.participant.filter((participant) => participant.actor?.reference !== patientReference),
+      { actor: createReference(patient), required: 'required', status: 'needs-action' },
+    ],
+  };
+}
+
+/**
+ * What tells one patient apart from another of the same name.
+ * @param patient - The patient on offer.
+ * @param mrnSystem - The system a project issues medical record numbers under.
+ * @returns The line under their name, or undefined when nothing is on file.
+ */
+function formatPatientDetail(patient: WithId<Patient>, mrnSystem: string | undefined): string | undefined {
+  const mrn = getMedicalRecordNumber(patient, mrnSystem);
+  return [formatDate(patient.birthDate), mrn && `MRN ${mrn}`].filter(Boolean).join(' · ') || undefined;
+}
+
+/**
+ * Reads a patient's medical record number.
+ *
+ * A typed identifier answers it whoever issued it, which is the case that needs
+ * no configuration. `mrnSystem` is for the project whose identifiers carry no
+ * type, where nothing but the system says which one this is.
+ *
+ * @param patient - The patient to read.
+ * @param mrnSystem - The system a project issues medical record numbers under.
+ * @returns The medical record number, or undefined for a patient with none.
+ */
+function getMedicalRecordNumber(patient: WithId<Patient>, mrnSystem: string | undefined): string | undefined {
+  return (
+    getIdentifierByType(patient, MRN_IDENTIFIER_TYPE) ?? (mrnSystem ? getIdentifier(patient, mrnSystem) : undefined)
+  );
+}
+
+/**
+ * Returns the range covering the bookable part of one day.
+ *
+ * `$find` treats `start` as a hard floor, so a day already under way starts from now
+ * rather than midnight: the calendar hands back local midnight, and asking from there
+ * would offer times that have already passed.
+ *
+ * @param date - Any instant during the day.
+ * @returns The day from now at the earliest, both ends closed, as `$find` requires.
+ */
+function oneDay(date: Date): DateRange {
+  const now = new Date();
+  const start = date > now ? date : now;
+  return { start, end: endOfDay(start) };
+}
+
+/**
+ * Writes an instant as the day and time it falls on at the site, not on the
+ * booker's own clock.
+ *
+ * @param value - The chosen start time.
+ * @param timezone - IANA timezone the visit is scheduled in.
+ * @returns The time to display.
+ */
+function formatZonedDateTime(value: Date, timezone: string | undefined): string {
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone: timezone,
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(value);
+}

--- a/packages/react-scheduling/src/index.ts
+++ b/packages/react-scheduling/src/index.ts
@@ -11,6 +11,7 @@ export * from './AppointmentFinder/AppointmentFinder.roles';
 export * from './AppointmentFinder/AppointmentFinder.schedules';
 export * from './AppointmentFinder/AppointmentFinder.times';
 export * from './AppointmentFinder/AppointmentOptionRow';
+export * from './AppointmentFinder/AppointmentProposalForm';
 export * from './AppointmentFinder/AppointmentServiceSelect';
 export * from './AppointmentFinder/AppointmentSlotGroupCard';
 export * from './Calendar/Calendar';

--- a/packages/react-scheduling/src/index.ts
+++ b/packages/react-scheduling/src/index.ts
@@ -5,6 +5,7 @@ export type * from './types';
 
 // Export all components
 export * from './AppointmentFinder/AppointmentActorSelect';
+export * from './AppointmentFinder/AppointmentBookingForm';
 export * from './AppointmentFinder/AppointmentDayTimes';
 export * from './AppointmentFinder/AppointmentFinder.roles';
 export * from './AppointmentFinder/AppointmentFinder.schedules';

--- a/packages/react-scheduling/src/stories/WithBookStub.tsx
+++ b/packages/react-scheduling/src/stories/WithBookStub.tsx
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { useMedplum } from '@medplum/react-hooks';
+import type { JSX, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+import { installBookStub } from './mockBook';
+
+export interface WithBookStubProps {
+  readonly children: ReactNode;
+}
+
+/**
+ * Teaches the ambient Storybook client to answer `Appointment/$book`.
+ *
+ * Installed before the children render, so a booking cannot reach the unpatched
+ * client and fail for want of an operation.
+ *
+ * @param props - The React props.
+ * @returns The children, once the stub is in place.
+ */
+export function WithBookStub(props: WithBookStubProps): JSX.Element | null {
+  const medplum = useMedplum();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const restore = installBookStub(medplum);
+    setReady(true);
+    return () => {
+      setReady(false);
+      restore();
+    };
+  }, [medplum]);
+
+  return ready ? <>{props.children}</> : null;
+}

--- a/packages/react-scheduling/src/stories/decorators.tsx
+++ b/packages/react-scheduling/src/stories/decorators.tsx
@@ -3,6 +3,7 @@
 import type { Resource } from '@medplum/fhirtypes';
 import type { Decorator } from '@storybook/react';
 import { MockDateWrapper } from './MockDateWrapper';
+import { WithBookStub } from './WithBookStub';
 import { WithChainedActorSearch } from './WithChainedActorSearch';
 import { WithFindStub } from './WithFindStub';
 import { WithFixtures } from './WithFixtures';
@@ -41,6 +42,17 @@ export const withFindStub =
       <Story />
     </WithFindStub>
   );
+
+/**
+ * Answers `Appointment/$book` by writing what it was handed, which MockClient
+ * cannot.
+ * @returns The decorator.
+ */
+export const withBookStub = (): Decorator => (Story) => (
+  <WithBookStub>
+    <Story />
+  </WithBookStub>
+);
 
 /**
  * Answers the chained `actor:` filters the role fields search with, which the

--- a/packages/react-scheduling/src/stories/mockBook.ts
+++ b/packages/react-scheduling/src/stories/mockBook.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { MedplumClient, MedplumRequestOptions } from '@medplum/core';
+import type { Appointment, Bundle, Parameters, Slot } from '@medplum/fhirtypes';
+
+/**
+ * Answers `Appointment/$book` by persisting what it was handed.
+ *
+ * `MockClient` has no scheduling operations, so a story that books has to stand
+ * in for the server. It reserves nothing and checks no availability — it writes
+ * the appointment and a Slot per schedule it is held on, which is enough for the
+ * flow around it to behave the way it will against a real server.
+ *
+ * @param medplum - The client to patch. Other requests are passed through.
+ * @returns A function restoring the client's own `post`.
+ */
+export function installBookStub(medplum: MedplumClient): () => void {
+  const original = medplum.post.bind(medplum);
+
+  medplum.post = async function stubbedPost<T>(
+    url: string | URL,
+    body?: unknown,
+    contentType?: string,
+    options?: MedplumRequestOptions
+  ): Promise<T> {
+    const asString = url.toString();
+    if (!asString.includes('Appointment/%24book') && !asString.includes('Appointment/$book')) {
+      return original(url, body, contentType, options);
+    }
+    return bookAppointment(medplum, body as Parameters) as Promise<T>;
+  } as MedplumClient['post'];
+
+  return () => {
+    medplum.post = original;
+  };
+}
+
+async function bookAppointment(medplum: MedplumClient, parameters: Parameters): Promise<Bundle> {
+  const proposal = parameters.parameter?.find((parameter) => parameter.name === 'appointment')?.resource as
+    Appointment | undefined;
+  if (!proposal) {
+    throw new Error('$book was called without an appointment');
+  }
+
+  // A proposal carries its Slots contained, having no id to reference them by
+  // until something writes them. Booking is what gives them one.
+  const contained = (proposal.contained ?? []).filter((resource): resource is Slot => resource.resourceType === 'Slot');
+  const slots = await Promise.all(contained.map(async (slot) => medplum.createResource<Slot>({ ...slot })));
+
+  const appointment = await medplum.createResource<Appointment>({
+    ...proposal,
+    status: 'booked',
+    contained: undefined,
+    slot: slots.map((slot) => ({ reference: `Slot/${slot.id}` })),
+  });
+
+  return {
+    resourceType: 'Bundle',
+    type: 'transaction-response',
+    entry: [appointment, ...slots].map((resource) => ({ resource })),
+  };
+}

--- a/packages/react-scheduling/src/stories/scheduling.ts
+++ b/packages/react-scheduling/src/stories/scheduling.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { SchedulingParametersURI, ServiceTypeReferenceURI, SNOMED } from '@medplum/core';
+import { HL7_V2_0203, SchedulingParametersURI, ServiceTypeReferenceURI, SNOMED } from '@medplum/core';
 import type {
   Appointment,
   AppointmentParticipant,
@@ -9,7 +9,9 @@ import type {
   CodeableConcept,
   Device,
   HealthcareService,
+  Identifier,
   Location,
+  Patient,
   Practitioner,
   PractitionerRole,
   Schedule,
@@ -450,3 +452,37 @@ export const DrOseiRole: WithId<PractitionerRole> = {
 export const DrOseiSchedule = buildSchedule('schedule-dr-osei', 'Practitioner/dr-osei', 'Dr. Ama Osei');
 
 export const SubClinicProviderFixtures = [DrOseiPractitioner, DrOseiRole, DrOseiSchedule];
+
+/** A project's own medical record number system, for identifiers carrying no type. */
+export const MRN_SYSTEM = 'http://example.org/mrn';
+
+// Patients for the field that has to tell one from another. Two of them share a
+// name, which is the case the option row exists to answer: a name alone cannot
+// separate them, so the row carries a birth date and a medical record number.
+// One has none on file, and must still be listed rather than hidden.
+function buildPatient(id: string, given: string, family: string, birthDate: string, mrn?: Identifier): WithId<Patient> {
+  return {
+    resourceType: 'Patient',
+    id,
+    name: [{ given: [given], family }],
+    birthDate,
+    identifier: mrn ? [mrn] : undefined,
+  };
+}
+
+/** Typed as a medical record number, which is how it is read without configuration. */
+export const ElderJordanPatient = buildPatient('jordan-elder', 'Jordan', 'Reyes', '1961-04-02', {
+  type: { coding: [{ system: HL7_V2_0203, code: 'MR' }] },
+  value: 'MRN-0041',
+});
+
+/** Same name, different person, and no medical record number on file. */
+export const YoungerJordanPatient = buildPatient('jordan-younger', 'Jordan', 'Reyes', '1994-11-30');
+
+/** Identified only by the system that issued it, which is what `mrnSystem` names. */
+export const UntypedMrnPatient = buildPatient('sam-whitfield', 'Sam', 'Whitfield', '1978-06-14', {
+  system: MRN_SYSTEM,
+  value: 'MRN-0099',
+});
+
+export const PatientFixtures = [ElderJordanPatient, YoungerJordanPatient, UntypedMrnPatient];

--- a/packages/react-scheduling/src/stories/searchParameters.ts
+++ b/packages/react-scheduling/src/stories/searchParameters.ts
@@ -117,6 +117,34 @@ const SCHEDULING_SEARCH_PARAMETERS: Bundle<SearchParameter> = {
     {
       resource: {
         resourceType: 'SearchParameter',
+        id: 'Patient-name',
+        url: 'http://hl7.org/fhir/SearchParameter/Patient-name',
+        name: 'name',
+        status: 'active',
+        description: 'A portion of either family or given name of the patient',
+        code: 'name',
+        base: ['Patient'],
+        type: 'string',
+        expression: 'Patient.name',
+      },
+    },
+    {
+      resource: {
+        resourceType: 'SearchParameter',
+        id: 'Patient-birthdate',
+        url: 'http://hl7.org/fhir/SearchParameter/Patient-birthdate',
+        name: 'birthdate',
+        status: 'active',
+        description: "The patient's date of birth",
+        code: 'birthdate',
+        base: ['Patient'],
+        type: 'date',
+        expression: 'Patient.birthDate',
+      },
+    },
+    {
+      resource: {
+        resourceType: 'SearchParameter',
         id: 'Location-name',
         url: 'http://hl7.org/fhir/SearchParameter/Location-name',
         name: 'name',

--- a/packages/react-scheduling/src/test-utils/bookingForm.tsx
+++ b/packages/react-scheduling/src/test-utils/bookingForm.tsx
@@ -1,0 +1,287 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { MedplumClient } from '@medplum/core';
+import { formatDate } from '@medplum/core';
+import type { Patient } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import type { MockInstance } from 'vitest';
+import {
+  ElderJordanPatient,
+  PatientFixtures,
+  SchedulingFixtures,
+  SubClinicProviderFixtures,
+  SurgicalFixtures,
+} from '../stories/scheduling';
+import { clickAutocompleteOption, settleAutocomplete, typeInAutocomplete } from './asyncAutocomplete';
+import { stubChainedActorSearch } from './chainedActorSearch';
+import { act, fireEvent, screen, within } from './render';
+
+// Drives the booking form the way a user does, for the tests of both the proposal
+// form and the wrapper that books for it. Assertion-free: what each test proves
+// differs, reaching the point where it can be proved does not.
+
+/** A Monday, so the stub has weekday hours ahead of it on the default search day. */
+export const MONDAY_MORNING = new Date(2026, 7, 17, 8, 0, 0);
+
+export async function setupBookingClient(): Promise<MockClient> {
+  const medplum = new MockClient();
+  for (const resource of [
+    ...SchedulingFixtures,
+    ...SurgicalFixtures,
+    ...SubClinicProviderFixtures,
+    ...PatientFixtures,
+  ]) {
+    await medplum.createResource(resource);
+  }
+  stubChainedActorSearch(medplum);
+  return medplum;
+}
+
+export function field(label: RegExp): HTMLElement {
+  return screen.getByRole('searchbox', { name: label });
+}
+
+export async function chooseImagingService(): Promise<void> {
+  await typeInAutocomplete(field(/visit type/i), 'Ultrasound');
+  await clickAutocompleteOption('Ultrasound Imaging');
+  await settleAutocomplete();
+}
+
+/**
+ * Opens one role's field on everything it has, by focusing: `fireEvent.change` to the
+ * value already in the box is not a change.
+ *
+ * @param role - The field to open.
+ * @returns The field's search box.
+ */
+export async function openRoleField(role: RegExp): Promise<HTMLElement> {
+  const input = field(role);
+  await act(async () => {
+    fireEvent.focus(input);
+  });
+  await settleAutocomplete();
+  return input;
+}
+
+/**
+ * Searches one field and returns the dropdown that field owns.
+ *
+ * Several autocompletes are on screen at once and a dropdown stays in the document
+ * once opened, so an unscoped query could read — or click — another field's option.
+ *
+ * @param label - Matches the label above the field.
+ * @param query - What to type, which is what the search narrows on.
+ * @returns The field's dropdown.
+ */
+export async function searchField(label: RegExp, query: string): Promise<HTMLElement> {
+  const input = field(label);
+  await typeInAutocomplete(input, query);
+
+  const listboxId = input.getAttribute('aria-controls');
+  const listbox = listboxId && document.getElementById(listboxId);
+  if (!listbox) {
+    throw new Error(`No dropdown found for ${label.source}`);
+  }
+  return listbox;
+}
+
+export async function chooseActor(role: RegExp, query: string, name: string): Promise<void> {
+  const listbox = await searchField(role, query);
+  await act(async () => {
+    fireEvent.click(within(listbox).getByText(name));
+  });
+  await settleAutocomplete();
+}
+
+/**
+ * Takes one chosen value back out of the field holding it: the only way to change the
+ * visit type, which takes its search box away while full.
+ *
+ * @param name - The value currently chosen.
+ */
+export async function removePill(name: string): Promise<void> {
+  // Scoped to the pill, since a named resource is also on the slot card and in the
+  // chosen time's description. Mantine's remove button is `aria-hidden`.
+  const pill = screen.queryAllByText(name).find((node) => node.className.includes('Pill'));
+  const remove = pill?.parentElement?.querySelector('button');
+  if (!remove) {
+    throw new Error(`No remove button on the ${name} pill`);
+  }
+  await act(async () => {
+    fireEvent.click(remove);
+  });
+  await settleAutocomplete();
+}
+
+/**
+ * Chooses a site in the location field, which holds one value at a time.
+ * @param query - What to type.
+ * @param name - The site to click out of what came back.
+ */
+export async function chooseSite(query: string, name: string): Promise<void> {
+  const listbox = await searchField(/location/i, query);
+  await act(async () => {
+    fireEvent.click(within(listbox).getByText(name));
+  });
+  await settleAutocomplete();
+}
+
+/** Opens the time search, which is what sends the `$find` request. */
+export async function openTimeFinder(): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /find a time/i }));
+  });
+  await settleAutocomplete();
+}
+
+/**
+ * Clicks a day in the time search's calendar.
+ * @param dayOfMonth - The number the cell is labelled with.
+ */
+export async function chooseDay(dayOfMonth: string): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: dayOfMonth }));
+  });
+  await settleAutocomplete();
+}
+
+/**
+ * Picks the first time on offer, by position: times are read at the site, whose
+ * timezone is not the runner's.
+ *
+ * @returns The label of the time that was picked.
+ */
+export async function chooseFirstOfferedTime(): Promise<string> {
+  const [firstGroup] = await screen.findAllByTestId(/^slot-group-/);
+  const [firstTime] = within(firstGroup).getAllByRole('button');
+  const label = firstTime.textContent ?? '';
+  await act(async () => {
+    fireEvent.click(firstTime);
+  });
+  return label;
+}
+
+/** Picks the next time along, for a change of mind about the first. */
+export async function chooseSecondOfferedTime(): Promise<void> {
+  const [firstGroup] = await screen.findAllByTestId(/^slot-group-/);
+  const [, secondTime] = within(firstGroup).getAllByRole('button');
+  await act(async () => {
+    fireEvent.click(secondTime);
+  });
+}
+
+/**
+ * Whether a field is holding a value, read off the pill rather than the state: the
+ * fields ignore `defaultValue` after mount, so a cleared form could still show one.
+ *
+ * @param name - The value's label.
+ * @returns Whether a pill is showing it.
+ */
+export function hasPill(name: string): boolean {
+  return screen.queryAllByText(name).some((node) => node.className.includes('Pill'));
+}
+
+/**
+ * The field holding the chosen time, or null while no time has been chosen — there is
+ * no field at all before one is picked, so its absence is an assertion of its own.
+ *
+ * @returns The field, or null.
+ */
+export function chosenTimeField(): HTMLInputElement | null {
+  return screen.queryByRole<HTMLInputElement>('textbox', { name: /date & time/i });
+}
+
+/**
+ * Whether one element comes before another in the document.
+ *
+ * Where a field sits is part of the behaviour: the form asks the criteria, finds the
+ * time, then takes the details, and the chosen time belongs above the control that
+ * produced it. Only document order carries either.
+ *
+ * @param first - The element expected to come first.
+ * @param second - The element expected to follow it.
+ * @returns Whether they are in that order.
+ */
+export function isBefore(first: Element, second: Element): boolean {
+  return Boolean(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING);
+}
+
+/**
+ * The `start` the most recent `$find` asked for.
+ * @param get - A spy on the client's `get`.
+ * @returns The `start` parameter, or undefined when nothing was asked.
+ */
+export function lastFindStart(get: MockInstance<MedplumClient['get']>): string | undefined {
+  const urls = get.mock.calls
+    .map(([url]) => String(url))
+    .filter((url) => url.includes('Appointment/$find') || url.includes('Appointment/%24find'));
+  const last = urls.at(-1);
+  return last ? (new URL(last, 'https://example.com').searchParams.get('start') ?? undefined) : undefined;
+}
+
+/**
+ * The action that finds a time, under whichever of its three labels.
+ * @returns The button.
+ */
+export function finderButton(): HTMLElement {
+  return screen.getByRole('button', { name: /find a time|change time|close time finder/i });
+}
+
+/**
+ * The action that writes the booking.
+ * @returns The button.
+ */
+export function bookButton(): HTMLElement {
+  return screen.getByRole('button', { name: /book appointment/i });
+}
+
+/**
+ * What one patient's option row reads under their name.
+ * @param patient - The patient on offer.
+ * @param mrn - Their medical record number, for a patient with one on file.
+ * @returns The line that tells them apart from a namesake.
+ */
+export function patientDetail(patient: Patient, mrn?: string): string {
+  return [formatDate(patient.birthDate), mrn && `MRN ${mrn}`].filter(Boolean).join(' · ');
+}
+
+/**
+ * Names the patient the visit is for.
+ *
+ * Chosen by the line under the name rather than the name itself, because two of
+ * the fixtures share one — which is the reason that line is there.
+ *
+ * @param query - What to type, which is what the search narrows on.
+ * @param detail - The birth date and medical record number of the one to pick.
+ */
+export async function choosePatient(query: string, detail: string): Promise<void> {
+  const input = field(/patient/i);
+  await typeInAutocomplete(input, query);
+
+  const listboxId = input.getAttribute('aria-controls');
+  const listbox = listboxId && document.getElementById(listboxId);
+  if (!listbox) {
+    throw new Error('No dropdown found for the patient field');
+  }
+  await act(async () => {
+    fireEvent.click(within(listbox).getByText(detail));
+  });
+  await settleAutocomplete();
+}
+
+/** Answers everything a booking needs: a visit type, a provider, a time, a patient. */
+export async function fillBooking(): Promise<void> {
+  await chooseImagingService();
+  await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+  await openTimeFinder();
+  await chooseFirstOfferedTime();
+  await choosePatient('Jordan', patientDetail(ElderJordanPatient, 'MRN-0041'));
+}
+
+/** Confirms the booking. */
+export async function clickBook(): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /book appointment/i }));
+  });
+  await settleAutocomplete();
+}

--- a/packages/react-scheduling/src/test-utils/chainedActorSearch.ts
+++ b/packages/react-scheduling/src/test-utils/chainedActorSearch.ts
@@ -39,10 +39,11 @@ export function stubChainedActorSearch(medplum: MockClient): () => void {
       }
     }
 
-    const bundle = await search(resourceType, criteria, options);
     if (chained.length === 0) {
-      return bundle;
+      return search(resourceType, query, options);
     }
+
+    const bundle = await search(resourceType, criteria, options);
 
     const actors = new Map<string, Resource>();
     for (const entry of bundle.entry ?? []) {


### PR DESCRIPTION
Stacked on #10266: names the patient, books the appointment, and exports the form so a host can finally mount it.

The patient field is `ResourceInput` composed inline, the same way the site field is, sorted by name then birth date, with the birth date and medical record number under each name. Name first because the list is not always narrowed by a typed name: the first click, or a short prefix, leaves one that only an alphabetical sort orders usefully. Birth date is the tie-break between people who share a name, and one story has two patients called Jordan Reyes for exactly this.

It sits below the action that finds a time, and it is the only field down there. `$find` proposes times on calendars and knows nothing about who the visit is for, so naming a patient cannot change which times are offered; putting the field above the action would place work that cannot affect the result in front of the one control that can, and in a narrow panel it pushes that control out of sight. The free text a practice records about a visit (the reason, an internal note, a patient-facing instruction) was here and is now deferred: review placed it with the customizable business-specific fields a practice persists on an appointment rather than in the MVP. The elements chosen for it are on the record for when it returns: `Appointment.description`, `Appointment.comment`, and `Appointment.patientInstruction`, kept separate because §4.3 asks for the last two separately.

Reading the medical record number is worth a look. `getIdentifierByType` with `MRN_IDENTIFIER_TYPE` answers it whoever issued the identifier, which is the case that needs no configuration. But which identifier is the medical record number is a project's own convention, and there is nothing on an untyped one to recognise it by — so `mrnSystem` names the system for a project whose identifiers carry no `type`. A patient with neither is listed by name and birth date rather than hidden, since hiding a patient from a search is worse than listing one without a number.

The write lives in a wrapper, and the fields live under it. `AppointmentProposalForm` is every field, the search and the chosen time: it builds the proposal and hands it to a required `onBook`, writing and announcing nothing. `AppointmentBookingForm` wraps it and supplies that `onBook`, which posts `Appointment/$book`, announces the written Appointment and each reserved Slot, then reports through `onBooked`. So a host embedding this needs no scheduling API code of its own, which is the point of the component, and what the third PR leans on when it deletes the `$book` block both integrations in `examples/medplum-provider` currently duplicate. `$book` is a custom operation, so `MedplumClient` cannot tell what it changed; announcing it is what refreshes a calendar mounted beside the form.

That split is a reversal on review. This was one component taking both `onBook` and `onBooked`: two props for one outcome, where passing both silently ignored the second, and "not called when `onBook` took it over" was the tell. Neither component offers the other's callback now, so the exclusivity a doc comment had to explain is in the types instead. A host doing something else with the proposal (holding it through `$hold`, or writing it inside a transaction of its own) mounts the proposal form and names an `onBook` that says the write is its own; it writes and announces nothing itself, so such a host owns invalidating its own caches. Two exports do make a host choose, and the names are what answer it: the one called `AppointmentBookingForm` is the one that writes.

A refused booking stays on screen with every answer still filled in. A refusal is usually somebody else taking the time, so the next attempt is one field away rather than a form to fill in again. That holds whichever side attempted the write, since a rejected `onBook` is shown the way the server's own refusal is. Once a booking lands the form stops offering to book until an answer changes: every answer is deliberately still there for the refusal case, and a second click would otherwise take a second slot for the same visit. Changing the time or the patient makes it a different visit, which offers it again. A failure after the write, an `onBooked` callback that throws, is reported where a host's own failures are rather than as the booking's, because the appointment exists by then and a red refusal over one that was written reads as a time still free.

Both components and their props are exported from `index.ts` here. #10266 deliberately exported nothing, so nothing it landed could break a consumer; this is the component's first public API. With the free text gone there is no field the form collects that is not a resource reference or a time, and no required ValueSet binding, so `onBooked` really is the only prop a host must supply.

Two smaller things. `stubChainedActorSearch` was rebuilding its criteria even when nothing was chained, so the patient search — which chains nothing — was going through a transform it had no business in; the original query now passes straight through. And `MockClient` has no scheduling operations, so the stories stand in for the server with a `$book` stub that writes the appointment and a Slot per schedule it is held on. It reserves nothing and checks no availability, which is enough for the flow around it to behave the way it will against a real server.

319 tests pass across the package, 62 of them the form's own and split the way the components are: the proposal form's drive `onBook` directly with no `$book` stub, and the wrapper's cover the `$book` call, the announcements, `onBooked`, and a refusal. The helpers that drive the form to a bookable state moved to `test-utils/bookingForm` rather than being copied into both files. `Basic` mounts the wrapper with `onBooked` and nothing else, which is the zero-configuration case a host should be able to copy, and `UntypedMedicalRecordNumbers` covers `mrnSystem`.
