### PR TITLE
docs(self-hosting): document MEDPLUM_BASE_URL for the app image

### DIFF
--- a/packages/docs/docs/self-hosting/running-full-medplum-stack-in-docker.md
+++ b/packages/docs/docs/self-hosting/running-full-medplum-stack-in-docker.md
@@ -16,6 +16,30 @@ The Docker Compose file includes the following containers:
 
 All the containers present are configured to work together out of the box with no configuration. Just run the commands above and go to http://localhost:3000 to get started with your own full-stack local instance of Medplum!
 
+## Pointing the app image at your API server
+
+The `medplum/medplum-app` image is a static nginx build. At container start, `packages/app/docker-entrypoint.sh` rewrites compiled assets with these environment variables:
+
+| Name | Default in the image | Purpose |
+| --- | --- | --- |
+| `MEDPLUM_BASE_URL` | `http://localhost:8103/` | API server URL used by the browser |
+| `MEDPLUM_CLIENT_ID` | empty | Optional Medplum client application ID |
+| `GOOGLE_CLIENT_ID` | empty | Optional Google Auth client ID |
+| `RECAPTCHA_SITE_KEY` | bundled demo key | Optional reCAPTCHA site key |
+| `MEDPLUM_REGISTER_ENABLED` | `true` | Whether open registration is enabled |
+| `MEDPLUM_AWS_TEXTRACT_ENABLED` | `true` | Whether AWS Textract is enabled |
+
+If the app container is reached at a host other than `localhost`, or the server is not on port 8103, set `MEDPLUM_BASE_URL` to the URL the **browser** should call. That is often a public hostname, not the Docker Compose service name.
+
+```yaml
+medplum-app:
+  image: medplum/medplum-app:latest
+  environment:
+    MEDPLUM_BASE_URL: 'https://api.example.com/'
+```
+
+These variables are substituted when the container starts. Changing them requires recreating the app container so the entrypoint can rewrite the files again.
+
 :::info[]
 
 Starting the whole stack can take a few minutes. This is due to the initial one-time setup Medplum server has to do before it is able to pass its healthcheck.

--- a/packages/docs/docs/self-hosting/running-medplum-docker-container.md
+++ b/packages/docs/docs/self-hosting/running-medplum-docker-container.md
@@ -27,3 +27,5 @@ If you are looking to get started fast or want to develop against a local copy o
 we also have a [full-stack Docker setup](/docs/self-hosting/running-full-medplum-stack-in-docker) that you can start up with just two commands!
 
 :::
+
+The published `medplum/medplum-app` image is configured at container start through environment variables, including `MEDPLUM_BASE_URL`. See [Pointing the app image at your API server](/docs/self-hosting/running-full-medplum-stack-in-docker#pointing-the-app-image-at-your-api-server).


### PR DESCRIPTION
Fixes #6544.

The `medplum/medplum-app` image is a static nginx build. `packages/app/docker-entrypoint.sh` substitutes `MEDPLUM_BASE_URL` and related variables when the container starts.

This documents those variables on the full-stack Docker page, notes that the browser needs a reachable API URL, and links from the server-container page.

Checked against `packages/app/docker-entrypoint.sh` and the existing app README env table.