### PR TITLE
test(agent): step the park-backlog yield instead of racing a timer

### DIFF
--- a/packages/agent/src/queue/worker.test.ts
+++ b/packages/agent/src/queue/worker.test.ts
@@ -1372,17 +1372,53 @@ describe('ChannelQueueWorker', () => {
         log: createMockLogger(),
         sendAck: () => true,
       });
-      // Yield after every park, so "did it yield at all?" is a count assertion
-      // rather than a wall-clock one.
-      startSlot(app, worker, { loopYieldBudgetMs: 0 });
+      // Stub the dispatcher's yield primitive with a queue released by hand: each step
+      // below then runs exactly one more loop iteration, so "did it yield a turn?" is a
+      // step count and not a race between nine parks and one clamped 0ms timer.
+      // `vi.advanceTimersToNextTimerAsync` will not do — it fires the next timer and
+      // then ticks, running two iterations per call.
+      const pendingYields: (() => void)[] = [];
+      const immediate = vi.spyOn(globalThis, 'setImmediate').mockImplementation((cb: () => void) => {
+        pendingYields.push(cb);
+        return undefined as unknown as NodeJS.Immediate;
+      });
+      /** Releases the turn the loop is suspended on and lets it run to its next yield. */
+      const stepOneTurn = async (): Promise<void> => {
+        // Nothing queued here would mean the loop never reached a real event-loop yield:
+        // a microtask downgrade drains the whole backlog on its own, unobserved.
+        expect(pendingYields).toHaveLength(1);
+        pendingYields.shift()?.();
+        await Promise.resolve();
+      };
 
-      // One `await` drains the whole microtask queue. Without the yield the loop
-      // never leaves that drain, so all nine would already be parked here.
-      await sleep(0);
-      expect(queue.getChannelDepth('ch1').delayed).toBeLessThan(followers.length);
+      try {
+        // Yield after every park, so one released turn is one park.
+        startSlot(app, worker, { loopYieldBudgetMs: 0 });
 
-      // The budget only spreads the parks out — it must not lose any.
-      await waitFor(() => queue.getChannelDepth('ch1').delayed === followers.length, 3000, 'backlog fully parked');
+        // `start()` runs the loop synchronously into its first yield, so exactly one row
+        // is parked here. Without the yield all nine would be.
+        expect(queue.getChannelDepth('ch1').delayed).toBe(1);
+
+        // One park per turn, all the way down: never a run of them in a single turn.
+        for (let parked = 2; parked <= followers.length; parked++) {
+          await stepOneTurn();
+          expect(queue.getChannelDepth('ch1').delayed).toBe(parked);
+        }
+
+        // The budget only spreads the parks out — it must not lose any. This last turn
+        // also takes the loop past the drained backlog into its idle wait, which is a
+        // timer rather than a yield, so nothing is left queued here.
+        await stepOneTurn();
+        expect(queue.getChannelDepth('ch1').delayed).toBe(followers.length);
+        expect(pendingYields).toHaveLength(0);
+      } finally {
+        // Restore before releasing: a loop resumed under the stub would park its next
+        // yield in an array nobody drains, and every stop awaiting that loop would hang.
+        immediate.mockRestore();
+        for (const resume of pendingYields.splice(0)) {
+          resume();
+        }
+      }
       await worker.stop();
     });
 


### PR DESCRIPTION
Supersedes #10271, which fixed the same flake with a 200-iteration microtask drain.

`packages/agent/src/queue/worker.test.ts` → "parks a blocked backlog across event-loop turns instead of draining it in one" has been failing in CI:

```
AssertionError: expected 9 to be less than 9
  expect(queue.getChannelDepth("ch1").delayed).toBeLessThan(followers.length);
```

### Why it flakes

The test asserted that fewer than nine rows were parked after `await sleep(0)`. But `sleep(0)` is a timer, and the dispatcher yields on `setImmediate` (`dispatcher.ts`, `yieldToEventLoop` — deliberately the check phase, not a 0ms timeout). Check-phase callbacks run *during* a clamped `setTimeout(…, 0)`, so the assertion was a race between nine parks and one timer.

Measured how many `setImmediate` turns fit inside one `setTimeout(0)`, varying the per-turn cost that stands in for `claimNext` + `markDelayed`:

| per-park cost | turns before the timer | result |
| --- | --- | --- |
| 200µs | 3–5 | passes |
| 120µs | 7–8 | passes, ~1.5x headroom |
| 60µs | 13–14 | **fails 15/15** |
| 20µs | ~30 | **fails 15/15** |

The assertion trips at 9 turns, so the tipping point is ~110µs per park — crossed by a faster runner, a warm SQLite cache, or a timer delayed under parallel-CI load.

### The fix

Take the clock out of the measurement entirely. `setImmediate` is stubbed with a queue the test releases one entry at a time, so each step runs exactly one more loop iteration and the property under test — one park per event-loop turn at `loopYieldBudgetMs: 0` — is a step count. Every step also asserts the loop is suspended on a real `setImmediate`, which is what keeps the test honest.

No production change; `dispatcher.ts` is untouched.

`vi.advanceTimersToNextTimerAsync()` was the first thing tried and does not work here: it fires the next timer *and then* ticks ([sinonjs/fake-timers#250](https://github.com/sinonjs/fake-timers/issues/250)), so each call runs two loop iterations.

### Verified

Patched the dispatcher three ways and confirmed the test fails each time, then reverted:

| dispatcher change | result |
| --- | --- |
| yield downgraded to a microtask | `expected [] to have a length of 1` |
| yield removed entirely | `expected 9 to be 1` |
| yield swapped for `setTimeout(resolve, 0)` | `expected [] to have a length of 1` |

Unpatched: passes 5/5 for the whole file, and the full `src/queue` suite is green (206 tests). `tsc --noEmit`, `eslint`, and `prettier --check` all clean.

Closes https://github.com/medplum/medplum/issues/10209