### PR TITLE
AsyncAutocomplete autosubmit fixes

### DIFF
--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.stories.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.stories.tsx
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { Title } from '@mantine/core';
 import type { Meta } from '@storybook/react';
 import type { JSX } from 'react';
+import { useState } from 'react';
 import { AsyncAutocomplete } from './AsyncAutocomplete';
 
 export default {
@@ -52,5 +54,49 @@ export function MultiSelectAsyncAutocomplete(): JSX.Element {
       })}
       onChange={console.log}
     />
+  );
+}
+
+// This story helps explore some of the loading, cancellation, and autosubmit
+// behaviors by making the search function take one second.
+export function SlowAsyncAutocomplete(): JSX.Element {
+  const [values, setValues] = useState<Option[]>([]);
+  return (
+    <>
+      <AsyncAutocomplete
+        label="Slow Multi Select Async Autocomplete with maxValues: 2"
+        loadOptions={async (input: string, signal: AbortSignal) => {
+          return new Promise<(typeof options)[number][]>((resolve, reject) => {
+            setTimeout(() => {
+              if (signal.aborted) {
+                console.log('Request aborted');
+                reject(new Error('aborted'));
+                return;
+              }
+
+              resolve(
+                options.filter(
+                  (o) =>
+                    o.code.toLowerCase().includes(input.toLowerCase()) ||
+                    o.display.toLowerCase().includes(input.toLowerCase())
+                )
+              );
+            }, 1000);
+          });
+        }}
+        toOption={(option) => ({
+          value: option.code,
+          label: option.display,
+          resource: option,
+        })}
+        onChange={setValues}
+        maxValues={2}
+      />
+
+      <Title order={6} mt="md">
+        Values
+      </Title>
+      <code>{JSON.stringify(values)}</code>
+    </>
   );
 }

--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.test.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.test.tsx
@@ -1,0 +1,455 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { showNotification } from '@mantine/notifications';
+import type { JSX } from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  selectAutocompleteOption,
+  typeInAutocomplete,
+  within,
+} from '../test-utils/render';
+import type { AsyncAutocompleteOption } from './AsyncAutocomplete';
+import { AsyncAutocomplete } from './AsyncAutocomplete';
+import { AsyncAutocompleteTestIds } from './AsyncAutocomplete.utils';
+
+vi.mock('@mantine/notifications');
+
+interface TestOption {
+  readonly id: string;
+  readonly name: string;
+}
+
+const apple: TestOption = { id: 'a', name: 'Apple' };
+const banana: TestOption = { id: 'b', name: 'Banana' };
+const cherry: TestOption = { id: 'c', name: 'Cherry' };
+const allOptions = [apple, banana, cherry];
+
+function toOption(item: TestOption): AsyncAutocompleteOption<TestOption> {
+  return { value: item.id, label: item.name, resource: item };
+}
+
+async function defaultLoadOptions(input: string): Promise<TestOption[]> {
+  return allOptions.filter((o) => o.name.toLowerCase().includes(input.toLowerCase()));
+}
+
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (err: Error) => void } {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (err: Error) => void = () => undefined;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('AsyncAutocomplete', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      vi.runOnlyPendingTimers();
+    });
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test('renders label, description, and placeholder', () => {
+    render(
+      <AsyncAutocomplete<TestOption>
+        label="Fruit"
+        description="Pick a fruit"
+        placeholder="Search fruit"
+        toOption={toOption}
+        loadOptions={defaultLoadOptions}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Fruit')).toBeInTheDocument();
+    expect(screen.getByText('Pick a fruit')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search fruit')).toBeInTheDocument();
+  });
+
+  test('renders a single defaultValue as a pill', () => {
+    render(
+      <AsyncAutocomplete<TestOption>
+        defaultValue={apple}
+        toOption={toOption}
+        loadOptions={defaultLoadOptions}
+        onChange={vi.fn()}
+      />
+    );
+
+    const selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
+    expect(selected.getByText('Apple')).toBeInTheDocument();
+  });
+
+  test('renders an array defaultValue as pills', () => {
+    render(
+      <AsyncAutocomplete<TestOption>
+        defaultValue={[apple, banana]}
+        toOption={toOption}
+        loadOptions={defaultLoadOptions}
+        onChange={vi.fn()}
+      />
+    );
+
+    const selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
+    expect(selected.getByText('Apple')).toBeInTheDocument();
+    expect(selected.getByText('Banana')).toBeInTheDocument();
+  });
+
+  test('dropdown is hidden until there are options or a creatable entry', () => {
+    render(<AsyncAutocomplete<TestOption> toOption={toOption} loadOptions={defaultLoadOptions} onChange={vi.fn()} />);
+
+    expect(screen.getByTestId(AsyncAutocompleteTestIds.options)).toHaveAttribute('data-hidden', 'true');
+  });
+
+  test('loads and displays options after the debounce', async () => {
+    const loadOptions = vi.fn(defaultLoadOptions);
+    render(<AsyncAutocomplete<TestOption> toOption={toOption} loadOptions={loadOptions} onChange={vi.fn()} />);
+
+    const input = screen.getByRole('searchbox');
+    await typeInAutocomplete(input, 'an');
+
+    expect(loadOptions).toHaveBeenCalledWith('an', expect.anything());
+    expect(screen.getByText('Banana')).toBeInTheDocument();
+  });
+
+  test('selecting an option adds a pill and calls onChange', async () => {
+    const onChange = vi.fn();
+    render(<AsyncAutocomplete<TestOption> toOption={toOption} loadOptions={defaultLoadOptions} onChange={onChange} />);
+
+    const input = screen.getByRole('searchbox');
+    await selectAutocompleteOption(input, 'Apple', 'Apple');
+
+    const selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
+    expect(selected.getByText('Apple')).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith([apple]);
+  });
+
+  test('selecting an already-selected option deselects it', async () => {
+    const onChange = vi.fn();
+    render(<AsyncAutocomplete<TestOption> toOption={toOption} loadOptions={defaultLoadOptions} onChange={onChange} />);
+
+    const input = screen.getByRole('searchbox');
+    await selectAutocompleteOption(input, 'Apple', 'Apple');
+    expect(onChange).toHaveBeenLastCalledWith([apple]);
+
+    // Don't wait for "Apple" text here — it's already ambiguous between the pill and the option
+    await selectAutocompleteOption(input, 'Apple');
+    expect(onChange).toHaveBeenLastCalledWith([]);
+
+    const selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
+    expect(selected.queryByText('Apple')).not.toBeInTheDocument();
+  });
+
+  test('maxValues=1 hides the search input once a value is selected', async () => {
+    const onChange = vi.fn();
+    render(
+      <AsyncAutocomplete<TestOption>
+        maxValues={1}
+        toOption={toOption}
+        loadOptions={defaultLoadOptions}
+        onChange={onChange}
+      />
+    );
+
+    const input = screen.getByRole('searchbox');
+    await selectAutocompleteOption(input, 'Apple', 'Apple');
+
+    expect(onChange).toHaveBeenCalledWith([apple]);
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
+    const selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
+    expect(selected.getByText('Apple')).toBeInTheDocument();
+  });
+
+  test('maxValues=0 calls onChange on every selection without keeping a pill', async () => {
+    const onChange = vi.fn();
+    render(
+      <AsyncAutocomplete<TestOption>
+        maxValues={0}
+        defaultValue={apple}
+        toOption={toOption}
+        loadOptions={defaultLoadOptions}
+        onChange={onChange}
+      />
+    );
+
+    let selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
+    expect(selected.getByText('Apple')).toBeInTheDocument();
+
+    const input = screen.getByRole('searchbox');
+    await selectAutocompleteOption(input, 'Banana', 'Banana');
+
+    // Selecting a new value clears any pre-existing selection and never adds a pill of its own
+    expect(onChange).toHaveBeenCalledWith([banana]);
+    selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
+    expect(selected.queryByText('Apple')).not.toBeInTheDocument();
+    expect(selected.queryByText('Banana')).not.toBeInTheDocument();
+
+    await selectAutocompleteOption(input, 'Cherry', 'Cherry');
+    expect(onChange).toHaveBeenLastCalledWith([cherry]);
+  });
+
+  test('creatable input creates a new resource via "+ Create"', async () => {
+    const onChange = vi.fn();
+    const onCreate = vi.fn((name: string) => ({ id: name.toLowerCase(), name }));
+    render(
+      <AsyncAutocomplete<TestOption>
+        creatable
+        onCreate={onCreate}
+        toOption={toOption}
+        loadOptions={defaultLoadOptions}
+        onChange={onChange}
+      />
+    );
+
+    const input = screen.getByRole('searchbox');
+    await typeInAutocomplete(input, 'Dragonfruit');
+
+    expect(screen.getByText('+ Create Dragonfruit')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('+ Create Dragonfruit'));
+    });
+
+    expect(onCreate).toHaveBeenCalledWith('Dragonfruit');
+    expect(onChange).toHaveBeenCalledWith([{ id: 'dragonfruit', name: 'Dragonfruit' }]);
+    const selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
+    expect(selected.getByText('Dragonfruit')).toBeInTheDocument();
+  });
+
+  test('shows the empty component when nothing matches and creation is disabled', async () => {
+    render(<AsyncAutocomplete<TestOption> toOption={toOption} loadOptions={defaultLoadOptions} onChange={vi.fn()} />);
+
+    const input = screen.getByRole('searchbox');
+    await typeInAutocomplete(input, 'zzz');
+
+    expect(screen.getByText('Nothing found')).toBeInTheDocument();
+  });
+
+  test('clear button removes all selections and calls onChange([])', async () => {
+    const onChange = vi.fn();
+    render(
+      <AsyncAutocomplete<TestOption>
+        clearable
+        defaultValue={[apple, banana]}
+        toOption={toOption}
+        loadOptions={defaultLoadOptions}
+        onChange={onChange}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTitle('Clear all'));
+    });
+
+    expect(onChange).toHaveBeenCalledWith([]);
+    const selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
+    expect(selected.queryByText('Apple')).not.toBeInTheDocument();
+    expect(selected.queryByText('Banana')).not.toBeInTheDocument();
+  });
+
+  test('disabled hides the search input and clear button but still shows pills', () => {
+    render(
+      <AsyncAutocomplete<TestOption>
+        disabled
+        clearable
+        defaultValue={apple}
+        toOption={toOption}
+        loadOptions={defaultLoadOptions}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Clear all')).not.toBeInTheDocument();
+    const selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
+    expect(selected.getByText('Apple')).toBeInTheDocument();
+  });
+
+  test('removing a pill calls onChange with the remaining selection', async () => {
+    const onChange = vi.fn();
+    render(
+      <AsyncAutocomplete<TestOption>
+        defaultValue={[apple, banana]}
+        toOption={toOption}
+        loadOptions={defaultLoadOptions}
+        onChange={onChange}
+      />
+    );
+
+    const selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
+    const removeButtons = selected.getAllByRole('button', { hidden: true });
+
+    await act(async () => {
+      fireEvent.click(removeButtons[0]);
+    });
+
+    expect(onChange).toHaveBeenCalledWith([banana]);
+    expect(selected.queryByText('Apple')).not.toBeInTheDocument();
+    expect(selected.getByText('Banana')).toBeInTheDocument();
+  });
+
+  test('Backspace on an empty search removes the last selected pill', async () => {
+    const onChange = vi.fn();
+    render(
+      <AsyncAutocomplete<TestOption>
+        defaultValue={[apple, banana]}
+        toOption={toOption}
+        loadOptions={defaultLoadOptions}
+        onChange={onChange}
+      />
+    );
+
+    const input = screen.getByRole('searchbox');
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Backspace', code: 'Backspace' });
+    });
+
+    expect(onChange).toHaveBeenCalledWith([apple]);
+    const selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
+    expect(selected.getByText('Apple')).toBeInTheDocument();
+    expect(selected.queryByText('Banana')).not.toBeInTheDocument();
+  });
+
+  test('minInputLength delays loadOptions until the threshold is met', async () => {
+    const loadOptions = vi.fn(defaultLoadOptions);
+    render(
+      <AsyncAutocomplete<TestOption>
+        minInputLength={3}
+        toOption={toOption}
+        loadOptions={loadOptions}
+        onChange={vi.fn()}
+      />
+    );
+
+    const input = screen.getByRole('searchbox');
+    await typeInAutocomplete(input, 'ap');
+    expect(loadOptions).not.toHaveBeenCalled();
+
+    await typeInAutocomplete(input, 'app');
+    expect(loadOptions).toHaveBeenCalledWith('app', expect.anything());
+  });
+
+  test('a load failure that is not an abort surfaces a notification', async () => {
+    const loadOptions = vi.fn().mockRejectedValue(new Error('Server exploded'));
+    render(<AsyncAutocomplete<TestOption> toOption={toOption} loadOptions={loadOptions} onChange={vi.fn()} />);
+
+    const input = screen.getByRole('searchbox');
+    await typeInAutocomplete(input, 'apple');
+
+    expect(showNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ color: 'red', message: expect.stringContaining('Server exploded') })
+    );
+  });
+
+  test('typing again aborts the pending request; only the latest result is applied', async () => {
+    const first = createDeferred<TestOption[]>();
+    const second = createDeferred<TestOption[]>();
+    const signals: AbortSignal[] = [];
+    const loadOptions = vi.fn((_input: string, signal: AbortSignal) => {
+      signals.push(signal);
+      return signals.length === 1 ? first.promise : second.promise;
+    });
+
+    render(<AsyncAutocomplete<TestOption> toOption={toOption} loadOptions={loadOptions} onChange={vi.fn()} />);
+    const input = screen.getByRole('searchbox');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'a' } });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(loadOptions).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'ab' } });
+    });
+    expect(signals[0].aborted).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(loadOptions).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      first.resolve([apple]);
+      await Promise.resolve();
+    });
+    expect(screen.queryByText('Apple')).not.toBeInTheDocument();
+
+    await act(async () => {
+      second.resolve([banana]);
+      await Promise.resolve();
+    });
+    expect(screen.getByText('Banana')).toBeInTheDocument();
+  });
+
+  test('Enter pressed while a search is pending auto-submits the first result once it resolves', async () => {
+    const deferred = createDeferred<TestOption[]>();
+    const onChange = vi.fn();
+    const loadOptions = vi.fn(() => deferred.promise);
+    render(<AsyncAutocomplete<TestOption> toOption={toOption} loadOptions={loadOptions} onChange={onChange} />);
+
+    const input = screen.getByRole('searchbox');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'ap' } });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(loadOptions).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    });
+
+    await act(async () => {
+      deferred.resolve([apple, cherry]);
+      await Promise.resolve();
+    });
+
+    expect(onChange).toHaveBeenCalledWith([apple]);
+    // Current implementation: auto-submit fires onChange directly and never
+    // adds the item to the selected pills.
+    const selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
+    expect(selected.queryByText('Apple')).not.toBeInTheDocument();
+  });
+
+  test('custom item, pill, and empty components render', async () => {
+    const ItemComponent = (props: AsyncAutocompleteOption<TestOption>): JSX.Element => <div>Item::{props.label}</div>;
+    const PillComponent = ({ item }: { item: AsyncAutocompleteOption<TestOption> }): JSX.Element => (
+      <div>Pill::{item.label}</div>
+    );
+    const EmptyComponent = ({ search }: { search: string }): JSX.Element => <div>Empty::{search}</div>;
+
+    render(
+      <AsyncAutocomplete<TestOption>
+        defaultValue={apple}
+        itemComponent={ItemComponent}
+        pillComponent={PillComponent}
+        emptyComponent={EmptyComponent}
+        toOption={toOption}
+        loadOptions={defaultLoadOptions}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Pill::Apple')).toBeInTheDocument();
+
+    const input = screen.getByRole('searchbox');
+    await typeInAutocomplete(input, 'an');
+    expect(screen.getByText('Item::Banana')).toBeInTheDocument();
+
+    await typeInAutocomplete(input, 'zzz');
+    expect(screen.getByText('Empty::zzz')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.test.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.test.tsx
@@ -170,6 +170,29 @@ describe('AsyncAutocomplete', () => {
     expect(selected.getByText('Apple')).toBeInTheDocument();
   });
 
+  test('maxValues=2 hides the search input and dropdown once the cap is reached', async () => {
+    // Regression test: reaching the cap must clean up dropdown state for any maxValues > 1, not just 1.
+    const onChange = vi.fn();
+    render(
+      <AsyncAutocomplete<TestOption>
+        maxValues={2}
+        toOption={toOption}
+        loadOptions={defaultLoadOptions}
+        onChange={onChange}
+      />
+    );
+
+    const input = screen.getByRole('searchbox');
+    await selectAutocompleteOption(input, 'Apple', 'Apple');
+    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+
+    await selectAutocompleteOption(input, 'Banana', 'Banana');
+
+    expect(onChange).toHaveBeenLastCalledWith([apple, banana]);
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
+    expect(screen.getByTestId(AsyncAutocompleteTestIds.options)).toHaveAttribute('data-hidden', 'true');
+  });
+
   test('maxValues=0 calls onChange on every selection without keeping a pill', async () => {
     const onChange = vi.fn();
     render(
@@ -421,6 +444,38 @@ describe('AsyncAutocomplete', () => {
     expect(onChange).toHaveBeenCalledWith([apple]);
     const selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
     expect(selected.getByText('Apple')).toBeInTheDocument();
+  });
+
+  test('maxValues=1 autosubmit hides the dropdown and clears search after adding the result', async () => {
+    // Regression test: the autosubmit path must clean up search/options/dropdown state the same way
+    // manual selection does for maxValues=1, instead of leaving a dangling dropdown with no search input.
+    const deferred = createDeferred<TestOption[]>();
+    const onChange = vi.fn();
+    const loadOptions = vi.fn(() => deferred.promise);
+    render(
+      <AsyncAutocomplete<TestOption> maxValues={1} toOption={toOption} loadOptions={loadOptions} onChange={onChange} />
+    );
+
+    const input = screen.getByRole('searchbox');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'ap' } });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    });
+
+    await act(async () => {
+      deferred.resolve([apple, cherry]);
+      await Promise.resolve();
+    });
+
+    expect(onChange).toHaveBeenCalledWith([apple]);
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
+    expect(screen.getByTestId(AsyncAutocompleteTestIds.options)).toHaveAttribute('data-hidden', 'true');
   });
 
   test('autosubmit under React.StrictMode calls onChange exactly once', async () => {

--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.test.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.test.tsx
@@ -418,10 +418,8 @@ describe('AsyncAutocomplete', () => {
     });
 
     expect(onChange).toHaveBeenCalledWith([apple]);
-    // Current implementation: auto-submit fires onChange directly and never
-    // adds the item to the selected pills.
     const selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
-    expect(selected.queryByText('Apple')).not.toBeInTheDocument();
+    expect(selected.getByText('Apple')).toBeInTheDocument();
   });
 
   test('custom item, pill, and empty components render', async () => {

--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.test.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { showNotification } from '@mantine/notifications';
 import type { JSX } from 'react';
+import { StrictMode } from 'react';
 import {
   act,
   fireEvent,
@@ -420,6 +421,38 @@ describe('AsyncAutocomplete', () => {
     expect(onChange).toHaveBeenCalledWith([apple]);
     const selected = within(screen.getByTestId(AsyncAutocompleteTestIds.selectedItems));
     expect(selected.getByText('Apple')).toBeInTheDocument();
+  });
+
+  test('autosubmit under React.StrictMode calls onChange exactly once', async () => {
+    // Regression test: handleValueAdd must not call onChange from inside a setState updater function,
+    // since React double-invokes updater functions under StrictMode to surface impurities.
+    const deferred = createDeferred<TestOption[]>();
+    const onChange = vi.fn();
+    const loadOptions = vi.fn(() => deferred.promise);
+    render(
+      <AsyncAutocomplete<TestOption> toOption={toOption} loadOptions={loadOptions} onChange={onChange} />,
+      ({ children }) => <StrictMode>{children}</StrictMode>
+    );
+
+    const input = screen.getByRole('searchbox');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'ap' } });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    });
+
+    await act(async () => {
+      deferred.resolve([apple, cherry]);
+      await Promise.resolve();
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith([apple]);
   });
 
   test('custom item, pill, and empty components render', async () => {

--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
@@ -120,12 +120,20 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
           // Remove from the front
           newSelected.shift();
         }
+
+        if (newSelected.length >= maxValues) {
+          // The search input is about to be hidden now that the cap is reached; reset the dropdown
+          // state so it doesn't linger with stale options and no input left to dismiss it.
+          setSearch('');
+          setOptions([]);
+          combobox.closeDropdown();
+        }
       }
 
       onChange(newSelected.map((v) => v.resource));
       setSelected(newSelected);
     },
-    [maxValues, onChange]
+    [maxValues, onChange, combobox, setSearch, setOptions]
   );
 
   const handleTimer = useCallback((): void => {
@@ -226,11 +234,6 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
       if (disabled) {
         return;
       }
-      if (maxValues === 1) {
-        setSearch('');
-        setOptions([]);
-        combobox.closeDropdown();
-      }
       lastValueRef.current = undefined;
       if (val === '$create') {
         setSearch('');
@@ -239,7 +242,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
         toggleSelected(val);
       }
     };
-  }, [toggleSelected, combobox, disabled, maxValues, search, setSearch]);
+  }, [toggleSelected, disabled, search, setSearch]);
 
   const handleValueRemove = useCallback(
     (item: AsyncAutocompleteOption<T>): void => {

--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
@@ -166,7 +166,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
     [combobox, options, creatable, handleTimer, setTimer, setSearch, setAbortController]
   );
 
-  const addSelected = useCallback(
+  const toggleSelected = useCallback(
     (newValue: string): void => {
       const alreadySelected = selected.some((v) => v.value === newValue);
       const newSelected = alreadySelected ? selected.filter((v) => v.value !== newValue) : [...selected];
@@ -223,12 +223,12 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
       lastValueRef.current = undefined;
       if (val === '$create') {
         setSearch('');
-        addSelected(search);
+        toggleSelected(search);
       } else {
-        addSelected(val);
+        toggleSelected(val);
       }
     };
-  }, [addSelected, combobox, disabled, maxValues, search, setSearch]);
+  }, [toggleSelected, combobox, disabled, maxValues, search, setSearch]);
 
   const handleValueRemove = useCallback(
     (item: AsyncAutocompleteOption<T>): void => {

--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
@@ -91,37 +91,39 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
   const timerRef = useRef<number>(timer);
   const abortControllerRef = useRef<AbortController>(abortController);
   const autoSubmitRef = useRef<boolean>(false);
+  const selectedRef = useRef(selected);
   useLayoutEffect(() => {
     searchRef.current = search;
     timerRef.current = timer;
     abortControllerRef.current = abortController;
+    selectedRef.current = selected;
   });
 
   const handleValueAdd = useCallback(
     (item: AsyncAutocompleteOption<T>): void => {
-      setSelected((selected) => {
-        if (selected.some((v) => v.value === item.value)) {
-          return selected;
+      const selected = selectedRef.current;
+      if (selected.some((v) => v.value === item.value)) {
+        return;
+      }
+
+      // when maxValues is 0, still fire the onChange when an item is selected
+      if (maxValues === 0) {
+        onChange([item.resource]);
+        setSelected([]);
+        return;
+      }
+
+      const newSelected = [...selected, item];
+
+      if (maxValues !== undefined) {
+        while (newSelected.length > maxValues) {
+          // Remove from the front
+          newSelected.shift();
         }
+      }
 
-        // when maxValues is 0, still fire the onChange when an item is selected
-        if (maxValues === 0) {
-          onChange([item.resource]);
-          return [];
-        }
-
-        const newSelected = [...selected, item];
-
-        if (maxValues !== undefined) {
-          while (newSelected.length > maxValues) {
-            // Remove from the front
-            newSelected.shift();
-          }
-        }
-
-        onChange(newSelected.map((v) => v.resource));
-        return newSelected;
-      });
+      onChange(newSelected.map((v) => v.resource));
+      setSelected(newSelected);
     },
     [maxValues, onChange]
   );

--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
@@ -140,7 +140,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
           setAbortController(undefined);
         }
       });
-  }, [combobox, loadOptions, onChange, toOption, minInputLength]);
+  }, [combobox, loadOptions, onChange, toOption, minInputLength, setTimer, setAutoSubmit, setAbortController]);
 
   const handleSearchChange = useCallback(
     (e: SyntheticEvent): void => {
@@ -163,7 +163,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
       const newTimer = window.setTimeout(() => handleTimer(), 100);
       setTimer(newTimer);
     },
-    [combobox, options, creatable, handleTimer]
+    [combobox, options, creatable, handleTimer, setTimer, setSearch, setAbortController]
   );
 
   const addSelected = useCallback(
@@ -228,7 +228,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
         addSelected(val);
       }
     };
-  }, [addSelected, combobox, disabled, maxValues, search]);
+  }, [addSelected, combobox, disabled, maxValues, search, setSearch]);
 
   const handleValueRemove = useCallback(
     (item: AsyncAutocompleteOption<T>): void => {
@@ -252,7 +252,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
         handleValueRemove(selected[selected.length - 1]);
       }
     },
-    [abortController, handleValueRemove, search.length, selected, timer]
+    [abortController, handleValueRemove, search.length, selected, timer, setAutoSubmit]
   );
 
   useEffect(() => {

--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
@@ -79,7 +79,6 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
   const [search, setSearch] = useState('');
   const [timer, setTimer] = useState<number>();
   const [abortController, setAbortController] = useState<AbortController>();
-  const [autoSubmit, setAutoSubmit] = useState<boolean>();
   const [selected, setSelected] = useState(defaultItems.map(toOption));
   const [options, setOptions] = useState<AsyncAutocompleteOption<T>[]>([]);
   const ItemComponent = itemComponent ?? DefaultItemComponent;
@@ -91,12 +90,11 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
   const lastValueRef = useRef<string>(undefined);
   const timerRef = useRef<number>(timer);
   const abortControllerRef = useRef<AbortController>(abortController);
-  const autoSubmitRef = useRef<boolean>(autoSubmit);
+  const autoSubmitRef = useRef<boolean>(false);
   useLayoutEffect(() => {
     searchRef.current = search;
     timerRef.current = timer;
     abortControllerRef.current = abortController;
-    autoSubmitRef.current = autoSubmit;
   });
 
   const handleValueAdd = useCallback(
@@ -154,7 +152,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
             if (newOptions.length > 0) {
               handleValueAdd(newOptions[0]);
             }
-            setAutoSubmit(false);
+            autoSubmitRef.current = false;
           } else if (newValues.length > 0) {
             combobox.openDropdown();
           }
@@ -170,7 +168,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
           setAbortController(undefined);
         }
       });
-  }, [combobox, loadOptions, handleValueAdd, toOption, minInputLength, setTimer, setAutoSubmit, setAbortController]);
+  }, [combobox, loadOptions, handleValueAdd, toOption, minInputLength, setTimer, setAbortController]);
 
   const handleSearchChange = useCallback(
     (e: SyntheticEvent): void => {
@@ -256,14 +254,14 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
         if (timer || abortController) {
           // The user pressed enter, but we don't have results yet.
           // We need to wait for the results to come in.
-          setAutoSubmit(true);
+          autoSubmitRef.current = true;
         }
       } else if (e.key === 'Backspace' && search.length === 0) {
         killEvent(e);
         handleValueRemove(selected[selected.length - 1]);
       }
     },
-    [abortController, handleValueRemove, search.length, selected, timer, setAutoSubmit]
+    [abortController, handleValueRemove, search.length, selected, timer]
   );
 
   useEffect(() => {

--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
@@ -99,6 +99,35 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
     autoSubmitRef.current = autoSubmit;
   });
 
+  const handleValueAdd = useCallback(
+    (item: AsyncAutocompleteOption<T>): void => {
+      setSelected((selected) => {
+        if (selected.some((v) => v.value === item.value)) {
+          return selected;
+        }
+
+        // when maxValues is 0, still fire the onChange when an item is selected
+        if (maxValues === 0) {
+          onChange([item.resource]);
+          return [];
+        }
+
+        const newSelected = [...selected, item];
+
+        if (maxValues !== undefined) {
+          while (newSelected.length > maxValues) {
+            // Remove from the front
+            newSelected.shift();
+          }
+        }
+
+        onChange(newSelected.map((v) => v.resource));
+        return newSelected;
+      });
+    },
+    [maxValues, onChange]
+  );
+
   const handleTimer = useCallback((): void => {
     setTimer(undefined);
 
@@ -119,10 +148,11 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
     loadOptions(searchRef.current ?? '', newAbortController.signal)
       .then((newValues: T[]) => {
         if (!newAbortController.signal.aborted) {
-          setOptions(newValues.map(toOption));
+          const newOptions = newValues.map(toOption);
+          setOptions(newOptions);
           if (autoSubmitRef.current) {
-            if (newValues.length > 0) {
-              onChange(newValues.slice(0, 1));
+            if (newOptions.length > 0) {
+              handleValueAdd(newOptions[0]);
             }
             setAutoSubmit(false);
           } else if (newValues.length > 0) {
@@ -140,7 +170,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
           setAbortController(undefined);
         }
       });
-  }, [combobox, loadOptions, onChange, toOption, minInputLength, setTimer, setAutoSubmit, setAbortController]);
+  }, [combobox, loadOptions, handleValueAdd, toOption, minInputLength, setTimer, setAutoSubmit, setAbortController]);
 
   const handleSearchChange = useCallback(
     (e: SyntheticEvent): void => {
@@ -169,41 +199,22 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
   const toggleSelected = useCallback(
     (newValue: string): void => {
       const alreadySelected = selected.some((v) => v.value === newValue);
-      const newSelected = alreadySelected ? selected.filter((v) => v.value !== newValue) : [...selected];
-      let option = options?.find((option) => option.value === newValue);
-      if (!option && creatable !== false && onCreate) {
-        const createdResource = onCreate(newValue);
-        option = toOption(createdResource);
-      }
-
-      if (option) {
-        // when maxValues is 0, still fire the onChange when an item is selected
-        if (maxValues === 0) {
-          onChange([option.resource]);
-
-          // and clear selected if necessary
-          if (selected.length > 0) {
-            setSelected([]);
-          }
-          return;
+      if (alreadySelected) {
+        const newSelected = selected.filter((v) => v.value !== newValue);
+        onChange(newSelected.map((v) => v.resource));
+        setSelected(newSelected);
+      } else {
+        let option = options?.find((option) => option.value === newValue);
+        if (!option && creatable !== false && onCreate) {
+          const createdResource = onCreate(newValue);
+          option = toOption(createdResource);
         }
-
-        if (!alreadySelected) {
-          newSelected.push(option);
+        if (option) {
+          handleValueAdd(option);
         }
       }
-
-      if (maxValues !== undefined) {
-        while (newSelected.length > maxValues) {
-          // Remove from the front
-          newSelected.shift();
-        }
-      }
-
-      onChange(newSelected.map((v) => v.resource));
-      setSelected(newSelected);
     },
-    [creatable, options, selected, maxValues, onChange, onCreate, toOption]
+    [selected, onChange, handleValueAdd, onCreate, toOption, options, creatable]
   );
 
   const handleValueSelect = useMemo(() => {


### PR DESCRIPTION
While testing some of the components coming up in Scheduling work like #10164 I noticed that when I throttle my network I could get into some seemingly broken states via the "autosubmit" feature built into the `<AsyncAutocomplete>` component we are building on top of.

The main fix is that when autosubmit fires, we now show the value emitted to `onChange` in the component's pills. While in here I took the opportunity to do some cleanup as well.

This branch is best reviewed commit-by-commit. The bulk of lines added are test coverage that Claude generated so I could refactor with a test loop running; these are somewhat duplicative of other tests (such as those for `<ValueSetAutocomplete>`), but having tighter unit tests for this helped me so I've chosen to leave them committed.