### PR TITLE
[Scheduling] Load the appointments and times a set of calendars holds

### DIFF
--- a/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
+++ b/examples/medplum-provider/src/components/schedule/ScheduleDetails.tsx
@@ -6,13 +6,12 @@ import type { WithId } from '@medplum/core';
 import { getReferenceString, isReference, isResourceWithId } from '@medplum/core';
 import type { Appointment, HealthcareService, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
 import { useMedplum, useResourceModified } from '@medplum/react';
-import { Calendar, getEffectiveAvailability } from '@medplum/react-scheduling';
+import { Calendar, getEffectiveAvailability, useSchedulingResources } from '@medplum/react-scheduling';
 import type { JSX } from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { AppointmentDetails } from '../../components/schedule/AppointmentDetails';
 import { CreateVisit } from '../../components/schedule/CreateVisit';
-import { useSchedulingResources } from '../../hooks/useSchedulingResources';
 import type { Range } from '../../types/scheduling';
 import { encounterUrl } from '../../utils/encounter';
 import { showErrorNotification } from '../../utils/notifications';
@@ -39,7 +38,14 @@ export function ScheduleDetails(props: ScheduleDetailsProps): JSX.Element | null
 
   const availableTime = getEffectiveAvailability(healthcareService, schedule);
 
-  const { slots, appointments, loading } = useSchedulingResources([schedule], range);
+  const { slots, appointments, loading, error } = useSchedulingResources([schedule], range);
+
+  // The hook reports a failed search rather than notifying; this app notifies.
+  useEffect(() => {
+    if (error) {
+      showErrorNotification(error);
+    }
+  }, [error]);
 
   const practitioner = schedule.actor.find((actor) => isReference<Practitioner>(actor, 'Practitioner'));
 

--- a/packages/react-scheduling/src/index.ts
+++ b/packages/react-scheduling/src/index.ts
@@ -20,6 +20,7 @@ export * from './ScheduleAvailabilityEditor/ScheduleAvailabilityEditor';
 
 // Hooks that load what the components display
 export * from './AppointmentFinder/useProposedAppointments';
+export * from './useSchedulingResources';
 
 // Helpers the components are built on, usable without them
 export * from './availability';

--- a/packages/react-scheduling/src/useSchedulingResources.test.tsx
+++ b/packages/react-scheduling/src/useSchedulingResources.test.tsx
@@ -4,19 +4,12 @@ import type { QueryTypes, WithId } from '@medplum/core';
 import { getQueryString } from '@medplum/core';
 import type { Appointment, ResourceType, Schedule, Slot } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
-import { MedplumProvider } from '@medplum/react';
+import { MedplumProvider } from '@medplum/react-hooks';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { JSX, ReactNode } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import type { Range } from '../types/scheduling';
-import { showErrorNotification } from '../utils/notifications';
+import type { DateTimeRange } from './types';
 import { useSchedulingAppointments, useSchedulingResources, useSchedulingSlots } from './useSchedulingResources';
-
-// Mock the notification helper so error-path tests can assert on it without a
-// Mantine <Notifications> provider.
-vi.mock('../utils/notifications', () => ({
-  showErrorNotification: vi.fn(),
-}));
 
 const SCHEDULE_A: WithId<Schedule> = {
   resourceType: 'Schedule',
@@ -33,7 +26,7 @@ const SCHEDULE_C: WithId<Schedule> = {
   id: 'schedule-c',
   actor: [{ reference: 'Practitioner/pract-c' }],
 };
-const RANGE: Range = {
+const RANGE: DateTimeRange = {
   start: new Date('2024-01-01T00:00:00.000Z'),
   end: new Date('2024-01-31T00:00:00.000Z'),
 };
@@ -82,10 +75,10 @@ const wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
 // Render any of the scheduling hooks with the shared provider, keeping `schedules`
 // and `range` as rerender-able props.
 function setup<T>(
-  hook: (schedules: WithId<Schedule>[], range: Range | undefined) => T,
+  hook: (schedules: WithId<Schedule>[], range: DateTimeRange | undefined) => T,
   schedules: WithId<Schedule>[],
-  range: Range | undefined
-): ReturnType<typeof renderHook<T, { schedules: WithId<Schedule>[]; range: Range | undefined }>> {
+  range: DateTimeRange | undefined
+): ReturnType<typeof renderHook<T, { schedules: WithId<Schedule>[]; range: DateTimeRange | undefined }>> {
   return renderHook(({ schedules, range }) => hook(schedules, range), {
     wrapper,
     initialProps: { schedules, range },
@@ -182,7 +175,7 @@ describe('useSchedulingSlots', () => {
 
       const { result } = setup(useSchedulingSlots, [SCHEDULE_A], RANGE);
 
-      await waitFor(() => expect(vi.mocked(showErrorNotification)).toHaveBeenCalled());
+      await waitFor(() => expect(result.current.error).toEqual(new Error('boom')));
       await waitFor(() => expect(result.current.loading).toBe(false));
     });
 
@@ -464,7 +457,7 @@ describe('useSchedulingAppointments', () => {
 
       const { result } = setup(useSchedulingAppointments, [SCHEDULE_A], RANGE);
 
-      await waitFor(() => expect(vi.mocked(showErrorNotification)).toHaveBeenCalled());
+      await waitFor(() => expect(result.current.error).toEqual(new Error('boom')));
       await waitFor(() => expect(result.current.loading).toBe(false));
     });
 
@@ -670,6 +663,14 @@ describe('useSchedulingResources', () => {
       expect(result.current.slots).toEqual([slotA]);
       expect(result.current.appointments).toEqual([apptA]);
     });
+  });
+
+  test('surfaces a failed search from either underlying hook', async () => {
+    medplum.searchResources = vi.fn().mockRejectedValue(new Error('boom'));
+
+    const { result } = setup(useSchedulingResources, [SCHEDULE_A], RANGE);
+
+    await waitFor(() => expect(result.current.error).toEqual(new Error('boom')));
   });
 
   test('stays loading until both the slot and appointment fetches settle', async () => {

--- a/packages/react-scheduling/src/useSchedulingResources.ts
+++ b/packages/react-scheduling/src/useSchedulingResources.ts
@@ -1,18 +1,17 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { WithId } from '@medplum/core';
-import { getReferenceString, isDefined } from '@medplum/core';
+import { getReferenceString, isDefined, isError, normalizeErrorString } from '@medplum/core';
 import type { Appointment, Schedule, Slot } from '@medplum/fhirtypes';
-import { useMedplum, useResourceModified } from '@medplum/react';
+import { useMedplum, useResourceModified } from '@medplum/react-hooks';
 import { useEffect, useState } from 'react';
-import type { Range } from '../types/scheduling';
-import { showErrorNotification } from '../utils/notifications';
+import type { DateTimeRange } from './types';
 
 // Whether an instant falls within the loaded range, matching the inclusive `ge`/`le`
 // bounds of the searches below. Used to keep created resources from a live update out of
 // state when they fall outside the range of the hook — a refetch wouldn't return
 // them, so appending them would drift from what the search reflects.
-function isWithinRange(instant: string | undefined, range: Range | undefined): boolean {
+function isWithinRange(instant: string | undefined, range: DateTimeRange | undefined): boolean {
   if (!instant || !range) {
     return false;
   }
@@ -20,20 +19,30 @@ function isWithinRange(instant: string | undefined, range: Range | undefined): b
   return time >= range.start.getTime() && time <= range.end.getTime();
 }
 
+function toError(reason: unknown): Error {
+  return isError(reason) ? reason : new Error(normalizeErrorString(reason), { cause: reason });
+}
+
 export interface UseSchedulingResourcesResult {
-  appointments: WithId<Appointment>[] | undefined;
-  slots: WithId<Slot>[] | undefined;
-  loading: boolean;
+  readonly appointments: WithId<Appointment>[] | undefined;
+  readonly slots: WithId<Slot>[] | undefined;
+  readonly loading: boolean;
+  /** Set when a search failed. What loaded before the failure is left in place. */
+  readonly error: Error | undefined;
 }
 
 export interface UseSchedulingSlotsResult {
-  slots: WithId<Slot>[] | undefined;
-  loading: boolean;
+  readonly slots: WithId<Slot>[] | undefined;
+  readonly loading: boolean;
+  /** Set when a search failed. What loaded before the failure is left in place. */
+  readonly error: Error | undefined;
 }
 
 export interface UseSchedulingAppointmentsResult {
-  appointments: WithId<Appointment>[] | undefined;
-  loading: boolean;
+  readonly appointments: WithId<Appointment>[] | undefined;
+  readonly loading: boolean;
+  /** Set when a search failed. What loaded before the failure is left in place. */
+  readonly error: Error | undefined;
 }
 
 /**
@@ -45,12 +54,17 @@ export interface UseSchedulingAppointmentsResult {
  *
  * @param schedules - The schedules whose Slots should be loaded.
  * @param range - The date range to search within; no search runs while this is undefined.
- * @returns The loaded Slots (undefined until the first fetch resolves) and a loading flag.
+ * @returns The loaded Slots (undefined until the first fetch resolves), a loading flag, and
+ *   the error from a failed search.
  */
-export function useSchedulingSlots(schedules: WithId<Schedule>[], range: Range | undefined): UseSchedulingSlotsResult {
+export function useSchedulingSlots(
+  schedules: readonly WithId<Schedule>[],
+  range: DateTimeRange | undefined
+): UseSchedulingSlotsResult {
   const medplum = useMedplum();
   const [slots, setSlots] = useState<WithId<Slot>[] | undefined>(undefined);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | undefined>(undefined);
 
   // The predicate that scopes this calendar's data. The FHIR search and the
   // `useResourceModified` handler both use this so the optimistic updates stay consistent
@@ -65,8 +79,7 @@ export function useSchedulingSlots(schedules: WithId<Schedule>[], range: Range |
   const rangeEnd = range?.end?.toISOString();
 
   // Keep the calendar's slots in sync with any Slot this client modifies, e.g. the
-  // slots created when booking a visit from the FindPane or soft-deleted when cancelling
-  // one from the appointment details drawer.
+  // slots written when booking a visit or soft-deleted when cancelling one.
   useResourceModified('Slot', (event) => {
     if (event.operation === 'delete') {
       // Deletes don't carry a resource, only the id of what went away.
@@ -122,8 +135,13 @@ export function useSchedulingSlots(schedules: WithId<Schedule>[], range: Range |
         ])
       )
     )
-      .then((results) => active && setSlots(results.flat()))
-      .catch((error: unknown) => active && showErrorNotification(error))
+      .then((results) => {
+        if (active) {
+          setSlots(results.flat());
+          setError(undefined);
+        }
+      })
+      .catch((reason: unknown) => active && setError(toError(reason)))
       .finally(() => {
         if (active) {
           setLoading(false);
@@ -139,6 +157,7 @@ export function useSchedulingSlots(schedules: WithId<Schedule>[], range: Range |
   return {
     slots,
     loading,
+    error,
   };
 }
 
@@ -152,15 +171,17 @@ export function useSchedulingSlots(schedules: WithId<Schedule>[], range: Range |
  * @param schedules - The schedules whose actors' Appointments should be loaded.
  * @param range - The date range to search within; no search runs while this is undefined
  *   or none of the schedules have an actor.
- * @returns The loaded Appointments (undefined until the first fetch resolves) and a loading flag.
+ * @returns The loaded Appointments (undefined until the first fetch resolves), a loading
+ *   flag, and the error from a failed search.
  */
 export function useSchedulingAppointments(
-  schedules: WithId<Schedule>[],
-  range: Range | undefined
+  schedules: readonly WithId<Schedule>[],
+  range: DateTimeRange | undefined
 ): UseSchedulingAppointmentsResult {
   const medplum = useMedplum();
   const [appointments, setAppointments] = useState<WithId<Appointment>[] | undefined>(undefined);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | undefined>(undefined);
 
   // The predicate that scopes this calendar's data. The FHIR search and the
   // `useResourceModified` handler both use this so the optimistic updates stay consistent
@@ -243,8 +264,9 @@ export function useSchedulingAppointments(
           byId.set(appointment.id, appointment);
         }
         setAppointments([...byId.values()]);
+        setError(undefined);
       })
-      .catch((error: unknown) => active && showErrorNotification(error))
+      .catch((reason: unknown) => active && setError(toError(reason)))
       .finally(() => {
         if (active) {
           setLoading(false);
@@ -260,6 +282,7 @@ export function useSchedulingAppointments(
   return {
     appointments,
     loading,
+    error,
   };
 }
 
@@ -271,12 +294,12 @@ export function useSchedulingAppointments(
  *
  * @param schedules - The schedules whose Slots and Appointments should be loaded.
  * @param range - The date range to search within; no search runs while this is undefined.
- * @returns The loaded Slots and Appointments (each undefined until its first fetch resolves)
- *   and a combined loading flag.
+ * @returns The loaded Slots and Appointments (each undefined until its first fetch resolves),
+ *   a combined loading flag, and whichever search failed first.
  */
 export function useSchedulingResources(
-  schedules: WithId<Schedule>[],
-  range: Range | undefined
+  schedules: readonly WithId<Schedule>[],
+  range: DateTimeRange | undefined
 ): UseSchedulingResourcesResult {
   const slotsResult = useSchedulingSlots(schedules, range);
   const appointmentsResult = useSchedulingAppointments(schedules, range);
@@ -285,5 +308,6 @@ export function useSchedulingResources(
     slots: slotsResult.slots,
     appointments: appointmentsResult.appointments,
     loading: slotsResult.loading || appointmentsResult.loading,
+    error: slotsResult.error ?? appointmentsResult.error,
   };
 }


### PR DESCRIPTION
Lifts the slot, appointment, and combined schedule-resource hooks out of `examples/medplum-provider` into `@medplum/react-scheduling` and exports them. They are the seam a host uses to load what a set of schedules holds and render its own calendar.

Kept as they were:

- **One search per schedule**, so each schedule's results cache independently rather than one toggle invalidating the whole set.
- **The live-update subscription and its range guard.** A resource created outside the loaded range is not appended, since a refetch would not return it.

Changed on the way out: the hooks return `error` instead of calling the example's `showErrorNotification`, which would have dragged `@mantine/notifications` into the package and made a host's error UI our decision. This matches `useProposedAppointments`. The example notifies from that error at its one call site.

## Testing

- 33 hook tests, ported with the two notification assertions rewritten against `error`, plus one covering the combined hook.
- The provider example's 9 scheduling test files — 118 tests — pass unchanged against the lifted hooks.