### PR TITLE
feat(server): add onlyActivePatients input parameter to Patient $match

### DIFF
--- a/packages/docs/docs/api/fhir/operations/patient-match.md
+++ b/packages/docs/docs/api/fhir/operations/patient-match.md
@@ -33,6 +33,7 @@ POST [base]/Patient/$match
 | -------------------- | ----------- | --------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `resource`           | 1..1        | `Patient` | The patient to match against (may be partial). Must include at least one of: `identifier`, `name`, `birthDate`, or `telecom`. |
 | `onlyCertainMatches` | 0..1        | `boolean` | Selects the matching mode. See [Matching Modes](#matching-modes). Defaults to `false`.                                        |
+| `onlyActivePatients` | 0..1        | `boolean` | Restricts candidates to active patients. See [Candidate Search](#candidate-search). Defaults to `false`.                      |
 | `count`              | 0..1        | `integer` | Maximum number of results (discovery mode only). Defaults to the server's default search count.                               |
 
 ## Matching Modes
@@ -147,6 +148,14 @@ Before scoring, candidates are gathered with selective FHIR searches anchored on
 - `Patient?identifier=<system>|<value>` for each identifier
 - `Patient?telecom=<value>` for each phone or email
 - `Patient?birthdate=<date>&family=<family>` and `Patient?birthdate=<date>&given=<given>` when a birth date is present
+
+When `onlyActivePatients` is `true`, every candidate search additionally filters on `active=true`.
+
+:::caution[Patients without an `active` element are excluded]
+
+`Patient.active` is optional in FHIR, and an unset value is not the same as `false`. Because `onlyActivePatients` requires `active=true`, any patient that omits the element is excluded from matching. In projects where records were created without `active`, this flag will exclude nearly everything until the field is backfilled.
+
+:::
 
 Results are deduplicated by patient ID, then compared and scored in memory. Discovery mode ranks the gathered candidate set; it is intended for review and is not an exhaustive population scan. In disclosure mode, if a search hits its result cap (uniqueness cannot be proven), the match is suppressed.
 

--- a/packages/server/src/fhir/operations/patientmatch.test.ts
+++ b/packages/server/src/fhir/operations/patientmatch.test.ts
@@ -367,8 +367,111 @@ describe('Patient $match Operation', () => {
     expect((bundle.entry ?? []).length).toBeLessThanOrEqual(2);
   });
 
+  test('Respects onlyActivePatients flag', async () => {
+    const birthDate = '1968-02-14';
+    const family = `Activetest${Date.now()}`;
+    const activePatient = await request(app)
+      .post('/fhir/R4/Patient')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Patient',
+        name: [{ family, given: ['Delta'] }],
+        birthDate,
+        active: true,
+      } satisfies Patient);
+    const inactivePatient = await request(app)
+      .post('/fhir/R4/Patient')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Patient',
+        name: [{ family, given: ['Delta'] }],
+        birthDate,
+        active: false,
+      } satisfies Patient);
+
+    const matchResource = {
+      resourceType: 'Patient',
+      name: [{ family, given: ['Delta'] }],
+      birthDate,
+    } satisfies Patient;
+
+    // Without the flag, both the active and the inactive patient are candidates.
+    const allRes = await request(app)
+      .post('/fhir/R4/Patient/$match')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'resource', resource: matchResource }],
+      });
+
+    expect(allRes).toHaveStatus(200);
+    const allIds = ((allRes.body as Bundle<Patient>).entry ?? []).map((e) => e.resource?.id);
+    expect(allIds).toContain(activePatient.body.id);
+    expect(allIds).toContain(inactivePatient.body.id);
+
+    // With the flag, the inactive patient is excluded from the candidate search.
+    const activeRes = await request(app)
+      .post('/fhir/R4/Patient/$match')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'resource', resource: matchResource },
+          { name: 'onlyActivePatients', valueBoolean: true },
+        ],
+      });
+
+    expect(activeRes).toHaveStatus(200);
+    const activeIds = ((activeRes.body as Bundle<Patient>).entry ?? []).map((e) => e.resource?.id);
+    expect(activeIds).toContain(activePatient.body.id);
+    expect(activeIds).not.toContain(inactivePatient.body.id);
+  });
+
+  test('onlyActivePatients excludes patients with no active element', async () => {
+    // `active` is optional in FHIR, and an unset value is not the same as false. The flag
+    // requires `active=true`, so records that omit the element are excluded.
+    const birthDate = '1969-08-30';
+    const family = `Activeunset${Date.now()}`;
+    const created = await request(app)
+      .post('/fhir/R4/Patient')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Patient',
+        name: [{ family, given: ['Epsilon'] }],
+        birthDate,
+      } satisfies Patient);
+    expect(created).toHaveStatus(201);
+
+    const res = await request(app)
+      .post('/fhir/R4/Patient/$match')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'resource',
+            resource: {
+              resourceType: 'Patient',
+              name: [{ family, given: ['Epsilon'] }],
+              birthDate,
+            } satisfies Patient,
+          },
+          { name: 'onlyActivePatients', valueBoolean: true },
+        ],
+      });
+
+    expect(res).toHaveStatus(200);
+    expect((res.body as Bundle<Patient>).entry ?? []).toHaveLength(0);
+  });
+
   describe('CMS mode (onlyCertainMatches=true)', () => {
-    const cmsMatch = (resource: Patient): Promise<request.Response> =>
+    const cmsMatch = (resource: Patient, onlyActivePatients?: boolean): Promise<request.Response> =>
       request(app)
         .post('/fhir/R4/Patient/$match')
         .set('Authorization', 'Bearer ' + accessToken)
@@ -378,6 +481,7 @@ describe('Patient $match Operation', () => {
           parameter: [
             { name: 'resource', resource },
             { name: 'onlyCertainMatches', valueBoolean: true },
+            ...(onlyActivePatients ? [{ name: 'onlyActivePatients', valueBoolean: true }] : []),
           ],
         });
 
@@ -446,6 +550,46 @@ describe('Patient $match Operation', () => {
       expect(res).toHaveStatus(200);
       const bundle = res.body as Bundle<Patient>;
       expect(bundle.entry ?? []).toHaveLength(0);
+    });
+
+    test('releases a unique active match that an inactive duplicate would make ambiguous', async () => {
+      const phone = '+1-617-555-0199';
+      const birthDate = '1974-01-09';
+      const family = `CmsInactiveDupe${Date.now()}`;
+      const active = await createPatient({
+        resourceType: 'Patient',
+        name: [{ family, given: ['Charles'] }],
+        birthDate,
+        telecom: [{ system: 'phone', value: phone }],
+        active: true,
+      });
+      expect(active).toHaveStatus(201);
+      await createPatient({
+        resourceType: 'Patient',
+        name: [{ family, given: ['Charles'] }],
+        birthDate,
+        telecom: [{ system: 'phone', value: phone }],
+        active: false,
+      });
+
+      const matchResource = {
+        resourceType: 'Patient',
+        name: [{ given: ['Charles'] }],
+        birthDate,
+        telecom: [{ system: 'phone', value: phone }],
+      } satisfies Patient;
+
+      // Both satisfy rule 11, so the uniqueness gate suppresses the disclosure.
+      const ambiguousRes = await cmsMatch(matchResource);
+      expect(ambiguousRes).toHaveStatus(200);
+      expect((ambiguousRes.body as Bundle<Patient>).entry ?? []).toHaveLength(0);
+
+      // The inactive duplicate never reaches the uniqueness gate, so the match is released.
+      const res = await cmsMatch(matchResource, true);
+      expect(res).toHaveStatus(200);
+      const bundle = res.body as Bundle<Patient>;
+      expect(bundle.entry).toHaveLength(1);
+      expect(bundle.entry?.[0]?.resource?.id).toBe(active.body.id);
     });
 
     test('no match when only a single non-discriminating field agrees', async () => {

--- a/packages/server/src/fhir/operations/patientmatch.ts
+++ b/packages/server/src/fhir/operations/patientmatch.ts
@@ -13,7 +13,7 @@ import {
   Operator,
 } from '@medplum/core';
 import type { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import type { Bundle, BundleEntry, Extension, Patient } from '@medplum/fhirtypes';
+import type { Bundle, BundleEntry, Extension, OperationDefinition, Patient } from '@medplum/fhirtypes';
 import type { AuthenticatedRequestContext } from '../../context';
 import { getAuthenticatedContext } from '../../context';
 import {
@@ -29,7 +29,16 @@ import type { CmsPatientMatchResult } from './utils/cms-patient-match';
 import { cmsPatientMatch } from './utils/cms-patient-match';
 import { parseInputParameters } from './utils/parameters';
 
-const operation = getOperationDefinition('Patient', 'match');
+const baseOperation = getOperationDefinition('Patient', 'match');
+
+// `onlyActivePatients` is a Medplum extension not in the standard OperationDefinition.
+const operation: OperationDefinition = {
+  ...baseOperation,
+  parameter: [
+    ...(baseOperation.parameter ?? EMPTY),
+    { use: 'in', name: 'onlyActivePatients', min: 0, max: '1', type: 'boolean' },
+  ],
+};
 
 // Extension URL for match-grade, as defined by the FHIR spec
 const MATCH_GRADE_EXTENSION_URL = `${HTTP_HL7_ORG}/fhir/StructureDefinition/match-grade`;
@@ -43,11 +52,16 @@ const PROBABLE_THRESHOLD = 0.65;
 const POSSIBLE_THRESHOLD = 0.2;
 const CMS_MATCH_FACTOR_COUNT = 11;
 
+// Restricts candidate searches to patients explicitly marked active. Patients without an
+// `active` element are excluded, since FHIR treats the field as optional and unset is not false.
+const ACTIVE_FILTER = { code: 'active', operator: Operator.EQUALS, value: 'true' };
+
 export type MatchGrade = 'certain' | 'probable' | 'possible' | 'certainly-not';
 
 export interface PatientMatchParameters {
   resource: Patient;
   onlyCertainMatches?: boolean;
+  onlyActivePatients?: boolean;
   count?: number;
 }
 
@@ -103,7 +117,7 @@ export async function matchPatients(
 ): Promise<{ bundle: Bundle<WithId<Patient>>; certainMatches: ScoredPatient[]; truncated: boolean }> {
   const input = params.resource;
   const maxCount = params.count ?? DEFAULT_SEARCH_COUNT;
-  const { candidates, truncated } = await gatherCandidates(repo, input);
+  const { candidates, truncated } = await gatherCandidates(repo, input, params.onlyActivePatients);
   const scored = candidates.map((candidate) => scoreCandidate(candidate, input));
   const relevant = scored.filter((s) => s.grade !== 'certainly-not');
   const certainMatches = relevant.filter((s) => s.grade === 'certain');
@@ -125,11 +139,13 @@ export async function matchPatients(
  * demographics in the input patient. Results are deduplicated by patient ID.
  * @param repo - The repository.
  * @param input - The input patient resource to match against.
+ * @param onlyActivePatients - Whether to restrict candidates to patients marked active.
  * @returns Deduplicated array of candidate patients and whether any search was truncated.
  */
 async function gatherCandidates(
   repo: Repository,
-  input: Patient
+  input: Patient,
+  onlyActivePatients?: boolean
 ): Promise<{ candidates: WithId<Patient>[]; truncated: boolean }> {
   const seen = new Map<string, WithId<Patient>>();
   let truncated = false;
@@ -137,7 +153,7 @@ async function gatherCandidates(
   const runSearch = async (filters: { code: string; operator: Operator; value: string }[]): Promise<void> => {
     const result = await repo.search<WithId<Patient>>({
       resourceType: 'Patient',
-      filters,
+      filters: onlyActivePatients ? [...filters, ACTIVE_FILTER] : filters,
       count: CANDIDATE_SEARCH_COUNT,
     });
     const entries = result.entry ?? EMPTY;


### PR DESCRIPTION
Closes #10285

## Summary

Adds an optional `onlyActivePatients` boolean input parameter to `Patient/$match`. When `true`, candidate gathering is restricted to patients with `active: true`.

Defaults to `false`, so existing callers are unaffected.


## Note on impact

`Patient.active` is optional in FHIR, and an unset value is not the same as `false`. Because the flag filters on `active=true`, patients that omit the element are also excluded.
