### PR TITLE
[Scheduling] Add booking form to scheduling workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44959,6 +44959,7 @@
         "@fullcalendar/react": "7.0.2",
         "@mantine/core": "8.3.18",
         "@mantine/hooks": "8.3.18",
+        "@mantine/notifications": "8.3.18",
         "@medplum/core": "5.1.32",
         "@medplum/definitions": "5.1.32",
         "@medplum/fhirtypes": "5.1.32",
@@ -44986,6 +44987,7 @@
       "peerDependencies": {
         "@mantine/core": "^8.0.0",
         "@mantine/hooks": "^8.0.0",
+        "@mantine/notifications": "^8.0.0",
         "@medplum/core": "5.1.32",
         "@medplum/fhirtypes": "5.1.32",
         "@medplum/react": "5.1.32",
@@ -45317,6 +45319,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@mantine/core": "8.3.18",
+        "@mantine/notifications": "8.3.18",
         "@mantine/spotlight": "8.3.18",
         "@medplum/core": "5.1.32",
         "@medplum/definitions": "5.1.32",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44987,7 +44987,6 @@
       "peerDependencies": {
         "@mantine/core": "^8.0.0",
         "@mantine/hooks": "^8.0.0",
-        "@mantine/notifications": "^8.0.0",
         "@medplum/core": "5.1.32",
         "@medplum/fhirtypes": "5.1.32",
         "@medplum/react": "5.1.32",

--- a/packages/react-scheduling/package.json
+++ b/packages/react-scheduling/package.json
@@ -94,7 +94,6 @@
   "peerDependencies": {
     "@mantine/core": "^8.0.0",
     "@mantine/hooks": "^8.0.0",
-    "@mantine/notifications": "^8.0.0",
     "@medplum/core": "5.1.32",
     "@medplum/fhirtypes": "5.1.32",
     "@medplum/react": "5.1.32",

--- a/packages/react-scheduling/package.json
+++ b/packages/react-scheduling/package.json
@@ -69,6 +69,7 @@
     "@fullcalendar/react": "7.0.2",
     "@mantine/core": "8.3.18",
     "@mantine/hooks": "8.3.18",
+    "@mantine/notifications": "8.3.18",
     "@medplum/core": "5.1.32",
     "@medplum/definitions": "5.1.32",
     "@medplum/fhirtypes": "5.1.32",
@@ -93,6 +94,7 @@
   "peerDependencies": {
     "@mantine/core": "^8.0.0",
     "@mantine/hooks": "^8.0.0",
+    "@mantine/notifications": "^8.0.0",
     "@medplum/core": "5.1.32",
     "@medplum/fhirtypes": "5.1.32",
     "@medplum/react": "5.1.32",

--- a/packages/react-scheduling/src/CalendarBase/CalendarBase.module.css
+++ b/packages/react-scheduling/src/CalendarBase/CalendarBase.module.css
@@ -39,7 +39,7 @@
   background-color: light-dark(#0000000a, #ffffff14);
 }
 
-.selectedSlot {
+.selectedRange {
   background-color: light-dark(#228be62e, #4dabf73d);
 }
 

--- a/packages/react-scheduling/src/CalendarBase/CalendarBase.module.css
+++ b/packages/react-scheduling/src/CalendarBase/CalendarBase.module.css
@@ -31,6 +31,18 @@
   cursor: pointer;
 }
 
+.selectableDay {
+  cursor: pointer;
+}
+
+.selectableDay:hover {
+  background-color: light-dark(#0000000a, #ffffff14);
+}
+
+.selectedSlot {
+  background-color: light-dark(#228be62e, #4dabf73d);
+}
+
 /* Put more important title info first */
 .eventTitle { order: 1; }
 .eventTime { order: 2 }

--- a/packages/react-scheduling/src/CalendarBase/CalendarBase.tsx
+++ b/packages/react-scheduling/src/CalendarBase/CalendarBase.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { EventApi, EventClickInfo, EventInput, EventSourceInput } from '@fullcalendar/react';
+import type { CalendarRef, EventApi, EventClickInfo, EventInput, EventSourceInput } from '@fullcalendar/react';
 import FullCalendar, { useCalendarController } from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/react/daygrid';
 import interactionPlugin from '@fullcalendar/react/interaction';
@@ -101,6 +101,7 @@ export interface CalendarBaseProps extends Omit<
   onDoubleClickAppointment?: (appointment: Appointment, schedule?: WithId<Schedule>) => void;
   onDoubleClickSlot?: (slot: Slot, schedule?: WithId<Schedule>) => void;
   onSelectInterval?: (interval: DateTimeRange) => void;
+  selection?: DateTimeRange;
   eventSources: FhirEventSource[];
 
   onRangeChange?: (range: DateTimeRange) => void;
@@ -126,6 +127,7 @@ export function CalendarBase(props: CalendarBaseProps): JSX.Element {
     onDoubleClickAppointment,
     onDoubleClickSlot,
     onSelectInterval,
+    selection,
     loading,
     ...fullCalendarProps
   } = props;
@@ -218,6 +220,17 @@ export function CalendarBase(props: CalendarBaseProps): JSX.Element {
 
   const businessHours = availableTime?.flatMap(availableTimeToBusinessHoursEntry);
 
+  const selectable = Boolean(onSelectInterval);
+
+  // Necessary because `unselectAuto` is false
+  const calendarRef = useRef<CalendarRef>(null);
+  useEffect(() => {
+    if (selectable && !selection) {
+      calendarRef.current?.getApi().unselect();
+    }
+  }, [selectable, selection]);
+
+
   return (
     <div data-testid="calendar" className={cx(classes.wrapper, className)}>
       <Group justify="space-between" pb="sm">
@@ -265,11 +278,13 @@ export function CalendarBase(props: CalendarBaseProps): JSX.Element {
             allDaySlot: false,
           },
         }}
-        selectable={Boolean(onSelectInterval)}
+        selectable={selectable}
+        unselectAuto={false} // keep selected even if user clicks elsewhere, like booking form
         select={(eventInfo) => {
           onSelectInterval?.({ start: eventInfo.start, end: eventInfo.end });
         }}
         {...fullCalendarProps}
+        ref={calendarRef}
         eventSources={eventSources}
         controller={controller}
         headerToolbar={false}
@@ -296,6 +311,9 @@ export function CalendarBase(props: CalendarBaseProps): JSX.Element {
         backgroundEventInnerClass={cx(props.backgroundEventInnerClass, classes.backgroundEventInner)}
         listItemEventBeforeClass={cx(props.listItemEventBeforeClass, classes.listItemEventBefore)}
         nonBusinessHoursClass={cx(props.nonBusinessHoursClass, classes.nonBusinessHours)}
+        dayLaneClass={cx(props.dayLaneClass, selectable && classes.selectableDay)}
+        dayCellClass={cx(props.dayCellClass, selectable && classes.selectableDay)}
+        highlightClass={cx(props.highlightClass, classes.selectedSlot)}
       />
     </div>
   );

--- a/packages/react-scheduling/src/CalendarBase/CalendarBase.tsx
+++ b/packages/react-scheduling/src/CalendarBase/CalendarBase.tsx
@@ -230,7 +230,6 @@ export function CalendarBase(props: CalendarBaseProps): JSX.Element {
     }
   }, [selectable, selection]);
 
-
   return (
     <div data-testid="calendar" className={cx(classes.wrapper, className)}>
       <Group justify="space-between" pb="sm">

--- a/packages/react-scheduling/src/CalendarBase/CalendarBase.tsx
+++ b/packages/react-scheduling/src/CalendarBase/CalendarBase.tsx
@@ -313,7 +313,7 @@ export function CalendarBase(props: CalendarBaseProps): JSX.Element {
         nonBusinessHoursClass={cx(props.nonBusinessHoursClass, classes.nonBusinessHours)}
         dayLaneClass={cx(props.dayLaneClass, selectable && classes.selectableDay)}
         dayCellClass={cx(props.dayCellClass, selectable && classes.selectableDay)}
-        highlightClass={cx(props.highlightClass, classes.selectedSlot)}
+        highlightClass={cx(props.highlightClass, classes.selectedRange)}
       />
     </div>
   );

--- a/packages/react-scheduling/src/MultiCalendar/MultiCalendar.tsx
+++ b/packages/react-scheduling/src/MultiCalendar/MultiCalendar.tsx
@@ -27,6 +27,7 @@ export interface MultiCalendarProps {
   onSelectAppointment?: (appointment: Appointment, schedule?: WithId<Schedule>) => void;
   onDoubleClickAppointment?: (appointment: Appointment, schedule?: WithId<Schedule>) => void;
   onRangeChange?: (range: DateTimeRange) => void;
+  selection?: DateTimeRange;
   className?: string;
   availableTime?: HealthcareServiceAvailableTime[];
   loading?: boolean;

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.booking.test.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.booking.test.tsx
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Notifications, notifications } from '@mantine/notifications';
+import type { MockClient } from '@medplum/mock';
+import type { JSX } from 'react';
+import { installBookStub } from '../stories/mockBook';
+import { installFindStub } from '../stories/mockFind';
+import { installAutocompleteTimers } from '../test-utils/asyncAutocomplete';
+import {
+  chooseActor,
+  chooseImagingService,
+  clickBook,
+  fillBooking,
+  hasPill,
+  lastFindStart,
+  MONDAY_MORNING,
+  openTimeFinder,
+  setupBookingClient,
+} from '../test-utils/bookingForm';
+import { act, fireEvent, renderWithMedplum, screen, within } from '../test-utils/render';
+import { SchedulingWorkspace } from './SchedulingWorkspace';
+
+// A separate file from SchedulingWorkspace.test.tsx, whose own fixtures block installs
+// sinon's fake timers: these tests drive autocompletes, which need vitest's.
+installAutocompleteTimers();
+
+// What the stubbed calendar reports being clicked on. All after MONDAY_MORNING, which
+// matters: `$find` treats the day as a floor and clamps a past one to now, so two past
+// days would be indistinguishable. Two instants on the Tuesday, because a second click
+// within the day already open has to be told from a click on a different day.
+const TUESDAY_MORNING = new Date(2026, 7, 18, 9, 0, 0);
+const TUESDAY_AFTERNOON = new Date(2026, 7, 18, 14, 0, 0);
+const THURSDAY_MORNING = new Date(2026, 7, 20, 9, 0, 0);
+
+const CLICK_TARGETS = {
+  'tuesday morning': TUESDAY_MORNING,
+  'tuesday afternoon': TUESDAY_AFTERNOON,
+  thursday: THURSDAY_MORNING,
+};
+
+type ClickTarget = keyof typeof CLICK_TARGETS;
+
+/*
+ * FullCalendar's selection is pointer-driven and needs real layout to hit-test against,
+ * which jsdom has none of. So the calendar is stood up as two buttons that report a click
+ * on a known day, leaving the real grid's own behaviour to Storybook. Everything under
+ * test here — what opens the pane, what it pre-fills, what closes it — belongs to the
+ * workspace either way.
+ */
+vi.mock('../MultiCalendar/MultiCalendar', () => ({
+  MultiCalendar: (props: { onSelectInterval?: (interval: { start: Date; end: Date }) => void }): JSX.Element => (
+    <div>
+      {Object.entries(CLICK_TARGETS).map(([name, target]) => (
+        <button
+          key={name}
+          type="button"
+          // A new Date per click, as the real calendar reports them: handing back one
+          // instance would make every same-day click look identical by reference and
+          // hide whether the day is actually being compared.
+          onClick={() => props.onSelectInterval?.({ start: new Date(target), end: new Date(target) })}
+        >
+          click {name}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+/**
+ * Clicks open time on the calendar, the way a user opens the booking form.
+ * @param target - Which of the stubbed instants to report a click on.
+ */
+async function clickCalendar(target: ClickTarget = 'tuesday morning'): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: `click ${target}` }));
+  });
+}
+
+function bookingPaneHeading(): HTMLElement | null {
+  return screen.queryByRole('heading', { name: /book appointment/i });
+}
+
+describe('SchedulingWorkspace booking', () => {
+  let medplum: MockClient;
+  let restoreFind: () => void;
+  let restoreBook: () => void;
+
+  beforeEach(async () => {
+    vi.setSystemTime(MONDAY_MORNING);
+    medplum = await setupBookingClient();
+    restoreFind = installFindStub(medplum);
+    restoreBook = installBookStub(medplum);
+  });
+
+  afterEach(() => {
+    restoreBook();
+    restoreFind();
+    // The notification store outlives the render, so one test's toast would otherwise
+    // still be on screen for the next.
+    notifications.clean();
+  });
+
+  function setup(): void {
+    // `Notifications` is the host's to mount, and the workspace raises one on a booking.
+    renderWithMedplum(
+      <>
+        <Notifications />
+        <SchedulingWorkspace />
+      </>,
+      medplum
+    );
+  }
+
+  test('Offers no booking form until the calendar is clicked', () => {
+    setup();
+
+    expect(bookingPaneHeading()).not.toBeInTheDocument();
+  });
+
+  test('Opens the booking form when the calendar is clicked', async () => {
+    setup();
+    await clickCalendar();
+
+    expect(bookingPaneHeading()).toBeInTheDocument();
+    expect(screen.getByRole('searchbox', { name: /visit type/i })).toBeInTheDocument();
+  });
+
+  test('Opens the time search on the day clicked rather than today', async () => {
+    const get = vi.spyOn(medplum, 'get');
+    setup();
+    await clickCalendar();
+
+    await chooseImagingService();
+    await chooseActor(/provider/i, 'riv', 'Dr. Maya Rivera');
+    await openTimeFinder();
+
+    // Read off the request rather than the day headings on screen: the pane writes the
+    // day it was opened on in the same words the search writes its own, so an assertion
+    // on the text would pass whether the search opened there or never opened at all.
+    const start = lastFindStart(get);
+    expect(start).toBeDefined();
+    expect(new Date(start as string).getDate()).toBe(TUESDAY_MORNING.getDate());
+  });
+
+  test('Books the appointment and closes the form', async () => {
+    const post = vi.spyOn(medplum, 'post');
+    setup();
+    await clickCalendar();
+
+    await fillBooking();
+    await clickBook();
+
+    expect(post.mock.calls.some(([url]) => String(url).includes('Appointment/$book'))).toBe(true);
+    // The calendar refreshes itself from the booking's own announcement, so there is
+    // nothing left for the pane to show.
+    expect(bookingPaneHeading()).not.toBeInTheDocument();
+  });
+
+  test('Announces the booking it wrote', async () => {
+    setup();
+    await clickCalendar();
+
+    await fillBooking();
+    await clickBook();
+
+    // The pane closes on success, and the appointment does not always turn up on the
+    // calendar to speak for itself — it may fall outside the visible range, or onto a
+    // schedule that is deselected. So the booking says so itself.
+    const toast = await screen.findByRole('alert');
+    expect(within(toast).getByText('Appointment booked')).toBeInTheDocument();
+    expect(within(toast).getByText(/Jordan Reyes/)).toBeInTheDocument();
+  });
+
+  test('Closes the form when dismissed', async () => {
+    setup();
+    await clickCalendar();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /close booking form/i }));
+    });
+
+    expect(bookingPaneHeading()).not.toBeInTheDocument();
+  });
+
+  test('Re-opens on a different day, clearing what was answered for the old one', async () => {
+    setup();
+    await clickCalendar('tuesday morning');
+    await chooseImagingService();
+    expect(hasPill('Ultrasound Imaging')).toBe(true);
+
+    await clickCalendar('thursday');
+
+    // A different day is a different visit, and the answers were for the old one.
+    expect(hasPill('Ultrasound Imaging')).toBe(false);
+  });
+
+  test('Keeps what was answered when the same day is clicked again', async () => {
+    setup();
+    await clickCalendar('tuesday morning');
+    await chooseImagingService();
+
+    await clickCalendar('tuesday afternoon');
+
+    // Clicking around inside the day being booked is not a change of mind about which
+    // day it is, and must not take the answers away.
+    expect(hasPill('Ultrasound Imaging')).toBe(true);
+  });
+});

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.booking.test.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.booking.test.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Notifications, notifications } from '@mantine/notifications';
 import type { MockClient } from '@medplum/mock';
 import type { JSX } from 'react';
+import type { AppointmentBooking } from '../AppointmentFinder/AppointmentBookingForm';
 import { installBookStub } from '../stories/mockBook';
 import { installFindStub } from '../stories/mockFind';
 import { installAutocompleteTimers } from '../test-utils/asyncAutocomplete';
@@ -17,7 +17,7 @@ import {
   openTimeFinder,
   setupBookingClient,
 } from '../test-utils/bookingForm';
-import { act, fireEvent, renderWithMedplum, screen, within } from '../test-utils/render';
+import { act, fireEvent, renderWithMedplum, screen } from '../test-utils/render';
 import { SchedulingWorkspace } from './SchedulingWorkspace';
 
 // A separate file from SchedulingWorkspace.test.tsx, whose own fixtures block installs
@@ -95,20 +95,10 @@ describe('SchedulingWorkspace booking', () => {
   afterEach(() => {
     restoreBook();
     restoreFind();
-    // The notification store outlives the render, so one test's toast would otherwise
-    // still be on screen for the next.
-    notifications.clean();
   });
 
-  function setup(): void {
-    // `Notifications` is the host's to mount, and the workspace raises one on a booking.
-    renderWithMedplum(
-      <>
-        <Notifications />
-        <SchedulingWorkspace />
-      </>,
-      medplum
-    );
+  function setup(onBooked?: (booking: AppointmentBooking) => void): void {
+    renderWithMedplum(<SchedulingWorkspace onBooked={onBooked} />, medplum);
   }
 
   test('Offers no booking form until the calendar is clicked', () => {
@@ -156,8 +146,9 @@ describe('SchedulingWorkspace booking', () => {
     expect(bookingPaneHeading()).not.toBeInTheDocument();
   });
 
-  test('Announces the booking it wrote', async () => {
-    setup();
+  test('Reports the booking it wrote to the host', async () => {
+    const onBooked = vi.fn();
+    setup(onBooked);
     await clickCalendar();
 
     await fillBooking();
@@ -165,10 +156,13 @@ describe('SchedulingWorkspace booking', () => {
 
     // The pane closes on success, and the appointment does not always turn up on the
     // calendar to speak for itself — it may fall outside the visible range, or onto a
-    // schedule that is deselected. So the booking says so itself.
-    const toast = await screen.findByRole('alert');
-    expect(within(toast).getByText('Appointment booked')).toBeInTheDocument();
-    expect(within(toast).getByText(/Jordan Reyes/)).toBeInTheDocument();
+    // schedule that is deselected. So the host is told what was booked, and announces
+    // it however it announces things.
+    expect(onBooked).toHaveBeenCalledTimes(1);
+    const booking = onBooked.mock.calls[0][0] as AppointmentBooking;
+    expect(booking.appointment.participant).toContainEqual(
+      expect.objectContaining({ actor: expect.objectContaining({ display: 'Jordan Reyes' }) })
+    );
   });
 
   test('Closes the form when dismissed', async () => {

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.module.css
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.module.css
@@ -18,4 +18,20 @@
   position: relative;
   flex: 1;
   min-width: 0;
+  overflow-x: auto;
+}
+
+/* The booking form, only present while a day is being booked. */
+.bookingPane {
+  flex-shrink: 0;
+  width: 320px;
+  overflow-y: auto;
+}
+
+.bookingPaneWide {
+  width: 760px;
+}
+
+.alert {
+  margin-bottom: var(--mantine-spacing-xs);
 }

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.stories.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.stories.tsx
@@ -8,13 +8,10 @@ import { SchedulingWorkspace } from './SchedulingWorkspace';
 
 const STORY_FIXTURES = [...SchedulingFixtures, ...CalendarWeekFixtures, ...PatientFixtures];
 
-// `withFindStub` is left to the stories rather than set here: a story's own decorators
-// add to these rather than replacing them, so two stubs would both install and which one
-// answered would be an accident of effect ordering.
 export default {
   title: 'Medplum/SchedulingWorkspace',
   component: SchedulingWorkspace,
-  decorators: [withBookStub(), withFixtures(STORY_FIXTURES), withMockedDate],
+  decorators: [withBookStub(), withFindStub(), withFixtures(STORY_FIXTURES), withMockedDate],
   parameters: {
     // Default seeding includes a lot of cluttering Slot resources for Dr. Alice Smith; skip it.
     skipDefaultSeeding: true,
@@ -47,4 +44,3 @@ export const Basic = (): JSX.Element => (
     <SchedulingWorkspace />
   </div>
 );
-Basic.decorators = [withFindStub()];

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.stories.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.stories.tsx
@@ -2,16 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Meta } from '@storybook/react';
 import type { JSX } from 'react';
-import { withFixtures, withMockedDate } from '../stories/decorators';
-import { CalendarWeekFixtures, SchedulingFixtures } from '../stories/scheduling';
+import { withBookStub, withFindStub, withFixtures, withMockedDate } from '../stories/decorators';
+import { CalendarWeekFixtures, PatientFixtures, SchedulingFixtures } from '../stories/scheduling';
 import { SchedulingWorkspace } from './SchedulingWorkspace';
 
-const STORY_FIXTURES = [...SchedulingFixtures, ...CalendarWeekFixtures];
+const STORY_FIXTURES = [...SchedulingFixtures, ...CalendarWeekFixtures, ...PatientFixtures];
 
+// `withFindStub` is left to the stories rather than set here: a story's own decorators
+// add to these rather than replacing them, so two stubs would both install and which one
+// answered would be an accident of effect ordering.
 export default {
   title: 'Medplum/SchedulingWorkspace',
   component: SchedulingWorkspace,
-  decorators: [withFixtures(STORY_FIXTURES), withMockedDate],
+  decorators: [withBookStub(), withFixtures(STORY_FIXTURES), withMockedDate],
   parameters: {
     // Default seeding includes a lot of cluttering Slot resources for Dr. Alice Smith; skip it.
     skipDefaultSeeding: true,
@@ -23,10 +26,25 @@ export default {
  * across the week `MockDateWrapper` pins "today" to (Mon May 4 2020), so selecting
  * a few Providers/Devices/Rooms rows shows real events on the calendar.
  *
+ * Click — or drag over — open time on the grid and the booking form opens on the right,
+ * headed with the day clicked. Choose "Ultrasound Imaging", then Dr. Maya Rivera, then
+ * "Find a time": the search opens on that day rather than today, and the pane widens to
+ * lay the times beside the form. Pick one, name a patient ("Jordan"), and book — the
+ * pane closes and the appointment appears on the calendar without a reload, because the
+ * booking announces what it wrote and the calendar is listening.
+ *
+ * Clicking a different day with the form part-filled re-opens it on the new day and
+ * clears the answers; clicking again inside the day already open leaves them alone.
+ *
  * @returns The story.
  */
 export const Basic = (): JSX.Element => (
-  <div style={{ height: 700, padding: '1em' }}>
+  // The workspace fills whatever it is given, so the story hands it the rest of the
+  // viewport rather than a fixed height: the calendar and the booking pane both scroll
+  // inside it, and a short host makes each of them look cramped for reasons of its own.
+  // 72px is the package banner `withSchedulingHeader` puts above every story here.
+  <div style={{ height: 'calc(100vh - 72px)', padding: '1em', boxSizing: 'border-box' }}>
     <SchedulingWorkspace />
   </div>
 );
+Basic.decorators = [withFindStub()];

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.stories.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.stories.tsx
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { showNotification } from '@mantine/notifications';
+import type { Appointment } from '@medplum/fhirtypes';
 import type { Meta } from '@storybook/react';
+import { IconCalendarCheck } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { withBookStub, withFindStub, withFixtures, withMockedDate } from '../stories/decorators';
 import { CalendarWeekFixtures, PatientFixtures, SchedulingFixtures } from '../stories/scheduling';
@@ -28,7 +31,9 @@ export default {
  * "Find a time": the search opens on that day rather than today, and the pane widens to
  * lay the times beside the form. Pick one, name a patient ("Jordan"), and book — the
  * pane closes and the appointment appears on the calendar without a reload, because the
- * booking announces what it wrote and the calendar is listening.
+ * booking announces what it wrote and the calendar is listening. The toast naming the
+ * visit is this story's, raised from `onBooked`: the workspace reports what was booked
+ * and leaves how to say so to whatever is hosting it.
  *
  * Clicking a different day with the form part-filled re-opens it on the new day and
  * clears the answers; clicking again inside the day already open leaves them alone.
@@ -41,6 +46,36 @@ export const Basic = (): JSX.Element => (
   // inside it, and a short host makes each of them look cramped for reasons of its own.
   // 72px is the package banner `withSchedulingHeader` puts above every story here.
   <div style={{ height: 'calc(100vh - 72px)', padding: '1em', boxSizing: 'border-box' }}>
-    <SchedulingWorkspace />
+    <SchedulingWorkspace
+      onBooked={({ appointment }) => {
+        showNotification({
+          color: 'green',
+          icon: <IconCalendarCheck size={18} />,
+          title: 'Appointment booked',
+          message: describeBooking(appointment),
+        });
+      }}
+    />
   </div>
 );
+
+/**
+ * Names the visit that was booked, for the notification announcing it.
+ * @param appointment - The appointment `$book` wrote.
+ * @returns Who it is for and when, as far as each is known.
+ */
+function describeBooking(appointment: Appointment): string {
+  const patient = (appointment.participant ?? []).find((participant) =>
+    participant.actor?.reference?.startsWith('Patient/')
+  );
+  const when = appointment.start
+    ? new Date(appointment.start).toLocaleString(undefined, {
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      })
+    : undefined;
+  return [patient?.actor?.display, when].filter(Boolean).join(' · ');
+}

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { Alert, useMantineTheme } from '@mantine/core';
+import { Alert, CloseButton, Group, Title, useMantineTheme } from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
 import {
   getExtensionValue,
   getReferenceString,
@@ -10,12 +11,17 @@ import {
 } from '@medplum/core';
 import type { Appointment, Slot } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
+import { IconCalendarCheck } from '@tabler/icons-react';
+import cx from 'clsx';
 import type { JSX } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { AppointmentBooking } from '../AppointmentFinder/AppointmentBookingForm';
+import { AppointmentBookingForm } from '../AppointmentFinder/AppointmentBookingForm';
 import type { SchedulingRole } from '../AppointmentFinder/AppointmentFinder.roles';
 import { SCHEDULING_ROLES } from '../AppointmentFinder/AppointmentFinder.roles';
 import type { ScheduleCandidate } from '../AppointmentFinder/AppointmentFinder.schedules';
 import { getCandidateDisplay, searchScheduleCandidates } from '../AppointmentFinder/AppointmentFinder.schedules';
+import { isSameDay } from '../AppointmentFinder/AppointmentFinder.times';
 import { resolveThemeColor } from '../colors';
 import { useSchedulingResources } from '../hooks/useSchedulingResources';
 import type { MultiCalendarSource } from '../MultiCalendar/MultiCalendar';
@@ -36,6 +42,10 @@ export interface SchedulingWorkspaceProps {
  *
  * - Picks a color for each Schedule so that it can render consistently across
  *   those components.
+ * - Books from the calendar: clicking open time opens {@link AppointmentBookingForm}
+ *   in a pane on the right, with its time search opened on the day that was clicked.
+ *   The form writes the booking and announces what it wrote, which is what puts the
+ *   new appointment on the calendar beside it — a host supplies nothing for any of it.
  *
  * @param props - Component props
  * @returns A React Node with the coordinated Calendars panel + calendar UI in it
@@ -55,6 +65,15 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
   const [deselectedRoomIds, setDeselectedRoomIds] = useState<ReadonlySet<string>>(new Set());
 
   const [range, setRange] = useState<DateTimeRange>();
+
+  // The day the calendar was clicked on, and whether the form's time search is open.
+  // The times render beside the form rather than under it, so the pane has to widen to
+  // hold them, and `onToggleTimeFinder` is what reports when.
+  const [bookingDay, setBookingDay] = useState<Date>();
+  // What the calendar marks: the slot that was clicked, kept until the pane closes. The
+  // day above is what the form is opened on, and only changes when the day does.
+  const [bookingSelection, setBookingSelection] = useState<DateTimeRange>();
+  const [timeFinderOpen, setTimeFinderOpen] = useState(false);
 
   // Finds all bookable Schedules, with one search per schedulable role.
   useEffect(() => {
@@ -135,6 +154,30 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
     });
   }, [activeCandidates, slots, appointments, colorByScheduleId]);
 
+  const openBooking = useCallback((interval: DateTimeRange): void => {
+    setBookingSelection(interval);
+    setBookingDay((current) => (isSameDay(interval.start, current) ? current : interval.start));
+  }, []);
+
+  const closeBooking = useCallback((): void => {
+    setBookingDay(undefined);
+    setBookingSelection(undefined);
+    setTimeFinderOpen(false);
+  }, []);
+
+  const finishBooking = useCallback(
+    (booking: AppointmentBooking): void => {
+      closeBooking();
+      showNotification({
+        color: 'green',
+        icon: <IconCalendarCheck size={18} />,
+        title: 'Appointment booked',
+        message: describeBooking(booking.appointment),
+      });
+    },
+    [closeBooking]
+  );
+
   const toItem = (candidate: ScheduleCandidate, selected: boolean): CalendarsPanelItem => {
     const color = colorByScheduleId.get(candidate.schedule.id);
     if (!color) {
@@ -169,10 +212,51 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
             {normalizeErrorString(displayError)}
           </Alert>
         )}
-        <MultiCalendar sources={sources} onRangeChange={setRange} loading={resourcesLoading} />
+        <MultiCalendar
+          sources={sources}
+          onRangeChange={setRange}
+          loading={resourcesLoading}
+          onSelectInterval={openBooking}
+          selection={bookingSelection}
+        />
       </div>
+      {bookingDay && (
+        <div className={cx(classes.bookingPane, { [classes.bookingPaneWide]: timeFinderOpen })}>
+          <Group justify="space-between" wrap="nowrap" mb="sm">
+            <Title order={4}>Book appointment</Title>
+            <CloseButton aria-label="Close booking form" onClick={closeBooking} />
+          </Group>
+          <AppointmentBookingForm
+            key={bookingDay.getTime()}
+            defaultStart={bookingDay}
+            onToggleTimeFinder={setTimeFinderOpen}
+            onBooked={finishBooking}
+          />
+        </div>
+      )}
     </div>
   );
+}
+
+/**
+ * Names the visit that was booked, for the notification announcing it.
+ * @param appointment - The appointment `$book` wrote.
+ * @returns Who it is for and when, as far as each is known.
+ */
+function describeBooking(appointment: Appointment): string {
+  const patient = (appointment.participant ?? []).find((participant) =>
+    participant.actor?.reference?.startsWith('Patient/')
+  );
+  const when = appointment.start
+    ? new Date(appointment.start).toLocaleString(undefined, {
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      })
+    : undefined;
+  return [patient?.actor?.display, when].filter(Boolean).join(' · ');
 }
 
 function toggleId(ids: ReadonlySet<string>, id: string): Set<string> {

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
@@ -21,7 +21,6 @@ import type { SchedulingRole } from '../AppointmentFinder/AppointmentFinder.role
 import { SCHEDULING_ROLES } from '../AppointmentFinder/AppointmentFinder.roles';
 import type { ScheduleCandidate } from '../AppointmentFinder/AppointmentFinder.schedules';
 import { getCandidateDisplay, searchScheduleCandidates } from '../AppointmentFinder/AppointmentFinder.schedules';
-import { isSameDay } from '../AppointmentFinder/AppointmentFinder.times';
 import { resolveThemeColor } from '../colors';
 import { useSchedulingResources } from '../hooks/useSchedulingResources';
 import type { MultiCalendarSource } from '../MultiCalendar/MultiCalendar';
@@ -66,12 +65,6 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
 
   const [range, setRange] = useState<DateTimeRange>();
 
-  // The day the calendar was clicked on, and whether the form's time search is open.
-  // The times render beside the form rather than under it, so the pane has to widen to
-  // hold them, and `onToggleTimeFinder` is what reports when.
-  const [bookingDay, setBookingDay] = useState<Date>();
-  // What the calendar marks: the slot that was clicked, kept until the pane closes. The
-  // day above is what the form is opened on, and only changes when the day does.
   const [bookingSelection, setBookingSelection] = useState<DateTimeRange>();
   const [timeFinderOpen, setTimeFinderOpen] = useState(false);
 
@@ -154,13 +147,7 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
     });
   }, [activeCandidates, slots, appointments, colorByScheduleId]);
 
-  const openBooking = useCallback((interval: DateTimeRange): void => {
-    setBookingSelection(interval);
-    setBookingDay((current) => (isSameDay(interval.start, current) ? current : interval.start));
-  }, []);
-
   const closeBooking = useCallback((): void => {
-    setBookingDay(undefined);
     setBookingSelection(undefined);
     setTimeFinderOpen(false);
   }, []);
@@ -216,19 +203,19 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
           sources={sources}
           onRangeChange={setRange}
           loading={resourcesLoading}
-          onSelectInterval={openBooking}
+          onSelectInterval={setBookingSelection}
           selection={bookingSelection}
         />
       </div>
-      {bookingDay && (
+      {bookingSelection && (
         <div className={cx(classes.bookingPane, { [classes.bookingPaneWide]: timeFinderOpen })}>
           <Group justify="space-between" wrap="nowrap" mb="sm">
             <Title order={4}>Book appointment</Title>
             <CloseButton aria-label="Close booking form" onClick={closeBooking} />
           </Group>
           <AppointmentBookingForm
-            key={bookingDay.getTime()}
-            defaultStart={bookingDay}
+            key={bookingSelection.start.toDateString()}
+            defaultStart={bookingSelection.start}
             onToggleTimeFinder={setTimeFinderOpen}
             onBooked={finishBooking}
           />

--- a/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
+++ b/packages/react-scheduling/src/SchedulingWorkspace/SchedulingWorkspace.tsx
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Alert, CloseButton, Group, Title, useMantineTheme } from '@mantine/core';
-import { showNotification } from '@mantine/notifications';
 import {
   getExtensionValue,
   getReferenceString,
@@ -11,7 +10,6 @@ import {
 } from '@medplum/core';
 import type { Appointment, Slot } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
-import { IconCalendarCheck } from '@tabler/icons-react';
 import cx from 'clsx';
 import type { JSX } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -34,6 +32,7 @@ const EMPTY_CANDIDATES: Readonly<Record<SchedulingRole, ScheduleCandidate[]>> = 
 
 export interface SchedulingWorkspaceProps {
   readonly className?: string;
+  readonly onBooked?: (booking: AppointmentBooking) => void | Promise<void>;
 }
 
 /**
@@ -44,12 +43,14 @@ export interface SchedulingWorkspaceProps {
  * - Books from the calendar: clicking open time opens {@link AppointmentBookingForm}
  *   in a pane on the right, with its time search opened on the day that was clicked.
  *   The form writes the booking and announces what it wrote, which is what puts the
- *   new appointment on the calendar beside it — a host supplies nothing for any of it.
+ *   new appointment on the calendar beside it — a host supplies no data for any of it.
+ *   What was written is reported through `onBooked`, for a host that wants to say so.
  *
  * @param props - Component props
  * @returns A React Node with the coordinated Calendars panel + calendar UI in it
  */
 export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Element {
+  const { onBooked } = props;
   const medplum = useMedplum();
   const theme = useMantineTheme();
 
@@ -153,16 +154,11 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
   }, []);
 
   const finishBooking = useCallback(
-    (booking: AppointmentBooking): void => {
+    (booking: AppointmentBooking): void | Promise<void> => {
       closeBooking();
-      showNotification({
-        color: 'green',
-        icon: <IconCalendarCheck size={18} />,
-        title: 'Appointment booked',
-        message: describeBooking(booking.appointment),
-      });
+      return onBooked?.(booking);
     },
-    [closeBooking]
+    [closeBooking, onBooked]
   );
 
   const toItem = (candidate: ScheduleCandidate, selected: boolean): CalendarsPanelItem => {
@@ -223,27 +219,6 @@ export function SchedulingWorkspace(props: SchedulingWorkspaceProps): JSX.Elemen
       )}
     </div>
   );
-}
-
-/**
- * Names the visit that was booked, for the notification announcing it.
- * @param appointment - The appointment `$book` wrote.
- * @returns Who it is for and when, as far as each is known.
- */
-function describeBooking(appointment: Appointment): string {
-  const patient = (appointment.participant ?? []).find((participant) =>
-    participant.actor?.reference?.startsWith('Patient/')
-  );
-  const when = appointment.start
-    ? new Date(appointment.start).toLocaleString(undefined, {
-        weekday: 'long',
-        month: 'long',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-      })
-    : undefined;
-  return [patient?.actor?.display, when].filter(Boolean).join(' · ');
 }
 
 function toggleId(ids: ReadonlySet<string>, id: string): Set<string> {

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -1,5 +1,7 @@
 import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import '@mantine/core/styles.css';
+import { Notifications } from '@mantine/notifications';
+import '@mantine/notifications/styles.css';
 import '@mantine/spotlight/styles.css';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
@@ -84,6 +86,7 @@ export const decorators: Decorator[] = [
     const selectedTheme = themePresetMap[context.globals.theme ?? 'medplumDefault'] ?? themePresetMap.medplumDefault;
     return (
       <MantineProvider theme={selectedTheme}>
+        <Notifications />
         <Story />
       </MantineProvider>
     );

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@mantine/core": "8.3.18",
+    "@mantine/notifications": "8.3.18",
     "@mantine/spotlight": "8.3.18",
     "@medplum/core": "5.1.32",
     "@medplum/definitions": "5.1.32",


### PR DESCRIPTION
Stacked on #10316

Adds the booking form to the top-level calendar component. Click on the calendar to open the booking form, fill it out to schedule an appointment.

<img width="1517" height="946" alt="image" src="https://github.com/user-attachments/assets/e82d153d-4434-49b3-a90b-b883f63991c8" />
<img width="2095" height="1168" alt="image" src="https://github.com/user-attachments/assets/a9756da9-f91e-4040-a305-cbc00e570ab4" />


The form opens in a pane on the right, with its time search seeded to the day that was clicked rather than to today. The pane widens while that search is open, because the times render beside the form rather than under it. Nothing in the workspace puts the new appointment on the calendar: the booking form announces what `$book` wrote, and the calendar beside it is already listening, so it appears without a reload.

Clicking a different day re-opens the form on it and clears what was answered for the old one; clicking around inside the day already open leaves a part-filled form alone. `defaultStart` is read at mount only, so remounting is the only way to move the search day.

`CalendarBase` takes a `selection` prop so the clicked slot stays marked while the pane is open, and turns off FullCalendar's `unselectAuto` (a click into the booking form would otherwise clear the mark). The cost is that clearing it has to go through the calendar ref when the pane closes.

A booking reports what it wrote through `onBooked`, and how to announce it is the host's — the workspace pulls in no notification library of its own. The Storybook story is the host here: it raises a toast naming the visit, which is why the shared preview now renders `<Notifications />` for every story.

Booking is all that is wired up here. Editing, rescheduling and cancelling from the calendar are not in this PR.

