### PR TITLE
fix(server): handle missing and present operators in buildIdSearchFilter

### DIFF
--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -1252,7 +1252,12 @@ function buildIdSearchFilter(table: string, impl: ColumnSearchParameterImplement
   if (filter.operator === Operator.IN || filter.operator === Operator.NOT_IN) {
     throw new OperationOutcomeError(invalidSearchOperator(filter.operator, filter.code));
   }
+ if(filter.operator===Operator.PRESENT||filter.operator===Operator.MISSING){
+  const isMissing=(filter.operator===Operator.MISSING && filter.value==='true')||
+          (filter.operator === Operator.PRESENT && filter.value !== 'true')
 
+    return new Condition(new Column(table,impl.columnName),isMissing?"=":"!=",null)
+ }
   const values = splitSearchOnComma(filter.value);
   for (let i = 0; i < values.length; i++) {
     if (values[i].includes('/')) {


### PR DESCRIPTION
## Description
This PR fixes a bug where `_id` and `_compartment` searches evaluate incorrectly and return 0 results when using `:missing` or `:present` modifiers (e.g., `Patient?_id:missing=false`).

## Root Cause
Inside `trySpecialSearchParameter`, execution routing for `_id` and `_compartment` drops directly into `buildIdSearchFilter` without checking the operator type. `buildIdSearchFilter` was blind to operators, treating the modifier values (`"true"`/`"false"`) as literal IDs. Failing `isUUID()` validation, it coerced them into a dummy UUID (`00000000-0000-0000-0000-000000000000`), breaking reverse chaining (`_has`) existence checks like:
`Practitioner?_has:ProjectMembership:profile:_id:missing=false`

## Solution
Upgraded `buildIdSearchFilter` to natively recognize `Operator.MISSING` and `Operator.PRESENT` parameters, converting them to structural database null checks (`IS NULL` / `IS NOT NULL`) before running UUID loops.

## Testing Done
- Validated locally on Docker setup.
- Confirmed `Patient?_id:missing=false` correctly returns existing resources instead of an empty bundle.

Closes #10222 
