### PR TITLE
[Scheduling] Extract `useSchedulingResources` from Provider-App

### DIFF
--- a/examples/medplum-provider/src/components/schedule/CreateVisit.test.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateVisit.test.tsx
@@ -6,17 +6,17 @@ import { createReference } from '@medplum/core';
 import type { Patient, Schedule } from '@medplum/fhirtypes';
 import { DrAliceSmith, HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
+import type { DateTimeRange } from '@medplum/react-scheduling';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import type { Range } from '../../types/scheduling';
 import { CreateVisit } from './CreateVisit';
 
 describe('CreateVisit', () => {
   let medplum: MockClient;
   let mockPatient: Patient;
-  let range: Range;
+  let range: DateTimeRange;
 
   beforeEach(async () => {
     medplum = new MockClient();
@@ -43,7 +43,7 @@ describe('CreateVisit', () => {
     });
   });
 
-  const setup = (appointmentSlot?: Range, schedule?: Schedule): ReturnType<typeof render> => {
+  const setup = (appointmentSlot?: DateTimeRange, schedule?: Schedule): ReturnType<typeof render> => {
     return render(
       <MemoryRouter>
         <MedplumProvider medplum={medplum}>
@@ -166,7 +166,7 @@ describe('CreateVisit', () => {
         expect(screen.getByText(/Jan.*15.*2024/i)).toBeInTheDocument();
       });
 
-      const newSlot: Range = {
+      const newSlot: DateTimeRange = {
         start: new Date('2024-02-20T14:00:00Z'),
         end: new Date('2024-02-20T14:30:00Z'),
       };

--- a/examples/medplum-provider/src/components/schedule/CreateVisit.tsx
+++ b/examples/medplum-provider/src/components/schedule/CreateVisit.tsx
@@ -4,17 +4,17 @@ import { Button, Flex, Stack, Text, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import type { Coding, Patient, PlanDefinition, Practitioner, Reference, Schedule } from '@medplum/fhirtypes';
 import { CodingInput, DateTimeInput, Form, ResourceInput, useMedplum } from '@medplum/react';
+import type { DateTimeRange } from '@medplum/react-scheduling';
 import { IconAlertSquareRounded, IconCircleCheck, IconCirclePlus } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
-import type { Range } from '../../types/scheduling';
 import { createAppointment, createEncounter } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
 import { PlanDefinitionSummary } from '../plandefinition/PlanDefinitionSummary';
 
 interface CreateVisitProps {
-  appointmentSlot: Range | undefined;
+  appointmentSlot: DateTimeRange | undefined;
   practitioner: Reference<Practitioner>;
   schedule?: Schedule;
 }

--- a/examples/medplum-provider/src/components/schedule/FindPane.tsx
+++ b/examples/medplum-provider/src/components/schedule/FindPane.tsx
@@ -12,13 +12,13 @@ import {
 } from '@medplum/core';
 import type { Appointment, Bundle, Encounter, HealthcareService, Patient, Schedule, Slot } from '@medplum/fhirtypes';
 import { CodeableConceptDisplay, useMedplum } from '@medplum/react';
+import type { DateTimeRange } from '@medplum/react-scheduling';
 import { IconChevronRight, IconX } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { BookAppointmentForm } from '../../components/schedule/BookAppointmentForm';
 import { useSchedulingStartsAt } from '../../hooks/useSchedulingStartsAt';
-import type { Range } from '../../types/scheduling';
 import { showErrorNotification } from '../../utils/notifications';
 import { SchedulingTransientIdentifier } from '../../utils/scheduling';
 
@@ -26,7 +26,7 @@ const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
 type FindPaneProps = {
   schedule: WithId<Schedule>;
-  range: Range;
+  range: DateTimeRange;
   onSuccess: (results: { appointment: WithId<Appointment>; slots: WithId<Slot>[] }) => void;
   healthcareService: WithId<HealthcareService> | undefined;
   onSelectHealthcareService: (healthcareService: WithId<HealthcareService> | undefined) => void;

--- a/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
@@ -6,13 +6,12 @@ import type { WithId } from '@medplum/core';
 import { getReferenceString, isReference, isResourceWithId } from '@medplum/core';
 import type { Appointment, HealthcareService, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
 import { useMedplum, useResourceModified } from '@medplum/react';
-import { Calendar, getEffectiveAvailability } from '@medplum/react-scheduling';
+import { Calendar, getEffectiveAvailability, useSchedulingResources } from '@medplum/react-scheduling';
 import type { JSX } from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { AppointmentDetails } from '../../components/schedule/AppointmentDetails';
 import { CreateVisit } from '../../components/schedule/CreateVisit';
-import { useSchedulingResources } from '../../hooks/useSchedulingResources';
 import type { Range } from '../../types/scheduling';
 import { encounterUrl } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
@@ -39,7 +38,9 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
 
   const availableTime = getEffectiveAvailability(healthcareService, schedule);
 
-  const { slots, appointments, loading } = useSchedulingResources([schedule], range);
+  const { slots, appointments, loading } = useSchedulingResources([schedule], range, {
+    onError: showErrorNotification,
+  });
 
   const practitioner = schedule.actor.find((actor) => isReference<Practitioner>(actor, 'Practitioner'));
 

--- a/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
@@ -6,13 +6,13 @@ import type { WithId } from '@medplum/core';
 import { getReferenceString, isReference, isResourceWithId } from '@medplum/core';
 import type { Appointment, HealthcareService, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
 import { useMedplum, useResourceModified } from '@medplum/react';
+import type { DateTimeRange } from '@medplum/react-scheduling';
 import { Calendar, getEffectiveAvailability, useSchedulingResources } from '@medplum/react-scheduling';
 import type { JSX } from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { AppointmentDetails } from '../../components/schedule/AppointmentDetails';
 import { CreateVisit } from '../../components/schedule/CreateVisit';
-import type { Range } from '../../types/scheduling';
 import { encounterUrl } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
 import { mergeOverlappingSlots } from '../../utils/slots';
@@ -30,9 +30,9 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
 
   const [createAppointmentOpened, createAppointmentHandlers] = useDisclosure(false);
   const [appointmentDetailsOpened, appointmentDetailsHandlers] = useDisclosure(false);
-  const [range, setRange] = useState<Range | undefined>(undefined);
+  const [range, setRange] = useState<DateTimeRange | undefined>(undefined);
 
-  const [appointmentSlot, setAppointmentSlot] = useState<Range>();
+  const [appointmentSlot, setAppointmentSlot] = useState<DateTimeRange>();
   const [appointmentDetails, setAppointmentDetails] = useState<WithId<Appointment> | undefined>(undefined);
   const [healthcareService, setHealthcareService] = useState<WithId<HealthcareService> | undefined>(undefined);
 
@@ -59,7 +59,7 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
   // When a date/time interval is selected, set the event object and open the
   // create appointment modal
   const handleSelectInterval = useCallback(
-    (slot: Range) => {
+    (slot: DateTimeRange) => {
       if (!practitioner) {
         showErrorNotification("Can't create visit without associated Practitioner");
         return;

--- a/examples/medplum-provider/src/types/scheduling.ts
+++ b/examples/medplum-provider/src/types/scheduling.ts
@@ -1,3 +1,0 @@
-// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
-// SPDX-License-Identifier: Apache-2.0
-export type Range = { start: Date; end: Date };

--- a/packages/react-scheduling/src/hooks/useSchedulingResources.test.tsx
+++ b/packages/react-scheduling/src/hooks/useSchedulingResources.test.tsx
@@ -8,15 +8,8 @@ import { MedplumProvider } from '@medplum/react';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { JSX, ReactNode } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import type { Range } from '../types/scheduling';
-import { showErrorNotification } from '../utils/notifications';
+import type { DateTimeRange } from '../types';
 import { useSchedulingAppointments, useSchedulingResources, useSchedulingSlots } from './useSchedulingResources';
-
-// Mock the notification helper so error-path tests can assert on it without a
-// Mantine <Notifications> provider.
-vi.mock('../utils/notifications', () => ({
-  showErrorNotification: vi.fn(),
-}));
 
 const SCHEDULE_A: WithId<Schedule> = {
   resourceType: 'Schedule',
@@ -33,7 +26,7 @@ const SCHEDULE_C: WithId<Schedule> = {
   id: 'schedule-c',
   actor: [{ reference: 'Practitioner/pract-c' }],
 };
-const RANGE: Range = {
+const RANGE: DateTimeRange = {
   start: new Date('2024-01-01T00:00:00.000Z'),
   end: new Date('2024-01-31T00:00:00.000Z'),
 };
@@ -79,16 +72,25 @@ const wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
   <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
 );
 
+type SchedulingOptions = NonNullable<Parameters<typeof useSchedulingResources>[2]>;
+
+interface SetupProps {
+  schedules: WithId<Schedule>[];
+  range: DateTimeRange | undefined;
+  options?: SchedulingOptions;
+}
+
 // Render any of the scheduling hooks with the shared provider, keeping `schedules`
 // and `range` as rerender-able props.
 function setup<T>(
-  hook: (schedules: WithId<Schedule>[], range: Range | undefined) => T,
+  hook: (schedules: WithId<Schedule>[], range: DateTimeRange | undefined, options?: SchedulingOptions) => T,
   schedules: WithId<Schedule>[],
-  range: Range | undefined
-): ReturnType<typeof renderHook<T, { schedules: WithId<Schedule>[]; range: Range | undefined }>> {
-  return renderHook(({ schedules, range }) => hook(schedules, range), {
+  range: DateTimeRange | undefined,
+  options?: SchedulingOptions
+): ReturnType<typeof renderHook<T, SetupProps>> {
+  return renderHook<T, SetupProps>(({ schedules, range, options }) => hook(schedules, range, options), {
     wrapper,
-    initialProps: { schedules, range },
+    initialProps: { schedules, range, options },
   });
 }
 
@@ -180,9 +182,10 @@ describe('useSchedulingSlots', () => {
     test('reports errors and stops loading when a search fails', async () => {
       medplum.searchResources = vi.fn().mockRejectedValue(new Error('boom'));
 
-      const { result } = setup(useSchedulingSlots, [SCHEDULE_A], RANGE);
+      const onError = vi.fn();
+      const { result } = setup(useSchedulingSlots, [SCHEDULE_A], RANGE, { onError });
 
-      await waitFor(() => expect(vi.mocked(showErrorNotification)).toHaveBeenCalled());
+      await waitFor(() => expect(onError).toHaveBeenCalled());
       await waitFor(() => expect(result.current.loading).toBe(false));
     });
 
@@ -462,9 +465,10 @@ describe('useSchedulingAppointments', () => {
     test('reports errors and stops loading when a search fails', async () => {
       medplum.searchResources = vi.fn().mockRejectedValue(new Error('boom'));
 
-      const { result } = setup(useSchedulingAppointments, [SCHEDULE_A], RANGE);
+      const onError = vi.fn();
+      const { result } = setup(useSchedulingAppointments, [SCHEDULE_A], RANGE, { onError });
 
-      await waitFor(() => expect(vi.mocked(showErrorNotification)).toHaveBeenCalled());
+      await waitFor(() => expect(onError).toHaveBeenCalled());
       await waitFor(() => expect(result.current.loading).toBe(false));
     });
 

--- a/packages/react-scheduling/src/hooks/useSchedulingResources.ts
+++ b/packages/react-scheduling/src/hooks/useSchedulingResources.ts
@@ -115,7 +115,7 @@ export function useSchedulingSlots(
   });
 
   useEffect(() => {
-    if (!rangeStart || !rangeEnd) {
+    if (scheduleRefsKey.length === 0 || !rangeStart || !rangeEnd) {
       return () => {};
     }
     let active = true;

--- a/packages/react-scheduling/src/hooks/useSchedulingResources.ts
+++ b/packages/react-scheduling/src/hooks/useSchedulingResources.ts
@@ -4,15 +4,14 @@ import type { WithId } from '@medplum/core';
 import { getReferenceString, isDefined } from '@medplum/core';
 import type { Appointment, Schedule, Slot } from '@medplum/fhirtypes';
 import { useMedplum, useResourceModified } from '@medplum/react';
-import { useEffect, useState } from 'react';
-import type { Range } from '../types/scheduling';
-import { showErrorNotification } from '../utils/notifications';
+import { useEffect, useEffectEvent, useState } from 'react';
+import type { DateTimeRange } from '../types';
 
 // Whether an instant falls within the loaded range, matching the inclusive `ge`/`le`
 // bounds of the searches below. Used to keep created resources from a live update out of
 // state when they fall outside the range of the hook — a refetch wouldn't return
 // them, so appending them would drift from what the search reflects.
-function isWithinRange(instant: string | undefined, range: Range | undefined): boolean {
+function isWithinRange(instant: string | undefined, range: DateTimeRange | undefined): boolean {
   if (!instant || !range) {
     return false;
   }
@@ -45,12 +44,22 @@ export interface UseSchedulingAppointmentsResult {
  *
  * @param schedules - The schedules whose Slots should be loaded.
  * @param range - The date range to search within; no search runs while this is undefined.
+ * @param options - Optional parameters
+ * @param options.onError - Callback fired when fetching appointments fails
  * @returns The loaded Slots (undefined until the first fetch resolves) and a loading flag.
  */
-export function useSchedulingSlots(schedules: WithId<Schedule>[], range: Range | undefined): UseSchedulingSlotsResult {
+export function useSchedulingSlots(
+  schedules: WithId<Schedule>[],
+  range: DateTimeRange | undefined,
+  options?: { onError?: (error: unknown) => void }
+): UseSchedulingSlotsResult {
   const medplum = useMedplum();
   const [slots, setSlots] = useState<WithId<Slot>[] | undefined>(undefined);
   const [loading, setLoading] = useState(false);
+
+  const handleError = useEffectEvent((error: unknown) => {
+    options?.onError?.(error);
+  });
 
   // The predicate that scopes this calendar's data. The FHIR search and the
   // `useResourceModified` handler both use this so the optimistic updates stay consistent
@@ -123,7 +132,7 @@ export function useSchedulingSlots(schedules: WithId<Schedule>[], range: Range |
       )
     )
       .then((results) => active && setSlots(results.flat()))
-      .catch((error: unknown) => active && showErrorNotification(error))
+      .catch((error: unknown) => active && handleError(error))
       .finally(() => {
         if (active) {
           setLoading(false);
@@ -152,15 +161,22 @@ export function useSchedulingSlots(schedules: WithId<Schedule>[], range: Range |
  * @param schedules - The schedules whose actors' Appointments should be loaded.
  * @param range - The date range to search within; no search runs while this is undefined
  *   or none of the schedules have an actor.
+ * @param options - Optional parameters
+ * @param options.onError - Callback fired when fetching appointments fails
  * @returns The loaded Appointments (undefined until the first fetch resolves) and a loading flag.
  */
 export function useSchedulingAppointments(
   schedules: WithId<Schedule>[],
-  range: Range | undefined
+  range: DateTimeRange | undefined,
+  options?: { onError?: (error: unknown) => void }
 ): UseSchedulingAppointmentsResult {
   const medplum = useMedplum();
   const [appointments, setAppointments] = useState<WithId<Appointment>[] | undefined>(undefined);
   const [loading, setLoading] = useState(false);
+
+  const handleError = useEffectEvent((error: unknown) => {
+    options?.onError?.(error);
+  });
 
   // The predicate that scopes this calendar's data. The FHIR search and the
   // `useResourceModified` handler both use this so the optimistic updates stay consistent
@@ -244,7 +260,7 @@ export function useSchedulingAppointments(
         }
         setAppointments([...byId.values()]);
       })
-      .catch((error: unknown) => active && showErrorNotification(error))
+      .catch((error: unknown) => active && handleError(error))
       .finally(() => {
         if (active) {
           setLoading(false);
@@ -271,15 +287,18 @@ export function useSchedulingAppointments(
  *
  * @param schedules - The schedules whose Slots and Appointments should be loaded.
  * @param range - The date range to search within; no search runs while this is undefined.
+ * @param options - Optional parameters
+ * @param options.onError - Callback fired when fetching appointments fails
  * @returns The loaded Slots and Appointments (each undefined until its first fetch resolves)
  *   and a combined loading flag.
  */
 export function useSchedulingResources(
   schedules: WithId<Schedule>[],
-  range: Range | undefined
+  range: DateTimeRange | undefined,
+  options?: { onError?: (error: unknown) => void }
 ): UseSchedulingResourcesResult {
-  const slotsResult = useSchedulingSlots(schedules, range);
-  const appointmentsResult = useSchedulingAppointments(schedules, range);
+  const slotsResult = useSchedulingSlots(schedules, range, options);
+  const appointmentsResult = useSchedulingAppointments(schedules, range, options);
 
   return {
     slots: slotsResult.slots,

--- a/packages/react-scheduling/src/hooks/useSchedulingResources.ts
+++ b/packages/react-scheduling/src/hooks/useSchedulingResources.ts
@@ -4,7 +4,7 @@ import type { WithId } from '@medplum/core';
 import { getReferenceString, isDefined } from '@medplum/core';
 import type { Appointment, Schedule, Slot } from '@medplum/fhirtypes';
 import { useMedplum, useResourceModified } from '@medplum/react';
-import { useEffect, useEffectEvent, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { DateTimeRange } from '../types';
 
 // Whether an instant falls within the loaded range, matching the inclusive `ge`/`le`
@@ -57,9 +57,15 @@ export function useSchedulingSlots(
   const [slots, setSlots] = useState<WithId<Slot>[] | undefined>(undefined);
   const [loading, setLoading] = useState(false);
 
-  const handleError = useEffectEvent((error: unknown) => {
-    options?.onError?.(error);
-  });
+  const onErrorRef = useRef(options?.onError);
+
+  useEffect(() => {
+    onErrorRef.current = options?.onError;
+  }, [options?.onError]);
+
+  const handleError = useCallback((error: unknown) => {
+    onErrorRef.current?.(error);
+  }, []);
 
   // The predicate that scopes this calendar's data. The FHIR search and the
   // `useResourceModified` handler both use this so the optimistic updates stay consistent
@@ -143,7 +149,7 @@ export function useSchedulingSlots(
       active = false;
       setLoading(false);
     };
-  }, [medplum, scheduleRefsKey, rangeStart, rangeEnd]);
+  }, [medplum, scheduleRefsKey, rangeStart, rangeEnd, handleError]);
 
   return {
     slots,
@@ -174,9 +180,15 @@ export function useSchedulingAppointments(
   const [appointments, setAppointments] = useState<WithId<Appointment>[] | undefined>(undefined);
   const [loading, setLoading] = useState(false);
 
-  const handleError = useEffectEvent((error: unknown) => {
-    options?.onError?.(error);
-  });
+  const onErrorRef = useRef(options?.onError);
+
+  useEffect(() => {
+    onErrorRef.current = options?.onError;
+  }, [options?.onError]);
+
+  const handleError = useCallback((error: unknown) => {
+    onErrorRef.current?.(error);
+  }, []);
 
   // The predicate that scopes this calendar's data. The FHIR search and the
   // `useResourceModified` handler both use this so the optimistic updates stay consistent
@@ -271,7 +283,7 @@ export function useSchedulingAppointments(
       active = false;
       setLoading(false);
     };
-  }, [medplum, actorRefsKey, rangeStart, rangeEnd]);
+  }, [medplum, actorRefsKey, rangeStart, rangeEnd, handleError]);
 
   return {
     appointments,

--- a/packages/react-scheduling/src/index.ts
+++ b/packages/react-scheduling/src/index.ts
@@ -20,6 +20,7 @@ export * from './ScheduleAvailabilityEditor/ScheduleAvailabilityEditor';
 
 // Hooks that load what the components display
 export * from './AppointmentFinder/useProposedAppointments';
+export * from './hooks/useSchedulingResources';
 
 // Helpers the components are built on, usable without them
 export * from './availability';


### PR DESCRIPTION
We want to use this in more places, let's extract it.

- Added a new `onError` option to the hook that takes a callback to be invoked when fetching resources fails. This decouples the hook from the notifications system used in the Provider example app.

- The `Range` type in Provider was renamed to `DateTimeRange` in React-Scheduling, to avoid conflicting with the native [`Range`](https://developer.mozilla.org/en-US/docs/Web/API/Range) type.