### PR TITLE
Implements RFC 9727 API catalog

### DIFF
--- a/packages/core/src/contenttype.ts
+++ b/packages/core/src/contenttype.ts
@@ -19,6 +19,8 @@ export const ContentType = {
   JSON: 'application/json',
   JSON_PATCH: 'application/json-patch+json',
   JWT: 'application/jwt',
+  // See: https://www.rfc-editor.org/rfc/rfc9264.html
+  LINKSET_JSON: 'application/linkset+json',
   MULTIPART_FORM_DATA: 'multipart/form-data',
   PNG: 'image/png',
   SCIM_JSON: 'application/scim+json',

--- a/packages/docs/vercel.json
+++ b/packages/docs/vercel.json
@@ -148,6 +148,11 @@
     {
       "source": "/docs/communications/task-based-message-response-tracking-and-routing",
       "destination": "/docs/communications/message-response-tracking-and-routing"
+    },
+    {
+      "source": "/.well-known/api-catalog",
+      "destination": "https://api.medplum.com/.well-known/api-catalog",
+      "permanent": true
     }
   ]
 }

--- a/packages/server/src/api-catalog.test.ts
+++ b/packages/server/src/api-catalog.test.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { ContentType } from '@medplum/core';
+import express from 'express';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import request from 'supertest';
+import { initApp, shutdownApp } from './app';
+import { getConfig, loadTestConfig } from './config/loader';
+
+const app = express();
+
+describe('API catalog', () => {
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initApp(app, config);
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test('Get /.well-known/api-catalog', async () => {
+    const { baseUrl, issuer } = getConfig();
+    const res = await request(app).get('/.well-known/api-catalog');
+    expect(res).toHaveStatus(200);
+    expect(res.headers['content-type']).toStrictEqual(
+      `${ContentType.LINKSET_JSON}; profile="https://www.rfc-editor.org/info/rfc9727"`
+    );
+    expect(res.headers['link']).toStrictEqual(`<${baseUrl}.well-known/api-catalog>; rel="api-catalog"`);
+
+    const linkset = JSON.parse(res.text).linkset;
+    expect(linkset).toStrictEqual([
+      {
+        anchor: `${baseUrl}fhir/R4`,
+        'service-desc': [{ href: `${baseUrl}fhir/R4/metadata`, type: ContentType.FHIR_JSON }],
+        'service-doc': [{ href: 'https://www.medplum.com/docs/api/fhir', type: ContentType.HTML }],
+      },
+      {
+        anchor: `${baseUrl}oauth2`,
+        'service-desc': [{ href: `${baseUrl}.well-known/oauth-authorization-server`, type: ContentType.JSON }],
+        'service-doc': [{ href: 'https://www.medplum.com/docs/api/oauth', type: ContentType.HTML }],
+      },
+      {
+        anchor: issuer,
+        'service-desc': [{ href: `${baseUrl}.well-known/openid-configuration`, type: ContentType.JSON }],
+        'service-doc': [{ href: 'https://www.medplum.com/docs/auth/medplum-as-idp', type: ContentType.HTML }],
+      },
+      {
+        anchor: `${baseUrl}dicomweb`,
+        'service-doc': [{ href: 'https://www.medplum.com/docs/dicom/dicomweb-api', type: ContentType.HTML }],
+      },
+      {
+        anchor: `${baseUrl}scim/v2`,
+        'service-doc': [{ href: 'https://www.medplum.com/docs/api/scim/overview', type: ContentType.HTML }],
+      },
+    ]);
+  });
+
+  test('Head /.well-known/api-catalog', async () => {
+    const res = await request(app).head('/.well-known/api-catalog');
+    expect(res).toHaveStatus(200);
+    expect(res.headers['link']).toStrictEqual(`<${getConfig().baseUrl}.well-known/api-catalog>; rel="api-catalog"`);
+    expect(res.headers['content-type']).toStrictEqual(
+      `${ContentType.LINKSET_JSON}; profile="https://www.rfc-editor.org/info/rfc9727"`
+    );
+    expect(res.text).toBeUndefined();
+  });
+
+  test('Advertised endpoints resolve', async () => {
+    const linkset = JSON.parse((await request(app).get('/.well-known/api-catalog')).text).linkset;
+    const { baseUrl } = getConfig();
+
+    // Only the machine-readable descriptions are hosted by this server.
+    const serviceDescPaths = linkset
+      .flatMap((context: any) => context['service-desc'] ?? [])
+      .map((target: any) => target.href.substring(baseUrl.length - 1));
+    expect(serviceDescPaths).toHaveLength(3);
+
+    for (const path of serviceDescPaths) {
+      expect(await request(app).get(path)).toHaveStatus(200);
+    }
+  });
+
+  test('www.medplum.com redirects to the canonical catalog', () => {
+    // RFC 9727 section 5.1 - other instances redirect to the canonical instance.
+    // www.medplum.com is served by Vercel, so the redirect lives in the docs site config.
+    const vercelConfig = JSON.parse(readFileSync(resolve(__dirname, '../../docs/vercel.json'), 'utf8'));
+    expect(vercelConfig.redirects).toContainEqual({
+      source: '/.well-known/api-catalog',
+      destination: 'https://api.medplum.com/.well-known/api-catalog',
+      permanent: true,
+    });
+  });
+
+  test('Catalog is not project scoped', async () => {
+    // RFC 9727 section 5.1 - there is only one authoritative catalog document.
+    const projectId = '00000000-0000-0000-0000-000000000000';
+    const res = await request(app).get(`/projects/${projectId}/.well-known/api-catalog`);
+    expect(res).toHaveStatus(200);
+    expect(JSON.parse(res.text)).toStrictEqual(JSON.parse((await request(app).get('/.well-known/api-catalog')).text));
+  });
+});

--- a/packages/server/src/api-catalog.ts
+++ b/packages/server/src/api-catalog.ts
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { concatUrls, ContentType } from '@medplum/core';
+import type { Request, Response } from 'express';
+import { getConfig } from './config/loader';
+
+// RFC 9727 API catalog
+// See: https://www.rfc-editor.org/rfc/rfc9727.html
+//
+// The catalog is a discovery bootstrap, not a replacement for the discovery mechanisms of the
+// protocols it references. It lists only the major independently usable protocol surfaces, and
+// points each one at its own native machine-readable description.  Individual FHIR capabilities
+// such as SMART App Launch, Bulk Data, CDS Hooks, and FHIRcast have their own discovery
+// mechanisms, and are intentionally not top level catalog entries.
+
+const API_CATALOG_PATH = '.well-known/api-catalog';
+
+const RFC_9727_PROFILE = 'https://www.rfc-editor.org/info/rfc9727';
+const API_CATALOG_CONTENT_TYPE = `${ContentType.LINKSET_JSON}; profile="${RFC_9727_PROFILE}"`;
+const DOCS_URL = 'https://www.medplum.com/docs/';
+
+/** RFC 9264 link target object. */
+interface LinksetTarget {
+  readonly href: string;
+  readonly type: string;
+}
+
+/** RFC 9264 link context object. */
+interface LinksetContext {
+  readonly anchor: string;
+  readonly 'service-desc'?: LinksetTarget[];
+  readonly 'service-doc'?: LinksetTarget[];
+}
+
+/**
+ * Builds the RFC 9264 JSON Linkset describing this server's public protocol surfaces.
+ * @returns The link context objects, one per API.
+ */
+function buildLinkset(): LinksetContext[] {
+  const { baseUrl, issuer } = getConfig();
+  return [
+    {
+      anchor: concatUrls(baseUrl, 'fhir/R4'),
+      'service-desc': [{ href: concatUrls(baseUrl, 'fhir/R4/metadata'), type: ContentType.FHIR_JSON }],
+      'service-doc': [{ href: concatUrls(DOCS_URL, 'api/fhir'), type: ContentType.HTML }],
+    },
+    {
+      anchor: concatUrls(baseUrl, 'oauth2'),
+      'service-desc': [{ href: concatUrls(baseUrl, '.well-known/oauth-authorization-server'), type: ContentType.JSON }],
+      'service-doc': [{ href: concatUrls(DOCS_URL, 'api/oauth'), type: ContentType.HTML }],
+    },
+    {
+      // OpenID Connect identifies its service by the Issuer Identifier, which is what the
+      // OpenID Provider Configuration document advertises as "issuer".
+      anchor: issuer,
+      'service-desc': [{ href: concatUrls(baseUrl, '.well-known/openid-configuration'), type: ContentType.JSON }],
+      'service-doc': [{ href: concatUrls(DOCS_URL, 'auth/medplum-as-idp'), type: ContentType.HTML }],
+    },
+    {
+      // DICOMweb has no standard machine-readable service description, so "service-desc" is omitted.
+      anchor: concatUrls(baseUrl, 'dicomweb'),
+      'service-doc': [{ href: concatUrls(DOCS_URL, 'dicom/dicomweb-api'), type: ContentType.HTML }],
+    },
+    {
+      // Medplum does not implement the SCIM discovery endpoints, so "service-desc" is omitted.
+      anchor: concatUrls(baseUrl, 'scim/v2'),
+      'service-doc': [{ href: concatUrls(DOCS_URL, 'api/scim/overview'), type: ContentType.HTML }],
+    },
+  ];
+}
+
+/**
+ * Handles `GET` and `HEAD` of the RFC 9727 API catalog.
+ *
+ * There is exactly one authoritative catalog document, hosted on the API server. Other hosts, such
+ * as the organizational web site, permanently redirect here rather than keeping their own copy.
+ * @param _req - The request.
+ * @param res - The response.
+ */
+export function apiCatalogHandler(_req: Request, res: Response): void {
+  res.set('Link', `<${concatUrls(getConfig().baseUrl, API_CATALOG_PATH)}>; rel="api-catalog"`);
+  res.set('Content-Type', API_CATALOG_CONTENT_TYPE);
+  // Send a Buffer rather than using res.json(), because Express appends a "charset" parameter to
+  // the Content-Type of string bodies, which would reorder the RFC 9727 "profile" parameter.
+  res.status(200).send(Buffer.from(JSON.stringify({ linkset: buildLinkset() }), 'utf8'));
+}

--- a/packages/server/src/wellknown.ts
+++ b/packages/server/src/wellknown.ts
@@ -3,6 +3,7 @@
 import { OAuthGrantType, OAuthSigningAlgorithm, OAuthTokenAuthMethod } from '@medplum/core';
 import type { Request, Response } from 'express';
 import { Router } from 'express';
+import { apiCatalogHandler } from './api-catalog';
 import { getConfig } from './config/loader';
 import { smartConfigurationHandler, smartStylingHandler } from './fhir/smart';
 import { getJwks } from './oauth/keys';
@@ -72,6 +73,10 @@ function handleOauthProtectedResource(req: Request, res: Response): void {
     introspection_endpoint: getProjectScopedUrl(req.originalUrl, config.baseUrl, config.introspectUrl),
   });
 }
+
+// RFC 9727 API catalog
+// Express routes HEAD requests to the GET handler, which is how HEAD support is provided.
+wellKnownRouter.get('/api-catalog', apiCatalogHandler);
 
 wellKnownRouter.get('/oauth-authorization-server', handleOAuthConfig);
 wellKnownRouter.get('/openid-configuration', handleOAuthConfig);


### PR DESCRIPTION
Implements the [RFC 9727](https://www.rfc-editor.org/rfc/rfc9727.html) `/.well-known/api-catalog` endpoint, giving clients a single machine-readable starting point for discovering the standards-based APIs Medplum publishes.

The catalog is deliberately minimal. It lists only the major independently usable protocol surfaces — FHIR, OAuth 2.0, OpenID Connect, DICOMweb, and SCIM — and points each one at its own native discovery document. It is a discovery bootstrap, not a replacement for the discovery mechanisms of the protocols it references:

```text
/.well-known/api-catalog -> protocol endpoint -> native protocol discovery -> capabilities
```

Individual FHIR capabilities such as SMART App Launch, Bulk Data, CDS Hooks, and FHIRcast already have their own discovery mechanisms, so they are intentionally not top-level catalog entries. No internal or private APIs are listed.

The canonical catalog lives on the API host, alongside the other machine-readable discovery endpoints Medplum already serves:

```text
https://api.medplum.com/.well-known/api-catalog
https://api.medplum.com/.well-known/oauth-authorization-server
https://api.medplum.com/.well-known/openid-configuration
```

RFC 9727 §5.1 gives the Publisher's primary API portal as an example of an appropriate canonical location, and lets other instances redirect to it. `https://www.medplum.com/.well-known/api-catalog` permanently redirects here, so there is exactly one authoritative catalog document.