### PR TITLE
Storybook test mode and cleanups

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -49,8 +49,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build:all -- --filter=@medplum/storybook
+      - name: Build Storybook dependencies
+        # Chromatic runs build:test itself to inject output and TurboSnap stats options.
+        # Build only dependencies here to avoid building Storybook twice.
+        run: npx turbo run build '--filter=@medplum/storybook^...'
 
       - name: Publish @medplum/react Chromatic
         uses: chromaui/action@94713c544284a14195de3b50ef24301579f1877e # v18.0.1
@@ -59,7 +61,7 @@ jobs:
         with:
           projectToken: chpt_429b596edaecafb
           workingDir: packages/storybook
-          buildScriptName: build
+          buildScriptName: build:test
           autoAcceptChanges: 'main'
           exitOnceUploaded: true
           exitZeroOnChanges: true

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.stories.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.stories.tsx
@@ -72,27 +72,28 @@ export const Simple = (): JSX.Element => (
 
 export const WithCategories = (): JSX.Element => {
   const medplum = useMedplum();
-  const [loaded, setLoaded] = useState(false);
+  const [report, setReport] = useState<DiagnosticReport>();
 
   useEffect(() => {
-    (async (): Promise<boolean> => {
+    (async (): Promise<DiagnosticReport> => {
       const obs = await medplum.createResource(CreatinineObservation);
-      ExampleReport.result = [createReference(obs)];
+      // Clone to avoid mutating the shared fixture across story renders.
+      const report = deepClone(ExampleReport);
+      report.result = [createReference(obs)];
 
-      await medplum.updateResource(ExampleReport);
-      return true;
+      return medplum.updateResource(report);
     })()
-      .then(setLoaded)
+      .then(setReport)
       .catch(console.log);
   }, [medplum]);
 
-  if (!loaded) {
+  if (!report) {
     return <></>;
   }
 
   return (
     <Document>
-      <DiagnosticReportDisplay value={ExampleReport} />
+      <DiagnosticReportDisplay value={report} />
     </Document>
   );
 };
@@ -118,27 +119,28 @@ export const HideSpecimenInfo = (): JSX.Element => {
 
 export const HideNotes = (): JSX.Element => {
   const medplum = useMedplum();
-  const [loaded, setLoaded] = useState(false);
+  const [report, setReport] = useState<DiagnosticReport>();
 
   useEffect(() => {
-    (async (): Promise<boolean> => {
+    (async (): Promise<DiagnosticReport> => {
       const obs = await medplum.createResource({ ...CreatinineObservation, category: undefined });
-      (HomerDiagnosticReport.result as Reference<Observation>[]).push(createReference(obs));
+      // Clone to avoid mutating the shared fixture across story renders.
+      const report = deepClone(HomerDiagnosticReport);
+      (report.result as Reference<Observation>[]).push(createReference(obs));
 
-      await medplum.updateResource(HomerDiagnosticReport);
-      return true;
+      return medplum.updateResource(report);
     })()
-      .then(setLoaded)
+      .then(setReport)
       .catch(console.log);
   }, [medplum]);
 
-  if (!loaded) {
+  if (!report) {
     return <></>;
   }
 
   return (
     <Document>
-      <DiagnosticReportDisplay hideObservationNotes value={HomerDiagnosticReport} />
+      <DiagnosticReportDisplay hideObservationNotes value={report} />
     </Document>
   );
 };

--- a/packages/storybook/.storybook/main.ts
+++ b/packages/storybook/.storybook/main.ts
@@ -8,12 +8,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const config: StorybookConfig = {
   stories: [
-    '../src/stories/Introduction.mdx',
     '../src/**/*.mdx',
-    '../src/**/*.stories.@(js|jsx|ts|tsx)',
-    '../../react/src/**/*.stories.@(js|jsx|ts|tsx)',
+    '../src/**/*.stories.@(ts|tsx)',
+    '../../react/src/**/*.stories.@(ts|tsx)',
     '../../react-scheduling/src/**/*.mdx',
-    '../../react-scheduling/src/**/*.stories.@(js|jsx|ts|tsx)',
+    '../../react-scheduling/src/**/*.stories.@(ts|tsx)',
   ],
   addons: ['@storybook/addon-links', '@storybook/addon-docs', '@vueless/storybook-dark-mode'],
   staticDirs: ['../public'],

--- a/packages/storybook/.storybook/main.ts
+++ b/packages/storybook/.storybook/main.ts
@@ -8,6 +8,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const config: StorybookConfig = {
   stories: [
+    '../src/stories/Introduction.mdx', // redundant, but ensure Intro goes first
     '../src/**/*.mdx',
     '../src/**/*.stories.@(ts|tsx)',
     '../../react/src/**/*.stories.@(ts|tsx)',

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -59,10 +59,12 @@ function ColorSchemeWrapper({ children }: { children: React.ReactNode }) {
   const { setColorScheme } = useMantineColorScheme();
   useEffect(() => {
     const channel = addons.getChannel();
-    channel.on(DARK_MODE_EVENT_NAME, (darkMode: boolean) => {
+    const handleDarkMode = (darkMode: boolean): void => {
       setColorScheme(darkMode ? 'dark' : 'light');
-    });
-  }, []);
+    };
+    channel.on(DARK_MODE_EVENT_NAME, handleDarkMode);
+    return () => channel.off(DARK_MODE_EVENT_NAME, handleDarkMode);
+  }, [setColorScheme]);
   return <>{children}</>;
 }
 

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -39,7 +39,7 @@
   "type": "module",
   "scripts": {
     "build": "npm run clean && tsc && storybook build",
-    "build:test": "tsc && storybook build --test",
+    "build:test": "npm run clean && tsc && storybook build --test",
     "chromatic": "chromatic --exit-zero-on-changes --build-script-name=build:test --exit-once-uploaded",
     "clean": "rimraf storybook-static",
     "dev": "storybook dev -p 6006",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -39,7 +39,8 @@
   "type": "module",
   "scripts": {
     "build": "npm run clean && tsc && storybook build",
-    "chromatic": "chromatic --exit-zero-on-changes --build-script-name=build --exit-once-uploaded",
+    "build:test": "tsc && storybook build --test",
+    "chromatic": "chromatic --exit-zero-on-changes --build-script-name=build:test --exit-once-uploaded",
     "clean": "rimraf storybook-static",
     "dev": "storybook dev -p 6006",
     "lint": "eslint .",


### PR DESCRIPTION
The star of the show is adding `--test` when building for tests. That along with avoiding building storybook twice should save about two minutes when running on GH