### PR TITLE
Proactively drain DB pools on graceful shutdown

### DIFF
--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -294,6 +294,7 @@ export interface MedplumDatabaseConfig {
   disableRunPostDeployMigrations?: boolean;
   maxConnections?: number;
   minConnections?: number;
+  maxConnectionUses?: number;
   idleTimeoutMs?: number;
   connectionTimeoutMs?: number;
   disableConnectionConfiguration?: boolean;

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -293,9 +293,13 @@ export interface MedplumDatabaseConfig {
    */
   disableRunPostDeployMigrations?: boolean;
   maxConnections?: number;
+  /** Minimum number of clients the pool retains and _not_ destroy via idleTimeoutMs. Default is 0 */
   minConnections?: number;
+  /** Maximum times a pool client can be used before being replaced. Active connection pruner. Default is Infinity */
   maxConnectionUses?: number;
-  idleTimeoutMs?: number;
+  /** Duration a client must sit idle before being disconnected. Idle connection pruner. Default is 10,000ms */
+  idleTimeoutMs?: number; // idle pruner
+  /** Duration to wait before timing out when connecting a new client. Defaults to no timeout */
   connectionTimeoutMs?: number;
   disableConnectionConfiguration?: boolean;
 }

--- a/packages/server/src/config/utils.ts
+++ b/packages/server/src/config/utils.ts
@@ -141,9 +141,17 @@ const integerKeys = new Set([
   'fhirSearchMinLimit',
 
   'database.maxConnections',
+  'database.minConnections',
+  'database.maxConnectionUses',
+  'database.idleTimeoutMs',
+  'database.connectionTimeoutMs',
   'database.port',
   'database.queryTimeout',
   'readonlyDatabase.maxConnections',
+  'readonlyDatabase.minConnections',
+  'readonlyDatabase.maxConnectionUses',
+  'readonlyDatabase.idleTimeoutMs',
+  'readonlyDatabase.connectionTimeoutMs',
   'readonlyDatabase.port',
   'readonlyDatabase.queryTimeout',
 

--- a/packages/server/src/database-config.test.ts
+++ b/packages/server/src/database-config.test.ts
@@ -176,6 +176,7 @@ describe('Database config', () => {
     const config = await loadTestConfig();
     config.database.maxConnections = 20;
     config.database.minConnections = 5;
+    config.database.maxConnectionUses = 555;
     config.database.idleTimeoutMs = 30_000;
     config.database.connectionTimeoutMs = 10_000;
 
@@ -185,6 +186,7 @@ describe('Database config', () => {
       expect.objectContaining({
         max: 20,
         min: 5,
+        maxUses: 555,
         idleTimeoutMillis: 30_000,
         connectionTimeoutMillis: 10_000,
       })

--- a/packages/server/src/database.test.ts
+++ b/packages/server/src/database.test.ts
@@ -9,7 +9,7 @@ import {
   DatabaseMode,
   getDatabasePool,
   initDatabase,
-  purgeIdleDatabasePoolConnections,
+  prepareDatabasePoolsForShutdown,
   releaseAdvisoryLock,
 } from './database';
 
@@ -60,9 +60,10 @@ describe('Advisory locks', () => {
   });
 });
 
-describe('purgeAllIdlePoolConnections', () => {
+describe('prepareDatabasePoolsForShutdown', () => {
   beforeEach(async () => {
     const config = await loadTestConfig();
+    config.database.minConnections = 2;
     await initDatabase(config);
   });
 
@@ -70,14 +71,38 @@ describe('purgeAllIdlePoolConnections', () => {
     await closeDatabase();
   });
 
-  test('Closes all idle connections', async () => {
+  test('Closes all idle connections regardless of the configured minimum', async () => {
     const pool = getDatabasePool(DatabaseMode.WRITER);
     const clients = await Promise.all([pool.connect(), pool.connect()]);
     clients.forEach((client) => client.release());
+    expect(pool.options.min).toBe(2);
     expect(pool.idleCount).toBe(2);
 
-    purgeIdleDatabasePoolConnections();
+    prepareDatabasePoolsForShutdown();
 
+    expect(pool.options.min).toBe(0);
+    expect(pool.idleCount).toBe(0);
+    expect(pool.totalCount).toBe(0);
+  });
+
+  test('Closes connections released during graceful shutdown', async () => {
+    const pool = getDatabasePool(DatabaseMode.WRITER);
+    const idleClient = await pool.connect();
+    const activeClient = await pool.connect();
+    idleClient.release();
+    expect(pool.idleCount).toBe(1);
+    expect(pool.totalCount).toBe(2);
+
+    prepareDatabasePoolsForShutdown();
+
+    expect(pool.idleCount).toBe(0);
+    expect(pool.totalCount).toBe(1);
+
+    await pool.query('SELECT 1');
+    expect(pool.idleCount).toBe(0);
+    expect(pool.totalCount).toBe(1);
+
+    expect(() => activeClient.release()).not.toThrow();
     expect(pool.idleCount).toBe(0);
     expect(pool.totalCount).toBe(0);
   });

--- a/packages/server/src/database.test.ts
+++ b/packages/server/src/database.test.ts
@@ -9,6 +9,7 @@ import {
   DatabaseMode,
   getDatabasePool,
   initDatabase,
+  purgeIdleDatabasePoolConnections,
   releaseAdvisoryLock,
 } from './database';
 
@@ -56,5 +57,28 @@ describe('Advisory locks', () => {
     await Promise.all([aPromise(), bPromise()]);
 
     expect(bLock).toBe(true);
+  });
+});
+
+describe('purgeAllIdlePoolConnections', () => {
+  beforeEach(async () => {
+    const config = await loadTestConfig();
+    await initDatabase(config);
+  });
+
+  afterEach(async () => {
+    await closeDatabase();
+  });
+
+  test('Closes all idle connections', async () => {
+    const pool = getDatabasePool(DatabaseMode.WRITER);
+    const clients = await Promise.all([pool.connect(), pool.connect()]);
+    clients.forEach((client) => client.release());
+    expect(pool.idleCount).toBe(2);
+
+    purgeIdleDatabasePoolConnections();
+
+    expect(pool.idleCount).toBe(0);
+    expect(pool.totalCount).toBe(0);
   });
 });

--- a/packages/server/src/database.test.ts
+++ b/packages/server/src/database.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { sleep } from '@medplum/core';
-import type { PoolClient } from 'pg';
+import type { Pool, PoolClient } from 'pg';
 import { loadTestConfig } from './config/loader';
 import {
   acquireAdvisoryLock,
@@ -12,6 +12,7 @@ import {
   prepareDatabasePoolsForShutdown,
   releaseAdvisoryLock,
 } from './database';
+import { globalLogger } from './logger';
 
 describe('Advisory locks', () => {
   let clientA: PoolClient;
@@ -83,6 +84,44 @@ describe('prepareDatabasePoolsForShutdown', () => {
     expect(pool.options.min).toBe(0);
     expect(pool.idleCount).toBe(0);
     expect(pool.totalCount).toBe(0);
+
+    await closeDatabase();
+
+    // idempotent
+    prepareDatabasePoolsForShutdown();
+  });
+
+  test('Handles errors thrown while preparing pools', async () => {
+    type PoolWithRemove = Pool & { _remove: (client: PoolClient) => void };
+
+    const writerPool = getDatabasePool(DatabaseMode.WRITER);
+    const readerPool = getDatabasePool(DatabaseMode.READER);
+    const clients = await Promise.all([writerPool.connect(), readerPool.connect()]);
+    clients.forEach((client) => client.release());
+
+    const writerError = new Error('Writer test error');
+    const readerError = new Error('Reader test error');
+    const writerRemoveSpy = vi.spyOn(writerPool as PoolWithRemove, '_remove').mockImplementation(() => {
+      throw writerError;
+    });
+    const readerRemoveSpy = vi.spyOn(readerPool as PoolWithRemove, '_remove').mockImplementation(() => {
+      throw readerError;
+    });
+    const errorSpy = vi.spyOn(globalLogger, 'error').mockImplementation(() => undefined);
+
+    try {
+      prepareDatabasePoolsForShutdown();
+
+      expect(writerRemoveSpy).toHaveBeenCalledTimes(1);
+      expect(readerRemoveSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+      expect(errorSpy).toHaveBeenCalledWith('Error purging idle pool connections', { err: writerError });
+      expect(errorSpy).toHaveBeenCalledWith('Error purging idle pool connections', { err: readerError });
+    } finally {
+      writerRemoveSpy.mockRestore();
+      readerRemoveSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
   });
 
   test('Closes connections released during graceful shutdown', async () => {

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -70,6 +70,7 @@ function initPoolConfig(
     max: config.maxConnections ?? DEFAULT_MAX_CONNECTIONS,
     min: config.minConnections,
     idleTimeoutMillis: config.idleTimeoutMs,
+    maxUses: config.maxConnectionUses,
     connectionTimeoutMillis: config.connectionTimeoutMs,
     options: config.disableConnectionConfiguration
       ? undefined

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -267,14 +267,15 @@ async function runAllPendingPreDeployMigrations(client: PoolClient, currentVersi
 }
 
 /**
- * Synchronously close all idle connections DB pool connections to immediately free
- * up DB resources instead of waiting for the graceful server shutdown to invoke
- * {@link closeDatabase}.
+ * Prepares the database pools for graceful shutdown. Existing idle connections are
+ * removed immediately, regardless of the configured minimum. Checked-out and subsequently
+ * created connections remain usable, but are removed when released instead of returning
+ * to the pool. {@link closeDatabase} later ends the pools completely.
  */
-export function purgeIdleDatabasePoolConnections(): void {
+export function prepareDatabasePoolsForShutdown(): void {
   try {
     if (pool) {
-      purgeIdleConnections(pool, DatabaseMode.WRITER);
+      preparePoolForShutdown(pool, DatabaseMode.WRITER);
     }
   } catch (err) {
     globalLogger.error('Error purging idle pool connections', { err });
@@ -282,7 +283,7 @@ export function purgeIdleDatabasePoolConnections(): void {
 
   try {
     if (readonlyPool) {
-      purgeIdleConnections(readonlyPool, DatabaseMode.READER);
+      preparePoolForShutdown(readonlyPool, DatabaseMode.READER);
     }
   } catch (err) {
     globalLogger.error('Error purging idle pool connections', { err });
@@ -290,12 +291,17 @@ export function purgeIdleDatabasePoolConnections(): void {
 }
 
 /**
- * Synchronously removes all idle connections from the given pool and initiates their closure.
- * @param pool - The Pool to purge
- * @param mode - The database mode
- * @returns The number of idle connections that were purged.
+ * Prepares a pool for graceful shutdown by disabling its minimum connection count,
+ * removing its idle connections, and preventing released connections from returning
+ * to the pool.
+ * @param pool - The pool to prepare
+ * @param mode - The database mode, used for logging
+ * @returns The number of idle connections removed immediately
  */
-function purgeIdleConnections(pool: Pool, mode: DatabaseMode): number {
+function preparePoolForShutdown(pool: Pool, mode: DatabaseMode): number {
+  pool.options.min = 0; // do not retain a min during graceful shutdown
+  pool.options.maxUses = 1; // do not reuse connections during graceful shutdown
+
   const poolInternal = pool as Pool & {
     _idle: { client: PoolClient }[];
     _remove: (client: PoolClient) => void;

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -265,3 +265,50 @@ async function runAllPendingPreDeployMigrations(client: PoolClient, currentVersi
     }
   }
 }
+
+/**
+ * Synchronously close all idle connections DB pool connections to immediately free
+ * up DB resources instead of waiting for the graceful server shutdown to invoke
+ * {@link closeDatabase}.
+ */
+export function purgeIdleDatabasePoolConnections(): void {
+  try {
+    if (pool) {
+      purgeIdleConnections(pool, DatabaseMode.WRITER);
+    }
+  } catch (err) {
+    globalLogger.error('Error purging idle pool connections', { err });
+  }
+
+  try {
+    if (readonlyPool) {
+      purgeIdleConnections(readonlyPool, DatabaseMode.READER);
+    }
+  } catch (err) {
+    globalLogger.error('Error purging idle pool connections', { err });
+  }
+}
+
+/**
+ * Synchronously removes all idle connections from the given pool and initiates their closure.
+ * @param pool - The Pool to purge
+ * @param mode - The database mode
+ * @returns The number of idle connections that were purged.
+ */
+function purgeIdleConnections(pool: Pool, mode: DatabaseMode): number {
+  const poolInternal = pool as Pool & {
+    _idle: { client: PoolClient }[];
+    _remove: (client: PoolClient) => void;
+  };
+
+  const idleItems = poolInternal._idle;
+  const count = idleItems.length;
+
+  // Iterate backwards because _remove mutates _idle.
+  for (let i = count - 1; i >= 0; i--) {
+    poolInternal._remove(idleItems[i].client);
+  }
+
+  globalLogger.info(`Purged idle connections from pool`, { mode, count });
+  return count;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,7 +4,7 @@ import express from 'express';
 import gracefulShutdown from 'http-graceful-shutdown';
 import { initApp, shutdownApp } from './app';
 import { loadConfig } from './config/loader';
-import { purgeIdleDatabasePoolConnections } from './database';
+import { prepareDatabasePoolsForShutdown } from './database';
 import { exitAfterStdoutDrain, globalLogger } from './logger';
 import { getServerVersion } from './util/version';
 
@@ -49,7 +49,7 @@ export async function main(configName: string): Promise<void> {
         `Shutdown signal received... allowing graceful shutdown for up to ${config.shutdownTimeoutMilliseconds} milliseconds`,
         { signal }
       );
-      purgeIdleDatabasePoolConnections();
+      prepareDatabasePoolsForShutdown();
     },
     onShutdown: () => shutdownApp(),
     finally: () => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,7 @@ import express from 'express';
 import gracefulShutdown from 'http-graceful-shutdown';
 import { initApp, shutdownApp } from './app';
 import { loadConfig } from './config/loader';
+import { purgeIdleDatabasePoolConnections } from './database';
 import { exitAfterStdoutDrain, globalLogger } from './logger';
 import { getServerVersion } from './util/version';
 
@@ -48,6 +49,7 @@ export async function main(configName: string): Promise<void> {
         `Shutdown signal received... allowing graceful shutdown for up to ${config.shutdownTimeoutMilliseconds} milliseconds`,
         { signal }
       );
+      purgeIdleDatabasePoolConnections();
     },
     onShutdown: () => shutdownApp(),
     finally: () => {


### PR DESCRIPTION
Avoid the spikes to double the number of desired DB connections during deploys