### PR TITLE
Fix $expand displayLanguage filter

### DIFF
--- a/packages/server/src/fhir/operations/expand.test.ts
+++ b/packages/server/src/fhir/operations/expand.test.ts
@@ -2288,6 +2288,12 @@ describe('Expand', () => {
         ],
       },
       {
+        name: 'Filter selects the matching translation among several',
+        valueSet: pagingValueSet,
+        query: 'filter=premier&displayLanguage=fr',
+        expected: [{ system: pagingSystem, code: 'P1', display: 'Article premier' }],
+      },
+      {
         name: 'Enumerated concepts exclude non-matching translations',
         valueSet: conceptValueSet,
         query: 'filter=toux&displayLanguage=fr',

--- a/packages/server/src/fhir/operations/expand.test.ts
+++ b/packages/server/src/fhir/operations/expand.test.ts
@@ -18,6 +18,7 @@ import { createTestProject, initTestAuth, withTestContext } from '../../test.set
 import { repoAccess } from '../repository/access-tracker';
 import type { PgQueryable } from '../sql';
 import { addExpansionItems, countCandidatesBounded, expansionQuery, hydrateCodeSystemProperties } from './expand';
+import { abstractProperty } from './utils/terminology';
 
 describe('Expand', () => {
   const app = express();
@@ -1980,5 +1981,410 @@ describe('Expand', () => {
       .set('Authorization', 'Bearer ' + superAdminToken);
     expect(res).toHaveStatus(200);
     expect(res.body.expansion.contains[0].display).toStrictEqual('ClientApplication');
+  });
+
+  describe('Display language', () => {
+    const flatSystem = 'http://example.com/CodeSystem/' + randomUUID();
+    const flatCodeSystem: CodeSystem = {
+      resourceType: 'CodeSystem',
+      status: 'active',
+      content: 'complete',
+      url: flatSystem,
+      concept: [
+        {
+          code: 'FVR',
+          display: 'Fever',
+          designation: [
+            { language: 'fr', value: 'Fièvre' },
+            { language: 'es', value: 'Fiebre' },
+          ],
+        },
+        { code: 'NOFR', display: 'Fieval English-only term' },
+        { code: 'LYMPH', display: 'Naïve lymphocyte' },
+        { code: 'TOUX', display: 'Cough', designation: [{ language: 'fr', value: 'Toux' }] },
+        { code: 'RHUME', display: 'Cold', designation: [{ language: 'fr', value: 'Rhume' }] },
+      ],
+    };
+    const flatValueSet: ValueSet = {
+      resourceType: 'ValueSet',
+      status: 'active',
+      url: 'http://example.com/ValueSet/' + randomUUID(),
+      compose: { include: [{ system: flatSystem }] },
+    };
+
+    // Enumerated concepts: FVR and TOUX take their translation from the CodeSystem, while RHUME carries an
+    // inline designation that differs from it ('Rhume'), so the two sources can be told apart
+    const conceptValueSet: ValueSet = {
+      resourceType: 'ValueSet',
+      status: 'active',
+      url: 'http://example.com/ValueSet/' + randomUUID(),
+      compose: {
+        include: [
+          {
+            system: flatSystem,
+            concept: [
+              { code: 'FVR', display: 'Fever' },
+              { code: 'TOUX', display: 'Cough' },
+              { code: 'RHUME', display: 'Cold', designation: [{ language: 'fr', value: 'Rhume sévère' }] },
+            ],
+          },
+        ],
+      },
+    };
+
+    // Stored full expansion, so filtering happens in memory rather than in SQL
+    const preExpandedValueSet: ValueSet = {
+      resourceType: 'ValueSet',
+      status: 'active',
+      url: 'http://example.com/ValueSet/' + randomUUID(),
+      expansion: {
+        timestamp: '2024-05-02T06:30:00.000Z',
+        total: 3,
+        contains: [
+          { system: flatSystem, code: 'LYMPH', display: 'Naïve lymphocyte' },
+          { system: flatSystem, code: 'TCELL', display: 'Naive T cell' },
+          { system: flatSystem, code: 'TOUX', display: 'Cough' },
+        ],
+      },
+    };
+
+    const hierarchySystem = 'http://example.com/CodeSystem/' + randomUUID();
+    const hierarchyCodeSystem: CodeSystem = {
+      resourceType: 'CodeSystem',
+      status: 'active',
+      content: 'complete',
+      url: hierarchySystem,
+      hierarchyMeaning: 'is-a',
+      concept: [
+        {
+          code: 'SYMPTOM',
+          display: 'Symptom',
+          designation: [{ language: 'fr', value: 'Symptôme' }],
+          concept: [
+            { code: 'FVR', display: 'Fever', designation: [{ language: 'fr', value: 'Fièvre' }] },
+            { code: 'COUGH', display: 'Cough', designation: [{ language: 'fr', value: 'Toux' }] },
+          ],
+        },
+      ],
+    };
+    const isaValueSet: ValueSet = {
+      resourceType: 'ValueSet',
+      status: 'active',
+      url: 'http://example.com/ValueSet/' + randomUUID(),
+      compose: {
+        include: [{ system: hierarchySystem, filter: [{ property: 'concept', op: 'is-a', value: 'SYMPTOM' }] }],
+      },
+    };
+    const descendentValueSet: ValueSet = {
+      resourceType: 'ValueSet',
+      status: 'active',
+      url: 'http://example.com/ValueSet/' + randomUUID(),
+      compose: {
+        include: [
+          { system: hierarchySystem, filter: [{ property: 'concept', op: 'descendent-of', value: 'SYMPTOM' }] },
+        ],
+      },
+    };
+
+    const abstractSystem = 'http://example.com/CodeSystem/' + randomUUID();
+    const abstractCodeSystem: CodeSystem = {
+      resourceType: 'CodeSystem',
+      status: 'active',
+      content: 'complete',
+      url: abstractSystem,
+      property: [{ code: 'notSelectable', uri: abstractProperty, type: 'boolean' }],
+      concept: [
+        {
+          code: 'GRP',
+          display: 'Grouper',
+          designation: [{ language: 'fr', value: 'Groupeur' }],
+          property: [{ code: 'notSelectable', valueBoolean: true }],
+        },
+        { code: 'LEAF', display: 'Leaf', designation: [{ language: 'fr', value: 'Feuille' }] },
+      ],
+    };
+    const abstractValueSet: ValueSet = {
+      resourceType: 'ValueSet',
+      status: 'active',
+      url: 'http://example.com/ValueSet/' + randomUUID(),
+      compose: { include: [{ system: abstractSystem }] },
+    };
+
+    const propertySystem = 'http://example.com/CodeSystem/' + randomUUID();
+    const propertyCodeSystem: CodeSystem = {
+      resourceType: 'CodeSystem',
+      status: 'active',
+      content: 'complete',
+      url: propertySystem,
+      property: [{ code: 'status', type: 'code' }],
+      concept: [
+        {
+          code: 'ACT',
+          display: 'Active thing',
+          designation: [{ language: 'fr', value: 'Chose active' }],
+          property: [{ code: 'status', valueCode: 'active' }],
+        },
+        {
+          code: 'RET',
+          display: 'Retired thing',
+          designation: [{ language: 'fr', value: 'Chose retirée' }],
+          property: [{ code: 'status', valueCode: 'retired' }],
+        },
+      ],
+    };
+    const propertyValueSet: ValueSet = {
+      resourceType: 'ValueSet',
+      status: 'active',
+      url: 'http://example.com/ValueSet/' + randomUUID(),
+      compose: { include: [{ system: propertySystem, filter: [{ property: 'status', op: '=', value: 'active' }] }] },
+    };
+
+    const pagingSystem = 'http://example.com/CodeSystem/' + randomUUID();
+    const pagingCodeSystem: CodeSystem = {
+      resourceType: 'CodeSystem',
+      status: 'active',
+      content: 'complete',
+      url: pagingSystem,
+      concept: [
+        {
+          code: 'P1',
+          display: 'Item one',
+          designation: [
+            { language: 'fr', value: 'Article un' },
+            { language: 'fr', value: 'Article premier' },
+          ],
+        },
+        { code: 'P2', display: 'Item two', designation: [{ language: 'fr', value: 'Article deux' }] },
+        { code: 'P3', display: 'Item three', designation: [{ language: 'fr', value: 'Article trois' }] },
+        { code: 'P4', display: 'Item four', designation: [{ language: 'fr', value: 'Article quatre' }] },
+      ],
+    };
+    const pagingValueSet: ValueSet = {
+      resourceType: 'ValueSet',
+      status: 'active',
+      url: 'http://example.com/ValueSet/' + randomUUID(),
+      compose: { include: [{ system: pagingSystem }] },
+    };
+
+    let storedHierarchy: WithId<CodeSystem>;
+    let db: PgQueryable;
+
+    beforeAll(async () => {
+      for (const resource of [
+        flatCodeSystem,
+        hierarchyCodeSystem,
+        abstractCodeSystem,
+        propertyCodeSystem,
+        pagingCodeSystem,
+        flatValueSet,
+        conceptValueSet,
+        preExpandedValueSet,
+        isaValueSet,
+        descendentValueSet,
+        abstractValueSet,
+        propertyValueSet,
+        pagingValueSet,
+      ]) {
+        const res = await request(app)
+          .post(`/fhir/R4/${resource.resourceType}`)
+          .set('Authorization', 'Bearer ' + accessToken)
+          .set('Content-Type', ContentType.FHIR_JSON)
+          .send(resource);
+        expect(res).toHaveStatus(201);
+        if (resource === hierarchyCodeSystem) {
+          storedHierarchy = res.body as WithId<CodeSystem>;
+        }
+      }
+
+      await withTestContext(async () => {
+        const { repo } = await createTestProject({ withRepo: true });
+        db = repo.getDatabaseClient(repoAccess.sqlRead('CodeSystem', { source: 'test' }));
+        await hydrateCodeSystemProperties(db, storedHierarchy);
+      });
+    });
+
+    test.each([
+      {
+        name: 'Unaccented filter matches accented translation',
+        valueSet: flatValueSet,
+        query: 'filter=fiev&displayLanguage=fr',
+        expected: [{ system: flatSystem, code: 'FVR', display: 'Fièvre' }],
+      },
+      {
+        name: 'Unaccented filter matches accented display without displayLanguage',
+        valueSet: flatValueSet,
+        query: 'filter=naive',
+        expected: [{ system: flatSystem, code: 'LYMPH', display: 'Naïve lymphocyte' }],
+      },
+      {
+        name: 'Without displayLanguage, only untranslated displays match',
+        valueSet: flatValueSet,
+        query: 'filter=fiev',
+        expected: [{ system: flatSystem, code: 'NOFR', display: 'Fieval English-only term' }],
+      },
+      {
+        name: 'Translations in other languages do not match',
+        valueSet: flatValueSet,
+        query: 'filter=fiev&displayLanguage=es',
+        expected: [],
+      },
+      {
+        name: 'Filter matches the requested language',
+        valueSet: flatValueSet,
+        query: 'filter=fieb&displayLanguage=es',
+        expected: [{ system: flatSystem, code: 'FVR', display: 'Fiebre' }],
+      },
+      {
+        name: 'Code prefix filter with displayLanguage',
+        valueSet: flatValueSet,
+        query: 'filter=FVR&displayLanguage=fr',
+        expected: [{ system: flatSystem, code: 'FVR', display: 'Fièvre' }],
+      },
+      {
+        // RHUME's inline designation takes precedence over the CodeSystem's 'Rhume'
+        name: 'Enumerated concepts resolve the translated display',
+        valueSet: conceptValueSet,
+        query: 'displayLanguage=fr',
+        expected: [
+          { system: flatSystem, code: 'FVR', display: 'Fièvre' },
+          { system: flatSystem, code: 'TOUX', display: 'Toux' },
+          { system: flatSystem, code: 'RHUME', display: 'Rhume sévère' },
+        ],
+      },
+      {
+        name: 'Enumerated concepts filter on the translated display',
+        valueSet: conceptValueSet,
+        query: 'filter=vre&displayLanguage=fr',
+        expected: [{ system: flatSystem, code: 'FVR', display: 'Fièvre' }],
+      },
+      {
+        name: 'Unaccented filter matches accented translation of an enumerated concept',
+        valueSet: conceptValueSet,
+        query: 'filter=fiev&displayLanguage=fr',
+        expected: [{ system: flatSystem, code: 'FVR', display: 'Fièvre' }],
+      },
+      {
+        name: 'Unaccented filter matches an accented inline designation',
+        valueSet: conceptValueSet,
+        query: 'filter=sever&displayLanguage=fr',
+        expected: [{ system: flatSystem, code: 'RHUME', display: 'Rhume sévère' }],
+      },
+      {
+        name: 'Unaccented filter matches accented display in a stored expansion',
+        valueSet: preExpandedValueSet,
+        query: 'filter=naive',
+        expected: [
+          { system: flatSystem, code: 'LYMPH', display: 'Naïve lymphocyte' },
+          { system: flatSystem, code: 'TCELL', display: 'Naive T cell' },
+        ],
+      },
+      {
+        name: 'Accented filter matches unaccented display in a stored expansion',
+        valueSet: preExpandedValueSet,
+        query: 'filter=na%C3%AFve',
+        expected: [
+          { system: flatSystem, code: 'LYMPH', display: 'Naïve lymphocyte' },
+          { system: flatSystem, code: 'TCELL', display: 'Naive T cell' },
+        ],
+      },
+      {
+        name: 'Enumerated concepts exclude non-matching translations',
+        valueSet: conceptValueSet,
+        query: 'filter=toux&displayLanguage=fr',
+        expected: [{ system: flatSystem, code: 'TOUX', display: 'Toux' }],
+      },
+      {
+        name: 'Enumerated concepts do not match the untranslated display',
+        valueSet: conceptValueSet,
+        query: 'filter=cough&displayLanguage=fr',
+        expected: [],
+      },
+      {
+        name: 'is-a filter with displayLanguage',
+        valueSet: isaValueSet,
+        query: 'displayLanguage=fr',
+        expected: [
+          { system: hierarchySystem, code: 'COUGH', display: 'Toux' },
+          { system: hierarchySystem, code: 'FVR', display: 'Fièvre' },
+          { system: hierarchySystem, code: 'SYMPTOM', display: 'Symptôme' },
+        ],
+      },
+      {
+        name: 'descendent-of filter with displayLanguage',
+        valueSet: descendentValueSet,
+        query: 'displayLanguage=fr',
+        expected: [
+          { system: hierarchySystem, code: 'COUGH', display: 'Toux' },
+          { system: hierarchySystem, code: 'FVR', display: 'Fièvre' },
+        ],
+      },
+      {
+        name: 'is-a filter with displayLanguage and text filter',
+        valueSet: isaValueSet,
+        query: 'filter=fiev&displayLanguage=fr',
+        expected: [{ system: hierarchySystem, code: 'FVR', display: 'Fièvre' }],
+      },
+      {
+        name: 'excludeNotForUI with displayLanguage',
+        valueSet: abstractValueSet,
+        query: 'displayLanguage=fr&excludeNotForUI=true',
+        expected: [{ system: abstractSystem, code: 'LEAF', display: 'Feuille' }],
+      },
+      {
+        name: 'Property filter with displayLanguage',
+        valueSet: propertyValueSet,
+        query: 'displayLanguage=fr',
+        expected: [{ system: propertySystem, code: 'ACT', display: 'Chose active' }],
+      },
+    ])('$name', async ({ valueSet, query, expected }) => {
+      const res = await request(app)
+        .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(valueSet.url as string)}&${query}`)
+        .set('Authorization', 'Bearer ' + accessToken);
+      expect(res).toHaveStatus(200);
+
+      const contains = (res.body.expansion as ValueSetExpansion).contains ?? [];
+      // Sorted, since an expansion without a text filter has no deterministic order
+      const byCode = (a: ValueSetExpansionContains, b: ValueSetExpansionContains): number =>
+        (a.code as string).localeCompare(b.code as string);
+      expect([...contains].sort(byCode)).toStrictEqual<ValueSetExpansionContains[]>([...expected].sort(byCode));
+    });
+
+    test('Ancestor and descendant strategies agree under displayLanguage', async () => {
+      const include = {
+        system: hierarchySystem,
+        filter: [{ property: 'concept', op: 'is-a' as const, value: 'SYMPTOM' }],
+      };
+      const params = { filter: 'fiev', displayLanguage: 'fr' };
+
+      const ancestorQuery = expansionQuery(include, storedHierarchy, params, 'ancestor');
+      const descendantQuery = expansionQuery(include, storedHierarchy, params, 'descendant');
+      if (!ancestorQuery || !descendantQuery) {
+        throw new Error('expected both strategies to build a query');
+      }
+      const ancestorRows = await ancestorQuery.execute(db);
+      const descendantRows = await descendantQuery.execute(db);
+
+      expect(ancestorRows.map((r) => [r.code, r.display])).toStrictEqual([['FVR', 'Fièvre']]);
+      expect(descendantRows.map((r) => [r.code, r.display])).toStrictEqual(
+        ancestorRows.map((r) => [r.code, r.display])
+      );
+    });
+
+    test('Paging counts codes, not translation rows', async () => {
+      // P1 has two French designations; a page of 2 must still hold 2 distinct codes
+      const res = await request(app)
+        .get(
+          `/fhir/R4/ValueSet/$expand?url=${encodeURIComponent(pagingValueSet.url as string)}&filter=article&displayLanguage=fr&count=2`
+        )
+        .set('Authorization', 'Bearer ' + accessToken);
+      expect(res).toHaveStatus(200);
+
+      const contains = (res.body.expansion as ValueSetExpansion).contains as ValueSetExpansionContains[];
+      expect(contains).toHaveLength(2);
+      expect(new Set(contains.map((c) => c.code)).size).toBe(2);
+      for (const entry of contains) {
+        expect(entry.display).toMatch(/^Article /);
+      }
+    });
   });
 });

--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -501,6 +501,18 @@ function buildDisplayMatch(filterText: string, tableName: string): Expression {
   );
 }
 
+function buildDisplayMatchRank(filterText: string, tableName: string): Expression {
+  return new Conjunction(
+    filterText.split(/\s+/g).map((word) => {
+      const pattern = `%${escapeLikeString(word)}%`;
+      return new Disjunction([
+        new Condition(new Column(tableName, 'display'), 'ILIKE', pattern), // Cheaper check first to short-circuit
+        new Condition(new Column(tableName, 'display'), 'UNACCENT_ILIKE', pattern),
+      ]);
+    })
+  );
+}
+
 /**
  * Anchors the query on canonical rows and attaches each code's translation in the requested language, replacing
  * the projected display with the translated one. Codes without a translation drop out of the expansion, since the
@@ -508,9 +520,15 @@ function buildDisplayMatch(filterText: string, tableName: string): Expression {
  * @param query - The expansion query, projecting the columns of `ExpansionRow`.
  * @param codeSystem - The CodeSystem being expanded (with resolved id).
  * @param displayLanguage - The requested display language.
+ * @param filterText - The `filter` parameter value, if any, used to choose among a code's designations.
  * @returns The column holding the translated display, for use in ordering.
  */
-function joinTranslation(query: SelectQuery, codeSystem: WithId<CodeSystem>, displayLanguage: string): Column {
+function joinTranslation(
+  query: SelectQuery,
+  codeSystem: WithId<CodeSystem>,
+  displayLanguage: string,
+  filterText?: string
+): Column {
   // Staying anchored on canonical rows keeps the property and hierarchy filters working against a single row per code
   const anchorAlias = query.effectiveTableName;
   query.where(new Column(anchorAlias, 'synonymOf'), '=', null);
@@ -521,9 +539,12 @@ function joinTranslation(query: SelectQuery, codeSystem: WithId<CodeSystem>, dis
     .column(new Column(innerAlias, 'language'))
     .where(new Column(innerAlias, 'system'), '=', codeSystem.id)
     .where(new Column(innerAlias, 'code'), '=', new Column(anchorAlias, 'code'))
-    .where(new Column(innerAlias, 'language'), '=', displayLanguage)
-    .orderBy(new Column(innerAlias, 'id'))
-    .limit(1);
+    .where(new Column(innerAlias, 'language'), '=', displayLanguage);
+
+  if (filterText && filterText.length >= 3) {
+    translation.orderByExpr(buildDisplayMatchRank(filterText, innerAlias), true);
+  }
+  translation.orderBy(new Column(innerAlias, 'id')).limit(1);
 
   const translationAlias = query.getNextJoinAlias();
   query.join('INNER JOIN LATERAL', translation, translationAlias, new Constant('true'));
@@ -651,7 +672,7 @@ function applyExpansionFilters(
 
   const tableAlias = query.effectiveTableName;
   const displayColumn = params.displayLanguage
-    ? joinTranslation(query, codeSystem, params.displayLanguage)
+    ? joinTranslation(query, codeSystem, params.displayLanguage, params.filter)
     : new Column(tableAlias, 'display');
 
   if (!params.displayLanguage && !params.includeDesignations) {

--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -16,6 +16,7 @@ import type {
 import { getAuthenticatedContext } from '../../context';
 import { DatabaseMode } from '../../database';
 import { getLogger } from '../../logger';
+import { foldText } from '../../util/text';
 import type { Repository } from '../repo';
 import { repoAccess } from '../repository/access-tracker';
 import type { Expression, PgQueryable } from '../sql';
@@ -23,11 +24,14 @@ import {
   Column,
   Condition,
   Conjunction,
+  Constant,
   Disjunction,
   escapeLikeString,
+  MedplumUnaccentFn,
   Parameter,
   SelectQuery,
   SqlFunction,
+  Union,
 } from '../sql';
 import { validateCodings } from './codesystemvalidatecode';
 import { getOperationDefinition } from './definitions';
@@ -112,21 +116,13 @@ export async function expandOperator(
 
 const MAX_EXPANSION_SIZE = 1000;
 
-export function filterIncludedConcepts(
-  concepts: ValueSetComposeIncludeConcept[] | ValueSetExpansionContains[] | Coding[],
-  params: ValueSetExpandParameters,
-  system?: string
-): ValueSetExpansionContains[] {
-  const filter = params.filter?.trim().toLowerCase();
-  return flattenConcepts(concepts, { filter, system, displayLanguage: params.displayLanguage });
-}
-
 function flattenConcepts(
   concepts: ValueSetComposeIncludeConcept[] | ValueSetExpansionContains[] | Coding[],
   options?: {
     filter?: string;
     system?: string;
     displayLanguage?: string;
+    dropUntranslated?: boolean;
   }
 ): ValueSetExpansionContains[] {
   const result: Coding[] = [];
@@ -144,6 +140,9 @@ function flattenConcepts(
 
     const filter = options?.filter;
     const display = getDisplayText(concept, options?.displayLanguage);
+    if (!display && options?.displayLanguage && options?.dropUntranslated) {
+      continue;
+    }
     if (!filter || matchesTextFilter(display, filter)) {
       result.push({ system, code: concept.code, display });
     }
@@ -187,7 +186,11 @@ async function computeExpansion(
     (!preExpansion.total || preExpansion.total === preExpansion.contains.length)
   ) {
     // Full expansion is already available, use that
-    return filterIncludedConcepts(preExpansion.contains, params);
+    return flattenConcepts(preExpansion.contains, {
+      filter: normalizeTextFilter(params.filter),
+      displayLanguage: params.displayLanguage,
+      dropUntranslated: true,
+    });
   }
 
   if (!valueSet.compose?.include.length) {
@@ -237,10 +240,17 @@ async function computeExpansion(
     terminologyResources[include.system] = codeSystem;
 
     if (include.concept) {
-      const filteredCodings = filterIncludedConcepts(include.concept, params, include.system);
-      const validCodings = await validateCodings(codeSystem, filteredCodings, params);
-      for (const c of validCodings) {
-        if (c) {
+      // Under displayLanguage, an enumerated concept's display is resolved from the CodeSystem by
+      // validateCodings below, so the text filter has nothing to match against until after that
+      const filter = normalizeTextFilter(params.filter);
+      const deferredFilter = params.displayLanguage ? filter : undefined;
+      const codings = flattenConcepts(include.concept, {
+        system: include.system,
+        displayLanguage: params.displayLanguage,
+        filter: deferredFilter ? undefined : filter,
+      });
+      for (const c of await validateCodings(codeSystem, codings, params)) {
+        if (c && (!deferredFilter || matchesTextFilter(c.display, deferredFilter))) {
           c.id = undefined;
           expansion.push(c);
         }
@@ -428,38 +438,105 @@ const CANDIDATE_THRESHOLD = 2000;
 
 /**
  * Builds the text-filter predicate used by `$expand` filtering: an exact code match, plus (for filters of at
- * least 3 characters) a per-word `display ILIKE` substring match. Below 3 characters the `display ILIKE
- * '%filter%'` branch cannot use the trigram GIN index (a substring needs at least one full trigram), so only the
- * exact code is matched.
+ * least 3 characters) a per-word accent-insensitive `display` substring match. Below 3 characters the display
+ * branch cannot use the trigram GIN index, so only the exact code is matched.
+ * @param codeSystem - The CodeSystem being expanded (with resolved id).
  * @param filterText - The `filter` parameter value.
  * @param tableName - Table/alias that the `code` column belongs to (`Coding` or the descendant CTE).
+ * @param displayLanguage - The requested display language, if any.
  * @returns The WHERE expression selecting rows that match the filter text.
  */
-function buildTextFilterPredicate(filterText: string, tableName: string): Expression {
-  // Match the code by case-insensitive prefix for filters of at least 3 characters, backed by the
-  // database index. Shorter filters fall back to exact code equality to avoid an under-selective prefix scan
-  const codeMatch =
-    filterText.length >= 3
-      ? new Condition(new Column(tableName, 'code'), 'LOWER_LIKE', `${escapeLikeString(filterText)}%`)
-      : new Condition(new Column(tableName, 'code'), '=', filterText);
+function buildFilterPredicate(
+  codeSystem: WithId<CodeSystem>,
+  filterText: string,
+  tableName: string,
+  displayLanguage?: string
+): Expression {
+  // Below 3 characters the display-substring branch cannot use the trigram GIN index
+  // (a substring needs at least one full trigram), so match on the code alone.
+  const matchDisplay = filterText.length >= 3;
 
   // Restrict the `code` branch to canonical rows: synonyms for the same code are redundant. This scoping lets the planner
   // use the partial `(system, lower(code)) WHERE "synonymOf" IS NULL` index, keeping the `code` branch of the query plan
   // well-indexed. The `display` branch intentionally still matches synonym rows, so alternate terms remain searchable.
-  const codeCondition = new Conjunction([codeMatch, new Condition(new Column(tableName, 'synonymOf'), '=', null)]);
-
-  // Below 3 characters the display-substring branch cannot use the trigram GIN index
-  // (a substring needs at least one full trigram), so match the exact code only.
-  if (filterText.length < 3) {
-    return codeCondition;
+  if (!displayLanguage) {
+    const codeCondition = new Conjunction([
+      buildCodeMatch(filterText, tableName),
+      new Condition(new Column(tableName, 'synonymOf'), '=', null),
+    ]);
+    return matchDisplay ? new Disjunction([codeCondition, buildDisplayMatch(filterText, tableName)]) : codeCondition;
   }
 
-  return new Disjunction([
-    codeCondition,
-    new Conjunction(
-      filterText.split(/\s+/g).map((word) => new Condition('display', 'ILIKE', `%${escapeLikeString(word)}%`))
-    ),
-  ]);
+  // The display to match against lives on the translation rows, which the canonical-row anchor in
+  // applyExpansionFilters excludes, so collect matching codes in a subquery and semi-join the outer query onto it
+  const codeArm = new SelectQuery('Coding')
+    .column('code')
+    .where('system', '=', codeSystem.id)
+    .where('synonymOf', '=', null)
+    .whereExpr(buildCodeMatch(filterText, 'Coding'));
+  let candidates: Expression = codeArm;
+  if (matchDisplay) {
+    const displayArm = new SelectQuery('Coding')
+      .column('code')
+      .where('system', '=', codeSystem.id)
+      .where('language', '=', displayLanguage)
+      .whereExpr(buildDisplayMatch(filterText, 'Coding'));
+    // UNION ALL: the semi-join below makes duplicate candidate codes irrelevant, so skip the dedup pass
+    candidates = new Union(codeArm, displayArm).all();
+  }
+  return new Condition(new Column(tableName, 'code'), 'IN_SUBQUERY', candidates);
+}
+
+function buildCodeMatch(filterText: string, tableName: string): Expression {
+  return filterText.length >= 3
+    ? new Condition(new Column(tableName, 'code'), 'LOWER_LIKE', `${escapeLikeString(filterText)}%`)
+    : new Condition(new Column(tableName, 'code'), '=', filterText);
+}
+
+function buildDisplayMatch(filterText: string, tableName: string): Expression {
+  return new Conjunction(
+    filterText
+      .split(/\s+/g)
+      .map((word) => new Condition(new Column(tableName, 'display'), 'UNACCENT_ILIKE', `%${escapeLikeString(word)}%`))
+  );
+}
+
+/**
+ * Anchors the query on canonical rows and attaches each code's translation in the requested language, replacing
+ * the projected display with the translated one. Codes without a translation drop out of the expansion, since the
+ * join is an inner one.
+ * @param query - The expansion query, projecting the columns of `ExpansionRow`.
+ * @param codeSystem - The CodeSystem being expanded (with resolved id).
+ * @param displayLanguage - The requested display language.
+ * @returns The column holding the translated display, for use in ordering.
+ */
+function joinTranslation(query: SelectQuery, codeSystem: WithId<CodeSystem>, displayLanguage: string): Column {
+  // Staying anchored on canonical rows keeps the property and hierarchy filters working against a single row per code
+  const anchorAlias = query.effectiveTableName;
+  query.where(new Column(anchorAlias, 'synonymOf'), '=', null);
+
+  const innerAlias = 'translation';
+  const translation = new SelectQuery('Coding', undefined, innerAlias)
+    .column(new Column(innerAlias, 'display'))
+    .column(new Column(innerAlias, 'language'))
+    .where(new Column(innerAlias, 'system'), '=', codeSystem.id)
+    .where(new Column(innerAlias, 'code'), '=', new Column(anchorAlias, 'code'))
+    .where(new Column(innerAlias, 'language'), '=', displayLanguage)
+    .orderBy(new Column(innerAlias, 'id'))
+    .limit(1);
+
+  const translationAlias = query.getNextJoinAlias();
+  query.join('INNER JOIN LATERAL', translation, translationAlias, new Constant('true'));
+
+  const displayColumn = new Column(translationAlias, 'display');
+  query
+    .clearColumns() // Replace rather than append: the descendant CTE projects its own display/language columns
+    .column(new Column(anchorAlias, 'id'))
+    .column(new Column(anchorAlias, 'code'))
+    .column(displayColumn)
+    .column(new Column(translationAlias, 'language'))
+    .column(new Column(anchorAlias, 'synonymOf')); // Always NULL, per the canonical-row anchor above
+  return displayColumn;
 }
 
 /**
@@ -469,19 +546,21 @@ function buildTextFilterPredicate(filterText: string, tableName: string): Expres
  * @param codeSystem - The CodeSystem being expanded (with resolved id).
  * @param filterText - The `filter` parameter value.
  * @param limit - Upper bound on the count (candidates beyond this don't change the decision).
+ * @param displayLanguage - The requested display language, if any.
  * @returns The number of matching candidate codes, capped at `limit`.
  */
 export async function countCandidatesBounded(
   db: PgQueryable,
   codeSystem: WithId<CodeSystem>,
   filterText: string,
-  limit: number
+  limit: number,
+  displayLanguage?: string
 ): Promise<number> {
   const inner = new SelectQuery('Coding')
     .column('id')
     .where('system', '=', codeSystem.id)
     .where('synonymOf', '=', null)
-    .whereExpr(buildTextFilterPredicate(filterText, 'Coding'))
+    .whereExpr(buildFilterPredicate(codeSystem, filterText, 'Coding', displayLanguage))
     .limit(limit);
   const countQuery = new SelectQuery('c', inner).raw('COUNT(*)::int AS "count"');
   const rows = await countQuery.execute(db);
@@ -514,7 +593,13 @@ async function chooseParentFilterStrategy(
     return undefined;
   }
 
-  const count = await countCandidatesBounded(db, codeSystem, filterText, CANDIDATE_THRESHOLD + 1);
+  const count = await countCandidatesBounded(
+    db,
+    codeSystem,
+    filterText,
+    CANDIDATE_THRESHOLD + 1,
+    params.displayLanguage
+  );
   return count > CANDIDATE_THRESHOLD ? 'descendant' : 'ancestor';
 }
 
@@ -564,26 +649,28 @@ function applyExpansionFilters(
     return undefined;
   }
 
+  const tableAlias = query.effectiveTableName;
+  const displayColumn = params.displayLanguage
+    ? joinTranslation(query, codeSystem, params.displayLanguage)
+    : new Column(tableAlias, 'display');
+
+  if (!params.displayLanguage && !params.includeDesignations) {
+    // Include translations of codes only by request
+    query.where('language', '=', null);
+  }
+
   if (params.filter) {
     const filterText = params.filter;
-    const tableAlias = query.effectiveTableName;
     query
-      .whereExpr(buildTextFilterPredicate(filterText, tableAlias))
+      .whereExpr(buildFilterPredicate(codeSystem, filterText, tableAlias, params.displayLanguage))
       // Surface exact code match ahead of longer prefix and code-only matches, which would otherwise sort arbitrarily
       .orderByExpr(new Condition(new Column(tableAlias, 'code'), '=', filterText), true)
       .orderByExpr(
-        new SqlFunction('strict_word_similarity', [new Column(undefined, 'display'), new Parameter(filterText)]),
+        new SqlFunction('strict_word_similarity', [unaccent(displayColumn), unaccent(new Parameter(filterText))]),
         true
       )
       // Final tiebreaker so the overall order is deterministic
       .orderBy(new Column(tableAlias, 'code'));
-  }
-
-  if (params.displayLanguage) {
-    query.where('language', '=', params.displayLanguage);
-  } else if (!params.includeDesignations) {
-    // Include translations of codes only by request
-    query.where('language', '=', null);
   }
 
   if (params.excludeNotForUI) {
@@ -617,16 +704,32 @@ function addAbstractFilter(query: SelectQuery, codeSystem: WithId<CodeSystem>): 
   return query;
 }
 
+function unaccent(expr: Expression): Expression {
+  return new SqlFunction(MedplumUnaccentFn.name, [expr]);
+}
+
+/**
+ * Folds the `filter` parameter for in-memory matching (enumerated concepts and stored expansions), so that it
+ * approximates the accent-insensitive `medplum_unaccent` comparison the DB-backed filter performs. See
+ * {@link foldText} for the characters where the two diverge.
+ * @param filter - The `filter` parameter value.
+ * @returns The folded filter text, or undefined when the filter is absent or blank.
+ */
+function normalizeTextFilter(filter: string | undefined): string | undefined {
+  const trimmed = filter?.trim();
+  return trimmed ? foldText(trimmed) : undefined;
+}
+
 function matchesTextFilter(text: string | undefined, filter: string): boolean {
-  return text ? text.toLowerCase().includes(filter) : false;
+  return text ? foldText(text).includes(filter) : false;
 }
 
 function getDisplayText(
   concept: ValueSetComposeIncludeConcept | ValueSetExpansionContains | Coding,
   language?: string
 ): string | undefined {
-  if (language && 'designation' in concept) {
-    return concept.designation?.find((c) => c.language === language)?.value ?? concept.display;
+  if (language) {
+    return (concept as ValueSetExpansionContains).designation?.find((d) => d.language === language)?.value;
   }
   return concept.display;
 }

--- a/packages/server/src/fhir/operations/utils/cms-patient-match.ts
+++ b/packages/server/src/fhir/operations/utils/cms-patient-match.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { evalFhirPathTyped, HTTP_HL7_ORG, isString, toTypedValue } from '@medplum/core';
 import type { Patient } from '@medplum/fhirtypes';
+import { foldText } from '../../../util/text';
 
 const SSN_IDENTIFIER_SYSTEM = `${HTTP_HL7_ORG}/fhir/sid/us-ssn`;
 const ITIN_IDENTIFIER_SYSTEM = `${HTTP_HL7_ORG}/fhir/sid/us-itin`;
@@ -241,11 +242,7 @@ export function hasGenerationalSuffixConflict(p1: Patient, p2: Patient): boolean
  * @returns The folded string (may be empty).
  */
 export function foldString(value: string): string {
-  return value
-    .normalize('NFD')
-    .replace(/\p{Diacritic}/gu, '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]/g, '');
+  return foldText(value).replace(/[^a-z0-9]/g, '');
 }
 
 function extractGenerationalSuffixes(patient: Patient): Set<string> {

--- a/packages/server/src/fhir/sql.test.ts
+++ b/packages/server/src/fhir/sql.test.ts
@@ -330,6 +330,15 @@ describe('SqlBuilder', () => {
       expect(sql.toString()).toBe('SELECT "MyTable"."id" FROM "MyTable" WHERE "MyTable"."name" ILIKE $1');
     });
 
+    test('Select where unaccent ilike', () => {
+      const sql = new SqlBuilder();
+      new SelectQuery('MyTable').column('id').where('name', 'UNACCENT_ILIKE', '%x%').buildSql(sql);
+      expect(sql.toString()).toBe(
+        'SELECT "MyTable"."id" FROM "MyTable" WHERE medplum_unaccent("MyTable"."name") ILIKE medplum_unaccent($1)'
+      );
+      expect(sql.getValues()).toStrictEqual(['%x%']);
+    });
+
     test('Select missing columns', () => {
       const sql = new SqlBuilder();
       new SelectQuery('MyTable').buildSql(sql);

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -82,6 +82,13 @@ export const Operator = {
     sql.append(' ILIKE ');
     sql.param(parameter as string);
   },
+  UNACCENT_ILIKE: (sql: SqlBuilder, column: Column, parameter: any, _paramType?: string) => {
+    sql.append(`${MedplumUnaccentFn.name}(`);
+    sql.appendColumn(column);
+    sql.append(`) ILIKE ${MedplumUnaccentFn.name}(`);
+    sql.param(parameter as string);
+    sql.append(')');
+  },
   '<': simpleBinaryOperator('<'),
   '<=': simpleBinaryOperator('<='),
   '>': simpleBinaryOperator('>'),
@@ -823,6 +830,11 @@ export class SelectQuery extends BaseQuery {
 
   column(column: Column | string): this {
     this.columns.push(getColumn(column, this.effectiveTableName));
+    return this;
+  }
+
+  clearColumns(): this {
+    this.columns.length = 0;
     return this;
   }
 

--- a/packages/server/src/util/text.ts
+++ b/packages/server/src/util/text.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+const DIACRITICS = /\p{Diacritic}/gu;
+
+/**
+ * Folds text for case- and diacritic-insensitive comparison: NFD-decompose, drop the combining marks, lowercase.
+ *
+ * This covers every diacritic with a canonical decomposition, but not characters that Postgres's `unaccent`
+ * transliterates without one (ø, æ, ß, ł), so it is not exactly equivalent to the `medplum_unaccent` SQL function.
+ * @param value - The raw string.
+ * @returns The string lowercased with diacritics removed.
+ */
+export function foldText(value: string): string {
+  return value.normalize('NFD').replace(DIACRITICS, '').toLowerCase();
+}


### PR DESCRIPTION
Previously, `displayLanguage` was implemented as a plain WHERE clause:

```ts
if (params.displayLanguage) {
  query.where('language', '=', params.displayLanguage);
}
```

Translations live in `Coding` as **synonym rows** (`synonymOf` = canonical coding id, `language` = the translation's language). The simple WHERE clause inadvertantly swaps the row the whole query anchors on:
instead of the canonical row (where properties etc. are attached), it selects synonym rows.

## Implementation changes

### 1. Translation as a LATERAL join

The query is now always anchored on canonical rows, and attaches the translation via `INNER JOIN LATERAL … ORDER BY id LIMIT 1`.
The returned `Column` is reused for the `strict_word_similarity` ordering, so the ranking is done against the _translated_ display.

### 2. Text filter predicate refactored to be language-aware

Extracted `buildCodeMatch` (exact code below 3 chars, `LOWER(code) LIKE 'x%'` at ≥3 chars) and `buildDisplayMatch` (per-word substring match).

- **Without `displayLanguage`**: same shape as before — `(codeMatch AND synonymOf IS NULL) OR displayMatch` — except the display branch now uses the new `UNACCENT_ILIKE` operator.
- **With `displayLanguage`**: the display text to match lives on translation rows, which the canonical anchor excludes. So candidate codes are collected in a subquery and the outer query semi-joins onto it:
  - code arm: `system = ? AND synonymOf IS NULL AND <codeMatch>`
  - display arm (only when filter ≥ 3 chars): `system = ? AND language = ? AND medplum_unaccent(display) ILIKE medplum_unaccent(?)`
  - combined with `UNION ALL` (the semi-join makes dedup pointless), consumed as `code = ANY(<subquery>)`.

### 3. Accent-insensitive matching across DB and in-memory cases

- `UNACCENT_ILIKE` operator added to `sql.ts`
- New `foldText()` helper to NFD-decompose, strip diacritics, and convert to lowercase — used for in-memory paths

### 4. In-memory paths made consistent with the DB path

- `filterIncludedConcepts` was deleted; callers now call `flattenConcepts` directly with a pre-normalized filter.
- `getDisplayText` no longer falls back to `concept.display` when a `designation` for the requested language is missing — it returns `undefined`, matching the inner-join semantics.
- `flattenConcepts` gains `dropUntranslated`, used for stored (pre-computed) expansions so untranslated concepts are omitted rather than emitted with a null display.
- For enumerated `compose.include.concept` lists under `displayLanguage`, the display is only known _after_ `validateCodings` resolves it from the CodeSystem, so the text filter is **deferred**: concepts are flattened unfiltered, then `matchesTextFilter` is applied to the resolved display after validation.

## Expected query shape: is-a ValueSet + `displayLanguage` + `filter`

For an include like `{system, filter: [{property: 'concept', op: 'is-a', value: 'ROOT'}]}` with `filter=fievre&displayLanguage=fr`. Both parent-filter strategies are shown; the strategy is chosen by the bounded candidate count (`CANDIDATE_THRESHOLD = 2000`).

Shared elements, new in this commit:

```sql
-- projection: display/language come from the translation alias
SELECT <anchor>."id", <anchor>."code", "T"."display", "T"."language", <anchor>."synonymOf"
...
INNER JOIN LATERAL (
  SELECT "translation"."display", "translation"."language"
  FROM "Coding" "translation"
  WHERE "translation"."system" = $sys
    AND "translation"."code" = <anchor>."code"
    AND "translation"."language" = 'fr'
  ORDER BY "translation"."id" LIMIT 1
) AS "T" ON true
WHERE <anchor>."synonymOf" IS NULL          -- canonical-row anchor
  AND <anchor>."code" = ANY(
        SELECT "Coding"."code" FROM "Coding"
        WHERE "Coding"."system" = $sys AND "Coding"."synonymOf" IS NULL
          AND LOWER("Coding"."code") LIKE 'fievre%'
        UNION ALL
        SELECT "Coding"."code" FROM "Coding"
        WHERE "Coding"."system" = $sys AND "Coding"."language" = 'fr'
          AND medplum_unaccent("Coding"."display") ILIKE medplum_unaccent('%fievre%')
      )
ORDER BY <anchor>."code" = 'fievre' DESC,
         strict_word_similarity(medplum_unaccent("T"."display"), medplum_unaccent('fievre')) DESC,
         <anchor>."code"
LIMIT 1001
```

### `ancestor` strategy (selective filter)

```sql
SELECT "Coding"."id", "Coding"."code", "T1"."display", "T1"."language", "Coding"."synonymOf"
FROM "Coding"
INNER JOIN LATERAL (
  SELECT "translation"."display", "translation"."language"
  FROM "Coding" "translation"
  WHERE ("translation"."system" = $1 AND "translation"."code" = "Coding"."code"
         AND "translation"."language" = $2)
  ORDER BY "translation"."id" LIMIT 1
) AS "T1" ON true
WHERE ("Coding"."system" = $3
  AND EXISTS(
    WITH RECURSIVE "cte_ancestors" AS (...walk up via Coding_Property...)
    SELECT ... FROM "cte_ancestors" WHERE "cte_ancestors"."code" = $7 LIMIT 1)
  AND "Coding"."synonymOf" IS NULL
  AND "Coding"."code" = ANY(
        SELECT "Coding"."code" FROM "Coding"
         WHERE ("Coding"."system" = $8 AND "Coding"."synonymOf" IS NULL
                AND LOWER("Coding"."code") LIKE $9)
        UNION ALL
        SELECT "Coding"."code" FROM "Coding"
         WHERE ("Coding"."system" = $10 AND "Coding"."language" = $11
                AND medplum_unaccent("Coding"."display") ILIKE medplum_unaccent($12))))
ORDER BY "Coding"."code" = $13 DESC,
         strict_word_similarity(medplum_unaccent("T1"."display"), medplum_unaccent($14)) DESC,
         "Coding"."code"
LIMIT 1001
```

### `descendant` strategy (broad filter over a large subtree)

```sql
WITH RECURSIVE "cte_descendants" AS (...subtree from $2 via Coding_Property...)
SELECT "cte_descendants"."id", "cte_descendants"."code", "T1"."display", "T1"."language",
       "cte_descendants"."synonymOf"
FROM "cte_descendants"
INNER JOIN LATERAL (
  SELECT "translation"."display", "translation"."language"
  FROM "Coding" "translation"
  WHERE ("translation"."system" = $5 AND "translation"."code" = "cte_descendants"."code"
         AND "translation"."language" = $6)
  ORDER BY "translation"."id" LIMIT 1
) AS "T1" ON true
WHERE ("cte_descendants"."synonymOf" IS NULL
  AND "cte_descendants"."code" = ANY(
        SELECT "Coding"."code" FROM "Coding"
         WHERE ("Coding"."system" = $7 AND "Coding"."synonymOf" IS NULL
                AND LOWER("Coding"."code") LIKE $8)
        UNION ALL
        SELECT "Coding"."code" FROM "Coding"
         WHERE ("Coding"."system" = $9 AND "Coding"."language" = $10
                AND medplum_unaccent("Coding"."display") ILIKE medplum_unaccent($11))))
ORDER BY "cte_descendants"."code" = $12 DESC,
         strict_word_similarity(medplum_unaccent("T1"."display"), medplum_unaccent($13)) DESC,
         "cte_descendants"."code"
LIMIT 1001
```

### What that replaced

The pre-commit query for the same request (descendant strategy) was:

```sql
WITH RECURSIVE "cte_descendants" AS (...)
SELECT "cte_descendants"."id", "cte_descendants"."code", "cte_descendants"."display",
       "cte_descendants"."synonymOf", "cte_descendants"."language"
FROM "cte_descendants"
WHERE (((LOWER("cte_descendants"."code") LIKE $5 AND "cte_descendants"."synonymOf" IS NULL)
        OR "display" ILIKE $6)
   AND "cte_descendants"."language" = $7)      -- <- anchored on translation rows
ORDER BY "cte_descendants"."code" = $8 DESC,
         strict_word_similarity("display", $9) DESC, "cte_descendants"."code"
LIMIT 1001
```

Differences between the plans:

| Before                                                                | After                                                                        |
| --------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| `language = 'fr'` on the anchor row                                   | `synonymOf IS NULL` on the anchor + `INNER JOIN LATERAL` for the translation |
| `display` projected from the anchor/CTE                               | `display`/`language` projected from the translation alias                    |
| Filter inline as `(codeMatch AND synonymOf IS NULL) OR display ILIKE` | Semi-join `code = ANY(code arm UNION ALL display arm)`                       |
| Unqualified `"display"` in filter/order                               | Qualified columns; `medplum_unaccent(...)` on both sides                     |
| Up to N rows per code (one per translation)                           | Exactly one row per code                                                     |

Note the filter branch is still dropped entirely for filters under 3 characters (no full trigram → no GIN index usage); under `displayLanguage` that means only the code arm of the `UNION ALL` is emitted.
