### PR TITLE
feat(server): split DICOM processing by cardinality, derive `ImagingStudy`

### DIFF
--- a/packages/docs/docs/dicom/agent-dimse.md
+++ b/packages/docs/docs/dicom/agent-dimse.md
@@ -140,9 +140,11 @@ export async function handler(medplum: MedplumClient, event: BotEvent<DicomNotif
 }
 ```
 
-In `dicomweb` mode this is the natural place to reconcile imaging against the chart — look up the
-`DicomStudy` the server just created, match `patientId` against your MRN identifier system, and link
-the two. See [Relationship to FHIR ImagingStudy](./data-model.md#relationship-to-fhir-imagingstudy).
+In `dicomweb` mode the server already creates an `ImagingStudy` and resolves its `subject` when the
+DICOM Patient ID matches exactly one `Patient` in the project. A Bot is the place to handle the cases
+that need judgment — studies whose patient could not be resolved, or one matched to the wrong record.
+Correcting `ImagingStudy.subject` by hand sticks; the server never downgrades it. See
+[Relationship to FHIR ImagingStudy](./data-model.md#relationship-to-fhir-imagingstudy).
 
 ## Testing a channel
 

--- a/packages/docs/docs/dicom/data-model.md
+++ b/packages/docs/docs/dicom/data-model.md
@@ -11,6 +11,10 @@ translation at ingest time would throw away exactly the attributes a viewer need
 study. Storing the DICOM shape natively means a DICOMweb response can be reconstructed faithfully,
 while the resources remain searchable and access-controlled like anything else in the project.
 
+An [`ImagingStudy`](#relationship-to-fhir-imagingstudy) is generated _alongside_ those resources, not
+instead of them, so the study is reachable from the rest of the chart without the DICOM shape being
+lost.
+
 ```mermaid
 flowchart TD
   Study["DicomStudy<br/><i>studyInstanceUid</i>"]
@@ -18,11 +22,15 @@ flowchart TD
   Instance["DicomInstance<br/><i>sopInstanceUid</i>"]
   Raw["Binary<br/><i>original .dcm file</i>"]
   Pixels["Binary[]<br/><i>pixel data, one per frame</i>"]
+  Imaging["ImagingStudy<br/><i>derived, chart-facing</i>"]
+  Endpoint["Endpoint<br/><i>WADO-RS</i>"]
 
   Study --> Series
   Series --> Instance
   Instance -- "raw" --> Raw
   Instance -- "pixelData" --> Pixels
+  Study -. "derived" .-> Imaging
+  Imaging -- "endpoint" --> Endpoint
 ```
 
 ## Resource types
@@ -69,7 +77,9 @@ One [`DicomSeries`](/docs/api/fhir/medplum/dicomseries) per Series Instance UID,
 
 ### DicomInstance
 
-One [`DicomInstance`](/docs/api/fhir/medplum/dicominstance) per stored SOP instance. Unlike study and series, instances are **not** created conditionally.
+One [`DicomInstance`](/docs/api/fhir/medplum/dicominstance) per stored SOP instance, created
+conditionally on `sopInstanceUid` so that re-uploading the same instance resolves the existing
+resource rather than duplicating it.
 
 | Field                   | DICOM tag                    | Notes                                                                      |
 | ----------------------- | ---------------------------- | -------------------------------------------------------------------------- |
@@ -102,18 +112,38 @@ Only the **first 100 KB** of each uploaded file is parsed for metadata during th
 That is far more than a DICOM header needs and it keeps ingest streaming rather than buffering whole
 studies in memory. The complete file is always preserved in the `raw` `Binary` regardless.
 
-## Pixel data extraction
+## Background processing
 
 Storing an instance does not extract its pixels inline — that would make every `C-STORE` wait on
-decoding. Instead, the create is dispatched to a background worker:
+decoding. The work is split across two queues, by how often it needs to run.
 
-1. A `DicomInstance` is created, or its `raw` reference changes.
-2. The `dicom` worker enqueues a job on the `DicomQueue` BullMQ queue (three attempts, exponential
-   backoff starting at one second).
-3. The worker reads the raw `Binary`, parses the full file, and splits `PixelData` into frames.
-4. Each frame is written as its own `Binary`, with `securityContext` set to the `DicomInstance` so it
-   inherits the instance's access control.
-5. `DicomInstance.pixelData` is patched with references to those binaries, in frame order.
+Both entry points feed the same queues. Whether an instance arrives through
+[STOW-RS](./dicomweb-api.md#stow-rs-store-instances) or as a `DicomInstance` created through the FHIR
+API, the same jobs run, so the two routes produce the same resources.
+
+Both run on the `DicomQueue` BullMQ queue, as two job types.
+
+**Instance job — once per instance.** Triggered when a `DicomInstance` is created or its `raw`
+reference changes (three attempts, exponential backoff starting at one second):
+
+1. The worker reads the raw `Binary` and parses the full file.
+2. Instance attributes read from the dataset — `rows`, `columns`, `bitsAllocated`, `numberOfFrames`,
+   and the rest — are patched onto the `DicomInstance`.
+3. `PixelData` is split into frames. Each frame is written as its own `Binary`, with
+   `securityContext` set to the `DicomInstance` so it inherits the instance's access control.
+4. `DicomInstance.pixelData` is patched with references to those binaries, in frame order.
+
+**Study job — once per study.** Enqueued for the parent study whenever an instance lands or is
+deleted, and deduplicated per study, so a five-hundred-instance upload recomputes the study about
+twice rather than five hundred times:
+
+1. Study-level aggregates — `modalitiesInStudy`, `numberOfStudyRelatedSeries`,
+   `numberOfStudyRelatedInstances` — are recomputed from the stored series and instances.
+2. `numberOfSeriesRelatedInstances` is recomputed for every series in the study.
+3. The study's [`ImagingStudy`](#relationship-to-fhir-imagingstudy) is created or refreshed.
+
+These are Q/R query keys the archive is responsible for computing, so the values a sender puts in its
+own headers are ignored rather than trusted. Until this job runs they are absent rather than wrong.
 
 The `Binary.contentType` of each frame is derived from the file's Transfer Syntax UID:
 
@@ -124,13 +154,14 @@ The `Binary.contentType` of each frame is derived from the file's Transfer Synta
 | `1.2.840.10008.1.2.4.201`, `.202`      | `image/jxl`                |
 | Anything else, including uncompressed  | `application/octet-stream` |
 
-Until the worker finishes, [frame retrieval](./dicomweb-api.md#wado-rs-retrieve-frames) returns
-`404` for that instance. Study and series queries work immediately.
+Until the instance job finishes, [frame retrieval](./dicomweb-api.md#wado-rs-retrieve-frames)
+returns `404` for that instance. Studies and series appear in query results immediately, because they
+are created during the upload itself; their instance counts fill in once the study job runs.
 
 The worker is named `dicom` and can be enabled or disabled per server instance through the
 `workers.enabled` configuration setting, like any other Medplum worker. A deployment that runs
 workers on dedicated hosts needs `dicom` enabled on at least one of them, or pixel data is never
-extracted.
+extracted, aggregate counts stay absent, and no `ImagingStudy` is created.
 
 ## Search parameters
 
@@ -159,13 +190,58 @@ parameters are `string` searches, and `study-date` is a `date` search.
 
 ## Relationship to FHIR ImagingStudy
 
-Medplum does not currently create an [`ImagingStudy`](/docs/api/fhir/resources/imagingstudy)
-alongside a `DicomStudy`, and `DicomStudy.patientId` holds the DICOM Patient ID string rather than a
-reference to a Medplum [`Patient`](/docs/api/fhir/resources/patient). Linking imaging into the chart
-is on the roadmap.
+Medplum generates an [`ImagingStudy`](/docs/api/fhir/resources/imagingstudy) for every `DicomStudy`,
+as part of the study job described above. It is a derived, chart-facing view: the DICOM resources
+remain the source of truth, and the `ImagingStudy` is what a `DiagnosticReport` cites and what a
+search by patient returns.
 
-In the meantime, a [Bot](/docs/bots) subscribed to `DicomStudy` creation can do the reconciliation
-your workflow needs — matching `patientId` against your MRN identifier system, creating an
-`ImagingStudy` that references both the `Patient` and the study's UIDs, and flagging studies whose
-patient could not be resolved for manual review. Doing it in a Bot rather than at ingest keeps the
-matching logic — which is highly site-specific — under your control.
+It is identified by the study's UID, so it converges rather than duplicating:
+
+```json
+{
+  "resourceType": "ImagingStudy",
+  "identifier": [{ "system": "urn:dicom:uid", "value": "urn:oid:1.2.826.0.1.3680043.10.543.2" }],
+  "status": "available",
+  "numberOfSeries": 2,
+  "numberOfInstances": 148,
+  "endpoint": [{ "reference": "Endpoint/..." }]
+}
+```
+
+`ImagingStudy.endpoint` points at an [`Endpoint`](/docs/api/fhir/resources/endpoint) with
+`connectionType` `dicom-wado-rs`, created once per project, whose `address` is this server's DICOMweb
+root. A client composes retrieve URLs from it:
+
+```
+{endpoint.address}/studies/{identifier}/series/{series.uid}/instances/{sopInstanceUid}
+```
+
+Series are listed on the `ImagingStudy`; individual instances are not. Enumerating every SOP instance
+would make the resource grow without bound on a large study, and viewers read the instance list from
+[`/series/{uid}/metadata`](./dicomweb-api.md#wado-rs-retrieve-series-metadata) anyway.
+
+### Which fields the server owns
+
+The study job rewrites only the fields it derives — `identifier`, `status`, `modality`, `started`,
+`endpoint`, `numberOfSeries`, `numberOfInstances`, and `series`. Everything else is yours to set:
+`basedOn`, `encounter`, `procedureReference`, `note`, `description`, and the rest survive every
+recompute. Resources the server maintains carry the tag `https://medplum.com/dicom|derived-from-dicom`.
+
+Two fields latch, so that a human correction is never undone by a later instance arriving:
+
+- **`subject`** — resolved by matching `DicomStudy.patientId` against `Patient.identifier` within the
+  same project. A single match becomes a real reference; zero or multiple matches leave a logical
+  reference carrying the DICOM Patient ID and name. A logical reference is upgraded to a real one
+  once exactly one `Patient` matches, but a real reference is **never** downgraded — so correcting
+  the patient by hand, or through a [Bot](/docs/bots), sticks.
+- **`status`** — `cancelled` and `entered-in-error` are preserved. Everything else follows the
+  instance count: `available` once the study has instances, `registered` before that.
+
+:::note Upgrading from an earlier version
+
+If you already create `ImagingStudy` resources in a Bot using the `urn:dicom:uid` identifier, the
+server will **adopt** them rather than create duplicates: the fields listed above start being
+recomputed, and everything else your Bot set is preserved. Bots that write to the server-owned fields
+should be retired, since their values will be overwritten on the next recompute.
+
+:::

--- a/packages/docs/docs/dicom/dicomweb-api.md
+++ b/packages/docs/docs/dicom/dicomweb-api.md
@@ -70,7 +70,7 @@ Instance UID `(0008,1155)`, and a Retrieve URL `(0008,1190)`.
 
 :::caution
 
-The Retrieve URL returned in the response is currently a placeholder of the form `/instances/{id}/raw`, which is not a resolvable endpoint. Use the QIDO-RS and WADO-RS routes below to retrieve stored instances.
+The Retrieve URL returned in the response is currently a placeholder of the form `/instances/{id}/raw`, which is not a resolvable endpoint. Use the QIDO-RS and WADO-RS routes below to retrieve stored instances, or the `Endpoint` referenced by the study's [`ImagingStudy`](./data-model.md#relationship-to-fhir-imagingstudy).
 
 :::
 

--- a/packages/docs/docs/dicom/index.md
+++ b/packages/docs/docs/dicom/index.md
@@ -51,7 +51,7 @@ the [OHIF Viewer](./ohif-viewer.md) makes.
 
 ## What gets stored
 
-A single DICOM instance arriving at Medplum produces four things:
+A single DICOM instance arriving at Medplum produces five things:
 
 | Resource                                                | Holds                                                                                   |
 | ------------------------------------------------------- | --------------------------------------------------------------------------------------- |
@@ -59,12 +59,14 @@ A single DICOM instance arriving at Medplum produces four things:
 | [`DicomSeries`](/docs/api/fhir/medplum/dicomseries)     | Series-level attributes — series UID, modality, series description                      |
 | [`DicomInstance`](/docs/api/fhir/medplum/dicominstance) | Instance-level attributes, plus the full DICOM JSON metadata and references to binaries |
 | [`Binary`](/docs/api/fhir/resources/binary)             | The original, unmodified `.dcm` file                                                    |
+| [`ImagingStudy`](/docs/api/fhir/resources/imagingstudy) | A derived, chart-facing view of the study, with a WADO-RS endpoint to retrieve it from  |
 
 Studies and series are created conditionally on their DICOM UIDs, so the second instance of a series
 attaches to the study and series the first one created rather than duplicating them.
 
-A background worker then reads the raw file and extracts pixel data into one additional `Binary` per
-frame, which is what [WADO-RS frame retrieval](./dicomweb-api.md#wado-rs-retrieve-frames) serves.
+Background workers then read the raw file and extract pixel data into one additional `Binary` per
+frame, which is what [WADO-RS frame retrieval](./dicomweb-api.md#wado-rs-retrieve-frames) serves, and
+recompute the study's instance counts and its `ImagingStudy`.
 See the [Data Model](./data-model.md) for the full mapping from DICOM attributes to resource fields.
 
 Because these are ordinary Medplum resources, they are searchable with the standard FHIR search API,

--- a/packages/server/src/dicom/imaging-study.test.ts
+++ b/packages/server/src/dicom/imaging-study.test.ts
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { WithId } from '@medplum/core';
+import { createReference, Operator } from '@medplum/core';
+import type { DicomInstance, DicomSeries, DicomStudy, ImagingStudy, Patient } from '@medplum/fhirtypes';
+import express from 'express';
+import { randomUUID } from 'node:crypto';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { initApp, shutdownApp } from '../app';
+import { loadTestConfig } from '../config/loader';
+import type { Repository } from '../fhir/repo';
+import { getShardSystemRepo } from '../fhir/repo';
+import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
+import { createTestProject, withTestContext } from '../test.setup';
+import { DICOM_UID_SYSTEM, reconcileImagingStudy } from './imaging-study';
+import { scanStudy } from './utils';
+
+describe('ImagingStudy reconciliation', () => {
+  const app = express();
+  let repo: Repository;
+  let projectId: string;
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initApp(app, config);
+    const testProject = await createTestProject({ withRepo: true });
+    repo = testProject.repo;
+    projectId = testProject.project.id;
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  async function createStudy(fields: Partial<DicomStudy> = {}): Promise<WithId<DicomStudy>> {
+    return repo.createResource<DicomStudy>({
+      resourceType: 'DicomStudy',
+      studyInstanceUid: randomUUID(),
+      ...fields,
+    });
+  }
+
+  async function addSeries(
+    study: DicomStudy,
+    modality: string | undefined,
+    instances: number,
+    seriesNumber?: string
+  ): Promise<WithId<DicomSeries>> {
+    const series = await repo.createResource<DicomSeries>({
+      resourceType: 'DicomSeries',
+      study: createReference(study),
+      seriesInstanceUid: randomUUID(),
+      seriesNumber,
+      modality,
+    });
+    for (let i = 0; i < instances; i++) {
+      await repo.createResource<DicomInstance>({
+        resourceType: 'DicomInstance',
+        study: createReference(study),
+        series: createReference(series),
+        sopInstanceUid: randomUUID(),
+        sopClassUid: '1.2.840.10008.5.1.4.1.1.7',
+        metadata: '{}',
+        raw: { reference: 'Binary/123' },
+      });
+    }
+    return series;
+  }
+
+  async function reconcile(study: WithId<DicomStudy>): Promise<ImagingStudy | undefined> {
+    // The system repo, because that is what the worker uses: it spans every project on the shard,
+    // which is what makes the _project filters inside load-bearing.
+    const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID);
+    await reconcileImagingStudy(systemRepo, study, await scanStudy(systemRepo, study.id));
+    return repo.searchOne<ImagingStudy>({
+      resourceType: 'ImagingStudy',
+      filters: [
+        {
+          code: 'identifier',
+          operator: Operator.EXACT,
+          value: `${DICOM_UID_SYSTEM}|urn:oid:${study.studyInstanceUid}`,
+        },
+      ],
+    });
+  }
+
+  test('Derives an ImagingStudy from the study, its series, and its instances', () =>
+    withTestContext(async () => {
+      const study = await createStudy({ patientName: 'TEST^PATIENT', studyId: 'ACC-1' });
+      await addSeries(study, 'CT', 3, '1');
+      await addSeries(study, 'PT', 2, '2');
+
+      const imagingStudy = await reconcile(study);
+
+      expect(imagingStudy).toMatchObject({
+        status: 'available',
+        numberOfSeries: 2,
+        numberOfInstances: 5,
+      });
+      expect(imagingStudy?.modality?.map((m) => m.code)).toStrictEqual(['CT', 'PT']);
+      expect(imagingStudy?.series?.map((s) => s.numberOfInstances)).toStrictEqual([3, 2]);
+      // Instances are not enumerated; viewers read them from the series metadata route.
+      expect(imagingStudy?.series?.[0].instance).toBeUndefined();
+      expect(imagingStudy?.endpoint).toHaveLength(1);
+    }));
+
+  test('Reports a study with no instances as registered rather than available', () =>
+    withTestContext(async () => {
+      const study = await createStudy();
+
+      expect(await reconcile(study)).toMatchObject({ status: 'registered', numberOfInstances: 0 });
+    }));
+
+  test('Does not create a new version when nothing changed', () =>
+    withTestContext(async () => {
+      const study = await createStudy();
+      await addSeries(study, 'CT', 1);
+
+      const first = await reconcile(study);
+      const second = await reconcile(study);
+
+      // A new version on every run would write a history row and re-dispatch every matching
+      // Subscription once per arriving instance.
+      expect(second?.meta?.versionId).toBe(first?.meta?.versionId);
+    }));
+
+  test('Picks up a series added after the first run, and drops one that was deleted', () =>
+    withTestContext(async () => {
+      const study = await createStudy();
+      const first = await addSeries(study, 'CT', 1, '1');
+      await reconcile(study);
+
+      await addSeries(study, 'MR', 2, '2');
+      expect(await reconcile(study)).toMatchObject({ numberOfSeries: 2, numberOfInstances: 3 });
+
+      await repo.deleteResource('DicomSeries', first.id);
+      const afterDelete = await reconcile(study);
+      expect(afterDelete?.numberOfSeries).toBe(1);
+      expect(afterDelete?.series?.[0].modality.code).toBe('MR');
+    }));
+
+  test('Orders series by series number regardless of the order they were stored in', () =>
+    withTestContext(async () => {
+      const study = await createStudy();
+      await addSeries(study, 'MR', 1, '3');
+      await addSeries(study, 'CT', 1, '1');
+      await addSeries(study, 'PT', 1, '2');
+
+      // Unsorted, this would churn a new version on every run: see the sort in deriveImagingStudy.
+      expect((await reconcile(study))?.series?.map((series) => series.number)).toStrictEqual([1, 2, 3]);
+    }));
+
+  test('States the absence of a modality rather than asserting one the sender never sent', () =>
+    withTestContext(async () => {
+      const study = await createStudy();
+      await addSeries(study, undefined, 1);
+
+      const imagingStudy = await reconcile(study);
+
+      // series.modality is required, so it cannot be dropped the way an unparseable date is. An
+      // extension-only Coding satisfies the cardinality without inventing a code.
+      const modality = imagingStudy?.series?.[0].modality;
+      expect(modality?.code).toBeUndefined();
+      expect(modality?.extension?.[0].valueCode).toBe('unknown');
+    }));
+
+  describe('subject resolution', () => {
+    test('Links the Patient when exactly one matches the DICOM Patient ID', () =>
+      withTestContext(async () => {
+        const mrn = randomUUID();
+        const patient = await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          identifier: [{ value: mrn }],
+        });
+        const study = await createStudy({ patientId: mrn, patientName: 'TEST^PATIENT' });
+
+        expect((await reconcile(study))?.subject).toMatchObject({ reference: `Patient/${patient.id}` });
+      }));
+
+    test('Falls back to a logical reference when the Patient ID is ambiguous', () =>
+      withTestContext(async () => {
+        const mrn = randomUUID();
+        await repo.createResource<Patient>({ resourceType: 'Patient', identifier: [{ value: mrn }] });
+        await repo.createResource<Patient>({ resourceType: 'Patient', identifier: [{ value: mrn }] });
+        const study = await createStudy({ patientId: mrn, patientName: 'TEST^PATIENT' });
+
+        const subject = (await reconcile(study))?.subject;
+        expect(subject?.reference).toBeUndefined();
+        expect(subject).toMatchObject({ identifier: { value: mrn }, display: 'TEST^PATIENT' });
+      }));
+
+    test('Never matches a Patient in another project', () =>
+      withTestContext(async () => {
+        const mrn = randomUUID();
+        const other = await createTestProject({ withRepo: true });
+        await other.repo.createResource<Patient>({ resourceType: 'Patient', identifier: [{ value: mrn }] });
+        const study = await createStudy({ patientId: mrn, patientName: 'TEST^PATIENT' });
+
+        // The study job runs on a system repository, which has no project of its own. Without an
+        // explicit _project filter this would link a study to a patient in a different tenant.
+        expect((await reconcile(study))?.subject?.reference).toBeUndefined();
+      }));
+
+    test('Upgrades a logical reference once the Patient exists', () =>
+      withTestContext(async () => {
+        const mrn = randomUUID();
+        const study = await createStudy({ patientId: mrn, patientName: 'TEST^PATIENT' });
+        expect((await reconcile(study))?.subject?.reference).toBeUndefined();
+
+        const patient = await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          identifier: [{ value: mrn }],
+        });
+
+        expect((await reconcile(study))?.subject).toMatchObject({ reference: `Patient/${patient.id}` });
+      }));
+
+    test('Keeps a corrected Patient reference even when nothing resolves any more', () =>
+      withTestContext(async () => {
+        const study = await createStudy({ patientId: randomUUID(), patientName: 'TEST^PATIENT' });
+        const imagingStudy = await reconcile(study);
+        expect(imagingStudy?.subject?.reference).toBeUndefined();
+
+        // A human corrects the patient by hand. Re-deriving on every arriving instance must not
+        // undo that, so the transition is one-way: logical to literal, never back.
+        const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+        await repo.updateResource<ImagingStudy>({
+          ...(imagingStudy as ImagingStudy),
+          subject: createReference(patient),
+        });
+
+        expect((await reconcile(study))?.subject).toMatchObject({ reference: `Patient/${patient.id}` });
+      }));
+  });
+
+  test('Preserves fields written by a human or a Bot', () =>
+    withTestContext(async () => {
+      const study = await createStudy();
+      await addSeries(study, 'CT', 1);
+      const imagingStudy = await reconcile(study);
+
+      await repo.updateResource<ImagingStudy>({
+        ...(imagingStudy as ImagingStudy),
+        status: 'entered-in-error',
+        note: [{ text: 'Wrong patient' }],
+        description: 'Chest CT',
+      });
+
+      await addSeries(study, 'MR', 1);
+      const after = await reconcile(study);
+
+      expect(after?.note?.[0].text).toBe('Wrong patient');
+      expect(after?.description).toBe('Chest CT');
+      // A study someone retired is not resurrected by the next instance to arrive.
+      expect(after?.status).toBe('entered-in-error');
+      expect(after?.numberOfSeries).toBe(2);
+    }));
+
+  test('Reuses one WADO-RS Endpoint for the whole project', () =>
+    withTestContext(async () => {
+      const first = await createStudy();
+      const second = await createStudy();
+
+      const a = await reconcile(first);
+      const b = await reconcile(second);
+
+      expect(a?.endpoint?.[0].reference).toBe(b?.endpoint?.[0].reference);
+      expect(projectId).toBeDefined();
+    }));
+});

--- a/packages/server/src/dicom/imaging-study.ts
+++ b/packages/server/src/dicom/imaging-study.ts
@@ -1,0 +1,404 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import type { SearchRequest, WithId } from '@medplum/core';
+import { createReference, deepEquals, HTTP_HL7_ORG, isCreated, Operator } from '@medplum/core';
+import type {
+  Coding,
+  Device,
+  DicomSeries,
+  DicomStudy,
+  Endpoint,
+  Group,
+  ImagingStudy,
+  ImagingStudySeries,
+  Meta,
+  Patient,
+  Reference,
+} from '@medplum/fhirtypes';
+import { getConfig } from '../config/loader';
+import type { Repository } from '../fhir/repo';
+import { getLogger } from '../logger';
+import { updateWithRetry } from './utils';
+
+export const DICOM_UID_SYSTEM = 'urn:dicom:uid';
+const DCM_SYSTEM = 'http://dicom.nema.org/resources/ontology/DCM';
+const ENDPOINT_CONNECTION_TYPE_SYSTEM = 'http://terminology.hl7.org/CodeSystem/endpoint-connection-type';
+const MEDPLUM_DICOM_SYSTEM = 'https://medplum.com/dicom';
+
+/** Marks the resources this module maintains, so `ImagingStudy?_tag=` can find them. */
+const DERIVED_TAG: Coding = { system: MEDPLUM_DICOM_SYSTEM, code: 'derived-from-dicom' };
+
+/**
+ * Stated for a series whose `DicomSeries.modality` is missing.
+ *
+ * Modality (0008,0060) is Type 1 in every image IOD, so its absence means a malformed sender rather
+ * than a study with genuinely no modality. `ImagingStudy.series.modality` is required, so it cannot
+ * simply be dropped the way `dicomDateToFhirDate` drops an unparseable date; this states the absence
+ * instead of asserting a code - such as DCM "OT" - that no instance actually carried.
+ */
+const UNKNOWN_MODALITY: Coding = {
+  extension: [{ url: `${HTTP_HL7_ORG}/fhir/StructureDefinition/data-absent-reason`, valueCode: 'unknown' }],
+};
+
+/**
+ * The `ImagingStudy` elements this module owns.
+ *
+ * Everything absent from this list belongs to whoever wrote it - a human correcting the chart, or a
+ * Bot linking the study to an order - and survives by construction, because the merge spreads the
+ * stored resource first and overlays only these keys.
+ */
+type DerivedKey =
+  | 'identifier'
+  | 'status'
+  | 'modality'
+  | 'subject'
+  | 'started'
+  | 'endpoint'
+  | 'numberOfSeries'
+  | 'numberOfInstances'
+  | 'series';
+
+/**
+ * Every derived key must be produced on every run, even when the answer is `undefined`.
+ *
+ * The `-?` is what makes convergence structural: a field that no longer has a value must be spelled
+ * `modality: undefined`, so the spread clears it rather than letting a stale server-written value
+ * survive because someone forgot to null it out.
+ */
+type DerivedImagingStudy = { [K in DerivedKey]-?: ImagingStudy[K] };
+
+/** A status someone set by hand to retire a study, which no arriving instance should undo. */
+const RETIRED_STATUSES: ImagingStudy['status'][] = ['cancelled', 'entered-in-error'];
+
+export interface StudyScan {
+  readonly seriesList: WithId<DicomSeries>[];
+  readonly instanceCounts: Map<string, number>;
+  readonly totalInstances: number;
+}
+
+/**
+ * Creates or refreshes the `ImagingStudy` mirroring a `DicomStudy`.
+ *
+ * `DicomStudy`/`DicomSeries`/`DicomInstance` are the archive's own representation, reachable only
+ * through DICOMweb. `ImagingStudy` is how the rest of a FHIR server finds imaging: what a
+ * `DiagnosticReport` cites, what a search by patient returns. Deriving it here means a DICOMweb STOW
+ * and a directly created `DicomInstance` produce the same chart-visible study.
+ *
+ * Instances are deliberately not enumerated into `series.instance`. Viewers read them from
+ * `GET .../series/{uid}/metadata` instead, and indexing every SOP instance UID would rewrite tens of
+ * thousands of token rows on each recompute for no consumer.
+ *
+ * @param repo - The repository to read and write with, scoped to the study's project.
+ * @param study - The study to mirror.
+ * @param scan - Series and instance counts already gathered for the aggregate pass.
+ */
+export async function reconcileImagingStudy(
+  repo: Repository,
+  study: WithId<DicomStudy>,
+  scan: StudyScan
+): Promise<void> {
+  const projectId = study.meta?.project;
+  if (!projectId) {
+    getLogger().warn('Skipping ImagingStudy for a DicomStudy with no project', { studyId: study.id });
+    return;
+  }
+
+  const search: SearchRequest<ImagingStudy> = {
+    resourceType: 'ImagingStudy',
+    filters: [
+      { code: '_project', operator: Operator.EQUALS, value: projectId },
+      {
+        code: 'identifier',
+        operator: Operator.EXACT,
+        value: `${DICOM_UID_SYSTEM}|urn:oid:${study.studyInstanceUid}`,
+      },
+    ],
+  };
+
+  const matches = await repo.searchResources<ImagingStudy>({ ...search, count: 2 });
+  if (matches.length > 1) {
+    // Two resources claim one Study Instance UID. Choosing between them could strip a chart link,
+    // so leave both alone and surface it rather than guessing.
+    getLogger().error('Multiple ImagingStudy resources for one DICOM study', {
+      studyId: study.id,
+      studyInstanceUid: study.studyInstanceUid,
+    });
+    return;
+  }
+
+  const endpoint = await getWadoEndpoint(repo, projectId);
+  const existing = matches[0];
+
+  if (!existing) {
+    const derived = await deriveImagingStudy(repo, projectId, study, scan, endpoint, undefined);
+    const result = await repo.conditionalCreate<ImagingStudy>(mergeImagingStudy(undefined, derived, projectId), search);
+    if (isCreated(result.outcome)) {
+      return;
+    }
+    // Another worker created it between the search and the create; fall through onto theirs.
+  }
+
+  const id = existing?.id ?? (await repo.searchResources<ImagingStudy>({ ...search, count: 1 }))[0]?.id;
+  if (!id) {
+    return;
+  }
+
+  await updateWithRetry<ImagingStudy>(repo, 'ImagingStudy', id, async (current) => {
+    const derived = await deriveImagingStudy(repo, projectId, study, scan, endpoint, current);
+    const merged = mergeImagingStudy(current, derived, projectId);
+    // Skip the write when nothing changed: every version writes a full history row and dispatches to
+    // every matching Subscription, and this runs again for each instance that arrives.
+    return deepEquals(current, merged) ? undefined : merged;
+  });
+}
+
+/**
+ * Builds the server-owned projection of a study.
+ * @param repo - The repository to resolve the subject with.
+ * @param projectId - The project the study belongs to.
+ * @param study - The source study.
+ * @param scan - Series and instance counts.
+ * @param endpoint - The project's WADO-RS endpoint.
+ * @param existing - The stored ImagingStudy, if any, for the fields that latch.
+ * @returns The derived fields.
+ */
+async function deriveImagingStudy(
+  repo: Repository,
+  projectId: string,
+  study: WithId<DicomStudy>,
+  scan: StudyScan,
+  endpoint: Reference<Endpoint>,
+  existing: ImagingStudy | undefined
+): Promise<DerivedImagingStudy> {
+  const modalities = new Set<string>();
+  const series: ImagingStudySeries[] = [];
+
+  for (const dicomSeries of scan.seriesList) {
+    const modality = dicomSeries.modality?.trim().toUpperCase();
+    if (modality) {
+      modalities.add(modality);
+    }
+    series.push({
+      uid: dicomSeries.seriesInstanceUid,
+      number: toUnsignedInt(dicomSeries.seriesNumber),
+      modality: modality ? { system: DCM_SYSTEM, code: modality } : UNKNOWN_MODALITY,
+      description: dicomSeries.seriesDescription,
+      numberOfInstances: scan.instanceCounts.get(dicomSeries.id) ?? 0,
+      started: toFhirDateTime(
+        dicomSeries.performedProcedureStepStartDate,
+        dicomSeries.performedProcedureStepStartTime,
+        dicomSeries.timezoneOffsetFromUtc
+      ),
+    });
+  }
+
+  // Sorted so an unchanged study compares equal below. Search paging gives no ordering guarantee
+  // across pages, and deepEquals compares arrays positionally, so an unsorted list would churn a new
+  // version - and a fresh round of subscription dispatches - on every single run.
+  series.sort(compareByNumberThenUid);
+
+  return {
+    identifier: mergeSlot(
+      existing?.identifier,
+      [{ system: DICOM_UID_SYSTEM, value: `urn:oid:${study.studyInstanceUid}` }],
+      (identifier) => identifier.system === DICOM_UID_SYSTEM
+    ),
+    status: resolveStatus(existing, scan.totalInstances),
+    modality: Array.from(modalities)
+      .sort((a, b) => a.localeCompare(b))
+      .map((code) => ({ system: DCM_SYSTEM, code })),
+    subject: await resolveSubject(repo, projectId, study, existing?.subject),
+    started: toFhirDateTime(study.studyDate, study.studyTime, study.timezoneOffsetFromUtc),
+    endpoint: mergeSlot(existing?.endpoint, [endpoint], (value) => value.reference === endpoint.reference),
+    numberOfSeries: series.length,
+    numberOfInstances: scan.totalInstances,
+    series: series.length > 0 ? series : undefined,
+  };
+}
+
+/**
+ * Overlays the derived fields onto the stored resource.
+ * @param existing - The stored resource, if any.
+ * @param derived - The server-owned projection.
+ * @param projectId - The project the study belongs to.
+ * @returns The resource to write.
+ */
+function mergeImagingStudy(
+  existing: ImagingStudy | undefined,
+  derived: DerivedImagingStudy,
+  projectId: string
+): ImagingStudy {
+  const meta: Meta = {
+    ...existing?.meta,
+    project: projectId,
+    tag: mergeSlot(existing?.meta?.tag, [DERIVED_TAG], (tag) => tag.system === MEDPLUM_DICOM_SYSTEM),
+  };
+  // Spreading `existing` first is what preserves caller-owned fields - basedOn, encounter, note,
+  // procedureReference - without this module having to enumerate them.
+  return { ...existing, ...derived, resourceType: 'ImagingStudy', meta };
+}
+
+/**
+ * Replaces the entries this module owns, preserving every other entry and its order.
+ * @param existing - The stored array.
+ * @param derived - The entries this module contributes.
+ * @param owns - Identifies an entry this module wrote.
+ * @returns The merged array, or undefined when empty.
+ */
+function mergeSlot<T>(existing: T[] | undefined, derived: T[], owns: (value: T) => boolean): T[] | undefined {
+  const merged = [...derived, ...(existing?.filter((value) => !owns(value)) ?? [])];
+  return merged.length > 0 ? merged : undefined;
+}
+
+/**
+ * Resolves `ImagingStudy.subject`, upgrading a logical reference to a literal one but never the reverse.
+ *
+ * A stored literal reference is a statement someone made about identity - an earlier run that
+ * matched, or a human correcting a study we could not match. DICOM cannot outrank it: a `patientId`
+ * that failed to resolve once will keep failing, so re-deriving on every arriving instance would undo
+ * that correction over and over. Downgrading is not a decision made here; it is unreachable, because
+ * the only transition this performs is logical to literal.
+ *
+ * @param repo - The repository to search with.
+ * @param projectId - The project to confine the search to.
+ * @param study - The source study.
+ * @param existing - The stored subject, if any.
+ * @returns The subject reference.
+ */
+async function resolveSubject(
+  repo: Repository,
+  projectId: string,
+  study: DicomStudy,
+  existing: Reference<Patient | Device | Group> | undefined
+): Promise<Reference<Patient | Device | Group>> {
+  if (existing?.reference) {
+    return existing;
+  }
+
+  const patientId = study.patientId?.trim();
+  if (patientId) {
+    // _project is required, not hardening: the study job runs on a system repository, which has no
+    // project of its own and would otherwise match a Patient in another tenant that happens to share
+    // an MRN. `count: 2` so an ambiguous match is detected rather than silently taking the first.
+    const matches = await repo.searchResources<Patient>({
+      resourceType: 'Patient',
+      filters: [
+        { code: '_project', operator: Operator.EQUALS, value: projectId },
+        { code: 'identifier', operator: Operator.EXACT, value: patientId },
+      ],
+      count: 2,
+    });
+    if (matches.length === 1) {
+      return createReference(matches[0]);
+    }
+  }
+
+  if (!patientId && !study.patientName) {
+    // PatientID and PatientName are both Type 2 and may legitimately be empty for an unidentified
+    // study, but subject is required, so state the absence rather than write an empty reference.
+    return { extension: UNKNOWN_MODALITY.extension };
+  }
+
+  return { identifier: patientId ? { value: patientId } : undefined, display: study.patientName };
+}
+
+/**
+ * Resolves `ImagingStudy.status`.
+ * @param existing - The stored resource, if any.
+ * @param totalInstances - Instances stored for the study.
+ * @returns The status to write.
+ */
+function resolveStatus(existing: ImagingStudy | undefined, totalInstances: number): ImagingStudy['status'] {
+  // A study someone retired is not resurrected by the next instance to arrive.
+  if (existing && RETIRED_STATUSES.includes(existing.status)) {
+    return existing.status;
+  }
+  return totalInstances > 0 ? 'available' : 'registered';
+}
+
+/**
+ * Returns the project's WADO-RS endpoint, creating it on first use.
+ *
+ * Matched on an identifier this server owns rather than on `connection-type`, so a `dicom-wado-rs`
+ * Endpoint the customer created for their own archive is never adopted and rewritten.
+ *
+ * @param repo - The repository to read and write with.
+ * @param projectId - The project the endpoint belongs to.
+ * @returns A reference to the endpoint.
+ */
+export async function getWadoEndpoint(repo: Repository, projectId: string): Promise<Reference<Endpoint>> {
+  const result = await repo.conditionalCreate<Endpoint>(
+    {
+      resourceType: 'Endpoint',
+      meta: { project: projectId },
+      identifier: [{ system: MEDPLUM_DICOM_SYSTEM, value: 'wado-rs' }],
+      status: 'active',
+      connectionType: { system: ENDPOINT_CONNECTION_TYPE_SYSTEM, code: 'dicom-wado-rs' },
+      name: 'DICOMweb WADO-RS',
+      payloadType: [
+        { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/endpoint-payload-type', code: 'any' }] },
+      ],
+      payloadMimeType: ['application/dicom'],
+      address: new URL('dicomweb', getConfig().baseUrl).toString(),
+    },
+    {
+      resourceType: 'Endpoint',
+      filters: [
+        { code: '_project', operator: Operator.EQUALS, value: projectId },
+        { code: 'identifier', operator: Operator.EXACT, value: `${MEDPLUM_DICOM_SYSTEM}|wado-rs` },
+      ],
+    }
+  );
+  return createReference(result.resource);
+}
+
+/**
+ * Orders series by DICOM series number, falling back to UID.
+ * @param a - The first series.
+ * @param b - The second series.
+ * @returns The sort order.
+ */
+function compareByNumberThenUid(a: ImagingStudySeries, b: ImagingStudySeries): number {
+  const aNumber = a.number ?? Number.MAX_SAFE_INTEGER;
+  const bNumber = b.number ?? Number.MAX_SAFE_INTEGER;
+  return aNumber === bNumber ? a.uid.localeCompare(b.uid) : aNumber - bNumber;
+}
+
+/**
+ * Parses a DICOM Integer String into an `unsignedInt`.
+ * @param value - The string value, which callers may have set to anything.
+ * @returns The parsed number, or undefined if it is not a non-negative integer.
+ */
+function toUnsignedInt(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+/**
+ * Combines a DICOM date, time, and UTC offset into a FHIR dateTime.
+ *
+ * Emits date-only unless both the time and the offset are known: FHIR requires a timezone whenever a
+ * time is present, and DICOM times are local wall time carrying no offset of their own, so inventing
+ * `Z` would move the study by up to twelve hours.
+ *
+ * @param date - The FHIR-normalized date.
+ * @param time - The FHIR-normalized time.
+ * @param offset - TimezoneOffsetFromUTC (0008,0201), as `&plusmn;HHMM`.
+ * @returns The dateTime, or undefined when there is no date.
+ */
+function toFhirDateTime(
+  date: string | undefined,
+  time: string | undefined,
+  offset: string | undefined
+): string | undefined {
+  if (!date) {
+    return undefined;
+  }
+  if (!time || !offset || !/^[+-]\d{4}$/.test(offset)) {
+    return date;
+  }
+  return `${date}T${time}${offset.slice(0, 3)}:${offset.slice(3)}`;
+}

--- a/packages/server/src/dicom/routes.test.ts
+++ b/packages/server/src/dicom/routes.test.ts
@@ -12,6 +12,7 @@ import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import { getBinaryStorage } from '../storage/loader';
 import { createTestProject } from '../test.setup';
+import { execPendingDicomStudyJobs } from '../workers/test-utils';
 import { handleSearchSeries } from './qido-rs';
 import { handleRetrieveInstanceFrame, handleRetrieveSeriesMetadata } from './wado-rs';
 
@@ -124,7 +125,10 @@ describe('DICOM Routes', () => {
     const res = await request(app)
       .get(`/dicomweb/studies/123`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res).toHaveStatus(200);
+    expect(res).toHaveStatus(404);
+    // The body is what separates an unbuilt route from a study that genuinely does not exist, since
+    // both answer 404.
+    expect(res.body).toMatchObject({ error: 'DICOMweb endpoint not implemented' });
   });
 
   test.skip('Update study', async () => {
@@ -140,7 +144,7 @@ describe('DICOM Routes', () => {
     const res = await request(app)
       .get(`/dicomweb/studies/123/rendered`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res).toHaveStatus(200);
+    expect(res).toHaveStatus(404);
   });
 
   test('Get all series', async () => {
@@ -163,14 +167,14 @@ describe('DICOM Routes', () => {
     const res = await request(app)
       .get(`/dicomweb/studies/123/series/456`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res).toHaveStatus(200);
+    expect(res).toHaveStatus(404);
   });
 
   test('Get rendered series', async () => {
     const res = await request(app)
       .get(`/dicomweb/studies/123/series/456/rendered`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res).toHaveStatus(200);
+    expect(res).toHaveStatus(404);
   });
 
   test('Get series metadata', async () => {
@@ -205,28 +209,28 @@ describe('DICOM Routes', () => {
     const res = await request(app)
       .get(`/dicomweb/studies/123/series/456/instances`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res).toHaveStatus(200);
+    expect(res).toHaveStatus(404);
   });
 
   test('Get instance', async () => {
     const res = await request(app)
       .get(`/dicomweb/studies/123/series/456/instances/789`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res).toHaveStatus(200);
+    expect(res).toHaveStatus(404);
   });
 
   test('Get rendered instance', async () => {
     const res = await request(app)
       .get(`/dicomweb/studies/123/series/456/instances/789/rendered`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res).toHaveStatus(200);
+    expect(res).toHaveStatus(404);
   });
 
   test('Get instance metadata', async () => {
     const res = await request(app)
       .get(`/dicomweb/studies/123/series/456/instances/789/metadata`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res).toHaveStatus(200);
+    expect(res).toHaveStatus(404);
   });
 
   test('Get frame', async () => {
@@ -302,7 +306,7 @@ describe('DICOM Routes', () => {
     const res = await request(app)
       .get(`/dicomweb/bulkdataUriReference`)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res).toHaveStatus(200);
+    expect(res).toHaveStatus(404);
   });
 
   test('Create study invalid multipart content-type', async () => {
@@ -332,6 +336,10 @@ describe('DICOM Routes', () => {
     expect(res).toHaveStatus(200);
     expect(JSON.stringify(res.body)).toContain('1.2.840.10008.5.1.4.1.1.7');
     expect(JSON.stringify(res.body)).toContain('1.2.826.0.1.3680043.10.543.1');
+
+    // Study level aggregates are computed by the coalesced study job rather than during the upload,
+    // so they are only correct once it has run.
+    await execPendingDicomStudyJobs();
 
     // The uploaded instance carries no ModalitiesInStudy (0008,0061), so the value below can only
     // come from reconciling the study against its stored series.
@@ -388,6 +396,8 @@ describe('DICOM Routes', () => {
     ].Value?.map((item) => item['00081155'].Value[0]);
     expect(referenced).toStrictEqual(sopInstanceUids);
 
+    await execPendingDicomStudyJobs();
+
     // A single study and series absorbed all three, rather than one being created per instance
     const studies = await request(app)
       .get(`/dicomweb/studies`)
@@ -433,6 +443,8 @@ describe('DICOM Routes', () => {
     // Store the same SOP instance twice, in two separate requests
     expect(await upload()).toHaveStatus(200);
     expect(await upload()).toHaveStatus(200);
+
+    await execPendingDicomStudyJobs();
 
     // The conditional create resolved the existing instance the second time, so the study and series
     // still count a single instance rather than two. NumberOfStudyRelatedInstances (0020,1208) and

--- a/packages/server/src/dicom/routes.ts
+++ b/packages/server/src/dicom/routes.ts
@@ -39,5 +39,9 @@ async function notImplementedStub(req: Request, res: Response): Promise<void> {
     path: req.path,
     query: req.query,
   });
-  res.sendStatus(200);
+  // Not the empty 200 this used to send: an ImagingStudy advertises a WADO-RS Endpoint, and a client
+  // following it to a route we do not serve must not read success-with-no-content as "this study is
+  // empty". 404 rather than 501 because an unbuilt route is not a server fault and should not page
+  // anyone; the body is what distinguishes it from a study that genuinely does not exist.
+  res.status(404).json({ error: 'DICOMweb endpoint not implemented' });
 }

--- a/packages/server/src/dicom/stow-rs.ts
+++ b/packages/server/src/dicom/stow-rs.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { createReference, isString, Operator, resolveId } from '@medplum/core';
+import { createReference, isString, Operator } from '@medplum/core';
 import type { Binary, DicomInstance, DicomSeries, DicomStudy } from '@medplum/fhirtypes';
 import type { DcmjsDicomDict } from 'dcmjs';
 import dcmjs from 'dcmjs';
@@ -10,13 +10,7 @@ import { PassThrough } from 'node:stream';
 import { getAuthenticatedContext } from '../context';
 import { uploadBinaryData } from '../fhir/binary';
 import { getLogger } from '../logger';
-import {
-  cleanDicomJsonDict,
-  dcmjsSeriesToMedplumSeries,
-  dcmjsStudyToMedplumStudy,
-  updateSeriesAggregates,
-  updateStudyAggregates,
-} from './utils';
+import { cleanDicomJsonDict, dcmjsSeriesToMedplumSeries, dcmjsStudyToMedplumStudy } from './utils';
 
 // eslint-disable-next-line import/no-named-as-default-member
 const { async, data, utilities } = dcmjs;
@@ -123,38 +117,7 @@ export async function handleStoreInstances(req: Request, res: Response): Promise
     for (const instance of parsed) {
       instances.push(await processInstance(instance));
     }
-    await updateAggregates(instances);
     return instances;
-  }
-
-  /**
-   * Recomputes Study and Series level aggregates once each, after every instance is stored.
-   *
-   * Doing this here rather than in `processInstance` keeps a large series to a single study update
-   * instead of one per instance. Only the series this request touched are updated, since the rest of
-   * the study cannot have changed. Failure is logged but not fatal: the instances are already stored,
-   * and the next upload recomputes them again.
-   *
-   * @param instances - The instances stored by this request.
-   */
-  async function updateAggregates(instances: DicomInstance[]): Promise<void> {
-    const studyIds = new Set(instances.map((instance) => resolveId(instance.study)).filter(isString));
-    for (const studyId of studyIds) {
-      try {
-        await updateStudyAggregates(repo, studyId);
-      } catch (err) {
-        getLogger().error('Error updating DICOM study aggregates', { err, studyId });
-      }
-    }
-
-    const seriesIds = new Set(instances.map((instance) => resolveId(instance.series)).filter(isString));
-    for (const seriesId of seriesIds) {
-      try {
-        await updateSeriesAggregates(repo, seriesId);
-      } catch (err) {
-        getLogger().error('Error updating DICOM series aggregates', { err, seriesId });
-      }
-    }
   }
 
   function sendStowResponse(instances: DicomInstance[]): void {

--- a/packages/server/src/dicom/utils.test.ts
+++ b/packages/server/src/dicom/utils.test.ts
@@ -23,6 +23,7 @@ import {
   medplumSeriesToDcmjsSeries,
   medplumStudyToDcmjsStudy,
   parseQueryInt,
+  scanStudy,
   stringToDicomPersonName,
   updateSeriesAggregates,
   updateStudyAggregates,
@@ -31,25 +32,25 @@ import {
 
 describe('DICOM utils', () => {
   test('converts DICOM study metadata to Medplum study', () => {
-    expect(
-      dcmjsStudyToMedplumStudy({
-        StudyInstanceUID: 'study-uid',
-        StudyID: 'study-id',
-        StudyDate: '20240102',
-        StudyTime: '030405',
-        AccessionNumber: 'A123',
-        InstanceAvailability: 'ONLINE',
-        ModalitiesInStudy: ['CT'],
-        ReferringPhysiciansName: 'Dr Test',
-        TimezoneOffsetFromUTC: '-0700',
-        PatientName: [{ Alphabetic: 'TEST^PATIENT ' }],
-        PatientID: 'P123',
-        PatientBirthDate: '20000101',
-        PatientSex: 'O',
-        NumberOfStudyRelatedSeries: 2,
-        NumberOfStudyRelatedInstances: 3,
-      })
-    ).toMatchObject({
+    const study = dcmjsStudyToMedplumStudy({
+      StudyInstanceUID: 'study-uid',
+      StudyID: 'study-id',
+      StudyDate: '20240102',
+      StudyTime: '030405',
+      AccessionNumber: 'A123',
+      InstanceAvailability: 'ONLINE',
+      ModalitiesInStudy: ['CT'],
+      ReferringPhysiciansName: 'Dr Test',
+      TimezoneOffsetFromUTC: '-0700',
+      PatientName: [{ Alphabetic: 'TEST^PATIENT ' }],
+      PatientID: 'P123',
+      PatientBirthDate: '20000101',
+      PatientSex: 'O',
+      NumberOfStudyRelatedSeries: 2,
+      NumberOfStudyRelatedInstances: 3,
+    });
+
+    expect(study).toMatchObject({
       resourceType: 'DicomStudy',
       studyInstanceUid: 'study-uid',
       studyId: 'study-id',
@@ -58,9 +59,12 @@ describe('DICOM utils', () => {
       accessionNumber: 'A123',
       patientName: 'TEST^PATIENT',
       patientBirthDate: '2000-01-01',
-      numberOfStudyRelatedSeries: 2,
-      numberOfStudyRelatedInstances: 3,
     });
+
+    // The sender's own NumberOfStudyRelated* are dropped rather than trusted; the study job
+    // recomputes them from what is actually stored.
+    expect(study.numberOfStudyRelatedSeries).toBeUndefined();
+    expect(study.numberOfStudyRelatedInstances).toBeUndefined();
   });
 
   test('converts Medplum study metadata to DICOM naturalized metadata', () => {
@@ -96,29 +100,31 @@ describe('DICOM utils', () => {
     const study = { resourceType: 'DicomStudy' as const, id: 'study-id', studyInstanceUid: 'study-uid' };
     const studyRef = { reference: 'DicomStudy/study-id' };
 
-    expect(
-      dcmjsSeriesToMedplumSeries(studyRef, {
-        SeriesInstanceUID: 'series-uid',
-        SeriesNumber: 7,
-        Modality: 'CT',
-        SeriesDescription: 'Head CT',
-        TimezoneOffsetFromUTC: '-0700',
-        NumberOfSeriesRelatedInstances: 4,
-        PerformedProcedureStepStartDate: '20240102',
-        PerformedProcedureStepStartTime: '030405',
-      })
-    ).toMatchObject({
+    const series = dcmjsSeriesToMedplumSeries(studyRef, {
+      SeriesInstanceUID: 'series-uid',
+      SeriesNumber: 7,
+      Modality: 'CT',
+      SeriesDescription: 'Head CT',
+      TimezoneOffsetFromUTC: '-0700',
+      NumberOfSeriesRelatedInstances: 4,
+      PerformedProcedureStepStartDate: '20240102',
+      PerformedProcedureStepStartTime: '030405',
+    });
+
+    expect(series).toMatchObject({
       resourceType: 'DicomSeries',
       study: studyRef,
       seriesInstanceUid: 'series-uid',
       seriesNumber: '7',
       modality: 'CT',
       seriesDescription: 'Head CT',
-      numberOfSeriesRelatedInstances: 4,
       // DICOM DA and TM, reformatted to the FHIR date and time the elements are typed as
       performedProcedureStepStartDate: '2024-01-02',
       performedProcedureStepStartTime: '03:04:05',
     });
+
+    // Dropped rather than trusted, as with the study level counts above.
+    expect(series.numberOfSeriesRelatedInstances).toBeUndefined();
 
     expect(
       medplumSeriesToDcmjsSeries(study, {
@@ -306,7 +312,7 @@ describe('DICOM study aggregates', () => {
       await addSeries(study, 'CT', 1); // Duplicate modality, counted once
       await addSeries(study, undefined, 1); // Missing modality is skipped, but the series still counts
 
-      await updateStudyAggregates(repo, study.id);
+      await updateStudyAggregates(repo, study.id, await scanStudy(repo, study.id));
 
       expect(await repo.readResource<DicomStudy>('DicomStudy', study.id)).toMatchObject({
         modalitiesInStudy: ['CT', 'PT'],
@@ -320,7 +326,7 @@ describe('DICOM study aggregates', () => {
       const study = await createStudy();
       await addSeries(study, undefined, 1);
 
-      await updateStudyAggregates(repo, study.id);
+      await updateStudyAggregates(repo, study.id, await scanStudy(repo, study.id));
 
       const result = await repo.readResource<DicomStudy>('DicomStudy', study.id);
       expect(result.modalitiesInStudy).toBeUndefined();
@@ -332,10 +338,10 @@ describe('DICOM study aggregates', () => {
       const study = await createStudy();
       await addSeries(study, 'CT', 1);
 
-      await updateStudyAggregates(repo, study.id);
+      await updateStudyAggregates(repo, study.id, await scanStudy(repo, study.id));
       const first = await repo.readResource<DicomStudy>('DicomStudy', study.id);
 
-      await updateStudyAggregates(repo, study.id);
+      await updateStudyAggregates(repo, study.id, await scanStudy(repo, study.id));
       const second = await repo.readResource<DicomStudy>('DicomStudy', study.id);
 
       expect(second.meta?.versionId).toBe(first.meta?.versionId);
@@ -350,7 +356,7 @@ describe('DICOM study aggregates', () => {
         .spyOn(repo, 'updateResource')
         .mockRejectedValueOnce(new OperationOutcomeError(preconditionFailed));
 
-      await updateStudyAggregates(repo, study.id);
+      await updateStudyAggregates(repo, study.id, await scanStudy(repo, study.id));
 
       expect(updateResource).toHaveBeenCalledTimes(2);
       expect(await repo.readResource<DicomStudy>('DicomStudy', study.id)).toMatchObject({
@@ -364,11 +370,12 @@ describe('DICOM study aggregates', () => {
       const study = await createStudy();
       await addSeries(study, 'CT', 1);
 
+      const scan = await scanStudy(repo, study.id);
       const updateResource = vi
         .spyOn(repo, 'updateResource')
         .mockRejectedValue(new OperationOutcomeError(preconditionFailed));
 
-      await expect(updateStudyAggregates(repo, study.id)).resolves.toBeUndefined();
+      await expect(updateStudyAggregates(repo, study.id, scan)).resolves.toBeUndefined();
 
       expect(updateResource).toHaveBeenCalledTimes(3);
       updateResource.mockRestore();
@@ -379,9 +386,10 @@ describe('DICOM study aggregates', () => {
       const study = await createStudy();
       await addSeries(study, 'CT', 1);
 
+      const scan = await scanStudy(repo, study.id);
       const updateResource = vi.spyOn(repo, 'updateResource').mockRejectedValue(new Error('boom'));
 
-      await expect(updateStudyAggregates(repo, study.id)).rejects.toThrow('boom');
+      await expect(updateStudyAggregates(repo, study.id, scan)).rejects.toThrow('boom');
 
       expect(updateResource).toHaveBeenCalledTimes(1);
       updateResource.mockRestore();
@@ -393,8 +401,7 @@ describe('DICOM study aggregates', () => {
       const ct = await addSeries(study, 'CT', 3);
       const pt = await addSeries(study, 'PT', 2);
 
-      await updateSeriesAggregates(repo, ct.id);
-      await updateSeriesAggregates(repo, pt.id);
+      await updateSeriesAggregates(repo, await scanStudy(repo, study.id));
 
       expect(await repo.readResource<DicomSeries>('DicomSeries', ct.id)).toMatchObject({
         numberOfSeriesRelatedInstances: 3,
@@ -409,10 +416,10 @@ describe('DICOM study aggregates', () => {
       const study = await createStudy();
       const series = await addSeries(study, 'CT', 2);
 
-      await updateSeriesAggregates(repo, series.id);
+      await updateSeriesAggregates(repo, await scanStudy(repo, study.id));
       const first = await repo.readResource<DicomSeries>('DicomSeries', series.id);
 
-      await updateSeriesAggregates(repo, series.id);
+      await updateSeriesAggregates(repo, await scanStudy(repo, study.id));
       const second = await repo.readResource<DicomSeries>('DicomSeries', series.id);
 
       expect(second.meta?.versionId).toBe(first.meta?.versionId);
@@ -427,7 +434,7 @@ describe('DICOM study aggregates', () => {
         .spyOn(repo, 'updateResource')
         .mockRejectedValueOnce(new OperationOutcomeError(preconditionFailed));
 
-      await updateSeriesAggregates(repo, series.id);
+      await updateSeriesAggregates(repo, await scanStudy(repo, study.id));
 
       expect(updateResource).toHaveBeenCalledTimes(2);
       expect(await repo.readResource<DicomSeries>('DicomSeries', series.id)).toMatchObject({

--- a/packages/server/src/dicom/utils.ts
+++ b/packages/server/src/dicom/utils.ts
@@ -34,8 +34,10 @@ export function dcmjsStudyToMedplumStudy(naturalized: Record<string, unknown>): 
     patientId: naturalized.PatientID as string,
     patientBirthDate: dicomDateToFhirDate(naturalized.PatientBirthDate),
     patientSex: naturalized.PatientSex as string,
-    numberOfStudyRelatedSeries: naturalized.NumberOfStudyRelatedSeries as number,
-    numberOfStudyRelatedInstances: naturalized.NumberOfStudyRelatedInstances as number,
+    // NumberOfStudyRelatedSeries/Instances are Q/R query keys the archive computes, so a sender's
+    // own values are dropped rather than trusted: a modality that stamps 512 while pushing one
+    // instance at a time would otherwise have QIDO report 512 from the first instance onward. The
+    // study job fills them in from what is actually stored.
   };
 }
 
@@ -85,7 +87,7 @@ const MAX_UPDATE_ATTEMPTS = 3;
  * @param id - The ID of the resource to update.
  * @param recompute - Returns the updated resource, or undefined when it already holds the right values.
  */
-async function updateWithRetry<T extends Resource>(
+export async function updateWithRetry<T extends Resource>(
   repo: Repository,
   resourceType: T['resourceType'],
   id: string,
@@ -109,11 +111,80 @@ async function updateWithRetry<T extends Resource>(
     }
   }
 
-  getLogger().warn('Unable to update DICOM aggregates', { resourceType, id });
+  getLogger().warn('Unable to update derived DICOM resource', { resourceType, id });
 }
 
 /**
- * Recomputes the Study level aggregate attributes of a `DicomStudy` from its series and instances.
+ * A single consistent read of a study's series and instance counts.
+ *
+ * Gathered once and reused for the study aggregates, the series aggregates, and the `ImagingStudy`,
+ * so those three cannot disagree with each other the way they could if each recomputed its own view.
+ */
+export interface StudyScan {
+  readonly seriesList: WithId<DicomSeries>[];
+  readonly instanceCounts: Map<string, number>;
+  readonly totalInstances: number;
+}
+
+/**
+ * Reads every series in a study, plus the instance counts for the study and each series.
+ *
+ * Instances are counted rather than enumerated: nothing downstream needs the instances themselves,
+ * and a large study holds more of them than is reasonable to hold in memory.
+ *
+ * @param repo - The repository to read with.
+ * @param studyId - The ID of the `DicomStudy` to scan.
+ * @returns The scan.
+ */
+export async function scanStudy(repo: Repository, studyId: string): Promise<StudyScan> {
+  const studyReference = `DicomStudy/${studyId}`;
+  const seriesList: WithId<DicomSeries>[] = [];
+
+  await repo.processAllResources<DicomSeries>(
+    {
+      resourceType: 'DicomSeries',
+      filters: [{ code: 'study', operator: Operator.EQUALS, value: studyReference }],
+      // Sorted by _lastUpdated ascending so the search pages by cursor rather than by offset.
+      // Offset paging throws past `maxSearchOffset` (default 10,000), which a large study reaches.
+      sortRules: [{ code: '_lastUpdated' }],
+      count: 1000,
+    },
+    async (series) => {
+      seriesList.push(series);
+    }
+  );
+
+  const instanceCounts = new Map<string, number>();
+  for (const series of seriesList) {
+    instanceCounts.set(series.id, await countInstances(repo, 'series', `DicomSeries/${series.id}`));
+  }
+
+  return {
+    seriesList,
+    instanceCounts,
+    totalInstances: await countInstances(repo, 'study', studyReference),
+  };
+}
+
+/**
+ * Counts the instances matching one reference search parameter.
+ * @param repo - The repository to read with.
+ * @param code - The search parameter to filter on.
+ * @param value - The reference to match.
+ * @returns The instance count.
+ */
+async function countInstances(repo: Repository, code: string, value: string): Promise<number> {
+  const bundle = await repo.search<DicomInstance>({
+    resourceType: 'DicomInstance',
+    filters: [{ code, operator: Operator.EQUALS, value }],
+    count: 0,
+    total: 'accurate',
+  });
+  return bundle.total ?? 0;
+}
+
+/**
+ * Recomputes the Study level aggregate attributes of a `DicomStudy` from a scan.
  *
  * ModalitiesInStudy (0008,0061), NumberOfStudyRelatedSeries (0020,1206), and
  * NumberOfStudyRelatedInstances (0020,1208) are Study level query keys that the archive computes
@@ -126,34 +197,17 @@ async function updateWithRetry<T extends Resource>(
  *
  * @param repo - The repository to read and write with.
  * @param studyId - The ID of the `DicomStudy` to update.
+ * @param scan - The scan to compute from.
  */
-export async function updateStudyAggregates(repo: Repository, studyId: string): Promise<void> {
-  const studyReference = `DicomStudy/${studyId}`;
-
+export async function updateStudyAggregates(repo: Repository, studyId: string, scan: StudyScan): Promise<void> {
   await updateWithRetry<DicomStudy>(repo, 'DicomStudy', studyId, async (study) => {
     const modalities = new Set<string>();
-    let seriesCount = 0;
-    await repo.processAllResources<DicomSeries>(
-      {
-        resourceType: 'DicomSeries',
-        filters: [{ code: 'study', operator: Operator.EQUALS, value: studyReference }],
-        count: 1000,
-      },
-      async (series) => {
-        seriesCount++;
-        const modality = series.modality?.trim().toUpperCase();
-        if (modality) {
-          modalities.add(modality);
-        }
+    for (const series of scan.seriesList) {
+      const modality = series.modality?.trim().toUpperCase();
+      if (modality) {
+        modalities.add(modality);
       }
-    );
-
-    const instanceBundle = await repo.search<DicomInstance>({
-      resourceType: 'DicomInstance',
-      filters: [{ code: 'study', operator: Operator.EQUALS, value: studyReference }],
-      count: 0,
-      total: 'accurate',
-    });
+    }
 
     // Sorted so that an unchanged study compares equal below, rather than churning a new version.
     const modalitiesInStudy =
@@ -161,8 +215,8 @@ export async function updateStudyAggregates(repo: Repository, studyId: string): 
 
     if (
       deepEquals(study.modalitiesInStudy, modalitiesInStudy) &&
-      study.numberOfStudyRelatedSeries === seriesCount &&
-      study.numberOfStudyRelatedInstances === instanceBundle.total
+      study.numberOfStudyRelatedSeries === scan.seriesList.length &&
+      study.numberOfStudyRelatedInstances === scan.totalInstances
     ) {
       return undefined;
     }
@@ -170,37 +224,32 @@ export async function updateStudyAggregates(repo: Repository, studyId: string): 
     return {
       ...study,
       modalitiesInStudy,
-      numberOfStudyRelatedSeries: seriesCount,
-      numberOfStudyRelatedInstances: instanceBundle.total,
+      numberOfStudyRelatedSeries: scan.seriesList.length,
+      numberOfStudyRelatedInstances: scan.totalInstances,
     };
   });
 }
 
 /**
- * Recomputes NumberOfSeriesRelatedInstances (0020,1209) for a `DicomSeries`.
+ * Recomputes NumberOfSeriesRelatedInstances (0020,1209) for every series in a scan.
  *
  * Another Q/R query key absent from the composite IOD, for the same reasons described on
- * {@link updateStudyAggregates}. Only series that actually received instances need this, so STOW
- * calls it for the series it touched rather than every series in the study.
+ * {@link updateStudyAggregates}. Every series in the study is recomputed rather than only the ones a
+ * request touched, because a coalesced study job cannot know which instances arrived since it last
+ * ran. Series whose count is unchanged return early without a write.
  *
  * @param repo - The repository to read and write with.
- * @param seriesId - The ID of the `DicomSeries` to update.
+ * @param scan - The scan to compute from.
  */
-export async function updateSeriesAggregates(repo: Repository, seriesId: string): Promise<void> {
-  await updateWithRetry<DicomSeries>(repo, 'DicomSeries', seriesId, async (series) => {
-    const instanceBundle = await repo.search<DicomInstance>({
-      resourceType: 'DicomInstance',
-      filters: [{ code: 'series', operator: Operator.EQUALS, value: `DicomSeries/${seriesId}` }],
-      count: 0,
-      total: 'accurate',
-    });
-
-    if (series.numberOfSeriesRelatedInstances === instanceBundle.total) {
-      return undefined;
-    }
-
-    return { ...series, numberOfSeriesRelatedInstances: instanceBundle.total };
-  });
+export async function updateSeriesAggregates(repo: Repository, scan: StudyScan): Promise<void> {
+  for (const series of scan.seriesList) {
+    const count = scan.instanceCounts.get(series.id) ?? 0;
+    await updateWithRetry<DicomSeries>(repo, 'DicomSeries', series.id, async (existing) =>
+      existing.numberOfSeriesRelatedInstances === count
+        ? undefined
+        : { ...existing, numberOfSeriesRelatedInstances: count }
+    );
+  }
 }
 
 export function dcmjsSeriesToMedplumSeries(
@@ -215,7 +264,7 @@ export function dcmjsSeriesToMedplumSeries(
     modality: naturalized.Modality as string,
     seriesDescription: naturalized.SeriesDescription as string,
     timezoneOffsetFromUtc: naturalized.TimezoneOffsetFromUTC as string,
-    numberOfSeriesRelatedInstances: naturalized.NumberOfSeriesRelatedInstances as number,
+    // Recomputed by the DICOM study job, not taken from the sender. See dcmjsStudyToMedplumStudy.
     performedProcedureStepStartDate: dicomDateToFhirDate(naturalized.PerformedProcedureStepStartDate),
     performedProcedureStepStartTime: dicomTimeToFhirTime(naturalized.PerformedProcedureStepStartTime),
   };

--- a/packages/server/src/otel/otel.test.ts
+++ b/packages/server/src/otel/otel.test.ts
@@ -9,6 +9,7 @@ import * as databaseModule from '../database';
 import { heartbeat } from '../heartbeat';
 import * as batchModule from '../workers/batch';
 import * as cronModule from '../workers/cron';
+import * as dicomModule from '../workers/dicom';
 import * as downloadModule from '../workers/download';
 import * as setAccountsModule from '../workers/set-accounts';
 import * as subscriptionModule from '../workers/subscription';
@@ -57,6 +58,7 @@ function mockQueueGetters(queue: ReturnType<typeof createMockQueue> | undefined)
   vi.spyOn(downloadModule, 'getDownloadQueue').mockReturnValue(queue as never);
   vi.spyOn(batchModule, 'getBatchQueue').mockReturnValue(queue as never);
   vi.spyOn(setAccountsModule, 'getSetAccountsQueue').mockReturnValue(queue as never);
+  vi.spyOn(dicomModule, 'getDicomQueue').mockReturnValue(queue as never);
 }
 
 describe('OpenTelemetry', () => {
@@ -218,9 +220,9 @@ describe('OpenTelemetry', () => {
     expect(getDatabasePoolSpy).toHaveBeenCalled();
 
     // Every queue is read: subscription, cron, download, batch, set-accounts
-    expect(mockSharedQueue.getWaitingCount).toHaveBeenCalledTimes(5);
-    expect(mockSharedQueue.getDelayedCount).toHaveBeenCalledTimes(5);
-    expect(mockSharedQueue.getActiveCount).toHaveBeenCalledTimes(5);
+    expect(mockSharedQueue.getWaitingCount).toHaveBeenCalledTimes(6);
+    expect(mockSharedQueue.getDelayedCount).toHaveBeenCalledTimes(6);
+    expect(mockSharedQueue.getActiveCount).toHaveBeenCalledTimes(6);
 
     // Each count is published under its per-queue metric name, carrying the mocked value
     expect(gaugeRecorder('medplum.batch.waitingCount')).toHaveBeenCalledWith(5, undefined);

--- a/packages/server/src/otel/otel.ts
+++ b/packages/server/src/otel/otel.ts
@@ -10,6 +10,7 @@ import { DatabaseMode, getDatabasePool } from '../database';
 import { heartbeat } from '../heartbeat';
 import { getBatchQueue } from '../workers/batch';
 import { getCronQueue } from '../workers/cron';
+import { getDicomQueue } from '../workers/dicom';
 import { getDownloadQueue } from '../workers/download';
 import { getSetAccountsQueue } from '../workers/set-accounts';
 import { getSubscriptionQueue } from '../workers/subscription';
@@ -37,7 +38,14 @@ export function getQueueMetricName(queueName: WorkerName, metric: QueueMetric): 
 let queueEntries: [WorkerName, Queue][] | undefined;
 function getQueueEntries(): [WorkerName, Queue][] {
   if (!queueEntries) {
-    if (!(getSubscriptionQueue() && getCronQueue() && getDownloadQueue() && getBatchQueue() && getSetAccountsQueue())) {
+    if (!(
+      getSubscriptionQueue() &&
+      getCronQueue() &&
+      getDownloadQueue() &&
+      getBatchQueue() &&
+      getSetAccountsQueue() &&
+      getDicomQueue()
+    )) {
       throw new Error('Queues not initialized');
     }
     queueEntries = [
@@ -46,6 +54,7 @@ function getQueueEntries(): [WorkerName, Queue][] {
       ['download', getDownloadQueue() as Queue],
       ['batch', getBatchQueue() as Queue],
       ['set-accounts', getSetAccountsQueue() as Queue],
+      ['dicom', getDicomQueue() as Queue],
     ];
   }
   return queueEntries;

--- a/packages/server/src/workers/dicom.test.ts
+++ b/packages/server/src/workers/dicom.test.ts
@@ -117,6 +117,33 @@ describe('DICOM Worker', () => {
     });
   });
 
+  test('addDicomJobs also queues the study job, deduplicated per study', async () => {
+    const add = vi.fn();
+    vi.spyOn(queueRegistry, 'get').mockReturnValue({ add } as any);
+
+    await withTestContext(
+      () =>
+        addDicomJobs(
+          {
+            resourceType: 'DicomInstance',
+            id: 'instance-id',
+            study: { reference: 'DicomStudy/study-id' },
+            raw: { reference: 'Binary/new' },
+          } as WithId<DicomInstance>,
+          {} as DicomInstance
+        ),
+      { requestId: 'request-id', traceId: 'trace-id' }
+    );
+
+    // Same queue as the instance job, discriminated by name. The deduplication id is what collapses
+    // a burst of instances into roughly one recomputation of their study.
+    expect(add).toHaveBeenCalledWith(
+      'DicomStudyJobData',
+      { studyId: 'study-id', requestId: 'request-id', traceId: 'trace-id' },
+      { deduplication: { id: 'dicom-study:study-id', keepLastIfActive: true } }
+    );
+  });
+
   test('addDicomJobs skips job when raw binary is unchanged', async () => {
     const add = vi.fn();
     vi.spyOn(queueRegistry, 'get').mockReturnValue({ add } as any);

--- a/packages/server/src/workers/dicom.ts
+++ b/packages/server/src/workers/dicom.ts
@@ -1,14 +1,17 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { WithId } from '@medplum/core';
-import { createReference, isGone, normalizeOperationOutcome } from '@medplum/core';
-import type { Binary, DicomInstance } from '@medplum/fhirtypes';
+import type { Logger, Operation, WithId } from '@medplum/core';
+import { createReference, isGone, isString, normalizeOperationOutcome, Operator, resolveId } from '@medplum/core';
+import type { Binary, DicomInstance, DicomStudy, Reference } from '@medplum/fhirtypes';
 import type { Job } from 'bullmq';
 import { Queue, Worker } from 'bullmq';
 import dcmjs from 'dcmjs';
 import { Readable } from 'node:stream';
 import { tryGetRequestContext, tryRunInRequestContext } from '../context';
+import { reconcileImagingStudy } from '../dicom/imaging-study';
+import { scanStudy, updateSeriesAggregates, updateStudyAggregates } from '../dicom/utils';
+import type { Repository } from '../fhir/repo';
 import { getShardSystemRepo } from '../fhir/repo';
 import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
 import { getLogger, globalLogger } from '../logger';
@@ -23,7 +26,17 @@ const { DicomMetaDictionary } = data;
 const { DicomMetadataListener } = utilities;
 
 /*
- * The DICOM worker processes DICOM instances, extracts metadata, and updates corresponding resources.
+ * DICOM processing, split by the cardinality of the work rather than by how the bytes arrived.
+ *
+ * `DicomJobData` runs once per instance: parse the file, fill in the instance attributes, split out
+ * the pixel data. `DicomStudyJobData` runs once per study and is coalesced, because the study level
+ * work - the Q/R aggregates and the derived `ImagingStudy` - costs the same whether one instance
+ * arrived or five hundred did. Both a DICOMweb STOW and a directly created `DicomInstance` enqueue
+ * both, so neither entry point can drift away from the other.
+ *
+ * They share one queue rather than getting one each: `deduplication` is a per-job option, so the
+ * coalescing works either way, and a single queue cannot be half-enabled by configuration or close
+ * out from under an instance job that is still draining and needs to enqueue its study job.
  */
 
 export interface DicomJobData {
@@ -32,12 +45,22 @@ export interface DicomJobData {
   readonly traceId?: string;
 }
 
+export interface DicomStudyJobData {
+  readonly studyId: string;
+  readonly requestId?: string;
+  readonly traceId?: string;
+}
+
+/** Both job types share one queue, discriminated by job name. */
+export type DicomQueueJobData = DicomJobData | DicomStudyJobData;
+
 const queueName = 'DicomQueue';
 const jobName = 'DicomJobData';
+const studyJobName = 'DicomStudyJobData';
 
 export const initDicomWorker: WorkerInitializer = (config, options?: WorkerInitializerOptions) => {
   const defaultOptions = defaultQueueOptions(config);
-  const queue = new Queue<DicomJobData>(queueName, {
+  const queue = new Queue<DicomQueueJobData>(queueName, {
     ...defaultOptions,
     defaultJobOptions: {
       attempts: 3,
@@ -48,12 +71,16 @@ export const initDicomWorker: WorkerInitializer = (config, options?: WorkerIniti
     },
   });
 
-  let worker: Worker<DicomJobData> | undefined;
+  let worker: Worker<DicomQueueJobData> | undefined;
   if (options?.workerEnabled !== false) {
-    worker = new Worker<DicomJobData>(
+    worker = new Worker<DicomQueueJobData>(
       queueName,
       trackJobMetrics('dicom', (job) =>
-        tryRunInRequestContext(job.data.requestId, job.data.traceId, () => execDicomJob(job))
+        tryRunInRequestContext(job.data.requestId, job.data.traceId, () =>
+          job.name === studyJobName
+            ? execDicomStudyJob(job as Job<DicomStudyJobData>)
+            : execDicomJob(job as Job<DicomJobData>)
+        )
       ),
       getWorkerBullmqConfig(config, 'dicom', defaultOptions)
     );
@@ -69,8 +96,31 @@ export const initDicomWorker: WorkerInitializer = (config, options?: WorkerIniti
  * This is used by the unit tests.
  * @returns The DICOM queue (if available).
  */
-export function getDicomQueue(): Queue<DicomJobData> | undefined {
+export function getDicomQueue(): Queue<DicomQueueJobData> | undefined {
   return queueRegistry.get(queueName);
+}
+
+/**
+ * Enqueues the study level work for a study, collapsing a burst of instances into one run.
+ *
+ * `keepLastIfActive` bounds a study to one running job plus one waiting job, so a five hundred
+ * instance upload does not schedule five hundred full recomputations. It is a cost control, not a
+ * correctness guarantee: a stalled job is requeued without releasing the deduplication key, so
+ * `execDicomStudyJob` re-checks for late arrivals itself rather than trusting the queue to be exact.
+ *
+ * @param studyId - The ID of the `DicomStudy` to recompute.
+ */
+export async function addDicomStudyJob(studyId: string): Promise<void> {
+  const queue = getDicomQueue();
+  if (!queue) {
+    return;
+  }
+  const ctx = tryGetRequestContext();
+  await queue.add(
+    studyJobName,
+    { studyId, requestId: ctx?.requestId, traceId: ctx?.traceId },
+    { deduplication: { id: `dicom-study:${studyId}`, keepLastIfActive: true } }
+  );
 }
 
 /**
@@ -88,6 +138,20 @@ export async function addDicomJobs(resource: WithId<DicomInstance>, previousVers
       requestId: ctx?.requestId,
       traceId: ctx?.traceId,
     });
+    // Enqueued here as well as after the instance job succeeds, so a study still converges when an
+    // instance fails permanently - a corrupt file should not hold back the counts for its siblings.
+    await addStudyJobForInstance(resource);
+  }
+}
+
+/**
+ * Enqueues the study level work for whichever study an instance belongs to.
+ * @param resource - The instance whose study should be recomputed.
+ */
+async function addStudyJobForInstance(resource: DicomInstance): Promise<void> {
+  const studyId = resolveId(resource.study);
+  if (studyId) {
+    await addDicomStudyJob(studyId);
   }
 }
 
@@ -133,71 +197,188 @@ export async function execDicomJob(job: Job<DicomJobData>): Promise<void> {
     const result = await reader.readFile({ listener });
 
     const meta = result.meta as Record<string, unknown> | undefined;
-    if (!meta) {
-      log.info('No DICOM metadata found in instance', { id });
-      return;
-    }
-
     const dict = result.dict as Record<string, unknown> | undefined;
-    if (!dict) {
+    if (!meta || !dict) {
       log.info('No DICOM metadata found in instance', { id });
       return;
     }
 
     const naturalized = DicomMetaDictionary.naturalizeDataset({ ...meta, ...dict }) as Record<string, unknown>;
-    const pixelData = naturalized.PixelData;
-    if (!pixelData) {
-      log.info('No PixelData found in DICOM instance', { id });
-      return;
+    const pixelData = await extractPixelData(systemRepo, resource, naturalized, log);
+
+    // Patched rather than updated: the parse and the pixel extraction above can take a while, and a
+    // read-modify-write spanning them would clobber anything written to the instance in between.
+    const patch = buildInstancePatch(resource, {
+      instanceAvailability: naturalized.InstanceAvailability,
+      timezoneOffsetFromUtc: naturalized.TimezoneOffsetFromUTC,
+      instanceNumber: toInstanceNumber(naturalized.InstanceNumber),
+      rows: naturalized.Rows,
+      columns: naturalized.Columns,
+      bitsAllocated: naturalized.BitsAllocated,
+      numberOfFrames: naturalized.NumberOfFrames,
+      pixelData,
+    });
+    if (patch.length > 0) {
+      await systemRepo.patchResource('DicomInstance', id, patch);
     }
-
-    if (!Array.isArray(pixelData) || pixelData.length === 0) {
-      log.info('PixelData is empty or not an array', { id, pixelData });
-      return;
-    }
-
-    const transferSyntaxUid = naturalized.TransferSyntaxUID as string | undefined;
-    const contentType = getContentTypeForTransferSyntax(transferSyntaxUid);
-    const securityContext = createReference(resource);
-    const binaries: Binary[] = [];
-
-    async function processPixelData(pixelData: unknown): Promise<void> {
-      if (Array.isArray(pixelData)) {
-        for (const entry of pixelData) {
-          await processPixelData(entry);
-        }
-      } else if (pixelData instanceof ArrayBuffer) {
-        const buffer = Buffer.from(pixelData);
-        const readable = Readable.from(buffer);
-        const binary = await systemRepo.createResource<Binary>({
-          resourceType: 'Binary',
-          contentType,
-          meta: {
-            project: resource.meta?.project,
-          },
-          securityContext,
-        });
-        await getBinaryStorage().writeBinary(binary, 'pixeldata.bin', contentType, readable);
-        binaries.push(binary);
-      } else {
-        log.info('Unexpected PixelData format', { id, pixelData });
-      }
-    }
-
-    await processPixelData(pixelData);
-
-    await systemRepo.patchResource('DicomInstance', id, [
-      { op: 'replace', path: '/meta/author', value: { reference: 'system' } },
-      {
-        op: resource.pixelData ? 'replace' : 'add',
-        path: '/pixelData',
-        value: binaries.map(createReference),
-      },
-    ]);
   } catch (err) {
     log.info('DICOM processing error', { id, err });
     throw err;
   }
+
+  // After the instance is stored, not in a `finally`: a job that threw will be retried, and each
+  // retry would otherwise schedule another full study recomputation against an unhealthy system.
+  await addStudyJobForInstance(resource);
+}
+
+/**
+ * Builds the patch for the attributes read out of an instance's dataset.
+ *
+ * An attribute the dataset does not carry is skipped rather than patched to null: JSON Patch has no
+ * value to write, and an instance whose file omits an element is not a reason to erase whatever the
+ * uploader recorded for it.
+ *
+ * @param resource - The stored instance, read to choose between `add` and `replace`.
+ * @param values - The attribute values read from the dataset.
+ * @returns The patch operations to apply.
+ */
+function buildInstancePatch(resource: WithId<DicomInstance>, values: Record<string, unknown>): Operation[] {
+  const patch: Operation[] = [];
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== undefined) {
+      const op = resource[key as keyof DicomInstance] === undefined ? 'add' : 'replace';
+      patch.push({ op, path: `/${key}`, value });
+    }
+  }
+  return patch;
+}
+
+/**
+ * Recomputes everything derived from a study: the DICOM Q/R aggregates and the `ImagingStudy`.
+ *
+ * @param job - The DICOM study job details.
+ */
+export async function execDicomStudyJob(job: Job<DicomStudyJobData>): Promise<void> {
+  const systemRepo = getShardSystemRepo(PLACEHOLDER_SHARD_ID); // shardId will be part of job.data in future
+  const log = getLogger();
+  const { studyId } = job.data;
+
+  let study: WithId<DicomStudy>;
+  try {
+    study = await systemRepo.readResource<DicomStudy>('DicomStudy', studyId);
+  } catch (err) {
+    if (isGone(normalizeOperationOutcome(err))) {
+      return;
+    }
+    throw err;
+  }
+
+  const watermark = await readInstanceWatermark(systemRepo, studyId);
+  const scan = await scanStudy(systemRepo, studyId);
+
+  // Aggregates are committed before the ImagingStudy, and the ImagingStudy failure is caught, so a
+  // series that cannot produce a valid ImagingStudy - a missing Modality, say - does not also stop
+  // the Q/R counts from ever converging again.
+  await updateStudyAggregates(systemRepo, studyId, scan);
+  await updateSeriesAggregates(systemRepo, scan);
+
+  try {
+    await reconcileImagingStudy(systemRepo, study, scan);
+  } catch (err) {
+    log.error('Error reconciling ImagingStudy', { studyId, err });
+  }
+
+  // The queue collapses overlapping runs, but a stalled job is requeued without releasing its
+  // deduplication key, so an instance can commit after this job read the study and still be dropped.
+  // Re-checking here means convergence does not depend on the queue being exact.
+  if ((await readInstanceWatermark(systemRepo, studyId)) !== watermark) {
+    await addDicomStudyJob(studyId);
+  }
+}
+
+/**
+ * Returns the most recent instance write time for a study.
+ * @param systemRepo - The repository to read with.
+ * @param studyId - The ID of the `DicomStudy`.
+ * @returns The latest `meta.lastUpdated` across the study's instances, or undefined if it has none.
+ */
+async function readInstanceWatermark(systemRepo: Repository, studyId: string): Promise<string | undefined> {
+  const latest = await systemRepo.searchResources<DicomInstance>({
+    resourceType: 'DicomInstance',
+    filters: [{ code: 'study', operator: Operator.EQUALS, value: `DicomStudy/${studyId}` }],
+    sortRules: [{ code: '_lastUpdated', descending: true }],
+    count: 1,
+  });
+  return latest[0]?.meta?.lastUpdated;
+}
+
+/**
+ * Writes each frame of PixelData to its own Binary.
+ * @param systemRepo - The repository to write with.
+ * @param resource - The instance being processed, used as the security context for the frames.
+ * @param naturalized - The naturalized DICOM dataset.
+ * @param log - The logger to report unusable PixelData to.
+ * @returns References to the frame Binaries, or undefined if the instance carries no PixelData.
+ */
+async function extractPixelData(
+  systemRepo: Repository,
+  resource: WithId<DicomInstance>,
+  naturalized: Record<string, unknown>,
+  log: Logger
+): Promise<Reference<Binary>[] | undefined> {
+  const { id } = resource;
+  const pixelData = naturalized.PixelData;
+  if (!pixelData) {
+    log.info('No PixelData found in DICOM instance', { id });
+    return undefined;
+  }
+
+  if (!Array.isArray(pixelData) || pixelData.length === 0) {
+    log.info('PixelData is empty or not an array', { id, pixelData });
+    return undefined;
+  }
+
+  const contentType = getContentTypeForTransferSyntax(naturalized.TransferSyntaxUID as string | undefined);
+  const securityContext = createReference(resource);
+  const binaries: Binary[] = [];
+
+  async function processPixelData(pixelData: unknown): Promise<void> {
+    if (Array.isArray(pixelData)) {
+      for (const entry of pixelData) {
+        await processPixelData(entry);
+      }
+    } else if (pixelData instanceof ArrayBuffer) {
+      const readable = Readable.from(Buffer.from(pixelData));
+      const binary = await systemRepo.createResource<Binary>({
+        resourceType: 'Binary',
+        contentType,
+        meta: { project: resource.meta?.project },
+        securityContext,
+      });
+      await getBinaryStorage().writeBinary(binary, 'pixeldata.bin', contentType, readable);
+      binaries.push(binary);
+    } else {
+      log.info('Unexpected PixelData format', { id, pixelData });
+    }
+  }
+
+  await processPixelData(pixelData);
+  return binaries.map(createReference);
+}
+
+/**
+ * Returns InstanceNumber (0020,0013) as a string, defaulting to "1".
+ * @param value - The naturalized InstanceNumber, which dcmjs may give as a string or a number.
+ * @returns The instance number.
+ */
+function toInstanceNumber(value: unknown): string {
+  if (isString(value)) {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value.toString();
+  }
+  return '1'; // InstanceNumber is required in DICOM, so a missing one is filled in rather than dropped
 }
 
 function getContentTypeForTransferSyntax(transferSyntaxUID: string | undefined): string {

--- a/packages/server/src/workers/dispatch.ts
+++ b/packages/server/src/workers/dispatch.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ResourceNotFoundException } from '@aws-sdk/client-lambda';
 import type { BackgroundJobContext, BackgroundJobInteraction, WithId } from '@medplum/core';
+import { resolveId } from '@medplum/core';
 import type { DicomInstance, Project, Resource, ResourceType } from '@medplum/fhirtypes';
 import type { Job } from 'bullmq';
 import { Queue, Worker } from 'bullmq';
@@ -13,7 +14,7 @@ import { getShardSystemRepo } from '../fhir/repo';
 import { PLACEHOLDER_SHARD_ID } from '../fhir/sharding';
 import { getLogger } from '../logger';
 import { addCronJobs } from './cron';
-import { addDicomJobs } from './dicom';
+import { addDicomJobs, addDicomStudyJob } from './dicom';
 import { addDownloadJobs } from './download';
 import { addSubscriptionJobs } from './subscription';
 import type { WorkerInitializer, WorkerInitializerOptions } from './utils';
@@ -156,6 +157,20 @@ export async function execDispatchJob(job: Job<DispatchJobData>): Promise<void> 
     });
   }
 
+  if (interaction === 'delete') {
+    // Deletes are otherwise excluded from this block, but a removed instance or series leaves the
+    // study's Q/R counts and its ImagingStudy overstating what is actually retrievable.
+    try {
+      await addDicomStudyJobForDeletedResource(resource);
+    } catch (err) {
+      getLogger().error('Error adding DICOM study job for delete', {
+        resourceType: resource.resourceType,
+        resource: resource.id,
+        err,
+      });
+    }
+  }
+
   if (interaction !== 'delete') {
     try {
       await addDownloadJobs(resource, previousVersion, context);
@@ -188,5 +203,22 @@ export async function execDispatchJob(job: Job<DispatchJobData>): Promise<void> 
         });
       }
     }
+  }
+}
+
+/**
+ * Recomputes the parent study when a DICOM instance or series is deleted.
+ * @param resource - The deleted resource.
+ */
+async function addDicomStudyJobForDeletedResource(resource: Resource): Promise<void> {
+  let studyId: string | undefined;
+  if (resource.resourceType === 'DicomInstance' || resource.resourceType === 'DicomSeries') {
+    studyId = resolveId(resource.study);
+  } else if (resource.resourceType === 'DicomStudy') {
+    return; // The study itself is gone; there is nothing left to recompute.
+  }
+
+  if (studyId) {
+    await addDicomStudyJob(studyId);
   }
 }

--- a/packages/server/src/workers/test-utils.ts
+++ b/packages/server/src/workers/test-utils.ts
@@ -7,6 +7,8 @@ import type { Job, Queue } from 'bullmq';
 import { UnrecoverableError } from 'bullmq';
 import type { Mock } from 'vitest';
 import { vi } from 'vitest';
+import type { DicomStudyJobData } from './dicom';
+import { execDicomStudyJob, getDicomQueue } from './dicom';
 import { execDispatchJob, getDispatchQueue } from './dispatch';
 import { execDownloadJob, getDownloadQueue } from './download';
 import { execSubscriptionJob, getSubscriptionQueue } from './subscription';
@@ -161,4 +163,39 @@ export function mockFetchResponse(status: number, body: any, headers: Record<str
       ...headers,
     },
   });
+}
+
+/**
+ * Runs the deferred DICOM study work for everything enqueued so far.
+ *
+ * Study aggregates and the derived `ImagingStudy` are computed by a coalesced background job rather
+ * than during the STOW request, so a test that uploads instances and then reads counts has to drain
+ * that job first. Dispatch is drained on the way through, since that is what enqueues it.
+ */
+export async function execPendingDicomStudyJobs(): Promise<void> {
+  // Only DICOM instances, because the mock queue accumulates every dispatch job the file has ever
+  // enqueued and replaying an unrelated one can fail on a version that no longer resolves.
+  const dispatchQueue = getDispatchQueue();
+  if (dispatchQueue) {
+    for (const [, data] of (dispatchQueue.add as Mock).mock.calls) {
+      if (data?.resourceType === 'DicomInstance') {
+        await execDispatchJob({ id: 1, data } as unknown as Job);
+      }
+    }
+  }
+
+  const dicomQueue = getDicomQueue();
+  if (!dicomQueue) {
+    return;
+  }
+
+  // Instance and study jobs share the queue, so select on the job name.
+  const studyIds = new Set<string>(
+    (dicomQueue.add as Mock).mock.calls
+      .filter((call) => call[0] === 'DicomStudyJobData')
+      .map((call) => (call[1] as DicomStudyJobData).studyId)
+  );
+  for (const studyId of studyIds) {
+    await execDicomStudyJob({ id: 1, data: { studyId } } as unknown as Job<DicomStudyJobData>);
+  }
 }


### PR DESCRIPTION
## Summary

Makes DICOM processing neutral across entry points, and derives an `ImagingStudy` as part of it.

Two ingest paths were doing very different amounts of work. STOW-RS parsed each instance, created the study and series, and recomputed aggregates **inline on the request**. A `DicomInstance` created through the FHIR API only ever reached the worker's pixel extraction — it never recomputed aggregates, so its study reported wrong `numberOfStudyRelatedInstances` / `numberOfSeriesRelatedInstances` (the values QIDO returns) until some later STOW happened to touch the same study.

The fix splits work by **how often it needs to run**, not by how the bytes arrived:

- **Instance job** (existing) — parse the file, fill in the instance attributes, split out pixel data.
- **Study job** (new, deduplicated per study) — recompute study aggregates, all series aggregates, and the `ImagingStudy` from a single scan.

Both entry points enqueue both, so they can't drift apart. `deduplication: { keepLastIfActive }` collapses a 500-instance upload to roughly two study recomputes.

**Both are job types on the existing `DicomQueue`, not a queue each.** Deduplication is a per-job option, so coalescing works identically — and one queue can't be half-enabled by configuration, or close out from under an instance job that's still draining and needs to enqueue its study job. `WorkerName`, `workerDefs`, and the shutdown path are unchanged.

STOW keeps its inline study/series/instance creates: it needs the SOP UIDs for its own `ReferencedSOPSequence` response, and `data-model.md` documents that studies and series are queryable immediately after upload.

## ImagingStudy

Keyed by Study Instance UID (`urn:dicom:uid`), pointing at a per-project `Endpoint` with `connectionType` `dicom-wado-rs`. WADO references are compositional, which is what the spec intends — `{endpoint.address}/studies/{uid}/series/{uid}/instances/{uid}` — and every WADO handler already resolves by UID.

**Series are listed; instances are not.** No viewer reads `series.instance[]` (OHIF/Cornerstone enumerate from `/series/{uid}/metadata`, which we implement), and the `instance` and `dicom-class` token search params index into it — a 10,000-slice study would rewrite ~20,000 token rows on *every* recompute.

Only server-derived fields are rewritten. `basedOn`, `encounter`, `note`, `description` and the rest survive every run. Two fields latch so a human correction is never undone:
- **`subject`** — matched against `Patient.identifier` within the same project. Logical reference upgrades to a real one once exactly one Patient matches; a real reference is **never** downgraded.
- **`status`** — `cancelled` / `entered-in-error` are preserved.

## Bugs fixed along the way

- **Sender-supplied Q/R counts were being trusted.** `dcmjsStudyToMedplumStudy` copied `NumberOfStudyRelatedInstances` from the sender; the inline recompute used to overwrite it. Deferring would have made QIDO serve the sender's claim — a modality stamping `512` while pushing one instance at a time would report 512 from the first instance on, and viewers size prefetch from that. Now dropped at ingest: absent rather than wrong.
- **The series walk paged by offset**, which throws past `maxSearchOffset` (10,000). Now cursor-paged.
- **Deletes never reached the pipeline** (`dispatch.ts` gates them out), so counts stayed overstated. `DicomInstance`/`DicomSeries` deletes now enqueue a recompute.
- **Unimplemented WADO routes returned an empty `200`**, which a client following our now-advertised Endpoint would read as "this study is empty." Now `404` with `{"error": "DICOMweb endpoint not implemented"}` — 404 rather than 501 so an unbuilt route does not trip 5xx alerting, with the body distinguishing it from a study that genuinely does not exist.
- **`data-model.md:72`** claimed instances are "not created conditionally," contradicting `stow-rs.ts`.

## Notes for review

- `keepLastIfActive` is a cost control, **not** a correctness guarantee — a stalled job is requeued without releasing the dedup key, and adds during `wait`/`delayed` are dropped with no stash. The study job re-checks an instance watermark at the end and self-enqueues, so convergence doesn't depend on the queue being exact.
- Aggregates commit **before** the ImagingStudy, in separate try/catch. `ImagingStudy.series.modality` is `1..1` while `DicomSeries.modality` is `0..1`, so coupling them would let one malformed series permanently block a study's counts.
- Every search in the study job filters on `_project`. It runs on a system repo, which spans the shard — there's a test that fails without it by linking a study to a Patient in another tenant.
- `series[]` is sorted deterministically. Search paging gives no cross-page ordering guarantee and `deepEquals` compares arrays positionally, so an unsorted list would churn a new version — and a fresh round of subscription dispatches — on every run.

## Test plan

- `packages/server/src/dicom/imaging-study.test.ts` — 13 new tests: derivation, no-op reruns (asserting `versionId` is unchanged), deterministic series ordering, absent-modality handling, and each subject rule including the one-way ratchet and the cross-project isolation case.
- `workers/dicom.test.ts` pins that the study job lands on the shared queue with the right deduplication id.
- Existing `routes.test.ts` aggregate assertions now drain the study job via a new `execPendingDicomStudyJobs` helper. Study/series *existence* assertions were unaffected, since STOW still creates them inline.
- 115 passing across `src/dicom`, `src/workers`, `src/otel`. `eslint`, `prettier --check`, and `tsc --noEmit` clean (`tsc` matches clean main's 2 pre-existing errors).
- One unrelated pre-existing failure in `reindex.test.ts` (`permission denied for table User`), confirmed failing on clean main.

## Deferred

Backfill for studies ingested before this change — a `$reprocess` operation hitting the same code path. Note that reindex will *not* do it: `reindexResources` never calls `addBackgroundJobs`.
